### PR TITLE
Fix session encryption: use env var and fresh cipher per login

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -36,15 +36,13 @@ declare global {
 const main = async () => {
   const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 })
 
-  const config = {
-    sessionSalt: 'very very secretvery very secret', //  256-bit encryption key (32 bytes)
+  const sessionSalt = process.env.SESSION_SALT
+  if (!sessionSalt || Buffer.from(sessionSalt).length !== 32) {
+    throw new Error('SESSION_SALT must be set and be exactly 32 bytes (256 bits)')
   }
 
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
   const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost)
-
-  const iv = randomBytes(12).toString('base64')
-  const cipher = createCipheriv('aes-256-gcm', config.sessionSalt, iv)
 
   const httpd = express()
 
@@ -52,7 +50,7 @@ const main = async () => {
     try {
       if (!sessid) throw new Error('unauthenticated')
       const [encrypted, sessionIv, tag] = sessid.split('-')
-      const decipher = createDecipheriv('aes-256-gcm', config.sessionSalt, sessionIv)
+      const decipher = createDecipheriv('aes-256-gcm', sessionSalt, sessionIv)
       decipher.setAuthTag(Buffer.from(tag, 'base64'))
       return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
     } catch {
@@ -67,7 +65,7 @@ const main = async () => {
   httpd.use(cors({ origin: true }))
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
-  httpd.use('/mcp', createMcpRouter({ sessionSalt: config.sessionSalt }))
+  httpd.use('/mcp', createMcpRouter({ sessionSalt }))
 
   httpd.use(json({ limit: '10mb' }))
 
@@ -116,10 +114,12 @@ const main = async () => {
       }
     } else return next(unauthorized)
 
+    const iv = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', sessionSalt, iv)
     const token =
       cipher.update(user, 'utf8', 'base64') +
       cipher.final('base64') +
-      `-${iv}-${cipher.getAuthTag().toString('base64')}`
+      `-${iv.toString('base64')}-${cipher.getAuthTag().toString('base64')}`
 
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ refresh: token, token }))


### PR DESCRIPTION
## Summary
- Read `SESSION_SALT` from environment instead of hardcoded placeholder
- Validate on startup that `SESSION_SALT` is exactly 32 bytes (256 bits)
- Create fresh cipher and IV for each login request instead of reusing a single instance

## Root Cause
The previous code created a single cipher instance at startup and reused it for every login. After calling `cipher.final()`, the cipher enters a finalized state and cannot accept more data - causing the "Trying to add data in unsupported state" error on subsequent login attempts.

## Test plan
- [ ] Set `SESSION_SALT` environment variable to a 32-byte string
- [ ] Verify backend starts successfully with valid SESSION_SALT
- [ ] Verify backend fails to start with missing or invalid SESSION_SALT
- [ ] Login multiple times consecutively and verify no errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)