### PR TITLE
Fix cumulative metrics to use aggregate source only

### DIFF
--- a/apps/backend/src/db.integration.test.ts
+++ b/apps/backend/src/db.integration.test.ts
@@ -325,23 +325,25 @@ describe('Database Integration Tests', () => {
     test('upserts on conflict (same time + metric + source)', async () => {
       const user = getTestUser()
 
+      // Use a non-cumulative metric since cumulative metrics (steps, distance, etc.)
+      // filter by aggregate source in getTimeSeries
       await insertTimeSeries(user, [
-        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T00:00:00Z'), value: 5000 },
+        { metric: 'weight', source: 'health_connect', time: new Date('2024-01-15T00:00:00Z'), value: 75.5 },
       ])
 
       await insertTimeSeries(user, [
-        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T00:00:00Z'), value: 10000 },
+        { metric: 'weight', source: 'health_connect', time: new Date('2024-01-15T00:00:00Z'), value: 76.0 },
       ])
 
       const data = await getTimeSeries(
         user,
-        'steps',
+        'weight',
         new Date('2024-01-15T00:00:00Z'),
         new Date('2024-01-15T23:59:59Z'),
       )
 
       expect(data).toHaveLength(1)
-      expect(data[0][1]).toBe(10000)
+      expect(data[0][1]).toBe(76.0)
     })
 
     test('handles empty array gracefully', async () => {
@@ -430,6 +432,58 @@ describe('Database Integration Tests', () => {
       expect(hrData[0][1]).toBe(80) // Last heart_rate value
       expect(restingHrData).toHaveLength(1)
       expect(restingHrData[0][1]).toBe(65) // resting_heart_rate unchanged
+    })
+
+    test('cumulative metrics (steps) only return aggregate source data', async () => {
+      const user = getTestUser()
+
+      // Insert raw health_connect data (individual readings throughout the day)
+      await insertTimeSeries(user, [
+        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T10:00:00Z'), value: 500 },
+        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T12:00:00Z'), value: 1200 },
+        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T14:00:00Z'), value: 800 },
+      ])
+
+      // Insert aggregate data (deduplicated daily totals)
+      await insertTimeSeries(user, [
+        {
+          metric: 'steps',
+          source: 'health_connect_aggregate',
+          time: new Date('2024-01-15T00:00:00Z'),
+          value: 8500,
+        },
+      ])
+
+      // getTimeSeries should only return the aggregate, not the raw readings
+      const data = await getTimeSeries(
+        user,
+        'steps',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(data).toHaveLength(1)
+      expect(data[0][1]).toBe(8500) // Only the aggregate, not sum of raw readings
+    })
+
+    test('non-cumulative metrics (heart_rate) return all source data', async () => {
+      const user = getTestUser()
+
+      // Insert data from multiple sources
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'health_connect', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+        { metric: 'heart_rate', source: 'oura', time: new Date('2024-01-15T10:05:00Z'), value: 74 },
+      ])
+
+      // getTimeSeries should return all sources for non-cumulative metrics
+      const data = await getTimeSeries(
+        user,
+        'heart_rate',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(data).toHaveLength(2)
     })
   })
 

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -207,11 +207,20 @@ export const getTimeSeries = async (
   start: Date,
   end: Date,
 ): Promise<[Date, number][]> => {
+  // For cumulative metrics (steps, distance, etc.), only use aggregate source
+  // to avoid mixing raw readings with deduplicated daily totals
+  const isCumulative = cumulativeMetrics.includes(metric as MetricType)
+
   const result = await query(
     user,
-    `SELECT time, value FROM time_series
-     WHERE metric = $1 AND time >= $2 AND time <= $3
-     ORDER BY time`,
+    isCumulative ?
+      `SELECT time, value FROM time_series
+       WHERE metric = $1 AND time >= $2 AND time <= $3
+         AND source = 'health_connect_aggregate'
+       ORDER BY time`
+    : `SELECT time, value FROM time_series
+       WHERE metric = $1 AND time >= $2 AND time <= $3
+       ORDER BY time`,
     [metric, start, end],
   )
 
@@ -224,18 +233,43 @@ export const getTimeSeriesMultiMetric = async (
   start: Date,
   end: Date,
 ): Promise<Record<MetricType, [Date, number][]>> => {
-  const result = await query(
-    user,
-    `SELECT time, metric, value FROM time_series
-     WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-     ORDER BY metric, time`,
-    [metrics, start, end],
-  )
+  if (metrics.length === 0) return {} as Record<MetricType, [Date, number][]>
+
+  // Split metrics into cumulative (steps, distance, etc.) and non-cumulative
+  const cumulativeRequested = metrics.filter((m) => cumulativeMetrics.includes(m))
+  const nonCumulativeRequested = metrics.filter((m) => !cumulativeMetrics.includes(m))
 
   const data: Record<string, [Date, number][]> = {}
-  for (const row of result.rows) {
-    if (!data[row.metric]) data[row.metric] = []
-    data[row.metric].push([new Date(row.time), row.value])
+
+  // Query cumulative metrics using only aggregate source (deduplicated daily totals)
+  if (cumulativeRequested.length > 0) {
+    const cumulativeResult = await query(
+      user,
+      `SELECT time, metric, value FROM time_series
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+         AND source = 'health_connect_aggregate'
+       ORDER BY metric, time`,
+      [cumulativeRequested, start, end],
+    )
+    for (const row of cumulativeResult.rows) {
+      if (!data[row.metric]) data[row.metric] = []
+      data[row.metric].push([new Date(row.time), row.value])
+    }
+  }
+
+  // Query non-cumulative metrics (all sources)
+  if (nonCumulativeRequested.length > 0) {
+    const nonCumulativeResult = await query(
+      user,
+      `SELECT time, metric, value FROM time_series
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+       ORDER BY metric, time`,
+      [nonCumulativeRequested, start, end],
+    )
+    for (const row of nonCumulativeResult.rows) {
+      if (!data[row.metric]) data[row.metric] = []
+      data[row.metric].push([new Date(row.time), row.value])
+    }
   }
 
   return data as Record<MetricType, [Date, number][]>
@@ -263,32 +297,77 @@ export const getTimeSeriesStats = async (
 ): Promise<MetricStats[]> => {
   if (metrics.length === 0) return []
 
-  const result = await query(
-    user,
-    `SELECT
-       metric,
-       COUNT(*)::integer as count,
-       MIN(value) as min,
-       MAX(value) as max,
-       AVG(value) as avg,
-       STDDEV_POP(value) as stddev,
-       MAX(unit) as unit
-     FROM time_series
-     WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-     GROUP BY metric
-     ORDER BY metric`,
-    [metrics, start, end],
-  )
+  // Split metrics into cumulative (steps, distance, etc.) and non-cumulative
+  const cumulativeRequested = metrics.filter((m) => cumulativeMetrics.includes(m as MetricType))
+  const nonCumulativeRequested = metrics.filter((m) => !cumulativeMetrics.includes(m as MetricType))
 
-  return result.rows.map((row) => ({
-    avg: row.avg !== null ? Number(row.avg) : 0,
-    count: row.count,
-    max: row.max !== null ? Number(row.max) : 0,
-    metric: row.metric as string,
-    min: row.min !== null ? Number(row.min) : 0,
-    stddev: row.stddev !== null ? Number(row.stddev) : 0,
-    unit: row.unit,
-  }))
+  const results: MetricStats[] = []
+
+  // Query cumulative metrics using only aggregate source (deduplicated daily totals)
+  if (cumulativeRequested.length > 0) {
+    const cumulativeResult = await query(
+      user,
+      `SELECT
+         metric,
+         COUNT(*)::integer as count,
+         MIN(value) as min,
+         MAX(value) as max,
+         AVG(value) as avg,
+         STDDEV_POP(value) as stddev,
+         MAX(unit) as unit
+       FROM time_series
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+         AND source = 'health_connect_aggregate'
+       GROUP BY metric
+       ORDER BY metric`,
+      [cumulativeRequested, start, end],
+    )
+    results.push(
+      ...cumulativeResult.rows.map((row) => ({
+        avg: row.avg !== null ? Number(row.avg) : 0,
+        count: row.count,
+        max: row.max !== null ? Number(row.max) : 0,
+        metric: row.metric as string,
+        min: row.min !== null ? Number(row.min) : 0,
+        stddev: row.stddev !== null ? Number(row.stddev) : 0,
+        unit: row.unit,
+      })),
+    )
+  }
+
+  // Query non-cumulative metrics (all sources)
+  if (nonCumulativeRequested.length > 0) {
+    const nonCumulativeResult = await query(
+      user,
+      `SELECT
+         metric,
+         COUNT(*)::integer as count,
+         MIN(value) as min,
+         MAX(value) as max,
+         AVG(value) as avg,
+         STDDEV_POP(value) as stddev,
+         MAX(unit) as unit
+       FROM time_series
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+       GROUP BY metric
+       ORDER BY metric`,
+      [nonCumulativeRequested, start, end],
+    )
+    results.push(
+      ...nonCumulativeResult.rows.map((row) => ({
+        avg: row.avg !== null ? Number(row.avg) : 0,
+        count: row.count,
+        max: row.max !== null ? Number(row.max) : 0,
+        metric: row.metric as string,
+        min: row.min !== null ? Number(row.min) : 0,
+        stddev: row.stddev !== null ? Number(row.stddev) : 0,
+        unit: row.unit,
+      })),
+    )
+  }
+
+  // Sort by metric name for consistent ordering
+  return results.sort((a, b) => a.metric.localeCompare(b.metric))
 }
 
 export interface DailyMetricAggregate {
@@ -306,26 +385,70 @@ export const getDailyAggregates = async (
 ): Promise<DailyMetricAggregate[]> => {
   if (metrics.length === 0) return []
 
-  const result = await query(
-    user,
-    `SELECT
-       DATE(time) as date,
-       metric,
-       AVG(value) as avg,
-       SUM(value) as sum
-     FROM time_series
-     WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-     GROUP BY DATE(time), metric
-     ORDER BY metric, date`,
-    [metrics, start, end],
-  )
+  // Split metrics into cumulative (steps, distance, etc.) and non-cumulative
+  const cumulativeRequested = metrics.filter((m) => cumulativeMetrics.includes(m as MetricType))
+  const nonCumulativeRequested = metrics.filter((m) => !cumulativeMetrics.includes(m as MetricType))
 
-  return result.rows.map((row) => ({
-    avg: Number(row.avg),
-    date: row.date.toISOString().split('T')[0],
-    metric: row.metric as string,
-    sum: Number(row.sum),
-  }))
+  const results: DailyMetricAggregate[] = []
+
+  // Query cumulative metrics using only aggregate source (deduplicated daily totals)
+  // For cumulative metrics, avg and sum are the same (one value per day)
+  if (cumulativeRequested.length > 0) {
+    const cumulativeResult = await query(
+      user,
+      `SELECT
+         DATE(time) as date,
+         metric,
+         AVG(value) as avg,
+         SUM(value) as sum
+       FROM time_series
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+         AND source = 'health_connect_aggregate'
+       GROUP BY DATE(time), metric
+       ORDER BY metric, date`,
+      [cumulativeRequested, start, end],
+    )
+    results.push(
+      ...cumulativeResult.rows.map((row) => ({
+        avg: Number(row.avg),
+        date: row.date.toISOString().split('T')[0],
+        metric: row.metric as string,
+        sum: Number(row.sum),
+      })),
+    )
+  }
+
+  // Query non-cumulative metrics (all sources)
+  if (nonCumulativeRequested.length > 0) {
+    const nonCumulativeResult = await query(
+      user,
+      `SELECT
+         DATE(time) as date,
+         metric,
+         AVG(value) as avg,
+         SUM(value) as sum
+       FROM time_series
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+       GROUP BY DATE(time), metric
+       ORDER BY metric, date`,
+      [nonCumulativeRequested, start, end],
+    )
+    results.push(
+      ...nonCumulativeResult.rows.map((row) => ({
+        avg: Number(row.avg),
+        date: row.date.toISOString().split('T')[0],
+        metric: row.metric as string,
+        sum: Number(row.sum),
+      })),
+    )
+  }
+
+  // Sort by metric and date for consistent ordering
+  return results.sort((a, b) => {
+    const metricCmp = a.metric.localeCompare(b.metric)
+    if (metricCmp !== 0) return metricCmp
+    return a.date.localeCompare(b.date)
+  })
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Fixed `getTimeSeries`, `getTimeSeriesMultiMetric`, `getTimeSeriesStats`, and `getDailyAggregates` to filter cumulative metrics by `source='health_connect_aggregate'`
- Cumulative metrics (steps, distance, floors_climbed, calories_active, calories_total) now only use deduplicated daily totals instead of mixing raw readings with aggregates
- This fixes incorrect statistics like steps showing average of 103 instead of thousands

## Test plan
- [x] Added integration tests for cumulative metrics filtering behavior
- [x] All 567 tests pass
- [ ] Manual testing: Verify dashboard shows correct steps average after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)