### PR TITLE
Move Last.fm API key from env variable to admin settings

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -317,6 +317,7 @@ const main = async () => {
     createSyncRouter(
       {
         getCalendarSyncStates: (user) => transformSyncStates(user, 'calendar'),
+        getLastFmApiKey: () => centralDb.getLastFmApiKey(),
         getLastFmSyncStates: (user) => transformSyncStates(user, 'lastfm'),
         getOuraSyncStates: (user) => transformSyncStates(user, 'oura'),
         getRescueTimeSyncStates: (user) => transformSyncStates(user, 'rescuetime'),

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -9,6 +9,7 @@ import { syncLastFmData } from '../lastfm-sync'
 import { ouraClient } from '../oura'
 import { syncAllOuraData } from '../oura-sync'
 import { syncRescueTimeData } from '../rescuetime-sync'
+import { getCentralDb } from '../services/central-db'
 import { getSettings } from '../services/settings'
 import { errorResponse, jsonResponse, type McpServer } from './helpers'
 
@@ -150,7 +151,7 @@ export const registerSyncTools = (server: McpServer, user: string, oura?: OuraCl
         .describe('Optional start date for sync in YYYY-MM-DD format. Only used with full_resync.'),
     },
     async ({ full_resync, start_date }) => {
-      const lastFmApiKey = process.env.LASTFM_API_KEY
+      const lastFmApiKey = await getCentralDb().getLastFmApiKey()
       if (!lastFmApiKey) {
         return errorResponse('Last.fm API key is not configured on this server.')
       }

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -33,8 +33,10 @@ export const createAdminRouter = (
     async (_req, res) => {
       const signupMode = await centralDb.getSignupMode()
       const adminCount = await centralDb.getAdminCount()
+      const lastFmApiKey = await centralDb.getLastFmApiKey()
       res.json({
         admin_count: adminCount,
+        lastfm_api_key_set: !!lastFmApiKey,
         signup_mode: signupMode,
         success: true,
       })
@@ -48,14 +50,19 @@ export const createAdminRouter = (
     adminMiddleware,
     validateBody(updateAdminSettingsBodySchema),
     async (req, res) => {
-      const { signup_mode } = req.body
+      const { lastfm_api_key, signup_mode } = req.body
       if (signup_mode) {
         await centralDb.setSignupMode(signup_mode)
       }
+      if (lastfm_api_key !== undefined) {
+        await centralDb.setLastFmApiKey(lastfm_api_key)
+      }
       const currentMode = await centralDb.getSignupMode()
       const adminCount = await centralDb.getAdminCount()
+      const lastFmApiKey = await centralDb.getLastFmApiKey()
       res.json({
         admin_count: adminCount,
+        lastfm_api_key_set: !!lastFmApiKey,
         signup_mode: currentMode,
         success: true,
       })

--- a/apps/backend/src/services/central-db.test.ts
+++ b/apps/backend/src/services/central-db.test.ts
@@ -50,6 +50,49 @@ describe('central-db', () => {
     })
   })
 
+  describe('getLastFmApiKey', () => {
+    test('returns API key when set', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ value: 'test-api-key' }] })
+
+      const result = await centralDb.getLastFmApiKey()
+
+      expect(result).toBe('test-api-key')
+      expect(mockClient.query).toHaveBeenCalledWith('SELECT value FROM server_settings WHERE key = $1', [
+        'lastfm_api_key',
+      ])
+    })
+
+    test('returns null when not set', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getLastFmApiKey()
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('setLastFmApiKey', () => {
+    test('stores API key', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.setLastFmApiKey('my-api-key')
+
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO server_settings'), [
+        JSON.stringify('my-api-key'),
+      ])
+    })
+
+    test('deletes key when set to null', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.setLastFmApiKey(null)
+
+      expect(mockClient.query).toHaveBeenCalledWith('DELETE FROM server_settings WHERE key = $1', [
+        'lastfm_api_key',
+      ])
+    })
+  })
+
   describe('getServerSetting', () => {
     test('returns setting value when found', async () => {
       mockClient.query.mockResolvedValue({ rows: [{ value: 'invite_only' }] })

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -15,6 +15,7 @@ import pg from 'pg'
 export type SignupMode = 'open' | 'invite_only' | 'closed'
 
 export interface ServerSettings {
+  lastfm_api_key: string
   signup_mode: SignupMode
 }
 
@@ -26,6 +27,8 @@ export interface CentralDb {
   initializeCentralDb: () => Promise<void>
   getServerSetting: <K extends keyof ServerSettings>(key: K) => Promise<ServerSettings[K] | null>
   setServerSetting: <K extends keyof ServerSettings>(key: K, value: ServerSettings[K]) => Promise<void>
+  getLastFmApiKey: () => Promise<string | null>
+  setLastFmApiKey: (key: string | null) => Promise<void>
   getSignupMode: () => Promise<SignupMode>
   setSignupMode: (mode: SignupMode) => Promise<void>
   isAdmin: (username: string) => Promise<boolean>
@@ -138,6 +141,15 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       return result.rows.map((row) => row.username)
     },
 
+    getLastFmApiKey: async (): Promise<string | null> => {
+      const client = await getClient()
+      const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [
+        'lastfm_api_key',
+      ])
+      if (result.rows.length === 0) return null
+      return result.rows[0].value as string
+    },
+
     getServerSetting: async <K extends keyof ServerSettings>(key: K): Promise<ServerSettings[K] | null> => {
       const client = await getClient()
       const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [key])
@@ -175,6 +187,20 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       const client = await getClient()
       const result = await client.query('DELETE FROM admins WHERE username = $1', [username])
       return (result.rowCount ?? 0) > 0
+    },
+
+    setLastFmApiKey: async (key: string | null): Promise<void> => {
+      const client = await getClient()
+      if (key === null) {
+        await client.query('DELETE FROM server_settings WHERE key = $1', ['lastfm_api_key'])
+      } else {
+        await client.query(
+          `INSERT INTO server_settings (key, value, updated_at)
+           VALUES ('lastfm_api_key', $1, NOW())
+           ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+          [JSON.stringify(key)],
+        )
+      }
     },
 
     setServerSetting: async <K extends keyof ServerSettings>(

--- a/apps/backend/src/services/settings.test.ts
+++ b/apps/backend/src/services/settings.test.ts
@@ -17,6 +17,13 @@ vi.mock('../db', () => ({
   upsertUserSettings: vi.fn(),
 }))
 
+// Mock the central-db module
+vi.mock('./central-db', () => ({
+  getCentralDb: () => ({
+    getLastFmApiKey: vi.fn().mockResolvedValue(null),
+  }),
+}))
+
 describe('calculateDefaultHrZones', () => {
   test('returns default zones when no birth date provided', () => {
     const zones = calculateDefaultHrZones(null)

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -15,6 +15,7 @@ import {
   type UserSettingsResponse,
 } from '@aurboda/api-spec'
 import { getOAuthToken, getUserSettings, upsertUserSettings } from '../db'
+import { getCentralDb } from './central-db'
 
 // Re-export types from api-spec for use by other modules
 export type { HrZoneSecs, HrZoneSource, HrZoneThresholds }
@@ -145,7 +146,8 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
   const { zones, source } = await getEffectiveHrZones(user)
   const ouraToken = await getOAuthToken(user, 'oura')
   const ouraConfigured = !!(process.env.OURA_CLIENT && process.env.OURA_SECRET)
-  const lastFmConfigured = !!process.env.LASTFM_API_KEY
+  const lastFmApiKey = await getCentralDb().getLastFmApiKey()
+  const lastFmConfigured = !!lastFmApiKey
 
   return {
     birth_date: settings.birthDate ?? null,
@@ -182,7 +184,7 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
       goals: defaultGoals,
       hr_zone_start: calculateDefaultHrZones(null),
       hr_zone_start_source: 'default',
-      lastfm_configured: !!process.env.LASTFM_API_KEY,
+      lastfm_configured: !!(await getCentralDb().getLastFmApiKey()),
       lastfm_username: null,
       oura_configured: !!(process.env.OURA_CLIENT && process.env.OURA_SECRET),
       oura_connected: false,

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -6,6 +6,7 @@ import { createSyncRouter, SyncRouterDeps } from './sync-router'
 describe('sync router', () => {
   const mockDeps: SyncRouterDeps = {
     getCalendarSyncStates: vi.fn().mockResolvedValue([]),
+    getLastFmApiKey: vi.fn().mockResolvedValue('test-lastfm-key'),
     getLastFmSyncStates: vi.fn().mockResolvedValue([]),
     getOuraSyncStates: vi.fn().mockResolvedValue([]),
     getRescueTimeSyncStates: vi.fn().mockResolvedValue([]),

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -67,6 +67,7 @@ export interface SyncRouterDeps {
   getSettings: (
     user: string,
   ) => Promise<{ rescueTimeKey?: string; calendars?: CalendarConfig[]; lastFmUsername?: string }>
+  getLastFmApiKey: () => Promise<string | null>
 }
 
 /**
@@ -273,7 +274,7 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       const user = req.user!
       const { full_resync, start_date } = req.body
 
-      const lastFmApiKey = process.env.LASTFM_API_KEY
+      const lastFmApiKey = await deps.getLastFmApiKey()
       if (!lastFmApiKey) {
         return res.status(400).json({ error: 'Last.fm API key not configured on server', success: false })
       }

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -63,6 +63,8 @@ export function AdminSettings() {
   })
 
   const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [lastfmSaveStatus, setLastfmSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [lastfmApiKey, setLastfmApiKey] = useState('')
   const [invitation, setInvitation] = useState<InvitationResult | null>(null)
   const [invitationLoading, setInvitationLoading] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -84,6 +86,37 @@ export function AdminSettings() {
     },
     [queryClient],
   )
+
+  const handleLastfmApiKeyBlur = useCallback(async () => {
+    if (!lastfmApiKey) return
+    setLastfmSaveStatus({ status: 'saving' })
+    try {
+      const result = await updateAdminSettings({ lastfm_api_key: lastfmApiKey })
+      queryClient.setQueryData(['adminSettings'], result)
+      setLastfmApiKey('')
+      setLastfmSaveStatus({ status: 'saved', time: new Date() })
+    } catch (err) {
+      setLastfmSaveStatus({
+        error: err instanceof Error ? err.message : 'Failed to save',
+        status: 'error',
+      })
+    }
+  }, [lastfmApiKey, queryClient])
+
+  const handleClearLastfmApiKey = useCallback(async () => {
+    setLastfmSaveStatus({ status: 'saving' })
+    try {
+      const result = await updateAdminSettings({ lastfm_api_key: null })
+      queryClient.setQueryData(['adminSettings'], result)
+      setLastfmApiKey('')
+      setLastfmSaveStatus({ status: 'saved', time: new Date() })
+    } catch (err) {
+      setLastfmSaveStatus({
+        error: err instanceof Error ? err.message : 'Failed to save',
+        status: 'error',
+      })
+    }
+  }, [queryClient])
 
   const handleGenerateInvitation = useCallback(async () => {
     setInvitationLoading(true)
@@ -161,6 +194,42 @@ export function AdminSettings() {
           <label>Admin Count</label>
           <p class="stat-value">{settings?.admin_count ?? 0}</p>
           <p class="field-description">Number of users with admin privileges.</p>
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <div class="section-header-row">
+          <h2>Integrations</h2>
+          <SaveStatusIndicator saveStatus={lastfmSaveStatus} />
+        </div>
+
+        <div class="form-field">
+          <label for="lastfm-api-key">Last.fm API Key</label>
+          {settings?.lastfm_api_key_set ?
+            <p class="connected-status">Configured</p>
+          : null}
+          <div class="api-key-input-row">
+            <input
+              id="lastfm-api-key"
+              type="password"
+              value={lastfmApiKey}
+              onInput={(e) => setLastfmApiKey((e.target as HTMLInputElement).value)}
+              onBlur={handleLastfmApiKeyBlur}
+              placeholder={settings?.lastfm_api_key_set ? 'Enter new key to update' : 'Enter Last.fm API key'}
+            />
+            {settings?.lastfm_api_key_set && (
+              <button type="button" class="clear-button" onClick={handleClearLastfmApiKey}>
+                Clear
+              </button>
+            )}
+          </div>
+          <p class="field-description">
+            Server-wide Last.fm API key used for scrobble syncing.{' '}
+            <a href="https://www.last.fm/api/account/create" target="_blank" rel="noopener noreferrer">
+              Register for an API key
+            </a>
+            . Saves automatically when you leave the field.
+          </p>
         </div>
       </section>
 

--- a/apps/web/src/pages/AdminSettings/style.css
+++ b/apps/web/src/pages/AdminSettings/style.css
@@ -92,6 +92,41 @@
   margin: 0;
 }
 
+.connected-status {
+  color: #4caf50;
+  font-weight: 500;
+  margin: 0 0 0.5rem;
+}
+
+.api-key-input-row {
+  display: flex;
+  gap: 0.5rem;
+  max-width: 400px;
+}
+
+.api-key-input-row input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.clear-button {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.clear-button:hover {
+  background: #d32f2f;
+}
+
 .generate-button {
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
@@ -166,7 +201,8 @@
     color: #aaa;
   }
 
-  .form-field select {
+  .form-field select,
+  .api-key-input-row input {
     background: #333;
     border-color: #555;
     color: #fff;

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -295,8 +295,8 @@ export function Settings() {
           : null}
           {userSettings?.lastfm_configured === false ?
             <p class="field-description warning">
-              Last.fm API key is not configured on the server. Ask your administrator to set the
-              LASTFM_API_KEY environment variable.
+              Last.fm API key is not configured on the server. Ask your administrator to configure the Last.fm
+              API key in Admin Settings.
             </p>
           : <>
               <input

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -412,6 +412,7 @@ export type SignupMode = 'open' | 'invite_only' | 'closed'
 export interface AdminSettings {
   signup_mode: SignupMode
   admin_count: number
+  lastfm_api_key_set: boolean
 }
 
 export interface InvitationResult {
@@ -429,12 +430,16 @@ export const fetchAdminSettings = async (): Promise<AdminSettings> => {
 
   return {
     admin_count: response.data.admin_count,
+    lastfm_api_key_set: response.data.lastfm_api_key_set,
     signup_mode: response.data.signup_mode,
   }
 }
 
 // Update admin settings
-export const updateAdminSettings = async (params: { signup_mode?: SignupMode }): Promise<AdminSettings> => {
+export const updateAdminSettings = async (params: {
+  signup_mode?: SignupMode
+  lastfm_api_key?: string | null
+}): Promise<AdminSettings> => {
   const { token } = auth.value
   const response = await axios.patch<{ success: boolean } & AdminSettings>(
     `${API_URL}/admin/settings`,
@@ -446,6 +451,7 @@ export const updateAdminSettings = async (params: { signup_mode?: SignupMode }):
 
   return {
     admin_count: response.data.admin_count,
+    lastfm_api_key_set: response.data.lastfm_api_key_set,
     signup_mode: response.data.signup_mode,
   }
 }

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -98,6 +98,7 @@ export type LoginResponse = z.infer<typeof loginResponseSchema>
 export const adminSettingsResponseSchema = baseResponseSchema
   .extend({
     admin_count: z.number().int().meta({ description: 'Number of admin users' }),
+    lastfm_api_key_set: z.boolean().meta({ description: 'Whether a Last.fm API key is configured' }),
     signup_mode: signupModeSchema.meta({ description: 'Current signup mode' }),
   })
   .meta({ id: 'AdminSettingsResponse' })
@@ -109,6 +110,11 @@ export type AdminSettingsResponse = z.infer<typeof adminSettingsResponseSchema>
  */
 export const updateAdminSettingsBodySchema = z
   .object({
+    lastfm_api_key: z
+      .string()
+      .nullable()
+      .optional()
+      .meta({ description: 'Last.fm API key (set to null to clear)' }),
     signup_mode: signupModeSchema.optional().meta({ description: 'New signup mode' }),
   })
   .meta({ id: 'UpdateAdminSettingsBody' })


### PR DESCRIPTION
## Summary
- Replaces `LASTFM_API_KEY` environment variable with a database-stored setting managed via the admin settings UI
- Adds `getLastFmApiKey`/`setLastFmApiKey` to the central-db service, storing in the existing `server_settings` table
- Adds an "Integrations" section to the admin settings page with a password input for the API key, including save-on-blur and a "Clear" button
- Updates all consumers (settings service, sync router, MCP sync tools) to read from DB instead of env

## Test plan
- [ ] Verify admin settings page shows new "Integrations" section with Last.fm API Key field
- [ ] Set the key via admin UI and verify `lastfm_api_key_set` shows as "Configured"
- [ ] Clear the key and verify it returns to unconfigured state
- [ ] Verify Last.fm sync works using the DB-stored key
- [ ] Verify user settings page shows updated message referencing "Admin Settings" instead of env var
- [ ] All 661 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)