### PR TITLE
Multi-device support and step sensor fixes

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ble/RscParser.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/RscParser.kt
@@ -13,9 +13,13 @@ import java.time.Instant
  *
  * Data fields:
  *   - Instantaneous Speed: 2 bytes, uint16, unit 1/256 m/s (mandatory)
- *   - Instantaneous Cadence: 1 byte, uint8, unit steps/minute (mandatory)
+ *   - Instantaneous Cadence: 1 byte, uint8, unit 1/minute (mandatory)
  *   - Instantaneous Stride Length: 2 bytes, uint16, unit cm (optional)
  *   - Total Distance: 4 bytes, uint32, unit 1/10 m (optional)
+ *
+ * Note: The BLE spec is ambiguous about whether cadence is steps or strides per minute.
+ * Many foot pods (including Zwift RunPod) report stride rate (cycles/min), not step rate.
+ * We multiply by 2 to convert to steps per minute (each foot strike = 1 step).
  */
 fun parseRscMeasurement(data: ByteArray): CadenceSample? {
     if (data.size < 4) return null // Minimum: flags (1) + speed (2) + cadence (1)
@@ -32,8 +36,11 @@ fun parseRscMeasurement(data: ByteArray): CadenceSample? {
     val speedMs = speedRaw / 256f
     offset += 2
 
-    // Parse instantaneous cadence (steps/minute)
-    val cadence = data[offset].toInt() and 0xFF
+    // Parse instantaneous cadence
+    // Raw value is in 1/minute - many sensors report stride rate (cycles/min)
+    // We multiply by 2 to convert to steps per minute (left + right = 2 steps)
+    val rawCadence = data[offset].toInt() and 0xFF
+    val cadence = rawCadence * 2  // Convert stride rate to step rate
     offset += 1
 
     // Parse optional stride length (cm)

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -53,21 +53,41 @@ private const val CHANNEL_ID = "sensor_service_channel"
 private const val SYNC_INTERVAL_MS = 5000L
 
 /**
+ * State for an individual connected device.
+ */
+data class DeviceState(
+    val device: ConnectedDevice,
+    val connectionState: BleConnectionState = BleConnectionState.Connected,
+    val batteryLevel: Int? = null,
+    // HR device specific
+    val currentHeartRate: Int? = null,
+    // RSC device specific
+    val currentCadence: Int? = null,
+    val currentSpeed: Float? = null,
+    val stepsSinceStart: Int = 0
+)
+
+/**
  * State exposed by SensorService to the UI.
+ * Supports multiple simultaneously connected devices.
  */
 data class SensorServiceState(
     val isRunning: Boolean = false,
-    val connectionState: BleConnectionState = BleConnectionState.Disconnected,
-    val connectedDevice: ConnectedDevice? = null,
-    val currentHeartRate: Int? = null,
-    val currentCadence: Int? = null,
-    val currentSpeed: Float? = null,
-    val stepsSinceStart: Int = 0,
-    val batteryLevel: Int? = null,
+    val connectedDevices: Map<String, DeviceState> = emptyMap(),  // keyed by device address
+    val connectingDevices: Set<String> = emptySet(),  // addresses of devices currently connecting
     val lastSyncTime: Instant? = null,
     val pendingSamples: Int = 0,
     val pendingCadenceSamples: Int = 0
-)
+) {
+    // Convenience accessors for backward compatibility and easy access
+    val hrDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.HEART_RATE }
+    val rscDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.RUNNING_SPEED_CADENCE }
+    val currentHeartRate: Int? get() = hrDevice?.currentHeartRate
+    val currentCadence: Int? get() = rscDevice?.currentCadence
+    val stepsSinceStart: Int get() = rscDevice?.stepsSinceStart ?: 0
+    val hasConnectedDevices: Boolean get() = connectedDevices.isNotEmpty()
+    val isConnecting: Boolean get() = connectingDevices.isNotEmpty()
+}
 
 /**
  * Heart rate sample in Health Connect format for backend sync.
@@ -131,10 +151,9 @@ private data class StepsSyncBody(val data: List<LiveStepsRecord>)
 class SensorService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private var connectionManager: BleConnectionManager? = null
+    private val connectionManagers = mutableMapOf<String, BleConnectionManager>()
+    private val deviceJobs = mutableMapOf<String, List<Job>>()  // Jobs per device address
     private var syncJob: Job? = null
-    private var hrCollectionJob: Job? = null
-    private var cadenceCollectionJob: Job? = null
 
     private val sampleBuffer = mutableListOf<HeartRateSample>()
     private val cadenceSampleBuffer = mutableListOf<CadenceSample>()
@@ -161,15 +180,25 @@ class SensorService : Service() {
             ACTION_CONNECT -> {
                 val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
                 if (deviceAddress != null) {
-                    startForegroundWithNotification()
+                    // Start foreground if not already running
+                    if (!_serviceState.value.isRunning) {
+                        startForegroundWithNotification()
+                    }
                     connectToDevice(deviceAddress)
                 } else {
                     Log.w(TAG, "No device address provided")
-                    stopSelf()
+                    if (!_serviceState.value.hasConnectedDevices) {
+                        stopSelf()
+                    }
                 }
             }
             ACTION_DISCONNECT -> {
-                disconnect()
+                val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
+                if (deviceAddress != null) {
+                    disconnectDevice(deviceAddress)
+                } else {
+                    disconnectAll()
+                }
             }
             ACTION_STOP -> {
                 stopSensorService()
@@ -226,15 +255,18 @@ class SensorService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val contentText = when {
-            state.connectedDevice?.type == SensorType.HEART_RATE && state.currentHeartRate != null ->
-                "Heart rate: ${state.currentHeartRate} BPM"
-            state.connectedDevice?.type == SensorType.RUNNING_SPEED_CADENCE && state.currentCadence != null ->
-                "Cadence: ${state.currentCadence} spm • ${state.stepsSinceStart} steps"
-            state.connectionState is BleConnectionState.Connected ->
-                "Connected"
-            else ->
-                "Connecting to sensor..."
+        val contentText = buildString {
+            val hrText = state.currentHeartRate?.let { "HR: $it BPM" }
+            val cadenceText = state.currentCadence?.let { "Cadence: $it spm • ${state.stepsSinceStart} steps" }
+
+            when {
+                hrText != null && cadenceText != null -> append("$hrText • $cadenceText")
+                hrText != null -> append(hrText)
+                cadenceText != null -> append(cadenceText)
+                state.hasConnectedDevices -> append("${state.connectedDevices.size} sensor(s) connected")
+                state.isConnecting -> append("Connecting...")
+                else -> append("Ready")
+            }
         }
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
@@ -255,83 +287,142 @@ class SensorService : Service() {
     }
 
     private fun connectToDevice(deviceAddress: String) {
+        // Don't connect if already connected or connecting to this device
+        if (connectionManagers.containsKey(deviceAddress)) {
+            Log.w(TAG, "Already connected to device: $deviceAddress")
+            return
+        }
+        if (_serviceState.value.connectingDevices.contains(deviceAddress)) {
+            Log.w(TAG, "Already connecting to device: $deviceAddress")
+            return
+        }
+
         Log.d(TAG, "Connecting to device: $deviceAddress")
+        updateState { it.copy(connectingDevices = it.connectingDevices + deviceAddress) }
 
-        connectionManager = BleConnectionManager(this).also { manager ->
-            // Observe connection state
-            serviceScope.launch {
-                manager.connectionState.collect { state ->
-                    Log.d(TAG, "Connection state: $state")
-                    updateState { it.copy(connectionState = state) }
+        val manager = BleConnectionManager(this)
+        val jobs = mutableListOf<Job>()
 
-                    when (state) {
-                        is BleConnectionState.Connected -> {
-                            startDataCollection(manager)
-                            startSyncLoop()
-                        }
-                        is BleConnectionState.Disconnected -> {
-                            stopDataCollection()
-                            // Auto-reconnect could be added here
-                        }
-                        is BleConnectionState.Error -> {
-                            Log.e(TAG, "Connection error: ${state.message}")
-                        }
-                        else -> {}
+        // Observe connection state
+        jobs += serviceScope.launch {
+            manager.connectionState.collect { state ->
+                Log.d(TAG, "Connection state for $deviceAddress: $state")
+
+                when (state) {
+                    is BleConnectionState.Connected -> {
+                        updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
+                        startDataCollection(manager, deviceAddress)
+                        startSyncLoop()
                     }
+                    is BleConnectionState.Disconnected -> {
+                        handleDeviceDisconnected(deviceAddress)
+                    }
+                    is BleConnectionState.Error -> {
+                        Log.e(TAG, "Connection error for $deviceAddress: ${state.message}")
+                        updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
+                    }
+                    else -> {}
                 }
             }
+        }
 
-            // Observe connected device info
-            serviceScope.launch {
-                manager.connectedDeviceInfo.collect { device ->
-                    updateState { it.copy(connectedDevice = device) }
-                }
-            }
-
-            // Observe current heart rate for notification
-            serviceScope.launch {
-                manager.currentHeartRate.collect { hr ->
-                    updateState { it.copy(currentHeartRate = hr) }
+        // Observe connected device info
+        jobs += serviceScope.launch {
+            manager.connectedDeviceInfo.collect { device ->
+                if (device != null) {
+                    updateState { state ->
+                        val deviceState = state.connectedDevices[deviceAddress]?.copy(device = device)
+                            ?: DeviceState(device = device)
+                        state.copy(connectedDevices = state.connectedDevices + (deviceAddress to deviceState))
+                    }
                     updateNotification()
                 }
             }
+        }
 
-            // Observe battery level
-            serviceScope.launch {
-                manager.batteryLevel.collect { level ->
-                    updateState { it.copy(batteryLevel = level) }
-                }
+        // Observe battery level
+        jobs += serviceScope.launch {
+            manager.batteryLevel.collect { level ->
+                updateDeviceState(deviceAddress) { it.copy(batteryLevel = level) }
             }
+        }
 
-            // Observe current cadence and speed
-            serviceScope.launch {
-                manager.currentCadence.collect { cadence ->
-                    updateState { it.copy(currentCadence = cadence) }
-                    updateNotification()
-                }
+        // Observe current heart rate
+        jobs += serviceScope.launch {
+            manager.currentHeartRate.collect { hr ->
+                updateDeviceState(deviceAddress) { it.copy(currentHeartRate = hr) }
+                updateNotification()
             }
+        }
 
-            serviceScope.launch {
-                manager.currentSpeed.collect { speed ->
-                    updateState { it.copy(currentSpeed = speed) }
-                }
+        // Observe current cadence
+        jobs += serviceScope.launch {
+            manager.currentCadence.collect { cadence ->
+                updateDeviceState(deviceAddress) { it.copy(currentCadence = cadence) }
+                updateNotification()
             }
+        }
 
-            // Observe cumulative steps
-            serviceScope.launch {
-                manager.stepsSinceStart.collect { steps ->
-                    updateState { it.copy(stepsSinceStart = steps) }
-                    updateNotification()
-                }
+        // Observe current speed
+        jobs += serviceScope.launch {
+            manager.currentSpeed.collect { speed ->
+                updateDeviceState(deviceAddress) { it.copy(currentSpeed = speed) }
             }
+        }
 
-            manager.connect(deviceAddress)
+        // Observe cumulative steps
+        jobs += serviceScope.launch {
+            manager.stepsSinceStart.collect { steps ->
+                updateDeviceState(deviceAddress) { it.copy(stepsSinceStart = steps) }
+                updateNotification()
+            }
+        }
+
+        connectionManagers[deviceAddress] = manager
+        deviceJobs[deviceAddress] = jobs
+
+        manager.connect(deviceAddress)
+    }
+
+    private fun updateDeviceState(deviceAddress: String, update: (DeviceState) -> DeviceState) {
+        updateState { state ->
+            val deviceState = state.connectedDevices[deviceAddress] ?: return@updateState state
+            state.copy(connectedDevices = state.connectedDevices + (deviceAddress to update(deviceState)))
         }
     }
 
-    private fun startDataCollection(manager: BleConnectionManager) {
-        hrCollectionJob?.cancel()
-        hrCollectionJob = serviceScope.launch {
+    private fun handleDeviceDisconnected(deviceAddress: String) {
+        Log.d(TAG, "Device disconnected: $deviceAddress")
+
+        // Cancel jobs for this device
+        deviceJobs[deviceAddress]?.forEach { it.cancel() }
+        deviceJobs.remove(deviceAddress)
+
+        // Close and remove connection manager
+        connectionManagers[deviceAddress]?.close()
+        connectionManagers.remove(deviceAddress)
+
+        // Update state
+        updateState { state ->
+            state.copy(
+                connectedDevices = state.connectedDevices - deviceAddress,
+                connectingDevices = state.connectingDevices - deviceAddress
+            )
+        }
+        updateNotification()
+
+        // Stop service if no devices connected
+        if (connectionManagers.isEmpty() && _serviceState.value.connectingDevices.isEmpty()) {
+            Log.d(TAG, "No devices connected, stopping service")
+            stopSensorService()
+        }
+    }
+
+    private fun startDataCollection(manager: BleConnectionManager, deviceAddress: String) {
+        // Add collection jobs to the device's job list
+        val existingJobs = deviceJobs[deviceAddress]?.toMutableList() ?: mutableListOf()
+
+        existingJobs += serviceScope.launch {
             manager.heartRateSamples.collect { sample ->
                 synchronized(bufferLock) {
                     sampleBuffer.add(sample)
@@ -340,8 +431,7 @@ class SensorService : Service() {
             }
         }
 
-        cadenceCollectionJob?.cancel()
-        cadenceCollectionJob = serviceScope.launch {
+        existingJobs += serviceScope.launch {
             manager.cadenceSamples.collect { sample ->
                 synchronized(bufferLock) {
                     cadenceSampleBuffer.add(sample)
@@ -349,13 +439,8 @@ class SensorService : Service() {
                 }
             }
         }
-    }
 
-    private fun stopDataCollection() {
-        hrCollectionJob?.cancel()
-        hrCollectionJob = null
-        cadenceCollectionJob?.cancel()
-        cadenceCollectionJob = null
+        deviceJobs[deviceAddress] = existingJobs
     }
 
     private fun startSyncLoop() {
@@ -428,8 +513,11 @@ class SensorService : Service() {
         // Generate unique ID for this batch based on start time
         val recordId = "live-hr-${startTime.epochSecond}-${startTime.nano}"
 
-        // Get device info if available
-        val deviceInfo = connectionManager?.connectedDeviceInfo?.value?.let { device ->
+        // Get device info from HR device if available
+        val hrManager = connectionManagers.values.find {
+            it.connectedDeviceInfo.value?.type == SensorType.HEART_RATE
+        }
+        val deviceInfo = hrManager?.connectedDeviceInfo?.value?.let { device ->
             LiveDeviceInfo(
                 type = 2, // TYPE_CHEST_STRAP
                 model = device.name
@@ -544,7 +632,11 @@ class SensorService : Service() {
 
         val recordId = "live-steps-${startTime.epochSecond}-${startTime.nano}"
 
-        val deviceInfo = connectionManager?.connectedDeviceInfo?.value?.let { device ->
+        // Get device info from RSC device if available
+        val rscManager = connectionManagers.values.find {
+            it.connectedDeviceInfo.value?.type == SensorType.RUNNING_SPEED_CADENCE
+        }
+        val deviceInfo = rscManager?.connectedDeviceInfo?.value?.let { device ->
             LiveDeviceInfo(
                 type = 4, // TYPE_WATCH or foot pod
                 model = device.name
@@ -629,9 +721,16 @@ class SensorService : Service() {
         }
     }
 
-    private fun disconnect() {
-        Log.d(TAG, "Disconnecting...")
-        connectionManager?.disconnect()
+    private fun disconnectDevice(deviceAddress: String) {
+        Log.d(TAG, "Disconnecting device: $deviceAddress")
+        connectionManagers[deviceAddress]?.disconnect()
+    }
+
+    private fun disconnectAll() {
+        Log.d(TAG, "Disconnecting all devices...")
+        connectionManagers.keys.toList().forEach { address ->
+            connectionManagers[address]?.disconnect()
+        }
     }
 
     private fun stopSensorService() {
@@ -644,10 +743,16 @@ class SensorService : Service() {
 
     private fun cleanup() {
         syncJob?.cancel()
-        hrCollectionJob?.cancel()
-        cadenceCollectionJob?.cancel()
-        connectionManager?.close()
-        connectionManager = null
+
+        // Cancel all device jobs
+        deviceJobs.values.forEach { jobs ->
+            jobs.forEach { it.cancel() }
+        }
+        deviceJobs.clear()
+
+        // Close all connection managers
+        connectionManagers.values.forEach { it.close() }
+        connectionManagers.clear()
     }
 
     private fun updateState(update: (SensorServiceState) -> SensorServiceState) {
@@ -671,7 +776,15 @@ class SensorService : Service() {
             context.startForegroundService(intent)
         }
 
-        fun disconnect(context: Context) {
+        fun disconnect(context: Context, deviceAddress: String) {
+            val intent = Intent(context, SensorService::class.java).apply {
+                action = ACTION_DISCONNECT
+                putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
+            }
+            context.startService(intent)
+        }
+
+        fun disconnectAll(context: Context) {
             val intent = Intent(context, SensorService::class.java).apply {
                 action = ACTION_DISCONNECT
             }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -91,11 +91,15 @@ fun LiveScreen(
     val healthConnectPermissionLauncher = rememberLauncherForActivityResult(
         contract = PermissionController.createRequestPermissionResultContract()
     ) { granted: Set<String> ->
-        val hasHrPermission = granted.contains(hrWritePermission)
-        val hasStepsPermission = granted.contains(stepsWritePermission)
-        hasHrWritePermission = hasHrPermission
-        hasStepsWritePermission = hasStepsPermission
-        Log.d("LiveScreen", "Health Connect permission result: hr=$hasHrPermission, steps=$hasStepsPermission")
+        // Only update permission state if we actually asked for that permission
+        // (don't set to false if we didn't ask for it)
+        if (granted.contains(hrWritePermission)) {
+            hasHrWritePermission = true
+        }
+        if (granted.contains(stepsWritePermission)) {
+            hasStepsWritePermission = true
+        }
+        Log.d("LiveScreen", "Health Connect permission granted: $granted")
 
         // Connect to device regardless of permission result - data still syncs to backend,
         // and SensorService gracefully handles missing Health Connect write permission

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -55,8 +55,8 @@ import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.StepsRecord
-import net.aurboda.ble.BleConnectionState
 import net.aurboda.ble.BleScanState
+import net.aurboda.ble.DeviceState
 import net.aurboda.ble.DiscoveredDevice
 import net.aurboda.ble.SensorService
 import net.aurboda.ble.SensorType
@@ -118,13 +118,17 @@ fun LiveScreen(
 
     // Observe service state
     val serviceState by SensorService.serviceState.collectAsState()
-    val connectionState = serviceState.connectionState
-    val connectedDevice = serviceState.connectedDevice
-    val currentHeartRate = serviceState.currentHeartRate
+    val connectedDevices = serviceState.connectedDevices
+    val connectingDevices = serviceState.connectingDevices
 
     var isScanning by remember { mutableStateOf(false) }
     var scanError by remember { mutableStateOf<String?>(null) }
     val discoveredDevices = remember { mutableStateListOf<DiscoveredDevice>() }
+
+    // Filter out already connected devices from discovered list
+    val availableDevices = discoveredDevices.filter { device ->
+        !connectedDevices.containsKey(device.address) && !connectingDevices.contains(device.address)
+    }
 
     // Permission launcher
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -231,145 +235,123 @@ fun LiveScreen(
             return@Column
         }
 
-        // Connected Device Section
-        when (val state = connectionState) {
-            is BleConnectionState.Connected -> {
-                val healthConnectEnabled = when (connectedDevice?.type) {
+        // Connected Devices Section
+        if (connectedDevices.isNotEmpty()) {
+            connectedDevices.forEach { (address, deviceState) ->
+                val healthConnectEnabled = when (deviceState.device.type) {
                     SensorType.HEART_RATE -> hasHrWritePermission == true
                     SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission == true
-                    null -> false
                 }
-                val requiredPermissions = when (connectedDevice?.type) {
+                val requiredPermissions = when (deviceState.device.type) {
                     SensorType.HEART_RATE -> setOf(hrWritePermission)
                     SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
-                    null -> emptySet()
                 }
                 ConnectedDeviceCard(
-                    device = connectedDevice,
-                    heartRate = currentHeartRate,
-                    cadence = serviceState.currentCadence,
-                    stepsSinceStart = serviceState.stepsSinceStart,
-                    batteryLevel = serviceState.batteryLevel,
+                    deviceState = deviceState,
                     serviceRunning = serviceState.isRunning,
                     pendingSamples = serviceState.pendingSamples + serviceState.pendingCadenceSamples,
                     healthConnectEnabled = healthConnectEnabled,
                     onEnableHealthConnect = {
                         healthConnectPermissionLauncher.launch(requiredPermissions)
                     },
-                    onDisconnect = { SensorService.stop(context) }
+                    onDisconnect = { SensorService.disconnect(context, address) }
                 )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-            is BleConnectionState.Connecting -> {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer
-                    )
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text("Connecting...")
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-            is BleConnectionState.Error -> {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer
-                    )
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            text = "Connection Error",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                        Text(
-                            text = state.message,
-                            color = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-            is BleConnectionState.Disconnected -> {
-                // Show nothing when disconnected, scan section will be visible
+                Spacer(modifier = Modifier.height(12.dp))
             }
         }
 
-        // Scanner Section
-        if (connectionState is BleConnectionState.Disconnected || connectionState is BleConnectionState.Error) {
-            ScannerSection(
-                isScanning = isScanning,
-                discoveredDevices = discoveredDevices,
-                scanError = scanError,
-                onStartScan = {
-                    isScanning = true
-                },
-                onStopScan = {
-                    isScanning = false
-                },
-                onConnectDevice = { device ->
-                    // Check Health Connect write permission based on device type
-                    val hasPermission = when (device.sensorType) {
-                        SensorType.HEART_RATE -> hasHrWritePermission
-                        SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission
-                    }
-                    val requiredPermissions = when (device.sensorType) {
-                        SensorType.HEART_RATE -> setOf(hrWritePermission)
-                        SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
-                    }
+        // Connecting indicator
+        if (connectingDevices.isNotEmpty()) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text("Connecting to ${connectingDevices.size} device(s)...")
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
 
-                    when (hasPermission) {
-                        true -> {
-                            // Permission already granted, connect directly
-                            SensorService.connect(context, device.address)
-                        }
-                        false -> {
-                            // Permission was denied previously, connect anyway
-                            // (data still syncs to backend, just not to Health Connect)
-                            SensorService.connect(context, device.address)
-                        }
-                        null -> {
-                            // Haven't asked yet, request permission first
-                            pendingDeviceToConnect = device
-                            healthConnectPermissionLauncher.launch(requiredPermissions)
-                        }
+        // Stop All button when multiple devices connected
+        if (connectedDevices.size > 1) {
+            OutlinedButton(
+                onClick = { SensorService.stop(context) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Stop All Sensors")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        // Scanner Section - always visible to allow adding more devices
+        ScannerSection(
+            isScanning = isScanning,
+            discoveredDevices = availableDevices,
+            scanError = scanError,
+            onStartScan = {
+                isScanning = true
+            },
+            onStopScan = {
+                isScanning = false
+            },
+            onConnectDevice = { device ->
+                // Check Health Connect write permission based on device type
+                val hasPermission = when (device.sensorType) {
+                    SensorType.HEART_RATE -> hasHrWritePermission
+                    SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission
+                }
+                val requiredPermissions = when (device.sensorType) {
+                    SensorType.HEART_RATE -> setOf(hrWritePermission)
+                    SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
+                }
+
+                when (hasPermission) {
+                    true -> {
+                        // Permission already granted, connect directly
+                        SensorService.connect(context, device.address)
+                    }
+                    false -> {
+                        // Permission was denied previously, connect anyway
+                        // (data still syncs to backend, just not to Health Connect)
+                        SensorService.connect(context, device.address)
+                    }
+                    null -> {
+                        // Haven't asked yet, request permission first
+                        pendingDeviceToConnect = device
+                        healthConnectPermissionLauncher.launch(requiredPermissions)
                     }
                 }
-            )
-        }
+            }
+        )
     }
 }
 
 @Composable
 private fun ConnectedDeviceCard(
-    device: net.aurboda.ble.ConnectedDevice?,
-    heartRate: Int?,
-    cadence: Int?,
-    stepsSinceStart: Int,
-    batteryLevel: Int?,
+    deviceState: DeviceState,
     serviceRunning: Boolean,
     pendingSamples: Int,
     healthConnectEnabled: Boolean,
     onEnableHealthConnect: () -> Unit,
     onDisconnect: () -> Unit
 ) {
+    val device = deviceState.device
+    val heartRate = deviceState.currentHeartRate
+    val cadence = deviceState.currentCadence
+    val stepsSinceStart = deviceState.stepsSinceStart
+    val batteryLevel = deviceState.batteryLevel
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -387,13 +369,19 @@ private fun ConnectedDeviceCard(
                 horizontalArrangement = Arrangement.Center
             ) {
                 Icon(
-                    imageVector = Icons.Default.Info,
+                    imageVector = when (device.type) {
+                        SensorType.HEART_RATE -> Icons.Default.Favorite
+                        SensorType.RUNNING_SPEED_CADENCE -> Icons.Default.PlayArrow
+                    },
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = when (device.type) {
+                        SensorType.HEART_RATE -> MaterialTheme.colorScheme.error
+                        SensorType.RUNNING_SPEED_CADENCE -> MaterialTheme.colorScheme.primary
+                    }
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = device?.name ?: "Unknown Device",
+                    text = device.name ?: "Unknown Device",
                     style = MaterialTheme.typography.titleMedium
                 )
                 // Battery indicator
@@ -403,83 +391,71 @@ private fun ConnectedDeviceCard(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
-            when (device?.type) {
+            when (device.type) {
                 SensorType.HEART_RATE -> {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.Favorite,
-                            contentDescription = "Heart Rate",
-                            tint = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.size(48.dp)
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
                         Text(
                             text = heartRate?.toString() ?: "--",
-                            fontSize = 64.sp,
+                            fontSize = 48.sp,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = "BPM",
-                            style = MaterialTheme.typography.titleLarge,
+                            style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                         )
                     }
                 }
                 SensorType.RUNNING_SPEED_CADENCE -> {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
                     ) {
-                        // Cadence row
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.PlayArrow,
-                                contentDescription = "Cadence",
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(48.dp)
-                            )
-                            Spacer(modifier = Modifier.width(12.dp))
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(
                                 text = cadence?.toString() ?: "--",
-                                fontSize = 64.sp,
+                                fontSize = 48.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer
                             )
-                            Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = "SPM",
-                                style = MaterialTheme.typography.titleLarge,
+                                style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
                             )
                         }
-                        Spacer(modifier = Modifier.height(8.dp))
-                        // Steps since start
-                        Text(
-                            text = "$stepsSinceStart steps since start",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
-                        )
+                        Spacer(modifier = Modifier.width(24.dp))
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = stepsSinceStart.toString(),
+                                fontSize = 32.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                            Text(
+                                text = "steps",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                            )
+                        }
                     }
                 }
-                null -> { /* Unknown device type */ }
             }
 
             // Service status
             if (serviceRunning) {
                 Spacer(modifier = Modifier.height(8.dp))
                 val statusText = buildString {
-                    append(if (pendingSamples > 0) "Syncing ($pendingSamples pending)" else "Syncing to cloud")
+                    append(if (pendingSamples > 0) "Syncing ($pendingSamples pending)" else "Syncing")
                     if (!healthConnectEnabled) {
-                        append(" • Health Connect disabled")
+                        append(" • HC off")
                     }
                 }
                 Text(
@@ -492,17 +468,17 @@ private fun ConnectedDeviceCard(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 OutlinedButton(onClick = onDisconnect) {
-                    Text("Stop")
+                    Text("Disconnect")
                 }
                 if (!healthConnectEnabled) {
                     Button(onClick = onEnableHealthConnect) {
-                        Text("Enable Health Connect")
+                        Text("Enable HC")
                     }
                 }
             }
@@ -576,9 +552,9 @@ private fun ScannerSection(
                     )
                 }
             }
-        } else if (!isScanning) {
+        } else if (!isScanning && discoveredDevices.isEmpty()) {
             Text(
-                text = "No devices found. Make sure your heart rate monitor is turned on and in pairing mode.",
+                text = "Tap 'Scan for Devices' to find heart rate monitors and step sensors.",
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/apps/android/app/src/test/java/net/aurboda/RscParserTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/RscParserTest.kt
@@ -10,17 +10,20 @@ import org.junit.Test
 
 class RscParserTest {
 
+    // Note: Raw cadence from sensor is multiplied by 2 to convert stride rate to step rate
+    // So raw value 60 becomes 120 SPM, raw 90 becomes 180 SPM, etc.
+
     @Test
     fun `parse basic RSC measurement without optional fields`() {
         // Flags: 0x00 = no stride length, no total distance, walking
         // Speed: 0x0100 = 256 raw = 1.0 m/s (little-endian: 0x00, 0x01)
-        // Cadence: 120 spm
-        val data = byteArrayOf(0x00, 0x00, 0x01, 120)
+        // Raw cadence: 60 (stride rate) -> 120 spm (step rate)
+        val data = byteArrayOf(0x00, 0x00, 0x01, 60)
 
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(120, sample!!.cadence)
+        assertEquals(120, sample!!.cadence)  // 60 * 2 = 120 steps/min
         assertEquals(1.0f, sample.speed!!, 0.01f)
         assertNull(sample.strideLengthCm)
         assertNull(sample.totalDistanceMeters)
@@ -31,13 +34,13 @@ class RscParserTest {
     fun `parse RSC measurement with running flag`() {
         // Flags: 0x04 = running
         // Speed: 0x0200 = 512 raw = 2.0 m/s
-        // Cadence: 180 spm
-        val data = byteArrayOf(0x04, 0x00, 0x02, 180.toByte())
+        // Raw cadence: 90 -> 180 spm
+        val data = byteArrayOf(0x04, 0x00, 0x02, 90)
 
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(180, sample!!.cadence)
+        assertEquals(180, sample!!.cadence)  // 90 * 2 = 180 steps/min
         assertEquals(2.0f, sample.speed!!, 0.01f)
         assertTrue(sample.isRunning)
     }
@@ -46,14 +49,14 @@ class RscParserTest {
     fun `parse RSC measurement with stride length`() {
         // Flags: 0x01 = stride length present
         // Speed: 0x0180 = 384 raw = 1.5 m/s
-        // Cadence: 160 spm
+        // Raw cadence: 80 -> 160 spm
         // Stride length: 0x0064 = 100 cm
-        val data = byteArrayOf(0x01, 0x80.toByte(), 0x01, 160.toByte(), 0x64, 0x00)
+        val data = byteArrayOf(0x01, 0x80.toByte(), 0x01, 80, 0x64, 0x00)
 
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(160, sample!!.cadence)
+        assertEquals(160, sample!!.cadence)  // 80 * 2 = 160 steps/min
         assertEquals(1.5f, sample.speed!!, 0.01f)
         assertEquals(100, sample.strideLengthCm)
         assertNull(sample.totalDistanceMeters)
@@ -63,14 +66,14 @@ class RscParserTest {
     fun `parse RSC measurement with total distance`() {
         // Flags: 0x02 = total distance present
         // Speed: 0x0100 = 256 raw = 1.0 m/s
-        // Cadence: 120 spm
+        // Raw cadence: 60 -> 120 spm
         // Total distance: 0x000003E8 = 1000 raw = 100.0 meters (little-endian)
-        val data = byteArrayOf(0x02, 0x00, 0x01, 120, 0xE8.toByte(), 0x03, 0x00, 0x00)
+        val data = byteArrayOf(0x02, 0x00, 0x01, 60, 0xE8.toByte(), 0x03, 0x00, 0x00)
 
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(120, sample!!.cadence)
+        assertEquals(120, sample!!.cadence)  // 60 * 2 = 120 steps/min
         assertEquals(100.0f, sample.totalDistanceMeters!!, 0.01f)
     }
 
@@ -78,13 +81,13 @@ class RscParserTest {
     fun `parse RSC measurement with all optional fields`() {
         // Flags: 0x07 = stride length + total distance + running
         // Speed: 0x0280 = 640 raw = 2.5 m/s
-        // Cadence: 175 spm
+        // Raw cadence: 88 -> 176 spm (close to 175, adjusted for integer math)
         // Stride length: 0x0078 = 120 cm
         // Total distance: 0x00001388 = 5000 raw = 500.0 meters
         val data = byteArrayOf(
             0x07,
             0x80.toByte(), 0x02,  // speed
-            175.toByte(),         // cadence
+            88,                   // raw cadence -> 176 spm
             0x78, 0x00,           // stride length
             0x88.toByte(), 0x13, 0x00, 0x00  // total distance
         )
@@ -92,7 +95,7 @@ class RscParserTest {
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(175, sample!!.cadence)
+        assertEquals(176, sample!!.cadence)  // 88 * 2 = 176 steps/min
         assertEquals(2.5f, sample.speed!!, 0.01f)
         assertEquals(120, sample.strideLengthCm)
         assertEquals(500.0f, sample.totalDistanceMeters!!, 0.01f)
@@ -102,12 +105,13 @@ class RscParserTest {
     @Test
     fun `parse zero speed returns null speed`() {
         // Speed of 0 should return null (stationary)
-        val data = byteArrayOf(0x00, 0x00, 0x00, 60)
+        // Raw cadence: 30 -> 60 spm
+        val data = byteArrayOf(0x00, 0x00, 0x00, 30)
 
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(60, sample!!.cadence)
+        assertEquals(60, sample!!.cadence)  // 30 * 2 = 60 steps/min
         assertNull(sample.speed)
     }
 
@@ -135,21 +139,33 @@ class RscParserTest {
         // Typical footpod running data
         // Flags: 0x05 = stride length + running
         // Speed: ~3.5 m/s (fast run)
-        // Cadence: 185 spm
+        // Raw cadence: 92 -> 184 spm (typical fast running cadence)
         // Stride length: 115 cm
         val data = byteArrayOf(
             0x05,
             0x80.toByte(), 0x03,  // speed: 896/256 = 3.5 m/s
-            185.toByte(),         // cadence
+            92,                   // raw cadence -> 184 spm
             0x73, 0x00            // stride length: 115 cm
         )
 
         val sample = parseRscMeasurement(data)
 
         assertNotNull(sample)
-        assertEquals(185, sample!!.cadence)
+        assertEquals(184, sample!!.cadence)  // 92 * 2 = 184 steps/min
         assertEquals(3.5f, sample.speed!!, 0.01f)
         assertEquals(115, sample.strideLengthCm)
         assertTrue(sample.isRunning)
+    }
+
+    @Test
+    fun `cadence is doubled from raw stride rate to step rate`() {
+        // Verify the stride-to-step conversion explicitly
+        // Walking at 55 strides/min should show as 110 steps/min
+        val data = byteArrayOf(0x00, 0x00, 0x01, 55)
+
+        val sample = parseRscMeasurement(data)
+
+        assertNotNull(sample)
+        assertEquals(110, sample!!.cadence)  // 55 strides * 2 = 110 steps
     }
 }

--- a/apps/android/app/src/test/java/net/aurboda/SensorServiceTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/SensorServiceTest.kt
@@ -2,6 +2,7 @@ package net.aurboda
 
 import net.aurboda.ble.BleConnectionState
 import net.aurboda.ble.ConnectedDevice
+import net.aurboda.ble.DeviceState
 import net.aurboda.ble.LiveHeartRateSample
 import net.aurboda.ble.SensorServiceState
 import net.aurboda.ble.SensorType
@@ -28,11 +29,13 @@ class SensorServiceTest {
         val state = SensorServiceState()
 
         assertFalse(state.isRunning)
-        assertTrue(state.connectionState is BleConnectionState.Disconnected)
-        assertNull(state.connectedDevice)
+        assertTrue(state.connectedDevices.isEmpty())
+        assertTrue(state.connectingDevices.isEmpty())
         assertNull(state.currentHeartRate)
         assertNull(state.lastSyncTime)
         assertEquals(0, state.pendingSamples)
+        assertFalse(state.hasConnectedDevices)
+        assertFalse(state.isConnecting)
     }
 
     @Test
@@ -45,35 +48,48 @@ class SensorServiceTest {
     }
 
     @Test
-    fun `SensorServiceState copy updates connectionState`() {
+    fun `SensorServiceState copy updates connectingDevices`() {
         val initial = SensorServiceState()
-        val updated = initial.copy(connectionState = BleConnectionState.Connected)
+        val updated = initial.copy(connectingDevices = setOf("AA:BB:CC:DD:EE:FF"))
 
-        assertTrue(updated.connectionState is BleConnectionState.Connected)
-        assertTrue(initial.connectionState is BleConnectionState.Disconnected)
+        assertTrue(updated.isConnecting)
+        assertEquals(1, updated.connectingDevices.size)
+        assertFalse(initial.isConnecting)
     }
 
     @Test
-    fun `SensorServiceState copy updates connectedDevice`() {
+    fun `SensorServiceState copy updates connectedDevices`() {
         val device = ConnectedDevice(
             address = "AA:BB:CC:DD:EE:FF",
             name = "Polar H10",
             type = SensorType.HEART_RATE
         )
+        val deviceState = DeviceState(device = device, currentHeartRate = 72)
         val initial = SensorServiceState()
-        val updated = initial.copy(connectedDevice = device)
+        val updated = initial.copy(connectedDevices = mapOf(device.address to deviceState))
 
-        assertEquals(device, updated.connectedDevice)
-        assertNull(initial.connectedDevice)
+        assertEquals(1, updated.connectedDevices.size)
+        assertTrue(updated.hasConnectedDevices)
+        assertEquals(deviceState, updated.connectedDevices[device.address])
+        assertTrue(initial.connectedDevices.isEmpty())
     }
 
     @Test
-    fun `SensorServiceState copy updates currentHeartRate`() {
-        val initial = SensorServiceState()
-        val updated = initial.copy(currentHeartRate = 72)
+    fun `SensorServiceState convenience accessor for HR device`() {
+        val hrDevice = ConnectedDevice(
+            address = "AA:BB:CC:DD:EE:FF",
+            name = "Polar H10",
+            type = SensorType.HEART_RATE
+        )
+        val hrState = DeviceState(device = hrDevice, currentHeartRate = 72)
 
-        assertEquals(72, updated.currentHeartRate)
-        assertNull(initial.currentHeartRate)
+        val state = SensorServiceState(
+            connectedDevices = mapOf(hrDevice.address to hrState)
+        )
+
+        assertEquals(hrState, state.hrDevice)
+        assertEquals(72, state.currentHeartRate)
+        assertNull(state.rscDevice)
     }
 
     @Test
@@ -96,24 +112,36 @@ class SensorServiceTest {
     }
 
     @Test
-    fun `SensorServiceState supports chained updates`() {
-        val device = ConnectedDevice(
+    fun `SensorServiceState supports multiple connected devices`() {
+        val hrDevice = ConnectedDevice(
             address = "AA:BB:CC:DD:EE:FF",
             name = "Polar H10",
             type = SensorType.HEART_RATE
         )
+        val rscDevice = ConnectedDevice(
+            address = "11:22:33:44:55:66",
+            name = "Stryd",
+            type = SensorType.RUNNING_SPEED_CADENCE
+        )
+        val hrState = DeviceState(device = hrDevice, currentHeartRate = 85)
+        val rscState = DeviceState(device = rscDevice, currentCadence = 180, stepsSinceStart = 500)
 
-        val state = SensorServiceState()
-            .copy(isRunning = true)
-            .copy(connectionState = BleConnectionState.Connected)
-            .copy(connectedDevice = device)
-            .copy(currentHeartRate = 85)
-            .copy(pendingSamples = 3)
+        val state = SensorServiceState(
+            isRunning = true,
+            connectedDevices = mapOf(
+                hrDevice.address to hrState,
+                rscDevice.address to rscState
+            ),
+            pendingSamples = 3
+        )
 
         assertTrue(state.isRunning)
-        assertTrue(state.connectionState is BleConnectionState.Connected)
-        assertEquals(device, state.connectedDevice)
+        assertEquals(2, state.connectedDevices.size)
+        assertEquals(hrState, state.hrDevice)
+        assertEquals(rscState, state.rscDevice)
         assertEquals(85, state.currentHeartRate)
+        assertEquals(180, state.currentCadence)
+        assertEquals(500, state.stepsSinceStart)
         assertEquals(3, state.pendingSamples)
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #102 with additional improvements:

1. **Support multiple simultaneous BLE device connections** - Connect HR monitor and step sensor at the same time
2. **Fix Health Connect permission state** - Permission for one device type was incorrectly resetting the other type's state
3. **Convert stride rate to step rate** - Multiply cadence by 2 since foot pods (like Zwift RunPod) report stride rate, not step rate

## Changes

**SensorService.kt:**
- Refactored to manage multiple `BleConnectionManager` instances via a map
- `SensorServiceState` now holds `connectedDevices: Map<String, DeviceState>`
- Added `DeviceState` class for per-device state (battery, HR, cadence, steps)
- Per-device disconnect via `SensorService.disconnect(context, deviceAddress)`

**LiveScreen.kt:**
- Display multiple connected devices simultaneously
- Scanner always visible to allow adding more devices
- Filter already-connected devices from scan results
- "Stop All Sensors" button when multiple devices connected
- Fixed HC permission callback to not reset other device type's state

**RscParser.kt:**
- Multiply raw cadence by 2 to convert stride rate to step rate
- Each foot strike now counts as 1 step (left + right = 2 per stride)

**Tests:**
- Updated `SensorServiceTest` for new multi-device state structure
- Updated `RscParserTest` for stride-to-step conversion

## Test plan

- [x] Unit tests pass
- [ ] Connect to step sensor, verify cadence shows ~100-130 SPM when walking
- [ ] Connect to HR monitor while step sensor connected
- [ ] Verify both devices display correctly
- [ ] Verify individual device disconnect works
- [ ] Verify switching between connecting devices doesn't cause permission issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)