### PR TITLE
Add real-time HRV (RMSSD) calculation on Android (#93)

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
 
     <!-- Write permissions for BLE sensor data -->
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
     <uses-permission android:name="android.permission.health.WRITE_STEPS" />
 
     <application

--- a/apps/android/app/src/main/java/net/aurboda/ble/HrvCalculator.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/HrvCalculator.kt
@@ -1,0 +1,118 @@
+package net.aurboda.ble
+
+import kotlin.math.sqrt
+
+/**
+ * Result of HRV calculation including RMSSD value and quality metrics.
+ */
+data class HrvResult(
+    val rmssd: Double?,           // null if insufficient valid data
+    val validIntervals: Int,
+    val artifactCount: Int,
+    val artifactPercentage: Double,
+    val isReliable: Boolean       // <10% artifacts && >=30 valid intervals
+)
+
+/**
+ * Filters RR intervals based on physiological bounds and successive difference.
+ *
+ * @param intervals Raw RR intervals in milliseconds
+ * @param minMs Minimum physiologically valid RR interval (default 300ms = 200 bpm)
+ * @param maxMs Maximum physiologically valid RR interval (default 2000ms = 30 bpm)
+ * @param maxSuccessiveDiffPercent Maximum allowed difference between successive intervals
+ *                                  as a percentage of the previous interval (default 20%)
+ * @return List of filtered RR intervals
+ */
+fun filterRrIntervals(
+    intervals: List<Int>,
+    minMs: Int = 300,
+    maxMs: Int = 2000,
+    maxSuccessiveDiffPercent: Double = 0.20
+): List<Int> {
+    if (intervals.isEmpty()) return emptyList()
+
+    val result = mutableListOf<Int>()
+
+    for (i in intervals.indices) {
+        val rr = intervals[i]
+
+        // Check physiological bounds
+        if (rr < minMs || rr > maxMs) continue
+
+        // Check successive difference (only if we have a previous valid interval)
+        if (result.isNotEmpty()) {
+            val prevRr = result.last()
+            val diff = kotlin.math.abs(rr - prevRr)
+            val threshold = prevRr * maxSuccessiveDiffPercent
+            if (diff > threshold) continue
+        }
+
+        result.add(rr)
+    }
+
+    return result
+}
+
+/**
+ * Calculates RMSSD (Root Mean Square of Successive Differences) from filtered RR intervals.
+ *
+ * RMSSD is a time-domain HRV metric that reflects parasympathetic (vagal) activity.
+ * It requires at least 2 intervals to calculate a meaningful value, but statistically
+ * valid measurements need 30+ intervals.
+ *
+ * @param filteredIntervals RR intervals in milliseconds (should already be filtered)
+ * @return RMSSD value in milliseconds, or null if insufficient data
+ */
+fun calculateRmssd(filteredIntervals: List<Int>): Double? {
+    if (filteredIntervals.size < 2) return null
+
+    var sumSquaredDiffs = 0.0
+    var count = 0
+
+    for (i in 1 until filteredIntervals.size) {
+        val diff = filteredIntervals[i] - filteredIntervals[i - 1]
+        sumSquaredDiffs += diff.toDouble() * diff.toDouble()
+        count++
+    }
+
+    if (count == 0) return null
+
+    return sqrt(sumSquaredDiffs / count)
+}
+
+/**
+ * Calculates HRV (RMSSD) with artifact filtering and quality metrics.
+ *
+ * @param rrIntervals Raw RR intervals in milliseconds
+ * @param minValidIntervals Minimum number of valid intervals for reliable measurement (default 30)
+ * @param maxArtifactPercent Maximum artifact percentage for reliable measurement (default 10%)
+ * @return HrvResult containing RMSSD value and quality metrics
+ */
+fun calculateHrv(
+    rrIntervals: List<Int>,
+    minValidIntervals: Int = 30,
+    maxArtifactPercent: Double = 10.0
+): HrvResult {
+    val totalCount = rrIntervals.size
+    val filtered = filterRrIntervals(rrIntervals)
+    val artifactCount = totalCount - filtered.size
+    val artifactPercentage = if (totalCount > 0) {
+        (artifactCount.toDouble() / totalCount) * 100.0
+    } else {
+        0.0
+    }
+
+    val rmssd = calculateRmssd(filtered)
+
+    val isReliable = filtered.size >= minValidIntervals &&
+            artifactPercentage <= maxArtifactPercent &&
+            rmssd != null
+
+    return HrvResult(
+        rmssd = rmssd,
+        validIntervals = filtered.size,
+        artifactCount = artifactCount,
+        artifactPercentage = artifactPercentage,
+        isReliable = isReliable
+    )
+}

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -80,7 +80,10 @@ data class SensorServiceState(
     val connectingDevices: Set<String> = emptySet(),  // addresses of devices currently connecting
     val lastSyncTime: Instant? = null,
     val pendingSamples: Int = 0,
-    val pendingCadenceSamples: Int = 0
+    val pendingCadenceSamples: Int = 0,
+    val currentHrv: Double? = null,           // Latest RMSSD in ms
+    val hrvReliable: Boolean = false,         // Whether HRV measurement is reliable
+    val rrIntervalCount: Int = 0              // Number of RR intervals in buffer
 ) {
     // Convenience accessors for backward compatibility and easy access
     val hrDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.HEART_RATE }
@@ -411,13 +414,14 @@ class SensorService : Service() {
     private fun handleDeviceDisconnected(deviceAddress: String) {
         Log.d(TAG, "Device disconnected: $deviceAddress")
 
-        // Check if this was an HR device and clear RR buffer
+        // Check if this was an HR device and clear RR buffer + HRV state
         val wasHrDevice = _serviceState.value.connectedDevices[deviceAddress]?.device?.type == SensorType.HEART_RATE
         if (wasHrDevice) {
             synchronized(bufferLock) {
                 rrIntervalBuffer.clear()
                 Log.d(TAG, "Cleared RR interval buffer due to HR device disconnect")
             }
+            updateState { it.copy(currentHrv = null, hrvReliable = false, rrIntervalCount = 0) }
         }
 
         // Cancel jobs for this device
@@ -539,13 +543,28 @@ class SensorService : Service() {
                     "artifacts=${hrvResult.artifactCount} (${String.format("%.1f", hrvResult.artifactPercentage)}%), " +
                     "reliable=${hrvResult.isReliable}")
 
+            // Update state for UI display
+            updateState { it.copy(
+                currentHrv = hrvResult.rmssd,
+                hrvReliable = hrvResult.isReliable,
+                rrIntervalCount = rrIntervalsForHrv.size
+            ) }
+
             if (hrvResult.isReliable && hrvResult.rmssd != null) {
                 val timestamp = Instant.now()
                 syncHrvToBackend(hrvResult.rmssd, timestamp)
                 writeHrvToHealthConnect(hrvResult.rmssd, timestamp)
             }
-        } else if (rrIntervalsForHrv.isNotEmpty()) {
-            Log.d(TAG, "HRV: Collecting RR intervals (${rrIntervalsForHrv.size}/$RR_BUFFER_MIN_SIZE)")
+        } else {
+            // Update state to show collecting progress
+            updateState { it.copy(
+                currentHrv = null,
+                hrvReliable = false,
+                rrIntervalCount = rrIntervalsForHrv.size
+            ) }
+            if (rrIntervalsForHrv.isNotEmpty()) {
+                Log.d(TAG, "HRV: Collecting RR intervals (${rrIntervalsForHrv.size}/$RR_BUFFER_MIN_SIZE)")
+            }
         }
 
         updateState { it.copy(lastSyncTime = Instant.now()) }

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -15,6 +15,7 @@ import androidx.core.app.NotificationCompat
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.metadata.Device
 import androidx.health.connect.client.records.metadata.Metadata
@@ -51,6 +52,8 @@ private const val TAG = "SensorService"
 private const val NOTIFICATION_ID = 1001
 private const val CHANNEL_ID = "sensor_service_channel"
 private const val SYNC_INTERVAL_MS = 5000L
+private const val RR_BUFFER_MIN_SIZE = 30   // Minimum intervals for HRV calculation
+private const val RR_BUFFER_MAX_SIZE = 300  // Maximum intervals (~5 minutes at 60bpm)
 
 /**
  * State for an individual connected device.
@@ -144,6 +147,19 @@ data class LiveStepsRecord(
 private data class StepsSyncBody(val data: List<LiveStepsRecord>)
 
 /**
+ * HRV record in Health Connect format for backend sync.
+ */
+@Serializable
+data class LiveHrvRecord(
+    val time: String,
+    val heartRateVariabilityMillis: Double,
+    val metadata: LiveRecordMetadata
+)
+
+@Serializable
+private data class HrvSyncBody(val data: List<LiveHrvRecord>)
+
+/**
  * Foreground service that manages BLE sensor connections.
  * Keeps connections alive in the background, buffers HR samples,
  * syncs to backend every 5 seconds, and writes to Health Connect.
@@ -157,6 +173,7 @@ class SensorService : Service() {
 
     private val sampleBuffer = mutableListOf<HeartRateSample>()
     private val cadenceSampleBuffer = mutableListOf<CadenceSample>()
+    private val rrIntervalBuffer = ArrayDeque<Int>(RR_BUFFER_MAX_SIZE)
     private val bufferLock = Any()
 
     private val httpClient by lazy {
@@ -394,6 +411,15 @@ class SensorService : Service() {
     private fun handleDeviceDisconnected(deviceAddress: String) {
         Log.d(TAG, "Device disconnected: $deviceAddress")
 
+        // Check if this was an HR device and clear RR buffer
+        val wasHrDevice = _serviceState.value.connectedDevices[deviceAddress]?.device?.type == SensorType.HEART_RATE
+        if (wasHrDevice) {
+            synchronized(bufferLock) {
+                rrIntervalBuffer.clear()
+                Log.d(TAG, "Cleared RR interval buffer due to HR device disconnect")
+            }
+        }
+
         // Cancel jobs for this device
         deviceJobs[deviceAddress]?.forEach { it.cancel() }
         deviceJobs.remove(deviceAddress)
@@ -427,6 +453,14 @@ class SensorService : Service() {
                 synchronized(bufferLock) {
                     sampleBuffer.add(sample)
                     updateState { it.copy(pendingSamples = sampleBuffer.size) }
+
+                    // Collect RR intervals for HRV calculation (rolling window)
+                    sample.rrIntervals?.forEach { rr ->
+                        if (rrIntervalBuffer.size >= RR_BUFFER_MAX_SIZE) {
+                            rrIntervalBuffer.removeFirst()
+                        }
+                        rrIntervalBuffer.addLast(rr)
+                    }
                 }
             }
         }
@@ -456,10 +490,14 @@ class SensorService : Service() {
     private suspend fun syncPendingSamples() {
         val hrSamplesToSync: List<HeartRateSample>
         val cadenceSamplesToSync: List<CadenceSample>
+        val rrIntervalsForHrv: List<Int>
 
         synchronized(bufferLock) {
             hrSamplesToSync = sampleBuffer.toList()
             cadenceSamplesToSync = cadenceSampleBuffer.toList()
+            // Copy RR intervals for HRV calculation (don't clear - rolling window)
+            rrIntervalsForHrv = rrIntervalBuffer.toList()
+
             if (hrSamplesToSync.isEmpty() && cadenceSamplesToSync.isEmpty()) return
             sampleBuffer.clear()
             cadenceSampleBuffer.clear()
@@ -492,6 +530,22 @@ class SensorService : Service() {
             } else {
                 writeStepsToHealthConnect(cadenceSamplesToSync)
             }
+        }
+
+        // Calculate and sync HRV if we have enough RR intervals
+        if (rrIntervalsForHrv.size >= RR_BUFFER_MIN_SIZE) {
+            val hrvResult = calculateHrv(rrIntervalsForHrv)
+            Log.d(TAG, "HRV calculation: rmssd=${hrvResult.rmssd}, valid=${hrvResult.validIntervals}, " +
+                    "artifacts=${hrvResult.artifactCount} (${String.format("%.1f", hrvResult.artifactPercentage)}%), " +
+                    "reliable=${hrvResult.isReliable}")
+
+            if (hrvResult.isReliable && hrvResult.rmssd != null) {
+                val timestamp = Instant.now()
+                syncHrvToBackend(hrvResult.rmssd, timestamp)
+                writeHrvToHealthConnect(hrvResult.rmssd, timestamp)
+            }
+        } else if (rrIntervalsForHrv.isNotEmpty()) {
+            Log.d(TAG, "HRV: Collecting RR intervals (${rrIntervalsForHrv.size}/$RR_BUFFER_MIN_SIZE)")
         }
 
         updateState { it.copy(lastSyncTime = Instant.now()) }
@@ -718,6 +772,73 @@ class SensorService : Service() {
             Log.d(TAG, "Wrote $totalSteps steps to Health Connect")
         } catch (e: Exception) {
             Log.e(TAG, "Health Connect steps write error", e)
+        }
+    }
+
+    private suspend fun syncHrvToBackend(rmssd: Double, timestamp: Instant) {
+        val credentials = CredentialsManager.getCredentials(this) ?: run {
+            Log.w(TAG, "No credentials, skipping HRV backend sync")
+            return
+        }
+
+        val recordId = "live-hrv-${timestamp.epochSecond}-${timestamp.nano}"
+
+        // Get device info from HR device if available
+        val hrManager = connectionManagers.values.find {
+            it.connectedDeviceInfo.value?.type == SensorType.HEART_RATE
+        }
+        val deviceInfo = hrManager?.connectedDeviceInfo?.value?.let { device ->
+            LiveDeviceInfo(
+                type = 2, // TYPE_CHEST_STRAP
+                model = device.name
+            )
+        }
+
+        val record = LiveHrvRecord(
+            time = timestamp.toString(),
+            heartRateVariabilityMillis = rmssd,
+            metadata = LiveRecordMetadata(
+                id = recordId,
+                device = deviceInfo
+            )
+        )
+
+        try {
+            val response = httpClient.post("${credentials.apiUrl}/sync/HeartRateVariabilityRmssdRecord") {
+                contentType(ContentType.Application.Json)
+                headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
+                setBody(HrvSyncBody(listOf(record)))
+            }
+            val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+            Log.d(TAG, "HRV backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")
+        } catch (e: Exception) {
+            Log.e(TAG, "HRV backend sync error", e)
+        }
+    }
+
+    private suspend fun writeHrvToHealthConnect(rmssd: Double, timestamp: Instant) {
+        try {
+            // Check write permission
+            val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+            val writePermission = HealthPermission.getWritePermission(HeartRateVariabilityRmssdRecord::class)
+            if (writePermission !in grantedPermissions) {
+                Log.w(TAG, "No Health Connect write permission for HeartRateVariabilityRmssdRecord")
+                return
+            }
+
+            val record = HeartRateVariabilityRmssdRecord(
+                time = timestamp,
+                zoneOffset = ZoneOffset.systemDefault().rules.getOffset(timestamp),
+                heartRateVariabilityMillis = rmssd,
+                metadata = Metadata.autoRecorded(
+                    device = Device(type = Device.TYPE_CHEST_STRAP)
+                )
+            )
+
+            healthConnectClient.insertRecords(listOf(record))
+            Log.d(TAG, "Wrote HRV (RMSSD=${String.format("%.1f", rmssd)}ms) to Health Connect")
+        } catch (e: Exception) {
+            Log.e(TAG, "Health Connect HRV write error", e)
         }
     }
 

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -255,6 +255,9 @@ fun LiveScreen(
                     serviceRunning = serviceState.isRunning,
                     pendingSamples = serviceState.pendingSamples + serviceState.pendingCadenceSamples,
                     healthConnectEnabled = healthConnectEnabled,
+                    currentHrv = serviceState.currentHrv,
+                    hrvReliable = serviceState.hrvReliable,
+                    rrIntervalCount = serviceState.rrIntervalCount,
                     onEnableHealthConnect = {
                         healthConnectPermissionLauncher.launch(requiredPermissions)
                     },
@@ -347,6 +350,9 @@ private fun ConnectedDeviceCard(
     serviceRunning: Boolean,
     pendingSamples: Int,
     healthConnectEnabled: Boolean,
+    currentHrv: Double?,
+    hrvReliable: Boolean,
+    rrIntervalCount: Int,
     onEnableHealthConnect: () -> Unit,
     onDisconnect: () -> Unit
 ) {
@@ -403,18 +409,36 @@ private fun ConnectedDeviceCard(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Center
                     ) {
-                        Text(
-                            text = heartRate?.toString() ?: "--",
-                            fontSize = 48.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "BPM",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                        )
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = heartRate?.toString() ?: "--",
+                                fontSize = 48.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                            Text(
+                                text = "BPM",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(24.dp))
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = currentHrv?.let { String.format("%.0f", it) } ?: "--",
+                                fontSize = 32.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = if (hrvReliable)
+                                    MaterialTheme.colorScheme.onPrimaryContainer
+                                else
+                                    MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.5f)
+                            )
+                            Text(
+                                text = if (rrIntervalCount < 30) "HRV ($rrIntervalCount/30)" else "HRV",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                            )
+                        }
                     }
                 }
                 SensorType.RUNNING_SPEED_CADENCE -> {

--- a/apps/android/app/src/test/java/net/aurboda/ble/HrvCalculatorTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/ble/HrvCalculatorTest.kt
@@ -1,0 +1,222 @@
+package net.aurboda.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.sqrt
+
+class HrvCalculatorTest {
+
+    // --- filterRrIntervals tests ---
+
+    @Test
+    fun `filterRrIntervals returns empty for empty input`() {
+        val result = filterRrIntervals(emptyList())
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `filterRrIntervals filters out intervals below minimum`() {
+        val intervals = listOf(800, 200, 850, 250, 900)
+        val result = filterRrIntervals(intervals, minMs = 300)
+        // 200 and 250 are below minimum, should be filtered
+        assertEquals(listOf(800, 850, 900), result)
+    }
+
+    @Test
+    fun `filterRrIntervals filters out intervals above maximum`() {
+        val intervals = listOf(800, 2500, 850, 3000, 900)
+        val result = filterRrIntervals(intervals, maxMs = 2000)
+        // 2500 and 3000 are above maximum, should be filtered
+        assertEquals(listOf(800, 850, 900), result)
+    }
+
+    @Test
+    fun `filterRrIntervals filters out large successive differences`() {
+        // At 20% threshold, jumping from 800ms to 1100ms (37.5% change) should be filtered
+        val intervals = listOf(800, 850, 1100, 900)
+        val result = filterRrIntervals(intervals, maxSuccessiveDiffPercent = 0.20)
+        // 1100 is >20% change from 850 (threshold = 170ms, diff = 250ms)
+        // 900 is also >20% change from 850 if we skipped 1100
+        // But if 1100 is rejected, we compare 900 to 850, which is 50ms (5.9% change) - OK
+        assertEquals(listOf(800, 850, 900), result)
+    }
+
+    @Test
+    fun `filterRrIntervals accepts intervals within successive difference threshold`() {
+        // Normal variation within 20%
+        val intervals = listOf(800, 840, 810, 850, 830)
+        val result = filterRrIntervals(intervals, maxSuccessiveDiffPercent = 0.20)
+        assertEquals(intervals, result)
+    }
+
+    @Test
+    fun `filterRrIntervals keeps first valid interval even if previous was filtered`() {
+        val intervals = listOf(200, 800, 850)  // 200 is below min
+        val result = filterRrIntervals(intervals, minMs = 300)
+        // 200 is filtered, 800 is first valid, 850 compared to 800 (6.25% change)
+        assertEquals(listOf(800, 850), result)
+    }
+
+    // --- calculateRmssd tests ---
+
+    @Test
+    fun `calculateRmssd returns null for empty list`() {
+        val result = calculateRmssd(emptyList())
+        assertNull(result)
+    }
+
+    @Test
+    fun `calculateRmssd returns null for single interval`() {
+        val result = calculateRmssd(listOf(800))
+        assertNull(result)
+    }
+
+    @Test
+    fun `calculateRmssd calculates correctly for known values`() {
+        // RR intervals: 800, 810, 830, 820, 840
+        // Successive differences: 10, 20, -10, 20
+        // Squared differences: 100, 400, 100, 400
+        // Mean of squared: 1000/4 = 250
+        // RMSSD = sqrt(250) ≈ 15.81
+        val intervals = listOf(800, 810, 830, 820, 840)
+        val result = calculateRmssd(intervals)
+        assertNotNull(result)
+        assertEquals(sqrt(250.0), result!!, 0.01)
+    }
+
+    @Test
+    fun `calculateRmssd with constant intervals returns zero`() {
+        // All intervals are the same, so all differences are 0
+        val intervals = listOf(800, 800, 800, 800, 800)
+        val result = calculateRmssd(intervals)
+        assertNotNull(result)
+        assertEquals(0.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `calculateRmssd with two intervals returns absolute difference`() {
+        // With just two intervals, RMSSD = |diff|
+        val intervals = listOf(800, 850)
+        val result = calculateRmssd(intervals)
+        assertNotNull(result)
+        assertEquals(50.0, result!!, 0.001)
+    }
+
+    // --- calculateHrv tests ---
+
+    @Test
+    fun `calculateHrv returns null rmssd for empty input`() {
+        val result = calculateHrv(emptyList())
+        assertNull(result.rmssd)
+        assertEquals(0, result.validIntervals)
+        assertEquals(0, result.artifactCount)
+        assertFalse(result.isReliable)
+    }
+
+    @Test
+    fun `calculateHrv returns unreliable for insufficient intervals`() {
+        // Only 5 intervals, minimum required is 30
+        val intervals = listOf(800, 810, 820, 830, 840)
+        val result = calculateHrv(intervals, minValidIntervals = 30)
+        assertNotNull(result.rmssd)
+        assertEquals(5, result.validIntervals)
+        assertEquals(0, result.artifactCount)
+        assertFalse(result.isReliable)
+    }
+
+    @Test
+    fun `calculateHrv returns reliable for sufficient valid intervals`() {
+        // Create 50 normal intervals with small variation
+        val intervals = (0 until 50).map { 800 + (it % 5) * 10 }
+        val result = calculateHrv(intervals, minValidIntervals = 30)
+        assertNotNull(result.rmssd)
+        assertEquals(50, result.validIntervals)
+        assertEquals(0, result.artifactCount)
+        assertEquals(0.0, result.artifactPercentage, 0.001)
+        assertTrue(result.isReliable)
+    }
+
+    @Test
+    fun `calculateHrv marks unreliable when artifact percentage too high`() {
+        // Mix of valid and artifact intervals
+        val validIntervals = (0 until 40).map { 800 + (it % 3) * 10 }
+        val artifacts = listOf(100, 100, 100, 100, 100, 3000, 3000, 3000, 3000, 3000)
+        val intervals = validIntervals + artifacts
+
+        val result = calculateHrv(intervals, minValidIntervals = 30, maxArtifactPercent = 10.0)
+
+        assertEquals(40, result.validIntervals)
+        assertEquals(10, result.artifactCount)
+        assertEquals(20.0, result.artifactPercentage, 0.1)
+        assertFalse(result.isReliable)  // 20% artifacts > 10% max
+    }
+
+    @Test
+    fun `calculateHrv marks reliable when artifact percentage acceptable`() {
+        // 45 valid + 5 artifacts = 10% artifact rate
+        val validIntervals = (0 until 45).map { 800 + (it % 3) * 10 }
+        val artifacts = listOf(100, 100, 3000, 3000, 3000)
+        val intervals = validIntervals + artifacts
+
+        val result = calculateHrv(intervals, minValidIntervals = 30, maxArtifactPercent = 10.0)
+
+        assertEquals(45, result.validIntervals)
+        assertEquals(5, result.artifactCount)
+        assertEquals(10.0, result.artifactPercentage, 0.1)
+        assertTrue(result.isReliable)  // 10% artifacts == 10% max, still acceptable
+    }
+
+    @Test
+    fun `calculateHrv handles all intervals being filtered`() {
+        // All intervals are artifacts
+        val intervals = listOf(100, 100, 3000, 3000)
+        val result = calculateHrv(intervals)
+        assertNull(result.rmssd)
+        assertEquals(0, result.validIntervals)
+        assertEquals(4, result.artifactCount)
+        assertEquals(100.0, result.artifactPercentage, 0.001)
+        assertFalse(result.isReliable)
+    }
+
+    @Test
+    fun `calculateHrv produces realistic RMSSD values for resting heart rate`() {
+        // Simulating resting HR of ~60bpm with typical HRV variation
+        // RR intervals around 1000ms with 20-40ms variation
+        val intervals = mutableListOf<Int>()
+        var rr = 1000
+        repeat(60) {
+            rr += (-20..20).random()
+            rr = rr.coerceIn(900, 1100)
+            intervals.add(rr)
+        }
+
+        val result = calculateHrv(intervals)
+
+        // RMSSD at rest is typically 20-100ms for healthy adults
+        assertNotNull(result.rmssd)
+        assertTrue("RMSSD ${result.rmssd} should be in realistic range 5-150ms",
+            result.rmssd!! in 5.0..150.0)
+        assertTrue(result.isReliable)
+    }
+
+    @Test
+    fun `calculateHrv handles successive difference filtering in artifact count`() {
+        // Intervals where some pass bounds but fail successive diff check
+        val intervals = listOf(
+            800, 810, 820,  // Normal
+            1200,          // >20% jump from 820 (threshold 164ms, diff 380ms)
+            830, 840, 850  // These might be filtered too due to diff from 1200
+        )
+
+        val result = calculateHrv(intervals)
+
+        // 1200 should be filtered due to successive diff
+        // After 1200 is skipped, 830 vs 820 is ~1.2% change, OK
+        assertTrue(result.validIntervals >= 5)
+        assertTrue(result.artifactCount >= 1)
+    }
+}


### PR DESCRIPTION
## Summary

- Add HRV (RMSSD) calculation from RR intervals collected via BLE heart rate monitors
- Use rolling window buffer (30-300 intervals) for statistically valid measurements
- Apply artifact filtering: physiological bounds (300-2000ms) and successive difference (20%)
- Sync reliable HRV values to backend and Health Connect every 5 seconds
- Add `WRITE_HEART_RATE_VARIABILITY` permission to manifest
- **Display HRV alongside BPM on LiveScreen** with collecting progress indicator

## Implementation Details

**New files:**
- `HrvCalculator.kt` - Pure functional HRV calculation with artifact filtering
- `HrvCalculatorTest.kt` - Comprehensive unit tests

**Modified files:**
- `SensorService.kt` - RR interval collection, HRV sync logic, expose HRV state
- `AndroidManifest.xml` - Write permission for HRV
- `LiveScreen.kt` - Display HRV next to BPM (shows "HRV 15/30" while collecting)

## Test plan

- [ ] Run unit tests: `./gradlew testDebugUnitTest --tests "net.aurboda.ble.HrvCalculatorTest"`
- [ ] Connect Polar H10 or other HR monitor with RR interval support
- [ ] Verify UI shows "HRV --" initially, then "HRV (n/30)" while collecting
- [ ] Wait ~30 seconds for minimum intervals to accumulate
- [ ] Verify RMSSD values are in realistic range (20-100ms at rest)
- [ ] Check Health Connect app for HRV records
- [ ] Verify backend receives HRV data via `/sync/HeartRateVariabilityRmssdRecord`

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)