### PR TITLE
Fix default goal UUIDs to pass Zod validation

### DIFF
--- a/packages/api-spec/src/schemas/goals.ts
+++ b/packages/api-spec/src/schemas/goals.ts
@@ -76,20 +76,20 @@ export type Goals = z.infer<typeof goalsSchema>
  */
 export const defaultGoals: Goal[] = [
   {
-    id: '00000000-0000-0000-0000-000000000001',
+    id: 'a0000001-0000-4000-8000-000000000001',
     metric: 'hr_zone_2_sec',
     min: 9000, // 150 minutes in seconds
     window: '7d',
   },
   {
-    id: '00000000-0000-0000-0000-000000000002',
+    id: 'a0000002-0000-4000-8000-000000000002',
     max: 600, // 10 minutes in seconds
     metric: 'hr_zone_5_sec',
     min: 300, // 5 minutes in seconds
     window: '7d',
   },
   {
-    id: '00000000-0000-0000-0000-000000000003',
+    id: 'a0000003-0000-4000-8000-000000000003',
     metric: 'steps',
     min: 70000,
     window: '7d',


### PR DESCRIPTION
## Summary
- Zod's `uuid()` validator requires valid UUID versions (1-8) in the version field
- The previous default goal IDs (`00000000-0000-0000-...`) used version 0 which fails validation
- Updated to use UUIDs with version 4 and valid variant bits

This was causing 400 errors when users tried to reorder the default goals.

## Test plan
- [ ] Reorder default goals on Settings page - should work without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)