### PR TITLE
Add Oura webhook push with admin toggle

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -367,18 +367,19 @@ const main = async () => {
       ouraClientId,
       ouraClientSecret,
       syncOuraDataTypeForUser,
+      webHost,
     })
 
     // Mount proxy handler (delegates to inner router when enabled, 404 when disabled)
     httpd.use('/webhooks/oura', (req, res, next) => ouraWebhookManager!.handleWebhookRequest(req, res, next))
 
-    // Enable from stored URL if previously configured
-    const storedWebhookUrl = await centralDb.getOuraWebhookUrl()
-    if (storedWebhookUrl) {
+    // Enable if previously configured and host supports it
+    const webhookEnabled = await centralDb.getOuraWebhookEnabled()
+    if (webhookEnabled && ouraWebhookManager.canEnable()) {
       try {
-        await ouraWebhookManager.enable(storedWebhookUrl)
+        await ouraWebhookManager.enable()
       } catch (error) {
-        console.error('Oura webhook: failed to enable from stored URL:', error)
+        console.error('Oura webhook: failed to enable on startup:', error)
       }
     }
   }

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -36,11 +36,12 @@ export const createAdminRouter = (
       const signupMode = await centralDb.getSignupMode()
       const adminCount = await centralDb.getAdminCount()
       const lastFmApiKey = await centralDb.getLastFmApiKey()
-      const ouraWebhookUrl = await centralDb.getOuraWebhookUrl()
+      const ouraWebhookEnabled = await centralDb.getOuraWebhookEnabled()
       res.json({
         admin_count: adminCount,
         lastfm_api_key_set: !!lastFmApiKey,
-        oura_webhook_url: ouraWebhookUrl,
+        oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
+        oura_webhook_enabled: ouraWebhookEnabled,
         signup_mode: signupMode,
         success: true,
       })
@@ -54,18 +55,18 @@ export const createAdminRouter = (
     adminMiddleware,
     validateBody(updateAdminSettingsBodySchema),
     async (req, res) => {
-      const { lastfm_api_key, oura_webhook_url, signup_mode } = req.body
+      const { lastfm_api_key, oura_webhook_enabled, signup_mode } = req.body
       if (signup_mode) {
         await centralDb.setSignupMode(signup_mode)
       }
       if (lastfm_api_key !== undefined) {
         await centralDb.setLastFmApiKey(lastfm_api_key)
       }
-      if (oura_webhook_url !== undefined) {
-        await centralDb.setOuraWebhookUrl(oura_webhook_url)
+      if (oura_webhook_enabled !== undefined) {
+        await centralDb.setOuraWebhookEnabled(oura_webhook_enabled)
         if (ouraWebhookManager) {
-          if (oura_webhook_url) {
-            await ouraWebhookManager.enable(oura_webhook_url)
+          if (oura_webhook_enabled) {
+            await ouraWebhookManager.enable()
           } else {
             await ouraWebhookManager.disable()
           }
@@ -74,11 +75,12 @@ export const createAdminRouter = (
       const currentMode = await centralDb.getSignupMode()
       const adminCount = await centralDb.getAdminCount()
       const lastFmApiKey = await centralDb.getLastFmApiKey()
-      const ouraWebhookUrl = await centralDb.getOuraWebhookUrl()
+      const ouraWebhookEnabledValue = await centralDb.getOuraWebhookEnabled()
       res.json({
         admin_count: adminCount,
         lastfm_api_key_set: !!lastFmApiKey,
-        oura_webhook_url: ouraWebhookUrl,
+        oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
+        oura_webhook_enabled: ouraWebhookEnabledValue,
         signup_mode: currentMode,
         success: true,
       })

--- a/apps/backend/src/services/central-db.test.ts
+++ b/apps/backend/src/services/central-db.test.ts
@@ -259,45 +259,45 @@ describe('central-db', () => {
     })
   })
 
-  describe('getOuraWebhookUrl', () => {
-    test('returns URL when set', async () => {
-      mockClient.query.mockResolvedValue({ rows: [{ value: 'https://example.com/webhooks/oura' }] })
+  describe('getOuraWebhookEnabled', () => {
+    test('returns true when enabled', async () => {
+      mockClient.query.mockResolvedValue({ rows: [{ value: true }] })
 
-      const result = await centralDb.getOuraWebhookUrl()
+      const result = await centralDb.getOuraWebhookEnabled()
 
-      expect(result).toBe('https://example.com/webhooks/oura')
+      expect(result).toBe(true)
       expect(mockClient.query).toHaveBeenCalledWith('SELECT value FROM server_settings WHERE key = $1', [
-        'oura_webhook_url',
+        'oura_webhook_enabled',
       ])
     })
 
-    test('returns null when not set', async () => {
+    test('returns false when not set', async () => {
       mockClient.query.mockResolvedValue({ rows: [] })
 
-      const result = await centralDb.getOuraWebhookUrl()
+      const result = await centralDb.getOuraWebhookEnabled()
 
-      expect(result).toBeNull()
+      expect(result).toBe(false)
     })
   })
 
-  describe('setOuraWebhookUrl', () => {
-    test('stores URL', async () => {
+  describe('setOuraWebhookEnabled', () => {
+    test('stores enabled state', async () => {
       mockClient.query.mockResolvedValue({ rows: [] })
 
-      await centralDb.setOuraWebhookUrl('https://example.com/webhooks/oura')
+      await centralDb.setOuraWebhookEnabled(true)
 
       expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO server_settings'), [
-        JSON.stringify('https://example.com/webhooks/oura'),
+        JSON.stringify(true),
       ])
     })
 
-    test('deletes URL when set to null', async () => {
+    test('stores disabled state', async () => {
       mockClient.query.mockResolvedValue({ rows: [] })
 
-      await centralDb.setOuraWebhookUrl(null)
+      await centralDb.setOuraWebhookEnabled(false)
 
-      expect(mockClient.query).toHaveBeenCalledWith('DELETE FROM server_settings WHERE key = $1', [
-        'oura_webhook_url',
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO server_settings'), [
+        JSON.stringify(false),
       ])
     })
   })

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -16,7 +16,7 @@ export type SignupMode = 'open' | 'invite_only' | 'closed'
 
 export interface ServerSettings {
   lastfm_api_key: string
-  oura_webhook_url: string
+  oura_webhook_enabled: boolean
   oura_webhook_verification_token: string
   signup_mode: SignupMode
 }
@@ -55,8 +55,8 @@ export interface CentralDb {
   removeAdmin: (username: string) => Promise<boolean>
   getAdminCount: () => Promise<number>
   getAdmins: () => Promise<string[]>
-  getOuraWebhookUrl: () => Promise<string | null>
-  setOuraWebhookUrl: (url: string | null) => Promise<void>
+  getOuraWebhookEnabled: () => Promise<boolean>
+  setOuraWebhookEnabled: (enabled: boolean) => Promise<void>
   upsertOuraUserMapping: (ouraUserId: string, username: string) => Promise<void>
   getUsernameByOuraUserId: (ouraUserId: string) => Promise<string | null>
   deleteOuraUserMapping: (ouraUserId: string) => Promise<boolean>
@@ -224,21 +224,21 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       return result.rows[0].value as string
     },
 
+    getOuraWebhookEnabled: async (): Promise<boolean> => {
+      const client = await getClient()
+      const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [
+        'oura_webhook_enabled',
+      ])
+      if (result.rows.length === 0) return false
+      return result.rows[0].value as boolean
+    },
+
     getOuraWebhookSubscriptions: async (): Promise<OuraWebhookSubscription[]> => {
       const client = await getClient()
       const result = await client.query(
         'SELECT oura_subscription_id, data_type, event_type, callback_url, expiration_time, created_at, updated_at FROM oura_webhook_subscriptions ORDER BY created_at',
       )
       return result.rows
-    },
-
-    getOuraWebhookUrl: async (): Promise<string | null> => {
-      const client = await getClient()
-      const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [
-        'oura_webhook_url',
-      ])
-      if (result.rows.length === 0) return null
-      return result.rows[0].value as string
     },
 
     getServerSetting: async <K extends keyof ServerSettings>(key: K): Promise<ServerSettings[K] | null> => {
@@ -305,18 +305,14 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       }
     },
 
-    setOuraWebhookUrl: async (url: string | null): Promise<void> => {
+    setOuraWebhookEnabled: async (enabled: boolean): Promise<void> => {
       const client = await getClient()
-      if (url === null) {
-        await client.query('DELETE FROM server_settings WHERE key = $1', ['oura_webhook_url'])
-      } else {
-        await client.query(
-          `INSERT INTO server_settings (key, value, updated_at)
-           VALUES ('oura_webhook_url', $1, NOW())
-           ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
-          [JSON.stringify(url)],
-        )
-      }
+      await client.query(
+        `INSERT INTO server_settings (key, value, updated_at)
+         VALUES ('oura_webhook_enabled', $1, NOW())
+         ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+        [JSON.stringify(enabled)],
+      )
     },
 
     setServerSetting: async <K extends keyof ServerSettings>(

--- a/apps/backend/src/services/oura-webhook-manager.test.ts
+++ b/apps/backend/src/services/oura-webhook-manager.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createOuraWebhookManager, type OuraWebhookManagerDeps } from './oura-webhook-manager'
 
 describe('oura-webhook-manager', () => {
-  const createDeps = (): OuraWebhookManagerDeps => ({
+  const createDeps = (webHost = 'https://example.com'): OuraWebhookManagerDeps => ({
     centralDb: {
       deleteAllOuraWebhookSubscriptions: vi.fn().mockResolvedValue(0),
       deleteOuraWebhookSubscription: vi.fn().mockResolvedValue(true),
@@ -15,6 +15,7 @@ describe('oura-webhook-manager', () => {
     ouraClientId: 'test-client-id',
     ouraClientSecret: 'test-client-secret',
     syncOuraDataTypeForUser: vi.fn().mockResolvedValue(undefined),
+    webHost,
   })
 
   beforeEach(() => {
@@ -26,13 +27,30 @@ describe('oura-webhook-manager', () => {
     vi.clearAllMocks()
   })
 
+  describe('canEnable', () => {
+    test('returns true for HTTPS host', () => {
+      const manager = createOuraWebhookManager(createDeps('https://aurboda.net'))
+      expect(manager.canEnable()).toBe(true)
+    })
+
+    test('returns false for HTTP host', () => {
+      const manager = createOuraWebhookManager(createDeps('http://localhost:5173'))
+      expect(manager.canEnable()).toBe(false)
+    })
+
+    test('returns false for invalid URL', () => {
+      const manager = createOuraWebhookManager(createDeps('not-a-url'))
+      expect(manager.canEnable()).toBe(false)
+    })
+  })
+
   describe('enable', () => {
     test('creates router and service, initializes subscriptions', async () => {
       const deps = createDeps()
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const manager = createOuraWebhookManager(deps)
 
-      await manager.enable('https://example.com/webhooks/oura')
+      await manager.enable()
 
       expect(manager.isEnabled()).toBe(true)
       consoleSpy.mockRestore()
@@ -43,7 +61,7 @@ describe('oura-webhook-manager', () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const manager = createOuraWebhookManager(deps)
 
-      await manager.enable('https://example.com/webhooks/oura')
+      await manager.enable()
 
       expect(deps.centralDb.getServerSetting).toHaveBeenCalledWith('oura_webhook_verification_token')
       // Should NOT generate a new token since one exists
@@ -60,7 +78,7 @@ describe('oura-webhook-manager', () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const manager = createOuraWebhookManager(deps)
 
-      await manager.enable('https://example.com/webhooks/oura')
+      await manager.enable()
 
       expect(deps.centralDb.setServerSetting).toHaveBeenCalledWith(
         'oura_webhook_verification_token',
@@ -76,7 +94,7 @@ describe('oura-webhook-manager', () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const manager = createOuraWebhookManager(deps)
 
-      await manager.enable('https://example.com/webhooks/oura')
+      await manager.enable()
       expect(manager.isEnabled()).toBe(true)
 
       await manager.disable()
@@ -118,7 +136,7 @@ describe('oura-webhook-manager', () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const manager = createOuraWebhookManager(deps)
 
-      await manager.enable('https://example.com/webhooks/oura')
+      await manager.enable()
       manager.shutdown()
 
       expect(manager.isEnabled()).toBe(false)

--- a/apps/backend/src/services/oura-webhook-manager.ts
+++ b/apps/backend/src/services/oura-webhook-manager.ts
@@ -31,10 +31,12 @@ export interface OuraWebhookManagerDeps {
   ouraClientId: string
   ouraClientSecret: string
   syncOuraDataTypeForUser: (username: string, dataType: OuraDataType) => Promise<void>
+  webHost: string
 }
 
 export interface OuraWebhookManager {
-  enable: (callbackUrl: string) => Promise<void>
+  canEnable: () => boolean
+  enable: () => Promise<void>
   disable: () => Promise<void>
   isEnabled: () => boolean
   handleWebhookRequest: (req: Request, res: Response, next: NextFunction) => void
@@ -46,7 +48,18 @@ export const createOuraWebhookManager = (deps: OuraWebhookManagerDeps): OuraWebh
   let webhookService: OuraWebhookService | null = null
   let enabled = false
 
-  const enable = async (callbackUrl: string): Promise<void> => {
+  const callbackUrl = `${deps.webHost}/api/webhooks/oura`
+
+  const canEnable = (): boolean => {
+    try {
+      const url = new URL(deps.webHost)
+      return url.protocol === 'https:'
+    } catch {
+      return false
+    }
+  }
+
+  const enable = async (): Promise<void> => {
     // Disable first if already enabled (clean swap)
     if (enabled) {
       await disable()
@@ -143,6 +156,7 @@ export const createOuraWebhookManager = (deps: OuraWebhookManagerDeps): OuraWebh
   }
 
   return {
+    canEnable,
     disable,
     enable,
     handleWebhookRequest,

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -66,7 +66,6 @@ export function AdminSettings() {
   const [lastfmSaveStatus, setLastfmSaveStatus] = useState<SaveStatus>({ status: 'idle' })
   const [lastfmApiKey, setLastfmApiKey] = useState('')
   const [ouraWebhookSaveStatus, setOuraWebhookSaveStatus] = useState<SaveStatus>({ status: 'idle' })
-  const [ouraWebhookUrl, setOuraWebhookUrl] = useState('')
   const [invitation, setInvitation] = useState<InvitationResult | null>(null)
   const [invitationLoading, setInvitationLoading] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -120,13 +119,12 @@ export function AdminSettings() {
     }
   }, [queryClient])
 
-  const handleOuraWebhookUrlBlur = useCallback(async () => {
-    if (!ouraWebhookUrl) return
+  const handleOuraWebhookToggle = useCallback(async () => {
+    const newValue = !settings?.oura_webhook_enabled
     setOuraWebhookSaveStatus({ status: 'saving' })
     try {
-      const result = await updateAdminSettings({ oura_webhook_url: ouraWebhookUrl })
+      const result = await updateAdminSettings({ oura_webhook_enabled: newValue })
       queryClient.setQueryData(['adminSettings'], result)
-      setOuraWebhookUrl('')
       setOuraWebhookSaveStatus({ status: 'saved', time: new Date() })
     } catch (err) {
       setOuraWebhookSaveStatus({
@@ -134,22 +132,7 @@ export function AdminSettings() {
         status: 'error',
       })
     }
-  }, [ouraWebhookUrl, queryClient])
-
-  const handleClearOuraWebhookUrl = useCallback(async () => {
-    setOuraWebhookSaveStatus({ status: 'saving' })
-    try {
-      const result = await updateAdminSettings({ oura_webhook_url: null })
-      queryClient.setQueryData(['adminSettings'], result)
-      setOuraWebhookUrl('')
-      setOuraWebhookSaveStatus({ status: 'saved', time: new Date() })
-    } catch (err) {
-      setOuraWebhookSaveStatus({
-        error: err instanceof Error ? err.message : 'Failed to save',
-        status: 'error',
-      })
-    }
-  }, [queryClient])
+  }, [settings?.oura_webhook_enabled, queryClient])
 
   const handleGenerateInvitation = useCallback(async () => {
     setInvitationLoading(true)
@@ -265,38 +248,26 @@ export function AdminSettings() {
           </p>
         </div>
 
-        <div class="form-field">
-          <div class="section-header-row">
-            <label for="oura-webhook-url">Oura Webhook URL</label>
-            <SaveStatusIndicator saveStatus={ouraWebhookSaveStatus} />
+        {settings?.oura_webhook_available && (
+          <div class="form-field">
+            <div class="section-header-row">
+              <label for="oura-webhook-toggle">Oura Webhook Push</label>
+              <SaveStatusIndicator saveStatus={ouraWebhookSaveStatus} />
+            </div>
+            <label class="toggle-row">
+              <input
+                id="oura-webhook-toggle"
+                type="checkbox"
+                checked={settings?.oura_webhook_enabled ?? false}
+                onChange={handleOuraWebhookToggle}
+              />
+              <span>{settings?.oura_webhook_enabled ? 'Enabled' : 'Disabled'}</span>
+            </label>
+            <p class="field-description">
+              Enable near-real-time data sync from Oura via webhook push notifications.
+            </p>
           </div>
-          {settings?.oura_webhook_url ?
-            <p class="connected-status">Enabled</p>
-          : null}
-          <div class="api-key-input-row">
-            <input
-              id="oura-webhook-url"
-              type="text"
-              value={ouraWebhookUrl}
-              onInput={(e) => setOuraWebhookUrl((e.target as HTMLInputElement).value)}
-              onBlur={handleOuraWebhookUrlBlur}
-              placeholder={
-                settings?.oura_webhook_url ? 'Enter new URL to update' : (
-                  'https://yourdomain.com/api/webhooks/oura'
-                )
-              }
-            />
-            {settings?.oura_webhook_url && (
-              <button type="button" class="clear-button" onClick={handleClearOuraWebhookUrl}>
-                Disable
-              </button>
-            )}
-          </div>
-          <p class="field-description">
-            Webhook callback URL for near-real-time Oura data sync. Requires Oura client credentials to be
-            configured on the server. Saves automatically when you leave the field.
-          </p>
-        </div>
+        )}
       </section>
 
       {settings?.signup_mode === 'invite_only' && (

--- a/apps/web/src/pages/AdminSettings/style.css
+++ b/apps/web/src/pages/AdminSettings/style.css
@@ -127,6 +127,20 @@
   background: #d32f2f;
 }
 
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.toggle-row input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+  cursor: pointer;
+}
+
 .generate-button {
   padding: 0.75rem 1.5rem;
   font-size: 1rem;

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -413,7 +413,8 @@ export interface AdminSettings {
   signup_mode: SignupMode
   admin_count: number
   lastfm_api_key_set: boolean
-  oura_webhook_url: string | null
+  oura_webhook_available: boolean
+  oura_webhook_enabled: boolean
 }
 
 export interface InvitationResult {
@@ -432,7 +433,8 @@ export const fetchAdminSettings = async (): Promise<AdminSettings> => {
   return {
     admin_count: response.data.admin_count,
     lastfm_api_key_set: response.data.lastfm_api_key_set,
-    oura_webhook_url: response.data.oura_webhook_url,
+    oura_webhook_available: response.data.oura_webhook_available,
+    oura_webhook_enabled: response.data.oura_webhook_enabled,
     signup_mode: response.data.signup_mode,
   }
 }
@@ -441,7 +443,7 @@ export const fetchAdminSettings = async (): Promise<AdminSettings> => {
 export const updateAdminSettings = async (params: {
   signup_mode?: SignupMode
   lastfm_api_key?: string | null
-  oura_webhook_url?: string | null
+  oura_webhook_enabled?: boolean
 }): Promise<AdminSettings> => {
   const { token } = auth.value
   const response = await axios.patch<{ success: boolean } & AdminSettings>(
@@ -455,7 +457,8 @@ export const updateAdminSettings = async (params: {
   return {
     admin_count: response.data.admin_count,
     lastfm_api_key_set: response.data.lastfm_api_key_set,
-    oura_webhook_url: response.data.oura_webhook_url,
+    oura_webhook_available: response.data.oura_webhook_available,
+    oura_webhook_enabled: response.data.oura_webhook_enabled,
     signup_mode: response.data.signup_mode,
   }
 }

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -99,10 +99,10 @@ export const adminSettingsResponseSchema = baseResponseSchema
   .extend({
     admin_count: z.number().int().meta({ description: 'Number of admin users' }),
     lastfm_api_key_set: z.boolean().meta({ description: 'Whether a Last.fm API key is configured' }),
-    oura_webhook_url: z
-      .string()
-      .nullable()
-      .meta({ description: 'Oura webhook callback URL for push sync (null if not configured)' }),
+    oura_webhook_available: z
+      .boolean()
+      .meta({ description: 'Whether Oura webhook push can be enabled (requires HTTPS and Oura credentials)' }),
+    oura_webhook_enabled: z.boolean().meta({ description: 'Whether Oura webhook push sync is enabled' }),
     signup_mode: signupModeSchema.meta({ description: 'Current signup mode' }),
   })
   .meta({ id: 'AdminSettingsResponse' })
@@ -119,12 +119,10 @@ export const updateAdminSettingsBodySchema = z
       .nullable()
       .optional()
       .meta({ description: 'Last.fm API key (set to null to clear)' }),
-    oura_webhook_url: z
-      .string()
-      .url()
-      .nullable()
+    oura_webhook_enabled: z
+      .boolean()
       .optional()
-      .meta({ description: 'Oura webhook callback URL (set to null to disable)' }),
+      .meta({ description: 'Enable or disable Oura webhook push sync' }),
     signup_mode: signupModeSchema.optional().meta({ description: 'New signup mode' }),
   })
   .meta({ id: 'UpdateAdminSettingsBody' })


### PR DESCRIPTION
## Summary

- Add Oura webhook push integration for near-real-time data sync via Oura's notification-then-fetch pattern
- Admin UI has a simple enable/disable toggle (no manual URL entry) — callback URL is derived from `WEB_HOST`
- Toggle only appears when `WEB_HOST` is HTTPS and Oura client credentials are configured
- `OuraWebhookManager` encapsulates enable/disable/shutdown lifecycle for clean runtime toggling

## Changes

**Backend:**
- `oura-webhook-manager` — lifecycle manager with `canEnable()`, `enable()`, `disable()`, `shutdown()`
- `oura-webhook-api` — HTTP client for Oura subscription management API
- `oura-webhook-router` — Express handler for POST callbacks with debounced per-user sync
- `oura-webhook-service` — Subscription lifecycle (init, renew, cleanup)
- `admin-router` — GET returns `oura_webhook_enabled` + `oura_webhook_available`; PATCH toggles webhook
- `central-db` — Oura user mappings, subscription tracking, `oura_webhook_enabled` setting
- `api.ts` — Creates manager with `webHost`, auto-enables on startup if previously enabled

**Frontend:**
- Admin Settings Integrations section shows checkbox toggle when available
- Simple enable/disable with save status indicator

## Test plan

- [x] All 746 backend tests pass (46 test files)
- [x] TypeScript compiles clean (backend + web)
- [x] Lint passes with only pre-existing warnings
- [ ] Manual: Enable webhook toggle on HTTPS host, verify subscriptions register
- [ ] Manual: Disable toggle, verify subscriptions are cleaned up
- [ ] Manual: Verify toggle hidden on HTTP/localhost

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)