### PR TITLE
Add bottom navigation to Android app

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -10,7 +10,12 @@ import androidx.compose.ui.platform.LocalContext
 
 enum class AppScreen {
     Login,
-    HealthConnect
+    Main
+}
+
+enum class MainTab {
+    Sync,
+    Account
 }
 
 class AppState(
@@ -20,16 +25,33 @@ class AppState(
     var currentScreen by mutableStateOf(initialScreen)
         private set
 
+    var currentTab by mutableStateOf(MainTab.Sync)
+        private set
+
+    var pendingServerUrl by mutableStateOf<String?>(null)
+        private set
+
     val credentials: CredentialsManager.Credentials?
         get() = CredentialsManager.getCredentials(context)
 
     fun onLoginSuccess() {
-        currentScreen = AppScreen.HealthConnect
+        pendingServerUrl = null
+        currentScreen = AppScreen.Main
     }
 
     fun logout() {
         CredentialsManager.clearCredentials(context)
+        currentTab = MainTab.Sync
         currentScreen = AppScreen.Login
+    }
+
+    fun changeServerUrl(newUrl: String) {
+        pendingServerUrl = newUrl
+        logout()
+    }
+
+    fun selectTab(tab: MainTab) {
+        currentTab = tab
     }
 }
 
@@ -40,7 +62,7 @@ fun rememberAppState(): AppState {
         val hasCredentials = CredentialsManager.hasCredentials(context)
         AppState(
             context = context,
-            initialScreen = if (hasCredentials) AppScreen.HealthConnect else AppScreen.Login
+            initialScreen = if (hasCredentials) AppScreen.Main else AppScreen.Login
         )
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -210,16 +209,32 @@ fun AurbodaApp() {
     when (appState.currentScreen) {
         AppScreen.Login -> {
             net.aurboda.ui.screens.LoginScreen(
+                initialServerUrl = appState.pendingServerUrl,
                 onLoginSuccess = { appState.onLoginSuccess() }
             )
         }
-        AppScreen.HealthConnect -> {
+        AppScreen.Main -> {
             val credentials = appState.credentials
             if (credentials != null) {
-                HealthConnectScreen(
-                    serverUrl = credentials.serverUrl,
-                    authToken = credentials.authToken,
-                    onLogout = { appState.logout() }
+                net.aurboda.ui.screens.MainScreen(
+                    currentTab = appState.currentTab,
+                    onTabSelected = { appState.selectTab(it) },
+                    syncContent = { modifier ->
+                        HealthConnectScreen(
+                            serverUrl = credentials.serverUrl,
+                            authToken = credentials.authToken,
+                            modifier = modifier
+                        )
+                    },
+                    accountContent = { modifier ->
+                        net.aurboda.ui.screens.AccountScreen(
+                            username = credentials.username,
+                            serverUrl = credentials.serverUrl,
+                            onServerUrlChange = { newUrl -> appState.changeServerUrl(newUrl) },
+                            onLogout = { appState.logout() },
+                            modifier = modifier
+                        )
+                    }
                 )
             } else {
                 // Should not happen, but handle gracefully
@@ -233,7 +248,7 @@ fun AurbodaApp() {
 fun HealthConnectScreen(
     serverUrl: String,
     authToken: String,
-    onLogout: () -> Unit
+    modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -540,18 +555,10 @@ fun HealthConnectScreen(
     val yesterday = remember { today.minusDays(1) }
 
     Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
+        modifier = modifier.fillMaxSize().padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
-        ) {
-            TextButton(onClick = onLogout) {
-                Text("Logout")
-            }
-        }
         Text(statusMessage)
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -647,8 +654,7 @@ fun HealthConnectScreenPreview() {
     AurbodaAppTheme {
         HealthConnectScreen(
             serverUrl = "https://example.com",
-            authToken = "preview-token",
-            onLogout = {}
+            authToken = "preview-token"
         )
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/AccountScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/AccountScreen.kt
@@ -1,0 +1,107 @@
+package net.aurboda.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AccountScreen(
+    username: String,
+    serverUrl: String,
+    onServerUrlChange: (String) -> Unit,
+    onLogout: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var editedServerUrl by remember(serverUrl) { mutableStateOf(serverUrl) }
+    val hasChanges = editedServerUrl != serverUrl
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = "Account",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = username,
+            onValueChange = {},
+            label = { Text("Username") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            readOnly = true
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = editedServerUrl,
+            onValueChange = { editedServerUrl = it },
+            label = { Text("Server URL") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
+        )
+
+        if (hasChanges) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Changing the server URL will require you to log in again.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (hasChanges) {
+            Button(
+                onClick = { onServerUrlChange(editedServerUrl.trimEnd('/')) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = editedServerUrl.isNotBlank()
+            ) {
+                Text("Save & Log Out")
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        OutlinedButton(
+            onClick = onLogout,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = MaterialTheme.colorScheme.error
+            )
+        ) {
+            Text("Log Out")
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LoginScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LoginScreen.kt
@@ -33,13 +33,14 @@ import net.aurboda.LoginResult
 
 @Composable
 fun LoginScreen(
+    initialServerUrl: String? = null,
     onLoginSuccess: () -> Unit
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val authApi = remember { AuthApi.create() }
 
-    var serverUrl by remember { mutableStateOf("https://aurboda.net/api") }
+    var serverUrl by remember { mutableStateOf(initialServerUrl ?: "https://aurboda.net/api") }
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
@@ -3,7 +3,7 @@ package net.aurboda.ui.screens
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -28,7 +28,7 @@ fun MainScreen(
     accountContent: @Composable (Modifier) -> Unit
 ) {
     val navItems = listOf(
-        BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Sync),
+        BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Refresh),
         BottomNavItem(MainTab.Account, "Account", Icons.Default.Person)
     )
 

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
@@ -1,0 +1,54 @@
+package net.aurboda.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import net.aurboda.MainTab
+
+data class BottomNavItem(
+    val tab: MainTab,
+    val label: String,
+    val icon: ImageVector
+)
+
+@Composable
+fun MainScreen(
+    currentTab: MainTab,
+    onTabSelected: (MainTab) -> Unit,
+    syncContent: @Composable (Modifier) -> Unit,
+    accountContent: @Composable (Modifier) -> Unit
+) {
+    val navItems = listOf(
+        BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Sync),
+        BottomNavItem(MainTab.Account, "Account", Icons.Default.Person)
+    )
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                navItems.forEach { item ->
+                    NavigationBarItem(
+                        selected = currentTab == item.tab,
+                        onClick = { onTabSelected(item.tab) },
+                        icon = { Icon(item.icon, contentDescription = item.label) },
+                        label = { Text(item.label) }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        when (currentTab) {
+            MainTab.Sync -> syncContent(Modifier.padding(innerPadding))
+            MainTab.Account -> accountContent(Modifier.padding(innerPadding))
+        }
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
@@ -1,0 +1,46 @@
+package net.aurboda
+
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Unit tests for AppState enums and related logic.
+ * Note: Full AppState tests with Compose state and Context
+ * require instrumented tests (androidTest) or Compose testing libraries.
+ */
+class AppStateTest {
+
+    @Test
+    fun `AppScreen has Login and Main values`() {
+        val screens = AppScreen.entries
+        assertEquals(2, screens.size)
+        assertTrue(screens.contains(AppScreen.Login))
+        assertTrue(screens.contains(AppScreen.Main))
+    }
+
+    @Test
+    fun `MainTab has Sync and Account values`() {
+        val tabs = MainTab.entries
+        assertEquals(2, tabs.size)
+        assertTrue(tabs.contains(MainTab.Sync))
+        assertTrue(tabs.contains(MainTab.Account))
+    }
+
+    @Test
+    fun `MainTab ordinal values are correct`() {
+        assertEquals(0, MainTab.Sync.ordinal)
+        assertEquals(1, MainTab.Account.ordinal)
+    }
+
+    @Test
+    fun `AppScreen ordinal values are correct`() {
+        assertEquals(0, AppScreen.Login.ordinal)
+        assertEquals(1, AppScreen.Main.ordinal)
+    }
+
+    @Test
+    fun `MainTab names are descriptive`() {
+        assertEquals("Sync", MainTab.Sync.name)
+        assertEquals("Account", MainTab.Account.name)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds bottom navigation bar with two tabs: Sync (health data) and Account (settings)
- Creates AccountScreen with username display, editable server URL, and logout button
- Server URL changes trigger logout and pre-fill the new URL on login screen

## Test plan
- [ ] Build and install the APK
- [ ] Verify bottom navigation appears after login
- [ ] Test tab switching between Sync and Account
- [ ] Verify logout works from Account screen
- [ ] Test server URL change flow (should log out and show new URL on login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)