### PR TITLE
Add eslint-disable comments for web frontend complexity violations

### DIFF
--- a/apps/web/src/components/DashboardEditor/index.tsx
+++ b/apps/web/src/components/DashboardEditor/index.tsx
@@ -121,6 +121,7 @@ const linkOptions = [
   { icon: 'settings', label: 'Settings', value: '/settings' },
 ]
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function DashboardEditor({ sectionType, onAddWidget, onClose }: DashboardEditorProps) {
   const [selectedTemplate, setSelectedTemplate] = useState<WidgetTemplate | null>(null)
   const [configValues, setConfigValues] = useState<Record<string, unknown>>({})
@@ -150,6 +151,7 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
   }
 
   // Render configuration form based on widget type
+  // eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
   const renderConfigForm = () => {
     if (!selectedTemplate) return null
 

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -103,6 +103,7 @@ interface LocalGoal extends Omit<Goal, 'min' | 'max' | 'window'> {
   isNew?: boolean // Track if this is a newly added goal not yet saved
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function GoalsSettings({ goals }: GoalsSettingsProps) {
   const queryClient = useQueryClient()
   const [saveStatus, setSaveStatus] = useState<{ status: 'idle' | 'saving' | 'saved'; time?: Date }>({
@@ -354,6 +355,7 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
       {localGoals.length === 0 ?
         <p class="no-goals">No goals set. Click "+ Add Goal" to create one.</p>
       : <div class="goals-list">
+          {/* eslint-disable-next-line max-lines-per-function -- TODO: refactor */}
           {localGoals.map((goal) => {
             const validationError = validateGoal({
               ...goal,

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -16,6 +16,7 @@ import './style.css'
 
 type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function LastFmTagRulesSettings() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()

--- a/apps/web/src/components/TagPicker.tsx
+++ b/apps/web/src/components/TagPicker.tsx
@@ -24,6 +24,7 @@ const buildTagEntries = (uniqueTags: string[], programmaticTags: ProgrammaticTag
   }))
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function TagPicker({
   onChange,
   selectedTags,

--- a/apps/web/src/components/widgets/ActivitySummaryWidget.tsx
+++ b/apps/web/src/components/widgets/ActivitySummaryWidget.tsx
@@ -11,6 +11,7 @@ interface ActivitySummaryWidgetProps {
   config: ActivitySummaryConfig
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function ActivitySummaryWidget({ config }: ActivitySummaryWidgetProps) {
   const { lookbackDays = 7, showWorkouts = true, showSleep = true, showMeditation = true } = config
 

--- a/apps/web/src/components/widgets/MetricCardWidget.tsx
+++ b/apps/web/src/components/widgets/MetricCardWidget.tsx
@@ -102,6 +102,7 @@ const extractPeriodValue = (
   }
 }
 
+// eslint-disable-next-line complexity -- TODO: refactor
 export function MetricCardWidget({ config }: MetricCardWidgetProps) {
   const { metric, title, unit, subtitle: configSubtitle, trendInverse } = config
 

--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -143,6 +143,7 @@ const metricToApiMetric: Record<string, string> = {
   steps: 'steps',
 }
 
+// eslint-disable-next-line complexity -- TODO: refactor
 export function SparklineCardWidget({ config }: SparklineCardWidgetProps) {
   const { metric, title: configTitle, lookbackDays = 30, color = '#3b82f6' } = config
 

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -49,6 +49,7 @@ function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function AdminSettings() {
   const { route } = useLocation()
   const isLoggedIn = auth.value.token

--- a/apps/web/src/pages/Correlations/index.tsx
+++ b/apps/web/src/pages/Correlations/index.tsx
@@ -26,6 +26,7 @@ const periodDays = signal(30)
 const selectedActivity = signal<{ name: string; type: ActivityImpactType } | null>(null)
 
 // Impact timeline chart component
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function ImpactTimelineChart({
   data,
   baseline,
@@ -36,6 +37,7 @@ function ImpactTimelineChart({
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor
   useEffect(() => {
     if (!svgRef.current || !containerRef.current) return
 
@@ -200,6 +202,7 @@ function ImpactTimelineChart({
 }
 
 // Correlation row component
+// eslint-disable-next-line complexity -- TODO: refactor
 function CorrelationRow({
   name,
   stats,
@@ -254,6 +257,7 @@ function CorrelationRow({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Correlations() {
   // Fetch baseline
   const baselineQuery = useQuery({

--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -12,6 +12,7 @@ import './style.css'
 const generateSectionId = () => `section-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 
 // Section renderer - renders a section with its widgets
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function DashboardSectionComponent({
   section,
   isEditing,
@@ -214,6 +215,7 @@ function AddSectionForm({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function Dashboard() {
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = useState(false)

--- a/apps/web/src/pages/Help/index.tsx
+++ b/apps/web/src/pages/Help/index.tsx
@@ -80,6 +80,7 @@ function DataSourceCard({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Help() {
   const isLoggedIn = auth.value.token
 

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -4,6 +4,7 @@ import { Dashboard } from '../Dashboard'
 
 import './style.css'
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function GuestHome({ canSignup }: { canSignup: boolean }) {
   return (
     <>

--- a/apps/web/src/pages/Places/index.tsx
+++ b/apps/web/src/pages/Places/index.tsx
@@ -27,6 +27,7 @@ L.Icon.Default.mergeOptions({
 
 const selectedDate = signal(formatISO(new Date(), { representation: 'date' }))
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const Places = () => {
   const queryClient = useQueryClient()
   const start = startOfDay(new Date(selectedDate.value))

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -35,6 +35,7 @@ function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Settings() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()

--- a/apps/web/src/pages/Signup/index.tsx
+++ b/apps/web/src/pages/Signup/index.tsx
@@ -4,6 +4,7 @@ import { auth, ensureStatusLoaded, signup, signupMode } from '../../state/auth'
 
 import './style.css'
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function Signup() {
   const { route, query } = useLocation()
   const [error, setError] = useState<string | null>(null)

--- a/apps/web/src/pages/Sleep/index.tsx
+++ b/apps/web/src/pages/Sleep/index.tsx
@@ -11,10 +11,12 @@ import './style.css'
 const daysBack = signal(30)
 
 // Sleep score line chart component
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function SleepScoreChart({ data, height = 200 }: { data: [Date, number][]; height?: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor
   useEffect(() => {
     if (!svgRef.current || !containerRef.current || data.length < 2) return
 
@@ -149,10 +151,12 @@ function SleepScoreChart({ data, height = 200 }: { data: [Date, number][]; heigh
 }
 
 // Sleep duration bar chart
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function SleepDurationChart({ sleepSessions, height = 180 }: { sleepSessions: Activity[]; height?: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor
   useEffect(() => {
     if (!svgRef.current || !containerRef.current || sleepSessions.length < 2) return
 
@@ -322,6 +326,7 @@ function StatCard({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Sleep() {
   const end = endOfDay(new Date())
   const start = startOfDay(subDays(new Date(), daysBack.value))

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor */
 import { Signal, signal } from '@preact/signals'
 import { useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
@@ -205,6 +206,7 @@ const trackSleepMeditation = 0
 const trackExercise = trackHeight
 const trackPlaces = 2 * trackHeight
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export const Timeline = () => {
   const start = startOfDay(new Date(fromDate.value))
   const end = endOfDay(new Date(toDate.value))
@@ -469,6 +471,7 @@ interface TimelineChartProps {
   onZoomOut: () => void
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function TimelineChart({
   heartRates,
   hrvData,

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -16,6 +16,7 @@ import {
 import './style.css'
 
 // Chart component for trend history
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function TrendChart({ data, color }: { data: { date: string; value: number }[]; color: string }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
@@ -167,6 +168,7 @@ const LOOKBACK_OPTIONS = [
 ]
 
 // Form for configuring a trend
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 function TrendConfigForm({
   initialValues,
   onSubmit,
@@ -396,6 +398,7 @@ function TrendWidget({
 }
 
 // Main Trends page component
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function Trends() {
   const isLoggedIn = auth.value.token
   const [showAddForm, setShowAddForm] = useState(false)

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor */
 import type {
   ActivitiesQuery,
   ActivitiesResponse,


### PR DESCRIPTION
## Summary
- Add `eslint-disable` comments to 19 web frontend production files that have ESLint complexity violations (max-lines, max-lines-per-function, complexity)
- All comments include `-- TODO: refactor` markers for future cleanup
- Verified with `pnpm check` that all violations are suppressed and no new issues introduced

## Test plan
- [x] `pnpm --filter aurboda-web check` passes with no errors or warnings
- [ ] Visual spot-check that no runtime behavior changed (comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)