### PR TITLE
Add delete and update endpoints for activities

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -27,6 +27,7 @@ import {
   type DailySummaryQuery,
   dailySummaryQuerySchema,
   type DailySummaryResponse,
+  type DeleteActivityResponse,
   type DeleteTagResponse,
   type DetectedLocationsQuery,
   detectedLocationsQuerySchema,
@@ -77,6 +78,9 @@ import {
   trendQuerySchema,
   type TrendResponse,
   type UniqueTagsResponse,
+  type UpdateActivityBody,
+  updateActivityBodySchema,
+  type UpdateActivityResponse,
   type UpdateAdminSettingsBody,
   updateAdminSettingsBodySchema,
   type UpdateNamedLocationBody,
@@ -138,7 +142,14 @@ import {
   insertNamedLocation,
   updateNamedLocation,
 } from './services/locations'
-import { addActivity, addMetric, addTag, deleteTag } from './services/mutations'
+import {
+  addActivity,
+  addMetric,
+  addTag,
+  deleteActivity,
+  deleteTag,
+  updateActivity,
+} from './services/mutations'
 import {
   getDailySummary,
   getPeriodSummary,
@@ -716,6 +727,60 @@ const main = async () => {
 
       if (!result.success) {
         return res.status(400).json({ error: result.error, success: false })
+      }
+
+      res.json({
+        data: {
+          activityType: result.activityType!,
+          endTime: result.endTime!,
+          id: result.id!,
+          notes: result.notes,
+          startTime: result.startTime!,
+          title: result.title,
+        },
+        success: true,
+      })
+    },
+  )
+
+  // DELETE /activities/:id - Delete an activity by ID
+  httpd.delete<{ id: string }, DeleteActivityResponse>(
+    '/activities/:id',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
+
+      const result = await deleteActivity(user, id)
+
+      if (!result.success) {
+        return res.status(404).json({ error: 'Activity not found', success: false })
+      }
+
+      res.json({ success: true })
+    },
+  )
+
+  // PATCH /activities/:id - Update an activity by ID
+  httpd.patch<{ id: string }, UpdateActivityResponse, UpdateActivityBody>(
+    '/activities/:id',
+    authMiddleware,
+    validateBody(updateActivityBodySchema),
+    async (req, res) => {
+      const { id } = req.params
+      const { start_time, end_time, title, notes } = req.body
+      const user = req.user!
+
+      const result = await updateActivity(user, id, {
+        endTime: end_time ? new Date(end_time) : undefined,
+        notes,
+        startTime: start_time ? new Date(start_time) : undefined,
+        title,
+      })
+
+      if (!result.success) {
+        const status = result.error === 'Activity not found' ? 404 : 400
+        return res.status(status).json({ error: result.error, success: false })
       }
 
       res.json({

--- a/apps/backend/src/db.integration.test.ts
+++ b/apps/backend/src/db.integration.test.ts
@@ -8,10 +8,12 @@
 import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
+  deleteActivity,
   deleteMcpSession,
   deleteTag,
   findMergeableTag,
   getActivities,
+  getActivityById,
   getDailyAggregateValue,
   getMcpSession,
   getMcpSessionsForUser,
@@ -29,6 +31,7 @@ import {
   processDailyAggregate,
   saveMcpSession,
   touchMcpSession,
+  updateActivity,
   updateTagEndTime,
   upsertUserSettings,
 } from './db'
@@ -995,6 +998,143 @@ describe('Database Integration Tests', () => {
 
       expect(sessions).toHaveLength(1)
       expect(sessions[0].activityType).toBe('sleep')
+    })
+  })
+
+  describe('getActivityById', () => {
+    test('retrieves activity by ID', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+        title: 'Morning run',
+      })
+
+      const activity = await getActivityById(user, activityId)
+
+      expect(activity).not.toBeNull()
+      expect(activity?.id).toBe(activityId)
+      expect(activity?.activityType).toBe('exercise')
+      expect(activity?.title).toBe('Morning run')
+    })
+
+    test('returns null for non-existent activity', async () => {
+      const user = getTestUser()
+      const nonExistentId = randomUUID()
+
+      const activity = await getActivityById(user, nonExistentId)
+
+      expect(activity).toBeNull()
+    })
+  })
+
+  describe('deleteActivity', () => {
+    test('deletes activity and returns true when found', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const result = await deleteActivity(user, activityId)
+      expect(result).toBe(true)
+
+      const activity = await getActivityById(user, activityId)
+      expect(activity).toBeNull()
+    })
+
+    test('returns false when activity not found', async () => {
+      const user = getTestUser()
+      const nonExistentId = randomUUID()
+
+      const result = await deleteActivity(user, nonExistentId)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('updateActivity', () => {
+    test('updates activity times', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const updated = await updateActivity(user, activityId, {
+        endTime: new Date('2024-01-15T12:00:00Z'),
+        startTime: new Date('2024-01-15T09:00:00Z'),
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.startTime).toEqual(new Date('2024-01-15T09:00:00Z'))
+      expect(updated?.endTime).toEqual(new Date('2024-01-15T12:00:00Z'))
+    })
+
+    test('updates activity title and notes', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        startTime: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const updated = await updateActivity(user, activityId, {
+        notes: 'Felt great!',
+        title: 'Morning workout',
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.title).toBe('Morning workout')
+      expect(updated?.notes).toBe('Felt great!')
+    })
+
+    test('returns null when activity not found', async () => {
+      const user = getTestUser()
+      const nonExistentId = randomUUID()
+
+      const updated = await updateActivity(user, nonExistentId, {
+        title: 'New title',
+      })
+
+      expect(updated).toBeNull()
+    })
+
+    test('returns existing activity when no updates provided', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activityType: 'meditation',
+        endTime: new Date('2024-01-15T08:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        startTime: new Date('2024-01-15T07:30:00Z'),
+        title: 'Morning meditation',
+      })
+
+      const updated = await updateActivity(user, activityId, {})
+
+      expect(updated).not.toBeNull()
+      expect(updated?.title).toBe('Morning meditation')
     })
   })
 

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -482,14 +482,15 @@ export const mergeOverlappingActivities = (activities: Activity[]): Activity[] =
 export const insertActivity = async (user: string, activity: Activity) => {
   await query(
     user,
-    `INSERT INTO activities (source, activity_type, start_time, end_time, title, notes, data)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+    `INSERT INTO activities (id, source, activity_type, start_time, end_time, title, notes, data)
+     VALUES (COALESCE($1, gen_random_uuid()), $2, $3, $4, $5, $6, $7, $8)
      ON CONFLICT (source, activity_type, start_time) DO UPDATE SET
        end_time = EXCLUDED.end_time,
        title = EXCLUDED.title,
        notes = EXCLUDED.notes,
        data = EXCLUDED.data`,
     [
+      activity.id,
       activity.source,
       activity.activityType,
       activity.startTime,
@@ -499,6 +500,105 @@ export const insertActivity = async (user: string, activity: Activity) => {
       activity.data,
     ],
   )
+}
+
+export const getActivityById = async (user: string, id: string): Promise<Activity | null> => {
+  const result = await query(
+    user,
+    `SELECT id, source, activity_type, start_time, end_time, title, notes, data
+     FROM activities
+     WHERE id = $1`,
+    [id],
+  )
+
+  if (result.rows.length === 0) {
+    return null
+  }
+
+  const row = result.rows[0]
+  return {
+    activityType: row.activity_type as ActivityType,
+    data: row.data,
+    endTime: row.end_time ? new Date(row.end_time) : undefined,
+    id: row.id,
+    notes: row.notes,
+    source: row.source as DataSource,
+    startTime: new Date(row.start_time),
+    title: row.title,
+  }
+}
+
+export const deleteActivity = async (user: string, id: string): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM activities WHERE id = $1`, [id])
+
+  return (result.rowCount ?? 0) > 0
+}
+
+export interface ActivityUpdate {
+  startTime?: Date
+  endTime?: Date
+  title?: string
+  notes?: string
+}
+
+export const updateActivity = async (
+  user: string,
+  id: string,
+  updates: ActivityUpdate,
+): Promise<Activity | null> => {
+  // Build SET clause dynamically based on provided updates
+  const setClauses: string[] = []
+  const values: unknown[] = []
+  let paramIndex = 1
+
+  if (updates.startTime !== undefined) {
+    setClauses.push(`start_time = $${paramIndex++}`)
+    values.push(updates.startTime)
+  }
+  if (updates.endTime !== undefined) {
+    setClauses.push(`end_time = $${paramIndex++}`)
+    values.push(updates.endTime)
+  }
+  if (updates.title !== undefined) {
+    setClauses.push(`title = $${paramIndex++}`)
+    values.push(updates.title)
+  }
+  if (updates.notes !== undefined) {
+    setClauses.push(`notes = $${paramIndex++}`)
+    values.push(updates.notes)
+  }
+
+  if (setClauses.length === 0) {
+    // No updates provided, just return existing activity
+    return getActivityById(user, id)
+  }
+
+  values.push(id)
+
+  const result = await query(
+    user,
+    `UPDATE activities
+     SET ${setClauses.join(', ')}
+     WHERE id = $${paramIndex}
+     RETURNING id, source, activity_type, start_time, end_time, title, notes, data`,
+    values,
+  )
+
+  if (result.rows.length === 0) {
+    return null
+  }
+
+  const row = result.rows[0]
+  return {
+    activityType: row.activity_type as ActivityType,
+    data: row.data,
+    endTime: row.end_time ? new Date(row.end_time) : undefined,
+    id: row.id,
+    notes: row.notes,
+    source: row.source as DataSource,
+    startTime: new Date(row.start_time),
+    title: row.title,
+  }
 }
 
 export const getActivities = async (

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -50,7 +50,14 @@ import {
   insertNamedLocation,
   updateNamedLocation,
 } from './services/locations'
-import { addActivity, addMetric, addTag, deleteTag } from './services/mutations'
+import {
+  addActivity,
+  addMetric,
+  addTag,
+  deleteActivity,
+  deleteTag,
+  updateActivity,
+} from './services/mutations'
 import {
   BucketSize,
   getDailySummary,
@@ -467,6 +474,46 @@ Use cases:
 
         if (!result.success) {
           return errorResponse(result.error ?? 'Failed to add activity')
+        }
+
+        return jsonResponse(result)
+      },
+    )
+
+    // Tool: delete_activity
+    server.tool(
+      'delete_activity',
+      'Delete an activity by its ID. Returns success if the activity was found and deleted.',
+      {
+        id: z.string().uuid().describe('The ID of the activity to delete'),
+      },
+      async ({ id }) => {
+        const result = await deleteActivity(user, id)
+        return jsonResponse(result)
+      },
+    )
+
+    // Tool: update_activity
+    server.tool(
+      'update_activity',
+      'Update an existing activity. Can modify start_time, end_time, title, and notes. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
+      {
+        end_time: endDateTimeQuerySchema.optional().describe('New end time in ISO 8601 format'),
+        id: z.string().uuid().describe('The ID of the activity to update'),
+        notes: z.string().optional().describe('New activity notes'),
+        start_time: startDateTimeQuerySchema.optional().describe('New start time in ISO 8601 format'),
+        title: z.string().optional().describe('New activity title'),
+      },
+      async ({ id, start_time, end_time, title, notes }) => {
+        const result = await updateActivity(user, id, {
+          endTime: end_time ? new Date(end_time) : undefined,
+          notes,
+          startTime: start_time ? new Date(start_time) : undefined,
+          title,
+        })
+
+        if (!result.success) {
+          return errorResponse(result.error ?? 'Failed to update activity')
         }
 
         return jsonResponse(result)

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import * as db from '../db'
-import { addActivity, addMetric, addTag, deleteTag } from './mutations'
+import { addActivity, addMetric, addTag, deleteActivity, deleteTag, updateActivity } from './mutations'
 
 // Mock the db module
 vi.mock('../db', () => ({
+  deleteActivity: vi.fn(),
   deleteTag: vi.fn(),
   findMergeableTag: vi.fn(),
+  getActivityById: vi.fn(),
   insertActivity: vi.fn(),
   insertTag: vi.fn(),
   insertTimeSeries: vi.fn(),
+  updateActivity: vi.fn(),
   updateTagEndTime: vi.fn(),
 }))
 
@@ -399,5 +402,166 @@ describe('addActivity', () => {
 
     expect(result.success).toBe(true)
     expect(result.activityType).toBe('nap')
+  })
+})
+
+describe('deleteActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('deletes activity and returns success when found', async () => {
+    vi.mocked(db.deleteActivity).mockResolvedValue(true)
+
+    const result = await deleteActivity('testuser', 'activity-123')
+
+    expect(result.success).toBe(true)
+    expect(result.deleted).toBe(true)
+    expect(result.id).toBe('activity-123')
+    expect(db.deleteActivity).toHaveBeenCalledWith('testuser', 'activity-123')
+  })
+
+  test('returns success false when activity not found', async () => {
+    vi.mocked(db.deleteActivity).mockResolvedValue(false)
+
+    const result = await deleteActivity('testuser', 'nonexistent-activity')
+
+    expect(result.success).toBe(false)
+    expect(result.deleted).toBe(false)
+    expect(result.id).toBe('nonexistent-activity')
+  })
+})
+
+describe('updateActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('updates activity times successfully', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T12:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      startTime: new Date('2024-03-15T09:00:00Z'),
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      endTime: new Date('2024-03-15T12:00:00Z'),
+      startTime: new Date('2024-03-15T09:00:00Z'),
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.startTime).toBe('2024-03-15T09:00:00.000Z')
+    expect(result.endTime).toBe('2024-03-15T12:00:00.000Z')
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      endTime: new Date('2024-03-15T12:00:00Z'),
+      notes: undefined,
+      startTime: new Date('2024-03-15T09:00:00Z'),
+      title: undefined,
+    })
+  })
+
+  test('updates activity title and notes', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      notes: 'Felt great!',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:00:00Z'),
+      title: 'Morning workout',
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      notes: 'Felt great!',
+      title: 'Morning workout',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.title).toBe('Morning workout')
+    expect(result.notes).toBe('Felt great!')
+  })
+
+  test('returns error when activity not found', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue(null)
+
+    const result = await updateActivity('testuser', 'nonexistent-activity', {
+      title: 'New title',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Activity not found')
+    expect(result.id).toBe('nonexistent-activity')
+    expect(db.updateActivity).not.toHaveBeenCalled()
+  })
+
+  test('returns error when new end_time is before existing start_time', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      endTime: new Date('2024-03-15T09:00:00Z'), // Before existing start_time
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('end_time must be after start_time')
+    expect(db.updateActivity).not.toHaveBeenCalled()
+  })
+
+  test('returns error when new start_time is after existing end_time', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      startTime: new Date('2024-03-15T12:00:00Z'), // After existing end_time
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('end_time must be after start_time')
+    expect(db.updateActivity).not.toHaveBeenCalled()
+  })
+
+  test('validates both new start and end times together', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activityType: 'exercise',
+      endTime: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      startTime: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      endTime: new Date('2024-03-15T08:00:00Z'),
+      startTime: new Date('2024-03-15T09:00:00Z'), // end_time before start_time
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('end_time must be after start_time')
+    expect(db.updateActivity).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -8,8 +8,11 @@
 import type { ActivityType } from '@aurboda/api-spec'
 import { randomUUID } from 'crypto'
 import {
+  deleteActivity as dbDeleteActivity,
   deleteTag as dbDeleteTag,
+  getActivityById as dbGetActivityById,
   insertActivity as dbInsertActivity,
+  updateActivity as dbUpdateActivity,
   findMergeableTag,
   insertTag,
   insertTimeSeries,
@@ -68,6 +71,30 @@ export interface AddActivityInput {
 }
 
 export interface AddActivityResult {
+  success: boolean
+  id?: string
+  activityType?: ActivityType
+  startTime?: string
+  endTime?: string
+  title?: string
+  notes?: string
+  error?: string
+}
+
+export interface DeleteActivityResult {
+  success: boolean
+  deleted: boolean
+  id: string
+}
+
+export interface UpdateActivityInput {
+  startTime?: Date
+  endTime?: Date
+  title?: string
+  notes?: string
+}
+
+export interface UpdateActivityResult {
   success: boolean
   id?: string
   activityType?: ActivityType
@@ -209,5 +236,78 @@ export async function addActivity(user: string, input: AddActivityInput): Promis
     startTime: input.startTime.toISOString(),
     success: true,
     title: input.title,
+  }
+}
+
+/**
+ * Delete an activity by its ID.
+ */
+export async function deleteActivity(user: string, id: string): Promise<DeleteActivityResult> {
+  const deleted = await dbDeleteActivity(user, id)
+
+  return {
+    deleted,
+    id,
+    success: deleted,
+  }
+}
+
+/**
+ * Update an existing activity.
+ *
+ * Validates that if both start_time and end_time are provided, end_time is after start_time.
+ * Also validates against existing values if only one is provided.
+ */
+export async function updateActivity(
+  user: string,
+  id: string,
+  input: UpdateActivityInput,
+): Promise<UpdateActivityResult> {
+  // First, get the existing activity to validate times
+  const existing = await dbGetActivityById(user, id)
+  if (!existing) {
+    return {
+      error: 'Activity not found',
+      id,
+      success: false,
+    }
+  }
+
+  // Determine final start and end times
+  const finalStartTime = input.startTime ?? existing.startTime
+  const finalEndTime = input.endTime ?? existing.endTime
+
+  // Validate that endTime is after startTime
+  if (finalEndTime && finalEndTime <= finalStartTime) {
+    return {
+      error: 'end_time must be after start_time',
+      id,
+      success: false,
+    }
+  }
+
+  const updated = await dbUpdateActivity(user, id, {
+    endTime: input.endTime,
+    notes: input.notes,
+    startTime: input.startTime,
+    title: input.title,
+  })
+
+  if (!updated) {
+    return {
+      error: 'Failed to update activity',
+      id,
+      success: false,
+    }
+  }
+
+  return {
+    activityType: updated.activityType,
+    endTime: updated.endTime?.toISOString(),
+    id: updated.id,
+    notes: updated.notes,
+    startTime: updated.startTime.toISOString(),
+    success: true,
+    title: updated.title,
   }
 }

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -211,3 +211,58 @@ export const addActivityResponseSchema = baseResponseSchema
   .meta({ id: 'AddActivityResponse' })
 
 export type AddActivityResponse = z.infer<typeof addActivityResponseSchema>
+
+/**
+ * Delete activity params.
+ */
+export const deleteActivityParamsSchema = z
+  .object({
+    id: z.string().uuid().meta({ description: 'ID of the activity to delete' }),
+  })
+  .meta({ id: 'DeleteActivityParams' })
+
+export type DeleteActivityParams = z.infer<typeof deleteActivityParamsSchema>
+
+/**
+ * Delete activity response.
+ */
+export const deleteActivityResponseSchema = baseResponseSchema.meta({ id: 'DeleteActivityResponse' })
+
+export type DeleteActivityResponse = z.infer<typeof deleteActivityResponseSchema>
+
+/**
+ * Update activity request body schema.
+ * All fields are optional - only provided fields will be updated.
+ */
+export const updateActivityBodySchema = z
+  .object({
+    end_time: iso8601DateTimeSchema.optional().meta({ description: 'New end time of the activity' }),
+    notes: z.string().optional().meta({ description: 'New activity notes' }),
+    start_time: iso8601DateTimeSchema.optional().meta({ description: 'New start time of the activity' }),
+    title: z.string().optional().meta({ description: 'New activity title' }),
+  })
+  .meta({ id: 'UpdateActivityBody' })
+
+export type UpdateActivityBody = z.infer<typeof updateActivityBodySchema>
+
+/**
+ * Update activity params.
+ */
+export const updateActivityParamsSchema = z
+  .object({
+    id: z.string().uuid().meta({ description: 'ID of the activity to update' }),
+  })
+  .meta({ id: 'UpdateActivityParams' })
+
+export type UpdateActivityParams = z.infer<typeof updateActivityParamsSchema>
+
+/**
+ * Update activity response schema.
+ */
+export const updateActivityResponseSchema = baseResponseSchema
+  .extend({
+    data: addedActivitySchema.optional(),
+  })
+  .meta({ id: 'UpdateActivityResponse' })
+
+export type UpdateActivityResponse = z.infer<typeof updateActivityResponseSchema>

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -174,7 +174,9 @@ export type SetTagMappingResponse = z.infer<typeof setTagMappingResponseSchema>
  */
 export const tagMappingsResponseSchema = baseResponseSchema
   .extend({
-    mappings: z.record(z.string(), z.string()).meta({ description: 'All tag mappings (tag key -> display name)' }),
+    mappings: z
+      .record(z.string(), z.string())
+      .meta({ description: 'All tag mappings (tag key -> display name)' }),
   })
   .meta({ id: 'TagMappingsResponse' })
 


### PR DESCRIPTION
## Summary

Implements #141 - adds ability to delete and update activities:

- Add `deleteActivity` and `updateActivity` mutation functions with validation
- Add `DELETE /activities/:id` and `PATCH /activities/:id` REST API endpoints  
- Add `delete_activity` and `update_activity` MCP tools
- Add database functions: `getActivityById`, `deleteActivity`, `updateActivity`
- Add comprehensive unit and integration tests
- Update `insertActivity` to accept optional `id` field for testing

## Details

### New MCP Tools
- `delete_activity` - Delete an activity by its ID
- `update_activity` - Update an existing activity's start/end time, title, or notes

### New REST Endpoints
- `DELETE /activities/:id` - Delete an activity  
- `PATCH /activities/:id` - Partial update of an activity

### Validation
- Update validates that end_time is after start_time (considering both new and existing values)
- Returns appropriate 404 for not found, 400 for validation errors

## Test plan
- [x] Unit tests for mutations (deleteActivity, updateActivity)
- [x] Integration tests for database functions
- [x] All 515 backend tests pass

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/claude-code)