### PR TITLE
Add comprehensive data source documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,15 @@ For typescript:
 * `pnpm check` to check typescript etc
 
 
-Deployment:
+## Documentation
+
+* Keep documentation in `docs/` up to date when changing related code.
+* When adding or modifying a data source, update `docs/data-sources.md` and the relevant per-source doc (e.g., `docs/oura.md`).
+* When changing APIs, sync behavior, admin/user setup, or data models, update the corresponding docs to reflect the new behavior.
+* Documentation should stay well structured: the overview page (`docs/data-sources.md`) links to per-topic docs, each covering what data is synced, admin setup, user setup, and how sync works.
+
+
+## Deployment
 
 * aurboda-backend is automatically deployed to https://aurboda.net/api on merge to `develop`.
 * aurboda-web is automatically deployed to https://aurboda.net/ on merge to `develop`.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Replace `:latest` with `:develop` in docker-compose.yml to use development build
 Data Sources
 ------------
 
+See [docs/data-sources.md](docs/data-sources.md) for detailed documentation on all data sources, including admin and user setup instructions.
+
 | Source | Setup |
 |--------|-------|
 | Android Health Connect | Install the [Android APK](https://github.com/fiddur/aurboda/releases/download/latest/aurboda.apk), enter your server URL (e.g., `http://YOUR_SERVER_IP`), and log in with your credentials |
@@ -79,6 +81,8 @@ Data Sources
 | OwnTracks | [OwnTracks setup guide](docs/owntracks.md) (JSON HTTP mode) |
 | Oura | Connect via OAuth in user settings (web UI). Requires `OURA_CLIENT` and `OURA_SECRET` env vars on backend. |
 | RescueTime | Configure API key in user settings (web UI). Get key from [RescueTime API settings](https://www.rescuetime.com/anapi/manage). |
+| Last.fm | Configure API key in admin settings, username in user settings. See [docs/lastfm.md](docs/lastfm.md). |
+| Calendars | Add ICS URLs in user settings. See [docs/calendars.md](docs/calendars.md). |
 
 
 API Documentation

--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -1,0 +1,63 @@
+# Calendars (ICS)
+
+Aurboda can sync events from any calendar that provides an ICS URL. Events are stored as tags, enabling correlation analysis between scheduled activities and health metrics.
+
+## Data Synced
+
+Calendar events are stored as **tags** with:
+- Tag text: event summary (title)
+- Start time and end time from the event
+- Source: `calendar`
+
+This means calendar events appear on the timeline alongside other tags and can be used in trend analysis and correlations (e.g., "does my HRV drop on days with many meetings?").
+
+## Admin Setup
+
+No server-side configuration is needed.
+
+## User Setup
+
+1. Go to **Settings > Data Sources > Calendars**
+2. Add one or more calendars by providing:
+   - **Name** -- A display name for the calendar
+   - **ICS URL** -- The calendar's ICS feed URL
+
+### Finding Your ICS URL
+
+Most calendar providers offer ICS export URLs:
+
+- **Google Calendar:** Calendar Settings > "Secret address in iCal format"
+- **Outlook/Office 365:** Calendar Settings > Shared calendars > Publish a calendar
+- **Apple iCloud:** Calendar sharing > Public Calendar link
+- **Nextcloud:** Calendar > sharing icon > copy link with `.ics` extension
+
+## Sync
+
+### Manual Sync
+
+- **REST:** `POST /api/sync/calendars`
+- **MCP:** `sync_calendars()`
+
+Options:
+- `full_resync: true` -- Re-fetch and reprocess all events
+
+### Auto-Sync
+
+Calendar data is automatically refreshed before tag-related queries if the last sync was more than 30 minutes ago.
+
+### Sync Process
+
+1. Fetch ICS data from each configured URL
+2. Parse events from the ICS feed
+3. Store events as tags with the calendar source
+4. Each calendar tracks its own sync state independently
+
+Results show events processed per calendar:
+```json
+{
+  "results": [
+    { "calendar": "Work", "status": "success", "events_processed": 42 },
+    { "calendar": "Personal", "status": "success", "events_processed": 15 }
+  ]
+}
+```

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,0 +1,40 @@
+# Data Sources
+
+Aurboda aggregates health, productivity, and location data from multiple sources. Each data source has its own setup requirements and sync mechanisms.
+
+## Overview
+
+| Source | Data Types | Sync Method | Admin Setup | User Setup |
+|--------|-----------|-------------|-------------|------------|
+| [Oura Ring](./oura.md) | Sleep, readiness, resilience, cardiovascular age, meditation, HRV, tags | Pull (API) + Push (webhook) | OAuth credentials (env vars) | OAuth connect |
+| [Health Connect](./health-connect.md) | HR, HRV, weight, body composition, steps, sleep, exercise, 40+ record types | Push (Android app) | None | Install Android app |
+| [RescueTime](./rescuetime.md) | App/website usage, productivity scores | Pull (API) | None | API key |
+| [Last.fm](./lastfm.md) | Music scrobbles, auto-generated tags | Pull (API) | API key (admin setting) | Last.fm username |
+| [Calendars](./calendars.md) | Calendar events (stored as tags) | Pull (ICS fetch) | None | ICS URL(s) |
+| [OwnTracks](./owntracks.md) | GPS location, geofences | Push (HTTP) | None | OwnTracks app config |
+
+## Sync Behavior
+
+All pull-based sources support:
+
+- **Manual sync** via REST API (`POST /api/sync/{provider}`) or MCP tool (`sync_{provider}`)
+- **Auto-sync** triggered before queries if data is older than 30 minutes
+- **Full resync** option to re-fetch historical data
+- **Sync state tracking** per provider with rate limit handling
+
+Check sync status for all providers:
+- REST: `GET /api/sync/status`
+- MCP: `get_sync_status()`
+
+## Data Storage
+
+All sources feed into a common data model:
+
+- **`time_series`** -- Timestamped metric values (HR, weight, steps, etc.)
+- **`activities`** -- Duration-based events (sleep, exercise, meditation, nap)
+- **`tags`** -- Labeled time points or spans (from Oura tags, Last.fm rules, calendar events)
+- **`productivity`** -- App/website usage records (from RescueTime)
+- **`locations`** -- GPS coordinates (from OwnTracks)
+- **`raw_records`** -- Original data preserved in full JSON form
+
+See [data-storage.md](./data-storage.md) for the complete data model.

--- a/docs/health-connect.md
+++ b/docs/health-connect.md
@@ -1,0 +1,111 @@
+# Health Connect (Android App)
+
+[Health Connect](https://developer.android.com/health-and-fitness/health-connect) is Android's unified health data API. The Aurboda Android app reads data from Health Connect and pushes it to the backend.
+
+## Data Synced
+
+### Metrics (time series)
+
+| Health Connect Record | Aurboda Metric |
+|----------------------|----------------|
+| HeartRateRecord | `heart_rate` |
+| HeartRateVariabilityRmssdRecord | `hrv_rmssd` |
+| RestingHeartRateRecord | `resting_heart_rate` |
+| WeightRecord | `weight` |
+| BodyFatRecord | `body_fat` |
+| BoneMassRecord | `bone_mass` |
+| LeanBodyMassRecord | `lean_body_mass` |
+| BodyWaterMassRecord | `body_water_mass` |
+| HeightRecord | `height` |
+| BloodPressureRecord | `blood_pressure_systolic`, `blood_pressure_diastolic` |
+| BloodGlucoseRecord | `blood_glucose` |
+| BodyTemperatureRecord | `body_temperature` |
+| BasalBodyTemperatureRecord | `basal_body_temperature` |
+| OxygenSaturationRecord | `spo2` |
+| RespiratoryRateRecord | `respiratory_rate` |
+| Vo2MaxRecord | `vo2_max` |
+| BasalMetabolicRateRecord | `calories_basal` |
+
+### Cumulative Metrics (daily aggregates)
+
+These metrics use Health Connect's built-in deduplication to avoid double-counting across sources (e.g., Fitbit + phone sensor):
+
+| Health Connect Record | Aurboda Metric |
+|----------------------|----------------|
+| StepsRecord | `steps` |
+| DistanceRecord | `distance` |
+| FloorsClimbedRecord | `floors_climbed` |
+| ActiveCaloriesBurnedRecord | `calories_active` |
+| TotalCaloriesBurnedRecord | `calories_total` |
+
+These are sent as daily aggregates (one value per day) rather than raw records.
+
+### Activities
+
+| Health Connect Record | Aurboda Activity Type |
+|----------------------|----------------------|
+| ExerciseSessionRecord | `exercise` (with exercise type, title, notes, GPS route) |
+| SleepSessionRecord | `sleep` (with sleep stage breakdowns) |
+
+## Admin Setup
+
+No server-side configuration is needed. The Android app communicates directly with the backend API using the user's auth token.
+
+## User Setup
+
+### 1. Install the App
+
+Build from source or install from releases. The app requires Android with Health Connect support.
+
+### 2. Log In
+
+On first launch, enter:
+- **Server URL** (e.g., `https://aurboda.net`)
+- **Username**
+- **Auth token** (from the web interface)
+
+Credentials are stored encrypted on-device using Android EncryptedSharedPreferences.
+
+### 3. Grant Permissions
+
+The app requests read access to ~40 Health Connect data types. Grant all permissions for full data collection.
+
+### 4. Initial Sync
+
+After granting permissions, the app automatically fetches the last 7 days of data and generates a change tracking token for future incremental syncs.
+
+### 5. Enable Background Sync (Recommended)
+
+Toggle **Background Sync** in the app. This schedules automatic syncs every 15 minutes (Android WorkManager minimum interval).
+
+The app may prompt you to disable battery optimization for reliable background syncing.
+
+## How Sync Works
+
+### Incremental Sync (Background)
+
+The app uses Health Connect's **Changes API** with token-based tracking:
+
+1. On first sync: fetch 7 days of data, get initial change token
+2. On subsequent syncs: use the token to get only new/updated/deleted records
+3. The token is only saved after successful upload to prevent data loss
+
+### Data Flow
+
+1. App reads records from Health Connect
+2. Cumulative metrics (steps, distance, etc.) are sent as deduplicated **daily aggregates** to `POST /api/sync/daily-aggregates`
+3. All other records are sent as raw data to `POST /api/sync/{recordType}` (e.g., `/api/sync/HeartRateRecord`)
+4. Deleted records are reported to `POST /api/sync/deletions`
+5. Backend processes each record: stores raw JSON, extracts metrics to time series, creates activities for exercise/sleep
+
+### Chunking
+
+HeartRateRecord data (which can contain thousands of samples) is sent in chunks of 10 records per request to avoid HTTP 413 errors.
+
+### Scheduling
+
+| Mode | Interval | Conditions |
+|------|----------|------------|
+| Background | Every 15 minutes | Requires network connection |
+| Foreground (app open) | Every 60 seconds | Only if background sync enabled |
+| Manual | On demand | "Fetch New Data" button |

--- a/docs/lastfm.md
+++ b/docs/lastfm.md
@@ -1,0 +1,85 @@
+# Last.fm
+
+[Last.fm](https://www.last.fm/) tracks music listening history ("scrobbles"). Aurboda syncs scrobbles and can automatically create tags based on configurable rules, enabling correlation analysis between music and health metrics.
+
+## Data Synced
+
+Scrobbles are stored as raw records with:
+- Track name, artist, album
+- MusicBrainz IDs (when available)
+- Timestamp
+
+Scrobbles themselves are not directly visible in the timeline. Instead, the **auto-tagging rules** system creates tags from matching scrobbles, which appear on the timeline and can be used in correlations.
+
+## Admin Setup
+
+The server administrator must configure a Last.fm API key:
+
+1. Register for an API key at [Last.fm API](https://www.last.fm/api/account/create)
+2. Go to **Admin Settings > Integrations > Last.fm API Key**
+3. Enter the key (saves automatically on blur)
+
+This is a server-wide key shared by all users.
+
+## User Setup
+
+1. Go to **Settings > Data Sources > Last.fm**
+2. Enter your Last.fm username
+3. Set up auto-tagging rules (see below)
+
+## Auto-Tagging Rules
+
+Rules define how scrobbles become tags. Each rule specifies what to match and what tag to create.
+
+### Match Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `track` | Match by track name | Track "Breathe" creates tag "meditation-music" |
+| `artist` | Match by artist name | Artist "Nils Frahm" creates tag "ambient" |
+| `track_artist` | Match by both track and artist | Specific track by specific artist |
+
+### Match Modes
+
+| Mode | Description |
+|------|-------------|
+| `exact` | Case-insensitive exact match (default) |
+| `contains` | Substring match |
+
+### Multiple Artists
+
+Rules can match multiple artists at once using the `artist_names` field. This is useful for grouping several artists under one tag.
+
+### Session Merging
+
+When `merge_gap_seconds` is set, consecutive matching scrobbles within the specified gap are merged into a single span tag (with start and end time) instead of creating individual point tags. This is useful for treating a listening session as a single activity.
+
+For example, with a 10-minute merge gap: if you listen to 5 tracks by the same artist over 20 minutes, they become one tag spanning the full session rather than 5 separate tags.
+
+### Managing Rules
+
+Rules can be managed in **Settings > Last.fm Tag Rules** or via MCP tools:
+
+- `get_lastfm_tag_rules()` -- List all rules
+- `add_lastfm_tag_rule(...)` -- Create a rule
+- `delete_lastfm_tag_rule(rule_id)` -- Delete a rule
+
+## Sync
+
+### Manual Sync
+
+- **REST:** `POST /api/sync/lastfm`
+- **MCP:** `sync_lastfm()`
+
+Options:
+- `full_resync: true` -- Re-fetch historical data (default: last 30 days)
+- `start_date: "YYYY-MM-DD"` -- Start date for full resync
+
+### Sync Process
+
+1. Fetch recent scrobbles from Last.fm API (paginated, 200 per page)
+2. Store each scrobble as a raw record
+3. Apply auto-tagging rules to each scrobble
+4. Create tags (or extend existing span tags) for matching rules
+
+Currently-playing tracks are skipped (no timestamp yet).

--- a/docs/oura.md
+++ b/docs/oura.md
@@ -1,0 +1,91 @@
+# Oura Ring
+
+[Oura Ring](https://ouraring.com/) provides sleep tracking, readiness scores, HRV, and more. Aurboda supports both pull-based sync (on-demand API calls) and push-based sync (near-real-time webhooks).
+
+## Data Synced
+
+| Oura Data Type | Stored As | Metrics |
+|----------------|-----------|---------|
+| Daily Sleep | time_series | `sleep_score`, `sleep_deep_score`, `sleep_efficiency`, `sleep_latency`, `sleep_rem_score`, `sleep_restfulness`, `sleep_timing`, `sleep_total_score` |
+| Daily Readiness | time_series | `readiness_score` |
+| Daily Resilience | time_series | `resilience_score` (mapped: exceptional=100, strong=75, solid=50, limited=25) |
+| Daily Cardiovascular Age | time_series | `cardiovascular_age` |
+| Sessions (meditation) | activity + time_series | Activities with type `meditation`; HR and HRV interval data extracted as time series |
+| Enhanced Tags | tags | User tags from Oura, with optional custom names via tag mappings |
+
+All data is also preserved as raw JSON in the `raw_records` table.
+
+## Admin Setup
+
+The server administrator must register an Oura developer application and configure:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `OURA_CLIENT` | OAuth client ID from [Oura Developer Portal](https://cloud.ouraring.com/oauth/applications) |
+| `OURA_SECRET` | OAuth client secret |
+| `WEB_HOST` | Public URL of the server (e.g., `https://aurboda.net`). Must be HTTPS for webhooks. |
+
+The OAuth callback URL to register with Oura is: `{WEB_HOST}/auth/ouracb`
+
+If these are not set, the "Connect Oura" button in user settings will be disabled with a message asking the admin to configure them.
+
+## User Setup
+
+1. Go to **Settings > Data Sources > Oura Ring**
+2. Click **Connect Oura**
+3. Authorize Aurboda on the Oura website
+4. You'll be redirected back. Settings will show "Connected" when successful.
+
+This uses a standard OAuth 2.0 flow. The access token is stored per-user and automatically refreshed when it expires.
+
+## Pull-Based Sync
+
+Manually trigger a sync to fetch the latest data:
+
+- **REST:** `POST /api/sync/oura`
+- **MCP:** `sync_oura()`
+
+Options:
+- `full_resync: true` -- Re-fetch all historical data (default: last 90 days)
+- `start_date: "YYYY-MM-DD"` -- Start date for full resync
+
+The sync fetches all 6 data types sequentially. Each type tracks its own sync state, so only new data since the last sync is fetched during incremental syncs.
+
+Rate limiting (HTTP 429) is handled automatically with exponential backoff (1, 5, 15, 60 minutes).
+
+## Webhook Push (Near-Real-Time)
+
+When enabled, Oura sends notifications to Aurboda whenever new data is available, enabling near-real-time sync without polling.
+
+### How It Works
+
+1. Admin enables webhooks in **Admin Settings > Integrations > Oura Webhook Push**
+2. The server creates webhook subscriptions with Oura for all data types (create + update events)
+3. When Oura has new data for any connected user, it sends a notification to `{WEB_HOST}/api/webhooks/oura`
+4. The server looks up which local user the notification is for (via the Oura user ID mapping created during OAuth) and triggers a sync for that user and data type
+5. Notifications are debounced (5-second window) to batch rapid updates
+
+### Subscription Lifecycle
+
+- **12 subscriptions** are created (6 data types x 2 event types: create, update)
+- Subscriptions expire after ~30 days
+- A renewal timer runs every 12 hours and renews subscriptions expiring within 24 hours
+- A verification token is auto-generated and stored server-side to validate incoming webhooks
+
+### Per-User Behavior
+
+Webhooks are a **system-level** feature, not per-user. Once the admin enables webhooks:
+
+- All currently connected Oura users automatically benefit from push sync
+- New users who connect Oura after webhooks are enabled also benefit -- the user-to-Oura-ID mapping is created during the OAuth flow
+- No re-authentication is needed for existing users
+
+### Requirements
+
+- `WEB_HOST` must use HTTPS (the toggle is hidden if HTTP)
+- `OURA_CLIENT` and `OURA_SECRET` must be configured
+- The webhook endpoint must be publicly accessible
+
+### Disabling
+
+When the admin disables webhooks, all remote subscriptions are deleted from Oura and local tracking records are cleaned up.

--- a/docs/rescuetime.md
+++ b/docs/rescuetime.md
@@ -1,0 +1,48 @@
+# RescueTime
+
+[RescueTime](https://www.rescuetime.com/) tracks application and website usage, assigning productivity scores to each activity.
+
+## Data Synced
+
+Each record contains:
+
+| Field | Description |
+|-------|-------------|
+| `activity` | Application or website name (e.g., "VS Code", "Chrome - GitHub") |
+| `category` | Classification (e.g., "Software Development", "Social Media") |
+| `productivity` | Score from -2 to +2 (-2 = very distracting, 0 = neutral, +2 = very productive) |
+| `duration_sec` | Time spent in seconds |
+| `start_time` / `end_time` | Precise timestamps |
+| `is_mobile` | Whether the activity was on mobile |
+
+Data resolution is minute-level intervals from RescueTime's API.
+
+## Admin Setup
+
+No server-side configuration is needed. Each user provides their own RescueTime API key.
+
+## User Setup
+
+1. Get a personal API key from [RescueTime API settings](https://www.rescuetime.com/anapi/manage)
+2. Go to **Settings > Data Sources > RescueTime API Key**
+3. Paste the key and leave the field (saves automatically on blur)
+4. Settings will show "Configured" once saved
+
+## Sync
+
+### Manual Sync
+
+- **REST:** `POST /api/sync/rescuetime`
+- **MCP:** `sync_rescuetime()`
+
+Options:
+- `full_resync: true` -- Re-fetch historical data (default: last 30 days)
+- `start_date: "YYYY-MM-DD"` -- Start date for full resync
+
+### Auto-Sync
+
+RescueTime data is automatically refreshed before productivity-related queries (correlations, trends) if the last sync was more than 30 minutes ago.
+
+### Rate Limiting
+
+HTTP 429 responses are handled with exponential backoff: 1, 5, 15, 60 minutes.


### PR DESCRIPTION
## Summary
- Added `docs/data-sources.md` as an overview page linking all data sources with a comparison table
- Added individual docs for each data source:
  - `docs/oura.md` -- Oura Ring (pull sync + webhook push, admin OAuth setup, per-user behavior)
  - `docs/health-connect.md` -- Android app / Health Connect (40+ record types, daily aggregates, background sync)
  - `docs/rescuetime.md` -- RescueTime (productivity data, user API key setup)
  - `docs/lastfm.md` -- Last.fm (scrobbles, auto-tagging rules with session merging)
  - `docs/calendars.md` -- ICS calendars (events as tags)
- Existing `docs/owntracks.md` already covers OwnTracks and is linked from the overview

Each doc covers: what data is synced, admin setup, user setup, and how sync works.

## Test plan
- [ ] Review docs for accuracy against the actual codebase
- [ ] Verify all internal doc links work

🤖 Generated with [Claude Code](https://claude.ai/code)