### PR TITLE
Add responsive dashboard sections and section management

### DIFF
--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import type { DashboardConfig, DashboardSection, DashboardWidget } from '@aurboda/api-spec'
+import type { DashboardConfig, DashboardSection, DashboardWidget, SectionType } from '@aurboda/api-spec'
 import { defaultDashboardConfig } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
@@ -8,6 +8,9 @@ import { fetchDashboard, resetDashboard, saveDashboard } from '../../state/api'
 
 import './style.css'
 
+// Generate unique section ID
+const generateSectionId = () => `section-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
 // Section renderer - renders a section with its widgets
 function DashboardSectionComponent({
   section,
@@ -15,12 +18,14 @@ function DashboardSectionComponent({
   onRemoveWidget,
   onMoveWidget,
   onAddWidgetClick,
+  onDeleteSection,
 }: {
   section: DashboardSection
   isEditing: boolean
   onRemoveWidget?: (widgetId: string) => void
   onMoveWidget?: (widgetId: string, direction: 'up' | 'down') => void
   onAddWidgetClick?: () => void
+  onDeleteSection?: () => void
 }) {
   const [collapsed, setCollapsed] = useState(section.collapsed ?? false)
 
@@ -39,6 +44,22 @@ function DashboardSectionComponent({
             <span class="collapse-indicator">{collapsed ? '\u25B6' : '\u25BC'}</span>
           )}
         </h2>
+        {isEditing && (
+          <div class="section-edit-controls">
+            <button class="section-delete-btn" onClick={onDeleteSection} title="Delete section">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+              </svg>
+            </button>
+          </div>
+        )}
       </div>
       {!collapsed && (
         <div class={gridClass}>
@@ -116,10 +137,88 @@ function DashboardSectionComponent({
   )
 }
 
+// Add Section form component
+function AddSectionForm({
+  onAdd,
+  onCancel,
+}: {
+  onAdd: (title: string, type: SectionType) => void
+  onCancel: () => void
+}) {
+  const [title, setTitle] = useState('')
+  const [type, setType] = useState<SectionType>('metrics')
+
+  const handleSubmit = (e: Event) => {
+    e.preventDefault()
+    if (title.trim()) {
+      onAdd(title.trim(), type)
+    }
+  }
+
+  return (
+    <div class="add-section-placeholder">
+      <form onSubmit={handleSubmit} style={{ maxWidth: '300px', width: '100%' }}>
+        <div class="form-group" style={{ marginBottom: '0.75rem' }}>
+          <input
+            type="text"
+            value={title}
+            onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+            placeholder="Section title"
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              fontSize: '0.875rem',
+              padding: '0.5rem',
+              width: '100%',
+            }}
+            autoFocus
+          />
+        </div>
+        <div class="form-group" style={{ marginBottom: '0.75rem' }}>
+          <select
+            value={type}
+            onChange={(e) => setType((e.target as HTMLSelectElement).value as SectionType)}
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              fontSize: '0.875rem',
+              padding: '0.5rem',
+              width: '100%',
+            }}
+          >
+            <option value="metrics">Metrics (cards)</option>
+            <option value="charts">Charts (full width)</option>
+            <option value="links">Links (navigation)</option>
+          </select>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            class="btn-secondary"
+            style={{ fontSize: '0.875rem', padding: '0.375rem 0.75rem' }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="btn-primary"
+            style={{ fontSize: '0.875rem', padding: '0.375rem 0.75rem' }}
+            disabled={!title.trim()}
+          >
+            Add Section
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
 export function Dashboard() {
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = useState(false)
   const [showWidgetPicker, setShowWidgetPicker] = useState<string | null>(null) // section id or null
+  const [showAddSection, setShowAddSection] = useState(false)
 
   // Fetch dashboard configuration
   const dashboardQuery = useQuery({
@@ -192,17 +291,46 @@ export function Dashboard() {
     setShowWidgetPicker(null)
   }
 
+  const handleAddSection = (title: string, type: SectionType) => {
+    const newSection: DashboardSection = {
+      id: generateSectionId(),
+      title,
+      type,
+      widgets: [],
+    }
+    const newDashboard: DashboardConfig = {
+      ...dashboard,
+      sections: [...dashboard.sections, newSection],
+    }
+    saveMutation.mutate(newDashboard)
+    setShowAddSection(false)
+  }
+
+  const handleDeleteSection = (sectionId: string) => {
+    const section = dashboard.sections.find((s) => s.id === sectionId)
+    if (!section) return
+
+    const widgetCount = section.widgets.length
+    const message =
+      widgetCount > 0 ?
+        `Delete section "${section.title}" and its ${widgetCount} widget${widgetCount > 1 ? 's' : ''}?`
+      : `Delete section "${section.title}"?`
+
+    if (confirm(message)) {
+      const newDashboard: DashboardConfig = {
+        ...dashboard,
+        sections: dashboard.sections.filter((s) => s.id !== sectionId),
+      }
+      saveMutation.mutate(newDashboard)
+    }
+  }
+
   const handleReset = () => {
     if (confirm('Reset dashboard to default configuration? Your customizations will be lost.')) {
       resetMutation.mutate()
       setIsEditing(false)
     }
   }
-
-  // Organize sections into columns for layout
-  const metricsSections = dashboard.sections.filter((s) => s.type === 'metrics')
-  const chartsSections = dashboard.sections.filter((s) => s.type === 'charts')
-  const linksSections = dashboard.sections.filter((s) => s.type === 'links')
 
   return (
     <div class="dashboard">
@@ -237,47 +365,40 @@ export function Dashboard() {
 
       {isLoading && <div class="loading">Loading your dashboard...</div>}
 
-      {/* Metrics sections in two columns */}
-      {metricsSections.length > 0 && (
-        <div class="metrics-columns">
-          {metricsSections.map((section) => (
-            <DashboardSectionComponent
-              key={section.id}
-              section={section}
-              isEditing={isEditing}
-              onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
-              onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
-              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
-            />
-          ))}
-        </div>
-      )}
+      {/* All sections in responsive grid */}
+      <div class="sections-grid">
+        {dashboard.sections.map((section) => (
+          <DashboardSectionComponent
+            key={section.id}
+            section={section}
+            isEditing={isEditing}
+            onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
+            onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
+            onAddWidgetClick={() => setShowWidgetPicker(section.id)}
+            onDeleteSection={() => handleDeleteSection(section.id)}
+          />
+        ))}
 
-      {/* Charts and links sections in two columns */}
-      {(chartsSections.length > 0 || linksSections.length > 0) && (
-        <div class="bottom-columns">
-          {chartsSections.map((section) => (
-            <DashboardSectionComponent
-              key={section.id}
-              section={section}
-              isEditing={isEditing}
-              onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
-              onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
-              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
-            />
-          ))}
-          {linksSections.map((section) => (
-            <DashboardSectionComponent
-              key={section.id}
-              section={section}
-              isEditing={isEditing}
-              onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
-              onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
-              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
-            />
-          ))}
-        </div>
-      )}
+        {/* Add Section button/form in edit mode */}
+        {isEditing &&
+          (showAddSection ?
+            <AddSectionForm onAdd={handleAddSection} onCancel={() => setShowAddSection(false)} />
+          : <div class="add-section-placeholder">
+              <button class="add-section-btn" onClick={() => setShowAddSection(true)}>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M12 5v14M5 12h14" />
+                </svg>
+                Add Section
+              </button>
+            </div>)}
+      </div>
 
       {/* Widget picker modal */}
       {showWidgetPicker && (

--- a/apps/web/src/pages/Dashboard/style.css
+++ b/apps/web/src/pages/Dashboard/style.css
@@ -102,27 +102,16 @@
   color: #888;
 }
 
-/* Two-column layout for baseline and summary on wide screens */
-.dashboard .metrics-columns {
+/* Responsive sections grid - flows naturally based on available width */
+.dashboard .sections-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr));
   gap: 2rem;
   margin-bottom: 2rem;
-}
-
-/* Two-column layout for activity summary and quick links */
-.dashboard .bottom-columns {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2rem;
 }
 
 .dashboard .metrics-section {
-  margin-bottom: 2rem;
-}
-
-.dashboard .metrics-columns .metrics-section {
-  margin-bottom: 0;
+  min-width: 0; /* Prevent grid blowout */
 }
 
 /* Metrics grid */
@@ -449,23 +438,7 @@
   }
 }
 
-/* Responsive */
-@media (max-width: 1100px) {
-  .dashboard .metrics-columns,
-  .dashboard .bottom-columns {
-    grid-template-columns: 1fr;
-  }
-
-  .dashboard .metrics-columns .metrics-section,
-  .dashboard .bottom-columns .metrics-section {
-    margin-bottom: 2rem;
-  }
-
-  .dashboard .metrics-columns .metrics-section:last-child,
-  .dashboard .bottom-columns .metrics-section:last-child {
-    margin-bottom: 0;
-  }
-}
+/* Responsive - sections grid handles this automatically via auto-fit */
 
 @media (max-width: 639px) {
   .dashboard {
@@ -611,6 +584,61 @@
   color: #9ca3af;
 }
 
+/* Add Section placeholder */
+.dashboard .add-section-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  border: 2px dashed #d1d5db;
+  border-radius: 12px;
+  background: #f9fafb;
+  padding: 2rem;
+}
+
+.dashboard .add-section-btn {
+  background: none;
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  color: #6b7280;
+  font-size: 0.875rem;
+  cursor: pointer;
+  padding: 1rem 1.5rem;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard .add-section-btn:hover {
+  border-color: #673ab8;
+  color: #673ab8;
+  background: #faf5ff;
+}
+
+/* Section editing controls */
+.dashboard .section-edit-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.dashboard .section-delete-btn {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.dashboard .section-delete-btn:hover {
+  color: #dc2626;
+  background: #fee2e2;
+}
+
 /* Dark mode additions for editing */
 @media (prefers-color-scheme: dark) {
   .dashboard .btn-edit {
@@ -672,5 +700,26 @@
   .dashboard .trend-chart-widget h4,
   .dashboard .correlation-widget h4 {
     color: #d1d5db;
+  }
+
+  .dashboard .add-section-placeholder {
+    background: #111827;
+    border-color: #4b5563;
+  }
+
+  .dashboard .add-section-btn {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .dashboard .add-section-btn:hover {
+    border-color: #8b5cf6;
+    color: #a855f7;
+    background: #1e1b4b;
+  }
+
+  .dashboard .section-delete-btn:hover {
+    color: #f87171;
+    background: #7f1d1d;
   }
 }


### PR DESCRIPTION
## Summary
- Changed dashboard layout to use responsive CSS grid with `auto-fit`
- Sections now flow naturally and wrap based on available width
- Wider screens will show more columns (2, 3, or more sections side by side)
- Added ability to create new sections (with title and type selection)
- Added ability to delete sections (with confirmation dialog)

## Changes
- **Responsive grid**: Uses `repeat(auto-fit, minmax(min(100%, 400px), 1fr))` so sections automatically fill available space
- **Add Section**: In edit mode, a "+ Add Section" button appears. Click to add a new section with custom title and type (metrics/charts/links)
- **Delete Section**: Each section now has a delete button in edit mode (trash icon)

## Test plan
- [ ] Resize browser window to see sections reflow (1 col on mobile, 2-3+ on wide screens)
- [ ] In edit mode, add a new section and verify it appears
- [ ] Delete a section and verify it's removed (with confirmation)
- [ ] Reset to default still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)