### PR TITLE
Extract db.ts shared utilities: row mappers, dynamic update, cumulative query

### DIFF
--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -2,6 +2,18 @@
 import { type CustomMetricDefinition, type DashboardConfig, type Goal } from '@aurboda/api-spec'
 import { Client, QueryResultRow } from 'pg'
 import format from 'pg-format'
+import { querySplitByCumulative } from './db/cumulative-query'
+import { buildDynamicUpdate, type UpdateEntry } from './db/dynamic-update'
+import {
+  mapActivityRow,
+  mapDetectedLocationRow,
+  mapLastFmTagRuleRow,
+  mapMcpSessionRow,
+  mapNamedLocationRow,
+  mapSyncStateRow,
+  mapTagRow,
+  parseMetricType,
+} from './db/row-mappers'
 import {
   ActivityType,
   createTableStatements,
@@ -236,41 +248,24 @@ export const getTimeSeriesMultiMetric = async (
 ): Promise<Record<MetricType, [Date, number][]>> => {
   if (metrics.length === 0) return {} as Record<MetricType, [Date, number][]>
 
-  // Split metrics into cumulative (steps, distance, etc.) and non-cumulative
-  const cumulativeRequested = metrics.filter((m) => cumulativeMetrics.includes(m))
-  const nonCumulativeRequested = metrics.filter((m) => !cumulativeMetrics.includes(m))
-
-  const data: Record<string, [Date, number][]> = {}
-
-  // Query cumulative metrics using only aggregate source (deduplicated daily totals)
-  if (cumulativeRequested.length > 0) {
-    const cumulativeResult = await query(
-      user,
-      `SELECT time, metric, value FROM time_series
+  const rows = await querySplitByCumulative<{ metric: string; time: Date; value: number }>({
+    mapRow: (row) => ({ metric: row.metric as string, time: new Date(row.time), value: row.value as number }),
+    metrics,
+    params: [start, end],
+    queryFn: (sql, params) => query(user, sql, params),
+    sqlCumulative: `SELECT time, metric, value FROM time_series
        WHERE metric = ANY($1) AND time >= $2 AND time <= $3
          AND source = 'health_connect_aggregate'
        ORDER BY metric, time`,
-      [cumulativeRequested, start, end],
-    )
-    for (const row of cumulativeResult.rows) {
-      if (!data[row.metric]) data[row.metric] = []
-      data[row.metric].push([new Date(row.time), row.value])
-    }
-  }
-
-  // Query non-cumulative metrics (all sources)
-  if (nonCumulativeRequested.length > 0) {
-    const nonCumulativeResult = await query(
-      user,
-      `SELECT time, metric, value FROM time_series
+    sqlNonCumulative: `SELECT time, metric, value FROM time_series
        WHERE metric = ANY($1) AND time >= $2 AND time <= $3
        ORDER BY metric, time`,
-      [nonCumulativeRequested, start, end],
-    )
-    for (const row of nonCumulativeResult.rows) {
-      if (!data[row.metric]) data[row.metric] = []
-      data[row.metric].push([new Date(row.time), row.value])
-    }
+  })
+
+  const data: Record<string, [Date, number][]> = {}
+  for (const row of rows) {
+    if (!data[row.metric]) data[row.metric] = []
+    data[row.metric].push([row.time, row.value])
   }
 
   return data as Record<MetricType, [Date, number][]>
@@ -298,17 +293,7 @@ export const getTimeSeriesStats = async (
 ): Promise<MetricStats[]> => {
   if (metrics.length === 0) return []
 
-  // Split metrics into cumulative (steps, distance, etc.) and non-cumulative
-  const cumulativeRequested = metrics.filter((m) => cumulativeMetrics.includes(m as MetricType))
-  const nonCumulativeRequested = metrics.filter((m) => !cumulativeMetrics.includes(m as MetricType))
-
-  const results: MetricStats[] = []
-
-  // Query cumulative metrics using only aggregate source (deduplicated daily totals)
-  if (cumulativeRequested.length > 0) {
-    const cumulativeResult = await query(
-      user,
-      `SELECT
+  const statsSql = (sourceFilter: string) => `SELECT
          metric,
          COUNT(*)::integer as count,
          MIN(value) as min,
@@ -317,55 +302,28 @@ export const getTimeSeriesStats = async (
          STDDEV_POP(value) as stddev,
          MAX(unit) as unit
        FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-         AND source = 'health_connect_aggregate'
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3${sourceFilter}
        GROUP BY metric
-       ORDER BY metric`,
-      [cumulativeRequested, start, end],
-    )
-    results.push(
-      ...cumulativeResult.rows.map((row) => ({
-        avg: row.avg !== null ? Number(row.avg) : 0,
-        count: row.count,
-        max: row.max !== null ? Number(row.max) : 0,
-        metric: row.metric as string,
-        min: row.min !== null ? Number(row.min) : 0,
-        stddev: row.stddev !== null ? Number(row.stddev) : 0,
-        unit: row.unit,
-      })),
-    )
-  }
+       ORDER BY metric`
 
-  // Query non-cumulative metrics (all sources)
-  if (nonCumulativeRequested.length > 0) {
-    const nonCumulativeResult = await query(
-      user,
-      `SELECT
-         metric,
-         COUNT(*)::integer as count,
-         MIN(value) as min,
-         MAX(value) as max,
-         AVG(value) as avg,
-         STDDEV_POP(value) as stddev,
-         MAX(unit) as unit
-       FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-       GROUP BY metric
-       ORDER BY metric`,
-      [nonCumulativeRequested, start, end],
-    )
-    results.push(
-      ...nonCumulativeResult.rows.map((row) => ({
-        avg: row.avg !== null ? Number(row.avg) : 0,
-        count: row.count,
-        max: row.max !== null ? Number(row.max) : 0,
-        metric: row.metric as string,
-        min: row.min !== null ? Number(row.min) : 0,
-        stddev: row.stddev !== null ? Number(row.stddev) : 0,
-        unit: row.unit,
-      })),
-    )
-  }
+  const mapRow = (row: { [key: string]: unknown }): MetricStats => ({
+    avg: row.avg !== null ? Number(row.avg) : 0,
+    count: row.count as number,
+    max: row.max !== null ? Number(row.max) : 0,
+    metric: row.metric as string,
+    min: row.min !== null ? Number(row.min) : 0,
+    stddev: row.stddev !== null ? Number(row.stddev) : 0,
+    unit: row.unit as string,
+  })
+
+  const results = await querySplitByCumulative<MetricStats>({
+    mapRow,
+    metrics,
+    params: [start, end],
+    queryFn: (sql, params) => query(user, sql, params),
+    sqlCumulative: statsSql(`\n         AND source = 'health_connect_aggregate'`),
+    sqlNonCumulative: statsSql(''),
+  })
 
   // Sort by metric name for consistent ordering
   return results.sort((a, b) => a.metric.localeCompare(b.metric))
@@ -386,63 +344,31 @@ export const getDailyAggregates = async (
 ): Promise<DailyMetricAggregate[]> => {
   if (metrics.length === 0) return []
 
-  // Split metrics into cumulative (steps, distance, etc.) and non-cumulative
-  const cumulativeRequested = metrics.filter((m) => cumulativeMetrics.includes(m as MetricType))
-  const nonCumulativeRequested = metrics.filter((m) => !cumulativeMetrics.includes(m as MetricType))
-
-  const results: DailyMetricAggregate[] = []
-
-  // Query cumulative metrics using only aggregate source (deduplicated daily totals)
-  // For cumulative metrics, avg and sum are the same (one value per day)
-  if (cumulativeRequested.length > 0) {
-    const cumulativeResult = await query(
-      user,
-      `SELECT
+  const dailySql = (sourceFilter: string) => `SELECT
          DATE(time) as date,
          metric,
          AVG(value) as avg,
          SUM(value) as sum
        FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-         AND source = 'health_connect_aggregate'
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3${sourceFilter}
        GROUP BY DATE(time), metric
-       ORDER BY metric, date`,
-      [cumulativeRequested, start, end],
-    )
-    results.push(
-      ...cumulativeResult.rows.map((row) => ({
-        avg: Number(row.avg),
-        date: row.date.toISOString().split('T')[0],
-        metric: row.metric as string,
-        sum: Number(row.sum),
-      })),
-    )
-  }
+       ORDER BY metric, date`
 
-  // Query non-cumulative metrics (all sources)
-  if (nonCumulativeRequested.length > 0) {
-    const nonCumulativeResult = await query(
-      user,
-      `SELECT
-         DATE(time) as date,
-         metric,
-         AVG(value) as avg,
-         SUM(value) as sum
-       FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-       GROUP BY DATE(time), metric
-       ORDER BY metric, date`,
-      [nonCumulativeRequested, start, end],
-    )
-    results.push(
-      ...nonCumulativeResult.rows.map((row) => ({
-        avg: Number(row.avg),
-        date: row.date.toISOString().split('T')[0],
-        metric: row.metric as string,
-        sum: Number(row.sum),
-      })),
-    )
-  }
+  const mapRow = (row: { [key: string]: unknown }): DailyMetricAggregate => ({
+    avg: Number(row.avg),
+    date: (row.date as Date).toISOString().split('T')[0],
+    metric: row.metric as string,
+    sum: Number(row.sum),
+  })
+
+  const results = await querySplitByCumulative<DailyMetricAggregate>({
+    mapRow,
+    metrics,
+    params: [start, end],
+    queryFn: (sql, params) => query(user, sql, params),
+    sqlCumulative: dailySql(`\n         AND source = 'health_connect_aggregate'`),
+    sqlNonCumulative: dailySql(''),
+  })
 
   // Sort by metric and date for consistent ordering
   return results.sort((a, b) => {
@@ -507,7 +433,7 @@ export const getTimeSeriesBucketed = async (
     bucketStart: new Date(row.bucket_start),
     count: row.count,
     max: row.max !== null ? Number(row.max) : 0,
-    metric: row.metric as MetricType,
+    metric: parseMetricType(row.metric),
     min: row.min !== null ? Number(row.min) : 0,
   }))
 }
@@ -641,17 +567,7 @@ export const getActivityById = async (user: string, id: string): Promise<Activit
     return null
   }
 
-  const row = result.rows[0]
-  return {
-    activityType: row.activity_type as ActivityType,
-    data: row.data,
-    endTime: row.end_time ? new Date(row.end_time) : undefined,
-    id: row.id,
-    notes: row.notes,
-    source: row.source as DataSource,
-    startTime: new Date(row.start_time),
-    title: row.title,
-  }
+  return mapActivityRow(result.rows[0])
 }
 
 export const deleteActivity = async (user: string, id: string): Promise<boolean> => {
@@ -672,59 +588,22 @@ export const updateActivity = async (
   id: string,
   updates: ActivityUpdate,
 ): Promise<Activity | null> => {
-  // Build SET clause dynamically based on provided updates
-  const setClauses: string[] = []
-  const values: unknown[] = []
-  let paramIndex = 1
+  const fields: UpdateEntry[] = []
+  if (updates.startTime !== undefined) fields.push({ column: 'start_time', value: updates.startTime })
+  if (updates.endTime !== undefined) fields.push({ column: 'end_time', value: updates.endTime })
+  if (updates.title !== undefined) fields.push({ column: 'title', value: updates.title })
+  if (updates.notes !== undefined) fields.push({ column: 'notes', value: updates.notes })
 
-  if (updates.startTime !== undefined) {
-    setClauses.push(`start_time = $${paramIndex++}`)
-    values.push(updates.startTime)
-  }
-  if (updates.endTime !== undefined) {
-    setClauses.push(`end_time = $${paramIndex++}`)
-    values.push(updates.endTime)
-  }
-  if (updates.title !== undefined) {
-    setClauses.push(`title = $${paramIndex++}`)
-    values.push(updates.title)
-  }
-  if (updates.notes !== undefined) {
-    setClauses.push(`notes = $${paramIndex++}`)
-    values.push(updates.notes)
-  }
+  if (fields.length === 0) return getActivityById(user, id)
 
-  if (setClauses.length === 0) {
-    // No updates provided, just return existing activity
-    return getActivityById(user, id)
-  }
+  const update = buildDynamicUpdate('activities', id, fields, {
+    returning: 'id, source, activity_type, start_time, end_time, title, notes, data',
+  })
+  if (!update) return getActivityById(user, id)
 
-  values.push(id)
-
-  const result = await query(
-    user,
-    `UPDATE activities
-     SET ${setClauses.join(', ')}
-     WHERE id = $${paramIndex}
-     RETURNING id, source, activity_type, start_time, end_time, title, notes, data`,
-    values,
-  )
-
-  if (result.rows.length === 0) {
-    return null
-  }
-
-  const row = result.rows[0]
-  return {
-    activityType: row.activity_type as ActivityType,
-    data: row.data,
-    endTime: row.end_time ? new Date(row.end_time) : undefined,
-    id: row.id,
-    notes: row.notes,
-    source: row.source as DataSource,
-    startTime: new Date(row.start_time),
-    title: row.title,
-  }
+  const result = await query(user, update.sql, update.params)
+  if (result.rows.length === 0) return null
+  return mapActivityRow(result.rows[0])
 }
 
 export const getActivities = async (
@@ -744,16 +623,7 @@ export const getActivities = async (
     [types, start, end],
   )
 
-  const activities = result.rows.map((row) => ({
-    activityType: row.activity_type as ActivityType,
-    data: row.data,
-    endTime: row.end_time ? new Date(row.end_time) : undefined,
-    id: row.id,
-    notes: row.notes,
-    source: row.source as DataSource,
-    startTime: new Date(row.start_time),
-    title: row.title,
-  }))
+  const activities = result.rows.map(mapActivityRow)
 
   return mergeOverlappingActivities(activities)
 }
@@ -775,16 +645,7 @@ export const getSleepSessions = async (user: string, start: Date, end: Date): Pr
     [start, end],
   )
 
-  const activities = result.rows.map((row) => ({
-    activityType: row.activity_type as ActivityType,
-    data: row.data,
-    endTime: row.end_time ? new Date(row.end_time) : undefined,
-    id: row.id,
-    notes: row.notes,
-    source: row.source as DataSource,
-    startTime: new Date(row.start_time),
-    title: row.title,
-  }))
+  const activities = result.rows.map(mapActivityRow)
 
   return mergeOverlappingActivities(activities)
 }
@@ -914,16 +775,7 @@ export const insertNamedLocation = async (
      RETURNING id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at`,
     [location.name, location.lon, location.lat, location.radius ?? 200],
   )
-  const row = result.rows[0]
-  return {
-    createdAt: new Date(row.created_at),
-    id: row.id,
-    lat: row.lat,
-    lon: row.lon,
-    name: row.name,
-    radius: row.radius,
-    updatedAt: new Date(row.updated_at),
-  }
+  return mapNamedLocationRow(result.rows[0])
 }
 
 export const getNamedLocations = async (user: string): Promise<NamedLocation[]> => {
@@ -934,15 +786,7 @@ export const getNamedLocations = async (user: string): Promise<NamedLocation[]> 
      ORDER BY name`,
     [],
   )
-  return result.rows.map((row) => ({
-    createdAt: new Date(row.created_at),
-    id: row.id,
-    lat: row.lat,
-    lon: row.lon,
-    name: row.name,
-    radius: row.radius,
-    updatedAt: new Date(row.updated_at),
-  }))
+  return result.rows.map(mapNamedLocationRow)
 }
 
 export const getNamedLocationById = async (user: string, id: string): Promise<NamedLocation | null> => {
@@ -954,16 +798,7 @@ export const getNamedLocationById = async (user: string, id: string): Promise<Na
     [id],
   )
   if (result.rows.length === 0) return null
-  const row = result.rows[0]
-  return {
-    createdAt: new Date(row.created_at),
-    id: row.id,
-    lat: row.lat,
-    lon: row.lon,
-    name: row.name,
-    radius: row.radius,
-    updatedAt: new Date(row.updated_at),
-  }
+  return mapNamedLocationRow(result.rows[0])
 }
 
 export const updateNamedLocation = async (
@@ -971,46 +806,26 @@ export const updateNamedLocation = async (
   id: string,
   updates: Partial<NamedLocationInput>,
 ): Promise<NamedLocation | null> => {
-  const setClauses: string[] = ['updated_at = NOW()']
-  const values: unknown[] = []
-  let paramIndex = 1
-
-  if (updates.name !== undefined) {
-    setClauses.push(`name = $${paramIndex++}`)
-    values.push(updates.name)
-  }
+  const fields: UpdateEntry[] = []
+  if (updates.name !== undefined) fields.push({ column: 'name', value: updates.name })
   if (updates.lat !== undefined && updates.lon !== undefined) {
-    setClauses.push(`location = ST_MakePoint($${paramIndex}, $${paramIndex + 1})::geography`)
-    values.push(updates.lon, updates.lat)
-    paramIndex += 2
+    fields.push({
+      expression: 'location = ST_MakePoint($NEXT, $NEXT)::geography',
+      values: [updates.lon, updates.lat],
+    })
   }
-  if (updates.radius !== undefined) {
-    setClauses.push(`radius = $${paramIndex++}`)
-    values.push(updates.radius)
-  }
+  if (updates.radius !== undefined) fields.push({ column: 'radius', value: updates.radius })
 
-  values.push(id)
+  const update = buildDynamicUpdate('named_locations', id, fields, {
+    defaultClauses: ['updated_at = NOW()'],
+    returning:
+      'id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at',
+  })
+  if (!update) return null
 
-  const result = await query(
-    user,
-    `UPDATE named_locations
-     SET ${setClauses.join(', ')}
-     WHERE id = $${paramIndex}
-     RETURNING id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at`,
-    values,
-  )
-
+  const result = await query(user, update.sql, update.params)
   if (result.rows.length === 0) return null
-  const row = result.rows[0]
-  return {
-    createdAt: new Date(row.created_at),
-    id: row.id,
-    lat: row.lat,
-    lon: row.lon,
-    name: row.name,
-    radius: row.radius,
-    updatedAt: new Date(row.updated_at),
-  }
+  return mapNamedLocationRow(result.rows[0])
 }
 
 export const deleteNamedLocation = async (user: string, id: string): Promise<boolean> => {
@@ -1069,21 +884,7 @@ export const insertDetectedLocation = async (
       location.lastVisit,
     ],
   )
-  const row = result.rows[0]
-  return {
-    address: row.address,
-    createdAt: new Date(row.created_at),
-    firstVisit: new Date(row.first_visit),
-    geocodeStatus: row.geocode_status as GeocodeStatus,
-    id: row.id,
-    lastVisit: new Date(row.last_visit),
-    lat: row.lat,
-    lon: row.lon,
-    radius: row.radius,
-    totalMinutes: row.total_minutes,
-    updatedAt: new Date(row.updated_at),
-    visitCount: row.visit_count,
-  }
+  return mapDetectedLocationRow(result.rows[0])
 }
 
 export const getDetectedLocations = async (user: string): Promise<DetectedLocation[]> => {
@@ -1095,20 +896,7 @@ export const getDetectedLocations = async (user: string): Promise<DetectedLocati
      ORDER BY last_visit DESC`,
     [],
   )
-  return result.rows.map((row) => ({
-    address: row.address,
-    createdAt: new Date(row.created_at),
-    firstVisit: new Date(row.first_visit),
-    geocodeStatus: row.geocode_status as GeocodeStatus,
-    id: row.id,
-    lastVisit: new Date(row.last_visit),
-    lat: row.lat,
-    lon: row.lon,
-    radius: row.radius,
-    totalMinutes: row.total_minutes,
-    updatedAt: new Date(row.updated_at),
-    visitCount: row.visit_count,
-  }))
+  return result.rows.map(mapDetectedLocationRow)
 }
 
 export const getDetectedLocationById = async (user: string, id: string): Promise<DetectedLocation | null> => {
@@ -1121,21 +909,7 @@ export const getDetectedLocationById = async (user: string, id: string): Promise
     [id],
   )
   if (result.rows.length === 0) return null
-  const row = result.rows[0]
-  return {
-    address: row.address,
-    createdAt: new Date(row.created_at),
-    firstVisit: new Date(row.first_visit),
-    geocodeStatus: row.geocode_status as GeocodeStatus,
-    id: row.id,
-    lastVisit: new Date(row.last_visit),
-    lat: row.lat,
-    lon: row.lon,
-    radius: row.radius,
-    totalMinutes: row.total_minutes,
-    updatedAt: new Date(row.updated_at),
-    visitCount: row.visit_count,
-  }
+  return mapDetectedLocationRow(result.rows[0])
 }
 
 /**
@@ -1160,21 +934,7 @@ export const findNearbyDetectedLocation = async (
     [lon, lat, distanceMeters],
   )
   if (result.rows.length === 0) return null
-  const row = result.rows[0]
-  return {
-    address: row.address,
-    createdAt: new Date(row.created_at),
-    firstVisit: new Date(row.first_visit),
-    geocodeStatus: row.geocode_status as GeocodeStatus,
-    id: row.id,
-    lastVisit: new Date(row.last_visit),
-    lat: row.lat,
-    lon: row.lon,
-    radius: row.radius,
-    totalMinutes: row.total_minutes,
-    updatedAt: new Date(row.updated_at),
-    visitCount: row.visit_count,
-  }
+  return mapDetectedLocationRow(result.rows[0])
 }
 
 export interface DetectedLocationUpdate {
@@ -1194,72 +954,33 @@ export const updateDetectedLocation = async (
   id: string,
   updates: DetectedLocationUpdate,
 ): Promise<DetectedLocation | null> => {
-  const setClauses: string[] = ['updated_at = NOW()']
-  const values: unknown[] = []
-  let paramIndex = 1
-
+  const fields: UpdateEntry[] = []
   if (updates.lat !== undefined && updates.lon !== undefined) {
-    setClauses.push(`location = ST_MakePoint($${paramIndex}, $${paramIndex + 1})::geography`)
-    values.push(updates.lon, updates.lat)
-    paramIndex += 2
+    fields.push({
+      expression: 'location = ST_MakePoint($NEXT, $NEXT)::geography',
+      values: [updates.lon, updates.lat],
+    })
   }
-  if (updates.radius !== undefined) {
-    setClauses.push(`radius = $${paramIndex++}`)
-    values.push(updates.radius)
-  }
-  if (updates.totalMinutes !== undefined) {
-    setClauses.push(`total_minutes = $${paramIndex++}`)
-    values.push(updates.totalMinutes)
-  }
-  if (updates.visitCount !== undefined) {
-    setClauses.push(`visit_count = $${paramIndex++}`)
-    values.push(updates.visitCount)
-  }
-  if (updates.firstVisit !== undefined) {
-    setClauses.push(`first_visit = $${paramIndex++}`)
-    values.push(updates.firstVisit)
-  }
-  if (updates.lastVisit !== undefined) {
-    setClauses.push(`last_visit = $${paramIndex++}`)
-    values.push(updates.lastVisit)
-  }
-  if (updates.address !== undefined) {
-    setClauses.push(`address = $${paramIndex++}`)
-    values.push(updates.address)
-  }
-  if (updates.geocodeStatus !== undefined) {
-    setClauses.push(`geocode_status = $${paramIndex++}`)
-    values.push(updates.geocodeStatus)
-  }
+  if (updates.radius !== undefined) fields.push({ column: 'radius', value: updates.radius })
+  if (updates.totalMinutes !== undefined)
+    fields.push({ column: 'total_minutes', value: updates.totalMinutes })
+  if (updates.visitCount !== undefined) fields.push({ column: 'visit_count', value: updates.visitCount })
+  if (updates.firstVisit !== undefined) fields.push({ column: 'first_visit', value: updates.firstVisit })
+  if (updates.lastVisit !== undefined) fields.push({ column: 'last_visit', value: updates.lastVisit })
+  if (updates.address !== undefined) fields.push({ column: 'address', value: updates.address })
+  if (updates.geocodeStatus !== undefined)
+    fields.push({ column: 'geocode_status', value: updates.geocodeStatus })
 
-  values.push(id)
+  const update = buildDynamicUpdate('detected_locations', id, fields, {
+    defaultClauses: ['updated_at = NOW()'],
+    returning:
+      'id, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, total_minutes, visit_count, first_visit, last_visit, address, geocode_status, created_at, updated_at',
+  })
+  if (!update) return null
 
-  const result = await query(
-    user,
-    `UPDATE detected_locations
-     SET ${setClauses.join(', ')}
-     WHERE id = $${paramIndex}
-     RETURNING id, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius,
-       total_minutes, visit_count, first_visit, last_visit, address, geocode_status, created_at, updated_at`,
-    values,
-  )
-
+  const result = await query(user, update.sql, update.params)
   if (result.rows.length === 0) return null
-  const row = result.rows[0]
-  return {
-    address: row.address,
-    createdAt: new Date(row.created_at),
-    firstVisit: new Date(row.first_visit),
-    geocodeStatus: row.geocode_status as GeocodeStatus,
-    id: row.id,
-    lastVisit: new Date(row.last_visit),
-    lat: row.lat,
-    lon: row.lon,
-    radius: row.radius,
-    totalMinutes: row.total_minutes,
-    updatedAt: new Date(row.updated_at),
-    visitCount: row.visit_count,
-  }
+  return mapDetectedLocationRow(result.rows[0])
 }
 
 export const deleteDetectedLocation = async (user: string, id: string): Promise<boolean> => {
@@ -1280,20 +1001,7 @@ export const getDetectedLocationsNeedingGeocode = async (user: string): Promise<
      ORDER BY created_at`,
     [],
   )
-  return result.rows.map((row) => ({
-    address: row.address,
-    createdAt: new Date(row.created_at),
-    firstVisit: new Date(row.first_visit),
-    geocodeStatus: row.geocode_status as GeocodeStatus,
-    id: row.id,
-    lastVisit: new Date(row.last_visit),
-    lat: row.lat,
-    lon: row.lon,
-    radius: row.radius,
-    totalMinutes: row.total_minutes,
-    updatedAt: new Date(row.updated_at),
-    visitCount: row.visit_count,
-  }))
+  return result.rows.map(mapDetectedLocationRow)
 }
 
 // ============================================================================
@@ -1332,14 +1040,7 @@ export const getTags = async (user: string, start: Date, end: Date): Promise<Tag
     [start, end],
   )
 
-  return result.rows.map((row) => ({
-    endTime: row.end_time ? new Date(row.end_time) : undefined,
-    externalId: row.external_id,
-    id: row.id,
-    source: row.source,
-    startTime: new Date(row.start_time),
-    tag: row.tag,
-  }))
+  return result.rows.map(mapTagRow)
 }
 
 export const deleteTag = async (user: string, externalId: string): Promise<boolean> => {
@@ -1382,15 +1083,7 @@ export const findMergeableTag = async (
 
   if (result.rows.length === 0) return undefined
 
-  const row = result.rows[0]
-  return {
-    endTime: row.end_time ? new Date(row.end_time) : undefined,
-    externalId: row.external_id,
-    id: row.id,
-    source: row.source,
-    startTime: new Date(row.start_time),
-    tag: row.tag,
-  }
+  return mapTagRow(result.rows[0])
 }
 
 /**
@@ -1682,18 +1375,7 @@ export const getSyncState = async (
 
   if (result.rows.length === 0) return null
 
-  const row = result.rows[0]
-  return {
-    dataType: row.data_type,
-    errorMessage: row.error_message,
-    id: row.id,
-    lastSyncTime: row.last_sync_time ? new Date(row.last_sync_time) : undefined,
-    provider: row.provider,
-    retryAfter: row.retry_after ? new Date(row.retry_after) : undefined,
-    status: row.status as SyncStatus,
-    syncStartDate: row.sync_start_date ? new Date(row.sync_start_date) : undefined,
-    updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
-  }
+  return mapSyncStateRow(result.rows[0])
 }
 
 export const upsertSyncState = async (user: string, state: SyncState) => {
@@ -1730,17 +1412,7 @@ export const getAllSyncStates = async (user: string, provider: string): Promise<
     [provider],
   )
 
-  return result.rows.map((row) => ({
-    dataType: row.data_type,
-    errorMessage: row.error_message,
-    id: row.id,
-    lastSyncTime: row.last_sync_time ? new Date(row.last_sync_time) : undefined,
-    provider: row.provider,
-    retryAfter: row.retry_after ? new Date(row.retry_after) : undefined,
-    status: row.status as SyncStatus,
-    syncStartDate: row.sync_start_date ? new Date(row.sync_start_date) : undefined,
-    updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
-  }))
+  return result.rows.map(mapSyncStateRow)
 }
 
 export const resetSyncState = async (user: string, provider: string, dataType?: string) => {
@@ -2116,16 +1788,7 @@ export const getLastFmTagRules = async (user: string): Promise<LastFmTagRule[]> 
      ORDER BY created_at DESC`,
   )
 
-  return result.rows.map((row) => ({
-    artistName: row.artist_name ?? undefined,
-    createdAt: new Date(row.created_at),
-    id: row.id,
-    matchMode: row.match_mode as LastFmMatchMode,
-    matchType: row.match_type as LastFmMatchType,
-    ruleName: row.rule_name,
-    tagName: row.tag_name,
-    trackName: row.track_name ?? undefined,
-  }))
+  return result.rows.map(mapLastFmTagRuleRow)
 }
 
 /**
@@ -2147,17 +1810,7 @@ export const insertLastFmTagRule = async (user: string, rule: LastFmTagRuleInput
     ],
   )
 
-  const row = result.rows[0]
-  return {
-    artistName: row.artist_name ?? undefined,
-    createdAt: new Date(row.created_at),
-    id: row.id,
-    matchMode: row.match_mode as LastFmMatchMode,
-    matchType: row.match_type as LastFmMatchType,
-    ruleName: row.rule_name,
-    tagName: row.tag_name,
-    trackName: row.track_name ?? undefined,
-  }
+  return mapLastFmTagRuleRow(result.rows[0])
 }
 
 /**
@@ -2193,14 +1846,8 @@ export const saveMcpSession = async (user: string, sessionId: string): Promise<M
     [sessionId, user],
   )
 
-  const row = result.rows[0]
-  console.log(`[MCP-DB] saveMcpSession: saved session ${sessionId}, result:`, row)
-  return {
-    createdAt: new Date(row.created_at),
-    lastActivity: new Date(row.last_activity),
-    sessionId: row.session_id,
-    username: row.username,
-  }
+  console.log(`[MCP-DB] saveMcpSession: saved session ${sessionId}, result:`, result.rows[0])
+  return mapMcpSessionRow(result.rows[0])
 }
 
 /**
@@ -2221,14 +1868,8 @@ export const getMcpSession = async (user: string, sessionId: string): Promise<Mc
     return null
   }
 
-  const row = result.rows[0]
-  console.log(`[MCP-DB] getMcpSession: found session ${sessionId}:`, row)
-  return {
-    createdAt: new Date(row.created_at),
-    lastActivity: new Date(row.last_activity),
-    sessionId: row.session_id,
-    username: row.username,
-  }
+  console.log(`[MCP-DB] getMcpSession: found session ${sessionId}:`, result.rows[0])
+  return mapMcpSessionRow(result.rows[0])
 }
 
 /**
@@ -2280,10 +1921,5 @@ export const getMcpSessionsForUser = async (user: string): Promise<McpSessionRec
     [user],
   )
 
-  return result.rows.map((row) => ({
-    createdAt: new Date(row.created_at),
-    lastActivity: new Date(row.last_activity),
-    sessionId: row.session_id,
-    username: row.username,
-  }))
+  return result.rows.map(mapMcpSessionRow)
 }

--- a/apps/backend/src/db/cumulative-query.test.ts
+++ b/apps/backend/src/db/cumulative-query.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test, vi } from 'vitest'
+import { querySplitByCumulative, splitMetricsByCumulative } from './cumulative-query'
+
+describe('splitMetricsByCumulative', () => {
+  test('splits metrics into cumulative and non-cumulative', () => {
+    const { cumulative, nonCumulative } = splitMetricsByCumulative([
+      'heart_rate',
+      'steps',
+      'distance',
+      'hrv_rmssd',
+      'floors_climbed',
+    ])
+
+    expect(cumulative).toEqual(['steps', 'distance', 'floors_climbed'])
+    expect(nonCumulative).toEqual(['heart_rate', 'hrv_rmssd'])
+  })
+
+  test('handles empty metrics', () => {
+    const { cumulative, nonCumulative } = splitMetricsByCumulative([])
+    expect(cumulative).toEqual([])
+    expect(nonCumulative).toEqual([])
+  })
+
+  test('handles all cumulative', () => {
+    const { cumulative, nonCumulative } = splitMetricsByCumulative(['steps', 'distance'])
+    expect(cumulative).toEqual(['steps', 'distance'])
+    expect(nonCumulative).toEqual([])
+  })
+
+  test('handles all non-cumulative', () => {
+    const { cumulative, nonCumulative } = splitMetricsByCumulative(['heart_rate', 'hrv_rmssd'])
+    expect(cumulative).toEqual([])
+    expect(nonCumulative).toEqual(['heart_rate', 'hrv_rmssd'])
+  })
+})
+
+describe('querySplitByCumulative', () => {
+  test('runs queries for both cumulative and non-cumulative metrics', async () => {
+    const queryFn = vi.fn()
+
+    // Cumulative query result
+    queryFn.mockResolvedValueOnce({
+      rows: [{ metric: 'steps', value: 10000 }],
+    })
+    // Non-cumulative query result
+    queryFn.mockResolvedValueOnce({
+      rows: [{ metric: 'heart_rate', value: 72 }],
+    })
+
+    const results = await querySplitByCumulative({
+      mapRow: (row) => ({ metric: row.metric as string, value: row.value as number }),
+      metrics: ['steps', 'heart_rate'],
+      params: [new Date('2024-01-15'), new Date('2024-01-16')],
+      queryFn,
+      sqlCumulative: `SELECT metric, value FROM time_series WHERE metric = ANY($1) AND time >= $2 AND time <= $3 AND source = 'health_connect_aggregate'`,
+      sqlNonCumulative: `SELECT metric, value FROM time_series WHERE metric = ANY($1) AND time >= $2 AND time <= $3`,
+    })
+
+    expect(results).toEqual([
+      { metric: 'steps', value: 10000 },
+      { metric: 'heart_rate', value: 72 },
+    ])
+
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    // Cumulative query
+    expect(queryFn).toHaveBeenCalledWith(
+      `SELECT metric, value FROM time_series WHERE metric = ANY($1) AND time >= $2 AND time <= $3 AND source = 'health_connect_aggregate'`,
+      [['steps'], new Date('2024-01-15'), new Date('2024-01-16')],
+    )
+    // Non-cumulative query
+    expect(queryFn).toHaveBeenCalledWith(
+      `SELECT metric, value FROM time_series WHERE metric = ANY($1) AND time >= $2 AND time <= $3`,
+      [['heart_rate'], new Date('2024-01-15'), new Date('2024-01-16')],
+    )
+  })
+
+  test('skips cumulative query when no cumulative metrics', async () => {
+    const queryFn = vi.fn().mockResolvedValueOnce({
+      rows: [{ metric: 'heart_rate', value: 72 }],
+    })
+
+    const results = await querySplitByCumulative({
+      mapRow: (row) => ({ metric: row.metric as string, value: row.value as number }),
+      metrics: ['heart_rate'],
+      params: [new Date('2024-01-15'), new Date('2024-01-16')],
+      queryFn,
+      sqlCumulative: 'CUMULATIVE SQL',
+      sqlNonCumulative: 'NON-CUMULATIVE SQL',
+    })
+
+    expect(results).toEqual([{ metric: 'heart_rate', value: 72 }])
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(queryFn).toHaveBeenCalledWith('NON-CUMULATIVE SQL', [
+      ['heart_rate'],
+      new Date('2024-01-15'),
+      new Date('2024-01-16'),
+    ])
+  })
+
+  test('skips non-cumulative query when no non-cumulative metrics', async () => {
+    const queryFn = vi.fn().mockResolvedValueOnce({
+      rows: [{ metric: 'steps', value: 5000 }],
+    })
+
+    const results = await querySplitByCumulative({
+      mapRow: (row) => ({ metric: row.metric as string, value: row.value as number }),
+      metrics: ['steps'],
+      params: [new Date('2024-01-15'), new Date('2024-01-16')],
+      queryFn,
+      sqlCumulative: 'CUMULATIVE SQL',
+      sqlNonCumulative: 'NON-CUMULATIVE SQL',
+    })
+
+    expect(results).toEqual([{ metric: 'steps', value: 5000 }])
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(queryFn).toHaveBeenCalledWith('CUMULATIVE SQL', [
+      ['steps'],
+      new Date('2024-01-15'),
+      new Date('2024-01-16'),
+    ])
+  })
+
+  test('returns empty when no metrics', async () => {
+    const queryFn = vi.fn()
+
+    const results = await querySplitByCumulative({
+      mapRow: (row) => row,
+      metrics: [],
+      params: [],
+      queryFn,
+      sqlCumulative: 'SQL',
+      sqlNonCumulative: 'SQL',
+    })
+
+    expect(results).toEqual([])
+    expect(queryFn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/db/cumulative-query.ts
+++ b/apps/backend/src/db/cumulative-query.ts
@@ -1,0 +1,56 @@
+/**
+ * Helper for splitting metric queries by cumulative/non-cumulative type.
+ *
+ * Cumulative metrics (steps, distance, etc.) use only the aggregate source
+ * to avoid mixing raw readings with deduplicated daily totals.
+ */
+import { cumulativeMetrics, type MetricType } from '@aurboda/api-spec'
+import type { QueryResultRow } from 'pg'
+
+/**
+ * Split a list of metric names into cumulative and non-cumulative groups.
+ */
+export const splitMetricsByCumulative = (
+  metrics: string[],
+): { cumulative: string[]; nonCumulative: string[] } => ({
+  cumulative: metrics.filter((m) => cumulativeMetrics.includes(m as MetricType)),
+  nonCumulative: metrics.filter((m) => !cumulativeMetrics.includes(m as MetricType)),
+})
+
+interface SplitQueryOptions<T> {
+  /** The metric names to query */
+  metrics: string[]
+  /** Additional query parameters after the metrics array (e.g. start, end dates) */
+  params: unknown[]
+  /** SQL for cumulative metrics (with source filter). $1 = metrics array, remaining = params */
+  sqlCumulative: string
+  /** SQL for non-cumulative metrics (all sources). $1 = metrics array, remaining = params */
+  sqlNonCumulative: string
+  /** Map a database row to the result type */
+  mapRow: (row: QueryResultRow) => T
+  /** Execute a query and return rows */
+  queryFn: (sql: string, params: unknown[]) => Promise<{ rows: QueryResultRow[] }>
+}
+
+/**
+ * Run split queries for cumulative and non-cumulative metrics, combining results.
+ *
+ * The SQL templates should use $1 for the metrics array, with remaining placeholders
+ * for the additional params (e.g. $2 for start, $3 for end).
+ */
+export const querySplitByCumulative = async <T>(options: SplitQueryOptions<T>): Promise<T[]> => {
+  const { cumulative, nonCumulative } = splitMetricsByCumulative(options.metrics)
+  const results: T[] = []
+
+  if (cumulative.length > 0) {
+    const result = await options.queryFn(options.sqlCumulative, [cumulative, ...options.params])
+    results.push(...result.rows.map(options.mapRow))
+  }
+
+  if (nonCumulative.length > 0) {
+    const result = await options.queryFn(options.sqlNonCumulative, [nonCumulative, ...options.params])
+    results.push(...result.rows.map(options.mapRow))
+  }
+
+  return results
+}

--- a/apps/backend/src/db/dynamic-update.test.ts
+++ b/apps/backend/src/db/dynamic-update.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest'
+import { buildDynamicUpdate } from './dynamic-update'
+
+describe('buildDynamicUpdate', () => {
+  test('builds a simple update with one field', () => {
+    const result = buildDynamicUpdate('activities', 'abc-123', [{ column: 'title', value: 'New title' }], {
+      returning: 'id, title',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.sql).toBe('UPDATE activities SET title = $1 WHERE id = $2 RETURNING id, title')
+    expect(result!.params).toEqual(['New title', 'abc-123'])
+  })
+
+  test('builds an update with multiple fields', () => {
+    const result = buildDynamicUpdate(
+      'activities',
+      'abc-123',
+      [
+        { column: 'title', value: 'New title' },
+        { column: 'notes', value: 'Some notes' },
+        { column: 'start_time', value: new Date('2024-01-15T10:00:00Z') },
+      ],
+      { returning: 'id' },
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.sql).toBe(
+      'UPDATE activities SET title = $1, notes = $2, start_time = $3 WHERE id = $4 RETURNING id',
+    )
+    expect(result!.params).toEqual(['New title', 'Some notes', new Date('2024-01-15T10:00:00Z'), 'abc-123'])
+  })
+
+  test('returns null when no fields provided', () => {
+    const result = buildDynamicUpdate('activities', 'abc-123', [], { returning: 'id' })
+    expect(result).toBeNull()
+  })
+
+  test('includes default clauses', () => {
+    const result = buildDynamicUpdate('named_locations', 'loc-1', [{ column: 'name', value: 'Office' }], {
+      defaultClauses: ['updated_at = NOW()'],
+      returning: 'id, name',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.sql).toBe(
+      'UPDATE named_locations SET updated_at = NOW(), name = $1 WHERE id = $2 RETURNING id, name',
+    )
+    expect(result!.params).toEqual(['Office', 'loc-1'])
+  })
+
+  test('returns non-null with only default clauses and no fields', () => {
+    const result = buildDynamicUpdate('named_locations', 'loc-1', [], {
+      defaultClauses: ['updated_at = NOW()'],
+      returning: 'id',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.sql).toBe('UPDATE named_locations SET updated_at = NOW() WHERE id = $1 RETURNING id')
+    expect(result!.params).toEqual(['loc-1'])
+  })
+
+  test('handles multi-value expressions', () => {
+    const result = buildDynamicUpdate(
+      'named_locations',
+      'loc-1',
+      [{ expression: 'location = ST_MakePoint($NEXT, $NEXT)::geography', values: [18.0686, 59.3293] }],
+      {
+        defaultClauses: ['updated_at = NOW()'],
+        returning: 'id',
+      },
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.sql).toBe(
+      'UPDATE named_locations SET updated_at = NOW(), location = ST_MakePoint($1, $2)::geography WHERE id = $3 RETURNING id',
+    )
+    expect(result!.params).toEqual([18.0686, 59.3293, 'loc-1'])
+  })
+
+  test('mixes simple fields and expressions', () => {
+    const result = buildDynamicUpdate(
+      'detected_locations',
+      'det-1',
+      [
+        { expression: 'location = ST_MakePoint($NEXT, $NEXT)::geography', values: [18.0686, 59.3293] },
+        { column: 'radius', value: 300 },
+        { column: 'address', value: '123 Main St' },
+      ],
+      {
+        defaultClauses: ['updated_at = NOW()'],
+        returning: 'id',
+      },
+    )
+
+    expect(result).not.toBeNull()
+    expect(result!.sql).toBe(
+      'UPDATE detected_locations SET updated_at = NOW(), location = ST_MakePoint($1, $2)::geography, radius = $3, address = $4 WHERE id = $5 RETURNING id',
+    )
+    expect(result!.params).toEqual([18.0686, 59.3293, 300, '123 Main St', 'det-1'])
+  })
+})

--- a/apps/backend/src/db/dynamic-update.ts
+++ b/apps/backend/src/db/dynamic-update.ts
@@ -1,0 +1,55 @@
+/**
+ * Dynamic SQL UPDATE builder for reducing duplication across update functions.
+ */
+
+export type UpdateEntry = { column: string; value: unknown } | { expression: string; values: unknown[] }
+
+const isExpression = (entry: UpdateEntry): entry is { expression: string; values: unknown[] } =>
+  'expression' in entry
+
+/**
+ * Build a dynamic UPDATE statement from a list of field entries.
+ *
+ * Returns null if there are no SET clauses to apply (no fields and no defaults).
+ *
+ * @param table - Table name
+ * @param idValue - The value of the id column for the WHERE clause
+ * @param fields - Fields to update (simple column=value or multi-param expressions)
+ * @param options.defaultClauses - Static SET clauses always included (e.g. "updated_at = NOW()")
+ * @param options.returning - RETURNING clause content
+ * @param options.idColumn - Column name for WHERE (default: "id")
+ */
+export const buildDynamicUpdate = (
+  table: string,
+  idValue: unknown,
+  fields: UpdateEntry[],
+  options: { defaultClauses?: string[]; returning: string; idColumn?: string },
+): { sql: string; params: unknown[] } | null => {
+  const setClauses: string[] = [...(options.defaultClauses ?? [])]
+  const params: unknown[] = []
+  let paramIndex = 1
+
+  for (const entry of fields) {
+    if (isExpression(entry)) {
+      let expr = entry.expression
+      for (const val of entry.values) {
+        expr = expr.replace('$NEXT', `$${paramIndex++}`)
+        params.push(val)
+      }
+      setClauses.push(expr)
+    } else {
+      setClauses.push(`${entry.column} = $${paramIndex++}`)
+      params.push(entry.value)
+    }
+  }
+
+  if (setClauses.length === 0) return null
+
+  const idColumn = options.idColumn ?? 'id'
+  params.push(idValue)
+
+  return {
+    params,
+    sql: `UPDATE ${table} SET ${setClauses.join(', ')} WHERE ${idColumn} = $${paramIndex} RETURNING ${options.returning}`,
+  }
+}

--- a/apps/backend/src/db/row-mappers.test.ts
+++ b/apps/backend/src/db/row-mappers.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from 'vitest'
+import {
+  mapActivityRow,
+  mapDetectedLocationRow,
+  mapLastFmTagRuleRow,
+  mapMcpSessionRow,
+  mapNamedLocationRow,
+  mapSyncStateRow,
+  mapTagRow,
+  parseActivityType,
+  parseDataSource,
+  parseGeocodeStatus,
+  parseSyncStatus,
+} from './row-mappers'
+
+describe('type guards', () => {
+  test('parseActivityType accepts valid types', () => {
+    expect(parseActivityType('sleep')).toBe('sleep')
+    expect(parseActivityType('exercise')).toBe('exercise')
+    expect(parseActivityType('meditation')).toBe('meditation')
+    expect(parseActivityType('nap')).toBe('nap')
+  })
+
+  test('parseActivityType throws on invalid type', () => {
+    expect(() => parseActivityType('invalid')).toThrow('Invalid ActivityType')
+    expect(() => parseActivityType(null)).toThrow('Invalid ActivityType')
+    expect(() => parseActivityType(undefined)).toThrow('Invalid ActivityType')
+    expect(() => parseActivityType(42)).toThrow('Invalid ActivityType')
+  })
+
+  test('parseDataSource accepts valid sources', () => {
+    expect(parseDataSource('health_connect')).toBe('health_connect')
+    expect(parseDataSource('oura')).toBe('oura')
+    expect(parseDataSource('manual')).toBe('manual')
+    expect(parseDataSource('lastfm')).toBe('lastfm')
+  })
+
+  test('parseDataSource throws on invalid source', () => {
+    expect(() => parseDataSource('invalid')).toThrow('Invalid DataSource')
+  })
+
+  test('parseGeocodeStatus accepts valid statuses', () => {
+    expect(parseGeocodeStatus('pending')).toBe('pending')
+    expect(parseGeocodeStatus('geocoding')).toBe('geocoding')
+    expect(parseGeocodeStatus('success')).toBe('success')
+    expect(parseGeocodeStatus('failed')).toBe('failed')
+  })
+
+  test('parseGeocodeStatus throws on invalid status', () => {
+    expect(() => parseGeocodeStatus('invalid')).toThrow('Invalid GeocodeStatus')
+  })
+
+  test('parseSyncStatus accepts valid statuses including rate_limited', () => {
+    expect(parseSyncStatus('idle')).toBe('idle')
+    expect(parseSyncStatus('syncing')).toBe('syncing')
+    expect(parseSyncStatus('error')).toBe('error')
+    expect(parseSyncStatus('rate_limited')).toBe('rate_limited')
+  })
+
+  test('parseSyncStatus throws on invalid status', () => {
+    expect(() => parseSyncStatus('invalid')).toThrow('Invalid SyncStatus')
+  })
+})
+
+describe('mapActivityRow', () => {
+  test('maps a database row to Activity', () => {
+    const row = {
+      activity_type: 'exercise',
+      data: { hr: 150 },
+      end_time: '2024-01-15T11:00:00Z',
+      id: 'abc-123',
+      notes: 'Morning run',
+      source: 'manual',
+      start_time: '2024-01-15T10:00:00Z',
+      title: 'Run',
+    }
+
+    const result = mapActivityRow(row)
+
+    expect(result).toEqual({
+      activityType: 'exercise',
+      data: { hr: 150 },
+      endTime: new Date('2024-01-15T11:00:00Z'),
+      id: 'abc-123',
+      notes: 'Morning run',
+      source: 'manual',
+      startTime: new Date('2024-01-15T10:00:00Z'),
+      title: 'Run',
+    })
+  })
+
+  test('handles null end_time', () => {
+    const row = {
+      activity_type: 'sleep',
+      data: null,
+      end_time: null,
+      id: 'abc-123',
+      notes: null,
+      source: 'oura',
+      start_time: '2024-01-15T23:00:00Z',
+      title: null,
+    }
+
+    const result = mapActivityRow(row)
+    expect(result.endTime).toBeUndefined()
+  })
+
+  test('throws on invalid activity type', () => {
+    const row = {
+      activity_type: 'invalid',
+      data: null,
+      end_time: null,
+      id: 'abc',
+      notes: null,
+      source: 'manual',
+      start_time: '2024-01-15T10:00:00Z',
+      title: null,
+    }
+
+    expect(() => mapActivityRow(row)).toThrow('Invalid ActivityType')
+  })
+})
+
+describe('mapNamedLocationRow', () => {
+  test('maps a database row to NamedLocation', () => {
+    const row = {
+      created_at: '2024-01-15T10:00:00Z',
+      id: 'loc-1',
+      lat: 59.3293,
+      lon: 18.0686,
+      name: 'Home',
+      radius: 200,
+      updated_at: '2024-01-15T10:00:00Z',
+    }
+
+    const result = mapNamedLocationRow(row)
+
+    expect(result).toEqual({
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+      id: 'loc-1',
+      lat: 59.3293,
+      lon: 18.0686,
+      name: 'Home',
+      radius: 200,
+      updatedAt: new Date('2024-01-15T10:00:00Z'),
+    })
+  })
+})
+
+describe('mapDetectedLocationRow', () => {
+  test('maps a database row to DetectedLocation', () => {
+    const row = {
+      address: '123 Main St',
+      created_at: '2024-01-15T10:00:00Z',
+      first_visit: '2024-01-10T08:00:00Z',
+      geocode_status: 'success',
+      id: 'det-1',
+      last_visit: '2024-01-15T08:00:00Z',
+      lat: 59.3293,
+      lon: 18.0686,
+      radius: 150,
+      total_minutes: 480,
+      updated_at: '2024-01-15T10:00:00Z',
+      visit_count: 5,
+    }
+
+    const result = mapDetectedLocationRow(row)
+
+    expect(result).toEqual({
+      address: '123 Main St',
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+      firstVisit: new Date('2024-01-10T08:00:00Z'),
+      geocodeStatus: 'success',
+      id: 'det-1',
+      lastVisit: new Date('2024-01-15T08:00:00Z'),
+      lat: 59.3293,
+      lon: 18.0686,
+      radius: 150,
+      totalMinutes: 480,
+      updatedAt: new Date('2024-01-15T10:00:00Z'),
+      visitCount: 5,
+    })
+  })
+
+  test('throws on invalid geocode status', () => {
+    const row = {
+      address: null,
+      created_at: '2024-01-15T10:00:00Z',
+      first_visit: '2024-01-10T08:00:00Z',
+      geocode_status: 'bogus',
+      id: 'det-1',
+      last_visit: '2024-01-15T08:00:00Z',
+      lat: 59.3293,
+      lon: 18.0686,
+      radius: 150,
+      total_minutes: 480,
+      updated_at: '2024-01-15T10:00:00Z',
+      visit_count: 5,
+    }
+
+    expect(() => mapDetectedLocationRow(row)).toThrow('Invalid GeocodeStatus')
+  })
+})
+
+describe('mapSyncStateRow', () => {
+  test('maps a database row to SyncState', () => {
+    const row = {
+      data_type: 'sleep',
+      error_message: null,
+      id: 'sync-1',
+      last_sync_time: '2024-01-15T10:00:00Z',
+      provider: 'oura',
+      retry_after: null,
+      status: 'idle',
+      sync_start_date: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-15T10:00:00Z',
+    }
+
+    const result = mapSyncStateRow(row)
+
+    expect(result).toEqual({
+      dataType: 'sleep',
+      errorMessage: null,
+      id: 'sync-1',
+      lastSyncTime: new Date('2024-01-15T10:00:00Z'),
+      provider: 'oura',
+      retryAfter: undefined,
+      status: 'idle',
+      syncStartDate: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-01-15T10:00:00Z'),
+    })
+  })
+
+  test('handles rate_limited status', () => {
+    const row = {
+      data_type: 'sleep',
+      error_message: 'Rate limited',
+      id: 'sync-1',
+      last_sync_time: null,
+      provider: 'oura',
+      retry_after: '2024-01-15T11:00:00Z',
+      status: 'rate_limited',
+      sync_start_date: null,
+      updated_at: '2024-01-15T10:00:00Z',
+    }
+
+    const result = mapSyncStateRow(row)
+    expect(result.status).toBe('rate_limited')
+    expect(result.retryAfter).toEqual(new Date('2024-01-15T11:00:00Z'))
+  })
+})
+
+describe('mapTagRow', () => {
+  test('maps a database row to Tag', () => {
+    const row = {
+      end_time: '2024-01-15T11:00:00Z',
+      external_id: 'ext-1',
+      id: 'tag-1',
+      source: 'manual',
+      start_time: '2024-01-15T10:00:00Z',
+      tag: 'coffee',
+    }
+
+    const result = mapTagRow(row)
+
+    expect(result).toEqual({
+      endTime: new Date('2024-01-15T11:00:00Z'),
+      externalId: 'ext-1',
+      id: 'tag-1',
+      source: 'manual',
+      startTime: new Date('2024-01-15T10:00:00Z'),
+      tag: 'coffee',
+    })
+  })
+
+  test('handles null end_time', () => {
+    const row = {
+      end_time: null,
+      external_id: 'ext-1',
+      id: 'tag-1',
+      source: 'manual',
+      start_time: '2024-01-15T10:00:00Z',
+      tag: 'coffee',
+    }
+
+    const result = mapTagRow(row)
+    expect(result.endTime).toBeUndefined()
+  })
+})
+
+describe('mapMcpSessionRow', () => {
+  test('maps a database row to McpSessionRecord', () => {
+    const row = {
+      created_at: '2024-01-15T10:00:00Z',
+      last_activity: '2024-01-15T12:00:00Z',
+      session_id: 'sess-1',
+      username: 'testuser',
+    }
+
+    const result = mapMcpSessionRow(row)
+
+    expect(result).toEqual({
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+      lastActivity: new Date('2024-01-15T12:00:00Z'),
+      sessionId: 'sess-1',
+      username: 'testuser',
+    })
+  })
+})
+
+describe('mapLastFmTagRuleRow', () => {
+  test('maps a database row to LastFmTagRule', () => {
+    const row = {
+      artist_name: 'Pink Floyd',
+      created_at: '2024-01-15T10:00:00Z',
+      id: 'rule-1',
+      match_mode: 'exact',
+      match_type: 'artist',
+      rule_name: 'Pink Floyd tag',
+      tag_name: 'psychedelic',
+      track_name: null,
+    }
+
+    const result = mapLastFmTagRuleRow(row)
+
+    expect(result).toEqual({
+      artistName: 'Pink Floyd',
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+      id: 'rule-1',
+      matchMode: 'exact',
+      matchType: 'artist',
+      ruleName: 'Pink Floyd tag',
+      tagName: 'psychedelic',
+      trackName: undefined,
+    })
+  })
+})

--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -1,0 +1,168 @@
+/**
+ * Row mapper functions for converting PostgreSQL rows to typed objects.
+ *
+ * Replaces inline `as Type` casts with validated type guards.
+ */
+import { activityTypes, type ActivityType, type DataSource, type MetricType } from '@aurboda/api-spec'
+import type { QueryResultRow } from 'pg'
+import type {
+  Activity,
+  DetectedLocation,
+  GeocodeStatus,
+  LastFmTagRule,
+  McpSessionRecord,
+  NamedLocation,
+  SyncState,
+  SyncStatus,
+  Tag,
+} from '../db'
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+const VALID_DATA_SOURCES = [
+  'health_connect',
+  'health_connect_aggregate',
+  'oura',
+  'garmin',
+  'rescuetime',
+  'owntracks',
+  'calendar',
+  'manual',
+  'lastfm',
+] as const
+
+const VALID_GEOCODE_STATUSES = ['pending', 'geocoding', 'success', 'failed'] as const
+const VALID_SYNC_STATUSES = ['idle', 'syncing', 'error', 'rate_limited'] as const
+const VALID_LASTFM_MATCH_TYPES = ['track', 'artist', 'track_artist'] as const
+const VALID_LASTFM_MATCH_MODES = ['exact', 'contains'] as const
+
+export const parseActivityType = (value: unknown): ActivityType => {
+  if (typeof value === 'string' && (activityTypes as readonly string[]).includes(value)) {
+    return value as ActivityType
+  }
+  throw new Error(`Invalid ActivityType: ${JSON.stringify(value)}`)
+}
+
+export const parseDataSource = (value: unknown): DataSource => {
+  if (typeof value === 'string' && (VALID_DATA_SOURCES as readonly string[]).includes(value)) {
+    return value as DataSource
+  }
+  throw new Error(`Invalid DataSource: ${JSON.stringify(value)}`)
+}
+
+export const parseGeocodeStatus = (value: unknown): GeocodeStatus => {
+  if (typeof value === 'string' && (VALID_GEOCODE_STATUSES as readonly string[]).includes(value)) {
+    return value as GeocodeStatus
+  }
+  throw new Error(`Invalid GeocodeStatus: ${JSON.stringify(value)}`)
+}
+
+export const parseSyncStatus = (value: unknown): SyncStatus => {
+  if (typeof value === 'string' && (VALID_SYNC_STATUSES as readonly string[]).includes(value)) {
+    return value as SyncStatus
+  }
+  throw new Error(`Invalid SyncStatus: ${JSON.stringify(value)}`)
+}
+
+export const parseMetricType = (value: unknown): MetricType => {
+  // MetricType is a wide union; for DB rows we trust the value is valid
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid MetricType: ${JSON.stringify(value)}`)
+  }
+  return value as MetricType
+}
+
+const parseLastFmMatchType = (value: unknown) => {
+  if (typeof value === 'string' && (VALID_LASTFM_MATCH_TYPES as readonly string[]).includes(value)) {
+    return value as (typeof VALID_LASTFM_MATCH_TYPES)[number]
+  }
+  throw new Error(`Invalid LastFmMatchType: ${JSON.stringify(value)}`)
+}
+
+const parseLastFmMatchMode = (value: unknown) => {
+  if (typeof value === 'string' && (VALID_LASTFM_MATCH_MODES as readonly string[]).includes(value)) {
+    return value as (typeof VALID_LASTFM_MATCH_MODES)[number]
+  }
+  throw new Error(`Invalid LastFmMatchMode: ${JSON.stringify(value)}`)
+}
+
+// ============================================================================
+// Row Mappers
+// ============================================================================
+
+export const mapActivityRow = (row: QueryResultRow): Activity => ({
+  activityType: parseActivityType(row.activity_type),
+  data: row.data,
+  endTime: row.end_time ? new Date(row.end_time) : undefined,
+  id: row.id,
+  notes: row.notes,
+  source: parseDataSource(row.source),
+  startTime: new Date(row.start_time),
+  title: row.title,
+})
+
+export const mapNamedLocationRow = (row: QueryResultRow): NamedLocation => ({
+  createdAt: new Date(row.created_at),
+  id: row.id,
+  lat: row.lat,
+  lon: row.lon,
+  name: row.name,
+  radius: row.radius,
+  updatedAt: new Date(row.updated_at),
+})
+
+export const mapDetectedLocationRow = (row: QueryResultRow): DetectedLocation => ({
+  address: row.address,
+  createdAt: new Date(row.created_at),
+  firstVisit: new Date(row.first_visit),
+  geocodeStatus: parseGeocodeStatus(row.geocode_status),
+  id: row.id,
+  lastVisit: new Date(row.last_visit),
+  lat: row.lat,
+  lon: row.lon,
+  radius: row.radius,
+  totalMinutes: row.total_minutes,
+  updatedAt: new Date(row.updated_at),
+  visitCount: row.visit_count,
+})
+
+export const mapSyncStateRow = (row: QueryResultRow): SyncState => ({
+  dataType: row.data_type,
+  errorMessage: row.error_message,
+  id: row.id,
+  lastSyncTime: row.last_sync_time ? new Date(row.last_sync_time) : undefined,
+  provider: row.provider,
+  retryAfter: row.retry_after ? new Date(row.retry_after) : undefined,
+  status: parseSyncStatus(row.status),
+  syncStartDate: row.sync_start_date ? new Date(row.sync_start_date) : undefined,
+  updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
+})
+
+export const mapTagRow = (row: QueryResultRow): Tag => ({
+  endTime: row.end_time ? new Date(row.end_time) : undefined,
+  externalId: row.external_id,
+  id: row.id,
+  source: row.source,
+  startTime: new Date(row.start_time),
+  tag: row.tag,
+})
+
+export const mapMcpSessionRow = (row: QueryResultRow): McpSessionRecord => ({
+  createdAt: new Date(row.created_at),
+  lastActivity: new Date(row.last_activity),
+  sessionId: row.session_id,
+  username: row.username,
+})
+
+export const mapLastFmTagRuleRow = (row: QueryResultRow): LastFmTagRule => ({
+  artistName: row.artist_name ?? undefined,
+  createdAt: new Date(row.created_at),
+  id: row.id,
+  matchMode: parseLastFmMatchMode(row.match_mode),
+  matchType: parseLastFmMatchType(row.match_type),
+  ruleName: row.rule_name,
+  tagName: row.tag_name,
+  trackName: row.track_name ?? undefined,
+})


### PR DESCRIPTION
## Summary

- **row-mappers.ts**: Type-safe row mapper functions with validated type guards, replacing ~20 inline `as Type` casts across db.ts
- **dynamic-update.ts**: Reusable SQL UPDATE builder with `$NEXT` placeholder system for multi-param expressions (e.g. PostGIS `ST_MakePoint`), replacing 3 duplicate update functions
- **cumulative-query.ts**: Splits metric queries by cumulative/non-cumulative type to handle Health Connect aggregate vs raw sources, replacing 3 duplicate query-splitting blocks
- db.ts reduced from 2,290 to 1,925 lines (-365 lines)

Phase 2 of the backend refactoring plan.

## Test plan

- [x] Unit tests for all three new modules (row-mappers, dynamic-update, cumulative-query)
- [x] All 640 backend tests pass
- [x] All 72 web tests pass
- [x] `pnpm fix` and `pnpm check` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)