### PR TITLE
Add backend location recognition with named locations

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -31,6 +31,13 @@ import { createOwnTracksRouter } from './owntracks'
 import { rescuetimeClient } from './rescuetime'
 import { syncRescueTimeData } from './rescuetime-sync'
 import { isValidMetric, MetricType, validMetrics } from './schema'
+import {
+  deleteNamedLocation,
+  getDetectedLocations,
+  getNamedLocations,
+  insertNamedLocation,
+  updateNamedLocation,
+} from './services/locations'
 import { addMetric, addTag } from './services/mutations'
 import {
   getDailySummary,
@@ -549,6 +556,135 @@ const main = async () => {
 
     const places = await queryLocations(user, startDate, endDate)
     res.json({ data: places, success: true })
+  })
+
+  // ==========================================================================
+  // Named Locations API
+  // ==========================================================================
+
+  // GET /locations/named - List all named locations
+  httpd.get('/locations/named', authMiddleware, async (req, res) => {
+    const locations = await getNamedLocations(req.user!)
+    res.json({ data: locations, success: true })
+  })
+
+  // POST /locations/named - Create a named location
+  httpd.post('/locations/named', authMiddleware, async (req, res) => {
+    const { name, lat, lon, radius } = req.body as {
+      name?: string
+      lat?: number
+      lon?: number
+      radius?: number
+    }
+    const user = req.user!
+
+    if (!name || lat === undefined || lon === undefined) {
+      return res.status(400).json({ error: 'Missing required fields: name, lat, lon', success: false })
+    }
+
+    if (typeof lat !== 'number' || typeof lon !== 'number') {
+      return res.status(400).json({ error: 'lat and lon must be numbers', success: false })
+    }
+
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+      return res.status(400).json({ error: 'Invalid coordinates', success: false })
+    }
+
+    const location = await insertNamedLocation(user, { lat, lon, name, radius })
+    res.json({ data: location, success: true })
+  })
+
+  // PATCH /locations/named/:id - Update a named location
+  httpd.patch('/locations/named/:id', authMiddleware, async (req, res) => {
+    const { id } = req.params
+    const { name, lat, lon, radius } = req.body as {
+      name?: string
+      lat?: number
+      lon?: number
+      radius?: number
+    }
+    const user = req.user!
+
+    if (lat !== undefined && lon === undefined) {
+      return res.status(400).json({ error: 'lat and lon must be updated together', success: false })
+    }
+    if (lon !== undefined && lat === undefined) {
+      return res.status(400).json({ error: 'lat and lon must be updated together', success: false })
+    }
+
+    if (lat !== undefined && (lat < -90 || lat > 90)) {
+      return res.status(400).json({ error: 'Invalid latitude', success: false })
+    }
+    if (lon !== undefined && (lon < -180 || lon > 180)) {
+      return res.status(400).json({ error: 'Invalid longitude', success: false })
+    }
+
+    const location = await updateNamedLocation(user, id, { lat, lon, name, radius })
+    if (!location) {
+      return res.status(404).json({ error: 'Named location not found', success: false })
+    }
+    res.json({ data: location, success: true })
+  })
+
+  // DELETE /locations/named/:id - Delete a named location
+  httpd.delete('/locations/named/:id', authMiddleware, async (req, res) => {
+    const { id } = req.params
+    const deleted = await deleteNamedLocation(req.user!, id)
+    if (!deleted) {
+      return res.status(404).json({ error: 'Named location not found', success: false })
+    }
+    res.json({ success: true })
+  })
+
+  // GET /locations/detected - Get detected location clusters
+  httpd.get('/locations/detected', authMiddleware, async (req, res) => {
+    const { start, end, minDuration } = req.query as { start?: string; end?: string; minDuration?: string }
+    const user = req.user!
+
+    if (!start || !end) {
+      return res.status(400).json({ error: 'Missing required query parameters: start, end', success: false })
+    }
+
+    const startDate = new Date(start)
+    const endDate = new Date(end)
+
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+      return res.status(400).json({ error: 'Invalid date format. Use ISO 8601 format.', success: false })
+    }
+
+    const minDurationMinutes = minDuration ? parseInt(minDuration, 10) : undefined
+    if (minDuration && (isNaN(minDurationMinutes!) || minDurationMinutes! <= 0)) {
+      return res.status(400).json({ error: 'minDuration must be a positive number', success: false })
+    }
+
+    const detected = await getDetectedLocations(user, {
+      end: endDate,
+      minDurationMinutes,
+      start: startDate,
+    })
+    res.json({ data: detected, success: true })
+  })
+
+  // POST /locations/detected/promote - Promote detected location to named
+  httpd.post('/locations/detected/promote', authMiddleware, async (req, res) => {
+    const { lat, lon, name, radius } = req.body as {
+      lat?: number
+      lon?: number
+      name?: string
+      radius?: number
+    }
+    const user = req.user!
+
+    if (!name || lat === undefined || lon === undefined) {
+      return res.status(400).json({ error: 'Missing required fields: name, lat, lon', success: false })
+    }
+
+    if (typeof lat !== 'number' || typeof lon !== 'number') {
+      return res.status(400).json({ error: 'lat and lon must be numbers', success: false })
+    }
+
+    const location = await insertNamedLocation(user, { lat, lon, name, radius })
+    res.json({ data: location, success: true })
   })
 
   // POST /metrics - Add a manual metric measurement

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -474,6 +474,142 @@ export const insertPlace = async (user: string, place: Place) => {
 }
 
 // ============================================================================
+// Named Locations (user-defined via Aurboda)
+// ============================================================================
+
+export interface NamedLocation {
+  id: string
+  name: string
+  lat: number
+  lon: number
+  radius: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface NamedLocationInput {
+  name: string
+  lat: number
+  lon: number
+  radius?: number
+}
+
+export const insertNamedLocation = async (
+  user: string,
+  location: NamedLocationInput,
+): Promise<NamedLocation> => {
+  const result = await query(
+    user,
+    `INSERT INTO named_locations (name, location, radius)
+     VALUES ($1, ST_MakePoint($2, $3)::geography, $4)
+     RETURNING id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at`,
+    [location.name, location.lon, location.lat, location.radius ?? 200],
+  )
+  const row = result.rows[0]
+  return {
+    createdAt: new Date(row.created_at),
+    id: row.id,
+    lat: row.lat,
+    lon: row.lon,
+    name: row.name,
+    radius: row.radius,
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+export const getNamedLocations = async (user: string): Promise<NamedLocation[]> => {
+  const result = await query(
+    user,
+    `SELECT id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at
+     FROM named_locations
+     ORDER BY name`,
+    [],
+  )
+  return result.rows.map((row) => ({
+    createdAt: new Date(row.created_at),
+    id: row.id,
+    lat: row.lat,
+    lon: row.lon,
+    name: row.name,
+    radius: row.radius,
+    updatedAt: new Date(row.updated_at),
+  }))
+}
+
+export const getNamedLocationById = async (user: string, id: string): Promise<NamedLocation | null> => {
+  const result = await query(
+    user,
+    `SELECT id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at
+     FROM named_locations
+     WHERE id = $1`,
+    [id],
+  )
+  if (result.rows.length === 0) return null
+  const row = result.rows[0]
+  return {
+    createdAt: new Date(row.created_at),
+    id: row.id,
+    lat: row.lat,
+    lon: row.lon,
+    name: row.name,
+    radius: row.radius,
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+export const updateNamedLocation = async (
+  user: string,
+  id: string,
+  updates: Partial<NamedLocationInput>,
+): Promise<NamedLocation | null> => {
+  const setClauses: string[] = ['updated_at = NOW()']
+  const values: unknown[] = []
+  let paramIndex = 1
+
+  if (updates.name !== undefined) {
+    setClauses.push(`name = $${paramIndex++}`)
+    values.push(updates.name)
+  }
+  if (updates.lat !== undefined && updates.lon !== undefined) {
+    setClauses.push(`location = ST_MakePoint($${paramIndex}, $${paramIndex + 1})::geography`)
+    values.push(updates.lon, updates.lat)
+    paramIndex += 2
+  }
+  if (updates.radius !== undefined) {
+    setClauses.push(`radius = $${paramIndex++}`)
+    values.push(updates.radius)
+  }
+
+  values.push(id)
+
+  const result = await query(
+    user,
+    `UPDATE named_locations
+     SET ${setClauses.join(', ')}
+     WHERE id = $${paramIndex}
+     RETURNING id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at`,
+    values,
+  )
+
+  if (result.rows.length === 0) return null
+  const row = result.rows[0]
+  return {
+    createdAt: new Date(row.created_at),
+    id: row.id,
+    lat: row.lat,
+    lon: row.lon,
+    name: row.name,
+    radius: row.radius,
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+export const deleteNamedLocation = async (user: string, id: string): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM named_locations WHERE id = $1`, [id])
+  return (result.rowCount ?? 0) > 0
+}
+
+// ============================================================================
 // Tags
 // ============================================================================
 

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -9,6 +9,13 @@ import { ouraClient } from './oura'
 import { syncAllOuraData } from './oura-sync'
 import { syncRescueTimeData } from './rescuetime-sync'
 import { isValidMetric, MetricType, validMetrics } from './schema'
+import {
+  deleteNamedLocation,
+  getDetectedLocations,
+  getNamedLocations,
+  insertNamedLocation,
+  updateNamedLocation,
+} from './services/locations'
 import { addMetric, addTag, deleteTag } from './services/mutations'
 import { getDailySummary, getPeriodSummary, queryMetrics, SyncProvider } from './services/queries'
 import { getSettingsResponse, validateAndUpdateSettings } from './services/settings'
@@ -443,6 +450,178 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
         })
         return {
           content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
+        }
+      },
+    )
+
+    // Tool 11: get_named_locations
+    server.tool(
+      'get_named_locations',
+      'List all named locations. These are user-defined places with names and coordinates.',
+      {},
+      async () => {
+        const locations = await getNamedLocations(user)
+        return {
+          content: [
+            { text: JSON.stringify({ data: locations, success: true }, null, 2), type: 'text' as const },
+          ],
+        }
+      },
+    )
+
+    // Tool 12: get_detected_locations
+    server.tool(
+      'get_detected_locations',
+      'Get frequently visited locations that are not yet named. Detects places where user spent 60+ minutes. Returns coordinates, visit count, and total time spent.',
+      {
+        end: z.string().describe('End date/time in ISO 8601 format (e.g., 2024-01-31T23:59:59Z)'),
+        min_duration: z.number().optional().describe('Minimum stay duration in minutes. Defaults to 60.'),
+        start: z.string().describe('Start date/time in ISO 8601 format (e.g., 2024-01-01T00:00:00Z)'),
+      },
+      async ({ end, min_duration, start }) => {
+        const startDate = new Date(start)
+        const endDate = new Date(end)
+
+        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+          return {
+            content: [{ text: 'Invalid date format. Use ISO 8601 format.', type: 'text' as const }],
+          }
+        }
+
+        const detected = await getDetectedLocations(user, {
+          end: endDate,
+          minDurationMinutes: min_duration,
+          start: startDate,
+        })
+
+        return {
+          content: [
+            { text: JSON.stringify({ data: detected, success: true }, null, 2), type: 'text' as const },
+          ],
+        }
+      },
+    )
+
+    // Tool 13: add_named_location
+    server.tool(
+      'add_named_location',
+      'Create a named location. Use this to save a frequently visited place with a name.',
+      {
+        lat: z.number().describe('Latitude of the location (-90 to 90)'),
+        lon: z.number().describe('Longitude of the location (-180 to 180)'),
+        name: z.string().describe('Name for the location (e.g., "Home", "Office", "Gym")'),
+        radius: z.number().optional().describe('Radius in meters. Defaults to 200.'),
+      },
+      async ({ lat, lon, name, radius }) => {
+        if (lat < -90 || lat > 90) {
+          return {
+            content: [{ text: 'Invalid latitude. Must be between -90 and 90.', type: 'text' as const }],
+          }
+        }
+        if (lon < -180 || lon > 180) {
+          return {
+            content: [{ text: 'Invalid longitude. Must be between -180 and 180.', type: 'text' as const }],
+          }
+        }
+
+        const location = await insertNamedLocation(user, { lat, lon, name, radius })
+        return {
+          content: [
+            { text: JSON.stringify({ data: location, success: true }, null, 2), type: 'text' as const },
+          ],
+        }
+      },
+    )
+
+    // Tool 14: update_named_location
+    server.tool(
+      'update_named_location',
+      'Update an existing named location. Can change name, coordinates, or radius.',
+      {
+        id: z.string().describe('The ID of the named location to update'),
+        lat: z.number().optional().describe('New latitude (-90 to 90). Must be provided with lon.'),
+        lon: z.number().optional().describe('New longitude (-180 to 180). Must be provided with lat.'),
+        name: z.string().optional().describe('New name for the location'),
+        radius: z.number().optional().describe('New radius in meters'),
+      },
+      async ({ id, lat, lon, name, radius }) => {
+        if ((lat !== undefined && lon === undefined) || (lon !== undefined && lat === undefined)) {
+          return {
+            content: [{ text: 'lat and lon must be provided together.', type: 'text' as const }],
+          }
+        }
+
+        if (lat !== undefined && (lat < -90 || lat > 90)) {
+          return {
+            content: [{ text: 'Invalid latitude. Must be between -90 and 90.', type: 'text' as const }],
+          }
+        }
+        if (lon !== undefined && (lon < -180 || lon > 180)) {
+          return {
+            content: [{ text: 'Invalid longitude. Must be between -180 and 180.', type: 'text' as const }],
+          }
+        }
+
+        const location = await updateNamedLocation(user, id, { lat, lon, name, radius })
+        if (!location) {
+          return {
+            content: [
+              {
+                text: JSON.stringify({ error: 'Named location not found', success: false }, null, 2),
+                type: 'text' as const,
+              },
+            ],
+          }
+        }
+        return {
+          content: [
+            { text: JSON.stringify({ data: location, success: true }, null, 2), type: 'text' as const },
+          ],
+        }
+      },
+    )
+
+    // Tool 15: delete_named_location
+    server.tool(
+      'delete_named_location',
+      'Delete a named location by its ID.',
+      {
+        id: z.string().describe('The ID of the named location to delete'),
+      },
+      async ({ id }) => {
+        const deleted = await deleteNamedLocation(user, id)
+        if (!deleted) {
+          return {
+            content: [
+              {
+                text: JSON.stringify({ error: 'Named location not found', success: false }, null, 2),
+                type: 'text' as const,
+              },
+            ],
+          }
+        }
+        return {
+          content: [{ text: JSON.stringify({ success: true }, null, 2), type: 'text' as const }],
+        }
+      },
+    )
+
+    // Tool 16: promote_detected_location
+    server.tool(
+      'promote_detected_location',
+      'Create a named location from detected coordinates. Use after get_detected_locations to save a frequently visited place.',
+      {
+        lat: z.number().describe('Latitude from detected location'),
+        lon: z.number().describe('Longitude from detected location'),
+        name: z.string().describe('Name for the location'),
+        radius: z.number().optional().describe('Radius in meters. Uses suggested radius if not provided.'),
+      },
+      async ({ lat, lon, name, radius }) => {
+        const location = await insertNamedLocation(user, { lat, lon, name, radius })
+        return {
+          content: [
+            { text: JSON.stringify({ data: location, success: true }, null, 2), type: 'text' as const },
+          ],
         }
       },
     )

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -76,6 +76,21 @@ export const createTableStatements: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_locations_geo ON locations USING GIST (location)
   `,
 
+  // User-defined named locations (detected and named via Aurboda)
+  named_locations: `
+    CREATE TABLE IF NOT EXISTS named_locations (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name            VARCHAR(255) NOT NULL,
+      location        GEOGRAPHY(POINT, 4326) NOT NULL,
+      radius          INTEGER NOT NULL DEFAULT 200,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
+  named_locations_indexes: `
+    CREATE INDEX IF NOT EXISTS idx_named_locations_geo ON named_locations USING GIST (location)
+  `,
+
   // OAuth tokens for third-party APIs
   oauth_tokens: `
     CREATE TABLE IF NOT EXISTS oauth_tokens (
@@ -223,6 +238,8 @@ export const tableCreationOrder = [
   'locations_indexes',
   'places',
   'places_indexes',
+  'named_locations',
+  'named_locations_indexes',
   'tags',
   'tags_indexes',
   'productivity',

--- a/apps/backend/src/services/locations.test.ts
+++ b/apps/backend/src/services/locations.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from 'vitest'
+import { clusterStays, detectStays, LocationPoint, Stay } from './locations'
+
+describe('detectStays', () => {
+  const makePoint = (lat: number, lon: number, minutesOffset: number): LocationPoint => ({
+    lat,
+    lon,
+    time: new Date(Date.UTC(2024, 0, 15, 10, minutesOffset, 0)),
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(detectStays([])).toEqual([])
+  })
+
+  test('returns empty array for single point', () => {
+    const points = [makePoint(59.33, 18.07, 0)]
+    expect(detectStays(points)).toEqual([])
+  })
+
+  test('detects a stay when points are within radius for 60+ minutes', () => {
+    // Points within ~100m of each other over 90 minutes
+    const points = [
+      makePoint(59.33, 18.07, 0),
+      makePoint(59.33005, 18.07005, 15),
+      makePoint(59.3301, 18.0701, 30),
+      makePoint(59.33005, 18.07005, 45),
+      makePoint(59.33, 18.07, 60),
+      makePoint(59.33005, 18.07005, 90),
+    ]
+
+    const stays = detectStays(points, 200, 60)
+
+    expect(stays).toHaveLength(1)
+    expect(stays[0].durationMinutes).toBe(90)
+    expect(stays[0].lat).toBeCloseTo(59.33, 2)
+    expect(stays[0].lon).toBeCloseTo(18.07, 2)
+  })
+
+  test('does not detect stay if duration is less than minimum', () => {
+    // Points within radius but only 45 minutes
+    const points = [
+      makePoint(59.33, 18.07, 0),
+      makePoint(59.33005, 18.07005, 15),
+      makePoint(59.3301, 18.0701, 30),
+      makePoint(59.33005, 18.07005, 45),
+    ]
+
+    const stays = detectStays(points, 200, 60)
+    expect(stays).toHaveLength(0)
+  })
+
+  test('detects multiple stays', () => {
+    // First stay: 0-90 minutes at location A
+    // Movement: 100 minutes
+    // Second stay: 110-200 minutes at location B (far away)
+    const points = [
+      // Stay 1 (59.33, 18.07)
+      makePoint(59.33, 18.07, 0),
+      makePoint(59.33005, 18.07005, 30),
+      makePoint(59.33, 18.07, 60),
+      makePoint(59.33005, 18.07005, 90),
+      // Movement
+      makePoint(59.35, 18.1, 100),
+      // Stay 2 (59.40, 18.15) - ~10km away
+      makePoint(59.4, 18.15, 110),
+      makePoint(59.40005, 18.15005, 140),
+      makePoint(59.4, 18.15, 170),
+      makePoint(59.40005, 18.15005, 200),
+    ]
+
+    const stays = detectStays(points, 200, 60)
+
+    expect(stays).toHaveLength(2)
+    expect(stays[0].durationMinutes).toBe(90)
+    expect(stays[0].lat).toBeCloseTo(59.33, 2)
+    expect(stays[1].durationMinutes).toBe(90)
+    expect(stays[1].lat).toBeCloseTo(59.4, 2)
+  })
+
+  test('respects custom radius', () => {
+    // Points are ~150m apart - should be one stay with 200m radius, two with 100m
+    const points = [
+      makePoint(59.33, 18.07, 0),
+      makePoint(59.331, 18.071, 30), // ~140m away
+      makePoint(59.33, 18.07, 60),
+      makePoint(59.331, 18.071, 90),
+    ]
+
+    const staysLargeRadius = detectStays(points, 200, 60)
+    expect(staysLargeRadius).toHaveLength(1)
+
+    const staysSmallRadius = detectStays(points, 100, 60)
+    expect(staysSmallRadius).toHaveLength(0) // Can't form valid stay with small radius
+  })
+})
+
+describe('clusterStays', () => {
+  const makeStay = (lat: number, lon: number, durationMinutes: number, dayOffset: number): Stay => ({
+    durationMinutes,
+    endTime: new Date(Date.UTC(2024, 0, 15 + dayOffset, 12, 0, 0)),
+    lat,
+    lon,
+    points: [{ lat, lon, time: new Date(Date.UTC(2024, 0, 15 + dayOffset, 10, 0, 0)) }],
+    startTime: new Date(Date.UTC(2024, 0, 15 + dayOffset, 10, 0, 0)),
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(clusterStays([])).toEqual([])
+  })
+
+  test('returns single cluster for single stay', () => {
+    const stays = [makeStay(59.33, 18.07, 120, 0)]
+
+    const clusters = clusterStays(stays)
+
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].lat).toBeCloseTo(59.33, 2)
+    expect(clusters[0].lon).toBeCloseTo(18.07, 2)
+    expect(clusters[0].totalMinutes).toBe(120)
+    expect(clusters[0].visitCount).toBe(1)
+  })
+
+  test('clusters nearby stays together', () => {
+    // Two stays at the same location on different days
+    const stays = [
+      makeStay(59.33, 18.07, 120, 0),
+      makeStay(59.3305, 18.0705, 90, 1), // ~70m away
+    ]
+
+    const clusters = clusterStays(stays, 200)
+
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].totalMinutes).toBe(210)
+    expect(clusters[0].visitCount).toBe(2)
+  })
+
+  test('keeps distant stays as separate clusters', () => {
+    // Two stays at different locations
+    const stays = [
+      makeStay(59.33, 18.07, 120, 0),
+      makeStay(59.4, 18.15, 90, 1), // ~10km away
+    ]
+
+    const clusters = clusterStays(stays, 200)
+
+    expect(clusters).toHaveLength(2)
+    expect(clusters[0].totalMinutes).toBe(120)
+    expect(clusters[1].totalMinutes).toBe(90)
+  })
+
+  test('tracks first and last visit times', () => {
+    const stays = [
+      makeStay(59.33, 18.07, 60, 0),
+      makeStay(59.33, 18.07, 60, 5),
+      makeStay(59.33, 18.07, 60, 10),
+    ]
+
+    const clusters = clusterStays(stays)
+
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].visitCount).toBe(3)
+    expect(clusters[0].firstVisit).toContain('2024-01-15')
+    expect(clusters[0].lastVisit).toContain('2024-01-25')
+  })
+})

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -1,0 +1,448 @@
+/**
+ * Location services for detecting frequently visited places.
+ *
+ * Uses GPS location data to identify "stays" - places where the user
+ * spent significant time (default 60+ minutes).
+ */
+
+import {
+  deleteNamedLocation,
+  getNamedLocationById,
+  getNamedLocations,
+  insertNamedLocation,
+  NamedLocation,
+  NamedLocationInput,
+  query,
+  updateNamedLocation,
+} from '../db'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DetectedLocation {
+  lat: number
+  lon: number
+  totalMinutes: number
+  visitCount: number
+  firstVisit: string
+  lastVisit: string
+  suggestedRadius: number
+}
+
+export interface LocationPoint {
+  lat: number
+  lon: number
+  time: Date
+}
+
+export interface Stay {
+  lat: number
+  lon: number
+  startTime: Date
+  endTime: Date
+  durationMinutes: number
+  points: LocationPoint[]
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const DEFAULT_CLUSTER_RADIUS_METERS = 200
+const DEFAULT_MIN_STAY_MINUTES = 60
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+const haversineDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
+  const R = 6371000 // Earth radius in meters
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLon = ((lon2 - lon1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}
+
+const calculateCentroid = (points: LocationPoint[]): { lat: number; lon: number } => {
+  const sumLat = points.reduce((sum, p) => sum + p.lat, 0)
+  const sumLon = points.reduce((sum, p) => sum + p.lon, 0)
+  return { lat: sumLat / points.length, lon: sumLon / points.length }
+}
+
+const calculateSuggestedRadius = (
+  points: LocationPoint[],
+  centroid: { lat: number; lon: number },
+): number => {
+  if (points.length === 0) return DEFAULT_CLUSTER_RADIUS_METERS
+  const distances = points.map((p) => haversineDistance(centroid.lat, centroid.lon, p.lat, p.lon))
+  const maxDistance = Math.max(...distances)
+  // Round up to nearest 50m, minimum 100m
+  return Math.max(100, Math.ceil(maxDistance / 50) * 50)
+}
+
+// ============================================================================
+// Stay Detection Algorithm
+// ============================================================================
+
+/**
+ * Detect "stays" from a sequence of location points.
+ * A stay is a cluster of consecutive points within a radius where the user spent minStayMinutes+.
+ */
+export const detectStays = (
+  points: LocationPoint[],
+  radiusMeters: number = DEFAULT_CLUSTER_RADIUS_METERS,
+  minStayMinutes: number = DEFAULT_MIN_STAY_MINUTES,
+): Stay[] => {
+  if (points.length === 0) return []
+
+  const stays: Stay[] = []
+  let currentStay: LocationPoint[] = [points[0]]
+  let currentCentroid = { lat: points[0].lat, lon: points[0].lon }
+
+  for (let i = 1; i < points.length; i++) {
+    const point = points[i]
+    const distanceFromCentroid = haversineDistance(
+      currentCentroid.lat,
+      currentCentroid.lon,
+      point.lat,
+      point.lon,
+    )
+
+    if (distanceFromCentroid <= radiusMeters) {
+      // Point is within radius, add to current stay
+      currentStay.push(point)
+      currentCentroid = calculateCentroid(currentStay)
+    } else {
+      // Point is outside radius, finalize current stay if long enough
+      if (currentStay.length >= 2) {
+        const startTime = currentStay[0].time
+        const endTime = currentStay[currentStay.length - 1].time
+        const durationMinutes = (endTime.getTime() - startTime.getTime()) / (1000 * 60)
+
+        if (durationMinutes >= minStayMinutes) {
+          stays.push({
+            durationMinutes,
+            endTime,
+            lat: currentCentroid.lat,
+            lon: currentCentroid.lon,
+            points: currentStay,
+            startTime,
+          })
+        }
+      }
+
+      // Start new potential stay
+      currentStay = [point]
+      currentCentroid = { lat: point.lat, lon: point.lon }
+    }
+  }
+
+  // Check final stay
+  if (currentStay.length >= 2) {
+    const startTime = currentStay[0].time
+    const endTime = currentStay[currentStay.length - 1].time
+    const durationMinutes = (endTime.getTime() - startTime.getTime()) / (1000 * 60)
+
+    if (durationMinutes >= minStayMinutes) {
+      stays.push({
+        durationMinutes,
+        endTime,
+        lat: currentCentroid.lat,
+        lon: currentCentroid.lon,
+        points: currentStay,
+        startTime,
+      })
+    }
+  }
+
+  return stays
+}
+
+/**
+ * Merge stays at similar locations into clusters.
+ * Returns aggregated info about each unique location.
+ */
+export const clusterStays = (
+  stays: Stay[],
+  radiusMeters: number = DEFAULT_CLUSTER_RADIUS_METERS,
+): DetectedLocation[] => {
+  if (stays.length === 0) return []
+
+  const clusters: { stays: Stay[]; centroid: { lat: number; lon: number } }[] = []
+
+  for (const stay of stays) {
+    let foundCluster = false
+
+    for (const cluster of clusters) {
+      const distance = haversineDistance(cluster.centroid.lat, cluster.centroid.lon, stay.lat, stay.lon)
+      if (distance <= radiusMeters) {
+        cluster.stays.push(stay)
+        // Recalculate centroid
+        const allPoints = cluster.stays.flatMap((s) => s.points)
+        cluster.centroid = calculateCentroid(allPoints)
+        foundCluster = true
+        break
+      }
+    }
+
+    if (!foundCluster) {
+      clusters.push({
+        centroid: { lat: stay.lat, lon: stay.lon },
+        stays: [stay],
+      })
+    }
+  }
+
+  return clusters.map((cluster) => {
+    const allPoints = cluster.stays.flatMap((s) => s.points)
+    const totalMinutes = cluster.stays.reduce((sum, s) => sum + s.durationMinutes, 0)
+    const firstVisit = cluster.stays.reduce(
+      (earliest, s) => (s.startTime < earliest ? s.startTime : earliest),
+      cluster.stays[0].startTime,
+    )
+    const lastVisit = cluster.stays.reduce(
+      (latest, s) => (s.endTime > latest ? s.endTime : latest),
+      cluster.stays[0].endTime,
+    )
+
+    return {
+      firstVisit: firstVisit.toISOString(),
+      lastVisit: lastVisit.toISOString(),
+      lat: cluster.centroid.lat,
+      lon: cluster.centroid.lon,
+      suggestedRadius: calculateSuggestedRadius(allPoints, cluster.centroid),
+      totalMinutes: Math.round(totalMinutes),
+      visitCount: cluster.stays.length,
+    }
+  })
+}
+
+// ============================================================================
+// Database Queries
+// ============================================================================
+
+/**
+ * Get location points from the database for a time range.
+ */
+export const getLocationPoints = async (user: string, start: Date, end: Date): Promise<LocationPoint[]> => {
+  const result = await query(
+    user,
+    `SELECT ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, time
+     FROM locations
+     WHERE time >= $1 AND time <= $2
+     ORDER BY time`,
+    [start, end],
+  )
+
+  return result.rows.map((row) => ({
+    lat: row.lat,
+    lon: row.lon,
+    time: new Date(row.time),
+  }))
+}
+
+/**
+ * Filter out detected locations that overlap with existing named locations.
+ */
+export const filterOverlappingLocations = async (
+  user: string,
+  detected: DetectedLocation[],
+): Promise<DetectedLocation[]> => {
+  const namedLocations = await getNamedLocations(user)
+  if (namedLocations.length === 0) return detected
+
+  return detected.filter((d) => {
+    for (const named of namedLocations) {
+      const distance = haversineDistance(d.lat, d.lon, named.lat, named.lon)
+      // Consider overlapping if within either radius
+      if (distance <= Math.max(d.suggestedRadius, named.radius)) {
+        return false
+      }
+    }
+    return true
+  })
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export interface GetDetectedLocationsOptions {
+  start: Date
+  end: Date
+  minDurationMinutes?: number
+}
+
+/**
+ * Get detected locations where user spent significant time.
+ * Filters out locations that already have named locations nearby.
+ */
+export const getDetectedLocations = async (
+  user: string,
+  options: GetDetectedLocationsOptions,
+): Promise<DetectedLocation[]> => {
+  const { end, minDurationMinutes = DEFAULT_MIN_STAY_MINUTES, start } = options
+
+  // Get all location points in the time range
+  const points = await getLocationPoints(user, start, end)
+  if (points.length === 0) return []
+
+  // Detect stays
+  const stays = detectStays(points, DEFAULT_CLUSTER_RADIUS_METERS, minDurationMinutes)
+  if (stays.length === 0) return []
+
+  // Cluster stays at similar locations
+  const clusters = clusterStays(stays)
+
+  // Filter out locations that overlap with named locations
+  const filtered = await filterOverlappingLocations(user, clusters)
+
+  // Sort by total time spent (descending)
+  return filtered.sort((a, b) => b.totalMinutes - a.totalMinutes)
+}
+
+// ============================================================================
+// Location Matching for Places
+// ============================================================================
+
+export interface PlaceVisit {
+  name: string
+  lat: number
+  lon: number
+  startTime: Date
+  endTime: Date
+  durationMinutes: number
+  source: 'named' | 'owntracks' | 'unknown'
+}
+
+/**
+ * Match a location point against named locations.
+ * Returns the name of the matching location, or null if no match.
+ */
+export const matchLocationToNamed = (
+  lat: number,
+  lon: number,
+  namedLocations: NamedLocation[],
+): NamedLocation | null => {
+  for (const named of namedLocations) {
+    const distance = haversineDistance(lat, lon, named.lat, named.lon)
+    if (distance <= named.radius) {
+      return named
+    }
+  }
+  return null
+}
+
+/**
+ * Get place visits for a time range, using named locations when available.
+ * Falls back to OwnTracks regions if no named location matches.
+ */
+export const getPlaceVisits = async (user: string, start: Date, end: Date): Promise<PlaceVisit[]> => {
+  // Get location data from db with regions
+  const result = await query(
+    user,
+    `SELECT ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, time, regions
+     FROM locations
+     WHERE time >= $1 AND time <= $2
+     ORDER BY time`,
+    [start, end],
+  )
+
+  if (result.rows.length === 0) return []
+
+  const namedLocations = await getNamedLocations(user)
+
+  interface LocationWithRegion extends LocationPoint {
+    regions: string[]
+  }
+
+  const locations: LocationWithRegion[] = result.rows.map((row) => ({
+    lat: row.lat,
+    lon: row.lon,
+    regions: row.regions || [],
+    time: new Date(row.time),
+  }))
+
+  // Group consecutive locations at the same place
+  const visits: PlaceVisit[] = []
+  let currentVisit: {
+    name: string
+    lat: number
+    lon: number
+    startTime: Date
+    endTime: Date
+    source: 'named' | 'owntracks' | 'unknown'
+  } | null = null
+
+  for (const loc of locations) {
+    // Try to match against named locations first
+    const namedMatch = matchLocationToNamed(loc.lat, loc.lon, namedLocations)
+
+    let placeName: string
+    let source: 'named' | 'owntracks' | 'unknown'
+
+    if (namedMatch) {
+      placeName = namedMatch.name
+      source = 'named'
+    } else if (loc.regions.length > 0) {
+      placeName = loc.regions[0]
+      source = 'owntracks'
+    } else {
+      placeName = 'Somewhere'
+      source = 'unknown'
+    }
+
+    if (currentVisit && currentVisit.name === placeName) {
+      // Extend current visit
+      currentVisit.endTime = loc.time
+    } else {
+      // Finalize previous visit if exists
+      if (currentVisit) {
+        const duration = (currentVisit.endTime.getTime() - currentVisit.startTime.getTime()) / (1000 * 60)
+        visits.push({
+          ...currentVisit,
+          durationMinutes: Math.round(duration),
+        })
+      }
+
+      // Start new visit
+      currentVisit = {
+        endTime: loc.time,
+        lat: loc.lat,
+        lon: loc.lon,
+        name: placeName,
+        source,
+        startTime: loc.time,
+      }
+    }
+  }
+
+  // Don't forget the last visit
+  if (currentVisit) {
+    const duration = (currentVisit.endTime.getTime() - currentVisit.startTime.getTime()) / (1000 * 60)
+    visits.push({
+      ...currentVisit,
+      durationMinutes: Math.round(duration),
+    })
+  }
+
+  return visits
+}
+
+// Re-export CRUD operations from db
+export {
+  deleteNamedLocation,
+  getNamedLocationById,
+  getNamedLocations,
+  insertNamedLocation,
+  NamedLocation,
+  NamedLocationInput,
+  updateNamedLocation,
+}

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import * as db from '../db'
 import { MetricType } from '../schema'
+import * as locationsService from './locations'
 import { getDailySummary, getPeriodSummary, queryMetrics } from './queries'
 
 // Mock the db module
@@ -16,6 +17,11 @@ vi.mock('../db', () => ({
   getTimeSeriesMultiMetric: vi.fn(),
   getTimeSeriesStats: vi.fn(),
   getUserSettings: vi.fn(),
+}))
+
+// Mock the locations service
+vi.mock('./locations', () => ({
+  getPlaceVisits: vi.fn(),
 }))
 
 describe('queryMetrics', () => {
@@ -121,16 +127,17 @@ describe('getDailySummary', () => {
       },
     ])
 
-    vi.mocked(db.getLocations).mockResolvedValue({
-      locations: [],
-      places: [
-        {
-          endTime: new Date('2024-01-15T18:00:00Z'),
-          region: 'Home',
-          startTime: new Date('2024-01-15T00:00:00Z'),
-        },
-      ],
-    })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([
+      {
+        durationMinutes: 1080,
+        endTime: new Date('2024-01-15T18:00:00Z'),
+        lat: 59.33,
+        lon: 18.07,
+        name: 'Home',
+        source: 'named',
+        startTime: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
 
     // No aggregate available, should fall back to summing raw records
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -174,7 +181,8 @@ describe('getDailySummary', () => {
 
     // Places
     expect(result.places).toHaveLength(1)
-    expect(result.places[0].region).toBe('Home')
+    expect(result.places[0].name).toBe('Home')
+    expect(result.places[0].source).toBe('named')
   })
 
   test('returns null for heartRate when no data', async () => {
@@ -183,7 +191,7 @@ describe('getDailySummary', () => {
     vi.mocked(db.getActivities).mockResolvedValue([])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
@@ -206,7 +214,7 @@ describe('getDailySummary', () => {
     vi.mocked(db.getActivities).mockResolvedValue([])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
     // Aggregate returns 5000 (deduplicated value)
@@ -230,7 +238,7 @@ describe('getDailySummary', () => {
     vi.mocked(db.getActivities).mockResolvedValue([])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
     // No aggregate available
@@ -248,7 +256,7 @@ describe('getDailySummary', () => {
     vi.mocked(db.getActivities).mockResolvedValue([])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
 
     // Mock Oura scores data
@@ -275,7 +283,7 @@ describe('getDailySummary', () => {
     vi.mocked(db.getActivities).mockResolvedValue([])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
@@ -290,7 +298,7 @@ describe('getDailySummary', () => {
     vi.mocked(db.getActivities).mockResolvedValue([])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
 
     // Only some Oura metrics available
@@ -333,7 +341,7 @@ describe('getDailySummary', () => {
     ])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
@@ -363,7 +371,7 @@ describe('getDailySummary', () => {
     ])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
@@ -400,7 +408,7 @@ describe('getDailySummary', () => {
     ])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
@@ -429,7 +437,7 @@ describe('getDailySummary', () => {
     ])
     vi.mocked(db.getTags).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
-    vi.mocked(db.getLocations).mockResolvedValue({ locations: [], places: [] })
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -9,7 +9,6 @@ import {
   getActivities,
   getDailyAggregates,
   getDailyAggregateValue,
-  getLocations,
   getProductivity,
   getSleepSessions,
   getTags,
@@ -18,6 +17,7 @@ import {
   getTimeSeriesStats,
 } from '../db'
 import { ActivityType, isHrZoneMetric, MetricType, metricUnits } from '../schema'
+import { getPlaceVisits } from './locations'
 import { computeHrZoneSecs, getEffectiveHrZones, HrZoneSecs } from './settings'
 
 // ============================================================================
@@ -70,10 +70,13 @@ export interface TagSummary {
 }
 
 export interface PlaceSummary {
-  region: string
+  name: string
   startTime: string
   endTime: string
   duration: number // minutes
+  source: 'named' | 'owntracks' | 'unknown'
+  lat?: number
+  lon?: number
 }
 
 export interface ProductivitySummary {
@@ -178,7 +181,7 @@ export async function getDailySummary(
     exerciseSessions,
     tags,
     productivity,
-    locations,
+    placeVisits,
     ouraMetrics,
   ] = await Promise.all([
     getTimeSeries(user, 'heart_rate', start, end),
@@ -187,7 +190,7 @@ export async function getDailySummary(
     getActivities(user, 'exercise', start, end),
     getTags(user, start, end),
     getProductivity(user, start, end),
-    getLocations(user, start, end),
+    getPlaceVisits(user, start, end),
     getTimeSeriesMultiMetric(
       user,
       ['sleep_score', 'readiness_score', 'resilience_score', 'cardiovascular_age'],
@@ -284,10 +287,13 @@ export async function getDailySummary(
     exerciseSessions: exerciseSessionsWithHrZones,
     heartRate: heartRateStats,
     ouraScores,
-    places: locations.places.map((p) => ({
-      duration: Math.round((p.endTime.getTime() - p.startTime.getTime()) / 1000 / 60),
+    places: placeVisits.map((p) => ({
+      duration: p.durationMinutes,
       endTime: p.endTime.toISOString(),
-      region: p.region,
+      lat: p.lat,
+      lon: p.lon,
+      name: p.name,
+      source: p.source,
       startTime: p.startTime.toISOString(),
     })),
     productivity: productivitySummary,
@@ -597,11 +603,14 @@ export async function queryProductivity(
  * Query locations/places for a time range.
  */
 export async function queryLocations(user: string, start: Date, end: Date): Promise<PlaceSummary[]> {
-  const { places } = await getLocations(user, start, end)
-  return places.map((p) => ({
-    duration: Math.round((p.endTime.getTime() - p.startTime.getTime()) / 1000 / 60),
+  const visits = await getPlaceVisits(user, start, end)
+  return visits.map((p) => ({
+    duration: p.durationMinutes,
     endTime: p.endTime.toISOString(),
-    region: p.region,
+    lat: p.lat,
+    lon: p.lon,
+    name: p.name,
+    source: p.source,
     startTime: p.startTime.toISOString(),
   }))
 }


### PR DESCRIPTION
## Summary

Implements server-side location intelligence for #57:

- **Named locations table** - User-defined places stored in backend (survives device changes)
- **Stay detection algorithm** - Identifies places where user spent 60+ minutes
- **Clustering** - Groups stays at similar locations across time periods
- **REST API** - Full CRUD for named and detected locations
- **MCP tools** - 6 new tools for location management
- **Daily summary integration** - Uses named locations with fallback to OwnTracks regions

## API Endpoints

```
GET/POST /locations/named
PATCH/DELETE /locations/named/:id
GET /locations/detected?start=...&end=...&minDuration=60
POST /locations/detected/promote
```

## MCP Tools

- `get_named_locations` - List all named locations
- `get_detected_locations` - Find frequently visited unnamed places
- `add_named_location` - Create a named location
- `update_named_location` - Update existing location
- `delete_named_location` - Remove a location
- `promote_detected_location` - Convert detected to named

## Test plan

- [x] Unit tests for stay detection algorithm
- [x] Unit tests for clustering algorithm
- [x] Updated tests for daily summary with new places format
- [x] All 195 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)