### PR TITLE
Make goals widget scrollable with overflow support

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -119,6 +119,12 @@
                 android:resource="@xml/hr_zone_widget_info" />
         </receiver>
 
+        <!-- Widget RemoteViews Service for scrollable goals list -->
+        <service
+            android:name=".widget.GoalsWidgetService"
+            android:exported="false"
+            android:permission="android.permission.BIND_REMOTEVIEWS" />
+
         <!-- BLE Sensor Foreground Service -->
         <service
             android:name=".ble.SensorService"

--- a/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
@@ -3,6 +3,7 @@ package net.aurboda.widget
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import kotlinx.coroutines.runBlocking
@@ -108,8 +109,18 @@ class GoalsRemoteViewsFactory(private val context: Context) : RemoteViewsService
 
         // Calculate progress percentage
         val target = goal.max ?: goal.min ?: 1.0
-        val progress = ((goal.current / target) * 100).coerceIn(0.0, 100.0).toInt()
-        views.setProgressBar(R.id.goal_progress, 100, progress, false)
+        val progressPercent = (goal.current / target) * 100
+        val cappedProgress = progressPercent.coerceIn(0.0, 100.0).toInt()
+        views.setProgressBar(R.id.goal_progress, 100, cappedProgress, false)
+
+        // Handle overflow (progress > 100%)
+        if (progressPercent > 100) {
+            val overflow = (progressPercent - 100).coerceIn(0.0, 100.0).toInt()
+            views.setViewVisibility(R.id.goal_overflow, View.VISIBLE)
+            views.setProgressBar(R.id.goal_overflow, 100, overflow, false)
+        } else {
+            views.setViewVisibility(R.id.goal_overflow, View.GONE)
+        }
 
         return views
     }

--- a/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
@@ -1,0 +1,133 @@
+package net.aurboda.widget
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import kotlinx.coroutines.runBlocking
+import net.aurboda.CredentialsManager
+import net.aurboda.DataResult
+import net.aurboda.R
+import net.aurboda.fetchGoalsProgress
+import net.aurboda.formatZoneTime
+import net.aurboda.GoalProgress
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import net.aurboda.appJson
+
+private const val TAG = "GoalsWidgetService"
+
+// Friendly names for metrics
+private val metricLabels = mapOf(
+    "hr_zone_0_sec" to "Zone 0",
+    "hr_zone_1_sec" to "Zone 1",
+    "hr_zone_2_sec" to "Zone 2",
+    "hr_zone_3_sec" to "Zone 3",
+    "hr_zone_4_sec" to "Zone 4",
+    "hr_zone_5_sec" to "Zone 5",
+    "steps" to "Steps",
+    "distance" to "Distance",
+    "calories_active" to "Calories"
+)
+
+
+class GoalsWidgetService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return GoalsRemoteViewsFactory(applicationContext)
+    }
+}
+
+class GoalsRemoteViewsFactory(private val context: Context) : RemoteViewsService.RemoteViewsFactory {
+
+    private var goals: List<GoalProgress> = emptyList()
+
+    override fun onCreate() {
+        Log.d(TAG, "RemoteViewsFactory created")
+    }
+
+    override fun onDataSetChanged() {
+        Log.d(TAG, "onDataSetChanged called")
+        // Fetch goals synchronously (this runs on a binder thread, not main thread)
+        goals = runBlocking { fetchGoals() }
+        Log.d(TAG, "Fetched ${goals.size} goals")
+    }
+
+    private suspend fun fetchGoals(): List<GoalProgress> {
+        val credentials = CredentialsManager.getCredentials(context) ?: return emptyList()
+
+        val httpClient = HttpClient(Android) {
+            install(ContentNegotiation) { json(appJson) }
+        }
+
+        return try {
+            when (val result = fetchGoalsProgress(httpClient, credentials.apiUrl, credentials.authToken)) {
+                is DataResult.Success -> result.data.goals
+                is DataResult.Error -> {
+                    Log.e(TAG, "Error fetching goals: ${result.message}")
+                    emptyList()
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception fetching goals", e)
+            emptyList()
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    override fun onDestroy() {
+        goals = emptyList()
+    }
+
+    override fun getCount(): Int = goals.size
+
+    override fun getViewAt(position: Int): RemoteViews {
+        val goal = goals.getOrNull(position)
+            ?: return RemoteViews(context.packageName, R.layout.widget_goal_item)
+
+        val views = RemoteViews(context.packageName, R.layout.widget_goal_item)
+
+        // Set label
+        val label = metricLabels[goal.metric] ?: goal.metric
+        views.setTextViewText(R.id.goal_label, label)
+
+        // Set current value
+        val valueText = formatGoalValue(goal.metric, goal.current, goal.unit)
+        views.setTextViewText(R.id.goal_value, valueText)
+
+        // Set "losing tomorrow" text
+        if (goal.losingTomorrow > 0) {
+            val losingText = "(-${formatGoalValue(goal.metric, goal.losingTomorrow, goal.unit)} tomorrow)"
+            views.setTextViewText(R.id.goal_losing, losingText)
+        } else {
+            views.setTextViewText(R.id.goal_losing, "")
+        }
+
+        // Calculate progress percentage
+        val target = goal.max ?: goal.min ?: 1.0
+        val progress = ((goal.current / target) * 100).coerceIn(0.0, 100.0).toInt()
+        views.setProgressBar(R.id.goal_progress, 100, progress, false)
+
+        return views
+    }
+
+    private fun formatGoalValue(metric: String, value: Double, unit: String): String {
+        return when (unit) {
+            "sec", "seconds" -> formatZoneTime(value)
+            "count" -> value.toLong().toString()
+            "m" -> "${(value / 1000).toInt()} km"
+            else -> "${value.toInt()} $unit"
+        }
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long = position.toLong()
+
+    override fun hasStableIds(): Boolean = false
+}

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -6,43 +6,16 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.util.Log
+import android.view.View
 import android.widget.RemoteViews
 import net.aurboda.MainActivity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import net.aurboda.CredentialsManager
-import net.aurboda.DataResult
 import net.aurboda.R
-import net.aurboda.fetchGoalsProgress
-import net.aurboda.formatZoneTime
-import net.aurboda.GoalProgress
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.android.Android
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
-import net.aurboda.appJson
 
 private const val TAG = "HrZoneWidgetProvider"
 
-// Friendly names for metrics
-private val metricLabels = mapOf(
-    "hr_zone_0_sec" to "Zone 0",
-    "hr_zone_1_sec" to "Zone 1",
-    "hr_zone_2_sec" to "Zone 2",
-    "hr_zone_3_sec" to "Zone 3",
-    "hr_zone_4_sec" to "Zone 4",
-    "hr_zone_5_sec" to "Zone 5",
-    "steps" to "Steps",
-    "distance" to "Distance",
-    "calories_active" to "Calories"
-)
-
 class HrZoneWidgetProvider : AppWidgetProvider() {
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onUpdate(
         context: Context,
@@ -62,7 +35,9 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
             val appWidgetManager = AppWidgetManager.getInstance(context)
             val componentName = ComponentName(context, HrZoneWidgetProvider::class.java)
             val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
-            onUpdate(context, appWidgetManager, appWidgetIds)
+
+            // Notify the ListView adapter to refresh data
+            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.goals_list)
         }
     }
 
@@ -71,156 +46,37 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
         appWidgetManager: AppWidgetManager,
         appWidgetId: Int
     ) {
-        scope.launch {
-            val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
+        val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
 
-            // Set up click handler to open the app on the Data tab
-            val openAppIntent = Intent(context, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_DATA)
-            }
-            val pendingIntent = PendingIntent.getActivity(
-                context,
-                appWidgetId,
-                openAppIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
-
-            val credentials = CredentialsManager.getCredentials(context)
-            if (credentials == null) {
-                Log.w(TAG, "No credentials, showing empty widget")
-                setEmptyWidget(views)
-                appWidgetManager.updateAppWidget(appWidgetId, views)
-                return@launch
-            }
-
-            val httpClient = HttpClient(Android) {
-                install(ContentNegotiation) { json(appJson) }
-            }
-
-            try {
-                val goalsResult = fetchGoalsProgress(
-                    httpClient,
-                    credentials.apiUrl,
-                    credentials.authToken
-                )
-
-                when (goalsResult) {
-                    is DataResult.Success -> {
-                        val goals = goalsResult.data.goals
-                        Log.d(TAG, "Fetched ${goals.size} goals")
-                        setWidgetData(views, goals)
-                    }
-                    is DataResult.Error -> {
-                        Log.e(TAG, "Error fetching goals: ${goalsResult.message}")
-                        setEmptyWidget(views)
-                    }
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error fetching goal data", e)
-                setEmptyWidget(views)
-            } finally {
-                httpClient.close()
-            }
-
-            appWidgetManager.updateAppWidget(appWidgetId, views)
+        // Set up click handler to open the app on the Goals tab
+        val openAppIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_DATA)
         }
-    }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            appWidgetId,
+            openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        views.setPendingIntentTemplate(R.id.goals_list, pendingIntent)
+        views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
 
-    private fun setEmptyWidget(views: RemoteViews) {
-        views.setTextViewText(R.id.zone2_label, "Zone 2")
-        views.setTextViewText(R.id.zone2_time, "-- min")
-        views.setTextViewText(R.id.zone2_losing, "")
-        views.setProgressBar(R.id.zone2_progress, 100, 0, false)
-
-        views.setTextViewText(R.id.zone5_label, "Zone 5")
-        views.setTextViewText(R.id.zone5_time, "-- min")
-        views.setTextViewText(R.id.zone5_losing, "")
-        views.setProgressBar(R.id.zone5_progress, 100, 0, false)
-    }
-
-    private fun setWidgetData(views: RemoteViews, goals: List<GoalProgress>) {
-        // Find Zone 2 and Zone 5 goals, or use first two goals
-        val zone2Goal = goals.find { it.metric == "hr_zone_2_sec" }
-        val zone5Goal = goals.find { it.metric == "hr_zone_5_sec" }
-
-        // If specific zones not found, use first two goals
-        val goal1 = zone2Goal ?: goals.getOrNull(0)
-        val goal2 = zone5Goal ?: goals.getOrNull(1)
-
-        // Set Goal 1 (Zone 2 slot)
-        if (goal1 != null) {
-            setGoalView(
-                views,
-                goal1,
-                R.id.zone2_label,
-                R.id.zone2_time,
-                R.id.zone2_losing,
-                R.id.zone2_progress
-            )
-        } else {
-            views.setTextViewText(R.id.zone2_label, "No Goal")
-            views.setTextViewText(R.id.zone2_time, "--")
-            views.setTextViewText(R.id.zone2_losing, "")
-            views.setProgressBar(R.id.zone2_progress, 100, 0, false)
+        // Set up the RemoteViews adapter for the ListView
+        val serviceIntent = Intent(context, GoalsWidgetService::class.java).apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            // Unique data URI to ensure fresh adapter per widget
+            data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
         }
+        views.setRemoteAdapter(R.id.goals_list, serviceIntent)
 
-        // Set Goal 2 (Zone 5 slot)
-        if (goal2 != null) {
-            setGoalView(
-                views,
-                goal2,
-                R.id.zone5_label,
-                R.id.zone5_time,
-                R.id.zone5_losing,
-                R.id.zone5_progress
-            )
-        } else {
-            views.setTextViewText(R.id.zone5_label, "No Goal")
-            views.setTextViewText(R.id.zone5_time, "--")
-            views.setTextViewText(R.id.zone5_losing, "")
-            views.setProgressBar(R.id.zone5_progress, 100, 0, false)
-        }
-    }
+        // Set empty view
+        views.setEmptyView(R.id.goals_list, R.id.empty_view)
 
-    private fun setGoalView(
-        views: RemoteViews,
-        goal: GoalProgress,
-        labelId: Int,
-        timeId: Int,
-        losingId: Int,
-        progressId: Int
-    ) {
-        // Set label
-        val label = metricLabels[goal.metric] ?: goal.metric
-        views.setTextViewText(labelId, label)
+        appWidgetManager.updateAppWidget(appWidgetId, views)
 
-        // Set current value
-        val valueText = formatGoalValue(goal.metric, goal.current, goal.unit)
-        views.setTextViewText(timeId, valueText)
-
-        // Set "losing tomorrow" text
-        if (goal.losingTomorrow > 0) {
-            val losingText = "(-${formatGoalValue(goal.metric, goal.losingTomorrow, goal.unit)} tomorrow)"
-            views.setTextViewText(losingId, losingText)
-        } else {
-            views.setTextViewText(losingId, "")
-        }
-
-        // Calculate progress percentage
-        val target = goal.max ?: goal.min ?: 1.0
-        val progress = ((goal.current / target) * 100).coerceIn(0.0, 100.0).toInt()
-        views.setProgressBar(progressId, 100, progress, false)
-    }
-
-    private fun formatGoalValue(metric: String, value: Double, unit: String): String {
-        return when (unit) {
-            "sec", "seconds" -> formatZoneTime(value)
-            "count" -> value.toLong().toString()
-            "m" -> "${(value / 1000).toInt()} km"
-            else -> "${value.toInt()} $unit"
-        }
+        // Trigger data refresh
+        appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.goals_list)
     }
 
     companion object {

--- a/apps/android/app/src/main/res/drawable/progress_bar_goal1_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_goal1_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Green (#4CAF50) at 20% alpha -->
+            <solid android:color="#334CAF50" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Green -->
+                <solid android:color="#FF4CAF50" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/progress_bar_goal3_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_goal3_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Blue (#2196F3) at 20% alpha -->
+            <solid android:color="#332196F3" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Blue -->
+                <solid android:color="#FF2196F3" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/progress_bar_goal4_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_goal4_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Orange (#FF9800) at 20% alpha -->
+            <solid android:color="#33FF9800" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Orange -->
+                <solid android:color="#FFFF9800" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/progress_bar_goal5_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_goal5_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Purple (#9C27B0) at 20% alpha -->
+            <solid android:color="#339C27B0" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Purple -->
+                <solid android:color="#FF9C27B0" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/progress_bar_overflow_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_overflow_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="4dp" />
+            <!-- Light gray at 30% alpha -->
+            <solid android:color="#4DFFFFFF" />
+        </shape>
+    </item>
+    <!-- Progress - lighter shade to indicate overflow -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="4dp" />
+                <!-- Lighter teal for overflow -->
+                <solid android:color="#FF80CBC4" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/drawable/progress_bar_widget_drawable.xml
+++ b/apps/android/app/src/main/res/drawable/progress_bar_widget_drawable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background track -->
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <!-- Light gray at 30% alpha -->
+            <solid android:color="#4DFFFFFF" />
+        </shape>
+    </item>
+    <!-- Progress -->
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="6dp" />
+                <!-- Teal/Cyan accent color -->
+                <solid android:color="#FF26A69A" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/apps/android/app/src/main/res/layout/widget_goal_item.xml
+++ b/apps/android/app/src/main/res/layout/widget_goal_item.xml
@@ -45,4 +45,16 @@
         android:progress="0"
         android:progressDrawable="@drawable/progress_bar_widget_drawable" />
 
+    <!-- Overflow progress bar (shown when > 100%) -->
+    <ProgressBar
+        android:id="@+id/goal_overflow"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="8dp"
+        android:layout_marginTop="2dp"
+        android:max="100"
+        android:progress="0"
+        android:visibility="gone"
+        android:progressDrawable="@drawable/progress_bar_overflow_drawable" />
+
 </LinearLayout>

--- a/apps/android/app/src/main/res/layout/widget_goal_item.xml
+++ b/apps/android/app/src/main/res/layout/widget_goal_item.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingVertical="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/goal_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="#FFFFFFFF" />
+
+        <TextView
+            android:id="@+id/goal_losing"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textSize="10sp"
+            android:textColor="#88FFFFFF"
+            android:paddingStart="8dp"
+            android:gravity="center" />
+
+        <TextView
+            android:id="@+id/goal_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="#FFFFFFFF" />
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/goal_progress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="12dp"
+        android:layout_marginTop="4dp"
+        android:max="100"
+        android:progress="0"
+        android:progressDrawable="@drawable/progress_bar_widget_drawable" />
+
+</LinearLayout>

--- a/apps/android/app/src/main/res/layout/widget_hr_zones.xml
+++ b/apps/android/app/src/main/res/layout/widget_hr_zones.xml
@@ -7,110 +7,25 @@
     android:padding="8dp"
     android:background="@drawable/widget_background">
 
-    <!-- Goal 1 (Zone 2 by default - Green) -->
-    <LinearLayout
+    <ListView
+        android:id="@+id/goals_list"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:gravity="center_vertical"
-        android:paddingVertical="2dp">
+        android:layout_height="match_parent"
+        android:divider="@null"
+        android:dividerHeight="0dp"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="true"
+        android:scrollbarStyle="outsideOverlay" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/zone2_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Zone 2"
-                android:textSize="12sp"
-                android:textColor="#FFFFFFFF" />
-
-            <TextView
-                android:id="@+id/zone2_losing"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text=""
-                android:textSize="10sp"
-                android:textColor="#88FFFFFF"
-                android:paddingStart="8dp"
-                android:gravity="center" />
-
-            <TextView
-                android:id="@+id/zone2_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="0 min"
-                android:textSize="12sp"
-                android:textColor="#FFFFFFFF" />
-        </LinearLayout>
-
-        <ProgressBar
-            android:id="@+id/zone2_progress"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="match_parent"
-            android:layout_height="12dp"
-            android:layout_marginTop="4dp"
-            android:max="100"
-            android:progress="0"
-            android:progressDrawable="@drawable/progress_bar_zone2_drawable" />
-    </LinearLayout>
-
-    <!-- Goal 2 (Zone 5 by default - Red) -->
-    <LinearLayout
+    <!-- Empty view shown when no goals -->
+    <TextView
+        android:id="@+id/empty_view"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:gravity="center_vertical"
-        android:paddingVertical="2dp">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/zone5_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Zone 5"
-                android:textSize="12sp"
-                android:textColor="#FFFFFFFF" />
-
-            <TextView
-                android:id="@+id/zone5_losing"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text=""
-                android:textSize="10sp"
-                android:textColor="#88FFFFFF"
-                android:paddingStart="8dp"
-                android:gravity="center" />
-
-            <TextView
-                android:id="@+id/zone5_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="0 min"
-                android:textSize="12sp"
-                android:textColor="#FFFFFFFF" />
-        </LinearLayout>
-
-        <ProgressBar
-            android:id="@+id/zone5_progress"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="match_parent"
-            android:layout_height="12dp"
-            android:layout_marginTop="4dp"
-            android:max="100"
-            android:progress="0"
-            android:progressDrawable="@drawable/progress_bar_zone5_drawable" />
-    </LinearLayout>
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="No goals configured"
+        android:textColor="#88FFFFFF"
+        android:textSize="14sp"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/apps/web/src/components/GoalsSettings.css
+++ b/apps/web/src/components/GoalsSettings.css
@@ -61,6 +61,53 @@
   background: var(--bg-secondary, #f5f5f5);
   border-radius: 8px;
   flex-wrap: wrap;
+  position: relative;
+}
+
+.goal-row.invalid {
+  border: 2px solid #f44336;
+}
+
+.goal-row.new {
+  border: 2px dashed #673ab8;
+}
+
+.goal-reorder {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reorder-button {
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.6rem;
+  padding: 2px 6px;
+  line-height: 1;
+  color: #666;
+}
+
+.reorder-button:hover:not(:disabled) {
+  background: #ddd;
+}
+
+.reorder-button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.field-error input {
+  border-color: #f44336 !important;
+  background-color: rgba(244, 67, 54, 0.05);
+}
+
+.validation-error {
+  width: 100%;
+  color: #f44336;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
 }
 
 .goal-field {
@@ -218,6 +265,19 @@
 
   .duration-help code {
     background: #444;
+  }
+
+  .reorder-button {
+    border-color: #555;
+    color: #aaa;
+  }
+
+  .reorder-button:hover:not(:disabled) {
+    background: #444;
+  }
+
+  .field-error input {
+    background-color: rgba(244, 67, 54, 0.15);
   }
 }
 

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -70,12 +70,60 @@ const fromDisplayValue = (metric: string, displayValue: string): number | undefi
   return num
 }
 
+// Validate a goal - returns error message or null if valid
+const validateGoal = (goal: Goal): string | null => {
+  if (goal.min === undefined && goal.max === undefined) {
+    return 'At least one of Min or Max is required'
+  }
+  if (goal.min !== undefined && goal.min <= 0) {
+    return 'Min must be positive'
+  }
+  if (goal.max !== undefined && goal.max <= 0) {
+    return 'Max must be positive'
+  }
+  if (goal.min !== undefined && goal.max !== undefined && goal.min > goal.max) {
+    return 'Min cannot be greater than Max'
+  }
+  if (!/^\d+[smhdwM]$/.test(goal.window)) {
+    return 'Invalid window format'
+  }
+  return null
+}
+
+// Check if all goals are valid
+const allGoalsValid = (goals: Goal[]): boolean => {
+  return goals.every((g) => validateGoal(g) === null)
+}
+
+// Local goal state for editing (allows invalid intermediate states)
+interface LocalGoal extends Omit<Goal, 'min' | 'max' | 'window'> {
+  min?: number
+  max?: number
+  window: string
+  isNew?: boolean // Track if this is a newly added goal not yet saved
+}
+
 export function GoalsSettings({ goals }: GoalsSettingsProps) {
   const queryClient = useQueryClient()
   const [saveStatus, setSaveStatus] = useState<{ status: 'idle' | 'saving' | 'saved'; time?: Date }>({
     status: 'idle',
   })
   const [showDurationHelp, setShowDurationHelp] = useState(false)
+
+  // Local state for goals being edited (includes unsaved new goals)
+  const [localGoals, setLocalGoals] = useState<LocalGoal[]>(() => goals.map((g) => ({ ...g, isNew: false })))
+
+  // Sync local state when props change (e.g., after successful save)
+  const [prevGoals, setPrevGoals] = useState(goals)
+  if (goals !== prevGoals) {
+    setPrevGoals(goals)
+    // Merge: keep local new goals, update saved goals from props
+    setLocalGoals((local) => {
+      const newGoals = local.filter((g) => g.isNew)
+      const savedGoals = goals.map((g) => ({ ...g, isNew: false }))
+      return [...savedGoals, ...newGoals]
+    })
+  }
 
   const mutation = useMutation({
     mutationFn: updateUserSettings,
@@ -88,59 +136,147 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
     onSuccess: (data) => {
       queryClient.setQueryData(['userSettings'], data)
       setSaveStatus({ status: 'saved', time: new Date() })
+      // Mark all goals as saved
+      setLocalGoals((local) => local.map((g) => ({ ...g, isNew: false })))
     },
   })
 
-  const saveGoals = (newGoals: Goal[]) => {
-    mutation.mutate({ goals: newGoals })
+  const saveGoals = (goalsToSave: Goal[]) => {
+    // Only save if all goals are valid
+    if (!allGoalsValid(goalsToSave)) {
+      return false
+    }
+    mutation.mutate({ goals: goalsToSave })
+    return true
   }
 
-  const handleFieldBlur = (goalId: string, field: 'min' | 'max' | 'window', value: string) => {
-    const goal = goals.find((g) => g.id === goalId)
-    if (!goal) return
+  const handleFieldChange = (goalId: string, field: 'min' | 'max' | 'window', value: string) => {
+    setLocalGoals((local) =>
+      local.map((g) => {
+        if (g.id !== goalId) return g
 
-    const updatedGoals = goals.map((g) => {
-      if (g.id !== goalId) return g
+        if (field === 'window') {
+          return { ...g, window: value }
+        }
 
-      if (field === 'window') {
-        // Validate window format
-        if (!/^\d+[smhdwM]$/.test(value)) return g
-        return { ...g, window: value }
-      }
+        const numValue = fromDisplayValue(g.metric, value)
+        return { ...g, [field]: numValue }
+      }),
+    )
+  }
 
-      const numValue = fromDisplayValue(g.metric, value)
-      return { ...g, [field]: numValue }
-    })
+  const handleFieldBlur = (goalId: string) => {
+    const localGoal = localGoals.find((g) => g.id === goalId)
+    if (!localGoal) return
 
-    // Only save if something actually changed
-    const updatedGoal = updatedGoals.find((g) => g.id === goalId)
-    const originalGoal = goals.find((g) => g.id === goalId)
-    if (JSON.stringify(updatedGoal) !== JSON.stringify(originalGoal)) {
-      saveGoals(updatedGoals)
+    // Convert to Goal type for validation and saving
+    const goalToValidate: Goal = {
+      id: localGoal.id,
+      max: localGoal.max,
+      metric: localGoal.metric,
+      min: localGoal.min,
+      window: localGoal.window || '7d',
     }
+
+    // Only save if valid
+    if (validateGoal(goalToValidate) !== null) {
+      return
+    }
+
+    // Build the full goals array to save
+    const goalsToSave: Goal[] = localGoals
+      .filter((g) => validateGoal({ ...g, window: g.window || '7d' } as Goal) === null)
+      .map((g) => ({
+        id: g.id,
+        max: g.max,
+        metric: g.metric,
+        min: g.min,
+        window: g.window || '7d',
+      }))
+
+    // Check if anything changed from the saved state
+    const savedGoal = goals.find((g) => g.id === goalId)
+    if (savedGoal && JSON.stringify(goalToValidate) === JSON.stringify(savedGoal)) {
+      return
+    }
+
+    saveGoals(goalsToSave)
   }
 
   const handleMetricChange = (goalId: string, newMetric: string) => {
-    const updatedGoals = goals.map((g) => {
-      if (g.id !== goalId) return g
-      return { ...g, metric: newMetric as Goal['metric'] }
-    })
-    saveGoals(updatedGoals)
+    setLocalGoals((local) =>
+      local.map((g) => {
+        if (g.id !== goalId) return g
+        return { ...g, metric: newMetric as Goal['metric'] }
+      }),
+    )
+
+    // Auto-save if goal is valid
+    setTimeout(() => handleFieldBlur(goalId), 0)
   }
 
   const handleAddGoal = () => {
-    const newGoal: Goal = {
+    const newGoal: LocalGoal = {
       id: crypto.randomUUID(),
+      isNew: true,
       metric: 'steps',
-      min: 10000,
+      min: undefined, // Start empty so user fills it in
       window: '7d',
     }
-    saveGoals([...goals, newGoal])
+    setLocalGoals((local) => [...local, newGoal])
   }
 
   const handleDeleteGoal = (goalId: string) => {
+    const localGoal = localGoals.find((g) => g.id === goalId)
+
+    // If it's a new unsaved goal, just remove from local state
+    if (localGoal?.isNew) {
+      setLocalGoals((local) => local.filter((g) => g.id !== goalId))
+      return
+    }
+
+    // Otherwise, remove and save
     const updatedGoals = goals.filter((g) => g.id !== goalId)
+    setLocalGoals((local) => local.filter((g) => g.id !== goalId))
     saveGoals(updatedGoals)
+  }
+
+  const handleMoveGoal = (goalId: string, direction: 'up' | 'down') => {
+    setLocalGoals((local) => {
+      const index = local.findIndex((g) => g.id === goalId)
+      if (index === -1) return local
+      if (direction === 'up' && index === 0) return local
+      if (direction === 'down' && index === local.length - 1) return local
+
+      const newIndex = direction === 'up' ? index - 1 : index + 1
+      const newGoals = [...local]
+      const [removed] = newGoals.splice(index, 1)
+      newGoals.splice(newIndex, 0, removed)
+      return newGoals
+    })
+
+    // Save the new order (only valid goals)
+    setTimeout(() => {
+      const goalsToSave: Goal[] = localGoals
+        .filter((g) => !g.isNew && validateGoal({ ...g, window: g.window || '7d' } as Goal) === null)
+        .map((g) => ({
+          id: g.id,
+          max: g.max,
+          metric: g.metric,
+          min: g.min,
+          window: g.window || '7d',
+        }))
+
+      // Reorder based on current local state
+      const reordered = localGoals
+        .filter((g) => !g.isNew)
+        .map((lg) => goalsToSave.find((g) => g.id === lg.id))
+        .filter((g): g is Goal => g !== undefined)
+
+      if (reordered.length > 0) {
+        saveGoals(reordered)
+      }
+    }, 0)
   }
 
   const formatSavedTime = (time: Date): string => {
@@ -163,8 +299,8 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
       </div>
 
       <p class="section-description">
-        Set targets for metrics over a rolling time window. Goals are saved automatically when you change a
-        field.
+        Set targets for metrics over a rolling time window. Goals are saved automatically when valid. Use
+        arrows to reorder goals for the widget.
       </p>
 
       {saveStatus.status === 'saving' && <p class="save-status saving">Saving...</p>}
@@ -177,81 +313,121 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
         </p>
       )}
 
-      {goals.length === 0 ?
+      {localGoals.length === 0 ?
         <p class="no-goals">No goals set. Click "+ Add Goal" to create one.</p>
       : <div class="goals-list">
-          {goals.map((goal) => (
-            <div class="goal-row" key={goal.id}>
-              <div class="goal-field metric-field">
-                <label>Metric</label>
-                <select
-                  value={goal.metric}
-                  onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
-                >
-                  {validMetrics.map((metric) => (
-                    <option key={metric} value={metric}>
-                      {metricLabels[metric] ?? metric}
-                    </option>
-                  ))}
-                </select>
-              </div>
+          {localGoals.map((goal, index) => {
+            const validationError = validateGoal({
+              ...goal,
+              window: goal.window || '7d',
+            } as Goal)
+            const isInvalid = validationError !== null
 
-              <div class="goal-field min-field">
-                <label>Min</label>
-                <div class="input-with-unit">
-                  <input
-                    type="number"
-                    value={toDisplayValue(goal.metric, goal.min)}
-                    onBlur={(e) => handleFieldBlur(goal.id, 'min', (e.target as HTMLInputElement).value)}
-                    placeholder="-"
-                  />
-                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
-                </div>
-              </div>
-
-              <div class="goal-field max-field">
-                <label>Max</label>
-                <div class="input-with-unit">
-                  <input
-                    type="number"
-                    value={toDisplayValue(goal.metric, goal.max)}
-                    onBlur={(e) => handleFieldBlur(goal.id, 'max', (e.target as HTMLInputElement).value)}
-                    placeholder="-"
-                  />
-                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
-                </div>
-              </div>
-
-              <div class="goal-field window-field">
-                <label>
-                  Window{' '}
+            return (
+              <div class={`goal-row ${isInvalid ? 'invalid' : ''} ${goal.isNew ? 'new' : ''}`} key={goal.id}>
+                <div class="goal-reorder">
                   <button
                     type="button"
-                    class="info-button"
-                    onClick={() => setShowDurationHelp(!showDurationHelp)}
-                    aria-label="Duration format help"
+                    class="reorder-button"
+                    onClick={() => handleMoveGoal(goal.id, 'up')}
+                    disabled={index === 0}
+                    aria-label="Move up"
                   >
-                    i
+                    ▲
                   </button>
-                </label>
-                <input
-                  type="text"
-                  value={goal.window}
-                  onBlur={(e) => handleFieldBlur(goal.id, 'window', (e.target as HTMLInputElement).value)}
-                  placeholder="7d"
-                />
-              </div>
+                  <button
+                    type="button"
+                    class="reorder-button"
+                    onClick={() => handleMoveGoal(goal.id, 'down')}
+                    disabled={index === localGoals.length - 1}
+                    aria-label="Move down"
+                  >
+                    ▼
+                  </button>
+                </div>
 
-              <button
-                type="button"
-                class="delete-goal-button"
-                onClick={() => handleDeleteGoal(goal.id)}
-                aria-label="Delete goal"
-              >
-                🗑
-              </button>
-            </div>
-          ))}
+                <div class="goal-field metric-field">
+                  <label>Metric</label>
+                  <select
+                    value={goal.metric}
+                    onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
+                  >
+                    {validMetrics.map((metric) => (
+                      <option key={metric} value={metric}>
+                        {metricLabels[metric] ?? metric}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div
+                  class={`goal-field min-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
+                >
+                  <label>Min</label>
+                  <div class="input-with-unit">
+                    <input
+                      type="number"
+                      value={toDisplayValue(goal.metric, goal.min)}
+                      onInput={(e) => handleFieldChange(goal.id, 'min', (e.target as HTMLInputElement).value)}
+                      onBlur={() => handleFieldBlur(goal.id)}
+                      placeholder="-"
+                    />
+                    <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                  </div>
+                </div>
+
+                <div
+                  class={`goal-field max-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
+                >
+                  <label>Max</label>
+                  <div class="input-with-unit">
+                    <input
+                      type="number"
+                      value={toDisplayValue(goal.metric, goal.max)}
+                      onInput={(e) => handleFieldChange(goal.id, 'max', (e.target as HTMLInputElement).value)}
+                      onBlur={() => handleFieldBlur(goal.id)}
+                      placeholder="-"
+                    />
+                    <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                  </div>
+                </div>
+
+                <div class="goal-field window-field">
+                  <label>
+                    Window{' '}
+                    <button
+                      type="button"
+                      class="info-button"
+                      onClick={() => setShowDurationHelp(!showDurationHelp)}
+                      aria-label="Duration format help"
+                    >
+                      i
+                    </button>
+                  </label>
+                  <input
+                    type="text"
+                    value={goal.window}
+                    onInput={(e) =>
+                      handleFieldChange(goal.id, 'window', (e.target as HTMLInputElement).value)
+                    }
+                    onBlur={() => handleFieldBlur(goal.id)}
+                    placeholder="7d"
+                  />
+                </div>
+
+                <button
+                  type="button"
+                  class="delete-goal-button"
+                  onClick={() => handleDeleteGoal(goal.id)}
+                  aria-label="Delete goal"
+                >
+                  ×
+                </button>
+
+                {isInvalid && <div class="validation-error">{validationError}</div>}
+              </div>
+            )
+          })}
         </div>
       }
 


### PR DESCRIPTION
## Summary
- Convert widget from fixed slots to scrollable ListView (like Google Calendar/Gmail widgets)
- Display all configured goals with automatic scrolling when widget height is limited
- Add overflow progress bar for goals exceeding 100%
- Fix Add Goal UI to validate before sending to backend
- Add goal reordering with up/down arrows

## Changes
- **GoalsWidgetService**: New RemoteViewsService for efficient ListView data loading
- **widget_hr_zones.xml**: Replace fixed layout with scrollable ListView
- **widget_goal_item.xml**: Individual goal item layout with overflow bar
- **HrZoneWidgetProvider**: Updated to use RemoteViews adapter pattern
- **GoalsSettings.tsx**: Client-side validation, inline error display, reorder buttons

## Test plan
- [ ] Manual test: Add 4+ goals and verify scrolling works
- [ ] Manual test: Exceed goal target and verify overflow bar appears
- [ ] Manual test: Widget updates when data syncs
- [ ] Manual test: Add new goal - form should be empty, not send to backend
- [ ] Manual test: Clear both min and max - should show error, not send to backend
- [ ] Manual test: Use arrows to reorder goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)