### PR TITLE
Add debug logging for MCP session persistence

### DIFF
--- a/apps/backend/src/db.integration.test.ts
+++ b/apps/backend/src/db.integration.test.ts
@@ -5,12 +5,16 @@
  * instance to verify they work correctly.
  */
 
+import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
+  deleteMcpSession,
   deleteTag,
   findMergeableTag,
   getActivities,
   getDailyAggregateValue,
+  getMcpSession,
+  getMcpSessionsForUser,
   getSleepSessions,
   getTags,
   getTimeSeries,
@@ -18,6 +22,8 @@ import {
   insertTag,
   insertTimeSeries,
   processDailyAggregate,
+  saveMcpSession,
+  touchMcpSession,
   updateTagEndTime,
 } from './db'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from './test/db-test-helper'
@@ -741,6 +747,135 @@ describe('Database Integration Tests', () => {
 
       expect(sessions).toHaveLength(1)
       expect(sessions[0].activityType).toBe('sleep')
+    })
+  })
+
+  // ==========================================================================
+  // MCP Sessions
+  // ==========================================================================
+
+  describe('saveMcpSession', () => {
+    test('saves a new session', async () => {
+      const user = getTestUser()
+      const sessionId = randomUUID()
+
+      const result = await saveMcpSession(user, sessionId)
+
+      expect(result.sessionId).toBe(sessionId)
+      expect(result.username).toBe(user)
+      expect(result.createdAt).toBeInstanceOf(Date)
+      expect(result.lastActivity).toBeInstanceOf(Date)
+    })
+
+    test('upserts existing session and updates lastActivity', async () => {
+      const user = getTestUser()
+      const sessionId = randomUUID()
+
+      const first = await saveMcpSession(user, sessionId)
+
+      // Wait a bit to ensure timestamp changes
+      await new Promise((r) => setTimeout(r, 10))
+
+      const second = await saveMcpSession(user, sessionId)
+
+      expect(second.sessionId).toBe(sessionId)
+      expect(second.createdAt.getTime()).toBe(first.createdAt.getTime())
+      expect(second.lastActivity.getTime()).toBeGreaterThanOrEqual(first.lastActivity.getTime())
+    })
+  })
+
+  describe('getMcpSession', () => {
+    test('retrieves existing session', async () => {
+      const user = getTestUser()
+      const sessionId = randomUUID()
+
+      await saveMcpSession(user, sessionId)
+
+      const result = await getMcpSession(user, sessionId)
+
+      expect(result).not.toBeNull()
+      expect(result!.sessionId).toBe(sessionId)
+      expect(result!.username).toBe(user)
+    })
+
+    test('returns null for non-existent session', async () => {
+      const user = getTestUser()
+
+      const result = await getMcpSession(user, randomUUID())
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('touchMcpSession', () => {
+    test('updates lastActivity timestamp', async () => {
+      const user = getTestUser()
+      const sessionId = randomUUID()
+
+      await saveMcpSession(user, sessionId)
+      const before = await getMcpSession(user, sessionId)
+
+      // Wait a bit to ensure timestamp changes
+      await new Promise((r) => setTimeout(r, 10))
+
+      await touchMcpSession(user, sessionId)
+      const after = await getMcpSession(user, sessionId)
+
+      expect(after!.lastActivity.getTime()).toBeGreaterThanOrEqual(before!.lastActivity.getTime())
+    })
+  })
+
+  describe('deleteMcpSession', () => {
+    test('deletes existing session and returns true', async () => {
+      const user = getTestUser()
+      const sessionId = randomUUID()
+
+      await saveMcpSession(user, sessionId)
+
+      const result = await deleteMcpSession(user, sessionId)
+
+      expect(result).toBe(true)
+
+      const check = await getMcpSession(user, sessionId)
+      expect(check).toBeNull()
+    })
+
+    test('returns false for non-existent session', async () => {
+      const user = getTestUser()
+
+      const result = await deleteMcpSession(user, randomUUID())
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getMcpSessionsForUser', () => {
+    test('returns all sessions for a user', async () => {
+      const user = getTestUser()
+
+      await saveMcpSession(user, randomUUID())
+      await saveMcpSession(user, randomUUID())
+      await saveMcpSession(user, randomUUID())
+
+      const sessions = await getMcpSessionsForUser(user)
+
+      expect(sessions).toHaveLength(3)
+    })
+
+    test('returns sessions ordered by lastActivity descending', async () => {
+      const user = getTestUser()
+
+      const oldSessionId = randomUUID()
+      const newSessionId = randomUUID()
+
+      await saveMcpSession(user, oldSessionId)
+      await new Promise((r) => setTimeout(r, 10))
+      await saveMcpSession(user, newSessionId)
+
+      const sessions = await getMcpSessionsForUser(user)
+
+      expect(sessions[0].sessionId).toBe(newSessionId)
+      expect(sessions[1].sessionId).toBe(oldSessionId)
     })
   })
 })

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1628,6 +1628,7 @@ export interface McpSessionRecord {
  * Save an MCP session to the database.
  */
 export const saveMcpSession = async (user: string, sessionId: string): Promise<McpSessionRecord> => {
+  console.log(`[MCP-DB] saveMcpSession: saving session ${sessionId} for user ${user}`)
   const result = await query(
     user,
     `INSERT INTO mcp_sessions (session_id, username, created_at, last_activity)
@@ -1638,6 +1639,7 @@ export const saveMcpSession = async (user: string, sessionId: string): Promise<M
   )
 
   const row = result.rows[0]
+  console.log(`[MCP-DB] saveMcpSession: saved session ${sessionId}, result:`, row)
   return {
     createdAt: new Date(row.created_at),
     lastActivity: new Date(row.last_activity),
@@ -1650,6 +1652,7 @@ export const saveMcpSession = async (user: string, sessionId: string): Promise<M
  * Get an MCP session by ID.
  */
 export const getMcpSession = async (user: string, sessionId: string): Promise<McpSessionRecord | null> => {
+  console.log(`[MCP-DB] getMcpSession: looking for session ${sessionId}`)
   const result = await query(
     user,
     `SELECT session_id, username, created_at, last_activity
@@ -1658,9 +1661,13 @@ export const getMcpSession = async (user: string, sessionId: string): Promise<Mc
     [sessionId],
   )
 
-  if (result.rows.length === 0) return null
+  if (result.rows.length === 0) {
+    console.log(`[MCP-DB] getMcpSession: session ${sessionId} not found`)
+    return null
+  }
 
   const row = result.rows[0]
+  console.log(`[MCP-DB] getMcpSession: found session ${sessionId}:`, row)
   return {
     createdAt: new Date(row.created_at),
     lastActivity: new Date(row.last_activity),

--- a/apps/backend/src/mcp.integration.test.ts
+++ b/apps/backend/src/mcp.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * MCP Integration tests with real PostgreSQL.
+ *
+ * Tests the full MCP session persistence flow using a real database.
+ */
+
+import express from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { createAuth } from './auth'
+import { createMcpRouter } from './mcp'
+import { createDbSessionStore } from './mcp-session-store'
+import { cleanTestDb, startTestDb, stopTestDb } from './test/db-test-helper'
+
+// Increase timeout for container startup
+const CONTAINER_TIMEOUT = 60_000
+
+const auth = createAuth('very very secretvery very secret') // 32 bytes for AES-256
+
+function createTestApp() {
+  const app = express()
+  // Use database-backed session store
+  const sessionStore = createDbSessionStore()
+  app.use('/mcp', createMcpRouter(auth, undefined, undefined, { sessionStore }))
+  return app
+}
+
+const mcpPost = (app: ReturnType<typeof createTestApp>) =>
+  request(app).post('/mcp').set('Accept', 'application/json, text/event-stream')
+
+describe('MCP Database Integration Tests', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('session persists in database and survives app restart', async () => {
+    const token = auth.createToken('testuser')
+
+    // Create first app instance
+    const app1 = createTestApp()
+
+    // Initialize a session
+    const initResponse = await mcpPost(app1)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      })
+
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers['mcp-session-id'] as string
+    expect(sessionId).toBeDefined()
+    console.log('Got session ID:', sessionId)
+
+    // Simulate restart by creating a new app instance
+    // This creates a fresh in-memory sessions map but uses the same database
+    const app2 = createTestApp()
+
+    // Try to use the same session ID on the new app instance
+    const response = await mcpPost(app2)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Mcp-Session-Id', sessionId)
+      .send({
+        id: 2,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      })
+
+    expect(response.status).toBe(200)
+    // The session ID should be preserved
+    expect(response.headers['mcp-session-id']).toBe(sessionId)
+  })
+
+  test('session is saved to database on creation', async () => {
+    const token = auth.createToken('testuser')
+    const app = createTestApp()
+
+    const initResponse = await mcpPost(app)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      })
+
+    expect(initResponse.status).toBe(200)
+    const sessionId = initResponse.headers['mcp-session-id'] as string
+
+    // Verify session was saved to database by creating a new app and restoring
+    const app2 = createTestApp()
+
+    // After restart, we need to re-initialize (but the session ID is preserved)
+    const response = await mcpPost(app2)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Mcp-Session-Id', sessionId)
+      .send({
+        id: 2,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      })
+
+    // If the session was restored, we should get a 200 response with the same session ID
+    expect(response.status).toBe(200)
+    expect(response.headers['mcp-session-id']).toBe(sessionId)
+  })
+
+  test('session for different user cannot be restored', async () => {
+    const token1 = auth.createToken('user1')
+    const token2 = auth.createToken('user2')
+
+    const app1 = createTestApp()
+
+    // Create session for user1
+    const initResponse = await mcpPost(app1)
+      .set('Authorization', `Bearer ${token1}`)
+      .send({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      })
+
+    const sessionId = initResponse.headers['mcp-session-id'] as string
+
+    // Create new app instance and try to use user1's session as user2
+    const app2 = createTestApp()
+
+    const response = await mcpPost(app2)
+      .set('Authorization', `Bearer ${token2}`)
+      .set('Mcp-Session-Id', sessionId)
+      .send({
+        id: 2,
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+          protocolVersion: '2024-11-05',
+        },
+      })
+
+    // Should get a 200 response but with a NEW session ID (not the old one)
+    expect(response.status).toBe(200)
+    expect(response.headers['mcp-session-id']).not.toBe(sessionId)
+  })
+})

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -639,21 +639,39 @@ export function createMcpRouter(
 
   // Helper to restore a session from the store (lazy restoration after restart)
   const restoreSessionFromStore = async (user: string, sessionId: string): Promise<McpSession | null> => {
-    if (!sessionStore) return null
+    if (!sessionStore) {
+      console.log('[MCP] restoreSessionFromStore: no sessionStore configured')
+      return null
+    }
 
+    console.log(`[MCP] restoreSessionFromStore: attempting to restore session ${sessionId} for user ${user}`)
     const record = await sessionStore.get(user, sessionId)
-    if (!record || record.username !== user) return null
+    if (!record) {
+      console.log(`[MCP] restoreSessionFromStore: session ${sessionId} not found in store`)
+      return null
+    }
+    if (record.username !== user) {
+      console.log(
+        `[MCP] restoreSessionFromStore: session ${sessionId} belongs to ${record.username}, not ${user}`,
+      )
+      return null
+    }
 
     // Check if session is expired (older than 7 days by default)
     const maxAge = DEFAULT_SESSION_INACTIVITY_MS
     const age = Date.now() - record.lastActivity.getTime()
+    console.log(
+      `[MCP] restoreSessionFromStore: session ${sessionId} age=${age}ms, maxAge=${maxAge}ms, lastActivity=${record.lastActivity.toISOString()}`,
+    )
     if (age > maxAge) {
       // Session expired - clean it up
+      console.log(`[MCP] restoreSessionFromStore: session ${sessionId} expired, deleting`)
       await sessionStore.delete(user, sessionId)
       return null
     }
 
     // Recreate the McpServer and transport
+    console.log(`[MCP] restoreSessionFromStore: recreating McpServer for session ${sessionId}`)
     const server = createMcpServer(user)
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => sessionId,
@@ -664,6 +682,7 @@ export function createMcpRouter(
     const session: McpSession = { server, transport, user }
     sessions.set(sessionId, session)
 
+    console.log(`[MCP] restoreSessionFromStore: session ${sessionId} restored successfully`)
     return session
   }
 
@@ -700,11 +719,15 @@ export function createMcpRouter(
     }
 
     const sessionId = req.headers['mcp-session-id'] as string | undefined
+    console.log(
+      `[MCP] POST request: user=${user}, sessionId=${sessionId ?? 'none'}, hasStore=${!!sessionStore}`,
+    )
 
     let session: McpSession | undefined
 
     if (sessionId && sessions.has(sessionId)) {
       // Session is in memory
+      console.log(`[MCP] POST: session ${sessionId} found in memory`)
       session = sessions.get(sessionId)!
       if (session.user !== user) {
         res.status(403).json({ error: 'Session belongs to different user' })
@@ -712,15 +735,22 @@ export function createMcpRouter(
       }
     } else if (sessionId && sessionStore) {
       // Session not in memory - try to restore from store
-      const restored = await restoreSessionFromStore(user, sessionId)
-      if (restored) {
-        session = restored
+      console.log(`[MCP] POST: session ${sessionId} not in memory, attempting restore from store`)
+      try {
+        const restored = await restoreSessionFromStore(user, sessionId)
+        if (restored) {
+          session = restored
+        }
+      } catch (err) {
+        console.error(`[MCP] POST: error restoring session ${sessionId}:`, err)
+        // Continue to create new session
       }
     }
 
     if (!session) {
       // Create new session - generate ID first so transport and our map use the same one
       const newSessionId = randomUUID()
+      console.log(`[MCP] POST: creating new session ${newSessionId} for user ${user}`)
       const server = createMcpServer(user)
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => newSessionId,
@@ -733,7 +763,13 @@ export function createMcpRouter(
 
       // Persist to store if available
       if (sessionStore) {
-        await sessionStore.save(user, newSessionId)
+        console.log(`[MCP] POST: saving new session ${newSessionId} to store`)
+        try {
+          await sessionStore.save(user, newSessionId)
+        } catch (err) {
+          console.error(`[MCP] POST: error saving session ${newSessionId}:`, err)
+          // Continue without persistence
+        }
       }
     }
 
@@ -741,7 +777,11 @@ export function createMcpRouter(
 
     // Update last activity in store
     if (sessionStore && sessionId) {
-      await sessionStore.touch(user, sessionId)
+      try {
+        await sessionStore.touch(user, sessionId)
+      } catch (err) {
+        console.error(`[MCP] POST: error touching session ${sessionId}:`, err)
+      }
     }
   })
 


### PR DESCRIPTION
## Summary

- Add extensive debug logging to track MCP session restoration flow
- Add error handling to prevent crashes on database failures
- Add database integration tests for MCP session CRUD operations
- Add full MCP flow integration tests with real PostgreSQL

## Problem

MCP sessions require reconnect after backend restart, even though persistence code was added.

## Changes

The debug logging will reveal the actual cause by tracking:
- When sessions are saved/restored/touched
- Database operation results
- Error details when operations fail

Possible root causes the logging will identify:
- Database schema not migrated (missing `mcp_sessions` table)
- Database connectivity issues after restart
- Token/user mismatch during restoration

## Test plan

- [x] All 399 existing tests pass
- [x] New MCP session database integration tests pass
- [x] New MCP flow integration tests with PostgreSQL pass
- [ ] Deploy to production and check logs during reconnect scenario

🤖 Generated with [Claude Code](https://claude.ai/code)