### PR TITLE
Add POST /activities REST API endpoint

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -2,6 +2,9 @@ import {
   type ActivitiesQuery,
   activitiesQuerySchema,
   type ActivitiesResponse,
+  type AddActivityBody,
+  addActivityBodySchema,
+  type AddActivityResponse,
   type AddMetricBody,
   addMetricBodySchema,
   type AddMetricResponse,
@@ -21,8 +24,10 @@ import {
   type DetectedLocationsQuery,
   detectedLocationsQuerySchema,
   type DetectedLocationsResponse,
+  getExerciseTypeValue,
   type GoalsProgressResponse,
   type InvitationResponse,
+  isValidExerciseType,
   type LocationsQuery,
   locationsQuerySchema,
   type LocationsResponse,
@@ -94,7 +99,7 @@ import {
   insertNamedLocation,
   updateNamedLocation,
 } from './services/locations'
-import { addMetric, addTag } from './services/mutations'
+import { addActivity, addMetric, addTag } from './services/mutations'
 import {
   getDailySummary,
   getPeriodSummary,
@@ -519,6 +524,60 @@ const main = async () => {
 
       const activities = await queryActivities(user, types, new Date(start), new Date(end), syncProvider)
       res.json({ data: activities, success: true })
+    },
+  )
+
+  // POST /activities - Add a manual activity
+  httpd.post<Record<string, never>, AddActivityResponse, AddActivityBody>(
+    '/activities',
+    authMiddleware,
+    validateBody(addActivityBodySchema),
+    async (req, res) => {
+      const { activity_type, start_time, end_time, title, notes, exercise_type } = req.body
+      const user = req.user!
+
+      const startDate = new Date(start_time)
+      const endDate = new Date(end_time)
+
+      // Validate and convert exercise_type name to value if provided
+      let data: Record<string, unknown> | undefined
+      if (exercise_type !== undefined) {
+        if (!isValidExerciseType(exercise_type)) {
+          return res.status(400).json({
+            error: `Invalid exercise_type "${exercise_type}"`,
+            success: false,
+          })
+        }
+        data = {
+          exerciseType: getExerciseTypeValue(exercise_type),
+          exerciseTypeName: exercise_type,
+        }
+      }
+
+      const result = await addActivity(user, {
+        activityType: activity_type,
+        data,
+        endTime: endDate,
+        notes,
+        startTime: startDate,
+        title,
+      })
+
+      if (!result.success) {
+        return res.status(400).json({ error: result.error, success: false })
+      }
+
+      res.json({
+        data: {
+          activityType: result.activityType!,
+          endTime: result.endTime!,
+          id: result.id!,
+          notes: result.notes,
+          startTime: result.startTime!,
+          title: result.title,
+        },
+        success: true,
+      })
     },
   )
 

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -468,9 +468,9 @@ export const Timeline = () => {
           productivity={showProductivity.value ? productivityQuery.data || [] : []}
           places={showPlaces.value ? places : []}
           tags={showTags.value ? tagsQuery.data || [] : []}
-          showSleepMeditation={showSleepMeditation}
-          showExercise={showExercise}
-          showPlaces={showPlaces}
+          showSleepMeditationSignal={showSleepMeditation}
+          showExerciseSignal={showExercise}
+          showPlacesSignal={showPlaces}
           dataStart={start}
           dataEnd={end}
           visibleStart={effectiveViewStart}
@@ -492,9 +492,9 @@ interface TimelineChartProps {
   productivity: ProductivityRecord[]
   places: Place[]
   tags: Tag[]
-  showSleepMeditation: Signal<boolean>
-  showExercise: Signal<boolean>
-  showPlaces: Signal<boolean>
+  showSleepMeditationSignal: Signal<boolean>
+  showExerciseSignal: Signal<boolean>
+  showPlacesSignal: Signal<boolean>
   dataStart: Date
   dataEnd: Date
   visibleStart: Date
@@ -512,9 +512,9 @@ function TimelineChart({
   productivity,
   places,
   tags,
-  showSleepMeditation,
-  showExercise,
-  showPlaces,
+  showSleepMeditationSignal,
+  showExerciseSignal,
+  showPlacesSignal,
   dataStart,
   dataEnd,
   visibleStart,
@@ -537,10 +537,12 @@ function TimelineChart({
   const yHrv = d3.scaleLinear().domain([0, 150]).range([chartHeight, 0])
 
   // Filter activities by type
-  const sleepSessions = showSleepMeditation.value ? activities.filter((a) => a.activityType === 'sleep') : []
+  const sleepSessions =
+    showSleepMeditationSignal.value ? activities.filter((a) => a.activityType === 'sleep') : []
   const meditationSessions =
-    showSleepMeditation.value ? activities.filter((a) => a.activityType === 'meditation') : []
-  const exerciseSessions = showExercise.value ? activities.filter((a) => a.activityType === 'exercise') : []
+    showSleepMeditationSignal.value ? activities.filter((a) => a.activityType === 'meditation') : []
+  const exerciseSessions =
+    showExerciseSignal.value ? activities.filter((a) => a.activityType === 'exercise') : []
 
   // Setup brush for selection zoom
   useEffect(() => {
@@ -666,8 +668,8 @@ function TimelineChart({
           >
             <input
               type="checkbox"
-              checked={showSleepMeditation.value}
-              onChange={(e) => (showSleepMeditation.value = (e.target as HTMLInputElement).checked)}
+              checked={showSleepMeditationSignal.value}
+              onChange={(e) => (showSleepMeditationSignal.value = (e.target as HTMLInputElement).checked)}
             />
             <span>
               Sleep <span style={{ color: colors.sleep }}>●</span> / Meditation{' '}
@@ -690,8 +692,8 @@ function TimelineChart({
           >
             <input
               type="checkbox"
-              checked={showExercise.value}
-              onChange={(e) => (showExercise.value = (e.target as HTMLInputElement).checked)}
+              checked={showExerciseSignal.value}
+              onChange={(e) => (showExerciseSignal.value = (e.target as HTMLInputElement).checked)}
             />
             <span>
               Exercise <span style={{ color: colors.exercise }}>●</span>
@@ -713,8 +715,8 @@ function TimelineChart({
           >
             <input
               type="checkbox"
-              checked={showPlaces.value}
-              onChange={(e) => (showPlaces.value = (e.target as HTMLInputElement).checked)}
+              checked={showPlacesSignal.value}
+              onChange={(e) => (showPlacesSignal.value = (e.target as HTMLInputElement).checked)}
             />
             <span>Location</span>
           </label>
@@ -815,7 +817,7 @@ function TimelineChart({
         )}
 
         {/* Places - in places lane */}
-        {showPlaces.value &&
+        {showPlacesSignal.value &&
           places.map((place, i) => (
             <rect
               key={`place-${i}`}

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -4,6 +4,8 @@
 
 import { z } from 'zod'
 import {
+  activityTypeSchema,
+  baseResponseSchema,
   createDataArrayResponseSchema,
   durationMinutesSchema,
   iso8601DateTimeSchema,
@@ -164,3 +166,46 @@ export const activitiesResponseSchema = createDataArrayResponseSchema(activitySc
 })
 
 export type ActivitiesResponse = z.infer<typeof activitiesResponseSchema>
+
+/**
+ * Add activity request body schema.
+ */
+export const addActivityBodySchema = z
+  .object({
+    activity_type: activityTypeSchema.meta({ description: 'Type of activity' }),
+    end_time: iso8601DateTimeSchema.meta({ description: 'End time of the activity' }),
+    exercise_type: exerciseTypeSchema.optional().meta({
+      description: 'Exercise type name (only for exercise activities)',
+    }),
+    notes: z.string().optional().meta({
+      description: 'Activity notes. For workouts, use format: "Exercise Name: reps×weight, reps×weight" per line.',
+    }),
+    start_time: iso8601DateTimeSchema.meta({ description: 'Start time of the activity' }),
+    title: z.string().optional().meta({ description: 'Activity title (e.g., "Upper body", "Morning meditation")' }),
+  })
+  .meta({ id: 'AddActivityBody' })
+
+export type AddActivityBody = z.infer<typeof addActivityBodySchema>
+
+/**
+ * Added activity data schema.
+ */
+const addedActivitySchema = z.object({
+  activityType: activityTypeSchema,
+  endTime: iso8601DateTimeSchema,
+  id: z.string().uuid(),
+  notes: z.string().optional(),
+  startTime: iso8601DateTimeSchema,
+  title: z.string().optional(),
+})
+
+/**
+ * Add activity response schema.
+ */
+export const addActivityResponseSchema = baseResponseSchema
+  .extend({
+    data: addedActivitySchema.optional(),
+  })
+  .meta({ id: 'AddActivityResponse' })
+
+export type AddActivityResponse = z.infer<typeof addActivityResponseSchema>


### PR DESCRIPTION
## Summary
- Add a structured REST API endpoint `POST /activities` for creating activities (exercise, meditation, nap)
- Add `AddActivityBody` and `AddActivityResponse` schemas to api-spec
- Symmetric with the existing MCP `add_activity` tool
- Supports exercise type validation and conversion to numeric values

## Test plan
- [x] TypeScript compilation passes (`pnpm check`)
- [x] Lint passes (`pnpm fix`)
- [x] Unit tests pass (361 passed, integration tests skipped due to no container)
- [ ] Manual test: Create exercise activity via API
- [ ] Manual test: Create meditation activity via API
- [ ] Manual test: Verify exercise_type validation rejects invalid types
- [ ] Manual test: Verify end_time must be after start_time

🤖 Generated with [Claude Code](https://claude.ai/code)