### PR TITLE
Add contextual HRV metrics (hrv_sleep, hrv_activity, hrv_awake)

### DIFF
--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -7,8 +7,10 @@
 
 // Re-export common types from shared api-spec package
 export {
+  contextualHrvMetrics,
   cumulativeMetrics,
   hrZoneMetrics,
+  isContextualHrvMetric,
   isHrZoneMetric,
   isValidMetric,
   metricUnits,

--- a/apps/backend/src/services/hrv-context.test.ts
+++ b/apps/backend/src/services/hrv-context.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for contextual HRV filtering.
+ */
+
+import { describe, expect, test } from 'vitest'
+import { classifyHrvByContext } from './hrv-context'
+
+describe('classifyHrvByContext', () => {
+  test('classifies HRV samples as sleep when in sleep window', () => {
+    const hrvData: [Date, number][] = [
+      [new Date('2024-01-15T02:00:00Z'), 45],
+      [new Date('2024-01-15T03:00:00Z'), 48],
+      [new Date('2024-01-15T04:00:00Z'), 50],
+    ]
+
+    const sleepWindows = [{ end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }]
+    const activityWindows: { start: Date; end: Date }[] = []
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(3)
+    expect(result.activity).toHaveLength(0)
+    expect(result.awake).toHaveLength(0)
+    expect(result.sleep.map(([, v]) => v)).toEqual([45, 48, 50])
+  })
+
+  test('classifies HRV samples as activity when in exercise window', () => {
+    const hrvData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 25],
+      [new Date('2024-01-15T10:15:00Z'), 22],
+      [new Date('2024-01-15T10:30:00Z'), 20],
+    ]
+
+    const sleepWindows: { start: Date; end: Date }[] = []
+    const activityWindows = [
+      { end: new Date('2024-01-15T11:00:00Z'), start: new Date('2024-01-15T09:30:00Z') },
+    ]
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(0)
+    expect(result.activity).toHaveLength(3)
+    expect(result.awake).toHaveLength(0)
+    expect(result.activity.map(([, v]) => v)).toEqual([25, 22, 20])
+  })
+
+  test('classifies HRV samples as awake when not in any window', () => {
+    const hrvData: [Date, number][] = [
+      [new Date('2024-01-15T12:00:00Z'), 30],
+      [new Date('2024-01-15T14:00:00Z'), 28],
+      [new Date('2024-01-15T16:00:00Z'), 32],
+    ]
+
+    const sleepWindows = [{ end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }]
+    const activityWindows = [
+      { end: new Date('2024-01-15T10:00:00Z'), start: new Date('2024-01-15T09:00:00Z') },
+    ]
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(0)
+    expect(result.activity).toHaveLength(0)
+    expect(result.awake).toHaveLength(3)
+    expect(result.awake.map(([, v]) => v)).toEqual([30, 28, 32])
+  })
+
+  test('correctly classifies mixed HRV samples across all contexts', () => {
+    const hrvData: [Date, number][] = [
+      // Sleep samples
+      [new Date('2024-01-15T02:00:00Z'), 45],
+      [new Date('2024-01-15T04:00:00Z'), 50],
+      // Morning awake
+      [new Date('2024-01-15T08:00:00Z'), 35],
+      // Exercise samples
+      [new Date('2024-01-15T10:00:00Z'), 22],
+      [new Date('2024-01-15T10:30:00Z'), 18],
+      // Afternoon awake
+      [new Date('2024-01-15T14:00:00Z'), 30],
+      [new Date('2024-01-15T16:00:00Z'), 28],
+    ]
+
+    const sleepWindows = [{ end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }]
+    const activityWindows = [
+      { end: new Date('2024-01-15T11:00:00Z'), start: new Date('2024-01-15T09:30:00Z') },
+    ]
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(2)
+    expect(result.sleep.map(([, v]) => v)).toEqual([45, 50])
+
+    expect(result.activity).toHaveLength(2)
+    expect(result.activity.map(([, v]) => v)).toEqual([22, 18])
+
+    expect(result.awake).toHaveLength(3)
+    expect(result.awake.map(([, v]) => v)).toEqual([35, 30, 28])
+  })
+
+  test('handles samples at window boundaries (inclusive)', () => {
+    const hrvData: [Date, number][] = [
+      [new Date('2024-01-15T07:00:00Z'), 42], // Exactly at sleep end
+      [new Date('2024-01-15T09:30:00Z'), 25], // Exactly at activity start
+      [new Date('2024-01-15T11:00:00Z'), 22], // Exactly at activity end
+    ]
+
+    const sleepWindows = [{ end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }]
+    const activityWindows = [
+      { end: new Date('2024-01-15T11:00:00Z'), start: new Date('2024-01-15T09:30:00Z') },
+    ]
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(1) // 07:00 is within sleep (<=end)
+    expect(result.activity).toHaveLength(2) // 09:30 and 11:00 are within activity
+    expect(result.awake).toHaveLength(0)
+  })
+
+  test('handles empty HRV data', () => {
+    const hrvData: [Date, number][] = []
+    const sleepWindows = [{ end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }]
+    const activityWindows: { start: Date; end: Date }[] = []
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(0)
+    expect(result.activity).toHaveLength(0)
+    expect(result.awake).toHaveLength(0)
+  })
+
+  test('handles empty windows (all samples become awake)', () => {
+    const hrvData: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 30],
+      [new Date('2024-01-15T12:00:00Z'), 28],
+    ]
+
+    const sleepWindows: { start: Date; end: Date }[] = []
+    const activityWindows: { start: Date; end: Date }[] = []
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(0)
+    expect(result.activity).toHaveLength(0)
+    expect(result.awake).toHaveLength(2)
+  })
+
+  test('handles multiple sleep windows (e.g., naps)', () => {
+    const hrvData: [Date, number][] = [
+      [new Date('2024-01-15T02:00:00Z'), 45], // Night sleep
+      [new Date('2024-01-15T10:00:00Z'), 30], // Awake
+      [new Date('2024-01-15T14:30:00Z'), 40], // Nap
+    ]
+
+    const sleepWindows = [
+      { end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }, // Night
+      { end: new Date('2024-01-15T15:00:00Z'), start: new Date('2024-01-15T14:00:00Z') }, // Nap
+    ]
+    const activityWindows: { start: Date; end: Date }[] = []
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    expect(result.sleep).toHaveLength(2)
+    expect(result.sleep.map(([, v]) => v)).toEqual([45, 40])
+    expect(result.awake).toHaveLength(1)
+    expect(result.awake.map(([, v]) => v)).toEqual([30])
+  })
+
+  test('sleep window takes priority over activity (overlapping windows)', () => {
+    // This scenario shouldn't happen in practice, but tests the implementation
+    const hrvData: [Date, number][] = [[new Date('2024-01-15T06:30:00Z'), 42]]
+
+    const sleepWindows = [{ end: new Date('2024-01-15T07:00:00Z'), start: new Date('2024-01-15T00:00:00Z') }]
+    const activityWindows = [
+      { end: new Date('2024-01-15T08:00:00Z'), start: new Date('2024-01-15T06:00:00Z') },
+    ]
+
+    const result = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+    // Sleep check comes first, so it's classified as sleep
+    expect(result.sleep).toHaveLength(1)
+    expect(result.activity).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/services/hrv-context.ts
+++ b/apps/backend/src/services/hrv-context.ts
@@ -1,0 +1,144 @@
+/**
+ * Contextual HRV filtering service.
+ *
+ * HRV (RMSSD) is fundamentally different depending on when it's measured:
+ * - Sleep HRV (Oura): ~35-50 avg - the standard recovery/readiness indicator
+ * - Daytime HRV: ~15-30 avg - reflects sympathetic activity, movement, stress
+ *
+ * This service filters HRV samples by context:
+ * - hrv_sleep: HRV during detected sleep windows
+ * - hrv_activity: HRV during exercise/activity sessions
+ * - hrv_awake: Everything else (resting but awake)
+ */
+
+import { Activity, getActivities, getSleepSessions, getTimeSeries, TimeSeriesPoint } from '../db'
+import { MetricType } from '../schema'
+
+export type HrvContext = 'sleep' | 'activity' | 'awake'
+
+interface TimeWindow {
+  start: Date
+  end: Date
+}
+
+/**
+ * Check if a timestamp falls within any of the given time windows.
+ */
+const isInWindow = (time: Date, windows: TimeWindow[]): boolean => {
+  const t = time.getTime()
+  return windows.some((w) => t >= w.start.getTime() && t <= w.end.getTime())
+}
+
+/**
+ * Convert activities to time windows, handling optional end times.
+ */
+const activitiesToWindows = (activities: Activity[]): TimeWindow[] =>
+  activities
+    .filter((a) => a.endTime !== undefined)
+    .map((a) => ({
+      end: a.endTime!,
+      start: a.startTime,
+    }))
+
+/**
+ * Classify HRV samples by context.
+ * Returns samples categorized as sleep, activity, or awake.
+ */
+export const classifyHrvByContext = (
+  hrvData: [Date, number][],
+  sleepWindows: TimeWindow[],
+  activityWindows: TimeWindow[],
+): Record<HrvContext, [Date, number][]> => {
+  const result: Record<HrvContext, [Date, number][]> = {
+    activity: [],
+    awake: [],
+    sleep: [],
+  }
+
+  for (const [time, value] of hrvData) {
+    if (isInWindow(time, sleepWindows)) {
+      result.sleep.push([time, value])
+    } else if (isInWindow(time, activityWindows)) {
+      result.activity.push([time, value])
+    } else {
+      result.awake.push([time, value])
+    }
+  }
+
+  return result
+}
+
+/**
+ * Get contextual HRV time windows for a date range.
+ * Returns sleep and activity windows that can be used for filtering.
+ */
+export const getHrvContextWindows = async (
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<{ sleepWindows: TimeWindow[]; activityWindows: TimeWindow[] }> => {
+  // Fetch sleep sessions and exercise activities in parallel
+  const [sleepSessions, exerciseActivities] = await Promise.all([
+    getSleepSessions(user, start, end),
+    getActivities(user, 'exercise', start, end),
+  ])
+
+  return {
+    activityWindows: activitiesToWindows(exerciseActivities),
+    sleepWindows: activitiesToWindows(sleepSessions),
+  }
+}
+
+/**
+ * Get HRV data filtered by context.
+ *
+ * @param user - The username
+ * @param context - The HRV context ('sleep', 'activity', or 'awake')
+ * @param start - Start of time range
+ * @param end - End of time range
+ * @returns Array of [Date, number] tuples with HRV values
+ */
+export const getContextualHrv = async (
+  user: string,
+  context: HrvContext,
+  start: Date,
+  end: Date,
+): Promise<[Date, number][]> => {
+  // Fetch HRV data and context windows in parallel
+  const [hrvData, { sleepWindows, activityWindows }] = await Promise.all([
+    getTimeSeries(user, 'hrv_rmssd', start, end),
+    getHrvContextWindows(user, start, end),
+  ])
+
+  const classified = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+  return classified[context]
+}
+
+/**
+ * Map contextual HRV metric names to their context.
+ */
+export const contextualHrvMetricToContext: Record<string, HrvContext> = {
+  hrv_activity: 'activity',
+  hrv_awake: 'awake',
+  hrv_sleep: 'sleep',
+}
+
+/**
+ * Get the HRV context for a metric, or null if not a contextual HRV metric.
+ */
+export const getHrvContextForMetric = (metric: MetricType): HrvContext | null =>
+  contextualHrvMetricToContext[metric] ?? null
+
+/**
+ * Convert contextual HRV data to TimeSeriesPoint format for insertion.
+ * Note: Contextual HRV is computed, not stored - this is for consistency.
+ */
+export const hrvDataToTimeSeriesPoints = (
+  data: [Date, number][],
+  metric: MetricType,
+): Omit<TimeSeriesPoint, 'source'>[] =>
+  data.map(([time, value]) => ({
+    metric,
+    time,
+    value,
+  }))

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -980,4 +980,229 @@ describe('queryMetricsBucketed', () => {
     expect(result.buckets[1].metrics.heart_rate).toBeDefined()
     expect(result.buckets[1].metrics.hrv_rmssd).toBeUndefined()
   })
+
+  test('returns bucketed data for contextual HRV metric (hrv_sleep)', async () => {
+    // Raw HRV data during sleep
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T02:00:00Z'), 45],
+      [new Date('2024-01-15T03:00:00Z'), 48],
+      [new Date('2024-01-15T04:00:00Z'), 50],
+    ])
+
+    // Sleep session covering the HRV data
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activityType: 'sleep',
+        endTime: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        startTime: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+
+    // No exercise
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      ['hrv_sleep'],
+      new Date('2024-01-15T00:00:00Z'),
+      new Date('2024-01-15T08:00:00Z'),
+      '1h',
+    )
+
+    // Should have buckets for the hours with HRV data during sleep
+    expect(result.buckets.length).toBeGreaterThan(0)
+
+    // All returned data should be hrv_sleep
+    for (const bucket of result.buckets) {
+      if (bucket.metrics.hrv_sleep) {
+        expect(bucket.metrics.hrv_sleep.avg).toBeGreaterThan(0)
+        expect(bucket.metrics.hrv_sleep.count).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test('returns bucketed data for mixed regular and contextual HRV metrics', async () => {
+    // Mock regular bucketed data for heart_rate
+    vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue([
+      {
+        avg: 72,
+        bucketStart: new Date('2024-01-15T02:00:00Z'),
+        count: 100,
+        max: 80,
+        metric: 'heart_rate' as MetricType,
+        min: 65,
+      },
+    ])
+
+    // Raw HRV data for contextual processing
+    vi.mocked(db.getTimeSeries).mockResolvedValue([[new Date('2024-01-15T02:30:00Z'), 45]])
+
+    // Sleep session
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activityType: 'sleep',
+        endTime: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        startTime: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+
+    // No exercise
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      ['heart_rate', 'hrv_sleep'],
+      new Date('2024-01-15T00:00:00Z'),
+      new Date('2024-01-15T08:00:00Z'),
+      '1h',
+    )
+
+    // Should have bucket with heart_rate from regular query
+    const bucketWithHr = result.buckets.find((b) => b.metrics.heart_rate)
+    expect(bucketWithHr).toBeDefined()
+    expect(bucketWithHr!.metrics.heart_rate?.avg).toBe(72)
+
+    // Should have bucket with hrv_sleep from contextual query
+    const bucketWithHrvSleep = result.buckets.find((b) => b.metrics.hrv_sleep)
+    expect(bucketWithHrvSleep).toBeDefined()
+  })
+
+  test('returns empty contextual HRV when no HRV data during context', async () => {
+    // HRV data only during awake hours
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T12:00:00Z'), 30],
+      [new Date('2024-01-15T14:00:00Z'), 28],
+    ])
+
+    // Sleep session doesn't overlap with HRV data
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activityType: 'sleep',
+        endTime: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        startTime: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+
+    // No exercise
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      ['hrv_sleep'],
+      new Date('2024-01-15T00:00:00Z'),
+      new Date('2024-01-15T23:59:59Z'),
+      '1h',
+    )
+
+    // Should have no hrv_sleep buckets since HRV data is during awake hours
+    const hrvSleepBuckets = result.buckets.filter((b) => b.metrics.hrv_sleep)
+    expect(hrvSleepBuckets).toHaveLength(0)
+  })
+})
+
+describe('queryMetrics with contextual HRV', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns filtered HRV data for hrv_sleep', async () => {
+    // Raw HRV data - some during sleep, some during awake
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T02:00:00Z'), 45],
+      [new Date('2024-01-15T03:00:00Z'), 48],
+      [new Date('2024-01-15T12:00:00Z'), 30], // This is during awake
+    ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activityType: 'sleep',
+        endTime: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        startTime: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await queryMetrics(
+      'testuser',
+      'hrv_sleep',
+      new Date('2024-01-15T00:00:00Z'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metric).toBe('hrv_sleep')
+    expect(result.unit).toBe('ms')
+    // Only samples during sleep should be included
+    expect(result.count).toBe(2)
+    expect(result.data.map((d) => d.value)).toEqual([45, 48])
+  })
+
+  test('returns filtered HRV data for hrv_awake', async () => {
+    // Raw HRV data
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T02:00:00Z'), 45], // During sleep
+      [new Date('2024-01-15T12:00:00Z'), 30], // During awake
+      [new Date('2024-01-15T14:00:00Z'), 28], // During awake
+    ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activityType: 'sleep',
+        endTime: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        startTime: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await queryMetrics(
+      'testuser',
+      'hrv_awake',
+      new Date('2024-01-15T00:00:00Z'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metric).toBe('hrv_awake')
+    // Only samples during awake (not sleep, not activity) should be included
+    expect(result.count).toBe(2)
+    expect(result.data.map((d) => d.value)).toEqual([30, 28])
+  })
+
+  test('returns filtered HRV data for hrv_activity', async () => {
+    // Raw HRV data
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T10:00:00Z'), 22], // During exercise
+      [new Date('2024-01-15T10:30:00Z'), 18], // During exercise
+      [new Date('2024-01-15T14:00:00Z'), 30], // After exercise (awake)
+    ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activityType: 'exercise',
+        endTime: new Date('2024-01-15T11:00:00Z'),
+        source: 'health_connect',
+        startTime: new Date('2024-01-15T09:30:00Z'),
+        title: 'Morning Run',
+      },
+    ])
+
+    const result = await queryMetrics(
+      'testuser',
+      'hrv_activity',
+      new Date('2024-01-15T00:00:00Z'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metric).toBe('hrv_activity')
+    // Only samples during exercise should be included
+    expect(result.count).toBe(2)
+    expect(result.data.map((d) => d.value)).toEqual([22, 18])
+  })
 })

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -17,7 +17,8 @@ import {
   getTimeSeriesMultiMetric,
   getTimeSeriesStats,
 } from '../db'
-import { ActivityType, isHrZoneMetric, MetricType, metricUnits } from '../schema'
+import { ActivityType, isContextualHrvMetric, isHrZoneMetric, MetricType, metricUnits } from '../schema'
+import { classifyHrvByContext, getHrvContextWindows, HrvContext } from './hrv-context'
 import { getPlaceVisits } from './locations'
 import { computeHrZoneSecs, getEffectiveHrZones, HrZoneSecs } from './settings'
 
@@ -171,6 +172,9 @@ export interface PeriodSummaryResult {
 
 /**
  * Query time series data for a single metric.
+ *
+ * Supports contextual HRV metrics (hrv_sleep, hrv_activity, hrv_awake) which
+ * are computed by filtering hrv_rmssd data by overlapping sleep/activity windows.
  */
 export async function queryMetrics(
   user: string,
@@ -178,8 +182,20 @@ export async function queryMetrics(
   start: Date,
   end: Date,
 ): Promise<QueryMetricsResult> {
-  const data = await getTimeSeries(user, metric, start, end)
   const unit = metricUnits[metric]
+
+  // Handle contextual HRV metrics
+  if (isContextualHrvMetric(metric)) {
+    const data = await getContextualHrvData(user, metric, start, end)
+    return {
+      count: data.length,
+      data: data.map(([time, value]) => ({ time: time.toISOString(), value })),
+      metric,
+      unit,
+    }
+  }
+
+  const data = await getTimeSeries(user, metric, start, end)
 
   return {
     count: data.length,
@@ -187,6 +203,36 @@ export async function queryMetrics(
     metric,
     unit,
   }
+}
+
+/**
+ * Get contextual HRV data for a single metric.
+ */
+async function getContextualHrvData(
+  user: string,
+  metric: MetricType,
+  start: Date,
+  end: Date,
+): Promise<[Date, number][]> {
+  const contextMap: Record<string, HrvContext> = {
+    hrv_activity: 'activity',
+    hrv_awake: 'awake',
+    hrv_sleep: 'sleep',
+  }
+  const context = contextMap[metric]
+  if (!context) return []
+
+  // Fetch raw HRV data and context windows in parallel
+  const [hrvData, { sleepWindows, activityWindows }] = await Promise.all([
+    getTimeSeries(user, 'hrv_rmssd', start, end),
+    getHrvContextWindows(user, start, end),
+  ])
+
+  if (hrvData.length === 0) return []
+
+  // Classify and return the requested context
+  const classified = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+  return classified[context]
 }
 
 /**
@@ -201,10 +247,67 @@ const bucketSizeToMinutes: Record<BucketSize, number> = {
 }
 
 /**
+ * Compute bucket start time for a given timestamp.
+ */
+const getBucketStart = (time: Date, bucketMinutes: number, rangeStart: Date): Date => {
+  const msPerBucket = bucketMinutes * 60 * 1000
+  const startMs = rangeStart.getTime()
+  const timeMs = time.getTime()
+  const bucketIndex = Math.floor((timeMs - startMs) / msPerBucket)
+  return new Date(startMs + bucketIndex * msPerBucket)
+}
+
+/**
+ * Map contextual HRV metric names to their context.
+ */
+const contextualHrvMetricToContext: Record<string, HrvContext> = {
+  hrv_activity: 'activity',
+  hrv_awake: 'awake',
+  hrv_sleep: 'sleep',
+}
+
+/**
+ * Compute bucketed aggregations for contextual HRV data.
+ * Returns buckets with min/max/avg/count for filtered HRV samples.
+ */
+const computeContextualHrvBuckets = (
+  hrvData: [Date, number][],
+  metric: MetricType,
+  bucketMinutes: number,
+  rangeStart: Date,
+): { bucketStart: Date; metric: MetricType; avg: number; min: number; max: number; count: number }[] => {
+  if (hrvData.length === 0) return []
+
+  // Group data by bucket
+  const bucketMap = new Map<string, number[]>()
+  for (const [time, value] of hrvData) {
+    const bucketStart = getBucketStart(time, bucketMinutes, rangeStart)
+    const key = bucketStart.toISOString()
+    if (!bucketMap.has(key)) {
+      bucketMap.set(key, [])
+    }
+    bucketMap.get(key)!.push(value)
+  }
+
+  // Compute aggregations for each bucket
+  return Array.from(bucketMap.entries()).map(([key, values]) => ({
+    avg: values.reduce((a, b) => a + b, 0) / values.length,
+    bucketStart: new Date(key),
+    count: values.length,
+    max: Math.max(...values),
+    metric,
+    min: Math.min(...values),
+  }))
+}
+
+/**
  * Query bucketed/aggregated time series data for multiple metrics.
  *
  * Returns pre-aggregated buckets with min/max/avg/count for each metric,
  * significantly reducing data size compared to raw time series queries.
+ *
+ * Supports contextual HRV metrics (hrv_sleep, hrv_activity, hrv_awake) which
+ * are computed by filtering hrv_rmssd data by overlapping sleep/activity windows.
  *
  * @param user - The username
  * @param metrics - Array of metric types to query
@@ -220,12 +323,27 @@ export async function queryMetricsBucketed(
   bucket: BucketSize,
 ): Promise<QueryMetricsBucketedResult> {
   const bucketMinutes = bucketSizeToMinutes[bucket]
-  const data = await getTimeSeriesBucketed(user, metrics, start, end, bucketMinutes)
+
+  // Separate regular metrics from contextual HRV metrics
+  const regularMetrics = metrics.filter((m) => !isContextualHrvMetric(m))
+  const contextualHrvMetricsRequested = metrics.filter(isContextualHrvMetric)
+
+  // Fetch regular bucketed data and contextual HRV data in parallel
+  const needsContextualHrv = contextualHrvMetricsRequested.length > 0
+  const [regularData, contextualHrvData] = await Promise.all([
+    regularMetrics.length > 0 ? getTimeSeriesBucketed(user, regularMetrics, start, end, bucketMinutes) : [],
+    needsContextualHrv ?
+      computeContextualHrvData(user, contextualHrvMetricsRequested, start, end, bucketMinutes)
+    : [],
+  ])
+
+  // Combine all data
+  const allData = [...regularData, ...contextualHrvData]
 
   // Group data by bucket start time
   const bucketMap = new Map<string, MetricBucket>()
 
-  for (const row of data) {
+  for (const row of allData) {
     const bucketKey = row.bucketStart.toISOString()
     const bucketEndMs = row.bucketStart.getTime() + bucketMinutes * 60 * 1000
     const bucketEnd = new Date(bucketEndMs).toISOString()
@@ -258,6 +376,52 @@ export async function queryMetricsBucketed(
     end: end.toISOString(),
     start: start.toISOString(),
   }
+}
+
+/**
+ * Compute bucketed data for contextual HRV metrics.
+ * Fetches raw hrv_rmssd data, classifies by context, and computes bucket aggregations.
+ */
+async function computeContextualHrvData(
+  user: string,
+  metrics: MetricType[],
+  start: Date,
+  end: Date,
+  bucketMinutes: number,
+): Promise<
+  { bucketStart: Date; metric: MetricType; avg: number; min: number; max: number; count: number }[]
+> {
+  // Fetch raw HRV data and context windows in parallel
+  const [hrvData, { sleepWindows, activityWindows }] = await Promise.all([
+    getTimeSeries(user, 'hrv_rmssd', start, end),
+    getHrvContextWindows(user, start, end),
+  ])
+
+  if (hrvData.length === 0) return []
+
+  // Classify HRV data by context
+  const classified = classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+
+  // Compute buckets for each requested contextual HRV metric
+  const results: {
+    bucketStart: Date
+    metric: MetricType
+    avg: number
+    min: number
+    max: number
+    count: number
+  }[] = []
+
+  for (const metric of metrics) {
+    const context = contextualHrvMetricToContext[metric]
+    if (context) {
+      const contextData = classified[context]
+      const buckets = computeContextualHrvBuckets(contextData, metric, bucketMinutes, start)
+      results.push(...buckets)
+    }
+  }
+
+  return results
 }
 
 /**

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -13,6 +13,9 @@ export const validMetrics = [
   'heart_rate',
   'resting_heart_rate',
   'hrv_rmssd',
+  'hrv_sleep',
+  'hrv_activity',
+  'hrv_awake',
   'weight',
   'body_fat',
   'bone_mass',
@@ -84,6 +87,20 @@ export const hrZoneMetrics = [
  */
 export const isHrZoneMetric = (metric: MetricType): boolean =>
   (hrZoneMetrics as readonly string[]).includes(metric)
+
+/**
+ * Contextual HRV metrics are computed by filtering hrv_rmssd data by context.
+ * - hrv_sleep: HRV during sleep windows
+ * - hrv_activity: HRV during exercise sessions
+ * - hrv_awake: HRV when not sleeping or exercising
+ */
+export const contextualHrvMetrics = ['hrv_sleep', 'hrv_activity', 'hrv_awake'] as const
+
+/**
+ * Check if a metric is a contextual HRV metric (computed from hrv_rmssd).
+ */
+export const isContextualHrvMetric = (metric: MetricType): boolean =>
+  (contextualHrvMetrics as readonly string[]).includes(metric)
 
 /**
  * Valid activity types.
@@ -158,7 +175,10 @@ export const metricUnits: Record<MetricType, string> = {
   hr_zone_3_sec: 'sec',
   hr_zone_4_sec: 'sec',
   hr_zone_5_sec: 'sec',
+  hrv_activity: 'ms',
+  hrv_awake: 'ms',
   hrv_rmssd: 'ms',
+  hrv_sleep: 'ms',
   lean_body_mass: 'kg',
   productivity_score: 'score',
   readiness_score: 'score',


### PR DESCRIPTION
## Summary

- Adds three new virtual metrics: `hrv_sleep`, `hrv_activity`, `hrv_awake`
- Filters HRV (hrv_rmssd) data by context at query time
- Cross-references HRV timestamps with sleep/activity windows from the activities table
- Supports both raw time series queries (`queryMetrics`) and bucketed queries (`queryMetricsBucketed`)

## Problem

HRV measured during sleep vs waking hours are fundamentally different signals:
- **Sleep HRV** (Oura): ~35-50 avg, ~10-12 samples/hour — the standard recovery indicator
- **Daytime HRV**: ~15-30 avg, 400-700 samples/hour — reflects sympathetic activity

When both sources are present, daytime samples outnumber sleep samples ~50:1, completely swamping daily averages and creating misleading trends.

## Solution

Virtual metrics that are computed at query time:
- `hrv_sleep`: HRV during detected sleep windows
- `hrv_activity`: HRV during exercise sessions
- `hrv_awake`: Everything else (not sleeping, not exercising)

The existing `hrv_rmssd` metric remains unchanged for raw access.

## Test plan

- [x] Unit tests for HRV context classification (`hrv-context.test.ts`)
- [x] Unit tests for contextual HRV in `queryMetrics` and `queryMetricsBucketed`
- [x] All 498 tests pass

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)