### PR TITLE
Extract HR and HRV from Oura meditation sessions to time_series

### DIFF
--- a/apps/backend/src/oura-sync.test.ts
+++ b/apps/backend/src/oura-sync.test.ts
@@ -357,11 +357,11 @@ describe('processOuraData', () => {
       const data = [
         {
           endTime: new Date('2025-01-01T10:30:00Z'),
-          heartRate: { items: [60, 62, 58] },
-          hrv: { items: [50, 55] },
+          heartRate: { interval: 5, items: [60, 62, 58] },
+          hrv: { interval: 5, items: [50, 55] },
           id: 'sess-1',
           mood: 'good',
-          motion: { items: [1, 0, 2] },
+          motion: { interval: 5, items: [1, 0, 2] },
           startTime: new Date('2025-01-01T10:00:00Z'),
           type: 'meditation',
         },
@@ -391,6 +391,117 @@ describe('processOuraData', () => {
         startTime: new Date('2025-01-01T10:00:00Z'),
         title: 'meditation',
       })
+    })
+
+    test('extracts heart rate samples to time series', async () => {
+      const data = [
+        {
+          endTime: new Date('2025-01-01T10:00:15Z'),
+          heartRate: { interval: 5, items: [60, 62, 58] },
+          hrv: undefined,
+          id: 'sess-hr',
+          mood: 'good',
+          motion: undefined,
+          startTime: new Date('2025-01-01T10:00:00Z'),
+          type: 'meditation',
+        },
+      ]
+
+      await processOuraData(user, 'sessions', data)
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:00Z'), value: 60 },
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:05Z'), value: 62 },
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:10Z'), value: 58 },
+      ])
+    })
+
+    test('extracts HRV samples to time series', async () => {
+      const data = [
+        {
+          endTime: new Date('2025-01-01T10:00:10Z'),
+          heartRate: undefined,
+          hrv: { interval: 5, items: [50, 55] },
+          id: 'sess-hrv',
+          mood: 'good',
+          motion: undefined,
+          startTime: new Date('2025-01-01T10:00:00Z'),
+          type: 'meditation',
+        },
+      ]
+
+      await processOuraData(user, 'sessions', data)
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        { metric: 'hrv_rmssd', source: 'oura', time: new Date('2025-01-01T10:00:00Z'), value: 50 },
+        { metric: 'hrv_rmssd', source: 'oura', time: new Date('2025-01-01T10:00:05Z'), value: 55 },
+      ])
+    })
+
+    test('extracts both HR and HRV samples together', async () => {
+      const data = [
+        {
+          endTime: new Date('2025-01-01T10:00:10Z'),
+          heartRate: { interval: 5, items: [60, 62] },
+          hrv: { interval: 5, items: [50, 55] },
+          id: 'sess-both',
+          mood: 'good',
+          motion: undefined,
+          startTime: new Date('2025-01-01T10:00:00Z'),
+          type: 'meditation',
+        },
+      ]
+
+      await processOuraData(user, 'sessions', data)
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:00Z'), value: 60 },
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:05Z'), value: 62 },
+        { metric: 'hrv_rmssd', source: 'oura', time: new Date('2025-01-01T10:00:00Z'), value: 50 },
+        { metric: 'hrv_rmssd', source: 'oura', time: new Date('2025-01-01T10:00:05Z'), value: 55 },
+      ])
+    })
+
+    test('skips null values in HR and HRV samples', async () => {
+      const data = [
+        {
+          endTime: new Date('2025-01-01T10:00:15Z'),
+          heartRate: { interval: 5, items: [60, null, 58] },
+          hrv: { interval: 5, items: [null, 55, null] },
+          id: 'sess-nulls',
+          mood: 'good',
+          motion: undefined,
+          startTime: new Date('2025-01-01T10:00:00Z'),
+          type: 'meditation',
+        },
+      ]
+
+      await processOuraData(user, 'sessions', data)
+
+      expect(db.insertTimeSeries).toHaveBeenCalledWith(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:00Z'), value: 60 },
+        { metric: 'heart_rate', source: 'oura', time: new Date('2025-01-01T10:00:10Z'), value: 58 },
+        { metric: 'hrv_rmssd', source: 'oura', time: new Date('2025-01-01T10:00:05Z'), value: 55 },
+      ])
+    })
+
+    test('does not call insertTimeSeries when no HR/HRV data', async () => {
+      const data = [
+        {
+          endTime: new Date('2025-01-01T10:30:00Z'),
+          heartRate: undefined,
+          hrv: undefined,
+          id: 'sess-no-data',
+          mood: 'good',
+          motion: undefined,
+          startTime: new Date('2025-01-01T10:00:00Z'),
+          type: 'meditation',
+        },
+      ]
+
+      await processOuraData(user, 'sessions', data)
+
+      expect(db.insertTimeSeries).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -73,14 +73,20 @@ interface OuraSleep extends OuraDailyRecord {
   }
 }
 
+/** Oura interval-based time series data (HR, HRV, motion) */
+interface OuraIntervalData {
+  interval: number // interval in seconds
+  items: (number | null)[]
+}
+
 interface OuraSession {
   id: string
   startTime: Date
   endTime: Date
   type: string
   mood?: string
-  heartRate?: unknown
-  hrv?: unknown
+  heartRate?: OuraIntervalData
+  hrv?: OuraIntervalData
   motion?: unknown
 }
 
@@ -276,6 +282,34 @@ const processDailySleep = async (user: string, data: OuraSleep[]) => {
 }
 
 /**
+ * Extract time series points from Oura interval-based data.
+ */
+const extractIntervalPoints = (
+  startTime: Date,
+  intervalData: OuraIntervalData | undefined,
+  metric: MetricType,
+): TimeSeriesPoint[] => {
+  if (!intervalData?.items) return []
+
+  const points: TimeSeriesPoint[] = []
+  const intervalMs = intervalData.interval * 1000
+
+  for (let i = 0; i < intervalData.items.length; i++) {
+    const value = intervalData.items[i]
+    if (value !== null) {
+      points.push({
+        metric,
+        source: 'oura',
+        time: new Date(startTime.getTime() + i * intervalMs),
+        value,
+      })
+    }
+  }
+
+  return points
+}
+
+/**
  * Process Oura session data (meditation).
  */
 const processSessions = async (user: string, data: OuraSession[]) => {
@@ -302,6 +336,15 @@ const processSessions = async (user: string, data: OuraSession[]) => {
       startTime: record.startTime,
       title: record.type,
     })
+
+    // Extract HR and HRV samples to time series
+    const hrPoints = extractIntervalPoints(record.startTime, record.heartRate, 'heart_rate')
+    const hrvPoints = extractIntervalPoints(record.startTime, record.hrv, 'hrv_rmssd')
+    const timeSeriesPoints = [...hrPoints, ...hrvPoints]
+
+    if (timeSeriesPoints.length > 0) {
+      await insertTimeSeries(user, timeSeriesPoints)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Oura meditation sessions contain interval-based HR and HRV data that was previously only stored in the activity's JSON data field
- Now extracts these samples and stores them in the `time_series` table
- Makes Oura meditation HR/HRV queryable alongside Health Connect data via the same metrics API

## Test plan
- [x] Unit tests for HR extraction to time_series
- [x] Unit tests for HRV extraction to time_series
- [x] Unit tests for combined HR + HRV extraction
- [x] Unit tests for handling null values in sample arrays
- [x] Unit tests for sessions without HR/HRV data
- [ ] Manual test: sync Oura data and verify meditation HR/HRV appears in time_series queries

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)