### PR TITLE
Fix Dashboard width by removing .home wrapper when logged in

### DIFF
--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -191,10 +191,6 @@ function GuestHome({ canSignup }: { canSignup: boolean }) {
   )
 }
 
-function LoggedInHome() {
-  return <Dashboard />
-}
-
 export function Home() {
   const isLoggedIn = auth.value.token
   const canSignup = signupAllowed.value
@@ -202,6 +198,11 @@ export function Home() {
   useEffect(() => {
     ensureStatusLoaded()
   }, [])
+
+  // When logged in, show Dashboard without the .home wrapper (which has max-width: 800px)
+  if (isLoggedIn) {
+    return <Dashboard />
+  }
 
   return (
     <div class="home">
@@ -213,9 +214,7 @@ export function Home() {
         </div>
       </div>
 
-      {isLoggedIn ?
-        <LoggedInHome />
-      : <GuestHome canSignup={canSignup} />}
+      <GuestHome canSignup={canSignup} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
The Home page's `.home` class has `max-width: 800px` which was constraining the Dashboard to a single column even on wide screens.

## Fix
When logged in, render the Dashboard directly without the `.home` wrapper, allowing it to use the full viewport width for the responsive grid layout.

## Test plan
- [ ] Log in and verify Dashboard sections now display in multiple columns on wide screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)