### PR TITLE
Add battery optimization prompt for reliable background sync


### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <!-- Alphabetically Sorted Health Permissions -->
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED"/>

--- a/apps/android/app/src/main/java/net/aurboda/BatteryOptimizationHelper.kt
+++ b/apps/android/app/src/main/java/net/aurboda/BatteryOptimizationHelper.kt
@@ -1,0 +1,18 @@
+package net.aurboda
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.PowerManager
+import android.provider.Settings
+
+fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+    val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+}
+
+fun createBatteryOptimizationIntent(context: Context): Intent {
+    return Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+        data = Uri.parse("package:${context.packageName}")
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -283,6 +284,18 @@ fun HealthConnectScreen(
     var pendingTokenToPersist by remember { mutableStateOf<String?>(null) }
     var statusMessage by remember { mutableStateOf("Checking permissions...") }
     var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
+    var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
+
+    val batteryOptimizationLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) {
+        // Check if exemption was granted after returning from settings
+        if (isIgnoringBatteryOptimizations(context)) {
+            Log.d("BatteryOptimization", "Battery optimization exemption granted")
+        } else {
+            Log.d("BatteryOptimization", "Battery optimization exemption was not granted")
+        }
+    }
 
     val scope = rememberCoroutineScope()
     val permissions = remember(allRecordTypes) { allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet() }
@@ -658,6 +671,42 @@ fun HealthConnectScreen(
                     onCheckedChange = { enabled ->
                         backgroundSyncEnabled = enabled
                         setBackgroundSyncEnabled(context, enabled)
+                        if (enabled && !isIgnoringBatteryOptimizations(context)) {
+                            showBatteryOptimizationDialog = true
+                        }
+                    }
+                )
+            }
+
+            if (showBatteryOptimizationDialog) {
+                AlertDialog(
+                    onDismissRequest = { showBatteryOptimizationDialog = false },
+                    title = { Text("Battery Optimization") },
+                    text = {
+                        Text(
+                            "For reliable background sync, allow Aurboda to run " +
+                            "without battery restrictions. This helps ensure your " +
+                            "health data syncs even when the app is closed."
+                        )
+                    },
+                    confirmButton = {
+                        Button(
+                            onClick = {
+                                showBatteryOptimizationDialog = false
+                                batteryOptimizationLauncher.launch(
+                                    createBatteryOptimizationIntent(context)
+                                )
+                            }
+                        ) {
+                            Text("Allow")
+                        }
+                    },
+                    dismissButton = {
+                        Button(
+                            onClick = { showBatteryOptimizationDialog = false }
+                        ) {
+                            Text("Not Now")
+                        }
                     }
                 )
             }


### PR DESCRIPTION
When enabling background sync, prompt the user to disable battery
optimization for the app. This helps ensure WorkManager tasks run
reliably even when the app is in the background.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>