### PR TITLE
Add invitation system and admin settings

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -11,6 +11,9 @@ import {
   type AddTagBody,
   addTagBodySchema,
   type AddTagResponse,
+  type AdminSettingsResponse,
+  type CreateInvitationBody,
+  createInvitationBodySchema,
   type DailySummaryQuery,
   dailySummaryQuerySchema,
   type DailySummaryResponse,
@@ -19,9 +22,11 @@ import {
   detectedLocationsQuerySchema,
   type DetectedLocationsResponse,
   type GoalsProgressResponse,
+  type InvitationResponse,
   type LocationsQuery,
   locationsQuerySchema,
   type LocationsResponse,
+  type LoginResponse,
   type NamedLocationsResponse,
   type PeriodSummaryQuery,
   periodSummaryQuerySchema,
@@ -34,9 +39,13 @@ import {
   type QueryMetricsQuery,
   queryMetricsQuerySchema,
   type QueryMetricsResponse,
+  type ServerStatusResponse,
+  type SignupResponse,
   type TagsQuery,
   tagsQuerySchema,
   type TagsResponse,
+  type UpdateAdminSettingsBody,
+  updateAdminSettingsBodySchema,
   type UpdateNamedLocationBody,
   updateNamedLocationBodySchema,
   type UpdateSettingsInput,
@@ -72,10 +81,12 @@ import { syncAllOuraData } from './oura-sync'
 import { createOwnTracksRouter } from './owntracks'
 import { syncRescueTimeData } from './rescuetime-sync'
 import { isValidMetric, MetricType, validMetrics } from './schema'
+import { getCentralDb, initializeCentralDb } from './services/central-db'
 import { createDetectionTrigger, DetectionTrigger } from './services/detection-trigger'
 import { runDetectionForUser } from './services/detection-worker'
 import { createGeocodeQueue, GeocodeQueue } from './services/geocode-queue'
 import { getGoalsProgress } from './services/goals'
+import { createInvitationAuth } from './services/invitation'
 import {
   deleteNamedLocation,
   getDetectedLocations,
@@ -109,11 +120,18 @@ declare global {
 
 const main = async () => {
   const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 })
+  const forbidden = Object.assign(new Error('Forbidden'), { status: 403 })
 
-  const auth = createAuth(process.env.SESSION_SECRET ?? '')
+  const sessionSecret = process.env.SESSION_SECRET ?? ''
+  const auth = createAuth(sessionSecret)
+  const invitationAuth = createInvitationAuth(sessionSecret)
 
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
   const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost)
+
+  // Initialize central database (server settings, admins)
+  await initializeCentralDb()
+  const centralDb = getCentralDb()
 
   // Create sync provider for auto-syncing data before queries
   const syncProvider = createSyncProvider({
@@ -152,19 +170,50 @@ const main = async () => {
     return next(unauthorized)
   }
 
-  const allowSignup = process.env.ALLOW_SIGNUP === 'true'
+  const adminMiddleware: RequestHandler = async (req, res, next) => {
+    if (!req.user) {
+      return next(unauthorized)
+    }
+    const isAdmin = await centralDb.isAdmin(req.user)
+    if (!isAdmin) {
+      return next(forbidden)
+    }
+    next()
+  }
 
-  httpd.get('/status', (_req, res) => {
-    res.json({ signupAllowed: allowSignup, success: true })
+  httpd.get<Record<string, never>, ServerStatusResponse>('/status', async (_req, res) => {
+    const signupMode = await centralDb.getSignupMode()
+    res.json({
+      signupAllowed: signupMode === 'open',
+      signupMode,
+      success: true,
+    })
   })
 
-  httpd.post('/signup', async (req, res, next) => {
-    if (!allowSignup) {
-      res.status(403).json({ error: 'Signup is disabled', success: false })
+  httpd.post<Record<string, never>, SignupResponse>('/signup', async (req, res, next) => {
+    const signupMode = await centralDb.getSignupMode()
+
+    if (signupMode === 'closed') {
+      res.status(403).json({ error: 'Signup is currently closed', success: false })
       return
     }
 
-    const { username: user, password } = req.body
+    const { username: user, password, invitation } = req.body
+
+    // In invite_only mode, require valid invitation token
+    if (signupMode === 'invite_only') {
+      if (!invitation || typeof invitation !== 'string') {
+        res.status(403).json({ error: 'An invitation is required to sign up', success: false })
+        return
+      }
+      const validation = invitationAuth.validateInvitationToken(invitation)
+      if (!validation.valid) {
+        const errorMsg = validation.expired ? 'Invitation has expired' : 'Invalid invitation'
+        res.status(403).json({ error: errorMsg, success: false })
+        return
+      }
+    }
+
     if (!user || typeof user !== 'string' || !password || typeof password !== 'string') {
       res.status(400).json({ error: 'Username and password are required', success: false })
       return
@@ -208,14 +257,24 @@ const main = async () => {
     try {
       await makeNewUserDb(userDb, user, password)
       const token = auth.createToken(user)
-      res.json({ success: true, token })
+
+      // First user becomes admin automatically
+      const adminCount = await centralDb.getAdminCount()
+      let isAdmin = false
+      if (adminCount === 0) {
+        await centralDb.addAdmin(user)
+        isAdmin = true
+        console.log(`First user ${user} automatically made admin`)
+      }
+
+      res.json({ isAdmin, success: true, token })
     } catch (err) {
       console.error('Signup error:', err)
       next(err)
     }
   })
 
-  httpd.post('/login', async (req, res, next) => {
+  httpd.post<Record<string, never>, LoginResponse>('/login', async (req, res, next) => {
     const { username: user, password } = req.body
     if (!user) return next(unauthorized)
 
@@ -238,9 +297,10 @@ const main = async () => {
     } else return next(unauthorized)
 
     const token = auth.createToken(user)
+    const isAdmin = await centralDb.isAdmin(user)
 
     res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ refresh: token, token }))
+    res.end(JSON.stringify({ isAdmin, refresh: token, token }))
   })
 
   httpd.post('/refresh', async (req, res) => {
@@ -645,6 +705,67 @@ const main = async () => {
         return res.status(400).json(result)
       }
       res.json(result)
+    },
+  )
+
+  // ==========================================================================
+  // Admin API
+  // ==========================================================================
+
+  // GET /admin/settings - Get admin settings
+  httpd.get<Record<string, never>, AdminSettingsResponse>(
+    '/admin/settings',
+    authMiddleware,
+    adminMiddleware,
+    async (_req, res) => {
+      const signupMode = await centralDb.getSignupMode()
+      const adminCount = await centralDb.getAdminCount()
+      res.json({
+        admin_count: adminCount,
+        signup_mode: signupMode,
+        success: true,
+      })
+    },
+  )
+
+  // PATCH /admin/settings - Update admin settings
+  httpd.patch<Record<string, never>, AdminSettingsResponse, UpdateAdminSettingsBody>(
+    '/admin/settings',
+    authMiddleware,
+    adminMiddleware,
+    validateBody(updateAdminSettingsBodySchema),
+    async (req, res) => {
+      const { signup_mode } = req.body
+      if (signup_mode) {
+        await centralDb.setSignupMode(signup_mode)
+      }
+      const currentMode = await centralDb.getSignupMode()
+      const adminCount = await centralDb.getAdminCount()
+      res.json({
+        admin_count: adminCount,
+        signup_mode: currentMode,
+        success: true,
+      })
+    },
+  )
+
+  // POST /admin/invitations - Create a new invitation
+  httpd.post<Record<string, never>, InvitationResponse, CreateInvitationBody>(
+    '/admin/invitations',
+    authMiddleware,
+    adminMiddleware,
+    validateBody(createInvitationBodySchema),
+    async (req, res) => {
+      const { expiryHours } = req.body
+      const token = invitationAuth.createInvitationToken(expiryHours)
+      const expiresAt = invitationAuth.getTokenExpiry(token)
+
+      res.json({
+        expiresAt: expiresAt!.toISOString(),
+        success: true,
+        token,
+        url: `${webHost}/signup?invite=${encodeURIComponent(token)}`,
+      })
     },
   )
 

--- a/apps/backend/src/services/central-db.test.ts
+++ b/apps/backend/src/services/central-db.test.ts
@@ -1,0 +1,218 @@
+import pg from 'pg'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createCentralDb, type CentralDb, type SignupMode } from './central-db'
+
+// Mock pg.Client
+vi.mock('pg', () => {
+  const mockQuery = vi.fn()
+  const MockClient = vi.fn(() => ({
+    connect: vi.fn(),
+    end: vi.fn(),
+    query: mockQuery,
+  }))
+  return { Client: MockClient, default: { Client: MockClient } }
+})
+
+describe('central-db', () => {
+  let mockClient: {
+    connect: ReturnType<typeof vi.fn>
+    end: ReturnType<typeof vi.fn>
+    query: ReturnType<typeof vi.fn>
+  }
+  let centralDb: CentralDb
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClient = {
+      connect: vi.fn(),
+      end: vi.fn(),
+      query: vi.fn(),
+    }
+    centralDb = createCentralDb({ getClient: async () => mockClient as unknown as pg.Client })
+  })
+
+  describe('initializeCentralDb', () => {
+    test('creates tables and sets default signup_mode', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.initializeCentralDb()
+
+      // Should create server_settings table
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS server_settings'),
+      )
+      // Should create admins table
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS admins'),
+      )
+      // Should insert default signup_mode (third call, no params array)
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO server_settings'))
+    })
+  })
+
+  describe('getServerSetting', () => {
+    test('returns setting value when found', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ value: 'invite_only' }] })
+
+      const result = await centralDb.getServerSetting('signup_mode')
+
+      expect(result).toBe('invite_only')
+      expect(mockClient.query).toHaveBeenCalledWith('SELECT value FROM server_settings WHERE key = $1', [
+        'signup_mode',
+      ])
+    })
+
+    test('returns null when setting not found', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getServerSetting('signup_mode')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('setServerSetting', () => {
+    test('upserts setting value', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.setServerSetting('signup_mode', 'closed')
+
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO server_settings'), [
+        'signup_mode',
+        '"closed"',
+      ])
+    })
+  })
+
+  describe('getSignupMode', () => {
+    test('returns signup mode when found', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ value: 'invite_only' }] })
+
+      const result = await centralDb.getSignupMode()
+
+      expect(result).toBe('invite_only')
+    })
+
+    test('returns "open" when no setting exists', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getSignupMode()
+
+      expect(result).toBe('open')
+    })
+  })
+
+  describe('setSignupMode', () => {
+    test('sets signup mode', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.setSignupMode('invite_only')
+
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO server_settings'), [
+        '"invite_only"',
+      ])
+    })
+
+    test.each(['open', 'invite_only', 'closed'] as SignupMode[])('accepts valid mode: %s', async (mode) => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await expect(centralDb.setSignupMode(mode)).resolves.not.toThrow()
+    })
+  })
+
+  describe('isAdmin', () => {
+    test('returns true when user is admin', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ username: 'admin' }] })
+
+      const result = await centralDb.isAdmin('admin')
+
+      expect(result).toBe(true)
+      expect(mockClient.query).toHaveBeenCalledWith('SELECT 1 FROM admins WHERE username = $1', ['admin'])
+    })
+
+    test('returns false when user is not admin', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.isAdmin('user')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('addAdmin', () => {
+    test('inserts admin user', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.addAdmin('newadmin')
+
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO admins'), [
+        'newadmin',
+      ])
+    })
+
+    test('handles duplicate admin gracefully', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await expect(centralDb.addAdmin('existingadmin')).resolves.not.toThrow()
+    })
+  })
+
+  describe('removeAdmin', () => {
+    test('returns true when admin removed', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 1 })
+
+      const result = await centralDb.removeAdmin('admin')
+
+      expect(result).toBe(true)
+      expect(mockClient.query).toHaveBeenCalledWith('DELETE FROM admins WHERE username = $1', ['admin'])
+    })
+
+    test('returns false when admin not found', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 0 })
+
+      const result = await centralDb.removeAdmin('nonexistent')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getAdminCount', () => {
+    test('returns count of admins', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ count: 3 }] })
+
+      const result = await centralDb.getAdminCount()
+
+      expect(result).toBe(3)
+      expect(mockClient.query).toHaveBeenCalledWith('SELECT COUNT(*)::integer as count FROM admins')
+    })
+
+    test('returns 0 when no admins', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ count: 0 }] })
+
+      const result = await centralDb.getAdminCount()
+
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('getAdmins', () => {
+    test('returns list of admin usernames', async () => {
+      mockClient.query.mockResolvedValue({
+        rows: [{ username: 'admin1' }, { username: 'admin2' }],
+      })
+
+      const result = await centralDb.getAdmins()
+
+      expect(result).toEqual(['admin1', 'admin2'])
+      expect(mockClient.query).toHaveBeenCalledWith('SELECT username FROM admins ORDER BY created_at')
+    })
+
+    test('returns empty array when no admins', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getAdmins()
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -1,0 +1,263 @@
+/**
+ * Central database service for server-wide settings and admin management.
+ *
+ * Uses the shared 'aurboda' database (same as pg-boss queue) for:
+ * - Server-wide configuration (signup mode, etc.)
+ * - Admin user list
+ */
+
+import pg from 'pg'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type SignupMode = 'open' | 'invite_only' | 'closed'
+
+export interface ServerSettings {
+  signup_mode: SignupMode
+}
+
+export interface CentralDbDeps {
+  getClient: () => Promise<pg.Client>
+}
+
+export interface CentralDb {
+  initializeCentralDb: () => Promise<void>
+  getServerSetting: <K extends keyof ServerSettings>(key: K) => Promise<ServerSettings[K] | null>
+  setServerSetting: <K extends keyof ServerSettings>(key: K, value: ServerSettings[K]) => Promise<void>
+  getSignupMode: () => Promise<SignupMode>
+  setSignupMode: (mode: SignupMode) => Promise<void>
+  isAdmin: (username: string) => Promise<boolean>
+  addAdmin: (username: string) => Promise<void>
+  removeAdmin: (username: string) => Promise<boolean>
+  getAdminCount: () => Promise<number>
+  getAdmins: () => Promise<string[]>
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const DEFAULT_CENTRAL_DB = 'aurboda'
+
+// ============================================================================
+// Database helpers
+// ============================================================================
+
+/**
+ * Get database connection parameters from environment.
+ */
+const getDbParams = () => ({
+  database: process.env.CENTRAL_DB || DEFAULT_CENTRAL_DB,
+  host: process.env.PGHOST || 'localhost',
+  password: process.env.PGPASSWORD,
+  port: parseInt(process.env.PGPORT || '5432', 10),
+  user: process.env.PGUSER,
+})
+
+/**
+ * Ensure the central database exists, creating it if necessary.
+ */
+const ensureDatabase = async (): Promise<boolean> => {
+  const params = getDbParams()
+
+  // First, try connecting directly to the target database (it might already exist)
+  const targetClient = new pg.Client({ database: params.database })
+
+  try {
+    await targetClient.connect()
+    await targetClient.end()
+    return true
+  } catch {
+    await targetClient.end().catch(() => {})
+  }
+
+  // Connect to postgres database to create the target database
+  const postgresClient = new pg.Client({ database: 'postgres' })
+
+  try {
+    await postgresClient.connect()
+    await postgresClient.query(`CREATE DATABASE "${params.database}"`)
+    console.log(`Created central database: ${params.database}`)
+    return true
+  } catch (error) {
+    console.error(`Failed to create central database '${params.database}':`, error)
+    return false
+  } finally {
+    await postgresClient.end()
+  }
+}
+
+// ============================================================================
+// Schema initialization
+// ============================================================================
+
+const CREATE_SERVER_SETTINGS_TABLE = `
+  CREATE TABLE IF NOT EXISTS server_settings (
+    key VARCHAR(100) PRIMARY KEY,
+    value JSONB NOT NULL,
+    updated_at TIMESTAMP DEFAULT NOW()
+  )
+`
+
+const CREATE_ADMINS_TABLE = `
+  CREATE TABLE IF NOT EXISTS admins (
+    username VARCHAR(255) PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT NOW()
+  )
+`
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create a central database service instance.
+ */
+export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
+  const { getClient } = deps
+
+  return {
+    addAdmin: async (username: string): Promise<void> => {
+      const client = await getClient()
+      await client.query(`INSERT INTO admins (username) VALUES ($1) ON CONFLICT (username) DO NOTHING`, [
+        username,
+      ])
+    },
+
+    getAdminCount: async (): Promise<number> => {
+      const client = await getClient()
+      const result = await client.query('SELECT COUNT(*)::integer as count FROM admins')
+      return result.rows[0].count
+    },
+
+    getAdmins: async (): Promise<string[]> => {
+      const client = await getClient()
+      const result = await client.query('SELECT username FROM admins ORDER BY created_at')
+      return result.rows.map((row) => row.username)
+    },
+
+    getServerSetting: async <K extends keyof ServerSettings>(key: K): Promise<ServerSettings[K] | null> => {
+      const client = await getClient()
+      const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [key])
+      if (result.rows.length === 0) return null
+      return result.rows[0].value as ServerSettings[K]
+    },
+
+    getSignupMode: async (): Promise<SignupMode> => {
+      const client = await getClient()
+      const result = await client.query('SELECT value FROM server_settings WHERE key = $1', ['signup_mode'])
+      if (result.rows.length === 0) return 'open'
+      return result.rows[0].value as SignupMode
+    },
+
+    initializeCentralDb: async () => {
+      const client = await getClient()
+      await client.query(CREATE_SERVER_SETTINGS_TABLE)
+      await client.query(CREATE_ADMINS_TABLE)
+
+      // Set default signup_mode if not exists
+      await client.query(
+        `INSERT INTO server_settings (key, value)
+         VALUES ('signup_mode', '"open"')
+         ON CONFLICT (key) DO NOTHING`,
+      )
+    },
+
+    isAdmin: async (username: string): Promise<boolean> => {
+      const client = await getClient()
+      const result = await client.query('SELECT 1 FROM admins WHERE username = $1', [username])
+      return result.rows.length > 0
+    },
+
+    removeAdmin: async (username: string): Promise<boolean> => {
+      const client = await getClient()
+      const result = await client.query('DELETE FROM admins WHERE username = $1', [username])
+      return (result.rowCount ?? 0) > 0
+    },
+
+    setServerSetting: async <K extends keyof ServerSettings>(
+      key: K,
+      value: ServerSettings[K],
+    ): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO server_settings (key, value, updated_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = NOW()`,
+        [key, JSON.stringify(value)],
+      )
+    },
+
+    setSignupMode: async (mode: SignupMode): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO server_settings (key, value, updated_at)
+         VALUES ('signup_mode', $1, NOW())
+         ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+        [JSON.stringify(mode)],
+      )
+    },
+  }
+}
+
+// ============================================================================
+// Singleton instance for use in api.ts
+// ============================================================================
+
+let centralDbClient: pg.Client | null = null
+let centralDbInstance: CentralDb | null = null
+
+/**
+ * Get or create the singleton central database client.
+ */
+const getCentralDbClient = async (): Promise<pg.Client> => {
+  if (centralDbClient) return centralDbClient
+
+  // Ensure database exists
+  const dbReady = await ensureDatabase()
+  if (!dbReady) {
+    throw new Error('Failed to initialize central database')
+  }
+
+  const params = getDbParams()
+  centralDbClient = new pg.Client({ database: params.database })
+  await centralDbClient.connect()
+  return centralDbClient
+}
+
+/**
+ * Get the singleton central database instance.
+ * Call initializeCentralDb() before using other methods.
+ */
+export const getCentralDb = (): CentralDb => {
+  if (!centralDbInstance) {
+    centralDbInstance = createCentralDb({ getClient: getCentralDbClient })
+  }
+  return centralDbInstance
+}
+
+/**
+ * Initialize the central database (create tables and default settings).
+ * Should be called once at server startup.
+ */
+export const initializeCentralDb = async (): Promise<void> => {
+  const db = getCentralDb()
+  await db.initializeCentralDb()
+
+  // Check for ALLOW_SIGNUP env for backwards compatibility
+  const allowSignupEnv = process.env.ALLOW_SIGNUP
+  if (allowSignupEnv !== undefined) {
+    const currentMode = await db.getSignupMode()
+    // Only migrate if still at default 'open' mode
+    if (currentMode === 'open') {
+      const newMode: SignupMode = allowSignupEnv === 'true' ? 'open' : 'closed'
+      await db.setSignupMode(newMode)
+      console.log(`Migrated ALLOW_SIGNUP=${allowSignupEnv} to signup_mode=${newMode}`)
+      console.log('DEPRECATION: ALLOW_SIGNUP env is deprecated. Use admin settings to control signup mode.')
+    }
+  }
+
+  console.log('Central database initialized')
+}

--- a/apps/backend/src/services/invitation.test.ts
+++ b/apps/backend/src/services/invitation.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createInvitationAuth } from './invitation'
+
+const VALID_SALT = 'test-secret-key-32-bytes-long!!!' // exactly 32 bytes
+
+describe('invitation', () => {
+  describe('createInvitationAuth', () => {
+    test('throws if sessionSalt is empty', () => {
+      expect(() => createInvitationAuth('')).toThrow(
+        'SESSION_SECRET must be set and be exactly 32 bytes (256 bits)',
+      )
+    })
+
+    test('throws if sessionSalt is too short', () => {
+      expect(() => createInvitationAuth('too-short')).toThrow(
+        'SESSION_SECRET must be set and be exactly 32 bytes (256 bits)',
+      )
+    })
+
+    test('throws if sessionSalt is too long', () => {
+      expect(() =>
+        createInvitationAuth('this-is-way-too-long-for-a-256-bit-key-it-has-too-many-bytes'),
+      ).toThrow('SESSION_SECRET must be set and be exactly 32 bytes (256 bits)')
+    })
+
+    test('succeeds with exactly 32 bytes', () => {
+      expect(() => createInvitationAuth(VALID_SALT)).not.toThrow()
+    })
+  })
+
+  describe('createInvitationToken', () => {
+    const auth = createInvitationAuth(VALID_SALT)
+
+    test('creates a token with expected format (3 parts separated by dashes)', () => {
+      const token = auth.createInvitationToken()
+      const parts = token.split('-')
+      expect(parts).toHaveLength(3)
+    })
+
+    test('creates different tokens each time (unique IV)', () => {
+      const token1 = auth.createInvitationToken()
+      const token2 = auth.createInvitationToken()
+      expect(token1).not.toBe(token2)
+    })
+
+    test('creates valid tokens with default 7-day expiry', () => {
+      const token = auth.createInvitationToken()
+      const result = auth.validateInvitationToken(token)
+      expect(result.valid).toBe(true)
+    })
+
+    test('creates valid tokens with custom expiry', () => {
+      const token = auth.createInvitationToken(24) // 24 hours
+      const result = auth.validateInvitationToken(token)
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe('validateInvitationToken', () => {
+    const auth = createInvitationAuth(VALID_SALT)
+
+    test('validates a valid token', () => {
+      const token = auth.createInvitationToken()
+      const result = auth.validateInvitationToken(token)
+      expect(result.valid).toBe(true)
+      expect(result.expired).toBeUndefined()
+      expect(result.error).toBeUndefined()
+    })
+
+    test('returns invalid for empty token', () => {
+      const result = auth.validateInvitationToken('')
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Invalid token')
+    })
+
+    test('returns invalid for malformed token (wrong number of parts)', () => {
+      expect(auth.validateInvitationToken('only-two-parts').valid).toBe(false)
+      expect(auth.validateInvitationToken('too-many-parts-here-now').valid).toBe(false)
+    })
+
+    test('returns invalid for tampered token', () => {
+      const token = auth.createInvitationToken()
+      const parts = token.split('-')
+      parts[0] = 'tampered' + parts[0]
+      const tamperedToken = parts.join('-')
+      const result = auth.validateInvitationToken(tamperedToken)
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Invalid token')
+    })
+
+    test('returns invalid for token from different salt', () => {
+      const otherAuth = createInvitationAuth('other-secret-key-32-bytes-long!!') // exactly 32 bytes
+      const token = otherAuth.createInvitationToken()
+      const result = auth.validateInvitationToken(token)
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('Invalid token')
+    })
+  })
+
+  describe('token expiry', () => {
+    const auth = createInvitationAuth(VALID_SALT)
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    test('token expires after specified time', () => {
+      const now = new Date('2024-01-15T12:00:00Z')
+      vi.setSystemTime(now)
+
+      const token = auth.createInvitationToken(1) // 1 hour
+
+      // Still valid after 59 minutes
+      vi.setSystemTime(new Date('2024-01-15T12:59:00Z'))
+      expect(auth.validateInvitationToken(token).valid).toBe(true)
+
+      // Expired after 61 minutes
+      vi.setSystemTime(new Date('2024-01-15T13:01:00Z'))
+      const result = auth.validateInvitationToken(token)
+      expect(result.valid).toBe(false)
+      expect(result.expired).toBe(true)
+      expect(result.error).toBe('Token expired')
+    })
+
+    test('default expiry is 7 days', () => {
+      const now = new Date('2024-01-15T12:00:00Z')
+      vi.setSystemTime(now)
+
+      const token = auth.createInvitationToken()
+
+      // Still valid after 6 days
+      vi.setSystemTime(new Date('2024-01-21T12:00:00Z'))
+      expect(auth.validateInvitationToken(token).valid).toBe(true)
+
+      // Expired after 8 days
+      vi.setSystemTime(new Date('2024-01-23T12:00:00Z'))
+      const result = auth.validateInvitationToken(token)
+      expect(result.valid).toBe(false)
+      expect(result.expired).toBe(true)
+    })
+  })
+
+  describe('getTokenExpiry', () => {
+    const auth = createInvitationAuth(VALID_SALT)
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    test('returns correct expiry date', () => {
+      const now = new Date('2024-01-15T12:00:00Z')
+      vi.setSystemTime(now)
+
+      const token = auth.createInvitationToken(24) // 24 hours
+      const expiry = auth.getTokenExpiry(token)
+
+      expect(expiry).toEqual(new Date('2024-01-16T12:00:00Z'))
+    })
+
+    test('returns null for invalid token', () => {
+      expect(auth.getTokenExpiry('')).toBeNull()
+      expect(auth.getTokenExpiry('invalid-token-here')).toBeNull()
+    })
+  })
+
+  describe('stress test', () => {
+    const auth = createInvitationAuth(VALID_SALT)
+
+    test('can create and validate many tokens without errors', () => {
+      for (let i = 0; i < 100; i++) {
+        const token = auth.createInvitationToken()
+        expect(auth.validateInvitationToken(token).valid).toBe(true)
+      }
+    })
+  })
+})

--- a/apps/backend/src/services/invitation.ts
+++ b/apps/backend/src/services/invitation.ts
@@ -1,0 +1,118 @@
+/**
+ * Invitation token service for invite-only signup mode.
+ *
+ * Uses AES-256-GCM encryption (same pattern as auth.ts) to create secure,
+ * time-limited invitation tokens.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface InvitationPayload {
+  type: 'invitation'
+  iat: number // Issued at (timestamp in seconds)
+  exp: number // Expiration (timestamp in seconds)
+}
+
+export interface InvitationValidationResult {
+  valid: boolean
+  expired?: boolean
+  error?: string
+}
+
+export interface InvitationAuth {
+  createInvitationToken: (expiryHours?: number) => string
+  validateInvitationToken: (token: string) => InvitationValidationResult
+  getTokenExpiry: (token: string) => Date | null
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_EXPIRY_HOURS = 168 // 7 days
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create an invitation auth service.
+ *
+ * @param sessionSalt - The 32-byte session secret (same as used for auth tokens)
+ * @returns InvitationAuth instance
+ */
+export const createInvitationAuth = (sessionSalt: string): InvitationAuth => {
+  if (!sessionSalt || Buffer.from(sessionSalt).length !== 32) {
+    throw new Error('SESSION_SECRET must be set and be exactly 32 bytes (256 bits)')
+  }
+
+  const encrypt = (payload: InvitationPayload): string => {
+    const iv = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', sessionSalt, iv)
+    const json = JSON.stringify(payload)
+    return (
+      cipher.update(json, 'utf8', 'base64') +
+      cipher.final('base64') +
+      `-${iv.toString('base64')}-${cipher.getAuthTag().toString('base64')}`
+    )
+  }
+
+  const decrypt = (token: string): InvitationPayload | null => {
+    if (!token) return null
+
+    const parts = token.split('-')
+    if (parts.length !== 3) return null
+
+    const [encrypted, iv, tag] = parts
+
+    try {
+      const decipher = createDecipheriv('aes-256-gcm', sessionSalt, Buffer.from(iv, 'base64'))
+      decipher.setAuthTag(Buffer.from(tag, 'base64'))
+      const json = decipher.update(encrypted, 'base64', 'utf8') + decipher.final('utf8')
+      return JSON.parse(json) as InvitationPayload
+    } catch {
+      return null
+    }
+  }
+
+  return {
+    createInvitationToken: (expiryHours = DEFAULT_EXPIRY_HOURS): string => {
+      const now = Math.floor(Date.now() / 1000)
+      const payload: InvitationPayload = {
+        exp: now + expiryHours * 60 * 60,
+        iat: now,
+        type: 'invitation',
+      }
+      return encrypt(payload)
+    },
+
+    getTokenExpiry: (token: string): Date | null => {
+      const payload = decrypt(token)
+      if (!payload) return null
+      return new Date(payload.exp * 1000)
+    },
+
+    validateInvitationToken: (token: string): InvitationValidationResult => {
+      const payload = decrypt(token)
+
+      if (!payload) {
+        return { error: 'Invalid token', valid: false }
+      }
+
+      if (payload.type !== 'invitation') {
+        return { error: 'Invalid token type', valid: false }
+      }
+
+      const now = Math.floor(Date.now() / 1000)
+      if (payload.exp < now) {
+        return { error: 'Token expired', expired: true, valid: false }
+      }
+
+      return { valid: true }
+    },
+  }
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { auth, logout } from '../state/auth'
 export function Header() {
   const { url } = useLocation()
   const isLoggedIn = auth.value.token
+  const isAdmin = auth.value.isAdmin
 
   const handleLogout = (e: Event) => {
     e.preventDefault()
@@ -30,6 +31,11 @@ export function Header() {
             <a href="/places" class={url == '/places' && 'active'}>
               Places
             </a>
+            {isAdmin && (
+              <a href="/admin" class={url == '/admin' && 'active'}>
+                Admin
+              </a>
+            )}
             <span class="spacer" />
             <a href="/settings" class={url == '/settings' ? 'active user-link' : 'user-link'}>
               {auth.value.user}

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { LocationProvider, Route, Router } from 'preact-iso'
 import { Footer } from './components/Footer.jsx'
 import { Header } from './components/Header.jsx'
+import { AdminSettings } from './pages/AdminSettings/index.jsx'
 import { Goals } from './pages/Goals/index.jsx'
 import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
@@ -31,6 +32,7 @@ export function App() {
             <Route path="/timeline" component={Timeline} />
             <Route path="/places" component={Places} />
             <Route path="/settings" component={Settings} />
+            <Route path="/admin" component={AdminSettings} />
             <Route default component={NotFound} />
           </Router>
         </main>

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -1,0 +1,197 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocation } from 'preact-iso'
+import { useCallback, useState } from 'preact/hooks'
+import {
+  fetchAdminSettings,
+  generateInvitation,
+  InvitationResult,
+  SignupMode,
+  updateAdminSettings,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+
+import './style.css'
+
+type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
+
+const formatSavedTime = (time: Date): string => {
+  const now = new Date()
+  const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
+  if (diffSec < 5) return 'just now'
+  if (diffSec < 60) return `${diffSec} seconds ago`
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
+  return time.toLocaleTimeString()
+}
+
+const formatExpiryTime = (expiresAt: Date): string => {
+  const now = new Date()
+  const diffMs = expiresAt.getTime() - now.getTime()
+  if (diffMs <= 0) return 'expired'
+
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
+
+  if (days > 0) return `${days} day${days > 1 ? 's' : ''} ${hours}h`
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes} minute${minutes > 1 ? 's' : ''}`
+}
+
+function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
+  if (saveStatus.status === 'idle') return null
+  return (
+    <span class={`save-indicator ${saveStatus.status}`}>
+      {saveStatus.status === 'saving' && 'Saving...'}
+      {saveStatus.status === 'saved' && saveStatus.time && `Saved ${formatSavedTime(saveStatus.time)}`}
+      {saveStatus.status === 'error' && (saveStatus.error ?? 'Error saving')}
+    </span>
+  )
+}
+
+export function AdminSettings() {
+  const { route } = useLocation()
+  const isLoggedIn = auth.value.token
+  const isAdmin = auth.value.isAdmin
+  const queryClient = useQueryClient()
+
+  const { data: settings, isLoading } = useQuery({
+    enabled: !!isLoggedIn && !!isAdmin,
+    queryFn: fetchAdminSettings,
+    queryKey: ['adminSettings'],
+  })
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [invitation, setInvitation] = useState<InvitationResult | null>(null)
+  const [invitationLoading, setInvitationLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const handleSignupModeChange = useCallback(
+    async (e: Event) => {
+      const newMode = (e.target as HTMLSelectElement).value as SignupMode
+      setSaveStatus({ status: 'saving' })
+      try {
+        const result = await updateAdminSettings({ signup_mode: newMode })
+        queryClient.setQueryData(['adminSettings'], result)
+        setSaveStatus({ status: 'saved', time: new Date() })
+      } catch (err) {
+        setSaveStatus({
+          error: err instanceof Error ? err.message : 'Failed to save',
+          status: 'error',
+        })
+      }
+    },
+    [queryClient],
+  )
+
+  const handleGenerateInvitation = useCallback(async () => {
+    setInvitationLoading(true)
+    setCopied(false)
+    try {
+      const result = await generateInvitation()
+      setInvitation(result)
+    } catch (err) {
+      console.error('Failed to generate invitation:', err)
+    }
+    setInvitationLoading(false)
+  }, [])
+
+  const handleCopyLink = useCallback(async () => {
+    if (!invitation) return
+    try {
+      await navigator.clipboard.writeText(invitation.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 3000)
+    } catch (err) {
+      console.error('Failed to copy:', err)
+    }
+  }, [invitation])
+
+  // Redirect non-admins
+  if (!isLoggedIn || !isAdmin) {
+    if (isLoggedIn && isAdmin === false) {
+      route('/')
+      return null
+    }
+    return (
+      <div class="admin-settings-page">
+        <h1>Admin Settings</h1>
+        <p>You do not have permission to access this page.</p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div class="admin-settings-page">
+        <h1>Admin Settings</h1>
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="admin-settings-page">
+      <h1>Admin Settings</h1>
+
+      <section class="settings-section">
+        <div class="section-header-row">
+          <h2>Server Settings</h2>
+          <SaveStatusIndicator saveStatus={saveStatus} />
+        </div>
+
+        <div class="form-field">
+          <label for="signup-mode">Signup Mode</label>
+          <select id="signup-mode" value={settings?.signup_mode ?? 'open'} onChange={handleSignupModeChange}>
+            <option value="open">Open - Anyone can sign up</option>
+            <option value="invite_only">Invite Only - Requires invitation link</option>
+            <option value="closed">Closed - No new signups allowed</option>
+          </select>
+          <p class="field-description">
+            {settings?.signup_mode === 'open' && 'Anyone visiting the site can create an account.'}
+            {settings?.signup_mode === 'invite_only' &&
+              'New users need a valid invitation link to sign up. Generate invitation links below.'}
+            {settings?.signup_mode === 'closed' &&
+              'No new users can sign up. Only existing accounts can log in.'}
+          </p>
+        </div>
+
+        <div class="form-field">
+          <label>Admin Count</label>
+          <p class="stat-value">{settings?.admin_count ?? 0}</p>
+          <p class="field-description">Number of users with admin privileges.</p>
+        </div>
+      </section>
+
+      {settings?.signup_mode === 'invite_only' && (
+        <section class="settings-section">
+          <h2>Invitations</h2>
+          <p class="section-description">
+            Generate invitation links to share with people you want to invite to sign up.
+          </p>
+
+          <button
+            type="button"
+            class="generate-button"
+            onClick={handleGenerateInvitation}
+            disabled={invitationLoading}
+          >
+            {invitationLoading ? 'Generating...' : 'Generate Invitation Link'}
+          </button>
+
+          {invitation && (
+            <div class="invitation-result">
+              <div class="invitation-url">
+                <input type="text" value={invitation.url} readOnly />
+                <button type="button" class="copy-button" onClick={handleCopyLink}>
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+              <p class="invitation-expiry">Expires in: {formatExpiryTime(invitation.expiresAt)}</p>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/AdminSettings/style.css
+++ b/apps/web/src/pages/AdminSettings/style.css
@@ -1,0 +1,202 @@
+.admin-settings-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.admin-settings-page h1 {
+  font-size: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.admin-settings-page .loading {
+  text-align: center;
+  padding: 2rem;
+}
+
+.settings-section {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-section h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.section-header-row {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.section-header-row h2 {
+  margin-bottom: 0;
+}
+
+.section-description {
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.save-indicator {
+  font-size: 0.85rem;
+}
+
+.save-indicator.saving {
+  color: #888;
+}
+
+.save-indicator.saved {
+  color: #4caf50;
+}
+
+.save-indicator.error {
+  color: #f44336;
+}
+
+.form-field {
+  margin-bottom: 1rem;
+}
+
+.form-field label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.form-field select {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+  max-width: 400px;
+  background: white;
+}
+
+.field-description {
+  color: #666;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  line-height: 1.4;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #333;
+  margin: 0;
+}
+
+.generate-button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.generate-button:hover:not(:disabled) {
+  background: #5e35b1;
+}
+
+.generate-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.invitation-result {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: #f5f5f5;
+  border-radius: 8px;
+}
+
+.invitation-url {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.invitation-url input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+  background: white;
+}
+
+.copy-button {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.copy-button:hover {
+  background: #1976d2;
+}
+
+.invitation-expiry {
+  color: #666;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .settings-section {
+    border-bottom-color: #444;
+  }
+
+  .section-description,
+  .field-description {
+    color: #aaa;
+  }
+
+  .form-field select {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+
+  .stat-value {
+    color: #fff;
+  }
+
+  .invitation-result {
+    background: #333;
+  }
+
+  .invitation-url input {
+    background: #222;
+    border-color: #555;
+    color: #fff;
+  }
+}
+
+@media (max-width: 639px) {
+  .admin-settings-page {
+    padding: 1rem;
+  }
+
+  .admin-settings-page h1 {
+    font-size: 1.5rem;
+  }
+
+  .invitation-url {
+    flex-direction: column;
+  }
+}

--- a/apps/web/src/pages/Signup/index.tsx
+++ b/apps/web/src/pages/Signup/index.tsx
@@ -1,13 +1,19 @@
 import { useLocation } from 'preact-iso'
-import { useEffect, useState } from 'preact/hooks'
-import { auth, ensureStatusLoaded, signup, signupAllowed } from '../../state/auth'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { auth, ensureStatusLoaded, signup, signupMode } from '../../state/auth'
 
 import './style.css'
 
 export function Signup() {
-  const { route } = useLocation()
+  const { route, query } = useLocation()
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+
+  // Get invitation token from URL query param
+  const invitation = useMemo(() => {
+    const params = new URLSearchParams(query)
+    return params.get('invite') ?? undefined
+  }, [query])
 
   useEffect(() => {
     ensureStatusLoaded()
@@ -18,11 +24,26 @@ export function Signup() {
     return null
   }
 
-  if (signupAllowed.value === false) {
+  // Show different messages based on signup mode
+  if (signupMode.value === 'closed') {
     return (
       <div class="signup-page">
         <h1>Sign Up</h1>
-        <p class="not-available">Signup is currently not available on this server.</p>
+        <p class="not-available">Signup is currently closed on this server.</p>
+        <p class="login-link">
+          Already have an account? <a href="/login">Login</a>
+        </p>
+      </div>
+    )
+  }
+
+  if (signupMode.value === 'invite_only' && !invitation) {
+    return (
+      <div class="signup-page">
+        <h1>Sign Up</h1>
+        <p class="not-available">
+          This server requires an invitation to sign up. Please ask an administrator for an invitation link.
+        </p>
         <p class="login-link">
           Already have an account? <a href="/login">Login</a>
         </p>
@@ -46,7 +67,7 @@ export function Signup() {
         return
       }
 
-      const result = await signup(formData.get('user') as string, password)
+      const result = await signup(formData.get('user') as string, password, invitation)
 
       if (result.success) {
         route('/')
@@ -60,6 +81,8 @@ export function Signup() {
   return (
     <div class="signup-page">
       <h1>Sign Up</h1>
+
+      {invitation && <p class="invitation-notice">You have been invited to create an account.</p>}
 
       <form onSubmit={onSubmit} class="signup-form">
         <div class="form-field">

--- a/apps/web/src/pages/Signup/style.css
+++ b/apps/web/src/pages/Signup/style.css
@@ -15,6 +15,16 @@
   color: #666;
 }
 
+.signup-page .invitation-notice {
+  text-align: center;
+  color: #4caf50;
+  font-weight: 500;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  background: rgba(76, 175, 80, 0.1);
+  border-radius: 4px;
+}
+
 .signup-form {
   display: flex;
   flex-direction: column;
@@ -89,6 +99,10 @@
   .signup-page .not-available,
   .signup-form .field-hint {
     color: #aaa;
+  }
+
+  .signup-page .invitation-notice {
+    background: rgba(76, 175, 80, 0.2);
   }
 
   .signup-form .form-field input {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -302,3 +302,73 @@ export const fetchGoalsProgress = async (): Promise<GoalProgress[]> => {
 
   return response.data.goals
 }
+
+// ==========================================================================
+// Admin API
+// ==========================================================================
+
+export type SignupMode = 'open' | 'invite_only' | 'closed'
+
+export interface AdminSettings {
+  signup_mode: SignupMode
+  admin_count: number
+}
+
+export interface InvitationResult {
+  token: string
+  url: string
+  expiresAt: Date
+}
+
+// Fetch admin settings
+export const fetchAdminSettings = async (): Promise<AdminSettings> => {
+  const { token } = auth.value
+  const response = await axios.get<{ success: boolean } & AdminSettings>(`${API_URL}/admin/settings`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return {
+    admin_count: response.data.admin_count,
+    signup_mode: response.data.signup_mode,
+  }
+}
+
+// Update admin settings
+export const updateAdminSettings = async (params: { signup_mode?: SignupMode }): Promise<AdminSettings> => {
+  const { token } = auth.value
+  const response = await axios.patch<{ success: boolean } & AdminSettings>(
+    `${API_URL}/admin/settings`,
+    params,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  )
+
+  return {
+    admin_count: response.data.admin_count,
+    signup_mode: response.data.signup_mode,
+  }
+}
+
+// Generate invitation
+export const generateInvitation = async (expiryHours?: number): Promise<InvitationResult> => {
+  const { token } = auth.value
+  const response = await axios.post<{
+    success: boolean
+    token: string
+    url: string
+    expiresAt: string
+  }>(
+    `${API_URL}/admin/invitations`,
+    { expiryHours },
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  )
+
+  return {
+    expiresAt: new Date(response.data.expiresAt),
+    token: response.data.token,
+    url: response.data.url,
+  }
+}

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -2,25 +2,35 @@ import { signal } from '@preact/signals'
 import axios, { AxiosError } from 'axios'
 import { API_URL } from '../config'
 
+export type SignupMode = 'open' | 'invite_only' | 'closed'
+
 const savedAuth = localStorage.getItem('auth')
-export const auth = signal<{ user?: string; token?: string }>(savedAuth ? JSON.parse(savedAuth) : {})
+export const auth = signal<{ user?: string; token?: string; isAdmin?: boolean }>(
+  savedAuth ? JSON.parse(savedAuth) : {},
+)
 auth.subscribe((value) => localStorage.setItem('auth', JSON.stringify(value)))
 
+// Keep signupAllowed for backwards compatibility
 export const signupAllowed = signal<boolean | undefined>(undefined)
+export const signupMode = signal<SignupMode | undefined>(undefined)
 
 let statusFetchPromise: Promise<void> | null = null
 
 export const fetchStatus = async () => {
-  if (signupAllowed.value !== undefined) return
+  if (signupMode.value !== undefined) return
   if (statusFetchPromise) return statusFetchPromise
 
   statusFetchPromise = (async () => {
     try {
-      const response = await axios.get<{ signupAllowed: boolean }>(`${API_URL}/status`)
+      const response = await axios.get<{ signupAllowed: boolean; signupMode: SignupMode }>(
+        `${API_URL}/status`,
+      )
       signupAllowed.value = response.data.signupAllowed
+      signupMode.value = response.data.signupMode
     } catch (error) {
       console.error('Status fetch error:', error)
       signupAllowed.value = false
+      signupMode.value = 'closed'
     }
   })()
 
@@ -31,13 +41,13 @@ export const ensureStatusLoaded = () => fetchStatus()
 
 export const login = async (user: string, pass: string): Promise<{ success: boolean; error?: string }> => {
   try {
-    const response = await axios.post<{ token: string }>(`${API_URL}/login`, {
+    const response = await axios.post<{ token: string; isAdmin?: boolean }>(`${API_URL}/login`, {
       password: pass,
       username: user,
     })
 
     if (response.data.token) {
-      auth.value = { token: response.data.token, user }
+      auth.value = { isAdmin: response.data.isAdmin, token: response.data.token, user }
       return { success: true }
     }
     return { error: 'No token received', success: false }
@@ -49,15 +59,20 @@ export const login = async (user: string, pass: string): Promise<{ success: bool
   }
 }
 
-export const signup = async (user: string, pass: string): Promise<{ success: boolean; error?: string }> => {
+export const signup = async (
+  user: string,
+  pass: string,
+  invitation?: string,
+): Promise<{ success: boolean; error?: string }> => {
   try {
-    const response = await axios.post<{ token: string }>(`${API_URL}/signup`, {
+    const response = await axios.post<{ token: string; isAdmin?: boolean }>(`${API_URL}/signup`, {
+      invitation,
       password: pass,
       username: user,
     })
 
     if (response.data.token) {
-      auth.value = { token: response.data.token, user }
+      auth.value = { isAdmin: response.data.isAdmin, token: response.data.token, user }
       return { success: true }
     }
     return { error: 'No token received', success: false }

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -1,0 +1,142 @@
+/**
+ * Admin settings schemas.
+ */
+
+import { z } from 'zod'
+import { baseResponseSchema, iso8601DateTimeSchema } from './common.js'
+
+// ============================================================================
+// Signup Mode
+// ============================================================================
+
+/**
+ * Signup mode enum.
+ */
+export const signupModeSchema = z.enum(['open', 'invite_only', 'closed']).meta({
+  description: 'Server signup mode',
+  example: 'open',
+  id: 'SignupMode',
+})
+
+export type SignupMode = z.infer<typeof signupModeSchema>
+
+// ============================================================================
+// Status endpoint (public)
+// ============================================================================
+
+/**
+ * Server status response schema.
+ */
+export const serverStatusResponseSchema = baseResponseSchema
+  .extend({
+    // For backwards compatibility
+    signupAllowed: z.boolean().meta({ description: 'Whether signup is allowed (deprecated, use signupMode)' }),
+    signupMode: signupModeSchema.meta({ description: 'Current signup mode' }),
+  })
+  .meta({ id: 'ServerStatusResponse' })
+
+export type ServerStatusResponse = z.infer<typeof serverStatusResponseSchema>
+
+// ============================================================================
+// Signup endpoint
+// ============================================================================
+
+/**
+ * Signup request body schema.
+ */
+export const signupBodySchema = z
+  .object({
+    invitation: z.string().optional().meta({ description: 'Invitation token (required in invite_only mode)' }),
+    password: z.string().min(1).meta({ description: 'User password' }),
+    username: z.string().min(1).meta({ description: 'Username' }),
+  })
+  .meta({ id: 'SignupBody' })
+
+export type SignupBody = z.infer<typeof signupBodySchema>
+
+/**
+ * Signup response schema.
+ */
+export const signupResponseSchema = baseResponseSchema
+  .extend({
+    isAdmin: z.boolean().optional().meta({ description: 'Whether the user is an admin' }),
+    token: z.string().optional().meta({ description: 'Authentication token' }),
+  })
+  .meta({ id: 'SignupResponse' })
+
+export type SignupResponse = z.infer<typeof signupResponseSchema>
+
+// ============================================================================
+// Login endpoint
+// ============================================================================
+
+/**
+ * Login response schema.
+ */
+export const loginResponseSchema = z
+  .object({
+    isAdmin: z.boolean().optional().meta({ description: 'Whether the user is an admin' }),
+    refresh: z.string().meta({ description: 'Refresh token' }),
+    token: z.string().meta({ description: 'Authentication token' }),
+  })
+  .meta({ id: 'LoginResponse' })
+
+export type LoginResponse = z.infer<typeof loginResponseSchema>
+
+// ============================================================================
+// Admin settings endpoints
+// ============================================================================
+
+/**
+ * Admin settings response schema.
+ */
+export const adminSettingsResponseSchema = baseResponseSchema
+  .extend({
+    admin_count: z.number().int().meta({ description: 'Number of admin users' }),
+    signup_mode: signupModeSchema.meta({ description: 'Current signup mode' }),
+  })
+  .meta({ id: 'AdminSettingsResponse' })
+
+export type AdminSettingsResponse = z.infer<typeof adminSettingsResponseSchema>
+
+/**
+ * Update admin settings body schema.
+ */
+export const updateAdminSettingsBodySchema = z
+  .object({
+    signup_mode: signupModeSchema.optional().meta({ description: 'New signup mode' }),
+  })
+  .meta({ id: 'UpdateAdminSettingsBody' })
+
+export type UpdateAdminSettingsBody = z.infer<typeof updateAdminSettingsBodySchema>
+
+// ============================================================================
+// Invitation endpoints
+// ============================================================================
+
+/**
+ * Create invitation body schema.
+ */
+export const createInvitationBodySchema = z
+  .object({
+    expiryHours: z.number().int().positive().optional().meta({
+      description: 'Hours until invitation expires (default: 168 = 7 days)',
+      example: 168,
+    }),
+  })
+  .meta({ id: 'CreateInvitationBody' })
+
+export type CreateInvitationBody = z.infer<typeof createInvitationBodySchema>
+
+/**
+ * Invitation response schema.
+ */
+export const invitationResponseSchema = baseResponseSchema
+  .extend({
+    expiresAt: iso8601DateTimeSchema.meta({ description: 'Expiration timestamp' }),
+    token: z.string().meta({ description: 'Invitation token' }),
+    url: z.string().meta({ description: 'Full invitation URL' }),
+  })
+  .meta({ id: 'InvitationResponse' })
+
+export type InvitationResponse = z.infer<typeof invitationResponseSchema>

--- a/packages/api-spec/src/schemas/index.ts
+++ b/packages/api-spec/src/schemas/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './activities.js'
+export * from './admin.js'
 export * from './common.js'
 export * from './daily-summary.js'
 export * from './goals.js'


### PR DESCRIPTION
## Summary

- Add server-wide admin roles and centralized settings using the shared `aurboda` database
- Implement invitation system for controlled user signups
- First user to sign up automatically becomes admin
- Three signup modes: `open`, `invite_only`, `closed`

## Changes

### Backend
- New `central-db.ts` service for server settings and admin management
- New `invitation.ts` service for secure invitation tokens (AES-256-GCM)
- Modified `/status` endpoint to return `signupMode`
- Modified `/signup` to check signup mode, validate invitations, auto-promote first user
- Modified `/login` to return `isAdmin`
- New admin endpoints: `GET/PATCH /admin/settings`, `POST /admin/invitations`

### Frontend
- New Admin Settings page (`/admin`) with signup mode control
- Invitation link generation with copy-to-clipboard
- Signup page handles `?invite=` query parameter
- Auth state tracks `isAdmin` and `signupMode`

### API Spec
- New schemas for admin settings and invitations

## Test plan

- [ ] Start fresh: first signup creates admin user
- [ ] Admin can access `/admin`, non-admin gets redirected
- [ ] Change signup_mode to `closed` → new signup rejected
- [ ] Change to `invite_only` → generate link → signup with link works
- [ ] Signup without link in invite_only mode → rejected
- [ ] Existing ALLOW_SIGNUP env var migrates to DB setting on startup

🤖 Generated with [Claude Code](https://claude.ai/code)