### PR TITLE
Add push trigger to CI workflow for codecov baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     branches:
       - develop

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 node_modules
 dist/
+coverage/
 
 # Android/IntelliJ
 #

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,9 +21,9 @@
     "@types/pg": "^8.11.10",
     "@types/pg-format": "^1.0.5",
     "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^3.2.4",
     "supertest": "^7.2.2",
-    "vitest": "^3.2.4",
-    "@vitest/coverage-v8": "^3.2.4"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,13 +27,13 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.10.2",
     "@types/d3": "^7.4.3",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.36.0",
     "eslint-config-preact": "^2.0.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-sort-keys": "^2.3.5",
     "vite": "^7.1.7",
-    "vitest": "^3.2.4",
-    "@vitest/coverage-v8": "^3.2.4"
+    "vitest": "^3.2.4"
   },
   "eslintConfig": {
     "extends": "preact"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -17,5 +17,5 @@
 		}
 	},
 	"include": ["node_modules/vite/client.d.ts", "**/*"],
-	"exclude": ["dist"]
+	"exclude": ["dist", "coverage"]
 }


### PR DESCRIPTION
## Summary
- Adds `push` trigger for `develop` branch to CI workflow so coverage is uploaded when PRs are merged
- This provides the BASE report that codecov needs to compare PRs against
- Also excludes `coverage/` directory from git and TypeScript to prevent issues when running tests locally

## Test plan
- [ ] Merge this PR
- [ ] Verify CI runs on push to develop
- [ ] Check codecov badges populate after the push workflow completes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)