### PR TITLE
Add query-time deduplication for overlapping activities

### DIFF
--- a/apps/backend/src/activities.test.ts
+++ b/apps/backend/src/activities.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, test } from 'vitest'
+import { mergeOverlappingActivities, type Activity } from './db'
+
+describe('mergeOverlappingActivities', () => {
+  const makeActivity = (overrides: Partial<Activity>): Activity => ({
+    activityType: 'exercise',
+    source: 'health_connect',
+    startTime: new Date('2024-01-15T10:00:00Z'),
+    ...overrides,
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(mergeOverlappingActivities([])).toEqual([])
+  })
+
+  test('returns single activity unchanged', () => {
+    const activity = makeActivity({
+      endTime: new Date('2024-01-15T11:00:00Z'),
+      title: 'Running',
+    })
+    const result = mergeOverlappingActivities([activity])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(activity)
+  })
+
+  test('does not merge non-overlapping activities of same type', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Morning run',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T15:00:00Z'),
+        startTime: new Date('2024-01-15T14:00:00Z'),
+        title: 'Evening run',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(2)
+  })
+
+  test('merges overlapping activities of same type', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Strength training',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:05:00Z'),
+        source: 'manual',
+        startTime: new Date('2024-01-15T10:05:00Z'),
+        title: 'Weight lifting',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].endTime).toEqual(new Date('2024-01-15T11:05:00Z'))
+  })
+
+  test('uses earliest start and latest end when merging', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        startTime: new Date('2024-01-15T10:30:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T12:00:00Z'),
+        startTime: new Date('2024-01-15T11:00:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].endTime).toEqual(new Date('2024-01-15T12:00:00Z'))
+  })
+
+  test('does not merge activities of different types', () => {
+    const activities = [
+      makeActivity({
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        activityType: 'meditation',
+        endTime: new Date('2024-01-15T10:30:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(2)
+  })
+
+  test('merges three overlapping activities into one', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T10:30:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Part 1',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:15:00Z'),
+        title: 'Part 2',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        startTime: new Date('2024-01-15T10:45:00Z'),
+        title: 'Part 3',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].endTime).toEqual(new Date('2024-01-15T11:30:00Z'))
+  })
+
+  test('handles activity without endTime by using startTime for overlap check', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Completed workout',
+      }),
+      makeActivity({
+        // No endTime - ongoing or point-in-time activity starting during the first
+        startTime: new Date('2024-01-15T10:30:00Z'),
+        title: 'Ongoing workout',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    // Should merge because second starts within first's time range
+    expect(result).toHaveLength(1)
+    expect(result[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].endTime).toEqual(new Date('2024-01-15T11:00:00Z'))
+  })
+
+  test('keeps first title when merging activities with titles', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'First title',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        startTime: new Date('2024-01-15T10:30:00Z'),
+        title: 'Second title',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('First title')
+  })
+
+  test('uses available title when first activity has no title', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        // No title
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        startTime: new Date('2024-01-15T10:30:00Z'),
+        title: 'The title',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('The title')
+  })
+
+  test('merges data objects from overlapping activities', () => {
+    const activities = [
+      makeActivity({
+        data: { exerciseType: 'strength_training', sets: 3 },
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        data: { avgHeartRate: 120, maxHeartRate: 150 },
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        startTime: new Date('2024-01-15T10:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].data).toEqual({
+      avgHeartRate: 120,
+      exerciseType: 'strength_training',
+      maxHeartRate: 150,
+      sets: 3,
+    })
+  })
+
+  test('concatenates notes with newline when merging', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        notes: 'First note',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        notes: 'Second note',
+        startTime: new Date('2024-01-15T10:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].notes).toBe('First note\nSecond note')
+  })
+
+  test('preserves notes when only one activity has notes', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        notes: 'Only note',
+        startTime: new Date('2024-01-15T10:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].notes).toBe('Only note')
+  })
+
+  test('keeps first source when merging', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        source: 'manual',
+        startTime: new Date('2024-01-15T10:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].source).toBe('health_connect')
+  })
+
+  test('handles multiple separate groups of overlapping activities', () => {
+    const activities = [
+      // Morning workout group
+      makeActivity({
+        endTime: new Date('2024-01-15T08:00:00Z'),
+        startTime: new Date('2024-01-15T07:00:00Z'),
+        title: 'Morning A',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T08:30:00Z'),
+        startTime: new Date('2024-01-15T07:30:00Z'),
+        title: 'Morning B',
+      }),
+      // Evening workout group
+      makeActivity({
+        endTime: new Date('2024-01-15T19:00:00Z'),
+        startTime: new Date('2024-01-15T18:00:00Z'),
+        title: 'Evening A',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T19:30:00Z'),
+        startTime: new Date('2024-01-15T18:30:00Z'),
+        title: 'Evening B',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(2)
+    expect(result[0].startTime).toEqual(new Date('2024-01-15T07:00:00Z'))
+    expect(result[0].endTime).toEqual(new Date('2024-01-15T08:30:00Z'))
+    expect(result[1].startTime).toEqual(new Date('2024-01-15T18:00:00Z'))
+    expect(result[1].endTime).toEqual(new Date('2024-01-15T19:30:00Z'))
+  })
+
+  test('merges activities that touch exactly at boundary', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T12:00:00Z'),
+        startTime: new Date('2024-01-15T11:00:00Z'), // Starts exactly when previous ends
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    // Activities that touch should be merged (same workout logged as two parts)
+    expect(result).toHaveLength(1)
+    expect(result[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].endTime).toEqual(new Date('2024-01-15T12:00:00Z'))
+  })
+
+  test('handles unsorted input correctly', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        startTime: new Date('2024-01-15T10:30:00Z'),
+        title: 'Second',
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'First',
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('First') // First by startTime should be kept
+  })
+
+  test('preserves id from first activity when merging', () => {
+    const activities = [
+      makeActivity({
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        id: 'first-id',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        endTime: new Date('2024-01-15T11:30:00Z'),
+        id: 'second-id',
+        startTime: new Date('2024-01-15T10:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('first-id')
+  })
+})

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -342,6 +342,83 @@ export interface Activity {
   data?: Record<string, unknown>
 }
 
+/**
+ * Merge overlapping activities of the same type.
+ *
+ * When the same activity is logged in multiple apps (e.g., Polar for HR data
+ * and Gravl for workout details), this function merges them into a single
+ * activity using the earliest start time and latest end time.
+ *
+ * Merge rules:
+ * - Activities are grouped by activityType
+ * - Activities overlap if: a1.endTime >= a2.startTime (or a1 has no endTime and a2 starts during a1's day)
+ * - Merged activity uses: earliest startTime, latest endTime
+ * - First activity's source and id are kept
+ * - First non-empty title is used
+ * - Notes are concatenated with newline
+ * - Data objects are merged (later values override earlier for same keys)
+ */
+export const mergeOverlappingActivities = (activities: Activity[]): Activity[] => {
+  if (activities.length === 0) return []
+
+  // Group by activity type
+  const byType = new Map<string, Activity[]>()
+  for (const a of activities) {
+    const group = byType.get(a.activityType) ?? []
+    group.push(a)
+    byType.set(a.activityType, group)
+  }
+
+  const result: Activity[] = []
+
+  for (const [, typeActivities] of byType) {
+    // Sort by start time
+    const sorted = [...typeActivities].sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+
+    let current = { ...sorted[0] }
+
+    for (let i = 1; i < sorted.length; i++) {
+      const next = sorted[i]
+      const currentEnd = current.endTime?.getTime() ?? current.startTime.getTime()
+      const nextStart = next.startTime.getTime()
+
+      // Check if activities overlap or touch
+      if (currentEnd >= nextStart) {
+        // Merge: extend end time if needed
+        const nextEnd = next.endTime?.getTime()
+        if (nextEnd !== undefined && (current.endTime === undefined || nextEnd > current.endTime.getTime())) {
+          current.endTime = next.endTime
+        }
+
+        // Use first non-empty title
+        if (!current.title && next.title) {
+          current.title = next.title
+        }
+
+        // Concatenate notes
+        if (next.notes) {
+          current.notes = current.notes ? `${current.notes}\n${next.notes}` : next.notes
+        }
+
+        // Merge data objects
+        if (next.data) {
+          current.data = { ...current.data, ...next.data }
+        }
+      } else {
+        // No overlap, save current and start new
+        result.push(current)
+        current = { ...next }
+      }
+    }
+
+    // Don't forget the last one
+    result.push(current)
+  }
+
+  // Sort final result by start time
+  return result.sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+}
+
 export const insertActivity = async (user: string, activity: Activity) => {
   await query(
     user,
@@ -381,16 +458,18 @@ export const getActivities = async (
     [types, start, end],
   )
 
-  return result.rows.map((row) => ({
-    activityType: row.activity_type,
+  const activities = result.rows.map((row) => ({
+    activityType: row.activity_type as ActivityType,
     data: row.data,
     endTime: row.end_time ? new Date(row.end_time) : undefined,
     id: row.id,
     notes: row.notes,
-    source: row.source,
+    source: row.source as DataSource,
     startTime: new Date(row.start_time),
     title: row.title,
   }))
+
+  return mergeOverlappingActivities(activities)
 }
 
 /**
@@ -410,16 +489,18 @@ export const getSleepSessions = async (user: string, start: Date, end: Date): Pr
     [start, end],
   )
 
-  return result.rows.map((row) => ({
-    activityType: row.activity_type,
+  const activities = result.rows.map((row) => ({
+    activityType: row.activity_type as ActivityType,
     data: row.data,
     endTime: row.end_time ? new Date(row.end_time) : undefined,
     id: row.id,
     notes: row.notes,
-    source: row.source,
+    source: row.source as DataSource,
     startTime: new Date(row.start_time),
     title: row.title,
   }))
+
+  return mergeOverlappingActivities(activities)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `mergeOverlappingActivities()` function to merge overlapping activities of the same type at query time
- Applied to `getActivities()` and `getSleepSessions()` so all activity queries benefit from deduplication
- Allows logging the same workout in multiple apps (e.g., Polar for HR data, Gravl for workout details) while seeing it as a single entry

## Merge rules

- Activities are grouped by `activityType`
- Activities that overlap or touch (end >= next start) are merged
- Merged activity uses: earliest startTime, latest endTime
- First activity's source and id are kept
- First non-empty title is used
- Notes are concatenated with newline
- Data objects are merged (later values override earlier for same keys)

## Test plan

- [x] Unit tests for `mergeOverlappingActivities()` covering all merge scenarios
- [x] Existing `queries.test.ts` tests pass
- [x] `db.integration.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)