### PR TITLE
Add HR Zones page to web app

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -15,6 +15,9 @@ export function Header() {
         </a>
         {isLoggedIn && (
           <>
+            <a href="/hr-zones" class={url == '/hr-zones' && 'active'}>
+              HR Zones
+            </a>
             <a href="/timeline" class={url == '/timeline' && 'active'}>
               Timeline
             </a>

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { LocationProvider, Route, Router } from 'preact-iso'
 import { Header } from './components/Header.jsx'
 import { Home } from './pages/Home/index.jsx'
+import { HrZones } from './pages/HrZones/index.jsx'
 import { Places } from './pages/Places/index.jsx'
 import { Timeline } from './pages/Timeline/index.jsx'
 import { NotFound } from './pages/_404.jsx'
@@ -18,6 +19,7 @@ export function App() {
         <main>
           <Router>
             <Route path="/" component={Home} />
+            <Route path="/hr-zones" component={HrZones} />
             <Route path="/timeline" component={Timeline} />
             <Route path="/places" component={Places} />
             <Route default component={NotFound} />

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -89,17 +89,17 @@ export function Home() {
 
       <section class="features">
         <h2>Visualizations</h2>
-        <h3>Web</h3>
-        <ul>
-          <li>Timeline with Heartrate, tags, places etc...</li>
-          <li>Location timeline with option to name the locations.</li>
-        </ul>
-        <h3>Android app</h3>
+        <h3>Web &amp; Android</h3>
         <ul>
           <li>
             Minutes in HR zones for last 7 days (due to the Galpin/Huberman recommendation to be in zone 2
-            150-200 minutes per week and zone 5 5-10 minutes), with a widget.
+            150-200 minutes per week and zone 5 5-10 minutes). Android also has a widget.
           </li>
+        </ul>
+        <h3>Web only</h3>
+        <ul>
+          <li>Timeline with Heartrate, tags, places etc...</li>
+          <li>Location timeline with option to name the locations.</li>
         </ul>
       </section>
 
@@ -119,9 +119,17 @@ export function Home() {
       {isLoggedIn && (
         <section class="user-actions">
           <h2>Your Data</h2>
-          <p>
-            <a href="/timeline">View your heart rate timeline</a>
-          </p>
+          <ul>
+            <li>
+              <a href="/hr-zones">View HR zone minutes (last 7 days)</a>
+            </li>
+            <li>
+              <a href="/timeline">View your heart rate timeline</a>
+            </li>
+            <li>
+              <a href="/places">View your places</a>
+            </li>
+          </ul>
         </section>
       )}
     </div>

--- a/apps/web/src/pages/HrZones/index.tsx
+++ b/apps/web/src/pages/HrZones/index.tsx
@@ -1,0 +1,178 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchPeriodSummary, fetchUserSettings, HrZoneThresholds, PeriodMetricStats } from '../../state/api'
+import { auth } from '../../state/auth'
+
+import './style.css'
+
+// Default HR zone thresholds (matching Android app)
+const defaultHrZoneThresholds: HrZoneThresholds = {
+  1: 86,
+  2: 102,
+  3: 118,
+  4: 135,
+  5: 151,
+}
+
+// Weekly target minutes per zone (matching Android app)
+const hrZoneWeeklyTargetMinutes = [0, 60, 200, 60, 30, 10]
+
+// HR Zone colors (matching Android app)
+const hrZoneColors = [
+  '#9E9E9E', // Zone 0: Gray - Below threshold
+  '#64B5F6', // Zone 1: Light Blue - Warm-up
+  '#4CAF50', // Zone 2: Green - Aerobic
+  '#FFC107', // Zone 3: Amber - Tempo
+  '#FF9800', // Zone 4: Orange - Threshold
+  '#F44336', // Zone 5: Red - Max effort
+]
+
+const formatZoneTime = (seconds: number): string => {
+  const totalMinutes = Math.floor(seconds / 60)
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60)
+    const mins = totalMinutes % 60
+    return mins > 0 ? `${hours} h ${mins} min` : `${hours} h`
+  }
+  return `${totalMinutes} min`
+}
+
+const formatBpmRange = (zoneIndex: number, thresholds: HrZoneThresholds): string => {
+  const zoneStarts = [0, thresholds[1], thresholds[2], thresholds[3], thresholds[4], thresholds[5]]
+  switch (zoneIndex) {
+    case 0:
+      return `< ${thresholds[1]} bpm`
+    case 5:
+      return `${thresholds[5]}+ bpm`
+    default:
+      return `${zoneStarts[zoneIndex]} - ${zoneStarts[zoneIndex + 1] - 1} bpm`
+  }
+}
+
+const findMetricTimeSeconds = (metrics: PeriodMetricStats[], metricName: string): number => {
+  const metric = metrics.find((m) => m.metric === metricName)
+  return metric?.avg ?? 0
+}
+
+interface HrZoneBarProps {
+  zoneIndex: number
+  bpmRange: string
+  timeSeconds: number
+  targetMinutes: number
+  color: string
+}
+
+function HrZoneBar({ zoneIndex, bpmRange, timeSeconds, targetMinutes, color }: HrZoneBarProps) {
+  const progress = targetMinutes > 0 ? Math.min((timeSeconds / 60 / targetMinutes) * 100, 100) : 0
+  const percentText = targetMinutes > 0 ? `${Math.round(progress)}%` : ''
+
+  return (
+    <div class="hr-zone-bar">
+      <div class="hr-zone-header">
+        <span class="hr-zone-label">
+          Zone {zoneIndex} ({bpmRange})
+        </span>
+        <span class="hr-zone-time">{formatZoneTime(timeSeconds)}</span>
+      </div>
+      <div class="hr-zone-progress-container">
+        <div class="hr-zone-progress-track" style={{ backgroundColor: `${color}33` }}>
+          <div class="hr-zone-progress-bar" style={{ backgroundColor: color, width: `${progress}%` }} />
+        </div>
+        <span class="hr-zone-percent">{percentText}</span>
+      </div>
+    </div>
+  )
+}
+
+export function HrZones() {
+  const isLoggedIn = auth.value.token
+
+  // Calculate date range: last 7 days including today
+  const today = new Date()
+  today.setHours(23, 59, 59, 999)
+  const weekAgo = new Date()
+  weekAgo.setDate(weekAgo.getDate() - 6)
+  weekAgo.setHours(0, 0, 0, 0)
+
+  const hrZoneMetrics = [
+    'hr_zone_0_sec',
+    'hr_zone_1_sec',
+    'hr_zone_2_sec',
+    'hr_zone_3_sec',
+    'hr_zone_4_sec',
+    'hr_zone_5_sec',
+  ]
+
+  const {
+    data: periodSummary,
+    isLoading: isLoadingSummary,
+    error: summaryError,
+  } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => fetchPeriodSummary(weekAgo, today, hrZoneMetrics),
+    queryKey: ['periodSummary', weekAgo.toISOString(), today.toISOString()],
+  })
+
+  const { data: userSettings } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+  })
+
+  if (!isLoggedIn) {
+    return (
+      <div class="hr-zones-page">
+        <h1>HR Zone Minutes</h1>
+        <p>Please log in to view your heart rate zone data.</p>
+      </div>
+    )
+  }
+
+  if (isLoadingSummary) {
+    return (
+      <div class="hr-zones-page">
+        <h1>HR Zone Minutes</h1>
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+
+  if (summaryError) {
+    return (
+      <div class="hr-zones-page">
+        <h1>HR Zone Minutes</h1>
+        <p class="error">Error loading data: {String(summaryError)}</p>
+      </div>
+    )
+  }
+
+  const thresholds = userSettings?.hr_zone_start ?? defaultHrZoneThresholds
+  const metrics = periodSummary?.metrics ?? []
+
+  return (
+    <div class="hr-zones-page">
+      <h1>HR Zone Minutes (Last 7 Days)</h1>
+      <p class="description">
+        Based on the Galpin/Huberman recommendation: aim for 150-200 minutes in Zone 2 (aerobic) and 5-10
+        minutes in Zone 5 (max effort) per week.
+      </p>
+
+      <div class="hr-zones-list">
+        {[0, 1, 2, 3, 4, 5].map((zoneIndex) => {
+          const metricName = `hr_zone_${zoneIndex}_sec`
+          const timeSeconds = findMetricTimeSeconds(metrics, metricName)
+
+          return (
+            <HrZoneBar
+              key={zoneIndex}
+              zoneIndex={zoneIndex}
+              bpmRange={formatBpmRange(zoneIndex, thresholds)}
+              timeSeconds={timeSeconds}
+              targetMinutes={hrZoneWeeklyTargetMinutes[zoneIndex]}
+              color={hrZoneColors[zoneIndex]}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/HrZones/index.tsx
+++ b/apps/web/src/pages/HrZones/index.tsx
@@ -1,57 +1,18 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchPeriodSummary, fetchUserSettings, HrZoneThresholds, PeriodMetricStats } from '../../state/api'
+import { useMemo } from 'preact/hooks'
+import { fetchPeriodSummary, fetchUserSettings, HrZoneThresholds } from '../../state/api'
 import { auth } from '../../state/auth'
+import {
+  defaultHrZoneThresholds,
+  findMetricTimeSeconds,
+  formatBpmRange,
+  formatZoneTime,
+  getWeekDateRange,
+  hrZoneColors,
+  hrZoneWeeklyTargetMinutes,
+} from '../../utils/hrZones'
 
 import './style.css'
-
-// Default HR zone thresholds (matching Android app)
-const defaultHrZoneThresholds: HrZoneThresholds = {
-  1: 86,
-  2: 102,
-  3: 118,
-  4: 135,
-  5: 151,
-}
-
-// Weekly target minutes per zone (matching Android app)
-const hrZoneWeeklyTargetMinutes = [0, 60, 200, 60, 30, 10]
-
-// HR Zone colors (matching Android app)
-const hrZoneColors = [
-  '#9E9E9E', // Zone 0: Gray - Below threshold
-  '#64B5F6', // Zone 1: Light Blue - Warm-up
-  '#4CAF50', // Zone 2: Green - Aerobic
-  '#FFC107', // Zone 3: Amber - Tempo
-  '#FF9800', // Zone 4: Orange - Threshold
-  '#F44336', // Zone 5: Red - Max effort
-]
-
-const formatZoneTime = (seconds: number): string => {
-  const totalMinutes = Math.floor(seconds / 60)
-  if (totalMinutes >= 60) {
-    const hours = Math.floor(totalMinutes / 60)
-    const mins = totalMinutes % 60
-    return mins > 0 ? `${hours} h ${mins} min` : `${hours} h`
-  }
-  return `${totalMinutes} min`
-}
-
-const formatBpmRange = (zoneIndex: number, thresholds: HrZoneThresholds): string => {
-  const zoneStarts = [0, thresholds[1], thresholds[2], thresholds[3], thresholds[4], thresholds[5]]
-  switch (zoneIndex) {
-    case 0:
-      return `< ${thresholds[1]} bpm`
-    case 5:
-      return `${thresholds[5]}+ bpm`
-    default:
-      return `${zoneStarts[zoneIndex]} - ${zoneStarts[zoneIndex + 1] - 1} bpm`
-  }
-}
-
-const findMetricTimeSeconds = (metrics: PeriodMetricStats[], metricName: string): number => {
-  const metric = metrics.find((m) => m.metric === metricName)
-  return metric?.avg ?? 0
-}
 
 interface HrZoneBarProps {
   zoneIndex: number
@@ -83,24 +44,20 @@ function HrZoneBar({ zoneIndex, bpmRange, timeSeconds, targetMinutes, color }: H
   )
 }
 
+const hrZoneMetrics = [
+  'hr_zone_0_sec',
+  'hr_zone_1_sec',
+  'hr_zone_2_sec',
+  'hr_zone_3_sec',
+  'hr_zone_4_sec',
+  'hr_zone_5_sec',
+]
+
 export function HrZones() {
   const isLoggedIn = auth.value.token
 
-  // Calculate date range: last 7 days including today
-  const today = new Date()
-  today.setHours(23, 59, 59, 999)
-  const weekAgo = new Date()
-  weekAgo.setDate(weekAgo.getDate() - 6)
-  weekAgo.setHours(0, 0, 0, 0)
-
-  const hrZoneMetrics = [
-    'hr_zone_0_sec',
-    'hr_zone_1_sec',
-    'hr_zone_2_sec',
-    'hr_zone_3_sec',
-    'hr_zone_4_sec',
-    'hr_zone_5_sec',
-  ]
+  // Memoize date range to prevent query key instability
+  const dateRange = useMemo(() => getWeekDateRange(), [])
 
   const {
     data: periodSummary,
@@ -108,8 +65,8 @@ export function HrZones() {
     error: summaryError,
   } = useQuery({
     enabled: !!isLoggedIn,
-    queryFn: () => fetchPeriodSummary(weekAgo, today, hrZoneMetrics),
-    queryKey: ['periodSummary', weekAgo.toISOString(), today.toISOString()],
+    queryFn: () => fetchPeriodSummary(new Date(dateRange.start), new Date(dateRange.end), hrZoneMetrics),
+    queryKey: ['periodSummary', dateRange.start, dateRange.end],
   })
 
   const { data: userSettings } = useQuery({
@@ -137,15 +94,16 @@ export function HrZones() {
   }
 
   if (summaryError) {
+    const errorMessage = summaryError instanceof Error ? summaryError.message : 'Unknown error'
     return (
       <div class="hr-zones-page">
         <h1>HR Zone Minutes</h1>
-        <p class="error">Error loading data: {String(summaryError)}</p>
+        <p class="error">Error loading data: {errorMessage}</p>
       </div>
     )
   }
 
-  const thresholds = userSettings?.hr_zone_start ?? defaultHrZoneThresholds
+  const thresholds: HrZoneThresholds = userSettings?.hr_zone_start ?? defaultHrZoneThresholds
   const metrics = periodSummary?.metrics ?? []
 
   return (

--- a/apps/web/src/pages/HrZones/style.css
+++ b/apps/web/src/pages/HrZones/style.css
@@ -1,0 +1,97 @@
+.hr-zones-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.hr-zones-page h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.hr-zones-page .description {
+  color: #666;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.hr-zones-page .loading,
+.hr-zones-page .error {
+  text-align: center;
+  padding: 2rem;
+}
+
+.hr-zones-page .error {
+  color: #f44336;
+}
+
+.hr-zones-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hr-zone-bar {
+  padding: 0.75rem 0;
+}
+
+.hr-zone-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.hr-zone-label {
+  font-weight: 500;
+}
+
+.hr-zone-time {
+  font-weight: 500;
+}
+
+.hr-zone-progress-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hr-zone-progress-track {
+  flex: 1;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.hr-zone-progress-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.hr-zone-percent {
+  width: 3rem;
+  text-align: right;
+  font-size: 0.875rem;
+  color: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+  .hr-zones-page .description {
+    color: #aaa;
+  }
+
+  .hr-zone-percent {
+    color: #aaa;
+  }
+}
+
+@media (max-width: 639px) {
+  .hr-zones-page {
+    padding: 1rem;
+  }
+
+  .hr-zones-page h1 {
+    font-size: 1.5rem;
+  }
+}

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -256,3 +256,67 @@ export const promoteDetectedLocation = async (params: {
 
   return response.data.data
 }
+
+// HR Zone types and API functions
+export interface HrZoneThresholds {
+  1: number
+  2: number
+  3: number
+  4: number
+  5: number
+}
+
+export interface PeriodMetricStats {
+  metric: string
+  unit: string
+  avg?: number
+  min?: number
+  max?: number
+  sum?: number
+  count?: number
+  stddev?: number
+  trend?: number
+  data_points?: number
+}
+
+export interface PeriodSummaryResponse {
+  success: boolean
+  metrics: PeriodMetricStats[]
+  period_start?: string
+  period_end?: string
+}
+
+export interface UserSettingsResponse {
+  success: boolean
+  hr_zone_start?: HrZoneThresholds
+  birth_date?: string
+}
+
+// Fetch period summary for specified metrics
+export const fetchPeriodSummary = async (
+  start: Date,
+  end: Date,
+  metrics: string[],
+): Promise<PeriodSummaryResponse> => {
+  const { token } = auth.value
+  const response = await axios.get<PeriodSummaryResponse>(`${API_URL}/period-summary`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: {
+      end: end.toISOString(),
+      metrics: metrics.join(','),
+      start: start.toISOString(),
+    },
+  })
+
+  return response.data
+}
+
+// Fetch user settings (including HR zone thresholds)
+export const fetchUserSettings = async (): Promise<UserSettingsResponse> => {
+  const { token } = auth.value
+  const response = await axios.get<UserSettingsResponse>(`${API_URL}/user/settings`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return response.data
+}

--- a/apps/web/src/utils/hrZones.test.ts
+++ b/apps/web/src/utils/hrZones.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'vitest'
+import type { HrZoneThresholds, PeriodMetricStats } from '../state/api'
+import {
+  defaultHrZoneThresholds,
+  findMetricTimeSeconds,
+  formatBpmRange,
+  formatZoneTime,
+  getWeekDateRange,
+  hrZoneColors,
+  hrZoneWeeklyTargetMinutes,
+} from './hrZones'
+
+describe('formatZoneTime', () => {
+  test('formats minutes correctly', () => {
+    expect(formatZoneTime(300)).toBe('5 min')
+    expect(formatZoneTime(1800)).toBe('30 min')
+    expect(formatZoneTime(0)).toBe('0 min')
+  })
+
+  test('formats hours and minutes', () => {
+    expect(formatZoneTime(3600)).toBe('1 h')
+    expect(formatZoneTime(5400)).toBe('1 h 30 min')
+    expect(formatZoneTime(8100)).toBe('2 h 15 min')
+  })
+
+  test('handles fractional seconds by flooring', () => {
+    expect(formatZoneTime(89)).toBe('1 min') // 89 seconds = 1 min
+    expect(formatZoneTime(119)).toBe('1 min') // 119 seconds = 1 min
+    expect(formatZoneTime(120)).toBe('2 min') // 120 seconds = 2 min
+  })
+
+  test('handles large values', () => {
+    expect(formatZoneTime(36000)).toBe('10 h') // 600 min = 10 hours
+    expect(formatZoneTime(12300)).toBe('3 h 25 min') // 205 min
+  })
+})
+
+describe('formatBpmRange', () => {
+  test('formats zone 0 correctly', () => {
+    expect(formatBpmRange(0, defaultHrZoneThresholds)).toBe('< 86 bpm')
+  })
+
+  test('formats zone 5 correctly', () => {
+    expect(formatBpmRange(5, defaultHrZoneThresholds)).toBe('151+ bpm')
+  })
+
+  test('formats middle zones correctly', () => {
+    expect(formatBpmRange(1, defaultHrZoneThresholds)).toBe('86 - 101 bpm')
+    expect(formatBpmRange(2, defaultHrZoneThresholds)).toBe('102 - 117 bpm')
+    expect(formatBpmRange(3, defaultHrZoneThresholds)).toBe('118 - 134 bpm')
+    expect(formatBpmRange(4, defaultHrZoneThresholds)).toBe('135 - 150 bpm')
+  })
+
+  test('uses custom thresholds', () => {
+    const customThresholds: HrZoneThresholds = {
+      1: 100,
+      2: 120,
+      3: 140,
+      4: 160,
+      5: 180,
+    }
+    expect(formatBpmRange(0, customThresholds)).toBe('< 100 bpm')
+    expect(formatBpmRange(2, customThresholds)).toBe('120 - 139 bpm')
+    expect(formatBpmRange(5, customThresholds)).toBe('180+ bpm')
+  })
+})
+
+describe('findMetricTimeSeconds', () => {
+  test('returns time for existing metric', () => {
+    const metrics: PeriodMetricStats[] = [
+      { avg: 1000, metric: 'hr_zone_0_sec', unit: 'sec' },
+      { avg: 2000, metric: 'hr_zone_1_sec', unit: 'sec' },
+      { avg: 3000, metric: 'hr_zone_2_sec', unit: 'sec' },
+    ]
+
+    expect(findMetricTimeSeconds(metrics, 'hr_zone_1_sec')).toBe(2000)
+  })
+
+  test('returns 0 for missing metric', () => {
+    const metrics: PeriodMetricStats[] = [{ avg: 1000, metric: 'hr_zone_0_sec', unit: 'sec' }]
+
+    expect(findMetricTimeSeconds(metrics, 'hr_zone_5_sec')).toBe(0)
+  })
+
+  test('returns 0 when avg is undefined', () => {
+    const metrics: PeriodMetricStats[] = [{ metric: 'hr_zone_0_sec', unit: 'sec' }]
+
+    expect(findMetricTimeSeconds(metrics, 'hr_zone_0_sec')).toBe(0)
+  })
+
+  test('returns 0 for empty metrics array', () => {
+    expect(findMetricTimeSeconds([], 'hr_zone_0_sec')).toBe(0)
+  })
+
+  test('handles decimal values', () => {
+    const metrics: PeriodMetricStats[] = [{ avg: 2498.28, metric: 'hr_zone_1_sec', unit: 'sec' }]
+
+    expect(findMetricTimeSeconds(metrics, 'hr_zone_1_sec')).toBe(2498.28)
+  })
+})
+
+describe('getWeekDateRange', () => {
+  test('returns start and end as ISO strings', () => {
+    const range = getWeekDateRange()
+
+    expect(typeof range.start).toBe('string')
+    expect(typeof range.end).toBe('string')
+    expect(range.start).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(range.end).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  test('start is before end', () => {
+    const range = getWeekDateRange()
+    const start = new Date(range.start)
+    const end = new Date(range.end)
+
+    expect(start.getTime()).toBeLessThan(end.getTime())
+  })
+
+  test('range spans approximately 7 days', () => {
+    const range = getWeekDateRange()
+    const start = new Date(range.start)
+    const end = new Date(range.end)
+    const diffMs = end.getTime() - start.getTime()
+    const diffDays = diffMs / (1000 * 60 * 60 * 24)
+
+    // Should be close to 7 days (6 days + ~1 day from start of day to end of day)
+    expect(diffDays).toBeGreaterThanOrEqual(6)
+    expect(diffDays).toBeLessThanOrEqual(7)
+  })
+
+  test('returns consistent values when called multiple times', () => {
+    const range1 = getWeekDateRange()
+    const range2 = getWeekDateRange()
+
+    // Same day calls should return same values
+    expect(range1.start).toBe(range2.start)
+    expect(range1.end).toBe(range2.end)
+  })
+})
+
+describe('constants', () => {
+  test('defaultHrZoneThresholds has correct structure', () => {
+    expect(defaultHrZoneThresholds).toEqual({
+      1: 86,
+      2: 102,
+      3: 118,
+      4: 135,
+      5: 151,
+    })
+  })
+
+  test('hrZoneWeeklyTargetMinutes has 6 zones', () => {
+    expect(hrZoneWeeklyTargetMinutes).toHaveLength(6)
+    expect(hrZoneWeeklyTargetMinutes[0]).toBe(0) // Zone 0 no target
+    expect(hrZoneWeeklyTargetMinutes[2]).toBe(200) // Zone 2 target
+    expect(hrZoneWeeklyTargetMinutes[5]).toBe(10) // Zone 5 target
+  })
+
+  test('hrZoneColors has 6 colors', () => {
+    expect(hrZoneColors).toHaveLength(6)
+    hrZoneColors.forEach((color) => {
+      expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/)
+    })
+  })
+})

--- a/apps/web/src/utils/hrZones.ts
+++ b/apps/web/src/utils/hrZones.ts
@@ -1,0 +1,86 @@
+import type { HrZoneThresholds, PeriodMetricStats } from '../state/api'
+
+// Default HR zone thresholds (matching Android app)
+export const defaultHrZoneThresholds: HrZoneThresholds = {
+  1: 86,
+  2: 102,
+  3: 118,
+  4: 135,
+  5: 151,
+}
+
+// Weekly target minutes per zone (matching Android app)
+// Based on Galpin/Huberman recommendations
+export const hrZoneWeeklyTargetMinutes = [0, 60, 200, 60, 30, 10]
+
+// HR Zone colors (matching Android app)
+export const hrZoneColors = [
+  '#9E9E9E', // Zone 0: Gray - Below threshold
+  '#64B5F6', // Zone 1: Light Blue - Warm-up
+  '#4CAF50', // Zone 2: Green - Aerobic
+  '#FFC107', // Zone 3: Amber - Tempo
+  '#FF9800', // Zone 4: Orange - Threshold
+  '#F44336', // Zone 5: Red - Max effort
+]
+
+/**
+ * Format seconds as human-readable time string
+ * @param seconds - Time in seconds
+ * @returns Formatted string like "1 h 30 min" or "45 min"
+ */
+export const formatZoneTime = (seconds: number): string => {
+  const totalMinutes = Math.floor(seconds / 60)
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60)
+    const mins = totalMinutes % 60
+    return mins > 0 ? `${hours} h ${mins} min` : `${hours} h`
+  }
+  return `${totalMinutes} min`
+}
+
+/**
+ * Format BPM range string for a given HR zone
+ * @param zoneIndex - Zone index (0-5)
+ * @param thresholds - HR zone thresholds
+ * @returns Formatted string like "102 - 117 bpm"
+ */
+export const formatBpmRange = (zoneIndex: number, thresholds: HrZoneThresholds): string => {
+  const zoneStarts = [0, thresholds[1], thresholds[2], thresholds[3], thresholds[4], thresholds[5]]
+  switch (zoneIndex) {
+    case 0:
+      return `< ${thresholds[1]} bpm`
+    case 5:
+      return `${thresholds[5]}+ bpm`
+    default:
+      return `${zoneStarts[zoneIndex]} - ${zoneStarts[zoneIndex + 1] - 1} bpm`
+  }
+}
+
+/**
+ * Find metric time in seconds from a list of period metrics
+ * @param metrics - List of period metric stats
+ * @param metricName - Name of the metric to find
+ * @returns Time in seconds (avg value) or 0 if not found
+ */
+export const findMetricTimeSeconds = (metrics: PeriodMetricStats[], metricName: string): number => {
+  const metric = metrics.find((m) => m.metric === metricName)
+  return metric?.avg ?? 0
+}
+
+/**
+ * Calculate date range for last 7 days (including today)
+ * Returns stable date strings suitable for use as query keys
+ */
+export const getWeekDateRange = (): { start: string; end: string } => {
+  const today = new Date()
+  const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999)
+
+  const startDate = new Date(today)
+  startDate.setDate(startDate.getDate() - 6)
+  startDate.setHours(0, 0, 0, 0)
+
+  return {
+    end: endDate.toISOString(),
+    start: startDate.toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
- Added new `/hr-zones` page showing HR zone minutes for last 7 days (matching Android app functionality)
- Added "HR Zones" link to header navigation (visible when logged in)
- Added link to HR Zones from Home page "Your Data" section for logged-in users
- Updated Home page Visualizations section to reflect HR zones is now available on both Web & Android

## Details
The new page displays:
- All 6 HR zones (0-5) with color-coded progress bars
- Time spent in each zone formatted as hours/minutes
- Progress percentage toward weekly targets
- User's custom HR zone thresholds (or defaults)
- Description of the Galpin/Huberman recommendation

## Navigation
- **Logged out:** Only "Home" visible in header; `/hr-zones` shows "Please log in" message
- **Logged in:** "HR Zones", "Timeline", "Places" visible in header; Home page shows "Your Data" section with links

## Test plan
- [ ] Log in to web app
- [ ] Verify "HR Zones" link appears in header
- [ ] Click HR Zones link, verify page loads with zone data
- [ ] Verify progress bars and formatting match Android app
- [ ] Check Home page shows "Your Data" section with link to HR Zones
- [ ] Log out, verify HR Zones link hidden and page shows login prompt

🤖 Generated with [Claude Code](https://claude.ai/code)