### PR TITLE
Add CI for aurboda-web Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,15 +4,51 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - 'apps/backend/**'
+      - 'apps/web/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/docker.yml'
   workflow_dispatch:
-
-env:
-  IMAGE_NAME: fiddur/aurboda
+    inputs:
+      image:
+        description: 'Image to build'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - backend
+          - web
 
 jobs:
-  build-and-push:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'apps/backend/**'
+              - 'packages/**'
+              - 'pnpm-lock.yaml'
+            web:
+              - 'apps/web/**'
+              - 'packages/**'
+              - 'pnpm-lock.yaml'
 
+  build-backend:
+    needs: changes
+    if: |
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.image == 'all' || github.event.inputs.image == 'backend') ||
+      github.event_name == 'push' && needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,7 +66,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: fiddur/aurboda-backend
           tags: |
             type=ref,event=branch
             type=sha,prefix=
@@ -41,6 +77,46 @@ jobs:
         with:
           context: .
           file: apps/backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-web:
+    needs: changes
+    if: |
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.image == 'all' || github.event.inputs.image == 'web') ||
+      github.event_name == 'push' && needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: fiddur/aurboda-web
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: apps/web/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Rename backend image from `fiddur/aurboda` to `fiddur/aurboda-backend`
- Add build job for `fiddur/aurboda-web` image
- Use path filtering to only build images when relevant files change
- Add `workflow_dispatch` with image selector (all/backend/web) for manual triggers
- Both images build in parallel when both have changes

## Test plan

- [ ] Merge to develop and verify workflow triggers
- [ ] Verify `fiddur/aurboda-backend` image is pushed to Docker Hub
- [ ] Verify `fiddur/aurboda-web` image is pushed to Docker Hub
- [ ] Test manual workflow dispatch with each option (all/backend/web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)