### PR TITLE
Fix CI to only build web in Node job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm --filter aurboda-backend test && pnpm --filter aurboda-web test
 
       - name: Build web
-        run: pnpm build
+        run: pnpm --filter aurboda-web build
 
   android:
     name: Android (test, build)


### PR DESCRIPTION
## Summary
- The root `pnpm build` command builds both web and Android
- This caused the Node job's "Build web" step to redundantly run the Android build without Gradle caching
- Changed to use `pnpm --filter aurboda-web build` so Android is only built by the dedicated Android job (which has proper Gradle setup and caching)

## Test plan
- [ ] Verify CI passes and the Node job no longer runs Android build

🤖 Generated with [Claude Code](https://claude.com/claude-code)