### PR TITLE
Fix HR zone data showing 0 minutes and bar alignment

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/DataApi.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DataApi.kt
@@ -142,3 +142,8 @@ fun formatBpmRange(zoneIndex: Int, thresholds: HrZoneThresholds): String {
         else -> "${zoneStarts[zoneIndex]} - ${zoneStarts[zoneIndex + 1] - 1} bpm"
     }
 }
+
+fun getMetricTimeSeconds(metric: PeriodMetricStats): Double = metric.avg ?: 0.0
+
+fun findMetricTimeSeconds(metrics: List<PeriodMetricStats>, metricName: String): Double =
+    metrics.find { it.metric == metricName }?.let { getMetricTimeSeconds(it) } ?: 0.0

--- a/apps/android/app/src/main/java/net/aurboda/ui/components/HrZoneBar.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/components/HrZoneBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -72,13 +73,13 @@ fun HrZoneBar(
                 trackColor = color.copy(alpha = 0.2f),
                 strokeCap = StrokeCap.Round
             )
-            if (percentText.isNotEmpty()) {
-                Text(
-                    text = percentText,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(start = 4.dp)
-                )
-            }
+            Text(
+                text = percentText,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .width(36.dp)
+                    .padding(start = 4.dp)
+            )
         }
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/DataScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/DataScreen.kt
@@ -31,6 +31,7 @@ import net.aurboda.appJson
 import net.aurboda.defaultHrZoneThresholds
 import net.aurboda.fetchPeriodSummary
 import net.aurboda.fetchUserSettings
+import net.aurboda.findMetricTimeSeconds
 import net.aurboda.formatBpmRange
 import net.aurboda.hrZoneWeeklyTargetMinutes
 import net.aurboda.ui.components.HrZoneBar
@@ -145,8 +146,7 @@ private fun DataContent(
 
         for (zoneIndex in 0..5) {
             val metricName = "hr_zone_${zoneIndex}_sec"
-            val metricStats = periodSummary.metrics.find { it.metric == metricName }
-            val timeSeconds = metricStats?.sum ?: 0.0
+            val timeSeconds = findMetricTimeSeconds(periodSummary.metrics, metricName)
 
             HrZoneBar(
                 zoneIndex = zoneIndex,

--- a/apps/android/app/src/test/java/net/aurboda/DataApiTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/DataApiTest.kt
@@ -1,0 +1,145 @@
+package net.aurboda
+
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Unit tests for DataApi models and utilities
+ */
+class DataApiTest {
+
+    @Test
+    fun `getMetricTimeSeconds returns avg value for HR zone metric`() {
+        val metric = PeriodMetricStats(
+            metric = "hr_zone_2_sec",
+            unit = "sec",
+            avg = 3600.0,
+            min = 3600.0,
+            max = 3600.0,
+            count = 1,
+            stddev = 0.0
+        )
+
+        assertEquals(3600.0, getMetricTimeSeconds(metric), 0.01)
+    }
+
+    @Test
+    fun `getMetricTimeSeconds returns 0 when avg is null`() {
+        val metric = PeriodMetricStats(
+            metric = "hr_zone_0_sec",
+            unit = "sec",
+            avg = null
+        )
+
+        assertEquals(0.0, getMetricTimeSeconds(metric), 0.01)
+    }
+
+    @Test
+    fun `getMetricTimeSeconds handles decimal values`() {
+        val metric = PeriodMetricStats(
+            metric = "hr_zone_1_sec",
+            unit = "sec",
+            avg = 2498.28
+        )
+
+        assertEquals(2498.28, getMetricTimeSeconds(metric), 0.01)
+    }
+
+    @Test
+    fun `findMetricTimeSeconds returns time for existing metric`() {
+        val metrics = listOf(
+            PeriodMetricStats(metric = "hr_zone_0_sec", unit = "sec", avg = 1000.0),
+            PeriodMetricStats(metric = "hr_zone_1_sec", unit = "sec", avg = 2000.0),
+            PeriodMetricStats(metric = "hr_zone_2_sec", unit = "sec", avg = 3000.0)
+        )
+
+        assertEquals(2000.0, findMetricTimeSeconds(metrics, "hr_zone_1_sec"), 0.01)
+    }
+
+    @Test
+    fun `findMetricTimeSeconds returns 0 for missing metric`() {
+        val metrics = listOf(
+            PeriodMetricStats(metric = "hr_zone_0_sec", unit = "sec", avg = 1000.0)
+        )
+
+        assertEquals(0.0, findMetricTimeSeconds(metrics, "hr_zone_5_sec"), 0.01)
+    }
+
+    @Test
+    fun `formatZoneTime formats minutes correctly`() {
+        assertEquals("5 min", formatZoneTime(300.0))
+        assertEquals("30 min", formatZoneTime(1800.0))
+        assertEquals("0 min", formatZoneTime(0.0))
+    }
+
+    @Test
+    fun `formatZoneTime formats hours and minutes`() {
+        assertEquals("1 h", formatZoneTime(3600.0))
+        assertEquals("1 h 30 min", formatZoneTime(5400.0))
+        assertEquals("2 h 15 min", formatZoneTime(8100.0))
+    }
+
+    @Test
+    fun `formatBpmRange formats zone 0 correctly`() {
+        val thresholds = defaultHrZoneThresholds
+        assertEquals("< 86 bpm", formatBpmRange(0, thresholds))
+    }
+
+    @Test
+    fun `formatBpmRange formats zone 5 correctly`() {
+        val thresholds = defaultHrZoneThresholds
+        assertEquals("151+ bpm", formatBpmRange(5, thresholds))
+    }
+
+    @Test
+    fun `formatBpmRange formats middle zones correctly`() {
+        val thresholds = defaultHrZoneThresholds
+        assertEquals("86 - 101 bpm", formatBpmRange(1, thresholds))
+        assertEquals("102 - 117 bpm", formatBpmRange(2, thresholds))
+        assertEquals("118 - 134 bpm", formatBpmRange(3, thresholds))
+        assertEquals("135 - 150 bpm", formatBpmRange(4, thresholds))
+    }
+
+    @Test
+    fun `PeriodMetricStats parses JSON without sum field`() {
+        // Simulate API response that doesn't include 'sum'
+        val json = """
+            {
+                "metric": "hr_zone_0_sec",
+                "unit": "sec",
+                "avg": 3525.0,
+                "min": 3525.0,
+                "max": 3525.0,
+                "count": 1,
+                "stddev": 0
+            }
+        """.trimIndent()
+
+        val parsed = appJson.decodeFromString<PeriodMetricStats>(json)
+        assertEquals(3525.0, parsed.avg)
+        assertNull(parsed.sum)
+        assertEquals(3525.0, getMetricTimeSeconds(parsed), 0.01)
+    }
+
+    @Test
+    fun `PeriodSummaryResponse parses complete API response`() {
+        val json = """
+            {
+                "success": true,
+                "metrics": [
+                    {"metric": "hr_zone_0_sec", "unit": "sec", "avg": 3525.0, "count": 1},
+                    {"metric": "hr_zone_1_sec", "unit": "sec", "avg": 2498.28, "count": 1}
+                ],
+                "periodDays": 7,
+                "start": "2026-01-17T00:00:00Z",
+                "end": "2026-01-23T23:59:59Z"
+            }
+        """.trimIndent()
+
+        val parsed = appJson.decodeFromString<PeriodSummaryResponse>(json)
+        assertTrue(parsed.success)
+        assertEquals(2, parsed.metrics.size)
+        assertEquals(3525.0, findMetricTimeSeconds(parsed.metrics, "hr_zone_0_sec"), 0.01)
+        assertEquals(2498.28, findMetricTimeSeconds(parsed.metrics, "hr_zone_1_sec"), 0.01)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed HR zone data tab showing 0 minutes for all zones - was reading from non-existent `sum` field instead of `avg` from the API response
- Fixed bar alignment issue where Zone 0 had a longer bar because it had no percentage text - now uses fixed width for percentage area
- Added unit tests for the metric parsing logic

## Test plan
- [ ] Open the Data tab in Android app and verify HR zone times display correctly
- [ ] Verify all HR zone bars have the same length alignment
- [ ] Run `./gradlew test` to verify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)