### PR TITLE
Fix confusing Oura webhook toggle label

### DIFF
--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -261,7 +261,7 @@ export function AdminSettings() {
                 checked={settings?.oura_webhook_enabled ?? false}
                 onChange={handleOuraWebhookToggle}
               />
-              <span>{settings?.oura_webhook_enabled ? 'Enabled' : 'Disabled'}</span>
+              <span>Enable Oura webhook push notifications</span>
             </label>
             <p class="field-description">
               Enable near-real-time data sync from Oura via webhook push notifications.


### PR DESCRIPTION
## Summary
- Changed the Oura webhook checkbox label from showing "Disabled"/"Enabled" (which was ambiguous — it read as if the checkbox was to disable the feature) to a static "Enable Oura webhook push notifications" label that clearly communicates intent.

## Test plan
- [ ] Visit Admin Settings page with Oura webhook available
- [ ] Verify unchecked state shows "Enable Oura webhook push notifications"
- [ ] Verify checked state shows the same label (checkbox state communicates enabled/disabled)

🤖 Generated with [Claude Code](https://claude.ai/code)