### PR TITLE
Fix HRV field name to use Health Connect API naming

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -325,7 +325,7 @@ data class HeartRateRecordSerializable(
 @Serializable
 data class HrvRecordSerializable(
     val time: String,
-    val hrvInMilliseconds: Double,
+    val heartRateVariabilityMillis: Double,
     val metadata: HealthConnectRecordMetadata
 ) {
     companion object {
@@ -333,7 +333,7 @@ data class HrvRecordSerializable(
             return classRecords.filterIsInstance<HeartRateVariabilityRmssdRecord>().map { record ->
                 HrvRecordSerializable(
                     time = record.time.toIsoString(),
-                    hrvInMilliseconds = record.heartRateVariabilityMillis,
+                    heartRateVariabilityMillis = record.heartRateVariabilityMillis,
                     metadata = record.metadata.toSerializable()
                 )
             }

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1405,7 +1405,7 @@ function extractTimeSeriesPoints(
       value = data.beatsPerMinute as number
       break
     case 'HeartRateVariabilityRmssdRecord':
-      value = data.hrvInMilliseconds as number
+      value = data.heartRateVariabilityMillis as number
       break
     default:
       return []

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1405,7 +1405,8 @@ function extractTimeSeriesPoints(
       value = data.beatsPerMinute as number
       break
     case 'HeartRateVariabilityRmssdRecord':
-      value = data.heartRateVariabilityMillis as number
+      // Accept both field names for backwards compatibility with stored raw_records
+      value = (data.heartRateVariabilityMillis ?? data.hrvInMilliseconds) as number
       break
     default:
       return []

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -180,7 +180,8 @@ function extractTimeSeriesPoints(
       value = data.beatsPerMinute as number
       break
     case 'HeartRateVariabilityRmssdRecord':
-      value = data.heartRateVariabilityMillis as number
+      // Accept both field names for backwards compatibility with stored raw_records
+      value = (data.heartRateVariabilityMillis ?? data.hrvInMilliseconds) as number
       break
     default:
       return []

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -180,7 +180,7 @@ function extractTimeSeriesPoints(
       value = data.beatsPerMinute as number
       break
     case 'HeartRateVariabilityRmssdRecord':
-      value = data.hrvInMilliseconds as number
+      value = data.heartRateVariabilityMillis as number
       break
     default:
       return []


### PR DESCRIPTION
## Summary

Fixes live HRV data from BLE sensors not being stored correctly.

The issue was field name inconsistency:
- **BLE live sync** (`LiveHrvRecord`): Used `heartRateVariabilityMillis` ✓
- **Health Connect sync** (`HrvRecordSerializable`): Used `hrvInMilliseconds` ✗
- **Backend extraction**: Expected `hrvInMilliseconds`

This meant BLE live HRV was silently dropped because the field name didn't match.

## Changes

Standardize on `heartRateVariabilityMillis` (the Health Connect API field name):
- `HrvRecordSerializable` in HealthDataModels.kt
- Backend `db.ts` and `migrate.ts`

## Test plan

- [ ] Deploy backend
- [ ] Rebuild Android app
- [ ] Connect BLE HR sensor and verify live HRV appears in timeline (not just during sleep)
- [ ] Verify Oura HRV from Health Connect still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)