### PR TITLE
Fix goal windows to use calendar days for day-based durations

### DIFF
--- a/apps/backend/src/services/goals.test.ts
+++ b/apps/backend/src/services/goals.test.ts
@@ -44,19 +44,18 @@ describe('getGoalsProgress', () => {
       { id: 'goal-1', metric: 'steps', min: 10000, window: '1d' },
     ])
 
-    // For a 1d window at noon, we span 2 calendar days (yesterday and today)
-    // Mock aggregate values: yesterday had 5000, today has 4672 so far
-    // losingTomorrow queries yesterday separately
+    // For a 1d window with day-based duration, we only include today (1 calendar day)
+    // Mock aggregate value: today has 4672 so far
+    // losingTomorrow queries today separately (same day for 1d window)
     vi.mocked(db.getDailyAggregateValue)
-      .mockResolvedValueOnce(5000) // yesterday for current
       .mockResolvedValueOnce(4672) // today for current
-      .mockResolvedValueOnce(5000) // yesterday for losingTomorrow
+      .mockResolvedValueOnce(4672) // today for losingTomorrow
 
     const result = await getGoalsProgress('testuser')
 
     expect(result).toHaveLength(1)
-    expect(result[0].current).toBe(9672) // 5000 + 4672
-    expect(result[0].losingTomorrow).toBe(5000)
+    expect(result[0].current).toBe(4672) // only today
+    expect(result[0].losingTomorrow).toBe(4672) // tomorrow we lose today's steps
     expect(result[0].metric).toBe('steps')
 
     // Should use getDailyAggregateValue, not getDailyAggregates
@@ -88,26 +87,49 @@ describe('getGoalsProgress', () => {
       { id: 'goal-1', metric: 'steps', min: 70000, window: '7d' },
     ])
 
-    // For a 7d window at noon, we span 8 calendar days
-    // Mock aggregate values for current sum (8 days)
+    // For a 7d window with day-based duration, we include exactly 7 calendar days
+    // (today + 6 previous days)
+    // At 2026-02-02T12:00:00Z, this is Jan 27 through Feb 2
     vi.mocked(db.getDailyAggregateValue)
-      .mockResolvedValueOnce(10000) // Day 1 (oldest, partial)
-      .mockResolvedValueOnce(12000) // Day 2
-      .mockResolvedValueOnce(11000) // Day 3
-      .mockResolvedValueOnce(9000) // Day 4
-      .mockResolvedValueOnce(13000) // Day 5
-      .mockResolvedValueOnce(8000) // Day 6
-      .mockResolvedValueOnce(7000) // Day 7
-      .mockResolvedValueOnce(5000) // Day 8 (today, partial)
-      // losingTomorrow query for oldest day
+      .mockResolvedValueOnce(10000) // Jan 27 (oldest)
+      .mockResolvedValueOnce(12000) // Jan 28
+      .mockResolvedValueOnce(11000) // Jan 29
+      .mockResolvedValueOnce(9000) // Jan 30
+      .mockResolvedValueOnce(13000) // Jan 31
+      .mockResolvedValueOnce(8000) // Feb 1
+      .mockResolvedValueOnce(5000) // Feb 2 (today)
+      // losingTomorrow query for oldest day (Jan 27)
       .mockResolvedValueOnce(10000)
 
     const result = await getGoalsProgress('testuser')
 
     expect(result).toHaveLength(1)
-    // Total should be sum of all 8 days = 75000
-    expect(result[0].current).toBe(75000)
+    // Total should be sum of all 7 days = 68000
+    expect(result[0].current).toBe(68000)
     expect(result[0].losingTomorrow).toBe(10000)
+  })
+
+  test('uses rolling time for hour-based windows (24h spans 2 calendar days at noon)', async () => {
+    vi.mocked(settings.getSettings).mockResolvedValue({})
+    vi.mocked(settings.getEffectiveGoals).mockReturnValue([
+      { id: 'goal-1', metric: 'steps', min: 10000, window: '24h' },
+    ])
+
+    // For a 24h window at noon, we use rolling hours (not calendar days)
+    // At 2026-02-02T12:00:00Z, this is yesterday 12:00 through now
+    // This spans 2 calendar days: Feb 1 (partial) and Feb 2 (partial)
+    vi.mocked(db.getDailyAggregateValue)
+      .mockResolvedValueOnce(5000) // Feb 1 (partial)
+      .mockResolvedValueOnce(4672) // Feb 2 (partial)
+      // losingTomorrow query for Feb 1
+      .mockResolvedValueOnce(5000)
+
+    const result = await getGoalsProgress('testuser')
+
+    expect(result).toHaveLength(1)
+    // 24h rolling window spans 2 days
+    expect(result[0].current).toBe(9672) // 5000 + 4672
+    expect(result[0].losingTomorrow).toBe(5000)
   })
 
   test('uses getTimeSeries for HR zone metrics', async () => {

--- a/apps/backend/src/services/goals.ts
+++ b/apps/backend/src/services/goals.ts
@@ -4,6 +4,7 @@
 
 import {
   cumulativeMetrics,
+  isCalendarBasedUnit,
   metricUnits,
   parseDuration,
   type GoalProgress,
@@ -89,8 +90,23 @@ export const getGoalsProgress = async (user: string): Promise<GoalProgress[]> =>
   const results: GoalProgress[] = []
 
   for (const goal of goals) {
-    const windowMs = parseDuration(goal.window)
-    const windowStart = new Date(now.getTime() - windowMs)
+    const { ms: windowMs, unit, value } = parseDuration(goal.window)
+    let windowStart: Date
+
+    if (isCalendarBasedUnit(unit)) {
+      // Calendar-based: "1d" = today only, "7d" = today + 6 previous days
+      // Calculate days based on unit: d=days, w=weeks (7 days each), M=months (30 days each)
+      const daysInWindow =
+        unit === 'd' ? value
+        : unit === 'w' ? value * 7
+        : value * 30
+      windowStart = new Date(now)
+      windowStart.setUTCHours(0, 0, 0, 0)
+      windowStart.setUTCDate(windowStart.getUTCDate() - (daysInWindow - 1))
+    } else {
+      // Rolling time-based: "24h" = exactly 24 hours ago from now
+      windowStart = new Date(now.getTime() - windowMs)
+    }
 
     // Calculate "losing tomorrow" - the oldest day's contribution
     // For a 7-day window, this is the first day that will drop off tomorrow

--- a/packages/api-spec/src/schemas/goals.ts
+++ b/packages/api-spec/src/schemas/goals.ts
@@ -18,15 +18,23 @@ export const durationStringSchema = z
     id: 'DurationString',
   })
 
+export type DurationUnit = 'd' | 'h' | 'M' | 'm' | 's' | 'w'
+
+export interface ParsedDuration {
+  ms: number
+  unit: DurationUnit
+  value: number
+}
+
 /**
- * Parse duration string to milliseconds.
+ * Parse duration string to milliseconds and components.
  */
-export const parseDuration = (duration: string): number => {
+export const parseDuration = (duration: string): ParsedDuration => {
   const match = duration.match(/^(\d+)([smhdwM])$/)
   if (!match) throw new Error(`Invalid duration: ${duration}`)
 
   const value = parseInt(match[1], 10)
-  const unit = match[2]
+  const unit = match[2] as DurationUnit
 
   const multipliers: Record<string, number> = {
     M: 30 * 24 * 60 * 60 * 1000, // Approximate month
@@ -37,8 +45,15 @@ export const parseDuration = (duration: string): number => {
     w: 7 * 24 * 60 * 60 * 1000,
   }
 
-  return value * multipliers[unit]
+  return { ms: value * multipliers[unit], unit, value }
 }
+
+/**
+ * Check if a duration unit is calendar-based (days, weeks, months).
+ * Calendar-based windows align to day boundaries.
+ * Rolling windows (hours, minutes, seconds) use exact time offsets.
+ */
+export const isCalendarBasedUnit = (unit: DurationUnit): boolean => unit === 'd' || unit === 'w' || unit === 'M'
 
 /**
  * Goal schema for a single metric target.


### PR DESCRIPTION
## Summary

- Day-based duration units (d, w, M) now use calendar days instead of rolling time
- "1d" means today only, "7d" means today plus 6 previous days
- Hour-based units (h, m, s) remain rolling as before (e.g., "24h" = last 24 hours from now)

This fixes the issue where a "1d" step goal was showing steps from 2 calendar days instead of just today.

## Test plan

- [x] Updated unit tests to verify calendar-based behavior for day units
- [x] Added test for hour-based windows to verify rolling behavior is preserved
- [x] All 451 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)