### PR TITLE
Fix trend chart labels and improve dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Data Sources
 | RescueTime | Configure API key in user settings (web UI). Get key from [RescueTime API settings](https://www.rescuetime.com/anapi/manage). |
 
 
+API Documentation
+-----------------
+
+Interactive API documentation is available at https://aurboda.net/apispec (develop branch version).
+
+
 MCP Integration
 ---------------
 

--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -497,15 +497,16 @@ export function Dashboard() {
         </section>
       </div>
 
-      {/* Activity summary */}
-      <section class="metrics-section">
-        <ActivitySummary activities={activities} />
-      </section>
+      {/* Activity summary and Quick links in columns */}
+      <div class="bottom-columns">
+        <section class="metrics-section">
+          <ActivitySummary activities={activities} />
+        </section>
 
-      {/* Quick links */}
-      <section class="metrics-section">
-        <QuickLinks />
-      </section>
+        <section class="metrics-section">
+          <QuickLinks />
+        </section>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/Dashboard/style.css
+++ b/apps/web/src/pages/Dashboard/style.css
@@ -38,6 +38,13 @@
   margin-bottom: 2rem;
 }
 
+/* Two-column layout for activity summary and quick links */
+.dashboard .bottom-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
 .dashboard .metrics-section {
   margin-bottom: 2rem;
 }
@@ -372,15 +379,18 @@
 
 /* Responsive */
 @media (max-width: 1100px) {
-  .dashboard .metrics-columns {
+  .dashboard .metrics-columns,
+  .dashboard .bottom-columns {
     grid-template-columns: 1fr;
   }
 
-  .dashboard .metrics-columns .metrics-section {
+  .dashboard .metrics-columns .metrics-section,
+  .dashboard .bottom-columns .metrics-section {
     margin-bottom: 2rem;
   }
 
-  .dashboard .metrics-columns .metrics-section:last-child {
+  .dashboard .metrics-columns .metrics-section:last-child,
+  .dashboard .bottom-columns .metrics-section:last-child {
     margin-bottom: 0;
   }
 }

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -102,14 +102,18 @@ function TrendChart({ data, color }: { data: { date: string; value: number }[]; 
       .attr('r', 3)
       .attr('fill', color)
 
-    // X axis
+    // X axis - show year when date range spans multiple years
+    const dateExtent = d3.extent(parsedData, (d) => d.date) as [Date, Date]
+    const spanYears = dateExtent[1].getFullYear() - dateExtent[0].getFullYear()
+    const dateFormat = spanYears >= 1 ? d3.timeFormat("%b '%y") : d3.timeFormat('%b %d')
+
     g.append('g')
       .attr('transform', `translate(0,${innerHeight})`)
       .call(
         d3
           .axisBottom(x)
           .ticks(6)
-          .tickFormat((d) => d3.timeFormat('%b %d')(d as Date)),
+          .tickFormat((d) => dateFormat(d as Date)),
       )
       .selectAll('text')
       .attr('font-size', '11px')


### PR DESCRIPTION
## Summary

- Fix trend chart x-axis labels to show year when date range spans multiple years (e.g., "Jan '21" instead of "Jan 01" for 5-year lookback)
- Add two-column layout for Dashboard's "Last 7 Days" and "Explore" sections to use horizontal space better on wide screens
- Add API documentation link to README pointing to https://aurboda.net/apispec (develop branch version)

## Test plan

- [ ] Open Trends page with a 2+ year lookback - x-axis should show "Jan '21", "Jan '22", etc.
- [ ] Open Dashboard on wide screen - Activity summary and Explore should be side by side
- [ ] Resize browser - columns should stack on narrower screens (<1100px)
- [ ] Verify README has new API documentation section

🤖 Generated with [Claude Code](https://claude.com/claude-code)