### PR TITLE
Fix widget crash by replacing View with ImageView

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -48,7 +48,7 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
     ) {
         val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
 
-        // Set up click handler to open the app on the Goals tab
+        // Set up click handler to open the app on the Data tab
         val openAppIntent = Intent(context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_DATA)

--- a/apps/android/app/src/main/res/layout/widget_goal_item.xml
+++ b/apps/android/app/src/main/res/layout/widget_goal_item.xml
@@ -52,13 +52,15 @@
             android:progressDrawable="@drawable/progress_bar_widget_drawable" />
 
         <!-- Min marker line (positioned dynamically) -->
-        <View
+        <!-- Note: Using ImageView instead of View because RemoteViews doesn't support plain View -->
+        <ImageView
             android:id="@+id/min_marker"
             android:layout_width="2dp"
             android:layout_height="match_parent"
             android:layout_gravity="start"
             android:background="#CCFFFFFF"
-            android:visibility="gone" />
+            android:visibility="gone"
+            android:importantForAccessibility="no" />
 
     </FrameLayout>
 


### PR DESCRIPTION
## Summary
- Replace plain `View` element with `ImageView` in widget layout - RemoteViews doesn't support `View`, causing `InflateException` ("Couldn't add widget")
- Fix misleading comment that referenced "Goals tab" when code opens Data tab

## Root cause
The min-marker overlay in `widget_goal_item.xml` used a `<View>` element. Android's `RemoteViews` (used by widgets) only supports a limited set of views, and plain `View` is not one of them. This caused the widget to fail with:
```
InflateException: Binary XML file line #61 in net.aurboda:layout/widget_goal_item: Error inflating class android.view.View
```

## Test plan
- [ ] Install updated APK
- [ ] Add goals widget to home screen
- [ ] Verify widget displays goals correctly
- [ ] Verify tapping widget opens app to Data tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)