### PR TITLE
Fix Add Widget button click handler

### DIFF
--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -14,11 +14,13 @@ function DashboardSectionComponent({
   isEditing,
   onRemoveWidget,
   onMoveWidget,
+  onAddWidgetClick,
 }: {
   section: DashboardSection
   isEditing: boolean
   onRemoveWidget?: (widgetId: string) => void
   onMoveWidget?: (widgetId: string, direction: 'up' | 'down') => void
+  onAddWidgetClick?: () => void
 }) {
   const [collapsed, setCollapsed] = useState(section.collapsed ?? false)
 
@@ -103,7 +105,7 @@ function DashboardSectionComponent({
           ))}
           {isEditing && (
             <div class="add-widget-placeholder">
-              <button class="add-widget-btn" data-section-id={section.id}>
+              <button class="add-widget-btn" onClick={onAddWidgetClick}>
                 + Add Widget
               </button>
             </div>
@@ -245,6 +247,7 @@ export function Dashboard() {
               isEditing={isEditing}
               onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
               onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
+              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
             />
           ))}
         </div>
@@ -260,6 +263,7 @@ export function Dashboard() {
               isEditing={isEditing}
               onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
               onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
+              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
             />
           ))}
           {linksSections.map((section) => (
@@ -269,6 +273,7 @@ export function Dashboard() {
               isEditing={isEditing}
               onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
               onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
+              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Fix the Add Widget button which was missing an onClick handler
- Now clicking Add Widget opens the widget picker modal

## Changes
- Added `onAddWidgetClick` prop to `DashboardSectionComponent`
- Added `onClick` handler to the Add Widget button
- Pass the handler from `Dashboard` to each section component

## Test plan
- [x] TypeScript compiles without errors
- [ ] Manual: Click Add Widget button opens the widget picker modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)