### PR TITLE
Add Last.fm integration for auto-tagging scrobbles

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -124,6 +124,8 @@ import {
   upsertUserSettings,
 } from './db'
 import { syncAllCalendars } from './ical-sync'
+import { createLastFmRouter } from './lastfm-router'
+import { syncLastFmData } from './lastfm-sync'
 import { createMcpRouter } from './mcp'
 import { createDbSessionStore } from './mcp-session-store'
 import { ouraClient } from './oura'
@@ -420,27 +422,43 @@ const main = async () => {
     }
   }
 
+  // Transform Last.fm sync result
+  const transformLastFmSyncResult = async (
+    user: string,
+    apiKey: string,
+    username: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => {
+    return await syncLastFmData(user, apiKey, username, options)
+  }
+
   // Sync router - handles /sync/* endpoints
   httpd.use(
     '/sync',
     createSyncRouter(
       {
         getCalendarSyncStates: (user) => transformSyncStates(user, 'calendar'),
+        getLastFmSyncStates: (user) => transformSyncStates(user, 'lastfm'),
         getOuraSyncStates: (user) => transformSyncStates(user, 'oura'),
         getRescueTimeSyncStates: (user) => transformSyncStates(user, 'rescuetime'),
         getSettings,
         processDailyAggregate,
         processHealthConnectData,
         resetCalendarSyncState: (user) => resetSyncState(user, 'calendar'),
+        resetLastFmSyncState: (user) => resetSyncState(user, 'lastfm'),
         resetOuraSyncState: (user, dataType) => resetSyncState(user, 'oura', dataType),
         resetRescueTimeSyncState: (user) => resetSyncState(user, 'rescuetime'),
         syncCalendars: (user, calendars) => syncAllCalendars(user, calendars),
+        syncLastFm: transformLastFmSyncResult,
         syncOura: transformOuraSyncResults,
         syncRescueTime: transformRescueTimeSyncResult,
       },
       authMiddleware,
     ),
   )
+
+  // Last.fm router - handles /lastfm/* endpoints
+  httpd.use('/lastfm', createLastFmRouter(authMiddleware))
 
   httpd.get('/auth/connectOura', oura.redirectToAuthorize)
   httpd.get('/auth/ouracb', oura.authCb)

--- a/apps/backend/src/db.integration.test.ts
+++ b/apps/backend/src/db.integration.test.ts
@@ -9,12 +9,14 @@ import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   deleteActivity,
+  deleteLastFmTagRule,
   deleteMcpSession,
   deleteTag,
   findMergeableTag,
   getActivities,
   getActivityById,
   getDailyAggregateValue,
+  getLastFmTagRules,
   getMcpSession,
   getMcpSessionsForUser,
   getProgrammaticTags,
@@ -25,6 +27,7 @@ import {
   getUniqueTags,
   getUserSettings,
   insertActivity,
+  insertLastFmTagRule,
   insertTag,
   insertTimeSeries,
   isProgrammaticTag,
@@ -1710,6 +1713,190 @@ describe('Database Integration Tests', () => {
       expect(settings?.dashboard?.sections).toHaveLength(3)
       expect(settings?.dashboard?.sections[0].widgets).toHaveLength(2)
       expect(settings?.dashboard?.sections[1].collapsed).toBe(true)
+    })
+  })
+
+  // ==========================================================================
+  // Last.fm Tag Rules
+  // ==========================================================================
+
+  describe('Last.fm Tag Rules', () => {
+    test('insertLastFmTagRule creates a new rule', async () => {
+      const user = getTestUser()
+
+      const rule = await insertLastFmTagRule(user, {
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Vocal Exercises',
+        tagName: 'VocalExercises',
+        trackName: 'Warmup Track',
+      })
+
+      expect(rule.id).toBeDefined()
+      expect(rule.ruleName).toBe('Vocal Exercises')
+      expect(rule.matchType).toBe('track')
+      expect(rule.trackName).toBe('Warmup Track')
+      expect(rule.matchMode).toBe('exact')
+      expect(rule.tagName).toBe('VocalExercises')
+      expect(rule.createdAt).toBeInstanceOf(Date)
+    })
+
+    test('insertLastFmTagRule creates rule with artist match type', async () => {
+      const user = getTestUser()
+
+      const rule = await insertLastFmTagRule(user, {
+        artistName: 'Relaxation Artist',
+        matchMode: 'contains',
+        matchType: 'artist',
+        ruleName: 'Meditation Music',
+        tagName: 'Meditation',
+      })
+
+      expect(rule.matchType).toBe('artist')
+      expect(rule.artistName).toBe('Relaxation Artist')
+      expect(rule.matchMode).toBe('contains')
+      expect(rule.trackName).toBeUndefined()
+    })
+
+    test('insertLastFmTagRule creates rule with track_artist match type', async () => {
+      const user = getTestUser()
+
+      const rule = await insertLastFmTagRule(user, {
+        artistName: 'Favorite Artist',
+        matchMode: 'exact',
+        matchType: 'track_artist',
+        ruleName: 'Specific Song',
+        tagName: 'FavoriteSong',
+        trackName: 'Best Song',
+      })
+
+      expect(rule.matchType).toBe('track_artist')
+      expect(rule.trackName).toBe('Best Song')
+      expect(rule.artistName).toBe('Favorite Artist')
+    })
+
+    test('getLastFmTagRules returns all rules for user', async () => {
+      const user = getTestUser()
+
+      await insertLastFmTagRule(user, {
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Rule 1',
+        tagName: 'Tag1',
+        trackName: 'Track 1',
+      })
+      await insertLastFmTagRule(user, {
+        artistName: 'Artist 2',
+        matchMode: 'contains',
+        matchType: 'artist',
+        ruleName: 'Rule 2',
+        tagName: 'Tag2',
+      })
+
+      const rules = await getLastFmTagRules(user)
+
+      expect(rules).toHaveLength(2)
+      expect(rules.map((r) => r.ruleName).sort()).toEqual(['Rule 1', 'Rule 2'])
+    })
+
+    test('getLastFmTagRules returns empty array when no rules exist', async () => {
+      const user = getTestUser()
+
+      const rules = await getLastFmTagRules(user)
+
+      expect(rules).toEqual([])
+    })
+
+    test('deleteLastFmTagRule deletes existing rule and returns true', async () => {
+      const user = getTestUser()
+
+      const rule = await insertLastFmTagRule(user, {
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'To Delete',
+        tagName: 'ToDelete',
+        trackName: 'Some Track',
+      })
+
+      const deleted = await deleteLastFmTagRule(user, rule.id)
+
+      expect(deleted).toBe(true)
+
+      const rules = await getLastFmTagRules(user)
+      expect(rules).toHaveLength(0)
+    })
+
+    test('deleteLastFmTagRule returns false when rule not found', async () => {
+      const user = getTestUser()
+
+      const deleted = await deleteLastFmTagRule(user, randomUUID())
+
+      expect(deleted).toBe(false)
+    })
+
+    test('insertLastFmTagRule rejects duplicate rules', async () => {
+      const user = getTestUser()
+
+      // Use track_artist match type so both track and artist have non-null values
+      // (NULL values are not considered equal in PostgreSQL unique constraints)
+      await insertLastFmTagRule(user, {
+        artistName: 'Unique Artist',
+        matchMode: 'exact',
+        matchType: 'track_artist',
+        ruleName: 'Original Rule',
+        tagName: 'UniqueTag',
+        trackName: 'Unique Track',
+      })
+
+      // Attempt to insert duplicate (same match_type, track_name, artist_name, tag_name)
+      await expect(
+        insertLastFmTagRule(user, {
+          artistName: 'Unique Artist',
+          matchMode: 'contains', // different mode, but still same unique key
+          matchType: 'track_artist',
+          ruleName: 'Duplicate Rule',
+          tagName: 'UniqueTag',
+          trackName: 'Unique Track',
+        }),
+      ).rejects.toThrow()
+    })
+
+    test('insertLastFmTagRule allows same track with different tag names', async () => {
+      const user = getTestUser()
+
+      await insertLastFmTagRule(user, {
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Rule 1',
+        tagName: 'Tag1',
+        trackName: 'Same Track',
+      })
+
+      const rule2 = await insertLastFmTagRule(user, {
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Rule 2',
+        tagName: 'Tag2',
+        trackName: 'Same Track',
+      })
+
+      expect(rule2.tagName).toBe('Tag2')
+
+      const rules = await getLastFmTagRules(user)
+      expect(rules).toHaveLength(2)
+    })
+
+    test('insertLastFmTagRule defaults matchMode to exact', async () => {
+      const user = getTestUser()
+
+      const rule = await insertLastFmTagRule(user, {
+        matchType: 'track',
+        ruleName: 'Default Mode',
+        tagName: 'TestTag',
+        trackName: 'Test Track',
+      })
+
+      expect(rule.matchMode).toBe('exact')
     })
   })
 })

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1992,6 +1992,7 @@ export interface UserSettings {
   dashboard?: DashboardConfig // Custom dashboard configuration
   goals?: Goal[] // User-defined goals for tracking metrics
   hrZoneStart?: { 1: number; 2: number; 3: number; 4: number; 5: number }
+  lastFmUsername?: string // Last.fm username for scrobble sync
   rescueTimeKey?: string // RescueTime API key (personal token)
   tagMappings?: Record<string, string> // Tag name mappings from UUIDs to display names
 }
@@ -2013,6 +2014,7 @@ export const getUserSettings = async (user: string): Promise<UserSettings | null
     dashboard: settings.dashboard as DashboardConfig | undefined,
     goals: settings.goals as Goal[] | undefined,
     hrZoneStart: settings.hrZoneStart as UserSettings['hrZoneStart'],
+    lastFmUsername: settings.lastFmUsername as string | undefined,
     rescueTimeKey: settings.rescueTimeKey as string | undefined,
     tagMappings: settings.tagMappings as UserSettings['tagMappings'],
   }
@@ -2049,6 +2051,9 @@ export const upsertUserSettings = async (
   if (updates.hrZoneStart !== undefined) {
     merged.hrZoneStart = updates.hrZoneStart
   }
+  if (updates.lastFmUsername !== undefined) {
+    merged.lastFmUsername = updates.lastFmUsername
+  }
   if (updates.rescueTimeKey !== undefined) {
     merged.rescueTimeKey = updates.rescueTimeKey
   }
@@ -2068,6 +2073,96 @@ export const upsertUserSettings = async (
   }
 
   return merged
+}
+
+// ============================================================================
+// Last.fm Tag Rules
+// ============================================================================
+
+export type LastFmMatchType = 'track' | 'artist' | 'track_artist'
+export type LastFmMatchMode = 'exact' | 'contains'
+
+export interface LastFmTagRule {
+  id: string
+  ruleName: string
+  matchType: LastFmMatchType
+  trackName?: string
+  artistName?: string
+  matchMode: LastFmMatchMode
+  tagName: string
+  createdAt: Date
+}
+
+export interface LastFmTagRuleInput {
+  ruleName: string
+  matchType: LastFmMatchType
+  trackName?: string
+  artistName?: string
+  matchMode?: LastFmMatchMode
+  tagName: string
+}
+
+/**
+ * Get all Last.fm tag rules for a user.
+ */
+export const getLastFmTagRules = async (user: string): Promise<LastFmTagRule[]> => {
+  const result = await query(
+    user,
+    `SELECT id, rule_name, match_type, track_name, artist_name, match_mode, tag_name, created_at
+     FROM lastfm_tag_rules
+     ORDER BY created_at DESC`,
+  )
+
+  return result.rows.map((row) => ({
+    artistName: row.artist_name ?? undefined,
+    createdAt: new Date(row.created_at),
+    id: row.id,
+    matchMode: row.match_mode as LastFmMatchMode,
+    matchType: row.match_type as LastFmMatchType,
+    ruleName: row.rule_name,
+    tagName: row.tag_name,
+    trackName: row.track_name ?? undefined,
+  }))
+}
+
+/**
+ * Insert a new Last.fm tag rule.
+ */
+export const insertLastFmTagRule = async (user: string, rule: LastFmTagRuleInput): Promise<LastFmTagRule> => {
+  const result = await query(
+    user,
+    `INSERT INTO lastfm_tag_rules (rule_name, match_type, track_name, artist_name, match_mode, tag_name)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id, rule_name, match_type, track_name, artist_name, match_mode, tag_name, created_at`,
+    [
+      rule.ruleName,
+      rule.matchType,
+      rule.trackName ?? null,
+      rule.artistName ?? null,
+      rule.matchMode ?? 'exact',
+      rule.tagName,
+    ],
+  )
+
+  const row = result.rows[0]
+  return {
+    artistName: row.artist_name ?? undefined,
+    createdAt: new Date(row.created_at),
+    id: row.id,
+    matchMode: row.match_mode as LastFmMatchMode,
+    matchType: row.match_type as LastFmMatchType,
+    ruleName: row.rule_name,
+    tagName: row.tag_name,
+    trackName: row.track_name ?? undefined,
+  }
+}
+
+/**
+ * Delete a Last.fm tag rule by ID.
+ */
+export const deleteLastFmTagRule = async (user: string, ruleId: string): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM lastfm_tag_rules WHERE id = $1`, [ruleId])
+  return (result.rowCount ?? 0) > 0
 }
 
 // ============================================================================

--- a/apps/backend/src/lastfm-router.ts
+++ b/apps/backend/src/lastfm-router.ts
@@ -1,0 +1,129 @@
+/**
+ * Last.fm tag rules router.
+ *
+ * Provides REST API endpoints for managing Last.fm auto-tagging rules.
+ */
+
+import {
+  addLastFmTagRuleBodySchema,
+  type AddLastFmTagRuleBody,
+  type AddLastFmTagRuleResponse,
+  type LastFmTagRulesResponse,
+  type SyncResponse,
+} from '@aurboda/api-spec'
+import { RequestHandler, Router } from 'express'
+import type { ParamsDictionary } from 'express-serve-static-core'
+import {
+  deleteLastFmTagRule,
+  getLastFmTagRules,
+  insertLastFmTagRule,
+  type LastFmMatchMode,
+  type LastFmMatchType,
+} from './db'
+import { validateBody } from './validation'
+
+/**
+ * Creates the Last.fm router with tag rules CRUD endpoints.
+ */
+export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
+  const router = Router()
+
+  // GET /lastfm/tag-rules - List all tag rules
+  router.get<ParamsDictionary, LastFmTagRulesResponse>('/tag-rules', authMiddleware, async (req, res) => {
+    const user = req.user!
+
+    try {
+      const rules = await getLastFmTagRules(user)
+      const serialized = rules.map((r) => ({
+        artistName: r.artistName,
+        createdAt: r.createdAt.toISOString(),
+        id: r.id,
+        matchMode: r.matchMode,
+        matchType: r.matchType,
+        ruleName: r.ruleName,
+        tagName: r.tagName,
+        trackName: r.trackName,
+      }))
+      res.json({ data: serialized, success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false } as LastFmTagRulesResponse)
+    }
+  })
+
+  // POST /lastfm/tag-rules - Create a new tag rule
+  router.post<ParamsDictionary, AddLastFmTagRuleResponse, AddLastFmTagRuleBody>(
+    '/tag-rules',
+    authMiddleware,
+    validateBody(addLastFmTagRuleBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const { ruleName, matchType, trackName, artistName, matchMode, tagName } = req.body
+
+      // Validate required fields based on match_type
+      if ((matchType === 'track' || matchType === 'track_artist') && !trackName) {
+        return res
+          .status(400)
+          .json({ error: `trackName is required for matchType "${matchType}"`, success: false })
+      }
+      if ((matchType === 'artist' || matchType === 'track_artist') && !artistName) {
+        return res
+          .status(400)
+          .json({ error: `artistName is required for matchType "${matchType}"`, success: false })
+      }
+
+      try {
+        const rule = await insertLastFmTagRule(user, {
+          artistName,
+          matchMode: (matchMode ?? 'exact') as LastFmMatchMode,
+          matchType: matchType as LastFmMatchType,
+          ruleName,
+          tagName,
+          trackName,
+        })
+
+        res.json({
+          data: {
+            artistName: rule.artistName,
+            createdAt: rule.createdAt.toISOString(),
+            id: rule.id,
+            matchMode: rule.matchMode,
+            matchType: rule.matchType,
+            ruleName: rule.ruleName,
+            tagName: rule.tagName,
+            trackName: rule.trackName,
+          },
+          success: true,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        // Check for unique constraint violation
+        if (message.includes('unique_rule')) {
+          return res
+            .status(409)
+            .json({ error: 'A rule with the same match criteria and tag already exists', success: false })
+        }
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
+
+  // DELETE /lastfm/tag-rules/:id - Delete a tag rule
+  router.delete<{ id: string }, SyncResponse>('/tag-rules/:id', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { id } = req.params
+
+    try {
+      const deleted = await deleteLastFmTagRule(user, id)
+      if (!deleted) {
+        return res.status(404).json({ error: 'Rule not found', success: false })
+      }
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  return router
+}

--- a/apps/backend/src/lastfm-sync.test.ts
+++ b/apps/backend/src/lastfm-sync.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Last.fm sync module tests.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LastFmTagRule } from './db'
+import type { Scrobble } from './lastfm'
+import { applyTagRules, matchesRule, syncLastFmData } from './lastfm-sync'
+
+// Mock the db module
+vi.mock('./db', () => ({
+  getLastFmTagRules: vi.fn(),
+  getSyncState: vi.fn(),
+  insertRawRecord: vi.fn(),
+  insertTag: vi.fn(),
+  upsertSyncState: vi.fn(),
+}))
+
+// Mock the lastfm module
+vi.mock('./lastfm', () => ({
+  lastfmClient: vi.fn(() => ({
+    getRecentTracks: vi.fn(),
+  })),
+}))
+
+import { getLastFmTagRules, getSyncState, insertRawRecord, insertTag, upsertSyncState } from './db'
+import { lastfmClient } from './lastfm'
+
+describe('matchesRule', () => {
+  const baseScrobble: Scrobble = {
+    album: 'Test Album',
+    artist: 'Test Artist',
+    timestamp: new Date('2024-01-01T00:00:00Z'),
+    track: 'Test Track',
+  }
+
+  const baseRule: LastFmTagRule = {
+    createdAt: new Date(),
+    id: 'rule-1',
+    matchMode: 'exact',
+    matchType: 'track',
+    ruleName: 'Test Rule',
+    tagName: 'TestTag',
+  }
+
+  describe('track match type', () => {
+    it('matches exact track name (case insensitive)', () => {
+      const rule = { ...baseRule, matchType: 'track' as const, trackName: 'Test Track' }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+
+      const ruleUpperCase = { ...baseRule, matchType: 'track' as const, trackName: 'TEST TRACK' }
+      expect(matchesRule(baseScrobble, ruleUpperCase)).toBe(true)
+    })
+
+    it('does not match different track name with exact mode', () => {
+      const rule = { ...baseRule, matchType: 'track' as const, trackName: 'Different Track' }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+
+    it('matches substring with contains mode', () => {
+      const rule = {
+        ...baseRule,
+        matchMode: 'contains' as const,
+        matchType: 'track' as const,
+        trackName: 'Test',
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('returns false when trackName is missing', () => {
+      const rule = { ...baseRule, matchType: 'track' as const }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+  })
+
+  describe('artist match type', () => {
+    it('matches exact artist name (case insensitive)', () => {
+      const rule = { ...baseRule, artistName: 'Test Artist', matchType: 'artist' as const }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('does not match different artist name with exact mode', () => {
+      const rule = { ...baseRule, artistName: 'Different Artist', matchType: 'artist' as const }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+
+    it('matches substring with contains mode', () => {
+      const rule = {
+        ...baseRule,
+        artistName: 'Test',
+        matchMode: 'contains' as const,
+        matchType: 'artist' as const,
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('returns false when artistName is missing', () => {
+      const rule = { ...baseRule, matchType: 'artist' as const }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+  })
+
+  describe('track_artist match type', () => {
+    it('matches when both track and artist match', () => {
+      const rule = {
+        ...baseRule,
+        artistName: 'Test Artist',
+        matchType: 'track_artist' as const,
+        trackName: 'Test Track',
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('does not match when only track matches', () => {
+      const rule = {
+        ...baseRule,
+        artistName: 'Different Artist',
+        matchType: 'track_artist' as const,
+        trackName: 'Test Track',
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+
+    it('does not match when only artist matches', () => {
+      const rule = {
+        ...baseRule,
+        artistName: 'Test Artist',
+        matchType: 'track_artist' as const,
+        trackName: 'Different Track',
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+
+    it('returns false when trackName or artistName is missing', () => {
+      const ruleNoTrack = { ...baseRule, artistName: 'Test Artist', matchType: 'track_artist' as const }
+      const ruleNoArtist = { ...baseRule, matchType: 'track_artist' as const, trackName: 'Test Track' }
+
+      expect(matchesRule(baseScrobble, ruleNoTrack)).toBe(false)
+      expect(matchesRule(baseScrobble, ruleNoArtist)).toBe(false)
+    })
+  })
+})
+
+describe('applyTagRules', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('creates tags for matching scrobbles', async () => {
+    const scrobbles: Scrobble[] = [
+      { artist: 'Vocal Artist', timestamp: new Date('2024-01-01T10:00:00Z'), track: 'Warmup Song' },
+      { artist: 'Other Artist', timestamp: new Date('2024-01-01T11:00:00Z'), track: 'Other Song' },
+    ]
+
+    const rules: LastFmTagRule[] = [
+      {
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Vocal Exercises',
+        tagName: 'VocalExercises',
+        trackName: 'Warmup Song',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    expect(tagsCreated).toBe(1)
+    expect(insertTag).toHaveBeenCalledTimes(1)
+    expect(insertTag).toHaveBeenCalledWith('testuser', {
+      externalId: expect.stringMatching(/^lastfm-auto-rule-1-/),
+      source: 'lastfm-auto',
+      startTime: new Date('2024-01-01T10:00:00Z'),
+      tag: 'VocalExercises',
+    })
+  })
+
+  it('returns 0 when no rules', async () => {
+    const scrobbles: Scrobble[] = [
+      { artist: 'Test Artist', timestamp: new Date('2024-01-01T10:00:00Z'), track: 'Test Track' },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, [])
+
+    expect(tagsCreated).toBe(0)
+    expect(insertTag).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates tags with same name and timestamp', async () => {
+    const timestamp = new Date('2024-01-01T10:00:00Z')
+    const scrobbles: Scrobble[] = [{ artist: 'Test Artist', timestamp, track: 'Test Track' }]
+
+    const rules: LastFmTagRule[] = [
+      {
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Rule 1',
+        tagName: 'SameTag',
+        trackName: 'Test Track',
+      },
+      {
+        artistName: 'Test Artist',
+        createdAt: new Date(),
+        id: 'rule-2',
+        matchMode: 'exact',
+        matchType: 'artist',
+        ruleName: 'Rule 2',
+        tagName: 'SameTag',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    // Both rules match, but same tag + timestamp should only create one tag
+    expect(tagsCreated).toBe(1)
+    expect(insertTag).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates multiple tags for different rules with different tag names', async () => {
+    const timestamp = new Date('2024-01-01T10:00:00Z')
+    const scrobbles: Scrobble[] = [{ artist: 'Test Artist', timestamp, track: 'Test Track' }]
+
+    const rules: LastFmTagRule[] = [
+      {
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Rule 1',
+        tagName: 'Tag1',
+        trackName: 'Test Track',
+      },
+      {
+        artistName: 'Test Artist',
+        createdAt: new Date(),
+        id: 'rule-2',
+        matchMode: 'exact',
+        matchType: 'artist',
+        ruleName: 'Rule 2',
+        tagName: 'Tag2',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    expect(tagsCreated).toBe(2)
+    expect(insertTag).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('syncLastFmData', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('syncs scrobbles and applies tag rules', async () => {
+    const mockScrobbles: Scrobble[] = [
+      { artist: 'Test Artist', timestamp: new Date('2024-01-01T10:00:00Z'), track: 'Test Track' },
+    ]
+
+    const mockRules: LastFmTagRule[] = [
+      {
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'track',
+        ruleName: 'Test Rule',
+        tagName: 'TestTag',
+        trackName: 'Test Track',
+      },
+    ]
+
+    vi.mocked(getSyncState).mockResolvedValue(null)
+    vi.mocked(getLastFmTagRules).mockResolvedValue(mockRules)
+
+    const mockClient = {
+      getRecentTracks: vi.fn().mockResolvedValue(mockScrobbles),
+    }
+    vi.mocked(lastfmClient).mockReturnValue(mockClient as unknown as ReturnType<typeof lastfmClient>)
+
+    const result = await syncLastFmData('testuser', 'api-key', 'lastfm-username')
+
+    expect(result.status).toBe('success')
+    expect(result.scrobblesProcessed).toBe(1)
+    expect(result.tagsCreated).toBe(1)
+
+    expect(insertRawRecord).toHaveBeenCalledTimes(1)
+    expect(insertTag).toHaveBeenCalledTimes(1)
+    expect(upsertSyncState).toHaveBeenCalledWith(
+      'testuser',
+      expect.objectContaining({
+        dataType: 'scrobbles',
+        provider: 'lastfm',
+        status: 'idle',
+      }),
+    )
+  })
+
+  it('handles API errors', async () => {
+    vi.mocked(getSyncState).mockResolvedValue(null)
+
+    const mockClient = {
+      getRecentTracks: vi.fn().mockRejectedValue(new Error('API Error')),
+    }
+    vi.mocked(lastfmClient).mockReturnValue(mockClient as unknown as ReturnType<typeof lastfmClient>)
+
+    const result = await syncLastFmData('testuser', 'api-key', 'lastfm-username')
+
+    expect(result.status).toBe('error')
+    expect(result.error).toBe('API Error')
+    expect(result.scrobblesProcessed).toBe(0)
+    expect(result.tagsCreated).toBe(0)
+
+    expect(upsertSyncState).toHaveBeenCalledWith(
+      'testuser',
+      expect.objectContaining({
+        dataType: 'scrobbles',
+        provider: 'lastfm',
+        status: 'error',
+      }),
+    )
+  })
+
+  it('uses last sync time for incremental sync', async () => {
+    const lastSyncTime = new Date('2024-01-01T00:00:00Z')
+
+    vi.mocked(getSyncState).mockResolvedValue({
+      dataType: 'scrobbles',
+      lastSyncTime,
+      provider: 'lastfm',
+      status: 'idle',
+    })
+    vi.mocked(getLastFmTagRules).mockResolvedValue([])
+
+    const mockClient = {
+      getRecentTracks: vi.fn().mockResolvedValue([]),
+    }
+    vi.mocked(lastfmClient).mockReturnValue(mockClient as unknown as ReturnType<typeof lastfmClient>)
+
+    await syncLastFmData('testuser', 'api-key', 'lastfm-username')
+
+    expect(mockClient.getRecentTracks).toHaveBeenCalledWith('lastfm-username', lastSyncTime, expect.any(Date))
+  })
+
+  it('uses start date for full resync', async () => {
+    const startDate = new Date('2023-01-01T00:00:00Z')
+
+    vi.mocked(getSyncState).mockResolvedValue({
+      dataType: 'scrobbles',
+      lastSyncTime: new Date('2024-01-01T00:00:00Z'),
+      provider: 'lastfm',
+      status: 'idle',
+    })
+    vi.mocked(getLastFmTagRules).mockResolvedValue([])
+
+    const mockClient = {
+      getRecentTracks: vi.fn().mockResolvedValue([]),
+    }
+    vi.mocked(lastfmClient).mockReturnValue(mockClient as unknown as ReturnType<typeof lastfmClient>)
+
+    await syncLastFmData('testuser', 'api-key', 'lastfm-username', {
+      fullResync: true,
+      startDate,
+    })
+
+    expect(mockClient.getRecentTracks).toHaveBeenCalledWith('lastfm-username', startDate, expect.any(Date))
+  })
+})

--- a/apps/backend/src/lastfm-sync.ts
+++ b/apps/backend/src/lastfm-sync.ts
@@ -1,0 +1,205 @@
+/**
+ * Last.fm data sync module.
+ *
+ * Handles fetching scrobbles from Last.fm API and storing them in the database.
+ * Also applies auto-tagging rules to create tags from scrobbles.
+ */
+
+import { subDays } from 'date-fns'
+import {
+  getLastFmTagRules,
+  getSyncState,
+  insertRawRecord,
+  insertTag,
+  type LastFmTagRule,
+  upsertSyncState,
+} from './db'
+import { lastfmClient, type Scrobble } from './lastfm'
+
+/** Default start date for historical sync (30 days back) */
+const DEFAULT_SYNC_HISTORY_DAYS = 30
+
+/** Result of a sync operation */
+export interface LastFmSyncResult {
+  scrobblesProcessed: number
+  tagsCreated: number
+  status: 'success' | 'skipped' | 'error'
+  error?: string
+}
+
+/**
+ * Check if a scrobble matches a tag rule.
+ */
+export const matchesRule = (scrobble: Scrobble, rule: LastFmTagRule): boolean => {
+  const normalize = (s: string) => s.toLowerCase().trim()
+
+  switch (rule.matchType) {
+    case 'track': {
+      if (!rule.trackName) return false
+      if (rule.matchMode === 'exact') {
+        return normalize(scrobble.track) === normalize(rule.trackName)
+      }
+      return normalize(scrobble.track).includes(normalize(rule.trackName))
+    }
+
+    case 'artist': {
+      if (!rule.artistName) return false
+      if (rule.matchMode === 'exact') {
+        return normalize(scrobble.artist) === normalize(rule.artistName)
+      }
+      return normalize(scrobble.artist).includes(normalize(rule.artistName))
+    }
+
+    case 'track_artist': {
+      if (!rule.trackName || !rule.artistName) return false
+      const trackMatch =
+        rule.matchMode === 'exact' ?
+          normalize(scrobble.track) === normalize(rule.trackName)
+        : normalize(scrobble.track).includes(normalize(rule.trackName))
+      const artistMatch =
+        rule.matchMode === 'exact' ?
+          normalize(scrobble.artist) === normalize(rule.artistName)
+        : normalize(scrobble.artist).includes(normalize(rule.artistName))
+      return trackMatch && artistMatch
+    }
+
+    default:
+      return false
+  }
+}
+
+/**
+ * Apply tag rules to scrobbles and create tags.
+ * Returns the number of tags created.
+ */
+export const applyTagRules = async (
+  user: string,
+  scrobbles: Scrobble[],
+  rules: LastFmTagRule[],
+): Promise<number> => {
+  if (rules.length === 0) return 0
+
+  let tagsCreated = 0
+
+  // Track which tags we've created to avoid duplicates within the same sync
+  const createdTags = new Set<string>()
+
+  for (const scrobble of scrobbles) {
+    for (const rule of rules) {
+      if (matchesRule(scrobble, rule)) {
+        // Create a unique key for deduplication: tagName + timestamp
+        const tagKey = `${rule.tagName}|${scrobble.timestamp.toISOString()}`
+        if (createdTags.has(tagKey)) continue
+        createdTags.add(tagKey)
+
+        // Create external_id from scrobble details for deduplication
+        const externalId = `lastfm-auto-${rule.id}-${scrobble.timestamp.getTime()}`
+
+        await insertTag(user, {
+          externalId,
+          source: 'lastfm-auto',
+          startTime: scrobble.timestamp,
+          tag: rule.tagName,
+        })
+        tagsCreated++
+      }
+    }
+  }
+
+  return tagsCreated
+}
+
+/**
+ * Sync Last.fm scrobbles for a user.
+ */
+export const syncLastFmData = async (
+  user: string,
+  apiKey: string,
+  username: string,
+  options: { fullResync?: boolean; startDate?: Date } = {},
+): Promise<LastFmSyncResult> => {
+  const dataType = 'scrobbles'
+
+  // Check current sync state
+  const syncState = await getSyncState(user, 'lastfm', dataType)
+
+  // Determine date range
+  const end = new Date()
+  let start: Date
+
+  if (options.fullResync || !syncState?.lastSyncTime) {
+    start = options.startDate || subDays(end, DEFAULT_SYNC_HISTORY_DAYS)
+  } else {
+    start = syncState.lastSyncTime
+  }
+
+  // Mark as syncing
+  await upsertSyncState(user, {
+    dataType,
+    provider: 'lastfm',
+    status: 'syncing',
+    syncStartDate: start,
+  })
+
+  try {
+    const client = lastfmClient(apiKey)
+    const scrobbles = await client.getRecentTracks(username, start, end)
+
+    // Store raw scrobbles
+    for (const scrobble of scrobbles) {
+      const externalId = `${scrobble.timestamp.getTime()}-${scrobble.track}-${scrobble.artist}`
+      await insertRawRecord(user, {
+        data: {
+          album: scrobble.album,
+          albumMbid: scrobble.albumMbid,
+          artist: scrobble.artist,
+          artistMbid: scrobble.artistMbid,
+          mbid: scrobble.mbid,
+          track: scrobble.track,
+        },
+        externalId,
+        recordType: 'scrobble',
+        recordedAt: scrobble.timestamp,
+        source: 'lastfm',
+      })
+    }
+
+    // Apply tag rules
+    const rules = await getLastFmTagRules(user)
+    const tagsCreated = await applyTagRules(user, scrobbles, rules)
+
+    // Update sync state on success
+    await upsertSyncState(user, {
+      dataType,
+      lastSyncTime: end,
+      provider: 'lastfm',
+      status: 'idle',
+    })
+
+    return {
+      scrobblesProcessed: scrobbles.length,
+      status: 'success',
+      tagsCreated,
+    }
+  } catch (error: unknown) {
+    const axiosError = error as { response?: { status?: number; data?: unknown } }
+
+    // Handle specific API errors
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    const statusCode = axiosError.response?.status
+
+    await upsertSyncState(user, {
+      dataType,
+      errorMessage: `${errorMessage}${statusCode ? ` (HTTP ${statusCode})` : ''}`,
+      provider: 'lastfm',
+      status: 'error',
+    })
+
+    return {
+      error: errorMessage,
+      scrobblesProcessed: 0,
+      status: 'error',
+      tagsCreated: 0,
+    }
+  }
+}

--- a/apps/backend/src/lastfm.test.ts
+++ b/apps/backend/src/lastfm.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Last.fm API client tests.
+ */
+
+import axios from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { lastfmClient } from './lastfm'
+
+vi.mock('axios')
+
+describe('lastfmClient', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('throws error when API key is missing', () => {
+      expect(() => lastfmClient('')).toThrow('Last.fm API key missing')
+    })
+
+    it('creates client when API key is provided', () => {
+      expect(() => lastfmClient('test-api-key')).not.toThrow()
+    })
+  })
+
+  describe('getRecentTracks', () => {
+    it('fetches recent tracks successfully', async () => {
+      const mockResponse = {
+        data: {
+          recenttracks: {
+            '@attr': {
+              page: '1',
+              perPage: '200',
+              total: '2',
+              totalPages: '1',
+            },
+            track: [
+              {
+                album: { '#text': 'Test Album', mbid: 'album-mbid' },
+                artist: { '#text': 'Test Artist', mbid: 'artist-mbid' },
+                date: { uts: '1704067200' }, // 2024-01-01 00:00:00 UTC
+                mbid: 'track-mbid',
+                name: 'Test Track',
+              },
+              {
+                album: { '#text': 'Another Album' },
+                artist: { '#text': 'Another Artist' },
+                date: { uts: '1704070800' }, // 2024-01-01 01:00:00 UTC
+                name: 'Another Track',
+              },
+            ],
+          },
+        },
+      }
+
+      vi.mocked(axios.get).mockResolvedValue(mockResponse)
+
+      const client = lastfmClient('test-api-key')
+      const scrobbles = await client.getRecentTracks('testuser')
+
+      expect(scrobbles).toHaveLength(2)
+      expect(scrobbles[0]).toEqual({
+        album: 'Test Album',
+        albumMbid: 'album-mbid',
+        artist: 'Test Artist',
+        artistMbid: 'artist-mbid',
+        mbid: 'track-mbid',
+        timestamp: new Date('2024-01-01T00:00:00.000Z'),
+        track: 'Test Track',
+      })
+      expect(scrobbles[1]).toEqual({
+        album: 'Another Album',
+        albumMbid: undefined,
+        artist: 'Another Artist',
+        artistMbid: undefined,
+        mbid: undefined,
+        timestamp: new Date('2024-01-01T01:00:00.000Z'),
+        track: 'Another Track',
+      })
+
+      expect(axios.get).toHaveBeenCalledWith('https://ws.audioscrobbler.com/2.0/', {
+        params: expect.objectContaining({
+          api_key: 'test-api-key',
+          format: 'json',
+          limit: 200,
+          method: 'user.getrecenttracks',
+          page: 1,
+          user: 'testuser',
+        }),
+      })
+    })
+
+    it('skips now playing tracks', async () => {
+      const mockResponse = {
+        data: {
+          recenttracks: {
+            '@attr': { page: '1', perPage: '200', total: '2', totalPages: '1' },
+            track: [
+              {
+                '@attr': { nowplaying: 'true' },
+                artist: { '#text': 'Now Playing Artist' },
+                name: 'Now Playing Track',
+              },
+              {
+                artist: { '#text': 'Regular Artist' },
+                date: { uts: '1704067200' },
+                name: 'Regular Track',
+              },
+            ],
+          },
+        },
+      }
+
+      vi.mocked(axios.get).mockResolvedValue(mockResponse)
+
+      const client = lastfmClient('test-api-key')
+      const scrobbles = await client.getRecentTracks('testuser')
+
+      expect(scrobbles).toHaveLength(1)
+      expect(scrobbles[0].track).toBe('Regular Track')
+    })
+
+    it('handles date range filters', async () => {
+      const mockResponse = {
+        data: {
+          recenttracks: {
+            '@attr': { page: '1', perPage: '200', total: '0', totalPages: '1' },
+            track: [],
+          },
+        },
+      }
+
+      vi.mocked(axios.get).mockResolvedValue(mockResponse)
+
+      const client = lastfmClient('test-api-key')
+      const from = new Date('2024-01-01T00:00:00Z')
+      const to = new Date('2024-01-02T00:00:00Z')
+
+      await client.getRecentTracks('testuser', from, to)
+
+      expect(axios.get).toHaveBeenCalledWith(expect.any(String), {
+        params: expect.objectContaining({
+          from: 1704067200,
+          to: 1704153600,
+        }),
+      })
+    })
+
+    it('handles pagination', async () => {
+      const page1Response = {
+        data: {
+          recenttracks: {
+            '@attr': { page: '1', perPage: '2', total: '3', totalPages: '2' },
+            track: [
+              {
+                artist: { '#text': 'Artist 1' },
+                date: { uts: '1704067200' },
+                name: 'Track 1',
+              },
+              {
+                artist: { '#text': 'Artist 2' },
+                date: { uts: '1704070800' },
+                name: 'Track 2',
+              },
+            ],
+          },
+        },
+      }
+
+      const page2Response = {
+        data: {
+          recenttracks: {
+            '@attr': { page: '2', perPage: '2', total: '3', totalPages: '2' },
+            track: [
+              {
+                artist: { '#text': 'Artist 3' },
+                date: { uts: '1704074400' },
+                name: 'Track 3',
+              },
+            ],
+          },
+        },
+      }
+
+      vi.mocked(axios.get).mockResolvedValueOnce(page1Response).mockResolvedValueOnce(page2Response)
+
+      const client = lastfmClient('test-api-key')
+      const scrobbles = await client.getRecentTracks('testuser', undefined, undefined, 2)
+
+      expect(scrobbles).toHaveLength(3)
+      expect(axios.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('handles empty response', async () => {
+      const mockResponse = {
+        data: {
+          recenttracks: {
+            '@attr': { page: '1', perPage: '200', total: '0', totalPages: '0' },
+            track: [],
+          },
+        },
+      }
+
+      vi.mocked(axios.get).mockResolvedValue(mockResponse)
+
+      const client = lastfmClient('test-api-key')
+      const scrobbles = await client.getRecentTracks('testuser')
+
+      expect(scrobbles).toHaveLength(0)
+    })
+
+    it('handles single track response (not array)', async () => {
+      const mockResponse = {
+        data: {
+          recenttracks: {
+            '@attr': { page: '1', perPage: '200', total: '1', totalPages: '1' },
+            track: {
+              artist: { '#text': 'Single Artist' },
+              date: { uts: '1704067200' },
+              name: 'Single Track',
+            },
+          },
+        },
+      }
+
+      vi.mocked(axios.get).mockResolvedValue(mockResponse)
+
+      const client = lastfmClient('test-api-key')
+      const scrobbles = await client.getRecentTracks('testuser')
+
+      expect(scrobbles).toHaveLength(1)
+      expect(scrobbles[0].track).toBe('Single Track')
+    })
+  })
+})

--- a/apps/backend/src/lastfm.ts
+++ b/apps/backend/src/lastfm.ts
@@ -1,0 +1,123 @@
+/**
+ * Last.fm API client.
+ *
+ * Uses the Last.fm API to fetch user scrobble data.
+ * API key is stored at the app level, user provides only their username.
+ */
+
+import axios from 'axios'
+
+const LASTFM_API_BASE = 'https://ws.audioscrobbler.com/2.0/'
+
+export interface Scrobble {
+  artist: string
+  track: string
+  album?: string
+  mbid?: string // MusicBrainz ID for track
+  artistMbid?: string // MusicBrainz ID for artist
+  albumMbid?: string // MusicBrainz ID for album
+  timestamp: Date
+}
+
+interface LastFmTrack {
+  name: string
+  artist: { '#text': string; mbid?: string }
+  album?: { '#text': string; mbid?: string }
+  mbid?: string
+  date?: { uts: string }
+  '@attr'?: { nowplaying?: string }
+}
+
+interface LastFmRecentTracksResponse {
+  recenttracks: {
+    track: LastFmTrack[]
+    '@attr': {
+      page: string
+      perPage: string
+      totalPages: string
+      total: string
+    }
+  }
+}
+
+/**
+ * Create a Last.fm API client.
+ *
+ * @param apiKey - Last.fm API key (app-level, from LASTFM_API_KEY env var)
+ */
+export const lastfmClient = (apiKey: string) => {
+  if (!apiKey) throw new Error('Last.fm API key missing')
+
+  return {
+    /**
+     * Get recent tracks (scrobbles) for a user.
+     *
+     * @param username - Last.fm username
+     * @param from - Optional start date (Unix timestamp or Date)
+     * @param to - Optional end date (Unix timestamp or Date)
+     * @param limit - Number of tracks per page (max 200, default 200)
+     */
+    async getRecentTracks(
+      username: string,
+      from?: Date,
+      to?: Date,
+      limit: number = 200,
+    ): Promise<Scrobble[]> {
+      const allScrobbles: Scrobble[] = []
+      let page = 1
+      let totalPages = 1
+
+      const fromTs = from ? Math.floor(from.getTime() / 1000) : undefined
+      const toTs = to ? Math.floor(to.getTime() / 1000) : undefined
+
+      do {
+        const params: Record<string, string | number> = {
+          api_key: apiKey,
+          format: 'json',
+          limit,
+          method: 'user.getrecenttracks',
+          page,
+          user: username,
+        }
+
+        if (fromTs !== undefined) params.from = fromTs
+        if (toTs !== undefined) params.to = toTs
+
+        const response = await axios.get<LastFmRecentTracksResponse>(LASTFM_API_BASE, { params })
+
+        const data = response.data
+        if (!data.recenttracks?.track) {
+          break
+        }
+
+        totalPages = parseInt(data.recenttracks['@attr'].totalPages, 10)
+
+        const tracks =
+          Array.isArray(data.recenttracks.track) ? data.recenttracks.track : [data.recenttracks.track]
+
+        for (const track of tracks) {
+          // Skip "now playing" tracks (they don't have a timestamp)
+          if (track['@attr']?.nowplaying === 'true' || !track.date?.uts) {
+            continue
+          }
+
+          allScrobbles.push({
+            album: track.album?.['#text'] || undefined,
+            albumMbid: track.album?.mbid || undefined,
+            artist: track.artist['#text'],
+            artistMbid: track.artist.mbid || undefined,
+            mbid: track.mbid || undefined,
+            timestamp: new Date(parseInt(track.date.uts, 10) * 1000),
+            track: track.name,
+          })
+        }
+
+        page++
+      } while (page <= totalPages)
+
+      return allScrobbles
+    },
+  }
+}
+
+export type LastFmClient = ReturnType<typeof lastfmClient>

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -23,14 +23,20 @@ import { Request, Response, Router } from 'express'
 import { z } from 'zod'
 import { Auth } from './auth'
 import {
+  deleteLastFmTagRule,
   getAllSyncStates,
+  getLastFmTagRules,
   getProgrammaticTags,
   getDetectedLocations as getStoredDetectedLocations,
   getUniqueTags,
   getUserSettings,
+  insertLastFmTagRule,
   upsertUserSettings,
+  type LastFmMatchMode,
+  type LastFmMatchType,
 } from './db'
 import { syncAllCalendars } from './ical-sync'
+import { syncLastFmData } from './lastfm-sync'
 import { DEFAULT_SESSION_INACTIVITY_MS, McpSessionStore } from './mcp-session-store'
 import { ouraClient } from './oura'
 import { syncAllOuraData } from './oura-sync'
@@ -722,10 +728,57 @@ Use cases:
       },
     )
 
+    // Tool: sync_lastfm
+    server.tool(
+      'sync_lastfm',
+      'Sync scrobbles from Last.fm. Fetches recent tracks and applies auto-tagging rules.',
+      {
+        full_resync: z
+          .boolean()
+          .optional()
+          .describe(
+            'If true, fetches all historical data (default 30 days). Otherwise, fetches only since last sync.',
+          ),
+        start_date: z
+          .string()
+          .optional()
+          .describe('Optional start date for sync in YYYY-MM-DD format. Only used with full_resync.'),
+      },
+      async ({ full_resync, start_date }) => {
+        const lastFmApiKey = process.env.LASTFM_API_KEY
+        if (!lastFmApiKey) {
+          return errorResponse('Last.fm API key is not configured on this server.')
+        }
+
+        const settings = await getSettings(user)
+        if (!settings.lastFmUsername) {
+          return errorResponse('Last.fm username is not configured in user settings.')
+        }
+
+        try {
+          const result = await syncLastFmData(user, lastFmApiKey, settings.lastFmUsername, {
+            fullResync: full_resync,
+            startDate: start_date ? new Date(start_date) : undefined,
+          })
+
+          return jsonResponse({
+            error: result.error,
+            scrobblesProcessed: result.scrobblesProcessed,
+            status: result.status,
+            success: result.status === 'success',
+            tagsCreated: result.tagsCreated,
+          })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          return jsonResponse({ error: message, success: false })
+        }
+      },
+    )
+
     // Tool: get_sync_status
     server.tool(
       'get_sync_status',
-      'Get the current sync status for Oura, RescueTime, and Calendar data sources. Shows last sync time, status, and any errors.',
+      'Get the current sync status for Oura, RescueTime, Calendar, and Last.fm data sources. Shows last sync time, status, and any errors.',
       {
         provider: syncProviderSchema.optional().describe('Which provider to check. Defaults to "all".'),
       },
@@ -745,11 +798,112 @@ Use cases:
             states.calendar = await getAllSyncStates(user, 'calendar')
           }
 
+          if (provider === 'all' || provider === 'lastfm') {
+            states.lastfm = await getAllSyncStates(user, 'lastfm')
+          }
+
           return jsonResponse({ states, success: true })
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error'
           return jsonResponse({ error: message, success: false })
         }
+      },
+    )
+
+    // ========================================================================
+    // Last.fm Tag Rules Tools
+    // ========================================================================
+
+    // Tool: get_lastfm_tag_rules
+    server.tool(
+      'get_lastfm_tag_rules',
+      'Get all Last.fm auto-tagging rules. These rules create tags when scrobbles match specified criteria.',
+      {},
+      async () => {
+        const rules = await getLastFmTagRules(user)
+        const serialized = rules.map((r) => ({
+          ...r,
+          createdAt: r.createdAt.toISOString(),
+        }))
+        return jsonResponse({ data: serialized, success: true })
+      },
+    )
+
+    // Tool: add_lastfm_tag_rule
+    server.tool(
+      'add_lastfm_tag_rule',
+      'Add a Last.fm auto-tagging rule. Creates tags when scrobbles match the specified criteria.',
+      {
+        artist_name: z
+          .string()
+          .optional()
+          .describe('Artist name to match (required for artist or track_artist match type)'),
+        match_mode: z
+          .enum(['exact', 'contains'])
+          .optional()
+          .describe('Match mode: exact (case-insensitive) or contains (substring). Default: exact'),
+        match_type: z
+          .enum(['track', 'artist', 'track_artist'])
+          .describe(
+            'Type of match: track (any track with name), artist (any track by artist), track_artist (exact track + artist)',
+          ),
+        rule_name: z.string().min(1).describe('Human-readable name for the rule'),
+        tag_name: z.string().min(1).describe('Tag to create when rule matches'),
+        track_name: z
+          .string()
+          .optional()
+          .describe('Track name to match (required for track or track_artist match type)'),
+      },
+      async ({ artist_name, match_mode, match_type, rule_name, tag_name, track_name }) => {
+        // Validate required fields based on match_type
+        if ((match_type === 'track' || match_type === 'track_artist') && !track_name) {
+          return errorResponse(`track_name is required for match_type "${match_type}"`)
+        }
+        if ((match_type === 'artist' || match_type === 'track_artist') && !artist_name) {
+          return errorResponse(`artist_name is required for match_type "${match_type}"`)
+        }
+
+        try {
+          const rule = await insertLastFmTagRule(user, {
+            artistName: artist_name,
+            matchMode: (match_mode ?? 'exact') as LastFmMatchMode,
+            matchType: match_type as LastFmMatchType,
+            ruleName: rule_name,
+            tagName: tag_name,
+            trackName: track_name,
+          })
+
+          return jsonResponse({
+            data: {
+              ...rule,
+              createdAt: rule.createdAt.toISOString(),
+            },
+            success: true,
+          })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error'
+          // Check for unique constraint violation
+          if (message.includes('unique_rule')) {
+            return errorResponse('A rule with the same match criteria and tag already exists')
+          }
+          return jsonResponse({ error: message, success: false })
+        }
+      },
+    )
+
+    // Tool: delete_lastfm_tag_rule
+    server.tool(
+      'delete_lastfm_tag_rule',
+      'Delete a Last.fm auto-tagging rule by its ID.',
+      {
+        rule_id: z.string().uuid().describe('The ID of the rule to delete'),
+      },
+      async ({ rule_id }) => {
+        const deleted = await deleteLastFmTagRule(user, rule_id)
+        if (!deleted) {
+          return jsonResponse({ error: 'Rule not found', success: false })
+        }
+        return jsonResponse({ success: true })
       },
     )
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -101,6 +101,25 @@ export const createTableStatements: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_lab_results_category ON lab_results (test_category, test_date DESC)
   `,
 
+  // Last.fm auto-tagging rules
+  lastfm_tag_rules: `
+    CREATE TABLE IF NOT EXISTS lastfm_tag_rules (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      rule_name       VARCHAR(100) NOT NULL,
+      match_type      VARCHAR(20) NOT NULL,
+      track_name      VARCHAR(255),
+      artist_name     VARCHAR(255),
+      match_mode      VARCHAR(20) DEFAULT 'exact',
+      tag_name        VARCHAR(100) NOT NULL,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT unique_rule UNIQUE (match_type, track_name, artist_name, tag_name)
+    )
+  `,
+
+  lastfm_tag_rules_indexes: `
+    CREATE INDEX IF NOT EXISTS idx_lastfm_tag_rules_match ON lastfm_tag_rules (match_type, match_mode)
+  `,
+
   // GPS location data with PostGIS support
   locations: `
     CREATE TABLE IF NOT EXISTS locations (
@@ -292,6 +311,8 @@ export const tableCreationOrder = [
   'time_series_indexes',
   'activities',
   'activities_indexes',
+  'lastfm_tag_rules',
+  'lastfm_tag_rules_indexes',
   'locations',
   'locations_indexes',
   'places',

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -28,6 +28,7 @@ export interface UserSettings {
   calendars?: CalendarConfig[] // Calendar ICS URL configurations
   dashboard?: DashboardConfig // Custom dashboard configuration
   hrZoneStart?: HrZoneThresholds
+  lastFmUsername?: string // Last.fm username for scrobble sync
   rescueTimeKey?: string // RescueTime API key (personal token)
   goals?: Goal[] // User-defined goals for tracking metrics
   tagMappings?: TagMappings // Tag name mappings from UUIDs to display names
@@ -144,6 +145,7 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
   const { zones, source } = await getEffectiveHrZones(user)
   const ouraToken = await getOAuthToken(user, 'oura')
   const ouraConfigured = !!(process.env.OURA_CLIENT && process.env.OURA_SECRET)
+  const lastFmConfigured = !!process.env.LASTFM_API_KEY
 
   return {
     birth_date: settings.birthDate ?? null,
@@ -152,6 +154,8 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
     goals: getEffectiveGoals(settings),
     hr_zone_start: zones,
     hr_zone_start_source: source,
+    lastfm_configured: lastFmConfigured,
+    lastfm_username: settings.lastFmUsername ?? null,
     oura_configured: ouraConfigured,
     oura_connected: ouraToken !== null,
     rescue_time_key: settings.rescueTimeKey ?? null,
@@ -177,6 +181,8 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
       goals: defaultGoals,
       hr_zone_start: calculateDefaultHrZones(null),
       hr_zone_start_source: 'default',
+      lastfm_configured: !!process.env.LASTFM_API_KEY,
+      lastfm_username: null,
       oura_configured: !!(process.env.OURA_CLIENT && process.env.OURA_SECRET),
       oura_connected: false,
       rescue_time_key: null,
@@ -199,6 +205,9 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
   }
   if (parsed.data.hr_zone_start !== undefined) {
     updates.hrZoneStart = parsed.data.hr_zone_start === null ? undefined : parsed.data.hr_zone_start
+  }
+  if (parsed.data.lastfm_username !== undefined) {
+    updates.lastFmUsername = parsed.data.lastfm_username === null ? undefined : parsed.data.lastfm_username
   }
   if (parsed.data.rescue_time_key !== undefined) {
     updates.rescueTimeKey = parsed.data.rescue_time_key === null ? undefined : parsed.data.rescue_time_key

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -6,15 +6,18 @@ import { createSyncRouter, SyncRouterDeps } from './sync-router'
 describe('sync router', () => {
   const mockDeps: SyncRouterDeps = {
     getCalendarSyncStates: vi.fn().mockResolvedValue([]),
+    getLastFmSyncStates: vi.fn().mockResolvedValue([]),
     getOuraSyncStates: vi.fn().mockResolvedValue([]),
     getRescueTimeSyncStates: vi.fn().mockResolvedValue([]),
     getSettings: vi.fn().mockResolvedValue({ rescueTimeKey: 'test-key' }),
     processDailyAggregate: vi.fn().mockResolvedValue(undefined),
     processHealthConnectData: vi.fn().mockResolvedValue(undefined),
     resetCalendarSyncState: vi.fn().mockResolvedValue(undefined),
+    resetLastFmSyncState: vi.fn().mockResolvedValue(undefined),
     resetOuraSyncState: vi.fn().mockResolvedValue(undefined),
     resetRescueTimeSyncState: vi.fn().mockResolvedValue(undefined),
     syncCalendars: vi.fn().mockResolvedValue([]),
+    syncLastFm: vi.fn().mockResolvedValue({ scrobblesProcessed: 0, status: 'success', tagsCreated: 0 }),
     syncOura: vi.fn().mockResolvedValue({ success: true }),
     syncRescueTime: vi.fn().mockResolvedValue({ success: true }),
   }

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -2,6 +2,7 @@ import {
   dailyAggregatesBodySchema,
   healthConnectSyncBodySchema,
   syncCalendarsBodySchema,
+  syncLastFmBodySchema,
   syncOuraBodySchema,
   syncRescueTimeBodySchema,
   type CalendarConfig,
@@ -12,6 +13,9 @@ import {
   type DailyAggregatesBody,
   type HealthConnectRecord,
   type HealthConnectSyncBody,
+  type LastFmSyncResponse,
+  type LastFmSyncResult,
+  type LastFmSyncStatusResponse,
   type OuraSyncResponse,
   type OuraSyncResult,
   type OuraSyncStatusResponse,
@@ -20,6 +24,7 @@ import {
   type RescueTimeSyncResult,
   type RescueTimeSyncStatusResponse,
   type SyncCalendarsBody,
+  type SyncLastFmBody,
   type SyncOuraBody,
   type SyncRescueTimeBody,
   type SyncResponse,
@@ -51,7 +56,17 @@ export interface SyncRouterDeps {
   ) => Promise<CalendarSyncResult[]>
   getCalendarSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   resetCalendarSyncState: (user: string) => Promise<void>
-  getSettings: (user: string) => Promise<{ rescueTimeKey?: string; calendars?: CalendarConfig[] }>
+  syncLastFm: (
+    user: string,
+    apiKey: string,
+    username: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => Promise<LastFmSyncResult>
+  getLastFmSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
+  resetLastFmSyncState: (user: string) => Promise<void>
+  getSettings: (
+    user: string,
+  ) => Promise<{ rescueTimeKey?: string; calendars?: CalendarConfig[]; lastFmUsername?: string }>
 }
 
 /**
@@ -241,6 +256,71 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
 
     try {
       await deps.resetCalendarSyncState(user)
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  // Last.fm sync endpoints
+  router.post<ParamsDictionary, LastFmSyncResponse, SyncLastFmBody>(
+    '/lastfm',
+    authMiddleware,
+    validateBody(syncLastFmBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const { full_resync, start_date } = req.body
+
+      const lastFmApiKey = process.env.LASTFM_API_KEY
+      if (!lastFmApiKey) {
+        return res.status(400).json({ error: 'Last.fm API key not configured on server', success: false })
+      }
+
+      const settings = await deps.getSettings(user)
+      const lastFmUsername = settings.lastFmUsername
+
+      if (!lastFmUsername) {
+        return res
+          .status(400)
+          .json({ error: 'Last.fm username not configured in user settings', success: false })
+      }
+
+      try {
+        const result = await deps.syncLastFm(user, lastFmApiKey, lastFmUsername, {
+          fullResync: full_resync,
+          startDate: start_date ? new Date(start_date) : undefined,
+        })
+
+        res.json({ result, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
+
+  router.get<ParamsDictionary, LastFmSyncStatusResponse>(
+    '/lastfm/status',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+
+      try {
+        const states = await deps.getLastFmSyncStates(user)
+        res.json({ states, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
+
+  router.delete<ParamsDictionary, SyncResponse>('/lastfm/state', authMiddleware, async (req, res) => {
+    const user = req.user!
+
+    try {
+      await deps.resetLastFmSyncState(user)
       res.json({ success: true })
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/test/db-test-helper.ts
+++ b/apps/backend/src/test/db-test-helper.ts
@@ -87,6 +87,7 @@ export const cleanTestDb = async (): Promise<void> => {
     'sync_state',
     'user_settings',
     'mcp_sessions',
+    'lastfm_tag_rules',
   ]
 
   for (const table of tables) {

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -122,7 +122,18 @@ export type ActivityType = z.infer<typeof activityTypeSchema>
  * Supported data sources.
  */
 export const dataSourceSchema = z
-  .enum(['health_connect', 'health_connect_aggregate', 'oura', 'garmin', 'rescuetime', 'owntracks', 'calendar', 'manual'])
+  .enum([
+    'health_connect',
+    'health_connect_aggregate',
+    'oura',
+    'garmin',
+    'rescuetime',
+    'owntracks',
+    'calendar',
+    'manual',
+    'lastfm',
+    'lastfm-auto',
+  ])
   .meta({
     description: 'Source of the data',
     example: 'health_connect',
@@ -212,9 +223,16 @@ export const customMetricDefinitionSchema = z
       .string()
       .min(1)
       .max(50)
-      .regex(/^[a-z][a-z0-9_]*$/, 'Must be lowercase letters, numbers, and underscores, starting with a letter')
+      .regex(
+        /^[a-z][a-z0-9_]*$/,
+        'Must be lowercase letters, numbers, and underscores, starting with a letter',
+      )
       .meta({ description: 'Metric name (e.g., "mood", "caffeine_mg")', example: 'mood' }),
-    unit: z.string().min(1).max(20).meta({ description: 'Unit of measurement (e.g., "score", "mg")', example: 'score' }),
+    unit: z
+      .string()
+      .min(1)
+      .max(20)
+      .meta({ description: 'Unit of measurement (e.g., "score", "mg")', example: 'score' }),
   })
   .meta({ id: 'CustomMetricDefinition' })
 

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -39,10 +39,10 @@ export type DashboardMetric = z.infer<typeof dashboardMetricSchema>
 export const metricCardConfigSchema = z
   .object({
     metric: dashboardMetricSchema.meta({ description: 'The metric to display' }),
-    title: z.string().min(1).meta({ description: 'Display title for the metric' }),
     subtitle: z.string().optional().meta({ description: 'Optional subtitle text' }),
-    unit: z.string().optional().meta({ description: 'Unit label (e.g., "ms", "bpm")' }),
+    title: z.string().min(1).meta({ description: 'Display title for the metric' }),
     trendInverse: z.boolean().optional().meta({ description: 'If true, lower values are better' }),
+    unit: z.string().optional().meta({ description: 'Unit label (e.g., "ms", "bpm")' }),
   })
   .meta({ id: 'MetricCardConfig' })
 
@@ -53,10 +53,15 @@ export type MetricCardConfig = z.infer<typeof metricCardConfigSchema>
  */
 export const sparklineCardConfigSchema = z
   .object({
+    color: z.string().optional().meta({ description: 'Chart line color (CSS color)' }),
+    lookbackDays: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .meta({ description: 'Days of data to show in sparkline (default: 30)' }),
     metric: dashboardMetricSchema.meta({ description: 'The metric to display' }),
     title: z.string().optional().meta({ description: 'Display title for the metric' }),
-    lookbackDays: z.number().int().positive().optional().meta({ description: 'Days of data to show in sparkline (default: 30)' }),
-    color: z.string().optional().meta({ description: 'Chart line color (CSS color)' }),
   })
   .meta({ id: 'SparklineCardConfig' })
 
@@ -67,13 +72,16 @@ export type SparklineCardConfig = z.infer<typeof sparklineCardConfigSchema>
  */
 export const trendChartConfigSchema = z
   .object({
-    sourceType: z.enum(['tag', 'metric']).meta({ description: 'Data source type' }),
-    pattern: z.string().min(1).meta({ description: 'Tag pattern (regex) or metric name' }),
-    title: z.string().optional().meta({ description: 'Chart title' }),
+    aggregation: z.enum(['count', 'sum', 'mean']).optional().meta({ description: 'Aggregation method' }),
+    displayPeriod: z
+      .enum(['daily', 'weekly', 'monthly'])
+      .optional()
+      .meta({ description: 'Display period for rate' }),
     halfLifeDays: z.number().int().positive().optional().meta({ description: 'EMA half-life in days' }),
     lookbackDays: z.number().int().positive().optional().meta({ description: 'Days of data to analyze' }),
-    displayPeriod: z.enum(['daily', 'weekly', 'monthly']).optional().meta({ description: 'Display period for rate' }),
-    aggregation: z.enum(['count', 'sum', 'mean']).optional().meta({ description: 'Aggregation method' }),
+    pattern: z.string().min(1).meta({ description: 'Tag pattern (regex) or metric name' }),
+    sourceType: z.enum(['tag', 'metric']).meta({ description: 'Data source type' }),
+    title: z.string().optional().meta({ description: 'Chart title' }),
   })
   .meta({ id: 'TrendChartConfig' })
 
@@ -88,9 +96,14 @@ export const correlationConfigSchema = z
     activityType: z
       .enum(['productivity_category', 'productivity_app', 'location', 'tag', 'activity_type'])
       .meta({ description: 'Type of activity' }),
-    title: z.string().optional().meta({ description: 'Widget title' }),
     periodDays: z.number().int().positive().optional().meta({ description: 'Days of data to analyze' }),
-    windowMinutes: z.number().int().positive().optional().meta({ description: 'Minutes before/after to analyze' }),
+    title: z.string().optional().meta({ description: 'Widget title' }),
+    windowMinutes: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .meta({ description: 'Minutes before/after to analyze' }),
   })
   .meta({ id: 'CorrelationConfig' })
 
@@ -101,10 +114,18 @@ export type CorrelationConfig = z.infer<typeof correlationConfigSchema>
  */
 export const activitySummaryConfigSchema = z
   .object({
-    lookbackDays: z.number().int().positive().optional().meta({ description: 'Days of activities to summarize (default: 7)' }),
-    showWorkouts: z.boolean().optional().meta({ description: 'Show workout count and duration (default: true)' }),
-    showSleep: z.boolean().optional().meta({ description: 'Show average sleep hours (default: true)' }),
+    lookbackDays: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .meta({ description: 'Days of activities to summarize (default: 7)' }),
     showMeditation: z.boolean().optional().meta({ description: 'Show meditation count (default: true)' }),
+    showSleep: z.boolean().optional().meta({ description: 'Show average sleep hours (default: true)' }),
+    showWorkouts: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Show workout count and duration (default: true)' }),
   })
   .meta({ id: 'ActivitySummaryConfig' })
 
@@ -116,11 +137,11 @@ export type ActivitySummaryConfig = z.infer<typeof activitySummaryConfigSchema>
 export const quickLinkConfigSchema = z
   .object({
     href: z.string().min(1).meta({ description: 'Target URL path' }),
-    label: z.string().min(1).meta({ description: 'Link text' }),
     icon: z
       .enum(['timeline', 'sleep', 'hr-zones', 'correlations', 'goals', 'places', 'trends', 'settings'])
       .optional()
       .meta({ description: 'Icon name' }),
+    label: z.string().min(1).meta({ description: 'Link text' }),
   })
   .meta({ id: 'QuickLinkConfig' })
 
@@ -149,34 +170,34 @@ export type WidgetType = z.infer<typeof widgetTypeSchema>
  */
 export const dashboardWidgetSchema = z.discriminatedUnion('type', [
   z.object({
+    config: metricCardConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('metric_card'),
-    config: metricCardConfigSchema,
   }),
   z.object({
+    config: sparklineCardConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('sparkline_card'),
-    config: sparklineCardConfigSchema,
   }),
   z.object({
+    config: trendChartConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('trend_chart'),
-    config: trendChartConfigSchema,
   }),
   z.object({
+    config: correlationConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('correlation'),
-    config: correlationConfigSchema,
   }),
   z.object({
+    config: activitySummaryConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('activity_summary'),
-    config: activitySummaryConfigSchema,
   }),
   z.object({
+    config: quickLinkConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('quick_link'),
-    config: quickLinkConfigSchema,
   }),
 ])
 
@@ -198,10 +219,10 @@ export type SectionType = z.infer<typeof sectionTypeSchema>
  */
 export const dashboardSectionSchema = z
   .object({
-    id: z.string().min(1).meta({ description: 'Unique section ID' }),
-    type: sectionTypeSchema.meta({ description: 'Section type for layout' }),
-    title: z.string().min(1).meta({ description: 'Section title' }),
     collapsed: z.boolean().optional().meta({ description: 'Whether section is collapsed' }),
+    id: z.string().min(1).meta({ description: 'Unique section ID' }),
+    title: z.string().min(1).meta({ description: 'Section title' }),
+    type: sectionTypeSchema.meta({ description: 'Section type for layout' }),
     widgets: z.array(dashboardWidgetSchema).meta({ description: 'Widgets in this section' }),
   })
   .meta({ id: 'DashboardSection' })
@@ -213,8 +234,8 @@ export type DashboardSection = z.infer<typeof dashboardSectionSchema>
  */
 export const dashboardConfigSchema = z
   .object({
-    version: z.literal(1).meta({ description: 'Config version for future migrations' }),
     sections: z.array(dashboardSectionSchema).meta({ description: 'Dashboard sections' }),
+    version: z.literal(1).meta({ description: 'Config version for future migrations' }),
   })
   .meta({ id: 'DashboardConfig' })
 
@@ -250,96 +271,123 @@ export type UpdateDashboardInput = z.infer<typeof updateDashboardInputSchema>
  * Default dashboard configuration matching current Dashboard page layout.
  */
 export const defaultDashboardConfig: DashboardConfig = {
-  version: 1,
   sections: [
     {
       id: 'baseline',
-      type: 'metrics',
       title: 'Your Baseline',
+      type: 'metrics',
       widgets: [
         {
+          config: {
+            metric: 'hrv_7day',
+            subtitle: 'Heart Rate Variability',
+            title: 'HRV (7-day)',
+            unit: 'ms',
+          },
           id: 'hrv-7d',
           type: 'metric_card',
-          config: { metric: 'hrv_7day', title: 'HRV (7-day)', unit: 'ms', subtitle: 'Heart Rate Variability' },
         },
         {
+          config: { metric: 'hrv_30day', subtitle: 'Long-term average', title: 'HRV (30-day)', unit: 'ms' },
           id: 'hrv-30d',
           type: 'metric_card',
-          config: { metric: 'hrv_30day', title: 'HRV (30-day)', unit: 'ms', subtitle: 'Long-term average' },
         },
         {
-          id: 'rhr-7d',
-          type: 'metric_card',
           config: {
             metric: 'rhr_7day',
-            title: 'Resting HR (7-day)',
-            unit: 'bpm',
             subtitle: 'Lower is generally better',
+            title: 'Resting HR (7-day)',
             trendInverse: true,
+            unit: 'bpm',
           },
+          id: 'rhr-7d',
+          type: 'metric_card',
         },
         {
+          config: {
+            metric: 'rhr_30day',
+            subtitle: 'Long-term average',
+            title: 'Resting HR (30-day)',
+            unit: 'bpm',
+          },
           id: 'rhr-30d',
           type: 'metric_card',
-          config: { metric: 'rhr_30day', title: 'Resting HR (30-day)', unit: 'bpm', subtitle: 'Long-term average' },
         },
       ],
     },
     {
       id: 'summary',
-      type: 'metrics',
       title: '30-Day Summary',
+      type: 'metrics',
       widgets: [
         {
+          config: { color: '#3b82f6', lookbackDays: 30, metric: 'sleep_score' },
           id: 'sleep',
           type: 'sparkline_card',
-          config: { metric: 'sleep_score', lookbackDays: 30, color: '#3b82f6' },
         },
         {
+          config: { metric: 'readiness_score', title: 'Readiness Score' },
           id: 'readiness',
           type: 'metric_card',
-          config: { metric: 'readiness_score', title: 'Readiness Score' },
         },
         {
+          config: { metric: 'steps', title: 'Daily Steps' },
           id: 'steps',
           type: 'metric_card',
-          config: { metric: 'steps', title: 'Daily Steps' },
         },
         {
+          config: {
+            metric: 'zone2_weekly',
+            subtitle: 'Target: 150-200 min/week',
+            title: 'Zone 2 (Weekly)',
+            unit: 'min',
+          },
           id: 'zone2',
           type: 'metric_card',
-          config: { metric: 'zone2_weekly', title: 'Zone 2 (Weekly)', unit: 'min', subtitle: 'Target: 150-200 min/week' },
         },
       ],
     },
     {
       id: 'activity',
-      type: 'charts',
       title: 'Activity',
+      type: 'charts',
       widgets: [
         {
+          config: { lookbackDays: 7 },
           id: 'activity-summary',
           type: 'activity_summary',
-          config: { lookbackDays: 7 },
         },
       ],
     },
     {
       id: 'links',
-      type: 'links',
       title: 'Explore',
+      type: 'links',
       widgets: [
-        { id: 'link-timeline', type: 'quick_link', config: { href: '/timeline', label: 'Timeline', icon: 'timeline' } },
-        { id: 'link-sleep', type: 'quick_link', config: { href: '/sleep', label: 'Sleep', icon: 'sleep' } },
-        { id: 'link-hr-zones', type: 'quick_link', config: { href: '/hr-zones', label: 'HR Zones', icon: 'hr-zones' } },
         {
+          config: { href: '/timeline', icon: 'timeline', label: 'Timeline' },
+          id: 'link-timeline',
+          type: 'quick_link',
+        },
+        { config: { href: '/sleep', icon: 'sleep', label: 'Sleep' }, id: 'link-sleep', type: 'quick_link' },
+        {
+          config: { href: '/hr-zones', icon: 'hr-zones', label: 'HR Zones' },
+          id: 'link-hr-zones',
+          type: 'quick_link',
+        },
+        {
+          config: { href: '/correlations', icon: 'correlations', label: 'Correlations' },
           id: 'link-correlations',
           type: 'quick_link',
-          config: { href: '/correlations', label: 'Correlations', icon: 'correlations' },
         },
-        { id: 'link-goals', type: 'quick_link', config: { href: '/goals', label: 'Goals', icon: 'goals' } },
-        { id: 'link-places', type: 'quick_link', config: { href: '/places', label: 'Places', icon: 'places' } },
+        { config: { href: '/goals', icon: 'goals', label: 'Goals' }, id: 'link-goals', type: 'quick_link' },
+        {
+          config: { href: '/places', icon: 'places', label: 'Places' },
+          id: 'link-places',
+          type: 'quick_link',
+        },
       ],
     },
   ],
+  version: 1,
 }

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -63,6 +63,13 @@ export const rescueTimeKeySchema = z.string().min(1, 'RescueTime API key cannot 
 })
 
 /**
+ * Last.fm username schema.
+ */
+export const lastFmUsernameSchema = z.string().min(1, 'Last.fm username cannot be empty').meta({
+  description: 'Last.fm username for scrobble sync',
+})
+
+/**
  * Tag mappings schema (UUID -> display name).
  */
 export const tagMappingsSchema = z.record(z.string(), z.string()).meta({
@@ -112,6 +119,9 @@ export const updateSettingsInputSchema = z
     hr_zone_start: hrZoneThresholdsSchema.nullable().optional().meta({
       description: 'Custom HR zone thresholds (set to null to clear)',
     }),
+    lastfm_username: lastFmUsernameSchema.nullable().optional().meta({
+      description: 'Last.fm username for scrobble sync (set to null to clear)',
+    }),
     rescue_time_key: rescueTimeKeySchema.nullable().optional().meta({
       description: 'RescueTime API key (set to null to clear)',
     }),
@@ -130,12 +140,16 @@ export const userSettingsResponseSchema = baseResponseSchema
   .extend({
     birth_date: z.string().nullable().meta({ description: 'Birth date in YYYY-MM-DD format' }),
     calendars: calendarsSchema.meta({ description: 'Calendar ICS URL configurations' }),
-    dashboard: dashboardConfigSchema.nullable().meta({ description: 'Custom dashboard configuration (null = use default)' }),
+    dashboard: dashboardConfigSchema
+      .nullable()
+      .meta({ description: 'Custom dashboard configuration (null = use default)' }),
     goals: goalsSchema.meta({ description: 'User goals for tracking metrics' }),
     hr_zone_start: hrZoneThresholdsSchema.meta({ description: 'Effective HR zone thresholds' }),
     hr_zone_start_source: hrZoneSourceSchema.meta({
       description: 'Source of HR zone thresholds',
     }),
+    lastfm_configured: z.boolean().meta({ description: 'Whether Last.fm API key is configured on server' }),
+    lastfm_username: z.string().nullable().meta({ description: 'Last.fm username for scrobble sync' }),
     oura_configured: z.boolean().meta({ description: 'Whether Oura OAuth is configured on server' }),
     oura_connected: z.boolean().meta({ description: 'Whether Oura is connected via OAuth' }),
     rescue_time_key: z.string().nullable().meta({ description: 'RescueTime API key' }),

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -53,7 +53,7 @@ export type SyncStatusResponse = z.infer<typeof syncStatusResponseSchema>
  */
 export const syncStatusQuerySchema = z
   .object({
-    provider: z.enum(['oura', 'rescuetime', 'calendar', 'all']).optional().meta({
+    provider: z.enum(['oura', 'rescuetime', 'calendar', 'lastfm', 'all']).optional().meta({
       description: 'Provider to check (defaults to all)',
     }),
   })
@@ -64,7 +64,7 @@ export type SyncStatusQuery = z.infer<typeof syncStatusQuerySchema>
 /**
  * Sync provider schema (for MCP).
  */
-export const syncProviderSchema = z.enum(['oura', 'rescuetime', 'calendar', 'all']).meta({
+export const syncProviderSchema = z.enum(['oura', 'rescuetime', 'calendar', 'lastfm', 'all']).meta({
   description: 'Which provider to check',
 })
 
@@ -331,3 +331,155 @@ export const calendarSyncResponseSchema = baseResponseSchema
   .meta({ id: 'CalendarSyncResponse' })
 
 export type CalendarSyncResponse = z.infer<typeof calendarSyncResponseSchema>
+
+// ============================================================================
+// Last.fm sync schemas
+// ============================================================================
+
+/**
+ * Sync Last.fm body schema.
+ */
+export const syncLastFmBodySchema = z
+  .object({
+    full_resync: z.boolean().optional().meta({
+      description: 'If true, fetches all historical data (default 30 days)',
+    }),
+    start_date: dateOnlySchema.optional().meta({
+      description: 'Start date for sync (only used with full_resync)',
+    }),
+  })
+  .meta({ id: 'SyncLastFmBody' })
+
+export type SyncLastFmBody = z.infer<typeof syncLastFmBodySchema>
+
+/**
+ * Last.fm sync result.
+ */
+export const lastFmSyncResultSchema = z
+  .object({
+    error: z.string().optional().meta({ description: 'Error message if status is error' }),
+    scrobblesProcessed: z.number().int().meta({ description: 'Number of scrobbles processed' }),
+    status: syncResultStatusSchema,
+    tagsCreated: z.number().int().meta({ description: 'Number of tags created from rules' }),
+  })
+  .meta({ id: 'LastFmSyncResult' })
+
+export type LastFmSyncResult = z.infer<typeof lastFmSyncResultSchema>
+
+/**
+ * Last.fm sync response.
+ */
+export const lastFmSyncResponseSchema = baseResponseSchema
+  .extend({
+    result: lastFmSyncResultSchema.optional().meta({ description: 'Sync result' }),
+  })
+  .meta({ id: 'LastFmSyncResponse' })
+
+export type LastFmSyncResponse = z.infer<typeof lastFmSyncResponseSchema>
+
+/**
+ * Last.fm sync status response.
+ */
+export const lastFmSyncStatusResponseSchema = baseResponseSchema
+  .extend({
+    states: z.array(providerSyncStatusSchema).optional().meta({ description: 'Last.fm sync states' }),
+  })
+  .meta({ id: 'LastFmSyncStatusResponse' })
+
+export type LastFmSyncStatusResponse = z.infer<typeof lastFmSyncStatusResponseSchema>
+
+// ============================================================================
+// Last.fm tag rules schemas
+// ============================================================================
+
+/**
+ * Last.fm match type for tag rules.
+ */
+export const lastFmMatchTypeSchema = z.enum(['track', 'artist', 'track_artist']).meta({
+  description:
+    'Type of match: track (any scrobble with track name), artist (any scrobble by artist), track_artist (exact track + artist)',
+  id: 'LastFmMatchType',
+})
+
+export type LastFmMatchType = z.infer<typeof lastFmMatchTypeSchema>
+
+/**
+ * Last.fm match mode for tag rules.
+ */
+export const lastFmMatchModeSchema = z.enum(['exact', 'contains']).meta({
+  description: 'How to match: exact (case-insensitive exact match) or contains (substring match)',
+  id: 'LastFmMatchMode',
+})
+
+export type LastFmMatchMode = z.infer<typeof lastFmMatchModeSchema>
+
+/**
+ * Last.fm tag rule schema.
+ */
+export const lastFmTagRuleSchema = z
+  .object({
+    artistName: z
+      .string()
+      .optional()
+      .meta({ description: 'Artist name to match (for artist or track_artist match type)' }),
+    createdAt: z.string().meta({ description: 'When the rule was created' }),
+    id: z.string().uuid().meta({ description: 'Unique rule ID' }),
+    matchMode: lastFmMatchModeSchema,
+    matchType: lastFmMatchTypeSchema,
+    ruleName: z.string().meta({ description: 'Human-readable name for the rule' }),
+    tagName: z.string().meta({ description: 'Tag to create when rule matches' }),
+    trackName: z
+      .string()
+      .optional()
+      .meta({ description: 'Track name to match (for track or track_artist match type)' }),
+  })
+  .meta({ id: 'LastFmTagRule' })
+
+export type LastFmTagRule = z.infer<typeof lastFmTagRuleSchema>
+
+/**
+ * Add Last.fm tag rule body schema.
+ */
+export const addLastFmTagRuleBodySchema = z
+  .object({
+    artistName: z
+      .string()
+      .optional()
+      .meta({ description: 'Artist name to match (required for artist or track_artist match type)' }),
+    matchMode: lastFmMatchModeSchema
+      .optional()
+      .default('exact')
+      .meta({ description: 'Match mode (default: exact)' }),
+    matchType: lastFmMatchTypeSchema,
+    ruleName: z.string().min(1).meta({ description: 'Human-readable name for the rule' }),
+    tagName: z.string().min(1).meta({ description: 'Tag to create when rule matches' }),
+    trackName: z
+      .string()
+      .optional()
+      .meta({ description: 'Track name to match (required for track or track_artist match type)' }),
+  })
+  .meta({ id: 'AddLastFmTagRuleBody' })
+
+export type AddLastFmTagRuleBody = z.infer<typeof addLastFmTagRuleBodySchema>
+
+/**
+ * Last.fm tag rules response.
+ */
+export const lastFmTagRulesResponseSchema = baseResponseSchema
+  .extend({
+    data: z.array(lastFmTagRuleSchema).meta({ description: 'List of tag rules' }),
+  })
+  .meta({ id: 'LastFmTagRulesResponse' })
+
+export type LastFmTagRulesResponse = z.infer<typeof lastFmTagRulesResponseSchema>
+
+/**
+ * Add Last.fm tag rule response.
+ */
+export const addLastFmTagRuleResponseSchema = baseResponseSchema
+  .extend({
+    data: lastFmTagRuleSchema.optional().meta({ description: 'Created tag rule' }),
+  })
+  .meta({ id: 'AddLastFmTagRuleResponse' })
+
+export type AddLastFmTagRuleResponse = z.infer<typeof addLastFmTagRuleResponseSchema>


### PR DESCRIPTION
## Summary
- Integrates with Last.fm API to sync scrobbles and automatically create tags based on user-defined rules
- Users can configure their Last.fm username in settings and create rules to auto-tag listening sessions
- Supports matching by track name, artist name, or track+artist combinations with exact or contains modes

## Features
- **Last.fm API client**: Fetches scrobbles with pagination support
- **Auto-tagging rules**: Define rules that create tags when scrobbles match criteria (e.g., "when track X plays, create tag VocalExercises")
- **MCP tools**: `sync_lastfm`, `get_lastfm_tag_rules`, `add_lastfm_tag_rule`, `delete_lastfm_tag_rule`
- **REST API**: Sync endpoints at `/sync/lastfm` and tag rules CRUD at `/lastfm/tag-rules`

## Implementation Details
- App-level `LASTFM_API_KEY` environment variable required
- User provides Last.fm username in settings
- Scrobbles stored in `raw_records` table (source='lastfm')
- Tags created with source='lastfm-auto' for traceability
- Incremental sync using existing `sync_state` table pattern

## Test plan
- [x] Unit tests for Last.fm API client (lastfm.test.ts)
- [x] Unit tests for sync module and rule matching (lastfm-sync.test.ts)
- [x] Integration tests for tag rules CRUD (db.integration.test.ts)
- [x] All 605 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)