### PR TITLE
Add steps support to SparklineCardWidget

### DIFF
--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -13,6 +13,7 @@ import {
   fetchReadinessScores,
   fetchRestingHeartRate,
   fetchSleepScores,
+  fetchSteps,
   type PeriodMetricStats,
 } from '../../state/api'
 
@@ -121,6 +122,7 @@ const metricTitles: Record<string, string> = {
   readiness_score: 'Readiness Score',
   resting_heart_rate: 'Resting HR',
   sleep_score: 'Sleep Score',
+  steps: 'Steps',
 }
 
 // Map metric names to API fetch functions
@@ -129,6 +131,7 @@ const metricFetchers: Record<string, (start: Date, end: Date) => Promise<[Date, 
   readiness_score: fetchReadinessScores,
   resting_heart_rate: fetchRestingHeartRate,
   sleep_score: fetchSleepScores,
+  steps: fetchSteps,
 }
 
 // Map widget metric to API metric name for period summary
@@ -137,6 +140,7 @@ const metricToApiMetric: Record<string, string> = {
   readiness_score: 'readiness_score',
   resting_heart_rate: 'resting_heart_rate',
   sleep_score: 'sleep_score',
+  steps: 'steps',
 }
 
 export function SparklineCardWidget({ config }: SparklineCardWidgetProps) {


### PR DESCRIPTION
## Summary
- Fix sparkline widget showing "Insufficient data" for steps metric
- Add steps to the metric fetchers map so time series data is fetched

## Changes
Added `steps` to:
- `metricTitles` - display title
- `metricFetchers` - uses `fetchSteps` for time series data
- `metricToApiMetric` - API metric name mapping

## Test plan
- [x] TypeScript compiles without errors
- [ ] Manual: Add sparkline widget for steps, verify chart displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)