### PR TITLE
Handle Health Connect record deletions and fix step count double-counting

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -101,7 +101,18 @@ class HealthConnectSyncWorker(
             }
 
             // Step 2: Fetch and send raw records (filtered to exclude aggregated types)
-            val records = fetchHealthData()
+            val (records, deletionIds) = fetchHealthData()
+
+            // Step 3: Send deletions to backend
+            if (deletionIds.isNotEmpty()) {
+                val deletionSuccess = sendDeletions(deletionIds, credentials.apiUrl, credentials.authToken)
+                if (!deletionSuccess) {
+                    Log.w(TAG, "Failed to send deletions, will retry")
+                    return Result.retry()
+                }
+                Log.d(TAG, "Sent ${deletionIds.size} deletions")
+            }
+
             if (records.isNotEmpty()) {
                 // Filter out records that are handled by aggregates
                 val filteredRecords = records.filter { record ->
@@ -127,6 +138,10 @@ class HealthConnectSyncWorker(
                     Result.success()
                 }
             } else {
+                // If we had deletions but no records, save token
+                if (deletionIds.isNotEmpty()) {
+                    pendingToken?.let { saveChangesToken(it) }
+                }
                 Log.d(TAG, "No new data to sync")
                 HrZoneWidgetProvider.triggerUpdate(applicationContext)
                 Result.success()
@@ -137,13 +152,16 @@ class HealthConnectSyncWorker(
         }
     }
 
-    private suspend fun fetchHealthData(): List<Record> {
+    private data class FetchResult(val records: List<Record>, val deletionIds: List<String>)
+
+    private suspend fun fetchHealthData(): FetchResult {
         val records = mutableListOf<Record>()
+        val deletionIds = mutableListOf<String>()
         val lastToken = loadChangesToken()
 
         if (lastToken == null) {
             Log.d(TAG, "No token found, skipping background fetch (initial fetch should be done in foreground)")
-            return emptyList()
+            return FetchResult(emptyList(), emptyList())
         }
 
         var currentToken: String = lastToken
@@ -163,6 +181,7 @@ class HealthConnectSyncWorker(
             changesResponse.changes.forEach {
                 if (it is DeletionChange) {
                     Log.d(TAG, "Record deleted, ID: ${it.recordId}")
+                    deletionIds.add(it.recordId)
                 }
             }
 
@@ -171,15 +190,19 @@ class HealthConnectSyncWorker(
         }
 
         // Save the new token if we have records to send (token will be updated after successful send)
-        // If no records, save token now to avoid re-fetching empty changes
-        if (records.isEmpty()) {
+        // If no records and no deletions, save token now to avoid re-fetching empty changes
+        if (records.isEmpty() && deletionIds.isEmpty()) {
             saveChangesToken(currentToken)
         } else {
             // Store temporarily, will be saved after successful send
             pendingToken = currentToken
         }
 
-        return records
+        if (deletionIds.isNotEmpty()) {
+            Log.d(TAG, "Collected ${deletionIds.size} deletion IDs")
+        }
+
+        return FetchResult(records, deletionIds)
     }
 
     private var pendingToken: String? = null
@@ -436,6 +459,31 @@ class HealthConnectSyncWorker(
             response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
         } catch (e: Exception) {
             Log.e(TAG, "Error posting daily aggregates", e)
+            false
+        }
+    }
+
+    /**
+     * Send Health Connect deletion IDs to the backend.
+     */
+    private suspend fun sendDeletions(
+        deletionIds: List<String>,
+        serverUrl: String,
+        authToken: String
+    ): Boolean {
+        if (deletionIds.isEmpty()) return true
+
+        val postData = PostWrapper(deletionIds)
+        return try {
+            val response = httpClient.post("$serverUrl/sync/deletions") {
+                contentType(ContentType.Application.Json)
+                headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+                setBody(postData)
+            }
+            Log.d(TAG, "Deletions response: ${response.status}")
+            response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+        } catch (e: Exception) {
+            Log.e(TAG, "Error posting deletions", e)
             false
         }
     }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -392,8 +392,9 @@ fun HealthConnectScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val healthConnectClient = remember { HealthConnectClient.getOrCreate(context) }
     var hasPermissions by remember { mutableStateOf(false) }
-    var healthRecords by remember { mutableStateOf<List<Record>>(emptyList()) } 
-    var isProcessing by remember { mutableStateOf(false) } 
+    var healthRecords by remember { mutableStateOf<List<Record>>(emptyList()) }
+    var pendingDeletionIds by remember { mutableStateOf<List<String>>(emptyList()) }
+    var isProcessing by remember { mutableStateOf(false) }
     var pendingTokenToPersist by remember { mutableStateOf<String?>(null) }
     var statusMessage by remember { mutableStateOf("Checking permissions...") }
     var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
@@ -427,8 +428,9 @@ fun HealthConnectScreen(
         isProcessing = true 
         statusMessage = "Fetching data from Health Connect..."
         Log.d("HealthConnectScreen", "Starting data fetch for ${allRecordTypes.size} types...")
-        val localHealthRecords = mutableListOf<Record>() 
-        var localPendingTokenToPersist: String? = null 
+        val localHealthRecords = mutableListOf<Record>()
+        val localDeletionIds = mutableListOf<String>()
+        var localPendingTokenToPersist: String? = null
         var fetchSuccessful = true
 
         val lastTokenFromPrefs = loadChangesToken(currentActiveContext)
@@ -493,7 +495,12 @@ fun HealthConnectScreen(
                         localHealthRecords.addAll(upsertions)
                         totalUpsertions += upsertions.size
                     }
-                    changesResponse.changes.forEach { if (it is DeletionChange) Log.d("HealthConnect", "Record deleted, ID: ${it.recordId}. Deletion handling for server not implemented.") }
+                    changesResponse.changes.forEach {
+                        if (it is DeletionChange) {
+                            Log.d("HealthConnect", "Record deleted, ID: ${it.recordId}")
+                            localDeletionIds.add(it.recordId)
+                        }
+                    }
 
                     hasMore = changesResponse.hasMore
                     currentToken = changesResponse.nextChangesToken
@@ -505,14 +512,17 @@ fun HealthConnectScreen(
                 }
 
                 localPendingTokenToPersist = currentToken
-                Log.d("FetchData", "Fetched $totalUpsertions total upsertions. Next token candidate: ${localPendingTokenToPersist?.take(10)}...")
-                if (totalUpsertions == 0) {
+                Log.d("FetchData", "Fetched $totalUpsertions total upsertions, ${localDeletionIds.size} deletions. Next token candidate: ${localPendingTokenToPersist?.take(10)}...")
+                if (totalUpsertions == 0 && localDeletionIds.isEmpty()) {
                     statusMessage = "No new changes found."
                     saveChangesToken(currentActiveContext, localPendingTokenToPersist)
                     Log.d("FetchData", "Saved next changes token as no new data was found: ${localPendingTokenToPersist?.take(10)}...")
                     localPendingTokenToPersist = null
                 } else {
-                    statusMessage = "Fetched $totalUpsertions new/updated records. Ready to send."
+                    val parts = mutableListOf<String>()
+                    if (totalUpsertions > 0) parts.add("$totalUpsertions new/updated records")
+                    if (localDeletionIds.isNotEmpty()) parts.add("${localDeletionIds.size} deletions")
+                    statusMessage = "Fetched ${parts.joinToString(", ")}. Ready to send."
                 }
             } catch (e: Exception) {
                 Log.e("FetchData", "Error fetching changes from Health Connect.", e)
@@ -523,9 +533,11 @@ fun HealthConnectScreen(
 
         if (fetchSuccessful) {
             healthRecords = localHealthRecords.sortedByDescending { it.getPrimaryInstant() }
-            pendingTokenToPersist = localPendingTokenToPersist 
+            pendingDeletionIds = localDeletionIds
+            pendingTokenToPersist = localPendingTokenToPersist
         } else {
-            if (lastTokenFromPrefs != null) healthRecords = emptyList() 
+            if (lastTokenFromPrefs != null) healthRecords = emptyList()
+            pendingDeletionIds = emptyList()
             pendingTokenToPersist = null
         }
         Log.d("HealthConnectScreen", "Data fetch processing finished. status: $statusMessage")
@@ -568,93 +580,121 @@ fun HealthConnectScreen(
         }
     }
 
+    // Record types handled by daily aggregates (should not be sent as raw records)
+    val aggregatedRecordTypes = setOf(
+        StepsRecord::class,
+        DistanceRecord::class,
+        ActiveCaloriesBurnedRecord::class,
+        TotalCaloriesBurnedRecord::class,
+        FloorsClimbedRecord::class
+    )
+
     suspend fun sendPendingDataToServer(currentActiveContext: Context) {
-        if (healthRecords.isEmpty()) {
+        if (healthRecords.isEmpty() && pendingDeletionIds.isEmpty()) {
             statusMessage = "No records to send."
-            Log.d("SendData", "No records to send.")
+            Log.d("SendData", "No records or deletions to send.")
             return
         }
-        if(isProcessing){ 
+        if(isProcessing){
              Log.d("SendData", "sendPendingDataToServer called while already processing.")
             return
         }
         isProcessing = true
-        statusMessage = "Sending ${healthRecords.size} records with known serializers to server..."
         var allPostsSuccessful = true
 
-        val recordsWithKnownSerializers = healthRecords.filter {
-            when (it) {
-                is HeartRateVariabilityRmssdRecord, is WeightRecord, is StepsRecord, is HeartRateRecord,
-                is ExerciseSessionRecord, is DistanceRecord, is SpeedRecord, is ActiveCaloriesBurnedRecord,
-                is TotalCaloriesBurnedRecord, is PowerRecord, is NutritionRecord, is LeanBodyMassRecord,
-                is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is BodyWaterMassRecord,
-                is HeightRecord, is RestingHeartRateRecord -> true
-                else -> false
+        // Step 1: Send deletions to backend
+        if (pendingDeletionIds.isNotEmpty()) {
+            statusMessage = "Sending ${pendingDeletionIds.size} deletions..."
+            Log.d("SendData", "Sending ${pendingDeletionIds.size} deletion IDs to server")
+            val deletionResult = try {
+                val response = ktorHttpClient.post("$apiUrl/sync/deletions") {
+                    contentType(ContentType.Application.Json)
+                    headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+                    setBody(PostWrapper(pendingDeletionIds))
+                }
+                response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+            } catch (e: Exception) {
+                Log.e("SendData", "Error posting deletions", e)
+                false
             }
-        }
-
-        if (recordsWithKnownSerializers.isEmpty()) {
-            statusMessage = "No records with known serializers to send."
-            Log.d("SendData", "No records with known serializers to send. Other types might be present but not sent.")
-            isProcessing = false
-            return
-        }
-
-        Log.d("SendData", "Attempting to send ${recordsWithKnownSerializers.size} records with known serializers.")
-
-        val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
-        for ((recordClass, classRecords) in groupedRecords) {
-            if (classRecords.isEmpty()) continue
-            val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
-            val syncUrl = "$apiUrl/sync/$recordTypeSimpleName"
-
-            val postResult = when (recordClass) {
-                HeartRateVariabilityRmssdRecord::class -> handlePostData(HrvRecordSerializable.fromRecordsList(classRecords), HrvRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                WeightRecord::class -> handlePostData(WeightRecordSerializable.fromRecordsList(classRecords), WeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                StepsRecord::class -> handlePostData(StepsRecordSerializable.fromRecordsList(classRecords), StepsRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                HeartRateRecord::class -> handlePostDataChunked(HeartRateRecordSerializable.fromRecordsList(classRecords), HeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                ExerciseSessionRecord::class -> handlePostData(ExerciseSessionRecordSerializable.fromRecordsList(classRecords), ExerciseSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                DistanceRecord::class -> handlePostData(DistanceRecordSerializable.fromRecordsList(classRecords), DistanceRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                SpeedRecord::class -> handlePostData(SpeedRecordSerializable.fromRecordsList(classRecords), SpeedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                ActiveCaloriesBurnedRecord::class -> handlePostData(ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords), ActiveCaloriesBurnedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                TotalCaloriesBurnedRecord::class -> handlePostData(TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords), TotalCaloriesBurnedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                PowerRecord::class -> handlePostData(PowerRecordSerializable.fromRecordsList(classRecords), PowerRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                NutritionRecord::class -> handlePostData(NutritionRecordSerializable.fromRecordsList(classRecords), NutritionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                LeanBodyMassRecord::class -> handlePostData(LeanBodyMassRecordSerializable.fromRecordsList(classRecords), LeanBodyMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                BodyFatRecord::class -> handlePostData(BodyFatRecordSerializable.fromRecordsList(classRecords), BodyFatRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                SleepSessionRecord::class -> handlePostData(SleepSessionRecordSerializable.fromRecordsList(classRecords), SleepSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                BoneMassRecord::class -> handlePostData(BoneMassRecordSerializable.fromRecordsList(classRecords), BoneMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                BodyWaterMassRecord::class -> handlePostData(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), BodyWaterMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                HeightRecord::class -> handlePostData(HeightRecordSerializable.fromRecordsList(classRecords), HeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                RestingHeartRateRecord::class -> handlePostData(RestingHeartRateRecordSerializable.fromRecordsList(classRecords), RestingHeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                else -> { Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping."); PostResult.Success }
-            }
-            if (!postResult.isSuccess) {
+            if (!deletionResult) {
                 allPostsSuccessful = false
-                val errorDetail = postResult.errorMessage() ?: "Unknown error"
-                statusMessage = "Failed to send $recordTypeSimpleName: $errorDetail"
-                Log.w("SendData", "Post failed for $recordTypeSimpleName: $errorDetail")
-                break
+                statusMessage = "Failed to send deletions"
+                Log.w("SendData", "Failed to send deletions")
+            } else {
+                Log.d("SendData", "Deletions sent successfully")
+                pendingDeletionIds = emptyList()
+            }
+        }
+
+        // Step 2: Send raw records (excluding aggregated types handled by daily aggregates)
+        if (allPostsSuccessful && healthRecords.isNotEmpty()) {
+            // Filter out aggregated types (steps, distance, etc.) - these are handled by daily aggregates
+            val recordsWithKnownSerializers = healthRecords.filter {
+                it::class !in aggregatedRecordTypes && when (it) {
+                    is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
+                    is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
+                    is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
+                    is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord -> true
+                    else -> false
+                }
+            }
+
+            statusMessage = "Sending ${recordsWithKnownSerializers.size} records to server..."
+
+            if (recordsWithKnownSerializers.isEmpty()) {
+                Log.d("SendData", "No records with known serializers to send (aggregated types excluded).")
+            } else {
+                Log.d("SendData", "Attempting to send ${recordsWithKnownSerializers.size} records (excluded ${healthRecords.size - recordsWithKnownSerializers.size} aggregated/unsupported types).")
+
+                val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
+                for ((recordClass, classRecords) in groupedRecords) {
+                    if (classRecords.isEmpty()) continue
+                    val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
+                    val syncUrl = "$apiUrl/sync/$recordTypeSimpleName"
+
+                    val postResult = when (recordClass) {
+                        HeartRateVariabilityRmssdRecord::class -> handlePostData(HrvRecordSerializable.fromRecordsList(classRecords), HrvRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        WeightRecord::class -> handlePostData(WeightRecordSerializable.fromRecordsList(classRecords), WeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        HeartRateRecord::class -> handlePostDataChunked(HeartRateRecordSerializable.fromRecordsList(classRecords), HeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        ExerciseSessionRecord::class -> handlePostData(ExerciseSessionRecordSerializable.fromRecordsList(classRecords), ExerciseSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        SpeedRecord::class -> handlePostData(SpeedRecordSerializable.fromRecordsList(classRecords), SpeedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        PowerRecord::class -> handlePostData(PowerRecordSerializable.fromRecordsList(classRecords), PowerRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        NutritionRecord::class -> handlePostData(NutritionRecordSerializable.fromRecordsList(classRecords), NutritionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        LeanBodyMassRecord::class -> handlePostData(LeanBodyMassRecordSerializable.fromRecordsList(classRecords), LeanBodyMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        BodyFatRecord::class -> handlePostData(BodyFatRecordSerializable.fromRecordsList(classRecords), BodyFatRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        SleepSessionRecord::class -> handlePostData(SleepSessionRecordSerializable.fromRecordsList(classRecords), SleepSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        BoneMassRecord::class -> handlePostData(BoneMassRecordSerializable.fromRecordsList(classRecords), BoneMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        BodyWaterMassRecord::class -> handlePostData(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), BodyWaterMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        HeightRecord::class -> handlePostData(HeightRecordSerializable.fromRecordsList(classRecords), HeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        RestingHeartRateRecord::class -> handlePostData(RestingHeartRateRecordSerializable.fromRecordsList(classRecords), RestingHeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        else -> { Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping."); PostResult.Success }
+                    }
+                    if (!postResult.isSuccess) {
+                        allPostsSuccessful = false
+                        val errorDetail = postResult.errorMessage() ?: "Unknown error"
+                        statusMessage = "Failed to send $recordTypeSimpleName: $errorDetail"
+                        Log.w("SendData", "Post failed for $recordTypeSimpleName: $errorDetail")
+                        break
+                    }
+                }
             }
         }
 
         if (allPostsSuccessful) {
             if (pendingTokenToPersist != null) {
                 saveChangesToken(currentActiveContext, pendingTokenToPersist)
-                statusMessage = "Known data sent successfully. Token updated."
-                Log.d("SendData", "All posts for known types successful. Saved token: ${pendingTokenToPersist?.take(10)}...")
+                statusMessage = "Data sent successfully. Token updated."
+                Log.d("SendData", "All posts successful. Saved token: ${pendingTokenToPersist?.take(10)}...")
                 pendingTokenToPersist = null
+            } else {
+                statusMessage = "Data sent successfully, but no new token was pending."
+                Log.d("SendData", "All posts successful. No new token was pending to save.")
             }
-             else {
-                statusMessage = "Known data sent successfully, but no new token was pending."
-                 Log.d("SendData", "All posts for known types successful. No new token was pending to save.")
-            }
-            healthRecords = healthRecords.filterNot { recordsWithKnownSerializers.contains(it) } 
-            if (healthRecords.isEmpty()) statusMessage += " All pending records cleared."
-            else statusMessage += " Unsupported records remain."
-
+            healthRecords = emptyList()
+            pendingDeletionIds = emptyList()
         } else {
-            Log.w("SendData", "Not all posts for known types successful. Pending records and their token candidate remain.")
+            Log.w("SendData", "Not all posts successful. Pending records and their token candidate remain.")
         }
         isProcessing = false
     }
@@ -677,8 +717,8 @@ fun HealthConnectScreen(
                     scope.launch {
                         fetchHealthData(context)
                         // Auto-send when background sync is enabled
-                        if (backgroundSyncEnabled && healthRecords.isNotEmpty()) {
-                            Log.d("HealthConnectScreen", "Background sync enabled, auto-sending ${healthRecords.size} records.")
+                        if (backgroundSyncEnabled && (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty())) {
+                            Log.d("HealthConnectScreen", "Background sync enabled, auto-sending ${healthRecords.size} records and ${pendingDeletionIds.size} deletions.")
                             sendPendingDataToServer(context)
                         }
                     }
@@ -700,7 +740,7 @@ fun HealthConnectScreen(
                 if (!isProcessing) {
                     Log.d("HealthConnectScreen", "Periodic sync: fetching and sending data")
                     fetchHealthData(context)
-                    if (healthRecords.isNotEmpty()) {
+                    if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
                         sendPendingDataToServer(context)
                     }
                 }
@@ -775,16 +815,15 @@ fun HealthConnectScreen(
                 }
                 Button(
                     onClick = { scope.launch { sendPendingDataToServer(context) } },
-                    enabled = healthRecords.any { record ->
-                        when (record) {
-                            is HeartRateVariabilityRmssdRecord, is WeightRecord, is StepsRecord, is HeartRateRecord,
-                            is ExerciseSessionRecord, is DistanceRecord, is SpeedRecord, is ActiveCaloriesBurnedRecord,
-                            is TotalCaloriesBurnedRecord, is PowerRecord, is NutritionRecord, is LeanBodyMassRecord,
-                            is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord, is BodyWaterMassRecord,
-                            is HeightRecord, is RestingHeartRateRecord -> true
+                    enabled = (pendingDeletionIds.isNotEmpty() || healthRecords.any { record ->
+                        record::class !in aggregatedRecordTypes && when (record) {
+                            is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
+                            is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
+                            is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
+                            is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord -> true
                             else -> false
                         }
-                    } && !isProcessing
+                    }) && !isProcessing
                 ) {
                     Text("Send Pending Data")
                 }

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -11,6 +11,7 @@ import express, { RequestHandler } from 'express'
 import { Client } from 'pg'
 import { createAuth } from './auth'
 import {
+  deleteHealthConnectRecords,
   getAllSyncStates,
   getDetectedLocationById,
   initializeSchema,
@@ -316,6 +317,7 @@ const main = async () => {
     '/sync',
     createSyncRouter(
       {
+        deleteHealthConnectRecords,
         getCalendarSyncStates: (user) => transformSyncStates(user, 'calendar'),
         getLastFmApiKey: () => centralDb.getLastFmApiKey(),
         getLastFmSyncStates: (user) => transformSyncStates(user, 'lastfm'),

--- a/apps/backend/src/db/health-connect.integration.test.ts
+++ b/apps/backend/src/db/health-connect.integration.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
-import { getDailyAggregateValue, processDailyAggregate } from './health-connect'
+import { query } from './connection'
+import {
+  deleteHealthConnectRecords,
+  getDailyAggregateValue,
+  processDailyAggregate,
+  processHealthConnectData,
+} from './health-connect'
+import { getTimeSeries } from './time-series'
 
 const CONTAINER_TIMEOUT = 60_000
 
@@ -128,6 +135,125 @@ describe('Health Connect Integration Tests', () => {
 
       const result = await getDailyAggregateValue(user, 'steps', new Date('2024-01-15'))
       expect(result).toBeNull()
+    })
+  })
+
+  describe('deleteHealthConnectRecords', () => {
+    test('deletes raw record and time_series for a weight record', async () => {
+      const user = getTestUser()
+
+      // Insert a weight record via processHealthConnectData
+      await processHealthConnectData(user, 'WeightRecord', {
+        metadata: { id: 'weight-record-1' },
+        time: '2024-01-15T08:00:00Z',
+        weightInKilograms: 75.5,
+      })
+
+      // Verify data exists
+      const rawBefore = await query(user, `SELECT * FROM raw_records WHERE external_id = 'weight-record-1'`)
+      expect(rawBefore.rows).toHaveLength(1)
+
+      const tsBefore = await getTimeSeries(
+        user,
+        'weight',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(tsBefore).toHaveLength(1)
+      expect(tsBefore[0][1]).toBe(75.5)
+
+      // Delete the record
+      const deleted = await deleteHealthConnectRecords(user, ['weight-record-1'])
+      expect(deleted).toBe(1)
+
+      // Verify raw record is gone
+      const rawAfter = await query(user, `SELECT * FROM raw_records WHERE external_id = 'weight-record-1'`)
+      expect(rawAfter.rows).toHaveLength(0)
+
+      // Verify time_series entry is gone
+      const tsAfter = await getTimeSeries(
+        user,
+        'weight',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(tsAfter).toHaveLength(0)
+    })
+
+    test('deletes raw record and activity for an exercise record', async () => {
+      const user = getTestUser()
+
+      await processHealthConnectData(user, 'ExerciseSessionRecord', {
+        endTime: '2024-01-15T11:00:00Z',
+        metadata: { id: 'exercise-1' },
+        startTime: '2024-01-15T10:00:00Z',
+        title: 'Morning Run',
+      })
+
+      // Verify activity exists
+      const activitiesBefore = await query(user, `SELECT * FROM activities WHERE source = 'health_connect'`)
+      expect(activitiesBefore.rows).toHaveLength(1)
+
+      const deleted = await deleteHealthConnectRecords(user, ['exercise-1'])
+      expect(deleted).toBe(1)
+
+      // Verify activity is gone
+      const activitiesAfter = await query(user, `SELECT * FROM activities WHERE source = 'health_connect'`)
+      expect(activitiesAfter.rows).toHaveLength(0)
+    })
+
+    test('handles batch deletions', async () => {
+      const user = getTestUser()
+
+      await processHealthConnectData(user, 'WeightRecord', {
+        metadata: { id: 'w1' },
+        time: '2024-01-15T08:00:00Z',
+        weightInKilograms: 75.0,
+      })
+      await processHealthConnectData(user, 'WeightRecord', {
+        metadata: { id: 'w2' },
+        time: '2024-01-16T08:00:00Z',
+        weightInKilograms: 74.8,
+      })
+
+      const deleted = await deleteHealthConnectRecords(user, ['w1', 'w2'])
+      expect(deleted).toBe(2)
+
+      const rawAfter = await query(user, `SELECT * FROM raw_records WHERE source = 'health_connect'`)
+      expect(rawAfter.rows).toHaveLength(0)
+    })
+
+    test('returns 0 for non-existent record IDs', async () => {
+      const user = getTestUser()
+      const deleted = await deleteHealthConnectRecords(user, ['non-existent-id'])
+      expect(deleted).toBe(0)
+    })
+
+    test('deletes raw record for steps but preserves aggregate time_series', async () => {
+      const user = getTestUser()
+
+      // Insert raw steps record
+      await processHealthConnectData(user, 'StepsRecord', {
+        count: 500,
+        metadata: { id: 'steps-1' },
+        startTime: '2024-01-15T10:00:00Z',
+      })
+
+      // Also insert a daily aggregate (which should be preserved)
+      await processDailyAggregate(user, {
+        data_origins: ['com.fitbit'],
+        date: '2024-01-15',
+        metric: 'steps',
+        value: 10000,
+      })
+
+      // Delete the raw record
+      const deleted = await deleteHealthConnectRecords(user, ['steps-1'])
+      expect(deleted).toBe(1)
+
+      // Aggregate should still exist
+      const aggregate = await getDailyAggregateValue(user, 'steps', new Date('2024-01-15'))
+      expect(aggregate).toBe(10000)
     })
   })
 })

--- a/apps/backend/src/db/health-connect.ts
+++ b/apps/backend/src/db/health-connect.ts
@@ -173,6 +173,79 @@ function extractTimeSeriesPoints(
 }
 
 // ============================================================================
+// Health Connect Record Deletion
+// ============================================================================
+
+/**
+ * Delete Health Connect records by their external IDs.
+ *
+ * Removes the raw_record and cleans up corresponding time_series and activity entries.
+ * Only deletes time_series entries with source='health_connect' (preserves aggregates).
+ *
+ * @returns Number of raw records actually deleted.
+ */
+export const deleteHealthConnectRecords = async (user: string, externalIds: string[]): Promise<number> => {
+  let deleted = 0
+
+  for (const externalId of externalIds) {
+    // Delete raw record and return its data for cleanup
+    const result = await query(
+      user,
+      `DELETE FROM raw_records
+       WHERE source = 'health_connect' AND external_id = $1
+       RETURNING record_type, data`,
+      [externalId],
+    )
+
+    if (result.rows.length === 0) continue
+    deleted++
+
+    const { record_type: recordType, data } = result.rows[0] as {
+      record_type: string
+      data: Record<string, unknown>
+    }
+
+    // Clean up time_series entries
+    const metric = healthConnectMetricMapping[recordType]
+    if (metric) {
+      const points = extractTimeSeriesPoints(recordType, metric, data)
+      for (const point of points) {
+        await query(
+          user,
+          `DELETE FROM time_series WHERE time = $1 AND metric = $2 AND source = 'health_connect'`,
+          [point.time, point.metric],
+        )
+      }
+    }
+
+    // Clean up blood pressure entries (two metrics)
+    if (recordType === 'BloodPressureRecord') {
+      const time = new Date((data.time as string) || (data.startTime as string))
+      await query(
+        user,
+        `DELETE FROM time_series
+         WHERE time = $1 AND metric IN ('blood_pressure_systolic', 'blood_pressure_diastolic')
+           AND source = 'health_connect'`,
+        [time],
+      )
+    }
+
+    // Clean up activity entries
+    const activityType = healthConnectActivityMapping[recordType]
+    if (activityType && data.startTime) {
+      await query(
+        user,
+        `DELETE FROM activities
+         WHERE source = 'health_connect' AND activity_type = $1 AND start_time = $2`,
+        [activityType, new Date(data.startTime as string)],
+      )
+    }
+  }
+
+  return deleted
+}
+
+// ============================================================================
 // Daily Aggregates (Deduplicated cumulative metrics from Health Connect)
 // ============================================================================
 

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -119,7 +119,12 @@ export { getOAuthToken, upsertOAuthToken } from './oauth'
 export { getAllSyncStates, getSyncState, resetSyncState, upsertSyncState } from './sync-state'
 
 // Health Connect
-export { getDailyAggregateValue, processDailyAggregate, processHealthConnectData } from './health-connect'
+export {
+  deleteHealthConnectRecords,
+  getDailyAggregateValue,
+  processDailyAggregate,
+  processHealthConnectData,
+} from './health-connect'
 
 // Settings
 export { getUserSettings, upsertUserSettings } from './settings'

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -5,6 +5,7 @@ import { createSyncRouter, SyncRouterDeps } from './sync-router'
 
 describe('sync router', () => {
   const mockDeps: SyncRouterDeps = {
+    deleteHealthConnectRecords: vi.fn().mockResolvedValue(0),
     getCalendarSyncStates: vi.fn().mockResolvedValue([]),
     getLastFmApiKey: vi.fn().mockResolvedValue('test-lastfm-key'),
     getLastFmSyncStates: vi.fn().mockResolvedValue([]),
@@ -190,6 +191,47 @@ describe('sync router', () => {
 
       expect(response.status).toBe(200)
       expect(response.body).toEqual({ states: mockStates, success: true })
+    })
+  })
+
+  describe('deletions endpoint', () => {
+    test('POST /sync/deletions calls deleteHealthConnectRecords', async () => {
+      vi.mocked(mockDeps.deleteHealthConnectRecords).mockResolvedValueOnce(3)
+
+      const app = createTestApp()
+      const response = await request(app)
+        .post('/sync/deletions')
+        .send({ data: ['id1', 'id2', 'id3'] })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({ message: 'Deleted 3 records', success: true })
+      expect(mockDeps.deleteHealthConnectRecords).toHaveBeenCalledWith('testuser', ['id1', 'id2', 'id3'])
+    })
+
+    test('POST /sync/deletions does not call processHealthConnectData', async () => {
+      const app = createTestApp()
+      const response = await request(app)
+        .post('/sync/deletions')
+        .send({ data: ['id1'] })
+
+      expect(response.status).toBe(200)
+      expect(mockDeps.processHealthConnectData).not.toHaveBeenCalled()
+    })
+
+    test('POST /sync/deletions returns 400 for empty array', async () => {
+      const app = createTestApp()
+      const response = await request(app).post('/sync/deletions').send({ data: [] })
+
+      expect(response.status).toBe(400)
+      expect(mockDeps.deleteHealthConnectRecords).not.toHaveBeenCalled()
+    })
+
+    test('POST /sync/deletions returns 400 for missing data', async () => {
+      const app = createTestApp()
+      const response = await request(app).post('/sync/deletions').send({})
+
+      expect(response.status).toBe(400)
+      expect(mockDeps.deleteHealthConnectRecords).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -1,5 +1,6 @@
 import {
   dailyAggregatesBodySchema,
+  healthConnectDeletionsBodySchema,
   healthConnectSyncBodySchema,
   syncCalendarsBodySchema,
   syncLastFmBodySchema,
@@ -11,6 +12,7 @@ import {
   type CalendarSyncStatusResponse,
   type DailyAggregate,
   type DailyAggregatesBody,
+  type HealthConnectDeletionsBody,
   type HealthConnectRecord,
   type HealthConnectSyncBody,
   type LastFmSyncResponse,
@@ -37,6 +39,7 @@ import { validateBody } from './validation'
  * Dependencies for sync router - allows testing with mocks
  */
 export interface SyncRouterDeps {
+  deleteHealthConnectRecords: (user: string, externalIds: string[]) => Promise<number>
   processDailyAggregate: (user: string, aggregate: DailyAggregate) => Promise<void>
   processHealthConnectData: (user: string, recordType: string, data: HealthConnectRecord) => Promise<void>
   syncOura: (user: string, options: { fullResync?: boolean; startDate?: Date }) => Promise<OuraSyncResult[]>
@@ -329,6 +332,20 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       res.status(500).json({ error: message, success: false })
     }
   })
+
+  // Health Connect deletions endpoint
+  router.post<ParamsDictionary, SyncResponse, HealthConnectDeletionsBody>(
+    '/deletions',
+    authMiddleware,
+    validateBody(healthConnectDeletionsBodySchema),
+    async (req, res) => {
+      const { data } = req.body
+      const user = req.user!
+
+      const deleted = await deps.deleteHealthConnectRecords(user, data)
+      res.json({ message: `Deleted ${deleted} records`, success: true })
+    },
+  )
 
   // ===========================================================================
   // Generic Health Connect sync endpoint - MUST be defined AFTER specific routes

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -190,6 +190,24 @@ export const healthConnectSyncBodySchema = z
 export type HealthConnectSyncBody = z.infer<typeof healthConnectSyncBodySchema>
 
 // ============================================================================
+// Health Connect Deletions
+// ============================================================================
+
+/**
+ * Health Connect deletions request body schema.
+ * Used when Health Connect reports deleted records that should be removed from the backend.
+ */
+export const healthConnectDeletionsBodySchema = z
+  .object({
+    data: z.array(z.string()).min(1).meta({
+      description: 'Array of Health Connect record external IDs to delete',
+    }),
+  })
+  .meta({ id: 'HealthConnectDeletionsBody' })
+
+export type HealthConnectDeletionsBody = z.infer<typeof healthConnectDeletionsBodySchema>
+
+// ============================================================================
 // Provider-specific status responses
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **Backend**: Add `POST /sync/deletions` endpoint and `deleteHealthConnectRecords()` function that removes raw_records and cleans up corresponding time_series and activity entries when Health Connect reports record deletions
- **Android**: Collect `DeletionChange` record IDs from the Health Connect Changes API and forward them to the backend (both background worker and foreground sync)
- **Android**: Filter aggregated record types (steps, distance, calories, floors) from foreground raw record sync in MainActivity — these cumulative metrics are already correctly handled by daily aggregates in the background worker

Fixes the issue where Fitbit replacing step interval records caused step counts for past days to keep increasing, because old raw_records and time_series entries were never cleaned up.

## Test plan

- [x] Integration tests for `deleteHealthConnectRecords` (weight, exercise, batch, non-existent, aggregate preservation)
- [x] Unit tests for `POST /sync/deletions` endpoint (routing, validation, error cases)
- [x] Android compiles successfully
- [ ] Manual test: verify step counts stabilize after day ends
- [ ] Manual test: verify deletions are sent when Fitbit updates records

🤖 Generated with [Claude Code](https://claude.ai/code)