### PR TITLE
Add phone step counter as alternative to BLE foot pods

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Activity recognition for phone step counter (Android 10+) -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 
     <!-- Alphabetically Sorted Health Permissions -->

--- a/apps/android/app/src/main/java/net/aurboda/ble/PhoneStepCounter.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/PhoneStepCounter.kt
@@ -1,0 +1,118 @@
+package net.aurboda.ble
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.time.Instant
+
+private const val TAG = "PhoneStepCounter"
+
+/**
+ * Uses the phone's built-in step counter sensor to track steps.
+ *
+ * Android provides TYPE_STEP_COUNTER which gives cumulative steps since last reboot.
+ * We track the starting value when monitoring begins to calculate steps during the session.
+ */
+class PhoneStepCounter(context: Context) : SensorEventListener {
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val stepCounterSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
+
+    private var isMonitoring = false
+    private var initialStepCount: Float? = null
+
+    private val _stepsSinceStart = MutableStateFlow(0)
+    val stepsSinceStart: StateFlow<Int> = _stepsSinceStart.asStateFlow()
+
+    private val _isAvailable = MutableStateFlow(stepCounterSensor != null)
+    val isAvailable: StateFlow<Boolean> = _isAvailable.asStateFlow()
+
+    private val _lastUpdateTime = MutableStateFlow<Instant?>(null)
+    val lastUpdateTime: StateFlow<Instant?> = _lastUpdateTime.asStateFlow()
+
+    /**
+     * Start monitoring steps from the phone sensor.
+     * Returns true if monitoring started successfully, false if sensor not available.
+     */
+    fun startMonitoring(): Boolean {
+        if (stepCounterSensor == null) {
+            Log.w(TAG, "Step counter sensor not available on this device")
+            return false
+        }
+
+        if (isMonitoring) {
+            Log.d(TAG, "Already monitoring")
+            return true
+        }
+
+        // Reset state
+        initialStepCount = null
+        _stepsSinceStart.value = 0
+        _lastUpdateTime.value = null
+
+        val registered = sensorManager.registerListener(
+            this,
+            stepCounterSensor,
+            SensorManager.SENSOR_DELAY_NORMAL
+        )
+
+        if (registered) {
+            isMonitoring = true
+            Log.d(TAG, "Started monitoring phone step counter")
+        } else {
+            Log.e(TAG, "Failed to register step counter listener")
+        }
+
+        return registered
+    }
+
+    /**
+     * Stop monitoring steps.
+     */
+    fun stopMonitoring() {
+        if (!isMonitoring) return
+
+        sensorManager.unregisterListener(this)
+        isMonitoring = false
+        Log.d(TAG, "Stopped monitoring phone step counter, total steps: ${_stepsSinceStart.value}")
+    }
+
+    /**
+     * Reset the step counter to zero (for starting a new session).
+     */
+    fun resetSteps() {
+        initialStepCount = null
+        _stepsSinceStart.value = 0
+        _lastUpdateTime.value = null
+        Log.d(TAG, "Reset step counter")
+    }
+
+    override fun onSensorChanged(event: SensorEvent) {
+        if (event.sensor.type != Sensor.TYPE_STEP_COUNTER) return
+
+        val totalSteps = event.values[0]
+
+        if (initialStepCount == null) {
+            // First reading - store as baseline
+            initialStepCount = totalSteps
+            Log.d(TAG, "Initial step count baseline: $totalSteps")
+        }
+
+        val stepsSinceStart = (totalSteps - (initialStepCount ?: totalSteps)).toInt()
+        _stepsSinceStart.value = stepsSinceStart
+        _lastUpdateTime.value = Instant.now()
+
+        Log.d(TAG, "Phone steps: $stepsSinceStart (total: $totalSteps, baseline: $initialStepCount)")
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {
+        Log.d(TAG, "Step counter accuracy changed: $accuracy")
+    }
+
+    fun isMonitoring(): Boolean = isMonitoring
+}

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -97,7 +97,12 @@ data class SensorServiceState(
     val hrvReliable: Boolean = false,         // Whether HRV measurement is reliable
     val rrIntervalCount: Int = 0,             // Number of RR intervals in buffer
     val hrChartHistory: List<ChartDataPoint> = emptyList(),   // 5 min HR history for chart
-    val hrvChartHistory: List<ChartDataPoint> = emptyList()   // 5 min HRV history for chart
+    val hrvChartHistory: List<ChartDataPoint> = emptyList(),  // 5 min HRV history for chart
+    // Phone step counter
+    val phoneStepCounterAvailable: Boolean = false,
+    val phoneStepCounterActive: Boolean = false,
+    val phoneStepsSinceStart: Int = 0,
+    val phoneStepLastUpdateTime: Instant? = null
 ) {
     // Convenience accessors for backward compatibility and easy access
     val hrDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.HEART_RATE }
@@ -197,6 +202,10 @@ class SensorService : Service() {
     private val connectionManagers = mutableMapOf<String, BleConnectionManager>()
     private val deviceJobs = mutableMapOf<String, List<Job>>()  // Jobs per device address
     private var syncJob: Job? = null
+    private var phoneStepJob: Job? = null
+
+    // Phone step counter
+    private var phoneStepCounter: PhoneStepCounter? = null
 
     private val sampleBuffer = mutableListOf<HeartRateSample>()
     private val cadenceSampleBuffer = mutableListOf<CadenceSample>()
@@ -204,7 +213,9 @@ class SensorService : Service() {
     private val hrChartBuffer = mutableListOf<ChartDataPoint>()
     private val hrvChartBuffer = mutableListOf<ChartDataPoint>()
     // Step buckets keyed by minute start time (epoch millis truncated to minute)
+    // Also used for phone step counter data
     private val stepBuckets = mutableMapOf<Long, MinuteStepBucket>()
+    private val phoneStepBuckets = mutableMapOf<Long, MinuteStepBucket>()
     private val bufferLock = Any()
 
     private val httpClient by lazy {
@@ -250,6 +261,12 @@ class SensorService : Service() {
             }
             ACTION_STOP -> {
                 stopSensorService()
+            }
+            ACTION_START_PHONE_STEPS -> {
+                startPhoneStepCounter()
+            }
+            ACTION_STOP_PHONE_STEPS -> {
+                stopPhoneStepCounter()
             }
         }
         return START_NOT_STICKY
@@ -306,11 +323,14 @@ class SensorService : Service() {
         val contentText = buildString {
             val hrText = state.currentHeartRate?.let { "HR: $it BPM" }
             val cadenceText = state.currentCadence?.let { "Cadence: $it spm • ${state.stepsSinceStart} steps" }
+            val phoneStepsText = if (state.phoneStepCounterActive) "Phone: ${state.phoneStepsSinceStart} steps" else null
 
             when {
                 hrText != null && cadenceText != null -> append("$hrText • $cadenceText")
+                hrText != null && phoneStepsText != null -> append("$hrText • $phoneStepsText")
                 hrText != null -> append(hrText)
                 cadenceText != null -> append(cadenceText)
+                phoneStepsText != null -> append(phoneStepsText)
                 state.hasConnectedDevices -> append("${state.connectedDevices.size} sensor(s) connected")
                 state.isConnecting -> append("Connecting...")
                 else -> append("Ready")
@@ -955,6 +975,93 @@ class SensorService : Service() {
         }
     }
 
+    private fun startPhoneStepCounter() {
+        Log.d(TAG, "Starting phone step counter")
+
+        // Create counter if needed
+        if (phoneStepCounter == null) {
+            phoneStepCounter = PhoneStepCounter(applicationContext)
+        }
+
+        val counter = phoneStepCounter!!
+
+        // Update availability state
+        updateState { it.copy(phoneStepCounterAvailable = counter.isAvailable.value) }
+
+        if (!counter.isAvailable.value) {
+            Log.w(TAG, "Phone step counter not available on this device")
+            return
+        }
+
+        // Start foreground if not already running
+        if (!_serviceState.value.isRunning) {
+            startForegroundWithNotification()
+        }
+
+        // Start monitoring
+        if (counter.startMonitoring()) {
+            updateState { it.copy(phoneStepCounterActive = true) }
+
+            // Collect step updates
+            phoneStepJob?.cancel()
+            phoneStepJob = serviceScope.launch {
+                counter.stepsSinceStart.collect { steps ->
+                    updateState { it.copy(phoneStepsSinceStart = steps) }
+
+                    // Accumulate into minute buckets for syncing
+                    val now = Instant.now()
+                    val minuteStartMs = now.toEpochMilli() - (now.toEpochMilli() % ONE_MINUTE_MS)
+
+                    synchronized(bufferLock) {
+                        val bucket = phoneStepBuckets.getOrPut(minuteStartMs) {
+                            MinuteStepBucket(minuteStart = Instant.ofEpochMilli(minuteStartMs))
+                        }
+                        // Phone step counter gives cumulative steps, so just store the latest value
+                        // The bucket will track the steps accumulated during this minute
+                        bucket.totalSteps = steps.toLong()
+                    }
+
+                    updateNotification()
+                }
+            }
+
+            // Also collect last update time
+            serviceScope.launch {
+                counter.lastUpdateTime.collect { time ->
+                    updateState { it.copy(phoneStepLastUpdateTime = time) }
+                }
+            }
+
+            Log.d(TAG, "Phone step counter started")
+        } else {
+            Log.e(TAG, "Failed to start phone step counter")
+        }
+    }
+
+    private fun stopPhoneStepCounter() {
+        Log.d(TAG, "Stopping phone step counter")
+        phoneStepJob?.cancel()
+        phoneStepJob = null
+        phoneStepCounter?.stopMonitoring()
+        updateState {
+            it.copy(
+                phoneStepCounterActive = false,
+                phoneStepsSinceStart = 0,
+                phoneStepLastUpdateTime = null
+            )
+        }
+        synchronized(bufferLock) {
+            phoneStepBuckets.clear()
+        }
+
+        // Stop service if nothing else is running
+        if (!_serviceState.value.hasConnectedDevices && !_serviceState.value.isConnecting) {
+            stopSensorService()
+        } else {
+            updateNotification()
+        }
+    }
+
     private fun stopSensorService() {
         Log.d(TAG, "Stopping service...")
         cleanup()
@@ -965,6 +1072,11 @@ class SensorService : Service() {
 
     private fun cleanup() {
         syncJob?.cancel()
+        phoneStepJob?.cancel()
+
+        // Stop phone step counter
+        phoneStepCounter?.stopMonitoring()
+        phoneStepCounter = null
 
         // Cancel all device jobs
         deviceJobs.values.forEach { jobs ->
@@ -984,6 +1096,7 @@ class SensorService : Service() {
             hrChartBuffer.clear()
             hrvChartBuffer.clear()
             stepBuckets.clear()
+            phoneStepBuckets.clear()
         }
     }
 
@@ -995,6 +1108,8 @@ class SensorService : Service() {
         const val ACTION_CONNECT = "net.aurboda.action.CONNECT_SENSOR"
         const val ACTION_DISCONNECT = "net.aurboda.action.DISCONNECT_SENSOR"
         const val ACTION_STOP = "net.aurboda.action.STOP_SENSOR_SERVICE"
+        const val ACTION_START_PHONE_STEPS = "net.aurboda.action.START_PHONE_STEPS"
+        const val ACTION_STOP_PHONE_STEPS = "net.aurboda.action.STOP_PHONE_STEPS"
         const val EXTRA_DEVICE_ADDRESS = "device_address"
 
         private val _serviceState = MutableStateFlow(SensorServiceState())
@@ -1019,6 +1134,20 @@ class SensorService : Service() {
         fun disconnectAll(context: Context) {
             val intent = Intent(context, SensorService::class.java).apply {
                 action = ACTION_DISCONNECT
+            }
+            context.startService(intent)
+        }
+
+        fun startPhoneStepCounter(context: Context) {
+            val intent = Intent(context, SensorService::class.java).apply {
+                action = ACTION_START_PHONE_STEPS
+            }
+            context.startForegroundService(intent)
+        }
+
+        fun stopPhoneStepCounter(context: Context) {
+            val intent = Intent(context, SensorService::class.java).apply {
+                action = ACTION_STOP_PHONE_STEPS
             }
             context.startService(intent)
         }

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -597,6 +597,7 @@ class SensorService : Service() {
         val hrSamplesToSync: List<HeartRateSample>
         val rrIntervalsForHrv: List<Int>
         val completedStepBuckets: List<MinuteStepBucket>
+        val completedPhoneStepBuckets: List<MinuteStepBucket>
 
         synchronized(bufferLock) {
             hrSamplesToSync = sampleBuffer.toList()
@@ -607,6 +608,7 @@ class SensorService : Service() {
             val nowMs = System.currentTimeMillis()
             val currentMinuteStartMs = nowMs - (nowMs % ONE_MINUTE_MS)
 
+            // BLE foot pod step buckets
             completedStepBuckets = stepBuckets.entries
                 .filter { it.key < currentMinuteStartMs && it.value.totalSteps > 0 }
                 .map { it.value }
@@ -617,10 +619,21 @@ class SensorService : Service() {
                 stepBuckets.remove(bucket.minuteStart.toEpochMilli())
             }
 
+            // Phone step counter buckets
+            completedPhoneStepBuckets = phoneStepBuckets.entries
+                .filter { it.key < currentMinuteStartMs && it.value.totalSteps > 0 }
+                .map { it.value }
+                .sortedBy { it.minuteStart }
+
+            // Remove completed phone step buckets
+            completedPhoneStepBuckets.forEach { bucket ->
+                phoneStepBuckets.remove(bucket.minuteStart.toEpochMilli())
+            }
+
             // Clear raw cadence samples (they've been accumulated into buckets)
             cadenceSampleBuffer.clear()
 
-            if (hrSamplesToSync.isEmpty() && completedStepBuckets.isEmpty()) return
+            if (hrSamplesToSync.isEmpty() && completedStepBuckets.isEmpty() && completedPhoneStepBuckets.isEmpty()) return
             sampleBuffer.clear()
             updateState { it.copy(pendingSamples = 0, pendingCadenceSamples = 0) }
         }
@@ -639,11 +652,11 @@ class SensorService : Service() {
             }
         }
 
-        // Sync completed minute step buckets if any
+        // Sync completed minute step buckets if any (from BLE foot pod)
         if (completedStepBuckets.isNotEmpty()) {
             val totalSteps = completedStepBuckets.sumOf { it.totalSteps }
-            Log.d(TAG, "Syncing ${completedStepBuckets.size} minute bucket(s) with $totalSteps total steps")
-            val backendSuccess = syncStepBucketsToBackend(completedStepBuckets)
+            Log.d(TAG, "Syncing ${completedStepBuckets.size} BLE step bucket(s) with $totalSteps total steps")
+            val backendSuccess = syncStepBucketsToBackend(completedStepBuckets, "ble-footpod")
             if (!backendSuccess) {
                 // Re-add buckets on failure
                 synchronized(bufferLock) {
@@ -653,6 +666,23 @@ class SensorService : Service() {
                 }
             } else {
                 writeStepBucketsToHealthConnect(completedStepBuckets)
+            }
+        }
+
+        // Sync completed phone step buckets if any
+        if (completedPhoneStepBuckets.isNotEmpty()) {
+            val totalSteps = completedPhoneStepBuckets.sumOf { it.totalSteps }
+            Log.d(TAG, "Syncing ${completedPhoneStepBuckets.size} phone step bucket(s) with $totalSteps total steps")
+            val backendSuccess = syncStepBucketsToBackend(completedPhoneStepBuckets, "phone")
+            if (!backendSuccess) {
+                // Re-add buckets on failure
+                synchronized(bufferLock) {
+                    completedPhoneStepBuckets.forEach { bucket ->
+                        phoneStepBuckets[bucket.minuteStart.toEpochMilli()] = bucket
+                    }
+                }
+            } else {
+                writeStepBucketsToHealthConnect(completedPhoneStepBuckets)
             }
         }
 
@@ -805,7 +835,7 @@ class SensorService : Service() {
      * Sync step buckets to backend. Each bucket represents one clock minute with
      * timestamps aligned to minute boundaries (e.g., 11:46:00.000 - 11:46:59.999).
      */
-    private suspend fun syncStepBucketsToBackend(buckets: List<MinuteStepBucket>): Boolean {
+    private suspend fun syncStepBucketsToBackend(buckets: List<MinuteStepBucket>, source: String = "ble-footpod"): Boolean {
         val credentials = CredentialsManager.getCredentials(this) ?: run {
             Log.w(TAG, "No credentials, skipping backend sync")
             return true // Don't block on missing credentials
@@ -813,21 +843,30 @@ class SensorService : Service() {
 
         if (buckets.isEmpty()) return true
 
-        // Get device info from RSC device if available
-        val rscManager = connectionManagers.values.find {
-            it.connectedDeviceInfo.value?.type == SensorType.RUNNING_SPEED_CADENCE
-        }
-        val deviceInfo = rscManager?.connectedDeviceInfo?.value?.let { device ->
-            LiveDeviceInfo(
-                type = 4, // TYPE_WATCH or foot pod
-                model = device.name
+        // Get device info based on source
+        val deviceInfo = when (source) {
+            "phone" -> LiveDeviceInfo(
+                type = 1, // TYPE_PHONE
+                model = android.os.Build.MODEL
             )
+            else -> {
+                // BLE foot pod - get device info from RSC device if available
+                val rscManager = connectionManagers.values.find {
+                    it.connectedDeviceInfo.value?.type == SensorType.RUNNING_SPEED_CADENCE
+                }
+                rscManager?.connectedDeviceInfo?.value?.let { device ->
+                    LiveDeviceInfo(
+                        type = 4, // TYPE_WATCH or foot pod
+                        model = device.name
+                    )
+                }
+            }
         }
 
         // Create one record per minute bucket with clock-minute-aligned timestamps
         val records = buckets.map { bucket ->
             val minuteEnd = bucket.minuteStart.plusMillis(ONE_MINUTE_MS - 1) // 11:46:59.999
-            val recordId = "live-steps-${bucket.minuteStart.epochSecond}"
+            val recordId = "live-steps-$source-${bucket.minuteStart.epochSecond}"
 
             LiveStepsRecord(
                 startTime = bucket.minuteStart.toString(),
@@ -1002,9 +1041,17 @@ class SensorService : Service() {
         if (counter.startMonitoring()) {
             updateState { it.copy(phoneStepCounterActive = true) }
 
+            // Start sync loop if not already running
+            if (syncJob == null || syncJob?.isActive != true) {
+                startSyncLoop()
+            }
+
             // Collect step updates
             phoneStepJob?.cancel()
             phoneStepJob = serviceScope.launch {
+                var lastStepCount = 0
+                var lastMinuteStartMs = 0L
+
                 counter.stepsSinceStart.collect { steps ->
                     updateState { it.copy(phoneStepsSinceStart = steps) }
 
@@ -1013,12 +1060,22 @@ class SensorService : Service() {
                     val minuteStartMs = now.toEpochMilli() - (now.toEpochMilli() % ONE_MINUTE_MS)
 
                     synchronized(bufferLock) {
-                        val bucket = phoneStepBuckets.getOrPut(minuteStartMs) {
-                            MinuteStepBucket(minuteStart = Instant.ofEpochMilli(minuteStartMs))
+                        // Calculate delta since last update
+                        val stepsDelta = steps - lastStepCount
+
+                        if (stepsDelta > 0) {
+                            val bucket = phoneStepBuckets.getOrPut(minuteStartMs) {
+                                MinuteStepBucket(minuteStart = Instant.ofEpochMilli(minuteStartMs))
+                            }
+
+                            // If we're in a new minute, add the delta to the new bucket
+                            // If same minute, add to existing bucket
+                            bucket.totalSteps += stepsDelta
+                            Log.d(TAG, "Phone steps: +$stepsDelta in bucket ${bucket.minuteStart}, total in bucket: ${bucket.totalSteps}")
                         }
-                        // Phone step counter gives cumulative steps, so just store the latest value
-                        // The bucket will track the steps accumulated during this minute
-                        bucket.totalSteps = steps.toLong()
+
+                        lastStepCount = steps
+                        lastMinuteStartMs = minuteStartMs
                     }
 
                     updateNotification()

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -82,6 +82,24 @@ fun LiveScreen(
     var bleEnabled by remember { mutableStateOf(isBleEnabled(context)) }
     val bleSupported = remember { isBleSupported(context) }
 
+    // Activity recognition permission for phone step counter (Android 10+)
+    var hasActivityRecognitionPermission by remember {
+        mutableStateOf(
+            androidx.core.content.ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACTIVITY_RECOGNITION
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        )
+    }
+    val activityRecognitionPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        hasActivityRecognitionPermission = granted
+        if (granted) {
+            SensorService.startPhoneStepCounter(context)
+        }
+    }
+
     // Health Connect client and write permission state
     val healthConnectClient = remember { HealthConnectClient.getOrCreate(context) }
     var hasHrWritePermission by remember { mutableStateOf<Boolean?>(null) }
@@ -310,6 +328,22 @@ fun LiveScreen(
             }
             Spacer(modifier = Modifier.height(16.dp))
         }
+
+        // Phone Step Counter Section
+        PhoneStepCounterCard(
+            isActive = serviceState.phoneStepCounterActive,
+            stepCount = serviceState.phoneStepsSinceStart,
+            lastUpdateTime = serviceState.phoneStepLastUpdateTime,
+            onStart = {
+                if (hasActivityRecognitionPermission) {
+                    SensorService.startPhoneStepCounter(context)
+                } else {
+                    activityRecognitionPermissionLauncher.launch(Manifest.permission.ACTIVITY_RECOGNITION)
+                }
+            },
+            onStop = { SensorService.stopPhoneStepCounter(context) }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
 
         // Scanner Section - always visible to allow adding more devices
         ScannerSection(
@@ -543,6 +577,103 @@ private fun ConnectedDeviceCard(
             }
         }  // Column
         }  // Box
+    }
+}
+
+@Composable
+private fun PhoneStepCounterCard(
+    isActive: Boolean,
+    stepCount: Int,
+    lastUpdateTime: Instant?,
+    onStart: () -> Unit,
+    onStop: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isActive)
+                MaterialTheme.colorScheme.tertiaryContainer
+            else
+                MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PlayArrow,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Phone Step Counter",
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+
+            if (isActive) {
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    text = stepCount.toString(),
+                    fontSize = 48.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+                Text(
+                    text = "steps",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                )
+
+                // Data freshness indicator
+                if (lastUpdateTime != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    val now = remember { mutableStateOf(Instant.now()) }
+                    LaunchedEffect(Unit) {
+                        while (true) {
+                            now.value = Instant.now()
+                            kotlinx.coroutines.delay(1000)
+                        }
+                    }
+                    val staleness = Duration.between(lastUpdateTime, now.value).toMillis() / 1000.0
+                    val stalenessText = when {
+                        staleness < 1 -> "updating now"
+                        staleness < 60 -> "${staleness.toInt()}s ago"
+                        else -> "${(staleness / 60).toInt()}m ago"
+                    }
+                    Text(
+                        text = "Last update: $stalenessText",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedButton(onClick = onStop) {
+                    Text("Stop Counting")
+                }
+            } else {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Use your phone's built-in step sensor",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = onStart) {
+                    Text("Start Counting")
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **PhoneStepCounter class**: Uses Android's `TYPE_STEP_COUNTER` sensor for reliable step counting
- **SensorService integration**: Start/stop actions for phone step counter
- **LiveScreen UI**: Card to start/stop phone step counting with live step count display
- **Permission handling**: Requests `ACTIVITY_RECOGNITION` permission on Android 10+
- **Data accumulation**: Steps accumulated into minute buckets for backend syncing

## Context

The Zwift RunPod (and similar budget BLE foot pods) can have unreliable BLE connectivity, causing missing data or requiring specific motion to trigger. The phone's built-in step counter sensor provides a reliable alternative that works well for treadmill running and walking.

## UI

The phone step counter appears as a card in the Live screen:
- Inactive: Shows "Use your phone's built-in step sensor" with a Start button
- Active: Shows current step count, last update time, and a Stop button

## Test plan

- [ ] Verify phone step counter card appears on Live screen
- [ ] Tap "Start Counting" - should request ACTIVITY_RECOGNITION permission if not granted
- [ ] After permission granted, step counter should start
- [ ] Walk around - step count should increment
- [ ] Verify "last update" time shows when data is received
- [ ] Tap "Stop Counting" - should stop and reset count
- [ ] Notification should show phone step count when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)