### PR TITLE
Improve Trends UI with saved trends and better layouts

### DIFF
--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -416,79 +416,86 @@ export function Dashboard() {
 
       {isLoading && <div class="loading">Loading your health data...</div>}
 
-      {/* Baseline metrics */}
-      <section class="metrics-section">
-        <h2>Your Baseline</h2>
-        <div class="metrics-grid">
-          <MetricCard
-            title="HRV (7-day)"
-            value={baseline?.hrv.avg7day ?? null}
-            unit="ms"
-            trend={baseline?.hrv.trendPercent}
-            subtitle="Heart Rate Variability"
-          />
-          <MetricCard
-            title="HRV (30-day)"
-            value={baseline?.hrv.avg30day ?? null}
-            unit="ms"
-            subtitle="Long-term average"
-          />
-          <MetricCard
-            title="Resting HR (7-day)"
-            value={baseline?.restingHr.avg7day ?? null}
-            unit="bpm"
-            trend={baseline?.restingHr.trendPercent}
-            trendInverse={true}
-            subtitle="Lower is generally better"
-          />
-          <MetricCard
-            title="Resting HR (30-day)"
-            value={baseline?.restingHr.avg30day ?? null}
-            unit="bpm"
-            subtitle="Long-term average"
-          />
-        </div>
-      </section>
+      {/* Two-column layout for baseline and summary on wide screens */}
+      <div class="metrics-columns">
+        {/* Baseline metrics */}
+        <section class="metrics-section">
+          <h2>Your Baseline</h2>
+          <div class="metrics-grid">
+            <MetricCard
+              title="HRV (7-day)"
+              value={baseline?.hrv.avg7day ?? null}
+              unit="ms"
+              trend={baseline?.hrv.trendPercent}
+              subtitle="Heart Rate Variability"
+            />
+            <MetricCard
+              title="HRV (30-day)"
+              value={baseline?.hrv.avg30day ?? null}
+              unit="ms"
+              subtitle="Long-term average"
+            />
+            <MetricCard
+              title="Resting HR (7-day)"
+              value={baseline?.restingHr.avg7day ?? null}
+              unit="bpm"
+              trend={baseline?.restingHr.trendPercent}
+              trendInverse={true}
+              subtitle="Lower is generally better"
+            />
+            <MetricCard
+              title="Resting HR (30-day)"
+              value={baseline?.restingHr.avg30day ?? null}
+              unit="bpm"
+              subtitle="Long-term average"
+            />
+          </div>
+        </section>
 
-      {/* Period summary metrics */}
-      <section class="metrics-section">
-        <h2>30-Day Summary</h2>
-        <div class="metrics-grid">
-          <MetricCard
-            title="Sleep Score"
-            value={periodSummary.sleep_score?.avg ?? null}
-            trend={periodSummary.sleep_score?.changeFromPreviousPeriodPercent}
-            sparklineData={sleepScores}
-            sparklineColor="#3b82f6"
-            subtitle={periodSummary.sleep_score ? `${periodSummary.sleep_score.count} nights` : undefined}
-          />
-          <MetricCard
-            title="Readiness Score"
-            value={periodSummary.readiness_score?.avg ?? null}
-            trend={periodSummary.readiness_score?.changeFromPreviousPeriodPercent}
-            subtitle={
-              periodSummary.readiness_score ? `${periodSummary.readiness_score.count} days` : undefined
-            }
-          />
-          <MetricCard
-            title="Daily Steps"
-            value={periodSummary.steps?.avg ? Math.round(periodSummary.steps.avg).toLocaleString() : null}
-            trend={periodSummary.steps?.changeFromPreviousPeriodPercent}
-            subtitle={
-              periodSummary.steps ? `Max: ${Math.round(periodSummary.steps.max).toLocaleString()}` : undefined
-            }
-          />
-          <MetricCard
-            title="Zone 2 (Weekly)"
-            value={
-              periodSummary.hr_zone_2_sec?.avg ? Math.round((periodSummary.hr_zone_2_sec.avg * 7) / 60) : null
-            }
-            unit="min"
-            trend={periodSummary.hr_zone_2_sec?.changeFromPreviousPeriodPercent}
-            subtitle="Target: 150-200 min/week"
-          />
-        </div>
-      </section>
+        {/* Period summary metrics */}
+        <section class="metrics-section">
+          <h2>30-Day Summary</h2>
+          <div class="metrics-grid">
+            <MetricCard
+              title="Sleep Score"
+              value={periodSummary.sleep_score?.avg ?? null}
+              trend={periodSummary.sleep_score?.changeFromPreviousPeriodPercent}
+              sparklineData={sleepScores}
+              sparklineColor="#3b82f6"
+              subtitle={periodSummary.sleep_score ? `${periodSummary.sleep_score.count} nights` : undefined}
+            />
+            <MetricCard
+              title="Readiness Score"
+              value={periodSummary.readiness_score?.avg ?? null}
+              trend={periodSummary.readiness_score?.changeFromPreviousPeriodPercent}
+              subtitle={
+                periodSummary.readiness_score ? `${periodSummary.readiness_score.count} days` : undefined
+              }
+            />
+            <MetricCard
+              title="Daily Steps"
+              value={periodSummary.steps?.avg ? Math.round(periodSummary.steps.avg).toLocaleString() : null}
+              trend={periodSummary.steps?.changeFromPreviousPeriodPercent}
+              subtitle={
+                periodSummary.steps ?
+                  `Max: ${Math.round(periodSummary.steps.max).toLocaleString()}`
+                : undefined
+              }
+            />
+            <MetricCard
+              title="Zone 2 (Weekly)"
+              value={
+                periodSummary.hr_zone_2_sec?.avg ?
+                  Math.round((periodSummary.hr_zone_2_sec.avg * 7) / 60)
+                : null
+              }
+              unit="min"
+              trend={periodSummary.hr_zone_2_sec?.changeFromPreviousPeriodPercent}
+              subtitle="Target: 150-200 min/week"
+            />
+          </div>
+        </section>
+      </div>
 
       {/* Activity summary */}
       <section class="metrics-section">

--- a/apps/web/src/pages/Dashboard/style.css
+++ b/apps/web/src/pages/Dashboard/style.css
@@ -1,7 +1,7 @@
 .dashboard {
-  max-width: 1000px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .dashboard h1 {
@@ -30,8 +30,20 @@
   color: #888;
 }
 
+/* Two-column layout for baseline and summary on wide screens */
+.dashboard .metrics-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
 .dashboard .metrics-section {
   margin-bottom: 2rem;
+}
+
+.dashboard .metrics-columns .metrics-section {
+  margin-bottom: 0;
 }
 
 /* Metrics grid */
@@ -359,6 +371,20 @@
 }
 
 /* Responsive */
+@media (max-width: 1100px) {
+  .dashboard .metrics-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard .metrics-columns .metrics-section {
+    margin-bottom: 2rem;
+  }
+
+  .dashboard .metrics-columns .metrics-section:last-child {
+    margin-bottom: 0;
+  }
+}
+
 @media (max-width: 639px) {
   .dashboard {
     padding: 1rem;

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -3,43 +3,16 @@ import * as d3 from 'd3'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchTrend, type FetchTrendParams, type TrendDisplayPeriod, type TrendResult } from '../../state/api'
 import { auth } from '../../state/auth'
+import {
+  addSavedTrend,
+  removeSavedTrend,
+  resetToDefaults,
+  savedTrends,
+  updateSavedTrend,
+  type SavedTrend,
+} from '../../state/savedTrends'
 
 import './style.css'
-
-// Preset trend configurations for common use cases
-const PRESET_TRENDS: Array<{ name: string; params: FetchTrendParams }> = [
-  {
-    name: 'Painkillers',
-    params: {
-      displayPeriod: 'monthly',
-      halfLifeDays: 15,
-      lookbackDays: 180,
-      pattern: 'pain_killer|painkiller|ibuprofen',
-      sourceType: 'tag',
-    },
-  },
-  {
-    name: 'Coffee',
-    params: {
-      displayPeriod: 'daily',
-      halfLifeDays: 7,
-      lookbackDays: 90,
-      pattern: 'coffee',
-      sourceType: 'tag',
-    },
-  },
-  {
-    name: 'Weight',
-    params: {
-      aggregation: 'mean',
-      displayPeriod: 'daily',
-      halfLifeDays: 14,
-      lookbackDays: 180,
-      pattern: 'weight',
-      sourceType: 'metric',
-    },
-  },
-]
 
 // Chart component for trend history
 function TrendChart({ data, color }: { data: { date: string; value: number }[]; color: string }) {
@@ -176,26 +149,50 @@ function TrendValueCard({ result }: { result: TrendResult }) {
   )
 }
 
-// Form for configuring a custom trend query
+// Lookback options with extended range
+const LOOKBACK_OPTIONS = [
+  { label: '30 days', value: 30 },
+  { label: '90 days', value: 90 },
+  { label: '180 days', value: 180 },
+  { label: '1 year', value: 365 },
+  { label: '2 years', value: 730 },
+  { label: '3 years', value: 1095 },
+  { label: '5 years', value: 1825 },
+  { label: 'All time', value: 3650 }, // 10 years as "all time"
+]
+
+// Form for configuring a trend
 function TrendConfigForm({
+  initialValues,
   onSubmit,
+  onCancel,
   isLoading,
+  submitLabel = 'Calculate Trend',
 }: {
-  onSubmit: (params: FetchTrendParams) => void
+  initialValues?: { name?: string; params: FetchTrendParams }
+  onSubmit: (name: string, params: FetchTrendParams) => void
+  onCancel?: () => void
   isLoading: boolean
+  submitLabel?: string
 }) {
-  const [sourceType, setSourceType] = useState<'tag' | 'metric'>('tag')
-  const [pattern, setPattern] = useState('')
-  const [halfLifeDays, setHalfLifeDays] = useState(15)
-  const [lookbackDays, setLookbackDays] = useState(90)
-  const [displayPeriod, setDisplayPeriod] = useState<TrendDisplayPeriod>('monthly')
-  const [aggregation, setAggregation] = useState<'count' | 'mean' | 'sum'>('count')
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [sourceType, setSourceType] = useState<'tag' | 'metric'>(initialValues?.params.sourceType ?? 'tag')
+  const [pattern, setPattern] = useState(initialValues?.params.pattern ?? '')
+  const [halfLifeDays, setHalfLifeDays] = useState(initialValues?.params.halfLifeDays ?? 15)
+  const [lookbackDays, setLookbackDays] = useState(initialValues?.params.lookbackDays ?? 90)
+  const [displayPeriod, setDisplayPeriod] = useState<TrendDisplayPeriod>(
+    initialValues?.params.displayPeriod ?? 'monthly',
+  )
+  const [aggregation, setAggregation] = useState<'count' | 'mean' | 'sum'>(
+    initialValues?.params.aggregation ?? 'count',
+  )
 
   const handleSubmit = (e: Event) => {
     e.preventDefault()
     if (!pattern.trim()) return
 
-    onSubmit({
+    const trendName = name.trim() || pattern.trim()
+    onSubmit(trendName, {
       aggregation: sourceType === 'metric' ? aggregation : 'count',
       displayPeriod,
       halfLifeDays,
@@ -207,6 +204,18 @@ function TrendConfigForm({
 
   return (
     <form class="trend-config-form" onSubmit={handleSubmit}>
+      <div class="form-row">
+        <label class="name-input">
+          Name
+          <input
+            type="text"
+            value={name}
+            onInput={(e) => setName((e.target as HTMLInputElement).value)}
+            placeholder="e.g., My Coffee Trend"
+          />
+        </label>
+      </div>
+
       <div class="form-row">
         <label>
           Source Type
@@ -242,15 +251,16 @@ function TrendConfigForm({
           </select>
         </label>
         <label>
-          Lookback (days)
+          Lookback
           <select
             value={lookbackDays}
             onChange={(e) => setLookbackDays(Number((e.target as HTMLSelectElement).value))}
           >
-            <option value="30">30 days</option>
-            <option value="90">90 days</option>
-            <option value="180">180 days</option>
-            <option value="365">1 year</option>
+            {LOOKBACK_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
           </select>
         </label>
         <label>
@@ -280,33 +290,54 @@ function TrendConfigForm({
         )}
       </div>
 
-      <button type="submit" disabled={isLoading || !pattern.trim()}>
-        {isLoading ? 'Loading...' : 'Calculate Trend'}
-      </button>
+      <div class="form-actions">
+        <button type="submit" disabled={isLoading || !pattern.trim()}>
+          {isLoading ? 'Loading...' : submitLabel}
+        </button>
+        {onCancel && (
+          <button type="button" class="cancel-btn" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+      </div>
     </form>
   )
 }
 
-// Single trend widget that displays a preset or custom trend
-function TrendWidget({ name, params }: { name: string; params: FetchTrendParams }) {
-  const query = useQuery({
-    queryFn: () => fetchTrend(params),
-    queryKey: ['trend', params],
-    staleTime: 5 * 60 * 1000,
-  })
-
+// Widget color mapping
+const getColor = (name: string): string => {
   const colors: Record<string, string> = {
     Coffee: '#78350f',
     Painkillers: '#dc2626',
     Weight: '#2563eb',
-    default: '#8b5cf6',
   }
-  const color = colors[name] || colors.default
+  return colors[name] || '#8b5cf6'
+}
+
+// Single trend widget that displays a saved trend
+function TrendWidget({
+  trend,
+  onEdit,
+  onRemove,
+}: {
+  trend: SavedTrend
+  onEdit: (trend: SavedTrend) => void
+  onRemove: (id: string) => void
+}) {
+  const query = useQuery({
+    queryFn: () => fetchTrend(trend.params),
+    queryKey: ['trend', trend.params],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const color = getColor(trend.name)
 
   if (query.isLoading) {
     return (
       <div class="trend-widget loading">
-        <h3>{name}</h3>
+        <div class="trend-widget-header">
+          <h3>{trend.name}</h3>
+        </div>
         <div class="loading-spinner">Loading...</div>
       </div>
     )
@@ -315,7 +346,17 @@ function TrendWidget({ name, params }: { name: string; params: FetchTrendParams 
   if (query.error || !query.data) {
     return (
       <div class="trend-widget error">
-        <h3>{name}</h3>
+        <div class="trend-widget-header">
+          <h3>{trend.name}</h3>
+          <div class="trend-widget-actions">
+            <button class="edit-btn" onClick={() => onEdit(trend)} title="Edit">
+              Edit
+            </button>
+            <button class="remove-btn" onClick={() => onRemove(trend.id)} title="Remove">
+              ×
+            </button>
+          </div>
+        </div>
         <div class="error-message">Failed to load trend data</div>
       </div>
     )
@@ -323,7 +364,17 @@ function TrendWidget({ name, params }: { name: string; params: FetchTrendParams 
 
   return (
     <div class="trend-widget">
-      <h3>{name}</h3>
+      <div class="trend-widget-header">
+        <h3>{trend.name}</h3>
+        <div class="trend-widget-actions">
+          <button class="edit-btn" onClick={() => onEdit(trend)} title="Edit">
+            Edit
+          </button>
+          <button class="remove-btn" onClick={() => onRemove(trend.id)} title="Remove">
+            ×
+          </button>
+        </div>
+      </div>
       <TrendValueCard result={query.data} />
       <TrendChart data={query.data.history} color={color} />
     </div>
@@ -333,14 +384,34 @@ function TrendWidget({ name, params }: { name: string; params: FetchTrendParams 
 // Main Trends page component
 export function Trends() {
   const isLoggedIn = auth.value.token
-  const [customParams, setCustomParams] = useState<FetchTrendParams | null>(null)
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [editingTrend, setEditingTrend] = useState<SavedTrend | null>(null)
 
-  const customQuery = useQuery({
-    enabled: !!customParams,
-    queryFn: () => (customParams ? fetchTrend(customParams) : Promise.reject('No params')),
-    queryKey: ['trend', 'custom', customParams],
-    staleTime: 5 * 60 * 1000,
-  })
+  const trends = savedTrends.value
+
+  const handleAddTrend = (name: string, params: FetchTrendParams) => {
+    addSavedTrend(name, params)
+    setShowAddForm(false)
+  }
+
+  const handleEditTrend = (name: string, params: FetchTrendParams) => {
+    if (editingTrend) {
+      updateSavedTrend(editingTrend.id, name, params)
+      setEditingTrend(null)
+    }
+  }
+
+  const handleRemoveTrend = (id: string) => {
+    if (confirm('Remove this trend from your dashboard?')) {
+      removeSavedTrend(id)
+    }
+  }
+
+  const handleResetToDefaults = () => {
+    if (confirm('Reset all trends to the default presets? Your custom trends will be lost.')) {
+      resetToDefaults()
+    }
+  }
 
   if (!isLoggedIn) {
     return (
@@ -363,28 +434,54 @@ export function Trends() {
         </p>
       </header>
 
-      <section class="preset-trends">
-        <h2>Preset Trends</h2>
-        <div class="trends-grid">
-          {PRESET_TRENDS.map((preset) => (
-            <TrendWidget key={preset.name} name={preset.name} params={preset.params} />
-          ))}
+      <section class="saved-trends">
+        <div class="section-header">
+          <h2>Your Trends</h2>
+          <div class="section-actions">
+            <button class="add-trend-btn" onClick={() => setShowAddForm(true)}>
+              + Add Trend
+            </button>
+            <button class="reset-btn" onClick={handleResetToDefaults} title="Reset to defaults">
+              Reset
+            </button>
+          </div>
         </div>
-      </section>
 
-      <section class="custom-trend">
-        <h2>Custom Trend</h2>
-        <TrendConfigForm onSubmit={setCustomParams} isLoading={customQuery.isLoading} />
-
-        {customParams && customQuery.data && (
-          <div class="custom-result">
-            <TrendWidget name={`Custom: ${customParams.pattern}`} params={customParams} />
+        {showAddForm && (
+          <div class="add-trend-form-container">
+            <h3>Add New Trend</h3>
+            <TrendConfigForm
+              onSubmit={handleAddTrend}
+              onCancel={() => setShowAddForm(false)}
+              isLoading={false}
+              submitLabel="Add Trend"
+            />
           </div>
         )}
 
-        {customParams && customQuery.error && (
-          <div class="custom-error">
-            <p>Error loading custom trend. Check your pattern and try again.</p>
+        {editingTrend && (
+          <div class="edit-trend-form-container">
+            <h3>Edit Trend: {editingTrend.name}</h3>
+            <TrendConfigForm
+              initialValues={{ name: editingTrend.name, params: editingTrend.params }}
+              onSubmit={handleEditTrend}
+              onCancel={() => setEditingTrend(null)}
+              isLoading={false}
+              submitLabel="Save Changes"
+            />
+          </div>
+        )}
+
+        <div class="trends-grid">
+          {trends.map((trend) => (
+            <TrendWidget key={trend.id} trend={trend} onEdit={setEditingTrend} onRemove={handleRemoveTrend} />
+          ))}
+        </div>
+
+        {trends.length === 0 && !showAddForm && (
+          <div class="no-trends">
+            <p>No trends configured. Add one to get started!</p>
+            <button onClick={() => setShowAddForm(true)}>+ Add Your First Trend</button>
           </div>
         )}
       </section>

--- a/apps/web/src/pages/Trends/style.css
+++ b/apps/web/src/pages/Trends/style.css
@@ -1,11 +1,12 @@
 .trends-page {
-  max-width: 1200px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .page-header {
   margin-bottom: 2rem;
+  max-width: 800px;
 }
 
 .page-header h1 {
@@ -19,27 +20,68 @@
   color: #6b7280;
   font-size: 0.9rem;
   line-height: 1.5;
-  max-width: 600px;
 }
 
-.preset-trends,
-.custom-trend {
+.saved-trends {
   margin-bottom: 3rem;
 }
 
-.preset-trends h2,
-.custom-trend h2 {
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.section-header h2 {
   font-size: 1.25rem;
   font-weight: 600;
   color: #374151;
-  margin: 0 0 1rem 0;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid #e5e7eb;
+  margin: 0;
+}
+
+.section-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.add-trend-btn {
+  padding: 0.5rem 1rem;
+  background: #8b5cf6;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.add-trend-btn:hover {
+  background: #7c3aed;
+}
+
+.reset-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.reset-btn:hover {
+  background: #f3f4f6;
+  color: #374151;
 }
 
 .trends-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
   gap: 1.5rem;
 }
 
@@ -52,11 +94,56 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
+.trend-widget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
 .trend-widget h3 {
   font-size: 1rem;
   font-weight: 600;
   color: #374151;
-  margin: 0 0 1rem 0;
+  margin: 0;
+}
+
+.trend-widget-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.edit-btn {
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.edit-btn:hover {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.remove-btn {
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  color: #9ca3af;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.remove-btn:hover {
+  color: #dc2626;
+  background: #fef2f2;
 }
 
 .trend-widget.loading,
@@ -151,24 +238,35 @@
   border-radius: 8px;
 }
 
-/* Config Form */
-.trend-config-form {
+/* Form containers */
+.add-trend-form-container,
+.edit-trend-form-container {
   background: #f9fafb;
   border: 1px solid #e5e7eb;
   border-radius: 12px;
-  padding: 1.25rem;
+  padding: 1.5rem;
   margin-bottom: 1.5rem;
+}
+
+.add-trend-form-container h3,
+.edit-trend-form-container h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 1rem 0;
+}
+
+/* Config Form */
+.trend-config-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .form-row {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.form-row:last-of-type {
-  margin-bottom: 1.25rem;
 }
 
 .trend-config-form label {
@@ -180,6 +278,12 @@
   color: #374151;
   flex: 1;
   min-width: 120px;
+}
+
+.trend-config-form label.name-input {
+  flex: 1;
+  min-width: 200px;
+  max-width: 400px;
 }
 
 .trend-config-form label.pattern-input {
@@ -204,8 +308,62 @@
   box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
 }
 
-.trend-config-form button {
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.form-actions button {
   padding: 0.625rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.form-actions button[type="submit"] {
+  background: #8b5cf6;
+  color: #fff;
+  border: none;
+}
+
+.form-actions button[type="submit"]:hover:not(:disabled) {
+  background: #7c3aed;
+}
+
+.form-actions button[type="submit"]:disabled {
+  background: #d1d5db;
+  cursor: not-allowed;
+}
+
+.form-actions .cancel-btn {
+  background: transparent;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+}
+
+.form-actions .cancel-btn:hover {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+/* No trends state */
+.no-trends {
+  text-align: center;
+  padding: 3rem 2rem;
+  background: #f9fafb;
+  border-radius: 12px;
+  border: 2px dashed #e5e7eb;
+}
+
+.no-trends p {
+  color: #6b7280;
+  margin: 0 0 1rem 0;
+}
+
+.no-trends button {
+  padding: 0.625rem 1.5rem;
   background: #8b5cf6;
   color: #fff;
   border: none;
@@ -213,29 +371,10 @@
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.2s;
 }
 
-.trend-config-form button:hover:not(:disabled) {
+.no-trends button:hover {
   background: #7c3aed;
-}
-
-.trend-config-form button:disabled {
-  background: #d1d5db;
-  cursor: not-allowed;
-}
-
-/* Custom Result */
-.custom-result {
-  max-width: 500px;
-}
-
-.custom-error {
-  padding: 1rem;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 8px;
-  color: #991b1b;
 }
 
 /* Login Prompt */
@@ -274,10 +413,18 @@
     color: #9ca3af;
   }
 
-  .preset-trends h2,
-  .custom-trend h2 {
+  .section-header h2 {
     color: #e5e7eb;
-    border-bottom-color: #374151;
+  }
+
+  .reset-btn {
+    color: #9ca3af;
+    border-color: #4b5563;
+  }
+
+  .reset-btn:hover {
+    background: #374151;
+    color: #e5e7eb;
   }
 
   .trend-widget {
@@ -287,6 +434,20 @@
 
   .trend-widget h3 {
     color: #e5e7eb;
+  }
+
+  .edit-btn {
+    color: #9ca3af;
+    border-color: #4b5563;
+  }
+
+  .edit-btn:hover {
+    background: #374151;
+    color: #e5e7eb;
+  }
+
+  .remove-btn:hover {
+    background: #450a0a;
   }
 
   .trend-value-card {
@@ -307,9 +468,15 @@
     color: #6b7280;
   }
 
-  .trend-config-form {
+  .add-trend-form-container,
+  .edit-trend-form-container {
     background: #1f2937;
     border-color: #374151;
+  }
+
+  .add-trend-form-container h3,
+  .edit-trend-form-container h3 {
+    color: #e5e7eb;
   }
 
   .trend-config-form label {
@@ -323,10 +490,23 @@
     color: #f9fafb;
   }
 
-  .custom-error {
-    background: #450a0a;
-    border-color: #7f1d1d;
-    color: #fecaca;
+  .form-actions .cancel-btn {
+    color: #9ca3af;
+    border-color: #4b5563;
+  }
+
+  .form-actions .cancel-btn:hover {
+    background: #374151;
+    color: #e5e7eb;
+  }
+
+  .no-trends {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .no-trends p {
+    color: #9ca3af;
   }
 
   .login-prompt h2 {
@@ -335,13 +515,28 @@
 }
 
 /* Responsive */
+@media (max-width: 900px) {
+  .trends-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 639px) {
   .trends-page {
     padding: 1rem;
   }
 
-  .trends-grid {
-    grid-template-columns: 1fr;
+  .section-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .section-actions {
+    justify-content: stretch;
+  }
+
+  .section-actions button {
+    flex: 1;
   }
 
   .form-row {
@@ -352,7 +547,18 @@
     min-width: 100%;
   }
 
+  .trend-config-form label.name-input,
   .trend-config-form label.pattern-input {
     min-width: 100%;
+    max-width: none;
+  }
+
+  .trend-value-card {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .trend-meta {
+    align-items: flex-start;
   }
 }

--- a/apps/web/src/state/savedTrends.ts
+++ b/apps/web/src/state/savedTrends.ts
@@ -1,0 +1,89 @@
+import { signal } from '@preact/signals'
+import type { FetchTrendParams } from './api'
+
+export interface SavedTrend {
+  id: string
+  name: string
+  params: FetchTrendParams
+}
+
+// Default trends shown when no saved trends exist
+export const DEFAULT_TRENDS: SavedTrend[] = [
+  {
+    id: 'preset-painkillers',
+    name: 'Painkillers',
+    params: {
+      displayPeriod: 'monthly',
+      halfLifeDays: 15,
+      lookbackDays: 180,
+      pattern: 'pain_killer|painkiller|ibuprofen',
+      sourceType: 'tag',
+    },
+  },
+  {
+    id: 'preset-coffee',
+    name: 'Coffee',
+    params: {
+      displayPeriod: 'daily',
+      halfLifeDays: 7,
+      lookbackDays: 90,
+      pattern: 'coffee',
+      sourceType: 'tag',
+    },
+  },
+  {
+    id: 'preset-weight',
+    name: 'Weight',
+    params: {
+      aggregation: 'mean',
+      displayPeriod: 'daily',
+      halfLifeDays: 14,
+      lookbackDays: 180,
+      pattern: 'weight',
+      sourceType: 'metric',
+    },
+  },
+]
+
+const STORAGE_KEY = 'savedTrends'
+
+const loadSavedTrends = (): SavedTrend[] => {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  if (saved) {
+    try {
+      return JSON.parse(saved) as SavedTrend[]
+    } catch {
+      return DEFAULT_TRENDS
+    }
+  }
+  return DEFAULT_TRENDS
+}
+
+export const savedTrends = signal<SavedTrend[]>(loadSavedTrends())
+
+savedTrends.subscribe((value) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+})
+
+export const generateTrendId = (): string => `trend-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+
+export const addSavedTrend = (name: string, params: FetchTrendParams): void => {
+  const newTrend: SavedTrend = {
+    id: generateTrendId(),
+    name,
+    params,
+  }
+  savedTrends.value = [...savedTrends.value, newTrend]
+}
+
+export const updateSavedTrend = (id: string, name: string, params: FetchTrendParams): void => {
+  savedTrends.value = savedTrends.value.map((t) => (t.id === id ? { ...t, name, params } : t))
+}
+
+export const removeSavedTrend = (id: string): void => {
+  savedTrends.value = savedTrends.value.filter((t) => t.id !== id)
+}
+
+export const resetToDefaults = (): void => {
+  savedTrends.value = DEFAULT_TRENDS
+}

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -52,10 +52,8 @@ header a:hover {
 main {
 	flex: auto;
 	display: flex;
-	align-items: center;
-	max-width: 1280px;
-	margin: 0 auto;
-	text-align: center;
+	width: 100%;
+	text-align: left;
 }
 
 @media (max-width: 639px) {


### PR DESCRIPTION
## Summary

- Add localStorage-backed saved trends that persist between sessions
- Extend lookback period options to include 2 years, 3 years, 5 years, and "all time" (10 years)
- Add edit, remove, and reset functionality for trend configurations
- Fix layout width issues on desktop to use full available space
- Add two-column layout for Dashboard when there's room (Baseline and Summary side by side)
- Remove max-width constraints that were limiting chart widths
- Fix custom trend width to match preset trend widths

## Test plan

- [ ] Open Trends page - saved trends should load from localStorage (defaults if first time)
- [ ] Add a new trend with extended lookback (e.g., 2 years) - verify it displays correctly
- [ ] Edit an existing trend - changes should persist after refresh
- [ ] Remove a trend - verify it's gone after refresh
- [ ] Reset to defaults - verify preset trends are restored
- [ ] Check Dashboard on wide screen - Baseline and Summary sections should be side by side
- [ ] Check responsive behavior on smaller screens - should stack vertically
- [ ] Verify charts use full available width

🤖 Generated with [Claude Code](https://claude.com/claude-code)