### PR TITLE
Refactor: extract shared auth module for DRY token handling

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -1,9 +1,9 @@
 import { json } from 'body-parser'
 import cors from 'cors'
-import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
 import { subHours } from 'date-fns'
 import express, { RequestHandler } from 'express'
 import { Client } from 'pg'
+import { createToken, getUsernameFromToken, initializeAuth } from './auth'
 import {
   getActivities,
   getLocations,
@@ -36,27 +36,12 @@ declare global {
 const main = async () => {
   const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 })
 
-  const sessionSalt = process.env.SESSION_SALT
-  if (!sessionSalt || Buffer.from(sessionSalt).length !== 32) {
-    throw new Error('SESSION_SALT must be set and be exactly 32 bytes (256 bits)')
-  }
+  initializeAuth()
 
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
   const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost)
 
   const httpd = express()
-
-  const getUsernameFromSession = (sessid: string) => {
-    try {
-      if (!sessid) throw new Error('unauthenticated')
-      const [encrypted, sessionIv, tag] = sessid.split('-')
-      const decipher = createDecipheriv('aes-256-gcm', sessionSalt, Buffer.from(sessionIv, 'base64'))
-      decipher.setAuthTag(Buffer.from(tag, 'base64'))
-      return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
-    } catch {
-      throw new Error('unauthenticated')
-    }
-  }
 
   const userDb = new Client({ database: 'postgres' })
   await userDb.connect()
@@ -65,7 +50,7 @@ const main = async () => {
   httpd.use(cors({ origin: true }))
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
-  httpd.use('/mcp', createMcpRouter({ sessionSalt }))
+  httpd.use('/mcp', createMcpRouter())
 
   httpd.use(json({ limit: '10mb' }))
 
@@ -78,8 +63,7 @@ const main = async () => {
     try {
       if (typeof req.headers.authorization === 'string') {
         const token = req.headers.authorization.slice('bearer '.length)
-        const user = getUsernameFromSession(token)
-        req.user = user
+        req.user = getUsernameFromToken(token)
         return next()
       }
     } catch {
@@ -114,12 +98,7 @@ const main = async () => {
       }
     } else return next(unauthorized)
 
-    const iv = randomBytes(12)
-    const cipher = createCipheriv('aes-256-gcm', sessionSalt, iv)
-    const token =
-      cipher.update(user, 'utf8', 'base64') +
-      cipher.final('base64') +
-      `-${iv.toString('base64')}-${cipher.getAuthTag().toString('base64')}`
+    const token = createToken(user)
 
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ refresh: token, token }))

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -3,7 +3,7 @@ import cors from 'cors'
 import { subHours } from 'date-fns'
 import express, { RequestHandler } from 'express'
 import { Client } from 'pg'
-import { createToken, getUsernameFromToken, initializeAuth } from './auth'
+import { createAuth } from './auth'
 import {
   getActivities,
   getLocations,
@@ -36,7 +36,7 @@ declare global {
 const main = async () => {
   const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 })
 
-  initializeAuth()
+  const auth = createAuth(process.env.SESSION_SALT ?? '')
 
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
   const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost)
@@ -50,7 +50,7 @@ const main = async () => {
   httpd.use(cors({ origin: true }))
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
-  httpd.use('/mcp', createMcpRouter())
+  httpd.use('/mcp', createMcpRouter(auth))
 
   httpd.use(json({ limit: '10mb' }))
 
@@ -59,11 +59,11 @@ const main = async () => {
     next()
   })
 
-  const auth: RequestHandler = (req, res, next) => {
+  const authMiddleware: RequestHandler = (req, res, next) => {
     try {
       if (typeof req.headers.authorization === 'string') {
         const token = req.headers.authorization.slice('bearer '.length)
-        req.user = getUsernameFromToken(token)
+        req.user = auth.getUsernameFromToken(token)
         return next()
       }
     } catch {
@@ -98,7 +98,7 @@ const main = async () => {
       }
     } else return next(unauthorized)
 
-    const token = createToken(user)
+    const token = auth.createToken(user)
 
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ refresh: token, token }))
@@ -109,28 +109,32 @@ const main = async () => {
     res.end(JSON.stringify({ refresh, token: refresh }))
   })
 
-  httpd.post<{ recordType: string }, { success: boolean }>('/sync/:recordType', auth, async (req, res) => {
-    const { recordType } = req.params
-    let { data } = req.body
+  httpd.post<{ recordType: string }, { success: boolean }>(
+    '/sync/:recordType',
+    authMiddleware,
+    async (req, res) => {
+      const { recordType } = req.params
+      let { data } = req.body
 
-    if (!Array.isArray(data) && typeof data === 'object' && Object.entries(data).length) {
-      data = [data]
-    }
+      if (!Array.isArray(data) && typeof data === 'object' && Object.entries(data).length) {
+        data = [data]
+      }
 
-    if (!data?.length) {
-      console.log('  empty?!')
-      return res.json({ success: true })
-    }
+      if (!data?.length) {
+        console.log('  empty?!')
+        return res.json({ success: true })
+      }
 
-    const user = req.user!
+      const user = req.user!
 
-    // Process each Health Connect record through the new schema
-    for (const item of data) {
-      await processHealthConnectData(user, recordType, item)
-    }
+      // Process each Health Connect record through the new schema
+      for (const item of data) {
+        await processHealthConnectData(user, recordType, item)
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
   httpd.get('/auth/connectOura', oura.redirectToAuthorize)
   httpd.get('/auth/ouracb', oura.authCb)
@@ -228,7 +232,7 @@ const main = async () => {
     )
   })
 
-  httpd.get('/heartrate', auth, async (req, res) => {
+  httpd.get('/heartrate', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -239,7 +243,7 @@ const main = async () => {
     res.end(JSON.stringify(hrs))
   })
 
-  httpd.get('/tags', auth, async (req, res) => {
+  httpd.get('/tags', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!

--- a/apps/backend/src/auth.test.ts
+++ b/apps/backend/src/auth.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { createToken, getUsernameFromToken, initializeAuth } from './auth'
+
+describe('auth', () => {
+  const originalEnv = process.env.SESSION_SALT
+
+  beforeEach(() => {
+    process.env.SESSION_SALT = 'test-secret-key-32-bytes-long!!!' // exactly 32 bytes
+    initializeAuth()
+  })
+
+  afterEach(() => {
+    process.env.SESSION_SALT = originalEnv
+  })
+
+  describe('initializeAuth', () => {
+    test('throws if SESSION_SALT is not set', () => {
+      delete process.env.SESSION_SALT
+      expect(() => initializeAuth()).toThrow('SESSION_SALT must be set and be exactly 32 bytes')
+    })
+
+    test('throws if SESSION_SALT is too short', () => {
+      process.env.SESSION_SALT = 'too-short'
+      expect(() => initializeAuth()).toThrow('SESSION_SALT must be set and be exactly 32 bytes')
+    })
+
+    test('throws if SESSION_SALT is too long', () => {
+      process.env.SESSION_SALT = 'this-is-way-too-long-for-a-256-bit-key-it-has-too-many-bytes'
+      expect(() => initializeAuth()).toThrow('SESSION_SALT must be set and be exactly 32 bytes')
+    })
+
+    test('succeeds with exactly 32 bytes', () => {
+      process.env.SESSION_SALT = 'exactly-32-bytes-long-key-here!!'
+      expect(() => initializeAuth()).not.toThrow()
+    })
+  })
+
+  describe('createToken', () => {
+    test('creates a token with expected format', () => {
+      const token = createToken('testuser')
+      const parts = token.split('-')
+      expect(parts).toHaveLength(3)
+    })
+
+    test('creates different tokens for same username (unique IV)', () => {
+      const token1 = createToken('testuser')
+      const token2 = createToken('testuser')
+      expect(token1).not.toBe(token2)
+    })
+
+    test('can create multiple tokens without error (fresh cipher each time)', () => {
+      expect(() => {
+        createToken('user1')
+        createToken('user2')
+        createToken('user3')
+      }).not.toThrow()
+    })
+  })
+
+  describe('getUsernameFromToken', () => {
+    test('decrypts token to original username', () => {
+      const token = createToken('testuser')
+      const username = getUsernameFromToken(token)
+      expect(username).toBe('testuser')
+    })
+
+    test('can decrypt the same token multiple times (no cipher reuse bug)', () => {
+      const token = createToken('testuser')
+
+      const username1 = getUsernameFromToken(token)
+      const username2 = getUsernameFromToken(token)
+
+      expect(username1).toBe('testuser')
+      expect(username2).toBe('testuser')
+    })
+
+    test('can decrypt different tokens consecutively', () => {
+      const token1 = createToken('user1')
+      const token2 = createToken('user2')
+
+      expect(getUsernameFromToken(token1)).toBe('user1')
+      expect(getUsernameFromToken(token2)).toBe('user2')
+      expect(getUsernameFromToken(token1)).toBe('user1')
+    })
+
+    test('throws on empty token', () => {
+      expect(() => getUsernameFromToken('')).toThrow('unauthenticated')
+    })
+
+    test('throws on malformed token', () => {
+      expect(() => getUsernameFromToken('not-a-valid-token')).toThrow()
+    })
+
+    test('throws on tampered token', () => {
+      const token = createToken('testuser')
+      const parts = token.split('-')
+      parts[0] = 'tampered' + parts[0]
+      const tamperedToken = parts.join('-')
+      expect(() => getUsernameFromToken(tamperedToken)).toThrow()
+    })
+  })
+
+  describe('round-trip token creation and validation', () => {
+    test('handles usernames with special characters', () => {
+      const usernames = ['user@example.com', 'user-name', 'user_name', 'user.name']
+      for (const username of usernames) {
+        const token = createToken(username)
+        expect(getUsernameFromToken(token)).toBe(username)
+      }
+    })
+
+    test('handles unicode usernames', () => {
+      const token = createToken('用户名')
+      expect(getUsernameFromToken(token)).toBe('用户名')
+    })
+
+    test('stress test: create and validate many tokens', () => {
+      for (let i = 0; i < 100; i++) {
+        const username = `user${i}`
+        const token = createToken(username)
+        expect(getUsernameFromToken(token)).toBe(username)
+      }
+    })
+  })
+})

--- a/apps/backend/src/auth.test.ts
+++ b/apps/backend/src/auth.test.ts
@@ -1,125 +1,138 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
-import { createToken, getUsernameFromToken, initializeAuth } from './auth'
+import { describe, expect, test } from 'vitest'
+import { createAuth } from './auth'
+
+const VALID_SALT = 'test-secret-key-32-bytes-long!!!' // exactly 32 bytes
 
 describe('auth', () => {
-  const originalEnv = process.env.SESSION_SALT
-
-  beforeEach(() => {
-    process.env.SESSION_SALT = 'test-secret-key-32-bytes-long!!!' // exactly 32 bytes
-    initializeAuth()
-  })
-
-  afterEach(() => {
-    process.env.SESSION_SALT = originalEnv
-  })
-
-  describe('initializeAuth', () => {
-    test('throws if SESSION_SALT is not set', () => {
-      delete process.env.SESSION_SALT
-      expect(() => initializeAuth()).toThrow('SESSION_SALT must be set and be exactly 32 bytes')
+  describe('createAuth', () => {
+    test('throws if sessionSalt is empty', () => {
+      expect(() => createAuth('')).toThrow('SESSION_SALT must be set and be exactly 32 bytes (256 bits)')
     })
 
-    test('throws if SESSION_SALT is too short', () => {
-      process.env.SESSION_SALT = 'too-short'
-      expect(() => initializeAuth()).toThrow('SESSION_SALT must be set and be exactly 32 bytes')
+    test('throws if sessionSalt is too short', () => {
+      expect(() => createAuth('too-short')).toThrow(
+        'SESSION_SALT must be set and be exactly 32 bytes (256 bits)',
+      )
     })
 
-    test('throws if SESSION_SALT is too long', () => {
-      process.env.SESSION_SALT = 'this-is-way-too-long-for-a-256-bit-key-it-has-too-many-bytes'
-      expect(() => initializeAuth()).toThrow('SESSION_SALT must be set and be exactly 32 bytes')
+    test('throws if sessionSalt is too long', () => {
+      expect(() => createAuth('this-is-way-too-long-for-a-256-bit-key-it-has-too-many-bytes')).toThrow(
+        'SESSION_SALT must be set and be exactly 32 bytes (256 bits)',
+      )
     })
 
     test('succeeds with exactly 32 bytes', () => {
-      process.env.SESSION_SALT = 'exactly-32-bytes-long-key-here!!'
-      expect(() => initializeAuth()).not.toThrow()
+      expect(() => createAuth(VALID_SALT)).not.toThrow()
     })
   })
 
   describe('createToken', () => {
-    test('creates a token with expected format', () => {
-      const token = createToken('testuser')
+    const auth = createAuth(VALID_SALT)
+
+    test('creates a token with expected format (3 parts separated by dashes)', () => {
+      const token = auth.createToken('testuser')
       const parts = token.split('-')
       expect(parts).toHaveLength(3)
     })
 
-    test('creates different tokens for same username (unique IV)', () => {
-      const token1 = createToken('testuser')
-      const token2 = createToken('testuser')
+    test('creates different tokens for same username (unique IV each time)', () => {
+      const token1 = auth.createToken('testuser')
+      const token2 = auth.createToken('testuser')
       expect(token1).not.toBe(token2)
     })
 
     test('can create multiple tokens without error (fresh cipher each time)', () => {
       expect(() => {
-        createToken('user1')
-        createToken('user2')
-        createToken('user3')
+        auth.createToken('user1')
+        auth.createToken('user2')
+        auth.createToken('user3')
       }).not.toThrow()
     })
   })
 
   describe('getUsernameFromToken', () => {
+    const auth = createAuth(VALID_SALT)
+
     test('decrypts token to original username', () => {
-      const token = createToken('testuser')
-      const username = getUsernameFromToken(token)
+      const token = auth.createToken('testuser')
+      const username = auth.getUsernameFromToken(token)
       expect(username).toBe('testuser')
     })
 
     test('can decrypt the same token multiple times (no cipher reuse bug)', () => {
-      const token = createToken('testuser')
+      const token = auth.createToken('testuser')
 
-      const username1 = getUsernameFromToken(token)
-      const username2 = getUsernameFromToken(token)
+      const username1 = auth.getUsernameFromToken(token)
+      const username2 = auth.getUsernameFromToken(token)
 
       expect(username1).toBe('testuser')
       expect(username2).toBe('testuser')
     })
 
     test('can decrypt different tokens consecutively', () => {
-      const token1 = createToken('user1')
-      const token2 = createToken('user2')
+      const token1 = auth.createToken('user1')
+      const token2 = auth.createToken('user2')
 
-      expect(getUsernameFromToken(token1)).toBe('user1')
-      expect(getUsernameFromToken(token2)).toBe('user2')
-      expect(getUsernameFromToken(token1)).toBe('user1')
+      expect(auth.getUsernameFromToken(token1)).toBe('user1')
+      expect(auth.getUsernameFromToken(token2)).toBe('user2')
+      expect(auth.getUsernameFromToken(token1)).toBe('user1')
     })
 
-    test('throws on empty token', () => {
-      expect(() => getUsernameFromToken('')).toThrow('unauthenticated')
+    test('throws "unauthenticated" on empty token', () => {
+      expect(() => auth.getUsernameFromToken('')).toThrow('unauthenticated')
     })
 
-    test('throws on malformed token', () => {
-      expect(() => getUsernameFromToken('not-a-valid-token')).toThrow()
+    test('throws "unauthenticated" on malformed token (wrong number of parts)', () => {
+      expect(() => auth.getUsernameFromToken('only-two-parts')).toThrow('unauthenticated')
+      expect(() => auth.getUsernameFromToken('too-many-parts-here-now')).toThrow('unauthenticated')
     })
 
-    test('throws on tampered token', () => {
-      const token = createToken('testuser')
+    test('throws "unauthenticated" on tampered token', () => {
+      const token = auth.createToken('testuser')
       const parts = token.split('-')
       parts[0] = 'tampered' + parts[0]
       const tamperedToken = parts.join('-')
-      expect(() => getUsernameFromToken(tamperedToken)).toThrow()
+      expect(() => auth.getUsernameFromToken(tamperedToken)).toThrow('unauthenticated')
+    })
+
+    test('throws "unauthenticated" on invalid base64 in token', () => {
+      expect(() => auth.getUsernameFromToken('invalid!base64-also!bad-more!bad')).toThrow('unauthenticated')
     })
   })
 
   describe('round-trip token creation and validation', () => {
+    const auth = createAuth(VALID_SALT)
+
     test('handles usernames with special characters', () => {
       const usernames = ['user@example.com', 'user-name', 'user_name', 'user.name']
       for (const username of usernames) {
-        const token = createToken(username)
-        expect(getUsernameFromToken(token)).toBe(username)
+        const token = auth.createToken(username)
+        expect(auth.getUsernameFromToken(token)).toBe(username)
       }
     })
 
     test('handles unicode usernames', () => {
-      const token = createToken('用户名')
-      expect(getUsernameFromToken(token)).toBe('用户名')
+      const token = auth.createToken('用户名')
+      expect(auth.getUsernameFromToken(token)).toBe('用户名')
     })
 
-    test('stress test: create and validate many tokens', () => {
+    test('stress test: create and validate many tokens without cipher reuse errors', () => {
       for (let i = 0; i < 100; i++) {
         const username = `user${i}`
-        const token = createToken(username)
-        expect(getUsernameFromToken(token)).toBe(username)
+        const token = auth.createToken(username)
+        expect(auth.getUsernameFromToken(token)).toBe(username)
       }
+    })
+  })
+
+  describe('isolation between auth instances', () => {
+    test('tokens from one auth instance cannot be decoded by another', () => {
+      const auth1 = createAuth('salt-one-32-bytes-exactly-here!!')
+      const auth2 = createAuth('salt-two-32-bytes-exactly-here!!')
+
+      const token = auth1.createToken('testuser')
+
+      expect(() => auth2.getUsernameFromToken(token)).toThrow('unauthenticated')
     })
   })
 })

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -1,37 +1,41 @@
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
 
-let sessionSalt: string | undefined
+export interface Auth {
+  createToken: (username: string) => string
+  getUsernameFromToken: (token: string) => string
+}
 
-export function initializeAuth(): void {
-  sessionSalt = process.env.SESSION_SALT
+export function createAuth(sessionSalt: string): Auth {
   if (!sessionSalt || Buffer.from(sessionSalt).length !== 32) {
     throw new Error('SESSION_SALT must be set and be exactly 32 bytes (256 bits)')
   }
-}
 
-export function getSessionSalt(): string {
-  if (!sessionSalt) {
-    throw new Error('Auth not initialized. Call initializeAuth() first.')
+  return {
+    createToken(username: string): string {
+      const iv = randomBytes(12)
+      const cipher = createCipheriv('aes-256-gcm', sessionSalt, iv)
+      return (
+        cipher.update(username, 'utf8', 'base64') +
+        cipher.final('base64') +
+        `-${iv.toString('base64')}-${cipher.getAuthTag().toString('base64')}`
+      )
+    },
+
+    getUsernameFromToken(token: string): string {
+      if (!token) throw new Error('unauthenticated')
+
+      const parts = token.split('-')
+      if (parts.length !== 3) throw new Error('unauthenticated')
+
+      const [encrypted, iv, tag] = parts
+
+      try {
+        const decipher = createDecipheriv('aes-256-gcm', sessionSalt, Buffer.from(iv, 'base64'))
+        decipher.setAuthTag(Buffer.from(tag, 'base64'))
+        return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
+      } catch {
+        throw new Error('unauthenticated')
+      }
+    },
   }
-  return sessionSalt
-}
-
-export function createToken(username: string): string {
-  const salt = getSessionSalt()
-  const iv = randomBytes(12)
-  const cipher = createCipheriv('aes-256-gcm', salt, iv)
-  return (
-    cipher.update(username, 'utf8', 'base64') +
-    cipher.final('base64') +
-    `-${iv.toString('base64')}-${cipher.getAuthTag().toString('base64')}`
-  )
-}
-
-export function getUsernameFromToken(token: string): string {
-  const salt = getSessionSalt()
-  if (!token) throw new Error('unauthenticated')
-  const [encrypted, iv, tag] = token.split('-')
-  const decipher = createDecipheriv('aes-256-gcm', salt, Buffer.from(iv, 'base64'))
-  decipher.setAuthTag(Buffer.from(tag, 'base64'))
-  return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
 }

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -1,0 +1,37 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+
+let sessionSalt: string | undefined
+
+export function initializeAuth(): void {
+  sessionSalt = process.env.SESSION_SALT
+  if (!sessionSalt || Buffer.from(sessionSalt).length !== 32) {
+    throw new Error('SESSION_SALT must be set and be exactly 32 bytes (256 bits)')
+  }
+}
+
+export function getSessionSalt(): string {
+  if (!sessionSalt) {
+    throw new Error('Auth not initialized. Call initializeAuth() first.')
+  }
+  return sessionSalt
+}
+
+export function createToken(username: string): string {
+  const salt = getSessionSalt()
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', salt, iv)
+  return (
+    cipher.update(username, 'utf8', 'base64') +
+    cipher.final('base64') +
+    `-${iv.toString('base64')}-${cipher.getAuthTag().toString('base64')}`
+  )
+}
+
+export function getUsernameFromToken(token: string): string {
+  const salt = getSessionSalt()
+  if (!token) throw new Error('unauthenticated')
+  const [encrypted, iv, tag] = token.split('-')
+  const decipher = createDecipheriv('aes-256-gcm', salt, Buffer.from(iv, 'base64'))
+  decipher.setAuthTag(Buffer.from(tag, 'base64'))
+  return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
+}

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import request from 'supertest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createToken, initializeAuth } from './auth'
+import { createAuth } from './auth'
 import { createMcpRouter } from './mcp'
 
 // Mock the db module
@@ -15,14 +15,12 @@ vi.mock('./db', () => ({
   insertTimeSeries: vi.fn(),
 }))
 
-// Set up test SESSION_SALT before initializing auth
-process.env.SESSION_SALT = 'very very secretvery very secret' // 32 bytes for AES-256
-initializeAuth()
+const auth = createAuth('very very secretvery very secret') // 32 bytes for AES-256
 
 function createTestApp() {
   const app = express()
   // MCP router must be mounted BEFORE body-parser, as the MCP SDK handles its own body parsing
-  app.use('/mcp', createMcpRouter())
+  app.use('/mcp', createMcpRouter(auth))
   return app
 }
 
@@ -65,7 +63,7 @@ describe('MCP Server', () => {
 
     test('accepts valid bearer token and returns session ID', async () => {
       const app = createTestApp()
-      const token = createToken('testuser')
+      const token = auth.createToken('testuser')
 
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
@@ -99,7 +97,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for missing session ID', async () => {
       const app = createTestApp()
-      const token = createToken('testuser')
+      const token = auth.createToken('testuser')
 
       const response = await request(app).get('/mcp').set('Authorization', `Bearer ${token}`)
 
@@ -109,7 +107,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for invalid session ID', async () => {
       const app = createTestApp()
-      const token = createToken('testuser')
+      const token = auth.createToken('testuser')
 
       const response = await request(app)
         .get('/mcp')
@@ -132,7 +130,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for missing session ID', async () => {
       const app = createTestApp()
-      const token = createToken('testuser')
+      const token = auth.createToken('testuser')
 
       const response = await mcpDelete(app).set('Authorization', `Bearer ${token}`)
 
@@ -142,7 +140,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for invalid session ID', async () => {
       const app = createTestApp()
-      const token = createToken('testuser')
+      const token = auth.createToken('testuser')
 
       const response = await mcpDelete(app)
         .set('Authorization', `Bearer ${token}`)

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -1,7 +1,7 @@
-import { createCipheriv, randomBytes } from 'crypto'
 import express from 'express'
 import request from 'supertest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createToken, initializeAuth } from './auth'
 import { createMcpRouter } from './mcp'
 
 // Mock the db module
@@ -15,20 +15,14 @@ vi.mock('./db', () => ({
   insertTimeSeries: vi.fn(),
 }))
 
-const SESSION_SALT = 'very very secretvery very secret' // 32 bytes for AES-256
-
-function createAuthToken(username: string): string {
-  const iv = randomBytes(12).toString('base64')
-  const cipher = createCipheriv('aes-256-gcm', SESSION_SALT, iv)
-  const encrypted = cipher.update(username, 'utf8', 'base64') + cipher.final('base64')
-  const tag = cipher.getAuthTag().toString('base64')
-  return `${encrypted}-${iv}-${tag}`
-}
+// Set up test SESSION_SALT before initializing auth
+process.env.SESSION_SALT = 'very very secretvery very secret' // 32 bytes for AES-256
+initializeAuth()
 
 function createTestApp() {
   const app = express()
   // MCP router must be mounted BEFORE body-parser, as the MCP SDK handles its own body parsing
-  app.use('/mcp', createMcpRouter({ sessionSalt: SESSION_SALT }))
+  app.use('/mcp', createMcpRouter())
   return app
 }
 
@@ -71,7 +65,7 @@ describe('MCP Server', () => {
 
     test('accepts valid bearer token and returns session ID', async () => {
       const app = createTestApp()
-      const token = createAuthToken('testuser')
+      const token = createToken('testuser')
 
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
@@ -105,7 +99,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for missing session ID', async () => {
       const app = createTestApp()
-      const token = createAuthToken('testuser')
+      const token = createToken('testuser')
 
       const response = await request(app).get('/mcp').set('Authorization', `Bearer ${token}`)
 
@@ -115,7 +109,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for invalid session ID', async () => {
       const app = createTestApp()
-      const token = createAuthToken('testuser')
+      const token = createToken('testuser')
 
       const response = await request(app)
         .get('/mcp')
@@ -138,7 +132,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for missing session ID', async () => {
       const app = createTestApp()
-      const token = createAuthToken('testuser')
+      const token = createToken('testuser')
 
       const response = await mcpDelete(app).set('Authorization', `Bearer ${token}`)
 
@@ -148,7 +142,7 @@ describe('MCP Server', () => {
 
     test('returns 400 for invalid session ID', async () => {
       const app = createTestApp()
-      const token = createAuthToken('testuser')
+      const token = createToken('testuser')
 
       const response = await mcpDelete(app)
         .set('Authorization', `Bearer ${token}`)

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -3,7 +3,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { randomUUID } from 'crypto'
 import { Request, Response, Router } from 'express'
 import { z } from 'zod'
-import { getUsernameFromToken } from './auth'
+import { Auth } from './auth'
 import {
   getActivities,
   getLocations,
@@ -54,7 +54,7 @@ interface McpSession {
   user: string
 }
 
-export function createMcpRouter(): Router {
+export function createMcpRouter(auth: Auth): Router {
   const router = Router()
   const sessions = new Map<string, McpSession>()
 
@@ -65,7 +65,7 @@ export function createMcpRouter(): Router {
     }
     try {
       const token = authHeader.slice('Bearer '.length)
-      return getUsernameFromToken(token)
+      return auth.getUsernameFromToken(token)
     } catch {
       return null
     }

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -1,8 +1,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { createDecipheriv, randomUUID } from 'crypto'
+import { randomUUID } from 'crypto'
 import { Request, Response, Router } from 'express'
 import { z } from 'zod'
+import { getUsernameFromToken } from './auth'
 import {
   getActivities,
   getLocations,
@@ -13,10 +14,6 @@ import {
   insertTimeSeries,
 } from './db'
 import { MetricType, metricUnits } from './schema'
-
-interface McpConfig {
-  sessionSalt: string
-}
 
 const validMetrics: MetricType[] = [
   'heart_rate',
@@ -57,21 +54,9 @@ interface McpSession {
   user: string
 }
 
-export function createMcpRouter(config: McpConfig): Router {
+export function createMcpRouter(): Router {
   const router = Router()
   const sessions = new Map<string, McpSession>()
-
-  const getUsernameFromSession = (sessid: string): string => {
-    try {
-      if (!sessid) throw new Error('unauthenticated')
-      const [encrypted, sessionIv, tag] = sessid.split('-')
-      const decipher = createDecipheriv('aes-256-gcm', config.sessionSalt, sessionIv)
-      decipher.setAuthTag(Buffer.from(tag, 'base64'))
-      return decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
-    } catch {
-      throw new Error('unauthenticated')
-    }
-  }
 
   const getAuthenticatedUser = (req: Request): string | null => {
     const authHeader = req.headers.authorization
@@ -80,7 +65,7 @@ export function createMcpRouter(config: McpConfig): Router {
     }
     try {
       const token = authHeader.slice('Bearer '.length)
-      return getUsernameFromSession(token)
+      return getUsernameFromToken(token)
     } catch {
       return null
     }


### PR DESCRIPTION
## Summary
- Create `auth.ts` module with `initializeAuth()`, `createToken()`, and `getUsernameFromToken()` functions
- Update `api.ts` to use shared auth functions instead of inline implementation
- Update `mcp.ts` to use shared auth functions, removing duplicated token validation code
- Update tests to use shared auth module

## Changes
Both `api.ts` and `mcp.ts` previously had their own implementations of session token encryption/decryption. The `mcp.ts` version also had the same bugs that were fixed in #25 (reused cipher, hardcoded salt issues). This refactoring:

1. Centralizes all token-related logic in a single `auth.ts` module
2. Ensures consistent behavior across the API and MCP endpoints
3. Makes the codebase easier to maintain

## Test plan
- [x] All existing tests pass
- [ ] Manual test: login via API works
- [ ] Manual test: MCP authentication works with valid tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)