### PR TITLE
Fix Places page: Leaflet map, naming, GPS jump filtering

### DIFF
--- a/apps/backend/src/services/locations.test.ts
+++ b/apps/backend/src/services/locations.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'vitest'
-import { clusterStays, detectStays, LocationPoint, Stay } from './locations'
+import {
+  clusterStays,
+  detectStays,
+  LocationPoint,
+  mergeShortUnknownVisits,
+  PlaceVisit,
+  Stay,
+} from './locations'
 
 describe('detectStays', () => {
   const makePoint = (lat: number, lon: number, minutesOffset: number): LocationPoint => ({
@@ -161,5 +168,119 @@ describe('clusterStays', () => {
     expect(clusters[0].visitCount).toBe(3)
     expect(clusters[0].firstVisit).toContain('2024-01-15')
     expect(clusters[0].lastVisit).toContain('2024-01-25')
+  })
+})
+
+describe('mergeShortUnknownVisits', () => {
+  const makeVisit = (
+    name: string,
+    source: PlaceVisit['source'],
+    startMinutes: number,
+    durationMinutes: number,
+  ): PlaceVisit => {
+    const startTime = new Date(Date.UTC(2024, 0, 15, 10, startMinutes, 0))
+    const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000)
+    return {
+      durationMinutes,
+      endTime,
+      lat: 59.33,
+      lon: 18.07,
+      name,
+      source,
+      startTime,
+    }
+  }
+
+  test('returns empty array for empty input', () => {
+    expect(mergeShortUnknownVisits([])).toEqual([])
+  })
+
+  test('keeps all visits when none are short unknown', () => {
+    const visits = [makeVisit('Home', 'named', 0, 60), makeVisit('Office', 'named', 70, 120)]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Home')
+    expect(result[1].name).toBe('Office')
+  })
+
+  test('keeps unknown visits that are >= 5 minutes', () => {
+    const visits = [
+      makeVisit('Home', 'named', 0, 60),
+      makeVisit('Somewhere', 'unknown', 60, 10),
+      makeVisit('Office', 'named', 70, 120),
+    ]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(3)
+    expect(result[1].name).toBe('Somewhere')
+  })
+
+  test('merges short unknown visit into previous visit', () => {
+    const visits = [
+      makeVisit('Home', 'named', 0, 60),
+      makeVisit('Somewhere', 'unknown', 60, 3), // short GPS jump
+      makeVisit('Office', 'named', 63, 120),
+    ]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Home')
+    expect(result[0].durationMinutes).toBe(63) // extended to cover the gap
+    expect(result[1].name).toBe('Office')
+  })
+
+  test('extends next visit backwards when no previous visit exists', () => {
+    const visits = [
+      makeVisit('Somewhere', 'unknown', 0, 2), // short GPS jump at start
+      makeVisit('Home', 'named', 2, 60),
+    ]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Home')
+    expect(result[0].durationMinutes).toBe(62) // extended backwards
+  })
+
+  test('drops short unknown visit if it is the only visit', () => {
+    const visits = [makeVisit('Somewhere', 'unknown', 0, 2)]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(0)
+  })
+
+  test('handles multiple short unknown visits in sequence', () => {
+    const visits = [
+      makeVisit('Home', 'named', 0, 60),
+      makeVisit('Somewhere', 'unknown', 60, 2),
+      makeVisit('Somewhere', 'unknown', 62, 1),
+      makeVisit('Office', 'named', 63, 120),
+    ]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Home')
+    expect(result[0].durationMinutes).toBe(63) // extended through both gaps
+    expect(result[1].name).toBe('Office')
+  })
+
+  test('respects custom minDurationMinutes', () => {
+    const visits = [
+      makeVisit('Home', 'named', 0, 60),
+      makeVisit('Somewhere', 'unknown', 60, 8), // 8 min, below 10 min threshold
+      makeVisit('Office', 'named', 68, 120),
+    ]
+
+    const result = mergeShortUnknownVisits(visits, 10)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Home')
+    expect(result[0].durationMinutes).toBe(68) // extended
   })
 })

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -479,7 +479,44 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
     })
   }
 
-  return visits
+  // Filter out short "unknown" visits (GPS jumps) and merge into adjacent visits
+  return mergeShortUnknownVisits(visits)
+}
+
+/**
+ * Merge short "unknown" (Somewhere) visits into adjacent visits.
+ * Short visits (<5 min) at unknown locations are typically GPS jumps.
+ * They are removed and the previous/next visit is extended to cover the gap.
+ */
+export const mergeShortUnknownVisits = (visits: PlaceVisit[], minDurationMinutes = 5): PlaceVisit[] => {
+  if (visits.length === 0) return visits
+
+  const result: PlaceVisit[] = []
+
+  for (let i = 0; i < visits.length; i++) {
+    const visit = visits[i]
+
+    // Keep non-unknown visits and unknown visits >= minDuration
+    if (visit.source !== 'unknown' || visit.durationMinutes >= minDurationMinutes) {
+      result.push(visit)
+    } else {
+      // Short unknown visit - merge into adjacent visits
+      if (result.length > 0) {
+        // Extend previous visit to cover this gap
+        const prev = result[result.length - 1]
+        prev.endTime = visit.endTime
+        prev.durationMinutes = Math.round((prev.endTime.getTime() - prev.startTime.getTime()) / (1000 * 60))
+      } else if (i + 1 < visits.length) {
+        // No previous visit, extend next visit backwards
+        const next = visits[i + 1]
+        next.startTime = visit.startTime
+        next.durationMinutes = Math.round((next.endTime.getTime() - next.startTime.getTime()) / (1000 * 60))
+      }
+      // If it's the only visit and it's short unknown, we drop it entirely
+    }
+  }
+
+  return result
 }
 
 // Re-export CRUD operations from db

--- a/apps/web/src/pages/Places/index.tsx
+++ b/apps/web/src/pages/Places/index.tsx
@@ -1,8 +1,13 @@
+import 'leaflet/dist/leaflet.css'
+import './style.css'
+
 import { signal } from '@preact/signals'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { endOfDay, format, formatISO, startOfDay, subDays } from 'date-fns'
-import { useEffect, useState } from 'preact/hooks'
+import L from 'leaflet'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import {
+  addNamedLocation,
   fetchNamedLocations,
   fetchPlaceVisits,
   fetchStoredDetectedLocations,
@@ -11,7 +16,15 @@ import {
   StoredDetectedLocation,
 } from '../../state/api'
 
-// Signals for date selection
+// Fix Leaflet default marker icon path issue with bundlers
+// @ts-expect-error - Leaflet marker icon fix
+delete L.Icon.Default.prototype._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+})
+
 const selectedDate = signal(formatISO(new Date(), { representation: 'date' }))
 
 export const Places = () => {
@@ -19,16 +32,17 @@ export const Places = () => {
   const start = startOfDay(new Date(selectedDate.value))
   const end = endOfDay(new Date(selectedDate.value))
 
-  // Selected place for the map
   const [selectedPlace, setSelectedPlace] = useState<PlaceVisit | StoredDetectedLocation | null>(null)
-
-  // Modal state for naming locations
   const [namingLocation, setNamingLocation] = useState<{
     lat: number
     lon: number
     address?: string
   } | null>(null)
   const [nameInput, setNameInput] = useState('')
+
+  const mapRef = useRef<HTMLDivElement>(null)
+  const leafletMapRef = useRef<L.Map | null>(null)
+  const markerRef = useRef<L.Marker | null>(null)
 
   const placesQuery = useQuery({
     queryFn: () => fetchPlaceVisits(start, end),
@@ -59,6 +73,80 @@ export const Places = () => {
     },
   })
 
+  const addNamedMutation = useMutation({
+    mutationFn: addNamedLocation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['namedLocations'] })
+      queryClient.invalidateQueries({ queryKey: ['placeVisits'] })
+      setNamingLocation(null)
+      setNameInput('')
+    },
+  })
+
+  // Initialize Leaflet map
+  useEffect(() => {
+    if (!mapRef.current || leafletMapRef.current) return
+
+    const map = L.map(mapRef.current, {
+      center: [59.33, 18.07], // Default to Stockholm
+      zoom: 13,
+      zoomControl: true,
+    })
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      maxZoom: 19,
+    }).addTo(map)
+
+    leafletMapRef.current = map
+
+    // Cleanup on unmount
+    return () => {
+      map.remove()
+      leafletMapRef.current = null
+    }
+  }, [])
+
+  // Update map when selected place changes
+  useEffect(() => {
+    const map = leafletMapRef.current
+    if (!map) return
+
+    if (selectedPlace && 'lat' in selectedPlace && selectedPlace.lat && selectedPlace.lon) {
+      const latLng: L.LatLngExpression = [selectedPlace.lat, selectedPlace.lon]
+
+      // Remove existing marker
+      if (markerRef.current) {
+        markerRef.current.remove()
+      }
+
+      // Add new marker
+      const marker = L.marker(latLng).addTo(map)
+      const popupContent = 'name' in selectedPlace ? selectedPlace.name : 'Selected Location'
+      marker.bindPopup(popupContent).openPopup()
+      markerRef.current = marker
+
+      // Center map on the marker
+      map.setView(latLng, 15)
+    }
+  }, [selectedPlace])
+
+  // Resize map when container size changes
+  useEffect(() => {
+    const map = leafletMapRef.current
+    if (!map) return
+
+    const resizeObserver = new ResizeObserver(() => {
+      map.invalidateSize()
+    })
+
+    if (mapRef.current) {
+      resizeObserver.observe(mapRef.current)
+    }
+
+    return () => resizeObserver.disconnect()
+  }, [])
+
   const handleDateChange = (e: Event) => {
     const target = e.target as HTMLInputElement
     selectedDate.value = target.value
@@ -76,16 +164,27 @@ export const Places = () => {
 
   const handlePlaceClick = (place: PlaceVisit) => {
     setSelectedPlace(place)
-    // If it's a detected/unnamed location, offer to name it
-    if (place.source === 'detected' && place.lat && place.lon) {
+    // Open naming modal for unnamed locations (detected or unknown) with valid coordinates
+    if ((place.source === 'detected' || place.source === 'unknown') && place.lat && place.lon) {
       setNamingLocation({ address: place.address, lat: place.lat, lon: place.lon })
       setNameInput(place.address || '')
     }
   }
 
   const handlePromote = () => {
-    if (namingLocation && nameInput.trim()) {
+    if (!namingLocation || !nameInput.trim()) return
+
+    // Use appropriate mutation based on whether it's a detected location
+    const placeSource = selectedPlace && 'source' in selectedPlace ? selectedPlace.source : null
+    if (placeSource === 'detected') {
       promoteMutation.mutate({
+        lat: namingLocation.lat,
+        lon: namingLocation.lon,
+        name: nameInput.trim(),
+      })
+    } else {
+      // For unknown locations, create a new named location directly
+      addNamedMutation.mutate({
         lat: namingLocation.lat,
         lon: namingLocation.lon,
         name: nameInput.trim(),
@@ -114,7 +213,6 @@ export const Places = () => {
 
   const isLoading = placesQuery.isLoading || detectedQuery.isLoading || namedQuery.isLoading
   const hasError = placesQuery.isError || detectedQuery.isError || namedQuery.isError
-
   const places = placesQuery.data || []
 
   // Calculate transit periods between stays
@@ -136,188 +234,116 @@ export const Places = () => {
     return acc
   }, [])
 
+  const getSourceColor = (source: string): string => {
+    switch (source) {
+      case 'named':
+        return '#22c55e'
+      case 'detected':
+        return '#f97316'
+      case 'owntracks':
+        return '#3b82f6'
+      default:
+        return '#9ca3af'
+    }
+  }
+
+  const isPending = promoteMutation.isPending || addNamedMutation.isPending
+
   return (
-    <div
-      class="places-page"
-      style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '1rem' }}
-    >
-      <div style={{ alignItems: 'center', display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
-        <h1 style={{ margin: 0 }}>Places</h1>
-        <div style={{ alignItems: 'center', display: 'flex', gap: '0.5rem' }}>
+    <div class="places-page">
+      <div class="places-header">
+        <h1>Places</h1>
+        <div class="date-nav">
           <button onClick={handlePreviousDay}>&lt;</button>
           <input type="date" value={selectedDate.value} onChange={handleDateChange} />
           <button onClick={handleNextDay}>&gt;</button>
         </div>
       </div>
 
-      {isLoading && <div>Loading...</div>}
-      {hasError && <div>Error loading data</div>}
+      {isLoading && <div class="loading">Loading...</div>}
+      {hasError && <div class="error">Error loading data</div>}
 
-      <div style={{ display: 'flex', flex: 1, gap: '1rem', minHeight: 0 }}>
-        {/* Places list */}
-        <div
-          style={{
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            flex: '0 0 400px',
-            overflow: 'auto',
-            padding: '0.5rem',
-          }}
-        >
-          {placesWithTransit.length === 0 && !isLoading && (
-            <div style={{ color: '#666' }}>No places visited on this day</div>
-          )}
+      <div class="places-content">
+        <div class="places-list">
+          <div class="places-list-scroll">
+            {placesWithTransit.length === 0 && !isLoading && (
+              <div style={{ color: '#6b7280', padding: '1rem' }}>No places visited on this day</div>
+            )}
 
-          {placesWithTransit.map((item, index) => {
-            if ('type' in item && item.type === 'transit') {
+            {placesWithTransit.map((item, index) => {
+              if ('type' in item && item.type === 'transit') {
+                return (
+                  <div key={`transit-${index}`} class="transit-item">
+                    {format(item.startTime, 'HH:mm')} - {format(item.endTime, 'HH:mm')} Transit
+                  </div>
+                )
+              }
+
+              const place = item as PlaceVisit
+              const isSelected = selectedPlace === place
+              const isUnnamed = place.source === 'detected' || place.source === 'unknown'
+
               return (
                 <div
-                  key={`transit-${index}`}
-                  style={{
-                    borderLeft: '2px dashed #ccc',
-                    color: '#999',
-                    marginLeft: '0.5rem',
-                    padding: '0.25rem 0.5rem',
-                  }}
+                  key={`place-${index}`}
+                  class={`place-item ${isSelected ? 'selected' : ''}`}
+                  onClick={() => handlePlaceClick(place)}
+                  style={{ borderLeft: `3px solid ${getSourceColor(place.source)}` }}
                 >
-                  {format(item.startTime, 'HH:mm')} - {format(item.endTime, 'HH:mm')} Transit
+                  <div class="place-item-header">
+                    <span class="place-time">
+                      {format(place.startTime, 'HH:mm')} - {format(place.endTime, 'HH:mm')}
+                    </span>
+                    <span class={`place-name ${isUnnamed ? 'unnamed' : ''}`}>
+                      {place.name}
+                      {isUnnamed && place.lat && place.lon && ' (click to name)'}
+                    </span>
+                  </div>
+                  {place.address && place.source !== 'named' && (
+                    <div class="place-address">{place.address}</div>
+                  )}
+                  <div class="place-duration">{place.durationMinutes} min</div>
                 </div>
               )
-            }
+            })}
+          </div>
 
-            const place = item as PlaceVisit
-            const isSelected = selectedPlace === place
-            const isUnnamed = place.source === 'detected'
-
-            return (
-              <div
-                key={`place-${index}`}
-                onClick={() => handlePlaceClick(place)}
-                style={{
-                  backgroundColor: isSelected ? '#e3f2fd' : 'transparent',
-                  borderLeft: `3px solid ${getSourceColor(place.source)}`,
-                  cursor: 'pointer',
-                  marginBottom: '0.25rem',
-                  padding: '0.5rem',
-                }}
-              >
-                <div style={{ display: 'flex', gap: '0.5rem' }}>
-                  <span style={{ color: '#666', minWidth: '100px' }}>
-                    {format(place.startTime, 'HH:mm')} - {format(place.endTime, 'HH:mm')}
-                  </span>
-                  <span style={{ fontWeight: isUnnamed ? 'normal' : 'bold' }}>
-                    {place.name}
-                    {isUnnamed && ' ●'}
-                  </span>
-                </div>
-                {place.address && place.source !== 'named' && (
-                  <div style={{ color: '#666', fontSize: '0.85em', marginTop: '0.25rem' }}>
-                    {place.address}
-                  </div>
-                )}
-                <div style={{ color: '#999', fontSize: '0.8em' }}>{place.durationMinutes} min</div>
-              </div>
-            )
-          })}
-
-          <div
-            style={{
-              borderTop: '1px solid #ccc',
-              color: '#666',
-              fontSize: '0.85em',
-              marginTop: '1rem',
-              paddingTop: '0.5rem',
-            }}
-          >
-            ● = Unnamed location (click to name)
+          <div class="places-list-footer">
+            <span style={{ color: '#22c55e' }}>Named</span> |{' '}
+            <span style={{ color: '#f97316' }}>Detected</span> |{' '}
+            <span style={{ color: '#3b82f6' }}>OwnTracks</span> |{' '}
+            <span style={{ color: '#9ca3af' }}>Unknown</span>
           </div>
         </div>
 
-        {/* Map placeholder */}
-        <div
-          style={{
-            alignItems: 'center',
-            backgroundColor: '#f5f5f5',
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            display: 'flex',
-            flex: 1,
-            justifyContent: 'center',
-          }}
-        >
-          {selectedPlace && 'lat' in selectedPlace && selectedPlace.lat && selectedPlace.lon ?
-            <div style={{ textAlign: 'center' }}>
-              <div style={{ fontSize: '3rem' }}>📍</div>
-              <div style={{ marginTop: '0.5rem' }}>
-                {'name' in selectedPlace ? selectedPlace.name : 'Selected Location'}
-              </div>
-              <div style={{ color: '#666', fontSize: '0.9em' }}>
-                {selectedPlace.lat.toFixed(5)}, {selectedPlace.lon.toFixed(5)}
-              </div>
-            </div>
-          : <div style={{ color: '#999' }}>Select a place to view on map</div>}
+        <div class="map-container">
+          <div ref={mapRef} style={{ height: '100%', width: '100%' }} />
         </div>
       </div>
 
       {/* Naming Modal */}
       {namingLocation && (
-        <div
-          style={{
-            alignItems: 'center',
-            backgroundColor: 'rgba(0,0,0,0.5)',
-            bottom: 0,
-            display: 'flex',
-            justifyContent: 'center',
-            left: 0,
-            position: 'fixed',
-            right: 0,
-            top: 0,
-            zIndex: 1000,
-          }}
-          onClick={closeModal}
-        >
-          <div
-            style={{
-              backgroundColor: 'white',
-              borderRadius: '8px',
-              maxWidth: '400px',
-              padding: '1.5rem',
-              width: '90%',
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 style={{ marginBottom: '1rem', marginTop: 0 }}>Name this location</h3>
+        <div class="modal-overlay" onClick={closeModal}>
+          <div class="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Name this location</h3>
 
-            {namingLocation.address && (
-              <div style={{ color: '#666', marginBottom: '1rem' }}>Address: {namingLocation.address}</div>
-            )}
+            {namingLocation.address && <div class="modal-address">Address: {namingLocation.address}</div>}
 
-            <div style={{ marginBottom: '1rem' }}>
-              <label style={{ display: 'block', marginBottom: '0.25rem' }}>Location name:</label>
+            <div class="modal-field">
+              <label>Location name:</label>
               <input
                 type="text"
                 value={nameInput}
                 onInput={(e) => setNameInput((e.target as HTMLInputElement).value)}
                 placeholder="e.g., Home, Office, Gym"
-                style={{ padding: '0.5rem', width: '100%' }}
+                autofocus
               />
             </div>
 
-            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <div class="modal-actions">
               <button onClick={closeModal}>Cancel</button>
-              <button
-                onClick={handlePromote}
-                disabled={!nameInput.trim() || promoteMutation.isPending}
-                style={{
-                  backgroundColor: '#1976d2',
-                  border: 'none',
-                  borderRadius: '4px',
-                  color: 'white',
-                  cursor: nameInput.trim() ? 'pointer' : 'not-allowed',
-                  padding: '0.5rem 1rem',
-                }}
-              >
-                {promoteMutation.isPending ? 'Saving...' : 'Save'}
+              <button class="btn-primary" onClick={handlePromote} disabled={!nameInput.trim() || isPending}>
+                {isPending ? 'Saving...' : 'Save'}
               </button>
             </div>
           </div>
@@ -325,17 +351,4 @@ export const Places = () => {
       )}
     </div>
   )
-}
-
-const getSourceColor = (source: string): string => {
-  switch (source) {
-    case 'named':
-      return '#4caf50' // green
-    case 'detected':
-      return '#ff9800' // orange
-    case 'owntracks':
-      return '#2196f3' // blue
-    default:
-      return '#9e9e9e' // gray
-  }
 }

--- a/apps/web/src/pages/Places/style.css
+++ b/apps/web/src/pages/Places/style.css
@@ -1,0 +1,372 @@
+.places-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1rem;
+}
+
+.places-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.places-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #1f2937;
+}
+
+.date-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.date-nav button {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.date-nav button:hover {
+  background: #f3f4f6;
+  border-color: #3b82f6;
+}
+
+.date-nav input[type="date"] {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+/* Main content split layout */
+.places-content {
+  display: flex;
+  flex: 1;
+  gap: 1rem;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Places list panel */
+.places-list {
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  min-width: 280px;
+  max-width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+  overflow: hidden;
+}
+
+.places-list-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.places-list-footer {
+  border-top: 1px solid #e5e7eb;
+  padding: 0.5rem 1rem;
+  font-size: 0.85em;
+  color: #6b7280;
+  background: #f9fafb;
+}
+
+/* Place item */
+.place-item {
+  padding: 0.75rem;
+  margin-bottom: 0.25rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.place-item:hover {
+  background: #f3f4f6;
+}
+
+.place-item.selected {
+  background: #e0f2fe;
+}
+
+.place-item-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.place-time {
+  color: #6b7280;
+  font-size: 0.9em;
+  min-width: 100px;
+}
+
+.place-name {
+  font-weight: 500;
+}
+
+.place-name.unnamed {
+  font-weight: 400;
+  font-style: italic;
+}
+
+.place-address {
+  color: #6b7280;
+  font-size: 0.85em;
+  margin-top: 0.25rem;
+}
+
+.place-duration {
+  color: #9ca3af;
+  font-size: 0.8em;
+  margin-top: 0.25rem;
+}
+
+/* Transit item */
+.transit-item {
+  border-left: 2px dashed #d1d5db;
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  color: #9ca3af;
+  font-size: 0.9em;
+}
+
+/* Map container */
+.map-container {
+  flex: 1;
+  min-width: 300px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #f5f5f5;
+}
+
+.map-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #9ca3af;
+}
+
+/* Leaflet map overrides */
+.map-container .leaflet-container {
+  height: 100%;
+  width: 100%;
+}
+
+/* Naming modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+}
+
+.modal-content h3 {
+  margin: 0 0 1rem 0;
+  color: #1f2937;
+}
+
+.modal-address {
+  color: #6b7280;
+  margin-bottom: 1rem;
+  font-size: 0.9em;
+}
+
+.modal-field {
+  margin-bottom: 1rem;
+}
+
+.modal-field label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.modal-field input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+.modal-field input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.modal-actions button {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.modal-actions button:first-child {
+  background: white;
+  border: 1px solid #d1d5db;
+}
+
+.modal-actions button:first-child:hover {
+  background: #f3f4f6;
+}
+
+.btn-primary {
+  background: #3b82f6;
+  border: none;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.btn-primary:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+}
+
+/* Loading and error states */
+.loading, .error {
+  text-align: center;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+.error {
+  color: #dc2626;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .places-header h1 {
+    color: #f3f4f6;
+  }
+
+  .date-nav button {
+    background: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .date-nav button:hover {
+    background: #4b5563;
+  }
+
+  .date-nav input[type="date"] {
+    background: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .places-list {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .places-list-footer {
+    background: #111827;
+    border-color: #374151;
+    color: #9ca3af;
+  }
+
+  .place-item:hover {
+    background: #374151;
+  }
+
+  .place-item.selected {
+    background: #1e3a5f;
+  }
+
+  .map-container {
+    border-color: #374151;
+    background: #1f2937;
+  }
+
+  .modal-content {
+    background: #1f2937;
+  }
+
+  .modal-content h3 {
+    color: #f3f4f6;
+  }
+
+  .modal-field label {
+    color: #e5e7eb;
+  }
+
+  .modal-field input {
+    background: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .modal-actions button:first-child {
+    background: #374151;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .places-page {
+    padding: 0.5rem;
+  }
+
+  .places-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .places-content {
+    flex-direction: column;
+  }
+
+  .places-list {
+    width: 100%;
+    max-height: 40vh;
+    flex-shrink: 0;
+  }
+
+  .map-container {
+    min-height: 300px;
+    flex: 1;
+  }
+}

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -6,6 +6,7 @@ import type {
   ActivityImpactQuery,
   ActivityImpactResponse,
   ActivityImpactType,
+  AddNamedLocationBody,
   AddNamedLocationResponse,
   Activity as ApiActivity,
   DetectedLocation as ApiDetectedLocation,
@@ -287,6 +288,16 @@ export const promoteDetectedLocation = async (
       headers: { Authorization: `Bearer ${token}` },
     },
   )
+
+  return response.data.data!
+}
+
+// Add a new named location directly
+export const addNamedLocation = async (params: AddNamedLocationBody): Promise<NamedLocation> => {
+  const { token } = auth.value
+  const response = await axios.post<AddNamedLocationResponse>(`${API_URL}/locations/named`, params, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
 
   return response.data.data!
 }


### PR DESCRIPTION
## Summary
- Add real Leaflet/OpenStreetMap map instead of placeholder emoji
- Allow naming both 'detected' and 'unknown' source places (fixes clicking not opening input)
- Filter short (<5 min) "Somewhere" visits caused by GPS jumps by merging into adjacent visits
- Improve layout with responsive CSS for mobile and desktop

## Changes

### Backend
- Add `mergeShortUnknownVisits()` function to filter out short GPS jump visits
- Short unknown visits are merged into the previous visit's duration
- Includes unit tests for the new function

### Frontend
- Replace map placeholder with real Leaflet map using OpenStreetMap tiles
- Add zoom controls and marker popups
- Fix naming modal to work for both `detected` and `unknown` source places
- Add `addNamedLocation` API function for creating named locations directly
- Responsive CSS: stacked layout on mobile, side-by-side on desktop

## Test plan
- [ ] Verify map displays and can be zoomed/panned
- [ ] Verify clicking a place shows marker on map
- [ ] Verify clicking an unnamed place (Somewhere) opens naming modal
- [ ] Verify naming works for both detected and unknown locations
- [ ] Verify short GPS jump "Somewhere" entries are no longer shown
- [ ] Verify layout works on mobile devices


Generated with [Claude Code](https://claude.com/claude-code)