### PR TITLE
Share Zod schemas between API and MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,78 @@ The REST API and MCP tools should have the same capabilities:
 When adding new features, implement both the MCP tool and REST API endpoint.
 
 
+## Shared Schemas and Types (`packages/api-spec`)
+
+`@aurboda/api-spec` is the single source of truth for validation schemas and type definitions. All layers import from it — never duplicate schema definitions.
+
+### Schema location
+
+Zod schemas live in `packages/api-spec/src/schemas/`, organized by domain (tags, metrics, activities, locations, correlations, sync, settings, trends, etc.). All schemas are re-exported from the package root.
+
+Use `.meta({ id: 'SchemaName', description: '...' })` on schemas — the `id` drives OpenAPI model names and the `description` is used by both OpenAPI docs and MCP tool discovery.
+
+### Naming convention
+
+All field names use **snake_case** everywhere: schemas, REST API, MCP tools, DB columns, JSONB keys, frontend types. The only exception is Kotlin, which uses camelCase properties internally with `@SerialName("snake_case")` for serialization.
+
+### How each layer uses api-spec
+
+**REST API routers** (`apps/backend/src/routes/`) — import schemas for request validation:
+```typescript
+import { addTagBodySchema, type AddTagBody } from '@aurboda/api-spec'
+// Use with validation middleware:
+router.post('/', authMiddleware, validateBody(addTagBodySchema), async (req, res) => { ... })
+```
+
+**MCP tools** (`apps/backend/src/mcp/`) — use `.shape` to extract the flat field record that `server.tool()` expects:
+```typescript
+import { addTagBodySchema } from '@aurboda/api-spec'
+server.tool('add_tag', 'Description', { ...addTagBodySchema.shape }, async (params) => { ... })
+// To add extra fields: { id: z.string().uuid(), ...updateBodySchema.shape }
+// To override a field: { ...bodySchema.shape, field: z.string().optional() }
+```
+Keep simple 1-field tools (delete by id) inline — import overhead exceeds duplication savings.
+
+**Web frontend** (`apps/web/src/`) — import types only (no runtime schemas):
+```typescript
+import type { Tag, TagsQuery, TagsResponse } from '@aurboda/api-spec'
+```
+The frontend extends API types where Date objects are needed (API uses ISO strings):
+```typescript
+export interface Tag extends Omit<ApiTag, 'start_time' | 'end_time'> {
+  start_time: Date
+  end_time?: Date
+}
+```
+
+**Android app** (`apps/android/`) — uses generated Kotlin models from OpenAPI:
+```kotlin
+// Generated at packages/api-spec/generated/kotlin/src/main/kotlin/net/aurboda/api/models/
+@Serializable
+data class Tag(
+    @SerialName(value = "start_time") val startTime: OffsetDateTime,
+    @SerialName(value = "tag") val tag: String,
+)
+```
+
+**DB layer** (`apps/backend/src/db/`) — imports types for type safety, not schemas:
+```typescript
+import type { ActivityType, MetricType, DataSource } from '@aurboda/api-spec'
+```
+Row mappers in `db/row-mappers.ts` use type guards with api-spec constants (e.g. `activityTypes`).
+
+**Services** (`apps/backend/src/services/`) — import types for function signatures. Services contain the shared business logic used by both REST API and MCP.
+
+### Adding a new feature
+
+1. Define the Zod schema in `packages/api-spec/src/schemas/` with `.meta({ id, description })`.
+2. Export it from `schemas/index.ts`.
+3. Build: `pnpm --filter @aurboda/api-spec build`
+4. Import in the REST API router (for validation) and MCP tool (via `.shape`).
+5. Regenerate: `cd packages/api-spec && pnpm generate` (updates OpenAPI YAML/JSON, TypeScript types, and Kotlin models).
+6. Use the generated Kotlin models in the Android app.
+
+
 ## Work flow
 
 * NEVER alter already pushed commits.  No amend if the commit is pushed.  No force push.

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -2,45 +2,31 @@
  * MCP activity management tools.
  */
 import {
-  activityTypes,
-  activityTypeSchema,
-  endDateTimeQuerySchema,
+  addActivityBodySchema,
+  deleteActivityParamsSchema,
   exerciseTypeNames,
   getExerciseTypeValue,
   isValidExerciseType,
-  startDateTimeQuerySchema,
+  updateActivityBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 import { addActivity, deleteActivity, updateActivity } from '../services/mutations'
 import { errorResponse, jsonResponse, type McpServer } from './helpers'
 
-// eslint-disable-next-line max-lines-per-function -- tool registrations are inherently long
 export const registerActivityTools = (server: McpServer, user: string) => {
   // Tool: add_activity
   server.tool(
     'add_activity',
     'Add an activity session (exercise, meditation, nap). Use this to log workouts or other activities.',
     {
-      activity_type: activityTypeSchema.describe(
-        `Type of activity. Valid types: ${activityTypes.join(', ')}`,
-      ),
-      end_time: endDateTimeQuerySchema.describe('End time in ISO 8601 format (e.g., 2024-03-15T11:45:00Z)'),
+      ...addActivityBodySchema.shape,
+      // Override enum with z.string() to allow handler-level validation with friendlier error message
       exercise_type: z
         .string()
         .optional()
         .describe(
           `Exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
         ),
-      notes: z
-        .string()
-        .optional()
-        .describe(
-          'Activity notes. For workouts, use format: "Exercise Name: reps×weight, reps×weight" per line.',
-        ),
-      start_time: startDateTimeQuerySchema.describe(
-        'Start time in ISO 8601 format (e.g., 2024-03-15T10:30:00Z)',
-      ),
-      title: z.string().optional().describe('Activity title (e.g., "Upper body", "Morning meditation")'),
     },
     async ({ activity_type, end_time, exercise_type, notes, start_time, title }) => {
       const startDate = new Date(start_time)
@@ -80,9 +66,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
   server.tool(
     'delete_activity',
     'Delete an activity by its ID. Returns success if the activity was found and deleted.',
-    {
-      id: z.string().uuid().describe('The ID of the activity to delete'),
-    },
+    { ...deleteActivityParamsSchema.shape },
     async ({ id }) => {
       const result = await deleteActivity(user, id)
       return jsonResponse(result)
@@ -94,11 +78,8 @@ export const registerActivityTools = (server: McpServer, user: string) => {
     'update_activity',
     'Update an existing activity. Can modify start_time, end_time, title, and notes. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
     {
-      end_time: endDateTimeQuerySchema.optional().describe('New end time in ISO 8601 format'),
       id: z.string().uuid().describe('The ID of the activity to update'),
-      notes: z.string().optional().describe('New activity notes'),
-      start_time: startDateTimeQuerySchema.optional().describe('New start time in ISO 8601 format'),
-      title: z.string().optional().describe('New activity title'),
+      ...updateActivityBodySchema.shape,
     },
     async ({ id, start_time, end_time, title, notes }) => {
       const result = await updateActivity(user, id, {

--- a/apps/backend/src/mcp/correlation-tools.ts
+++ b/apps/backend/src/mcp/correlation-tools.ts
@@ -1,8 +1,13 @@
 /**
  * MCP correlation analysis tools.
  */
-import { dateOnlySchema } from '@aurboda/api-spec'
-import { z } from 'zod'
+import {
+  activityImpactInputSchema,
+  dateOnlySchema,
+  eventProbabilityInputSchema,
+  genericCorrelationBodySchema,
+  hrvCorrelationInputSchema,
+} from '@aurboda/api-spec'
 import {
   getActivityImpact,
   getBaseline,
@@ -14,7 +19,6 @@ import {
 } from '../services/correlations'
 import { jsonResponse, type McpServer, type SyncProvider } from './helpers'
 
-// eslint-disable-next-line max-lines-per-function -- tool registrations are inherently long
 export const registerCorrelationTools = (server: McpServer, user: string, sync?: SyncProvider) => {
   // Tool: get_baseline
   server.tool(
@@ -36,9 +40,7 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   server.tool(
     'get_hrv_activities_correlation',
     'Get HRV correlations with various activities. Returns Pearson correlation coefficients between HRV and productivity, locations, activities, and tags.',
-    {
-      period_days: z.number().int().optional().describe('Number of days to analyze. Defaults to 30.'),
-    },
+    { ...hrvCorrelationInputSchema.shape },
     async ({ period_days }) => {
       const periodDays = period_days ?? 30
       const correlations = await getHrvActivitiesCorrelation(user, periodDays, sync)
@@ -50,20 +52,7 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   server.tool(
     'get_activity_impact',
     'Get the impact of a specific activity/tag on HRV and heart rate. Compares metric values before, during, and after the activity using time windows.',
-    {
-      activity: z
-        .string()
-        .describe('The activity or tag name to analyze (e.g., "gym", "coffee", "meditation")'),
-      activity_type: z
-        .enum(['productivity_category', 'productivity_app', 'location', 'tag', 'activity_type'])
-        .describe('Type of activity to search for'),
-      period_days: z.number().int().optional().describe('Number of days to analyze. Defaults to 90.'),
-      window_minutes: z
-        .number()
-        .int()
-        .optional()
-        .describe('Minutes to analyze before/after the activity. Defaults to 30.'),
-    },
+    { ...activityImpactInputSchema.shape },
     async ({ activity, activity_type, period_days, window_minutes }) => {
       const periodDays = period_days ?? 90
       const windowMinutes = window_minutes ?? 30
@@ -77,22 +66,7 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   server.tool(
     'get_event_probability',
     'Get the probability correlation between two events. Analyzes whether one event (trigger) increases or decreases the probability of another event (outcome) occurring within specified time windows. Uses chi-squared test for statistical significance.',
-    {
-      lag_windows: z
-        .array(z.string())
-        .optional()
-        .describe(
-          'Time windows to analyze (e.g., ["12h", "24h", "36h", "48h"]). Uses hours (h) or days (d).',
-        ),
-      outcome_pattern: z
-        .string()
-        .describe('Regex pattern for outcome tags (e.g., "headache|migraine", "good_sleep")'),
-      period_days: z.number().int().optional().describe('Number of days to analyze. Defaults to 365.'),
-      trigger_type: z.enum(['activity', 'tag']).describe('Type of trigger event'),
-      trigger_value: z
-        .string()
-        .describe('Trigger activity type or tag pattern (e.g., "exercise", "gym", "coffee")'),
-    },
+    { ...eventProbabilityInputSchema.shape },
     async ({ lag_windows, outcome_pattern, period_days, trigger_type, trigger_value }) => {
       const probability = await getEventProbability(
         user,
@@ -116,34 +90,7 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
 Examples:
 - "Does meditation correlate with more productive time?" -> trigger: tag "meditation", outcome: productivity
 - "When I exercise 3x and tag FatCoffee 5x in a week, does my weight change?" -> compound triggers, metric outcome`,
-    {
-      lag_windows: z
-        .array(z.string())
-        .optional()
-        .describe('Time windows to analyze after trigger (e.g., ["24h", "7d"]). Uses hours (h) or days (d).'),
-      outcome: z
-        .object({
-          app: z.string().optional().describe('For productivity: specific app to measure'),
-          category: z.string().optional().describe('For productivity: category to measure'),
-          metric: z.string().optional().describe('For metric: metric name (e.g., "weight", "body_fat")'),
-          pattern: z.string().optional().describe('For tag: regex pattern to match'),
-          type: z.enum(['tag', 'metric', 'productivity']).describe('Type of outcome to measure'),
-        })
-        .describe('Outcome to measure'),
-      period_days: z.number().int().optional().describe('Number of days to analyze. Defaults to 90.'),
-      triggers: z
-        .array(
-          z.object({
-            minCount: z.number().int().optional().describe('Minimum occurrences in window (default: 1)'),
-            pattern: z.string().describe('Pattern to match (regex for tags, name for activities)'),
-            type: z
-              .enum(['activity', 'tag', 'productivity_category', 'productivity_app'])
-              .describe('Type of trigger'),
-            windowDays: z.number().int().optional().describe('Rolling window in days (default: 1)'),
-          }),
-        )
-        .describe('Trigger conditions (all must be met)'),
-    },
+    { ...genericCorrelationBodySchema.shape },
     async ({ lag_windows, outcome, period_days, triggers }) => {
       const result = await getGenericCorrelation(
         user,

--- a/apps/backend/src/mcp/helpers.ts
+++ b/apps/backend/src/mcp/helpers.ts
@@ -1,14 +1,8 @@
 /**
  * Shared helpers and schemas for MCP tool modules.
  */
-import { endDateTimeQuerySchema, startDateTimeQuerySchema, validMetrics } from '@aurboda/api-spec'
+import { validMetrics } from '@aurboda/api-spec'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-
-/** Common time range schema for MCP queries. */
-export const mcpTimeRangeSchema = {
-  end: endDateTimeQuerySchema,
-  start: startDateTimeQuerySchema,
-}
 
 /** Metric name description using validMetrics from api-spec. */
 export const metricDescription = `Metric name. Valid metrics: ${validMetrics.join(', ')}`

--- a/apps/backend/src/mcp/lastfm-tools.ts
+++ b/apps/backend/src/mcp/lastfm-tools.ts
@@ -1,6 +1,7 @@
 /**
  * MCP Last.fm tag rule tools.
  */
+import { addLastFmTagRuleBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 import {
   deleteLastFmTagRule,
@@ -11,7 +12,6 @@ import {
 } from '../db'
 import { errorResponse, jsonResponse, type McpServer } from './helpers'
 
-// eslint-disable-next-line max-lines-per-function -- tool registrations are inherently long
 export const registerLastFmTools = (server: McpServer, user: string) => {
   // Tool: get_lastfm_tag_rules
   server.tool(
@@ -32,39 +32,7 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
   server.tool(
     'add_lastfm_tag_rule',
     'Add a Last.fm auto-tagging rule. Creates tags when scrobbles match the specified criteria.',
-    {
-      artist_name: z
-        .string()
-        .optional()
-        .describe('Artist name to match (required for artist or track_artist match type)'),
-      artist_names: z
-        .array(z.string())
-        .optional()
-        .describe('Multiple artist names to match (takes precedence over artist_name when set)'),
-      match_mode: z
-        .enum(['exact', 'contains'])
-        .optional()
-        .describe('Match mode: exact (case-insensitive) or contains (substring). Default: exact'),
-      match_type: z
-        .enum(['track', 'artist', 'track_artist'])
-        .describe(
-          'Type of match: track (any track with name), artist (any track by artist), track_artist (exact track + artist)',
-        ),
-      merge_gap_seconds: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .describe(
-          'Session merge gap in seconds. When set, consecutive matching scrobbles within this gap are merged into a single span tag.',
-        ),
-      rule_name: z.string().min(1).describe('Human-readable name for the rule'),
-      tag_name: z.string().min(1).describe('Tag to create when rule matches'),
-      track_name: z
-        .string()
-        .optional()
-        .describe('Track name to match (required for track or track_artist match type)'),
-    },
+    { ...addLastFmTagRuleBodySchema.shape },
     async ({
       artist_name,
       artist_names,
@@ -89,7 +57,7 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
           artist_names,
           match_mode: (match_mode ?? 'exact') as LastFmMatchMode,
           match_type: match_type as LastFmMatchType,
-          merge_gap_seconds,
+          merge_gap_seconds: merge_gap_seconds ?? undefined,
           rule_name,
           tag_name,
           track_name,

--- a/apps/backend/src/mcp/location-tools.ts
+++ b/apps/backend/src/mcp/location-tools.ts
@@ -1,7 +1,12 @@
 /**
  * MCP location management tools.
  */
-import { latWithValidationSchema, lonWithValidationSchema } from '@aurboda/api-spec'
+import {
+  addNamedLocationBodySchema,
+  promoteDetectedLocationBodySchema,
+  timeRangeQuerySchema,
+  updateNamedLocationBodySchema,
+} from '@aurboda/api-spec'
 import { z } from 'zod'
 import { getDetectedLocations as getStoredDetectedLocations } from '../db'
 import {
@@ -11,7 +16,7 @@ import {
   insertNamedLocation,
   updateNamedLocation,
 } from '../services/locations'
-import { errorResponse, jsonResponse, type McpServer, mcpTimeRangeSchema } from './helpers'
+import { errorResponse, jsonResponse, type McpServer } from './helpers'
 
 // eslint-disable-next-line max-lines-per-function -- tool registrations are inherently long
 export const registerLocationTools = (server: McpServer, user: string) => {
@@ -31,7 +36,7 @@ export const registerLocationTools = (server: McpServer, user: string) => {
     'get_detected_locations',
     'Get frequently visited locations that are not yet named. Detects places where user spent 60+ minutes. Returns coordinates, visit count, and total time spent.',
     {
-      ...mcpTimeRangeSchema,
+      ...timeRangeQuerySchema.shape,
       min_duration: z.number().optional().describe('Minimum stay duration in minutes. Defaults to 60.'),
     },
     async ({ end, min_duration, start }) => {
@@ -60,12 +65,7 @@ export const registerLocationTools = (server: McpServer, user: string) => {
   server.tool(
     'add_named_location',
     'Create a named location. Use this to save a frequently visited place with a name.',
-    {
-      lat: latWithValidationSchema.describe('Latitude of the location (-90 to 90)'),
-      lon: lonWithValidationSchema.describe('Longitude of the location (-180 to 180)'),
-      name: z.string().describe('Name for the location (e.g., "Home", "Office", "Gym")'),
-      radius: z.number().optional().describe('Radius in meters. Defaults to 200.'),
-    },
+    { ...addNamedLocationBodySchema.shape },
     async ({ lat, lon, name, radius }) => {
       const location = await insertNamedLocation(user, { lat, lon, name, radius })
       return jsonResponse({ data: location, success: true })
@@ -78,10 +78,7 @@ export const registerLocationTools = (server: McpServer, user: string) => {
     'Update an existing named location. Can change name, coordinates, or radius.',
     {
       id: z.string().describe('The ID of the named location to update'),
-      lat: z.number().optional().describe('New latitude (-90 to 90). Must be provided with lon.'),
-      lon: z.number().optional().describe('New longitude (-180 to 180). Must be provided with lat.'),
-      name: z.string().optional().describe('New name for the location'),
-      radius: z.number().optional().describe('New radius in meters'),
+      ...updateNamedLocationBodySchema.shape,
     },
     async ({ id, lat, lon, name, radius }) => {
       if ((lat !== undefined && lon === undefined) || (lon !== undefined && lat === undefined)) {
@@ -123,12 +120,7 @@ export const registerLocationTools = (server: McpServer, user: string) => {
   server.tool(
     'promote_detected_location',
     'Create a named location from detected coordinates. Use after get_detected_locations to save a frequently visited place.',
-    {
-      lat: latWithValidationSchema.describe('Latitude from detected location'),
-      lon: lonWithValidationSchema.describe('Longitude from detected location'),
-      name: z.string().describe('Name for the location'),
-      radius: z.number().optional().describe('Radius in meters. Uses suggested radius if not provided.'),
-    },
+    { ...promoteDetectedLocationBodySchema.shape },
     async ({ lat, lon, name, radius }) => {
       const location = await insertNamedLocation(user, { lat, lon, name, radius })
       return jsonResponse({ data: location, success: true })

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -1,7 +1,12 @@
 /**
  * MCP metric management tools.
  */
-import { customMetricDefinitionSchema } from '@aurboda/api-spec'
+import {
+  addCustomMetricBodySchema,
+  addMetricBodySchema,
+  customMetricDefinitionSchema,
+  updateCustomMetricBodySchema,
+} from '@aurboda/api-spec'
 import { z } from 'zod'
 import {
   addCustomMetric,
@@ -20,14 +25,7 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   server.tool(
     'add_metric',
     'Add a manual health metric measurement. Use this to log data not captured automatically.',
-    {
-      metric: z.string().describe(metricDescription),
-      time: z
-        .string()
-        .optional()
-        .describe('Measurement time in ISO 8601 format. Defaults to current time if omitted.'),
-      value: z.number().describe('The metric value (e.g., 72 for heart rate, 75.5 for weight)'),
-    },
+    { ...addMetricBodySchema.shape },
     async ({ metric, time, value }) => {
       const measurementTime = time ? parseOptionalDate(time) : new Date()
       if (!measurementTime) {
@@ -46,17 +44,7 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   server.tool(
     'add_custom_metric',
     'Register a new custom metric type. Custom metrics allow tracking data not covered by built-in metrics.',
-    {
-      description: z.string().optional().describe('Human-readable description of the metric'),
-      max_value: z.number().optional().describe('Maximum allowed value for validation'),
-      min_value: z.number().optional().describe('Minimum allowed value for validation'),
-      name: z
-        .string()
-        .describe(
-          'Metric name (lowercase letters, numbers, underscores). Must not conflict with built-in metrics.',
-        ),
-      unit: z.string().describe('Unit of measurement (e.g., "score", "mg", "count")'),
-    },
+    { ...addCustomMetricBodySchema.shape },
     async ({ description, max_value, min_value, name, unit }) => {
       const definition = {
         ...(description !== undefined ? { description } : {}),
@@ -108,19 +96,8 @@ export const registerMetricTools = (server: McpServer, user: string) => {
     'update_custom_metric',
     'Update an existing custom metric definition. Only provided fields are changed. Set min_value/max_value to null to clear them.',
     {
-      description: z.string().optional().describe('Human-readable description of the metric'),
-      max_value: z
-        .number()
-        .nullable()
-        .optional()
-        .describe('Maximum allowed value for validation (null to clear)'),
-      min_value: z
-        .number()
-        .nullable()
-        .optional()
-        .describe('Minimum allowed value for validation (null to clear)'),
       name: z.string().describe('The name of the custom metric to update'),
-      unit: z.string().optional().describe('Unit of measurement (e.g., "score", "mg", "count")'),
+      ...updateCustomMetricBodySchema.shape,
     },
     async ({ description, max_value, min_value, name, unit }) => {
       const updates = {

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -4,9 +4,11 @@
 import {
   activityTypes,
   activityTypeSchema,
+  bucketSizeSchema,
   dateOnlySchema,
   isValidMetricOrCustom,
   type MetricType,
+  timeRangeQuerySchema,
   validMetrics,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -22,26 +24,16 @@ import {
   queryProductivity,
   queryTags,
 } from '../services/queries'
-import {
-  errorResponse,
-  jsonResponse,
-  type McpServer,
-  mcpTimeRangeSchema,
-  metricDescription,
-  type SyncProvider,
-} from './helpers'
+import { errorResponse, jsonResponse, type McpServer, metricDescription, type SyncProvider } from './helpers'
 
 // eslint-disable-next-line max-lines-per-function -- tool registrations are inherently long
 export const registerQueryTools = (server: McpServer, user: string, sync?: SyncProvider) => {
-  // Valid bucket sizes for bucketed metrics queries
-  const validBucketSizes = ['5m', '15m', '30m', '1h', '1d'] as const
-
   // Tool: query_metrics
   server.tool(
     'query_metrics',
     'Query health metrics for a time range. Returns time series data with timestamps and values.',
     {
-      ...mcpTimeRangeSchema,
+      ...timeRangeQuerySchema.shape,
       metric: z.string().describe(metricDescription),
     },
     async ({ end, metric, start }) => {
@@ -69,8 +61,8 @@ Use cases:
 - Exercise response: "Compare pre/during/post exercise HR"
 - Multi-day trends: "What's my average resting HR this week?" (use 1d bucket)`,
     {
-      ...mcpTimeRangeSchema,
-      bucket: z.enum(validBucketSizes).describe('Bucket size: "5m", "15m", "30m", "1h", or "1d"'),
+      ...timeRangeQuerySchema.shape,
+      bucket: bucketSizeSchema,
       metrics: z.array(z.string()).describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
     },
     async ({ bucket, end, metrics, start }) => {
@@ -124,7 +116,7 @@ Use cases:
     'query_period_summary',
     'Get aggregated statistics for a time period. Returns min/max/avg/stddev for each metric, trend compared to previous period, and data completeness.',
     {
-      ...mcpTimeRangeSchema,
+      ...timeRangeQuerySchema.shape,
       metrics: z.array(z.string()).describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
     },
     async ({ end, metrics, start }) => {
@@ -147,7 +139,7 @@ Use cases:
   server.tool(
     'query_tags',
     'Query tags/labels for a time range. Returns all tags with start times, optional end times, and tag text.',
-    mcpTimeRangeSchema,
+    { ...timeRangeQuerySchema.shape },
     async ({ end, start }) => {
       const tags = await queryTags(user, new Date(start), new Date(end), sync)
       return jsonResponse({ data: tags, success: true })
@@ -159,7 +151,7 @@ Use cases:
     'query_activities',
     'Query activities (sleep, exercise, meditation, nap) for a time range. Returns activity sessions with duration, HR zones for exercise, and other metadata.',
     {
-      ...mcpTimeRangeSchema,
+      ...timeRangeQuerySchema.shape,
       types: z
         .array(activityTypeSchema)
         .optional()
@@ -176,7 +168,7 @@ Use cases:
   server.tool(
     'query_productivity',
     'Query productivity data (from RescueTime) for a time range. Returns application/website usage with productivity scores.',
-    mcpTimeRangeSchema,
+    { ...timeRangeQuerySchema.shape },
     async ({ end, start }) => {
       const productivity = await queryProductivity(user, new Date(start), new Date(end), sync)
       return jsonResponse({ data: productivity, success: true })
@@ -187,7 +179,7 @@ Use cases:
   server.tool(
     'query_locations',
     'Query location/place visits for a time range. Returns places visited with names, coordinates, duration, and source (named, detected, or owntracks).',
-    mcpTimeRangeSchema,
+    { ...timeRangeQuerySchema.shape },
     async ({ end, start }) => {
       const places = await queryLocations(user, new Date(start), new Date(end))
       return jsonResponse({ data: places, success: true })

--- a/apps/backend/src/mcp/settings-tools.ts
+++ b/apps/backend/src/mcp/settings-tools.ts
@@ -1,14 +1,12 @@
 /**
  * MCP user settings and tag mapping tools.
  */
-import { hrZoneThresholdsSchema } from '@aurboda/api-spec'
-import { z } from 'zod'
+import { setTagMappingBodySchema, updateSettingsInputSchema } from '@aurboda/api-spec'
 import { getProgrammaticTags, getUniqueTags, getUserSettings, upsertUserSettings } from '../db'
 import { getGoalsProgress } from '../services/goals'
 import { getSettingsResponse, validateAndUpdateSettings } from '../services/settings'
 import { jsonResponse, type McpServer } from './helpers'
 
-// eslint-disable-next-line max-lines-per-function -- tool registrations are inherently long
 export const registerSettingsTools = (server: McpServer, user: string) => {
   // Tool: get_user_settings
   server.tool(
@@ -25,22 +23,9 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
   server.tool(
     'update_user_settings',
     'Update user settings. Can set birth date (for age-based HR zones) and/or custom HR zone thresholds.',
-    {
-      birth_date: z
-        .string()
-        .nullable()
-        .optional()
-        .describe('Birth date in YYYY-MM-DD format. Set to null to clear.'),
-      hr_zone_start: hrZoneThresholdsSchema
-        .nullable()
-        .optional()
-        .describe('Custom HR zone start thresholds. Values must be ascending. Set to null to clear.'),
-    },
-    async ({ birth_date, hr_zone_start }) => {
-      const result = await validateAndUpdateSettings(user, {
-        birth_date,
-        hr_zone_start,
-      })
+    { ...updateSettingsInputSchema.shape },
+    async (params) => {
+      const result = await validateAndUpdateSettings(user, params)
       return jsonResponse(result)
     },
   )
@@ -81,10 +66,7 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
   server.tool(
     'set_tag_mapping',
     'Set a display name for a programmatic tag (UUID, tag_* prefix, etc.). Use after get_programmatic_tags to name unmapped tags.',
-    {
-      name: z.string().min(1).describe('Display name for the tag'),
-      tag_key: z.string().min(1).describe('The programmatic tag identifier (UUID, tag_* prefix, etc.)'),
-    },
+    { ...setTagMappingBodySchema.shape },
     async ({ name, tag_key }) => {
       const settings = await getUserSettings(user)
       const currentMappings = settings?.tag_mappings ?? {}

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -1,8 +1,13 @@
 /**
  * MCP sync tools - data synchronization with external services.
  */
-import { syncProviderSchema } from '@aurboda/api-spec'
-import { z } from 'zod'
+import {
+  syncCalendarsBodySchema,
+  syncLastFmBodySchema,
+  syncOuraBodySchema,
+  syncProviderSchema,
+  syncRescueTimeBodySchema,
+} from '@aurboda/api-spec'
 import { getAllSyncStates } from '../db'
 import { syncAllCalendars } from '../ical-sync'
 import { syncLastFmData } from '../lastfm-sync'
@@ -21,18 +26,7 @@ export const registerSyncTools = (server: McpServer, user: string, oura?: OuraCl
   server.tool(
     'sync_oura',
     'Sync data from Oura Ring API. Fetches cardiovascular age, readiness, resilience, sleep scores, meditation sessions, and tags.',
-    {
-      full_resync: z
-        .boolean()
-        .optional()
-        .describe(
-          'If true, fetches all historical data (default 90 days). Otherwise, fetches only since last sync.',
-        ),
-      start_date: z
-        .string()
-        .optional()
-        .describe('Optional start date for sync in YYYY-MM-DD format. Only used with full_resync.'),
-    },
+    { ...syncOuraBodySchema.shape },
     async ({ full_resync, start_date }) => {
       if (!oura) {
         return errorResponse('Oura integration is not configured on this server.')
@@ -63,18 +57,7 @@ export const registerSyncTools = (server: McpServer, user: string, oura?: OuraCl
   server.tool(
     'sync_rescuetime',
     'Sync productivity data from RescueTime API. Fetches application and website usage with productivity scores.',
-    {
-      full_resync: z
-        .boolean()
-        .optional()
-        .describe(
-          'If true, fetches all historical data (default 30 days). Otherwise, fetches only since last sync.',
-        ),
-      start_date: z
-        .string()
-        .optional()
-        .describe('Optional start date for sync in YYYY-MM-DD format. Only used with full_resync.'),
-    },
+    { ...syncRescueTimeBodySchema.shape },
     async ({ full_resync, start_date }) => {
       const settings = await getSettings(user)
       if (!settings.rescue_time_key) {
@@ -104,12 +87,7 @@ export const registerSyncTools = (server: McpServer, user: string, oura?: OuraCl
   server.tool(
     'sync_calendars',
     'Sync events from configured calendar ICS URLs. Fetches ICS data and stores events as tags for correlation analysis.',
-    {
-      full_resync: z
-        .boolean()
-        .optional()
-        .describe('If true, re-fetches all events. Otherwise, performs a normal sync.'),
-    },
+    { ...syncCalendarsBodySchema.shape },
     async () => {
       const settings = await getSettings(user)
       if (!settings.calendars || settings.calendars.length === 0) {
@@ -138,18 +116,7 @@ export const registerSyncTools = (server: McpServer, user: string, oura?: OuraCl
   server.tool(
     'sync_lastfm',
     'Sync scrobbles from Last.fm. Fetches recent tracks and applies auto-tagging rules.',
-    {
-      full_resync: z
-        .boolean()
-        .optional()
-        .describe(
-          'If true, fetches all historical data (default 30 days). Otherwise, fetches only since last sync.',
-        ),
-      start_date: z
-        .string()
-        .optional()
-        .describe('Optional start date for sync in YYYY-MM-DD format. Only used with full_resync.'),
-    },
+    { ...syncLastFmBodySchema.shape },
     async ({ full_resync, start_date }) => {
       const lastFmApiKey = await getCentralDb().getLastFmApiKey()
       if (!lastFmApiKey) {

--- a/apps/backend/src/mcp/tag-tools.ts
+++ b/apps/backend/src/mcp/tag-tools.ts
@@ -1,8 +1,7 @@
 /**
  * MCP tag management tools.
  */
-import { startDateTimeQuerySchema } from '@aurboda/api-spec'
-import { z } from 'zod'
+import { addTagBodySchema, deleteTagParamsSchema } from '@aurboda/api-spec'
 import { addTag, deleteTag } from '../services/mutations'
 import { errorResponse, jsonResponse, type McpServer, parseOptionalDate } from './helpers'
 
@@ -11,25 +10,7 @@ export const registerTagTools = (server: McpServer, user: string) => {
   server.tool(
     'add_tag',
     'Add a manual tag/label to mark an activity or event. Tags can have a start time and optional end time.',
-    {
-      end_time: z
-        .string()
-        .optional()
-        .describe('Optional end time in ISO 8601 format. Omit for point-in-time tags.'),
-      merge_span: z
-        .number()
-        .int()
-        .positive()
-        .max(3600)
-        .optional()
-        .describe(
-          'If provided, merge with existing tag of same name if its end_time (or start_time for point-in-time tags) is within this many seconds of new start_time. Max 3600.',
-        ),
-      start_time: startDateTimeQuerySchema.describe(
-        'Start time in ISO 8601 format (e.g., 2024-01-15T14:30:00Z)',
-      ),
-      tag: z.string().describe('The tag/label text (e.g., "coffee", "meditation", "headache")'),
-    },
+    { ...addTagBodySchema.shape },
     async ({ end_time, merge_span, start_time, tag }) => {
       const startDate = new Date(start_time)
 
@@ -56,9 +37,7 @@ export const registerTagTools = (server: McpServer, user: string) => {
   server.tool(
     'delete_tag',
     'Delete a tag by its external ID. Returns success if the tag was found and deleted.',
-    {
-      external_id: z.string().describe('The external ID of the tag to delete'),
-    },
+    { ...deleteTagParamsSchema.shape },
     async ({ external_id }) => {
       const result = await deleteTag(user, external_id)
       return jsonResponse(result)

--- a/apps/backend/src/mcp/trend-tools.ts
+++ b/apps/backend/src/mcp/trend-tools.ts
@@ -1,7 +1,7 @@
 /**
  * MCP trend analysis tools.
  */
-import { z } from 'zod'
+import { getTrendQuerySchema } from '@aurboda/api-spec'
 import { getTrend } from '../services/trends'
 import { jsonResponse, type McpServer } from './helpers'
 
@@ -21,34 +21,7 @@ Common half-life values:
 - 7 days (quick): Responds to changes within a week
 - 15 days (responsive): Balanced, good default
 - 30 days (stable): Smooths out short-term variation`,
-    {
-      aggregation: z
-        .enum(['count', 'sum', 'mean'])
-        .optional()
-        .describe('Aggregation method. For tags: "count" (default). For metrics: "mean" or "sum".'),
-      display_period: z
-        .enum(['daily', 'weekly', 'monthly'])
-        .optional()
-        .describe('Period to normalize rate to. Default: "monthly".'),
-      half_life_days: z
-        .number()
-        .positive()
-        .optional()
-        .describe(
-          'EMA half-life in days. Default: 15. Common values: 7 (quick), 15 (responsive), 30 (stable).',
-        ),
-      lookback_days: z
-        .number()
-        .positive()
-        .optional()
-        .describe('Days of historical data to include. Default: 90.'),
-      pattern: z
-        .string()
-        .describe(
-          'For tags: regex pattern to match (e.g., "pain_killer|headache"). For metrics: metric name.',
-        ),
-      source_type: z.enum(['tag', 'metric']).describe('Type of data source: "tag" or "metric".'),
-    },
+    { ...getTrendQuerySchema.shape },
     async ({ aggregation, display_period, half_life_days, lookback_days, pattern, source_type }) => {
       try {
         const result = await getTrend(user, {

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -535,3 +535,56 @@ export const genericCorrelationResponseSchema = createDataResponseSchema(generic
 })
 
 export type GenericCorrelationResponse = z.infer<typeof genericCorrelationResponseSchema>
+
+// ============================================================================
+// MCP input schemas (typed params, complementing Express string-based queries)
+// ============================================================================
+
+/** Activity impact MCP input schema (typed numbers instead of query strings) */
+export const activityImpactInputSchema = z
+  .object({
+    activity: z
+      .string()
+      .meta({ description: 'The activity or tag name to analyze (e.g., "gym", "coffee", "meditation")' }),
+    activity_type: activityImpactTypeSchema.meta({ description: 'Type of activity to search for' }),
+    period_days: z.number().int().optional().meta({ description: 'Number of days to analyze. Defaults to 90.' }),
+    window_minutes: z
+      .number()
+      .int()
+      .optional()
+      .meta({ description: 'Minutes to analyze before/after the activity. Defaults to 30.' }),
+  })
+  .meta({ id: 'ActivityImpactInput' })
+
+export type ActivityImpactInput = z.infer<typeof activityImpactInputSchema>
+
+/** Event probability MCP input schema (typed numbers instead of query strings) */
+export const eventProbabilityInputSchema = z
+  .object({
+    lag_windows: z
+      .array(z.string())
+      .optional()
+      .meta({
+        description: 'Time windows to analyze (e.g., ["12h", "24h", "36h", "48h"]). Uses hours (h) or days (d).',
+      }),
+    outcome_pattern: z
+      .string()
+      .meta({ description: 'Regex pattern for outcome tags (e.g., "headache|migraine", "good_sleep")' }),
+    period_days: z.number().int().optional().meta({ description: 'Number of days to analyze. Defaults to 365.' }),
+    trigger_type: eventTriggerTypeSchema.meta({ description: 'Type of trigger event' }),
+    trigger_value: z
+      .string()
+      .meta({ description: 'Trigger activity type or tag pattern (e.g., "exercise", "gym", "coffee")' }),
+  })
+  .meta({ id: 'EventProbabilityInput' })
+
+export type EventProbabilityInput = z.infer<typeof eventProbabilityInputSchema>
+
+/** HRV correlation MCP input schema */
+export const hrvCorrelationInputSchema = z
+  .object({
+    period_days: z.number().int().optional().meta({ description: 'Number of days to analyze. Defaults to 30.' }),
+  })
+  .meta({ id: 'HrvCorrelationInput' })
+
+export type HrvCorrelationInput = z.infer<typeof hrvCorrelationInputSchema>


### PR DESCRIPTION
## Summary

- Replace ~300 lines of inline Zod schemas in MCP tools with imports from `@aurboda/api-spec` using the `.shape` pattern, making api-spec the single source of truth for validation and types
- Fix bug in `get_generic_correlation` MCP tool where `triggers[].minCount` and `triggers[].windowDays` (camelCase) were silently dropped — the service expects `min_count` and `window_days` (snake_case), so defaults were always used
- Add 3 new typed input schemas to api-spec for MCP correlation tools (`activityImpactInputSchema`, `eventProbabilityInputSchema`, `hrvCorrelationInputSchema`)
- `update_user_settings` MCP tool now exposes all settings fields (calendars, dashboard, goals, lastfm_username, rescue_time_key, tag_mappings) in addition to birth_date and hr_zone_start

## Breaking MCP changes

- `get_generic_correlation`: `triggers[].minCount` → `min_count`, `triggers[].windowDays` → `window_days` (fixes silent bug where these were ignored)

## No REST API changes

All changes are MCP-only. REST API endpoints are unchanged.

## Test plan

- [x] Backend: 691 tests pass (0 failures)
- [x] `pnpm fix` — no errors (only pre-existing warnings)
- [x] `pnpm check` — no errors (only pre-existing warnings)
- [x] api-spec builds cleanly
- [x] OpenAPI spec regenerated (no changes — new schemas are MCP-only, not REST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)