### PR TITLE
Add Oura webhook push integration

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -33,7 +33,9 @@ import { syncLastFmData } from './lastfm-sync'
 import { createMcpRouter } from './mcp'
 import { createDbSessionStore } from './mcp-session-store'
 import { ouraClient } from './oura'
-import { syncAllOuraData } from './oura-sync'
+import { syncAllOuraData, syncOuraDataType } from './oura-sync'
+import { createOuraWebhookApi } from './oura-webhook-api'
+import { createOuraWebhookRouter, type OuraWebhookRouter } from './oura-webhook-router'
 import { createOwnTracksRouter } from './owntracks'
 import { syncRescueTimeData } from './rescuetime-sync'
 import { createActivitiesRouter } from './routes/activities-router'
@@ -50,6 +52,7 @@ import { createDetectionTrigger, DetectionTrigger } from './services/detection-t
 import { runDetectionForUser } from './services/detection-worker'
 import { createGeocodeQueue, GeocodeQueue } from './services/geocode-queue'
 import { createInvitationAuth } from './services/invitation'
+import { createOuraWebhookService, type OuraWebhookService } from './services/oura-webhook-service'
 import { getSettings } from './services/settings'
 import { createSyncProvider } from './services/sync-provider'
 import { createSyncRouter } from './sync-router'
@@ -72,12 +75,14 @@ const main = async () => {
   const auth = createAuth(sessionSecret)
   const invitationAuth = createInvitationAuth(sessionSecret)
 
-  const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
-  const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost)
-
   // Initialize central database (server settings, admins)
   await initializeCentralDb()
   const centralDb = getCentralDb()
+
+  const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
+  const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost, {
+    onUserAuthenticated: (ouraUserId, username) => centralDb.upsertOuraUserMapping(ouraUserId, username),
+  })
 
   // Create sync provider for auto-syncing data before queries
   const syncProvider = createSyncProvider({
@@ -344,6 +349,71 @@ const main = async () => {
   httpd.get('/auth/connectOura', oura.redirectToAuthorize)
   httpd.get('/auth/ouracb', oura.authCb)
 
+  // ==========================================================================
+  // Oura webhook push integration (opt-in via OURA_WEBHOOK_URL env var)
+  // ==========================================================================
+
+  let ouraWebhookRouter: OuraWebhookRouter | null = null
+  let ouraWebhookService: OuraWebhookService | null = null
+  const ouraWebhookUrl = process.env.OURA_WEBHOOK_URL
+  const ouraClientId = process.env.OURA_CLIENT ?? ''
+  const ouraClientSecret = process.env.OURA_SECRET ?? ''
+
+  if (ouraWebhookUrl && ouraClientId && ouraClientSecret) {
+    try {
+      // Get or generate verification token
+      let verificationToken = await centralDb.getServerSetting('oura_webhook_verification_token')
+      if (!verificationToken) {
+        const { randomBytes } = await import('crypto')
+        verificationToken = randomBytes(32).toString('hex')
+        await centralDb.setServerSetting('oura_webhook_verification_token', verificationToken)
+        console.log('Oura webhook: generated new verification token')
+      }
+
+      // Create webhook API client
+      const webhookApi = createOuraWebhookApi({
+        callbackUrl: ouraWebhookUrl,
+        clientId: ouraClientId,
+        clientSecret: ouraClientSecret,
+        verificationToken,
+      })
+
+      // Create and mount webhook router
+      ouraWebhookRouter = createOuraWebhookRouter({
+        getUsernameByOuraUserId: (ouraUserId) => centralDb.getUsernameByOuraUserId(ouraUserId),
+        syncOuraDataTypeForUser: async (username, dataType) => {
+          const accessToken = await oura.getAccessToken(username)
+          await syncOuraDataType(username, oura, dataType, accessToken)
+        },
+        verificationToken,
+      })
+      httpd.use('/webhooks/oura', ouraWebhookRouter)
+
+      // Create subscription service and initialize
+      ouraWebhookService = createOuraWebhookService({
+        createSubscription: (dataType, eventType) => webhookApi.createSubscription(dataType, eventType),
+        deleteLocalSubscription: (id) => centralDb.deleteOuraWebhookSubscription(id),
+        deleteRemoteSubscription: (id) => webhookApi.deleteSubscription(id),
+        getLocalSubscriptions: () => centralDb.getOuraWebhookSubscriptions(),
+        listRemoteSubscriptions: () => webhookApi.listSubscriptions(),
+        renewSubscription: (id) => webhookApi.renewSubscription(id),
+        upsertLocalSubscription: (sub) => centralDb.upsertOuraWebhookSubscription(sub),
+      })
+
+      // Initialize subscriptions in background (don't block startup)
+      ouraWebhookService.initSubscriptions().catch((error) => {
+        console.error('Oura webhook: failed to initialize subscriptions:', error)
+      })
+
+      // Start periodic renewal timer
+      ouraWebhookService.startRenewalTimer()
+
+      console.log(`Oura webhook: enabled at ${ouraWebhookUrl}`)
+    } catch (error) {
+      console.error('Oura webhook: failed to initialize:', error)
+    }
+  }
+
   // Initialize geocode queue (creates 'aurboda' database if needed)
   let geocodeQueue: GeocodeQueue | null = null
   try {
@@ -399,6 +469,12 @@ const main = async () => {
   const shutdown = async () => {
     console.log('Shutting down...')
     detectionTrigger.clearPendingDetections()
+    if (ouraWebhookRouter) {
+      ouraWebhookRouter.clearPendingWebhookSyncs()
+    }
+    if (ouraWebhookService) {
+      ouraWebhookService.stopRenewalTimer()
+    }
     if (geocodeQueue) {
       await geocodeQueue.stop()
     }

--- a/apps/backend/src/oura-webhook-api.test.ts
+++ b/apps/backend/src/oura-webhook-api.test.ts
@@ -1,0 +1,146 @@
+import axios from 'axios'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  createOuraWebhookApi,
+  OURA_DATA_TYPES,
+  OURA_EVENT_TYPES,
+  type OuraWebhookApiDeps,
+} from './oura-webhook-api'
+
+vi.mock('axios')
+const mockedAxios = vi.mocked(axios)
+
+describe('oura-webhook-api', () => {
+  const createDeps = (): OuraWebhookApiDeps => ({
+    callbackUrl: 'https://example.com/webhooks/oura',
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    verificationToken: 'test-verification-token',
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('listSubscriptions', () => {
+    test('returns list of subscriptions from Oura API', async () => {
+      const subscriptions = [
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          expiration_time: '2026-03-01T00:00:00Z',
+          id: 'sub-1',
+          verification_token: 'test-verification-token',
+        },
+      ]
+      mockedAxios.get = vi.fn().mockResolvedValue({ data: subscriptions })
+
+      const api = createOuraWebhookApi(createDeps())
+      const result = await api.listSubscriptions()
+
+      expect(result).toEqual(subscriptions)
+      expect(mockedAxios.get).toHaveBeenCalledWith('https://api.ouraring.com/v2/webhook/subscription', {
+        headers: {
+          'x-client-id': 'test-client-id',
+          'x-client-secret': 'test-client-secret',
+        },
+      })
+    })
+  })
+
+  describe('createSubscription', () => {
+    test('creates a subscription via Oura API', async () => {
+      const responseData = {
+        callback_url: 'https://example.com/webhooks/oura',
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        expiration_time: '2026-03-01T00:00:00Z',
+        id: 'sub-new',
+        verification_token: 'test-verification-token',
+      }
+      mockedAxios.post = vi.fn().mockResolvedValue({ data: responseData })
+
+      const api = createOuraWebhookApi(createDeps())
+      const result = await api.createSubscription('daily_sleep', 'create')
+
+      expect(result).toEqual(responseData)
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://api.ouraring.com/v2/webhook/subscription',
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          verification_token: 'test-verification-token',
+        },
+        {
+          headers: {
+            'x-client-id': 'test-client-id',
+            'x-client-secret': 'test-client-secret',
+          },
+        },
+      )
+    })
+  })
+
+  describe('renewSubscription', () => {
+    test('renews a subscription via Oura API', async () => {
+      const responseData = {
+        expiration_time: '2026-04-01T00:00:00Z',
+        id: 'sub-1',
+      }
+      mockedAxios.put = vi.fn().mockResolvedValue({ data: responseData })
+
+      const api = createOuraWebhookApi(createDeps())
+      const result = await api.renewSubscription('sub-1')
+
+      expect(result).toEqual(responseData)
+      expect(mockedAxios.put).toHaveBeenCalledWith(
+        'https://api.ouraring.com/v2/webhook/subscription/renew/sub-1',
+        undefined,
+        {
+          headers: {
+            'x-client-id': 'test-client-id',
+            'x-client-secret': 'test-client-secret',
+          },
+        },
+      )
+    })
+  })
+
+  describe('deleteSubscription', () => {
+    test('deletes a subscription via Oura API', async () => {
+      mockedAxios.delete = vi.fn().mockResolvedValue({ status: 204 })
+
+      const api = createOuraWebhookApi(createDeps())
+      await api.deleteSubscription('sub-1')
+
+      expect(mockedAxios.delete).toHaveBeenCalledWith(
+        'https://api.ouraring.com/v2/webhook/subscription/sub-1',
+        {
+          headers: {
+            'x-client-id': 'test-client-id',
+            'x-client-secret': 'test-client-secret',
+          },
+        },
+      )
+    })
+  })
+
+  describe('constants', () => {
+    test('OURA_DATA_TYPES contains all expected types', () => {
+      expect(OURA_DATA_TYPES).toEqual([
+        'daily_cardiovascular_age',
+        'daily_readiness',
+        'daily_resilience',
+        'daily_sleep',
+        'session',
+        'enhanced_tag',
+      ])
+    })
+
+    test('OURA_EVENT_TYPES contains create and update', () => {
+      expect(OURA_EVENT_TYPES).toEqual(['create', 'update'])
+    })
+  })
+})

--- a/apps/backend/src/oura-webhook-api.ts
+++ b/apps/backend/src/oura-webhook-api.ts
@@ -1,0 +1,103 @@
+/**
+ * HTTP client for Oura webhook subscription management.
+ *
+ * Uses x-client-id / x-client-secret headers (app-level auth, not per-user OAuth).
+ */
+
+import axios from 'axios'
+import type { OuraDataType } from './oura-sync'
+
+const OURA_WEBHOOK_BASE = 'https://api.ouraring.com/v2/webhook/subscription'
+
+/** Oura API data type identifiers used in webhook subscriptions */
+export const OURA_DATA_TYPES = [
+  'daily_cardiovascular_age',
+  'daily_readiness',
+  'daily_resilience',
+  'daily_sleep',
+  'session',
+  'enhanced_tag',
+] as const
+
+export type OuraWebhookDataType = (typeof OURA_DATA_TYPES)[number]
+
+export const OURA_EVENT_TYPES = ['create', 'update'] as const
+export type OuraEventType = (typeof OURA_EVENT_TYPES)[number]
+
+/** Map from Oura webhook data_type to our internal OuraDataType */
+export const ouraWebhookDataTypeMap: Record<OuraWebhookDataType, OuraDataType> = {
+  daily_cardiovascular_age: 'dailyCardiovascularAge',
+  daily_readiness: 'dailyReadiness',
+  daily_resilience: 'dailyResilience',
+  daily_sleep: 'dailySleep',
+  enhanced_tag: 'tags',
+  session: 'sessions',
+}
+
+export interface OuraSubscriptionResponse {
+  id: string
+  callback_url: string
+  data_type: string
+  event_type: string
+  expiration_time: string
+  verification_token: string
+}
+
+export interface OuraRenewResponse {
+  id: string
+  expiration_time: string
+}
+
+export interface OuraWebhookApiDeps {
+  clientId: string
+  clientSecret: string
+  callbackUrl: string
+  verificationToken: string
+}
+
+export interface OuraWebhookApi {
+  listSubscriptions: () => Promise<OuraSubscriptionResponse[]>
+  createSubscription: (
+    dataType: OuraWebhookDataType,
+    eventType: OuraEventType,
+  ) => Promise<OuraSubscriptionResponse>
+  renewSubscription: (subscriptionId: string) => Promise<OuraRenewResponse>
+  deleteSubscription: (subscriptionId: string) => Promise<void>
+}
+
+export const createOuraWebhookApi = (deps: OuraWebhookApiDeps): OuraWebhookApi => {
+  const headers = {
+    'x-client-id': deps.clientId,
+    'x-client-secret': deps.clientSecret,
+  }
+
+  return {
+    createSubscription: async (dataType, eventType) => {
+      const response = await axios.post(
+        OURA_WEBHOOK_BASE,
+        {
+          callback_url: deps.callbackUrl,
+          data_type: dataType,
+          event_type: eventType,
+          verification_token: deps.verificationToken,
+        },
+        { headers },
+      )
+      return response.data
+    },
+
+    deleteSubscription: async (subscriptionId) => {
+      await axios.delete(`${OURA_WEBHOOK_BASE}/${subscriptionId}`, { headers })
+    },
+
+    listSubscriptions: async () => {
+      const response = await axios.get(OURA_WEBHOOK_BASE, { headers })
+      return response.data
+    },
+
+    renewSubscription: async (subscriptionId) => {
+      const response = await axios.put(`${OURA_WEBHOOK_BASE}/renew/${subscriptionId}`, undefined, { headers })
+      return response.data
+    },
+  }
+}

--- a/apps/backend/src/oura-webhook-router.test.ts
+++ b/apps/backend/src/oura-webhook-router.test.ts
@@ -1,0 +1,179 @@
+import { json } from 'body-parser'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createOuraWebhookRouter, type OuraWebhookRouterDeps } from './oura-webhook-router'
+
+describe('oura-webhook-router', () => {
+  const createDeps = (): OuraWebhookRouterDeps => ({
+    getUsernameByOuraUserId: vi.fn().mockResolvedValue('testuser'),
+    syncOuraDataTypeForUser: vi.fn().mockResolvedValue(undefined),
+    verificationToken: 'test-verification-token',
+  })
+
+  const createApp = (deps: OuraWebhookRouterDeps) => {
+    const app = express()
+    app.use(json())
+    app.use('/webhooks/oura', createOuraWebhookRouter(deps))
+    return app
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  describe('POST /webhooks/oura - notification handling', () => {
+    test('returns 200 and triggers sync for valid notification', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const response = await request(app).post('/webhooks/oura').send({
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        user_id: 'oura-user-123',
+        verification_token: 'test-verification-token',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({ status: 'ok' })
+      expect(deps.getUsernameByOuraUserId).toHaveBeenCalledWith('oura-user-123')
+
+      // Sync is debounced, advance timer
+      await vi.advanceTimersByTimeAsync(5000)
+
+      expect(deps.syncOuraDataTypeForUser).toHaveBeenCalledWith('testuser', 'dailySleep')
+    })
+
+    test('returns 200 but skips sync for unknown data type', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const response = await request(app).post('/webhooks/oura').send({
+        data_type: 'unknown_type',
+        event_type: 'create',
+        user_id: 'oura-user-123',
+        verification_token: 'test-verification-token',
+      })
+
+      expect(response.status).toBe(200)
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(deps.syncOuraDataTypeForUser).not.toHaveBeenCalled()
+    })
+
+    test('returns 200 but skips sync for unknown user', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.getUsernameByOuraUserId).mockResolvedValue(null)
+      const app = createApp(deps)
+
+      const response = await request(app).post('/webhooks/oura').send({
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        user_id: 'unknown-user',
+        verification_token: 'test-verification-token',
+      })
+
+      expect(response.status).toBe(200)
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(deps.syncOuraDataTypeForUser).not.toHaveBeenCalled()
+    })
+
+    test('returns 403 for invalid verification token', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const response = await request(app).post('/webhooks/oura').send({
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        user_id: 'oura-user-123',
+        verification_token: 'wrong-token',
+      })
+
+      expect(response.status).toBe(403)
+    })
+
+    test('debounces multiple notifications for same user+dataType', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const body = {
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        user_id: 'oura-user-123',
+        verification_token: 'test-verification-token',
+      }
+
+      await request(app).post('/webhooks/oura').send(body)
+      await vi.advanceTimersByTimeAsync(2000)
+      await request(app).post('/webhooks/oura').send(body)
+      await vi.advanceTimersByTimeAsync(2000)
+      await request(app).post('/webhooks/oura').send(body)
+
+      // Not enough time passed since last notification
+      expect(deps.syncOuraDataTypeForUser).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(5000)
+
+      // Only one sync despite 3 notifications
+      expect(deps.syncOuraDataTypeForUser).toHaveBeenCalledTimes(1)
+    })
+
+    test('maps all known Oura data types correctly', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const dataTypeMappings: Array<[string, string]> = [
+        ['daily_cardiovascular_age', 'dailyCardiovascularAge'],
+        ['daily_readiness', 'dailyReadiness'],
+        ['daily_resilience', 'dailyResilience'],
+        ['daily_sleep', 'dailySleep'],
+        ['session', 'sessions'],
+        ['enhanced_tag', 'tags'],
+      ]
+
+      for (const [ouraType, expectedType] of dataTypeMappings) {
+        vi.mocked(deps.syncOuraDataTypeForUser).mockClear()
+
+        await request(app)
+          .post('/webhooks/oura')
+          .send({
+            data_type: ouraType,
+            event_type: 'create',
+            user_id: `user-${ouraType}`,
+            verification_token: 'test-verification-token',
+          })
+
+        await vi.advanceTimersByTimeAsync(5000)
+
+        expect(deps.syncOuraDataTypeForUser).toHaveBeenCalledWith('testuser', expectedType)
+      }
+    })
+  })
+
+  describe('cleanup', () => {
+    test('clearPendingWebhookSyncs cancels pending syncs', async () => {
+      const deps = createDeps()
+      const router = createOuraWebhookRouter(deps)
+      const app = express()
+      app.use(json())
+      app.use('/webhooks/oura', router)
+
+      await request(app).post('/webhooks/oura').send({
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        user_id: 'oura-user-123',
+        verification_token: 'test-verification-token',
+      })
+
+      router.clearPendingWebhookSyncs()
+
+      await vi.advanceTimersByTimeAsync(5000)
+
+      expect(deps.syncOuraDataTypeForUser).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/backend/src/oura-webhook-router.ts
+++ b/apps/backend/src/oura-webhook-router.ts
@@ -1,0 +1,85 @@
+/**
+ * Express router for Oura webhook callback endpoint.
+ *
+ * Receives push notifications from Oura when user data changes,
+ * then triggers a debounced sync for the affected user and data type.
+ */
+
+import { Router } from 'express'
+import type { OuraDataType } from './oura-sync'
+import { ouraWebhookDataTypeMap, type OuraWebhookDataType } from './oura-webhook-api'
+
+const DEBOUNCE_MS = 5000
+
+export interface OuraWebhookRouterDeps {
+  verificationToken: string
+  getUsernameByOuraUserId: (ouraUserId: string) => Promise<string | null>
+  syncOuraDataTypeForUser: (username: string, dataType: OuraDataType) => Promise<void>
+}
+
+export interface OuraWebhookRouter extends Router {
+  clearPendingWebhookSyncs: () => void
+}
+
+export const createOuraWebhookRouter = (deps: OuraWebhookRouterDeps): OuraWebhookRouter => {
+  const router = Router() as OuraWebhookRouter
+  const pendingSyncs = new Map<string, NodeJS.Timeout>()
+
+  const scheduleDebouncedSync = (username: string, dataType: OuraDataType): void => {
+    const key = `${username}:${dataType}`
+
+    const existing = pendingSyncs.get(key)
+    if (existing) {
+      clearTimeout(existing)
+    }
+
+    const timeout = setTimeout(() => {
+      pendingSyncs.delete(key)
+      deps.syncOuraDataTypeForUser(username, dataType).catch((error) => {
+        console.error(`Webhook-triggered sync failed for ${username}/${dataType}:`, error)
+      })
+    }, DEBOUNCE_MS)
+
+    pendingSyncs.set(key, timeout)
+  }
+
+  router.clearPendingWebhookSyncs = (): void => {
+    for (const timeout of pendingSyncs.values()) {
+      clearTimeout(timeout)
+    }
+    pendingSyncs.clear()
+  }
+
+  router.post('/', async (req, res) => {
+    const { data_type, event_type, user_id, verification_token } = req.body ?? {}
+
+    // Validate verification token
+    if (verification_token !== deps.verificationToken) {
+      res.status(403).json({ error: 'Invalid verification token' })
+      return
+    }
+
+    // Map Oura data type to our internal type
+    const ourDataType = ouraWebhookDataTypeMap[data_type as OuraWebhookDataType]
+    if (!ourDataType) {
+      console.log(`Oura webhook: ignoring unknown data_type=${data_type} event_type=${event_type}`)
+      res.json({ status: 'ok' })
+      return
+    }
+
+    // Look up local username from Oura user ID
+    const username = await deps.getUsernameByOuraUserId(user_id)
+    if (!username) {
+      console.log(`Oura webhook: ignoring unknown user_id=${user_id}`)
+      res.json({ status: 'ok' })
+      return
+    }
+
+    console.log(`Oura webhook: ${event_type} ${data_type} for user ${username}, scheduling sync`)
+    scheduleDebouncedSync(username, ourDataType)
+
+    res.json({ status: 'ok' })
+  })
+
+  return router
+}

--- a/apps/backend/src/oura.ts
+++ b/apps/backend/src/oura.ts
@@ -22,8 +22,12 @@ type OuraSession = {
   motion_count: unknown
 }
 
+export interface OuraClientOptions {
+  onUserAuthenticated?: (ouraUserId: string, username: string) => Promise<void>
+}
+
 // eslint-disable-next-line max-lines-per-function -- TODO: refactor
-export const ouraClient = (client: string, secret: string, webHost: string) => {
+export const ouraClient = (client: string, secret: string, webHost: string, options?: OuraClientOptions) => {
   if (!client || !secret) throw new Error('Oura missing client or secret')
   const redirectUri = `${webHost}/auth/ouracb`
 
@@ -34,6 +38,18 @@ export const ouraClient = (client: string, secret: string, webHost: string) => {
     )
     console.log(type, start, end, response.data)
     return response.data.data
+  }
+
+  const getPersonalInfo = async (accessToken: string): Promise<{ id: string } | null> => {
+    try {
+      const response = await axios.get('https://api.ouraring.com/v2/usercollection/personal_info', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+      return response.data
+    } catch (error) {
+      console.error('Failed to fetch Oura personal info:', error instanceof Error ? error.message : error)
+      return null
+    }
   }
 
   return {
@@ -72,6 +88,15 @@ export const ouraClient = (client: string, secret: string, webHost: string) => {
         refresh_token,
         scopes: scope ? scope.split(' ') : undefined,
       })
+
+      // Store Oura user ID mapping for webhook notifications
+      if (options?.onUserAuthenticated) {
+        const personalInfo = await getPersonalInfo(access_token)
+        if (personalInfo?.id) {
+          await options.onUserAuthenticated(personalInfo.id, user)
+          console.log(`Stored Oura user mapping: ${personalInfo.id} -> ${user}`)
+        }
+      }
 
       res.end()
     },

--- a/apps/backend/src/services/central-db.test.ts
+++ b/apps/backend/src/services/central-db.test.ts
@@ -258,4 +258,139 @@ describe('central-db', () => {
       expect(result).toEqual([])
     })
   })
+
+  describe('upsertOuraUserMapping', () => {
+    test('inserts oura user mapping', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.upsertOuraUserMapping('oura-123', 'testuser')
+
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO oura_user_mappings'),
+        ['oura-123', 'testuser'],
+      )
+    })
+  })
+
+  describe('getUsernameByOuraUserId', () => {
+    test('returns username when mapping exists', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ username: 'testuser' }] })
+
+      const result = await centralDb.getUsernameByOuraUserId('oura-123')
+
+      expect(result).toBe('testuser')
+      expect(mockClient.query).toHaveBeenCalledWith(
+        'SELECT username FROM oura_user_mappings WHERE oura_user_id = $1',
+        ['oura-123'],
+      )
+    })
+
+    test('returns null when mapping does not exist', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getUsernameByOuraUserId('unknown')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('deleteOuraUserMapping', () => {
+    test('returns true when mapping deleted', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 1 })
+
+      const result = await centralDb.deleteOuraUserMapping('oura-123')
+
+      expect(result).toBe(true)
+    })
+
+    test('returns false when mapping not found', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 0 })
+
+      const result = await centralDb.deleteOuraUserMapping('unknown')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('upsertOuraWebhookSubscription', () => {
+    test('inserts webhook subscription', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.upsertOuraWebhookSubscription({
+        callback_url: 'https://example.com/webhooks/oura',
+        data_type: 'daily_sleep',
+        event_type: 'create',
+        expiration_time: new Date('2026-03-01T00:00:00Z'),
+        oura_subscription_id: 'sub-1',
+      })
+
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO oura_webhook_subscriptions'),
+        [
+          'sub-1',
+          'daily_sleep',
+          'create',
+          'https://example.com/webhooks/oura',
+          new Date('2026-03-01T00:00:00Z'),
+        ],
+      )
+    })
+  })
+
+  describe('getOuraWebhookSubscriptions', () => {
+    test('returns all subscriptions', async () => {
+      const rows = [
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          created_at: new Date(),
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          expiration_time: new Date(),
+          oura_subscription_id: 'sub-1',
+          updated_at: new Date(),
+        },
+      ]
+      mockClient.query.mockResolvedValue({ rows })
+
+      const result = await centralDb.getOuraWebhookSubscriptions()
+
+      expect(result).toEqual(rows)
+    })
+
+    test('returns empty array when no subscriptions', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getOuraWebhookSubscriptions()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('deleteOuraWebhookSubscription', () => {
+    test('returns true when subscription deleted', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 1 })
+
+      const result = await centralDb.deleteOuraWebhookSubscription('sub-1')
+
+      expect(result).toBe(true)
+    })
+
+    test('returns false when subscription not found', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 0 })
+
+      const result = await centralDb.deleteOuraWebhookSubscription('unknown')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('deleteAllOuraWebhookSubscriptions', () => {
+    test('returns count of deleted subscriptions', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 5 })
+
+      const result = await centralDb.deleteAllOuraWebhookSubscriptions()
+
+      expect(result).toBe(5)
+    })
+  })
 })

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -17,6 +17,24 @@ export type SignupMode = 'open' | 'invite_only' | 'closed'
 export interface ServerSettings {
   lastfm_api_key: string
   signup_mode: SignupMode
+  oura_webhook_verification_token: string
+}
+
+export interface OuraUserMapping {
+  oura_user_id: string
+  username: string
+  created_at: Date
+  updated_at: Date
+}
+
+export interface OuraWebhookSubscription {
+  oura_subscription_id: string
+  data_type: string
+  event_type: string
+  callback_url: string
+  expiration_time: Date | null
+  created_at: Date
+  updated_at: Date
 }
 
 export interface CentralDbDeps {
@@ -36,6 +54,15 @@ export interface CentralDb {
   removeAdmin: (username: string) => Promise<boolean>
   getAdminCount: () => Promise<number>
   getAdmins: () => Promise<string[]>
+  upsertOuraUserMapping: (ouraUserId: string, username: string) => Promise<void>
+  getUsernameByOuraUserId: (ouraUserId: string) => Promise<string | null>
+  deleteOuraUserMapping: (ouraUserId: string) => Promise<boolean>
+  upsertOuraWebhookSubscription: (
+    sub: Omit<OuraWebhookSubscription, 'created_at' | 'updated_at'>,
+  ) => Promise<void>
+  getOuraWebhookSubscriptions: () => Promise<OuraWebhookSubscription[]>
+  deleteOuraWebhookSubscription: (ouraSubscriptionId: string) => Promise<boolean>
+  deleteAllOuraWebhookSubscriptions: () => Promise<number>
 }
 
 // ============================================================================
@@ -111,6 +138,27 @@ const CREATE_ADMINS_TABLE = `
   )
 `
 
+const CREATE_OURA_USER_MAPPINGS_TABLE = `
+  CREATE TABLE IF NOT EXISTS oura_user_mappings (
+    oura_user_id VARCHAR(255) PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`
+
+const CREATE_OURA_WEBHOOK_SUBSCRIPTIONS_TABLE = `
+  CREATE TABLE IF NOT EXISTS oura_webhook_subscriptions (
+    oura_subscription_id VARCHAR(255) PRIMARY KEY,
+    data_type VARCHAR(100) NOT NULL,
+    event_type VARCHAR(20) NOT NULL,
+    callback_url TEXT NOT NULL,
+    expiration_time TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`
+
 // ============================================================================
 // Factory
 // ============================================================================
@@ -127,6 +175,29 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       await client.query(`INSERT INTO admins (username) VALUES ($1) ON CONFLICT (username) DO NOTHING`, [
         username,
       ])
+    },
+
+    deleteAllOuraWebhookSubscriptions: async (): Promise<number> => {
+      const client = await getClient()
+      const result = await client.query('DELETE FROM oura_webhook_subscriptions')
+      return result.rowCount ?? 0
+    },
+
+    deleteOuraUserMapping: async (ouraUserId: string): Promise<boolean> => {
+      const client = await getClient()
+      const result = await client.query('DELETE FROM oura_user_mappings WHERE oura_user_id = $1', [
+        ouraUserId,
+      ])
+      return (result.rowCount ?? 0) > 0
+    },
+
+    deleteOuraWebhookSubscription: async (ouraSubscriptionId: string): Promise<boolean> => {
+      const client = await getClient()
+      const result = await client.query(
+        'DELETE FROM oura_webhook_subscriptions WHERE oura_subscription_id = $1',
+        [ouraSubscriptionId],
+      )
+      return (result.rowCount ?? 0) > 0
     },
 
     getAdminCount: async (): Promise<number> => {
@@ -150,6 +221,14 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       return result.rows[0].value as string
     },
 
+    getOuraWebhookSubscriptions: async (): Promise<OuraWebhookSubscription[]> => {
+      const client = await getClient()
+      const result = await client.query(
+        'SELECT oura_subscription_id, data_type, event_type, callback_url, expiration_time, created_at, updated_at FROM oura_webhook_subscriptions ORDER BY created_at',
+      )
+      return result.rows
+    },
+
     getServerSetting: async <K extends keyof ServerSettings>(key: K): Promise<ServerSettings[K] | null> => {
       const client = await getClient()
       const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [key])
@@ -164,10 +243,21 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       return result.rows[0].value as SignupMode
     },
 
+    getUsernameByOuraUserId: async (ouraUserId: string): Promise<string | null> => {
+      const client = await getClient()
+      const result = await client.query('SELECT username FROM oura_user_mappings WHERE oura_user_id = $1', [
+        ouraUserId,
+      ])
+      if (result.rows.length === 0) return null
+      return result.rows[0].username
+    },
+
     initializeCentralDb: async () => {
       const client = await getClient()
       await client.query(CREATE_SERVER_SETTINGS_TABLE)
       await client.query(CREATE_ADMINS_TABLE)
+      await client.query(CREATE_OURA_USER_MAPPINGS_TABLE)
+      await client.query(CREATE_OURA_WEBHOOK_SUBSCRIPTIONS_TABLE)
 
       // Set default signup_mode if not exists
       await client.query(
@@ -223,6 +313,29 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
          VALUES ('signup_mode', $1, NOW())
          ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
         [JSON.stringify(mode)],
+      )
+    },
+
+    upsertOuraUserMapping: async (ouraUserId: string, username: string): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO oura_user_mappings (oura_user_id, username, updated_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (oura_user_id) DO UPDATE SET username = $2, updated_at = NOW()`,
+        [ouraUserId, username],
+      )
+    },
+
+    upsertOuraWebhookSubscription: async (
+      sub: Omit<OuraWebhookSubscription, 'created_at' | 'updated_at'>,
+    ): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO oura_webhook_subscriptions (oura_subscription_id, data_type, event_type, callback_url, expiration_time, updated_at)
+         VALUES ($1, $2, $3, $4, $5, NOW())
+         ON CONFLICT (oura_subscription_id) DO UPDATE SET
+           data_type = $2, event_type = $3, callback_url = $4, expiration_time = $5, updated_at = NOW()`,
+        [sub.oura_subscription_id, sub.data_type, sub.event_type, sub.callback_url, sub.expiration_time],
       )
     },
   }

--- a/apps/backend/src/services/oura-webhook-service.test.ts
+++ b/apps/backend/src/services/oura-webhook-service.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  createOuraWebhookService,
+  DESIRED_SUBSCRIPTIONS_COUNT,
+  type OuraWebhookServiceDeps,
+} from './oura-webhook-service'
+
+describe('oura-webhook-service', () => {
+  const createDeps = (): OuraWebhookServiceDeps => ({
+    createSubscription: vi.fn().mockResolvedValue({
+      callback_url: 'https://example.com/webhooks/oura',
+      data_type: 'daily_sleep',
+      event_type: 'create',
+      expiration_time: '2026-03-15T00:00:00Z',
+      id: 'new-sub-id',
+    }),
+    deleteLocalSubscription: vi.fn().mockResolvedValue(true),
+    deleteRemoteSubscription: vi.fn().mockResolvedValue(undefined),
+    getLocalSubscriptions: vi.fn().mockResolvedValue([]),
+    listRemoteSubscriptions: vi.fn().mockResolvedValue([]),
+    renewSubscription: vi.fn().mockResolvedValue({
+      expiration_time: '2026-04-15T00:00:00Z',
+      id: 'sub-1',
+    }),
+    upsertLocalSubscription: vi.fn().mockResolvedValue(undefined),
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-15T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  describe('initSubscriptions', () => {
+    test('creates all missing subscriptions when none exist remotely', async () => {
+      const deps = createDeps()
+      const service = createOuraWebhookService(deps)
+
+      await service.initSubscriptions()
+
+      // 6 data types * 2 event types = 12 subscriptions
+      expect(deps.createSubscription).toHaveBeenCalledTimes(DESIRED_SUBSCRIPTIONS_COUNT)
+      expect(deps.upsertLocalSubscription).toHaveBeenCalledTimes(DESIRED_SUBSCRIPTIONS_COUNT)
+    })
+
+    test('skips creation when subscriptions already exist remotely', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.listRemoteSubscriptions).mockResolvedValue([
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          expiration_time: '2026-03-15T00:00:00Z',
+          id: 'existing-sub',
+          verification_token: 'token',
+        },
+      ])
+      const service = createOuraWebhookService(deps)
+
+      await service.initSubscriptions()
+
+      // Should create 11 (12 - 1 existing)
+      expect(deps.createSubscription).toHaveBeenCalledTimes(DESIRED_SUBSCRIPTIONS_COUNT - 1)
+      // Should upsert the existing one + the 11 new ones
+      expect(deps.upsertLocalSubscription).toHaveBeenCalledTimes(DESIRED_SUBSCRIPTIONS_COUNT)
+    })
+
+    test('handles API errors gracefully during creation', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.createSubscription).mockRejectedValue(new Error('API error'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const service = createOuraWebhookService(deps)
+
+      // Should not throw
+      await service.initSubscriptions()
+
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('renewExpiringSubscriptions', () => {
+    test('renews subscriptions expiring within 24 hours', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.getLocalSubscriptions).mockResolvedValue([
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          created_at: new Date('2026-02-01T00:00:00Z'),
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          // Expires in 12 hours — should be renewed
+          expiration_time: new Date('2026-02-16T00:00:00Z'),
+          oura_subscription_id: 'sub-1',
+          updated_at: new Date('2026-02-01T00:00:00Z'),
+        },
+      ])
+      const service = createOuraWebhookService(deps)
+
+      await service.renewExpiringSubscriptions()
+
+      expect(deps.renewSubscription).toHaveBeenCalledWith('sub-1')
+      expect(deps.upsertLocalSubscription).toHaveBeenCalled()
+    })
+
+    test('skips subscriptions not expiring soon', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.getLocalSubscriptions).mockResolvedValue([
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          created_at: new Date('2026-02-01T00:00:00Z'),
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          // Expires in 7 days — should NOT be renewed
+          expiration_time: new Date('2026-02-22T00:00:00Z'),
+          oura_subscription_id: 'sub-1',
+          updated_at: new Date('2026-02-01T00:00:00Z'),
+        },
+      ])
+      const service = createOuraWebhookService(deps)
+
+      await service.renewExpiringSubscriptions()
+
+      expect(deps.renewSubscription).not.toHaveBeenCalled()
+    })
+
+    test('skips subscriptions with null expiration_time', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.getLocalSubscriptions).mockResolvedValue([
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          created_at: new Date('2026-02-01T00:00:00Z'),
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          expiration_time: null,
+          oura_subscription_id: 'sub-1',
+          updated_at: new Date('2026-02-01T00:00:00Z'),
+        },
+      ])
+      const service = createOuraWebhookService(deps)
+
+      await service.renewExpiringSubscriptions()
+
+      expect(deps.renewSubscription).not.toHaveBeenCalled()
+    })
+
+    test('handles renewal errors gracefully', async () => {
+      const deps = createDeps()
+      vi.mocked(deps.getLocalSubscriptions).mockResolvedValue([
+        {
+          callback_url: 'https://example.com/webhooks/oura',
+          created_at: new Date('2026-02-01T00:00:00Z'),
+          data_type: 'daily_sleep',
+          event_type: 'create',
+          expiration_time: new Date('2026-02-16T00:00:00Z'),
+          oura_subscription_id: 'sub-1',
+          updated_at: new Date('2026-02-01T00:00:00Z'),
+        },
+      ])
+      vi.mocked(deps.renewSubscription).mockRejectedValue(new Error('Renewal failed'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const service = createOuraWebhookService(deps)
+
+      await service.renewExpiringSubscriptions()
+
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('startRenewalTimer / stopRenewalTimer', () => {
+    test('starts and stops periodic renewal timer', () => {
+      const deps = createDeps()
+      const service = createOuraWebhookService(deps)
+
+      service.startRenewalTimer()
+
+      // Advance 12 hours
+      vi.advanceTimersByTime(12 * 60 * 60 * 1000)
+
+      expect(deps.getLocalSubscriptions).toHaveBeenCalled()
+
+      service.stopRenewalTimer()
+
+      vi.mocked(deps.getLocalSubscriptions).mockClear()
+      vi.advanceTimersByTime(12 * 60 * 60 * 1000)
+
+      // Should not have been called again after stopping
+      expect(deps.getLocalSubscriptions).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/backend/src/services/oura-webhook-service.ts
+++ b/apps/backend/src/services/oura-webhook-service.ts
@@ -1,0 +1,143 @@
+/**
+ * Oura webhook subscription lifecycle management.
+ *
+ * Handles: initial subscription creation, periodic renewal, and cleanup.
+ */
+
+import { addHours, isBefore } from 'date-fns'
+import {
+  OURA_DATA_TYPES,
+  OURA_EVENT_TYPES,
+  type OuraEventType,
+  type OuraRenewResponse,
+  type OuraSubscriptionResponse,
+  type OuraWebhookDataType,
+} from '../oura-webhook-api'
+import type { OuraWebhookSubscription } from './central-db'
+
+const RENEWAL_INTERVAL_MS = 12 * 60 * 60 * 1000 // 12 hours
+const RENEWAL_THRESHOLD_HOURS = 24
+
+/** Total expected subscriptions: 6 data types * 2 event types */
+export const DESIRED_SUBSCRIPTIONS_COUNT = OURA_DATA_TYPES.length * OURA_EVENT_TYPES.length
+
+export interface OuraWebhookServiceDeps {
+  listRemoteSubscriptions: () => Promise<OuraSubscriptionResponse[]>
+  createSubscription: (
+    dataType: OuraWebhookDataType,
+    eventType: OuraEventType,
+  ) => Promise<OuraSubscriptionResponse>
+  renewSubscription: (subscriptionId: string) => Promise<OuraRenewResponse>
+  deleteRemoteSubscription: (subscriptionId: string) => Promise<void>
+  getLocalSubscriptions: () => Promise<OuraWebhookSubscription[]>
+  upsertLocalSubscription: (sub: Omit<OuraWebhookSubscription, 'created_at' | 'updated_at'>) => Promise<void>
+  deleteLocalSubscription: (ouraSubscriptionId: string) => Promise<boolean>
+}
+
+export interface OuraWebhookService {
+  initSubscriptions: () => Promise<void>
+  renewExpiringSubscriptions: () => Promise<void>
+  startRenewalTimer: () => void
+  stopRenewalTimer: () => void
+}
+
+export const createOuraWebhookService = (deps: OuraWebhookServiceDeps): OuraWebhookService => {
+  let renewalTimer: NodeJS.Timeout | null = null
+
+  const initSubscriptions = async (): Promise<void> => {
+    console.log('Oura webhook: initializing subscriptions...')
+
+    // Get existing remote subscriptions
+    let remoteSubscriptions: OuraSubscriptionResponse[] = []
+    try {
+      remoteSubscriptions = await deps.listRemoteSubscriptions()
+      console.log(`Oura webhook: found ${remoteSubscriptions.length} existing remote subscriptions`)
+    } catch (error) {
+      console.error('Oura webhook: failed to list remote subscriptions:', error)
+    }
+
+    // Build set of existing (data_type, event_type) pairs
+    const existingPairs = new Set(remoteSubscriptions.map((s) => `${s.data_type}:${s.event_type}`))
+
+    // Upsert existing subscriptions to local DB
+    for (const sub of remoteSubscriptions) {
+      await deps.upsertLocalSubscription({
+        callback_url: sub.callback_url,
+        data_type: sub.data_type,
+        event_type: sub.event_type,
+        expiration_time: sub.expiration_time ? new Date(sub.expiration_time) : null,
+        oura_subscription_id: sub.id,
+      })
+    }
+
+    // Create missing subscriptions
+    for (const dataType of OURA_DATA_TYPES) {
+      for (const eventType of OURA_EVENT_TYPES) {
+        const key = `${dataType}:${eventType}`
+        if (existingPairs.has(key)) continue
+
+        try {
+          const created = await deps.createSubscription(dataType, eventType)
+          await deps.upsertLocalSubscription({
+            callback_url: created.callback_url,
+            data_type: created.data_type,
+            event_type: created.event_type,
+            expiration_time: created.expiration_time ? new Date(created.expiration_time) : null,
+            oura_subscription_id: created.id,
+          })
+          console.log(`Oura webhook: created subscription for ${dataType}/${eventType} (id=${created.id})`)
+        } catch (error) {
+          console.error(`Oura webhook: failed to create subscription for ${dataType}/${eventType}:`, error)
+        }
+      }
+    }
+
+    console.log('Oura webhook: subscription initialization complete')
+  }
+
+  const renewExpiringSubscriptions = async (): Promise<void> => {
+    const localSubscriptions = await deps.getLocalSubscriptions()
+    const renewalThreshold = addHours(new Date(), RENEWAL_THRESHOLD_HOURS)
+
+    for (const sub of localSubscriptions) {
+      if (!sub.expiration_time) continue
+      if (!isBefore(sub.expiration_time, renewalThreshold)) continue
+
+      try {
+        const renewed = await deps.renewSubscription(sub.oura_subscription_id)
+        await deps.upsertLocalSubscription({
+          ...sub,
+          expiration_time: renewed.expiration_time ? new Date(renewed.expiration_time) : null,
+        })
+        console.log(`Oura webhook: renewed subscription ${sub.oura_subscription_id}`)
+      } catch (error) {
+        console.error(`Oura webhook: failed to renew subscription ${sub.oura_subscription_id}:`, error)
+      }
+    }
+  }
+
+  const startRenewalTimer = (): void => {
+    if (renewalTimer) return
+    renewalTimer = setInterval(() => {
+      renewExpiringSubscriptions().catch((error) => {
+        console.error('Oura webhook: renewal timer error:', error)
+      })
+    }, RENEWAL_INTERVAL_MS)
+    console.log('Oura webhook: renewal timer started (every 12h)')
+  }
+
+  const stopRenewalTimer = (): void => {
+    if (renewalTimer) {
+      clearInterval(renewalTimer)
+      renewalTimer = null
+      console.log('Oura webhook: renewal timer stopped')
+    }
+  }
+
+  return {
+    initSubscriptions,
+    renewExpiringSubscriptions,
+    startRenewalTimer,
+    stopRenewalTimer,
+  }
+}


### PR DESCRIPTION
## Summary

- Implements opt-in Oura webhook push notifications for near-real-time data sync
- When `OURA_WEBHOOK_URL` is set, Oura pushes data change events instead of relying solely on pull sync
- Uses notification-then-fetch pattern: Oura notifies us, we fetch using existing `syncOuraDataType()`
- No changes to existing pull sync — both coexist seamlessly

## Changes

- **Central DB**: New `oura_user_mappings` and `oura_webhook_subscriptions` tables with CRUD
- **OAuth callback**: Captures Oura user ID after token exchange for webhook user mapping
- **Webhook API client** (`oura-webhook-api.ts`): HTTP client for subscription CRUD using `x-client-id`/`x-client-secret`
- **Webhook router** (`oura-webhook-router.ts`): `POST /webhooks/oura` endpoint with verification + debounced sync
- **Subscription service** (`oura-webhook-service.ts`): Lifecycle management (init, 12h renewal timer, graceful cleanup)
- **api.ts**: Conditional wiring when `OURA_WEBHOOK_URL` env var is set

## Test plan

- [x] All 45 backend test files pass (732 tests)
- [x] `pnpm fix` and `pnpm check` pass (0 errors)
- [x] New unit tests for all 3 new modules (21 tests total)
- [x] Existing central-db tests updated for new CRUD methods
- [ ] Manual: set `OURA_WEBHOOK_URL`, verify subscription creation in logs
- [ ] Manual: connect Oura account, verify user mapping stored
- [ ] Manual: trigger Oura data change, verify webhook sync

🤖 Generated with [Claude Code](https://claude.ai/code)