### PR TITLE
Add Oura data storage with sync state tracking

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -1,6 +1,6 @@
 import { json } from 'body-parser'
 import cors from 'cors'
-import { subHours } from 'date-fns'
+import { isBefore, subHours, subMinutes } from 'date-fns'
 import express, { RequestHandler } from 'express'
 import { Client } from 'pg'
 import { createAuth } from './auth'
@@ -9,6 +9,7 @@ import {
   getAllSyncStates,
   getLocations,
   getProductivity,
+  getSyncState,
   getTags,
   getTimeSeries,
   initializeSchema,
@@ -24,7 +25,7 @@ import {
 } from './db'
 import { createMcpRouter } from './mcp'
 import { ouraClient } from './oura'
-import { syncAllOuraData } from './oura-sync'
+import { isRateLimited, OuraDataType, syncAllOuraData, syncOuraDataType } from './oura-sync'
 import { rescuetimeClient } from './rescuetime'
 import { ActivityType } from './schema'
 import { reduceTimeSeries } from './utils'
@@ -45,6 +46,39 @@ const main = async () => {
 
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
   const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost)
+
+  /** Sync threshold - sync if last sync was more than 30 minutes ago */
+  const SYNC_THRESHOLD_MINUTES = 30
+
+  /**
+   * Check if Oura data type needs sync and trigger if needed.
+   * Returns true if sync was triggered, false if skipped.
+   */
+  const syncOuraIfNeeded = async (user: string, dataType: OuraDataType): Promise<boolean> => {
+    try {
+      const syncState = await getSyncState(user, 'oura', dataType)
+
+      // Skip if rate limited
+      if (isRateLimited(syncState)) {
+        console.log(`Oura ${dataType} sync skipped - rate limited until ${syncState?.retryAfter}`)
+        return false
+      }
+
+      // Check if sync is needed (never synced or older than threshold)
+      const threshold = subMinutes(new Date(), SYNC_THRESHOLD_MINUTES)
+      if (syncState?.lastSyncTime && isBefore(threshold, syncState.lastSyncTime)) {
+        return false // Recently synced, no need to sync again
+      }
+
+      console.log(`Auto-syncing Oura ${dataType}...`)
+      const accessToken = await oura.getAccessToken(user)
+      await syncOuraDataType(user, oura, dataType, accessToken)
+      return true
+    } catch (error) {
+      console.error(`Failed to auto-sync Oura ${dataType}:`, error)
+      return false
+    }
+  }
 
   const httpd = express()
 
@@ -298,7 +332,9 @@ const main = async () => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
-    console.log({ end, start, user })
+
+    // Auto-sync Oura tags if needed
+    await syncOuraIfNeeded(user, 'tags')
 
     const tags = await getTags(user, start, end)
     res.writeHead(200, { 'Content-Type': 'application/json' })
@@ -310,6 +346,11 @@ const main = async () => {
     const end = new Date(req.query.end as string)
     const types = (req.query.types as string)?.split(',') || ['sleep', 'exercise', 'meditation']
     const user = req.user!
+
+    // Auto-sync Oura sessions if meditation is requested
+    if (types.includes('meditation')) {
+      await syncOuraIfNeeded(user, 'sessions')
+    }
 
     const activities = await getActivities(user, types as ActivityType[], start, end)
     res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -27,6 +27,11 @@ import { createMcpRouter } from './mcp'
 import { ouraClient } from './oura'
 import { isRateLimited, OuraDataType, syncAllOuraData, syncOuraDataType } from './oura-sync'
 import { rescuetimeClient } from './rescuetime'
+import {
+  isRateLimited as isRescueTimeRateLimited,
+  needsSync as rescueTimeNeedsSync,
+  syncRescueTimeData,
+} from './rescuetime-sync'
 import { ActivityType } from './schema'
 import { reduceTimeSeries } from './utils'
 
@@ -224,6 +229,53 @@ const main = async () => {
     }
   })
 
+  // RescueTime sync endpoints
+  httpd.post('/sync/rescuetime', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { fullResync, startDate } = req.body as { fullResync?: boolean; startDate?: string }
+    const rescueTimeKey = process.env.RESCUETIME_KEY
+
+    if (!rescueTimeKey) {
+      return res.status(400).json({ error: 'RescueTime API key not configured', success: false })
+    }
+
+    try {
+      const result = await syncRescueTimeData(user, rescueTimeKey, {
+        fullResync,
+        startDate: startDate ? new Date(startDate) : undefined,
+      })
+
+      res.json({ result, success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  httpd.get('/sync/rescuetime/status', authMiddleware, async (req, res) => {
+    const user = req.user!
+
+    try {
+      const states = await getAllSyncStates(user, 'rescuetime')
+      res.json({ states, success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  httpd.delete('/sync/rescuetime/state', authMiddleware, async (req, res) => {
+    const user = req.user!
+
+    try {
+      await resetSyncState(user, 'rescuetime')
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
   httpd.post('/ownTracks', async (req, res) => {
     const { topic, _type: type } = req.body
 
@@ -361,6 +413,20 @@ const main = async () => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
+
+    // Auto-sync RescueTime if needed and API key is configured
+    const rescueTimeKey = process.env.RESCUETIME_KEY
+    if (rescueTimeKey) {
+      try {
+        const syncState = await getSyncState(user, 'rescuetime', 'productivity')
+        if (!isRescueTimeRateLimited(syncState) && rescueTimeNeedsSync(syncState, SYNC_THRESHOLD_MINUTES)) {
+          console.log('Auto-syncing RescueTime productivity...')
+          await syncRescueTimeData(user, rescueTimeKey)
+        }
+      } catch (error) {
+        console.error('Failed to auto-sync RescueTime:', error)
+      }
+    }
 
     const productivity = await getProductivity(user, start, end)
     res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -6,6 +6,7 @@ import { Client } from 'pg'
 import { createAuth } from './auth'
 import {
   getActivities,
+  getAllSyncStates,
   getLocations,
   getProductivity,
   getTags,
@@ -15,12 +16,15 @@ import {
   insertPlace,
   insertProductivity,
   loginToUserDb,
+  migrateSchema,
   processHealthConnectData,
   query,
+  resetSyncState,
   schemaInitialized,
 } from './db'
 import { createMcpRouter } from './mcp'
 import { ouraClient } from './oura'
+import { syncAllOuraData } from './oura-sync'
 import { rescuetimeClient } from './rescuetime'
 import { reduceTimeSeries } from './utils'
 
@@ -88,9 +92,12 @@ const main = async () => {
     if (userRows.rowCount === 1) {
       try {
         await loginToUserDb(user, password)
-        // Ensure schema is initialized
+        // Ensure schema is initialized and migrated
         if (!(await schemaInitialized(user))) {
           await initializeSchema(user)
+        } else {
+          // Run migrations for existing databases
+          await migrateSchema(user)
         }
       } catch (err) {
         console.log(err)
@@ -138,6 +145,49 @@ const main = async () => {
 
   httpd.get('/auth/connectOura', oura.redirectToAuthorize)
   httpd.get('/auth/ouracb', oura.authCb)
+
+  // Oura sync endpoints
+  httpd.post('/sync/oura', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { fullResync, startDate } = req.body as { fullResync?: boolean; startDate?: string }
+
+    try {
+      const results = await syncAllOuraData(user, oura, {
+        fullResync,
+        startDate: startDate ? new Date(startDate) : undefined,
+      })
+
+      res.json({ results, success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  httpd.get('/sync/oura/status', authMiddleware, async (req, res) => {
+    const user = req.user!
+
+    try {
+      const states = await getAllSyncStates(user, 'oura')
+      res.json({ states, success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  httpd.delete('/sync/oura/state', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { dataType } = req.query as { dataType?: string }
+
+    try {
+      await resetSyncState(user, 'oura', dataType)
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
 
   httpd.post('/ownTracks', async (req, res) => {
     const { topic, _type: type } = req.body

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -111,7 +111,7 @@ const main = async () => {
     return next(unauthorized)
   }
 
-  // httpd.post('/api/v2/signup', async (req, res, next) => {
+  // httpd.post('/v2/signup', async (req, res, next) => {
   //   const { username: user, password } = req.body
   //   if (!user) return next(unauthorized)
   //   await makeNewUserDb(userDb, user, password)
@@ -182,7 +182,7 @@ const main = async () => {
   httpd.get('/auth/ouracb', oura.authCb)
 
   // Oura sync endpoints
-  httpd.post('/api/sync/oura', authMiddleware, async (req, res) => {
+  httpd.post('/sync/oura', authMiddleware, async (req, res) => {
     const user = req.user!
     const { fullResync, startDate } = req.body as { fullResync?: boolean; startDate?: string }
 
@@ -199,7 +199,7 @@ const main = async () => {
     }
   })
 
-  httpd.get('/api/sync/oura/status', authMiddleware, async (req, res) => {
+  httpd.get('/sync/oura/status', authMiddleware, async (req, res) => {
     const user = req.user!
 
     try {
@@ -211,7 +211,7 @@ const main = async () => {
     }
   })
 
-  httpd.delete('/api/sync/oura/state', authMiddleware, async (req, res) => {
+  httpd.delete('/sync/oura/state', authMiddleware, async (req, res) => {
     const user = req.user!
     const { dataType } = req.query as { dataType?: string }
 
@@ -317,7 +317,7 @@ const main = async () => {
     )
   })
 
-  httpd.get('/api/heartrate', authMiddleware, async (req, res) => {
+  httpd.get('/heartrate', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -328,7 +328,7 @@ const main = async () => {
     res.end(JSON.stringify(hrs))
   })
 
-  httpd.get('/api/tags', authMiddleware, async (req, res) => {
+  httpd.get('/tags', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -341,7 +341,7 @@ const main = async () => {
     res.end(JSON.stringify(tags))
   })
 
-  httpd.get('/api/activities', authMiddleware, async (req, res) => {
+  httpd.get('/activities', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const types = (req.query.types as string)?.split(',') || ['sleep', 'exercise', 'meditation']
@@ -357,7 +357,7 @@ const main = async () => {
     res.end(JSON.stringify(activities))
   })
 
-  httpd.get('/api/productivity', authMiddleware, async (req, res) => {
+  httpd.get('/productivity', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -367,7 +367,7 @@ const main = async () => {
     res.end(JSON.stringify(productivity))
   })
 
-  httpd.get('/api/locations', authMiddleware, async (req, res) => {
+  httpd.get('/locations', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -148,7 +148,7 @@ const main = async () => {
   httpd.get('/auth/ouracb', oura.authCb)
 
   // Oura sync endpoints
-  httpd.post('/sync/oura', authMiddleware, async (req, res) => {
+  httpd.post('/api/sync/oura', authMiddleware, async (req, res) => {
     const user = req.user!
     const { fullResync, startDate } = req.body as { fullResync?: boolean; startDate?: string }
 
@@ -165,7 +165,7 @@ const main = async () => {
     }
   })
 
-  httpd.get('/sync/oura/status', authMiddleware, async (req, res) => {
+  httpd.get('/api/sync/oura/status', authMiddleware, async (req, res) => {
     const user = req.user!
 
     try {
@@ -177,7 +177,7 @@ const main = async () => {
     }
   })
 
-  httpd.delete('/sync/oura/state', authMiddleware, async (req, res) => {
+  httpd.delete('/api/sync/oura/state', authMiddleware, async (req, res) => {
     const user = req.user!
     const { dataType } = req.query as { dataType?: string }
 
@@ -283,7 +283,7 @@ const main = async () => {
     )
   })
 
-  httpd.get('/heartrate', authMiddleware, async (req, res) => {
+  httpd.get('/api/heartrate', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -294,7 +294,7 @@ const main = async () => {
     res.end(JSON.stringify(hrs))
   })
 
-  httpd.get('/tags', authMiddleware, async (req, res) => {
+  httpd.get('/api/tags', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -305,7 +305,7 @@ const main = async () => {
     res.end(JSON.stringify(tags))
   })
 
-  httpd.get('/activities', authMiddleware, async (req, res) => {
+  httpd.get('/api/activities', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const types = (req.query.types as string)?.split(',') || ['sleep', 'exercise', 'meditation']
@@ -316,7 +316,7 @@ const main = async () => {
     res.end(JSON.stringify(activities))
   })
 
-  httpd.get('/productivity', authMiddleware, async (req, res) => {
+  httpd.get('/api/productivity', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!
@@ -326,7 +326,7 @@ const main = async () => {
     res.end(JSON.stringify(productivity))
   })
 
-  httpd.get('/locations', authMiddleware, async (req, res) => {
+  httpd.get('/api/locations', authMiddleware, async (req, res) => {
     const start = new Date(req.query.start as string)
     const end = new Date(req.query.end as string)
     const user = req.user!

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -67,6 +67,33 @@ export const initializeSchema = async (user: string) => {
 }
 
 /**
+ * Run database migrations for a user.
+ * Checks which tables exist and creates missing ones.
+ */
+export const migrateSchema = async (user: string) => {
+  const db = await getDbForUser(user)
+  const database = `aurboda_${user}`
+
+  // Check which tables exist
+  const existingTables = await query(
+    db,
+    `SELECT table_name FROM information_schema.tables WHERE table_catalog = $1 AND table_schema = 'public'`,
+    [database],
+  )
+  const existingTableNames = new Set(existingTables.rows.map((r) => r.table_name))
+
+  // Create missing tables
+  for (const key of tableCreationOrder) {
+    const tableName = key.replace('_indexes', '')
+    if (!existingTableNames.has(tableName) || key.endsWith('_indexes')) {
+      // Always run index creation (IF NOT EXISTS handles duplicates)
+      // Create tables only if they don't exist
+      await query(db, createTableStatements[key])
+    }
+  }
+}
+
+/**
  * Check if schema is initialized (has required tables).
  */
 export const schemaInitialized = async (user: string) => {
@@ -563,6 +590,108 @@ export const getOAuthToken = async (user: string, provider: string): Promise<OAu
     provider: row.provider,
     refreshToken: row.refresh_token,
     scopes: row.scopes,
+  }
+}
+
+// ============================================================================
+// Sync State
+// ============================================================================
+
+export type SyncStatus = 'idle' | 'syncing' | 'error' | 'rate_limited'
+
+export interface SyncState {
+  id?: string
+  provider: string
+  dataType: string
+  lastSyncTime?: Date
+  syncStartDate?: Date
+  status: SyncStatus
+  errorMessage?: string
+  retryAfter?: Date
+  updatedAt?: Date
+}
+
+export const getSyncState = async (
+  user: string,
+  provider: string,
+  dataType: string,
+): Promise<SyncState | null> => {
+  const result = await query(
+    user,
+    `SELECT id, provider, data_type, last_sync_time, sync_start_date, status, error_message, retry_after, updated_at
+     FROM sync_state
+     WHERE provider = $1 AND data_type = $2`,
+    [provider, dataType],
+  )
+
+  if (result.rows.length === 0) return null
+
+  const row = result.rows[0]
+  return {
+    dataType: row.data_type,
+    errorMessage: row.error_message,
+    id: row.id,
+    lastSyncTime: row.last_sync_time ? new Date(row.last_sync_time) : undefined,
+    provider: row.provider,
+    retryAfter: row.retry_after ? new Date(row.retry_after) : undefined,
+    status: row.status as SyncStatus,
+    syncStartDate: row.sync_start_date ? new Date(row.sync_start_date) : undefined,
+    updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
+  }
+}
+
+export const upsertSyncState = async (user: string, state: SyncState) => {
+  await query(
+    user,
+    `INSERT INTO sync_state (provider, data_type, last_sync_time, sync_start_date, status, error_message, retry_after, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+     ON CONFLICT (provider, data_type) DO UPDATE SET
+       last_sync_time = COALESCE(EXCLUDED.last_sync_time, sync_state.last_sync_time),
+       sync_start_date = COALESCE(EXCLUDED.sync_start_date, sync_state.sync_start_date),
+       status = EXCLUDED.status,
+       error_message = EXCLUDED.error_message,
+       retry_after = EXCLUDED.retry_after,
+       updated_at = NOW()`,
+    [
+      state.provider,
+      state.dataType,
+      state.lastSyncTime,
+      state.syncStartDate,
+      state.status,
+      state.errorMessage,
+      state.retryAfter,
+    ],
+  )
+}
+
+export const getAllSyncStates = async (user: string, provider: string): Promise<SyncState[]> => {
+  const result = await query(
+    user,
+    `SELECT id, provider, data_type, last_sync_time, sync_start_date, status, error_message, retry_after, updated_at
+     FROM sync_state
+     WHERE provider = $1
+     ORDER BY data_type`,
+    [provider],
+  )
+
+  return result.rows.map((row) => ({
+    dataType: row.data_type,
+    errorMessage: row.error_message,
+    id: row.id,
+    lastSyncTime: row.last_sync_time ? new Date(row.last_sync_time) : undefined,
+    provider: row.provider,
+    retryAfter: row.retry_after ? new Date(row.retry_after) : undefined,
+    status: row.status as SyncStatus,
+    syncStartDate: row.sync_start_date ? new Date(row.sync_start_date) : undefined,
+    updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
+  }))
+}
+
+export const resetSyncState = async (user: string, provider: string, dataType?: string) => {
+  if (dataType) {
+    await query(user, `DELETE FROM sync_state WHERE provider = $1 AND data_type = $2`, [provider, dataType])
+  } else {
+    await query(user, `DELETE FROM sync_state WHERE provider = $1`, [provider])
   }
 }
 

--- a/apps/backend/src/oura-sync.test.ts
+++ b/apps/backend/src/oura-sync.test.ts
@@ -1,0 +1,361 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import * as db from './db'
+import { calculateRetryAfter, isRateLimited, processOuraData } from './oura-sync'
+
+// Mock the db module
+vi.mock('./db', () => ({
+  getSyncState: vi.fn(),
+  insertActivity: vi.fn(),
+  insertRawRecord: vi.fn(),
+  insertTag: vi.fn(),
+  insertTimeSeries: vi.fn(),
+  upsertSyncState: vi.fn(),
+}))
+
+describe('calculateRetryAfter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'))
+  })
+
+  test('uses Retry-After header when available (seconds)', () => {
+    const result = calculateRetryAfter('120', 0)
+    expect(result).toEqual(new Date('2025-01-01T12:02:00Z'))
+  })
+
+  test('uses exponential backoff when no header (attempt 0)', () => {
+    const result = calculateRetryAfter(undefined, 0)
+    expect(result).toEqual(new Date('2025-01-01T12:01:00Z'))
+  })
+
+  test('uses exponential backoff when no header (attempt 1)', () => {
+    const result = calculateRetryAfter(undefined, 1)
+    expect(result).toEqual(new Date('2025-01-01T12:05:00Z'))
+  })
+
+  test('uses exponential backoff when no header (attempt 2)', () => {
+    const result = calculateRetryAfter(undefined, 2)
+    expect(result).toEqual(new Date('2025-01-01T12:15:00Z'))
+  })
+
+  test('caps backoff at max value (attempt >= 3)', () => {
+    const result = calculateRetryAfter(undefined, 5)
+    expect(result).toEqual(new Date('2025-01-01T13:00:00Z'))
+  })
+
+  test('handles invalid Retry-After header', () => {
+    const result = calculateRetryAfter('invalid', 0)
+    expect(result).toEqual(new Date('2025-01-01T12:01:00Z'))
+  })
+})
+
+describe('isRateLimited', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'))
+  })
+
+  test('returns false when syncState is null', () => {
+    expect(isRateLimited(null)).toBe(false)
+  })
+
+  test('returns false when status is not rate_limited', () => {
+    expect(
+      isRateLimited({
+        dataType: 'dailyReadiness',
+        provider: 'oura',
+        retryAfter: new Date('2025-01-01T13:00:00Z'),
+        status: 'idle',
+      }),
+    ).toBe(false)
+  })
+
+  test('returns false when retryAfter is in the past', () => {
+    expect(
+      isRateLimited({
+        dataType: 'dailyReadiness',
+        provider: 'oura',
+        retryAfter: new Date('2025-01-01T11:00:00Z'),
+        status: 'rate_limited',
+      }),
+    ).toBe(false)
+  })
+
+  test('returns true when rate_limited and retryAfter is in the future', () => {
+    expect(
+      isRateLimited({
+        dataType: 'dailyReadiness',
+        provider: 'oura',
+        retryAfter: new Date('2025-01-01T13:00:00Z'),
+        status: 'rate_limited',
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('processOuraData', () => {
+  const user = 'testuser'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('handles empty data array', async () => {
+    await processOuraData(user, 'dailyReadiness', [])
+    expect(db.insertRawRecord).not.toHaveBeenCalled()
+    expect(db.insertTimeSeries).not.toHaveBeenCalled()
+  })
+
+  describe('dailyCardiovascularAge', () => {
+    test('processes cardiovascular age data', async () => {
+      const data = [
+        {
+          id: 'cv-1',
+          timestamp: '2025-01-01T00:00:00Z',
+          vascular_age: 35,
+        },
+        {
+          day: '2025-01-02',
+          id: 'cv-2',
+          vascular_age: 34,
+        },
+      ]
+
+      await processOuraData(user, 'dailyCardiovascularAge', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalledTimes(2)
+      expect(db.insertRawRecord).toHaveBeenCalledWith(user, {
+        data: data[0],
+        externalId: 'cv-1',
+        recordType: 'daily_cardiovascular_age',
+        recordedAt: new Date('2025-01-01T00:00:00Z'),
+        source: 'oura',
+      })
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        {
+          metric: 'cardiovascular_age',
+          source: 'oura',
+          time: new Date('2025-01-01T00:00:00Z'),
+          value: 35,
+        },
+        {
+          metric: 'cardiovascular_age',
+          source: 'oura',
+          time: new Date('2025-01-02'),
+          value: 34,
+        },
+      ])
+    })
+  })
+
+  describe('dailyReadiness', () => {
+    test('processes readiness score data', async () => {
+      const data = [
+        {
+          contributors: { activity_balance: 90 },
+          id: 'rd-1',
+          score: 85,
+          timestamp: '2025-01-01T06:00:00Z',
+        },
+      ]
+
+      await processOuraData(user, 'dailyReadiness', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalledWith(user, {
+        data: data[0],
+        externalId: 'rd-1',
+        recordType: 'daily_readiness',
+        recordedAt: new Date('2025-01-01T06:00:00Z'),
+        source: 'oura',
+      })
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        {
+          metric: 'readiness_score',
+          source: 'oura',
+          time: new Date('2025-01-01T06:00:00Z'),
+          value: 85,
+        },
+      ])
+    })
+  })
+
+  describe('dailyResilience', () => {
+    test('processes resilience level data', async () => {
+      const data = [
+        { id: 'rs-1', level: 'solid', timestamp: '2025-01-01T00:00:00Z' },
+        { id: 'rs-2', level: 'exceptional', timestamp: '2025-01-02T00:00:00Z' },
+        { id: 'rs-3', level: 'limited', timestamp: '2025-01-03T00:00:00Z' },
+        { id: 'rs-4', level: 'strong', timestamp: '2025-01-04T00:00:00Z' },
+      ]
+
+      await processOuraData(user, 'dailyResilience', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalledTimes(4)
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        { metric: 'resilience_score', source: 'oura', time: new Date('2025-01-01T00:00:00Z'), value: 75 },
+        { metric: 'resilience_score', source: 'oura', time: new Date('2025-01-02T00:00:00Z'), value: 100 },
+        { metric: 'resilience_score', source: 'oura', time: new Date('2025-01-03T00:00:00Z'), value: 25 },
+        { metric: 'resilience_score', source: 'oura', time: new Date('2025-01-04T00:00:00Z'), value: 50 },
+      ])
+    })
+
+    test('handles unknown resilience level', async () => {
+      const data = [{ id: 'rs-1', level: 'unknown_level', timestamp: '2025-01-01T00:00:00Z' }]
+
+      await processOuraData(user, 'dailyResilience', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalled()
+      expect(db.insertTimeSeries).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('dailySleep', () => {
+    test('processes daily sleep score data', async () => {
+      const data = [
+        {
+          contributors: { deep_sleep: 88 },
+          id: 'sl-1',
+          score: 92,
+          timestamp: '2025-01-01T07:00:00Z',
+        },
+      ]
+
+      await processOuraData(user, 'dailySleep', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalledWith(user, {
+        data: data[0],
+        externalId: 'sl-1',
+        recordType: 'daily_sleep',
+        recordedAt: new Date('2025-01-01T07:00:00Z'),
+        source: 'oura',
+      })
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        {
+          metric: 'sleep_score',
+          source: 'oura',
+          time: new Date('2025-01-01T07:00:00Z'),
+          value: 92,
+        },
+      ])
+    })
+  })
+
+  describe('sessions', () => {
+    test('processes meditation session data', async () => {
+      const data = [
+        {
+          end_datetime: '2025-01-01T10:30:00Z',
+          heart_rate: { items: [60, 62, 58] },
+          heart_rate_variability: { items: [50, 55] },
+          id: 'sess-1',
+          mood: 'good',
+          motion_count: { items: [1, 0, 2] },
+          start_datetime: '2025-01-01T10:00:00Z',
+          type: 'meditation',
+        },
+      ]
+
+      await processOuraData(user, 'sessions', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalledWith(user, {
+        data: data[0],
+        externalId: 'sess-1',
+        recordType: 'session',
+        recordedAt: new Date('2025-01-01T10:00:00Z'),
+        source: 'oura',
+      })
+
+      expect(db.insertActivity).toHaveBeenCalledWith(user, {
+        activityType: 'meditation',
+        data: {
+          heartRate: data[0].heart_rate,
+          hrv: data[0].heart_rate_variability,
+          mood: 'good',
+          motion: data[0].motion_count,
+          sessionType: 'meditation',
+        },
+        endTime: new Date('2025-01-01T10:30:00Z'),
+        source: 'oura',
+        startTime: new Date('2025-01-01T10:00:00Z'),
+        title: 'meditation',
+      })
+    })
+  })
+
+  describe('tags', () => {
+    test('processes tag data with custom name', async () => {
+      const data = [
+        {
+          custom_name: 'Morning Coffee',
+          end_time: '2025-01-01T08:05:00Z',
+          id: 'tag-1',
+          start_time: '2025-01-01T08:00:00Z',
+          tag_type_code: 'caffeine',
+        },
+      ]
+
+      await processOuraData(user, 'tags', data)
+
+      expect(db.insertRawRecord).toHaveBeenCalledWith(user, {
+        data: data[0],
+        externalId: 'tag-1',
+        recordType: 'enhanced_tag',
+        recordedAt: new Date('2025-01-01T08:00:00Z'),
+        source: 'oura',
+      })
+
+      expect(db.insertTag).toHaveBeenCalledWith(user, {
+        endTime: new Date('2025-01-01T08:05:00Z'),
+        externalId: 'tag-1',
+        source: 'oura',
+        startTime: new Date('2025-01-01T08:00:00Z'),
+        tag: 'Morning Coffee',
+      })
+    })
+
+    test('processes tag data without custom name (uses tag_type_code)', async () => {
+      const data = [
+        {
+          custom_name: null,
+          id: 'tag-2',
+          start_time: '2025-01-01T14:00:00Z',
+          tag_type_code: 'stress_high',
+        },
+      ]
+
+      await processOuraData(user, 'tags', data)
+
+      expect(db.insertTag).toHaveBeenCalledWith(user, {
+        endTime: undefined,
+        externalId: 'tag-2',
+        source: 'oura',
+        startTime: new Date('2025-01-01T14:00:00Z'),
+        tag: 'stress_high',
+      })
+    })
+
+    test('handles tag with null tag_type_code', async () => {
+      const data = [
+        {
+          custom_name: null,
+          id: 'tag-3',
+          start_time: '2025-01-01T14:00:00Z',
+          tag_type_code: null,
+        },
+      ]
+
+      await processOuraData(user, 'tags', data)
+
+      expect(db.insertTag).toHaveBeenCalledWith(user, {
+        endTime: undefined,
+        externalId: 'tag-3',
+        source: 'oura',
+        startTime: new Date('2025-01-01T14:00:00Z'),
+        tag: 'unknown',
+      })
+    })
+  })
+})

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -1,0 +1,508 @@
+/**
+ * Oura data sync module.
+ *
+ * Handles fetching data from Oura API and storing it in the database.
+ * Supports incremental sync with rate limit handling.
+ */
+
+import { addMinutes, isFuture, subDays } from 'date-fns'
+import {
+  getSyncState,
+  insertActivity,
+  insertRawRecord,
+  insertTag,
+  insertTimeSeries,
+  SyncState,
+  TimeSeriesPoint,
+  upsertSyncState,
+} from './db'
+import { ouraClient } from './oura'
+
+/** Oura data types that can be synced */
+export type OuraDataType =
+  | 'dailyCardiovascularAge'
+  | 'dailyReadiness'
+  | 'dailyResilience'
+  | 'dailySleep'
+  | 'sessions'
+  | 'tags'
+
+/** Default start date for historical sync (90 days back) */
+const DEFAULT_SYNC_HISTORY_DAYS = 90
+
+/** Backoff intervals for rate limiting (in minutes) */
+const RATE_LIMIT_BACKOFF = [1, 5, 15, 60]
+
+interface OuraDailyRecord {
+  id: string
+  timestamp?: string
+  day?: string
+}
+
+interface OuraCardiovascularAge extends OuraDailyRecord {
+  vascular_age: number
+}
+
+interface OuraReadiness extends OuraDailyRecord {
+  score: number
+  temperature_deviation?: number
+  temperature_trend_deviation?: number
+  contributors?: Record<string, number>
+}
+
+interface OuraResilience extends OuraDailyRecord {
+  level: string
+  contributors?: {
+    sleep_recovery?: number
+    daytime_recovery?: number
+    stress?: number
+  }
+}
+
+interface OuraSleep extends OuraDailyRecord {
+  score: number
+  contributors?: Record<string, number>
+}
+
+interface OuraSession {
+  id: string
+  start_datetime: string
+  end_datetime: string
+  type: string
+  mood?: string
+  heart_rate?: unknown
+  heart_rate_variability?: unknown
+  motion_count?: unknown
+}
+
+interface OuraTag {
+  id: string
+  tag_type_code: string | null
+  start_time: string
+  end_time?: string
+  custom_name: string | null
+}
+
+/**
+ * Calculate retry time based on Retry-After header or exponential backoff.
+ */
+export const calculateRetryAfter = (retryAfterHeader?: string, attemptCount = 0): Date => {
+  if (retryAfterHeader) {
+    const seconds = parseInt(retryAfterHeader, 10)
+    if (!isNaN(seconds)) {
+      return addMinutes(new Date(), Math.ceil(seconds / 60))
+    }
+  }
+
+  const backoffIndex = Math.min(attemptCount, RATE_LIMIT_BACKOFF.length - 1)
+  return addMinutes(new Date(), RATE_LIMIT_BACKOFF[backoffIndex])
+}
+
+/**
+ * Check if a data type is currently rate limited.
+ */
+export const isRateLimited = (syncState: SyncState | null): boolean => {
+  if (!syncState?.retryAfter) return false
+  return syncState.status === 'rate_limited' && isFuture(syncState.retryAfter)
+}
+
+/**
+ * Process Oura cardiovascular age data.
+ */
+const processCardiovascularAge = async (user: string, data: OuraCardiovascularAge[]) => {
+  const points: TimeSeriesPoint[] = []
+
+  for (const record of data) {
+    const time = new Date(record.timestamp || record.day || '')
+
+    await insertRawRecord(user, {
+      data: record as unknown as Record<string, unknown>,
+      externalId: record.id,
+      recordType: 'daily_cardiovascular_age',
+      recordedAt: time,
+      source: 'oura',
+    })
+
+    if (record.vascular_age !== undefined) {
+      points.push({
+        metric: 'cardiovascular_age',
+        source: 'oura',
+        time,
+        value: record.vascular_age,
+      })
+    }
+  }
+
+  if (points.length > 0) {
+    await insertTimeSeries(user, points)
+  }
+}
+
+/**
+ * Process Oura readiness data.
+ */
+const processReadiness = async (user: string, data: OuraReadiness[]) => {
+  const points: TimeSeriesPoint[] = []
+
+  for (const record of data) {
+    const time = new Date(record.timestamp || record.day || '')
+
+    await insertRawRecord(user, {
+      data: record as unknown as Record<string, unknown>,
+      externalId: record.id,
+      recordType: 'daily_readiness',
+      recordedAt: time,
+      source: 'oura',
+    })
+
+    if (record.score !== undefined) {
+      points.push({
+        metric: 'readiness_score',
+        source: 'oura',
+        time,
+        value: record.score,
+      })
+    }
+  }
+
+  if (points.length > 0) {
+    await insertTimeSeries(user, points)
+  }
+}
+
+/**
+ * Process Oura resilience data.
+ */
+const processResilience = async (user: string, data: OuraResilience[]) => {
+  const points: TimeSeriesPoint[] = []
+  const levelToScore: Record<string, number> = {
+    exceptional: 100,
+    limited: 25,
+    solid: 75,
+    strong: 50,
+  }
+
+  for (const record of data) {
+    const time = new Date(record.timestamp || record.day || '')
+
+    await insertRawRecord(user, {
+      data: record as unknown as Record<string, unknown>,
+      externalId: record.id,
+      recordType: 'daily_resilience',
+      recordedAt: time,
+      source: 'oura',
+    })
+
+    if (record.level && record.level in levelToScore) {
+      points.push({
+        metric: 'resilience_score',
+        source: 'oura',
+        time,
+        value: levelToScore[record.level],
+      })
+    }
+  }
+
+  if (points.length > 0) {
+    await insertTimeSeries(user, points)
+  }
+}
+
+/**
+ * Process Oura daily sleep data.
+ */
+const processDailySleep = async (user: string, data: OuraSleep[]) => {
+  const points: TimeSeriesPoint[] = []
+
+  for (const record of data) {
+    const time = new Date(record.timestamp || record.day || '')
+
+    await insertRawRecord(user, {
+      data: record as unknown as Record<string, unknown>,
+      externalId: record.id,
+      recordType: 'daily_sleep',
+      recordedAt: time,
+      source: 'oura',
+    })
+
+    if (record.score !== undefined) {
+      points.push({
+        metric: 'sleep_score',
+        source: 'oura',
+        time,
+        value: record.score,
+      })
+    }
+  }
+
+  if (points.length > 0) {
+    await insertTimeSeries(user, points)
+  }
+}
+
+/**
+ * Process Oura session data (meditation).
+ */
+const processSessions = async (user: string, data: OuraSession[]) => {
+  for (const record of data) {
+    const startTime = new Date(record.start_datetime)
+    const endTime = new Date(record.end_datetime)
+
+    await insertRawRecord(user, {
+      data: record as unknown as Record<string, unknown>,
+      externalId: record.id,
+      recordType: 'session',
+      recordedAt: startTime,
+      source: 'oura',
+    })
+
+    await insertActivity(user, {
+      activityType: 'meditation',
+      data: {
+        heartRate: record.heart_rate,
+        hrv: record.heart_rate_variability,
+        mood: record.mood,
+        motion: record.motion_count,
+        sessionType: record.type,
+      },
+      endTime,
+      source: 'oura',
+      startTime,
+      title: record.type,
+    })
+  }
+}
+
+/**
+ * Process Oura tag data.
+ */
+const processTags = async (user: string, data: OuraTag[]) => {
+  for (const record of data) {
+    const startTime = new Date(record.start_time)
+    const endTime = record.end_time ? new Date(record.end_time) : undefined
+
+    await insertRawRecord(user, {
+      data: record as unknown as Record<string, unknown>,
+      externalId: record.id,
+      recordType: 'enhanced_tag',
+      recordedAt: startTime,
+      source: 'oura',
+    })
+
+    await insertTag(user, {
+      endTime,
+      externalId: record.id,
+      source: 'oura',
+      startTime,
+      tag: record.custom_name || record.tag_type_code || 'unknown',
+    })
+  }
+}
+
+/**
+ * Process Oura data and store in database.
+ *
+ * @param user - The user identifier
+ * @param dataType - The type of Oura data being processed
+ * @param data - Array of Oura records
+ */
+export const processOuraData = async (
+  user: string,
+  dataType: OuraDataType,
+  data: unknown[],
+): Promise<void> => {
+  if (!data || data.length === 0) return
+
+  switch (dataType) {
+    case 'dailyCardiovascularAge':
+      await processCardiovascularAge(user, data as OuraCardiovascularAge[])
+      break
+    case 'dailyReadiness':
+      await processReadiness(user, data as OuraReadiness[])
+      break
+    case 'dailyResilience':
+      await processResilience(user, data as OuraResilience[])
+      break
+    case 'dailySleep':
+      await processDailySleep(user, data as OuraSleep[])
+      break
+    case 'sessions':
+      await processSessions(user, data as OuraSession[])
+      break
+    case 'tags':
+      await processTags(user, data as OuraTag[])
+      break
+  }
+}
+
+/** Result of a sync operation */
+export interface SyncResult {
+  dataType: OuraDataType
+  recordsProcessed: number
+  status: 'success' | 'skipped' | 'error' | 'rate_limited'
+  error?: string
+  retryAfter?: Date
+}
+
+/**
+ * Sync a single Oura data type.
+ */
+export const syncOuraDataType = async (
+  user: string,
+  oura: ReturnType<typeof ouraClient>,
+  dataType: OuraDataType,
+  accessToken: string,
+  options: { fullResync?: boolean; startDate?: Date } = {},
+): Promise<SyncResult> => {
+  // Check current sync state
+  const syncState = await getSyncState(user, 'oura', dataType)
+
+  // Skip if rate limited
+  if (isRateLimited(syncState)) {
+    return {
+      dataType,
+      recordsProcessed: 0,
+      retryAfter: syncState!.retryAfter,
+      status: 'skipped',
+    }
+  }
+
+  // Determine date range
+  const end = new Date()
+  let start: Date
+
+  if (options.fullResync || !syncState?.lastSyncTime) {
+    start = options.startDate || subDays(end, DEFAULT_SYNC_HISTORY_DAYS)
+  } else {
+    start = syncState.lastSyncTime
+  }
+
+  // Mark as syncing
+  await upsertSyncState(user, {
+    dataType,
+    provider: 'oura',
+    status: 'syncing',
+    syncStartDate: start,
+  })
+
+  try {
+    let data: unknown[]
+
+    switch (dataType) {
+      case 'dailyCardiovascularAge':
+        data = await oura.getDailyCardiovascularAge(start, end, accessToken)
+        break
+      case 'dailyReadiness':
+        data = await oura.getDailyReadiness(start, end, accessToken)
+        break
+      case 'dailyResilience':
+        data = await oura.getDailyResilience(start, end, accessToken)
+        break
+      case 'dailySleep':
+        data = await oura.getDailySleep(start, end, accessToken)
+        break
+      case 'sessions':
+        data = await oura.getSessions(start, end, accessToken)
+        break
+      case 'tags':
+        data = await oura.getTags(start, end, accessToken)
+        break
+    }
+
+    await processOuraData(user, dataType, data)
+
+    // Update sync state on success
+    await upsertSyncState(user, {
+      dataType,
+      lastSyncTime: end,
+      provider: 'oura',
+      status: 'idle',
+    })
+
+    return {
+      dataType,
+      recordsProcessed: data.length,
+      status: 'success',
+    }
+  } catch (error: unknown) {
+    const axiosError = error as { response?: { status?: number; headers?: Record<string, string> } }
+
+    // Handle rate limiting
+    if (axiosError.response?.status === 429) {
+      const retryAfter = calculateRetryAfter(axiosError.response.headers?.['retry-after'])
+      await upsertSyncState(user, {
+        dataType,
+        errorMessage: 'Rate limited by Oura API',
+        provider: 'oura',
+        retryAfter,
+        status: 'rate_limited',
+      })
+
+      return {
+        dataType,
+        recordsProcessed: 0,
+        retryAfter,
+        status: 'rate_limited',
+      }
+    }
+
+    // Handle other errors
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    await upsertSyncState(user, {
+      dataType,
+      errorMessage,
+      provider: 'oura',
+      status: 'error',
+    })
+
+    return {
+      dataType,
+      error: errorMessage,
+      recordsProcessed: 0,
+      status: 'error',
+    }
+  }
+}
+
+/**
+ * Sync all Oura data types.
+ */
+export const syncAllOuraData = async (
+  user: string,
+  oura: ReturnType<typeof ouraClient>,
+  options: { fullResync?: boolean; startDate?: Date } = {},
+): Promise<SyncResult[]> => {
+  const accessToken = await oura.getAccessToken(user)
+  const dataTypes: OuraDataType[] = [
+    'dailyCardiovascularAge',
+    'dailyReadiness',
+    'dailyResilience',
+    'dailySleep',
+    'sessions',
+    'tags',
+  ]
+
+  const results: SyncResult[] = []
+
+  for (const dataType of dataTypes) {
+    const result = await syncOuraDataType(user, oura, dataType, accessToken, options)
+    results.push(result)
+
+    // Stop if we hit rate limiting to avoid more 429s
+    if (result.status === 'rate_limited') {
+      // Mark remaining types as skipped
+      const remaining = dataTypes.slice(dataTypes.indexOf(dataType) + 1)
+      for (const remainingType of remaining) {
+        results.push({
+          dataType: remainingType,
+          recordsProcessed: 0,
+          retryAfter: result.retryAfter,
+          status: 'skipped',
+        })
+      }
+      break
+    }
+  }
+
+  return results
+}

--- a/apps/backend/src/rescuetime-sync.test.ts
+++ b/apps/backend/src/rescuetime-sync.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { calculateRetryAfter, isRateLimited, needsSync } from './rescuetime-sync'
+
+describe('calculateRetryAfter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'))
+  })
+
+  test('uses exponential backoff (attempt 0)', () => {
+    const result = calculateRetryAfter(0)
+    expect(result).toEqual(new Date('2025-01-01T12:01:00Z'))
+  })
+
+  test('uses exponential backoff (attempt 1)', () => {
+    const result = calculateRetryAfter(1)
+    expect(result).toEqual(new Date('2025-01-01T12:05:00Z'))
+  })
+
+  test('uses exponential backoff (attempt 2)', () => {
+    const result = calculateRetryAfter(2)
+    expect(result).toEqual(new Date('2025-01-01T12:15:00Z'))
+  })
+
+  test('caps backoff at max value (attempt >= 3)', () => {
+    const result = calculateRetryAfter(5)
+    expect(result).toEqual(new Date('2025-01-01T13:00:00Z'))
+  })
+})
+
+describe('isRateLimited', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'))
+  })
+
+  test('returns false when syncState is null', () => {
+    expect(isRateLimited(null)).toBe(false)
+  })
+
+  test('returns false when status is not rate_limited', () => {
+    expect(
+      isRateLimited({
+        dataType: 'productivity',
+        provider: 'rescuetime',
+        retryAfter: new Date('2025-01-01T13:00:00Z'),
+        status: 'idle',
+      }),
+    ).toBe(false)
+  })
+
+  test('returns false when retryAfter is in the past', () => {
+    expect(
+      isRateLimited({
+        dataType: 'productivity',
+        provider: 'rescuetime',
+        retryAfter: new Date('2025-01-01T11:00:00Z'),
+        status: 'rate_limited',
+      }),
+    ).toBe(false)
+  })
+
+  test('returns true when rate_limited and retryAfter is in the future', () => {
+    expect(
+      isRateLimited({
+        dataType: 'productivity',
+        provider: 'rescuetime',
+        retryAfter: new Date('2025-01-01T13:00:00Z'),
+        status: 'rate_limited',
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('needsSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'))
+  })
+
+  test('returns true when syncState is null', () => {
+    expect(needsSync(null, 30)).toBe(true)
+  })
+
+  test('returns true when lastSyncTime is undefined', () => {
+    expect(
+      needsSync(
+        {
+          dataType: 'productivity',
+          provider: 'rescuetime',
+          status: 'idle',
+        },
+        30,
+      ),
+    ).toBe(true)
+  })
+
+  test('returns true when last sync is older than threshold', () => {
+    expect(
+      needsSync(
+        {
+          dataType: 'productivity',
+          lastSyncTime: new Date('2025-01-01T11:00:00Z'), // 1 hour ago
+          provider: 'rescuetime',
+          status: 'idle',
+        },
+        30, // 30 minute threshold
+      ),
+    ).toBe(true)
+  })
+
+  test('returns false when last sync is within threshold', () => {
+    expect(
+      needsSync(
+        {
+          dataType: 'productivity',
+          lastSyncTime: new Date('2025-01-01T11:45:00Z'), // 15 minutes ago
+          provider: 'rescuetime',
+          status: 'idle',
+        },
+        30, // 30 minute threshold
+      ),
+    ).toBe(false)
+  })
+})

--- a/apps/backend/src/rescuetime-sync.ts
+++ b/apps/backend/src/rescuetime-sync.ts
@@ -1,0 +1,159 @@
+/**
+ * RescueTime data sync module.
+ *
+ * Handles fetching data from RescueTime API and storing it in the database.
+ * Supports incremental sync with rate limit handling.
+ */
+
+import { addMinutes, isBefore, isFuture, subDays } from 'date-fns'
+import { getSyncState, insertProductivity, SyncState, upsertSyncState } from './db'
+import { rescuetimeClient } from './rescuetime'
+
+/** Default start date for historical sync (30 days back) */
+const DEFAULT_SYNC_HISTORY_DAYS = 30
+
+/** Backoff intervals for rate limiting (in minutes) */
+const RATE_LIMIT_BACKOFF = [1, 5, 15, 60]
+
+/**
+ * Calculate retry time based on exponential backoff.
+ */
+export const calculateRetryAfter = (attemptCount = 0): Date => {
+  const backoffIndex = Math.min(attemptCount, RATE_LIMIT_BACKOFF.length - 1)
+  return addMinutes(new Date(), RATE_LIMIT_BACKOFF[backoffIndex])
+}
+
+/**
+ * Check if RescueTime is currently rate limited.
+ */
+export const isRateLimited = (syncState: SyncState | null): boolean => {
+  if (!syncState?.retryAfter) return false
+  return syncState.status === 'rate_limited' && isFuture(syncState.retryAfter)
+}
+
+/** Result of a sync operation */
+export interface SyncResult {
+  recordsProcessed: number
+  status: 'success' | 'skipped' | 'error' | 'rate_limited'
+  error?: string
+  retryAfter?: Date
+}
+
+/**
+ * Sync RescueTime productivity data.
+ */
+export const syncRescueTimeData = async (
+  user: string,
+  apiKey: string,
+  options: { fullResync?: boolean; startDate?: Date } = {},
+): Promise<SyncResult> => {
+  const dataType = 'productivity'
+
+  // Check current sync state
+  const syncState = await getSyncState(user, 'rescuetime', dataType)
+
+  // Skip if rate limited
+  if (isRateLimited(syncState)) {
+    return {
+      recordsProcessed: 0,
+      retryAfter: syncState!.retryAfter,
+      status: 'skipped',
+    }
+  }
+
+  // Determine date range
+  const end = new Date()
+  let start: Date
+
+  if (options.fullResync || !syncState?.lastSyncTime) {
+    start = options.startDate || subDays(end, DEFAULT_SYNC_HISTORY_DAYS)
+  } else {
+    start = syncState.lastSyncTime
+  }
+
+  // Mark as syncing
+  await upsertSyncState(user, {
+    dataType,
+    provider: 'rescuetime',
+    status: 'syncing',
+    syncStartDate: start,
+  })
+
+  try {
+    const client = rescuetimeClient(apiKey)
+    const data = await client.getIntervalData(start, end)
+
+    // Store the data
+    const productivityRecords = data.map((r) => ({
+      activity: r.activity,
+      category: r.category,
+      durationSec: r.duration,
+      endTime: r.endTime,
+      isMobile: r.mobile,
+      productivity: r.productivity,
+      source: 'rescuetime' as const,
+      startTime: r.startTime,
+    }))
+
+    if (productivityRecords.length > 0) {
+      await insertProductivity(user, productivityRecords)
+    }
+
+    // Update sync state on success
+    await upsertSyncState(user, {
+      dataType,
+      lastSyncTime: end,
+      provider: 'rescuetime',
+      status: 'idle',
+    })
+
+    return {
+      recordsProcessed: productivityRecords.length,
+      status: 'success',
+    }
+  } catch (error: unknown) {
+    const axiosError = error as { response?: { status?: number } }
+
+    // Handle rate limiting (RescueTime uses 429)
+    if (axiosError.response?.status === 429) {
+      const retryAfter = calculateRetryAfter()
+      await upsertSyncState(user, {
+        dataType,
+        errorMessage: 'Rate limited by RescueTime API',
+        provider: 'rescuetime',
+        retryAfter,
+        status: 'rate_limited',
+      })
+
+      return {
+        recordsProcessed: 0,
+        retryAfter,
+        status: 'rate_limited',
+      }
+    }
+
+    // Handle other errors
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    await upsertSyncState(user, {
+      dataType,
+      errorMessage,
+      provider: 'rescuetime',
+      status: 'error',
+    })
+
+    return {
+      error: errorMessage,
+      recordsProcessed: 0,
+      status: 'error',
+    }
+  }
+}
+
+/**
+ * Check if RescueTime sync is needed based on last sync time.
+ */
+export const needsSync = (syncState: SyncState | null, thresholdMinutes: number): boolean => {
+  if (!syncState?.lastSyncTime) return true
+  const threshold = addMinutes(syncState.lastSyncTime, thresholdMinutes)
+  return isBefore(threshold, new Date())
+}

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -92,7 +92,6 @@ export const createTableStatements: Record<string, string> = {
   `,
 
   // Named places / geofences
-
   places: `
     CREATE TABLE IF NOT EXISTS places (
       id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -105,12 +104,12 @@ export const createTableStatements: Record<string, string> = {
       CONSTRAINT unique_place UNIQUE (source, external_id)
     )
   `,
+
   places_indexes: `
     CREATE INDEX IF NOT EXISTS idx_places_geo ON places USING GIST (location)
   `,
 
   // RescueTime productivity data
-
   productivity: `
     CREATE TABLE IF NOT EXISTS productivity (
       id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -125,12 +124,12 @@ export const createTableStatements: Record<string, string> = {
       CONSTRAINT unique_productivity UNIQUE (source, start_time, activity)
     )
   `,
+
   productivity_indexes: `
     CREATE INDEX IF NOT EXISTS idx_productivity_time ON productivity (start_time DESC);
     CREATE INDEX IF NOT EXISTS idx_productivity_category ON productivity (category, start_time DESC)
   `,
   // Raw data sink - stores all incoming data in original form
-
   raw_records: `
     CREATE TABLE IF NOT EXISTS raw_records (
       id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -143,10 +142,27 @@ export const createTableStatements: Record<string, string> = {
       CONSTRAINT unique_source_record UNIQUE (source, record_type, external_id)
     )
   `,
+
   raw_records_indexes: `
     CREATE INDEX IF NOT EXISTS idx_raw_records_source_time ON raw_records (source, recorded_at);
     CREATE INDEX IF NOT EXISTS idx_raw_records_type_time ON raw_records (record_type, recorded_at);
     CREATE INDEX IF NOT EXISTS idx_raw_records_data ON raw_records USING GIN (data)
+  `,
+
+  // Sync state tracking for incremental data pulls
+  sync_state: `
+    CREATE TABLE IF NOT EXISTS sync_state (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      provider        VARCHAR(50) NOT NULL,
+      data_type       VARCHAR(100) NOT NULL,
+      last_sync_time  TIMESTAMPTZ,
+      sync_start_date DATE,
+      status          VARCHAR(20) DEFAULT 'idle',
+      error_message   TEXT,
+      retry_after     TIMESTAMPTZ,
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT unique_sync_state UNIQUE (provider, data_type)
+    )
   `,
 
   // Activity labels/tags
@@ -205,6 +221,7 @@ export const tableCreationOrder = [
   'lab_results',
   'lab_results_indexes',
   'oauth_tokens',
+  'sync_state',
 ]
 
 /**
@@ -242,6 +259,8 @@ export type MetricType =
   | 'readiness_score'
   | 'resilience_score'
   | 'productivity_score'
+  | 'cardiovascular_age'
+  | 'sleep_score'
 
 /**
  * Activity types for activities table.
@@ -263,6 +282,7 @@ export const metricUnits: Record<MetricType, string> = {
   calories_active: 'kcal',
   calories_basal: 'kcal',
   calories_total: 'kcal',
+  cardiovascular_age: 'years',
   distance: 'm',
   floors_climbed: 'count',
   heart_rate: 'bpm',
@@ -274,6 +294,7 @@ export const metricUnits: Record<MetricType, string> = {
   resilience_score: 'score',
   respiratory_rate: 'brpm',
   resting_heart_rate: 'bpm',
+  sleep_score: 'score',
   spo2: 'percent',
   steps: 'count',
   vo2_max: 'mL/kg/min',

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -44,7 +44,7 @@ export interface Tag {
 // Fetch heart rate data for the specified date range
 export const fetchHeartRate = async (start: Date, end: Date): Promise<[Date, number][]> => {
   const { token } = auth.value
-  const response = await axios.get<[string, number][]>(`${API_URL}/api/heartrate`, {
+  const response = await axios.get<[string, number][]>(`${API_URL}/heartrate`, {
     headers: { Authorization: `Bearer ${token}` },
     params: {
       end: end.toISOString(),
@@ -62,7 +62,7 @@ export const fetchActivities = async (
   types?: ActivityType[],
 ): Promise<Activity[]> => {
   const { token } = auth.value
-  const response = await axios.get(`${API_URL}/api/activities`, {
+  const response = await axios.get(`${API_URL}/activities`, {
     headers: { Authorization: `Bearer ${token}` },
     params: {
       end: end.toISOString(),
@@ -81,7 +81,7 @@ export const fetchActivities = async (
 // Fetch productivity data (RescueTime) for the specified date range
 export const fetchProductivity = async (start: Date, end: Date): Promise<ProductivityRecord[]> => {
   const { token } = auth.value
-  const response = await axios.get(`${API_URL}/api/productivity`, {
+  const response = await axios.get(`${API_URL}/productivity`, {
     headers: { Authorization: `Bearer ${token}` },
     params: {
       end: end.toISOString(),
@@ -99,7 +99,7 @@ export const fetchProductivity = async (start: Date, end: Date): Promise<Product
 // Fetch location/place data for the specified date range
 export const fetchPlaces = async (start: Date, end: Date): Promise<Place[]> => {
   const { token } = auth.value
-  const response = await axios.get(`${API_URL}/api/locations`, {
+  const response = await axios.get(`${API_URL}/locations`, {
     headers: { Authorization: `Bearer ${token}` },
     params: {
       end: end.toISOString(),
@@ -117,7 +117,7 @@ export const fetchPlaces = async (start: Date, end: Date): Promise<Place[]> => {
 // Fetch tags for the specified date range
 export const fetchTags = async (start: Date, end: Date): Promise<Tag[]> => {
   const { token } = auth.value
-  const response = await axios.get(`${API_URL}/api/tags`, {
+  const response = await axios.get(`${API_URL}/tags`, {
     headers: { Authorization: `Bearer ${token}` },
     params: {
       end: end.toISOString(),

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -8,7 +8,7 @@ auth.subscribe((value) => localStorage.setItem('auth', JSON.stringify(value)))
 
 export const login = async (user: string, pass: string) => {
   try {
-    const response = await axios.post<{ token: string }>(`${API_URL}/api/login`, {
+    const response = await axios.post<{ token: string }>(`${API_URL}/login`, {
       password: pass,
       username: user,
     })


### PR DESCRIPTION
## Summary
- Adds `sync_state` table for tracking incremental sync progress per data type
- Creates `oura-sync.ts` module to process and store all Oura API data types
- Adds 3 API endpoints for triggering sync, checking status, and resetting state
- Implements rate limit handling with exponential backoff (1m → 5m → 15m → 1hr)
- Adds automatic database migration for existing users on login

## Data Flow
| Oura Data Type | Stored As |
|----------------|-----------|
| `dailyCardiovascularAge` | `time_series.cardiovascular_age` |
| `dailyReadiness` | `time_series.readiness_score` |
| `dailyResilience` | `time_series.resilience_score` |
| `dailySleep` | `time_series.sleep_score` |
| `sessions` | `activities` (type=meditation) |
| `tags` | `tags` table |

All data types also stored in `raw_records` for preservation.

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm test` passes (72 tests, including 20 new tests for oura-sync)
- [ ] Manual test: Call `POST /sync/oura` and verify data in database tables

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)