### PR TITLE
Add HR Zone Data tab to Android app

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -15,6 +15,7 @@ enum class AppScreen {
 
 enum class MainTab {
     Sync,
+    Data,
     Account
 }
 

--- a/apps/android/app/src/main/java/net/aurboda/DataApi.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DataApi.kt
@@ -1,0 +1,144 @@
+package net.aurboda
+
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PeriodMetricStats(
+    val metric: String,
+    val unit: String,
+    val avg: Double? = null,
+    val min: Double? = null,
+    val max: Double? = null,
+    val sum: Double? = null,
+    val count: Int? = null,
+    val stddev: Double? = null,
+    val trend: Double? = null,
+    @SerialName("data_points") val dataPoints: Int? = null
+)
+
+@Serializable
+data class PeriodSummaryResponse(
+    val success: Boolean,
+    val metrics: List<PeriodMetricStats>,
+    @SerialName("period_start") val periodStart: String? = null,
+    @SerialName("period_end") val periodEnd: String? = null
+)
+
+@Serializable
+data class HrZoneThresholds(
+    @SerialName("1") val zone1: Int,
+    @SerialName("2") val zone2: Int,
+    @SerialName("3") val zone3: Int,
+    @SerialName("4") val zone4: Int,
+    @SerialName("5") val zone5: Int
+)
+
+@Serializable
+data class UserSettingsResponse(
+    val success: Boolean,
+    @SerialName("hr_zone_start") val hrZoneStart: HrZoneThresholds? = null,
+    @SerialName("birth_date") val birthDate: String? = null
+)
+
+sealed class DataResult<out T> {
+    data class Success<T>(val data: T) : DataResult<T>()
+    data class Error(val message: String) : DataResult<Nothing>()
+}
+
+suspend fun fetchPeriodSummary(
+    httpClient: HttpClient,
+    serverUrl: String,
+    authToken: String,
+    start: String,
+    end: String,
+    metrics: List<String>
+): DataResult<PeriodSummaryResponse> {
+    return try {
+        val metricsParam = metrics.joinToString(",")
+        val url = "$serverUrl/period-summary?start=$start&end=$end&metrics=$metricsParam"
+        Log.d("DataApi", "Fetching period summary from: $url")
+
+        val response = httpClient.get(url) {
+            headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        }
+
+        if (response.status == HttpStatusCode.OK) {
+            val body = response.bodyAsText()
+            Log.d("DataApi", "Period summary response: $body")
+            val parsed = appJson.decodeFromString<PeriodSummaryResponse>(body)
+            DataResult.Success(parsed)
+        } else {
+            Log.e("DataApi", "Period summary error: ${response.status}")
+            DataResult.Error("Server returned ${response.status}")
+        }
+    } catch (e: Exception) {
+        Log.e("DataApi", "Error fetching period summary", e)
+        DataResult.Error(e.message ?: "Unknown error")
+    }
+}
+
+suspend fun fetchUserSettings(
+    httpClient: HttpClient,
+    serverUrl: String,
+    authToken: String
+): DataResult<UserSettingsResponse> {
+    return try {
+        val url = "$serverUrl/user/settings"
+        Log.d("DataApi", "Fetching user settings from: $url")
+
+        val response = httpClient.get(url) {
+            headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        }
+
+        if (response.status == HttpStatusCode.OK) {
+            val body = response.bodyAsText()
+            Log.d("DataApi", "User settings response: $body")
+            val parsed = appJson.decodeFromString<UserSettingsResponse>(body)
+            DataResult.Success(parsed)
+        } else {
+            Log.e("DataApi", "User settings error: ${response.status}")
+            DataResult.Error("Server returned ${response.status}")
+        }
+    } catch (e: Exception) {
+        Log.e("DataApi", "Error fetching user settings", e)
+        DataResult.Error(e.message ?: "Unknown error")
+    }
+}
+
+val defaultHrZoneThresholds = HrZoneThresholds(
+    zone1 = 86,
+    zone2 = 102,
+    zone3 = 118,
+    zone4 = 135,
+    zone5 = 151
+)
+
+val hrZoneWeeklyTargetMinutes = listOf(0, 60, 200, 60, 30, 10)
+
+fun formatZoneTime(seconds: Double): String {
+    val totalMinutes = (seconds / 60).toInt()
+    return if (totalMinutes >= 60) {
+        val hours = totalMinutes / 60
+        val mins = totalMinutes % 60
+        if (mins > 0) "$hours h $mins min" else "$hours h"
+    } else {
+        "$totalMinutes min"
+    }
+}
+
+fun formatBpmRange(zoneIndex: Int, thresholds: HrZoneThresholds): String {
+    val zoneStarts = listOf(0, thresholds.zone1, thresholds.zone2, thresholds.zone3, thresholds.zone4, thresholds.zone5)
+    return when (zoneIndex) {
+        0 -> "< ${thresholds.zone1} bpm"
+        5 -> "${thresholds.zone5}+ bpm"
+        else -> "${zoneStarts[zoneIndex]} - ${zoneStarts[zoneIndex + 1] - 1} bpm"
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -243,6 +243,13 @@ fun AurbodaApp() {
                             modifier = modifier
                         )
                     },
+                    dataContent = { modifier ->
+                        net.aurboda.ui.screens.DataScreen(
+                            serverUrl = credentials.serverUrl,
+                            authToken = credentials.authToken,
+                            modifier = modifier
+                        )
+                    },
                     accountContent = { modifier ->
                         net.aurboda.ui.screens.AccountScreen(
                             username = credentials.username,

--- a/apps/android/app/src/main/java/net/aurboda/ui/components/HrZoneBar.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/components/HrZoneBar.kt
@@ -1,0 +1,84 @@
+package net.aurboda.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.dp
+import net.aurboda.formatZoneTime
+
+@Composable
+fun HrZoneBar(
+    zoneIndex: Int,
+    bpmRange: String,
+    timeSeconds: Double,
+    targetMinutes: Int,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    val progress = if (targetMinutes > 0) {
+        (timeSeconds / 60.0 / targetMinutes).coerceIn(0.0, 1.0).toFloat()
+    } else {
+        0f
+    }
+    val percentText = if (targetMinutes > 0) {
+        "${(progress * 100).toInt()}%"
+    } else {
+        ""
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Zone $zoneIndex ($bpmRange)",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = formatZoneTime(timeSeconds),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(8.dp),
+                color = color,
+                trackColor = color.copy(alpha = 0.2f),
+                strokeCap = StrokeCap.Round
+            )
+            if (percentText.isNotEmpty()) {
+                Text(
+                    text = percentText,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/DataScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/DataScreen.kt
@@ -1,0 +1,161 @@
+package net.aurboda.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import net.aurboda.DataResult
+import net.aurboda.HrZoneThresholds
+import net.aurboda.PeriodSummaryResponse
+import net.aurboda.appJson
+import net.aurboda.defaultHrZoneThresholds
+import net.aurboda.fetchPeriodSummary
+import net.aurboda.fetchUserSettings
+import net.aurboda.formatBpmRange
+import net.aurboda.hrZoneWeeklyTargetMinutes
+import net.aurboda.ui.components.HrZoneBar
+import net.aurboda.ui.theme.HrZoneColors
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+private sealed class DataScreenState {
+    data object Loading : DataScreenState()
+    data class Loaded(
+        val periodSummary: PeriodSummaryResponse,
+        val hrZoneThresholds: HrZoneThresholds
+    ) : DataScreenState()
+    data class Error(val message: String) : DataScreenState()
+}
+
+@Composable
+fun DataScreen(
+    serverUrl: String,
+    authToken: String,
+    modifier: Modifier = Modifier
+) {
+    val httpClient = remember {
+        HttpClient(Android) {
+            install(ContentNegotiation) {
+                json(appJson)
+            }
+        }
+    }
+
+    var state by remember { mutableStateOf<DataScreenState>(DataScreenState.Loading) }
+
+    LaunchedEffect(Unit) {
+        val today = LocalDate.now()
+        val weekAgo = today.minusDays(6)
+        val formatter = DateTimeFormatter.ISO_LOCAL_DATE
+        val start = "${weekAgo.format(formatter)}T00:00:00Z"
+        val end = "${today.format(formatter)}T23:59:59Z"
+
+        val metrics = listOf(
+            "hr_zone_0_sec",
+            "hr_zone_1_sec",
+            "hr_zone_2_sec",
+            "hr_zone_3_sec",
+            "hr_zone_4_sec",
+            "hr_zone_5_sec"
+        )
+
+        // Fetch user settings for HR zone thresholds
+        val thresholds = when (val settingsResult = fetchUserSettings(httpClient, serverUrl, authToken)) {
+            is DataResult.Success -> settingsResult.data.hrZoneStart ?: defaultHrZoneThresholds
+            is DataResult.Error -> defaultHrZoneThresholds
+        }
+
+        // Fetch period summary
+        when (val result = fetchPeriodSummary(httpClient, serverUrl, authToken, start, end, metrics)) {
+            is DataResult.Success -> {
+                state = DataScreenState.Loaded(result.data, thresholds)
+            }
+            is DataResult.Error -> {
+                state = DataScreenState.Error(result.message)
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        when (val currentState = state) {
+            is DataScreenState.Loading -> {
+                CircularProgressIndicator()
+            }
+            is DataScreenState.Error -> {
+                Text(
+                    text = "Error: ${currentState.message}",
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+            is DataScreenState.Loaded -> {
+                DataContent(
+                    periodSummary = currentState.periodSummary,
+                    hrZoneThresholds = currentState.hrZoneThresholds,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DataContent(
+    periodSummary: PeriodSummaryResponse,
+    hrZoneThresholds: HrZoneThresholds,
+    modifier: Modifier = Modifier
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .verticalScroll(scrollState)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "HR Zone Minutes (Last 7 Days)",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        for (zoneIndex in 0..5) {
+            val metricName = "hr_zone_${zoneIndex}_sec"
+            val metricStats = periodSummary.metrics.find { it.metric == metricName }
+            val timeSeconds = metricStats?.sum ?: 0.0
+
+            HrZoneBar(
+                zoneIndex = zoneIndex,
+                bpmRange = formatBpmRange(zoneIndex, hrZoneThresholds),
+                timeSeconds = timeSeconds,
+                targetMinutes = hrZoneWeeklyTargetMinutes[zoneIndex],
+                color = HrZoneColors[zoneIndex],
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
@@ -2,6 +2,7 @@ package net.aurboda.ui.screens
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
@@ -25,10 +26,12 @@ fun MainScreen(
     currentTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
     syncContent: @Composable (Modifier) -> Unit,
+    dataContent: @Composable (Modifier) -> Unit,
     accountContent: @Composable (Modifier) -> Unit
 ) {
     val navItems = listOf(
         BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Refresh),
+        BottomNavItem(MainTab.Data, "Data", Icons.Default.Favorite),
         BottomNavItem(MainTab.Account, "Account", Icons.Default.Person)
     )
 
@@ -48,6 +51,7 @@ fun MainScreen(
     ) { innerPadding ->
         when (currentTab) {
             MainTab.Sync -> syncContent(Modifier.padding(innerPadding))
+            MainTab.Data -> dataContent(Modifier.padding(innerPadding))
             MainTab.Account -> accountContent(Modifier.padding(innerPadding))
         }
     }

--- a/apps/android/app/src/main/java/net/aurboda/ui/theme/Color.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/theme/Color.kt
@@ -9,3 +9,20 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+
+// HR Zone Colors
+val HrZone0Color = Color(0xFF9E9E9E) // Gray - Below threshold
+val HrZone1Color = Color(0xFF64B5F6) // Light Blue - Warm-up
+val HrZone2Color = Color(0xFF4CAF50) // Green - Aerobic
+val HrZone3Color = Color(0xFFFFC107) // Amber - Tempo
+val HrZone4Color = Color(0xFFFF9800) // Orange - Threshold
+val HrZone5Color = Color(0xFFF44336) // Red - Max effort
+
+val HrZoneColors = listOf(
+    HrZone0Color,
+    HrZone1Color,
+    HrZone2Color,
+    HrZone3Color,
+    HrZone4Color,
+    HrZone5Color
+)

--- a/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
@@ -19,17 +19,19 @@ class AppStateTest {
     }
 
     @Test
-    fun `MainTab has Sync and Account values`() {
+    fun `MainTab has Sync, Data and Account values`() {
         val tabs = MainTab.entries
-        assertEquals(2, tabs.size)
+        assertEquals(3, tabs.size)
         assertTrue(tabs.contains(MainTab.Sync))
+        assertTrue(tabs.contains(MainTab.Data))
         assertTrue(tabs.contains(MainTab.Account))
     }
 
     @Test
     fun `MainTab ordinal values are correct`() {
         assertEquals(0, MainTab.Sync.ordinal)
-        assertEquals(1, MainTab.Account.ordinal)
+        assertEquals(1, MainTab.Data.ordinal)
+        assertEquals(2, MainTab.Account.ordinal)
     }
 
     @Test
@@ -41,6 +43,7 @@ class AppStateTest {
     @Test
     fun `MainTab names are descriptive`() {
         assertEquals("Sync", MainTab.Sync.name)
+        assertEquals("Data", MainTab.Data.name)
         assertEquals("Account", MainTab.Account.name)
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new "Data" tab to the Android app between Sync and Account
- Displays weekly HR zone time data with color-coded progress bars
- Fetches data from `period-summary` and `user/settings` API endpoints
- Shows progress toward weekly targets for each HR zone (0-5)

## Test plan
- [ ] Build and run the app on device/emulator
- [ ] Navigate to the new Data tab (heart icon)
- [ ] Verify loading indicator shows while fetching
- [ ] Verify HR zone bars display with correct colors
- [ ] Verify time values are properly formatted (e.g., "45 min" or "1 h 20 min")
- [ ] Verify BPM ranges match user settings or defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)