### PR TITLE
Fix PostgreSQL connection exhaustion

### DIFF
--- a/apps/backend/src/services/geocode-queue.ts
+++ b/apps/backend/src/services/geocode-queue.ts
@@ -131,6 +131,7 @@ export const initGeocodeQueue = async (): Promise<InstanceType<typeof PgBossModu
   const PgBoss = PgBossModule.PgBoss
   boss = new PgBoss({
     connectionString,
+    max: 3, // Limit connection pool to prevent exhausting PostgreSQL connections
     schema: 'pgboss',
   })
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
   postgres:
     image: postgis/postgis:16-3.4-alpine
+    command: postgres -c max_connections=200
     environment:
       - POSTGRES_USER=aurboda_service
       - POSTGRES_PASSWORD=aurboda_dev_password


### PR DESCRIPTION
## Summary
- Limit pg-boss connection pool to 3 connections to reduce connection usage
- Increase PostgreSQL max_connections from 100 (default) to 200

This fixes the crash caused by "remaining connection slots are reserved for roles with the SUPERUSER attribute" error when connections accumulate from pg-boss supervision and per-user database connections.

## Test plan
- [ ] Merge and deploy to valhall
- [ ] Monitor that backend no longer crashes with connection exhaustion errors
- [ ] Verify geocode queue still processes jobs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)