### PR TITLE
Fix web Dockerfile: remove nonexistent packages/ copy

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,7 +3,6 @@ RUN corepack enable && corepack prepare pnpm@10.15.1 --activate
 WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/web/package.json apps/web/
-COPY packages/ packages/
 RUN pnpm install --frozen-lockfile
 COPY apps/web/ apps/web/
 ARG VITE_API_URL


### PR DESCRIPTION
## Summary
- Removes `COPY packages/ packages/` line from web Dockerfile
- The `packages/` directory doesn't exist in the project (pnpm workspace only includes `apps/*`)
- This was causing the Docker build to fail in CI

## Test plan
- [ ] Verify CI Docker build passes for the web image

🤖 Generated with [Claude Code](https://claude.com/claude-code)