### PR TITLE
Fix step deduplication in goal progress calculation

### DIFF
--- a/apps/backend/src/services/goals.test.ts
+++ b/apps/backend/src/services/goals.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import * as db from '../db'
+import { getGoalsProgress } from './goals'
+import * as settings from './settings'
+
+// Mock the db module
+vi.mock('../db', () => ({
+  getDailyAggregateValue: vi.fn(),
+  getDailyAggregates: vi.fn(),
+  getTimeSeries: vi.fn(),
+}))
+
+// Mock the settings module
+vi.mock('./settings', () => ({
+  computeHrZoneSecs: vi.fn(),
+  getEffectiveGoals: vi.fn(),
+  getEffectiveHrZones: vi.fn(),
+  getSettings: vi.fn(),
+}))
+
+describe('getGoalsProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-02T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('returns empty array when no goals', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([])
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toEqual([])
+  })
+
+  test('uses getDailyAggregateValue for cumulative metrics like steps', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([
+      { id: 'goal-1', metric: 'steps', min: 10000, window: '1d' },
+    ])
+
+    // For a 1d window at noon, we span 2 calendar days (yesterday and today)
+    // Mock aggregate values: yesterday had 5000, today has 4672 so far
+    // losingTomorrow queries yesterday separately
+    vi.mocked(db.getDailyAggregateValue)
+      .mockResolvedValueOnce(5000) // yesterday for current
+      .mockResolvedValueOnce(4672) // today for current
+      .mockResolvedValueOnce(5000) // yesterday for losingTomorrow
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].current).toBe(9672) // 5000 + 4672
+    expect(result[0].losingTomorrow).toBe(5000)
+    expect(result[0].metric).toBe('steps')
+
+    // Should use getDailyAggregateValue, not getDailyAggregates
+    expect(db.getDailyAggregateValue).toHaveBeenCalled()
+    expect(db.getDailyAggregates).not.toHaveBeenCalled()
+  })
+
+  test('falls back to getDailyAggregates when no aggregate value exists', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([
+      { id: 'goal-1', metric: 'steps', min: 10000, window: '1d' },
+    ])
+
+    // No aggregate value exists
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([
+      { avg: 4672, date: '2026-02-02', metric: 'steps', sum: 4672 },
+    ])
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].current).toBe(4672)
+  })
+
+  test('sums aggregate values across multiple days for 7d window', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([
+      { id: 'goal-1', metric: 'steps', min: 70000, window: '7d' },
+    ])
+
+    // For a 7d window at noon, we span 8 calendar days
+    // Mock aggregate values for current sum (8 days)
+    vi.mocked(db.getDailyAggregateValue)
+      .mockResolvedValueOnce(10000) // Day 1 (oldest, partial)
+      .mockResolvedValueOnce(12000) // Day 2
+      .mockResolvedValueOnce(11000) // Day 3
+      .mockResolvedValueOnce(9000) // Day 4
+      .mockResolvedValueOnce(13000) // Day 5
+      .mockResolvedValueOnce(8000) // Day 6
+      .mockResolvedValueOnce(7000) // Day 7
+      .mockResolvedValueOnce(5000) // Day 8 (today, partial)
+      // losingTomorrow query for oldest day
+      .mockResolvedValueOnce(10000)
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toHaveLength(1)
+    // Total should be sum of all 8 days = 75000
+    expect(result[0].current).toBe(75000)
+    expect(result[0].losingTomorrow).toBe(10000)
+  })
+
+  test('uses getTimeSeries for HR zone metrics', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([
+      { id: 'goal-1', metric: 'hr_zone_2_sec', min: 9000, window: '7d' },
+    ])
+    vi.mocked(settings.getEffectiveHrZones).mockResolvedValue({
+      source: 'default',
+      zones: { 1: 90, 2: 108, 3: 126, 4: 144, 5: 162 },
+    })
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(settings.computeHrZoneSecs).mockReturnValue({ 0: 0, 1: 0, 2: 9000, 3: 0, 4: 0, 5: 0 })
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].current).toBe(9000)
+    expect(db.getTimeSeries).toHaveBeenCalledWith(
+      'testuser',
+      'heart_rate',
+      expect.any(Date),
+      expect.any(Date),
+    )
+  })
+
+  test('uses getDailyAggregates for non-cumulative metrics', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([
+      { id: 'goal-1', metric: 'weight', min: 70, window: '1d' },
+    ])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([
+      { avg: 72.5, date: '2026-02-02', metric: 'weight', sum: 72.5 },
+    ])
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toHaveLength(1)
+    // Non-cumulative metrics still use getDailyAggregates
+    expect(db.getDailyAggregates).toHaveBeenCalled()
+    expect(db.getDailyAggregateValue).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/services/goals.ts
+++ b/apps/backend/src/services/goals.ts
@@ -2,13 +2,39 @@
  * Goals service for calculating progress toward user-defined goals.
  */
 
-import { metricUnits, parseDuration, type GoalProgress, type MetricType } from '@aurboda/api-spec'
-import { getDailyAggregates, getTimeSeries } from '../db'
+import {
+  cumulativeMetrics,
+  metricUnits,
+  parseDuration,
+  type GoalProgress,
+  type MetricType,
+} from '@aurboda/api-spec'
+import { getDailyAggregates, getDailyAggregateValue, getTimeSeries } from '../db'
 import { computeHrZoneSecs, getEffectiveGoals, getEffectiveHrZones, getSettings } from './settings'
+
+/**
+ * Get all dates in a range (inclusive).
+ */
+const getDatesInRange = (start: Date, end: Date): Date[] => {
+  const dates: Date[] = []
+  const current = new Date(start)
+  current.setUTCHours(0, 0, 0, 0)
+
+  const endDay = new Date(end)
+  endDay.setUTCHours(23, 59, 59, 999)
+
+  while (current <= endDay) {
+    dates.push(new Date(current))
+    current.setUTCDate(current.getUTCDate() + 1)
+  }
+
+  return dates
+}
 
 /**
  * Calculate the sum of a metric over a time range.
  * Handles HR zone metrics specially (computed from heart_rate).
+ * Uses deduplicated aggregates for cumulative metrics (steps, distance, etc.).
  */
 const getMetricSum = async (user: string, metric: MetricType, start: Date, end: Date): Promise<number> => {
   // HR zone metrics need to be computed from heart rate data
@@ -28,7 +54,21 @@ const getMetricSum = async (user: string, metric: MetricType, start: Date, end: 
     return zoneSecs[zoneIndex]
   }
 
-  // For regular metrics, use daily aggregates and sum them
+  // For cumulative metrics (steps, distance, etc.), use deduplicated daily aggregates
+  if (cumulativeMetrics.includes(metric)) {
+    const dates = getDatesInRange(start, end)
+    const values = await Promise.all(dates.map((date) => getDailyAggregateValue(user, metric, date)))
+
+    // If we have any aggregate values, use them
+    const hasAggregates = values.some((v) => v !== null)
+    if (hasAggregates) {
+      return values.reduce<number>((sum, v) => sum + (v ?? 0), 0)
+    }
+
+    // Fall back to raw data if no aggregates exist
+  }
+
+  // For non-cumulative metrics or fallback, use daily aggregates and sum them
   const dailyData = await getDailyAggregates(user, [metric], start, end)
   return dailyData.reduce((sum, day) => sum + day.sum, 0)
 }


### PR DESCRIPTION
## Summary
- Use deduplicated aggregates (`health_connect_aggregate` records) for cumulative metrics (steps, distance, etc.) in goal progress calculation
- Fixes bug where multiple data sources (Fitbit, Oura, phone) caused step counts to be double/triple counted
- Falls back to raw data sum if no aggregates exist

## Root cause
The goal progress calculation used `getDailyAggregates` which sums ALL records from ALL sources. For steps, if you have Fitbit recording 4672 steps and Oura also recording ~5000 steps, the goal showed ~10000 instead of the correct ~4672.

The daily summary already had this correct by using `getDailyAggregateValue` which queries only the deduplicated `health_connect_aggregate` records.

## Changes
- Import `cumulativeMetrics` list and `getDailyAggregateValue` function
- For cumulative metrics, iterate over days and use deduplicated values
- Fall back to original behavior if no aggregates exist
- Add comprehensive unit tests for goal progress calculation

## Test plan
- [ ] Verify steps goal shows correct value matching daily summary
- [ ] Verify 7-day rolling windows sum correctly
- [ ] Verify HR zone goals still work (not affected)
- [ ] Verify non-cumulative metrics still work

## Future consideration
User mentioned wanting goals with different aggregation types (min/max/mean/median) for metrics like body fat percentage. This is not addressed in this PR but could be a future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)