### PR TITLE
Add HR zones feature with user settings

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -41,6 +41,7 @@ import {
   queryProductivity,
   queryTags,
 } from './services/queries'
+import { getEffectiveHrZones, getSettings, HrZoneThresholds, updateSettings } from './services/settings'
 import { createSyncProvider } from './services/sync-provider'
 import { reduceTimeSeries } from './utils'
 
@@ -573,6 +574,93 @@ const main = async () => {
 
     const result = await addMetric(user, { metric, time: measurementTime, value })
     res.json(result)
+  })
+
+  // GET /user/settings - Get user settings with effective HR zones
+  httpd.get('/user/settings', authMiddleware, async (req, res) => {
+    const user = req.user!
+
+    const settings = await getSettings(user)
+    const { zones, source } = await getEffectiveHrZones(user)
+
+    res.json({
+      birthDate: settings.birthDate ?? null,
+      hrZoneStart: zones,
+      hrZoneStartSource: source,
+      success: true,
+    })
+  })
+
+  // PATCH /user/settings - Update user settings
+  httpd.patch('/user/settings', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { birthDate, hrZoneStart } = req.body as {
+      birthDate?: string
+      hrZoneStart?: HrZoneThresholds
+    }
+
+    // Validate birthDate format (YYYY-MM-DD) if provided
+    if (birthDate !== undefined) {
+      if (birthDate !== null && !/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
+        return res.status(400).json({
+          error: 'Invalid birthDate format. Use YYYY-MM-DD format.',
+          success: false,
+        })
+      }
+      // Validate it's a real date
+      if (birthDate !== null) {
+        const dateObj = new Date(birthDate)
+        if (isNaN(dateObj.getTime())) {
+          return res.status(400).json({
+            error: 'Invalid birthDate. Not a valid date.',
+            success: false,
+          })
+        }
+      }
+    }
+
+    // Validate hrZoneStart if provided
+    if (hrZoneStart !== undefined && hrZoneStart !== null) {
+      const zones = [1, 2, 3, 4, 5] as const
+      const missingZones = zones.filter((z) => typeof hrZoneStart[z] !== 'number')
+      if (missingZones.length > 0) {
+        return res.status(400).json({
+          error: `hrZoneStart must have numeric values for zones 1-5. Missing: ${missingZones.join(', ')}`,
+          success: false,
+        })
+      }
+
+      // Check zones are ascending
+      for (let i = 1; i < 5; i++) {
+        const current = hrZoneStart[i as 1 | 2 | 3 | 4]
+        const next = hrZoneStart[(i + 1) as 2 | 3 | 4 | 5]
+        if (current >= next) {
+          return res.status(400).json({
+            error: `hrZoneStart zones must be in ascending order. Zone ${i} (${current}) must be less than zone ${i + 1} (${next}).`,
+            success: false,
+          })
+        }
+      }
+    }
+
+    // Build updates object
+    const updates: { birthDate?: string; hrZoneStart?: HrZoneThresholds } = {}
+    if (birthDate !== undefined) {
+      updates.birthDate = birthDate === null ? undefined : birthDate
+    }
+    if (hrZoneStart !== undefined) {
+      updates.hrZoneStart = hrZoneStart === null ? undefined : hrZoneStart
+    }
+
+    const updated = await updateSettings(user, updates)
+    const { zones, source } = await getEffectiveHrZones(user)
+
+    res.json({
+      birthDate: updated.birthDate ?? null,
+      hrZoneStart: zones,
+      hrZoneStartSource: source,
+      success: true,
+    })
   })
 
   const port = Number(process.env.PORT ?? 80)

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -41,7 +41,7 @@ import {
   queryProductivity,
   queryTags,
 } from './services/queries'
-import { getEffectiveHrZones, getSettings, HrZoneThresholds, updateSettings } from './services/settings'
+import { getSettingsResponse, validateAndUpdateSettings } from './services/settings'
 import { createSyncProvider } from './services/sync-provider'
 import { reduceTimeSeries } from './utils'
 
@@ -578,89 +578,17 @@ const main = async () => {
 
   // GET /user/settings - Get user settings with effective HR zones
   httpd.get('/user/settings', authMiddleware, async (req, res) => {
-    const user = req.user!
-
-    const settings = await getSettings(user)
-    const { zones, source } = await getEffectiveHrZones(user)
-
-    res.json({
-      birthDate: settings.birthDate ?? null,
-      hrZoneStart: zones,
-      hrZoneStartSource: source,
-      success: true,
-    })
+    const result = await getSettingsResponse(req.user!)
+    res.json(result)
   })
 
   // PATCH /user/settings - Update user settings
   httpd.patch('/user/settings', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const { birthDate, hrZoneStart } = req.body as {
-      birthDate?: string
-      hrZoneStart?: HrZoneThresholds
+    const result = await validateAndUpdateSettings(req.user!, req.body)
+    if (!result.success) {
+      return res.status(400).json(result)
     }
-
-    // Validate birthDate format (YYYY-MM-DD) if provided
-    if (birthDate !== undefined) {
-      if (birthDate !== null && !/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
-        return res.status(400).json({
-          error: 'Invalid birthDate format. Use YYYY-MM-DD format.',
-          success: false,
-        })
-      }
-      // Validate it's a real date
-      if (birthDate !== null) {
-        const dateObj = new Date(birthDate)
-        if (isNaN(dateObj.getTime())) {
-          return res.status(400).json({
-            error: 'Invalid birthDate. Not a valid date.',
-            success: false,
-          })
-        }
-      }
-    }
-
-    // Validate hrZoneStart if provided
-    if (hrZoneStart !== undefined && hrZoneStart !== null) {
-      const zones = [1, 2, 3, 4, 5] as const
-      const missingZones = zones.filter((z) => typeof hrZoneStart[z] !== 'number')
-      if (missingZones.length > 0) {
-        return res.status(400).json({
-          error: `hrZoneStart must have numeric values for zones 1-5. Missing: ${missingZones.join(', ')}`,
-          success: false,
-        })
-      }
-
-      // Check zones are ascending
-      for (let i = 1; i < 5; i++) {
-        const current = hrZoneStart[i as 1 | 2 | 3 | 4]
-        const next = hrZoneStart[(i + 1) as 2 | 3 | 4 | 5]
-        if (current >= next) {
-          return res.status(400).json({
-            error: `hrZoneStart zones must be in ascending order. Zone ${i} (${current}) must be less than zone ${i + 1} (${next}).`,
-            success: false,
-          })
-        }
-      }
-    }
-
-    // Build updates object
-    const updates: { birthDate?: string; hrZoneStart?: HrZoneThresholds } = {}
-    if (birthDate !== undefined) {
-      updates.birthDate = birthDate === null ? undefined : birthDate
-    }
-    if (hrZoneStart !== undefined) {
-      updates.hrZoneStart = hrZoneStart === null ? undefined : hrZoneStart
-    }
-
-    const updated = await updateSettings(user, updates)
-    const { zones, source } = await getEffectiveHrZones(user)
-
-    res.json({
-      birthDate: updated.birthDate ?? null,
-      hrZoneStart: zones,
-      hrZoneStartSource: source,
-      success: true,
-    })
+    res.json(result)
   })
 
   const port = Number(process.env.PORT ?? 80)

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1037,3 +1037,62 @@ export const getDailyAggregateValue = async (
   if (result.rows.length === 0) return null
   return result.rows[0].value
 }
+
+// ============================================================================
+// User Settings
+// ============================================================================
+
+export interface UserSettings {
+  birthDate?: string // YYYY-MM-DD
+  hrZoneStart?: { 1: number; 2: number; 3: number; 4: number; 5: number }
+}
+
+/**
+ * Get user settings from the database.
+ * Returns null if no settings exist.
+ */
+export const getUserSettings = async (user: string): Promise<UserSettings | null> => {
+  const result = await query(user, `SELECT settings FROM user_settings LIMIT 1`)
+
+  if (result.rows.length === 0) return null
+
+  const settings = result.rows[0].settings as Record<string, unknown>
+  return {
+    birthDate: settings.birthDate as string | undefined,
+    hrZoneStart: settings.hrZoneStart as UserSettings['hrZoneStart'],
+  }
+}
+
+/**
+ * Upsert user settings (creates or updates).
+ * Merges the provided updates with existing settings.
+ */
+export const upsertUserSettings = async (
+  user: string,
+  updates: Partial<UserSettings>,
+): Promise<UserSettings> => {
+  // Get existing settings
+  const existing = (await getUserSettings(user)) ?? {}
+
+  // Merge updates
+  const merged: UserSettings = { ...existing }
+  if (updates.birthDate !== undefined) {
+    merged.birthDate = updates.birthDate
+  }
+  if (updates.hrZoneStart !== undefined) {
+    merged.hrZoneStart = updates.hrZoneStart
+  }
+
+  // Check if settings row exists
+  const existingRow = await query(user, `SELECT id FROM user_settings LIMIT 1`)
+
+  if (existingRow.rows.length === 0) {
+    // Insert new row
+    await query(user, `INSERT INTO user_settings (settings) VALUES ($1)`, [merged])
+  } else {
+    // Update existing row
+    await query(user, `UPDATE user_settings SET settings = $1, updated_at = NOW()`, [merged])
+  }
+
+  return merged
+}

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -11,7 +11,7 @@ import { syncRescueTimeData } from './rescuetime-sync'
 import { isValidMetric, MetricType, validMetrics } from './schema'
 import { addMetric, addTag, deleteTag } from './services/mutations'
 import { getDailySummary, getPeriodSummary, queryMetrics, SyncProvider } from './services/queries'
-import { getEffectiveHrZones, getSettings, HrZoneThresholds, updateSettings } from './services/settings'
+import { getSettingsResponse, validateAndUpdateSettings } from './services/settings'
 
 interface McpSession {
   transport: StreamableHTTPServerTransport
@@ -406,25 +406,9 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       'Get user settings including birth date and effective HR zones. HR zones are used to calculate time spent in different heart rate zones during exercise.',
       {},
       async () => {
-        const settings = await getSettings(user)
-        const { zones, source } = await getEffectiveHrZones(user)
-
+        const result = await getSettingsResponse(user)
         return {
-          content: [
-            {
-              text: JSON.stringify(
-                {
-                  birthDate: settings.birthDate ?? null,
-                  hrZoneStart: zones,
-                  hrZoneStartSource: source,
-                  success: true,
-                },
-                null,
-                2,
-              ),
-              type: 'text' as const,
-            },
-          ],
+          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
         }
       },
     )
@@ -452,68 +436,13 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           .describe('Custom HR zone start thresholds. Values must be ascending. Set to null to clear.'),
       },
       async ({ birth_date, hr_zone_start }) => {
-        // Validate birthDate format if provided
-        if (birth_date !== undefined && birth_date !== null) {
-          if (!/^\d{4}-\d{2}-\d{2}$/.test(birth_date)) {
-            return {
-              content: [{ text: 'Invalid birth_date format. Use YYYY-MM-DD format.', type: 'text' as const }],
-            }
-          }
-          const dateObj = new Date(birth_date)
-          if (isNaN(dateObj.getTime())) {
-            return {
-              content: [{ text: 'Invalid birth_date. Not a valid date.', type: 'text' as const }],
-            }
-          }
-        }
-
-        // Validate HR zones are ascending if provided
-        if (hr_zone_start !== undefined && hr_zone_start !== null) {
-          const hrZones = hr_zone_start as HrZoneThresholds
-          for (let i = 1; i < 5; i++) {
-            const current = hrZones[i as 1 | 2 | 3 | 4]
-            const next = hrZones[(i + 1) as 2 | 3 | 4 | 5]
-            if (current >= next) {
-              return {
-                content: [
-                  {
-                    text: `HR zone thresholds must be ascending. Zone ${i} (${current}) must be less than zone ${i + 1} (${next}).`,
-                    type: 'text' as const,
-                  },
-                ],
-              }
-            }
-          }
-        }
-
-        // Build updates
-        const updates: { birthDate?: string; hrZoneStart?: HrZoneThresholds } = {}
-        if (birth_date !== undefined) {
-          updates.birthDate = birth_date === null ? undefined : birth_date
-        }
-        if (hr_zone_start !== undefined) {
-          updates.hrZoneStart = hr_zone_start === null ? undefined : (hr_zone_start as HrZoneThresholds)
-        }
-
-        const updated = await updateSettings(user, updates)
-        const { zones, source } = await getEffectiveHrZones(user)
-
+        // Transform snake_case MCP params to camelCase for service
+        const result = await validateAndUpdateSettings(user, {
+          birthDate: birth_date,
+          hrZoneStart: hr_zone_start,
+        })
         return {
-          content: [
-            {
-              text: JSON.stringify(
-                {
-                  birthDate: updated.birthDate ?? null,
-                  hrZoneStart: zones,
-                  hrZoneStartSource: source,
-                  success: true,
-                },
-                null,
-                2,
-              ),
-              type: 'text' as const,
-            },
-          ],
+          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
         }
       },
     )

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -11,6 +11,7 @@ import { syncRescueTimeData } from './rescuetime-sync'
 import { isValidMetric, MetricType, validMetrics } from './schema'
 import { addMetric, addTag, deleteTag } from './services/mutations'
 import { getDailySummary, getPeriodSummary, queryMetrics, SyncProvider } from './services/queries'
+import { getEffectiveHrZones, getSettings, HrZoneThresholds, updateSettings } from './services/settings'
 
 interface McpSession {
   transport: StreamableHTTPServerTransport
@@ -395,6 +396,124 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
 
         return {
           content: [{ text: JSON.stringify(summary, null, 2), type: 'text' as const }],
+        }
+      },
+    )
+
+    // Tool 9: get_user_settings
+    server.tool(
+      'get_user_settings',
+      'Get user settings including birth date and effective HR zones. HR zones are used to calculate time spent in different heart rate zones during exercise.',
+      {},
+      async () => {
+        const settings = await getSettings(user)
+        const { zones, source } = await getEffectiveHrZones(user)
+
+        return {
+          content: [
+            {
+              text: JSON.stringify(
+                {
+                  birthDate: settings.birthDate ?? null,
+                  hrZoneStart: zones,
+                  hrZoneStartSource: source,
+                  success: true,
+                },
+                null,
+                2,
+              ),
+              type: 'text' as const,
+            },
+          ],
+        }
+      },
+    )
+
+    // Tool 10: update_user_settings
+    server.tool(
+      'update_user_settings',
+      'Update user settings. Can set birth date (for age-based HR zones) and/or custom HR zone thresholds.',
+      {
+        birth_date: z
+          .string()
+          .nullable()
+          .optional()
+          .describe('Birth date in YYYY-MM-DD format. Set to null to clear.'),
+        hr_zone_start: z
+          .object({
+            1: z.number().describe('Zone 1 threshold (bpm)'),
+            2: z.number().describe('Zone 2 threshold (bpm)'),
+            3: z.number().describe('Zone 3 threshold (bpm)'),
+            4: z.number().describe('Zone 4 threshold (bpm)'),
+            5: z.number().describe('Zone 5 threshold (bpm)'),
+          })
+          .nullable()
+          .optional()
+          .describe('Custom HR zone start thresholds. Values must be ascending. Set to null to clear.'),
+      },
+      async ({ birth_date, hr_zone_start }) => {
+        // Validate birthDate format if provided
+        if (birth_date !== undefined && birth_date !== null) {
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(birth_date)) {
+            return {
+              content: [{ text: 'Invalid birth_date format. Use YYYY-MM-DD format.', type: 'text' as const }],
+            }
+          }
+          const dateObj = new Date(birth_date)
+          if (isNaN(dateObj.getTime())) {
+            return {
+              content: [{ text: 'Invalid birth_date. Not a valid date.', type: 'text' as const }],
+            }
+          }
+        }
+
+        // Validate HR zones are ascending if provided
+        if (hr_zone_start !== undefined && hr_zone_start !== null) {
+          const hrZones = hr_zone_start as HrZoneThresholds
+          for (let i = 1; i < 5; i++) {
+            const current = hrZones[i as 1 | 2 | 3 | 4]
+            const next = hrZones[(i + 1) as 2 | 3 | 4 | 5]
+            if (current >= next) {
+              return {
+                content: [
+                  {
+                    text: `HR zone thresholds must be ascending. Zone ${i} (${current}) must be less than zone ${i + 1} (${next}).`,
+                    type: 'text' as const,
+                  },
+                ],
+              }
+            }
+          }
+        }
+
+        // Build updates
+        const updates: { birthDate?: string; hrZoneStart?: HrZoneThresholds } = {}
+        if (birth_date !== undefined) {
+          updates.birthDate = birth_date === null ? undefined : birth_date
+        }
+        if (hr_zone_start !== undefined) {
+          updates.hrZoneStart = hr_zone_start === null ? undefined : (hr_zone_start as HrZoneThresholds)
+        }
+
+        const updated = await updateSettings(user, updates)
+        const { zones, source } = await getEffectiveHrZones(user)
+
+        return {
+          content: [
+            {
+              text: JSON.stringify(
+                {
+                  birthDate: updated.birthDate ?? null,
+                  hrZoneStart: zones,
+                  hrZoneStartSource: source,
+                  success: true,
+                },
+                null,
+                2,
+              ),
+              type: 'text' as const,
+            },
+          ],
         }
       },
     )

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -197,6 +197,16 @@ export const createTableStatements: Record<string, string> = {
   time_series_indexes: `
     CREATE INDEX IF NOT EXISTS idx_time_series_metric_time ON time_series (metric, time DESC)
   `,
+
+  // User settings (HR zones, birth date, etc.)
+  user_settings: `
+    CREATE TABLE IF NOT EXISTS user_settings (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      settings        JSONB NOT NULL DEFAULT '{}',
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
 }
 
 /**
@@ -221,6 +231,7 @@ export const tableCreationOrder = [
   'lab_results_indexes',
   'oauth_tokens',
   'sync_state',
+  'user_settings',
 ]
 
 /**

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -15,6 +15,7 @@ vi.mock('../db', () => ({
   getTimeSeries: vi.fn(),
   getTimeSeriesMultiMetric: vi.fn(),
   getTimeSeriesStats: vi.fn(),
+  getUserSettings: vi.fn(),
 }))
 
 describe('queryMetrics', () => {
@@ -62,6 +63,8 @@ describe('queryMetrics', () => {
 describe('getDailySummary', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default mock for getUserSettings - returns null so default HR zones are used
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
   })
 
   test('aggregates all data sources for a day', async () => {

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -308,6 +308,138 @@ describe('getDailySummary', () => {
       sleepScore: 92,
     })
   })
+
+  test('computes hrZoneSecs for exercise sessions with HR data', async () => {
+    // First call: daily heart rate, second call: daily steps, third call: exercise session HR
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([]) // daily heart_rate
+      .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([
+        // exercise session HR data - in zone 1 (90-107 with default zones)
+        [new Date('2024-01-15T10:00:00Z'), 95],
+        [new Date('2024-01-15T10:00:02Z'), 100],
+        [new Date('2024-01-15T10:00:04Z'), 98],
+      ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T10:30:00Z'),
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+    ])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.exerciseSessions).toHaveLength(1)
+    expect(result.exerciseSessions[0].hrZoneSecs).toBeDefined()
+    // All HR values (95, 100, 98) are in zone 1 (90-107 with default zones)
+    expect(result.exerciseSessions[0].hrZoneSecs![1]).toBeGreaterThan(0)
+  })
+
+  test('does not include hrZoneSecs when exercise has no HR data', async () => {
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([]) // daily heart_rate
+      .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([]) // exercise session HR data - empty
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T10:30:00Z'),
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+    ])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.exerciseSessions).toHaveLength(1)
+    expect(result.exerciseSessions[0].hrZoneSecs).toBeUndefined()
+  })
+
+  test('uses custom HR zones from user settings', async () => {
+    // Custom zones: zone 1 starts at 80 (lower than default 90)
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      hrZoneStart: { 1: 80, 2: 100, 3: 120, 4: 140, 5: 160 },
+    })
+
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([]) // daily heart_rate
+      .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([
+        // HR at 85 - would be zone 0 with defaults (90), but zone 1 with custom (80)
+        [new Date('2024-01-15T10:00:00Z'), 85],
+        [new Date('2024-01-15T10:00:02Z'), 85],
+      ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T10:30:00Z'),
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Walking',
+      },
+    ])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.exerciseSessions[0].hrZoneSecs).toBeDefined()
+    // With custom zones (zone 1 starts at 80), HR of 85 is in zone 1
+    expect(result.exerciseSessions[0].hrZoneSecs![1]).toBeGreaterThan(0)
+    expect(result.exerciseSessions[0].hrZoneSecs![0]).toBe(0)
+  })
+
+  test('does not compute hrZoneSecs for exercise without endTime', async () => {
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([]) // daily heart_rate
+      .mockResolvedValueOnce([]) // daily steps
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activityType: 'exercise',
+        // No endTime - ongoing session
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+    ])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.exerciseSessions).toHaveLength(1)
+    expect(result.exerciseSessions[0].hrZoneSecs).toBeUndefined()
+    // Should not have called getTimeSeries for the exercise session
+    expect(db.getTimeSeries).toHaveBeenCalledTimes(2) // Only daily HR and steps
+  })
 })
 
 describe('getPeriodSummary', () => {

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -18,6 +18,7 @@ import {
   getTimeSeriesStats,
 } from '../db'
 import { ActivityType, MetricType, metricUnits } from '../schema'
+import { computeHrZoneSecs, getEffectiveHrZones, HrZoneSecs } from './settings'
 
 // ============================================================================
 // Types
@@ -59,6 +60,7 @@ export interface SessionSummary {
   duration?: number // minutes
   title?: string
   data?: Record<string, unknown>
+  hrZoneSecs?: HrZoneSecs
 }
 
 export interface TagSummary {
@@ -250,15 +252,36 @@ export async function getDailySummary(
       }
     : null
 
+  // Get user's HR zones for exercise session HR zone calculation
+  const { zones: hrZones } = await getEffectiveHrZones(user)
+
+  // Compute HR zones for exercise sessions
+  const exerciseSessionsWithHrZones: SessionSummary[] = await Promise.all(
+    exerciseSessions.map(async (s) => {
+      const sessionSummary: SessionSummary = {
+        data: s.data,
+        duration:
+          s.endTime ? Math.round((s.endTime.getTime() - s.startTime.getTime()) / 1000 / 60) : undefined,
+        endTime: s.endTime?.toISOString(),
+        startTime: s.startTime.toISOString(),
+        title: s.title,
+      }
+
+      // Only compute HR zones for sessions with end time
+      if (s.endTime) {
+        const sessionHrData = await getTimeSeries(user, 'heart_rate', s.startTime, s.endTime)
+        if (sessionHrData.length > 0) {
+          sessionSummary.hrZoneSecs = computeHrZoneSecs(sessionHrData, hrZones)
+        }
+      }
+
+      return sessionSummary
+    }),
+  )
+
   return {
     date: date.toISOString().split('T')[0],
-    exerciseSessions: exerciseSessions.map((s) => ({
-      data: s.data,
-      duration: s.endTime ? Math.round((s.endTime.getTime() - s.startTime.getTime()) / 1000 / 60) : undefined,
-      endTime: s.endTime?.toISOString(),
-      startTime: s.startTime.toISOString(),
-      title: s.title,
-    })),
+    exerciseSessions: exerciseSessionsWithHrZones,
     heartRate: heartRateStats,
     ouraScores,
     places: locations.places.map((p) => ({
@@ -426,6 +449,7 @@ export interface ActivityResult {
   title?: string
   source: string
   data?: Record<string, unknown>
+  hrZoneSecs?: HrZoneSecs
 }
 
 /**
@@ -445,15 +469,35 @@ export async function queryActivities(
   }
 
   const activities = await getActivities(user, types, start, end)
-  return activities.map((a) => ({
-    activityType: a.activityType,
-    data: a.data,
-    duration: a.endTime ? Math.round((a.endTime.getTime() - a.startTime.getTime()) / 1000 / 60) : undefined,
-    endTime: a.endTime?.toISOString(),
-    source: a.source,
-    startTime: a.startTime.toISOString(),
-    title: a.title,
-  }))
+
+  // Get HR zones only if exercise activities are included
+  const includesExercise = types.includes('exercise')
+  const hrZones = includesExercise ? (await getEffectiveHrZones(user)).zones : null
+
+  return Promise.all(
+    activities.map(async (a) => {
+      const result: ActivityResult = {
+        activityType: a.activityType,
+        data: a.data,
+        duration:
+          a.endTime ? Math.round((a.endTime.getTime() - a.startTime.getTime()) / 1000 / 60) : undefined,
+        endTime: a.endTime?.toISOString(),
+        source: a.source,
+        startTime: a.startTime.toISOString(),
+        title: a.title,
+      }
+
+      // Compute HR zones for exercise activities with end time
+      if (hrZones && a.activityType === 'exercise' && a.endTime) {
+        const hrData = await getTimeSeries(user, 'heart_rate', a.startTime, a.endTime)
+        if (hrData.length > 0) {
+          result.hrZoneSecs = computeHrZoneSecs(hrData, hrZones)
+        }
+      }
+
+      return result
+    }),
+  )
 }
 
 /**

--- a/apps/backend/src/services/settings.test.ts
+++ b/apps/backend/src/services/settings.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import * as db from '../db'
+import {
+  calculateDefaultHrZones,
+  computeHrZoneSecs,
+  getEffectiveHrZones,
+  getSettings,
+  HrZoneThresholds,
+  updateSettings,
+} from './settings'
+
+// Mock the db module
+vi.mock('../db', () => ({
+  getUserSettings: vi.fn(),
+  upsertUserSettings: vi.fn(),
+}))
+
+describe('calculateDefaultHrZones', () => {
+  test('returns default zones when no birth date provided', () => {
+    const zones = calculateDefaultHrZones(null)
+
+    // Default max HR of 180 (age 40 assumed)
+    // Zones at 50%, 60%, 70%, 80%, 90% of max HR
+    expect(zones).toEqual({
+      1: 90, // 50% of 180
+      2: 108, // 60% of 180
+      3: 126, // 70% of 180
+      4: 144, // 80% of 180
+      5: 162, // 90% of 180
+    })
+  })
+
+  test('calculates age-based zones from birth date', () => {
+    // Person born 1985-03-15, age ~39-40 in 2025
+    // Max HR = 220 - 40 = 180 (approximately)
+    const zones = calculateDefaultHrZones('1985-03-15')
+
+    // Max HR should be 220 - age
+    // For someone ~40 years old: max HR = 180
+    expect(zones[1]).toBeLessThan(zones[2])
+    expect(zones[2]).toBeLessThan(zones[3])
+    expect(zones[3]).toBeLessThan(zones[4])
+    expect(zones[4]).toBeLessThan(zones[5])
+  })
+
+  test('calculates zones for younger person', () => {
+    // Person born 2000-01-01, age ~25
+    // Max HR = 220 - 25 = 195
+    const zones = calculateDefaultHrZones('2000-01-01')
+
+    // Zones should be higher than for older person
+    const olderZones = calculateDefaultHrZones('1970-01-01')
+    expect(zones[1]).toBeGreaterThan(olderZones[1])
+  })
+
+  test('zones are rounded to whole numbers', () => {
+    const zones = calculateDefaultHrZones('1990-06-15')
+
+    expect(Number.isInteger(zones[1])).toBe(true)
+    expect(Number.isInteger(zones[2])).toBe(true)
+    expect(Number.isInteger(zones[3])).toBe(true)
+    expect(Number.isInteger(zones[4])).toBe(true)
+    expect(Number.isInteger(zones[5])).toBe(true)
+  })
+})
+
+describe('getSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns empty settings when none exist', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    const settings = await getSettings('testuser')
+
+    expect(settings).toEqual({})
+    expect(db.getUserSettings).toHaveBeenCalledWith('testuser')
+  })
+
+  test('returns stored settings', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      birthDate: '1985-03-15',
+      hrZoneStart: { 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 },
+    })
+
+    const settings = await getSettings('testuser')
+
+    expect(settings.birthDate).toBe('1985-03-15')
+    expect(settings.hrZoneStart).toEqual({ 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 })
+  })
+})
+
+describe('updateSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('updates birth date', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue({})
+    vi.mocked(db.upsertUserSettings).mockResolvedValue({
+      birthDate: '1985-03-15',
+    })
+
+    const result = await updateSettings('testuser', { birthDate: '1985-03-15' })
+
+    expect(result.birthDate).toBe('1985-03-15')
+    expect(db.upsertUserSettings).toHaveBeenCalledWith('testuser', { birthDate: '1985-03-15' })
+  })
+
+  test('updates HR zones', async () => {
+    const hrZones: HrZoneThresholds = { 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 }
+    vi.mocked(db.getUserSettings).mockResolvedValue({})
+    vi.mocked(db.upsertUserSettings).mockResolvedValue({ hrZoneStart: hrZones })
+
+    const result = await updateSettings('testuser', { hrZoneStart: hrZones })
+
+    expect(result.hrZoneStart).toEqual(hrZones)
+  })
+})
+
+describe('getEffectiveHrZones', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns custom zones when configured', async () => {
+    const customZones: HrZoneThresholds = { 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 }
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      birthDate: '1985-03-15',
+      hrZoneStart: customZones,
+    })
+
+    const { zones, source } = await getEffectiveHrZones('testuser')
+
+    expect(zones).toEqual(customZones)
+    expect(source).toBe('custom')
+  })
+
+  test('returns age-based zones when birth date set but no custom zones', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      birthDate: '1985-03-15',
+    })
+
+    const { zones, source } = await getEffectiveHrZones('testuser')
+
+    expect(source).toBe('age_based')
+    // Zones should be calculated from birth date
+    expect(zones[1]).toBeLessThan(zones[2])
+  })
+
+  test('returns default zones when no settings configured', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    const { zones, source } = await getEffectiveHrZones('testuser')
+
+    expect(source).toBe('default')
+    expect(zones).toEqual({
+      1: 90,
+      2: 108,
+      3: 126,
+      4: 144,
+      5: 162,
+    })
+  })
+})
+
+describe('computeHrZoneSecs', () => {
+  const defaultZones: HrZoneThresholds = {
+    1: 90, // Zone 1: 90-107
+    2: 108, // Zone 2: 108-125
+    3: 126, // Zone 3: 126-143
+    4: 144, // Zone 4: 144-161
+    5: 162, // Zone 5: 162+
+  }
+
+  test('returns all zeros for empty data', () => {
+    const result = computeHrZoneSecs([], defaultZones)
+
+    expect(result).toEqual({ 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 })
+  })
+
+  test('correctly buckets HR into zone 0 (below zone 1)', () => {
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 80],
+      [new Date('2024-01-15T10:00:02Z'), 85],
+    ]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    // 2 seconds between samples, plus some time for the last sample
+    expect(result[0]).toBeGreaterThan(0)
+    expect(result[1]).toBe(0)
+    expect(result[2]).toBe(0)
+  })
+
+  test('correctly buckets HR into zone 1', () => {
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 95],
+      [new Date('2024-01-15T10:00:02Z'), 100],
+    ]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    expect(result[0]).toBe(0)
+    expect(result[1]).toBeGreaterThan(0)
+  })
+
+  test('correctly buckets HR into zone 5', () => {
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 175],
+      [new Date('2024-01-15T10:00:02Z'), 180],
+    ]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    expect(result[5]).toBeGreaterThan(0)
+  })
+
+  test('caps time gap at 5 seconds', () => {
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 95],
+      [new Date('2024-01-15T10:00:30Z'), 100], // 30 second gap
+    ]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    // Total should be capped at 5 + last sample time (uses mean gap which is 5)
+    const total = Object.values(result).reduce((a, b) => a + b, 0)
+    expect(total).toBeLessThanOrEqual(10) // 5 sec + 5 sec max for last sample
+  })
+
+  test('handles mixed zones correctly', () => {
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 80], // Zone 0
+      [new Date('2024-01-15T10:00:02Z'), 95], // Zone 1
+      [new Date('2024-01-15T10:00:04Z'), 110], // Zone 2
+      [new Date('2024-01-15T10:00:06Z'), 130], // Zone 3
+      [new Date('2024-01-15T10:00:08Z'), 150], // Zone 4
+      [new Date('2024-01-15T10:00:10Z'), 170], // Zone 5
+    ]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    // Each sample should have 2 seconds
+    expect(result[0]).toBe(2)
+    expect(result[1]).toBe(2)
+    expect(result[2]).toBe(2)
+    expect(result[3]).toBe(2)
+    expect(result[4]).toBe(2)
+    expect(result[5]).toBeGreaterThan(0) // Last sample uses mean gap
+  })
+
+  test('uses mean gap time for last sample', () => {
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 95],
+      [new Date('2024-01-15T10:00:02Z'), 95],
+      [new Date('2024-01-15T10:00:04Z'), 95],
+      [new Date('2024-01-15T10:00:06Z'), 95], // Last sample
+    ]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    // 3 gaps of 2 seconds = 6 seconds, plus mean gap (2 seconds) for last sample = 8 total
+    expect(result[1]).toBe(8)
+  })
+
+  test('single sample gets default time', () => {
+    const hrData: [Date, number][] = [[new Date('2024-01-15T10:00:00Z'), 95]]
+
+    const result = computeHrZoneSecs(hrData, defaultZones)
+
+    // Single sample gets 1 second default
+    expect(result[1]).toBe(1)
+  })
+
+  test('boundary values are handled correctly', () => {
+    const zones: HrZoneThresholds = { 1: 100, 2: 120, 3: 140, 4: 160, 5: 180 }
+
+    // Test exact boundary values
+    const hrData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 99], // Zone 0 (below 100)
+      [new Date('2024-01-15T10:00:02Z'), 100], // Zone 1 (>= 100)
+      [new Date('2024-01-15T10:00:04Z'), 119], // Zone 1 (< 120)
+      [new Date('2024-01-15T10:00:06Z'), 120], // Zone 2 (>= 120)
+    ]
+
+    const result = computeHrZoneSecs(hrData, zones)
+
+    expect(result[0]).toBe(2) // First sample below zone 1
+    expect(result[1]).toBe(4) // Two samples in zone 1
+  })
+})

--- a/apps/backend/src/services/settings.test.ts
+++ b/apps/backend/src/services/settings.test.ts
@@ -5,8 +5,9 @@ import {
   computeHrZoneSecs,
   getEffectiveHrZones,
   getSettings,
+  getSettingsResponse,
   HrZoneThresholds,
-  updateSettings,
+  validateAndUpdateSettings,
 } from './settings'
 
 // Mock the db module
@@ -91,31 +92,115 @@ describe('getSettings', () => {
   })
 })
 
-describe('updateSettings', () => {
+describe('getSettingsResponse', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  test('updates birth date', async () => {
-    vi.mocked(db.getUserSettings).mockResolvedValue({})
-    vi.mocked(db.upsertUserSettings).mockResolvedValue({
+  test('returns formatted response with defaults when no settings', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    const result = await getSettingsResponse('testuser')
+
+    expect(result.success).toBe(true)
+    expect(result.birthDate).toBeNull()
+    expect(result.hrZoneStartSource).toBe('default')
+    expect(result.hrZoneStart).toEqual({ 1: 90, 2: 108, 3: 126, 4: 144, 5: 162 })
+  })
+
+  test('returns formatted response with custom zones', async () => {
+    const customZones: HrZoneThresholds = { 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 }
+    vi.mocked(db.getUserSettings).mockResolvedValue({
       birthDate: '1985-03-15',
+      hrZoneStart: customZones,
     })
 
-    const result = await updateSettings('testuser', { birthDate: '1985-03-15' })
+    const result = await getSettingsResponse('testuser')
 
+    expect(result.success).toBe(true)
+    expect(result.birthDate).toBe('1985-03-15')
+    expect(result.hrZoneStartSource).toBe('custom')
+    expect(result.hrZoneStart).toEqual(customZones)
+  })
+})
+
+describe('validateAndUpdateSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('updates birth date with valid input', async () => {
+    // getSettingsResponse calls getSettings + getEffectiveHrZones, each calls getUserSettings
+    // So we need 2 mock returns for getSettingsResponse
+    vi.mocked(db.getUserSettings)
+      .mockResolvedValueOnce({ birthDate: '1985-03-15' }) // for getSettings in getSettingsResponse
+      .mockResolvedValueOnce({ birthDate: '1985-03-15' }) // for getEffectiveHrZones in getSettingsResponse
+    vi.mocked(db.upsertUserSettings).mockResolvedValue({ birthDate: '1985-03-15' })
+
+    const result = await validateAndUpdateSettings('testuser', { birthDate: '1985-03-15' })
+
+    expect(result.success).toBe(true)
     expect(result.birthDate).toBe('1985-03-15')
     expect(db.upsertUserSettings).toHaveBeenCalledWith('testuser', { birthDate: '1985-03-15' })
   })
 
-  test('updates HR zones', async () => {
+  test('updates HR zones with valid input', async () => {
     const hrZones: HrZoneThresholds = { 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 }
-    vi.mocked(db.getUserSettings).mockResolvedValue({})
+    // After update, getUserSettings returns the new zones
+    vi.mocked(db.getUserSettings).mockResolvedValue({ hrZoneStart: hrZones })
     vi.mocked(db.upsertUserSettings).mockResolvedValue({ hrZoneStart: hrZones })
 
-    const result = await updateSettings('testuser', { hrZoneStart: hrZones })
+    const result = await validateAndUpdateSettings('testuser', { hrZoneStart: hrZones })
 
-    expect(result.hrZoneStart).toEqual(hrZones)
+    expect(result.success).toBe(true)
+    expect(result.hrZoneStartSource).toBe('custom')
+  })
+
+  test('rejects invalid birth date format', async () => {
+    const result = await validateAndUpdateSettings('testuser', { birthDate: '15-03-1985' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('YYYY-MM-DD')
+    expect(db.upsertUserSettings).not.toHaveBeenCalled()
+  })
+
+  test('rejects invalid date', async () => {
+    const result = await validateAndUpdateSettings('testuser', { birthDate: '2024-13-45' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(db.upsertUserSettings).not.toHaveBeenCalled()
+  })
+
+  test('rejects non-ascending HR zones', async () => {
+    const result = await validateAndUpdateSettings('testuser', {
+      hrZoneStart: { 1: 100, 2: 90, 3: 120, 4: 140, 5: 160 }, // zone 2 < zone 1
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('ascending')
+    expect(db.upsertUserSettings).not.toHaveBeenCalled()
+  })
+
+  test('clears birth date when set to null', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue({ birthDate: '1985-03-15' })
+    vi.mocked(db.upsertUserSettings).mockResolvedValue({})
+
+    const result = await validateAndUpdateSettings('testuser', { birthDate: null })
+
+    expect(result.success).toBe(true)
+    expect(db.upsertUserSettings).toHaveBeenCalledWith('testuser', { birthDate: undefined })
+  })
+
+  test('clears HR zones when set to null', async () => {
+    const customZones: HrZoneThresholds = { 1: 86, 2: 103, 3: 121, 4: 138, 5: 155 }
+    vi.mocked(db.getUserSettings).mockResolvedValue({ hrZoneStart: customZones })
+    vi.mocked(db.upsertUserSettings).mockResolvedValue({})
+
+    const result = await validateAndUpdateSettings('testuser', { hrZoneStart: null })
+
+    expect(result.success).toBe(true)
+    expect(db.upsertUserSettings).toHaveBeenCalledWith('testuser', { hrZoneStart: undefined })
   })
 })
 

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -2,6 +2,7 @@
  * User settings service for HR zones and other user preferences.
  */
 
+import { z } from 'zod'
 import { getUserSettings, upsertUserSettings } from '../db'
 
 // ============================================================================
@@ -25,6 +26,49 @@ export interface HrZoneSecs {
 }
 
 export type HrZoneSource = 'custom' | 'age_based' | 'default'
+
+export interface SettingsResponse {
+  success: boolean
+  birthDate: string | null
+  hrZoneStart: HrZoneThresholds
+  hrZoneStartSource: HrZoneSource
+  error?: string
+}
+
+// ============================================================================
+// Zod Schemas (shared between API and MCP)
+// ============================================================================
+
+export const hrZoneThresholdsSchema = z
+  .object({
+    1: z.number().int().positive(),
+    2: z.number().int().positive(),
+    3: z.number().int().positive(),
+    4: z.number().int().positive(),
+    5: z.number().int().positive(),
+  })
+  .refine(
+    (zones) => zones[1] < zones[2] && zones[2] < zones[3] && zones[3] < zones[4] && zones[4] < zones[5],
+    { message: 'HR zone thresholds must be in ascending order' },
+  )
+
+export const birthDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Birth date must be in YYYY-MM-DD format')
+  .refine(
+    (date) => {
+      const parsed = new Date(date)
+      return !isNaN(parsed.getTime())
+    },
+    { message: 'Invalid date' },
+  )
+
+export const updateSettingsInputSchema = z.object({
+  birthDate: birthDateSchema.nullable().optional(),
+  hrZoneStart: hrZoneThresholdsSchema.nullable().optional(),
+})
+
+export type UpdateSettingsInput = z.infer<typeof updateSettingsInputSchema>
 
 // ============================================================================
 // Constants
@@ -86,9 +130,12 @@ export const getSettings = async (user: string): Promise<UserSettings> => {
 }
 
 /**
- * Update user settings (partial update).
+ * Update user settings (partial update) - internal, no validation.
  */
-export const updateSettings = async (user: string, updates: Partial<UserSettings>): Promise<UserSettings> => {
+const updateSettingsInternal = async (
+  user: string,
+  updates: Partial<UserSettings>,
+): Promise<UserSettings> => {
   return await upsertUserSettings(user, updates)
 }
 
@@ -113,6 +160,55 @@ export const getEffectiveHrZones = async (
 
   // Default zones
   return { source: 'default', zones: calculateDefaultHrZones(null) }
+}
+
+/**
+ * Get settings response in the format used by both API and MCP.
+ */
+export const getSettingsResponse = async (user: string): Promise<SettingsResponse> => {
+  const settings = await getSettings(user)
+  const { zones, source } = await getEffectiveHrZones(user)
+
+  return {
+    birthDate: settings.birthDate ?? null,
+    hrZoneStart: zones,
+    hrZoneStartSource: source,
+    success: true,
+  }
+}
+
+/**
+ * Validate and update user settings.
+ * Returns a SettingsResponse with either success or error.
+ */
+export const validateAndUpdateSettings = async (user: string, input: unknown): Promise<SettingsResponse> => {
+  // Validate input
+  const parsed = updateSettingsInputSchema.safeParse(input)
+  if (!parsed.success) {
+    const errorMessage = parsed.error.issues.map((e) => e.message).join('; ')
+    return {
+      birthDate: null,
+      error: errorMessage,
+      hrZoneStart: calculateDefaultHrZones(null),
+      hrZoneStartSource: 'default',
+      success: false,
+    }
+  }
+
+  // Build updates object, converting null to undefined for clearing
+  const updates: Partial<UserSettings> = {}
+  if (parsed.data.birthDate !== undefined) {
+    updates.birthDate = parsed.data.birthDate === null ? undefined : parsed.data.birthDate
+  }
+  if (parsed.data.hrZoneStart !== undefined) {
+    updates.hrZoneStart = parsed.data.hrZoneStart === null ? undefined : parsed.data.hrZoneStart
+  }
+
+  // Apply updates
+  await updateSettingsInternal(user, updates)
+
+  // Return updated settings
+  return getSettingsResponse(user)
 }
 
 /**

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -1,0 +1,175 @@
+/**
+ * User settings service for HR zones and other user preferences.
+ */
+
+import { getUserSettings, upsertUserSettings } from '../db'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type HrZoneThresholds = { 1: number; 2: number; 3: number; 4: number; 5: number }
+
+export interface UserSettings {
+  birthDate?: string // YYYY-MM-DD
+  hrZoneStart?: HrZoneThresholds
+}
+
+export interface HrZoneSecs {
+  0: number
+  1: number
+  2: number
+  3: number
+  4: number
+  5: number
+}
+
+export type HrZoneSource = 'custom' | 'age_based' | 'default'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_HR = 180 // Assumes age ~40
+const MAX_GAP_SECONDS = 5 // Cap time gap between samples
+const SINGLE_SAMPLE_SECONDS = 1 // Default time for single sample
+
+// Zone percentages of max HR
+const ZONE_PERCENTAGES = {
+  1: 0.5, // 50%
+  2: 0.6, // 60%
+  3: 0.7, // 70%
+  4: 0.8, // 80%
+  5: 0.9, // 90%
+}
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+/**
+ * Calculate age from birth date.
+ */
+const calculateAge = (birthDate: string): number => {
+  const birth = new Date(birthDate)
+  const today = new Date()
+  let age = today.getFullYear() - birth.getFullYear()
+  const monthDiff = today.getMonth() - birth.getMonth()
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--
+  }
+  return age
+}
+
+/**
+ * Calculate default HR zones based on birth date (age-based) or use defaults.
+ * Uses the 220-age formula for max HR, with zones at 50/60/70/80/90%.
+ */
+export const calculateDefaultHrZones = (birthDate: string | null): HrZoneThresholds => {
+  const maxHr = birthDate ? 220 - calculateAge(birthDate) : DEFAULT_MAX_HR
+
+  return {
+    1: Math.round(maxHr * ZONE_PERCENTAGES[1]),
+    2: Math.round(maxHr * ZONE_PERCENTAGES[2]),
+    3: Math.round(maxHr * ZONE_PERCENTAGES[3]),
+    4: Math.round(maxHr * ZONE_PERCENTAGES[4]),
+    5: Math.round(maxHr * ZONE_PERCENTAGES[5]),
+  }
+}
+
+/**
+ * Get user settings from database.
+ */
+export const getSettings = async (user: string): Promise<UserSettings> => {
+  const settings = await getUserSettings(user)
+  return settings ?? {}
+}
+
+/**
+ * Update user settings (partial update).
+ */
+export const updateSettings = async (user: string, updates: Partial<UserSettings>): Promise<UserSettings> => {
+  return await upsertUserSettings(user, updates)
+}
+
+/**
+ * Get effective HR zones for a user.
+ * Priority: custom zones > age-based zones (from birth date) > default zones
+ */
+export const getEffectiveHrZones = async (
+  user: string,
+): Promise<{ zones: HrZoneThresholds; source: HrZoneSource }> => {
+  const settings = await getSettings(user)
+
+  // Custom zones take priority
+  if (settings.hrZoneStart) {
+    return { source: 'custom', zones: settings.hrZoneStart }
+  }
+
+  // Age-based zones if birth date is set
+  if (settings.birthDate) {
+    return { source: 'age_based', zones: calculateDefaultHrZones(settings.birthDate) }
+  }
+
+  // Default zones
+  return { source: 'default', zones: calculateDefaultHrZones(null) }
+}
+
+/**
+ * Determine which zone a heart rate value belongs to.
+ * Zone 0: below zone 1 threshold
+ * Zone 1-4: between zone N and zone N+1 threshold
+ * Zone 5: at or above zone 5 threshold
+ */
+const getZone = (hr: number, zones: HrZoneThresholds): 0 | 1 | 2 | 3 | 4 | 5 => {
+  if (hr >= zones[5]) return 5
+  if (hr >= zones[4]) return 4
+  if (hr >= zones[3]) return 3
+  if (hr >= zones[2]) return 2
+  if (hr >= zones[1]) return 1
+  return 0
+}
+
+/**
+ * Compute time spent in each HR zone from heart rate data.
+ * Uses actual time gaps between consecutive samples, capped at MAX_GAP_SECONDS.
+ * Last sample uses mean gap time from preceding samples.
+ */
+export const computeHrZoneSecs = (hrData: [Date, number][], zones: HrZoneThresholds): HrZoneSecs => {
+  const result: HrZoneSecs = { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+
+  if (hrData.length === 0) {
+    return result
+  }
+
+  // Single sample case
+  if (hrData.length === 1) {
+    const zone = getZone(hrData[0][1], zones)
+    result[zone] = SINGLE_SAMPLE_SECONDS
+    return result
+  }
+
+  // Calculate gaps and track for mean calculation
+  const gaps: number[] = []
+
+  for (let i = 0; i < hrData.length - 1; i++) {
+    const [time, hr] = hrData[i]
+    const nextTime = hrData[i + 1][0]
+
+    // Calculate gap in seconds, capped at MAX_GAP_SECONDS
+    const gapMs = nextTime.getTime() - time.getTime()
+    const gapSec = Math.min(gapMs / 1000, MAX_GAP_SECONDS)
+    gaps.push(gapSec)
+
+    // Add time to appropriate zone
+    const zone = getZone(hr, zones)
+    result[zone] += gapSec
+  }
+
+  // Handle last sample using mean gap time
+  const meanGap = gaps.reduce((a, b) => a + b, 0) / gaps.length
+  const lastZone = getZone(hrData[hrData.length - 1][1], zones)
+  result[lastZone] += Math.min(meanGap, MAX_GAP_SECONDS)
+
+  return result
+}


### PR DESCRIPTION
## Summary

- Add user settings storage for birth date and custom HR zone thresholds
- Implement HR zone calculation with priority: custom > age-based (220-age) > defaults
- Add `hrZoneSecs` to exercise sessions showing time spent in each zone
- Add REST API endpoints (`GET/PATCH /user/settings`) and MCP tools for settings management

## Test plan

- [x] All 169 unit tests pass (including 20 new tests for settings service)
- [ ] Test REST API manually:
  - `GET /user/settings` returns defaults
  - `PATCH /user/settings` with `{ "birthDate": "1985-03-15" }` returns age-based zones
  - `PATCH /user/settings` with custom `hrZoneStart` returns custom zones
- [ ] Test `GET /daily-summary` includes `hrZoneSecs` for exercise sessions
- [ ] Test MCP tools via Claude Code connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)