### PR TITLE
Add Last.fm settings UI and tag rules management

### DIFF
--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -1,0 +1,247 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+import {
+  createLastFmTagRule,
+  deleteLastFmTagRule,
+  fetchLastFmTagRules,
+  fetchUserSettings,
+  type AddLastFmTagRuleBody,
+  type LastFmMatchMode,
+  type LastFmMatchType,
+  type LastFmTagRule,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+
+import './style.css'
+
+type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
+
+export function LastFmTagRulesSettings() {
+  const isLoggedIn = auth.value.token
+  const queryClient = useQueryClient()
+
+  const { data: userSettings } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+  })
+
+  const { data: rules, isLoading } = useQuery({
+    enabled: !!isLoggedIn && !!userSettings?.lastfm_username,
+    queryFn: fetchLastFmTagRules,
+    queryKey: ['lastfmTagRules'],
+  })
+
+  // Form state for new rule
+  const [ruleName, setRuleName] = useState('')
+  const [matchType, setMatchType] = useState<LastFmMatchType>('track')
+  const [trackName, setTrackName] = useState('')
+  const [artistName, setArtistName] = useState('')
+  const [matchMode, setMatchMode] = useState<LastFmMatchMode>('exact')
+  const [tagName, setTagName] = useState('')
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+
+  const handleAddRule = async () => {
+    if (!ruleName.trim() || !tagName.trim()) return
+
+    // Validate required fields based on match type
+    if ((matchType === 'track' || matchType === 'track_artist') && !trackName.trim()) {
+      setSaveStatus({ error: 'Track name is required', status: 'error' })
+      return
+    }
+    if ((matchType === 'artist' || matchType === 'track_artist') && !artistName.trim()) {
+      setSaveStatus({ error: 'Artist name is required', status: 'error' })
+      return
+    }
+
+    setSaveStatus({ status: 'saving' })
+    try {
+      const rule: AddLastFmTagRuleBody = {
+        matchMode,
+        matchType,
+        ruleName: ruleName.trim(),
+        tagName: tagName.trim(),
+      }
+      if (matchType === 'track' || matchType === 'track_artist') {
+        rule.trackName = trackName.trim()
+      }
+      if (matchType === 'artist' || matchType === 'track_artist') {
+        rule.artistName = artistName.trim()
+      }
+
+      await createLastFmTagRule(rule)
+      queryClient.invalidateQueries({ queryKey: ['lastfmTagRules'] })
+
+      // Reset form
+      setRuleName('')
+      setTrackName('')
+      setArtistName('')
+      setTagName('')
+      setSaveStatus({ status: 'saved', time: new Date() })
+    } catch (err) {
+      setSaveStatus({
+        error: err instanceof Error ? err.message : 'Failed to create rule',
+        status: 'error',
+      })
+    }
+  }
+
+  const handleDeleteRule = async (rule: LastFmTagRule) => {
+    if (!confirm(`Delete rule "${rule.ruleName}"?`)) return
+
+    try {
+      await deleteLastFmTagRule(rule.id)
+      queryClient.invalidateQueries({ queryKey: ['lastfmTagRules'] })
+    } catch (err) {
+      setSaveStatus({
+        error: err instanceof Error ? err.message : 'Failed to delete rule',
+        status: 'error',
+      })
+    }
+  }
+
+  // Don't show if Last.fm is not configured
+  if (!userSettings?.lastfm_username) {
+    return null
+  }
+
+  return (
+    <section class="settings-section lastfm-rules-section">
+      <div class="section-header-row">
+        <h2>Last.fm Auto-Tagging Rules</h2>
+        {saveStatus.status !== 'idle' && (
+          <span class={`save-indicator ${saveStatus.status}`}>
+            {saveStatus.status === 'saving' && 'Saving...'}
+            {saveStatus.status === 'saved' && 'Rule created'}
+            {saveStatus.status === 'error' && (saveStatus.error ?? 'Error')}
+          </span>
+        )}
+      </div>
+      <p class="section-description">
+        Create rules to automatically tag your listening sessions. When a scrobble matches a rule, a tag will
+        be created at the scrobble time.
+      </p>
+
+      {isLoading ?
+        <p class="loading">Loading rules...</p>
+      : <>
+          {/* Existing rules */}
+          {(rules ?? []).length > 0 && (
+            <div class="rules-list">
+              {(rules ?? []).map((rule) => (
+                <div class="rule-item" key={rule.id}>
+                  <div class="rule-info">
+                    <span class="rule-name">{rule.ruleName}</span>
+                    <span class="rule-details">
+                      {rule.matchType === 'track' && `Track: "${rule.trackName}"`}
+                      {rule.matchType === 'artist' && `Artist: "${rule.artistName}"`}
+                      {rule.matchType === 'track_artist' && `"${rule.trackName}" by "${rule.artistName}"`}
+                      {rule.matchMode === 'contains' && ' (contains)'}
+                      {' → '}
+                      <strong>{rule.tagName}</strong>
+                    </span>
+                  </div>
+                  <button type="button" class="remove-rule-button" onClick={() => handleDeleteRule(rule)}>
+                    Delete
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add new rule form */}
+          <div class="add-rule-form">
+            <h3>Add New Rule</h3>
+
+            <div class="form-row">
+              <div class="form-field">
+                <label for="rule-name">Rule Name</label>
+                <input
+                  id="rule-name"
+                  type="text"
+                  value={ruleName}
+                  onInput={(e) => setRuleName((e.target as HTMLInputElement).value)}
+                  placeholder="e.g., Vocal Exercises"
+                />
+              </div>
+
+              <div class="form-field">
+                <label for="tag-name">Tag to Create</label>
+                <input
+                  id="tag-name"
+                  type="text"
+                  value={tagName}
+                  onInput={(e) => setTagName((e.target as HTMLInputElement).value)}
+                  placeholder="e.g., VocalExercises"
+                />
+              </div>
+            </div>
+
+            <div class="form-row">
+              <div class="form-field">
+                <label for="match-type">Match Type</label>
+                <select
+                  id="match-type"
+                  value={matchType}
+                  onChange={(e) => setMatchType((e.target as HTMLSelectElement).value as LastFmMatchType)}
+                >
+                  <option value="track">Track Name (any artist)</option>
+                  <option value="artist">Artist Name (any track)</option>
+                  <option value="track_artist">Track + Artist (exact)</option>
+                </select>
+              </div>
+
+              <div class="form-field">
+                <label for="match-mode">Match Mode</label>
+                <select
+                  id="match-mode"
+                  value={matchMode}
+                  onChange={(e) => setMatchMode((e.target as HTMLSelectElement).value as LastFmMatchMode)}
+                >
+                  <option value="exact">Exact (case-insensitive)</option>
+                  <option value="contains">Contains (substring)</option>
+                </select>
+              </div>
+            </div>
+
+            {(matchType === 'track' || matchType === 'track_artist') && (
+              <div class="form-field">
+                <label for="track-name">Track Name</label>
+                <input
+                  id="track-name"
+                  type="text"
+                  value={trackName}
+                  onInput={(e) => setTrackName((e.target as HTMLInputElement).value)}
+                  placeholder="e.g., Warmup Track 1"
+                />
+              </div>
+            )}
+
+            {(matchType === 'artist' || matchType === 'track_artist') && (
+              <div class="form-field">
+                <label for="artist-name">Artist Name</label>
+                <input
+                  id="artist-name"
+                  type="text"
+                  value={artistName}
+                  onInput={(e) => setArtistName((e.target as HTMLInputElement).value)}
+                  placeholder="e.g., Meditation Artist"
+                />
+              </div>
+            )}
+
+            <button
+              type="button"
+              class="connect-button"
+              onClick={handleAddRule}
+              disabled={!ruleName.trim() || !tagName.trim()}
+            >
+              Add Rule
+            </button>
+          </div>
+        </>
+      }
+    </section>
+  )
+}

--- a/apps/web/src/components/LastFmTagRulesSettings/style.css
+++ b/apps/web/src/components/LastFmTagRulesSettings/style.css
@@ -1,0 +1,144 @@
+.lastfm-rules-section .loading {
+  color: #666;
+  font-style: italic;
+}
+
+.rules-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.rule-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  gap: 1rem;
+}
+
+.rule-info {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rule-name {
+  font-weight: 500;
+}
+
+.rule-details {
+  font-size: 0.875rem;
+  color: #666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remove-rule-button {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  background: transparent;
+  border: 1px solid #f44336;
+  color: #f44336;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.remove-rule-button:hover {
+  background: #f44336;
+  color: white;
+}
+
+.add-rule-form {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 1rem;
+  background: #fafafa;
+}
+
+.add-rule-form h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.form-row .form-field {
+  flex: 1;
+}
+
+.add-rule-form .form-field {
+  margin-bottom: 0.75rem;
+}
+
+.add-rule-form .form-field label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.add-rule-form .form-field input,
+.add-rule-form .form-field select {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.add-rule-form .connect-button {
+  margin-top: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .lastfm-rules-section .loading {
+    color: #aaa;
+  }
+
+  .rule-item {
+    border-color: #444;
+  }
+
+  .rule-details {
+    color: #aaa;
+  }
+
+  .add-rule-form {
+    border-color: #444;
+    background: #2a2a2a;
+  }
+
+  .add-rule-form .form-field input,
+  .add-rule-form .form-field select {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+}
+
+@media (max-width: 639px) {
+  .form-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .rule-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .remove-rule-button {
+    align-self: flex-end;
+  }
+}

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -2,6 +2,7 @@ import type { CalendarConfig } from '@aurboda/api-spec'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
 import { GoalsSettings } from '../../components/GoalsSettings'
+import { LastFmTagRulesSettings } from '../../components/LastFmTagRulesSettings'
 import { TagMappingsSettings } from '../../components/TagMappingsSettings'
 import { API_URL } from '../../config'
 import { fetchUserSettings, HrZoneThresholds, UpdateSettingsInput, updateUserSettings } from '../../state/api'
@@ -48,6 +49,7 @@ export function Settings() {
   const [birthDate, setBirthDate] = useState<string>('')
   const [hrZones, setHrZones] = useState<HrZoneThresholds | null>(null)
   const [rescueTimeKey, setRescueTimeKey] = useState<string>('')
+  const [lastfmUsername, setLastfmUsername] = useState<string>('')
 
   // Calendar form state
   const [newCalendarName, setNewCalendarName] = useState('')
@@ -56,6 +58,7 @@ export function Settings() {
   // Save status for each section
   const [birthDateStatus, setBirthDateStatus] = useState<SaveStatus>({ status: 'idle' })
   const [rescueTimeStatus, setRescueTimeStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [lastfmStatus, setLastfmStatus] = useState<SaveStatus>({ status: 'idle' })
   const [hrZonesStatus, setHrZonesStatus] = useState<SaveStatus>({ status: 'idle' })
   const [calendarsStatus, setCalendarsStatus] = useState<SaveStatus>({ status: 'idle' })
 
@@ -64,6 +67,7 @@ export function Settings() {
     setBirthDate(userSettings?.birth_date ?? '')
     setHrZones(userSettings?.hr_zone_start ?? null)
     setRescueTimeKey('')
+    setLastfmUsername(userSettings?.lastfm_username ?? '')
   }
 
   // Track if form has been initialized
@@ -147,6 +151,18 @@ export function Settings() {
 
     saveSection({ rescue_time_key: rescueTimeKey }, setRescueTimeStatus)
     setRescueTimeKey('')
+  }
+
+  const handleLastfmUsernameChange = (e: Event) => {
+    const value = (e.target as HTMLInputElement).value
+    setLastfmUsername(value)
+  }
+
+  const handleLastfmUsernameBlur = () => {
+    const serverValue = userSettings?.lastfm_username ?? ''
+    if (lastfmUsername === serverValue) return
+
+    saveSection({ lastfm_username: lastfmUsername || null }, setLastfmStatus)
   }
 
   const handleAddCalendar = () => {
@@ -267,6 +283,40 @@ export function Settings() {
             . Used to sync productivity data. Saves automatically when you leave the field.
           </p>
         </div>
+
+        <div class="form-field">
+          <div class="field-header-row">
+            <label for="lastfm-username">Last.fm Username</label>
+            <SaveStatusIndicator saveStatus={lastfmStatus} />
+          </div>
+          {userSettings?.lastfm_username ?
+            <p class="connected-status">Configured</p>
+          : null}
+          {userSettings?.lastfm_configured === false ?
+            <p class="field-description warning">
+              Last.fm API key is not configured on the server. Ask your administrator to set the
+              LASTFM_API_KEY environment variable.
+            </p>
+          : <>
+              <input
+                id="lastfm-username"
+                type="text"
+                value={lastfmUsername}
+                onInput={handleLastfmUsernameChange}
+                onBlur={handleLastfmUsernameBlur}
+                placeholder="Enter your Last.fm username"
+              />
+              <p class="field-description">
+                Enter your Last.fm username to sync scrobbles and create auto-tags based on your listening
+                history. Find your username on your{' '}
+                <a href="https://www.last.fm/user/_" target="_blank" rel="noopener noreferrer">
+                  Last.fm profile
+                </a>
+                .
+              </p>
+            </>
+          }
+        </div>
       </section>
 
       <section class="settings-section">
@@ -373,6 +423,8 @@ export function Settings() {
           <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
         )}
       </section>
+
+      <LastFmTagRulesSettings />
 
       <GoalsSettings goals={userSettings?.goals ?? []} />
 

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -78,8 +78,20 @@
   margin-bottom: 0.5rem;
 }
 
+.field-header-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.field-header-row label {
+  margin-bottom: 0;
+}
+
 .form-field input[type="date"],
-.form-field input[type="password"] {
+.form-field input[type="password"],
+.form-field input[type="text"] {
   padding: 0.5rem;
   font-size: 1rem;
   border: 1px solid #ccc;
@@ -270,13 +282,15 @@
 
   .form-field input[type="date"],
   .form-field input[type="password"],
+  .form-field input[type="text"],
   .zone-input input[type="number"] {
     background: #333;
     border-color: #555;
     color: #fff;
   }
 
-  .form-field input[type="password"]::placeholder {
+  .form-field input[type="password"]::placeholder,
+  .form-field input[type="text"]::placeholder {
     color: #888;
   }
 

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -6,6 +6,8 @@ import type {
   ActivityImpactQuery,
   ActivityImpactResponse,
   ActivityImpactType,
+  AddLastFmTagRuleBody,
+  AddLastFmTagRuleResponse,
   AddNamedLocationBody,
   AddNamedLocationResponse,
   Activity as ApiActivity,
@@ -25,6 +27,10 @@ import type {
   HrvStats,
   HrvStatsWithDelta,
   HrZoneThresholds,
+  LastFmMatchMode,
+  LastFmMatchType,
+  LastFmTagRule,
+  LastFmTagRulesResponse,
   LocationCorrelation,
   LocationsQuery,
   LocationsResponse,
@@ -42,6 +48,7 @@ import type {
   QueryMetricsQuery,
   QueryMetricsResponse,
   SetTagMappingResponse,
+  SyncResponse,
   TagCorrelation,
   TagMappings,
   TagsQuery,
@@ -99,6 +106,7 @@ export type {
   ActivityCorrelation,
   ActivityImpactData,
   ActivityImpactType,
+  AddLastFmTagRuleBody,
   BaselineData,
   DashboardConfig,
   Goal,
@@ -107,6 +115,9 @@ export type {
   HrvStats,
   HrvStatsWithDelta,
   HrZoneThresholds,
+  LastFmMatchMode,
+  LastFmMatchType,
+  LastFmTagRule,
   LocationCorrelation,
   NamedLocation,
   PeriodMetricStats,
@@ -639,4 +650,36 @@ export const resetDashboard = async (): Promise<DashboardConfig> => {
   })
 
   return response.data.dashboard
+}
+
+// ==========================================================================
+// Last.fm Tag Rules API
+// ==========================================================================
+
+// Fetch all Last.fm tag rules
+export const fetchLastFmTagRules = async (): Promise<LastFmTagRule[]> => {
+  const { token } = auth.value
+  const response = await axios.get<LastFmTagRulesResponse>(`${API_URL}/lastfm/tag-rules`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return response.data.data ?? []
+}
+
+// Create a new Last.fm tag rule
+export const createLastFmTagRule = async (rule: AddLastFmTagRuleBody): Promise<LastFmTagRule> => {
+  const { token } = auth.value
+  const response = await axios.post<AddLastFmTagRuleResponse>(`${API_URL}/lastfm/tag-rules`, rule, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return response.data.data!
+}
+
+// Delete a Last.fm tag rule
+export const deleteLastFmTagRule = async (ruleId: string): Promise<void> => {
+  const { token } = auth.value
+  await axios.delete<SyncResponse>(`${API_URL}/lastfm/tag-rules/${ruleId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
 }


### PR DESCRIPTION
## Summary
- Adds web UI for configuring Last.fm username in the Settings page
- Adds a component for managing Last.fm auto-tagging rules

## Features

### Settings Page (Data Sources section)
- Last.fm username text field with auto-save on blur
- Shows "Configured" status when username is set
- Warning message when `LASTFM_API_KEY` is not configured on server

### Tag Rules Management
- Lists all existing auto-tagging rules
- Shows rule name, match criteria, and resulting tag
- Create new rules with:
  - Rule name
  - Match type: Track (any artist), Artist (any track), or Track + Artist
  - Match mode: Exact (case-insensitive) or Contains (substring)
  - Track/artist names based on match type
  - Tag name to create
- Delete button for each rule
- Component only shows when Last.fm username is configured

## Test plan
- [x] TypeScript compiles without errors
- [x] All 605 backend tests pass
- [ ] Manual: Navigate to Settings, enter Last.fm username
- [ ] Manual: Create a tag rule with different match types
- [ ] Manual: Delete a tag rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)