### PR TITLE
Fix new user signup: enable PostGIS extension automatically

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -36,10 +36,10 @@ NOMINATIM_URL=https://nominatim.openstreetmap.org         # Nominatim API URL (d
 
 ### Creating the Service Account
 
-The service account needs `CREATEDB` privilege to create per-user databases:
+The service account needs `CREATEDB` privilege to create per-user databases, and `SUPERUSER` to enable the PostGIS extension in each user database:
 
 ```bash
-sudo -u postgres psql -c "CREATE USER aurboda_service WITH ENCRYPTED PASSWORD 'your_password' CREATEDB"
+sudo -u postgres psql -c "CREATE USER aurboda_service WITH ENCRYPTED PASSWORD 'your_password' CREATEDB SUPERUSER"
 ```
 
 ### Database Naming Convention
@@ -70,8 +70,14 @@ Install PostGIS for your PostgreSQL version:
 ```bash
 # Debian/Ubuntu (adjust version number)
 sudo apt install postgresql-15-postgis-3
+```
 
-# The extension is enabled per-database automatically when schema is initialized
+The PostGIS extension is automatically enabled in each user database when created via signup. This requires the service account to have `SUPERUSER` privilege (see above).
+
+For existing users whose databases were created before this automation, manually enable PostGIS:
+
+```bash
+sudo -u postgres psql aurboda_<username> -c "CREATE EXTENSION IF NOT EXISTS postgis"
 ```
 
 ## Location Detection and Geocoding

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -153,7 +153,13 @@ const main = async () => {
   httpd.use(json({ limit: '10mb' }))
 
   httpd.use((req, res, next) => {
-    console.log(req.path, req.body)
+    const sanitizedBody =
+      req.body && typeof req.body === 'object' ?
+        Object.fromEntries(
+          Object.entries(req.body).map(([k, v]) => (k === 'password' ? [k, '[REDACTED]'] : [k, v])),
+        )
+      : req.body
+    console.log(req.path, sanitizedBody)
     next()
   })
 

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -57,8 +57,14 @@ export const makeNewUserDb = async (userDb: Client, user: string, password: stri
   await query(userDb, format('GRANT %I TO %I', user, process.env.PGUSER))
   await query(userDb, format('CREATE DATABASE %I OWNER %I', database, user))
 
-  // Connect as admin to create PostGIS extension (requires superuser privileges)
-  const adminClient = new Client({ database })
+  // Connect as service account to create PostGIS extension (requires superuser privileges)
+  const adminClient = new Client({
+    database,
+    host: process.env.PGHOST,
+    password: process.env.PGPASSWORD,
+    port: process.env.PGPORT ? parseInt(process.env.PGPORT) : undefined,
+    user: process.env.PGUSER,
+  })
   await adminClient.connect()
   await query(adminClient, 'CREATE EXTENSION IF NOT EXISTS postgis')
   await adminClient.end()

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -56,6 +56,13 @@ export const makeNewUserDb = async (userDb: Client, user: string, password: stri
   await query(userDb, format('CREATE USER %I WITH ENCRYPTED PASSWORD %L', user, password))
   await query(userDb, format('GRANT %I TO %I', user, process.env.PGUSER))
   await query(userDb, format('CREATE DATABASE %I OWNER %I', database, user))
+
+  // Connect as admin to create PostGIS extension (requires superuser privileges)
+  const adminClient = new Client({ database })
+  await adminClient.connect()
+  await query(adminClient, 'CREATE EXTENSION IF NOT EXISTS postgis')
+  await adminClient.end()
+
   const client = new Client({ database, password, user })
   await client.connect()
   dbByUser[user] = client
@@ -74,12 +81,10 @@ export const getDbForUser = async (user: string) => {
 /**
  * Initialize the database schema for a user.
  * Creates all tables and indexes if they don't exist.
+ * Note: PostGIS extension is created in makeNewUserDb before this is called.
  */
 export const initializeSchema = async (user: string) => {
   const db = await getDbForUser(user)
-
-  // Note: PostGIS extension must be created by superuser before calling this
-  // sudo -u postgres psql <database> -c "CREATE EXTENSION postgis"
 
   for (const key of tableCreationOrder) {
     await query(db, createTableStatements[key])

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -50,24 +50,19 @@ export const loginToUserDb = async (user: string, password: string) => {
   dbByUser[user] = client
 }
 
-export const makeNewUserDb = async (userDb: Client, user: string, password: string) => {
+export const makeNewUserDb = async (adminClient: Client, user: string, password: string) => {
   const database = userDbName(user)
   console.log(`New user ${user}`)
-  await query(userDb, format('CREATE USER %I WITH ENCRYPTED PASSWORD %L', user, password))
-  await query(userDb, format('GRANT %I TO %I', user, process.env.PGUSER))
-  await query(userDb, format('CREATE DATABASE %I OWNER %I', database, user))
+  await query(adminClient, format('CREATE USER %I WITH ENCRYPTED PASSWORD %L', user, password))
+  await query(adminClient, format('GRANT %I TO %I', user, process.env.PGUSER))
+  await query(adminClient, format('CREATE DATABASE %I OWNER %I', database, user))
 
-  // Connect as service account to create PostGIS extension (requires superuser privileges)
-  const adminClient = new Client({
-    database,
-    host: process.env.PGHOST,
-    password: process.env.PGPASSWORD,
-    port: process.env.PGPORT ? parseInt(process.env.PGPORT) : undefined,
-    user: process.env.PGUSER,
-  })
-  await adminClient.connect()
-  await query(adminClient, 'CREATE EXTENSION IF NOT EXISTS postgis')
-  await adminClient.end()
+  // Connect to the new database to create PostGIS extension (requires superuser privileges)
+  // We need a separate connection because CREATE EXTENSION operates on the current database
+  const newDbClient = new Client({ database })
+  await newDbClient.connect()
+  await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS postgis')
+  await newDbClient.end()
 
   const client = new Client({ database, password, user })
   await client.connect()

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -89,7 +89,11 @@ docker compose up -d
 
 ### Using existing PostgreSQL
 
-If you have PostgreSQL running on your host machine:
+If you have PostgreSQL running on your host machine, ensure your service account has `CREATEDB` and `SUPERUSER` privileges (required for creating user databases and enabling PostGIS):
+
+```bash
+sudo -u postgres psql -c "ALTER USER aurboda_service WITH CREATEDB SUPERUSER"
+```
 
 ```yaml
 services:


### PR DESCRIPTION
## Summary
- Add PostGIS extension creation in `makeNewUserDb` before schema initialization
- Redact password field in request logger to avoid exposing credentials in logs
- Update docs to require `SUPERUSER` privilege for service account

## Problem
When a new user signed up via the invite system, their database was created but the PostGIS extension wasn't enabled. This caused login to fail with error:
```
error: type "geography" does not exist
```

The schema uses `GEOGRAPHY(POINT, 4326)` type for location tables (`locations`, `places`, `named_locations`, `detected_locations`), which requires PostGIS.

## Test plan
- [ ] Sign up a new user via invitation
- [ ] Verify they can login successfully
- [ ] Verify location-related features work (detected locations, places)

🤖 Generated with [Claude Code](https://claude.com/claude-code)