### PR TITLE
Add missing MCP tools and DRY up api-spec schemas

### DIFF
--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -303,7 +303,8 @@ describe('MCP Server', () => {
 
       expect(response.status).toBe(200)
       const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
-      expect(parsed.result.content[0].text).toContain('Invalid date format')
+      // Schema validation catches invalid dates before our handler runs
+      expect(parsed.result.content[0].text).toMatch(/Invalid (date|ISO datetime)/i)
     })
 
     test('returns error for invalid metrics', async () => {

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import request from 'supertest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createAuth } from './auth'
+import * as db from './db'
 import { createMcpRouter } from './mcp'
 import * as queries from './services/queries'
 
@@ -9,7 +10,11 @@ import * as queries from './services/queries'
 vi.mock('./services/queries', () => ({
   getDailySummary: vi.fn(),
   getPeriodSummary: vi.fn(),
+  queryActivities: vi.fn(),
+  queryLocations: vi.fn(),
   queryMetrics: vi.fn(),
+  queryProductivity: vi.fn(),
+  queryTags: vi.fn(),
 }))
 
 vi.mock('./services/mutations', () => ({
@@ -17,9 +22,10 @@ vi.mock('./services/mutations', () => ({
   addTag: vi.fn(),
 }))
 
-// Mock db for sync status (not moved to services yet)
+// Mock db for sync status and stored detected locations
 vi.mock('./db', () => ({
   getAllSyncStates: vi.fn(),
+  getDetectedLocations: vi.fn(),
 }))
 
 // Mock the sync modules
@@ -477,6 +483,504 @@ describe('MCP Server', () => {
 
       expect(response.status).toBe(200)
       expect(response.toolResult.metrics[0].completenessPercent).toBe(48)
+    })
+  })
+
+  describe('Tool: query_tags', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('returns tags for valid time range', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryTags).mockResolvedValue([
+        {
+          startTime: '2024-01-15T14:30:00Z',
+          tag: 'coffee',
+        },
+        {
+          endTime: '2024-01-15T16:00:00Z',
+          startTime: '2024-01-15T15:00:00Z',
+          tag: 'meeting',
+        },
+      ])
+
+      const response = await callTool(app, token, sessionId, 'query_tags', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(2)
+      expect(response.toolResult.data[0].tag).toBe('coffee')
+      expect(response.toolResult.data[1].tag).toBe('meeting')
+      expect(queries.queryTags).toHaveBeenCalledWith(
+        'testuser',
+        expect.any(Date),
+        expect.any(Date),
+        undefined,
+      )
+    })
+
+    test('returns empty array when no tags exist', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryTags).mockResolvedValue([])
+
+      const response = await callTool(app, token, sessionId, 'query_tags', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(0)
+    })
+  })
+
+  describe('Tool: query_activities', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('returns activities for valid time range', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryActivities).mockResolvedValue([
+        {
+          activityType: 'sleep',
+          duration: 480,
+          endTime: '2024-01-15T07:00:00Z',
+          source: 'health_connect',
+          startTime: '2024-01-14T23:00:00Z',
+          title: 'Sleep',
+        },
+        {
+          activityType: 'exercise',
+          duration: 45,
+          endTime: '2024-01-15T09:45:00Z',
+          hrZoneSecs: { 0: 60, 1: 300, 2: 900, 3: 1200, 4: 240, 5: 0 },
+          source: 'health_connect',
+          startTime: '2024-01-15T09:00:00Z',
+          title: 'Morning Run',
+        },
+      ])
+
+      const response = await callTool(app, token, sessionId, 'query_activities', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(2)
+      expect(response.toolResult.data[0].activityType).toBe('sleep')
+      expect(response.toolResult.data[1].activityType).toBe('exercise')
+      expect(response.toolResult.data[1].hrZoneSecs).toBeDefined()
+    })
+
+    test('filters by activity types when provided', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryActivities).mockResolvedValue([
+        {
+          activityType: 'exercise',
+          duration: 45,
+          endTime: '2024-01-15T09:45:00Z',
+          source: 'health_connect',
+          startTime: '2024-01-15T09:00:00Z',
+          title: 'Morning Run',
+        },
+      ])
+
+      const response = await callTool(app, token, sessionId, 'query_activities', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+        types: ['exercise'],
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(queries.queryActivities).toHaveBeenCalledWith(
+        'testuser',
+        ['exercise'],
+        expect.any(Date),
+        expect.any(Date),
+        undefined,
+      )
+    })
+  })
+
+  describe('Tool: query_productivity', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('returns productivity data for valid time range', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryProductivity).mockResolvedValue([
+        {
+          activity: 'Visual Studio Code',
+          category: 'Software Development',
+          durationSec: 7200,
+          endTime: '2024-01-15T17:00:00Z',
+          productivity: 2,
+          startTime: '2024-01-15T09:00:00Z',
+        },
+        {
+          activity: 'Twitter',
+          category: 'Social Networking',
+          durationSec: 1800,
+          endTime: '2024-01-15T18:00:00Z',
+          productivity: -2,
+          startTime: '2024-01-15T17:30:00Z',
+        },
+      ])
+
+      const response = await callTool(app, token, sessionId, 'query_productivity', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(2)
+      expect(response.toolResult.data[0].activity).toBe('Visual Studio Code')
+      expect(response.toolResult.data[0].productivity).toBe(2)
+      expect(queries.queryProductivity).toHaveBeenCalledWith(
+        'testuser',
+        expect.any(Date),
+        expect.any(Date),
+        undefined,
+      )
+    })
+  })
+
+  describe('Tool: query_locations', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('returns location visits for valid time range', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryLocations).mockResolvedValue([
+        {
+          duration: 480,
+          endTime: '2024-01-15T17:00:00Z',
+          lat: 59.3293,
+          lon: 18.0686,
+          name: 'Office',
+          source: 'named',
+          startTime: '2024-01-15T09:00:00Z',
+        },
+        {
+          duration: 120,
+          endTime: '2024-01-15T20:00:00Z',
+          lat: 59.3351,
+          lon: 18.0542,
+          name: 'Gym',
+          source: 'named',
+          startTime: '2024-01-15T18:00:00Z',
+        },
+      ])
+
+      const response = await callTool(app, token, sessionId, 'query_locations', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(2)
+      expect(response.toolResult.data[0].name).toBe('Office')
+      expect(response.toolResult.data[0].source).toBe('named')
+      expect(response.toolResult.data[1].name).toBe('Gym')
+      expect(queries.queryLocations).toHaveBeenCalledWith('testuser', expect.any(Date), expect.any(Date))
+    })
+
+    test('returns empty array when no visits exist', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(queries.queryLocations).mockResolvedValue([])
+
+      const response = await callTool(app, token, sessionId, 'query_locations', {
+        end: '2024-01-31T23:59:59Z',
+        start: '2024-01-01T00:00:00Z',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(0)
+    })
+  })
+
+  describe('Tool: get_stored_detected_locations', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('returns stored detected locations with addresses', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(db.getDetectedLocations).mockResolvedValue([
+        {
+          address: '123 Main St, Stockholm',
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+          firstVisit: new Date('2024-01-01T09:00:00Z'),
+          geocodeStatus: 'success',
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          lastVisit: new Date('2024-01-15T17:00:00Z'),
+          lat: 59.3293,
+          lon: 18.0686,
+          radius: 200,
+          totalMinutes: 4800,
+          updatedAt: new Date('2024-01-15T17:00:00Z'),
+          visitCount: 10,
+        },
+        {
+          address: null,
+          createdAt: new Date('2024-01-02T00:00:00Z'),
+          firstVisit: new Date('2024-01-02T10:00:00Z'),
+          geocodeStatus: 'pending',
+          id: '123e4567-e89b-12d3-a456-426614174001',
+          lastVisit: new Date('2024-01-16T18:00:00Z'),
+          lat: 59.3351,
+          lon: 18.0542,
+          radius: 150,
+          totalMinutes: 600,
+          updatedAt: new Date('2024-01-16T18:00:00Z'),
+          visitCount: 3,
+        },
+      ])
+
+      const response = await callTool(app, token, sessionId, 'get_stored_detected_locations', {})
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(2)
+      expect(response.toolResult.data[0].address).toBe('123 Main St, Stockholm')
+      expect(response.toolResult.data[0].geocodeStatus).toBe('success')
+      expect(response.toolResult.data[1].geocodeStatus).toBe('pending')
+      expect(db.getDetectedLocations).toHaveBeenCalledWith('testuser')
+    })
+
+    test('returns empty array when no stored locations exist', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(db.getDetectedLocations).mockResolvedValue([])
+
+      const response = await callTool(app, token, sessionId, 'get_stored_detected_locations', {})
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(0)
     })
   })
 })

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -1,14 +1,26 @@
+import {
+  activityTypeSchema,
+  dateOnlySchema,
+  endDateTimeQuerySchema,
+  hrZoneThresholdsSchema,
+  isValidMetric,
+  latWithValidationSchema,
+  lonWithValidationSchema,
+  MetricType,
+  startDateTimeQuerySchema,
+  syncProviderSchema,
+  validMetrics,
+} from '@aurboda/api-spec'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { randomUUID } from 'crypto'
 import { Request, Response, Router } from 'express'
 import { z } from 'zod'
 import { Auth } from './auth'
-import { getAllSyncStates } from './db'
+import { getAllSyncStates, getDetectedLocations as getStoredDetectedLocations } from './db'
 import { ouraClient } from './oura'
 import { syncAllOuraData } from './oura-sync'
 import { syncRescueTimeData } from './rescuetime-sync'
-import { isValidMetric, MetricType, validMetrics } from './schema'
 import {
   deleteNamedLocation,
   getDetectedLocations,
@@ -17,7 +29,16 @@ import {
   updateNamedLocation,
 } from './services/locations'
 import { addMetric, addTag, deleteTag } from './services/mutations'
-import { getDailySummary, getPeriodSummary, queryMetrics, SyncProvider } from './services/queries'
+import {
+  getDailySummary,
+  getPeriodSummary,
+  queryActivities,
+  queryLocations,
+  queryMetrics,
+  queryProductivity,
+  queryTags,
+  SyncProvider,
+} from './services/queries'
 import { getSettings, getSettingsResponse, validateAndUpdateSettings } from './services/settings'
 
 interface McpSession {
@@ -27,6 +48,19 @@ interface McpSession {
 }
 
 type OuraClientType = ReturnType<typeof ouraClient>
+
+// ============================================================================
+// MCP-specific input schemas (reusing fields from api-spec)
+// ============================================================================
+
+// Common time range schema for MCP queries
+const mcpTimeRangeSchema = {
+  end: endDateTimeQuerySchema,
+  start: startDateTimeQuerySchema,
+}
+
+// Metric name description using validMetrics from api-spec
+const metricDescription = `Metric name. Valid metrics: ${validMetrics.join(', ')}`
 
 export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncProvider): Router {
   const router = Router()
@@ -45,81 +79,195 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
     }
   }
 
+  // Helper to create JSON text response
+  const jsonResponse = (data: unknown) => ({
+    content: [{ text: JSON.stringify(data, null, 2), type: 'text' as const }],
+  })
+
+  // Helper to create error response
+  const errorResponse = (message: string) => ({
+    content: [{ text: message, type: 'text' as const }],
+  })
+
+  // Helper to parse and validate ISO date string
+  const parseDate = (dateStr: string): Date | null => {
+    const date = new Date(dateStr)
+    return isNaN(date.getTime()) ? null : date
+  }
+
   const createMcpServer = (user: string): McpServer => {
     const server = new McpServer({
       name: 'aurboda',
       version: '1.0.0',
     })
 
-    // Tool 1: query_metrics
+    // ========================================================================
+    // Query Tools
+    // ========================================================================
+
+    // Tool: query_metrics
     server.tool(
       'query_metrics',
       'Query health metrics for a time range. Returns time series data with timestamps and values.',
       {
-        end: z.string().describe('End date/time in ISO 8601 format (e.g., 2024-01-15T23:59:59Z)'),
-        metric: z.string().describe(`Metric name. Valid metrics: ${validMetrics.join(', ')}`),
-        start: z.string().describe('Start date/time in ISO 8601 format (e.g., 2024-01-15T00:00:00Z)'),
+        ...mcpTimeRangeSchema,
+        metric: z.string().describe(metricDescription),
       },
       async ({ end, metric, start }) => {
         if (!isValidMetric(metric)) {
-          return {
-            content: [
-              {
-                text: `Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`,
-                type: 'text' as const,
-              },
-            ],
-          }
+          return errorResponse(`Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`)
         }
 
-        const startDate = new Date(start)
-        const endDate = new Date(end)
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
 
-        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-          return {
-            content: [{ text: 'Invalid date format. Use ISO 8601 format.', type: 'text' as const }],
-          }
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
         }
 
         const result = await queryMetrics(user, metric, startDate, endDate)
-
-        return {
-          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(result)
       },
     )
 
-    // Tool 2: get_daily_summary
+    // Tool: get_daily_summary
     server.tool(
       'get_daily_summary',
       'Get a comprehensive summary of health data for a specific day including heart rate, steps, sleep, exercise, tags, productivity, and visited places. Also includes Oura scores (sleep_score, readiness_score, resilience_score, cardiovascular_age) when available.',
       {
-        date: z.string().describe('Date in YYYY-MM-DD format (e.g., 2024-01-15)'),
+        date: dateOnlySchema.describe('Date in YYYY-MM-DD format (e.g., 2024-01-15)'),
       },
       async ({ date }) => {
         const dateMatch = date.match(/^(\d{4})-(\d{2})-(\d{2})$/)
         if (!dateMatch) {
-          return {
-            content: [{ text: 'Invalid date format. Use YYYY-MM-DD format.', type: 'text' as const }],
-          }
+          return errorResponse('Invalid date format. Use YYYY-MM-DD format.')
         }
 
         const dateObj = new Date(date)
         if (isNaN(dateObj.getTime())) {
-          return {
-            content: [{ text: 'Invalid date.', type: 'text' as const }],
-          }
+          return errorResponse('Invalid date.')
         }
 
         const summary = await getDailySummary(user, dateObj, sync)
-
-        return {
-          content: [{ text: JSON.stringify(summary, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(summary)
       },
     )
 
-    // Tool 3: add_tag
+    // Tool: query_period_summary
+    server.tool(
+      'query_period_summary',
+      'Get aggregated statistics for a time period. Returns min/max/avg/stddev for each metric, trend compared to previous period, and data completeness.',
+      {
+        ...mcpTimeRangeSchema,
+        metrics: z
+          .array(z.string())
+          .describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
+      },
+      async ({ end, metrics, start }) => {
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
+
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
+        }
+
+        const invalidMetrics = metrics.filter((m) => !isValidMetric(m))
+        if (invalidMetrics.length > 0) {
+          return errorResponse(
+            `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${validMetrics.join(', ')}`,
+          )
+        }
+
+        const validatedMetrics = metrics as MetricType[]
+        const summary = await getPeriodSummary(user, validatedMetrics, startDate, endDate)
+        return jsonResponse(summary)
+      },
+    )
+
+    // Tool: query_tags
+    server.tool(
+      'query_tags',
+      'Query tags/labels for a time range. Returns all tags with start times, optional end times, and tag text.',
+      mcpTimeRangeSchema,
+      async ({ end, start }) => {
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
+
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
+        }
+
+        const tags = await queryTags(user, startDate, endDate, sync)
+        return jsonResponse({ data: tags, success: true })
+      },
+    )
+
+    // Tool: query_activities
+    server.tool(
+      'query_activities',
+      'Query activities (sleep, exercise, meditation, nap) for a time range. Returns activity sessions with duration, HR zones for exercise, and other metadata.',
+      {
+        ...mcpTimeRangeSchema,
+        types: z
+          .array(activityTypeSchema)
+          .optional()
+          .describe('Activity types to include. Defaults to all types (sleep, exercise, meditation, nap).'),
+      },
+      async ({ end, start, types }) => {
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
+
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
+        }
+
+        const activityTypes = types ?? ['sleep', 'exercise', 'meditation', 'nap']
+        const activities = await queryActivities(user, activityTypes, startDate, endDate, sync)
+        return jsonResponse({ data: activities, success: true })
+      },
+    )
+
+    // Tool: query_productivity
+    server.tool(
+      'query_productivity',
+      'Query productivity data (from RescueTime) for a time range. Returns application/website usage with productivity scores.',
+      mcpTimeRangeSchema,
+      async ({ end, start }) => {
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
+
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
+        }
+
+        const productivity = await queryProductivity(user, startDate, endDate, sync)
+        return jsonResponse({ data: productivity, success: true })
+      },
+    )
+
+    // Tool: query_locations
+    server.tool(
+      'query_locations',
+      'Query location/place visits for a time range. Returns places visited with names, coordinates, duration, and source (named, detected, or owntracks).',
+      mcpTimeRangeSchema,
+      async ({ end, start }) => {
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
+
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
+        }
+
+        const places = await queryLocations(user, startDate, endDate)
+        return jsonResponse({ data: places, success: true })
+      },
+    )
+
+    // ========================================================================
+    // Tag Management Tools
+    // ========================================================================
+
+    // Tool: add_tag
     server.tool(
       'add_tag',
       'Add a manual tag/label to mark an activity or event. Tags can have a start time and optional end time.',
@@ -128,36 +276,32 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           .string()
           .optional()
           .describe('Optional end time in ISO 8601 format. Omit for point-in-time tags.'),
-        start_time: z.string().describe('Start time in ISO 8601 format (e.g., 2024-01-15T14:30:00Z)'),
+        start_time: startDateTimeQuerySchema.describe(
+          'Start time in ISO 8601 format (e.g., 2024-01-15T14:30:00Z)',
+        ),
         tag: z.string().describe('The tag/label text (e.g., "coffee", "meditation", "headache")'),
       },
       async ({ end_time, start_time, tag }) => {
-        const startDate = new Date(start_time)
-        if (isNaN(startDate.getTime())) {
-          return {
-            content: [{ text: 'Invalid start_time format. Use ISO 8601 format.', type: 'text' as const }],
-          }
+        const startDate = parseDate(start_time)
+        if (!startDate) {
+          return errorResponse('Invalid start_time format. Use ISO 8601 format.')
         }
 
         let endDate: Date | undefined
         if (end_time) {
-          endDate = new Date(end_time)
-          if (isNaN(endDate.getTime())) {
-            return {
-              content: [{ text: 'Invalid end_time format. Use ISO 8601 format.', type: 'text' as const }],
-            }
+          const parsed = parseDate(end_time)
+          if (!parsed) {
+            return errorResponse('Invalid end_time format. Use ISO 8601 format.')
           }
+          endDate = parsed
         }
 
         const result = await addTag(user, { endTime: endDate, startTime: startDate, tag })
-
-        return {
-          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(result)
       },
     )
 
-    // Tool 4: delete_tag
+    // Tool: delete_tag
     server.tool(
       'delete_tag',
       'Delete a tag by its external ID. Returns success if the tag was found and deleted.',
@@ -166,19 +310,20 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       },
       async ({ external_id }) => {
         const result = await deleteTag(user, external_id)
-
-        return {
-          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(result)
       },
     )
 
-    // Tool 5: add_metric
+    // ========================================================================
+    // Metric Management Tools
+    // ========================================================================
+
+    // Tool: add_metric
     server.tool(
       'add_metric',
       'Add a manual health metric measurement. Use this to log data not captured automatically.',
       {
-        metric: z.string().describe(`Metric name. Valid metrics: ${validMetrics.join(', ')}`),
+        metric: z.string().describe(metricDescription),
         time: z
           .string()
           .optional()
@@ -187,32 +332,24 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       },
       async ({ metric, time, value }) => {
         if (!isValidMetric(metric)) {
-          return {
-            content: [
-              {
-                text: `Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`,
-                type: 'text' as const,
-              },
-            ],
-          }
+          return errorResponse(`Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`)
         }
 
-        const measurementTime = time ? new Date(time) : new Date()
-        if (isNaN(measurementTime.getTime())) {
-          return {
-            content: [{ text: 'Invalid time format. Use ISO 8601 format.', type: 'text' as const }],
-          }
+        const measurementTime = time ? parseDate(time) : new Date()
+        if (!measurementTime) {
+          return errorResponse('Invalid time format. Use ISO 8601 format.')
         }
 
         const result = await addMetric(user, { metric, time: measurementTime, value })
-
-        return {
-          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(result)
       },
     )
 
-    // Tool 5: sync_oura
+    // ========================================================================
+    // Sync Tools
+    // ========================================================================
+
+    // Tool: sync_oura
     server.tool(
       'sync_oura',
       'Sync data from Oura Ring API. Fetches cardiovascular age, readiness, resilience, sleep scores, meditation sessions, and tags.',
@@ -230,9 +367,7 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       },
       async ({ full_resync, start_date }) => {
         if (!oura) {
-          return {
-            content: [{ text: 'Oura integration is not configured on this server.', type: 'text' as const }],
-          }
+          return errorResponse('Oura integration is not configured on this server.')
         }
 
         try {
@@ -248,26 +383,15 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
             status: r.status,
           }))
 
-          return {
-            content: [
-              {
-                text: JSON.stringify({ results: summary, success: true }, null, 2),
-                type: 'text' as const,
-              },
-            ],
-          }
+          return jsonResponse({ results: summary, success: true })
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error'
-          return {
-            content: [
-              { text: JSON.stringify({ error: message, success: false }, null, 2), type: 'text' as const },
-            ],
-          }
+          return jsonResponse({ error: message, success: false })
         }
       },
     )
 
-    // Tool 6: sync_rescuetime
+    // Tool: sync_rescuetime
     server.tool(
       'sync_rescuetime',
       'Sync productivity data from RescueTime API. Fetches application and website usage with productivity scores.',
@@ -286,11 +410,7 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       async ({ full_resync, start_date }) => {
         const settings = await getSettings(user)
         if (!settings.rescueTimeKey) {
-          return {
-            content: [
-              { text: 'RescueTime API key is not configured in user settings.', type: 'text' as const },
-            ],
-          }
+          return errorResponse('RescueTime API key is not configured in user settings.')
         }
 
         try {
@@ -299,43 +419,25 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
             startDate: start_date ? new Date(start_date) : undefined,
           })
 
-          return {
-            content: [
-              {
-                text: JSON.stringify(
-                  {
-                    error: result.error,
-                    recordsProcessed: result.recordsProcessed,
-                    status: result.status,
-                    success: result.status === 'success',
-                  },
-                  null,
-                  2,
-                ),
-                type: 'text' as const,
-              },
-            ],
-          }
+          return jsonResponse({
+            error: result.error,
+            recordsProcessed: result.recordsProcessed,
+            status: result.status,
+            success: result.status === 'success',
+          })
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error'
-          return {
-            content: [
-              { text: JSON.stringify({ error: message, success: false }, null, 2), type: 'text' as const },
-            ],
-          }
+          return jsonResponse({ error: message, success: false })
         }
       },
     )
 
-    // Tool 7: get_sync_status
+    // Tool: get_sync_status
     server.tool(
       'get_sync_status',
       'Get the current sync status for Oura and RescueTime data sources. Shows last sync time, status, and any errors.',
       {
-        provider: z
-          .enum(['oura', 'rescuetime', 'all'])
-          .optional()
-          .describe('Which provider to check. Defaults to "all".'),
+        provider: syncProviderSchema.optional().describe('Which provider to check. Defaults to "all".'),
       },
       async ({ provider = 'all' }) => {
         try {
@@ -349,78 +451,30 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
             states.rescuetime = await getAllSyncStates(user, 'rescuetime')
           }
 
-          return {
-            content: [{ text: JSON.stringify({ states, success: true }, null, 2), type: 'text' as const }],
-          }
+          return jsonResponse({ states, success: true })
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error'
-          return {
-            content: [
-              { text: JSON.stringify({ error: message, success: false }, null, 2), type: 'text' as const },
-            ],
-          }
+          return jsonResponse({ error: message, success: false })
         }
       },
     )
 
-    // Tool 8: query_period_summary
-    server.tool(
-      'query_period_summary',
-      'Get aggregated statistics for a time period. Returns min/max/avg/stddev for each metric, trend compared to previous period, and data completeness.',
-      {
-        end: z.string().describe('End date/time in ISO 8601 format (e.g., 2024-01-31T23:59:59Z)'),
-        metrics: z
-          .array(z.string())
-          .describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
-        start: z.string().describe('Start date/time in ISO 8601 format (e.g., 2024-01-01T00:00:00Z)'),
-      },
-      async ({ end, metrics, start }) => {
-        // Validate dates
-        const startDate = new Date(start)
-        const endDate = new Date(end)
+    // ========================================================================
+    // User Settings Tools
+    // ========================================================================
 
-        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-          return {
-            content: [{ text: 'Invalid date format. Use ISO 8601 format.', type: 'text' as const }],
-          }
-        }
-
-        // Validate metrics
-        const invalidMetrics = metrics.filter((m) => !isValidMetric(m))
-        if (invalidMetrics.length > 0) {
-          return {
-            content: [
-              {
-                text: `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${validMetrics.join(', ')}`,
-                type: 'text' as const,
-              },
-            ],
-          }
-        }
-
-        const validatedMetrics = metrics as MetricType[]
-        const summary = await getPeriodSummary(user, validatedMetrics, startDate, endDate)
-
-        return {
-          content: [{ text: JSON.stringify(summary, null, 2), type: 'text' as const }],
-        }
-      },
-    )
-
-    // Tool 9: get_user_settings
+    // Tool: get_user_settings
     server.tool(
       'get_user_settings',
       'Get user settings including birth date and effective HR zones. HR zones are used to calculate time spent in different heart rate zones during exercise.',
       {},
       async () => {
         const result = await getSettingsResponse(user)
-        return {
-          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(result)
       },
     )
 
-    // Tool 10: update_user_settings
+    // Tool: update_user_settings
     server.tool(
       'update_user_settings',
       'Update user settings. Can set birth date (for age-based HR zones) and/or custom HR zone thresholds.',
@@ -430,62 +484,49 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           .nullable()
           .optional()
           .describe('Birth date in YYYY-MM-DD format. Set to null to clear.'),
-        hr_zone_start: z
-          .object({
-            1: z.number().describe('Zone 1 threshold (bpm)'),
-            2: z.number().describe('Zone 2 threshold (bpm)'),
-            3: z.number().describe('Zone 3 threshold (bpm)'),
-            4: z.number().describe('Zone 4 threshold (bpm)'),
-            5: z.number().describe('Zone 5 threshold (bpm)'),
-          })
+        hr_zone_start: hrZoneThresholdsSchema
           .nullable()
           .optional()
           .describe('Custom HR zone start thresholds. Values must be ascending. Set to null to clear.'),
       },
       async ({ birth_date, hr_zone_start }) => {
-        // Transform snake_case MCP params to camelCase for service
         const result = await validateAndUpdateSettings(user, {
           birthDate: birth_date,
           hrZoneStart: hr_zone_start,
         })
-        return {
-          content: [{ text: JSON.stringify(result, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse(result)
       },
     )
 
-    // Tool 11: get_named_locations
+    // ========================================================================
+    // Location Tools
+    // ========================================================================
+
+    // Tool: get_named_locations
     server.tool(
       'get_named_locations',
       'List all named locations. These are user-defined places with names and coordinates.',
       {},
       async () => {
         const locations = await getNamedLocations(user)
-        return {
-          content: [
-            { text: JSON.stringify({ data: locations, success: true }, null, 2), type: 'text' as const },
-          ],
-        }
+        return jsonResponse({ data: locations, success: true })
       },
     )
 
-    // Tool 12: get_detected_locations
+    // Tool: get_detected_locations
     server.tool(
       'get_detected_locations',
       'Get frequently visited locations that are not yet named. Detects places where user spent 60+ minutes. Returns coordinates, visit count, and total time spent.',
       {
-        end: z.string().describe('End date/time in ISO 8601 format (e.g., 2024-01-31T23:59:59Z)'),
+        ...mcpTimeRangeSchema,
         min_duration: z.number().optional().describe('Minimum stay duration in minutes. Defaults to 60.'),
-        start: z.string().describe('Start date/time in ISO 8601 format (e.g., 2024-01-01T00:00:00Z)'),
       },
       async ({ end, min_duration, start }) => {
-        const startDate = new Date(start)
-        const endDate = new Date(end)
+        const startDate = parseDate(start)
+        const endDate = parseDate(end)
 
-        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-          return {
-            content: [{ text: 'Invalid date format. Use ISO 8601 format.', type: 'text' as const }],
-          }
+        if (!startDate || !endDate) {
+          return errorResponse('Invalid date format. Use ISO 8601 format.')
         }
 
         const detected = await getDetectedLocations(user, {
@@ -494,46 +535,51 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           start: startDate,
         })
 
-        return {
-          content: [
-            { text: JSON.stringify({ data: detected, success: true }, null, 2), type: 'text' as const },
-          ],
-        }
+        return jsonResponse({ data: detected, success: true })
       },
     )
 
-    // Tool 13: add_named_location
+    // Tool: get_stored_detected_locations
+    server.tool(
+      'get_stored_detected_locations',
+      'Get stored detected locations with geocoded addresses. These are locations that have been previously detected and stored in the database.',
+      {},
+      async () => {
+        const detected = await getStoredDetectedLocations(user)
+        // Transform Date objects to ISO strings for API response
+        const serialized = detected.map((d) => ({
+          ...d,
+          firstVisit: d.firstVisit.toISOString(),
+          lastVisit: d.lastVisit.toISOString(),
+        }))
+        return jsonResponse({ data: serialized, success: true })
+      },
+    )
+
+    // Tool: add_named_location
     server.tool(
       'add_named_location',
       'Create a named location. Use this to save a frequently visited place with a name.',
       {
-        lat: z.number().describe('Latitude of the location (-90 to 90)'),
-        lon: z.number().describe('Longitude of the location (-180 to 180)'),
+        lat: latWithValidationSchema.describe('Latitude of the location (-90 to 90)'),
+        lon: lonWithValidationSchema.describe('Longitude of the location (-180 to 180)'),
         name: z.string().describe('Name for the location (e.g., "Home", "Office", "Gym")'),
         radius: z.number().optional().describe('Radius in meters. Defaults to 200.'),
       },
       async ({ lat, lon, name, radius }) => {
         if (lat < -90 || lat > 90) {
-          return {
-            content: [{ text: 'Invalid latitude. Must be between -90 and 90.', type: 'text' as const }],
-          }
+          return errorResponse('Invalid latitude. Must be between -90 and 90.')
         }
         if (lon < -180 || lon > 180) {
-          return {
-            content: [{ text: 'Invalid longitude. Must be between -180 and 180.', type: 'text' as const }],
-          }
+          return errorResponse('Invalid longitude. Must be between -180 and 180.')
         }
 
         const location = await insertNamedLocation(user, { lat, lon, name, radius })
-        return {
-          content: [
-            { text: JSON.stringify({ data: location, success: true }, null, 2), type: 'text' as const },
-          ],
-        }
+        return jsonResponse({ data: location, success: true })
       },
     )
 
-    // Tool 14: update_named_location
+    // Tool: update_named_location
     server.tool(
       'update_named_location',
       'Update an existing named location. Can change name, coordinates, or radius.',
@@ -546,42 +592,25 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       },
       async ({ id, lat, lon, name, radius }) => {
         if ((lat !== undefined && lon === undefined) || (lon !== undefined && lat === undefined)) {
-          return {
-            content: [{ text: 'lat and lon must be provided together.', type: 'text' as const }],
-          }
+          return errorResponse('lat and lon must be provided together.')
         }
 
         if (lat !== undefined && (lat < -90 || lat > 90)) {
-          return {
-            content: [{ text: 'Invalid latitude. Must be between -90 and 90.', type: 'text' as const }],
-          }
+          return errorResponse('Invalid latitude. Must be between -90 and 90.')
         }
         if (lon !== undefined && (lon < -180 || lon > 180)) {
-          return {
-            content: [{ text: 'Invalid longitude. Must be between -180 and 180.', type: 'text' as const }],
-          }
+          return errorResponse('Invalid longitude. Must be between -180 and 180.')
         }
 
         const location = await updateNamedLocation(user, id, { lat, lon, name, radius })
         if (!location) {
-          return {
-            content: [
-              {
-                text: JSON.stringify({ error: 'Named location not found', success: false }, null, 2),
-                type: 'text' as const,
-              },
-            ],
-          }
+          return jsonResponse({ error: 'Named location not found', success: false })
         }
-        return {
-          content: [
-            { text: JSON.stringify({ data: location, success: true }, null, 2), type: 'text' as const },
-          ],
-        }
+        return jsonResponse({ data: location, success: true })
       },
     )
 
-    // Tool 15: delete_named_location
+    // Tool: delete_named_location
     server.tool(
       'delete_named_location',
       'Delete a named location by its ID.',
@@ -591,38 +620,25 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       async ({ id }) => {
         const deleted = await deleteNamedLocation(user, id)
         if (!deleted) {
-          return {
-            content: [
-              {
-                text: JSON.stringify({ error: 'Named location not found', success: false }, null, 2),
-                type: 'text' as const,
-              },
-            ],
-          }
+          return jsonResponse({ error: 'Named location not found', success: false })
         }
-        return {
-          content: [{ text: JSON.stringify({ success: true }, null, 2), type: 'text' as const }],
-        }
+        return jsonResponse({ success: true })
       },
     )
 
-    // Tool 16: promote_detected_location
+    // Tool: promote_detected_location
     server.tool(
       'promote_detected_location',
       'Create a named location from detected coordinates. Use after get_detected_locations to save a frequently visited place.',
       {
-        lat: z.number().describe('Latitude from detected location'),
-        lon: z.number().describe('Longitude from detected location'),
+        lat: latWithValidationSchema.describe('Latitude from detected location'),
+        lon: lonWithValidationSchema.describe('Longitude from detected location'),
         name: z.string().describe('Name for the location'),
         radius: z.number().optional().describe('Radius in meters. Uses suggested radius if not provided.'),
       },
       async ({ lat, lon, name, radius }) => {
         const location = await insertNamedLocation(user, { lat, lon, name, radius })
-        return {
-          content: [
-            { text: JSON.stringify({ data: location, success: true }, null, 2), type: 'text' as const },
-          ],
-        }
+        return jsonResponse({ data: location, success: true })
       },
     )
 

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -1,4 +1,5 @@
 import {
+  activityTypes,
   activityTypeSchema,
   dateOnlySchema,
   endDateTimeQuerySchema,
@@ -89,8 +90,10 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
     content: [{ text: message, type: 'text' as const }],
   })
 
-  // Helper to parse and validate ISO date string
-  const parseDate = (dateStr: string): Date | null => {
+  // Helper to parse optional ISO date string (for fields using plain z.string())
+  // Note: Fields using startDateTimeQuerySchema/endDateTimeQuerySchema are already
+  // validated by zod, so they can be converted directly with new Date()
+  const parseOptionalDate = (dateStr: string): Date | null => {
     const date = new Date(dateStr)
     return isNaN(date.getTime()) ? null : date
   }
@@ -118,14 +121,8 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           return errorResponse(`Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`)
         }
 
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
-        const result = await queryMetrics(user, metric, startDate, endDate)
+        // Dates are pre-validated by zod schema (startDateTimeQuerySchema/endDateTimeQuerySchema)
+        const result = await queryMetrics(user, metric, new Date(start), new Date(end))
         return jsonResponse(result)
       },
     )
@@ -164,13 +161,6 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           .describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
       },
       async ({ end, metrics, start }) => {
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
         const invalidMetrics = metrics.filter((m) => !isValidMetric(m))
         if (invalidMetrics.length > 0) {
           return errorResponse(
@@ -178,8 +168,9 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           )
         }
 
+        // Dates are pre-validated by zod schema
         const validatedMetrics = metrics as MetricType[]
-        const summary = await getPeriodSummary(user, validatedMetrics, startDate, endDate)
+        const summary = await getPeriodSummary(user, validatedMetrics, new Date(start), new Date(end))
         return jsonResponse(summary)
       },
     )
@@ -190,14 +181,8 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       'Query tags/labels for a time range. Returns all tags with start times, optional end times, and tag text.',
       mcpTimeRangeSchema,
       async ({ end, start }) => {
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
-        const tags = await queryTags(user, startDate, endDate, sync)
+        // Dates are pre-validated by zod schema
+        const tags = await queryTags(user, new Date(start), new Date(end), sync)
         return jsonResponse({ data: tags, success: true })
       },
     )
@@ -214,15 +199,10 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           .describe('Activity types to include. Defaults to all types (sleep, exercise, meditation, nap).'),
       },
       async ({ end, start, types }) => {
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
-        const activityTypes = types ?? ['sleep', 'exercise', 'meditation', 'nap']
-        const activities = await queryActivities(user, activityTypes, startDate, endDate, sync)
+        // Dates are pre-validated by zod schema
+        // Use activityTypes from api-spec to avoid hardcoded values
+        const requestedTypes = types ?? [...activityTypes]
+        const activities = await queryActivities(user, requestedTypes, new Date(start), new Date(end), sync)
         return jsonResponse({ data: activities, success: true })
       },
     )
@@ -233,14 +213,8 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       'Query productivity data (from RescueTime) for a time range. Returns application/website usage with productivity scores.',
       mcpTimeRangeSchema,
       async ({ end, start }) => {
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
-        const productivity = await queryProductivity(user, startDate, endDate, sync)
+        // Dates are pre-validated by zod schema
+        const productivity = await queryProductivity(user, new Date(start), new Date(end), sync)
         return jsonResponse({ data: productivity, success: true })
       },
     )
@@ -251,14 +225,8 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       'Query location/place visits for a time range. Returns places visited with names, coordinates, duration, and source (named, detected, or owntracks).',
       mcpTimeRangeSchema,
       async ({ end, start }) => {
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
-        const places = await queryLocations(user, startDate, endDate)
+        // Dates are pre-validated by zod schema
+        const places = await queryLocations(user, new Date(start), new Date(end))
         return jsonResponse({ data: places, success: true })
       },
     )
@@ -282,14 +250,13 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
         tag: z.string().describe('The tag/label text (e.g., "coffee", "meditation", "headache")'),
       },
       async ({ end_time, start_time, tag }) => {
-        const startDate = parseDate(start_time)
-        if (!startDate) {
-          return errorResponse('Invalid start_time format. Use ISO 8601 format.')
-        }
+        // start_time is pre-validated by zod schema
+        const startDate = new Date(start_time)
 
+        // end_time uses plain z.string() so needs manual validation
         let endDate: Date | undefined
         if (end_time) {
-          const parsed = parseDate(end_time)
+          const parsed = parseOptionalDate(end_time)
           if (!parsed) {
             return errorResponse('Invalid end_time format. Use ISO 8601 format.')
           }
@@ -335,7 +302,8 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
           return errorResponse(`Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`)
         }
 
-        const measurementTime = time ? parseDate(time) : new Date()
+        // time uses plain z.string() so needs manual validation
+        const measurementTime = time ? parseOptionalDate(time) : new Date()
         if (!measurementTime) {
           return errorResponse('Invalid time format. Use ISO 8601 format.')
         }
@@ -522,17 +490,11 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
         min_duration: z.number().optional().describe('Minimum stay duration in minutes. Defaults to 60.'),
       },
       async ({ end, min_duration, start }) => {
-        const startDate = parseDate(start)
-        const endDate = parseDate(end)
-
-        if (!startDate || !endDate) {
-          return errorResponse('Invalid date format. Use ISO 8601 format.')
-        }
-
+        // Dates are pre-validated by zod schema
         const detected = await getDetectedLocations(user, {
-          end: endDate,
+          end: new Date(end),
           minDurationMinutes: min_duration,
-          start: startDate,
+          start: new Date(start),
         })
 
         return jsonResponse({ data: detected, success: true })
@@ -546,13 +508,8 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
       {},
       async () => {
         const detected = await getStoredDetectedLocations(user)
-        // Transform Date objects to ISO strings for API response
-        const serialized = detected.map((d) => ({
-          ...d,
-          firstVisit: d.firstVisit.toISOString(),
-          lastVisit: d.lastVisit.toISOString(),
-        }))
-        return jsonResponse({ data: serialized, success: true })
+        // JSON.stringify automatically converts Date objects to ISO strings
+        return jsonResponse({ data: detected, success: true })
       },
     )
 
@@ -567,13 +524,7 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
         radius: z.number().optional().describe('Radius in meters. Defaults to 200.'),
       },
       async ({ lat, lon, name, radius }) => {
-        if (lat < -90 || lat > 90) {
-          return errorResponse('Invalid latitude. Must be between -90 and 90.')
-        }
-        if (lon < -180 || lon > 180) {
-          return errorResponse('Invalid longitude. Must be between -180 and 180.')
-        }
-
+        // lat/lon are pre-validated by zod schema (latWithValidationSchema/lonWithValidationSchema)
         const location = await insertNamedLocation(user, { lat, lon, name, radius })
         return jsonResponse({ data: location, success: true })
       },

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -3,7 +3,12 @@
  */
 
 import { z } from 'zod'
-import { iso8601DateTimeSchema } from './common.js'
+import {
+  createDataArrayResponseSchema,
+  durationMinutesSchema,
+  iso8601DateTimeSchema,
+  timeRangeQuerySchema,
+} from './common.js'
 import { hrZoneSecsSchema } from './settings.js'
 
 /**
@@ -13,7 +18,7 @@ export const activitySchema = z
   .object({
     activityType: z.string().meta({ description: 'Activity type' }),
     data: z.record(z.string(), z.unknown()).optional(),
-    duration: z.number().optional().meta({ description: 'Duration in minutes' }),
+    duration: durationMinutesSchema.optional(),
     endTime: iso8601DateTimeSchema.optional(),
     hrZoneSecs: hrZoneSecsSchema.optional().meta({
       description: 'Time spent in each HR zone (for exercise)',
@@ -31,10 +36,8 @@ export type Activity = z.infer<typeof activitySchema>
 /**
  * Activities query schema.
  */
-export const activitiesQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
+export const activitiesQuerySchema = timeRangeQuerySchema
+  .extend({
     types: z.string().optional().meta({
       description: 'Comma-separated activity types',
       example: 'sleep,exercise',
@@ -47,12 +50,8 @@ export type ActivitiesQuery = z.infer<typeof activitiesQuerySchema>
 /**
  * Activities response schema.
  */
-export const activitiesResponseSchema = z
-  .object({
-    data: z.array(activitySchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'ActivitiesResponse' })
+export const activitiesResponseSchema = createDataArrayResponseSchema(activitySchema).meta({
+  id: 'ActivitiesResponse',
+})
 
 export type ActivitiesResponse = z.infer<typeof activitiesResponseSchema>

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -228,3 +228,84 @@ export const syncStatusSchema = z.enum(['idle', 'syncing', 'error']).meta({
 })
 
 export type SyncStatus = z.infer<typeof syncStatusSchema>
+
+// ============================================================================
+// Reusable Field Schemas
+// ============================================================================
+
+/**
+ * Geocoded address field.
+ * Use addressNullableSchema when geocoding might have been attempted but returned no result.
+ */
+export const addressSchema = z.string().meta({ description: 'Geocoded address' })
+export const addressNullableSchema = z.string().nullable().meta({ description: 'Geocoded address' })
+
+/**
+ * Latitude field with validation.
+ */
+export const latSchema = z.number().meta({ description: 'Latitude', example: 59.3293 })
+export const latWithValidationSchema = z.number().min(-90).max(90).meta({ description: 'Latitude' })
+
+/**
+ * Longitude field with validation.
+ */
+export const lonSchema = z.number().meta({ description: 'Longitude', example: 18.0686 })
+export const lonWithValidationSchema = z.number().min(-180).max(180).meta({ description: 'Longitude' })
+
+/**
+ * Radius in meters field.
+ */
+export const radiusSchema = z.number().int().meta({ description: 'Radius in meters', example: 200 })
+
+/**
+ * Duration in minutes field.
+ */
+export const durationMinutesSchema = z.number().meta({ description: 'Duration in minutes' })
+
+/**
+ * Common start/end date-time query fields.
+ */
+export const startDateTimeQuerySchema = iso8601DateTimeSchema.meta({ description: 'Start date/time' })
+export const endDateTimeQuerySchema = iso8601DateTimeSchema.meta({ description: 'End date/time' })
+
+/**
+ * Standard time range query schema - reusable for any query that needs start/end.
+ */
+export const timeRangeQuerySchema = z.object({
+  end: endDateTimeQuerySchema,
+  start: startDateTimeQuerySchema,
+})
+
+/**
+ * Success response field.
+ */
+export const successSchema = z.boolean()
+
+/**
+ * Error message field.
+ */
+export const errorSchema = z.string().optional()
+
+/**
+ * Base response schema with success and optional error.
+ */
+export const baseResponseSchema = z.object({
+  error: errorSchema,
+  success: successSchema,
+})
+
+/**
+ * Create a data response schema wrapping an array of items.
+ */
+export const createDataArrayResponseSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
+  baseResponseSchema.extend({
+    data: z.array(itemSchema).optional(),
+  })
+
+/**
+ * Create a data response schema wrapping a single item.
+ */
+export const createDataResponseSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
+  baseResponseSchema.extend({
+    data: itemSchema.optional(),
+  })

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -86,9 +86,14 @@ export const isHrZoneMetric = (metric: MetricType): boolean =>
   (hrZoneMetrics as readonly string[]).includes(metric)
 
 /**
+ * Valid activity types.
+ */
+export const activityTypes = ['sleep', 'exercise', 'meditation', 'nap'] as const
+
+/**
  * Activity types for activities table.
  */
-export const activityTypeSchema = z.enum(['sleep', 'exercise', 'meditation', 'nap']).meta({
+export const activityTypeSchema = z.enum(activityTypes).meta({
   description: 'Type of activity',
   example: 'exercise',
   id: 'ActivityType',
@@ -241,16 +246,44 @@ export const addressSchema = z.string().meta({ description: 'Geocoded address' }
 export const addressNullableSchema = z.string().nullable().meta({ description: 'Geocoded address' })
 
 /**
- * Latitude field with validation.
+ * Latitude field without range validation.
+ * Use for response schemas where data is already validated.
+ * @see latWithValidationSchema for input validation with -90 to 90 range check
  */
 export const latSchema = z.number().meta({ description: 'Latitude', example: 59.3293 })
+
+/**
+ * Latitude field with -90 to 90 range validation.
+ * Use for request/input schemas where user-provided data needs validation.
+ * @see latSchema for response schemas without validation
+ */
 export const latWithValidationSchema = z.number().min(-90).max(90).meta({ description: 'Latitude' })
 
 /**
- * Longitude field with validation.
+ * Longitude field without range validation.
+ * Use for response schemas where data is already validated.
+ * @see lonWithValidationSchema for input validation with -180 to 180 range check
  */
 export const lonSchema = z.number().meta({ description: 'Longitude', example: 18.0686 })
+
+/**
+ * Longitude field with -180 to 180 range validation.
+ * Use for request/input schemas where user-provided data needs validation.
+ * @see lonSchema for response schemas without validation
+ */
 export const lonWithValidationSchema = z.number().min(-180).max(180).meta({ description: 'Longitude' })
+
+/**
+ * Tag/label text field.
+ */
+export const tagTextSchema = z.string().meta({ description: 'Tag/label text', example: 'coffee' })
+
+/**
+ * Detected location ID field (UUID reference to a detected location).
+ */
+export const detectedLocationIdSchema = z.string().uuid().meta({
+  description: 'ID of detected location if source is detected',
+})
 
 /**
  * Radius in meters field.

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -3,8 +3,25 @@
  */
 
 import { z } from 'zod'
-import { dateOnlySchema, iso8601DateTimeSchema, placeSourceSchema } from './common.js'
+import {
+  addressSchema,
+  createDataResponseSchema,
+  dateOnlySchema,
+  durationMinutesSchema,
+  iso8601DateTimeSchema,
+  latSchema,
+  lonSchema,
+  placeSourceSchema,
+} from './common.js'
 import { hrZoneSecsSchema } from './settings.js'
+
+// Shared tag text field (also defined in tags.ts)
+const tagTextSchema = z.string().meta({ description: 'Tag/label text', example: 'coffee' })
+
+// Shared detected location ID field (also defined in locations.ts)
+const detectedLocationIdSchema = z.string().uuid().meta({
+  description: 'ID of detected location if source is detected',
+})
 
 /**
  * Heart rate stats schema.
@@ -26,7 +43,7 @@ export type HeartRateStats = z.infer<typeof heartRateStatsSchema>
 export const sessionSummarySchema = z
   .object({
     data: z.record(z.string(), z.unknown()).optional(),
-    duration: z.number().optional().meta({ description: 'Duration in minutes' }),
+    duration: durationMinutesSchema.optional(),
     endTime: iso8601DateTimeSchema.optional(),
     hrZoneSecs: hrZoneSecsSchema.optional().meta({
       description: 'Time spent in each HR zone during session',
@@ -45,7 +62,7 @@ export const tagSummarySchema = z
   .object({
     endTime: iso8601DateTimeSchema.optional(),
     startTime: iso8601DateTimeSchema,
-    tag: z.string().meta({ description: 'Tag/label text', example: 'coffee' }),
+    tag: tagTextSchema,
   })
   .meta({ id: 'TagSummary' })
 
@@ -56,14 +73,12 @@ export type TagSummary = z.infer<typeof tagSummarySchema>
  */
 export const placeSummarySchema = z
   .object({
-    address: z.string().optional().meta({ description: 'Geocoded address' }),
-    detectedLocationId: z.string().uuid().optional().meta({
-      description: 'ID of detected location if source is detected',
-    }),
-    duration: z.number().meta({ description: 'Duration in minutes' }),
+    address: addressSchema.optional(),
+    detectedLocationId: detectedLocationIdSchema.optional(),
+    duration: durationMinutesSchema,
     endTime: iso8601DateTimeSchema,
-    lat: z.number().optional().meta({ description: 'Latitude' }),
-    lon: z.number().optional().meta({ description: 'Longitude' }),
+    lat: latSchema.optional(),
+    lon: lonSchema.optional(),
     name: z.string().meta({ description: 'Place name', example: 'Home' }),
     source: placeSourceSchema,
     startTime: iso8601DateTimeSchema,
@@ -124,13 +139,9 @@ export type DailySummaryResult = z.infer<typeof dailySummaryResultSchema>
 /**
  * Daily summary response schema (API wrapper).
  */
-export const dailySummaryResponseSchema = z
-  .object({
-    data: dailySummaryResultSchema.optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'DailySummaryResponse' })
+export const dailySummaryResponseSchema = createDataResponseSchema(dailySummaryResultSchema).meta({
+  id: 'DailySummaryResponse',
+})
 
 export type DailySummaryResponse = z.infer<typeof dailySummaryResponseSchema>
 

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -7,21 +7,15 @@ import {
   addressSchema,
   createDataResponseSchema,
   dateOnlySchema,
+  detectedLocationIdSchema,
   durationMinutesSchema,
   iso8601DateTimeSchema,
   latSchema,
   lonSchema,
   placeSourceSchema,
+  tagTextSchema,
 } from './common.js'
 import { hrZoneSecsSchema } from './settings.js'
-
-// Shared tag text field (also defined in tags.ts)
-const tagTextSchema = z.string().meta({ description: 'Tag/label text', example: 'coffee' })
-
-// Shared detected location ID field (also defined in locations.ts)
-const detectedLocationIdSchema = z.string().uuid().meta({
-  description: 'ID of detected location if source is detected',
-})
 
 /**
  * Heart rate stats schema.

--- a/packages/api-spec/src/schemas/locations.ts
+++ b/packages/api-spec/src/schemas/locations.ts
@@ -8,6 +8,7 @@ import {
   addressSchema,
   createDataArrayResponseSchema,
   createDataResponseSchema,
+  detectedLocationIdSchema,
   durationMinutesSchema,
   geocodeStatusSchema,
   iso8601DateTimeSchema,
@@ -22,11 +23,6 @@ import {
 
 // Shared location name field
 const locationNameSchema = z.string().meta({ description: 'Location name', example: 'Home' })
-
-// Shared detected location ID field
-const detectedLocationIdSchema = z.string().uuid().meta({
-  description: 'ID of detected location if source is detected',
-})
 
 /**
  * Named location schema.

--- a/packages/api-spec/src/schemas/locations.ts
+++ b/packages/api-spec/src/schemas/locations.ts
@@ -3,7 +3,30 @@
  */
 
 import { z } from 'zod'
-import { geocodeStatusSchema, iso8601DateTimeSchema, placeSourceSchema } from './common.js'
+import {
+  addressNullableSchema,
+  addressSchema,
+  createDataArrayResponseSchema,
+  createDataResponseSchema,
+  durationMinutesSchema,
+  geocodeStatusSchema,
+  iso8601DateTimeSchema,
+  latSchema,
+  latWithValidationSchema,
+  lonSchema,
+  lonWithValidationSchema,
+  placeSourceSchema,
+  radiusSchema,
+  timeRangeQuerySchema,
+} from './common.js'
+
+// Shared location name field
+const locationNameSchema = z.string().meta({ description: 'Location name', example: 'Home' })
+
+// Shared detected location ID field
+const detectedLocationIdSchema = z.string().uuid().meta({
+  description: 'ID of detected location if source is detected',
+})
 
 /**
  * Named location schema.
@@ -11,10 +34,10 @@ import { geocodeStatusSchema, iso8601DateTimeSchema, placeSourceSchema } from '.
 export const namedLocationSchema = z
   .object({
     id: z.string().uuid().meta({ description: 'Location ID' }),
-    lat: z.number().meta({ description: 'Latitude', example: 59.3293 }),
-    lon: z.number().meta({ description: 'Longitude', example: 18.0686 }),
-    name: z.string().meta({ description: 'Location name', example: 'Home' }),
-    radius: z.number().int().meta({ description: 'Radius in meters', example: 200 }),
+    lat: latSchema,
+    lon: lonSchema,
+    name: locationNameSchema,
+    radius: radiusSchema,
   })
   .meta({ id: 'NamedLocation' })
 
@@ -25,14 +48,14 @@ export type NamedLocation = z.infer<typeof namedLocationSchema>
  */
 export const detectedLocationSchema = z
   .object({
-    address: z.string().nullable().optional().meta({ description: 'Geocoded address' }),
+    address: addressNullableSchema.optional(),
     firstVisit: z.string().meta({ description: 'First visit time' }),
     geocodeStatus: geocodeStatusSchema.optional(),
     id: z.string().uuid().optional().meta({ description: 'Location ID' }),
     lastVisit: z.string().meta({ description: 'Last visit time' }),
     lat: z.number().meta({ description: 'Latitude' }),
     lon: z.number().meta({ description: 'Longitude' }),
-    radius: z.number().int().optional().meta({ description: 'Radius in meters' }),
+    radius: radiusSchema.optional(),
     suggestedRadius: z.number().int().optional().meta({ description: 'Suggested radius in meters' }),
     totalMinutes: z.number().meta({ description: 'Total time spent at location' }),
     visitCount: z.number().int().meta({ description: 'Number of visits' }),
@@ -46,14 +69,12 @@ export type DetectedLocation = z.infer<typeof detectedLocationSchema>
  */
 export const placeVisitSchema = z
   .object({
-    address: z.string().optional().meta({ description: 'Geocoded address' }),
-    detectedLocationId: z.string().uuid().optional().meta({
-      description: 'ID of detected location if source is detected',
-    }),
-    duration: z.number().meta({ description: 'Duration in minutes' }),
+    address: addressSchema.optional(),
+    detectedLocationId: detectedLocationIdSchema.optional(),
+    duration: durationMinutesSchema,
     endTime: iso8601DateTimeSchema,
-    lat: z.number().optional().meta({ description: 'Latitude' }),
-    lon: z.number().optional().meta({ description: 'Longitude' }),
+    lat: latSchema.optional(),
+    lon: lonSchema.optional(),
     name: z.string().meta({ description: 'Place name' }),
     source: placeSourceSchema,
     startTime: iso8601DateTimeSchema,
@@ -65,51 +86,34 @@ export type PlaceVisit = z.infer<typeof placeVisitSchema>
 /**
  * Locations query schema.
  */
-export const locationsQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
-  })
-  .meta({ id: 'LocationsQuery' })
+export const locationsQuerySchema = timeRangeQuerySchema.meta({ id: 'LocationsQuery' })
 
 export type LocationsQuery = z.infer<typeof locationsQuerySchema>
 
 /**
  * Locations response schema (place visits).
  */
-export const locationsResponseSchema = z
-  .object({
-    data: z.array(placeVisitSchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'LocationsResponse' })
+export const locationsResponseSchema = createDataArrayResponseSchema(placeVisitSchema).meta({
+  id: 'LocationsResponse',
+})
 
 export type LocationsResponse = z.infer<typeof locationsResponseSchema>
 
 /**
  * Named locations response schema.
  */
-export const namedLocationsResponseSchema = z
-  .object({
-    data: z.array(namedLocationSchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'NamedLocationsResponse' })
+export const namedLocationsResponseSchema = createDataArrayResponseSchema(namedLocationSchema).meta({
+  id: 'NamedLocationsResponse',
+})
 
 export type NamedLocationsResponse = z.infer<typeof namedLocationsResponseSchema>
 
 /**
  * Detected locations response schema.
  */
-export const detectedLocationsResponseSchema = z
-  .object({
-    data: z.array(detectedLocationSchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'DetectedLocationsResponse' })
+export const detectedLocationsResponseSchema = createDataArrayResponseSchema(detectedLocationSchema).meta({
+  id: 'DetectedLocationsResponse',
+})
 
 export type DetectedLocationsResponse = z.infer<typeof detectedLocationsResponseSchema>
 
@@ -117,14 +121,12 @@ export type DetectedLocationsResponse = z.infer<typeof detectedLocationsResponse
  * Detected locations query schema.
  * Note: min_duration stays as string for Express ParsedQs compatibility.
  */
-export const detectedLocationsQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
+export const detectedLocationsQuerySchema = timeRangeQuerySchema
+  .extend({
     min_duration: z.string().regex(/^\d+$/, 'Must be a positive integer').optional().meta({
       description: 'Minimum stay duration in minutes',
       example: '60',
     }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
   })
   .meta({ id: 'DetectedLocationsQuery' })
 
@@ -135,8 +137,8 @@ export type DetectedLocationsQuery = z.infer<typeof detectedLocationsQuerySchema
  */
 export const addNamedLocationBodySchema = z
   .object({
-    lat: z.number().min(-90).max(90).meta({ description: 'Latitude' }),
-    lon: z.number().min(-180).max(180).meta({ description: 'Longitude' }),
+    lat: latWithValidationSchema,
+    lon: lonWithValidationSchema,
     name: z.string().min(1).meta({ description: 'Location name', example: 'Office' }),
     radius: z.number().int().positive().optional().meta({
       description: 'Radius in meters (defaults to 200)',
@@ -149,13 +151,9 @@ export type AddNamedLocationBody = z.infer<typeof addNamedLocationBodySchema>
 /**
  * Add named location response.
  */
-export const addNamedLocationResponseSchema = z
-  .object({
-    data: namedLocationSchema.optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'AddNamedLocationResponse' })
+export const addNamedLocationResponseSchema = createDataResponseSchema(namedLocationSchema).meta({
+  id: 'AddNamedLocationResponse',
+})
 
 export type AddNamedLocationResponse = z.infer<typeof addNamedLocationResponseSchema>
 
@@ -164,8 +162,8 @@ export type AddNamedLocationResponse = z.infer<typeof addNamedLocationResponseSc
  */
 export const updateNamedLocationBodySchema = z
   .object({
-    lat: z.number().min(-90).max(90).optional().meta({ description: 'New latitude' }),
-    lon: z.number().min(-180).max(180).optional().meta({ description: 'New longitude' }),
+    lat: latWithValidationSchema.optional().meta({ description: 'New latitude' }),
+    lon: lonWithValidationSchema.optional().meta({ description: 'New longitude' }),
     name: z.string().min(1).optional().meta({ description: 'New location name' }),
     radius: z.number().int().positive().optional().meta({ description: 'New radius in meters' }),
   })
@@ -178,8 +176,8 @@ export type UpdateNamedLocationBody = z.infer<typeof updateNamedLocationBodySche
  */
 export const promoteDetectedLocationBodySchema = z
   .object({
-    lat: z.number().min(-90).max(90).meta({ description: 'Latitude from detected location' }),
-    lon: z.number().min(-180).max(180).meta({ description: 'Longitude from detected location' }),
+    lat: latWithValidationSchema.meta({ description: 'Latitude from detected location' }),
+    lon: lonWithValidationSchema.meta({ description: 'Longitude from detected location' }),
     name: z.string().min(1).meta({ description: 'Name for the location' }),
     radius: z.number().int().positive().optional().meta({
       description: 'Radius in meters (uses suggested radius if not provided)',

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -3,7 +3,15 @@
  */
 
 import { z } from 'zod'
-import { iso8601DateTimeSchema, metricTypeSchema } from './common.js'
+import {
+  baseResponseSchema,
+  iso8601DateTimeSchema,
+  metricTypeSchema,
+  timeRangeQuerySchema,
+} from './common.js'
+
+// Shared metric value field
+const metricValueSchema = z.number().meta({ description: 'Metric value' })
 
 /**
  * Metric data point schema.
@@ -11,7 +19,7 @@ import { iso8601DateTimeSchema, metricTypeSchema } from './common.js'
 export const metricDataPointSchema = z
   .object({
     time: iso8601DateTimeSchema,
-    value: z.number().meta({ description: 'Metric value' }),
+    value: metricValueSchema,
   })
   .meta({ id: 'MetricDataPoint' })
 
@@ -20,13 +28,11 @@ export type MetricDataPoint = z.infer<typeof metricDataPointSchema>
 /**
  * Query metrics response schema.
  */
-export const queryMetricsResponseSchema = z
-  .object({
+export const queryMetricsResponseSchema = baseResponseSchema
+  .extend({
     count: z.number().int().optional().meta({ description: 'Number of data points' }),
     data: z.array(metricDataPointSchema).optional(),
-    error: z.string().optional(),
     metric: metricTypeSchema.optional(),
-    success: z.boolean(),
     unit: z.string().optional().meta({ description: 'Unit of measurement', example: 'bpm' }),
   })
   .meta({ id: 'QueryMetricsResponse' })
@@ -47,12 +53,7 @@ export type QueryMetricsParams = z.infer<typeof queryMetricsParamsSchema>
 /**
  * Query metrics request query.
  */
-export const queryMetricsQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
-  })
-  .meta({ id: 'QueryMetricsQuery' })
+export const queryMetricsQuerySchema = timeRangeQuerySchema.meta({ id: 'QueryMetricsQuery' })
 
 export type QueryMetricsQuery = z.infer<typeof queryMetricsQuerySchema>
 
@@ -65,7 +66,7 @@ export const addMetricBodySchema = z
     time: iso8601DateTimeSchema.optional().meta({
       description: 'Measurement time (defaults to current time)',
     }),
-    value: z.number().meta({ description: 'Metric value', example: 72 }),
+    value: metricValueSchema.meta({ example: 72 }),
   })
   .meta({ id: 'AddMetricBody' })
 
@@ -74,11 +75,6 @@ export type AddMetricBody = z.infer<typeof addMetricBodySchema>
 /**
  * Add metric response.
  */
-export const addMetricResponseSchema = z
-  .object({
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'AddMetricResponse' })
+export const addMetricResponseSchema = baseResponseSchema.meta({ id: 'AddMetricResponse' })
 
 export type AddMetricResponse = z.infer<typeof addMetricResponseSchema>

--- a/packages/api-spec/src/schemas/period-summary.ts
+++ b/packages/api-spec/src/schemas/period-summary.ts
@@ -3,7 +3,12 @@
  */
 
 import { z } from 'zod'
-import { iso8601DateTimeSchema, metricTypeSchema } from './common.js'
+import {
+  baseResponseSchema,
+  iso8601DateTimeSchema,
+  metricTypeSchema,
+  timeRangeQuerySchema,
+} from './common.js'
 
 /**
  * Outlier schema.
@@ -63,14 +68,12 @@ export type PeriodSummaryResult = z.infer<typeof periodSummaryResultSchema>
 /**
  * Period summary response schema (API wrapper).
  */
-export const periodSummaryResponseSchema = z
-  .object({
+export const periodSummaryResponseSchema = baseResponseSchema
+  .extend({
     end: iso8601DateTimeSchema.optional(),
-    error: z.string().optional(),
     metrics: z.array(periodMetricStatsSchema).optional(),
     periodDays: z.number().int().optional(),
     start: iso8601DateTimeSchema.optional(),
-    success: z.boolean(),
   })
   .meta({ id: 'PeriodSummaryResponse' })
 
@@ -79,14 +82,12 @@ export type PeriodSummaryResponse = z.infer<typeof periodSummaryResponseSchema>
 /**
  * Period summary query schema.
  */
-export const periodSummaryQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
+export const periodSummaryQuerySchema = timeRangeQuerySchema
+  .extend({
     metrics: z.string().meta({
       description: 'Comma-separated list of metrics',
       example: 'heart_rate,steps,sleep_score',
     }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
   })
   .meta({ id: 'PeriodSummaryQuery' })
 

--- a/packages/api-spec/src/schemas/productivity.ts
+++ b/packages/api-spec/src/schemas/productivity.ts
@@ -3,7 +3,12 @@
  */
 
 import { z } from 'zod'
-import { dataSourceSchema, iso8601DateTimeSchema } from './common.js'
+import {
+  createDataArrayResponseSchema,
+  dataSourceSchema,
+  iso8601DateTimeSchema,
+  timeRangeQuerySchema,
+} from './common.js'
 
 /**
  * Productivity record schema.
@@ -29,24 +34,15 @@ export type ProductivityRecord = z.infer<typeof productivityRecordSchema>
 /**
  * Productivity query schema.
  */
-export const productivityQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
-  })
-  .meta({ id: 'ProductivityQuery' })
+export const productivityQuerySchema = timeRangeQuerySchema.meta({ id: 'ProductivityQuery' })
 
 export type ProductivityQuery = z.infer<typeof productivityQuerySchema>
 
 /**
  * Productivity response schema.
  */
-export const productivityResponseSchema = z
-  .object({
-    data: z.array(productivityRecordSchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'ProductivityResponse' })
+export const productivityResponseSchema = createDataArrayResponseSchema(productivityRecordSchema).meta({
+  id: 'ProductivityResponse',
+})
 
 export type ProductivityResponse = z.infer<typeof productivityResponseSchema>

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -3,18 +3,21 @@
  */
 
 import { z } from 'zod'
-import { hrZoneSourceSchema } from './common.js'
+import { baseResponseSchema, hrZoneSourceSchema } from './common.js'
+
+// Shared HR zone threshold field
+const hrZoneThresholdSchema = z.number().int().positive()
 
 /**
  * HR zone thresholds (zone 1-5 start values in bpm).
  */
 export const hrZoneThresholdsSchema = z
   .object({
-    1: z.number().int().positive().meta({ description: 'Zone 1 threshold (bpm)', example: 90 }),
-    2: z.number().int().positive().meta({ description: 'Zone 2 threshold (bpm)', example: 108 }),
-    3: z.number().int().positive().meta({ description: 'Zone 3 threshold (bpm)', example: 126 }),
-    4: z.number().int().positive().meta({ description: 'Zone 4 threshold (bpm)', example: 144 }),
-    5: z.number().int().positive().meta({ description: 'Zone 5 threshold (bpm)', example: 162 }),
+    1: hrZoneThresholdSchema.meta({ description: 'Zone 1 threshold (bpm)', example: 90 }),
+    2: hrZoneThresholdSchema.meta({ description: 'Zone 2 threshold (bpm)', example: 108 }),
+    3: hrZoneThresholdSchema.meta({ description: 'Zone 3 threshold (bpm)', example: 126 }),
+    4: hrZoneThresholdSchema.meta({ description: 'Zone 4 threshold (bpm)', example: 144 }),
+    5: hrZoneThresholdSchema.meta({ description: 'Zone 5 threshold (bpm)', example: 162 }),
   })
   .refine((data) => data[1] < data[2] && data[2] < data[3] && data[3] < data[4] && data[4] < data[5], {
     message: 'HR zone thresholds must be in ascending order',
@@ -23,17 +26,20 @@ export const hrZoneThresholdsSchema = z
 
 export type HrZoneThresholds = z.infer<typeof hrZoneThresholdsSchema>
 
+// Shared HR zone seconds field
+const hrZoneSecsValueSchema = z.number()
+
 /**
  * HR zone seconds (time spent in each zone).
  */
 export const hrZoneSecsSchema = z
   .object({
-    0: z.number().meta({ description: 'Seconds below zone 1' }),
-    1: z.number().meta({ description: 'Seconds in zone 1' }),
-    2: z.number().meta({ description: 'Seconds in zone 2' }),
-    3: z.number().meta({ description: 'Seconds in zone 3' }),
-    4: z.number().meta({ description: 'Seconds in zone 4' }),
-    5: z.number().meta({ description: 'Seconds in zone 5' }),
+    0: hrZoneSecsValueSchema.meta({ description: 'Seconds below zone 1' }),
+    1: hrZoneSecsValueSchema.meta({ description: 'Seconds in zone 1' }),
+    2: hrZoneSecsValueSchema.meta({ description: 'Seconds in zone 2' }),
+    3: hrZoneSecsValueSchema.meta({ description: 'Seconds in zone 3' }),
+    4: hrZoneSecsValueSchema.meta({ description: 'Seconds in zone 4' }),
+    5: hrZoneSecsValueSchema.meta({ description: 'Seconds in zone 5' }),
   })
   .meta({ id: 'HrZoneSecs' })
 
@@ -76,10 +82,9 @@ export type UpdateSettingsInput = z.infer<typeof updateSettingsInputSchema>
 /**
  * User settings response schema.
  */
-export const userSettingsResponseSchema = z
-  .object({
+export const userSettingsResponseSchema = baseResponseSchema
+  .extend({
     birth_date: z.string().nullable().meta({ description: 'Birth date in YYYY-MM-DD format' }),
-    error: z.string().optional().meta({ description: 'Error message if request failed' }),
     hr_zone_start: hrZoneThresholdsSchema.meta({ description: 'Effective HR zone thresholds' }),
     hr_zone_start_source: hrZoneSourceSchema.meta({
       description: 'Source of HR zone thresholds',
@@ -87,7 +92,6 @@ export const userSettingsResponseSchema = z
     oura_configured: z.boolean().meta({ description: 'Whether Oura OAuth is configured on server' }),
     oura_connected: z.boolean().meta({ description: 'Whether Oura is connected via OAuth' }),
     rescue_time_key: z.string().nullable().meta({ description: 'RescueTime API key' }),
-    success: z.boolean(),
   })
   .meta({ id: 'UserSettingsResponse' })
 

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -3,7 +3,21 @@
  */
 
 import { z } from 'zod'
-import { dateOnlySchema, iso8601DateTimeSchema, syncStatusSchema } from './common.js'
+import {
+  baseResponseSchema,
+  createDataArrayResponseSchema,
+  dateOnlySchema,
+  iso8601DateTimeSchema,
+  syncStatusSchema,
+} from './common.js'
+
+// Shared sync options fields
+const fullResyncSchema = z.boolean().optional().meta({
+  description: 'If true, fetches all historical data',
+})
+const startDateSyncSchema = dateOnlySchema.optional().meta({
+  description: 'Start date for sync (only used with full_resync)',
+})
 
 /**
  * Provider sync status schema.
@@ -27,13 +41,9 @@ export type ProviderSyncStatus = z.infer<typeof providerSyncStatusSchema>
 /**
  * Sync status response schema.
  */
-export const syncStatusResponseSchema = z
-  .object({
-    data: z.array(providerSyncStatusSchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'SyncStatusResponse' })
+export const syncStatusResponseSchema = createDataArrayResponseSchema(providerSyncStatusSchema).meta({
+  id: 'SyncStatusResponse',
+})
 
 export type SyncStatusResponse = z.infer<typeof syncStatusResponseSchema>
 
@@ -51,16 +61,21 @@ export const syncStatusQuerySchema = z
 export type SyncStatusQuery = z.infer<typeof syncStatusQuerySchema>
 
 /**
+ * Sync provider schema (for MCP).
+ */
+export const syncProviderSchema = z.enum(['oura', 'rescuetime', 'all']).meta({
+  description: 'Which provider to check',
+})
+
+export type SyncProviderType = z.infer<typeof syncProviderSchema>
+
+/**
  * Sync Oura body schema.
  */
 export const syncOuraBodySchema = z
   .object({
-    full_resync: z.boolean().optional().meta({
-      description: 'If true, fetches all historical data',
-    }),
-    start_date: dateOnlySchema.optional().meta({
-      description: 'Start date for sync (only used with full_resync)',
-    }),
+    full_resync: fullResyncSchema,
+    start_date: startDateSyncSchema,
   })
   .meta({ id: 'SyncOuraBody' })
 
@@ -71,12 +86,8 @@ export type SyncOuraBody = z.infer<typeof syncOuraBodySchema>
  */
 export const syncRescueTimeBodySchema = z
   .object({
-    full_resync: z.boolean().optional().meta({
-      description: 'If true, fetches all historical data',
-    }),
-    start_date: dateOnlySchema.optional().meta({
-      description: 'Start date for sync (only used with full_resync)',
-    }),
+    full_resync: fullResyncSchema,
+    start_date: startDateSyncSchema,
   })
   .meta({ id: 'SyncRescueTimeBody' })
 
@@ -85,11 +96,9 @@ export type SyncRescueTimeBody = z.infer<typeof syncRescueTimeBodySchema>
 /**
  * Sync response schema.
  */
-export const syncResponseSchema = z
-  .object({
-    error: z.string().optional(),
+export const syncResponseSchema = baseResponseSchema
+  .extend({
     message: z.string().optional().meta({ description: 'Status message' }),
-    success: z.boolean(),
   })
   .meta({ id: 'SyncResponse' })
 

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -3,7 +3,16 @@
  */
 
 import { z } from 'zod'
-import { dataSourceSchema, iso8601DateTimeSchema } from './common.js'
+import {
+  baseResponseSchema,
+  createDataArrayResponseSchema,
+  dataSourceSchema,
+  iso8601DateTimeSchema,
+  timeRangeQuerySchema,
+} from './common.js'
+
+// Shared tag text field
+const tagTextSchema = z.string().meta({ description: 'Tag/label text', example: 'coffee' })
 
 /**
  * Tag schema.
@@ -15,7 +24,7 @@ export const tagSchema = z
     id: z.string().uuid().optional().meta({ description: 'Tag ID' }),
     source: dataSourceSchema.optional(),
     startTime: iso8601DateTimeSchema,
-    tag: z.string().meta({ description: 'Tag/label text', example: 'coffee' }),
+    tag: tagTextSchema,
   })
   .meta({ id: 'Tag' })
 
@@ -24,25 +33,14 @@ export type Tag = z.infer<typeof tagSchema>
 /**
  * Tags query schema.
  */
-export const tagsQuerySchema = z
-  .object({
-    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
-    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
-  })
-  .meta({ id: 'TagsQuery' })
+export const tagsQuerySchema = timeRangeQuerySchema.meta({ id: 'TagsQuery' })
 
 export type TagsQuery = z.infer<typeof tagsQuerySchema>
 
 /**
  * Tags response schema.
  */
-export const tagsResponseSchema = z
-  .object({
-    data: z.array(tagSchema).optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'TagsResponse' })
+export const tagsResponseSchema = createDataArrayResponseSchema(tagSchema).meta({ id: 'TagsResponse' })
 
 export type TagsResponse = z.infer<typeof tagsResponseSchema>
 
@@ -55,27 +53,28 @@ export const addTagBodySchema = z
       description: 'End time (omit for point-in-time tags)',
     }),
     start_time: iso8601DateTimeSchema.meta({ description: 'Start time of the tag' }),
-    tag: z.string().min(1).meta({ description: 'Tag/label text', example: 'coffee' }),
+    tag: tagTextSchema.min(1),
   })
   .meta({ id: 'AddTagBody' })
 
 export type AddTagBody = z.infer<typeof addTagBodySchema>
 
 /**
+ * Added tag data schema.
+ */
+const addedTagSchema = z.object({
+  endTime: iso8601DateTimeSchema.optional(),
+  id: z.string().uuid(),
+  startTime: iso8601DateTimeSchema,
+  tag: z.string(),
+})
+
+/**
  * Add tag response.
  */
-export const addTagResponseSchema = z
-  .object({
-    data: z
-      .object({
-        endTime: iso8601DateTimeSchema.optional(),
-        id: z.string().uuid(),
-        startTime: iso8601DateTimeSchema,
-        tag: z.string(),
-      })
-      .optional(),
-    error: z.string().optional(),
-    success: z.boolean(),
+export const addTagResponseSchema = baseResponseSchema
+  .extend({
+    data: addedTagSchema.optional(),
   })
   .meta({ id: 'AddTagResponse' })
 
@@ -95,11 +94,6 @@ export type DeleteTagParams = z.infer<typeof deleteTagParamsSchema>
 /**
  * Delete tag response.
  */
-export const deleteTagResponseSchema = z
-  .object({
-    error: z.string().optional(),
-    success: z.boolean(),
-  })
-  .meta({ id: 'DeleteTagResponse' })
+export const deleteTagResponseSchema = baseResponseSchema.meta({ id: 'DeleteTagResponse' })
 
 export type DeleteTagResponse = z.infer<typeof deleteTagResponseSchema>

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -8,11 +8,9 @@ import {
   createDataArrayResponseSchema,
   dataSourceSchema,
   iso8601DateTimeSchema,
+  tagTextSchema,
   timeRangeQuerySchema,
 } from './common.js'
-
-// Shared tag text field
-const tagTextSchema = z.string().meta({ description: 'Tag/label text', example: 'coffee' })
 
 /**
  * Tag schema.


### PR DESCRIPTION
## Summary

- Add 5 new MCP tools to achieve parity with REST API for read operations:
  - `query_tags` - Query tags/labels for a time range
  - `query_activities` - Query activities (sleep, exercise, meditation, nap)
  - `query_productivity` - Query productivity data from RescueTime
  - `query_locations` - Query place visits for a time range
  - `get_stored_detected_locations` - Get stored detected locations with geocoded addresses
- Create common reusable field schemas in `api-spec/common.ts`:
  - Address fields (with nullable variant for geocoding that returned no result)
  - Lat/lon fields (with optional validation)
  - Time range query schema
  - Base response and data response factory functions
- Refactor all api-spec schemas to use shared field definitions
- Update MCP to import and use schemas from `@aurboda/api-spec`

## Test plan

- [x] All existing tests pass
- [x] `pnpm check` passes for all packages
- [ ] Manual test MCP tools via Claude Desktop or similar client

🤖 Generated with [Claude Code](https://claude.com/claude-code)