### PR TITLE
Add continuous Health Connect sync and background sync support

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -90,6 +90,9 @@ dependencies {
     // Encrypted SharedPreferences for secure credential storage
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
+    // WorkManager for background sync
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -92,7 +92,7 @@ class HealthConnectSyncWorker(
             return emptyList()
         }
 
-        var currentToken = lastToken
+        var currentToken: String = lastToken
         var hasMore = true
 
         while (hasMore) {
@@ -112,8 +112,17 @@ class HealthConnectSyncWorker(
                 }
             }
 
-            currentToken = changesResponse.nextChangesToken
+            val nextToken = changesResponse.nextChangesToken
             hasMore = changesResponse.hasMore
+
+            if (hasMore && nextToken != null) {
+                currentToken = nextToken
+            } else {
+                hasMore = false
+                if (nextToken != null) {
+                    currentToken = nextToken
+                }
+            }
         }
 
         // Save the new token if we have records to send (token will be updated after successful send)

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -1,0 +1,334 @@
+package net.aurboda
+
+import android.content.Context
+import android.util.Log
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.changes.DeletionChange
+import androidx.health.connect.client.changes.UpsertionChange
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.*
+import androidx.health.connect.client.request.ChangesTokenRequest
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.KSerializer
+import java.util.concurrent.TimeUnit
+
+private const val TAG = "HealthConnectSyncWorker"
+private const val PREFS_NAME = "AurbodaAppPrefs"
+private const val CHANGES_TOKEN_KEY = "healthConnectChangesToken"
+private const val WORK_NAME = "health_connect_sync"
+
+class HealthConnectSyncWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    private val healthConnectClient by lazy { HealthConnectClient.getOrCreate(applicationContext) }
+    private val httpClient by lazy {
+        HttpClient(Android) {
+            install(ContentNegotiation) { json(appJson) }
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "Starting background sync")
+
+        val credentials = CredentialsManager.getCredentials(applicationContext)
+        if (credentials == null) {
+            Log.w(TAG, "No credentials found, skipping sync")
+            return Result.success()
+        }
+
+        // Check permissions
+        val permissions = allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet()
+        val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+        if (!grantedPermissions.containsAll(permissions)) {
+            Log.w(TAG, "Not all permissions granted, skipping sync")
+            return Result.success()
+        }
+
+        return try {
+            val records = fetchHealthData()
+            if (records.isNotEmpty()) {
+                val success = sendDataToServer(records, credentials.serverUrl, credentials.authToken)
+                if (success) {
+                    Log.d(TAG, "Background sync completed successfully")
+                    Result.success()
+                } else {
+                    Log.w(TAG, "Background sync failed to send data")
+                    Result.retry()
+                }
+            } else {
+                Log.d(TAG, "No new data to sync")
+                Result.success()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Background sync failed", e)
+            Result.retry()
+        }
+    }
+
+    private suspend fun fetchHealthData(): List<Record> {
+        val records = mutableListOf<Record>()
+        val lastToken = loadChangesToken()
+
+        if (lastToken == null) {
+            Log.d(TAG, "No token found, skipping background fetch (initial fetch should be done in foreground)")
+            return emptyList()
+        }
+
+        var currentToken = lastToken
+        var hasMore = true
+
+        while (hasMore) {
+            val changesResponse = healthConnectClient.getChanges(currentToken)
+            val upsertions = changesResponse.changes.mapNotNull {
+                if (it is UpsertionChange) it.record else null
+            }
+
+            if (upsertions.isNotEmpty()) {
+                Log.d(TAG, "Fetched ${upsertions.size} records")
+                records.addAll(upsertions)
+            }
+
+            changesResponse.changes.forEach {
+                if (it is DeletionChange) {
+                    Log.d(TAG, "Record deleted, ID: ${it.recordId}")
+                }
+            }
+
+            currentToken = changesResponse.nextChangesToken
+            hasMore = changesResponse.hasMore
+        }
+
+        // Save the new token if we have records to send (token will be updated after successful send)
+        // If no records, save token now to avoid re-fetching empty changes
+        if (records.isEmpty()) {
+            saveChangesToken(currentToken)
+        } else {
+            // Store temporarily, will be saved after successful send
+            pendingToken = currentToken
+        }
+
+        return records
+    }
+
+    private var pendingToken: String? = null
+
+    private suspend fun sendDataToServer(
+        records: List<Record>,
+        serverUrl: String,
+        authToken: String
+    ): Boolean {
+        val recordsWithKnownSerializers = records.filter {
+            when (it) {
+                is HeartRateVariabilityRmssdRecord, is WeightRecord, is StepsRecord, is HeartRateRecord,
+                is ExerciseSessionRecord, is DistanceRecord, is SpeedRecord, is ActiveCaloriesBurnedRecord,
+                is TotalCaloriesBurnedRecord, is PowerRecord, is NutritionRecord, is LeanBodyMassRecord,
+                is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is HeightRecord,
+                is RestingHeartRateRecord -> true
+                else -> false
+            }
+        }
+
+        if (recordsWithKnownSerializers.isEmpty()) {
+            Log.d(TAG, "No records with known serializers to send")
+            pendingToken?.let { saveChangesToken(it) }
+            return true
+        }
+
+        val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
+        var allPostsSuccessful = true
+
+        for ((recordClass, classRecords) in groupedRecords) {
+            if (classRecords.isEmpty()) continue
+            val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
+            val apiUrl = "$serverUrl/sync/$recordTypeSimpleName"
+
+            val postSuccessful = when (recordClass) {
+                HeartRateVariabilityRmssdRecord::class -> postData(
+                    HrvRecordSerializable.fromRecordsList(classRecords),
+                    HrvRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                WeightRecord::class -> postData(
+                    WeightRecordSerializable.fromRecordsList(classRecords),
+                    WeightRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                StepsRecord::class -> postData(
+                    StepsRecordSerializable.fromRecordsList(classRecords),
+                    StepsRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                HeartRateRecord::class -> postData(
+                    HeartRateRecordSerializable.fromRecordsList(classRecords),
+                    HeartRateRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                ExerciseSessionRecord::class -> postData(
+                    ExerciseSessionRecordSerializable.fromRecordsList(classRecords),
+                    ExerciseSessionRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                DistanceRecord::class -> postData(
+                    DistanceRecordSerializable.fromRecordsList(classRecords),
+                    DistanceRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                SpeedRecord::class -> postData(
+                    SpeedRecordSerializable.fromRecordsList(classRecords),
+                    SpeedRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                ActiveCaloriesBurnedRecord::class -> postData(
+                    ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+                    ActiveCaloriesBurnedRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                TotalCaloriesBurnedRecord::class -> postData(
+                    TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+                    TotalCaloriesBurnedRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                PowerRecord::class -> postData(
+                    PowerRecordSerializable.fromRecordsList(classRecords),
+                    PowerRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                NutritionRecord::class -> postData(
+                    NutritionRecordSerializable.fromRecordsList(classRecords),
+                    NutritionRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                LeanBodyMassRecord::class -> postData(
+                    LeanBodyMassRecordSerializable.fromRecordsList(classRecords),
+                    LeanBodyMassRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                BodyFatRecord::class -> postData(
+                    BodyFatRecordSerializable.fromRecordsList(classRecords),
+                    BodyFatRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                SleepSessionRecord::class -> postData(
+                    SleepSessionRecordSerializable.fromRecordsList(classRecords),
+                    SleepSessionRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                BoneMassRecord::class -> postData(
+                    BoneMassRecordSerializable.fromRecordsList(classRecords),
+                    BoneMassRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                HeightRecord::class -> postData(
+                    HeightRecordSerializable.fromRecordsList(classRecords),
+                    HeightRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                RestingHeartRateRecord::class -> postData(
+                    RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
+                    RestingHeartRateRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                else -> {
+                    Log.w(TAG, "No specific serialization for $recordTypeSimpleName. Skipping.")
+                    true
+                }
+            }
+
+            if (!postSuccessful) {
+                allPostsSuccessful = false
+                Log.w(TAG, "Post failed for $recordTypeSimpleName")
+                break
+            }
+        }
+
+        if (allPostsSuccessful) {
+            pendingToken?.let { saveChangesToken(it) }
+            Log.d(TAG, "All data sent successfully, token updated")
+        }
+
+        return allPostsSuccessful
+    }
+
+    private suspend fun <T : Any> postData(
+        dataList: List<T>,
+        itemSerializer: KSerializer<T>,
+        apiUrl: String,
+        recordTypeSimpleName: String,
+        authToken: String
+    ): Boolean {
+        if (dataList.isEmpty()) {
+            Log.d(TAG, "No data to send for $recordTypeSimpleName")
+            return true
+        }
+
+        val postData = PostWrapper(dataList)
+        return try {
+            val response = httpClient.post(apiUrl) {
+                contentType(ContentType.Application.Json)
+                headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+                setBody(postData)
+            }
+            Log.d(TAG, "$recordTypeSimpleName Server response: ${response.status}")
+            response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+        } catch (e: Exception) {
+            Log.e(TAG, "Error posting $recordTypeSimpleName data to $apiUrl", e)
+            false
+        }
+    }
+
+    private fun saveChangesToken(token: String?) {
+        val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        Log.d(TAG, "Saving token: ${token?.take(10)}...")
+        prefs.edit().putString(CHANGES_TOKEN_KEY, token).apply()
+    }
+
+    private fun loadChangesToken(): String? {
+        val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(CHANGES_TOKEN_KEY, null)
+    }
+
+    companion object {
+        /**
+         * Schedule periodic background sync.
+         * Sync runs every 15 minutes (minimum interval for periodic work).
+         */
+        fun schedule(context: Context) {
+            val workRequest = PeriodicWorkRequestBuilder<HealthConnectSyncWorker>(
+                15, TimeUnit.MINUTES
+            ).build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                workRequest
+            )
+            Log.d(TAG, "Background sync scheduled")
+        }
+
+        /**
+         * Cancel scheduled background sync.
+         */
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            Log.d(TAG, "Background sync cancelled")
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -78,6 +79,22 @@ import kotlin.reflect.KClass
 
 private const val PREFS_NAME = "AurbodaAppPrefs"
 private const val CHANGES_TOKEN_KEY = "healthConnectChangesToken"
+private const val BACKGROUND_SYNC_ENABLED_KEY = "backgroundSyncEnabled"
+
+private fun isBackgroundSyncEnabled(context: Context): Boolean {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return prefs.getBoolean(BACKGROUND_SYNC_ENABLED_KEY, false)
+}
+
+private fun setBackgroundSyncEnabled(context: Context, enabled: Boolean) {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    prefs.edit().putBoolean(BACKGROUND_SYNC_ENABLED_KEY, enabled).apply()
+    if (enabled) {
+        HealthConnectSyncWorker.schedule(context)
+    } else {
+        HealthConnectSyncWorker.cancel(context)
+    }
+}
 
 fun Record.getPrimaryInstant(): Instant {
     return when (this) {
@@ -257,7 +274,8 @@ fun HealthConnectScreen(
     var healthRecords by remember { mutableStateOf<List<Record>>(emptyList()) } 
     var isProcessing by remember { mutableStateOf(false) } 
     var pendingTokenToPersist by remember { mutableStateOf<String?>(null) }
-    var statusMessage by remember { mutableStateOf("Checking permissions...") } 
+    var statusMessage by remember { mutableStateOf("Checking permissions...") }
+    var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
 
     val scope = rememberCoroutineScope()
     val permissions = remember(allRecordTypes) { allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet() }
@@ -326,25 +344,42 @@ fun HealthConnectScreen(
                 statusMessage = "Error fetching initial data: ${e.message}"
                 fetchSuccessful = false
             }
-        } else { 
+        } else {
             Log.d("FetchData", "Token found: ${lastTokenFromPrefs.take(10)}... Fetching changes.")
             try {
-                val changesResponse = healthConnectClient.getChanges(lastTokenFromPrefs)
-                val upsertions = changesResponse.changes.mapNotNull { if (it is UpsertionChange) it.record else null }
-                if (upsertions.isNotEmpty()) {
-                    Log.d("FetchData", "Adding ${upsertions.size} upserted records to list.")
-                    localHealthRecords.addAll(upsertions)
+                var currentToken = lastTokenFromPrefs
+                var totalUpsertions = 0
+                var hasMore = true
+
+                // Loop to fetch all changes until hasMore is false
+                while (hasMore) {
+                    val changesResponse = healthConnectClient.getChanges(currentToken)
+                    val upsertions = changesResponse.changes.mapNotNull { if (it is UpsertionChange) it.record else null }
+                    if (upsertions.isNotEmpty()) {
+                        Log.d("FetchData", "Adding ${upsertions.size} upserted records to list.")
+                        localHealthRecords.addAll(upsertions)
+                        totalUpsertions += upsertions.size
+                    }
+                    changesResponse.changes.forEach { if (it is DeletionChange) Log.d("HealthConnect", "Record deleted, ID: ${it.recordId}. Deletion handling for server not implemented.") }
+
+                    currentToken = changesResponse.nextChangesToken
+                    hasMore = changesResponse.hasMore
+
+                    if (hasMore) {
+                        Log.d("FetchData", "More changes available, continuing fetch...")
+                        statusMessage = "Fetching more data... ($totalUpsertions records so far)"
+                    }
                 }
-                changesResponse.changes.forEach { if (it is DeletionChange) Log.d("HealthConnect", "Record deleted, ID: ${it.recordId}. Deletion handling for server not implemented.") }
-                localPendingTokenToPersist = changesResponse.nextChangesToken
-                Log.d("FetchData", "Fetched ${upsertions.size} upsertions. Next token candidate: ${localPendingTokenToPersist?.take(10)}...")
-                if (upsertions.isEmpty()) {
+
+                localPendingTokenToPersist = currentToken
+                Log.d("FetchData", "Fetched $totalUpsertions total upsertions. Next token candidate: ${localPendingTokenToPersist?.take(10)}...")
+                if (totalUpsertions == 0) {
                     statusMessage = "No new changes found."
-                    saveChangesToken(currentActiveContext, localPendingTokenToPersist) 
+                    saveChangesToken(currentActiveContext, localPendingTokenToPersist)
                     Log.d("FetchData", "Saved next changes token as no new data was found: ${localPendingTokenToPersist?.take(10)}...")
-                    localPendingTokenToPersist = null 
+                    localPendingTokenToPersist = null
                 } else {
-                    statusMessage = "Fetched ${upsertions.size} new/updated records. Ready to send."
+                    statusMessage = "Fetched $totalUpsertions new/updated records. Ready to send."
                 }
             } catch (e: Exception) {
                 Log.e("FetchData", "Error fetching changes from Health Connect.", e)
@@ -489,9 +524,13 @@ fun HealthConnectScreen(
         isProcessing = false
     }
     
-    LaunchedEffect(Unit) { 
+    LaunchedEffect(Unit) {
         Log.d("HealthConnectScreen", "LaunchedEffect: Initial check - current status: $statusMessage, isProcessing: $isProcessing")
-        checkPermissionsAndFetchData(this, context) 
+        checkPermissionsAndFetchData(this, context)
+        // Re-schedule background sync if it was previously enabled
+        if (backgroundSyncEnabled) {
+            HealthConnectSyncWorker.schedule(context)
+        }
     }
 
     DisposableEffect(lifecycleOwner) {
@@ -592,6 +631,22 @@ fun HealthConnectScreen(
                 ) {
                     Text("Send Pending Data")
                 }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text("Background Sync")
+                Switch(
+                    checked = backgroundSyncEnabled,
+                    onCheckedChange = { enabled ->
+                        backgroundSyncEnabled = enabled
+                        setBackgroundSyncEnabled(context, enabled)
+                    }
+                )
             }
         }
 

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -347,7 +347,7 @@ fun HealthConnectScreen(
         } else {
             Log.d("FetchData", "Token found: ${lastTokenFromPrefs.take(10)}... Fetching changes.")
             try {
-                var currentToken = lastTokenFromPrefs
+                var currentToken: String = lastTokenFromPrefs
                 var totalUpsertions = 0
                 var hasMore = true
 
@@ -362,12 +362,18 @@ fun HealthConnectScreen(
                     }
                     changesResponse.changes.forEach { if (it is DeletionChange) Log.d("HealthConnect", "Record deleted, ID: ${it.recordId}. Deletion handling for server not implemented.") }
 
-                    currentToken = changesResponse.nextChangesToken
+                    val nextToken = changesResponse.nextChangesToken
                     hasMore = changesResponse.hasMore
 
-                    if (hasMore) {
+                    if (hasMore && nextToken != null) {
+                        currentToken = nextToken
                         Log.d("FetchData", "More changes available, continuing fetch...")
                         statusMessage = "Fetching more data... ($totalUpsertions records so far)"
+                    } else {
+                        hasMore = false
+                        if (nextToken != null) {
+                            currentToken = nextToken
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Implements continuous sync loop that fetches all changes until no more entries are available (uses `hasMore` flag from Health Connect Changes API)
- Adds `HealthConnectSyncWorker` for periodic background syncing using WorkManager
- Adds a UI toggle on the Sync screen to enable/disable background sync (runs every 15 minutes minimum)

## Changes
- **MainActivity.kt**: Updated `fetchHealthData()` to loop while `changesResponse.hasMore` is true, ensuring all pending changes are fetched in one operation. Added background sync toggle UI.
- **HealthConnectSyncWorker.kt**: New WorkManager-based background sync worker that:
  - Checks for credentials and permissions before running
  - Uses the same continuous sync loop logic
  - Retries on failure
  - Updates the changes token only after successful sync
- **build.gradle.kts**: Added WorkManager dependency

## Test plan
- [ ] Enable background sync toggle and verify WorkManager schedules periodic work
- [ ] Disable toggle and verify work is cancelled
- [ ] Verify continuous sync fetches all changes when there are many pending entries
- [ ] Verify background sync runs and syncs data when app is backgrounded

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)