### PR TITLE
Fix BLE step calculation jumps and add connection health UI

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
@@ -10,14 +10,22 @@ import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 private const val TAG = "BleConnectionManager"
+private const val MAX_STEP_CALCULATION_GAP_SECONDS = 5.0
+private const val RSSI_POLL_INTERVAL_MS = 2000L
 
 class BleConnectionManager(private val context: Context) {
     private var bluetoothGatt: BluetoothGatt? = null
@@ -56,6 +64,18 @@ class BleConnectionManager(private val context: Context) {
     private val _stepsSinceStart = MutableStateFlow<Int>(0)
     val stepsSinceStart: StateFlow<Int> = _stepsSinceStart.asStateFlow()
 
+    // RSSI (signal strength) monitoring
+    private val _rssi = MutableStateFlow<Int?>(null)
+    val rssi: StateFlow<Int?> = _rssi.asStateFlow()
+
+    // Last time we received data from the device
+    private val _lastDataReceivedTime = MutableStateFlow<java.time.Instant?>(null)
+    val lastDataReceivedTime: StateFlow<java.time.Instant?> = _lastDataReceivedTime.asStateFlow()
+
+    // Coroutine scope for RSSI polling
+    private val scope = CoroutineScope(Dispatchers.Main)
+    private var rssiPollingJob: Job? = null
+
     // Queue for characteristics to read after notifications are set up
     private val pendingReads = mutableListOf<BluetoothGattCharacteristic>()
 
@@ -70,6 +90,7 @@ class BleConnectionManager(private val context: Context) {
                 }
                 BluetoothProfile.STATE_DISCONNECTED -> {
                     Log.d(TAG, "Disconnected from GATT server")
+                    stopRssiPolling()
                     _connectionState.value = BleConnectionState.Disconnected
                     _connectedDeviceInfo.value = null
                     _currentHeartRate.value = null
@@ -77,6 +98,7 @@ class BleConnectionManager(private val context: Context) {
                     _currentCadence.value = null
                     _currentSpeed.value = null
                     _stepsSinceStart.value = 0
+                    _lastDataReceivedTime.value = null
                     stepTrackingStartTime = null
                     lastCadenceTime = null
                     accumulatedSteps = 0.0
@@ -112,6 +134,7 @@ class BleConnectionManager(private val context: Context) {
                             name = gatt.device.name,
                             type = SensorType.HEART_RATE
                         )
+                        startRssiPolling()
                         Log.d(TAG, "Heart Rate service found and notifications enabled")
                         return
                     }
@@ -134,6 +157,7 @@ class BleConnectionManager(private val context: Context) {
                         lastCadenceTime = null
                         accumulatedSteps = 0.0
                         _stepsSinceStart.value = 0
+                        startRssiPolling()
                         Log.d(TAG, "RSC service found and notifications enabled, step tracking started")
                         return
                     }
@@ -161,27 +185,40 @@ class BleConnectionManager(private val context: Context) {
                         Log.d(TAG, "Heart rate: ${sample.bpm} bpm")
                         _currentHeartRate.value = sample.bpm
                         _heartRateSamples.tryEmit(sample)
+                        _lastDataReceivedTime.value = java.time.Instant.now()
                     }
                 }
                 RSC_MEASUREMENT_UUID -> {
+                    val now = java.time.Instant.now()
+                    val lastTime = lastCadenceTime
+                    val gapMs = if (lastTime != null) java.time.Duration.between(lastTime, now).toMillis() else null
+
                     val sample = parseRscMeasurement(value)
                     if (sample != null) {
-                        Log.d(TAG, "RSC: cadence=${sample.cadence} spm, speed=${sample.speed} m/s")
+                        Log.d(TAG, "RSC: cadence=${sample.cadence} spm, speed=${sample.speed} m/s, gap=${gapMs}ms, steps=${accumulatedSteps.toInt()}")
                         _currentCadence.value = sample.cadence
                         _currentSpeed.value = sample.speed
                         _cadenceSamples.tryEmit(sample)
+                        _lastDataReceivedTime.value = now
 
                         // Track cumulative steps by integrating cadence over time
-                        val now = java.time.Instant.now()
-                        val lastTime = lastCadenceTime
                         if (lastTime != null && sample.cadence > 0) {
-                            val elapsedSeconds = java.time.Duration.between(lastTime, now).toMillis() / 1000.0
-                            // cadence is steps per minute, convert to steps in elapsed time
-                            val stepsInInterval = sample.cadence * elapsedSeconds / 60.0
-                            accumulatedSteps += stepsInInterval
-                            _stepsSinceStart.value = accumulatedSteps.toInt()
+                            val elapsedSeconds = gapMs!! / 1000.0
+                            // Sanity check: ignore gaps larger than threshold to prevent
+                            // huge step jumps when the device stops sending data temporarily
+                            if (elapsedSeconds <= MAX_STEP_CALCULATION_GAP_SECONDS) {
+                                // cadence is steps per minute, convert to steps in elapsed time
+                                val stepsInInterval = sample.cadence * elapsedSeconds / 60.0
+                                accumulatedSteps += stepsInInterval
+                                _stepsSinceStart.value = accumulatedSteps.toInt()
+                                Log.d(TAG, "RSC step calc: +${String.format("%.1f", stepsInInterval)} steps (${elapsedSeconds}s * ${sample.cadence} spm / 60)")
+                            } else {
+                                Log.w(TAG, "RSC: Ignoring step calculation - gap of ${elapsedSeconds}s exceeds ${MAX_STEP_CALCULATION_GAP_SECONDS}s threshold")
+                            }
                         }
                         lastCadenceTime = now
+                    } else {
+                        Log.w(TAG, "RSC: Failed to parse data (${value.size} bytes), gap=${gapMs}ms")
                     }
                 }
             }
@@ -223,6 +260,12 @@ class BleConnectionManager(private val context: Context) {
             // Continue processing any remaining pending reads
             processPendingReads(gatt)
         }
+
+        override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                _rssi.value = rssi
+            }
+        }
     }
 
     @SuppressLint("MissingPermission")
@@ -233,6 +276,23 @@ class BleConnectionManager(private val context: Context) {
             @Suppress("DEPRECATION")
             gatt.readCharacteristic(characteristic)
         }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startRssiPolling() {
+        rssiPollingJob?.cancel()
+        rssiPollingJob = scope.launch {
+            while (isActive) {
+                bluetoothGatt?.readRemoteRssi()
+                delay(RSSI_POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun stopRssiPolling() {
+        rssiPollingJob?.cancel()
+        rssiPollingJob = null
+        _rssi.value = null
     }
 
     @SuppressLint("MissingPermission")
@@ -299,6 +359,7 @@ class BleConnectionManager(private val context: Context) {
     @SuppressLint("MissingPermission")
     fun close() {
         Log.d(TAG, "Closing connection manager...")
+        stopRssiPolling()
         try {
             bluetoothGatt?.close()
         } catch (e: SecurityException) {
@@ -314,6 +375,8 @@ class BleConnectionManager(private val context: Context) {
         _currentCadence.value = null
         _currentSpeed.value = null
         _stepsSinceStart.value = 0
+        _rssi.value = null
+        _lastDataReceivedTime.value = null
         stepTrackingStartTime = null
         lastCadenceTime = null
         accumulatedSteps = 0.0

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -72,6 +72,8 @@ data class DeviceState(
     val device: ConnectedDevice,
     val connectionState: BleConnectionState = BleConnectionState.Connected,
     val batteryLevel: Int? = null,
+    val rssi: Int? = null,
+    val lastDataReceivedTime: Instant? = null,
     // HR device specific
     val currentHeartRate: Int? = null,
     // RSC device specific
@@ -421,6 +423,20 @@ class SensorService : Service() {
             manager.stepsSinceStart.collect { steps ->
                 updateDeviceState(deviceAddress) { it.copy(stepsSinceStart = steps) }
                 updateNotification()
+            }
+        }
+
+        // Observe RSSI (signal strength)
+        jobs += serviceScope.launch {
+            manager.rssi.collect { rssi ->
+                updateDeviceState(deviceAddress) { it.copy(rssi = rssi) }
+            }
+        }
+
+        // Observe last data received time
+        jobs += serviceScope.launch {
+            manager.lastDataReceivedTime.collect { time ->
+                updateDeviceState(deviceAddress) { it.copy(lastDataReceivedTime = time) }
             }
         }
 

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -70,6 +70,8 @@ import net.aurboda.ble.hasBlePermissions
 import net.aurboda.ble.isBleEnabled
 import net.aurboda.ble.isBleSupported
 import net.aurboda.ble.scanForSensors
+import java.time.Duration
+import java.time.Instant
 
 @Composable
 fun LiveScreen(
@@ -423,6 +425,12 @@ private fun ConnectedDeviceCard(
                         BatteryIndicator(level = batteryLevel)
                     }
                 }
+
+                // Connection health indicator (RSSI + data freshness)
+                ConnectionHealthIndicator(
+                    rssi = deviceState.rssi,
+                    lastDataReceivedTime = deviceState.lastDataReceivedTime
+                )
 
                 Spacer(modifier = Modifier.height(12.dp))
 
@@ -782,6 +790,115 @@ private fun BatteryIndicator(level: Int) {
             text = "$level%",
             style = MaterialTheme.typography.bodySmall,
             color = color
+        )
+    }
+}
+
+@Composable
+private fun ConnectionHealthIndicator(
+    rssi: Int?,
+    lastDataReceivedTime: Instant?
+) {
+    val now = remember { mutableStateOf(Instant.now()) }
+
+    // Update "now" every second to keep staleness indicator current
+    LaunchedEffect(Unit) {
+        while (true) {
+            now.value = Instant.now()
+            kotlinx.coroutines.delay(1000)
+        }
+    }
+
+    val staleness = lastDataReceivedTime?.let {
+        Duration.between(it, now.value).toMillis() / 1000.0
+    }
+
+    // RSSI signal strength interpretation:
+    // > -50 dBm: Excellent
+    // -50 to -70 dBm: Good
+    // -70 to -80 dBm: Fair
+    // < -80 dBm: Weak
+    val signalStrength = rssi?.let {
+        when {
+            it > -50 -> "excellent"
+            it > -70 -> "good"
+            it > -80 -> "fair"
+            else -> "weak"
+        }
+    }
+
+    val signalColor = when (signalStrength) {
+        "excellent" -> Color(0xFF4CAF50) // Green
+        "good" -> Color(0xFF8BC34A) // Light green
+        "fair" -> Color(0xFFFF9800) // Orange
+        "weak" -> Color(0xFFF44336) // Red
+        else -> Color.Gray
+    }
+
+    // Staleness color: green if fresh, yellow if getting stale, red if very stale
+    val stalenessColor = staleness?.let {
+        when {
+            it < 3 -> Color(0xFF4CAF50) // Green - fresh
+            it < 10 -> Color(0xFFFF9800) // Orange - getting stale
+            else -> Color(0xFFF44336) // Red - stale
+        }
+    } ?: Color.Gray
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier.padding(vertical = 4.dp)
+    ) {
+        // Signal strength indicator (4 bars)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(1.dp),
+            verticalAlignment = Alignment.Bottom,
+            modifier = Modifier.height(14.dp)
+        ) {
+            val bars = when (signalStrength) {
+                "excellent" -> 4
+                "good" -> 3
+                "fair" -> 2
+                "weak" -> 1
+                else -> 0
+            }
+            for (i in 1..4) {
+                Box(
+                    modifier = Modifier
+                        .width(3.dp)
+                        .height((4 + i * 2).dp)
+                        .background(
+                            if (i <= bars) signalColor else signalColor.copy(alpha = 0.3f),
+                            shape = MaterialTheme.shapes.extraSmall
+                        )
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // RSSI value
+        Text(
+            text = rssi?.let { "${it}dBm" } ?: "--",
+            style = MaterialTheme.typography.labelSmall,
+            color = signalColor
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // Data freshness indicator
+        val stalenessText = staleness?.let {
+            when {
+                it < 1 -> "now"
+                it < 60 -> "${it.toInt()}s ago"
+                else -> "${(it / 60).toInt()}m ago"
+            }
+        } ?: "no data"
+
+        Text(
+            text = stalenessText,
+            style = MaterialTheme.typography.labelSmall,
+            color = stalenessColor
         )
     }
 }


### PR DESCRIPTION
## Summary

- **Fix step calculation jumps**: Add 5-second max gap threshold for step calculations to prevent huge step jumps when the Zwift RunPod (or other foot pods) stops sending data temporarily
- **Add RSSI monitoring**: Poll signal strength every 2 seconds while connected
- **Add data freshness tracking**: Track when we last received valid data from the device
- **Add ConnectionHealthIndicator UI**: Shows signal strength bars, dBm value, and data staleness ("now", "5s ago", etc.)
- **Add detailed logging**: Log RSC data reception frequency, gaps between notifications, and step calculation details for debugging

## Context

The Zwift RunPod can be unreliable with BLE notifications, sometimes going silent for extended periods. When it resumes sending, the step calculation was assuming continuous cadence during the gap, causing huge jumps (e.g., 93 to 613 steps suddenly).

## Test plan

- [ ] Connect to a foot pod (RSC device) and verify connection health indicator shows signal strength and data freshness
- [ ] Watch logcat for `BleConnectionManager` logs showing data reception frequency
- [ ] Verify step count doesn't jump unexpectedly when device has gaps in data transmission
- [ ] Test with HR monitor to ensure RSSI and staleness indicator also works for HR devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)