### PR TITLE
Add HR zone time metrics to period summary

### DIFF
--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -221,6 +221,8 @@ export const getTimeSeriesStats = async (
   start: Date,
   end: Date,
 ): Promise<MetricStats[]> => {
+  if (metrics.length === 0) return []
+
   const result = await query(
     user,
     `SELECT
@@ -261,6 +263,8 @@ export const getDailyAggregates = async (
   start: Date,
   end: Date,
 ): Promise<DailyMetricAggregate[]> => {
+  if (metrics.length === 0) return []
+
   const result = await query(
     user,
     `SELECT

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -247,65 +247,9 @@ export type DataSource =
   | 'manual'
 
 /**
- * Metric types for time_series table.
- */
-export type MetricType =
-  | 'heart_rate'
-  | 'resting_heart_rate'
-  | 'hrv_rmssd'
-  | 'weight'
-  | 'body_fat'
-  | 'bone_mass'
-  | 'lean_body_mass'
-  | 'body_water_mass'
-  | 'height'
-  | 'steps'
-  | 'distance'
-  | 'floors_climbed'
-  | 'calories_active'
-  | 'calories_total'
-  | 'calories_basal'
-  | 'spo2'
-  | 'respiratory_rate'
-  | 'body_temperature'
-  | 'basal_body_temperature'
-  | 'blood_glucose'
-  | 'blood_pressure_systolic'
-  | 'blood_pressure_diastolic'
-  | 'vo2_max'
-  | 'readiness_score'
-  | 'resilience_score'
-  | 'productivity_score'
-  | 'cardiovascular_age'
-  | 'sleep_score'
-  // Oura sleep contributors (0-100 scores)
-  | 'sleep_efficiency'
-  | 'sleep_latency'
-  | 'sleep_restfulness'
-  | 'sleep_timing'
-  | 'sleep_deep_score'
-  | 'sleep_rem_score'
-  | 'sleep_total_score'
-  // HR zone time (computed from heart_rate data)
-  | 'hr_zone_0_sec'
-  | 'hr_zone_1_sec'
-  | 'hr_zone_2_sec'
-  | 'hr_zone_3_sec'
-  | 'hr_zone_4_sec'
-  | 'hr_zone_5_sec'
-
-/**
- * Activity types for activities table.
- */
-export type ActivityType = 'sleep' | 'exercise' | 'meditation' | 'nap'
-
-/**
- * Unit definitions for metrics.
- */
-/**
  * List of all valid metric types.
  */
-export const validMetrics: MetricType[] = [
+export const validMetrics = [
   'heart_rate',
   'resting_heart_rate',
   'hrv_rmssd',
@@ -334,7 +278,7 @@ export const validMetrics: MetricType[] = [
   'productivity_score',
   'cardiovascular_age',
   'sleep_score',
-  // Oura sleep contributors
+  // Oura sleep contributors (0-100 scores)
   'sleep_efficiency',
   'sleep_latency',
   'sleep_restfulness',
@@ -349,32 +293,42 @@ export const validMetrics: MetricType[] = [
   'hr_zone_3_sec',
   'hr_zone_4_sec',
   'hr_zone_5_sec',
-]
+] as const
+
+/**
+ * Metric types for time_series table, derived from validMetrics.
+ */
+export type MetricType = (typeof validMetrics)[number]
+
+/**
+ * Activity types for activities table.
+ */
+export type ActivityType = 'sleep' | 'exercise' | 'meditation' | 'nap'
 
 /**
  * Check if a string is a valid metric type.
  */
 export function isValidMetric(metric: string): metric is MetricType {
-  return validMetrics.includes(metric as MetricType)
+  return (validMetrics as readonly string[]).includes(metric)
 }
 
 /**
  * HR zone metrics are computed from heart_rate data, not stored directly.
  */
-export const hrZoneMetrics: MetricType[] = [
+export const hrZoneMetrics = [
   'hr_zone_0_sec',
   'hr_zone_1_sec',
   'hr_zone_2_sec',
   'hr_zone_3_sec',
   'hr_zone_4_sec',
   'hr_zone_5_sec',
-]
+] as const
 
 /**
  * Check if a metric is an HR zone metric (computed, not stored).
  */
 export function isHrZoneMetric(metric: MetricType): boolean {
-  return hrZoneMetrics.includes(metric)
+  return (hrZoneMetrics as readonly string[]).includes(metric)
 }
 
 /**

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -286,6 +286,13 @@ export type MetricType =
   | 'sleep_deep_score'
   | 'sleep_rem_score'
   | 'sleep_total_score'
+  // HR zone time (computed from heart_rate data)
+  | 'hr_zone_0_sec'
+  | 'hr_zone_1_sec'
+  | 'hr_zone_2_sec'
+  | 'hr_zone_3_sec'
+  | 'hr_zone_4_sec'
+  | 'hr_zone_5_sec'
 
 /**
  * Activity types for activities table.
@@ -335,6 +342,13 @@ export const validMetrics: MetricType[] = [
   'sleep_deep_score',
   'sleep_rem_score',
   'sleep_total_score',
+  // HR zone time (computed from heart_rate data)
+  'hr_zone_0_sec',
+  'hr_zone_1_sec',
+  'hr_zone_2_sec',
+  'hr_zone_3_sec',
+  'hr_zone_4_sec',
+  'hr_zone_5_sec',
 ]
 
 /**
@@ -342,6 +356,25 @@ export const validMetrics: MetricType[] = [
  */
 export function isValidMetric(metric: string): metric is MetricType {
   return validMetrics.includes(metric as MetricType)
+}
+
+/**
+ * HR zone metrics are computed from heart_rate data, not stored directly.
+ */
+export const hrZoneMetrics: MetricType[] = [
+  'hr_zone_0_sec',
+  'hr_zone_1_sec',
+  'hr_zone_2_sec',
+  'hr_zone_3_sec',
+  'hr_zone_4_sec',
+  'hr_zone_5_sec',
+]
+
+/**
+ * Check if a metric is an HR zone metric (computed, not stored).
+ */
+export function isHrZoneMetric(metric: MetricType): boolean {
+  return hrZoneMetrics.includes(metric)
 }
 
 /**
@@ -364,6 +397,12 @@ export const metricUnits: Record<MetricType, string> = {
   floors_climbed: 'count',
   heart_rate: 'bpm',
   height: 'm',
+  hr_zone_0_sec: 'sec',
+  hr_zone_1_sec: 'sec',
+  hr_zone_2_sec: 'sec',
+  hr_zone_3_sec: 'sec',
+  hr_zone_4_sec: 'sec',
+  hr_zone_5_sec: 'sec',
   hrv_rmssd: 'ms',
   lean_body_mass: 'kg',
   productivity_score: 'score',

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -581,4 +581,126 @@ describe('getPeriodSummary', () => {
 
     expect(result.metrics[0].completenessPercent).toBe(50) // 15/30 = 50%
   })
+
+  test('computes HR zone metrics from heart_rate data', async () => {
+    // HR zone metrics should be computed from heart_rate data, not stored directly
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+    vi.mocked(db.getUserSettings).mockResolvedValue(null) // Use default HR zones
+
+    // Mock heart rate data with samples in different zones
+    // Default zones with age ~40 (max HR 180): 1=90, 2=108, 3=126, 4=144, 5=162
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T10:00:00Z'), 70], // Zone 0 (below 90)
+      [new Date('2024-01-15T10:00:02Z'), 70], // Zone 0
+      [new Date('2024-01-15T10:00:04Z'), 95], // Zone 1 (90-107)
+      [new Date('2024-01-15T10:00:06Z'), 115], // Zone 2 (108-125)
+      [new Date('2024-01-15T10:00:08Z'), 130], // Zone 3 (126-143)
+      [new Date('2024-01-15T10:00:10Z'), 150], // Zone 4 (144-161)
+      [new Date('2024-01-15T10:00:12Z'), 170], // Zone 5 (>=162)
+    ])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['hr_zone_1_sec', 'hr_zone_2_sec', 'hr_zone_5_sec'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metrics).toHaveLength(3)
+
+    const zone1 = result.metrics.find((m) => m.metric === 'hr_zone_1_sec')
+    const zone2 = result.metrics.find((m) => m.metric === 'hr_zone_2_sec')
+    const zone5 = result.metrics.find((m) => m.metric === 'hr_zone_5_sec')
+
+    expect(zone1).toBeDefined()
+    expect(zone2).toBeDefined()
+    expect(zone5).toBeDefined()
+
+    // Each zone should have sum as avg (total seconds) and count of 1
+    expect(zone1!.count).toBe(1)
+    expect(zone1!.unit).toBe('sec')
+    expect(zone1!.avg).toBeGreaterThan(0) // Should have some time in zone 1
+    expect(zone5!.avg).toBeGreaterThan(0) // Should have some time in zone 5
+  })
+
+  test('computes HR zone metrics using custom user HR zones', async () => {
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+
+    // Custom zones: zone 1 starts at 70 (lower than default 90)
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      hrZoneStart: { 1: 70, 2: 100, 3: 130, 4: 150, 5: 170 },
+    })
+
+    // HR at 75 - would be zone 0 with defaults (90), but zone 1 with custom (70)
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T10:00:00Z'), 75],
+      [new Date('2024-01-15T10:00:02Z'), 75],
+    ])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['hr_zone_0_sec', 'hr_zone_1_sec'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    const zone0 = result.metrics.find((m) => m.metric === 'hr_zone_0_sec')
+    const zone1 = result.metrics.find((m) => m.metric === 'hr_zone_1_sec')
+
+    // With custom zones, HR of 75 is in zone 1, not zone 0
+    expect(zone0!.avg).toBe(0)
+    expect(zone1!.avg).toBeGreaterThan(0)
+  })
+
+  test('returns zero for HR zone metrics when no heart_rate data', async () => {
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['hr_zone_1_sec'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    const zone1 = result.metrics.find((m) => m.metric === 'hr_zone_1_sec')
+    expect(zone1!.avg).toBe(0)
+    expect(zone1!.count).toBe(0)
+  })
+
+  test('mixes regular metrics with HR zone metrics', async () => {
+    // Regular metric stats
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([
+      { avg: 72, count: 100, max: 150, metric: 'heart_rate', min: 55, stddev: 15, unit: 'bpm' },
+    ])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    // HR data for zone calculation
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T10:00:00Z'), 95],
+      [new Date('2024-01-15T10:00:02Z'), 95],
+    ])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['heart_rate', 'hr_zone_1_sec'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metrics).toHaveLength(2)
+
+    const heartRate = result.metrics.find((m) => m.metric === 'heart_rate')
+    const zone1 = result.metrics.find((m) => m.metric === 'hr_zone_1_sec')
+
+    expect(heartRate).toBeDefined()
+    expect(heartRate!.avg).toBe(72)
+    expect(zone1).toBeDefined()
+    expect(zone1!.avg).toBeGreaterThan(0)
+  })
 })

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -17,7 +17,7 @@ import {
   getTimeSeriesMultiMetric,
   getTimeSeriesStats,
 } from '../db'
-import { ActivityType, MetricType, metricUnits } from '../schema'
+import { ActivityType, isHrZoneMetric, MetricType, metricUnits } from '../schema'
 import { computeHrZoneSecs, getEffectiveHrZones, HrZoneSecs } from './settings'
 
 // ============================================================================
@@ -307,6 +307,54 @@ export async function getDailySummary(
 }
 
 /**
+ * Compute HR zone stats for period summary.
+ * Returns PeriodMetricStats for each requested HR zone metric.
+ */
+async function computeHrZoneStats(
+  user: string,
+  hrZoneMetrics: MetricType[],
+  start: Date,
+  end: Date,
+): Promise<PeriodMetricStats[]> {
+  if (hrZoneMetrics.length === 0) return []
+
+  // Get heart rate data and user's HR zones
+  const [hrData, { zones: hrZones }] = await Promise.all([
+    getTimeSeries(user, 'heart_rate', start, end),
+    getEffectiveHrZones(user),
+  ])
+
+  // Compute total time in each zone
+  const zoneSecs = computeHrZoneSecs(hrData, hrZones)
+
+  // Build stats for each requested HR zone metric
+  return hrZoneMetrics.map((metric) => {
+    const zoneIndex = parseInt(metric.replace('hr_zone_', '').replace('_sec', ''), 10) as
+      | 0
+      | 1
+      | 2
+      | 3
+      | 4
+      | 5
+    const totalSecs = zoneSecs[zoneIndex]
+
+    return {
+      avg: Math.round(totalSecs * 100) / 100,
+      changeFromPreviousPeriodPercent: null, // Could compute if needed
+      completenessPercent: hrData.length > 0 ? 100 : 0,
+      count: hrData.length > 0 ? 1 : 0, // Treat as single aggregated value
+      max: Math.round(totalSecs * 100) / 100,
+      metric,
+      min: Math.round(totalSecs * 100) / 100,
+      outliers: undefined,
+      stddev: 0,
+      trendPerDay: null,
+      unit: metricUnits[metric],
+    }
+  })
+}
+
+/**
  * Get aggregated statistics for a time period.
  */
 export async function getPeriodSummary(
@@ -315,22 +363,29 @@ export async function getPeriodSummary(
   start: Date,
   end: Date,
 ): Promise<PeriodSummaryResult> {
+  // Separate HR zone metrics from regular metrics
+  const regularMetrics = metrics.filter((m) => !isHrZoneMetric(m))
+  const hrZoneMetricsRequested = metrics.filter(isHrZoneMetric)
+
   // Calculate period length for previous period comparison
   const periodMs = end.getTime() - start.getTime()
   const prevStart = new Date(start.getTime() - periodMs)
   const prevEnd = new Date(start.getTime() - 1)
 
-  // Fetch current and previous period stats in parallel
-  const [currentStats, previousStats, dailyAggregates] = await Promise.all([
-    getTimeSeriesStats(user, metrics, start, end),
-    getTimeSeriesStats(user, metrics, prevStart, prevEnd),
-    getDailyAggregates(user, metrics, start, end),
+  // Fetch current and previous period stats in parallel (for regular metrics)
+  const [currentStats, previousStats, dailyAggregates, hrZoneStats] = await Promise.all([
+    regularMetrics.length > 0 ? getTimeSeriesStats(user, regularMetrics, start, end) : Promise.resolve([]),
+    regularMetrics.length > 0 ?
+      getTimeSeriesStats(user, regularMetrics, prevStart, prevEnd)
+    : Promise.resolve([]),
+    regularMetrics.length > 0 ? getDailyAggregates(user, regularMetrics, start, end) : Promise.resolve([]),
+    computeHrZoneStats(user, hrZoneMetricsRequested, start, end),
   ])
 
   // Calculate days in period for completeness calculation
   const daysInPeriod = Math.ceil(periodMs / (1000 * 60 * 60 * 24))
 
-  // Build response with trends and completeness
+  // Build response with trends and completeness for regular metrics
   const metricsWithTrends: PeriodMetricStats[] = currentStats.map((stat) => {
     const prevStat = previousStats.find((p) => p.metric === stat.metric)
     const dailyData = dailyAggregates.filter((d) => d.metric === stat.metric)
@@ -390,9 +445,9 @@ export async function getPeriodSummary(
     }
   })
 
-  // Add metrics with no data in current period
-  const missingMetrics = metrics.filter((m) => !currentStats.some((s) => s.metric === m))
-  for (const metric of missingMetrics) {
+  // Add regular metrics with no data in current period
+  const missingRegularMetrics = regularMetrics.filter((m) => !currentStats.some((s) => s.metric === m))
+  for (const metric of missingRegularMetrics) {
     metricsWithTrends.push({
       avg: 0,
       changeFromPreviousPeriodPercent: null,
@@ -407,6 +462,9 @@ export async function getPeriodSummary(
       unit: metricUnits[metric],
     })
   }
+
+  // Add HR zone stats
+  metricsWithTrends.push(...hrZoneStats)
 
   return {
     end: end.toISOString(),

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -374,11 +374,9 @@ export async function getPeriodSummary(
 
   // Fetch current and previous period stats in parallel (for regular metrics)
   const [currentStats, previousStats, dailyAggregates, hrZoneStats] = await Promise.all([
-    regularMetrics.length > 0 ? getTimeSeriesStats(user, regularMetrics, start, end) : Promise.resolve([]),
-    regularMetrics.length > 0 ?
-      getTimeSeriesStats(user, regularMetrics, prevStart, prevEnd)
-    : Promise.resolve([]),
-    regularMetrics.length > 0 ? getDailyAggregates(user, regularMetrics, start, end) : Promise.resolve([]),
+    getTimeSeriesStats(user, regularMetrics, start, end),
+    getTimeSeriesStats(user, regularMetrics, prevStart, prevEnd),
+    getDailyAggregates(user, regularMetrics, start, end),
     computeHrZoneStats(user, hrZoneMetricsRequested, start, end),
   ])
 


### PR DESCRIPTION
## Summary
- Add `hr_zone_0_sec` through `hr_zone_5_sec` as queryable metrics in period summaries (GET /period-summary and MCP query_period_summary)
- These metrics are computed from heart_rate data using the user's configured HR zone thresholds, not stored directly in the database
- Enables querying total time spent in each HR zone for a date range (e.g., last week)

## Test plan
- [x] Unit tests added for HR zone metrics computation in getPeriodSummary
- [x] Tests verify metrics work with default HR zones
- [x] Tests verify metrics work with custom user HR zones
- [x] Tests verify zero values when no heart_rate data exists
- [x] Tests verify mixing regular metrics with HR zone metrics
- [x] All existing tests pass (184 tests)
- [x] `pnpm fix` and `pnpm check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)