### PR TITLE
Add HR Zone weekly minutes widget for Android

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -81,6 +81,20 @@
             android:exported="true"
             android:targetActivity=".MainActivity"
             tools:replace="android:targetActivity" />
+
+        <!-- HR Zone Widget -->
+        <receiver
+            android:name=".widget.HrZoneWidgetProvider"
+            android:exported="true"
+            android:label="@string/widget_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="net.aurboda.ACTION_UPDATE_HR_ZONE_WIDGETS" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/hr_zone_widget_info" />
+        </receiver>
     </application>
 
     <queries>

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -31,6 +31,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.KSerializer
+import net.aurboda.widget.HrZoneWidgetProvider
 import java.util.concurrent.TimeUnit
 
 private const val TAG = "HealthConnectSyncWorker"
@@ -110,6 +111,7 @@ class HealthConnectSyncWorker(
                     val success = sendDataToServer(filteredRecords, credentials.serverUrl, credentials.authToken)
                     if (success) {
                         Log.d(TAG, "Background sync completed successfully")
+                        HrZoneWidgetProvider.triggerUpdate(applicationContext)
                         Result.success()
                     } else {
                         Log.w(TAG, "Background sync failed to send data")
@@ -119,10 +121,12 @@ class HealthConnectSyncWorker(
                     Log.d(TAG, "No filtered records to sync (all were aggregated types)")
                     // Still save token since we successfully processed the records
                     pendingToken?.let { saveChangesToken(it) }
+                    HrZoneWidgetProvider.triggerUpdate(applicationContext)
                     Result.success()
                 }
             } else {
                 Log.d(TAG, "No new data to sync")
+                HrZoneWidgetProvider.triggerUpdate(applicationContext)
                 Result.success()
             }
         } catch (e: Exception) {

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -1,0 +1,171 @@
+package net.aurboda.widget
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.RemoteViews
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import net.aurboda.CredentialsManager
+import net.aurboda.DataResult
+import net.aurboda.R
+import net.aurboda.fetchPeriodSummary
+import net.aurboda.findMetricTimeSeconds
+import net.aurboda.formatZoneTime
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import net.aurboda.appJson
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+private const val TAG = "HrZoneWidgetProvider"
+
+// Widget targets: Zone 2 min 150, max 200; Zone 5 min 5, max 10
+private const val ZONE_2_TARGET_MIN = 150
+private const val ZONE_5_TARGET_MIN = 5
+
+class HrZoneWidgetProvider : AppWidgetProvider() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        Log.d(TAG, "onUpdate called for ${appWidgetIds.size} widgets")
+        for (appWidgetId in appWidgetIds) {
+            updateWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action == ACTION_UPDATE_WIDGETS) {
+            Log.d(TAG, "Received update broadcast")
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val componentName = ComponentName(context, HrZoneWidgetProvider::class.java)
+            val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+            onUpdate(context, appWidgetManager, appWidgetIds)
+        }
+    }
+
+    private fun updateWidget(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int
+    ) {
+        scope.launch {
+            val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
+
+            val credentials = CredentialsManager.getCredentials(context)
+            if (credentials == null) {
+                Log.w(TAG, "No credentials, showing empty widget")
+                setWidgetData(views, 0.0, 0.0)
+                appWidgetManager.updateAppWidget(appWidgetId, views)
+                return@launch
+            }
+
+            val httpClient = HttpClient(Android) {
+                install(ContentNegotiation) { json(appJson) }
+            }
+
+            try {
+                val hrZoneData = fetchHrZoneData(httpClient, credentials)
+                setWidgetData(views, hrZoneData.zone2Seconds, hrZoneData.zone5Seconds)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching HR zone data", e)
+                // Keep existing data or show zeros
+                setWidgetData(views, 0.0, 0.0)
+            } finally {
+                httpClient.close()
+            }
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+
+    private suspend fun fetchHrZoneData(
+        httpClient: HttpClient,
+        credentials: CredentialsManager.Credentials
+    ): HrZoneData {
+        val today = LocalDate.now()
+        val weekAgo = today.minusDays(6) // 7 days including today
+
+        val formatter = DateTimeFormatter.ISO_INSTANT
+        val startInstant = weekAgo.atStartOfDay().toInstant(ZoneOffset.UTC)
+        val endInstant = today.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+
+        val start = formatter.format(startInstant)
+        val end = formatter.format(endInstant)
+
+        val metrics = listOf("hr_zone_2_sec", "hr_zone_5_sec")
+
+        val result = fetchPeriodSummary(
+            httpClient,
+            credentials.serverUrl,
+            credentials.authToken,
+            start,
+            end,
+            metrics
+        )
+
+        return when (result) {
+            is DataResult.Success -> {
+                val zone2Seconds = findMetricTimeSeconds(result.data.metrics, "hr_zone_2_sec")
+                val zone5Seconds = findMetricTimeSeconds(result.data.metrics, "hr_zone_5_sec")
+                Log.d(TAG, "Fetched HR zone data: zone2=$zone2Seconds sec, zone5=$zone5Seconds sec")
+                HrZoneData(zone2Seconds, zone5Seconds)
+            }
+            is DataResult.Error -> {
+                Log.e(TAG, "Error fetching period summary: ${result.message}")
+                HrZoneData(0.0, 0.0)
+            }
+        }
+    }
+
+    private fun setWidgetData(views: RemoteViews, zone2Seconds: Double, zone5Seconds: Double) {
+        val zone2Minutes = (zone2Seconds / 60.0).toInt()
+        val zone5Minutes = (zone5Seconds / 60.0).toInt()
+
+        // Calculate progress as percentage (0-100)
+        val zone2Progress = ((zone2Minutes.toFloat() / ZONE_2_TARGET_MIN) * 100).coerceIn(0f, 100f).toInt()
+        val zone5Progress = ((zone5Minutes.toFloat() / ZONE_5_TARGET_MIN) * 100).coerceIn(0f, 100f).toInt()
+
+        // Set time text
+        views.setTextViewText(R.id.zone2_time, formatZoneTime(zone2Seconds))
+        views.setTextViewText(R.id.zone5_time, formatZoneTime(zone5Seconds))
+
+        // Set progress bar values
+        views.setProgressBar(R.id.zone2_progress, 100, zone2Progress, false)
+        views.setProgressBar(R.id.zone5_progress, 100, zone5Progress, false)
+    }
+
+    companion object {
+        const val ACTION_UPDATE_WIDGETS = "net.aurboda.ACTION_UPDATE_HR_ZONE_WIDGETS"
+
+        /**
+         * Trigger an update of all HR Zone widgets.
+         * Call this after background sync completes.
+         */
+        fun triggerUpdate(context: Context) {
+            val intent = Intent(context, HrZoneWidgetProvider::class.java).apply {
+                action = ACTION_UPDATE_WIDGETS
+            }
+            context.sendBroadcast(intent)
+        }
+    }
+}
+
+private data class HrZoneData(
+    val zone2Seconds: Double,
+    val zone5Seconds: Double
+)

--- a/apps/android/app/src/main/res/drawable/progress_bar_zone2_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_zone2_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Zone 2 Green (#4CAF50) at 20% alpha -->
+            <solid android:color="#334CAF50" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Zone 2 Green - Aerobic -->
+                <solid android:color="#FF4CAF50" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/progress_bar_zone5_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_zone5_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Zone 5 Red (#F44336) at 20% alpha -->
+            <solid android:color="#33F44336" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Zone 5 Red - Max effort -->
+                <solid android:color="#FFF44336" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/widget_background.xml
+++ b/apps/android/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="16dp" />
+    <solid android:color="#CC1C1B1F" />
+</shape>

--- a/apps/android/app/src/main/res/layout/widget_hr_zones.xml
+++ b/apps/android/app/src/main/res/layout/widget_hr_zones.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:background="@drawable/widget_background">
+
+    <!-- Zone 2 (Aerobic - Green) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center_vertical"
+        android:paddingVertical="2dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/zone2_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Zone 2"
+                android:textSize="12sp"
+                android:textColor="#FFFFFFFF" />
+
+            <TextView
+                android:id="@+id/zone2_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0 min"
+                android:textSize="12sp"
+                android:textColor="#FFFFFFFF" />
+        </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/zone2_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:layout_marginTop="4dp"
+            android:max="100"
+            android:progress="0"
+            android:progressDrawable="@drawable/progress_bar_zone2_drawable" />
+    </LinearLayout>
+
+    <!-- Zone 5 (Max effort - Red) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center_vertical"
+        android:paddingVertical="2dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/zone5_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Zone 5"
+                android:textSize="12sp"
+                android:textColor="#FFFFFFFF" />
+
+            <TextView
+                android:id="@+id/zone5_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="0 min"
+                android:textSize="12sp"
+                android:textColor="#FFFFFFFF" />
+        </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/zone5_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:layout_marginTop="4dp"
+            android:max="100"
+            android:progress="0"
+            android:progressDrawable="@drawable/progress_bar_zone5_drawable" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Aurboda</string>
+    <string name="widget_description">Weekly HR zone minutes for Zone 2 and Zone 5</string>
+    <string name="widget_name">HR Zones</string>
 </resources>

--- a/apps/android/app/src/main/res/xml/hr_zone_widget_info.xml
+++ b/apps/android/app/src/main/res/xml/hr_zone_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="40dp"
+    android:maxResizeWidth="530dp"
+    android:maxResizeHeight="200dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="900000"
+    android:initialLayout="@layout/widget_hr_zones"
+    android:previewLayout="@layout/widget_hr_zones"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description" />


### PR DESCRIPTION
## Summary

- Adds a resizable home screen widget (2x1 default) displaying Zone 2 and Zone 5 weekly progress
- Shows progress bars with minutes accumulated over last 7 days including today
- Uses the same colors as the Data tab (green for Zone 2, red for Zone 5)
- Widget targets: Zone 2 min 150 min, Zone 5 min 5 min (as specified in issue)
- Updates automatically after each 15-minute background sync

## Test plan

- [ ] Install the app on an Android device
- [ ] Long-press on home screen and add "HR Zones" widget
- [ ] Verify widget shows Zone 2 and Zone 5 progress bars
- [ ] Verify widget displays time in minutes/hours format
- [ ] Test resizing the widget horizontally and vertically
- [ ] Wait for background sync and verify widget updates

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)