### PR TITLE
Strip /api prefix in nginx proxy_pass

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,7 @@ server {
 
     # API proxy - forward /api requests to backend
     location /api/ {
-        proxy_pass http://127.0.0.1:3000;
+        proxy_pass http://127.0.0.1:3000/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Add trailing slash to `proxy_pass` for `/api/` location so the prefix is stripped when forwarding to backend
- `/api/health` now correctly routes to backend `/health` instead of `/api/health`
- `/mcp/something` still routes to backend `/mcp/something` (unchanged)

## Test plan
- [ ] Verify `/api/health` endpoint works after deployment
- [ ] Verify MCP endpoints still work at `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)