### PR TITLE
Fix serializer error: make sync functions inline with reified T

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -309,7 +309,7 @@ class HealthConnectSyncWorker(
         return allPostsSuccessful
     }
 
-    private suspend fun <T : Any> postData(
+    private suspend inline fun <reified T : Any> postData(
         dataList: List<T>,
         itemSerializer: KSerializer<T>,
         apiUrl: String,
@@ -328,7 +328,7 @@ class HealthConnectSyncWorker(
      * Post data in chunks to avoid 413 Request Entity Too Large errors.
      * HeartRateRecord can be very large (thousands of samples per record).
      */
-    private suspend fun <T : Any> postDataChunked(
+    private suspend inline fun <reified T : Any> postDataChunked(
         dataList: List<T>,
         itemSerializer: KSerializer<T>,
         apiUrl: String,

--- a/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
@@ -11,7 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 
-private const val TAG = "SyncUtils"
+const val SYNC_UTILS_TAG = "SyncUtils"
 
 /** Result of a POST operation with error details for display */
 sealed class PostResult {
@@ -31,13 +31,15 @@ sealed class PostResult {
 /**
  * Post a single chunk of data to the server.
  * This is the core posting logic used by both regular and chunked posting.
+ *
+ * Note: Must be inline with reified T to preserve type information for serialization.
  */
-suspend fun <T : Any> postChunk(
+suspend inline fun <reified T : Any> postChunk(
     data: PostWrapper<T>,
     apiUrl: String,
     authToken: String,
     httpClient: HttpClient,
-    logTag: String = TAG
+    logTag: String = SYNC_UTILS_TAG
 ): PostResult {
     return try {
         val response = httpClient.post(apiUrl) {
@@ -70,15 +72,17 @@ suspend fun <T : Any> postChunk(
  * @param recordTypeName Name of the record type for logging
  * @param logTag Tag for log messages
  * @return PostResult.Success if all chunks succeed, or the first error encountered
+ *
+ * Note: Must be inline with reified T to preserve type information for serialization.
  */
-suspend fun <T : Any> postDataChunked(
+suspend inline fun <reified T : Any> postDataChunked(
     dataList: List<T>,
     apiUrl: String,
     authToken: String,
     httpClient: HttpClient,
     chunkSize: Int = 10,
     recordTypeName: String = "data",
-    logTag: String = TAG
+    logTag: String = SYNC_UTILS_TAG
 ): PostResult {
     if (dataList.isEmpty()) {
         Log.d(logTag, "No $recordTypeName to send")


### PR DESCRIPTION
## Summary
Fixes the error: `Network error: Captured type parameter T from generic non-reified function`

The generic type parameter `T` was being erased at runtime, causing Ktor's `setBody()` to fail because it couldn't determine the serializer.

## Changes
- Make `postChunk` and `postDataChunked` in `SyncUtils.kt` inline functions with `reified T`
- Make `postData` and `postDataChunked` in `HealthConnectSyncWorker.kt` inline functions with `reified T`
- Make `SYNC_UTILS_TAG` public (required for inline functions to access it)

## Test plan
- [x] Build compiles successfully
- [x] SyncUtilsTest passes
- [ ] Manual test: sync all record types including ActiveCaloriesBurnedRecord

🤖 Generated with [Claude Code](https://claude.com/claude-code)