### PR TITLE
Add BLE heart rate monitor support with foreground service

### DIFF
--- a/PLAN-ble-sensors.md
+++ b/PLAN-ble-sensors.md
@@ -243,9 +243,9 @@ app/src/main/java/net/aurboda/
 1. **BLE permissions and scanner** - get device discovery working ✅ DONE
 2. **Connection manager** - connect and read HR data ✅ DONE
 3. **Live screen UI** - display discovered devices and connect ✅ DONE
-4. **Foreground service** - keep connections alive in background
-5. **Backend sync** - send HR data to server
-6. **Health Connect writes** - persist to Health Connect
+4. **Foreground service** - keep connections alive in background ✅ DONE
+5. **Backend sync** - send HR data to server ✅ DONE
+6. **Health Connect writes** - persist to Health Connect ✅ DONE
 7. **RSC support** - add step/cadence sensor support
 8. **Polish** - reconnection, error handling, UI refinements
 

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <!-- Location permission required for BLE scanning to return results -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- Foreground service for keeping BLE connections alive -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 
@@ -52,6 +56,10 @@
     <uses-permission android:name="android.permission.health.READ_VO2_MAX" />
     <uses-permission android:name="android.permission.health.READ_WEIGHT"/>
     <uses-permission android:name="android.permission.health.READ_WHEELCHAIR_PUSHES" />
+
+    <!-- Write permissions for BLE sensor data -->
+    <uses-permission android:name="android.permission.health.WRITE_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_STEPS" />
 
     <application
         android:name=".AurbodaApplication"
@@ -105,6 +113,12 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/hr_zone_widget_info" />
         </receiver>
+
+        <!-- BLE Sensor Foreground Service -->
+        <service
+            android:name=".ble.SensorService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
 
     </application>
 

--- a/apps/android/app/src/main/java/net/aurboda/ble/BleScanner.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleScanner.kt
@@ -56,7 +56,7 @@ fun isBleEnabled(context: Context): Boolean {
 }
 
 // Known heart rate monitor name patterns (case-insensitive)
-private val HR_MONITOR_NAME_PATTERNS = listOf(
+internal val HR_MONITOR_NAME_PATTERNS = listOf(
     "polar", "h10", "h9", "h7", "oh1", "verity",  // Polar
     "wahoo", "tickr",                              // Wahoo
     "garmin", "hrm",                               // Garmin
@@ -66,12 +66,16 @@ private val HR_MONITOR_NAME_PATTERNS = listOf(
 )
 
 // Known step sensor / footpod name patterns (case-insensitive)
-private val STEP_SENSOR_NAME_PATTERNS = listOf(
+internal val STEP_SENSOR_NAME_PATTERNS = listOf(
     "stryd", "runpod", "zwift", "footpod",
     "milestone", "runn", "speed", "cadence"
 )
 
-private fun detectSensorTypeFromName(name: String?): SensorType? {
+/**
+ * Detect sensor type from device name using known patterns.
+ * Returns null if the name doesn't match any known sensor pattern.
+ */
+internal fun detectSensorTypeFromName(name: String?): SensorType? {
     if (name == null) return null
     val lowerName = name.lowercase()
 

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -1,0 +1,436 @@
+package net.aurboda.ble
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.metadata.Device
+import androidx.health.connect.client.records.metadata.Metadata
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import net.aurboda.CredentialsManager
+import net.aurboda.MainActivity
+import net.aurboda.R
+import net.aurboda.appJson
+import java.time.Instant
+import java.time.ZoneOffset
+
+private const val TAG = "SensorService"
+private const val NOTIFICATION_ID = 1001
+private const val CHANNEL_ID = "sensor_service_channel"
+private const val SYNC_INTERVAL_MS = 5000L
+
+/**
+ * State exposed by SensorService to the UI.
+ */
+data class SensorServiceState(
+    val isRunning: Boolean = false,
+    val connectionState: BleConnectionState = BleConnectionState.Disconnected,
+    val connectedDevice: ConnectedDevice? = null,
+    val currentHeartRate: Int? = null,
+    val lastSyncTime: Instant? = null,
+    val pendingSamples: Int = 0
+)
+
+/**
+ * Heart rate sample for backend sync.
+ */
+@Serializable
+data class HeartRateSyncSample(
+    val time: String,
+    val bpm: Int,
+    @SerialName("rr_intervals") val rrIntervals: List<Int>? = null
+)
+
+@Serializable
+private data class HeartRateSyncBody(val data: List<HeartRateSyncSample>)
+
+/**
+ * Foreground service that manages BLE sensor connections.
+ * Keeps connections alive in the background, buffers HR samples,
+ * syncs to backend every 5 seconds, and writes to Health Connect.
+ */
+class SensorService : Service() {
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var connectionManager: BleConnectionManager? = null
+    private var syncJob: Job? = null
+    private var hrCollectionJob: Job? = null
+
+    private val sampleBuffer = mutableListOf<HeartRateSample>()
+    private val bufferLock = Any()
+
+    private val httpClient by lazy {
+        HttpClient(Android) {
+            install(ContentNegotiation) { json(appJson) }
+        }
+    }
+
+    private val healthConnectClient by lazy {
+        HealthConnectClient.getOrCreate(applicationContext)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Service created")
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_CONNECT -> {
+                val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
+                if (deviceAddress != null) {
+                    startForegroundWithNotification()
+                    connectToDevice(deviceAddress)
+                } else {
+                    Log.w(TAG, "No device address provided")
+                    stopSelf()
+                }
+            }
+            ACTION_DISCONNECT -> {
+                disconnect()
+            }
+            ACTION_STOP -> {
+                stopSensorService()
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Service destroyed")
+        cleanup()
+        serviceScope.cancel()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Sensor Service",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Keeps BLE sensor connections active"
+                setShowBadge(false)
+            }
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    @SuppressLint("ForegroundServiceType")
+    private fun startForegroundWithNotification() {
+        val notification = buildNotification(null)
+        startForeground(NOTIFICATION_ID, notification)
+        updateState { it.copy(isRunning = true) }
+    }
+
+    private fun buildNotification(heartRate: Int?): Notification {
+        val openIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val openPendingIntent = PendingIntent.getActivity(
+            this, 0, openIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val stopIntent = Intent(this, SensorService::class.java).apply {
+            action = ACTION_STOP
+        }
+        val stopPendingIntent = PendingIntent.getService(
+            this, 1, stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val contentText = if (heartRate != null) {
+            "Heart rate: $heartRate BPM"
+        } else {
+            "Connecting to sensor..."
+        }
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Aurboda - Sensors Active")
+            .setContentText(contentText)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .setSilent(true)
+            .setContentIntent(openPendingIntent)
+            .addAction(0, "Stop", stopPendingIntent)
+            .build()
+    }
+
+    private fun updateNotification(heartRate: Int?) {
+        val notification = buildNotification(heartRate)
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun connectToDevice(deviceAddress: String) {
+        Log.d(TAG, "Connecting to device: $deviceAddress")
+
+        connectionManager = BleConnectionManager(this).also { manager ->
+            // Observe connection state
+            serviceScope.launch {
+                manager.connectionState.collect { state ->
+                    Log.d(TAG, "Connection state: $state")
+                    updateState { it.copy(connectionState = state) }
+
+                    when (state) {
+                        is BleConnectionState.Connected -> {
+                            startDataCollection(manager)
+                            startSyncLoop()
+                        }
+                        is BleConnectionState.Disconnected -> {
+                            stopDataCollection()
+                            // Auto-reconnect could be added here
+                        }
+                        is BleConnectionState.Error -> {
+                            Log.e(TAG, "Connection error: ${state.message}")
+                        }
+                        else -> {}
+                    }
+                }
+            }
+
+            // Observe connected device info
+            serviceScope.launch {
+                manager.connectedDeviceInfo.collect { device ->
+                    updateState { it.copy(connectedDevice = device) }
+                }
+            }
+
+            // Observe current heart rate for notification
+            serviceScope.launch {
+                manager.currentHeartRate.collect { hr ->
+                    updateState { it.copy(currentHeartRate = hr) }
+                    updateNotification(hr)
+                }
+            }
+
+            manager.connect(deviceAddress)
+        }
+    }
+
+    private fun startDataCollection(manager: BleConnectionManager) {
+        hrCollectionJob?.cancel()
+        hrCollectionJob = serviceScope.launch {
+            manager.heartRateSamples.collect { sample ->
+                synchronized(bufferLock) {
+                    sampleBuffer.add(sample)
+                    updateState { it.copy(pendingSamples = sampleBuffer.size) }
+                }
+            }
+        }
+    }
+
+    private fun stopDataCollection() {
+        hrCollectionJob?.cancel()
+        hrCollectionJob = null
+    }
+
+    private fun startSyncLoop() {
+        syncJob?.cancel()
+        syncJob = serviceScope.launch {
+            while (true) {
+                delay(SYNC_INTERVAL_MS)
+                syncPendingSamples()
+            }
+        }
+    }
+
+    private suspend fun syncPendingSamples() {
+        val samplesToSync: List<HeartRateSample>
+        synchronized(bufferLock) {
+            if (sampleBuffer.isEmpty()) return
+            samplesToSync = sampleBuffer.toList()
+            sampleBuffer.clear()
+            updateState { it.copy(pendingSamples = 0) }
+        }
+
+        Log.d(TAG, "Syncing ${samplesToSync.size} HR samples")
+
+        // Sync to backend
+        val backendSuccess = syncToBackend(samplesToSync)
+        if (!backendSuccess) {
+            // Re-add samples to buffer on failure
+            synchronized(bufferLock) {
+                sampleBuffer.addAll(0, samplesToSync)
+                updateState { it.copy(pendingSamples = sampleBuffer.size) }
+            }
+            return
+        }
+
+        // Write to Health Connect
+        writeToHealthConnect(samplesToSync)
+
+        updateState { it.copy(lastSyncTime = Instant.now()) }
+    }
+
+    private suspend fun syncToBackend(samples: List<HeartRateSample>): Boolean {
+        val credentials = CredentialsManager.getCredentials(this) ?: run {
+            Log.w(TAG, "No credentials, skipping backend sync")
+            return true // Don't block on missing credentials
+        }
+
+        val syncSamples = samples.map { sample ->
+            HeartRateSyncSample(
+                time = sample.timestamp.toString(),
+                bpm = sample.bpm,
+                rrIntervals = sample.rrIntervals
+            )
+        }
+
+        return try {
+            val response = httpClient.post("${credentials.apiUrl}/sync/HeartRateRecord") {
+                contentType(ContentType.Application.Json)
+                headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
+                setBody(HeartRateSyncBody(syncSamples))
+            }
+            val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+            Log.d(TAG, "Backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")
+            success
+        } catch (e: Exception) {
+            Log.e(TAG, "Backend sync error", e)
+            false
+        }
+    }
+
+    private suspend fun writeToHealthConnect(samples: List<HeartRateSample>) {
+        if (samples.isEmpty()) return
+
+        try {
+            // Check write permission
+            val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+            val writePermission = HealthPermission.getWritePermission(HeartRateRecord::class)
+            if (writePermission !in grantedPermissions) {
+                Log.w(TAG, "No Health Connect write permission for HeartRateRecord")
+                return
+            }
+
+            // Group samples into 1-second intervals for Health Connect
+            // Health Connect expects HeartRateRecord with a time range and samples
+            val sortedSamples = samples.sortedBy { it.timestamp }
+            val startTime = sortedSamples.first().timestamp
+            val endTime = sortedSamples.last().timestamp.plusSeconds(1)
+
+            val hrSamples = sortedSamples.map { sample ->
+                HeartRateRecord.Sample(
+                    time = sample.timestamp,
+                    beatsPerMinute = sample.bpm.toLong()
+                )
+            }
+
+            val record = HeartRateRecord(
+                startTime = startTime,
+                startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
+                endTime = endTime,
+                endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+                samples = hrSamples,
+                metadata = Metadata.autoRecorded(
+                    device = Device(type = Device.TYPE_CHEST_STRAP)
+                )
+            )
+
+            healthConnectClient.insertRecords(listOf(record))
+            Log.d(TAG, "Wrote ${samples.size} HR samples to Health Connect")
+        } catch (e: Exception) {
+            Log.e(TAG, "Health Connect write error", e)
+        }
+    }
+
+    private fun disconnect() {
+        Log.d(TAG, "Disconnecting...")
+        connectionManager?.disconnect()
+    }
+
+    private fun stopSensorService() {
+        Log.d(TAG, "Stopping service...")
+        cleanup()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+        updateState { SensorServiceState() }
+    }
+
+    private fun cleanup() {
+        syncJob?.cancel()
+        hrCollectionJob?.cancel()
+        connectionManager?.close()
+        connectionManager = null
+    }
+
+    private fun updateState(update: (SensorServiceState) -> SensorServiceState) {
+        _serviceState.value = update(_serviceState.value)
+    }
+
+    companion object {
+        const val ACTION_CONNECT = "net.aurboda.action.CONNECT_SENSOR"
+        const val ACTION_DISCONNECT = "net.aurboda.action.DISCONNECT_SENSOR"
+        const val ACTION_STOP = "net.aurboda.action.STOP_SENSOR_SERVICE"
+        const val EXTRA_DEVICE_ADDRESS = "device_address"
+
+        private val _serviceState = MutableStateFlow(SensorServiceState())
+        val serviceState: StateFlow<SensorServiceState> = _serviceState.asStateFlow()
+
+        fun connect(context: Context, deviceAddress: String) {
+            val intent = Intent(context, SensorService::class.java).apply {
+                action = ACTION_CONNECT
+                putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun disconnect(context: Context) {
+            val intent = Intent(context, SensorService::class.java).apply {
+                action = ACTION_DISCONNECT
+            }
+            context.startService(intent)
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, SensorService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+
+        internal fun updateServiceState(state: SensorServiceState) {
+            _serviceState.value = state
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -46,10 +45,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import net.aurboda.ble.BleConnectionManager
 import net.aurboda.ble.BleConnectionState
 import net.aurboda.ble.BleScanState
 import net.aurboda.ble.DiscoveredDevice
+import net.aurboda.ble.SensorService
 import net.aurboda.ble.SensorType
 import net.aurboda.ble.hasBlePermissions
 import net.aurboda.ble.isBleEnabled
@@ -65,10 +64,11 @@ fun LiveScreen(
     var bleEnabled by remember { mutableStateOf(isBleEnabled(context)) }
     val bleSupported = remember { isBleSupported(context) }
 
-    val connectionManager = remember { BleConnectionManager(context) }
-    val connectionState by connectionManager.connectionState.collectAsState()
-    val connectedDevice by connectionManager.connectedDeviceInfo.collectAsState()
-    val currentHeartRate by connectionManager.currentHeartRate.collectAsState()
+    // Observe service state
+    val serviceState by SensorService.serviceState.collectAsState()
+    val connectionState = serviceState.connectionState
+    val connectedDevice = serviceState.connectedDevice
+    val currentHeartRate = serviceState.currentHeartRate
 
     var isScanning by remember { mutableStateOf(false) }
     var scanError by remember { mutableStateOf<String?>(null) }
@@ -79,13 +79,6 @@ fun LiveScreen(
         contract = ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         hasPermissions = permissions.values.all { it }
-    }
-
-    // Clean up connection manager when leaving screen
-    DisposableEffect(Unit) {
-        onDispose {
-            // Don't close here - let the service manage the connection
-        }
     }
 
     // Scan for devices
@@ -192,7 +185,9 @@ fun LiveScreen(
                 ConnectedDeviceCard(
                     device = connectedDevice,
                     heartRate = currentHeartRate,
-                    onDisconnect = { connectionManager.disconnect() }
+                    serviceRunning = serviceState.isRunning,
+                    pendingSamples = serviceState.pendingSamples,
+                    onDisconnect = { SensorService.stop(context) }
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }
@@ -261,7 +256,7 @@ fun LiveScreen(
                     isScanning = false
                 },
                 onConnectDevice = { device ->
-                    connectionManager.connect(device.address)
+                    SensorService.connect(context, device.address)
                 }
             )
         }
@@ -272,6 +267,8 @@ fun LiveScreen(
 private fun ConnectedDeviceCard(
     device: net.aurboda.ble.ConnectedDevice?,
     heartRate: Int?,
+    serviceRunning: Boolean,
+    pendingSamples: Int,
     onDisconnect: () -> Unit
 ) {
     Card(
@@ -331,10 +328,20 @@ private fun ConnectedDeviceCard(
                 }
             }
 
+            // Service status
+            if (serviceRunning) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = if (pendingSamples > 0) "Syncing ($pendingSamples pending)" else "Syncing to cloud",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                )
+            }
+
             Spacer(modifier = Modifier.height(16.dp))
 
             OutlinedButton(onClick = onDisconnect) {
-                Text("Disconnect")
+                Text("Stop")
             }
         }
     }

--- a/apps/android/app/src/test/java/net/aurboda/BleScannerTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/BleScannerTest.kt
@@ -1,0 +1,257 @@
+package net.aurboda
+
+import net.aurboda.ble.CLIENT_CHARACTERISTIC_CONFIG_UUID
+import net.aurboda.ble.HEART_RATE_MEASUREMENT_UUID
+import net.aurboda.ble.HEART_RATE_SERVICE_UUID
+import net.aurboda.ble.HR_MONITOR_NAME_PATTERNS
+import net.aurboda.ble.RSC_MEASUREMENT_UUID
+import net.aurboda.ble.RUNNING_SPEED_CADENCE_SERVICE_UUID
+import net.aurboda.ble.STEP_SENSOR_NAME_PATTERNS
+import net.aurboda.ble.SensorType
+import net.aurboda.ble.detectSensorTypeFromName
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Tests for BLE scanner utilities and constants.
+ * These tests verify that the Bluetooth GATT UUIDs are correct
+ * according to the Bluetooth SIG specifications.
+ */
+class BleScannerTest {
+
+    @Test
+    fun `heart rate service UUID matches Bluetooth SIG specification`() {
+        // Heart Rate Service UUID is 0x180D
+        // Full 128-bit UUID: 0000180d-0000-1000-8000-00805f9b34fb
+        val expected = UUID.fromString("0000180d-0000-1000-8000-00805f9b34fb")
+        assertEquals(expected, HEART_RATE_SERVICE_UUID)
+    }
+
+    @Test
+    fun `running speed and cadence service UUID matches Bluetooth SIG specification`() {
+        // RSC Service UUID is 0x1814
+        // Full 128-bit UUID: 00001814-0000-1000-8000-00805f9b34fb
+        val expected = UUID.fromString("00001814-0000-1000-8000-00805f9b34fb")
+        assertEquals(expected, RUNNING_SPEED_CADENCE_SERVICE_UUID)
+    }
+
+    @Test
+    fun `heart rate measurement characteristic UUID matches Bluetooth SIG specification`() {
+        // Heart Rate Measurement UUID is 0x2A37
+        val expected = UUID.fromString("00002a37-0000-1000-8000-00805f9b34fb")
+        assertEquals(expected, HEART_RATE_MEASUREMENT_UUID)
+    }
+
+    @Test
+    fun `RSC measurement characteristic UUID matches Bluetooth SIG specification`() {
+        // RSC Measurement UUID is 0x2A53
+        val expected = UUID.fromString("00002a53-0000-1000-8000-00805f9b34fb")
+        assertEquals(expected, RSC_MEASUREMENT_UUID)
+    }
+
+    @Test
+    fun `client characteristic config descriptor UUID matches Bluetooth SIG specification`() {
+        // CCCD UUID is 0x2902
+        val expected = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+        assertEquals(expected, CLIENT_CHARACTERISTIC_CONFIG_UUID)
+    }
+
+    @Test
+    fun `all BLE UUIDs use standard Bluetooth base UUID`() {
+        // All standard Bluetooth UUIDs should have the same base
+        val baseUuidSuffix = "-0000-1000-8000-00805f9b34fb"
+
+        listOf(
+            HEART_RATE_SERVICE_UUID,
+            RUNNING_SPEED_CADENCE_SERVICE_UUID,
+            HEART_RATE_MEASUREMENT_UUID,
+            RSC_MEASUREMENT_UUID,
+            CLIENT_CHARACTERISTIC_CONFIG_UUID
+        ).forEach { uuid ->
+            val uuidString = uuid.toString()
+            assert(uuidString.endsWith(baseUuidSuffix)) {
+                "UUID $uuid does not use standard Bluetooth base UUID"
+            }
+        }
+    }
+
+    // ========================================================================
+    // Sensor Type Detection Tests
+    // ========================================================================
+
+    @Test
+    fun `detectSensorTypeFromName returns null for null input`() {
+        val result = detectSensorTypeFromName(null)
+        assertNull(result)
+    }
+
+    @Test
+    fun `detectSensorTypeFromName returns null for empty string`() {
+        val result = detectSensorTypeFromName("")
+        assertNull(result)
+    }
+
+    @Test
+    fun `detectSensorTypeFromName returns null for unknown device`() {
+        val result = detectSensorTypeFromName("Random Bluetooth Device")
+        assertNull(result)
+    }
+
+    // Polar heart rate monitors
+    @Test
+    fun `detectSensorTypeFromName detects Polar H10`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Polar H10 12345678"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Polar H9`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Polar H9"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Polar H7`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Polar H7 ABCD1234"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Polar OH1`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Polar OH1"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Polar Verity Sense`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Polar Verity Sense"))
+    }
+
+    // Wahoo heart rate monitors
+    @Test
+    fun `detectSensorTypeFromName detects Wahoo TICKR`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("TICKR 1234"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Wahoo device`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Wahoo HR Monitor"))
+    }
+
+    // Garmin heart rate monitors
+    @Test
+    fun `detectSensorTypeFromName detects Garmin HRM`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Garmin HRM-Dual"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects generic HRM`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("HRM-Pro"))
+    }
+
+    // Coospo heart rate monitors
+    @Test
+    fun `detectSensorTypeFromName detects Coospo`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("CooSpo H808S"))
+    }
+
+    // Magene heart rate monitors
+    @Test
+    fun `detectSensorTypeFromName detects Magene`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Magene H64"))
+    }
+
+    // Generic heart rate
+    @Test
+    fun `detectSensorTypeFromName detects generic Heart Rate`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("Heart Rate Monitor"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects HR Sensor`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("HR Sensor"))
+    }
+
+    // Running/step sensors
+    @Test
+    fun `detectSensorTypeFromName detects Stryd`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Stryd"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Zwift Runpod`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Zwift Runpod"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects generic Footpod`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Footpod Sensor"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Milestone Pod`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Milestone Pod"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Runn sensor`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Runn Smart Treadmill"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Speed sensor`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Speed Sensor 2"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName detects Cadence sensor`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("Cadence Sensor"))
+    }
+
+    // Case insensitivity
+    @Test
+    fun `detectSensorTypeFromName is case insensitive for uppercase`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("POLAR H10"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName is case insensitive for mixed case`() {
+        assertEquals(SensorType.HEART_RATE, detectSensorTypeFromName("PoLaR h10"))
+    }
+
+    @Test
+    fun `detectSensorTypeFromName is case insensitive for lowercase`() {
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, detectSensorTypeFromName("zwift runpod"))
+    }
+
+    // Pattern list coverage
+    @Test
+    fun `HR_MONITOR_NAME_PATTERNS contains expected patterns`() {
+        val expectedPatterns = listOf(
+            "polar", "h10", "h9", "h7", "oh1", "verity",
+            "wahoo", "tickr",
+            "garmin", "hrm",
+            "coospo", "csc",
+            "magene",
+            "heart rate", "hr sensor"
+        )
+
+        expectedPatterns.forEach { pattern ->
+            assert(HR_MONITOR_NAME_PATTERNS.contains(pattern)) {
+                "HR_MONITOR_NAME_PATTERNS should contain '$pattern'"
+            }
+        }
+    }
+
+    @Test
+    fun `STEP_SENSOR_NAME_PATTERNS contains expected patterns`() {
+        val expectedPatterns = listOf(
+            "stryd", "runpod", "zwift", "footpod",
+            "milestone", "runn", "speed", "cadence"
+        )
+
+        expectedPatterns.forEach { pattern ->
+            assert(STEP_SENSOR_NAME_PATTERNS.contains(pattern)) {
+                "STEP_SENSOR_NAME_PATTERNS should contain '$pattern'"
+            }
+        }
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/BleSensorDataTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/BleSensorDataTest.kt
@@ -1,0 +1,275 @@
+package net.aurboda
+
+import net.aurboda.ble.CadenceSample
+import net.aurboda.ble.ConnectedDevice
+import net.aurboda.ble.DiscoveredDevice
+import net.aurboda.ble.HeartRateSample
+import net.aurboda.ble.SensorType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Tests for BLE sensor data classes.
+ * These tests verify the data structures used for sensor readings.
+ */
+class BleSensorDataTest {
+
+    // ========================================================================
+    // SensorType Tests
+    // ========================================================================
+
+    @Test
+    fun `SensorType has HEART_RATE value`() {
+        val type = SensorType.HEART_RATE
+        assertEquals("HEART_RATE", type.name)
+    }
+
+    @Test
+    fun `SensorType has RUNNING_SPEED_CADENCE value`() {
+        val type = SensorType.RUNNING_SPEED_CADENCE
+        assertEquals("RUNNING_SPEED_CADENCE", type.name)
+    }
+
+    @Test
+    fun `SensorType valueOf works for HEART_RATE`() {
+        val type = SensorType.valueOf("HEART_RATE")
+        assertEquals(SensorType.HEART_RATE, type)
+    }
+
+    @Test
+    fun `SensorType valueOf works for RUNNING_SPEED_CADENCE`() {
+        val type = SensorType.valueOf("RUNNING_SPEED_CADENCE")
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, type)
+    }
+
+    // ========================================================================
+    // HeartRateSample Tests
+    // ========================================================================
+
+    @Test
+    fun `HeartRateSample stores basic heart rate`() {
+        val timestamp = Instant.parse("2024-01-15T10:30:00Z")
+        val sample = HeartRateSample(
+            timestamp = timestamp,
+            bpm = 72
+        )
+
+        assertEquals(timestamp, sample.timestamp)
+        assertEquals(72, sample.bpm)
+        assertNull(sample.rrIntervals)
+    }
+
+    @Test
+    fun `HeartRateSample stores RR intervals`() {
+        val timestamp = Instant.now()
+        val rrIntervals = listOf(800, 810, 795)
+        val sample = HeartRateSample(
+            timestamp = timestamp,
+            bpm = 75,
+            rrIntervals = rrIntervals
+        )
+
+        assertEquals(75, sample.bpm)
+        assertEquals(rrIntervals, sample.rrIntervals)
+    }
+
+    @Test
+    fun `HeartRateSample equality based on all fields`() {
+        val timestamp = Instant.parse("2024-01-15T10:30:00Z")
+
+        val sample1 = HeartRateSample(timestamp, 72, listOf(800))
+        val sample2 = HeartRateSample(timestamp, 72, listOf(800))
+        val sample3 = HeartRateSample(timestamp, 73, listOf(800))
+
+        assertEquals(sample1, sample2)
+        assertNotEquals(sample1, sample3)
+    }
+
+    @Test
+    fun `HeartRateSample handles high heart rates`() {
+        val sample = HeartRateSample(
+            timestamp = Instant.now(),
+            bpm = 200  // Maximum athletic heart rate
+        )
+
+        assertEquals(200, sample.bpm)
+    }
+
+    @Test
+    fun `HeartRateSample handles low heart rates`() {
+        val sample = HeartRateSample(
+            timestamp = Instant.now(),
+            bpm = 40  // Bradycardia / athletic resting HR
+        )
+
+        assertEquals(40, sample.bpm)
+    }
+
+    // ========================================================================
+    // CadenceSample Tests
+    // ========================================================================
+
+    @Test
+    fun `CadenceSample stores cadence without speed`() {
+        val timestamp = Instant.now()
+        val sample = CadenceSample(
+            timestamp = timestamp,
+            cadence = 180,  // steps per minute
+            speed = null
+        )
+
+        assertEquals(180, sample.cadence)
+        assertNull(sample.speed)
+    }
+
+    @Test
+    fun `CadenceSample stores cadence with speed`() {
+        val timestamp = Instant.now()
+        val sample = CadenceSample(
+            timestamp = timestamp,
+            cadence = 175,
+            speed = 3.5f  // m/s (~12.6 km/h)
+        )
+
+        assertEquals(175, sample.cadence)
+        assertEquals(3.5f, sample.speed)
+    }
+
+    @Test
+    fun `CadenceSample equality based on all fields`() {
+        val timestamp = Instant.parse("2024-01-15T10:30:00Z")
+
+        val sample1 = CadenceSample(timestamp, 180, 3.5f)
+        val sample2 = CadenceSample(timestamp, 180, 3.5f)
+        val sample3 = CadenceSample(timestamp, 180, 3.6f)
+
+        assertEquals(sample1, sample2)
+        assertNotEquals(sample1, sample3)
+    }
+
+    // ========================================================================
+    // DiscoveredDevice Tests
+    // ========================================================================
+
+    @Test
+    fun `DiscoveredDevice stores all fields`() {
+        val device = DiscoveredDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Polar H10",
+            rssi = -65,
+            sensorType = SensorType.HEART_RATE
+        )
+
+        assertEquals("AA:BB:CC:DD:EE:FF", device.address)
+        assertEquals("Polar H10", device.name)
+        assertEquals(-65, device.rssi)
+        assertEquals(SensorType.HEART_RATE, device.sensorType)
+    }
+
+    @Test
+    fun `DiscoveredDevice handles null name`() {
+        val device = DiscoveredDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = null,
+            rssi = -70,
+            sensorType = SensorType.HEART_RATE
+        )
+
+        assertNull(device.name)
+        assertEquals("AA:BB:CC:DD:EE:FF", device.address)
+    }
+
+    @Test
+    fun `DiscoveredDevice stores RSC sensor type`() {
+        val device = DiscoveredDevice(
+            address = "11:22:33:44:55:66",
+            name = "Zwift Runpod",
+            rssi = -55,
+            sensorType = SensorType.RUNNING_SPEED_CADENCE
+        )
+
+        assertEquals(SensorType.RUNNING_SPEED_CADENCE, device.sensorType)
+    }
+
+    @Test
+    fun `DiscoveredDevice RSSI typical range`() {
+        // RSSI typically ranges from -30 (very close) to -100 (very far)
+        val closeDevice = DiscoveredDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Close Device",
+            rssi = -30,
+            sensorType = SensorType.HEART_RATE
+        )
+
+        val farDevice = DiscoveredDevice(
+            address = "11:22:33:44:55:66",
+            name = "Far Device",
+            rssi = -95,
+            sensorType = SensorType.HEART_RATE
+        )
+
+        assertTrue(closeDevice.rssi > farDevice.rssi)
+    }
+
+    // ========================================================================
+    // ConnectedDevice Tests
+    // ========================================================================
+
+    @Test
+    fun `ConnectedDevice stores all fields`() {
+        val device = ConnectedDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Polar H10",
+            type = SensorType.HEART_RATE
+        )
+
+        assertEquals("AA:BB:CC:DD:EE:FF", device.address)
+        assertEquals("Polar H10", device.name)
+        assertEquals(SensorType.HEART_RATE, device.type)
+    }
+
+    @Test
+    fun `ConnectedDevice handles null name`() {
+        val device = ConnectedDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = null,
+            type = SensorType.HEART_RATE
+        )
+
+        assertNull(device.name)
+    }
+
+    @Test
+    fun `ConnectedDevice equality based on all fields`() {
+        val device1 = ConnectedDevice("AA:BB:CC:DD:EE:FF", "Polar H10", SensorType.HEART_RATE)
+        val device2 = ConnectedDevice("AA:BB:CC:DD:EE:FF", "Polar H10", SensorType.HEART_RATE)
+        val device3 = ConnectedDevice("11:22:33:44:55:66", "Polar H10", SensorType.HEART_RATE)
+
+        assertEquals(device1, device2)
+        assertNotEquals(device1, device3)
+    }
+
+    @Test
+    fun `ConnectedDevice can be created from DiscoveredDevice data`() {
+        val discovered = DiscoveredDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Polar H10",
+            rssi = -65,
+            sensorType = SensorType.HEART_RATE
+        )
+
+        val connected = ConnectedDevice(
+            address = discovered.address,
+            name = discovered.name,
+            type = discovered.sensorType
+        )
+
+        assertEquals(discovered.address, connected.address)
+        assertEquals(discovered.name, connected.name)
+        assertEquals(discovered.sensorType, connected.type)
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/SensorServiceTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/SensorServiceTest.kt
@@ -1,0 +1,280 @@
+package net.aurboda
+
+import net.aurboda.ble.BleConnectionState
+import net.aurboda.ble.ConnectedDevice
+import net.aurboda.ble.HeartRateSyncSample
+import net.aurboda.ble.SensorServiceState
+import net.aurboda.ble.SensorType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Tests for SensorService data classes and serialization.
+ * These tests verify the data structures used for BLE sensor data sync.
+ */
+class SensorServiceTest {
+
+    // ========================================================================
+    // SensorServiceState Tests
+    // ========================================================================
+
+    @Test
+    fun `SensorServiceState has correct defaults`() {
+        val state = SensorServiceState()
+
+        assertFalse(state.isRunning)
+        assertTrue(state.connectionState is BleConnectionState.Disconnected)
+        assertNull(state.connectedDevice)
+        assertNull(state.currentHeartRate)
+        assertNull(state.lastSyncTime)
+        assertEquals(0, state.pendingSamples)
+    }
+
+    @Test
+    fun `SensorServiceState copy updates isRunning`() {
+        val initial = SensorServiceState()
+        val updated = initial.copy(isRunning = true)
+
+        assertTrue(updated.isRunning)
+        assertFalse(initial.isRunning) // Original unchanged
+    }
+
+    @Test
+    fun `SensorServiceState copy updates connectionState`() {
+        val initial = SensorServiceState()
+        val updated = initial.copy(connectionState = BleConnectionState.Connected)
+
+        assertTrue(updated.connectionState is BleConnectionState.Connected)
+        assertTrue(initial.connectionState is BleConnectionState.Disconnected)
+    }
+
+    @Test
+    fun `SensorServiceState copy updates connectedDevice`() {
+        val device = ConnectedDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Polar H10",
+            type = SensorType.HEART_RATE
+        )
+        val initial = SensorServiceState()
+        val updated = initial.copy(connectedDevice = device)
+
+        assertEquals(device, updated.connectedDevice)
+        assertNull(initial.connectedDevice)
+    }
+
+    @Test
+    fun `SensorServiceState copy updates currentHeartRate`() {
+        val initial = SensorServiceState()
+        val updated = initial.copy(currentHeartRate = 72)
+
+        assertEquals(72, updated.currentHeartRate)
+        assertNull(initial.currentHeartRate)
+    }
+
+    @Test
+    fun `SensorServiceState copy updates pendingSamples`() {
+        val initial = SensorServiceState()
+        val updated = initial.copy(pendingSamples = 5)
+
+        assertEquals(5, updated.pendingSamples)
+        assertEquals(0, initial.pendingSamples)
+    }
+
+    @Test
+    fun `SensorServiceState copy updates lastSyncTime`() {
+        val now = Instant.now()
+        val initial = SensorServiceState()
+        val updated = initial.copy(lastSyncTime = now)
+
+        assertEquals(now, updated.lastSyncTime)
+        assertNull(initial.lastSyncTime)
+    }
+
+    @Test
+    fun `SensorServiceState supports chained updates`() {
+        val device = ConnectedDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Polar H10",
+            type = SensorType.HEART_RATE
+        )
+
+        val state = SensorServiceState()
+            .copy(isRunning = true)
+            .copy(connectionState = BleConnectionState.Connected)
+            .copy(connectedDevice = device)
+            .copy(currentHeartRate = 85)
+            .copy(pendingSamples = 3)
+
+        assertTrue(state.isRunning)
+        assertTrue(state.connectionState is BleConnectionState.Connected)
+        assertEquals(device, state.connectedDevice)
+        assertEquals(85, state.currentHeartRate)
+        assertEquals(3, state.pendingSamples)
+    }
+
+    // ========================================================================
+    // HeartRateSyncSample Tests
+    // ========================================================================
+
+    @Test
+    fun `HeartRateSyncSample stores time as ISO string`() {
+        val sample = HeartRateSyncSample(
+            time = "2024-01-15T10:30:00Z",
+            bpm = 72
+        )
+
+        assertEquals("2024-01-15T10:30:00Z", sample.time)
+        assertEquals(72, sample.bpm)
+        assertNull(sample.rrIntervals)
+    }
+
+    @Test
+    fun `HeartRateSyncSample with RR intervals`() {
+        val sample = HeartRateSyncSample(
+            time = "2024-01-15T10:30:00Z",
+            bpm = 85,
+            rrIntervals = listOf(700, 710, 695)
+        )
+
+        assertEquals(85, sample.bpm)
+        assertEquals(listOf(700, 710, 695), sample.rrIntervals)
+    }
+
+    @Test
+    fun `HeartRateSyncSample serializes to correct JSON format`() {
+        val sample = HeartRateSyncSample(
+            time = "2024-01-15T10:30:00Z",
+            bpm = 72,
+            rrIntervals = null
+        )
+
+        val json = appJson.encodeToString(HeartRateSyncSample.serializer(), sample)
+
+        // Verify JSON contains expected fields
+        assertTrue(json.contains("\"time\""))
+        assertTrue(json.contains("\"bpm\""))
+        assertTrue(json.contains("2024-01-15T10:30:00Z"))
+        assertTrue(json.contains("72"))
+    }
+
+    @Test
+    fun `HeartRateSyncSample serializes rr_intervals with correct key`() {
+        val sample = HeartRateSyncSample(
+            time = "2024-01-15T10:30:00Z",
+            bpm = 85,
+            rrIntervals = listOf(700, 710)
+        )
+
+        val json = appJson.encodeToString(HeartRateSyncSample.serializer(), sample)
+
+        // The @SerialName annotation should serialize as "rr_intervals"
+        assertTrue("JSON should contain rr_intervals key: $json", json.contains("\"rr_intervals\""))
+        assertTrue(json.contains("700"))
+        assertTrue(json.contains("710"))
+    }
+
+    @Test
+    fun `HeartRateSyncSample deserializes from JSON`() {
+        val json = """{"time":"2024-01-15T10:30:00Z","bpm":72}"""
+
+        val sample = appJson.decodeFromString(HeartRateSyncSample.serializer(), json)
+
+        assertEquals("2024-01-15T10:30:00Z", sample.time)
+        assertEquals(72, sample.bpm)
+        assertNull(sample.rrIntervals)
+    }
+
+    @Test
+    fun `HeartRateSyncSample deserializes with rr_intervals`() {
+        val json = """{"time":"2024-01-15T10:30:00Z","bpm":85,"rr_intervals":[700,710,695]}"""
+
+        val sample = appJson.decodeFromString(HeartRateSyncSample.serializer(), json)
+
+        assertEquals(85, sample.bpm)
+        assertEquals(listOf(700, 710, 695), sample.rrIntervals)
+    }
+
+    @Test
+    fun `HeartRateSyncSample roundtrip serialization`() {
+        val original = HeartRateSyncSample(
+            time = "2024-01-15T10:30:00.123Z",
+            bpm = 142,
+            rrIntervals = listOf(423, 425, 420)
+        )
+
+        val json = appJson.encodeToString(HeartRateSyncSample.serializer(), original)
+        val restored = appJson.decodeFromString(HeartRateSyncSample.serializer(), json)
+
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun `HeartRateSyncSample list serialization for batch sync`() {
+        val samples = listOf(
+            HeartRateSyncSample("2024-01-15T10:30:00Z", 72),
+            HeartRateSyncSample("2024-01-15T10:30:01Z", 73),
+            HeartRateSyncSample("2024-01-15T10:30:02Z", 74)
+        )
+
+        val json = appJson.encodeToString(
+            kotlinx.serialization.builtins.ListSerializer(HeartRateSyncSample.serializer()),
+            samples
+        )
+
+        assertTrue(json.startsWith("["))
+        assertTrue(json.endsWith("]"))
+        assertTrue(json.contains("72"))
+        assertTrue(json.contains("73"))
+        assertTrue(json.contains("74"))
+    }
+
+    // ========================================================================
+    // BleConnectionState Tests
+    // ========================================================================
+
+    @Test
+    fun `BleConnectionState Disconnected is singleton`() {
+        val state1 = BleConnectionState.Disconnected
+        val state2 = BleConnectionState.Disconnected
+
+        assertTrue(state1 === state2)
+    }
+
+    @Test
+    fun `BleConnectionState Connected is singleton`() {
+        val state1 = BleConnectionState.Connected
+        val state2 = BleConnectionState.Connected
+
+        assertTrue(state1 === state2)
+    }
+
+    @Test
+    fun `BleConnectionState Connecting is singleton`() {
+        val state1 = BleConnectionState.Connecting
+        val state2 = BleConnectionState.Connecting
+
+        assertTrue(state1 === state2)
+    }
+
+    @Test
+    fun `BleConnectionState Error contains message`() {
+        val error = BleConnectionState.Error("Connection timeout")
+
+        assertEquals("Connection timeout", error.message)
+    }
+
+    @Test
+    fun `BleConnectionState Error equality based on message`() {
+        val error1 = BleConnectionState.Error("Error A")
+        val error2 = BleConnectionState.Error("Error A")
+        val error3 = BleConnectionState.Error("Error B")
+
+        assertEquals(error1, error2)
+        assertNotEquals(error1, error3)
+    }
+}


### PR DESCRIPTION
## Summary

- Add BLE scanning and connection infrastructure for heart rate monitors
- Create foreground service to keep BLE connections alive in background
- Sync heart rate data to backend every 5 seconds
- Write heart rate data to Health Connect with proper metadata
- Add Live screen UI to discover, connect, and view heart rate data

## Key Changes

### Phase 1 (completed in previous commits)
- BLE permissions and scanner
- Connection manager for GATT operations  
- Heart rate parser for BLE characteristic data
- Live screen UI with device discovery

### Phase 2 (this PR)
- `SensorService` foreground service with persistent notification
- Backend sync via `POST /sync/HeartRateRecord`
- Health Connect write integration with `Metadata.autoRecorded()`
- Updated LiveScreen to observe service state

## Test plan

- [ ] Scan for BLE heart rate monitors on Live screen
- [ ] Connect to a heart rate monitor (e.g., Polar H10)
- [ ] Verify foreground notification shows current HR
- [ ] Verify HR data syncs to backend (check server logs)
- [ ] Verify HR data appears in Health Connect
- [ ] Background the app and verify connection stays alive
- [ ] Stop the service and verify clean disconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)