### PR TITLE
Fix Android widget and goals persistence bugs

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
@@ -2,7 +2,10 @@ package net.aurboda.widget
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.util.Log
+import android.util.TypedValue
 import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
@@ -18,6 +21,11 @@ import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import net.aurboda.appJson
+
+// Progress bar colors matching web UI
+private const val COLOR_BELOW_MIN = 0xFF757575.toInt()  // Gray
+private const val COLOR_MET = 0xFF4CAF50.toInt()        // Green
+private const val COLOR_OVER_MAX = 0xFFF44336.toInt()   // Red
 
 private const val TAG = "GoalsWidgetService"
 
@@ -117,16 +125,69 @@ class GoalsRemoteViewsFactory(private val context: Context) : RemoteViewsService
         val cappedProgress = progressPercent.coerceIn(0.0, 100.0).toInt()
         views.setProgressBar(R.id.goal_progress, 100, cappedProgress, false)
 
+        // Determine progress bar color based on goal status
+        val progressColor = getProgressColor(goal)
+        views.setColorStateList(
+            R.id.goal_progress,
+            "setProgressTintList",
+            ColorStateList.valueOf(progressColor)
+        )
+
+        // Show min-marker when both min and max are set
+        if (goal.min != null && goal.max != null && goal.max > 0) {
+            val minPercent = (goal.min / goal.max).toFloat()
+            views.setViewVisibility(R.id.min_marker, View.VISIBLE)
+            views.setViewLayoutMargin(
+                R.id.min_marker,
+                RemoteViews.MARGIN_START,
+                minPercent,
+                TypedValue.COMPLEX_UNIT_FRACTION_PARENT
+            )
+        } else {
+            views.setViewVisibility(R.id.min_marker, View.GONE)
+        }
+
         // Handle overflow (progress > 100%)
         if (progressPercent > 100) {
             val overflow = (progressPercent - 100).coerceIn(0.0, 100.0).toInt()
             views.setViewVisibility(R.id.goal_overflow, View.VISIBLE)
             views.setProgressBar(R.id.goal_overflow, 100, overflow, false)
+            // Overflow bar uses same color
+            views.setColorStateList(
+                R.id.goal_overflow,
+                "setProgressTintList",
+                ColorStateList.valueOf(progressColor)
+            )
         } else {
             views.setViewVisibility(R.id.goal_overflow, View.GONE)
         }
 
         return views
+    }
+
+    /**
+     * Determine progress bar color based on goal status.
+     * Matches the web UI color scheme.
+     */
+    private fun getProgressColor(goal: GoalProgress): Int {
+        val min = goal.min
+        val max = goal.max
+        val current = goal.current
+
+        return when {
+            // Min-max goal
+            min != null && max != null -> when {
+                current >= max -> COLOR_OVER_MAX
+                current >= min -> COLOR_MET
+                else -> COLOR_BELOW_MIN
+            }
+            // Min-only goal
+            min != null -> if (current >= min) COLOR_MET else COLOR_BELOW_MIN
+            // Max-only goal
+            max != null -> if (current > max) COLOR_OVER_MAX else COLOR_MET
+            // No targets (shouldn't happen)
+            else -> COLOR_MET
+        }
     }
 
     private fun formatGoalValue(metric: String, value: Double, unit: String): String {

--- a/apps/android/app/src/main/res/layout/widget_goal_item.xml
+++ b/apps/android/app/src/main/res/layout/widget_goal_item.xml
@@ -4,10 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingVertical="4dp"
-    android:clickable="true"
-    android:focusable="true"
-    android:background="?android:attr/selectableItemBackground">
+    android:paddingVertical="4dp">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/apps/android/app/src/main/res/layout/widget_goal_item.xml
+++ b/apps/android/app/src/main/res/layout/widget_goal_item.xml
@@ -36,15 +36,31 @@
             android:textColor="#FFFFFFFF" />
     </LinearLayout>
 
-    <ProgressBar
-        android:id="@+id/goal_progress"
-        style="?android:attr/progressBarStyleHorizontal"
+    <!-- Progress bar container with min-marker overlay -->
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="12dp"
-        android:layout_marginTop="4dp"
-        android:max="100"
-        android:progress="0"
-        android:progressDrawable="@drawable/progress_bar_widget_drawable" />
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp">
+
+        <ProgressBar
+            android:id="@+id/goal_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:max="100"
+            android:progress="0"
+            android:progressDrawable="@drawable/progress_bar_widget_drawable" />
+
+        <!-- Min marker line (positioned dynamically) -->
+        <View
+            android:id="@+id/min_marker"
+            android:layout_width="2dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="start"
+            android:background="#CCFFFFFF"
+            android:visibility="gone" />
+
+    </FrameLayout>
 
     <!-- Overflow progress bar (shown when > 100%) -->
     <ProgressBar

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1,3 +1,4 @@
+import { type Goal } from '@aurboda/api-spec'
 import { Client, QueryResultRow } from 'pg'
 import format from 'pg-format'
 import {
@@ -1561,6 +1562,7 @@ export const getDailyAggregateValue = async (
 
 export interface UserSettings {
   birthDate?: string // YYYY-MM-DD
+  goals?: Goal[] // User-defined goals for tracking metrics
   hrZoneStart?: { 1: number; 2: number; 3: number; 4: number; 5: number }
   rescueTimeKey?: string // RescueTime API key (personal token)
 }
@@ -1577,6 +1579,7 @@ export const getUserSettings = async (user: string): Promise<UserSettings | null
   const settings = result.rows[0].settings as Record<string, unknown>
   return {
     birthDate: settings.birthDate as string | undefined,
+    goals: settings.goals as Goal[] | undefined,
     hrZoneStart: settings.hrZoneStart as UserSettings['hrZoneStart'],
     rescueTimeKey: settings.rescueTimeKey as string | undefined,
   }
@@ -1597,6 +1600,9 @@ export const upsertUserSettings = async (
   const merged: UserSettings = { ...existing }
   if (updates.birthDate !== undefined) {
     merged.birthDate = updates.birthDate
+  }
+  if (updates.goals !== undefined) {
+    merged.goals = updates.goals
   }
   if (updates.hrZoneStart !== undefined) {
     merged.hrZoneStart = updates.hrZoneStart


### PR DESCRIPTION
## Summary

- **Android widget tap-to-open**: Remove `clickable`, `focusable`, and `background` attributes that were interfering with RemoteViews' `setOnClickFillInIntent` click handling
- **Goals not persisting**: Add missing `goals` field to db layer's `UserSettings` interface and functions - goal changes were being silently dropped
- **Widget progress colors**: Progress bar now shows gray (below min), green (met), or red (over max) to match web UI
- **Widget min-marker**: Added white vertical line showing minimum threshold position when both min and max targets are set

## Test plan

- [ ] Android: Tap widget to verify app opens to Data page
- [ ] Web: Add/edit/reorder goals and verify changes persist after page refresh
- [ ] Android: Verify widget shows correct colors based on goal progress
- [ ] Android: Verify min-marker line appears for goals with both min and max

🤖 Generated with [Claude Code](https://claude.com/claude-code)