### PR TITLE
Fix auth token decryption and update browser title

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -50,7 +50,7 @@ const main = async () => {
     try {
       if (!sessid) throw new Error('unauthenticated')
       const [encrypted, sessionIv, tag] = sessid.split('-')
-      const decipher = createDecipheriv('aes-256-gcm', sessionSalt, sessionIv)
+      const decipher = createDecipheriv('aes-256-gcm', sessionSalt, Buffer.from(sessionIv, 'base64'))
       decipher.setAuthTag(Buffer.from(tag, 'base64'))
       return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
     } catch {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,7 +5,7 @@
 		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="color-scheme" content="light dark" />
-		<title>Vite + Preact</title>
+		<title>Aurboda</title>
 	</head>
 	<body>
 		<div id="app"></div>


### PR DESCRIPTION
## Summary
- Fix IV decoding in `getUsernameFromSession`: the IV was stored as base64 in the token but passed directly to `createDecipheriv` without decoding - this caused all authenticated API calls to fail with 401
- Update browser title from "Vite + Preact" to "Aurboda"

## Test plan
- [ ] Login and verify the timeline page loads heart rate data
- [ ] Verify browser tab shows "Aurboda" as the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)