### PR TITLE
Add GitHub Actions workflow for Android APK builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,66 @@
+name: Build Android APK
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'apps/android/**'
+      - '.github/workflows/android.yml'
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'apps/android/**'
+      - '.github/workflows/android.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: apps/android
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Create local.properties
+        run: |
+          echo "sdk.dir=$ANDROID_HOME" > local.properties
+          echo "nepheliaiApiToken=${{ secrets.NEPHELAI_API_TOKEN }}" >> local.properties
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: nephelai-debug-apk
+          path: apps/android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 30
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: apps/android/app/build/reports/tests/
+          retention-days: 7

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Create local.properties
         run: |
           echo "sdk.dir=$ANDROID_HOME" > local.properties
-          echo "nepheliaiApiToken=${{ secrets.NEPHELAI_API_TOKEN }}" >> local.properties
+          echo "aurbodaApiToken=${{ secrets.AURBODA_API_TOKEN }}" >> local.properties
 
       - name: Build debug APK
         run: ./gradlew assembleDebug
@@ -50,7 +50,7 @@ jobs:
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: nephelai-debug-apk
+          name: aurboda-debug-apk
           path: apps/android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 30
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ Visualizations:
 * ...served from backend is a timeline with HR, sleep, exercise and locations, but that is going into the web part...
 
 
+Downloads
+---------
+
+ - [Android APK (latest build artifacts)](https://github.com/fiddur/aurboda/actions/workflows/android.yml?query=branch%3Adevelop)
+
 Parts in apps
 -------------
 
  - Backend (needing PostgreSQL storage configured in .env)
  - Web (for visualizations)
- - Android (to colled Andoid Health Connect data)
+ - Android (to collect Android Health Connect data)

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -52,14 +52,14 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NephelaiApp"
+        android:theme="@style/Theme.Aurboda"
         android:usesCleartextTraffic="true">
 
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.NephelaiApp">
+            android:theme="@style/Theme.Aurboda">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">NephelaiApp</string>
+    <string name="app_name">Aurboda</string>
 </resources>

--- a/apps/android/app/src/main/res/values/themes.xml
+++ b/apps/android/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.NephelaiApp" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Aurboda" parent="android:Theme.Material.Light.NoActionBar" />
 </resources>

--- a/apps/android/settings.gradle.kts
+++ b/apps/android/settings.gradle.kts
@@ -19,5 +19,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "NephelaiApp"
+rootProject.name = "Aurboda"
 include(":app")

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,4 +1,4 @@
-# Nephelai Backend
+# Aurboda Backend
 
 This repo aims to collect a user's self quantification data into a single useful place.
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -1,5 +1,5 @@
 /**
- * Database schema definitions for Nephelai.
+ * Database schema definitions for Aurboda.
  *
  * This module contains all table creation SQL and schema-related utilities.
  * See docs/data-storage.md for design decisions and data flow documentation.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,4 +1,4 @@
-Nephelai Web
+Aurboda Web
 ============
 
 Visualizing the collected data.


### PR DESCRIPTION
## Summary

Add GitHub Actions CI to automatically build Android debug APKs when the android app changes.

Closes #8

### Workflow Triggers
- Push to `develop` branch (only when `apps/android/**` changes)
- Pull requests to `develop` (only when `apps/android/**` changes)
- Manual trigger via `workflow_dispatch`

### What it does
1. Sets up JDK 17 and Android SDK
2. Creates `local.properties` with API token from secrets
3. Builds debug APK
4. Runs unit tests
5. Uploads APK as artifact (30 day retention)
6. Uploads test results

### Required Secret
Add `AURBODA_API_TOKEN` to repository secrets for the API token used by the app.

### Artifacts
After each build, download the APK from the workflow run's Artifacts section.

## Test plan
- [ ] Trigger workflow manually via Actions tab
- [ ] Verify APK is built and uploaded as artifact
- [ ] Download and install APK on device

🤖 Generated with [Claude Code](https://claude.ai/code)