### PR TITLE
Add multi-tag picker to Trends page, improve tag mapping UX

### DIFF
--- a/apps/web/src/components/TagMappingsSettings.css
+++ b/apps/web/src/components/TagMappingsSettings.css
@@ -37,22 +37,6 @@
   font-style: italic;
 }
 
-.tag-mappings-section .save-status {
-  font-size: 0.9rem;
-  margin-bottom: 0.5rem;
-}
-
-.tag-mappings-section .save-status.saving {
-  color: #666;
-}
-
-.tag-mappings-section .save-status.saved {
-  color: #5cb85c;
-}
-
-.tag-mappings-section .save-status.error {
-  color: #d9534f;
-}
 
 .tag-mappings-list {
   display: flex;
@@ -94,10 +78,14 @@
 
 .tag-name-field {
   flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .tag-name-field input {
-  width: 100%;
+  flex: 1;
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
@@ -110,12 +98,52 @@
   box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.1);
 }
 
+.tag-name-field input:disabled {
+  opacity: 0.6;
+}
+
 .tag-name-field input.unmapped {
   border-color: #f0ad4e;
 }
 
 .tag-name-field input.unmapped::placeholder {
   color: #c09853;
+}
+
+.row-status {
+  width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.status-saving {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #d1d5db;
+  border-top-color: #8b5cf6;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.status-saved {
+  color: #22c55e;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.status-error {
+  color: #dc2626;
+  font-weight: 700;
+  font-size: 1.1rem;
 }
 
 .tag-uuid {

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -1,6 +1,6 @@
 import type { ProgrammaticTag } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { fetchProgrammaticTags, setTagMapping } from '../state/api'
 
 import './TagMappingsSettings.css'
@@ -17,91 +17,115 @@ const formatTagKey = (tagKey: string): string => {
   return tagKey
 }
 
+type RowStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+function TagMappingRow({
+  onSave,
+  tag,
+}: {
+  tag: ProgrammaticTag
+  onSave: (tagKey: string, name: string) => Promise<void>
+}) {
+  const [localValue, setLocalValue] = useState<string | undefined>(undefined)
+  const [status, setStatus] = useState<RowStatus>('idle')
+
+  // Clear saved indicator after 3 seconds
+  useEffect(() => {
+    if (status !== 'saved') return
+    const timer = setTimeout(() => setStatus('idle'), 3000)
+    return () => clearTimeout(timer)
+  }, [status])
+
+  const displayValue = localValue ?? tag.currentName ?? ''
+  const isUnmapped = !tag.currentName
+
+  const handleBlur = async () => {
+    if (localValue === undefined) return
+
+    const serverValue = tag.currentName ?? ''
+    if (localValue === serverValue) {
+      setLocalValue(undefined)
+      return
+    }
+
+    if (!localValue.trim()) {
+      setLocalValue(undefined)
+      return
+    }
+
+    setStatus('saving')
+    try {
+      await onSave(tag.tagKey, localValue.trim())
+      setLocalValue(undefined)
+      setStatus('saved')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  const date = new Date(tag.latestTime)
+
+  return (
+    <div class={`tag-mapping-row ${isUnmapped ? 'unmapped' : ''}`}>
+      <div class="tag-info">
+        <span class="tag-count" title={`Used ${tag.count} time${tag.count !== 1 ? 's' : ''}`}>
+          {tag.count} uses
+        </span>
+        <span class="tag-latest" title={date.toLocaleString()}>
+          Last: {date.toLocaleDateString()}
+        </span>
+      </div>
+
+      <div class="tag-name-field">
+        <input
+          type="text"
+          value={displayValue}
+          onInput={(e) => setLocalValue((e.target as HTMLInputElement).value)}
+          onBlur={() => void handleBlur()}
+          placeholder="Enter display name..."
+          class={isUnmapped ? 'unmapped' : ''}
+          disabled={status === 'saving'}
+        />
+        <span class="row-status">
+          {status === 'saving' && <span class="status-saving" title="Saving..." />}
+          {status === 'saved' && (
+            <span class="status-saved" title="Saved">
+              &#10003;
+            </span>
+          )}
+          {status === 'error' && (
+            <span class="status-error" title="Failed to save">
+              !
+            </span>
+          )}
+        </span>
+      </div>
+
+      <div class="tag-uuid" title={tag.tagKey}>
+        {formatTagKey(tag.tagKey)}
+      </div>
+    </div>
+  )
+}
+
 export function TagMappingsSettings() {
   const queryClient = useQueryClient()
-  const [saveStatus, setSaveStatus] = useState<{ status: 'idle' | 'saving' | 'saved'; time?: Date }>({
-    status: 'idle',
-  })
 
   const { data: tags, isLoading } = useQuery({
     queryFn: fetchProgrammaticTags,
     queryKey: ['programmaticTags'],
   })
 
-  // Local state for editing
-  const [localMappings, setLocalMappings] = useState<Map<string, string>>(new Map())
-
   const mutation = useMutation({
     mutationFn: ({ tagKey, name }: { tagKey: string; name: string }) => setTagMapping(tagKey, name),
-    onError: () => {
-      setSaveStatus({ status: 'idle' })
-    },
-    onMutate: () => {
-      setSaveStatus({ status: 'saving' })
-    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['programmaticTags'] })
       queryClient.invalidateQueries({ queryKey: ['userSettings'] })
-      setSaveStatus({ status: 'saved', time: new Date() })
     },
   })
 
-  const handleNameChange = (tagKey: string, value: string) => {
-    setLocalMappings((prev) => {
-      const next = new Map(prev)
-      next.set(tagKey, value)
-      return next
-    })
-  }
-
-  const handleNameBlur = (tag: ProgrammaticTag) => {
-    const localValue = localMappings.get(tag.tagKey)
-    const serverValue = tag.currentName ?? ''
-
-    // If no local changes or value is the same, skip
-    if (localValue === undefined || localValue === serverValue) {
-      return
-    }
-
-    // Don't save empty values
-    if (!localValue.trim()) {
-      return
-    }
-
-    mutation.mutate({ name: localValue.trim(), tagKey: tag.tagKey })
-
-    // Clear local state after save
-    setLocalMappings((prev) => {
-      const next = new Map(prev)
-      next.delete(tag.tagKey)
-      return next
-    })
-  }
-
-  const getValue = (tag: ProgrammaticTag): string => {
-    return localMappings.get(tag.tagKey) ?? tag.currentName ?? ''
-  }
-
-  const formatLatestTime = (isoTime: string): string => {
-    const date = new Date(isoTime)
-    const now = new Date()
-    const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24))
-
-    if (diffDays === 0) return 'today'
-    if (diffDays === 1) return 'yesterday'
-    if (diffDays < 7) return `${diffDays} days ago`
-    if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`
-    return date.toLocaleDateString()
-  }
-
-  const formatSavedTime = (time: Date): string => {
-    const now = new Date()
-    const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
-    if (diffSec < 5) return 'just now'
-    if (diffSec < 60) return `${diffSec} seconds ago`
-    const diffMin = Math.floor(diffSec / 60)
-    if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
-    return time.toLocaleTimeString()
+  const handleSave = async (tagKey: string, name: string): Promise<void> => {
+    await mutation.mutateAsync({ name, tagKey })
   }
 
   if (isLoading) {
@@ -124,52 +148,15 @@ export function TagMappingsSettings() {
 
       <p class="section-description">
         Set display names for programmatic tags (UUIDs, tag_* prefixes). Tags without names will show their
-        raw identifier. Changes save automatically.
+        raw identifier. Changes save automatically when you leave the field.
       </p>
-
-      {saveStatus.status === 'saving' && <p class="save-status saving">Saving...</p>}
-      {saveStatus.status === 'saved' && saveStatus.time && (
-        <p class="save-status saved">Saved {formatSavedTime(saveStatus.time)}</p>
-      )}
-      {mutation.isError && (
-        <p class="save-status error">
-          Error: {mutation.error instanceof Error ? mutation.error.message : 'Failed to save'}
-        </p>
-      )}
 
       {!tags || tags.length === 0 ?
         <p class="no-tags">No programmatic tags found. Tags will appear here after syncing data.</p>
       : <div class="tag-mappings-list">
-          {tags.map((tag) => {
-            const isUnmapped = !tag.currentName
-            return (
-              <div class={`tag-mapping-row ${isUnmapped ? 'unmapped' : ''}`} key={tag.tagKey}>
-                <div class="tag-info">
-                  <span class="tag-count" title={`Used ${tag.count} time${tag.count !== 1 ? 's' : ''}`}>
-                    {tag.count}x
-                  </span>
-                  <span class="tag-latest" title={`Last used: ${new Date(tag.latestTime).toLocaleString()}`}>
-                    {formatLatestTime(tag.latestTime)}
-                  </span>
-                </div>
-
-                <div class="tag-name-field">
-                  <input
-                    type="text"
-                    value={getValue(tag)}
-                    onInput={(e) => handleNameChange(tag.tagKey, (e.target as HTMLInputElement).value)}
-                    onBlur={() => handleNameBlur(tag)}
-                    placeholder="Enter tag name..."
-                    class={isUnmapped ? 'unmapped' : ''}
-                  />
-                </div>
-
-                <div class="tag-uuid" title={tag.tagKey}>
-                  {formatTagKey(tag.tagKey)}
-                </div>
-              </div>
-            )
-          })}
+          {tags.map((tag) => (
+            <TagMappingRow key={tag.tagKey} tag={tag} onSave={handleSave} />
+          ))}
         </div>
       }
     </section>

--- a/apps/web/src/components/TagPicker.css
+++ b/apps/web/src/components/TagPicker.css
@@ -1,0 +1,157 @@
+.tag-picker {
+  position: relative;
+}
+
+.tag-picker-input-area {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  cursor: text;
+  min-height: 38px;
+}
+
+.tag-picker-input-area:focus-within {
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.tag-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  background: #ede9fe;
+  color: #6d28d9;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.tag-badge-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: #7c3aed;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  margin-left: 0.125rem;
+  opacity: 0.7;
+}
+
+.tag-badge-remove:hover {
+  opacity: 1;
+}
+
+.tag-picker-input {
+  flex: 1;
+  min-width: 80px;
+  border: none;
+  outline: none;
+  font-size: 0.875rem;
+  padding: 0.125rem 0;
+  background: transparent;
+  color: #1f2937;
+}
+
+.tag-picker-input::placeholder {
+  color: #9ca3af;
+}
+
+.tag-picker-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 0.25rem 0 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 50;
+}
+
+.tag-picker-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.tag-picker-option:hover,
+.tag-picker-option.highlighted {
+  background: #f3f0ff;
+}
+
+.tag-option-display {
+  color: #1f2937;
+}
+
+.tag-option-raw {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .tag-picker-input-area {
+    background: #111827;
+    border-color: #4b5563;
+  }
+
+  .tag-badge {
+    background: #3b2d60;
+    color: #c4b5fd;
+  }
+
+  .tag-badge-remove {
+    color: #a78bfa;
+  }
+
+  .tag-picker-input {
+    color: #f9fafb;
+  }
+
+  .tag-picker-input::placeholder {
+    color: #6b7280;
+  }
+
+  .tag-picker-dropdown {
+    background: #1f2937;
+    border-color: #4b5563;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .tag-picker-option:hover,
+  .tag-picker-option.highlighted {
+    background: #374151;
+  }
+
+  .tag-option-display {
+    color: #f9fafb;
+  }
+
+  .tag-option-raw {
+    color: #6b7280;
+  }
+}

--- a/apps/web/src/components/TagPicker.tsx
+++ b/apps/web/src/components/TagPicker.tsx
@@ -1,0 +1,153 @@
+import type { ProgrammaticTag } from '@aurboda/api-spec'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { fetchProgrammaticTags, fetchUniqueTags } from '../state/api'
+
+import './TagPicker.css'
+
+interface TagEntry {
+  raw: string
+  display: string
+}
+
+const buildTagEntries = (uniqueTags: string[], programmaticTags: ProgrammaticTag[]): TagEntry[] => {
+  const mappings = new Map<string, string>()
+  for (const pt of programmaticTags) {
+    if (pt.currentName) {
+      mappings.set(pt.tagKey, pt.currentName)
+    }
+  }
+
+  return uniqueTags.map((raw) => ({
+    display: mappings.get(raw) ?? raw,
+    raw,
+  }))
+}
+
+export function TagPicker({
+  onChange,
+  selectedTags,
+}: {
+  selectedTags: string[]
+  onChange: (tags: string[]) => void
+}) {
+  const [inputValue, setInputValue] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { data: uniqueTags } = useQuery({
+    queryFn: fetchUniqueTags,
+    queryKey: ['uniqueTags'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { data: programmaticTags } = useQuery({
+    queryFn: fetchProgrammaticTags,
+    queryKey: ['programmaticTags'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const tagEntries = uniqueTags && programmaticTags ? buildTagEntries(uniqueTags, programmaticTags) : []
+
+  const filteredEntries = tagEntries.filter(
+    (entry) =>
+      !selectedTags.includes(entry.raw) &&
+      (entry.display.toLowerCase().includes(inputValue.toLowerCase()) ||
+        entry.raw.toLowerCase().includes(inputValue.toLowerCase())),
+  )
+
+  // Reset highlight when filter changes
+  useEffect(() => {
+    setHighlightedIndex(0)
+  }, [inputValue])
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const selectTag = (raw: string) => {
+    onChange([...selectedTags, raw])
+    setInputValue('')
+    setIsOpen(false)
+    inputRef.current?.focus()
+  }
+
+  const removeTag = (raw: string) => {
+    onChange(selectedTags.filter((t) => t !== raw))
+  }
+
+  const getDisplayName = (raw: string): string => tagEntries.find((e) => e.raw === raw)?.display ?? raw
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setIsOpen(true)
+      setHighlightedIndex((i) => Math.min(i + 1, filteredEntries.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, 0))
+    } else if ((e.key === 'Enter' || e.key === 'Tab') && isOpen && filteredEntries.length > 0) {
+      e.preventDefault()
+      selectTag(filteredEntries[highlightedIndex].raw)
+    } else if (e.key === 'Backspace' && inputValue === '' && selectedTags.length > 0) {
+      removeTag(selectedTags[selectedTags.length - 1])
+    } else if (e.key === 'Escape') {
+      setIsOpen(false)
+    }
+  }
+
+  return (
+    <div class="tag-picker" ref={containerRef}>
+      <div class="tag-picker-input-area" onClick={() => inputRef.current?.focus()}>
+        {selectedTags.map((raw) => (
+          <span class="tag-badge" key={raw}>
+            {getDisplayName(raw)}
+            <button type="button" class="tag-badge-remove" onClick={() => removeTag(raw)}>
+              &times;
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          class="tag-picker-input"
+          value={inputValue}
+          onInput={(e) => {
+            setInputValue((e.target as HTMLInputElement).value)
+            setIsOpen(true)
+          }}
+          onFocus={() => setIsOpen(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={selectedTags.length === 0 ? 'Search tags...' : ''}
+        />
+      </div>
+      {isOpen && filteredEntries.length > 0 && (
+        <ul class="tag-picker-dropdown">
+          {filteredEntries.map((entry, i) => (
+            <li
+              key={entry.raw}
+              class={`tag-picker-option ${i === highlightedIndex ? 'highlighted' : ''}`}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                selectTag(entry.raw)
+              }}
+              onMouseEnter={() => setHighlightedIndex(i)}
+            >
+              <span class="tag-option-display">{entry.display}</span>
+              {entry.display !== entry.raw && <span class="tag-option-raw">{entry.raw}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
 import { useEffect, useRef, useState } from 'preact/hooks'
+import { TagPicker } from '../../components/TagPicker'
 import { fetchTrend, type FetchTrendParams, type TrendDisplayPeriod, type TrendResult } from '../../state/api'
 import { auth } from '../../state/auth'
 import {
@@ -231,15 +232,24 @@ function TrendConfigForm({
             <option value="metric">Metric</option>
           </select>
         </label>
-        <label class="pattern-input">
-          {sourceType === 'tag' ? 'Tag Pattern (regex)' : 'Metric Name'}
-          <input
-            type="text"
-            value={pattern}
-            onInput={(e) => setPattern((e.target as HTMLInputElement).value)}
-            placeholder={sourceType === 'tag' ? 'e.g., coffee|caffeine' : 'e.g., weight'}
-          />
-        </label>
+        {sourceType === 'tag' ?
+          <label class="pattern-input">
+            Tags
+            <TagPicker
+              selectedTags={pattern ? pattern.split('|').filter(Boolean) : []}
+              onChange={(tags) => setPattern(tags.join('|'))}
+            />
+          </label>
+        : <label class="pattern-input">
+            Metric Name
+            <input
+              type="text"
+              value={pattern}
+              onInput={(e) => setPattern((e.target as HTMLInputElement).value)}
+              placeholder="e.g., weight"
+            />
+          </label>
+        }
       </div>
 
       <div class="form-row">


### PR DESCRIPTION
## Summary

- Replace the free-text regex input on the Trends page with a searchable multi-tag picker when configuring tag-type trends. Tags are shown as removable badges and the pattern is built by joining raw tag keys with `|` for full backward compatibility.
- Improve tag mappings settings UX: per-row save indicators (spinner while saving, green checkmark on success, error indicator on failure), clearer labels ("X uses", "Last: date"), and disabled input during save.

## Changes

- **New**: `TagPicker` component (`apps/web/src/components/TagPicker.tsx` + `.css`) - reusable multi-tag picker with search, dropdown, keyboard navigation, badge display
- **Modified**: `TrendConfigForm` in `apps/web/src/pages/Trends/index.tsx` - uses TagPicker for tag source type, keeps text input for metric
- **Modified**: `TagMappingsSettings` (`apps/web/src/components/TagMappingsSettings.tsx` + `.css`) - per-row status with spinner/checkmark, clearer labels

## Test plan

- [ ] Add a new tag-type trend, verify tag picker appears with searchable dropdown
- [ ] Edit an existing tag-type trend, verify pattern tags are pre-selected as badges
- [ ] Verify metric-type trends still show text input
- [ ] Verify tag search/filter, badge removal, keyboard navigation work
- [ ] Verify tag mappings settings show spinner while saving and green checkmark on success
- [ ] Verify "X uses" and "Last: date" labels are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)