### PR TITLE
Add add_activity MCP tool for creating exercise sessions

### DIFF
--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -5,6 +5,7 @@ import { createAuth } from './auth'
 import * as db from './db'
 import { createMcpRouter } from './mcp'
 import { createInMemorySessionStore, McpSessionStore } from './mcp-session-store'
+import * as mutations from './services/mutations'
 import * as queries from './services/queries'
 
 // Mock the services
@@ -19,6 +20,7 @@ vi.mock('./services/queries', () => ({
 }))
 
 vi.mock('./services/mutations', () => ({
+  addActivity: vi.fn(),
   addMetric: vi.fn(),
   addTag: vi.fn(),
 }))
@@ -982,6 +984,181 @@ describe('MCP Server', () => {
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
       expect(response.toolResult.data).toHaveLength(0)
+    })
+  })
+
+  describe('Tool: add_activity', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('creates exercise activity with exercise_type name', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.addActivity).mockResolvedValue({
+        activityType: 'exercise',
+        endTime: '2024-03-15T11:45:00.000Z',
+        id: 'test-uuid',
+        startTime: '2024-03-15T10:30:00.000Z',
+        success: true,
+        title: 'Upper body',
+      })
+
+      const response = await callTool(app, token, sessionId, 'add_activity', {
+        activity_type: 'exercise',
+        end_time: '2024-03-15T11:45:00Z',
+        exercise_type: 'weightlifting',
+        start_time: '2024-03-15T10:30:00Z',
+        title: 'Upper body',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.id).toBe('test-uuid')
+      expect(mutations.addActivity).toHaveBeenCalledWith('testuser', {
+        activityType: 'exercise',
+        data: {
+          exerciseType: 81,
+          exerciseTypeName: 'weightlifting',
+        },
+        endTime: expect.any(Date),
+        notes: undefined,
+        startTime: expect.any(Date),
+        title: 'Upper body',
+      })
+    })
+
+    test('creates activity without exercise_type', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.addActivity).mockResolvedValue({
+        activityType: 'meditation',
+        endTime: '2024-03-15T07:30:00.000Z',
+        id: 'test-uuid-2',
+        startTime: '2024-03-15T07:00:00.000Z',
+        success: true,
+        title: 'Morning meditation',
+      })
+
+      const response = await callTool(app, token, sessionId, 'add_activity', {
+        activity_type: 'meditation',
+        end_time: '2024-03-15T07:30:00Z',
+        start_time: '2024-03-15T07:00:00Z',
+        title: 'Morning meditation',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(mutations.addActivity).toHaveBeenCalledWith('testuser', {
+        activityType: 'meditation',
+        data: undefined,
+        endTime: expect.any(Date),
+        notes: undefined,
+        startTime: expect.any(Date),
+        title: 'Morning meditation',
+      })
+    })
+
+    test('returns error for invalid exercise_type name', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            arguments: {
+              activity_type: 'exercise',
+              end_time: '2024-03-15T11:45:00Z',
+              exercise_type: 'invalid_exercise_type',
+              start_time: '2024-03-15T10:30:00Z',
+            },
+            name: 'add_activity',
+          },
+        })
+
+      expect(response.status).toBe(200)
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      expect(parsed.result.content[0].text).toContain('Invalid exercise_type')
+      expect(mutations.addActivity).not.toHaveBeenCalled()
+    })
+
+    test('returns error when end_time is before start_time', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.addActivity).mockResolvedValue({
+        error: 'end_time must be after start_time',
+        success: false,
+      })
+
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            arguments: {
+              activity_type: 'exercise',
+              end_time: '2024-03-15T09:00:00Z',
+              start_time: '2024-03-15T10:30:00Z',
+            },
+            name: 'add_activity',
+          },
+        })
+
+      expect(response.status).toBe(200)
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      expect(parsed.result.content[0].text).toContain('end_time must be after start_time')
     })
   })
 

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -3,7 +3,10 @@ import {
   activityTypeSchema,
   dateOnlySchema,
   endDateTimeQuerySchema,
+  exerciseTypeNames,
+  getExerciseTypeValue,
   hrZoneThresholdsSchema,
+  isValidExerciseType,
   isValidMetric,
   latWithValidationSchema,
   lonWithValidationSchema,
@@ -357,11 +360,10 @@ export function createMcpRouter(
         ),
         end_time: endDateTimeQuerySchema.describe('End time in ISO 8601 format (e.g., 2024-03-15T11:45:00Z)'),
         exercise_type: z
-          .number()
-          .int()
+          .string()
           .optional()
           .describe(
-            'Health Connect exercise type enum (e.g., 79 for weightlifting). Only for exercise activities.',
+            `Exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
           ),
         notes: z
           .string()
@@ -379,9 +381,19 @@ export function createMcpRouter(
         const startDate = new Date(start_time)
         const endDate = new Date(end_time)
 
-        // Build data object for exercise-specific fields
-        const data: Record<string, unknown> | undefined =
-          exercise_type !== undefined ? { exerciseType: exercise_type } : undefined
+        // Validate and convert exercise_type name to value
+        let data: Record<string, unknown> | undefined
+        if (exercise_type !== undefined) {
+          if (!isValidExerciseType(exercise_type)) {
+            return errorResponse(
+              `Invalid exercise_type "${exercise_type}". Valid types include: ${exerciseTypeNames.slice(0, 15).join(', ')}...`,
+            )
+          }
+          data = {
+            exerciseType: getExerciseTypeValue(exercise_type),
+            exerciseTypeName: exercise_type,
+          }
+        }
 
         const result = await addActivity(user, {
           activityType: activity_type,

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -31,7 +31,7 @@ import {
   insertNamedLocation,
   updateNamedLocation,
 } from './services/locations'
-import { addMetric, addTag, deleteTag } from './services/mutations'
+import { addActivity, addMetric, addTag, deleteTag } from './services/mutations'
 import {
   getDailySummary,
   getPeriodSummary,
@@ -339,6 +339,63 @@ export function createMcpRouter(
         }
 
         const result = await addMetric(user, { metric, time: measurementTime, value })
+        return jsonResponse(result)
+      },
+    )
+
+    // ========================================================================
+    // Activity Management Tools
+    // ========================================================================
+
+    // Tool: add_activity
+    server.tool(
+      'add_activity',
+      'Add an activity session (exercise, meditation, nap). Use this to log workouts or other activities.',
+      {
+        activity_type: activityTypeSchema.describe(
+          `Type of activity. Valid types: ${activityTypes.join(', ')}`,
+        ),
+        end_time: endDateTimeQuerySchema.describe('End time in ISO 8601 format (e.g., 2024-03-15T11:45:00Z)'),
+        exercise_type: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'Health Connect exercise type enum (e.g., 79 for weightlifting). Only for exercise activities.',
+          ),
+        notes: z
+          .string()
+          .optional()
+          .describe(
+            'Activity notes. For workouts, use format: "Exercise Name: reps×weight, reps×weight" per line.',
+          ),
+        start_time: startDateTimeQuerySchema.describe(
+          'Start time in ISO 8601 format (e.g., 2024-03-15T10:30:00Z)',
+        ),
+        title: z.string().optional().describe('Activity title (e.g., "Upper body", "Morning meditation")'),
+      },
+      async ({ activity_type, end_time, exercise_type, notes, start_time, title }) => {
+        // Dates are pre-validated by zod schema
+        const startDate = new Date(start_time)
+        const endDate = new Date(end_time)
+
+        // Build data object for exercise-specific fields
+        const data: Record<string, unknown> | undefined =
+          exercise_type !== undefined ? { exerciseType: exercise_type } : undefined
+
+        const result = await addActivity(user, {
+          activityType: activity_type,
+          data,
+          endTime: endDate,
+          notes,
+          startTime: startDate,
+          title,
+        })
+
+        if (!result.success) {
+          return errorResponse(result.error ?? 'Failed to add activity')
+        }
+
         return jsonResponse(result)
       },
     )

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import * as db from '../db'
-import { addMetric, addTag, deleteTag } from './mutations'
+import { addActivity, addMetric, addTag, deleteTag } from './mutations'
 
 // Mock the db module
 vi.mock('../db', () => ({
   deleteTag: vi.fn(),
   findMergeableTag: vi.fn(),
+  insertActivity: vi.fn(),
   insertTag: vi.fn(),
   insertTimeSeries: vi.fn(),
   updateTagEndTime: vi.fn(),
@@ -274,5 +275,129 @@ describe('deleteTag', () => {
     expect(result.success).toBe(false)
     expect(result.deleted).toBe(false)
     expect(result.externalId).toBe('nonexistent-tag')
+  })
+})
+
+describe('addActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('creates an exercise activity with required fields', async () => {
+    vi.mocked(db.insertActivity).mockResolvedValue(undefined)
+
+    const result = await addActivity('testuser', {
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:45:00Z'),
+      startTime: new Date('2024-03-15T10:30:00Z'),
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.activityType).toBe('exercise')
+    expect(result.startTime).toBe('2024-03-15T10:30:00.000Z')
+    expect(result.endTime).toBe('2024-03-15T11:45:00.000Z')
+    expect(result.id).toBeDefined()
+
+    expect(db.insertActivity).toHaveBeenCalledWith('testuser', {
+      activityType: 'exercise',
+      data: undefined,
+      endTime: new Date('2024-03-15T11:45:00Z'),
+      id: expect.any(String),
+      notes: undefined,
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:30:00Z'),
+      title: undefined,
+    })
+  })
+
+  test('creates an activity with all fields', async () => {
+    vi.mocked(db.insertActivity).mockResolvedValue(undefined)
+
+    const result = await addActivity('testuser', {
+      activityType: 'exercise',
+      data: { exerciseType: 79 },
+      endTime: new Date('2024-03-15T11:45:00Z'),
+      notes: 'Dumbbell Bench Press: 12×30kg, 8×35kg',
+      startTime: new Date('2024-03-15T10:30:00Z'),
+      title: 'Upper body',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.title).toBe('Upper body')
+    expect(result.notes).toBe('Dumbbell Bench Press: 12×30kg, 8×35kg')
+    expect(result.id).toBeDefined()
+
+    expect(db.insertActivity).toHaveBeenCalledWith('testuser', {
+      activityType: 'exercise',
+      data: { exerciseType: 79 },
+      endTime: new Date('2024-03-15T11:45:00Z'),
+      id: expect.any(String),
+      notes: 'Dumbbell Bench Press: 12×30kg, 8×35kg',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:30:00Z'),
+      title: 'Upper body',
+    })
+  })
+
+  test('returns error when endTime is before startTime', async () => {
+    const result = await addActivity('testuser', {
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T09:00:00Z'),
+      startTime: new Date('2024-03-15T10:30:00Z'),
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('end_time must be after start_time')
+    expect(db.insertActivity).not.toHaveBeenCalled()
+  })
+
+  test('returns error when endTime equals startTime', async () => {
+    const result = await addActivity('testuser', {
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T10:30:00Z'),
+      startTime: new Date('2024-03-15T10:30:00Z'),
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('end_time must be after start_time')
+    expect(db.insertActivity).not.toHaveBeenCalled()
+  })
+
+  test('creates meditation activity', async () => {
+    vi.mocked(db.insertActivity).mockResolvedValue(undefined)
+
+    const result = await addActivity('testuser', {
+      activityType: 'meditation',
+      endTime: new Date('2024-03-15T07:30:00Z'),
+      startTime: new Date('2024-03-15T07:00:00Z'),
+      title: 'Morning meditation',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.activityType).toBe('meditation')
+
+    expect(db.insertActivity).toHaveBeenCalledWith('testuser', {
+      activityType: 'meditation',
+      data: undefined,
+      endTime: new Date('2024-03-15T07:30:00Z'),
+      id: expect.any(String),
+      notes: undefined,
+      source: 'manual',
+      startTime: new Date('2024-03-15T07:00:00Z'),
+      title: 'Morning meditation',
+    })
+  })
+
+  test('creates nap activity', async () => {
+    vi.mocked(db.insertActivity).mockResolvedValue(undefined)
+
+    const result = await addActivity('testuser', {
+      activityType: 'nap',
+      endTime: new Date('2024-03-15T14:30:00Z'),
+      startTime: new Date('2024-03-15T14:00:00Z'),
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.activityType).toBe('nap')
   })
 })

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -5,9 +5,11 @@
  * They are used by both the MCP tools and the REST API.
  */
 
+import type { ActivityType } from '@aurboda/api-spec'
 import { randomUUID } from 'crypto'
 import {
   deleteTag as dbDeleteTag,
+  insertActivity as dbInsertActivity,
   findMergeableTag,
   insertTag,
   insertTimeSeries,
@@ -54,6 +56,26 @@ export interface DeleteTagResult {
   success: boolean
   deleted: boolean
   externalId: string
+}
+
+export interface AddActivityInput {
+  activityType: ActivityType
+  startTime: Date
+  endTime: Date
+  title?: string
+  notes?: string
+  data?: Record<string, unknown>
+}
+
+export interface AddActivityResult {
+  success: boolean
+  id?: string
+  activityType?: ActivityType
+  startTime?: string
+  endTime?: string
+  title?: string
+  notes?: string
+  error?: string
 }
 
 // ============================================================================
@@ -149,5 +171,43 @@ export async function deleteTag(user: string, externalId: string): Promise<Delet
     deleted,
     externalId,
     success: deleted,
+  }
+}
+
+/**
+ * Add an activity (exercise, meditation, nap, etc.).
+ *
+ * Validates that end_time is after start_time.
+ */
+export async function addActivity(user: string, input: AddActivityInput): Promise<AddActivityResult> {
+  // Validate that endTime is after startTime
+  if (input.endTime <= input.startTime) {
+    return {
+      error: 'end_time must be after start_time',
+      success: false,
+    }
+  }
+
+  const id = randomUUID()
+
+  await dbInsertActivity(user, {
+    activityType: input.activityType,
+    data: input.data,
+    endTime: input.endTime,
+    id,
+    notes: input.notes,
+    source: 'manual',
+    startTime: input.startTime,
+    title: input.title,
+  })
+
+  return {
+    activityType: input.activityType,
+    endTime: input.endTime.toISOString(),
+    id,
+    notes: input.notes,
+    startTime: input.startTime.toISOString(),
+    success: true,
+    title: input.title,
   }
 }

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -12,6 +12,115 @@ import {
 import { hrZoneSecsSchema } from './settings.js'
 
 /**
+ * Health Connect exercise types mapping.
+ * Maps friendly names to Health Connect ExerciseSessionRecord type values.
+ * @see https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/ExerciseSessionRecord
+ */
+export const exerciseTypes = {
+  back_extension: 1,
+  badminton: 2,
+  barbell_shoulder_press: 3,
+  baseball: 4,
+  basketball: 5,
+  bench_press: 6,
+  bench_sit_up: 7,
+  biking: 8,
+  biking_stationary: 9,
+  boot_camp: 10,
+  boxing: 11,
+  burpee: 12,
+  calisthenics: 13,
+  cricket: 14,
+  crunch: 15,
+  dancing: 16,
+  deadlift: 17,
+  dumbbell_curl_left_arm: 18,
+  dumbbell_curl_right_arm: 19,
+  dumbbell_front_raise: 20,
+  dumbbell_lateral_raise: 21,
+  dumbbell_triceps_extension_left_arm: 22,
+  dumbbell_triceps_extension_right_arm: 23,
+  dumbbell_triceps_extension_two_arm: 24,
+  elliptical: 25,
+  exercise_class: 26,
+  fencing: 27,
+  football_american: 28,
+  football_australian: 29,
+  forward_twist: 30,
+  frisbee_disc: 31,
+  golf: 32,
+  guided_breathing: 33,
+  gymnastics: 34,
+  handball: 35,
+  high_intensity_interval_training: 36,
+  hiking: 37,
+  ice_hockey: 38,
+  ice_skating: 39,
+  jumping_jack: 40,
+  jump_rope: 41,
+  lat_pull_down: 42,
+  lunge: 43,
+  martial_arts: 44,
+  other_workout: 0,
+  paddling: 46,
+  paragliding: 47,
+  pilates: 48,
+  plank: 49,
+  racquetball: 50,
+  rock_climbing: 51,
+  roller_hockey: 52,
+  rowing: 53,
+  rowing_machine: 54,
+  rugby: 55,
+  running: 56,
+  running_treadmill: 57,
+  sailing: 58,
+  scuba_diving: 59,
+  skating: 60,
+  skiing: 61,
+  snowboarding: 62,
+  snowshoeing: 63,
+  soccer: 64,
+  softball: 65,
+  squash: 66,
+  squat: 67,
+  stair_climbing: 68,
+  stair_climbing_machine: 69,
+  strength_training: 70,
+  stretching: 71,
+  surfing: 72,
+  swimming_open_water: 73,
+  swimming_pool: 74,
+  table_tennis: 75,
+  tennis: 76,
+  upper_twist: 77,
+  volleyball: 78,
+  walking: 79,
+  water_polo: 80,
+  weightlifting: 81,
+  wheelchair: 82,
+  yoga: 83,
+} as const
+
+export type ExerciseTypeName = keyof typeof exerciseTypes
+
+export const exerciseTypeNames = Object.keys(exerciseTypes) as ExerciseTypeName[]
+
+export const exerciseTypeSchema = z
+  .enum(exerciseTypeNames as [ExerciseTypeName, ...ExerciseTypeName[]])
+  .meta({
+    description: 'Exercise type name',
+    example: 'weightlifting',
+    id: 'ExerciseTypeName',
+  })
+
+export const isValidExerciseType = (name: string): name is ExerciseTypeName =>
+  name in exerciseTypes
+
+export const getExerciseTypeValue = (name: ExerciseTypeName): number =>
+  exerciseTypes[name]
+
+/**
  * Activity schema.
  */
 export const activitySchema = z


### PR DESCRIPTION
## Summary

- Adds `add_activity` MCP tool to create exercise sessions via the existing activity infrastructure
- Enables importing historical workouts and logging sessions without the Android app
- Supports all activity types: exercise, meditation, nap (sleep also available but typically comes from Health Connect)

## Changes

- **mutations.ts**: Added `addActivity` mutation function with input validation (end_time must be after start_time)
- **mcp.ts**: Added `add_activity` MCP tool with parameters:
  - `activity_type`: exercise, meditation, nap, or sleep
  - `start_time`/`end_time`: ISO 8601 datetime
  - `title`: optional (e.g., "Upper body")
  - `notes`: optional (supports workout format like "Bench Press: 12×30kg, 8×35kg")
  - `exercise_type`: optional Health Connect exercise type enum
- **mutations.test.ts**: Added 6 unit tests covering all activity types and validation

## Test plan

- [x] Unit tests pass (393 tests, including 6 new ones)
- [ ] Manual test: Create exercise via MCP tool
- [ ] Manual test: Verify exercise appears in query_activities

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)