### PR TITLE
Fix Android widget tap to open app on Data tab

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -21,12 +21,13 @@ enum class MainTab {
 
 class AppState(
     private val context: Context,
-    initialScreen: AppScreen
+    initialScreen: AppScreen,
+    initialTab: MainTab = MainTab.Sync
 ) {
     var currentScreen by mutableStateOf(initialScreen)
         private set
 
-    var currentTab by mutableStateOf(MainTab.Sync)
+    var currentTab by mutableStateOf(initialTab)
         private set
 
     var pendingServerUrl by mutableStateOf<String?>(null)
@@ -57,13 +58,14 @@ class AppState(
 }
 
 @Composable
-fun rememberAppState(): AppState {
+fun rememberAppState(initialTab: MainTab? = null): AppState {
     val context = LocalContext.current
     return remember {
         val hasCredentials = CredentialsManager.hasCredentials(context)
         AppState(
             context = context,
-            initialScreen = if (hasCredentials) AppScreen.Main else AppScreen.Login
+            initialScreen = if (hasCredentials) AppScreen.Main else AppScreen.Login,
+            initialTab = initialTab ?: MainTab.Sync
         )
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -205,15 +205,24 @@ private suspend inline fun <reified T : Any> handlePostData(
 }
 
 class MainActivity : ComponentActivity() {
+    companion object {
+        const val EXTRA_OPEN_TAB = "open_tab"
+        const val TAB_DATA = "data"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val initialTab = when (intent?.getStringExtra(EXTRA_OPEN_TAB)) {
+            TAB_DATA -> MainTab.Data
+            else -> null
+        }
         setContent {
             AurbodaAppTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    AurbodaApp()
+                    AurbodaApp(initialTab = initialTab)
                 }
             }
         }
@@ -221,8 +230,8 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun AurbodaApp() {
-    val appState = rememberAppState()
+fun AurbodaApp(initialTab: MainTab? = null) {
+    val appState = rememberAppState(initialTab = initialTab)
 
     when (appState.currentScreen) {
         AppScreen.Login -> {

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -1,5 +1,6 @@
 package net.aurboda.widget
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
@@ -7,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import android.widget.RemoteViews
+import net.aurboda.MainActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -65,6 +67,19 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
     ) {
         scope.launch {
             val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
+
+            // Set up click handler to open the app on the Data tab
+            val openAppIntent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_DATA)
+            }
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                appWidgetId,
+                openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
 
             val credentials = CredentialsManager.getCredentials(context)
             if (credentials == null) {


### PR DESCRIPTION
## Summary
- Fixed widget not responding to taps - was missing click handler
- Widget now opens the app directly to the Data tab showing HR zones
- Added `PendingIntent` with intent extra to specify which tab to open

## Test plan
- [ ] Install updated APK on Android device
- [ ] Add HR Zone widget to home screen
- [ ] Tap widget and verify it opens Aurboda on the Data tab

🤖 Generated with [Claude Code](https://claude.ai/code)