### PR TITLE
Fix Android build warnings and add BodyWaterMassRecord

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -166,17 +166,8 @@ class HealthConnectSyncWorker(
                 }
             }
 
-            val nextToken = changesResponse.nextChangesToken
             hasMore = changesResponse.hasMore
-
-            if (hasMore && nextToken != null) {
-                currentToken = nextToken
-            } else {
-                hasMore = false
-                if (nextToken != null) {
-                    currentToken = nextToken
-                }
-            }
+            currentToken = changesResponse.nextChangesToken
         }
 
         // Save the new token if we have records to send (token will be updated after successful send)
@@ -205,7 +196,7 @@ class HealthConnectSyncWorker(
                 is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
                 is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
                 is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
-                is HeightRecord, is RestingHeartRateRecord -> true
+                is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord -> true
                 else -> false
             }
         }
@@ -280,6 +271,11 @@ class HealthConnectSyncWorker(
                 BoneMassRecord::class -> postData(
                     BoneMassRecordSerializable.fromRecordsList(classRecords),
                     BoneMassRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                BodyWaterMassRecord::class -> postData(
+                    BodyWaterMassRecordSerializable.fromRecordsList(classRecords),
+                    BodyWaterMassRecordSerializable.serializer(),
                     apiUrl, recordTypeSimpleName, authToken
                 )
                 HeightRecord::class -> postData(

--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -132,6 +132,26 @@ data class BodyFatRecordSerializable(
     }
 }
 
+// --- Body Water Mass Record ---
+@Serializable
+data class BodyWaterMassRecordSerializable(
+    val time: String,
+    val massInKilograms: Double,
+    val metadata: HealthConnectRecordMetadata
+) {
+    companion object {
+        fun fromRecordsList(classRecords: List<Record>): List<BodyWaterMassRecordSerializable> {
+            return classRecords.filterIsInstance<BodyWaterMassRecord>().map { record ->
+                BodyWaterMassRecordSerializable(
+                    time = record.time.toIsoString(),
+                    massInKilograms = record.mass.inKilograms,
+                    metadata = record.metadata.toSerializable()
+                )
+            }
+        }
+    }
+}
+
 // --- Bone Mass Record ---
 @Serializable
 data class BoneMassRecordSerializable(

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -157,6 +157,7 @@ fun getRecordSummary(record: Record): String {
         is BodyFatRecord -> "Body Fat: ${String.format("%.1f", record.percentage.value)}%%"
         is SleepSessionRecord -> "Sleep: ${record.title ?: "Session"} (Stages: ${record.stages.size})"
         is BoneMassRecord -> "Bone Mass: ${String.format("%.2f", record.mass.inKilograms)} kg"
+        is BodyWaterMassRecord -> "Body Water: ${String.format("%.2f", record.mass.inKilograms)} kg"
         is HeightRecord -> "Height: ${String.format("%.2f", record.height.inMeters)} m"
         is RestingHeartRateRecord -> "Resting HR: ${record.beatsPerMinute} bpm"
         else -> record::class.simpleName ?: "Record" 
@@ -400,18 +401,12 @@ fun HealthConnectScreen(
                     }
                     changesResponse.changes.forEach { if (it is DeletionChange) Log.d("HealthConnect", "Record deleted, ID: ${it.recordId}. Deletion handling for server not implemented.") }
 
-                    val nextToken = changesResponse.nextChangesToken
                     hasMore = changesResponse.hasMore
+                    currentToken = changesResponse.nextChangesToken
 
-                    if (hasMore && nextToken != null) {
-                        currentToken = nextToken
+                    if (hasMore) {
                         Log.d("FetchData", "More changes available, continuing fetch...")
                         statusMessage = "Fetching more data... ($totalUpsertions records so far)"
-                    } else {
-                        hasMore = false
-                        if (nextToken != null) {
-                            currentToken = nextToken
-                        }
                     }
                 }
 
@@ -498,8 +493,8 @@ fun HealthConnectScreen(
                 is HeartRateVariabilityRmssdRecord, is WeightRecord, is StepsRecord, is HeartRateRecord,
                 is ExerciseSessionRecord, is DistanceRecord, is SpeedRecord, is ActiveCaloriesBurnedRecord,
                 is TotalCaloriesBurnedRecord, is PowerRecord, is NutritionRecord, is LeanBodyMassRecord,
-                is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is HeightRecord,
-                is RestingHeartRateRecord -> true
+                is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is BodyWaterMassRecord,
+                is HeightRecord, is RestingHeartRateRecord -> true
                 else -> false
             }
         }
@@ -535,6 +530,7 @@ fun HealthConnectScreen(
                 BodyFatRecord::class -> handlePostData(BodyFatRecordSerializable.fromRecordsList(classRecords), BodyFatRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                 SleepSessionRecord::class -> handlePostData(SleepSessionRecordSerializable.fromRecordsList(classRecords), SleepSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                 BoneMassRecord::class -> handlePostData(BoneMassRecordSerializable.fromRecordsList(classRecords), BoneMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                BodyWaterMassRecord::class -> handlePostData(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), BodyWaterMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                 HeightRecord::class -> handlePostData(HeightRecordSerializable.fromRecordsList(classRecords), HeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                 RestingHeartRateRecord::class -> handlePostData(RestingHeartRateRecordSerializable.fromRecordsList(classRecords), RestingHeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                 else -> { Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping."); true }
@@ -667,8 +663,8 @@ fun HealthConnectScreen(
                             is HeartRateVariabilityRmssdRecord, is WeightRecord, is StepsRecord, is HeartRateRecord,
                             is ExerciseSessionRecord, is DistanceRecord, is SpeedRecord, is ActiveCaloriesBurnedRecord,
                             is TotalCaloriesBurnedRecord, is PowerRecord, is NutritionRecord, is LeanBodyMassRecord,
-                            is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is HeightRecord,
-                            is RestingHeartRateRecord -> true
+                            is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is BodyWaterMassRecord,
+                            is HeightRecord, is RestingHeartRateRecord -> true
                             else -> false
                         }
                     } && !isProcessing

--- a/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
@@ -105,14 +105,14 @@ class BleConnectionManager(private val context: Context) {
             }
         }
 
-        @Deprecated("Deprecated in Java")
         override fun onCharacteristicChanged(
             gatt: BluetoothGatt,
-            characteristic: BluetoothGattCharacteristic
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray
         ) {
             when (characteristic.uuid) {
                 HEART_RATE_MEASUREMENT_UUID -> {
-                    val sample = parseHeartRateMeasurement(characteristic.value)
+                    val sample = parseHeartRateMeasurement(value)
                     if (sample != null) {
                         Log.d(TAG, "Heart rate: ${sample.bpm} bpm")
                         _currentHeartRate.value = sample.bpm

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary
- Fix `LocalLifecycleOwner` deprecation by migrating to `androidx.lifecycle.compose` package
- Add `lifecycle-runtime-compose` dependency
- Simplify Health Connect token handling by removing redundant null checks (fixes "condition always true" warnings)
- Use new `onCharacteristicChanged` callback signature with `ByteArray` parameter (API 33+)
- Add `BodyWaterMassRecord` serialization and sync support

## Warnings Fixed
- `MainActivity.kt:297` - LocalLifecycleOwner deprecation
- `HealthConnectSyncWorker.kt:172,176` - Condition always true
- `MainActivity.kt:406,412` - Condition always true  
- `BleConnectionManager.kt:115` - Deprecated ByteArray property

## Test plan
- [x] Build compiles without Kotlin warnings
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)