### PR TITLE
Set PORT=3000 for backend in Docker entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,8 @@ window.__RUNTIME_CONFIG__ = {
 };
 EOF
 
-# Start backend (binds to 127.0.0.1:3000, only accessible via nginx proxy)
-cd /app && pnpm --filter aurboda-backend start &
+# Start backend on port 3000 (only accessible via nginx proxy)
+cd /app && PORT=3000 pnpm --filter aurboda-backend start &
 BACKEND_PID=$!
 
 # Give backend a moment to start


### PR DESCRIPTION
## Summary

Backend defaults to port 80 if PORT is not set, but nginx expects it on port 3000. Explicitly set PORT=3000 in the entrypoint to ensure the proxy works correctly.

## Test plan

- [ ] Build Docker image
- [ ] Verify backend starts on port 3000
- [ ] Verify nginx proxy to `/api` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)