### PR TITLE
Fix live HR sync to use Health Connect format

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.aurboda.CredentialsManager
 import net.aurboda.MainActivity
@@ -65,17 +64,44 @@ data class SensorServiceState(
 )
 
 /**
- * Heart rate sample for backend sync.
+ * Heart rate sample in Health Connect format for backend sync.
  */
 @Serializable
-data class HeartRateSyncSample(
+data class LiveHeartRateSample(
     val time: String,
-    val bpm: Int,
-    @SerialName("rr_intervals") val rrIntervals: List<Int>? = null
+    val beatsPerMinute: Long
+)
+
+/**
+ * Heart rate record in Health Connect format for backend sync.
+ * Uses simplified metadata suitable for live BLE data.
+ */
+@Serializable
+data class LiveHeartRateRecord(
+    val startTime: String,
+    val endTime: String,
+    val samples: List<LiveHeartRateSample>,
+    val metadata: LiveRecordMetadata
+)
+
+/**
+ * Simplified metadata for live sensor records.
+ */
+@Serializable
+data class LiveRecordMetadata(
+    val id: String,
+    val dataOrigin: String = "net.aurboda",
+    val device: LiveDeviceInfo? = null
 )
 
 @Serializable
-private data class HeartRateSyncBody(val data: List<HeartRateSyncSample>)
+data class LiveDeviceInfo(
+    val type: Int = 2, // TYPE_CHEST_STRAP
+    val model: String? = null
+)
+
+@Serializable
+private data class HeartRateSyncBody(val data: List<LiveHeartRateRecord>)
 
 /**
  * Foreground service that manages BLE sensor connections.
@@ -308,19 +334,44 @@ class SensorService : Service() {
             return true // Don't block on missing credentials
         }
 
-        val syncSamples = samples.map { sample ->
-            HeartRateSyncSample(
-                time = sample.timestamp.toString(),
-                bpm = sample.bpm,
-                rrIntervals = sample.rrIntervals
+        if (samples.isEmpty()) return true
+
+        // Sort samples and create a single HeartRateRecord in Health Connect format
+        val sortedSamples = samples.sortedBy { it.timestamp }
+        val startTime = sortedSamples.first().timestamp
+        val endTime = sortedSamples.last().timestamp.plusSeconds(1)
+
+        // Generate unique ID for this batch based on start time
+        val recordId = "live-hr-${startTime.epochSecond}-${startTime.nano}"
+
+        // Get device info if available
+        val deviceInfo = connectionManager?.connectedDeviceInfo?.value?.let { device ->
+            LiveDeviceInfo(
+                type = 2, // TYPE_CHEST_STRAP
+                model = device.name
             )
         }
+
+        val record = LiveHeartRateRecord(
+            startTime = startTime.toString(),
+            endTime = endTime.toString(),
+            samples = sortedSamples.map { sample ->
+                LiveHeartRateSample(
+                    time = sample.timestamp.toString(),
+                    beatsPerMinute = sample.bpm.toLong()
+                )
+            },
+            metadata = LiveRecordMetadata(
+                id = recordId,
+                device = deviceInfo
+            )
+        )
 
         return try {
             val response = httpClient.post("${credentials.apiUrl}/sync/HeartRateRecord") {
                 contentType(ContentType.Application.Json)
                 headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
-                setBody(HeartRateSyncBody(syncSamples))
+                setBody(HeartRateSyncBody(listOf(record)))
             }
             val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
             Log.d(TAG, "Backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")

--- a/apps/android/app/src/test/java/net/aurboda/SensorServiceTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/SensorServiceTest.kt
@@ -2,7 +2,7 @@ package net.aurboda
 
 import net.aurboda.ble.BleConnectionState
 import net.aurboda.ble.ConnectedDevice
-import net.aurboda.ble.HeartRateSyncSample
+import net.aurboda.ble.LiveHeartRateSample
 import net.aurboda.ble.SensorServiceState
 import net.aurboda.ble.SensorType
 import org.junit.Assert.assertEquals
@@ -118,111 +118,69 @@ class SensorServiceTest {
     }
 
     // ========================================================================
-    // HeartRateSyncSample Tests
+    // LiveHeartRateSample Tests (Health Connect format)
     // ========================================================================
 
     @Test
-    fun `HeartRateSyncSample stores time as ISO string`() {
-        val sample = HeartRateSyncSample(
+    fun `LiveHeartRateSample stores time and beatsPerMinute`() {
+        val sample = LiveHeartRateSample(
             time = "2024-01-15T10:30:00Z",
-            bpm = 72
+            beatsPerMinute = 72L
         )
 
         assertEquals("2024-01-15T10:30:00Z", sample.time)
-        assertEquals(72, sample.bpm)
-        assertNull(sample.rrIntervals)
+        assertEquals(72L, sample.beatsPerMinute)
     }
 
     @Test
-    fun `HeartRateSyncSample with RR intervals`() {
-        val sample = HeartRateSyncSample(
+    fun `LiveHeartRateSample serializes to Health Connect JSON format`() {
+        val sample = LiveHeartRateSample(
             time = "2024-01-15T10:30:00Z",
-            bpm = 85,
-            rrIntervals = listOf(700, 710, 695)
+            beatsPerMinute = 72L
         )
 
-        assertEquals(85, sample.bpm)
-        assertEquals(listOf(700, 710, 695), sample.rrIntervals)
-    }
+        val json = appJson.encodeToString(LiveHeartRateSample.serializer(), sample)
 
-    @Test
-    fun `HeartRateSyncSample serializes to correct JSON format`() {
-        val sample = HeartRateSyncSample(
-            time = "2024-01-15T10:30:00Z",
-            bpm = 72,
-            rrIntervals = null
-        )
-
-        val json = appJson.encodeToString(HeartRateSyncSample.serializer(), sample)
-
-        // Verify JSON contains expected fields
+        // Verify JSON contains expected fields (Health Connect format)
         assertTrue(json.contains("\"time\""))
-        assertTrue(json.contains("\"bpm\""))
+        assertTrue(json.contains("\"beatsPerMinute\""))
         assertTrue(json.contains("2024-01-15T10:30:00Z"))
         assertTrue(json.contains("72"))
     }
 
     @Test
-    fun `HeartRateSyncSample serializes rr_intervals with correct key`() {
-        val sample = HeartRateSyncSample(
-            time = "2024-01-15T10:30:00Z",
-            bpm = 85,
-            rrIntervals = listOf(700, 710)
-        )
+    fun `LiveHeartRateSample deserializes from JSON`() {
+        val json = """{"time":"2024-01-15T10:30:00Z","beatsPerMinute":72}"""
 
-        val json = appJson.encodeToString(HeartRateSyncSample.serializer(), sample)
-
-        // The @SerialName annotation should serialize as "rr_intervals"
-        assertTrue("JSON should contain rr_intervals key: $json", json.contains("\"rr_intervals\""))
-        assertTrue(json.contains("700"))
-        assertTrue(json.contains("710"))
-    }
-
-    @Test
-    fun `HeartRateSyncSample deserializes from JSON`() {
-        val json = """{"time":"2024-01-15T10:30:00Z","bpm":72}"""
-
-        val sample = appJson.decodeFromString(HeartRateSyncSample.serializer(), json)
+        val sample = appJson.decodeFromString(LiveHeartRateSample.serializer(), json)
 
         assertEquals("2024-01-15T10:30:00Z", sample.time)
-        assertEquals(72, sample.bpm)
-        assertNull(sample.rrIntervals)
+        assertEquals(72L, sample.beatsPerMinute)
     }
 
     @Test
-    fun `HeartRateSyncSample deserializes with rr_intervals`() {
-        val json = """{"time":"2024-01-15T10:30:00Z","bpm":85,"rr_intervals":[700,710,695]}"""
-
-        val sample = appJson.decodeFromString(HeartRateSyncSample.serializer(), json)
-
-        assertEquals(85, sample.bpm)
-        assertEquals(listOf(700, 710, 695), sample.rrIntervals)
-    }
-
-    @Test
-    fun `HeartRateSyncSample roundtrip serialization`() {
-        val original = HeartRateSyncSample(
+    fun `LiveHeartRateSample roundtrip serialization`() {
+        val original = LiveHeartRateSample(
             time = "2024-01-15T10:30:00.123Z",
-            bpm = 142,
-            rrIntervals = listOf(423, 425, 420)
+            beatsPerMinute = 142L
         )
 
-        val json = appJson.encodeToString(HeartRateSyncSample.serializer(), original)
-        val restored = appJson.decodeFromString(HeartRateSyncSample.serializer(), json)
+        val json = appJson.encodeToString(LiveHeartRateSample.serializer(), original)
+        val restored = appJson.decodeFromString(LiveHeartRateSample.serializer(), json)
 
         assertEquals(original, restored)
     }
 
     @Test
-    fun `HeartRateSyncSample list serialization for batch sync`() {
+    fun `LiveHeartRateSample list serialization for batch sync`() {
         val samples = listOf(
-            HeartRateSyncSample("2024-01-15T10:30:00Z", 72),
-            HeartRateSyncSample("2024-01-15T10:30:01Z", 73),
-            HeartRateSyncSample("2024-01-15T10:30:02Z", 74)
+            LiveHeartRateSample("2024-01-15T10:30:00Z", 72L),
+            LiveHeartRateSample("2024-01-15T10:30:01Z", 73L),
+            LiveHeartRateSample("2024-01-15T10:30:02Z", 74L)
         )
 
         val json = appJson.encodeToString(
-            kotlinx.serialization.builtins.ListSerializer(HeartRateSyncSample.serializer()),
+            kotlinx.serialization.builtins.ListSerializer(LiveHeartRateSample.serializer()),
             samples
         )
 


### PR DESCRIPTION
## Summary
- Fix SensorService to send live heart rate data in Health Connect format
- Backend was receiving `bpm` but expects `samples[].beatsPerMinute`
- Data was being stored in raw_records but not extracted to time_series metrics

## Changes
- Replace `HeartRateSyncSample` with `LiveHeartRateSample` using `beatsPerMinute` (Long)
- Wrap samples in `LiveHeartRateRecord` with `startTime`, `endTime`, and `metadata`
- Generate unique IDs based on timestamp for proper deduplication
- Remove `rr_intervals` (HRV will be calculated in app and sent as separate record type)

## Test plan
- [x] Android unit tests pass
- [ ] Deploy and test live HR streaming from BLE sensor
- [ ] Verify heart_rate metrics appear in MCP queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)