### PR TITLE
Fix sessions and tags sync to use transformed data format

### DIFF
--- a/apps/backend/src/oura-sync.test.ts
+++ b/apps/backend/src/oura-sync.test.ts
@@ -245,15 +245,16 @@ describe('processOuraData', () => {
 
   describe('sessions', () => {
     test('processes meditation session data', async () => {
+      // Data is pre-transformed by oura.ts getSessions()
       const data = [
         {
-          end_datetime: '2025-01-01T10:30:00Z',
-          heart_rate: { items: [60, 62, 58] },
-          heart_rate_variability: { items: [50, 55] },
+          endTime: new Date('2025-01-01T10:30:00Z'),
+          heartRate: { items: [60, 62, 58] },
+          hrv: { items: [50, 55] },
           id: 'sess-1',
           mood: 'good',
-          motion_count: { items: [1, 0, 2] },
-          start_datetime: '2025-01-01T10:00:00Z',
+          motion: { items: [1, 0, 2] },
+          startTime: new Date('2025-01-01T10:00:00Z'),
           type: 'meditation',
         },
       ]
@@ -271,10 +272,10 @@ describe('processOuraData', () => {
       expect(db.insertActivity).toHaveBeenCalledWith(user, {
         activityType: 'meditation',
         data: {
-          heartRate: data[0].heart_rate,
-          hrv: data[0].heart_rate_variability,
+          heartRate: data[0].heartRate,
+          hrv: data[0].hrv,
           mood: 'good',
-          motion: data[0].motion_count,
+          motion: data[0].motion,
           sessionType: 'meditation',
         },
         endTime: new Date('2025-01-01T10:30:00Z'),
@@ -287,13 +288,14 @@ describe('processOuraData', () => {
 
   describe('tags', () => {
     test('processes tag data with custom name', async () => {
+      // Data is pre-transformed by oura.ts getTags()
       const data = [
         {
-          custom_name: 'Morning Coffee',
-          end_time: '2025-01-01T08:05:00Z',
-          id: 'tag-1',
-          start_time: '2025-01-01T08:00:00Z',
-          tag_type_code: 'caffeine',
+          endTime: new Date('2025-01-01T08:05:00Z'),
+          externalId: 'tag-1',
+          source: 'oura',
+          startTime: new Date('2025-01-01T08:00:00Z'),
+          tag: 'Morning Coffee',
         },
       ]
 
@@ -316,13 +318,15 @@ describe('processOuraData', () => {
       })
     })
 
-    test('processes tag data without custom name (uses tag_type_code)', async () => {
+    test('processes tag data without endTime', async () => {
+      // Data is pre-transformed by oura.ts getTags()
       const data = [
         {
-          custom_name: null,
-          id: 'tag-2',
-          start_time: '2025-01-01T14:00:00Z',
-          tag_type_code: 'stress_high',
+          endTime: undefined,
+          externalId: 'tag-2',
+          source: 'oura',
+          startTime: new Date('2025-01-01T14:00:00Z'),
+          tag: 'stress_high',
         },
       ]
 
@@ -337,13 +341,15 @@ describe('processOuraData', () => {
       })
     })
 
-    test('handles tag with null tag_type_code', async () => {
+    test('handles tag with unknown type', async () => {
+      // Data is pre-transformed by oura.ts getTags() - 'unknown' is set by oura.ts when tag_type_code is null
       const data = [
         {
-          custom_name: null,
-          id: 'tag-3',
-          start_time: '2025-01-01T14:00:00Z',
-          tag_type_code: null,
+          endTime: undefined,
+          externalId: 'tag-3',
+          source: 'oura',
+          startTime: new Date('2025-01-01T14:00:00Z'),
+          tag: 'unknown',
         },
       ]
 

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -66,21 +66,21 @@ interface OuraSleep extends OuraDailyRecord {
 
 interface OuraSession {
   id: string
-  start_datetime: string
-  end_datetime: string
+  startTime: Date
+  endTime: Date
   type: string
   mood?: string
-  heart_rate?: unknown
-  heart_rate_variability?: unknown
-  motion_count?: unknown
+  heartRate?: unknown
+  hrv?: unknown
+  motion?: unknown
 }
 
 interface OuraTag {
-  id: string
-  tag_type_code: string | null
-  start_time: string
-  end_time?: string
-  custom_name: string | null
+  startTime: Date
+  endTime?: Date
+  tag: string
+  externalId: string
+  source: string
 }
 
 /**
@@ -245,29 +245,26 @@ const processDailySleep = async (user: string, data: OuraSleep[]) => {
  */
 const processSessions = async (user: string, data: OuraSession[]) => {
   for (const record of data) {
-    const startTime = new Date(record.start_datetime)
-    const endTime = new Date(record.end_datetime)
-
     await insertRawRecord(user, {
       data: record as unknown as Record<string, unknown>,
       externalId: record.id,
       recordType: 'session',
-      recordedAt: startTime,
+      recordedAt: record.startTime,
       source: 'oura',
     })
 
     await insertActivity(user, {
       activityType: 'meditation',
       data: {
-        heartRate: record.heart_rate,
-        hrv: record.heart_rate_variability,
+        heartRate: record.heartRate,
+        hrv: record.hrv,
         mood: record.mood,
-        motion: record.motion_count,
+        motion: record.motion,
         sessionType: record.type,
       },
-      endTime,
+      endTime: record.endTime,
       source: 'oura',
-      startTime,
+      startTime: record.startTime,
       title: record.type,
     })
   }
@@ -278,23 +275,20 @@ const processSessions = async (user: string, data: OuraSession[]) => {
  */
 const processTags = async (user: string, data: OuraTag[]) => {
   for (const record of data) {
-    const startTime = new Date(record.start_time)
-    const endTime = record.end_time ? new Date(record.end_time) : undefined
-
     await insertRawRecord(user, {
       data: record as unknown as Record<string, unknown>,
-      externalId: record.id,
+      externalId: record.externalId,
       recordType: 'enhanced_tag',
-      recordedAt: startTime,
+      recordedAt: record.startTime,
       source: 'oura',
     })
 
     await insertTag(user, {
-      endTime,
-      externalId: record.id,
+      endTime: record.endTime,
+      externalId: record.externalId,
       source: 'oura',
-      startTime,
-      tag: record.custom_name || record.tag_type_code || 'unknown',
+      startTime: record.startTime,
+      tag: record.tag,
     })
   }
 }


### PR DESCRIPTION
## Summary
- Fixes the timestamp parsing error when syncing Oura sessions and tags
- `oura.ts` `getSessions()` and `getTags()` return pre-transformed data with `startTime`/`endTime` as Date objects
- `oura-sync.ts` was expecting the raw API format with `start_time`/`end_time` as strings
- Updated interfaces and processing functions to match the actual data format

## Test plan
- [x] All backend unit tests pass
- [ ] Deploy and verify sessions sync works via MCP
- [ ] Deploy and verify tags sync works via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)