### PR TITLE
Fix widget goal marker, add Help page, update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Aurboda - Self Quantification Aggregator
 ========================================
 
-Backend [![Backend Coverage](https://codecov.io/gh/fiddur/aurboda/graph/badge.svg?flag=backend)](https://codecov.io/gh/fiddur/aurboda)
-Web [![Web Coverage](https://codecov.io/gh/fiddur/aurboda/graph/badge.svg?flag=web)](https://codecov.io/gh/fiddur/aurboda)
-Android [![Android Coverage](https://codecov.io/gh/fiddur/aurboda/graph/badge.svg?flag=android)](https://codecov.io/gh/fiddur/aurboda)
+[![Backend Coverage](https://codecov.io/gh/fiddur/aurboda/graph/badge.svg?flag=backend)](https://codecov.io/gh/fiddur/aurboda)
 
 Your health data is scattered across apps and services. Aurboda aggregates it into one place, provides visualizations, and exposes it to AI assistants via MCP (Model Context Protocol).
 

--- a/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
@@ -137,11 +137,16 @@ class GoalsRemoteViewsFactory(private val context: Context) : RemoteViewsService
         if (goal.min != null && goal.max != null && goal.max > 0) {
             val minPercent = (goal.min / goal.max).toFloat()
             views.setViewVisibility(R.id.min_marker, View.VISIBLE)
+            // COMPLEX_UNIT_FRACTION_PARENT doesn't work correctly in RemoteViews
+            // Calculate an approximate dp position based on typical widget width
+            // (widget width ~280dp minus padding, progress bar takes full width)
+            val estimatedProgressBarWidthDp = 260f
+            val markerPositionDp = minPercent * estimatedProgressBarWidthDp
             views.setViewLayoutMargin(
                 R.id.min_marker,
                 RemoteViews.MARGIN_START,
-                minPercent,
-                TypedValue.COMPLEX_UNIT_FRACTION_PARENT
+                markerPositionDp,
+                TypedValue.COMPLEX_UNIT_DIP
             )
         } else {
             views.setViewVisibility(R.id.min_marker, View.GONE)

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -40,6 +40,9 @@ export function Header() {
               </a>
             )}
             <span class="spacer" />
+            <a href="/help" class={url == '/help' ? 'active help-link' : 'help-link'}>
+              Help
+            </a>
             <a href="/settings" class={url == '/settings' ? 'active user-link' : 'user-link'}>
               {auth.value.user}
             </a>

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -7,6 +7,7 @@ import { Header } from './components/Header.jsx'
 import { AdminSettings } from './pages/AdminSettings/index.jsx'
 import { Correlations } from './pages/Correlations/index.jsx'
 import { Goals } from './pages/Goals/index.jsx'
+import { Help } from './pages/Help/index.jsx'
 import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
 import { Login } from './pages/Login/index.jsx'
@@ -39,6 +40,7 @@ export function App() {
             <Route path="/places" component={Places} />
             <Route path="/settings" component={Settings} />
             <Route path="/admin" component={AdminSettings} />
+            <Route path="/help" component={Help} />
             <Route default component={NotFound} />
           </Router>
         </main>

--- a/apps/web/src/pages/Help/index.tsx
+++ b/apps/web/src/pages/Help/index.tsx
@@ -1,0 +1,332 @@
+import { useQuery } from '@tanstack/react-query'
+import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
+import {
+  fetchActivities,
+  fetchHeartRate,
+  fetchPlaces,
+  fetchProductivity,
+  fetchUserSettings,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+
+import './style.css'
+
+interface DataSourceStatus {
+  hasData: boolean
+  isConfigured?: boolean
+  description: string
+}
+
+function StatusIcon({ hasData }: { hasData: boolean }) {
+  if (hasData) {
+    return (
+      <span class="status-icon connected" title="Data detected">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M22 11.08V12a10 10 0 11-5.93-9.14" />
+          <path d="M22 4L12 14.01l-3-3" />
+        </svg>
+      </span>
+    )
+  }
+  return (
+    <span class="status-icon missing" title="No recent data">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+    </span>
+  )
+}
+
+function DataSourceCard({
+  name,
+  status,
+  setupSteps,
+  links,
+}: {
+  name: string
+  status: DataSourceStatus
+  setupSteps: string[]
+  links?: { text: string; url: string }[]
+}) {
+  return (
+    <div class={`data-source-card ${status.hasData ? 'has-data' : 'no-data'}`}>
+      <div class="card-header">
+        <StatusIcon hasData={status.hasData} />
+        <h3>{name}</h3>
+      </div>
+      <p class="card-description">{status.description}</p>
+      {!status.hasData && (
+        <div class="setup-section">
+          <h4>Setup</h4>
+          <ol class="setup-steps">
+            {setupSteps.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+          {links && links.length > 0 && (
+            <div class="links">
+              {links.map((link, i) => (
+                <a key={i} href={link.url} target="_blank" rel="noopener noreferrer">
+                  {link.text}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function Help() {
+  const isLoggedIn = auth.value.token
+
+  const end = endOfDay(new Date())
+  const start7days = startOfDay(subDays(new Date(), 7))
+
+  // Fetch user settings to check configuration status
+  const settingsQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Fetch heart rate data (from Health Connect or other sources)
+  const heartRateQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => fetchHeartRate(start7days, end),
+    queryKey: ['heartRate7days', formatISO(start7days, { representation: 'date' })],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Fetch sleep data
+  const sleepQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => fetchActivities(start7days, end, ['sleep']),
+    queryKey: ['sleep7days', formatISO(start7days, { representation: 'date' })],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Fetch exercise data
+  const exerciseQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => fetchActivities(start7days, end, ['exercise']),
+    queryKey: ['exercise7days', formatISO(start7days, { representation: 'date' })],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Fetch productivity data (RescueTime)
+  const productivityQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => fetchProductivity(start7days, end),
+    queryKey: ['productivity7days', formatISO(start7days, { representation: 'date' })],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Fetch location data (OwnTracks)
+  const locationsQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => fetchPlaces(start7days, end),
+    queryKey: ['locations7days', formatISO(start7days, { representation: 'date' })],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const isLoading =
+    heartRateQuery.isLoading ||
+    sleepQuery.isLoading ||
+    exerciseQuery.isLoading ||
+    productivityQuery.isLoading ||
+    locationsQuery.isLoading ||
+    settingsQuery.isLoading
+
+  const hasHeartRate = (heartRateQuery.data?.length ?? 0) > 0
+  const hasSleep = (sleepQuery.data?.length ?? 0) > 0
+  const hasExercise = (exerciseQuery.data?.length ?? 0) > 0
+  const hasProductivity = (productivityQuery.data?.length ?? 0) > 0
+  const hasLocations = (locationsQuery.data?.length ?? 0) > 0
+  const isOuraConnected = settingsQuery.data?.oura_connected ?? false
+  const isRescueTimeConfigured = !!settingsQuery.data?.rescue_time_key
+
+  if (!isLoggedIn) {
+    return (
+      <div class="help-page">
+        <h1>Getting Started</h1>
+        <p class="login-prompt">Please log in to see your data source status and setup guides.</p>
+        <a href="/login" class="login-link">
+          Log in
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div class="help-page">
+      <header class="page-header">
+        <h1>Getting Started</h1>
+        <p class="page-subtitle">
+          Connect your data sources to start tracking. Below you can see which sources are active and how to
+          set up any that are missing.
+        </p>
+      </header>
+
+      {isLoading && <div class="loading">Checking your data sources...</div>}
+
+      <section class="data-sources">
+        <h2>Data Sources</h2>
+
+        <div class="sources-grid">
+          <DataSourceCard
+            name="Heart Rate & HRV"
+            status={{
+              description:
+                hasHeartRate ?
+                  'Heart rate data detected in the last 7 days.'
+                : 'No heart rate data in the last 7 days.',
+              hasData: hasHeartRate,
+            }}
+            setupSteps={[
+              'Install the Aurboda Android app on your phone.',
+              'Grant Health Connect permissions in the app.',
+              'Connect a Bluetooth heart rate monitor (e.g., Polar H10) for real-time tracking.',
+              'Alternatively, connect Oura for resting heart rate and HRV data.',
+            ]}
+            links={[
+              {
+                text: 'Download Android APK',
+                url: 'https://github.com/fiddur/aurboda/releases/download/latest/aurboda.apk',
+              },
+            ]}
+          />
+
+          <DataSourceCard
+            name="Sleep Tracking"
+            status={{
+              description:
+                hasSleep ? 'Sleep data detected in the last 7 days.' : 'No sleep data in the last 7 days.',
+              hasData: hasSleep,
+              isConfigured: isOuraConnected,
+            }}
+            setupSteps={[
+              'Connect your Oura Ring via Settings > Data Sources.',
+              'Or use the Android app with Health Connect if you track sleep with another app.',
+              'Sleep data includes duration, sleep stages, and sleep scores (Oura).',
+            ]}
+            links={[{ text: 'Go to Settings', url: '/settings' }]}
+          />
+
+          <DataSourceCard
+            name="Exercise & Activities"
+            status={{
+              description:
+                hasExercise ?
+                  'Exercise data detected in the last 7 days.'
+                : 'No exercise data in the last 7 days.',
+              hasData: hasExercise,
+            }}
+            setupSteps={[
+              'Use the Aurboda Android app to sync workouts from Health Connect.',
+              'Connect a Bluetooth heart rate monitor for real-time HR zone tracking during workouts.',
+              'Workouts recorded in Strava, Garmin, or other apps can sync via Health Connect.',
+            ]}
+            links={[
+              {
+                text: 'Download Android APK',
+                url: 'https://github.com/fiddur/aurboda/releases/download/latest/aurboda.apk',
+              },
+            ]}
+          />
+
+          <DataSourceCard
+            name="Oura Ring"
+            status={{
+              description:
+                isOuraConnected ? 'Oura Ring is connected.' : (
+                  'Oura Ring not connected. Connect for sleep scores, readiness, and HRV.'
+                ),
+              hasData: isOuraConnected,
+            }}
+            setupSteps={[
+              'Go to Settings > Data Sources.',
+              'Click "Connect Oura" to authorize access.',
+              'Data syncs automatically after connection.',
+            ]}
+            links={[
+              { text: 'Go to Settings', url: '/settings' },
+              { text: 'Learn about Oura', url: 'https://ouraring.com/' },
+            ]}
+          />
+
+          <DataSourceCard
+            name="RescueTime (Productivity)"
+            status={{
+              description:
+                hasProductivity ? 'Productivity data detected in the last 7 days.'
+                : isRescueTimeConfigured ? 'RescueTime configured but no recent data synced.'
+                : 'RescueTime not configured.',
+              hasData: hasProductivity,
+              isConfigured: isRescueTimeConfigured,
+            }}
+            setupSteps={[
+              'Sign up for RescueTime and install their app on your devices.',
+              'Get your API key from RescueTime API settings.',
+              'Enter the API key in Settings > Data Sources.',
+            ]}
+            links={[
+              { text: 'Go to Settings', url: '/settings' },
+              { text: 'RescueTime API Settings', url: 'https://www.rescuetime.com/anapi/manage' },
+            ]}
+          />
+
+          <DataSourceCard
+            name="Location Tracking (OwnTracks)"
+            status={{
+              description:
+                hasLocations ?
+                  'Location data detected in the last 7 days.'
+                : 'No location data in the last 7 days.',
+              hasData: hasLocations,
+            }}
+            setupSteps={[
+              'Install OwnTracks on your phone (iOS or Android).',
+              'Configure it in HTTP mode pointing to your Aurboda server.',
+              'Set up authentication with your Aurboda credentials.',
+              'See the OwnTracks setup guide for detailed instructions.',
+            ]}
+            links={[
+              {
+                text: 'OwnTracks Setup Guide',
+                url: 'https://github.com/fiddur/aurboda/blob/develop/docs/owntracks.md',
+              },
+              { text: 'OwnTracks Website', url: 'https://owntracks.org/' },
+            ]}
+          />
+        </div>
+      </section>
+
+      <section class="quick-tips">
+        <h2>Tips</h2>
+        <ul>
+          <li>
+            <strong>Real-time heart rate:</strong> Connect a Bluetooth heart rate monitor (like Polar H10) via
+            the Android app's Live screen for accurate HR zone tracking during workouts.
+          </li>
+          <li>
+            <strong>Step counting:</strong> Pair a running pod (like Zwift RunPod) for real-time cadence and
+            step counting, or sync steps from Health Connect.
+          </li>
+          <li>
+            <strong>AI analysis:</strong> Once you have data, you can use Claude or other MCP-compatible AI
+            assistants to analyze your health trends.
+          </li>
+          <li>
+            <strong>Goals:</strong> Set up weekly goals in Settings to track your progress toward health
+            targets.
+          </li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Help/style.css
+++ b/apps/web/src/pages/Help/style.css
@@ -1,0 +1,323 @@
+.help-page {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.help-page .page-header {
+  margin-bottom: 2rem;
+}
+
+.help-page h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0 0 0.5rem 0;
+}
+
+.help-page .page-subtitle {
+  color: #4b5563;
+  font-size: 1rem;
+  line-height: 1.6;
+  max-width: 700px;
+}
+
+.help-page h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 1.5rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #673ab8;
+}
+
+.help-page .loading {
+  text-align: center;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+.help-page .login-prompt {
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.help-page .login-link {
+  display: inline-block;
+  padding: 0.625rem 1.5rem;
+  background: #673ab8;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.help-page .login-link:hover {
+  background: #5b32a3;
+}
+
+/* Data sources section */
+.help-page .data-sources {
+  margin-bottom: 3rem;
+}
+
+.help-page .sources-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 1.5rem;
+}
+
+/* Data source card */
+.help-page .data-source-card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.25rem;
+  transition: box-shadow 0.2s;
+}
+
+.help-page .data-source-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.help-page .data-source-card.has-data {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.help-page .data-source-card.no-data {
+  border-color: #fcd34d;
+  background: #fffbeb;
+}
+
+.help-page .card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.help-page .card-header h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0;
+}
+
+.help-page .status-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+}
+
+.help-page .status-icon.connected {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.help-page .status-icon.missing {
+  background: #fef3c7;
+  color: #d97706;
+}
+
+.help-page .card-description {
+  font-size: 0.9rem;
+  color: #4b5563;
+  margin: 0 0 1rem 0;
+  line-height: 1.5;
+}
+
+.help-page .setup-section {
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.help-page .setup-section h4 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 0.75rem 0;
+}
+
+.help-page .setup-steps {
+  margin: 0 0 1rem 0;
+  padding-left: 1.25rem;
+  font-size: 0.875rem;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.help-page .setup-steps li {
+  margin-bottom: 0.5rem;
+}
+
+.help-page .links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.help-page .links a {
+  display: inline-block;
+  padding: 0.375rem 0.75rem;
+  background: #673ab8;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+
+.help-page .links a:hover {
+  background: #5b32a3;
+}
+
+/* Quick tips section */
+.help-page .quick-tips {
+  background: #f9fafb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid #e5e7eb;
+}
+
+.help-page .quick-tips h2 {
+  border-bottom: none;
+  margin-bottom: 1rem;
+  padding-bottom: 0;
+}
+
+.help-page .quick-tips ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #4b5563;
+  line-height: 1.7;
+}
+
+.help-page .quick-tips li {
+  margin-bottom: 0.75rem;
+}
+
+.help-page .quick-tips li:last-child {
+  margin-bottom: 0;
+}
+
+.help-page .quick-tips strong {
+  color: #1f2937;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .help-page h1 {
+    color: #f9fafb;
+  }
+
+  .help-page .page-subtitle {
+    color: #9ca3af;
+  }
+
+  .help-page h2 {
+    color: #e5e7eb;
+    border-color: #8b5cf6;
+  }
+
+  .help-page .data-source-card {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .help-page .data-source-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .help-page .data-source-card.has-data {
+    border-color: #166534;
+    background: #052e16;
+  }
+
+  .help-page .data-source-card.no-data {
+    border-color: #854d0e;
+    background: #422006;
+  }
+
+  .help-page .card-header h3 {
+    color: #f9fafb;
+  }
+
+  .help-page .status-icon.connected {
+    background: #166534;
+    color: #4ade80;
+  }
+
+  .help-page .status-icon.missing {
+    background: #854d0e;
+    color: #fbbf24;
+  }
+
+  .help-page .card-description {
+    color: #9ca3af;
+  }
+
+  .help-page .setup-section {
+    border-color: #374151;
+  }
+
+  .help-page .setup-section h4 {
+    color: #e5e7eb;
+  }
+
+  .help-page .setup-steps {
+    color: #9ca3af;
+  }
+
+  .help-page .links a {
+    background: #7c3aed;
+  }
+
+  .help-page .links a:hover {
+    background: #6d28d9;
+  }
+
+  .help-page .quick-tips {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .help-page .quick-tips ul {
+    color: #9ca3af;
+  }
+
+  .help-page .quick-tips strong {
+    color: #f9fafb;
+  }
+
+  .help-page .login-prompt {
+    color: #9ca3af;
+  }
+}
+
+/* Responsive */
+@media (max-width: 800px) {
+  .help-page .sources-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 639px) {
+  .help-page {
+    padding: 1rem;
+  }
+
+  .help-page h1 {
+    font-size: 1.5rem;
+  }
+
+  .help-page .page-subtitle {
+    font-size: 0.9rem;
+  }
+}

--- a/apps/web/src/pages/Trends/style.css
+++ b/apps/web/src/pages/Trends/style.css
@@ -17,9 +17,13 @@
 }
 
 .page-description {
-  color: #6b7280;
+  color: #4b5563;
   font-size: 0.9rem;
-  line-height: 1.5;
+  line-height: 1.6;
+  background: #f9fafb;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border-left: 3px solid #673ab8;
 }
 
 .saved-trends {
@@ -410,7 +414,9 @@
   }
 
   .page-description {
-    color: #9ca3af;
+    color: #d1d5db;
+    background: #1f2937;
+    border-color: #7c3aed;
   }
 
   .section-header h2 {


### PR DESCRIPTION
## Summary

- **Fix Android widget min marker positioning**: The `COMPLEX_UNIT_FRACTION_PARENT` unit type doesn't work correctly with `setViewLayoutMargin` in RemoteViews. Changed to calculate an approximate dp position based on typical widget width instead
- **Simplify README codecov badges**: Removed web and android badges since test coverage is low for those, keeping only the backend badge
- **Add Help page**: New page accessible via navigation that detects missing data sources in the last 7 days and provides setup guides for each (Health Connect, Oura, RescueTime, OwnTracks)
- **Improve Trends page styling**: Enhanced the page description with better dark mode contrast (boxed with border accent instead of plain text)

## Test plan

- [ ] Verify Android widget displays the min marker at the correct position for goals with both min and max
- [ ] Verify Help page shows correct status for data sources that have/don't have recent data
- [ ] Verify Help link appears in navigation for logged-in users
- [ ] Verify Trends page description is readable in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)