### PR TITLE
Add runtime API_URL configuration for Docker deployments

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -5,10 +5,12 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/web/package.json apps/web/
 RUN pnpm install --frozen-lockfile
 COPY apps/web/ apps/web/
-ARG VITE_API_URL
 RUN pnpm --filter aurboda-web build
 
 FROM nginx:alpine
 COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
 COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY apps/web/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 80
+CMD ["/entrypoint.sh"]

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Generate runtime config from environment variables
+cat > /usr/share/nginx/html/config.js << EOF
+window.__RUNTIME_CONFIG__ = {
+  API_URL: "${VITE_API_URL:-}"
+};
+EOF
+
+# Start nginx
+exec nginx -g 'daemon off;'

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,6 +9,7 @@
 	</head>
 	<body>
 		<div id="app"></div>
+		<script src="/config.js"></script>
 		<script type="module" src="/src/index.tsx"></script>
 	</body>
 </html>

--- a/apps/web/public/config.js
+++ b/apps/web/public/config.js
@@ -1,0 +1,5 @@
+// Runtime configuration - this file is overwritten at container startup
+// For local development, VITE_API_URL from .env is used instead
+window.__RUNTIME_CONFIG__ = {
+  API_URL: ""
+};

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,2 +1,5 @@
-// API configuration - reads from environment variable or falls back to current host
-export const API_URL = import.meta.env.VITE_API_URL || `${window.location.protocol}//${window.location.host}`
+// API configuration - reads from runtime config, build-time env, or falls back to current host
+export const API_URL =
+  window.__RUNTIME_CONFIG__?.API_URL ||
+  import.meta.env.VITE_API_URL ||
+  `${window.location.protocol}//${window.location.host}`

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -7,3 +7,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+interface Window {
+  __RUNTIME_CONFIG__?: {
+    API_URL?: string
+  }
+}


### PR DESCRIPTION
## Summary
- Add runtime configuration support for `VITE_API_URL` via docker-compose environment variables
- Create entrypoint script that generates `config.js` at container startup
- The app now checks `window.__RUNTIME_CONFIG__.API_URL` before falling back to build-time env or current host

## Usage
In docker-compose:
```yaml
aurboda-web:
  image: fiddur/aurboda-web:latest
  environment:
    - VITE_API_URL=https://aurboda.net/api
```

## Test plan
- [ ] Build Docker image without any build args
- [ ] Run container with `VITE_API_URL` environment variable
- [ ] Verify API calls use the runtime-configured URL
- [ ] Verify local development still works with `.env` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)