### PR TITLE
Add session-based tag merging for Last.fm auto-tagging rules

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -109,6 +109,12 @@ export const migrateSchema = async (user: string) => {
       await query(db, createTableStatements[key])
     }
   }
+
+  // Column migrations for existing tables
+  if (existingTableNames.has('lastfm_tag_rules')) {
+    await query(db, `ALTER TABLE lastfm_tag_rules ADD COLUMN IF NOT EXISTS merge_gap_seconds INTEGER`)
+    await query(db, `ALTER TABLE lastfm_tag_rules ADD COLUMN IF NOT EXISTS artist_names JSONB`)
+  }
 }
 
 /**

--- a/apps/backend/src/db/lastfm-rules.integration.test.ts
+++ b/apps/backend/src/db/lastfm-rules.integration.test.ts
@@ -183,6 +183,69 @@ describe('Last.fm Tag Rules Integration Tests', () => {
     expect(rules).toHaveLength(2)
   })
 
+  test('insertLastFmTagRule creates rule with mergeGapSeconds', async () => {
+    const user = getTestUser()
+
+    const rule = await insertLastFmTagRule(user, {
+      artistName: 'Warmup Artist',
+      matchMode: 'exact',
+      matchType: 'artist',
+      mergeGapSeconds: 600,
+      ruleName: 'Session Rule',
+      tagName: 'VocalExercise',
+    })
+
+    expect(rule.mergeGapSeconds).toBe(600)
+  })
+
+  test('insertLastFmTagRule creates rule with artistNames array', async () => {
+    const user = getTestUser()
+
+    const rule = await insertLastFmTagRule(user, {
+      artistNames: ['Artist 1', 'Artist 2', 'Artist 3'],
+      matchMode: 'exact',
+      matchType: 'artist',
+      ruleName: 'Multi-Artist Rule',
+      tagName: 'Warmup',
+    })
+
+    expect(rule.artistNames).toEqual(['Artist 1', 'Artist 2', 'Artist 3'])
+  })
+
+  test('getLastFmTagRules returns rules with mergeGapSeconds and artistNames', async () => {
+    const user = getTestUser()
+
+    await insertLastFmTagRule(user, {
+      artistNames: ['Artist A', 'Artist B'],
+      matchMode: 'exact',
+      matchType: 'artist',
+      mergeGapSeconds: 300,
+      ruleName: 'Session Rule',
+      tagName: 'SessionTag',
+    })
+
+    const rules = await getLastFmTagRules(user)
+
+    expect(rules).toHaveLength(1)
+    expect(rules[0].mergeGapSeconds).toBe(300)
+    expect(rules[0].artistNames).toEqual(['Artist A', 'Artist B'])
+  })
+
+  test('insertLastFmTagRule creates rule without mergeGapSeconds and artistNames', async () => {
+    const user = getTestUser()
+
+    const rule = await insertLastFmTagRule(user, {
+      artistName: 'Some Artist',
+      matchMode: 'exact',
+      matchType: 'artist',
+      ruleName: 'Simple Rule',
+      tagName: 'SimpleTag',
+    })
+
+    expect(rule.mergeGapSeconds).toBeUndefined()
+    expect(rule.artistNames).toBeUndefined()
+  })
+
   test('insertLastFmTagRule defaults matchMode to exact', async () => {
     const user = getTestUser()
 

--- a/apps/backend/src/db/lastfm-rules.ts
+++ b/apps/backend/src/db/lastfm-rules.ts
@@ -5,13 +5,16 @@ import { query } from './connection'
 import { mapLastFmTagRuleRow } from './row-mappers'
 import type { LastFmTagRule, LastFmTagRuleInput } from './types'
 
+const LASTFM_RULE_COLUMNS = `id, rule_name, match_type, track_name, artist_name, match_mode, tag_name,
+     merge_gap_seconds, artist_names, created_at`
+
 /**
  * Get all Last.fm tag rules for a user.
  */
 export const getLastFmTagRules = async (user: string): Promise<LastFmTagRule[]> => {
   const result = await query(
     user,
-    `SELECT id, rule_name, match_type, track_name, artist_name, match_mode, tag_name, created_at
+    `SELECT ${LASTFM_RULE_COLUMNS}
      FROM lastfm_tag_rules
      ORDER BY created_at DESC`,
   )
@@ -25,9 +28,10 @@ export const getLastFmTagRules = async (user: string): Promise<LastFmTagRule[]> 
 export const insertLastFmTagRule = async (user: string, rule: LastFmTagRuleInput): Promise<LastFmTagRule> => {
   const result = await query(
     user,
-    `INSERT INTO lastfm_tag_rules (rule_name, match_type, track_name, artist_name, match_mode, tag_name)
-     VALUES ($1, $2, $3, $4, $5, $6)
-     RETURNING id, rule_name, match_type, track_name, artist_name, match_mode, tag_name, created_at`,
+    `INSERT INTO lastfm_tag_rules (rule_name, match_type, track_name, artist_name, match_mode, tag_name,
+       merge_gap_seconds, artist_names)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING ${LASTFM_RULE_COLUMNS}`,
     [
       rule.ruleName,
       rule.matchType,
@@ -35,6 +39,8 @@ export const insertLastFmTagRule = async (user: string, rule: LastFmTagRuleInput
       rule.artistName ?? null,
       rule.matchMode ?? 'exact',
       rule.tagName,
+      rule.mergeGapSeconds ?? null,
+      rule.artistNames ? JSON.stringify(rule.artistNames) : null,
     ],
   )
 

--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -158,10 +158,12 @@ export const mapMcpSessionRow = (row: QueryResultRow): McpSessionRecord => ({
 
 export const mapLastFmTagRuleRow = (row: QueryResultRow): LastFmTagRule => ({
   artistName: row.artist_name ?? undefined,
+  artistNames: row.artist_names ?? undefined,
   createdAt: new Date(row.created_at),
   id: row.id,
   matchMode: parseLastFmMatchMode(row.match_mode),
   matchType: parseLastFmMatchType(row.match_type),
+  mergeGapSeconds: row.merge_gap_seconds ?? undefined,
   ruleName: row.rule_name,
   tagName: row.tag_name,
   trackName: row.track_name ?? undefined,

--- a/apps/backend/src/db/tags.integration.test.ts
+++ b/apps/backend/src/db/tags.integration.test.ts
@@ -226,6 +226,46 @@ describe('Tags Integration Tests', () => {
       expect(result).toBeUndefined()
     })
 
+    test('finds lastfm-auto source tags when source parameter is specified', async () => {
+      const user = getTestUser()
+
+      await insertTag(user, {
+        endTime: new Date('2024-01-15T09:59:00Z'),
+        externalId: 'lastfm-session-1',
+        source: 'lastfm-auto',
+        startTime: new Date('2024-01-15T09:00:00Z'),
+        tag: 'VocalExercise',
+      })
+
+      const result = await findMergeableTag(
+        user,
+        'VocalExercise',
+        new Date('2024-01-15T10:00:00Z'),
+        180,
+        'lastfm-auto',
+      )
+
+      expect(result).toBeDefined()
+      expect(result!.externalId).toBe('lastfm-session-1')
+      expect(result!.source).toBe('lastfm-auto')
+    })
+
+    test('does not find lastfm-auto source tags when searching for manual', async () => {
+      const user = getTestUser()
+
+      await insertTag(user, {
+        endTime: new Date('2024-01-15T09:59:00Z'),
+        externalId: 'lastfm-session-2',
+        source: 'lastfm-auto',
+        startTime: new Date('2024-01-15T09:00:00Z'),
+        tag: 'VocalExercise',
+      })
+
+      const result = await findMergeableTag(user, 'VocalExercise', new Date('2024-01-15T10:00:00Z'), 180)
+
+      expect(result).toBeUndefined()
+    })
+
     test('only finds tags with matching name', async () => {
       const user = getTestUser()
 

--- a/apps/backend/src/db/tags.ts
+++ b/apps/backend/src/db/tags.ts
@@ -43,13 +43,14 @@ export const deleteTag = async (user: string, externalId: string): Promise<boole
  * - Same tag name
  * - end_time within mergeSpanSeconds of newStartTime (for tags with end_time)
  * - OR start_time within mergeSpanSeconds of newStartTime (for point-in-time tags without end_time)
- * Only considers manual source tags.
+ * Only considers tags from the specified source (defaults to 'manual').
  */
 export const findMergeableTag = async (
   user: string,
   tagName: string,
   newStartTime: Date,
   mergeSpanSeconds: number,
+  source: string = 'manual',
 ): Promise<Tag | undefined> => {
   // Calculate the earliest allowed end_time/start_time for merging
   const earliestMergeTime = new Date(newStartTime.getTime() - mergeSpanSeconds * 1000)
@@ -59,14 +60,14 @@ export const findMergeableTag = async (
     `SELECT id, source, external_id, tag, start_time, end_time
      FROM tags
      WHERE tag = $1
-       AND source = 'manual'
+       AND source = $4
        AND (
          (end_time IS NOT NULL AND end_time >= $2 AND end_time <= $3)
          OR (end_time IS NULL AND start_time >= $2 AND start_time <= $3)
        )
      ORDER BY COALESCE(end_time, start_time) DESC
      LIMIT 1`,
-    [tagName, earliestMergeTime, newStartTime],
+    [tagName, earliestMergeTime, newStartTime, source],
   )
 
   if (result.rows.length === 0) return undefined

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -289,8 +289,10 @@ export interface LastFmTagRule {
   matchType: LastFmMatchType
   trackName?: string
   artistName?: string
+  artistNames?: string[]
   matchMode: LastFmMatchMode
   tagName: string
+  mergeGapSeconds?: number
   createdAt: Date
 }
 
@@ -299,8 +301,10 @@ export interface LastFmTagRuleInput {
   matchType: LastFmMatchType
   trackName?: string
   artistName?: string
+  artistNames?: string[]
   matchMode?: LastFmMatchMode
   tagName: string
+  mergeGapSeconds?: number
 }
 
 // ============================================================================

--- a/apps/backend/src/lastfm-router.ts
+++ b/apps/backend/src/lastfm-router.ts
@@ -37,10 +37,12 @@ export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
       const rules = await getLastFmTagRules(user)
       const serialized = rules.map((r) => ({
         artistName: r.artistName,
+        artistNames: r.artistNames,
         createdAt: r.createdAt.toISOString(),
         id: r.id,
         matchMode: r.matchMode,
         matchType: r.matchType,
+        mergeGapSeconds: r.mergeGapSeconds ?? null,
         ruleName: r.ruleName,
         tagName: r.tagName,
         trackName: r.trackName,
@@ -59,7 +61,8 @@ export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
     validateBody(addLastFmTagRuleBodySchema),
     async (req, res) => {
       const user = req.user!
-      const { ruleName, matchType, trackName, artistName, matchMode, tagName } = req.body
+      const { ruleName, matchType, trackName, artistName, artistNames, matchMode, tagName, mergeGapSeconds } =
+        req.body
 
       // Validate required fields based on match_type
       if ((matchType === 'track' || matchType === 'track_artist') && !trackName) {
@@ -67,17 +70,21 @@ export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
           .status(400)
           .json({ error: `trackName is required for matchType "${matchType}"`, success: false })
       }
-      if ((matchType === 'artist' || matchType === 'track_artist') && !artistName) {
-        return res
-          .status(400)
-          .json({ error: `artistName is required for matchType "${matchType}"`, success: false })
+      const hasArtist = artistName || (artistNames && artistNames.length > 0)
+      if ((matchType === 'artist' || matchType === 'track_artist') && !hasArtist) {
+        return res.status(400).json({
+          error: `artistName or artistNames is required for matchType "${matchType}"`,
+          success: false,
+        })
       }
 
       try {
         const rule = await insertLastFmTagRule(user, {
           artistName,
+          artistNames,
           matchMode: (matchMode ?? 'exact') as LastFmMatchMode,
           matchType: matchType as LastFmMatchType,
+          mergeGapSeconds: mergeGapSeconds ?? undefined,
           ruleName,
           tagName,
           trackName,
@@ -86,10 +93,12 @@ export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
         res.json({
           data: {
             artistName: rule.artistName,
+            artistNames: rule.artistNames,
             createdAt: rule.createdAt.toISOString(),
             id: rule.id,
             matchMode: rule.matchMode,
             matchType: rule.matchType,
+            mergeGapSeconds: rule.mergeGapSeconds ?? null,
             ruleName: rule.ruleName,
             tagName: rule.tagName,
             trackName: rule.trackName,

--- a/apps/backend/src/lastfm-sync.test.ts
+++ b/apps/backend/src/lastfm-sync.test.ts
@@ -9,10 +9,12 @@ import { applyTagRules, matchesRule, syncLastFmData } from './lastfm-sync'
 
 // Mock the db module
 vi.mock('./db', () => ({
+  findMergeableTag: vi.fn(),
   getLastFmTagRules: vi.fn(),
   getSyncState: vi.fn(),
   insertRawRecord: vi.fn(),
   insertTag: vi.fn(),
+  updateTagEndTime: vi.fn(),
   upsertSyncState: vi.fn(),
 }))
 
@@ -23,7 +25,15 @@ vi.mock('./lastfm', () => ({
   })),
 }))
 
-import { getLastFmTagRules, getSyncState, insertRawRecord, insertTag, upsertSyncState } from './db'
+import {
+  findMergeableTag,
+  getLastFmTagRules,
+  getSyncState,
+  insertRawRecord,
+  insertTag,
+  updateTagEndTime,
+  upsertSyncState,
+} from './db'
 import { lastfmClient } from './lastfm'
 
 describe('matchesRule', () => {
@@ -139,6 +149,66 @@ describe('matchesRule', () => {
       expect(matchesRule(baseScrobble, ruleNoArtist)).toBe(false)
     })
   })
+
+  describe('artistNames array matching', () => {
+    it('matches when scrobble artist is in artistNames array (artist type)', () => {
+      const rule = {
+        ...baseRule,
+        artistNames: ['Artist A', 'Test Artist', 'Artist B'],
+        matchType: 'artist' as const,
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('does not match when scrobble artist is not in artistNames array', () => {
+      const rule = {
+        ...baseRule,
+        artistNames: ['Artist A', 'Artist B', 'Artist C'],
+        matchType: 'artist' as const,
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+
+    it('artistNames takes precedence over artistName', () => {
+      const rule = {
+        ...baseRule,
+        artistName: 'Test Artist', // would match
+        artistNames: ['Different Artist'], // does not match, takes precedence
+        matchType: 'artist' as const,
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(false)
+    })
+
+    it('falls back to artistName when artistNames is empty', () => {
+      const rule = {
+        ...baseRule,
+        artistName: 'Test Artist',
+        artistNames: [] as string[],
+        matchType: 'artist' as const,
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('matches artistNames with contains mode', () => {
+      const rule = {
+        ...baseRule,
+        artistNames: ['Artist A', 'Test'],
+        matchMode: 'contains' as const,
+        matchType: 'artist' as const,
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+
+    it('matches artistNames in track_artist type', () => {
+      const rule = {
+        ...baseRule,
+        artistNames: ['Test Artist', 'Other Artist'],
+        matchType: 'track_artist' as const,
+        trackName: 'Test Track',
+      }
+      expect(matchesRule(baseScrobble, rule)).toBe(true)
+    })
+  })
 })
 
 describe('applyTagRules', () => {
@@ -217,6 +287,146 @@ describe('applyTagRules', () => {
     // Both rules match, but same tag + timestamp should only create one tag
     expect(tagsCreated).toBe(1)
     expect(insertTag).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates span tags for session rules', async () => {
+    vi.mocked(findMergeableTag).mockResolvedValue(undefined)
+
+    const scrobbles: Scrobble[] = [
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:00:00Z'), track: 'Song 1' },
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:04:00Z'), track: 'Song 2' },
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:08:00Z'), track: 'Song 3' },
+    ]
+
+    const rules: LastFmTagRule[] = [
+      {
+        artistName: 'Warmup Artist',
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'artist',
+        mergeGapSeconds: 600,
+        ruleName: 'Vocal Exercises',
+        tagName: 'VocalExercise',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    expect(tagsCreated).toBe(1)
+    expect(insertTag).toHaveBeenCalledTimes(1)
+    expect(insertTag).toHaveBeenCalledWith('testuser', {
+      endTime: new Date('2024-01-01T10:08:00Z'),
+      externalId: expect.stringMatching(/^lastfm-session-rule-1-/),
+      source: 'lastfm-auto',
+      startTime: new Date('2024-01-01T10:00:00Z'),
+      tag: 'VocalExercise',
+    })
+  })
+
+  it('creates multiple span tags for separate sessions', async () => {
+    vi.mocked(findMergeableTag).mockResolvedValue(undefined)
+
+    const scrobbles: Scrobble[] = [
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:00:00Z'), track: 'Song 1' },
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:04:00Z'), track: 'Song 2' },
+      // Gap > 600s
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T11:00:00Z'), track: 'Song 3' },
+    ]
+
+    const rules: LastFmTagRule[] = [
+      {
+        artistName: 'Warmup Artist',
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'artist',
+        mergeGapSeconds: 600,
+        ruleName: 'Vocal Exercises',
+        tagName: 'VocalExercise',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    expect(tagsCreated).toBe(2)
+    expect(insertTag).toHaveBeenCalledTimes(2)
+  })
+
+  it('extends existing tag via findMergeableTag for cross-sync merging', async () => {
+    const existingTag = {
+      endTime: new Date('2024-01-01T09:58:00Z'),
+      externalId: 'lastfm-session-rule-1-existing',
+      id: 'tag-id-1',
+      source: 'lastfm-auto' as const,
+      startTime: new Date('2024-01-01T09:50:00Z'),
+      tag: 'VocalExercise',
+    }
+    vi.mocked(findMergeableTag).mockResolvedValueOnce(existingTag)
+
+    const scrobbles: Scrobble[] = [
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:02:00Z'), track: 'Song 1' },
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:06:00Z'), track: 'Song 2' },
+    ]
+
+    const rules: LastFmTagRule[] = [
+      {
+        artistName: 'Warmup Artist',
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'artist',
+        mergeGapSeconds: 600,
+        ruleName: 'Vocal Exercises',
+        tagName: 'VocalExercise',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    expect(tagsCreated).toBe(1)
+    expect(updateTagEndTime).toHaveBeenCalledWith(
+      'testuser',
+      'lastfm-session-rule-1-existing',
+      new Date('2024-01-01T10:06:00Z'),
+    )
+    expect(insertTag).not.toHaveBeenCalled()
+  })
+
+  it('handles mix of point-in-time and session rules', async () => {
+    vi.mocked(findMergeableTag).mockResolvedValue(undefined)
+
+    const scrobbles: Scrobble[] = [
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:00:00Z'), track: 'Song 1' },
+      { artist: 'Warmup Artist', timestamp: new Date('2024-01-01T10:04:00Z'), track: 'Song 2' },
+    ]
+
+    const rules: LastFmTagRule[] = [
+      {
+        artistName: 'Warmup Artist',
+        createdAt: new Date(),
+        id: 'rule-1',
+        matchMode: 'exact',
+        matchType: 'artist',
+        mergeGapSeconds: 600,
+        ruleName: 'Session Rule',
+        tagName: 'SessionTag',
+      },
+      {
+        artistName: 'Warmup Artist',
+        createdAt: new Date(),
+        id: 'rule-2',
+        matchMode: 'exact',
+        matchType: 'artist',
+        ruleName: 'Point Rule',
+        tagName: 'PointTag',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    // 1 session tag + 2 point-in-time tags
+    expect(tagsCreated).toBe(3)
   })
 
   it('creates multiple tags for different rules with different tag names', async () => {

--- a/apps/backend/src/lastfm-sync.ts
+++ b/apps/backend/src/lastfm-sync.ts
@@ -7,14 +7,17 @@
 
 import { subDays } from 'date-fns'
 import {
+  findMergeableTag,
   getLastFmTagRules,
   getSyncState,
   insertRawRecord,
   insertTag,
   type LastFmTagRule,
+  updateTagEndTime,
   upsertSyncState,
 } from './db'
 import { lastfmClient, type Scrobble } from './lastfm'
+import { groupIntoSessions, type TimestampedEvent } from './session-grouping'
 
 /** Default start date for historical sync (30 days back) */
 const DEFAULT_SYNC_HISTORY_DAYS = 30
@@ -28,14 +31,33 @@ export interface LastFmSyncResult {
 }
 
 /**
+ * Check if a scrobble's artist matches one of the given names using the specified mode.
+ */
+const matchesAnyArtist = (scrobbleArtist: string, names: string[], mode: 'exact' | 'contains'): boolean => {
+  const normalized = scrobbleArtist.toLowerCase().trim()
+  return names.some((name) => {
+    const normalizedName = name.toLowerCase().trim()
+    return mode === 'exact' ? normalized === normalizedName : normalized.includes(normalizedName)
+  })
+}
+
+/**
+ * Get the effective artist names for a rule, preferring artistNames over artistName.
+ */
+const getEffectiveArtistNames = (rule: LastFmTagRule): string[] | undefined => {
+  if (rule.artistNames && rule.artistNames.length > 0) return rule.artistNames
+  if (rule.artistName) return [rule.artistName]
+  return undefined
+}
+
+/**
  * Check if a scrobble matches a tag rule.
  */
 export const matchesRule = (scrobble: Scrobble, rule: LastFmTagRule): boolean => {
-  const normalize = (s: string) => s.toLowerCase().trim()
-
   switch (rule.matchType) {
     case 'track': {
       if (!rule.trackName) return false
+      const normalize = (s: string) => s.toLowerCase().trim()
       if (rule.matchMode === 'exact') {
         return normalize(scrobble.track) === normalize(rule.trackName)
       }
@@ -43,29 +65,121 @@ export const matchesRule = (scrobble: Scrobble, rule: LastFmTagRule): boolean =>
     }
 
     case 'artist': {
-      if (!rule.artistName) return false
-      if (rule.matchMode === 'exact') {
-        return normalize(scrobble.artist) === normalize(rule.artistName)
-      }
-      return normalize(scrobble.artist).includes(normalize(rule.artistName))
+      const names = getEffectiveArtistNames(rule)
+      if (!names) return false
+      return matchesAnyArtist(scrobble.artist, names, rule.matchMode)
     }
 
     case 'track_artist': {
-      if (!rule.trackName || !rule.artistName) return false
+      if (!rule.trackName) return false
+      const names = getEffectiveArtistNames(rule)
+      if (!names) return false
+
+      const normalize = (s: string) => s.toLowerCase().trim()
       const trackMatch =
         rule.matchMode === 'exact' ?
           normalize(scrobble.track) === normalize(rule.trackName)
         : normalize(scrobble.track).includes(normalize(rule.trackName))
-      const artistMatch =
-        rule.matchMode === 'exact' ?
-          normalize(scrobble.artist) === normalize(rule.artistName)
-        : normalize(scrobble.artist).includes(normalize(rule.artistName))
+      const artistMatch = matchesAnyArtist(scrobble.artist, names, rule.matchMode)
       return trackMatch && artistMatch
     }
 
     default:
       return false
   }
+}
+
+/**
+ * Apply point-in-time rules (rules without mergeGapSeconds) to scrobbles.
+ */
+const applyPointInTimeRules = async (
+  user: string,
+  scrobbles: Scrobble[],
+  rules: LastFmTagRule[],
+): Promise<number> => {
+  let tagsCreated = 0
+  const createdTags = new Set<string>()
+
+  for (const scrobble of scrobbles) {
+    for (const rule of rules) {
+      if (matchesRule(scrobble, rule)) {
+        const tagKey = `${rule.tagName}|${scrobble.timestamp.toISOString()}`
+        if (createdTags.has(tagKey)) continue
+        createdTags.add(tagKey)
+
+        const externalId = `lastfm-auto-${rule.id}-${scrobble.timestamp.getTime()}`
+        await insertTag(user, {
+          externalId,
+          source: 'lastfm-auto',
+          startTime: scrobble.timestamp,
+          tag: rule.tagName,
+        })
+        tagsCreated++
+      }
+    }
+  }
+
+  return tagsCreated
+}
+
+interface ScrobbleEvent extends TimestampedEvent {
+  readonly scrobble: Scrobble
+}
+
+/**
+ * Apply session rules (rules with mergeGapSeconds) to scrobbles.
+ * Groups matching scrobbles into sessions and creates span tags.
+ */
+const applySessionRules = async (
+  user: string,
+  scrobbles: Scrobble[],
+  rules: LastFmTagRule[],
+): Promise<number> => {
+  let tagsCreated = 0
+
+  for (const rule of rules) {
+    const gapMs = rule.mergeGapSeconds! * 1000
+    const matching: ScrobbleEvent[] = scrobbles
+      .filter((s) => matchesRule(s, rule))
+      .map((s) => ({ scrobble: s, timestamp: s.timestamp }))
+
+    if (matching.length === 0) continue
+
+    const sessions = groupIntoSessions(matching, gapMs)
+
+    for (let i = 0; i < sessions.length; i++) {
+      const session = sessions[i]
+
+      // For the first session, try cross-sync merging
+      if (i === 0) {
+        const existingTag = await findMergeableTag(
+          user,
+          rule.tagName,
+          session.startTime,
+          rule.mergeGapSeconds!,
+          'lastfm-auto',
+        )
+
+        if (existingTag) {
+          await updateTagEndTime(user, existingTag.externalId!, session.endTime)
+          tagsCreated++
+          continue
+        }
+      }
+
+      const externalId = `lastfm-session-${rule.id}-${session.startTime.getTime()}`
+      await insertTag(user, {
+        endTime: session.endTime,
+        externalId,
+        source: 'lastfm-auto',
+        startTime: session.startTime,
+        tag: rule.tagName,
+      })
+      tagsCreated++
+    }
+  }
+
+  return tagsCreated
 }
 
 /**
@@ -79,34 +193,13 @@ export const applyTagRules = async (
 ): Promise<number> => {
   if (rules.length === 0) return 0
 
-  let tagsCreated = 0
+  const pointInTimeRules = rules.filter((r) => !r.mergeGapSeconds)
+  const sessionRules = rules.filter((r) => r.mergeGapSeconds)
 
-  // Track which tags we've created to avoid duplicates within the same sync
-  const createdTags = new Set<string>()
+  const pointTags = await applyPointInTimeRules(user, scrobbles, pointInTimeRules)
+  const sessionTags = await applySessionRules(user, scrobbles, sessionRules)
 
-  for (const scrobble of scrobbles) {
-    for (const rule of rules) {
-      if (matchesRule(scrobble, rule)) {
-        // Create a unique key for deduplication: tagName + timestamp
-        const tagKey = `${rule.tagName}|${scrobble.timestamp.toISOString()}`
-        if (createdTags.has(tagKey)) continue
-        createdTags.add(tagKey)
-
-        // Create external_id from scrobble details for deduplication
-        const externalId = `lastfm-auto-${rule.id}-${scrobble.timestamp.getTime()}`
-
-        await insertTag(user, {
-          externalId,
-          source: 'lastfm-auto',
-          startTime: scrobble.timestamp,
-          tag: rule.tagName,
-        })
-        tagsCreated++
-      }
-    }
-  }
-
-  return tagsCreated
+  return pointTags + sessionTags
 }
 
 /**

--- a/apps/backend/src/mcp/lastfm-tools.ts
+++ b/apps/backend/src/mcp/lastfm-tools.ts
@@ -37,6 +37,10 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
         .string()
         .optional()
         .describe('Artist name to match (required for artist or track_artist match type)'),
+      artist_names: z
+        .array(z.string())
+        .optional()
+        .describe('Multiple artist names to match (takes precedence over artist_name when set)'),
       match_mode: z
         .enum(['exact', 'contains'])
         .optional()
@@ -46,6 +50,14 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
         .describe(
           'Type of match: track (any track with name), artist (any track by artist), track_artist (exact track + artist)',
         ),
+      merge_gap_seconds: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'Session merge gap in seconds. When set, consecutive matching scrobbles within this gap are merged into a single span tag.',
+        ),
       rule_name: z.string().min(1).describe('Human-readable name for the rule'),
       tag_name: z.string().min(1).describe('Tag to create when rule matches'),
       track_name: z
@@ -53,19 +65,31 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
         .optional()
         .describe('Track name to match (required for track or track_artist match type)'),
     },
-    async ({ artist_name, match_mode, match_type, rule_name, tag_name, track_name }) => {
+    async ({
+      artist_name,
+      artist_names,
+      match_mode,
+      match_type,
+      merge_gap_seconds,
+      rule_name,
+      tag_name,
+      track_name,
+    }) => {
       if ((match_type === 'track' || match_type === 'track_artist') && !track_name) {
         return errorResponse(`track_name is required for match_type "${match_type}"`)
       }
-      if ((match_type === 'artist' || match_type === 'track_artist') && !artist_name) {
-        return errorResponse(`artist_name is required for match_type "${match_type}"`)
+      const hasArtist = artist_name || (artist_names && artist_names.length > 0)
+      if ((match_type === 'artist' || match_type === 'track_artist') && !hasArtist) {
+        return errorResponse(`artist_name or artist_names is required for match_type "${match_type}"`)
       }
 
       try {
         const rule = await insertLastFmTagRule(user, {
           artistName: artist_name,
+          artistNames: artist_names,
           matchMode: (match_mode ?? 'exact') as LastFmMatchMode,
           matchType: match_type as LastFmMatchType,
+          mergeGapSeconds: merge_gap_seconds,
           ruleName: rule_name,
           tagName: tag_name,
           trackName: track_name,

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -104,14 +104,16 @@ export const createTableStatements: Record<string, string> = {
   // Last.fm auto-tagging rules
   lastfm_tag_rules: `
     CREATE TABLE IF NOT EXISTS lastfm_tag_rules (
-      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      rule_name       VARCHAR(100) NOT NULL,
-      match_type      VARCHAR(20) NOT NULL,
-      track_name      VARCHAR(255),
-      artist_name     VARCHAR(255),
-      match_mode      VARCHAR(20) DEFAULT 'exact',
-      tag_name        VARCHAR(100) NOT NULL,
-      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      rule_name         VARCHAR(100) NOT NULL,
+      match_type        VARCHAR(20) NOT NULL,
+      track_name        VARCHAR(255),
+      artist_name       VARCHAR(255),
+      match_mode        VARCHAR(20) DEFAULT 'exact',
+      tag_name          VARCHAR(100) NOT NULL,
+      merge_gap_seconds INTEGER,
+      artist_names      JSONB,
+      created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       CONSTRAINT unique_rule UNIQUE (match_type, track_name, artist_name, tag_name)
     )
   `,

--- a/apps/backend/src/session-grouping.test.ts
+++ b/apps/backend/src/session-grouping.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Session grouping utility tests.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { groupIntoSessions, type TimestampedEvent } from './session-grouping'
+
+const event = (isoTime: string): TimestampedEvent => ({ timestamp: new Date(isoTime) })
+
+describe('groupIntoSessions', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupIntoSessions([], 600_000)).toEqual([])
+  })
+
+  it('returns single session for single event', () => {
+    const events = [event('2024-01-15T10:00:00Z')]
+    const sessions = groupIntoSessions(events, 600_000)
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].events).toHaveLength(1)
+    expect(sessions[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(sessions[0].endTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+  })
+
+  it('groups events within maxGapMs into one session', () => {
+    const events = [
+      event('2024-01-15T10:00:00Z'),
+      event('2024-01-15T10:04:00Z'), // 4 min gap
+      event('2024-01-15T10:08:00Z'), // 4 min gap
+    ]
+    const sessions = groupIntoSessions(events, 600_000) // 10 min gap
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].events).toHaveLength(3)
+    expect(sessions[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(sessions[0].endTime).toEqual(new Date('2024-01-15T10:08:00Z'))
+  })
+
+  it('splits into separate sessions when gap exceeds maxGapMs', () => {
+    const events = [
+      event('2024-01-15T10:00:00Z'),
+      event('2024-01-15T10:04:00Z'), // 4 min gap (same session)
+      event('2024-01-15T11:00:00Z'), // 56 min gap (new session)
+    ]
+    const sessions = groupIntoSessions(events, 600_000) // 10 min gap
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0].events).toHaveLength(2)
+    expect(sessions[0].startTime).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(sessions[0].endTime).toEqual(new Date('2024-01-15T10:04:00Z'))
+    expect(sessions[1].events).toHaveLength(1)
+    expect(sessions[1].startTime).toEqual(new Date('2024-01-15T11:00:00Z'))
+    expect(sessions[1].endTime).toEqual(new Date('2024-01-15T11:00:00Z'))
+  })
+
+  it('handles mixed gaps correctly', () => {
+    const events = [
+      event('2024-01-15T10:00:00Z'),
+      event('2024-01-15T10:03:00Z'), // 3 min (same session)
+      event('2024-01-15T10:06:00Z'), // 3 min (same session)
+      event('2024-01-15T11:00:00Z'), // 54 min (new session)
+      event('2024-01-15T11:05:00Z'), // 5 min (same session)
+      event('2024-01-15T12:00:00Z'), // 55 min (new session)
+    ]
+    const sessions = groupIntoSessions(events, 600_000) // 10 min gap
+
+    expect(sessions).toHaveLength(3)
+    expect(sessions[0].events).toHaveLength(3)
+    expect(sessions[1].events).toHaveLength(2)
+    expect(sessions[2].events).toHaveLength(1)
+  })
+
+  it('treats gap exactly equal to maxGapMs as same session', () => {
+    const events = [
+      event('2024-01-15T10:00:00Z'),
+      event('2024-01-15T10:10:00Z'), // exactly 10 min gap
+    ]
+    const sessions = groupIntoSessions(events, 600_000) // 10 min gap
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].events).toHaveLength(2)
+  })
+
+  it('preserves event data in sessions', () => {
+    interface ScrobbleEvent extends TimestampedEvent {
+      readonly artist: string
+    }
+    const events: ScrobbleEvent[] = [
+      { artist: 'Artist A', timestamp: new Date('2024-01-15T10:00:00Z') },
+      { artist: 'Artist B', timestamp: new Date('2024-01-15T10:04:00Z') },
+    ]
+    const sessions = groupIntoSessions(events, 600_000)
+
+    expect(sessions[0].events[0].artist).toBe('Artist A')
+    expect(sessions[0].events[1].artist).toBe('Artist B')
+  })
+})

--- a/apps/backend/src/session-grouping.ts
+++ b/apps/backend/src/session-grouping.ts
@@ -1,0 +1,55 @@
+/**
+ * Generic session grouping utility.
+ *
+ * Groups timestamped events into sessions based on a maximum gap between
+ * consecutive events. Reusable for any timestamped-event-to-session grouping.
+ */
+
+export interface TimestampedEvent {
+  readonly timestamp: Date
+}
+
+export interface Session<T> {
+  readonly events: T[]
+  readonly startTime: Date
+  readonly endTime: Date
+}
+
+/**
+ * Group sorted events into sessions based on maximum gap between consecutive events.
+ *
+ * @param events - Events sorted ascending by timestamp
+ * @param maxGapMs - Maximum gap in milliseconds between consecutive events in the same session
+ * @returns Array of sessions, each containing its events and start/end times
+ */
+export const groupIntoSessions = <T extends TimestampedEvent>(
+  events: T[],
+  maxGapMs: number,
+): Session<T>[] => {
+  if (events.length === 0) return []
+
+  const sessions: Session<T>[] = []
+  let currentEvents: T[] = [events[0]]
+
+  for (let i = 1; i < events.length; i++) {
+    const gap = events[i].timestamp.getTime() - events[i - 1].timestamp.getTime()
+    if (gap <= maxGapMs) {
+      currentEvents.push(events[i])
+    } else {
+      sessions.push({
+        endTime: currentEvents[currentEvents.length - 1].timestamp,
+        events: currentEvents,
+        startTime: currentEvents[0].timestamp,
+      })
+      currentEvents = [events[i]]
+    }
+  }
+
+  sessions.push({
+    endTime: currentEvents[currentEvents.length - 1].timestamp,
+    events: currentEvents,
+    startTime: currentEvents[0].timestamp,
+  })
+
+  return sessions
+}

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -38,10 +38,25 @@ export function LastFmTagRulesSettings() {
   const [matchType, setMatchType] = useState<LastFmMatchType>('track')
   const [trackName, setTrackName] = useState('')
   const [artistName, setArtistName] = useState('')
+  const [artistNames, setArtistNames] = useState<string[]>([])
+  const [newArtistInput, setNewArtistInput] = useState('')
   const [matchMode, setMatchMode] = useState<LastFmMatchMode>('exact')
   const [tagName, setTagName] = useState('')
+  const [mergeGapMinutes, setMergeGapMinutes] = useState('')
 
   const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+
+  const handleAddArtist = () => {
+    const name = newArtistInput.trim()
+    if (name && !artistNames.includes(name)) {
+      setArtistNames([...artistNames, name])
+      setNewArtistInput('')
+    }
+  }
+
+  const handleRemoveArtist = (index: number) => {
+    setArtistNames(artistNames.filter((_, i) => i !== index))
+  }
 
   const handleAddRule = async () => {
     if (!ruleName.trim() || !tagName.trim()) return
@@ -51,8 +66,12 @@ export function LastFmTagRulesSettings() {
       setSaveStatus({ error: 'Track name is required', status: 'error' })
       return
     }
-    if ((matchType === 'artist' || matchType === 'track_artist') && !artistName.trim()) {
-      setSaveStatus({ error: 'Artist name is required', status: 'error' })
+    const hasArtistInput =
+      matchType === 'artist' || matchType === 'track_artist' ?
+        artistNames.length > 0 || artistName.trim()
+      : true
+    if (!hasArtistInput) {
+      setSaveStatus({ error: 'At least one artist name is required', status: 'error' })
       return
     }
 
@@ -68,7 +87,16 @@ export function LastFmTagRulesSettings() {
         rule.trackName = trackName.trim()
       }
       if (matchType === 'artist' || matchType === 'track_artist') {
-        rule.artistName = artistName.trim()
+        if (artistNames.length > 0) {
+          rule.artistNames = artistNames
+        } else {
+          rule.artistName = artistName.trim()
+        }
+      }
+
+      const gapMinutes = parseFloat(mergeGapMinutes)
+      if (gapMinutes > 0) {
+        rule.mergeGapSeconds = Math.round(gapMinutes * 60)
       }
 
       await createLastFmTagRule(rule)
@@ -78,7 +106,10 @@ export function LastFmTagRulesSettings() {
       setRuleName('')
       setTrackName('')
       setArtistName('')
+      setArtistNames([])
+      setNewArtistInput('')
       setTagName('')
+      setMergeGapMinutes('')
       setSaveStatus({ status: 'saved', time: new Date() })
     } catch (err) {
       setSaveStatus({
@@ -100,6 +131,13 @@ export function LastFmTagRulesSettings() {
         status: 'error',
       })
     }
+  }
+
+  const formatRuleArtists = (rule: LastFmTagRule): string => {
+    if (rule.artistNames && rule.artistNames.length > 0) {
+      return rule.artistNames.join(', ')
+    }
+    return rule.artistName ?? ''
   }
 
   // Don't show if Last.fm is not configured
@@ -136,11 +174,18 @@ export function LastFmTagRulesSettings() {
                     <span class="rule-name">{rule.ruleName}</span>
                     <span class="rule-details">
                       {rule.matchType === 'track' && `Track: "${rule.trackName}"`}
-                      {rule.matchType === 'artist' && `Artist: "${rule.artistName}"`}
-                      {rule.matchType === 'track_artist' && `"${rule.trackName}" by "${rule.artistName}"`}
+                      {rule.matchType === 'artist' && `Artist: "${formatRuleArtists(rule)}"`}
+                      {rule.matchType === 'track_artist' &&
+                        `"${rule.trackName}" by "${formatRuleArtists(rule)}"`}
                       {rule.matchMode === 'contains' && ' (contains)'}
                       {' → '}
                       <strong>{rule.tagName}</strong>
+                      {rule.mergeGapSeconds && (
+                        <span class="rule-merge-info">
+                          {' '}
+                          (session merge: {Math.round(rule.mergeGapSeconds / 60)}min)
+                        </span>
+                      )}
                     </span>
                   </div>
                   <button type="button" class="remove-rule-button" onClick={() => handleDeleteRule(rule)}>
@@ -221,16 +266,81 @@ export function LastFmTagRulesSettings() {
 
             {(matchType === 'artist' || matchType === 'track_artist') && (
               <div class="form-field">
-                <label for="artist-name">Artist Name</label>
-                <input
-                  id="artist-name"
-                  type="text"
-                  value={artistName}
-                  onInput={(e) => setArtistName((e.target as HTMLInputElement).value)}
-                  placeholder="e.g., Meditation Artist"
-                />
+                <label>Artists</label>
+                {artistNames.length > 0 && (
+                  <div class="artist-names-list">
+                    {artistNames.map((name, idx) => (
+                      <span class="artist-name-chip" key={name}>
+                        {name}
+                        <button
+                          type="button"
+                          class="remove-artist-button"
+                          onClick={() => handleRemoveArtist(idx)}
+                        >
+                          x
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <div class="artist-input-row">
+                  <input
+                    type="text"
+                    value={artistNames.length > 0 ? newArtistInput : artistName}
+                    onInput={(e) => {
+                      const val = (e.target as HTMLInputElement).value
+                      if (artistNames.length > 0) {
+                        setNewArtistInput(val)
+                      } else {
+                        setArtistName(val)
+                      }
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && artistNames.length > 0) {
+                        e.preventDefault()
+                        handleAddArtist()
+                      }
+                    }}
+                    placeholder={artistNames.length > 0 ? 'Add another artist...' : 'e.g., Meditation Artist'}
+                  />
+                  <button
+                    type="button"
+                    class="add-artist-button"
+                    onClick={() => {
+                      if (artistNames.length === 0 && artistName.trim()) {
+                        setArtistNames([artistName.trim()])
+                        setArtistName('')
+                      } else {
+                        handleAddArtist()
+                      }
+                    }}
+                  >
+                    +
+                  </button>
+                </div>
+                <p class="field-help">
+                  Add multiple artists to match any of them. Use + button or Enter to add.
+                </p>
               </div>
             )}
+
+            <div class="form-field">
+              <label for="merge-gap">Session merge gap (minutes)</label>
+              <input
+                id="merge-gap"
+                type="number"
+                min="1"
+                step="1"
+                value={mergeGapMinutes}
+                onInput={(e) => setMergeGapMinutes((e.target as HTMLInputElement).value)}
+                placeholder="e.g., 10"
+              />
+              <p class="field-help">
+                When set, consecutive matching scrobbles within this gap are grouped into a single span tag.
+                Leave empty for one tag per scrobble. The gap should account for track length + pause between
+                tracks.
+              </p>
+            </div>
 
             <button
               type="button"

--- a/apps/web/src/components/LastFmTagRulesSettings/style.css
+++ b/apps/web/src/components/LastFmTagRulesSettings/style.css
@@ -96,6 +96,71 @@
   width: 100%;
 }
 
+.artist-names-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.artist-name-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background: #e3f2fd;
+  border-radius: 16px;
+  font-size: 0.875rem;
+}
+
+.remove-artist-button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: #666;
+  padding: 0 0.15rem;
+  line-height: 1;
+}
+
+.remove-artist-button:hover {
+  color: #f44336;
+}
+
+.artist-input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.artist-input-row input {
+  flex: 1;
+}
+
+.add-artist-button {
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.add-artist-button:hover {
+  background: #e0e0e0;
+}
+
+.field-help {
+  font-size: 0.75rem;
+  color: #888;
+  margin: 0.25rem 0 0 0;
+}
+
+.rule-merge-info {
+  color: #1976d2;
+  font-size: 0.8rem;
+}
+
 .add-rule-form .connect-button {
   margin-top: 0.5rem;
 }
@@ -123,6 +188,32 @@
     background: #333;
     border-color: #555;
     color: #fff;
+  }
+
+  .artist-name-chip {
+    background: #1e3a5f;
+    color: #e0e0e0;
+  }
+
+  .remove-artist-button {
+    color: #aaa;
+  }
+
+  .add-artist-button {
+    border-color: #555;
+    color: #ccc;
+  }
+
+  .add-artist-button:hover {
+    background: #444;
+  }
+
+  .field-help {
+    color: #777;
+  }
+
+  .rule-merge-info {
+    color: #64b5f6;
   }
 }
 

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -422,10 +422,24 @@ export const lastFmTagRuleSchema = z
       .string()
       .optional()
       .meta({ description: 'Artist name to match (for artist or track_artist match type)' }),
+    artistNames: z
+      .array(z.string())
+      .optional()
+      .meta({ description: 'Multiple artist names to match (takes precedence over artistName when set)' }),
     createdAt: z.string().meta({ description: 'When the rule was created' }),
     id: z.string().uuid().meta({ description: 'Unique rule ID' }),
     matchMode: lastFmMatchModeSchema,
     matchType: lastFmMatchTypeSchema,
+    mergeGapSeconds: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .optional()
+      .meta({
+        description:
+          'Session merge gap in seconds. When set, consecutive matching scrobbles within this gap are merged into a single span tag.',
+      }),
     ruleName: z.string().meta({ description: 'Human-readable name for the rule' }),
     tagName: z.string().meta({ description: 'Tag to create when rule matches' }),
     trackName: z
@@ -446,11 +460,25 @@ export const addLastFmTagRuleBodySchema = z
       .string()
       .optional()
       .meta({ description: 'Artist name to match (required for artist or track_artist match type)' }),
+    artistNames: z
+      .array(z.string())
+      .optional()
+      .meta({ description: 'Multiple artist names to match (takes precedence over artistName when set)' }),
     matchMode: lastFmMatchModeSchema
       .optional()
       .default('exact')
       .meta({ description: 'Match mode (default: exact)' }),
     matchType: lastFmMatchTypeSchema,
+    mergeGapSeconds: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .optional()
+      .meta({
+        description:
+          'Session merge gap in seconds. When set, consecutive matching scrobbles within this gap are merged into a single span tag.',
+      }),
     ruleName: z.string().min(1).meta({ description: 'Human-readable name for the rule' }),
     tagName: z.string().min(1).meta({ description: 'Tag to create when rule matches' }),
     trackName: z


### PR DESCRIPTION
## Summary

- Add generic `groupIntoSessions` utility for grouping timestamped events into sessions based on a maximum gap
- Last.fm tag rules can now specify `mergeGapSeconds` to merge consecutive matching scrobbles into span tags (start → end) instead of individual point-in-time tags
- Rules support `artistNames` array for matching multiple artists in a single rule
- Cross-sync session merging extends existing tags when a session straddles sync boundaries
- Frontend multi-artist input with chip UI and merge gap configuration (in minutes)

## Test plan

- [x] Session grouping utility: 7 unit tests covering empty, single, within-gap, across-gap, mixed, exact boundary, and data preservation
- [x] `matchesRule` with `artistNames`: 6 tests for single match, no match, precedence over `artistName`, empty fallback, contains mode, and track_artist type
- [x] Session tag creation: 4 tests for span tags, multiple sessions, cross-sync merging, and mixed point-in-time + session rules  
- [x] `findMergeableTag` with source parameter: 2 integration tests for lastfm-auto source
- [x] DB CRUD with new columns: 4 integration tests for mergeGapSeconds and artistNames
- [x] All 684 backend tests pass
- [x] TypeScript type checking passes for both backend and web

🤖 Generated with [Claude Code](https://claude.com/claude-code)