### PR TITLE
Add configurable goals with rolling window and progress tracking

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/DataApi.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DataApi.kt
@@ -42,10 +42,38 @@ data class HrZoneThresholds(
 )
 
 @Serializable
+data class Goal(
+    val id: String,
+    val metric: String,
+    val min: Double? = null,
+    val max: Double? = null,
+    val window: String = "7d"
+)
+
+@Serializable
+data class GoalProgress(
+    val id: String,
+    val metric: String,
+    val min: Double? = null,
+    val max: Double? = null,
+    val window: String,
+    val current: Double,
+    @SerialName("losingTomorrow") val losingTomorrow: Double,
+    val unit: String
+)
+
+@Serializable
+data class GoalsProgressResponse(
+    val success: Boolean,
+    val goals: List<GoalProgress>
+)
+
+@Serializable
 data class UserSettingsResponse(
     val success: Boolean,
     @SerialName("hr_zone_start") val hrZoneStart: HrZoneThresholds? = null,
-    @SerialName("birth_date") val birthDate: String? = null
+    @SerialName("birth_date") val birthDate: String? = null,
+    val goals: List<Goal>? = null
 )
 
 sealed class DataResult<out T> {
@@ -109,6 +137,34 @@ suspend fun fetchUserSettings(
         }
     } catch (e: Exception) {
         Log.e("DataApi", "Error fetching user settings", e)
+        DataResult.Error(e.message ?: "Unknown error")
+    }
+}
+
+suspend fun fetchGoalsProgress(
+    httpClient: HttpClient,
+    serverUrl: String,
+    authToken: String
+): DataResult<GoalsProgressResponse> {
+    return try {
+        val url = "$serverUrl/goals/progress"
+        Log.d("DataApi", "Fetching goals progress from: $url")
+
+        val response = httpClient.get(url) {
+            headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        }
+
+        if (response.status == HttpStatusCode.OK) {
+            val body = response.bodyAsText()
+            Log.d("DataApi", "Goals progress response: $body")
+            val parsed = appJson.decodeFromString<GoalsProgressResponse>(body)
+            DataResult.Success(parsed)
+        } else {
+            Log.e("DataApi", "Goals progress error: ${response.status}")
+            DataResult.Error("Server returned ${response.status}")
+        }
+    } catch (e: Exception) {
+        Log.e("DataApi", "Error fetching goals progress", e)
         DataResult.Error(e.message ?: "Unknown error")
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -16,23 +16,29 @@ import kotlinx.coroutines.launch
 import net.aurboda.CredentialsManager
 import net.aurboda.DataResult
 import net.aurboda.R
-import net.aurboda.fetchPeriodSummary
-import net.aurboda.findMetricTimeSeconds
+import net.aurboda.fetchGoalsProgress
 import net.aurboda.formatZoneTime
+import net.aurboda.GoalProgress
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import net.aurboda.appJson
-import java.time.LocalDate
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 
 private const val TAG = "HrZoneWidgetProvider"
 
-// Widget targets: Zone 2 min 150, max 200; Zone 5 min 5, max 10
-private const val ZONE_2_TARGET_MIN = 150
-private const val ZONE_5_TARGET_MIN = 5
+// Friendly names for metrics
+private val metricLabels = mapOf(
+    "hr_zone_0_sec" to "Zone 0",
+    "hr_zone_1_sec" to "Zone 1",
+    "hr_zone_2_sec" to "Zone 2",
+    "hr_zone_3_sec" to "Zone 3",
+    "hr_zone_4_sec" to "Zone 4",
+    "hr_zone_5_sec" to "Zone 5",
+    "steps" to "Steps",
+    "distance" to "Distance",
+    "calories_active" to "Calories"
+)
 
 class HrZoneWidgetProvider : AppWidgetProvider() {
 
@@ -84,7 +90,7 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
             val credentials = CredentialsManager.getCredentials(context)
             if (credentials == null) {
                 Log.w(TAG, "No credentials, showing empty widget")
-                setWidgetData(views, 0.0, 0.0)
+                setEmptyWidget(views)
                 appWidgetManager.updateAppWidget(appWidgetId, views)
                 return@launch
             }
@@ -94,12 +100,26 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
             }
 
             try {
-                val hrZoneData = fetchHrZoneData(httpClient, credentials)
-                setWidgetData(views, hrZoneData.zone2Seconds, hrZoneData.zone5Seconds)
+                val goalsResult = fetchGoalsProgress(
+                    httpClient,
+                    credentials.apiUrl,
+                    credentials.authToken
+                )
+
+                when (goalsResult) {
+                    is DataResult.Success -> {
+                        val goals = goalsResult.data.goals
+                        Log.d(TAG, "Fetched ${goals.size} goals")
+                        setWidgetData(views, goals)
+                    }
+                    is DataResult.Error -> {
+                        Log.e(TAG, "Error fetching goals: ${goalsResult.message}")
+                        setEmptyWidget(views)
+                    }
+                }
             } catch (e: Exception) {
-                Log.e(TAG, "Error fetching HR zone data", e)
-                // Keep existing data or show zeros
-                setWidgetData(views, 0.0, 0.0)
+                Log.e(TAG, "Error fetching goal data", e)
+                setEmptyWidget(views)
             } finally {
                 httpClient.close()
             }
@@ -108,60 +128,99 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
         }
     }
 
-    private suspend fun fetchHrZoneData(
-        httpClient: HttpClient,
-        credentials: CredentialsManager.Credentials
-    ): HrZoneData {
-        val today = LocalDate.now()
-        val weekAgo = today.minusDays(6) // 7 days including today
+    private fun setEmptyWidget(views: RemoteViews) {
+        views.setTextViewText(R.id.zone2_label, "Zone 2")
+        views.setTextViewText(R.id.zone2_time, "-- min")
+        views.setTextViewText(R.id.zone2_losing, "")
+        views.setProgressBar(R.id.zone2_progress, 100, 0, false)
 
-        val formatter = DateTimeFormatter.ISO_INSTANT
-        val startInstant = weekAgo.atStartOfDay().toInstant(ZoneOffset.UTC)
-        val endInstant = today.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+        views.setTextViewText(R.id.zone5_label, "Zone 5")
+        views.setTextViewText(R.id.zone5_time, "-- min")
+        views.setTextViewText(R.id.zone5_losing, "")
+        views.setProgressBar(R.id.zone5_progress, 100, 0, false)
+    }
 
-        val start = formatter.format(startInstant)
-        val end = formatter.format(endInstant)
+    private fun setWidgetData(views: RemoteViews, goals: List<GoalProgress>) {
+        // Find Zone 2 and Zone 5 goals, or use first two goals
+        val zone2Goal = goals.find { it.metric == "hr_zone_2_sec" }
+        val zone5Goal = goals.find { it.metric == "hr_zone_5_sec" }
 
-        val metrics = listOf("hr_zone_2_sec", "hr_zone_5_sec")
+        // If specific zones not found, use first two goals
+        val goal1 = zone2Goal ?: goals.getOrNull(0)
+        val goal2 = zone5Goal ?: goals.getOrNull(1)
 
-        val result = fetchPeriodSummary(
-            httpClient,
-            credentials.apiUrl,
-            credentials.authToken,
-            start,
-            end,
-            metrics
-        )
+        // Set Goal 1 (Zone 2 slot)
+        if (goal1 != null) {
+            setGoalView(
+                views,
+                goal1,
+                R.id.zone2_label,
+                R.id.zone2_time,
+                R.id.zone2_losing,
+                R.id.zone2_progress
+            )
+        } else {
+            views.setTextViewText(R.id.zone2_label, "No Goal")
+            views.setTextViewText(R.id.zone2_time, "--")
+            views.setTextViewText(R.id.zone2_losing, "")
+            views.setProgressBar(R.id.zone2_progress, 100, 0, false)
+        }
 
-        return when (result) {
-            is DataResult.Success -> {
-                val zone2Seconds = findMetricTimeSeconds(result.data.metrics, "hr_zone_2_sec")
-                val zone5Seconds = findMetricTimeSeconds(result.data.metrics, "hr_zone_5_sec")
-                Log.d(TAG, "Fetched HR zone data: zone2=$zone2Seconds sec, zone5=$zone5Seconds sec")
-                HrZoneData(zone2Seconds, zone5Seconds)
-            }
-            is DataResult.Error -> {
-                Log.e(TAG, "Error fetching period summary: ${result.message}")
-                HrZoneData(0.0, 0.0)
-            }
+        // Set Goal 2 (Zone 5 slot)
+        if (goal2 != null) {
+            setGoalView(
+                views,
+                goal2,
+                R.id.zone5_label,
+                R.id.zone5_time,
+                R.id.zone5_losing,
+                R.id.zone5_progress
+            )
+        } else {
+            views.setTextViewText(R.id.zone5_label, "No Goal")
+            views.setTextViewText(R.id.zone5_time, "--")
+            views.setTextViewText(R.id.zone5_losing, "")
+            views.setProgressBar(R.id.zone5_progress, 100, 0, false)
         }
     }
 
-    private fun setWidgetData(views: RemoteViews, zone2Seconds: Double, zone5Seconds: Double) {
-        val zone2Minutes = (zone2Seconds / 60.0).toInt()
-        val zone5Minutes = (zone5Seconds / 60.0).toInt()
+    private fun setGoalView(
+        views: RemoteViews,
+        goal: GoalProgress,
+        labelId: Int,
+        timeId: Int,
+        losingId: Int,
+        progressId: Int
+    ) {
+        // Set label
+        val label = metricLabels[goal.metric] ?: goal.metric
+        views.setTextViewText(labelId, label)
 
-        // Calculate progress as percentage (0-100)
-        val zone2Progress = ((zone2Minutes.toFloat() / ZONE_2_TARGET_MIN) * 100).coerceIn(0f, 100f).toInt()
-        val zone5Progress = ((zone5Minutes.toFloat() / ZONE_5_TARGET_MIN) * 100).coerceIn(0f, 100f).toInt()
+        // Set current value
+        val valueText = formatGoalValue(goal.metric, goal.current, goal.unit)
+        views.setTextViewText(timeId, valueText)
 
-        // Set time text
-        views.setTextViewText(R.id.zone2_time, formatZoneTime(zone2Seconds))
-        views.setTextViewText(R.id.zone5_time, formatZoneTime(zone5Seconds))
+        // Set "losing tomorrow" text
+        if (goal.losingTomorrow > 0) {
+            val losingText = "(-${formatGoalValue(goal.metric, goal.losingTomorrow, goal.unit)} tomorrow)"
+            views.setTextViewText(losingId, losingText)
+        } else {
+            views.setTextViewText(losingId, "")
+        }
 
-        // Set progress bar values
-        views.setProgressBar(R.id.zone2_progress, 100, zone2Progress, false)
-        views.setProgressBar(R.id.zone5_progress, 100, zone5Progress, false)
+        // Calculate progress percentage
+        val target = goal.max ?: goal.min ?: 1.0
+        val progress = ((goal.current / target) * 100).coerceIn(0.0, 100.0).toInt()
+        views.setProgressBar(progressId, 100, progress, false)
+    }
+
+    private fun formatGoalValue(metric: String, value: Double, unit: String): String {
+        return when (unit) {
+            "sec", "seconds" -> formatZoneTime(value)
+            "count" -> value.toLong().toString()
+            "m" -> "${(value / 1000).toInt()} km"
+            else -> "${value.toInt()} $unit"
+        }
     }
 
     companion object {
@@ -179,8 +238,3 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
         }
     }
 }
-
-private data class HrZoneData(
-    val zone2Seconds: Double,
-    val zone5Seconds: Double
-)

--- a/apps/android/app/src/main/res/layout/widget_hr_zones.xml
+++ b/apps/android/app/src/main/res/layout/widget_hr_zones.xml
@@ -7,7 +7,7 @@
     android:padding="8dp"
     android:background="@drawable/widget_background">
 
-    <!-- Zone 2 (Aerobic - Green) -->
+    <!-- Goal 1 (Zone 2 by default - Green) -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -23,12 +23,22 @@
 
             <TextView
                 android:id="@+id/zone2_label"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 android:text="Zone 2"
                 android:textSize="12sp"
                 android:textColor="#FFFFFFFF" />
+
+            <TextView
+                android:id="@+id/zone2_losing"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text=""
+                android:textSize="10sp"
+                android:textColor="#88FFFFFF"
+                android:paddingStart="8dp"
+                android:gravity="center" />
 
             <TextView
                 android:id="@+id/zone2_time"
@@ -50,7 +60,7 @@
             android:progressDrawable="@drawable/progress_bar_zone2_drawable" />
     </LinearLayout>
 
-    <!-- Zone 5 (Max effort - Red) -->
+    <!-- Goal 2 (Zone 5 by default - Red) -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -66,12 +76,22 @@
 
             <TextView
                 android:id="@+id/zone5_label"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 android:text="Zone 5"
                 android:textSize="12sp"
                 android:textColor="#FFFFFFFF" />
+
+            <TextView
+                android:id="@+id/zone5_losing"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text=""
+                android:textSize="10sp"
+                android:textColor="#88FFFFFF"
+                android:paddingStart="8dp"
+                android:gravity="center" />
 
             <TextView
                 android:id="@+id/zone5_time"

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -18,6 +18,7 @@ import {
   type DetectedLocationsQuery,
   detectedLocationsQuerySchema,
   type DetectedLocationsResponse,
+  type GoalsProgressResponse,
   type LocationsQuery,
   locationsQuerySchema,
   type LocationsResponse,
@@ -74,6 +75,7 @@ import { isValidMetric, MetricType, validMetrics } from './schema'
 import { createDetectionTrigger, DetectionTrigger } from './services/detection-trigger'
 import { runDetectionForUser } from './services/detection-worker'
 import { createGeocodeQueue, GeocodeQueue } from './services/geocode-queue'
+import { getGoalsProgress } from './services/goals'
 import {
   deleteNamedLocation,
   getDetectedLocations,
@@ -609,6 +611,16 @@ const main = async () => {
 
       const result = await addMetric(user, { metric, time: measurementTime, value })
       res.json(result)
+    },
+  )
+
+  // GET /goals/progress - Get progress toward all user goals
+  httpd.get<Record<string, never>, GoalsProgressResponse>(
+    '/goals/progress',
+    authMiddleware,
+    async (req, res) => {
+      const goals = await getGoalsProgress(req.user!)
+      res.json({ goals, success: true })
     },
   )
 

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -287,6 +287,7 @@ export interface DailyMetricAggregate {
   date: string
   metric: MetricType
   avg: number
+  sum: number
 }
 
 export const getDailyAggregates = async (
@@ -302,7 +303,8 @@ export const getDailyAggregates = async (
     `SELECT
        DATE(time) as date,
        metric,
-       AVG(value) as avg
+       AVG(value) as avg,
+       SUM(value) as sum
      FROM time_series
      WHERE metric = ANY($1) AND time >= $2 AND time <= $3
      GROUP BY DATE(time), metric
@@ -314,6 +316,7 @@ export const getDailyAggregates = async (
     avg: Number(row.avg),
     date: row.date.toISOString().split('T')[0],
     metric: row.metric as MetricType,
+    sum: Number(row.sum),
   }))
 }
 

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -23,6 +23,7 @@ import { DEFAULT_SESSION_INACTIVITY_MS, McpSessionStore } from './mcp-session-st
 import { ouraClient } from './oura'
 import { syncAllOuraData } from './oura-sync'
 import { syncRescueTimeData } from './rescuetime-sync'
+import { getGoalsProgress } from './services/goals'
 import {
   deleteNamedLocation,
   getDetectedLocations,
@@ -492,6 +493,17 @@ export function createMcpRouter(
           hrZoneStart: hr_zone_start,
         })
         return jsonResponse(result)
+      },
+    )
+
+    // Tool: get_goal_progress
+    server.tool(
+      'get_goal_progress',
+      'Get progress toward all user goals. Returns current value, min/max targets, and how much will be lost when the oldest day exits the rolling window.',
+      {},
+      async () => {
+        const goals = await getGoalsProgress(user)
+        return jsonResponse({ goals, success: true })
       },
     )
 

--- a/apps/backend/src/services/goals.ts
+++ b/apps/backend/src/services/goals.ts
@@ -1,0 +1,81 @@
+/**
+ * Goals service for calculating progress toward user-defined goals.
+ */
+
+import { metricUnits, parseDuration, type GoalProgress, type MetricType } from '@aurboda/api-spec'
+import { getDailyAggregates, getTimeSeries } from '../db'
+import { computeHrZoneSecs, getEffectiveGoals, getEffectiveHrZones, getSettings } from './settings'
+
+/**
+ * Calculate the sum of a metric over a time range.
+ * Handles HR zone metrics specially (computed from heart_rate).
+ */
+const getMetricSum = async (user: string, metric: MetricType, start: Date, end: Date): Promise<number> => {
+  // HR zone metrics need to be computed from heart rate data
+  if (metric.startsWith('hr_zone_')) {
+    const [hrData, { zones: hrZones }] = await Promise.all([
+      getTimeSeries(user, 'heart_rate', start, end),
+      getEffectiveHrZones(user),
+    ])
+    const zoneSecs = computeHrZoneSecs(hrData, hrZones)
+    const zoneIndex = parseInt(metric.replace('hr_zone_', '').replace('_sec', ''), 10) as
+      | 0
+      | 1
+      | 2
+      | 3
+      | 4
+      | 5
+    return zoneSecs[zoneIndex]
+  }
+
+  // For regular metrics, use daily aggregates and sum them
+  const dailyData = await getDailyAggregates(user, [metric], start, end)
+  return dailyData.reduce((sum, day) => sum + day.sum, 0)
+}
+
+/**
+ * Get progress for all user goals.
+ * Returns current value and "losing tomorrow" value for each goal.
+ */
+export const getGoalsProgress = async (user: string): Promise<GoalProgress[]> => {
+  const settings = await getSettings(user)
+  const goals = getEffectiveGoals(settings)
+
+  if (goals.length === 0) {
+    return []
+  }
+
+  const now = new Date()
+  const results: GoalProgress[] = []
+
+  for (const goal of goals) {
+    const windowMs = parseDuration(goal.window)
+    const windowStart = new Date(now.getTime() - windowMs)
+
+    // Calculate "losing tomorrow" - the oldest day's contribution
+    // For a 7-day window, this is the first day that will drop off tomorrow
+    const oldestDayStart = new Date(windowStart)
+    oldestDayStart.setUTCHours(0, 0, 0, 0)
+    const oldestDayEnd = new Date(oldestDayStart)
+    oldestDayEnd.setUTCHours(23, 59, 59, 999)
+
+    // Get current total and oldest day value in parallel
+    const [current, losingTomorrow] = await Promise.all([
+      getMetricSum(user, goal.metric, windowStart, now),
+      getMetricSum(user, goal.metric, oldestDayStart, oldestDayEnd),
+    ])
+
+    results.push({
+      current,
+      id: goal.id,
+      losingTomorrow,
+      max: goal.max,
+      metric: goal.metric,
+      min: goal.min,
+      unit: metricUnits[goal.metric],
+      window: goal.window,
+    })
+  }
+
+  return results
+}

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -465,9 +465,9 @@ describe('getPeriodSummary', () => {
       ])
 
     vi.mocked(db.getDailyAggregates).mockResolvedValue([
-      { avg: 40, date: '2024-01-01', metric: 'hrv_rmssd' },
-      { avg: 45, date: '2024-01-02', metric: 'hrv_rmssd' },
-      { avg: 50, date: '2024-01-03', metric: 'hrv_rmssd' },
+      { avg: 40, date: '2024-01-01', metric: 'hrv_rmssd', sum: 40 },
+      { avg: 45, date: '2024-01-02', metric: 'hrv_rmssd', sum: 45 },
+      { avg: 50, date: '2024-01-03', metric: 'hrv_rmssd', sum: 50 },
     ])
 
     const result = await getPeriodSummary(
@@ -493,9 +493,9 @@ describe('getPeriodSummary', () => {
 
     // Linear increase: 40, 45, 50 -> slope = 5
     vi.mocked(db.getDailyAggregates).mockResolvedValue([
-      { avg: 40, date: '2024-01-01', metric: 'hrv_rmssd' },
-      { avg: 45, date: '2024-01-02', metric: 'hrv_rmssd' },
-      { avg: 50, date: '2024-01-03', metric: 'hrv_rmssd' },
+      { avg: 40, date: '2024-01-01', metric: 'hrv_rmssd', sum: 40 },
+      { avg: 45, date: '2024-01-02', metric: 'hrv_rmssd', sum: 45 },
+      { avg: 50, date: '2024-01-03', metric: 'hrv_rmssd', sum: 50 },
     ])
 
     const result = await getPeriodSummary(
@@ -577,6 +577,7 @@ describe('getPeriodSummary', () => {
         avg: 50,
         date: `2024-01-${String(i + 1).padStart(2, '0')}`,
         metric: 'hrv_rmssd' as const,
+        sum: 50,
       })),
     )
 

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -2,6 +2,7 @@
  * User settings service for HR zones and other user preferences.
  */
 
+import { defaultGoals, goalsSchema, type Goal } from '@aurboda/api-spec'
 import { z } from 'zod'
 import { getOAuthToken, getUserSettings, upsertUserSettings } from '../db'
 
@@ -15,6 +16,7 @@ export interface UserSettings {
   birthDate?: string // YYYY-MM-DD
   hrZoneStart?: HrZoneThresholds
   rescueTimeKey?: string // RescueTime API key (personal token)
+  goals?: Goal[] // User-defined goals for tracking metrics
 }
 
 export interface HrZoneSecs {
@@ -36,6 +38,7 @@ export interface SettingsResponse {
   rescue_time_key: string | null
   oura_connected: boolean
   oura_configured: boolean // Whether Oura OAuth is configured on the server
+  goals: Goal[]
   error?: string
 }
 
@@ -71,6 +74,7 @@ export const rescueTimeKeySchema = z.string().min(1, 'RescueTime API key cannot 
 
 export const updateSettingsInputSchema = z.object({
   birthDate: birthDateSchema.nullable().optional(),
+  goals: goalsSchema.nullable().optional(),
   hrZoneStart: hrZoneThresholdsSchema.nullable().optional(),
   rescueTimeKey: rescueTimeKeySchema.nullable().optional(),
 })
@@ -170,6 +174,14 @@ export const getEffectiveHrZones = async (
 }
 
 /**
+ * Get effective goals for a user (user goals or defaults).
+ */
+export const getEffectiveGoals = (settings: UserSettings): Goal[] => {
+  // If goals is undefined, return defaults. If empty array, return empty.
+  return settings.goals ?? defaultGoals
+}
+
+/**
  * Get settings response in the format used by both API and MCP.
  */
 export const getSettingsResponse = async (user: string): Promise<SettingsResponse> => {
@@ -180,6 +192,7 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
 
   return {
     birth_date: settings.birthDate ?? null,
+    goals: getEffectiveGoals(settings),
     hr_zone_start: zones,
     hr_zone_start_source: source,
     oura_configured: ouraConfigured,
@@ -201,6 +214,7 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
     return {
       birth_date: null,
       error: errorMessage,
+      goals: defaultGoals,
       hr_zone_start: calculateDefaultHrZones(null),
       hr_zone_start_source: 'default',
       oura_configured: !!(process.env.OURA_CLIENT && process.env.OURA_SECRET),
@@ -220,6 +234,10 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
   }
   if (parsed.data.rescueTimeKey !== undefined) {
     updates.rescueTimeKey = parsed.data.rescueTimeKey === null ? undefined : parsed.data.rescueTimeKey
+  }
+  if (parsed.data.goals !== undefined) {
+    // null resets to defaults (by removing from storage), empty array clears all goals
+    updates.goals = parsed.data.goals === null ? undefined : parsed.data.goals
   }
 
   // Apply updates

--- a/apps/web/src/components/GoalsSettings.css
+++ b/apps/web/src/components/GoalsSettings.css
@@ -1,0 +1,238 @@
+.goals-section .section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.goals-section .section-header h2 {
+  margin: 0;
+}
+
+.add-goal-button {
+  background: #673ab8;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.add-goal-button:hover {
+  background: #7c4dcc;
+}
+
+.save-status {
+  font-size: 0.85rem;
+  margin: 0.5rem 0;
+  padding: 0.25rem 0;
+}
+
+.save-status.saving {
+  color: #888;
+}
+
+.save-status.saved {
+  color: #4caf50;
+}
+
+.save-status.error {
+  color: #f44336;
+}
+
+.no-goals {
+  color: #888;
+  font-style: italic;
+  padding: 1rem 0;
+}
+
+.goals-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.goal-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+  padding: 0.75rem;
+  background: var(--bg-secondary, #f5f5f5);
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+
+.goal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.goal-field label {
+  font-size: 0.75rem;
+  color: #666;
+  font-weight: 500;
+}
+
+.metric-field {
+  flex: 2;
+  min-width: 120px;
+}
+
+.metric-field select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  width: 100%;
+  background: white;
+}
+
+.min-field,
+.max-field {
+  flex: 1;
+  min-width: 80px;
+}
+
+.window-field {
+  flex: 1;
+  min-width: 70px;
+}
+
+.window-field input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.input-with-unit {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.input-with-unit input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.input-with-unit .unit {
+  font-size: 0.8rem;
+  color: #666;
+  min-width: 2rem;
+}
+
+.info-button {
+  background: #888;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 1.2em;
+  height: 1.2em;
+  font-size: 0.7rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 0.25rem;
+}
+
+.info-button:hover {
+  background: #666;
+}
+
+.delete-goal-button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 0.5rem;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+
+.delete-goal-button:hover {
+  opacity: 1;
+}
+
+.duration-help {
+  background: var(--bg-secondary, #f5f5f5);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+}
+
+.duration-help p {
+  margin: 0 0 0.5rem 0;
+}
+
+.duration-help ul {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.duration-help li {
+  margin: 0.25rem 0;
+}
+
+.duration-help code {
+  background: #e0e0e0;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .goal-row {
+    background: var(--bg-secondary, #2a2a2a);
+  }
+
+  .goal-field label {
+    color: #aaa;
+  }
+
+  .metric-field select,
+  .input-with-unit input,
+  .window-field input {
+    background: #333;
+    color: #fff;
+    border-color: #555;
+  }
+
+  .input-with-unit .unit {
+    color: #aaa;
+  }
+
+  .duration-help {
+    background: var(--bg-secondary, #2a2a2a);
+  }
+
+  .duration-help code {
+    background: #444;
+  }
+}
+
+/* Mobile responsive */
+@media (max-width: 639px) {
+  .goal-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .goal-field {
+    width: 100%;
+  }
+
+  .delete-goal-button {
+    align-self: flex-end;
+  }
+}

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -1,0 +1,273 @@
+import { metricUnits, validMetrics } from '@aurboda/api-spec'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+import { type Goal, updateUserSettings } from '../state/api'
+
+import './GoalsSettings.css'
+
+interface GoalsSettingsProps {
+  goals: Goal[]
+}
+
+// Duration unit descriptions for the info tooltip
+const durationUnits = [
+  { description: 'seconds', unit: 's' },
+  { description: 'minutes', unit: 'm' },
+  { description: 'hours', unit: 'h' },
+  { description: 'days', unit: 'd' },
+  { description: 'weeks', unit: 'w' },
+  { description: 'months', unit: 'M' },
+]
+
+// Friendly names for metrics
+const metricLabels: Record<string, string> = {
+  calories_active: 'Active Calories',
+  calories_basal: 'Basal Calories',
+  calories_total: 'Total Calories',
+  distance: 'Distance',
+  floors_climbed: 'Floors Climbed',
+  heart_rate: 'Heart Rate',
+  hr_zone_0_sec: 'Zone 0 (Below Z1)',
+  hr_zone_1_sec: 'Zone 1',
+  hr_zone_2_sec: 'Zone 2',
+  hr_zone_3_sec: 'Zone 3',
+  hr_zone_4_sec: 'Zone 4',
+  hr_zone_5_sec: 'Zone 5',
+  hrv_rmssd: 'HRV (RMSSD)',
+  readiness_score: 'Readiness Score',
+  resilience_score: 'Resilience Score',
+  resting_heart_rate: 'Resting HR',
+  sleep_score: 'Sleep Score',
+  spo2: 'SpO2',
+  steps: 'Steps',
+  vo2_max: 'VO2 Max',
+  weight: 'Weight',
+}
+
+// Get display unit for a metric (e.g., 'sec' -> 'min' for HR zones)
+const getDisplayUnit = (metric: string): string => {
+  const unit = metricUnits[metric as keyof typeof metricUnits]
+  if (unit === 'sec') return 'min'
+  if (unit === 'count') return ''
+  return unit ?? ''
+}
+
+// Convert value for display (seconds to minutes for HR zones)
+const toDisplayValue = (metric: string, value: number | undefined): string => {
+  if (value === undefined) return ''
+  const unit = metricUnits[metric as keyof typeof metricUnits]
+  if (unit === 'sec') return String(Math.round(value / 60))
+  return String(value)
+}
+
+// Convert display value back to storage value
+const fromDisplayValue = (metric: string, displayValue: string): number | undefined => {
+  if (displayValue === '') return undefined
+  const num = parseFloat(displayValue)
+  if (isNaN(num)) return undefined
+  const unit = metricUnits[metric as keyof typeof metricUnits]
+  if (unit === 'sec') return num * 60
+  return num
+}
+
+export function GoalsSettings({ goals }: GoalsSettingsProps) {
+  const queryClient = useQueryClient()
+  const [saveStatus, setSaveStatus] = useState<{ status: 'idle' | 'saving' | 'saved'; time?: Date }>({
+    status: 'idle',
+  })
+  const [showDurationHelp, setShowDurationHelp] = useState(false)
+
+  const mutation = useMutation({
+    mutationFn: updateUserSettings,
+    onError: () => {
+      setSaveStatus({ status: 'idle' })
+    },
+    onMutate: () => {
+      setSaveStatus({ status: 'saving' })
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['userSettings'], data)
+      setSaveStatus({ status: 'saved', time: new Date() })
+    },
+  })
+
+  const saveGoals = (newGoals: Goal[]) => {
+    mutation.mutate({ goals: newGoals })
+  }
+
+  const handleFieldBlur = (goalId: string, field: 'min' | 'max' | 'window', value: string) => {
+    const goal = goals.find((g) => g.id === goalId)
+    if (!goal) return
+
+    const updatedGoals = goals.map((g) => {
+      if (g.id !== goalId) return g
+
+      if (field === 'window') {
+        // Validate window format
+        if (!/^\d+[smhdwM]$/.test(value)) return g
+        return { ...g, window: value }
+      }
+
+      const numValue = fromDisplayValue(g.metric, value)
+      return { ...g, [field]: numValue }
+    })
+
+    // Only save if something actually changed
+    const updatedGoal = updatedGoals.find((g) => g.id === goalId)
+    const originalGoal = goals.find((g) => g.id === goalId)
+    if (JSON.stringify(updatedGoal) !== JSON.stringify(originalGoal)) {
+      saveGoals(updatedGoals)
+    }
+  }
+
+  const handleMetricChange = (goalId: string, newMetric: string) => {
+    const updatedGoals = goals.map((g) => {
+      if (g.id !== goalId) return g
+      return { ...g, metric: newMetric as Goal['metric'] }
+    })
+    saveGoals(updatedGoals)
+  }
+
+  const handleAddGoal = () => {
+    const newGoal: Goal = {
+      id: crypto.randomUUID(),
+      metric: 'steps',
+      min: 10000,
+      window: '7d',
+    }
+    saveGoals([...goals, newGoal])
+  }
+
+  const handleDeleteGoal = (goalId: string) => {
+    const updatedGoals = goals.filter((g) => g.id !== goalId)
+    saveGoals(updatedGoals)
+  }
+
+  const formatSavedTime = (time: Date): string => {
+    const now = new Date()
+    const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
+    if (diffSec < 5) return 'just now'
+    if (diffSec < 60) return `${diffSec} seconds ago`
+    const diffMin = Math.floor(diffSec / 60)
+    if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
+    return time.toLocaleTimeString()
+  }
+
+  return (
+    <section class="settings-section goals-section">
+      <div class="section-header">
+        <h2>Goals</h2>
+        <button type="button" class="add-goal-button" onClick={handleAddGoal}>
+          + Add Goal
+        </button>
+      </div>
+
+      <p class="section-description">
+        Set targets for metrics over a rolling time window. Goals are saved automatically when you change a
+        field.
+      </p>
+
+      {saveStatus.status === 'saving' && <p class="save-status saving">Saving...</p>}
+      {saveStatus.status === 'saved' && saveStatus.time && (
+        <p class="save-status saved">Saved {formatSavedTime(saveStatus.time)}</p>
+      )}
+      {mutation.isError && (
+        <p class="save-status error">
+          Error: {mutation.error instanceof Error ? mutation.error.message : 'Failed to save'}
+        </p>
+      )}
+
+      {goals.length === 0 ?
+        <p class="no-goals">No goals set. Click "+ Add Goal" to create one.</p>
+      : <div class="goals-list">
+          {goals.map((goal) => (
+            <div class="goal-row" key={goal.id}>
+              <div class="goal-field metric-field">
+                <label>Metric</label>
+                <select
+                  value={goal.metric}
+                  onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
+                >
+                  {validMetrics.map((metric) => (
+                    <option key={metric} value={metric}>
+                      {metricLabels[metric] ?? metric}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div class="goal-field min-field">
+                <label>Min</label>
+                <div class="input-with-unit">
+                  <input
+                    type="number"
+                    value={toDisplayValue(goal.metric, goal.min)}
+                    onBlur={(e) => handleFieldBlur(goal.id, 'min', (e.target as HTMLInputElement).value)}
+                    placeholder="-"
+                  />
+                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                </div>
+              </div>
+
+              <div class="goal-field max-field">
+                <label>Max</label>
+                <div class="input-with-unit">
+                  <input
+                    type="number"
+                    value={toDisplayValue(goal.metric, goal.max)}
+                    onBlur={(e) => handleFieldBlur(goal.id, 'max', (e.target as HTMLInputElement).value)}
+                    placeholder="-"
+                  />
+                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                </div>
+              </div>
+
+              <div class="goal-field window-field">
+                <label>
+                  Window{' '}
+                  <button
+                    type="button"
+                    class="info-button"
+                    onClick={() => setShowDurationHelp(!showDurationHelp)}
+                    aria-label="Duration format help"
+                  >
+                    i
+                  </button>
+                </label>
+                <input
+                  type="text"
+                  value={goal.window}
+                  onBlur={(e) => handleFieldBlur(goal.id, 'window', (e.target as HTMLInputElement).value)}
+                  placeholder="7d"
+                />
+              </div>
+
+              <button
+                type="button"
+                class="delete-goal-button"
+                onClick={() => handleDeleteGoal(goal.id)}
+                aria-label="Delete goal"
+              >
+                🗑
+              </button>
+            </div>
+          ))}
+        </div>
+      }
+
+      {showDurationHelp && (
+        <div class="duration-help">
+          <p>Duration format: number + unit</p>
+          <ul>
+            {durationUnits.map(({ unit, description }) => (
+              <li key={unit}>
+                <code>{unit}</code> - {description}
+              </li>
+            ))}
+          </ul>
+          <p>Examples: 7d (7 days), 2w (2 weeks), 1M (1 month)</p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -18,6 +18,9 @@ export function Header() {
         </a>
         {isLoggedIn ?
           <>
+            <a href="/goals" class={url == '/goals' && 'active'}>
+              Goals
+            </a>
             <a href="/hr-zones" class={url == '/hr-zones' && 'active'}>
               HR Zones
             </a>

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { LocationProvider, Route, Router } from 'preact-iso'
 import { Footer } from './components/Footer.jsx'
 import { Header } from './components/Header.jsx'
+import { Goals } from './pages/Goals/index.jsx'
 import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
 import { Login } from './pages/Login/index.jsx'
@@ -25,6 +26,7 @@ export function App() {
             <Route path="/" component={Home} />
             <Route path="/login" component={Login} />
             <Route path="/signup" component={Signup} />
+            <Route path="/goals" component={Goals} />
             <Route path="/hr-zones" component={HrZones} />
             <Route path="/timeline" component={Timeline} />
             <Route path="/places" component={Places} />

--- a/apps/web/src/pages/Goals/index.tsx
+++ b/apps/web/src/pages/Goals/index.tsx
@@ -1,0 +1,214 @@
+import { metricUnits } from '@aurboda/api-spec'
+import { useQuery } from '@tanstack/react-query'
+import { fetchGoalsProgress, fetchUserSettings, type GoalProgress } from '../../state/api'
+import { auth } from '../../state/auth'
+
+import './style.css'
+
+// Friendly names for metrics
+const metricLabels: Record<string, string> = {
+  calories_active: 'Active Calories',
+  calories_basal: 'Basal Calories',
+  calories_total: 'Total Calories',
+  distance: 'Distance',
+  floors_climbed: 'Floors Climbed',
+  heart_rate: 'Heart Rate',
+  hr_zone_0_sec: 'Zone 0 (Below Z1)',
+  hr_zone_1_sec: 'Zone 1',
+  hr_zone_2_sec: 'Zone 2',
+  hr_zone_3_sec: 'Zone 3',
+  hr_zone_4_sec: 'Zone 4',
+  hr_zone_5_sec: 'Zone 5',
+  hrv_rmssd: 'HRV (RMSSD)',
+  readiness_score: 'Readiness Score',
+  resilience_score: 'Resilience Score',
+  resting_heart_rate: 'Resting HR',
+  sleep_score: 'Sleep Score',
+  spo2: 'SpO2',
+  steps: 'Steps',
+  vo2_max: 'VO2 Max',
+  weight: 'Weight',
+}
+
+// Format value for display (e.g., seconds to hours:minutes)
+const formatValue = (metric: string, value: number): string => {
+  const unit = metricUnits[metric as keyof typeof metricUnits]
+  if (unit === 'sec') {
+    const hours = Math.floor(value / 3600)
+    const minutes = Math.floor((value % 3600) / 60)
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`
+    }
+    return `${minutes}m`
+  }
+  if (unit === 'm') {
+    // Distance in meters to km
+    return `${(value / 1000).toFixed(1)} km`
+  }
+  if (unit === 'count') {
+    return value.toLocaleString()
+  }
+  return `${value.toLocaleString()} ${unit}`
+}
+
+// Format "losing tomorrow" value
+const formatLosingTomorrow = (metric: string, value: number): string => {
+  if (value === 0) return ''
+  const unit = metricUnits[metric as keyof typeof metricUnits]
+  if (unit === 'sec') {
+    const hours = Math.floor(value / 3600)
+    const minutes = Math.floor((value % 3600) / 60)
+    if (hours > 0) {
+      return `-${hours}h ${minutes}m`
+    }
+    return `-${minutes}m`
+  }
+  if (unit === 'count') {
+    return `-${value.toLocaleString()}`
+  }
+  return `-${value.toLocaleString()} ${unit}`
+}
+
+interface GoalProgressBarProps {
+  goal: GoalProgress
+}
+
+function GoalProgressBar({ goal }: GoalProgressBarProps) {
+  const { current, losingTomorrow, max, metric, min } = goal
+
+  // Calculate progress percentages
+  const target = max ?? min ?? 1
+  const progressPercent = (current / target) * 100
+  const minPercent = min && max ? (min / max) * 100 : 100
+  const overflow = progressPercent > 100 ? progressPercent - 100 : 0
+  const cappedProgress = Math.min(progressPercent, 100)
+
+  // Determine bar color based on progress
+  const getBarColor = () => {
+    if (min && max) {
+      // Min-max goal
+      if (current >= max) return 'over-max'
+      if (current >= min) return 'in-range'
+      return 'below-min'
+    }
+    if (min) {
+      // Min-only goal
+      return current >= min ? 'met' : 'below-min'
+    }
+    if (max) {
+      // Max-only goal
+      return current > max ? 'over-max' : 'in-range'
+    }
+    return 'neutral'
+  }
+
+  const barColor = getBarColor()
+  const losingText = formatLosingTomorrow(metric, losingTomorrow)
+
+  return (
+    <div class="goal-progress">
+      <div class="goal-header">
+        <span class="goal-label">{metricLabels[metric] ?? metric}</span>
+        {losingText && <span class="losing-tomorrow">({losingText} tomorrow)</span>}
+        <span class="goal-value">{formatValue(metric, current)}</span>
+      </div>
+
+      <div class="progress-container">
+        <div class={`progress-bar ${barColor}`} style={{ width: `${cappedProgress}%` }} />
+        {min && max && <div class="min-marker" style={{ left: `${minPercent}%` }} />}
+      </div>
+
+      {overflow > 0 && (
+        <div class="progress-container overflow">
+          <div class={`progress-bar ${barColor}`} style={{ width: `${Math.min(overflow, 100)}%` }} />
+        </div>
+      )}
+
+      <div class="goal-targets">
+        {min && <span class="target-label">Min: {formatValue(metric, min)}</span>}
+        {max && <span class="target-label">Max: {formatValue(metric, max)}</span>}
+      </div>
+    </div>
+  )
+}
+
+export function Goals() {
+  const isLoggedIn = auth.value.token
+
+  const { data: userSettings, isLoading: settingsLoading } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+  })
+
+  const { data: goalsProgress, isLoading: progressLoading } = useQuery({
+    enabled: !!isLoggedIn && !!userSettings?.goals?.length,
+    queryFn: fetchGoalsProgress,
+    queryKey: ['goalsProgress'],
+    refetchInterval: 60000, // Refresh every minute
+  })
+
+  if (!isLoggedIn) {
+    return (
+      <div class="goals-page">
+        <h1>Goals</h1>
+        <p>Please log in to view your goals.</p>
+      </div>
+    )
+  }
+
+  if (settingsLoading || progressLoading) {
+    return (
+      <div class="goals-page">
+        <h1>Goals</h1>
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+
+  const goals = userSettings?.goals ?? []
+
+  if (goals.length === 0) {
+    return (
+      <div class="goals-page">
+        <h1>Goals</h1>
+        <p class="no-goals">
+          No goals set. Visit <a href="/settings">Settings</a> to create goals.
+        </p>
+      </div>
+    )
+  }
+
+  // Match progress data with goals
+  const progressMap = new Map(goalsProgress?.map((p) => [p.id, p]) ?? [])
+
+  return (
+    <div class="goals-page">
+      <h1>Goals</h1>
+
+      <div class="goals-list">
+        {goals.map((goal) => {
+          const progress = progressMap.get(goal.id)
+          if (!progress) {
+            // Fallback if progress not yet loaded
+            return (
+              <div key={goal.id} class="goal-progress loading">
+                <div class="goal-header">
+                  <span class="goal-label">{metricLabels[goal.metric] ?? goal.metric}</span>
+                </div>
+                <div class="progress-container">
+                  <div class="progress-bar loading" style={{ width: '0%' }} />
+                </div>
+              </div>
+            )
+          }
+          return <GoalProgressBar key={goal.id} goal={progress} />
+        })}
+      </div>
+
+      <p class="goals-footer">
+        Rolling {goals[0]?.window ?? '7d'} window from today. <a href="/settings">Edit goals</a>
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Goals/style.css
+++ b/apps/web/src/pages/Goals/style.css
@@ -1,0 +1,174 @@
+.goals-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.goals-page h1 {
+  margin-bottom: 1.5rem;
+}
+
+.goals-page .loading {
+  color: #888;
+}
+
+.goals-page .no-goals {
+  color: #888;
+  font-style: italic;
+}
+
+.goals-page .no-goals a {
+  color: #673ab8;
+}
+
+.goals-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.goal-progress {
+  background: var(--bg-secondary, #f5f5f5);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.goal-progress.loading {
+  opacity: 0.6;
+}
+
+.goal-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.goal-label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.losing-tomorrow {
+  color: #888;
+  font-size: 0.85rem;
+}
+
+.goal-value {
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.progress-container {
+  position: relative;
+  height: 24px;
+  background: #ddd;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 0.25rem;
+}
+
+.progress-container.overflow {
+  height: 16px;
+  margin-top: 4px;
+  opacity: 0.8;
+}
+
+.progress-bar {
+  height: 100%;
+  border-radius: 12px;
+  transition: width 0.3s ease;
+}
+
+.progress-bar.below-min {
+  background: linear-gradient(90deg, #9e9e9e, #757575);
+}
+
+.progress-bar.in-range {
+  background: linear-gradient(90deg, #4caf50, #45a045);
+}
+
+.progress-bar.met {
+  background: linear-gradient(90deg, #4caf50, #45a045);
+}
+
+.progress-bar.over-max {
+  background: linear-gradient(90deg, #f44336, #d32f2f);
+}
+
+.progress-bar.neutral {
+  background: linear-gradient(90deg, #2196f3, #1976d2);
+}
+
+.progress-bar.loading {
+  background: #ccc;
+}
+
+.min-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: white;
+  opacity: 0.8;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+}
+
+.goal-targets {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: #666;
+}
+
+.target-label {
+  font-weight: 500;
+}
+
+.goals-footer {
+  margin-top: 2rem;
+  font-size: 0.9rem;
+  color: #888;
+  text-align: center;
+}
+
+.goals-footer a {
+  color: #673ab8;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .goal-progress {
+    background: var(--bg-secondary, #2a2a2a);
+  }
+
+  .losing-tomorrow {
+    color: #aaa;
+  }
+
+  .progress-container {
+    background: #444;
+  }
+
+  .goal-targets {
+    color: #aaa;
+  }
+
+  .goals-footer {
+    color: #aaa;
+  }
+}
+
+/* Mobile responsive */
+@media (max-width: 639px) {
+  .goal-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .goal-value {
+    margin-left: 0;
+  }
+}

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
+import { GoalsSettings } from '../../components/GoalsSettings'
 import { API_URL } from '../../config'
 import { fetchUserSettings, HrZoneThresholds, updateUserSettings } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -150,12 +151,17 @@ export function Settings() {
 
         <div class="form-field">
           <label for="rescuetime-key">RescueTime API Key</label>
+          {userSettings?.rescue_time_key ?
+            <p class="connected-status">Configured</p>
+          : null}
           <input
             id="rescuetime-key"
             type="password"
             value={rescueTimeKey}
             onInput={handleRescueTimeKeyChange}
-            placeholder="Enter your RescueTime API key"
+            placeholder={
+              userSettings?.rescue_time_key ? 'Enter new key to update' : 'Enter your RescueTime API key'
+            }
           />
           <p class="field-description">
             Get your API key from{' '}
@@ -200,6 +206,8 @@ export function Settings() {
           <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
         )}
       </section>
+
+      <GoalsSettings goals={userSettings?.goals ?? []} />
 
       {mutation.isError && (
         <p class="error">

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -7,6 +7,9 @@ import type {
   PlaceVisit as ApiPlaceVisit,
   ProductivityRecord as ApiProductivityRecord,
   Tag as ApiTag,
+  Goal,
+  GoalProgress,
+  GoalsProgressResponse,
   HrZoneThresholds,
   LocationsQuery,
   LocationsResponse,
@@ -65,7 +68,15 @@ export interface Tag extends Omit<ApiTag, 'startTime' | 'endTime'> {
 }
 
 // Re-export API types that don't need Date conversion
-export type { HrZoneThresholds, NamedLocation, PeriodMetricStats, UpdateSettingsInput, UserSettingsResponse }
+export type {
+  Goal,
+  GoalProgress,
+  HrZoneThresholds,
+  NamedLocation,
+  PeriodMetricStats,
+  UpdateSettingsInput,
+  UserSettingsResponse,
+}
 
 // Fetch heart rate data for the specified date range
 export const fetchHeartRate = async (start: Date, end: Date): Promise<[Date, number][]> => {
@@ -280,4 +291,14 @@ export const updateUserSettings = async (params: UpdateSettingsInput): Promise<U
   })
 
   return response.data
+}
+
+// Fetch goal progress
+export const fetchGoalsProgress = async (): Promise<GoalProgress[]> => {
+  const { token } = auth.value
+  const response = await axios.get<GoalsProgressResponse>(`${API_URL}/goals/progress`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return response.data.goals
 }

--- a/docs/GOAL_WIDGET.md
+++ b/docs/GOAL_WIDGET.md
@@ -1,0 +1,368 @@
+# Goals Feature
+
+This document describes the goals functionality for tracking health metrics
+against user-defined targets.
+
+## Overview
+
+Users can set targets for any metric in the system. Goals have:
+- A **metric** (e.g., `hr_zone_2_sec`, `steps`, `distance`)
+- An optional **minimum** target value
+- An optional **maximum** target value (at least one of min/max required)
+- A configurable **window duration** (default: `7d` - 7 days rolling)
+
+Progress is calculated as a rolling window from today backwards.
+
+## Goal Examples
+
+| Metric | Min | Max | Meaning |
+|--------|-----|-----|---------|
+| HR Zone 2 | 150 min | - | At least 150 minutes per week |
+| HR Zone 5 | 5 min | 10 min | Between 5-10 minutes per week |
+| Steps | 70,000 | - | At least 70,000 steps per week |
+
+## Default Goals
+
+New users receive these default goals based on Huberman/Galpin recommendations
+(using default 7-day window):
+
+1. **Zone 2 cardio**: minimum 150 minutes (no max)
+2. **Zone 5 cardio**: minimum 5 minutes, maximum 10 minutes
+3. **Steps**: minimum 70,000 steps (~10k/day)
+
+## Window Duration Format
+
+The window duration uses standard duration notation:
+
+| Unit | Meaning | Example |
+|------|---------|---------|
+| `s` | seconds | `3600s` = 1 hour |
+| `m` | minutes | `30m` = 30 minutes |
+| `h` | hours | `24h` = 1 day |
+| `d` | days | `7d` = 1 week |
+| `w` | weeks | `2w` = 2 weeks |
+| `M` | months | `1M` = 1 month |
+
+Default is `7d` (7 days rolling window).
+
+An info icon (ⓘ) is displayed next to the duration field with a tooltip explaining
+these units.
+
+## Data Model
+
+### Goal Structure
+
+```typescript
+interface WeeklyGoal {
+  id: string              // UUID for identification
+  metric: string          // Valid metric name (e.g., 'hr_zone_2_sec', 'steps')
+  min?: number            // Minimum target (at least one of min/max required)
+  max?: number            // Maximum target
+  window: string          // Duration string, default '7d'
+}
+```
+
+### Storage
+
+Goals are stored in the `user_settings` JSONB field:
+
+```json
+{
+  "birthDate": "1990-01-15",
+  "hrZoneStart": { "1": 90, "2": 108, "3": 126, "4": 144, "5": 162 },
+  "goals": [
+    { "id": "uuid-1", "metric": "hr_zone_2_sec", "min": 9000, "window": "7d" },
+    { "id": "uuid-2", "metric": "hr_zone_5_sec", "min": 300, "max": 600, "window": "7d" },
+    { "id": "uuid-3", "metric": "steps", "min": 70000, "window": "7d" }
+  ]
+}
+```
+
+Note: HR zone times are stored in seconds internally, displayed as minutes to user.
+
+## Progress Calculation
+
+### Rolling Window
+
+Progress is calculated over a rolling window ending at the current moment:
+- For a `7d` window: from `now - 7 days` to `now`
+- Uses the existing `getPeriodSummary` query with sum aggregation
+
+### "Losing Tomorrow" Calculation
+
+Shows how much value will "drop off" when the oldest day exits the window.
+
+For a 7-day window on January 15th:
+- Current window: Jan 9 - Jan 15
+- Tomorrow's window: Jan 10 - Jan 16
+- "Losing tomorrow": Sum of Jan 9th values for that metric
+
+This helps users understand if they need to exercise more to maintain their target.
+
+## UI Components
+
+### Web Settings Page
+
+Located in the Settings page with other user preferences.
+
+#### Layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Weekly Goals                                          [+ Add]   │
+├─────────────────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ Metric: [Zone 2 ▼]  Min: [150] min  Max: [   ]  Window: [7d]│ │ │ │                                                         [🗑] │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ Metric: [Zone 5 ▼]  Min: [5  ] min  Max: [10 ]  Window: [7d]│ │
+│ │                                                         [🗑] │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ Metric: [Steps  ▼]  Min: [70000]    Max: [   ]  Window: [7d]│ │
+│ │                                                         [🗑] │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+                                          Saved 2 seconds ago
+```
+
+#### Behavior
+
+- **Inline editing**: Each field saves on blur (no separate save button)
+- **Save indicator**: Shows "Saving..." during save, then "Saved <timestamp>"
+- **Add button**: Opens a new row with metric dropdown
+- **Delete button**: Trash icon removes the goal (with confirmation)
+- **Validation**: At least one of min/max required, values must be positive
+- **Unit display**: Shows the unit for the selected metric (e.g., "min", "steps")
+
+### Web Goals Page
+
+A dedicated page showing current progress toward all goals.
+
+#### Layout (matches widget display)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Goals                                                           │
+├─────────────────────────────────────────────────────────────────┤
+│ Zone 2          (-1h 54 min tomorrow)              4 h 12 min   │
+│ [████████████████████████████░░░░░░░░░░░░░░░░░░░░]             │
+│                              ▲ min                              │
+├─────────────────────────────────────────────────────────────────┤
+│ Zone 5                  (-2 min tomorrow)              7 min    │
+│ [████████████████████████████████████████|░░░░░░░]             │
+│                              ▲ min       ▲ max                  │
+├─────────────────────────────────────────────────────────────────┤
+│ Steps             (-8,432 steps tomorrow)            72,145     │
+│ [██████████████████████████████████████████████████████████████]│
+│ [████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]│
+│                                                     ▲ min       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Android Widget
+
+Displays goals with progress bars, stacked vertically.
+
+#### Layout
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Zone 2          (-1h 54 min tomorrow)              4 h 12 min   │
+│ [████████████████████████████░░░░░░░░░░░░░░░░░░░░]             │
+│ Zone 5                  (-2 min tomorrow)              7 min    │
+│ [████████████████████████████████████████|░░░░░░░]             │
+│ Steps             (-8,432 steps tomorrow)            72,145     │
+│ [██████████████████████████████████████████████████████████████]│
+│ [████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Widget Sizing
+
+- Users with more goals should use a larger widget size
+- Minimum size: 4x2 (fits ~2 goals comfortably)
+- Recommended: 4x3 for 3 goals, 4x4 for 4+ goals
+
+## Progress Bar Visualization
+
+### Bar Types
+
+#### Min-only goals (e.g., Steps min 70,000)
+- Bar fills from left to right
+- 100% = min value reached
+- Color changes when min is reached (e.g., gray → green)
+
+```
+Progress: 50,000 / 70,000 min
+[███████████████████████████████████░░░░░░░░░░░░░░░░]
+                                                    ▲ min (100%)
+```
+
+#### Max-only goals
+- Bar fills from left to right
+- 100% = max value
+- Color changes when approaching max (e.g., green → yellow → red)
+
+```
+Progress: 7 / 10 max
+[██████████████████████████████████████████░░░░░░░░░]
+                                                    ▲ max (100%)
+```
+
+#### Min-max goals (e.g., Zone 5 min 5, max 10)
+- Bar fills from left to right
+- Vertical marker at min position
+- 100% = max value
+- Color: gray until min, green between min-max, red beyond max
+
+```
+Progress: 7 / min 5, max 10
+[████████████████████|███████████████████░░░░░░░░░░░]
+                     ▲ min (50%)                    ▲ max (100%)
+```
+
+### Overflow Display
+
+When progress exceeds the target (for min-only) or max (for min-max goals),
+the bar shows overflow by starting a second row:
+
+```
+Progress: 85,000 / 70,000 min (121%)
+[██████████████████████████████████████████████████] 100%
+[████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]  21%
+```
+
+The second row:
+- Starts from the left
+- Uses a slightly different shade or offset to indicate overflow
+- Shows the overflow percentage (amount over 100%)
+
+For goals with both min and max, exceeding max is shown in red:
+
+```
+Progress: 15 / min 5, max 10 (150% of max)
+[████████████████████|██████████████████████████████] 100%
+[██████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░]  50% (over)
+              ↑ red color indicates exceeding max
+```
+
+## API Endpoints
+
+### Get Goals (included in settings response)
+
+```
+GET /user/settings
+```
+
+Response includes:
+```json
+{
+  "goals": [
+    { "id": "...", "metric": "hr_zone_2_sec", "min": 9000, "window": "7d" },
+    ...
+  ]
+}
+```
+
+### Update Goals
+
+```
+PATCH /user/settings
+{
+  "goals": [
+    { "id": "...", "metric": "hr_zone_2_sec", "min": 9000, "window": "7d" },
+    ...
+  ]
+}
+```
+
+Set to `null` to reset to defaults, or `[]` to clear all goals.
+
+### Get Goal Progress
+
+Uses existing period summary endpoint:
+
+```
+GET /period-summary?start=<7d-ago>&end=<now>&metrics=hr_zone_2_sec,hr_zone_5_sec,steps
+```
+
+Response includes sum values for calculating progress.
+
+### Get "Losing Tomorrow" Values
+
+Separate query for the oldest day in the window:
+
+```
+GET /period-summary?start=<oldest-day-start>&end=<oldest-day-end>&metrics=...
+```
+
+Or a new dedicated endpoint:
+
+```
+GET /goals/progress
+```
+
+Response:
+```json
+{
+  "goals": [
+    {
+      "id": "...",
+      "metric": "hr_zone_2_sec",
+      "min": 9000,
+      "max": null,
+      "window": "7d",
+      "current": 15120,
+      "losingTomorrow": 6840,
+      "unit": "seconds",
+      "displayUnit": "minutes"
+    }
+  ]
+}
+```
+
+## MCP Tools
+
+### get_user_settings
+
+Existing tool, extended to include `goals` in response.
+
+### update_user_settings
+
+Existing tool, extended to accept `goals` parameter.
+
+### get_goal_progress (new)
+
+Returns current progress for all goals with losing-tomorrow calculations.
+
+## Implementation Notes
+
+### Metric Units
+
+| Metric | Storage Unit | Display Unit | Conversion |
+|--------|--------------|--------------|------------|
+| hr_zone_*_sec | seconds | minutes | ÷ 60 |
+| steps | steps | steps | none |
+| distance | meters | km/miles | ÷ 1000 |
+| weight | kg | kg/lbs | varies |
+
+### Aggregation
+
+- HR zone times: **SUM** over the window
+- Steps: **SUM** over the window
+- Distance: **SUM** over the window
+- Heart rate: **AVG** over the window (less common for goals)
+- Weight: **LATEST** value (not typical for weekly goals)
+
+### Timezone Handling
+
+- All calculations use UTC
+- "Tomorrow" means the next UTC day boundary
+- Widget should display times in user's local timezone
+
+### Performance
+
+- Goal progress can be calculated from existing period-summary queries
+- "Losing tomorrow" requires one additional query per goal (or batched)
+- Consider caching progress calculations with short TTL (1-5 minutes)

--- a/packages/api-spec/src/schemas/goals.ts
+++ b/packages/api-spec/src/schemas/goals.ts
@@ -1,0 +1,128 @@
+/**
+ * Goal schemas for tracking health metrics against targets.
+ */
+
+import { z } from 'zod'
+import { baseResponseSchema, metricTypeSchema } from './common.js'
+
+/**
+ * Duration string for goal window (e.g., '7d', '2w', '1M').
+ * Units: s=seconds, m=minutes, h=hours, d=days, w=weeks, M=months
+ */
+export const durationStringSchema = z
+  .string()
+  .regex(/^\d+[smhdwM]$/, 'Duration must be a number followed by a unit (s, m, h, d, w, M)')
+  .meta({
+    description: 'Duration string (e.g., "7d", "2w", "1M")',
+    example: '7d',
+    id: 'DurationString',
+  })
+
+/**
+ * Parse duration string to milliseconds.
+ */
+export const parseDuration = (duration: string): number => {
+  const match = duration.match(/^(\d+)([smhdwM])$/)
+  if (!match) throw new Error(`Invalid duration: ${duration}`)
+
+  const value = parseInt(match[1], 10)
+  const unit = match[2]
+
+  const multipliers: Record<string, number> = {
+    M: 30 * 24 * 60 * 60 * 1000, // Approximate month
+    d: 24 * 60 * 60 * 1000,
+    h: 60 * 60 * 1000,
+    m: 60 * 1000,
+    s: 1000,
+    w: 7 * 24 * 60 * 60 * 1000,
+  }
+
+  return value * multipliers[unit]
+}
+
+/**
+ * Goal schema for a single metric target.
+ */
+export const goalSchema = z
+  .object({
+    id: z.string().uuid().meta({ description: 'Unique identifier for the goal' }),
+    max: z.number().positive().optional().meta({ description: 'Maximum target value' }),
+    metric: metricTypeSchema.meta({ description: 'Metric to track' }),
+    min: z.number().positive().optional().meta({ description: 'Minimum target value' }),
+    window: durationStringSchema.default('7d').meta({ description: 'Rolling window duration' }),
+  })
+  .refine((data) => data.min !== undefined || data.max !== undefined, {
+    message: 'At least one of min or max must be specified',
+  })
+  .refine((data) => data.min === undefined || data.max === undefined || data.min <= data.max, {
+    message: 'Min must be less than or equal to max',
+  })
+  .meta({ id: 'Goal' })
+
+export type Goal = z.infer<typeof goalSchema>
+
+/**
+ * Goals array schema.
+ */
+export const goalsSchema = z.array(goalSchema).meta({
+  description: 'List of goals',
+  id: 'Goals',
+})
+
+export type Goals = z.infer<typeof goalsSchema>
+
+/**
+ * Default goals based on Huberman/Galpin recommendations.
+ */
+export const defaultGoals: Goal[] = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    metric: 'hr_zone_2_sec',
+    min: 9000, // 150 minutes in seconds
+    window: '7d',
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000002',
+    max: 600, // 10 minutes in seconds
+    metric: 'hr_zone_5_sec',
+    min: 300, // 5 minutes in seconds
+    window: '7d',
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000003',
+    metric: 'steps',
+    min: 70000,
+    window: '7d',
+  },
+]
+
+/**
+ * Goal progress schema - includes current value and losing-tomorrow calculation.
+ */
+export const goalProgressSchema = z
+  .object({
+    current: z.number().meta({ description: 'Current value within the window' }),
+    id: z.string().uuid().meta({ description: 'Goal ID' }),
+    losingTomorrow: z
+      .number()
+      .meta({ description: 'Value that will drop off when oldest period exits window' }),
+    max: z.number().positive().optional(),
+    metric: metricTypeSchema,
+    min: z.number().positive().optional(),
+    unit: z.string().meta({ description: 'Storage unit for the metric' }),
+    window: durationStringSchema,
+  })
+  .meta({ id: 'GoalProgress' })
+
+export type GoalProgress = z.infer<typeof goalProgressSchema>
+
+/**
+ * Goals progress response schema.
+ */
+export const goalsProgressResponseSchema = baseResponseSchema
+  .extend({
+    goals: z.array(goalProgressSchema).meta({ description: 'Progress for all goals' }),
+  })
+  .meta({ id: 'GoalsProgressResponse' })
+
+export type GoalsProgressResponse = z.infer<typeof goalsProgressResponseSchema>

--- a/packages/api-spec/src/schemas/index.ts
+++ b/packages/api-spec/src/schemas/index.ts
@@ -5,6 +5,7 @@
 export * from './activities.js'
 export * from './common.js'
 export * from './daily-summary.js'
+export * from './goals.js'
 export * from './locations.js'
 export * from './metrics.js'
 export * from './period-summary.js'

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -4,6 +4,7 @@
 
 import { z } from 'zod'
 import { baseResponseSchema, hrZoneSourceSchema } from './common.js'
+import { goalsSchema } from './goals.js'
 
 // Shared HR zone threshold field
 const hrZoneThresholdSchema = z.number().int().positive()
@@ -68,6 +69,9 @@ export const updateSettingsInputSchema = z
     birth_date: birthDateSchema.nullable().optional().meta({
       description: 'Birth date (set to null to clear)',
     }),
+    goals: goalsSchema.nullable().optional().meta({
+      description: 'Goals (set to null to reset to defaults, empty array to clear all)',
+    }),
     hr_zone_start: hrZoneThresholdsSchema.nullable().optional().meta({
       description: 'Custom HR zone thresholds (set to null to clear)',
     }),
@@ -85,6 +89,7 @@ export type UpdateSettingsInput = z.infer<typeof updateSettingsInputSchema>
 export const userSettingsResponseSchema = baseResponseSchema
   .extend({
     birth_date: z.string().nullable().meta({ description: 'Birth date in YYYY-MM-DD format' }),
+    goals: goalsSchema.meta({ description: 'User goals for tracking metrics' }),
     hr_zone_start: hrZoneThresholdsSchema.meta({ description: 'Effective HR zone thresholds' }),
     hr_zone_start_source: hrZoneSourceSchema.meta({
       description: 'Source of HR zone thresholds',

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -198,10 +198,7 @@ export type OuraSyncStatusResponse = z.infer<typeof ouraSyncStatusResponseSchema
  */
 export const rescueTimeSyncStatusResponseSchema = baseResponseSchema
   .extend({
-    states: z
-      .array(providerSyncStatusSchema)
-      .optional()
-      .meta({ description: 'RescueTime sync states' }),
+    states: z.array(providerSyncStatusSchema).optional().meta({ description: 'RescueTime sync states' }),
   })
   .meta({ id: 'RescueTimeSyncStatusResponse' })
 

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -50,16 +50,10 @@ export const addTagBodySchema = z
     end_time: iso8601DateTimeSchema.optional().meta({
       description: 'End time (omit for point-in-time tags)',
     }),
-    merge_span: z
-      .number()
-      .int()
-      .positive()
-      .max(3600)
-      .optional()
-      .meta({
-        description:
-          'If provided, merge with existing tag of same name if its end_time (or start_time for point-in-time tags) is within this many seconds of new start_time. Max 3600.',
-      }),
+    merge_span: z.number().int().positive().max(3600).optional().meta({
+      description:
+        'If provided, merge with existing tag of same name if its end_time (or start_time for point-in-time tags) is within this many seconds of new start_time. Max 3600.',
+    }),
     start_time: iso8601DateTimeSchema.meta({ description: 'Start time of the tag' }),
     tag: tagTextSchema.min(1),
   })
@@ -87,7 +81,8 @@ export const addTagResponseSchema = baseResponseSchema
       description: 'Number of seconds the tag was extended by (only present if merged)',
     }),
     merged: z.boolean().optional().meta({
-      description: 'Whether the tag was merged with an existing tag (only present if merge_span was specified)',
+      description:
+        'Whether the tag was merged with an existing tag (only present if merge_span was specified)',
     }),
   })
   .meta({ id: 'AddTagResponse' })


### PR DESCRIPTION
## Summary
- Add goals feature allowing users to set targets for any metric with optional min/max values
- Configurable rolling time window (default 7 days) with "losing tomorrow" indicator
- Default goals based on Huberman/Galpin recommendations (Zone 2: 150min, Zone 5: 5-10min, Steps: 70k/week)

## Changes
- **api-spec**: Goal and GoalProgress schemas with duration parsing
- **backend**: Goals in user settings, GET /goals/progress endpoint, MCP tool
- **web**: Goals section in Settings page with inline editing, dedicated Goals display page
- **android**: Widget updated to fetch and display goals from backend

## Test plan
- [x] Backend tests pass (349 tests)
- [x] TypeScript checks pass for api-spec, backend, and web
- [x] Android compiles successfully
- [ ] Manual test: Set goals in web Settings page
- [ ] Manual test: View progress on Goals page
- [ ] Manual test: Verify Android widget displays goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)