### PR TITLE
Add Settings page to web app

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -24,6 +24,9 @@ export function Header() {
             <a href="/places" class={url == '/places' && 'active'}>
               Places
             </a>
+            <a href="/settings" class={url == '/settings' && 'active'}>
+              Settings
+            </a>
           </>
         )}
       </nav>

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -6,6 +6,7 @@ import { Header } from './components/Header.jsx'
 import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
 import { Places } from './pages/Places/index.jsx'
+import { Settings } from './pages/Settings/index.jsx'
 import { Timeline } from './pages/Timeline/index.jsx'
 import { NotFound } from './pages/_404.jsx'
 import { queryClient } from './state/queryClient.js'
@@ -22,6 +23,7 @@ export function App() {
             <Route path="/hr-zones" component={HrZones} />
             <Route path="/timeline" component={Timeline} />
             <Route path="/places" component={Places} />
+            <Route path="/settings" component={Settings} />
             <Route default component={NotFound} />
           </Router>
         </main>

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,0 +1,188 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+import {
+  fetchUserSettings,
+  HrZoneThresholds,
+  updateUserSettings,
+  UpdateUserSettingsParams,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+import { defaultHrZoneThresholds } from '../../utils/hrZones'
+
+import './style.css'
+
+export function Settings() {
+  const isLoggedIn = auth.value.token
+  const queryClient = useQueryClient()
+
+  const { data: userSettings, isLoading } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+  })
+
+  // Form state
+  const [birthDate, setBirthDate] = useState<string>('')
+  const [hrZones, setHrZones] = useState<HrZoneThresholds | null>(null)
+  const [hasChanges, setHasChanges] = useState(false)
+
+  // Initialize form when data loads
+  const initializeForm = () => {
+    setBirthDate(userSettings?.birth_date ?? '')
+    setHrZones(userSettings?.hr_zone_start ?? null)
+    setHasChanges(false)
+  }
+
+  // Reset form to server values
+  const handleReset = () => {
+    initializeForm()
+  }
+
+  // Track if form has been initialized
+  const [initialized, setInitialized] = useState(false)
+  if (userSettings && !initialized) {
+    initializeForm()
+    setInitialized(true)
+  }
+
+  const mutation = useMutation({
+    mutationFn: updateUserSettings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+      setHasChanges(false)
+    },
+  })
+
+  const handleBirthDateChange = (e: Event) => {
+    const value = (e.target as HTMLInputElement).value
+    setBirthDate(value)
+    setHasChanges(true)
+  }
+
+  const handleZoneChange = (zone: keyof HrZoneThresholds, value: string) => {
+    const numValue = parseInt(value, 10)
+    if (isNaN(numValue)) return
+
+    const currentZones = hrZones ?? defaultHrZoneThresholds
+    setHrZones({ ...currentZones, [zone]: numValue })
+    setHasChanges(true)
+  }
+
+  const handleResetZones = () => {
+    setHrZones(null)
+    setHasChanges(true)
+  }
+
+  const handleSave = () => {
+    const params: UpdateUserSettingsParams = {}
+
+    // Only include birth_date if changed
+    const serverBirthDate = userSettings?.birth_date ?? ''
+    if (birthDate !== serverBirthDate) {
+      params.birth_date = birthDate || null
+    }
+
+    // Only include hr_zone_start if changed
+    const serverZones = userSettings?.hr_zone_start
+    if (JSON.stringify(hrZones) !== JSON.stringify(serverZones)) {
+      params.hr_zone_start = hrZones
+    }
+
+    if (Object.keys(params).length > 0) {
+      mutation.mutate(params)
+    }
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <div class="settings-page">
+        <h1>Settings</h1>
+        <p>Please log in to view and edit your settings.</p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div class="settings-page">
+        <h1>Settings</h1>
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+
+  const displayZones = hrZones ?? defaultHrZoneThresholds
+
+  return (
+    <div class="settings-page">
+      <h1>Settings</h1>
+
+      <section class="settings-section">
+        <h2>Personal Information</h2>
+        <div class="form-field">
+          <label for="birth-date">Birth Date</label>
+          <input id="birth-date" type="date" value={birthDate} onChange={handleBirthDateChange} />
+          <p class="field-description">
+            Used to calculate age-based HR zone thresholds if custom zones are not set.
+          </p>
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <h2>HR Zone Thresholds</h2>
+        <p class="section-description">
+          Customize the heart rate thresholds for each zone. These values represent the starting BPM for each
+          zone.
+        </p>
+
+        <div class="hr-zones-form">
+          {([1, 2, 3, 4, 5] as const).map((zone) => (
+            <div class="zone-input" key={zone}>
+              <label for={`zone-${zone}`}>Zone {zone} starts at</label>
+              <div class="input-with-unit">
+                <input
+                  id={`zone-${zone}`}
+                  type="number"
+                  min="40"
+                  max="220"
+                  value={displayZones[zone]}
+                  onInput={(e) => handleZoneChange(zone, (e.target as HTMLInputElement).value)}
+                />
+                <span class="unit">bpm</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <button type="button" class="reset-zones-button" onClick={handleResetZones}>
+          Reset to defaults
+        </button>
+        {hrZones === null && (
+          <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
+        )}
+      </section>
+
+      {mutation.isError && (
+        <p class="error">
+          Error saving settings: {mutation.error instanceof Error ? mutation.error.message : 'Unknown error'}
+        </p>
+      )}
+
+      {mutation.isSuccess && <p class="success">Settings saved successfully.</p>}
+
+      <div class="button-group">
+        <button type="button" onClick={handleReset} disabled={!hasChanges || mutation.isPending}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="primary"
+          onClick={handleSave}
+          disabled={!hasChanges || mutation.isPending}
+        >
+          {mutation.isPending ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,13 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
-import {
-  fetchUserSettings,
-  HrZoneThresholds,
-  updateUserSettings,
-  UpdateUserSettingsParams,
-} from '../../state/api'
+import { fetchUserSettings, HrZoneThresholds, updateUserSettings } from '../../state/api'
 import { auth } from '../../state/auth'
 import { defaultHrZoneThresholds } from '../../utils/hrZones'
+import { computeSettingsUpdateParams, parseZoneValue, updateZoneThreshold } from '../../utils/settings'
 
 import './style.css'
 
@@ -60,11 +56,10 @@ export function Settings() {
   }
 
   const handleZoneChange = (zone: keyof HrZoneThresholds, value: string) => {
-    const numValue = parseInt(value, 10)
-    if (isNaN(numValue)) return
+    const numValue = parseZoneValue(value)
+    if (numValue === null) return
 
-    const currentZones = hrZones ?? defaultHrZoneThresholds
-    setHrZones({ ...currentZones, [zone]: numValue })
+    setHrZones(updateZoneThreshold(hrZones, zone, numValue))
     setHasChanges(true)
   }
 
@@ -74,21 +69,8 @@ export function Settings() {
   }
 
   const handleSave = () => {
-    const params: UpdateUserSettingsParams = {}
-
-    // Only include birth_date if changed
-    const serverBirthDate = userSettings?.birth_date ?? ''
-    if (birthDate !== serverBirthDate) {
-      params.birth_date = birthDate || null
-    }
-
-    // Only include hr_zone_start if changed
-    const serverZones = userSettings?.hr_zone_start
-    if (JSON.stringify(hrZones) !== JSON.stringify(serverZones)) {
-      params.hr_zone_start = hrZones
-    }
-
-    if (Object.keys(params).length > 0) {
+    const params = computeSettingsUpdateParams(birthDate, hrZones, userSettings)
+    if (params) {
       mutation.mutate(params)
     }
   }

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -1,0 +1,213 @@
+.settings-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.settings-page h1 {
+  font-size: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.settings-page .loading,
+.settings-page .error {
+  text-align: center;
+  padding: 2rem;
+}
+
+.settings-page .error {
+  color: #f44336;
+}
+
+.settings-page .success {
+  color: #4caf50;
+  margin-bottom: 1rem;
+}
+
+.settings-section {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-section h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.section-description {
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.form-field {
+  margin-bottom: 1rem;
+}
+
+.form-field label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.form-field input[type="date"] {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+  max-width: 200px;
+}
+
+.field-description {
+  color: #666;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  line-height: 1.4;
+}
+
+.hr-zones-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.zone-input {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.zone-input label {
+  min-width: 120px;
+  font-weight: 500;
+}
+
+.input-with-unit {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.zone-input input[type="number"] {
+  width: 80px;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.zone-input .unit {
+  color: #666;
+}
+
+.reset-zones-button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.reset-zones-button:hover {
+  background: #f5f5f5;
+}
+
+.button-group {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+.button-group button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.button-group button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button-group button.primary {
+  background: #673ab8;
+  color: white;
+  border: none;
+}
+
+.button-group button.primary:hover:not(:disabled) {
+  background: #5e35b1;
+}
+
+.button-group button:not(.primary) {
+  background: transparent;
+  border: 1px solid #ccc;
+}
+
+.button-group button:not(.primary):hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+@media (prefers-color-scheme: dark) {
+  .settings-section {
+    border-bottom-color: #444;
+  }
+
+  .section-description,
+  .field-description,
+  .zone-input .unit {
+    color: #aaa;
+  }
+
+  .form-field input[type="date"],
+  .zone-input input[type="number"] {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+
+  .reset-zones-button {
+    border-color: #555;
+    color: #fff;
+  }
+
+  .reset-zones-button:hover {
+    background: #444;
+  }
+
+  .button-group button:not(.primary) {
+    border-color: #555;
+    color: #fff;
+  }
+
+  .button-group button:not(.primary):hover:not(:disabled) {
+    background: #444;
+  }
+}
+
+@media (max-width: 639px) {
+  .settings-page {
+    padding: 1rem;
+  }
+
+  .settings-page h1 {
+    font-size: 1.5rem;
+  }
+
+  .zone-input {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .zone-input label {
+    min-width: auto;
+  }
+}

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -320,3 +320,18 @@ export const fetchUserSettings = async (): Promise<UserSettingsResponse> => {
 
   return response.data
 }
+
+export interface UpdateUserSettingsParams {
+  birth_date?: string | null
+  hr_zone_start?: HrZoneThresholds | null
+}
+
+// Update user settings
+export const updateUserSettings = async (params: UpdateUserSettingsParams): Promise<UserSettingsResponse> => {
+  const { token } = auth.value
+  const response = await axios.post<UserSettingsResponse>(`${API_URL}/user/settings`, params, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return response.data
+}

--- a/apps/web/src/utils/settings.test.ts
+++ b/apps/web/src/utils/settings.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from 'vitest'
+import type { HrZoneThresholds, UserSettingsResponse } from '../state/api'
+import { defaultHrZoneThresholds } from './hrZones'
+import {
+  computeSettingsUpdateParams,
+  parseZoneValue,
+  updateZoneThreshold,
+  validateHrZoneThresholds,
+} from './settings'
+
+describe('parseZoneValue', () => {
+  test('parses valid integer strings', () => {
+    expect(parseZoneValue('100')).toBe(100)
+    expect(parseZoneValue('0')).toBe(0)
+    expect(parseZoneValue('220')).toBe(220)
+  })
+
+  test('returns null for invalid strings', () => {
+    expect(parseZoneValue('')).toBe(null)
+    expect(parseZoneValue('abc')).toBe(null)
+    expect(parseZoneValue('12.5')).toBe(12) // parseInt truncates
+  })
+
+  test('handles negative numbers', () => {
+    expect(parseZoneValue('-10')).toBe(-10)
+  })
+})
+
+describe('updateZoneThreshold', () => {
+  test('updates existing zones object', () => {
+    const current: HrZoneThresholds = { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 }
+    const result = updateZoneThreshold(current, 2, 115)
+
+    expect(result).toEqual({ 1: 90, 2: 115, 3: 130, 4: 150, 5: 170 })
+  })
+
+  test('uses defaults when current is null', () => {
+    const result = updateZoneThreshold(null, 3, 125)
+
+    expect(result).toEqual({
+      ...defaultHrZoneThresholds,
+      3: 125,
+    })
+  })
+
+  test('does not mutate original object', () => {
+    const current: HrZoneThresholds = { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 }
+    updateZoneThreshold(current, 2, 115)
+
+    expect(current[2]).toBe(110)
+  })
+})
+
+describe('computeSettingsUpdateParams', () => {
+  const baseServerSettings: UserSettingsResponse = {
+    birth_date: '1990-01-15',
+    hr_zone_start: { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 },
+    success: true,
+  }
+
+  test('returns null when nothing changed', () => {
+    const result = computeSettingsUpdateParams(
+      '1990-01-15',
+      baseServerSettings.hr_zone_start!,
+      baseServerSettings,
+    )
+
+    expect(result).toBe(null)
+  })
+
+  test('returns only birth_date when only that changed', () => {
+    const result = computeSettingsUpdateParams(
+      '1985-06-20',
+      baseServerSettings.hr_zone_start!,
+      baseServerSettings,
+    )
+
+    expect(result).toEqual({ birth_date: '1985-06-20' })
+  })
+
+  test('returns only hr_zone_start when only that changed', () => {
+    const newZones: HrZoneThresholds = { 1: 95, 2: 110, 3: 130, 4: 150, 5: 170 }
+    const result = computeSettingsUpdateParams('1990-01-15', newZones, baseServerSettings)
+
+    expect(result).toEqual({ hr_zone_start: newZones })
+  })
+
+  test('returns both when both changed', () => {
+    const newZones: HrZoneThresholds = { 1: 95, 2: 115, 3: 135, 4: 155, 5: 175 }
+    const result = computeSettingsUpdateParams('2000-12-25', newZones, baseServerSettings)
+
+    expect(result).toEqual({
+      birth_date: '2000-12-25',
+      hr_zone_start: newZones,
+    })
+  })
+
+  test('handles empty birth_date being set to null', () => {
+    const result = computeSettingsUpdateParams('', baseServerSettings.hr_zone_start!, baseServerSettings)
+
+    expect(result).toEqual({ birth_date: null })
+  })
+
+  test('handles clearing hr_zone_start (setting to null)', () => {
+    const result = computeSettingsUpdateParams('1990-01-15', null, baseServerSettings)
+
+    expect(result).toEqual({ hr_zone_start: null })
+  })
+
+  test('handles undefined server settings', () => {
+    const result = computeSettingsUpdateParams('1990-01-15', null, undefined)
+
+    expect(result).toEqual({ birth_date: '1990-01-15' })
+  })
+
+  test('handles server settings with no birth_date', () => {
+    const serverSettings: UserSettingsResponse = { success: true }
+    const result = computeSettingsUpdateParams('', null, serverSettings)
+
+    expect(result).toBe(null)
+  })
+
+  test('handles server settings with no hr_zone_start', () => {
+    const serverSettings: UserSettingsResponse = { birth_date: '1990-01-15', success: true }
+    const zones: HrZoneThresholds = { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 }
+    const result = computeSettingsUpdateParams('1990-01-15', zones, serverSettings)
+
+    expect(result).toEqual({ hr_zone_start: zones })
+  })
+})
+
+describe('validateHrZoneThresholds', () => {
+  test('valid zones pass validation', () => {
+    const zones: HrZoneThresholds = { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 }
+    const result = validateHrZoneThresholds(zones)
+
+    expect(result).toEqual({ valid: true })
+  })
+
+  test('default thresholds are valid', () => {
+    const result = validateHrZoneThresholds(defaultHrZoneThresholds)
+
+    expect(result).toEqual({ valid: true })
+  })
+
+  test('fails when zone is below minimum', () => {
+    const zones: HrZoneThresholds = { 1: 30, 2: 110, 3: 130, 4: 150, 5: 170 }
+    const result = validateHrZoneThresholds(zones)
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Zone 1')
+    expect(result.error).toContain('between 40 and 220')
+  })
+
+  test('fails when zone is above maximum', () => {
+    const zones: HrZoneThresholds = { 1: 90, 2: 110, 3: 130, 4: 150, 5: 230 }
+    const result = validateHrZoneThresholds(zones)
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Zone 5')
+  })
+
+  test('fails when zones are not in ascending order', () => {
+    const zones: HrZoneThresholds = { 1: 90, 2: 110, 3: 100, 4: 150, 5: 170 }
+    const result = validateHrZoneThresholds(zones)
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('greater than')
+  })
+
+  test('fails when zones are equal', () => {
+    const zones: HrZoneThresholds = { 1: 90, 2: 110, 3: 110, 4: 150, 5: 170 }
+    const result = validateHrZoneThresholds(zones)
+
+    expect(result.valid).toBe(false)
+  })
+
+  test('boundary values are valid', () => {
+    const zones: HrZoneThresholds = { 1: 40, 2: 80, 3: 120, 4: 160, 5: 220 }
+    const result = validateHrZoneThresholds(zones)
+
+    expect(result).toEqual({ valid: true })
+  })
+})

--- a/apps/web/src/utils/settings.ts
+++ b/apps/web/src/utils/settings.ts
@@ -1,0 +1,70 @@
+import type { HrZoneThresholds, UpdateUserSettingsParams, UserSettingsResponse } from '../state/api'
+import { defaultHrZoneThresholds } from './hrZones'
+
+/**
+ * Parse a zone value string to a number, returning null if invalid
+ */
+export const parseZoneValue = (value: string): number | null => {
+  const numValue = parseInt(value, 10)
+  return isNaN(numValue) ? null : numValue
+}
+
+/**
+ * Update a single zone threshold value in a thresholds object
+ */
+export const updateZoneThreshold = (
+  currentZones: HrZoneThresholds | null,
+  zone: keyof HrZoneThresholds,
+  value: number,
+): HrZoneThresholds => {
+  const baseZones = currentZones ?? defaultHrZoneThresholds
+  return { ...baseZones, [zone]: value }
+}
+
+/**
+ * Compute the update params to send to the API based on form vs server state
+ * Returns only the changed fields, or null if nothing changed
+ */
+export const computeSettingsUpdateParams = (
+  formBirthDate: string,
+  formHrZones: HrZoneThresholds | null,
+  serverSettings: UserSettingsResponse | undefined,
+): UpdateUserSettingsParams | null => {
+  const params: UpdateUserSettingsParams = {}
+
+  // Check birth_date changes
+  const serverBirthDate = serverSettings?.birth_date ?? ''
+  if (formBirthDate !== serverBirthDate) {
+    params.birth_date = formBirthDate || null
+  }
+
+  // Check hr_zone_start changes - treat null and undefined as equivalent
+  const serverZones = serverSettings?.hr_zone_start ?? null
+  if (JSON.stringify(formHrZones) !== JSON.stringify(serverZones)) {
+    params.hr_zone_start = formHrZones
+  }
+
+  return Object.keys(params).length > 0 ? params : null
+}
+
+/**
+ * Validate HR zone thresholds - zones must be in ascending order
+ */
+export const validateHrZoneThresholds = (zones: HrZoneThresholds): { valid: boolean; error?: string } => {
+  const values = [zones[1], zones[2], zones[3], zones[4], zones[5]]
+
+  for (let i = 0; i < values.length; i++) {
+    const val = values[i]
+    if (val < 40 || val > 220) {
+      return { error: `Zone ${i + 1} must be between 40 and 220 bpm`, valid: false }
+    }
+  }
+
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] <= values[i - 1]) {
+      return { error: `Zone ${i + 2} must be greater than Zone ${i + 1}`, valid: false }
+    }
+  }
+
+  return { valid: true }
+}


### PR DESCRIPTION
## Summary
- Add a new Settings page to the web app for configuring user settings
- Allow users to set their birth date (used for age-based HR zone calculations)
- Allow users to customize HR zone thresholds (zones 1-5)
- Add `updateUserSettings` API function for persisting changes
- Add Settings link to the navigation header

## Test plan
- [ ] Navigate to Settings page when logged in
- [ ] Verify birth date input works and persists after save
- [ ] Verify HR zone threshold inputs accept valid values (40-220 bpm)
- [ ] Verify "Reset to defaults" clears custom zones
- [ ] Verify Cancel button reverts unsaved changes
- [ ] Verify Save button is disabled when no changes are made
- [ ] Verify error/success messages display appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)