### PR TITLE
Add MCP session persistence across backend restarts

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -72,6 +72,7 @@ import {
   updateDetectedLocation,
 } from './db'
 import { createMcpRouter } from './mcp'
+import { createDbSessionStore } from './mcp-session-store'
 import { ouraClient } from './oura'
 import { syncAllOuraData } from './oura-sync'
 import { createOwnTracksRouter } from './owntracks'
@@ -135,7 +136,8 @@ const main = async () => {
   httpd.use(cors({ origin: true }))
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
-  httpd.use('/mcp', createMcpRouter(auth, oura, syncProvider))
+  // Use database-backed session store for persistence across restarts
+  httpd.use('/mcp', createMcpRouter(auth, oura, syncProvider, { sessionStore: createDbSessionStore() }))
 
   httpd.use(json({ limit: '10mb' }))
 

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1553,3 +1553,116 @@ export const upsertUserSettings = async (
 
   return merged
 }
+
+// ============================================================================
+// MCP Sessions (persist sessions across backend restarts)
+// ============================================================================
+
+export interface McpSessionRecord {
+  sessionId: string
+  username: string
+  createdAt: Date
+  lastActivity: Date
+}
+
+/**
+ * Save an MCP session to the database.
+ */
+export const saveMcpSession = async (user: string, sessionId: string): Promise<McpSessionRecord> => {
+  const result = await query(
+    user,
+    `INSERT INTO mcp_sessions (session_id, username, created_at, last_activity)
+     VALUES ($1, $2, NOW(), NOW())
+     ON CONFLICT (session_id) DO UPDATE SET last_activity = NOW()
+     RETURNING session_id, username, created_at, last_activity`,
+    [sessionId, user],
+  )
+
+  const row = result.rows[0]
+  return {
+    createdAt: new Date(row.created_at),
+    lastActivity: new Date(row.last_activity),
+    sessionId: row.session_id,
+    username: row.username,
+  }
+}
+
+/**
+ * Get an MCP session by ID.
+ */
+export const getMcpSession = async (user: string, sessionId: string): Promise<McpSessionRecord | null> => {
+  const result = await query(
+    user,
+    `SELECT session_id, username, created_at, last_activity
+     FROM mcp_sessions
+     WHERE session_id = $1`,
+    [sessionId],
+  )
+
+  if (result.rows.length === 0) return null
+
+  const row = result.rows[0]
+  return {
+    createdAt: new Date(row.created_at),
+    lastActivity: new Date(row.last_activity),
+    sessionId: row.session_id,
+    username: row.username,
+  }
+}
+
+/**
+ * Update the last_activity timestamp for a session.
+ */
+export const touchMcpSession = async (user: string, sessionId: string): Promise<void> => {
+  await query(user, `UPDATE mcp_sessions SET last_activity = NOW() WHERE session_id = $1`, [sessionId])
+}
+
+/**
+ * Delete an MCP session.
+ */
+export const deleteMcpSession = async (user: string, sessionId: string): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM mcp_sessions WHERE session_id = $1`, [sessionId])
+  return (result.rowCount ?? 0) > 0
+}
+
+/**
+ * Delete MCP sessions that have been inactive for longer than the specified duration.
+ * @param maxInactivityMs Maximum inactivity time in milliseconds (default: 7 days)
+ */
+export const deleteExpiredMcpSessions = async (
+  user: string,
+  maxInactivityMs: number = 7 * 24 * 60 * 60 * 1000,
+): Promise<string[]> => {
+  const cutoff = new Date(Date.now() - maxInactivityMs)
+
+  const result = await query(
+    user,
+    `DELETE FROM mcp_sessions
+     WHERE last_activity < $1
+     RETURNING session_id`,
+    [cutoff],
+  )
+
+  return result.rows.map((row) => row.session_id)
+}
+
+/**
+ * Get all active MCP sessions for a user.
+ */
+export const getMcpSessionsForUser = async (user: string): Promise<McpSessionRecord[]> => {
+  const result = await query(
+    user,
+    `SELECT session_id, username, created_at, last_activity
+     FROM mcp_sessions
+     WHERE username = $1
+     ORDER BY last_activity DESC`,
+    [user],
+  )
+
+  return result.rows.map((row) => ({
+    createdAt: new Date(row.created_at),
+    lastActivity: new Date(row.last_activity),
+    sessionId: row.session_id,
+    username: row.username,
+  }))
+}

--- a/apps/backend/src/mcp-session-store.test.ts
+++ b/apps/backend/src/mcp-session-store.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  createInMemorySessionStore,
+  DEFAULT_SESSION_INACTIVITY_MS,
+  McpSessionStore,
+} from './mcp-session-store'
+
+describe('createInMemorySessionStore', () => {
+  let store: McpSessionStore
+
+  beforeEach(() => {
+    store = createInMemorySessionStore()
+    vi.useFakeTimers()
+  })
+
+  describe('save', () => {
+    test('creates a new session with timestamps', async () => {
+      const now = new Date('2024-01-15T10:00:00Z')
+      vi.setSystemTime(now)
+
+      const record = await store.save('testuser', 'session-123')
+
+      expect(record.sessionId).toBe('session-123')
+      expect(record.username).toBe('testuser')
+      expect(record.createdAt).toEqual(now)
+      expect(record.lastActivity).toEqual(now)
+    })
+
+    test('updates lastActivity but preserves createdAt on re-save', async () => {
+      const createTime = new Date('2024-01-15T10:00:00Z')
+      vi.setSystemTime(createTime)
+
+      await store.save('testuser', 'session-123')
+
+      const updateTime = new Date('2024-01-15T12:00:00Z')
+      vi.setSystemTime(updateTime)
+
+      const record = await store.save('testuser', 'session-123')
+
+      expect(record.createdAt).toEqual(createTime)
+      expect(record.lastActivity).toEqual(updateTime)
+    })
+  })
+
+  describe('get', () => {
+    test('returns null for non-existent session', async () => {
+      const record = await store.get('testuser', 'non-existent')
+      expect(record).toBeNull()
+    })
+
+    test('returns saved session', async () => {
+      await store.save('testuser', 'session-123')
+      const record = await store.get('testuser', 'session-123')
+
+      expect(record).not.toBeNull()
+      expect(record!.sessionId).toBe('session-123')
+      expect(record!.username).toBe('testuser')
+    })
+  })
+
+  describe('touch', () => {
+    test('updates lastActivity timestamp', async () => {
+      const createTime = new Date('2024-01-15T10:00:00Z')
+      vi.setSystemTime(createTime)
+      await store.save('testuser', 'session-123')
+
+      const touchTime = new Date('2024-01-15T14:00:00Z')
+      vi.setSystemTime(touchTime)
+      await store.touch('testuser', 'session-123')
+
+      const record = await store.get('testuser', 'session-123')
+      expect(record!.lastActivity).toEqual(touchTime)
+      expect(record!.createdAt).toEqual(createTime)
+    })
+
+    test('does nothing for non-existent session', async () => {
+      // Should not throw
+      await store.touch('testuser', 'non-existent')
+    })
+  })
+
+  describe('delete', () => {
+    test('removes existing session and returns true', async () => {
+      await store.save('testuser', 'session-123')
+
+      const deleted = await store.delete('testuser', 'session-123')
+
+      expect(deleted).toBe(true)
+      expect(await store.get('testuser', 'session-123')).toBeNull()
+    })
+
+    test('returns false for non-existent session', async () => {
+      const deleted = await store.delete('testuser', 'non-existent')
+      expect(deleted).toBe(false)
+    })
+  })
+
+  describe('cleanup', () => {
+    test('removes sessions older than maxInactivityMs', async () => {
+      const day1 = new Date('2024-01-10T10:00:00Z')
+      vi.setSystemTime(day1)
+      await store.save('testuser', 'old-session')
+
+      // Use day 18 to ensure old-session is more than 7 days old
+      const day9 = new Date('2024-01-18T10:00:00Z')
+      vi.setSystemTime(day9)
+      await store.save('testuser', 'new-session')
+
+      // Cleanup with 7-day inactivity threshold
+      const deleted = await store.cleanup('testuser', DEFAULT_SESSION_INACTIVITY_MS)
+
+      expect(deleted).toContain('old-session')
+      expect(deleted).not.toContain('new-session')
+
+      expect(await store.get('testuser', 'old-session')).toBeNull()
+      expect(await store.get('testuser', 'new-session')).not.toBeNull()
+    })
+
+    test('returns empty array when no sessions expired', async () => {
+      const now = new Date('2024-01-15T10:00:00Z')
+      vi.setSystemTime(now)
+      await store.save('testuser', 'session-123')
+
+      const deleted = await store.cleanup('testuser', DEFAULT_SESSION_INACTIVITY_MS)
+
+      expect(deleted).toHaveLength(0)
+    })
+  })
+})

--- a/apps/backend/src/mcp-session-store.ts
+++ b/apps/backend/src/mcp-session-store.ts
@@ -1,0 +1,117 @@
+/**
+ * MCP Session Store Interface and Implementations
+ *
+ * Provides session persistence for MCP sessions, allowing them to survive
+ * backend restarts. Sessions are lazily restored when clients reconnect.
+ */
+
+import {
+  deleteExpiredMcpSessions,
+  deleteMcpSession,
+  getMcpSession,
+  McpSessionRecord,
+  saveMcpSession,
+  touchMcpSession,
+} from './db'
+
+/**
+ * Interface for MCP session persistence.
+ * Implementations can be in-memory only or database-backed.
+ */
+export interface McpSessionStore {
+  /**
+   * Save a new session or update an existing one.
+   * Returns the session record.
+   */
+  save(user: string, sessionId: string): Promise<McpSessionRecord>
+
+  /**
+   * Get a session by ID.
+   * Returns null if the session doesn't exist.
+   */
+  get(user: string, sessionId: string): Promise<McpSessionRecord | null>
+
+  /**
+   * Update the last_activity timestamp for a session.
+   */
+  touch(user: string, sessionId: string): Promise<void>
+
+  /**
+   * Delete a session.
+   * Returns true if the session was deleted.
+   */
+  delete(user: string, sessionId: string): Promise<boolean>
+
+  /**
+   * Delete sessions that have been inactive for longer than maxInactivityMs.
+   * Returns the IDs of deleted sessions.
+   */
+  cleanup(user: string, maxInactivityMs: number): Promise<string[]>
+}
+
+/**
+ * In-memory session store (no persistence across restarts).
+ * Useful for testing or when persistence is not needed.
+ */
+export const createInMemorySessionStore = (): McpSessionStore => {
+  const sessions = new Map<string, McpSessionRecord>()
+
+  return {
+    cleanup: async (_user, maxInactivityMs) => {
+      const cutoff = Date.now() - maxInactivityMs
+      const expired: string[] = []
+      for (const [id, record] of sessions) {
+        if (record.lastActivity.getTime() < cutoff) {
+          expired.push(id)
+          sessions.delete(id)
+        }
+      }
+      return expired
+    },
+
+    delete: async (_user, sessionId) => {
+      return sessions.delete(sessionId)
+    },
+
+    get: async (_user, sessionId) => {
+      return sessions.get(sessionId) ?? null
+    },
+
+    save: async (user, sessionId) => {
+      const now = new Date()
+      const existing = sessions.get(sessionId)
+      const record: McpSessionRecord = {
+        createdAt: existing?.createdAt ?? now,
+        lastActivity: now,
+        sessionId,
+        username: user,
+      }
+      sessions.set(sessionId, record)
+      return record
+    },
+
+    touch: async (_user, sessionId) => {
+      const existing = sessions.get(sessionId)
+      if (existing) {
+        existing.lastActivity = new Date()
+      }
+    },
+  }
+}
+
+/**
+ * Database-backed session store.
+ * Sessions persist across backend restarts.
+ */
+export const createDbSessionStore = (): McpSessionStore => ({
+  cleanup: deleteExpiredMcpSessions,
+  delete: deleteMcpSession,
+  get: getMcpSession,
+  save: saveMcpSession,
+  touch: touchMcpSession,
+})
+
+/**
+ * Default session inactivity timeout: 7 days
+ */
+export const DEFAULT_SESSION_INACTIVITY_MS = 7 * 24 * 60 * 60 * 1000

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createAuth } from './auth'
 import * as db from './db'
 import { createMcpRouter } from './mcp'
+import { createInMemorySessionStore, McpSessionStore } from './mcp-session-store'
 import * as queries from './services/queries'
 
 // Mock the services
@@ -981,6 +982,180 @@ describe('MCP Server', () => {
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
       expect(response.toolResult.data).toHaveLength(0)
+    })
+  })
+
+  describe('Session Persistence', () => {
+    function createTestAppWithStore(sessionStore: McpSessionStore) {
+      const app = express()
+      app.use('/mcp', createMcpRouter(auth, undefined, undefined, { sessionStore }))
+      return app
+    }
+
+    test('session can be restored after simulated restart', async () => {
+      const sessionStore = createInMemorySessionStore()
+      const app1 = createTestAppWithStore(sessionStore)
+      const token = auth.createToken('testuser')
+
+      // Create session on first "instance"
+      const initResponse = await mcpPost(app1)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+
+      expect(initResponse.status).toBe(200)
+      const sessionId = initResponse.headers['mcp-session-id'] as string
+      expect(sessionId).toBeDefined()
+
+      // Simulate restart by creating a new app instance (fresh in-memory sessions)
+      // but using the same session store
+      const app2 = createTestAppWithStore(sessionStore)
+
+      // Use the same session ID - it should be restored from store
+      // Note: The McpServer instance is recreated, so we need to re-initialize
+      // but the session ID is preserved (the key benefit of persistence)
+      const response = await mcpPost(app2)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+
+      expect(response.status).toBe(200)
+      // The session ID should be preserved (same as before)
+      expect(response.headers['mcp-session-id']).toBe(sessionId)
+    })
+
+    test('session store saves new sessions', async () => {
+      const sessionStore = createInMemorySessionStore()
+      const app = createTestAppWithStore(sessionStore)
+      const token = auth.createToken('testuser')
+
+      const initResponse = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+
+      expect(initResponse.status).toBe(200)
+      const sessionId = initResponse.headers['mcp-session-id'] as string
+
+      // Verify session was saved to store
+      const record = await sessionStore.get('testuser', sessionId)
+      expect(record).not.toBeNull()
+      expect(record!.username).toBe('testuser')
+      expect(record!.sessionId).toBe(sessionId)
+    })
+
+    test('session is deleted from store on DELETE', async () => {
+      const sessionStore = createInMemorySessionStore()
+      const app = createTestAppWithStore(sessionStore)
+      const token = auth.createToken('testuser')
+
+      // Create session
+      const initResponse = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+
+      const sessionId = initResponse.headers['mcp-session-id'] as string
+
+      // Delete session
+      await mcpDelete(app).set('Authorization', `Bearer ${token}`).set('Mcp-Session-Id', sessionId)
+
+      // Verify session was removed from store
+      const record = await sessionStore.get('testuser', sessionId)
+      expect(record).toBeNull()
+    })
+
+    test('expired sessions are not restored', async () => {
+      vi.useFakeTimers()
+      const sessionStore = createInMemorySessionStore()
+
+      // Create session at "time zero"
+      const day1 = new Date('2024-01-01T10:00:00Z')
+      vi.setSystemTime(day1)
+
+      const app1 = createTestAppWithStore(sessionStore)
+      const token = auth.createToken('testuser')
+
+      const initResponse = await mcpPost(app1)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+
+      expect(initResponse.status).toBe(200)
+      const sessionId = initResponse.headers['mcp-session-id'] as string
+
+      // Jump forward 8 days (past the 7-day expiry)
+      const day9 = new Date('2024-01-09T10:00:00Z')
+      vi.setSystemTime(day9)
+
+      // Simulate restart with fresh app
+      const app2 = createTestAppWithStore(sessionStore)
+
+      // Try to use the old session - should fail because it's expired
+      // Since the session can't be restored, the system will create a new one
+      // So the response will succeed but with a DIFFERENT session ID
+      const response = await mcpPost(app2)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+
+      expect(response.status).toBe(200)
+      // A new session should have been created
+      const newSessionId = response.headers['mcp-session-id'] as string
+      expect(newSessionId).toBeDefined()
+      expect(newSessionId).not.toBe(sessionId)
+
+      vi.useRealTimers()
     })
   })
 })

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -19,6 +19,7 @@ import { Request, Response, Router } from 'express'
 import { z } from 'zod'
 import { Auth } from './auth'
 import { getAllSyncStates, getDetectedLocations as getStoredDetectedLocations } from './db'
+import { DEFAULT_SESSION_INACTIVITY_MS, McpSessionStore } from './mcp-session-store'
 import { ouraClient } from './oura'
 import { syncAllOuraData } from './oura-sync'
 import { syncRescueTimeData } from './rescuetime-sync'
@@ -63,9 +64,23 @@ const mcpTimeRangeSchema = {
 // Metric name description using validMetrics from api-spec
 const metricDescription = `Metric name. Valid metrics: ${validMetrics.join(', ')}`
 
-export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncProvider): Router {
+/**
+ * Create an MCP router with optional session persistence.
+ *
+ * When a sessionStore is provided, sessions are persisted to the database
+ * and can survive backend restarts. When a client reconnects with a
+ * previously-issued session ID, the session is lazily restored.
+ */
+export function createMcpRouter(
+  auth: Auth,
+  oura?: OuraClientType,
+  sync?: SyncProvider,
+  options?: { sessionStore?: McpSessionStore; cleanupIntervalMs?: number },
+): Router {
   const router = Router()
   const sessions = new Map<string, McpSession>()
+  const sessionStore = options?.sessionStore
+  const cleanupIntervalMs = options?.cleanupIntervalMs ?? 60 * 60 * 1000 // Default: 1 hour
 
   const getAuthenticatedUser = (req: Request): string | null => {
     const authHeader = req.headers.authorization
@@ -596,6 +611,60 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
     return server
   }
 
+  // Helper to restore a session from the store (lazy restoration after restart)
+  const restoreSessionFromStore = async (user: string, sessionId: string): Promise<McpSession | null> => {
+    if (!sessionStore) return null
+
+    const record = await sessionStore.get(user, sessionId)
+    if (!record || record.username !== user) return null
+
+    // Check if session is expired (older than 7 days by default)
+    const maxAge = DEFAULT_SESSION_INACTIVITY_MS
+    const age = Date.now() - record.lastActivity.getTime()
+    if (age > maxAge) {
+      // Session expired - clean it up
+      await sessionStore.delete(user, sessionId)
+      return null
+    }
+
+    // Recreate the McpServer and transport
+    const server = createMcpServer(user)
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => sessionId,
+    })
+
+    await server.connect(transport)
+
+    const session: McpSession = { server, transport, user }
+    sessions.set(sessionId, session)
+
+    return session
+  }
+
+  // Periodic cleanup of in-memory sessions that have no recent activity
+  // This runs on an interval to free memory from abandoned sessions
+  let cleanupTimer: ReturnType<typeof setInterval> | undefined
+  if (sessionStore) {
+    cleanupTimer = setInterval(async () => {
+      const now = Date.now()
+      for (const [sessionId, session] of sessions) {
+        // Check store for last activity
+        const record = await sessionStore.get(session.user, sessionId)
+        if (!record || now - record.lastActivity.getTime() > DEFAULT_SESSION_INACTIVITY_MS) {
+          // Close and remove stale session
+          await session.server.close()
+          sessions.delete(sessionId)
+          if (record) {
+            await sessionStore.delete(session.user, sessionId)
+          }
+        }
+      }
+    }, cleanupIntervalMs)
+
+    // Don't let the timer prevent process exit
+    cleanupTimer.unref()
+  }
+
   // POST /mcp - Handle JSON-RPC requests
   router.post('/', async (req: Request, res: Response) => {
     const user = getAuthenticatedUser(req)
@@ -606,15 +675,24 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
 
     const sessionId = req.headers['mcp-session-id'] as string | undefined
 
-    let session: McpSession
+    let session: McpSession | undefined
 
     if (sessionId && sessions.has(sessionId)) {
+      // Session is in memory
       session = sessions.get(sessionId)!
       if (session.user !== user) {
         res.status(403).json({ error: 'Session belongs to different user' })
         return
       }
-    } else {
+    } else if (sessionId && sessionStore) {
+      // Session not in memory - try to restore from store
+      const restored = await restoreSessionFromStore(user, sessionId)
+      if (restored) {
+        session = restored
+      }
+    }
+
+    if (!session) {
       // Create new session - generate ID first so transport and our map use the same one
       const newSessionId = randomUUID()
       const server = createMcpServer(user)
@@ -626,10 +704,19 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
 
       session = { server, transport, user }
       sessions.set(newSessionId, session)
-      // Don't set header - transport.handleRequest will set it
+
+      // Persist to store if available
+      if (sessionStore) {
+        await sessionStore.save(user, newSessionId)
+      }
     }
 
     await session.transport.handleRequest(req, res)
+
+    // Update last activity in store
+    if (sessionStore && sessionId) {
+      await sessionStore.touch(user, sessionId)
+    }
   })
 
   // GET /mcp - SSE stream for server notifications
@@ -642,18 +729,34 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
 
     const sessionId = req.headers['mcp-session-id'] as string | undefined
 
-    if (!sessionId || !sessions.has(sessionId)) {
+    if (!sessionId) {
       res.status(400).json({ error: 'Invalid or missing session ID' })
       return
     }
 
-    const session = sessions.get(sessionId)!
+    let session = sessions.get(sessionId)
+
+    // Try to restore from store if not in memory
+    if (!session && sessionStore) {
+      session = (await restoreSessionFromStore(user, sessionId)) ?? undefined
+    }
+
+    if (!session) {
+      res.status(400).json({ error: 'Invalid or missing session ID' })
+      return
+    }
+
     if (session.user !== user) {
       res.status(403).json({ error: 'Session belongs to different user' })
       return
     }
 
     await session.transport.handleRequest(req, res)
+
+    // Update last activity in store
+    if (sessionStore) {
+      await sessionStore.touch(user, sessionId)
+    }
   })
 
   // DELETE /mcp - End session
@@ -666,12 +769,23 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
 
     const sessionId = req.headers['mcp-session-id'] as string | undefined
 
-    if (!sessionId || !sessions.has(sessionId)) {
+    if (!sessionId) {
       res.status(400).json({ error: 'Invalid or missing session ID' })
       return
     }
 
-    const session = sessions.get(sessionId)!
+    let session = sessions.get(sessionId)
+
+    // Try to restore from store if not in memory (so we can properly close it)
+    if (!session && sessionStore) {
+      session = (await restoreSessionFromStore(user, sessionId)) ?? undefined
+    }
+
+    if (!session) {
+      res.status(400).json({ error: 'Invalid or missing session ID' })
+      return
+    }
+
     if (session.user !== user) {
       res.status(403).json({ error: 'Session belongs to different user' })
       return
@@ -680,6 +794,11 @@ export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncPr
     await session.transport.handleRequest(req, res)
     await session.server.close()
     sessions.delete(sessionId)
+
+    // Also delete from store
+    if (sessionStore) {
+      await sessionStore.delete(user, sessionId)
+    }
   })
 
   return router

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -115,6 +115,20 @@ export const createTableStatements: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_locations_geo ON locations USING GIST (location)
   `,
 
+  // MCP session persistence for surviving backend restarts
+  mcp_sessions: `
+    CREATE TABLE IF NOT EXISTS mcp_sessions (
+      session_id      UUID PRIMARY KEY,
+      username        VARCHAR(255) NOT NULL,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_activity   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
+  mcp_sessions_indexes: `
+    CREATE INDEX IF NOT EXISTS idx_mcp_sessions_username ON mcp_sessions (username);
+    CREATE INDEX IF NOT EXISTS idx_mcp_sessions_last_activity ON mcp_sessions (last_activity)
+  `,
+
   // User-defined named locations (detected and named via Aurboda)
   named_locations: `
     CREATE TABLE IF NOT EXISTS named_locations (
@@ -126,6 +140,7 @@ export const createTableStatements: Record<string, string> = {
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `,
+
   named_locations_indexes: `
     CREATE INDEX IF NOT EXISTS idx_named_locations_geo ON named_locations USING GIST (location)
   `,
@@ -204,7 +219,6 @@ export const createTableStatements: Record<string, string> = {
   `,
 
   // Sync state tracking for incremental data pulls
-
   sync_state: `
     CREATE TABLE IF NOT EXISTS sync_state (
       id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -290,6 +304,8 @@ export const tableCreationOrder = [
   'oauth_tokens',
   'sync_state',
   'user_settings',
+  'mcp_sessions',
+  'mcp_sessions_indexes',
 ]
 
 /**


### PR DESCRIPTION
## Summary
- Add `mcp_sessions` database table to persist session ID to user mappings
- Add `McpSessionStore` interface with in-memory (for testing) and database-backed implementations
- Modify MCP router to lazily restore sessions from store when clients reconnect after restart
- Sessions automatically expire after 7 days of inactivity
- Periodic cleanup removes stale sessions from memory

## Key Behavior
- **On restart**: Clients can continue using their session ID; the server recreates the session runtime but requires re-initialization (MCP protocol limitation - server state is lost)
- **Cleanup**: Sessions expire after 7 days of inactivity and are cleaned up lazily or via periodic interval
- **Backwards compatible**: Without a session store, behavior is unchanged (in-memory only)

## Test plan
- [x] Unit tests for `McpSessionStore` implementations
- [x] Integration tests for session restoration after simulated restart
- [x] Test that expired sessions are rejected
- [x] Test that deleted sessions are removed from store
- [x] All 330 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)