### PR TITLE
Fix pg-boss queue creation for v10+

### DIFF
--- a/apps/backend/src/services/geocode-queue.ts
+++ b/apps/backend/src/services/geocode-queue.ts
@@ -141,6 +141,9 @@ export const initGeocodeQueue = async (): Promise<InstanceType<typeof PgBossModu
   await boss.start()
   console.log(`Geocode queue started (database: ${getDbParams().database})`)
 
+  // Create the queue if it doesn't exist (required in pg-boss v10+)
+  await boss.createQueue(QUEUE_NAME)
+
   // Register the job handler
   // batchSize: 1 ensures only one job processes at a time across all instances
   await boss.work(QUEUE_NAME, { batchSize: 1, pollingIntervalSeconds: 2 }, handleGeocodeJob)


### PR DESCRIPTION
## Summary
- Add `createQueue()` call before `work()` in geocode queue initialization
- pg-boss v10+ requires explicit queue creation before use
- Fixes "Queue geocode-location does not exist" error on startup

## Test plan
- [ ] Deploy to staging and verify geocode queue starts without errors
- [ ] Verify geocoding jobs are enqueued and processed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)