### PR TITLE
Address PR feedback for sync router types

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -16,6 +16,7 @@
     "@types/cors": "^2.8.19",
     "@types/d3": "^7.4.3",
     "@types/express": "^5.0.3",
+    "@types/express-serve-static-core": "^5.1.1",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.18.3",
     "@types/pg": "^8.11.10",

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -265,6 +265,31 @@ const main = async () => {
     }))
   }
 
+  // Transform Oura sync results (Date -> ISO string)
+  const transformOuraSyncResults = async (
+    user: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => {
+    const results = await syncAllOuraData(user, oura, options)
+    return results.map((r) => ({
+      ...r,
+      retryAfter: r.retryAfter?.toISOString(),
+    }))
+  }
+
+  // Transform RescueTime sync result (Date -> ISO string)
+  const transformRescueTimeSyncResult = async (
+    user: string,
+    apiKey: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => {
+    const result = await syncRescueTimeData(user, apiKey, options)
+    return {
+      ...result,
+      retryAfter: result.retryAfter?.toISOString(),
+    }
+  }
+
   // Sync router - handles /sync/* endpoints
   httpd.use(
     '/sync',
@@ -277,8 +302,8 @@ const main = async () => {
         processHealthConnectData,
         resetOuraSyncState: (user, dataType) => resetSyncState(user, 'oura', dataType),
         resetRescueTimeSyncState: (user) => resetSyncState(user, 'rescuetime'),
-        syncOura: (user, options) => syncAllOuraData(user, oura, options),
-        syncRescueTime: syncRescueTimeData,
+        syncOura: transformOuraSyncResults,
+        syncRescueTime: transformRescueTimeSyncResult,
       },
       authMiddleware,
     ),

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -8,19 +8,19 @@ import {
   type HealthConnectRecord,
   type HealthConnectSyncBody,
   type OuraSyncResponse,
+  type OuraSyncResult,
   type OuraSyncStatusResponse,
   type ProviderSyncStatus,
   type RescueTimeSyncResponse,
+  type RescueTimeSyncResult,
   type RescueTimeSyncStatusResponse,
   type SyncOuraBody,
   type SyncRescueTimeBody,
   type SyncResponse,
 } from '@aurboda/api-spec'
 import { RequestHandler, Router } from 'express'
+import type { ParamsDictionary } from 'express-serve-static-core'
 import { validateBody } from './validation'
-
-// Using Record<string, string> as Params equivalent
-type Params = Record<string, string>
 
 /**
  * Dependencies for sync router - allows testing with mocks
@@ -28,14 +28,14 @@ type Params = Record<string, string>
 export interface SyncRouterDeps {
   processDailyAggregate: (user: string, aggregate: DailyAggregate) => Promise<void>
   processHealthConnectData: (user: string, recordType: string, data: HealthConnectRecord) => Promise<void>
-  syncOura: (user: string, options: { fullResync?: boolean; startDate?: Date }) => Promise<unknown>
+  syncOura: (user: string, options: { fullResync?: boolean; startDate?: Date }) => Promise<OuraSyncResult[]>
   getOuraSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   resetOuraSyncState: (user: string, dataType?: string) => Promise<void>
   syncRescueTime: (
     user: string,
     apiKey: string,
     options: { fullResync?: boolean; startDate?: Date },
-  ) => Promise<unknown>
+  ) => Promise<RescueTimeSyncResult>
   getRescueTimeSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   resetRescueTimeSyncState: (user: string) => Promise<void>
   getSettings: (user: string) => Promise<{ rescueTimeKey?: string }>
@@ -55,7 +55,7 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
   // ===========================================================================
 
   // Daily aggregates endpoint for deduplicated cumulative metrics from Health Connect
-  router.post<Params, SyncResponse, DailyAggregatesBody>(
+  router.post<ParamsDictionary, SyncResponse, DailyAggregatesBody>(
     '/daily-aggregates',
     authMiddleware,
     validateBody(dailyAggregatesBodySchema),
@@ -72,7 +72,7 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
   )
 
   // Oura sync endpoints
-  router.post<Params, OuraSyncResponse, SyncOuraBody>(
+  router.post<ParamsDictionary, OuraSyncResponse, SyncOuraBody>(
     '/oura',
     authMiddleware,
     validateBody(syncOuraBodySchema),
@@ -94,7 +94,7 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     },
   )
 
-  router.get<Params, OuraSyncStatusResponse>('/oura/status', authMiddleware, async (req, res) => {
+  router.get<ParamsDictionary, OuraSyncStatusResponse>('/oura/status', authMiddleware, async (req, res) => {
     const user = req.user!
 
     try {
@@ -106,7 +106,7 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     }
   })
 
-  router.delete<Params, SyncResponse, unknown, { dataType?: string }>(
+  router.delete<ParamsDictionary, SyncResponse, unknown, { dataType?: string }>(
     '/oura/state',
     authMiddleware,
     async (req, res) => {
@@ -124,7 +124,7 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
   )
 
   // RescueTime sync endpoints
-  router.post<Params, RescueTimeSyncResponse, SyncRescueTimeBody>(
+  router.post<ParamsDictionary, RescueTimeSyncResponse, SyncRescueTimeBody>(
     '/rescuetime',
     authMiddleware,
     validateBody(syncRescueTimeBodySchema),
@@ -154,19 +154,23 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     },
   )
 
-  router.get<Params, RescueTimeSyncStatusResponse>('/rescuetime/status', authMiddleware, async (req, res) => {
-    const user = req.user!
+  router.get<ParamsDictionary, RescueTimeSyncStatusResponse>(
+    '/rescuetime/status',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
 
-    try {
-      const states = await deps.getRescueTimeSyncStates(user)
-      res.json({ states, success: true })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      res.status(500).json({ error: message, success: false })
-    }
-  })
+      try {
+        const states = await deps.getRescueTimeSyncStates(user)
+        res.json({ states, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
 
-  router.delete<Params, SyncResponse>('/rescuetime/state', authMiddleware, async (req, res) => {
+  router.delete<ParamsDictionary, SyncResponse>('/rescuetime/state', authMiddleware, async (req, res) => {
     const user = req.user!
 
     try {

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -207,23 +207,78 @@ export const rescueTimeSyncStatusResponseSchema = baseResponseSchema
 
 export type RescueTimeSyncStatusResponse = z.infer<typeof rescueTimeSyncStatusResponseSchema>
 
+// ============================================================================
+// Sync result schemas
+// ============================================================================
+
 /**
- * Oura sync response with results.
+ * Sync result status.
+ */
+export const syncResultStatusSchema = z.enum(['success', 'skipped', 'error', 'rate_limited']).meta({
+  description: 'Status of sync operation',
+  id: 'SyncResultStatus',
+})
+
+export type SyncResultStatus = z.infer<typeof syncResultStatusSchema>
+
+/**
+ * Oura data types that can be synced.
+ */
+export const ouraDataTypeSchema = z
+  .enum(['dailyCardiovascularAge', 'dailyReadiness', 'dailyResilience', 'dailySleep', 'sessions', 'tags'])
+  .meta({
+    description: 'Oura data type',
+    id: 'OuraDataType',
+  })
+
+export type OuraDataType = z.infer<typeof ouraDataTypeSchema>
+
+/**
+ * Oura sync result for a single data type.
+ */
+export const ouraSyncResultSchema = z
+  .object({
+    dataType: ouraDataTypeSchema,
+    error: z.string().optional().meta({ description: 'Error message if status is error' }),
+    recordsProcessed: z.number().int().meta({ description: 'Number of records processed' }),
+    retryAfter: iso8601DateTimeSchema.optional().meta({ description: 'Time when retry is allowed' }),
+    status: syncResultStatusSchema,
+  })
+  .meta({ id: 'OuraSyncResult' })
+
+export type OuraSyncResult = z.infer<typeof ouraSyncResultSchema>
+
+/**
+ * RescueTime sync result.
+ */
+export const rescueTimeSyncResultSchema = z
+  .object({
+    error: z.string().optional().meta({ description: 'Error message if status is error' }),
+    recordsProcessed: z.number().int().meta({ description: 'Number of records processed' }),
+    retryAfter: iso8601DateTimeSchema.optional().meta({ description: 'Time when retry is allowed' }),
+    status: syncResultStatusSchema,
+  })
+  .meta({ id: 'RescueTimeSyncResult' })
+
+export type RescueTimeSyncResult = z.infer<typeof rescueTimeSyncResultSchema>
+
+/**
+ * Oura sync response with typed results.
  */
 export const ouraSyncResponseSchema = baseResponseSchema
   .extend({
-    results: z.unknown().optional().meta({ description: 'Sync results' }),
+    results: z.array(ouraSyncResultSchema).optional().meta({ description: 'Sync results per data type' }),
   })
   .meta({ id: 'OuraSyncResponse' })
 
 export type OuraSyncResponse = z.infer<typeof ouraSyncResponseSchema>
 
 /**
- * RescueTime sync response with result.
+ * RescueTime sync response with typed result.
  */
 export const rescueTimeSyncResponseSchema = baseResponseSchema
   .extend({
-    result: z.unknown().optional().meta({ description: 'Sync result' }),
+    result: rescueTimeSyncResultSchema.optional().meta({ description: 'Sync result' }),
   })
   .meta({ id: 'RescueTimeSyncResponse' })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
+      '@types/express-serve-static-core':
+        specifier: ^5.1.1
+        version: 5.1.1
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7


### PR DESCRIPTION
## Summary
- Import `ParamsDictionary` from `express-serve-static-core` instead of defining a local `Params` type
- Add typed schemas for `OuraSyncResult` and `RescueTimeSyncResult` in api-spec instead of using `z.unknown()`
- Add transformation functions in api.ts to convert internal `Date` types to ISO strings for API responses

Note: The `start_date` validation already uses `z.iso.date()` which properly validates YYYY-MM-DD format, so no additional changes were needed for date parsing.

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm vitest run src/sync-router.test.ts` passes (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)