### PR TITLE
Add multi-data-type timeline visualization

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -22,6 +22,7 @@ import {
 import { createMcpRouter } from './mcp'
 import { ouraClient } from './oura'
 import { rescuetimeClient } from './rescuetime'
+import { ActivityType } from './schema'
 import { reduceTimeSeries } from './utils'
 
 declare global {
@@ -252,6 +253,37 @@ const main = async () => {
     const tags = await getTags(user, start, end)
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify(tags))
+  })
+
+  httpd.get('/activities', authMiddleware, async (req, res) => {
+    const start = new Date(req.query.start as string)
+    const end = new Date(req.query.end as string)
+    const types = (req.query.types as string)?.split(',') || ['sleep', 'exercise', 'meditation']
+    const user = req.user!
+
+    const activities = await getActivities(user, types as ActivityType[], start, end)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(activities))
+  })
+
+  httpd.get('/productivity', authMiddleware, async (req, res) => {
+    const start = new Date(req.query.start as string)
+    const end = new Date(req.query.end as string)
+    const user = req.user!
+
+    const productivity = await getProductivity(user, start, end)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(productivity))
+  })
+
+  httpd.get('/locations', authMiddleware, async (req, res) => {
+    const start = new Date(req.query.start as string)
+    const end = new Date(req.query.end as string)
+    const user = req.user!
+
+    const { places } = await getLocations(user, start, end)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(places))
   })
 
   const port = Number(process.env.PORT ?? 80)

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -2,18 +2,80 @@ import { signal } from '@preact/signals'
 import { useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
-import { fetchHeartRate } from '../../state/api'
+import {
+  Activity,
+  fetchActivities,
+  fetchHeartRate,
+  fetchPlaces,
+  fetchProductivity,
+  fetchTags,
+  Place,
+  ProductivityRecord,
+  Tag,
+} from '../../state/api'
 import { preprocessData } from '../../utils/chart'
 
 // Signals to handle user-selected dates
 const fromDate = signal(formatISO(subDays(new Date(), 1), { representation: 'date' }))
 const toDate = signal(formatISO(new Date(), { representation: 'date' }))
 
+// Signals for toggling data layers
+const showHeartRate = signal(true)
+const showSleep = signal(true)
+const showExercise = signal(true)
+const showMeditation = signal(true)
+const showProductivity = signal(true)
+const showPlaces = signal(true)
+const showTags = signal(true)
+
+// Legend configuration
+const legendItems = [
+  { color: 'red', label: 'Heart Rate', signal: showHeartRate },
+  { color: 'rgba(0, 0, 255, 0.3)', label: 'Sleep', signal: showSleep },
+  { color: 'rgba(0, 128, 0, 0.4)', label: 'Exercise', signal: showExercise },
+  { color: 'rgba(128, 0, 128, 0.6)', label: 'Meditation', signal: showMeditation },
+  { color: 'darkblue', label: 'Computer', signal: showProductivity },
+  { color: 'darkcyan', label: 'Mobile', signal: showProductivity },
+  { color: 'lightgray', label: 'Places', signal: showPlaces },
+  { color: 'black', label: 'Tags', signal: showTags },
+]
+
 export const Timeline = () => {
-  // Use TanStack Query to fetch heart rate data
-  const { data, isLoading, isError, error, refetch } = useQuery({
-    queryFn: () => fetchHeartRate(startOfDay(new Date(fromDate.value)), endOfDay(new Date(toDate.value))),
+  const start = startOfDay(new Date(fromDate.value))
+  const end = endOfDay(new Date(toDate.value))
+
+  const heartRateQuery = useQuery({
+    enabled: showHeartRate.value,
+    queryFn: () => fetchHeartRate(start, end),
     queryKey: ['heartRate', fromDate.value, toDate.value],
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const activitiesQuery = useQuery({
+    enabled: showSleep.value || showExercise.value || showMeditation.value,
+    queryFn: () => fetchActivities(start, end),
+    queryKey: ['activities', fromDate.value, toDate.value],
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const productivityQuery = useQuery({
+    enabled: showProductivity.value,
+    queryFn: () => fetchProductivity(start, end),
+    queryKey: ['productivity', fromDate.value, toDate.value],
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const placesQuery = useQuery({
+    enabled: showPlaces.value,
+    queryFn: () => fetchPlaces(start, end),
+    queryKey: ['places', fromDate.value, toDate.value],
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const tagsQuery = useQuery({
+    enabled: showTags.value,
+    queryFn: () => fetchTags(start, end),
+    queryKey: ['tags', fromDate.value, toDate.value],
     staleTime: 10 * 60 * 1000,
   })
 
@@ -21,69 +83,360 @@ export const Timeline = () => {
     const target = e.target as HTMLInputElement
     if (target.name === 'from') fromDate.value = target.value
     else if (target.name === 'to') toDate.value = target.value
-    refetch()
   }
 
-  if (isLoading) return <div>Loading Heart Rate...</div>
-  if (isError) return <div>Error: {(error as Error).message}</div>
+  const isLoading =
+    heartRateQuery.isLoading ||
+    activitiesQuery.isLoading ||
+    productivityQuery.isLoading ||
+    placesQuery.isLoading ||
+    tagsQuery.isLoading
+
+  const hasError =
+    heartRateQuery.isError ||
+    activitiesQuery.isError ||
+    productivityQuery.isError ||
+    placesQuery.isError ||
+    tagsQuery.isError
 
   return (
     <>
       <div class="timeline">
-        <h1>Heart Rate Timeline</h1>
-        <div>
+        <h1>Timeline</h1>
+        <div style={{ display: 'flex', gap: '2rem', marginBottom: '1rem' }}>
+          <div>
+            <label>
+              From: <input type="date" name="from" value={fromDate.value} onChange={handleDateChange} />
+            </label>
+            <label style={{ marginLeft: '1rem' }}>
+              To: <input type="date" name="to" value={toDate.value} onChange={handleDateChange} />
+            </label>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', marginBottom: '1rem' }}>
           <label>
-            From: <input type="date" name="from" value={fromDate.value} onChange={handleDateChange} />
+            <input
+              type="checkbox"
+              checked={showHeartRate.value}
+              onChange={(e) => (showHeartRate.value = (e.target as HTMLInputElement).checked)}
+            />
+            Heart Rate
           </label>
           <label>
-            To: <input type="date" name="to" value={toDate.value} onChange={handleDateChange} />
+            <input
+              type="checkbox"
+              checked={showSleep.value}
+              onChange={(e) => (showSleep.value = (e.target as HTMLInputElement).checked)}
+            />
+            Sleep
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showExercise.value}
+              onChange={(e) => (showExercise.value = (e.target as HTMLInputElement).checked)}
+            />
+            Exercise
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showMeditation.value}
+              onChange={(e) => (showMeditation.value = (e.target as HTMLInputElement).checked)}
+            />
+            Meditation
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showProductivity.value}
+              onChange={(e) => (showProductivity.value = (e.target as HTMLInputElement).checked)}
+            />
+            Productivity
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showPlaces.value}
+              onChange={(e) => (showPlaces.value = (e.target as HTMLInputElement).checked)}
+            />
+            Places
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showTags.value}
+              onChange={(e) => (showTags.value = (e.target as HTMLInputElement).checked)}
+            />
+            Tags
           </label>
         </div>
-        <LineChart data={data || []} />
+
+        <Legend />
+
+        {isLoading && <div>Loading...</div>}
+        {hasError && <div>Error loading data</div>}
+
+        <TimelineChart
+          heartRates={showHeartRate.value ? heartRateQuery.data || [] : []}
+          activities={activitiesQuery.data || []}
+          productivity={showProductivity.value ? productivityQuery.data || [] : []}
+          places={showPlaces.value ? placesQuery.data || [] : []}
+          tags={showTags.value ? tagsQuery.data || [] : []}
+          sleepVisible={showSleep.value}
+          exerciseVisible={showExercise.value}
+          meditationVisible={showMeditation.value}
+          start={start}
+          end={end}
+        />
       </div>
     </>
   )
 }
 
-function LineChart({ data }: { data: [Date, number][] }) {
-  const margin = { bottom: 20, left: 30, right: 20, top: 10 }
-  const width = 800
-  const height = 400
+function Legend() {
+  return (
+    <div
+      style={{
+        border: '1px solid #ccc',
+        borderRadius: '4px',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '1rem',
+        marginBottom: '1rem',
+        padding: '0.5rem 1rem',
+      }}
+    >
+      <strong>Legend:</strong>
+      {legendItems.map((item) => (
+        <div key={item.label} style={{ alignItems: 'center', display: 'flex', gap: '0.25rem' }}>
+          <div
+            style={{
+              backgroundColor: item.color,
+              border: item.label === 'Tags' ? '1px dashed black' : 'none',
+              height: '12px',
+              width: '20px',
+            }}
+          />
+          <span>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
 
-  const x = d3
-    .scaleTime()
-    .domain(d3.extent(data, ([time]) => time) as [Date, Date])
-    .range([margin.left, width - margin.right])
+interface TimelineChartProps {
+  heartRates: [Date, number][]
+  activities: Activity[]
+  productivity: ProductivityRecord[]
+  places: Place[]
+  tags: Tag[]
+  sleepVisible: boolean
+  exerciseVisible: boolean
+  meditationVisible: boolean
+  start: Date
+  end: Date
+}
 
-  const y = d3
-    .scaleLinear()
-    .domain([40, d3.max(data, ([, rate]) => rate)] as [number, number])
-    .range([height - margin.bottom, margin.top])
+function TimelineChart({
+  heartRates,
+  activities,
+  productivity,
+  places,
+  tags,
+  sleepVisible,
+  exerciseVisible,
+  meditationVisible,
+  start,
+  end,
+}: TimelineChartProps) {
+  const margin = { bottom: 30, left: 40, right: 20, top: 10 }
+  const width = 1000
+  const height = 500
+
+  const chartWidth = width - margin.left - margin.right
+  const chartHeight = height - margin.top - margin.bottom
+
+  // Track heights for different data layers
+  const trackHeight = chartHeight / 8
+  const trackComputer = 0
+  const trackMobile = trackHeight
+  const trackExercise = 2 * trackHeight
+  const trackPlaces = 3 * trackHeight
+
+  // Time scale
+  const x = d3.scaleTime().domain([start, end]).range([0, chartWidth])
+
+  // Heart rate y scale
+  const y = d3.scaleLinear().domain([40, 200]).range([chartHeight, 0])
+
+  // Place colors
+  const placeColors: Record<string, string> = {
+    Genki: 'darkgrey',
+    Hökås: 'lightgreen',
+    Lönnåsen: 'olive',
+  }
+
+  // Filter activities by type
+  const sleepSessions = sleepVisible ? activities.filter((a) => a.activityType === 'sleep') : []
+  const exerciseSessions = exerciseVisible ? activities.filter((a) => a.activityType === 'exercise') : []
+  const meditationSessions =
+    meditationVisible ? activities.filter((a) => a.activityType === 'meditation') : []
 
   return (
     <svg width={width} height={height}>
-      <path
-        fill="none"
-        stroke="red"
-        strokeWidth="2"
-        d={d3
-          .line<[Date, number] | null>()
-          .defined(Boolean)
-          .x(([time]) => x(time))
-          .y(([, rate]) => y(rate))(preprocessData(data, 10))}
-      />
-      <g
-        transform={`translate(${margin.left},0)`}
-        ref={(g) => {
-          if (g) d3.select(g).call(d3.axisLeft(y))
-        }}
-      />
-      <g
-        transform={`translate(0,${height - margin.bottom})`}
-        ref={(g) => {
-          if (g) d3.select(g).call(d3.axisBottom(x))
-        }}
-      />
+      <g transform={`translate(${margin.left},${margin.top})`}>
+        {/* Sleep sessions - full height blue background */}
+        {sleepSessions.map((session, i) =>
+          session.endTime ?
+            <rect
+              key={`sleep-${i}`}
+              x={x(session.startTime)}
+              y={0}
+              width={Math.max(0, x(session.endTime) - x(session.startTime))}
+              height={chartHeight}
+              fill="blue"
+              opacity={0.2}
+            />
+          : null,
+        )}
+
+        {/* Meditation sessions - full height purple background */}
+        {meditationSessions.map((session, i) =>
+          session.endTime ?
+            <rect
+              key={`meditation-${i}`}
+              x={x(session.startTime)}
+              y={0}
+              width={Math.max(0, x(session.endTime) - x(session.startTime))}
+              height={chartHeight}
+              fill="purple"
+              opacity={0.6}
+            />
+          : null,
+        )}
+
+        {/* Productivity (Computer) - track 0 */}
+        {productivity
+          .filter((p) => !p.isMobile)
+          .map((p, i) => (
+            <rect
+              key={`computer-${i}`}
+              x={x(p.startTime)}
+              y={trackComputer}
+              width={Math.max(0, x(p.endTime) - x(p.startTime))}
+              height={trackHeight}
+              fill="darkblue"
+              opacity={0.8}
+            />
+          ))}
+
+        {/* Productivity (Mobile) - track 1 */}
+        {productivity
+          .filter((p) => p.isMobile)
+          .map((p, i) => (
+            <rect
+              key={`mobile-${i}`}
+              x={x(p.startTime)}
+              y={trackMobile}
+              width={Math.max(0, x(p.endTime) - x(p.startTime))}
+              height={trackHeight}
+              fill="darkcyan"
+              opacity={0.8}
+            />
+          ))}
+
+        {/* Exercise sessions - track 2 */}
+        {exerciseSessions.map((session, i) =>
+          session.endTime ?
+            <rect
+              key={`exercise-${i}`}
+              x={x(session.startTime)}
+              y={trackExercise}
+              width={Math.max(0, x(session.endTime) - x(session.startTime))}
+              height={trackHeight}
+              fill="green"
+              opacity={0.4}
+            />
+          : null,
+        )}
+
+        {/* Places - track 3 */}
+        {places.map((place, i) => (
+          <rect
+            key={`place-${i}`}
+            x={x(place.startTime)}
+            y={trackPlaces}
+            width={Math.max(0, x(place.endTime) - x(place.startTime))}
+            height={trackHeight}
+            fill={placeColors[place.region] || 'lightgray'}
+          />
+        ))}
+
+        {/* Tags - dashed lines or rectangles */}
+        {tags.map((tag, i) =>
+          tag.endTime ?
+            <rect
+              key={`tag-${i}`}
+              x={x(tag.startTime)}
+              y={0}
+              width={Math.max(0, x(tag.endTime) - x(tag.startTime))}
+              height={chartHeight}
+              fill="none"
+              stroke="black"
+              strokeDasharray="4"
+              opacity={0.3}
+            />
+          : <line
+              key={`tag-${i}`}
+              x1={x(tag.startTime)}
+              y1={0}
+              x2={x(tag.startTime)}
+              y2={chartHeight}
+              stroke="black"
+              strokeDasharray="4"
+              opacity={0.3}
+            />,
+        )}
+
+        {/* Heart Rate Line */}
+        {heartRates.length > 0 && (
+          <path
+            fill="none"
+            stroke="red"
+            strokeWidth="1.5"
+            d={
+              d3
+                .line<[Date, number] | null>()
+                .defined(Boolean)
+                .x(([time]) => x(time))
+                .y(([, rate]) => y(rate))(preprocessData(heartRates, 10)) || ''
+            }
+          />
+        )}
+
+        {/* Y-axis for heart rate */}
+        <g
+          ref={(g) => {
+            if (g) d3.select(g).call(d3.axisLeft(y))
+          }}
+        />
+
+        {/* X-axis */}
+        <g
+          transform={`translate(0,${chartHeight})`}
+          ref={(g) => {
+            if (g)
+              d3.select(g).call(
+                d3
+                  .axisBottom(x)
+                  .ticks(d3.timeHour.every(6))
+                  .tickFormat((d) => d3.timeFormat('%a %H')(d as Date)),
+              )
+          }}
+        />
+      </g>
     </svg>
   )
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -2,6 +2,45 @@ import axios from 'axios'
 import { API_URL } from '../config'
 import { auth } from './auth'
 
+// Types for timeline data
+export type ActivityType = 'sleep' | 'exercise' | 'meditation' | 'nap'
+
+export interface Activity {
+  id?: string
+  source: string
+  activityType: ActivityType
+  startTime: Date
+  endTime?: Date
+  title?: string
+  notes?: string
+}
+
+export interface ProductivityRecord {
+  source?: string
+  startTime: Date
+  endTime: Date
+  activity: string
+  category?: string
+  productivity?: number
+  durationSec: number
+  isMobile?: boolean
+}
+
+export interface Place {
+  region: string
+  startTime: Date
+  endTime: Date
+}
+
+export interface Tag {
+  id?: string
+  source: string
+  externalId?: string
+  tag: string
+  startTime: Date
+  endTime?: Date
+}
+
 // Fetch heart rate data for the specified date range
 export const fetchHeartRate = async (start: Date, end: Date): Promise<[Date, number][]> => {
   const { token } = auth.value
@@ -14,4 +53,81 @@ export const fetchHeartRate = async (start: Date, end: Date): Promise<[Date, num
   })
 
   return response.data.map(([time, rate]) => [new Date(time), rate])
+}
+
+// Fetch activities (sleep, exercise, meditation) for the specified date range
+export const fetchActivities = async (
+  start: Date,
+  end: Date,
+  types?: ActivityType[],
+): Promise<Activity[]> => {
+  const { token } = auth.value
+  const response = await axios.get(`${API_URL}/api/activities`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: {
+      end: end.toISOString(),
+      start: start.toISOString(),
+      types: types?.join(','),
+    },
+  })
+
+  return response.data.map((activity: Activity & { startTime: string; endTime?: string }) => ({
+    ...activity,
+    endTime: activity.endTime ? new Date(activity.endTime) : undefined,
+    startTime: new Date(activity.startTime),
+  }))
+}
+
+// Fetch productivity data (RescueTime) for the specified date range
+export const fetchProductivity = async (start: Date, end: Date): Promise<ProductivityRecord[]> => {
+  const { token } = auth.value
+  const response = await axios.get(`${API_URL}/api/productivity`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: {
+      end: end.toISOString(),
+      start: start.toISOString(),
+    },
+  })
+
+  return response.data.map((record: ProductivityRecord & { startTime: string; endTime: string }) => ({
+    ...record,
+    endTime: new Date(record.endTime),
+    startTime: new Date(record.startTime),
+  }))
+}
+
+// Fetch location/place data for the specified date range
+export const fetchPlaces = async (start: Date, end: Date): Promise<Place[]> => {
+  const { token } = auth.value
+  const response = await axios.get(`${API_URL}/api/locations`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: {
+      end: end.toISOString(),
+      start: start.toISOString(),
+    },
+  })
+
+  return response.data.map((place: Place & { startTime: string; endTime: string }) => ({
+    ...place,
+    endTime: new Date(place.endTime),
+    startTime: new Date(place.startTime),
+  }))
+}
+
+// Fetch tags for the specified date range
+export const fetchTags = async (start: Date, end: Date): Promise<Tag[]> => {
+  const { token } = auth.value
+  const response = await axios.get(`${API_URL}/api/tags`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: {
+      end: end.toISOString(),
+      start: start.toISOString(),
+    },
+  })
+
+  return response.data.map((tag: Tag & { startTime: string; endTime?: string }) => ({
+    ...tag,
+    endTime: tag.endTime ? new Date(tag.endTime) : undefined,
+    startTime: new Date(tag.startTime),
+  }))
 }


### PR DESCRIPTION
## Summary
- Migrates timeline data visualization from server-side `ui.ts` to the frontend Timeline component
- Adds API endpoints for activities, productivity, and locations
- Adds checkboxes to toggle visibility of: heart rate, sleep, exercise, meditation, productivity (computer/mobile), places, and tags
- Adds a legend showing what each color represents

## Test plan
- [ ] Navigate to the Timeline page
- [ ] Verify all data types display correctly when enabled
- [ ] Toggle checkboxes on/off and verify data appears/disappears
- [ ] Verify the legend displays correct colors and labels
- [ ] Change date range and verify data updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)