### PR TITLE
Add ESLint complexity rules as CI guardrails

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor - split into route modules */
 import {
   type ActivitiesQuery,
   activitiesQuerySchema,
@@ -189,6 +190,7 @@ declare global {
   }
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor - extract route groups
 const main = async () => {
   const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 })
   const forbidden = Object.assign(new Error('Forbidden'), { status: 403 })
@@ -267,6 +269,7 @@ const main = async () => {
     })
   })
 
+  // eslint-disable-next-line complexity -- TODO: refactor
   httpd.post<Record<string, never>, SignupResponse>('/signup', async (req, res, next) => {
     const signupMode = await centralDb.getSignupMode()
 

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor - split into db/ modules */
 import { type CustomMetricDefinition, type DashboardConfig, type Goal } from '@aurboda/api-spec'
 import { Client, QueryResultRow } from 'pg'
 import format from 'pg-format'
@@ -542,6 +543,7 @@ export interface Activity {
  * - Notes are concatenated with newline
  * - Data objects are merged (later values override earlier for same keys)
  */
+// eslint-disable-next-line complexity -- TODO: refactor
 export const mergeOverlappingActivities = (activities: Activity[]): Activity[] => {
   if (activities.length === 0) return []
 
@@ -1818,6 +1820,7 @@ export const processHealthConnectData = async (
 /**
  * Extract time series points from Health Connect record.
  */
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 function extractTimeSeriesPoints(
   recordType: string,
   metric: MetricType,

--- a/apps/backend/src/lastfm-router.ts
+++ b/apps/backend/src/lastfm-router.ts
@@ -25,6 +25,7 @@ import { validateBody } from './validation'
 /**
  * Creates the Last.fm router with tag rules CRUD endpoints.
  */
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
   const router = Router()
 

--- a/apps/backend/src/lastfm.ts
+++ b/apps/backend/src/lastfm.ts
@@ -57,6 +57,7 @@ export const lastfmClient = (apiKey: string) => {
      * @param to - Optional end date (Unix timestamp or Date)
      * @param limit - Number of tracks per page (max 200, default 200)
      */
+    // eslint-disable-next-line complexity -- TODO: refactor
     async getRecentTracks(
       username: string,
       from?: Date,

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor - split into mcp/ tool modules */
 import {
   activityTypes,
   activityTypeSchema,
@@ -112,6 +113,7 @@ const metricDescription = `Metric name. Valid metrics: ${validMetrics.join(', ')
  * and can survive backend restarts. When a client reconnects with a
  * previously-issued session ID, the session is lazily restored.
  */
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor - split into tool modules
 export function createMcpRouter(
   auth: Auth,
   oura?: OuraClientType,
@@ -154,6 +156,7 @@ export function createMcpRouter(
     return isNaN(date.getTime()) ? null : date
   }
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor - extract tool registration
   const createMcpServer = (user: string): McpServer => {
     const server = new McpServer({
       name: 'aurboda',
@@ -1435,6 +1438,7 @@ Common half-life values:
   }
 
   // POST /mcp - Handle JSON-RPC requests
+  // eslint-disable-next-line complexity -- TODO: refactor
   router.post('/', async (req: Request, res: Response) => {
     const user = getAuthenticatedUser(req)
     if (!user) {

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -109,6 +109,7 @@ async function migrateHcData(db: Client, user: string) {
   console.log(`  Migrated ${result.rowCount} hcdata records`)
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 function extractTimeSeriesPoints(
   recordType: string,
   metric: MetricType,

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -420,6 +420,7 @@ export interface SyncResult {
 /**
  * Sync a single Oura data type.
  */
+/* eslint-disable max-lines-per-function, complexity -- TODO: refactor */
 export const syncOuraDataType = async (
   user: string,
   oura: ReturnType<typeof ouraClient>,
@@ -538,6 +539,7 @@ export const syncOuraDataType = async (
     }
   }
 }
+/* eslint-enable max-lines-per-function, complexity */
 
 /**
  * Sync all Oura data types.

--- a/apps/backend/src/oura.ts
+++ b/apps/backend/src/oura.ts
@@ -22,6 +22,7 @@ type OuraSession = {
   motion_count: unknown
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const ouraClient = (client: string, secret: string, webHost: string) => {
   if (!client || !secret) throw new Error('Oura missing client or secret')
   const redirectUri = `${webHost}/auth/ouracb`

--- a/apps/backend/src/rescuetime-sync.ts
+++ b/apps/backend/src/rescuetime-sync.ts
@@ -42,6 +42,7 @@ export interface SyncResult {
 /**
  * Sync RescueTime productivity data.
  */
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const syncRescueTimeData = async (
   user: string,
   apiKey: string,

--- a/apps/backend/src/services/correlations.ts
+++ b/apps/backend/src/services/correlations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor - split into correlations/ modules */
 /**
  * Correlation analysis services for health data.
  *
@@ -396,6 +397,7 @@ const addBaselineDelta = (stats: HrvStats, baseline: HrvStats): HrvStatsWithDelt
 /**
  * Get personal rolling baseline for HRV and resting HR.
  */
+// eslint-disable-next-line complexity -- TODO: refactor
 export async function getBaseline(user: string, referenceDate?: Date): Promise<BaselineResult> {
   const now = referenceDate ?? new Date()
 
@@ -461,6 +463,7 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
 /**
  * Get HRV/HR correlations with different activity types.
  */
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export async function getHrvActivitiesCorrelation(
   user: string,
   periodDays: number = 30,
@@ -687,6 +690,7 @@ export async function getHrvActivitiesCorrelation(
 /**
  * Get HRV timeline before/during/after a specific activity type.
  */
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export async function getActivityImpact(
   user: string,
   activity: string,
@@ -853,6 +857,7 @@ export async function getActivityImpact(
 /**
  * Get probability of outcome event after trigger event (for discrete event correlation).
  */
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export async function getEventProbability(
   user: string,
   trigger: { type: 'activity' | 'tag'; value: string },
@@ -1042,6 +1047,7 @@ interface EventWithTime {
  * - "Does meditation correlate with more productive time?"
  * - "When I exercise 3x and tag FatCoffee 5x in a week, does my weight change?"
  */
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export async function getGenericCorrelation(
   user: string,
   triggers: TriggerCondition[],

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -366,6 +366,7 @@ export const matchLocationToDetected = (
  * Get place visits for a time range, using named locations when available.
  * Falls back to detected locations, then OwnTracks regions.
  */
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const getPlaceVisits = async (user: string, start: Date, end: Date): Promise<PlaceVisit[]> => {
   // Get location data from db with regions
   const result = await query(

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor - extract helpers */
 /**
  * Query services for health data.
  *
@@ -438,6 +439,7 @@ async function computeContextualHrvData(
  * Get a comprehensive summary of health data for a specific day.
  * @param sync Optional sync provider to auto-refresh stale data before querying
  */
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export async function getDailySummary(
   user: string,
   date: Date,
@@ -650,6 +652,7 @@ async function computeHrZoneStats(
 /**
  * Get aggregated statistics for a time period.
  */
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export async function getPeriodSummary(
   user: string,
   metrics: string[],

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -168,6 +168,7 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
  * Validate and update user settings.
  * Returns a SettingsResponse with either success or error.
  */
+// eslint-disable-next-line complexity -- TODO: refactor
 export const validateAndUpdateSettings = async (user: string, input: unknown): Promise<SettingsResponse> => {
   // Validate input
   const parsed = updateSettingsInputSchema.safeParse(input)

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -75,6 +75,7 @@ export interface SyncRouterDeps {
  * IMPORTANT: Route order matters! Specific routes must be defined BEFORE
  * the generic /sync/:recordType route to avoid Express matching issues.
  */
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHandler): Router => {
   const router = Router()
 

--- a/apps/backend/src/ui.ts
+++ b/apps/backend/src/ui.ts
@@ -6,6 +6,7 @@ import { ouraClient } from './oura'
 import { rescuetimeClient } from './rescuetime'
 import { getSettings } from './services/settings'
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const getTimeline = async (oura: ReturnType<typeof ouraClient>) => {
   const now = new Date()
   const start = subDays(now, 4)

--- a/apps/web/src/components/DashboardEditor/index.tsx
+++ b/apps/web/src/components/DashboardEditor/index.tsx
@@ -121,6 +121,7 @@ const linkOptions = [
   { icon: 'settings', label: 'Settings', value: '/settings' },
 ]
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function DashboardEditor({ sectionType, onAddWidget, onClose }: DashboardEditorProps) {
   const [selectedTemplate, setSelectedTemplate] = useState<WidgetTemplate | null>(null)
   const [configValues, setConfigValues] = useState<Record<string, unknown>>({})
@@ -150,6 +151,7 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
   }
 
   // Render configuration form based on widget type
+  // eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
   const renderConfigForm = () => {
     if (!selectedTemplate) return null
 

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -103,6 +103,7 @@ interface LocalGoal extends Omit<Goal, 'min' | 'max' | 'window'> {
   isNew?: boolean // Track if this is a newly added goal not yet saved
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function GoalsSettings({ goals }: GoalsSettingsProps) {
   const queryClient = useQueryClient()
   const [saveStatus, setSaveStatus] = useState<{ status: 'idle' | 'saving' | 'saved'; time?: Date }>({
@@ -354,6 +355,7 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
       {localGoals.length === 0 ?
         <p class="no-goals">No goals set. Click "+ Add Goal" to create one.</p>
       : <div class="goals-list">
+          {/* eslint-disable-next-line max-lines-per-function -- TODO: refactor */}
           {localGoals.map((goal) => {
             const validationError = validateGoal({
               ...goal,

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -16,6 +16,7 @@ import './style.css'
 
 type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function LastFmTagRulesSettings() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()

--- a/apps/web/src/components/TagPicker.tsx
+++ b/apps/web/src/components/TagPicker.tsx
@@ -24,6 +24,7 @@ const buildTagEntries = (uniqueTags: string[], programmaticTags: ProgrammaticTag
   }))
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function TagPicker({
   onChange,
   selectedTags,

--- a/apps/web/src/components/widgets/ActivitySummaryWidget.tsx
+++ b/apps/web/src/components/widgets/ActivitySummaryWidget.tsx
@@ -11,6 +11,7 @@ interface ActivitySummaryWidgetProps {
   config: ActivitySummaryConfig
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function ActivitySummaryWidget({ config }: ActivitySummaryWidgetProps) {
   const { lookbackDays = 7, showWorkouts = true, showSleep = true, showMeditation = true } = config
 

--- a/apps/web/src/components/widgets/MetricCardWidget.tsx
+++ b/apps/web/src/components/widgets/MetricCardWidget.tsx
@@ -102,6 +102,7 @@ const extractPeriodValue = (
   }
 }
 
+// eslint-disable-next-line complexity -- TODO: refactor
 export function MetricCardWidget({ config }: MetricCardWidgetProps) {
   const { metric, title, unit, subtitle: configSubtitle, trendInverse } = config
 

--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -143,6 +143,7 @@ const metricToApiMetric: Record<string, string> = {
   steps: 'steps',
 }
 
+// eslint-disable-next-line complexity -- TODO: refactor
 export function SparklineCardWidget({ config }: SparklineCardWidgetProps) {
   const { metric, title: configTitle, lookbackDays = 30, color = '#3b82f6' } = config
 

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -49,6 +49,7 @@ function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function AdminSettings() {
   const { route } = useLocation()
   const isLoggedIn = auth.value.token

--- a/apps/web/src/pages/Correlations/index.tsx
+++ b/apps/web/src/pages/Correlations/index.tsx
@@ -26,6 +26,7 @@ const periodDays = signal(30)
 const selectedActivity = signal<{ name: string; type: ActivityImpactType } | null>(null)
 
 // Impact timeline chart component
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function ImpactTimelineChart({
   data,
   baseline,
@@ -36,6 +37,7 @@ function ImpactTimelineChart({
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor
   useEffect(() => {
     if (!svgRef.current || !containerRef.current) return
 
@@ -200,6 +202,7 @@ function ImpactTimelineChart({
 }
 
 // Correlation row component
+// eslint-disable-next-line complexity -- TODO: refactor
 function CorrelationRow({
   name,
   stats,
@@ -254,6 +257,7 @@ function CorrelationRow({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Correlations() {
   // Fetch baseline
   const baselineQuery = useQuery({

--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -12,6 +12,7 @@ import './style.css'
 const generateSectionId = () => `section-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 
 // Section renderer - renders a section with its widgets
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function DashboardSectionComponent({
   section,
   isEditing,
@@ -214,6 +215,7 @@ function AddSectionForm({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function Dashboard() {
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = useState(false)

--- a/apps/web/src/pages/Help/index.tsx
+++ b/apps/web/src/pages/Help/index.tsx
@@ -80,6 +80,7 @@ function DataSourceCard({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Help() {
   const isLoggedIn = auth.value.token
 

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -4,6 +4,7 @@ import { Dashboard } from '../Dashboard'
 
 import './style.css'
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function GuestHome({ canSignup }: { canSignup: boolean }) {
   return (
     <>

--- a/apps/web/src/pages/Places/index.tsx
+++ b/apps/web/src/pages/Places/index.tsx
@@ -27,6 +27,7 @@ L.Icon.Default.mergeOptions({
 
 const selectedDate = signal(formatISO(new Date(), { representation: 'date' }))
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export const Places = () => {
   const queryClient = useQueryClient()
   const start = startOfDay(new Date(selectedDate.value))

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -35,6 +35,7 @@ function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Settings() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()

--- a/apps/web/src/pages/Signup/index.tsx
+++ b/apps/web/src/pages/Signup/index.tsx
@@ -4,6 +4,7 @@ import { auth, ensureStatusLoaded, signup, signupMode } from '../../state/auth'
 
 import './style.css'
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function Signup() {
   const { route, query } = useLocation()
   const [error, setError] = useState<string | null>(null)

--- a/apps/web/src/pages/Sleep/index.tsx
+++ b/apps/web/src/pages/Sleep/index.tsx
@@ -11,10 +11,12 @@ import './style.css'
 const daysBack = signal(30)
 
 // Sleep score line chart component
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function SleepScoreChart({ data, height = 200 }: { data: [Date, number][]; height?: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor
   useEffect(() => {
     if (!svgRef.current || !containerRef.current || data.length < 2) return
 
@@ -149,10 +151,12 @@ function SleepScoreChart({ data, height = 200 }: { data: [Date, number][]; heigh
 }
 
 // Sleep duration bar chart
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function SleepDurationChart({ sleepSessions, height = 180 }: { sleepSessions: Activity[]; height?: number }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
+  // eslint-disable-next-line max-lines-per-function -- TODO: refactor
   useEffect(() => {
     if (!svgRef.current || !containerRef.current || sleepSessions.length < 2) return
 
@@ -322,6 +326,7 @@ function StatCard({
   )
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export function Sleep() {
   const end = endOfDay(new Date())
   const start = startOfDay(subDays(new Date(), daysBack.value))

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor */
 import { Signal, signal } from '@preact/signals'
 import { useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
@@ -205,6 +206,7 @@ const trackSleepMeditation = 0
 const trackExercise = trackHeight
 const trackPlaces = 2 * trackHeight
 
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 export const Timeline = () => {
   const start = startOfDay(new Date(fromDate.value))
   const end = endOfDay(new Date(toDate.value))
@@ -469,6 +471,7 @@ interface TimelineChartProps {
   onZoomOut: () => void
 }
 
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function TimelineChart({
   heartRates,
   hrvData,

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -16,6 +16,7 @@ import {
 import './style.css'
 
 // Chart component for trend history
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 function TrendChart({ data, color }: { data: { date: string; value: number }[]; color: string }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
@@ -167,6 +168,7 @@ const LOOKBACK_OPTIONS = [
 ]
 
 // Form for configuring a trend
+// eslint-disable-next-line max-lines-per-function, complexity -- TODO: refactor
 function TrendConfigForm({
   initialValues,
   onSubmit,
@@ -396,6 +398,7 @@ function TrendWidget({
 }
 
 // Main Trends page component
+// eslint-disable-next-line max-lines-per-function -- TODO: refactor
 export function Trends() {
   const isLoggedIn = auth.value.token
   const [showAddForm, setShowAddForm] = useState(false)

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- TODO: refactor */
 import type {
   ActivitiesQuery,
   ActivitiesResponse,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,9 +29,23 @@ export default [
   {
     plugins: { 'sort-keys': sortKeys },
     rules: {
+      complexity: ['warn', 15],
+      'max-depth': ['warn', 4],
+      'max-lines': ['warn', { max: 500, skipBlankLines: true, skipComments: true }],
+      'max-lines-per-function': [
+        'warn',
+        { max: 80, skipBlankLines: true, skipComments: true },
+      ],
       'no-shadow': 'warn',
       'object-shorthand': 'warn',
       'sort-keys/sort-keys-fix': ['error', 'asc', { natural: true }],
+    },
+  },
+  {
+    files: ['**/*.test.ts', '**/*.test.tsx', '**/*.integration.test.ts'],
+    rules: {
+      'max-lines': 'off',
+      'max-lines-per-function': 'off',
     },
   },
 ]


### PR DESCRIPTION
## Summary
- Add warn-level ESLint rules: `complexity` (15), `max-depth` (4), `max-lines` (500), `max-lines-per-function` (80)
- Add test file overrides to disable `max-lines` and `max-lines-per-function` for `*.test.ts`/`*.test.tsx` files
- Add `eslint-disable` comments with `// TODO: refactor` markers to all existing violations in production files (backend + web)
- Zero warnings after all suppressions — `pnpm check` passes cleanly

This is Phase 1 of the backend refactoring plan. Rules start as `warn` to establish guardrails; they will be upgraded to `error` after the monolithic files are split in later phases.

## Test plan
- [x] `pnpm check` passes with zero warnings
- [x] `pnpm test` passes (backend + web; Android failures are pre-existing)
- [x] No runtime behavior changes (comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)