### PR TITLE
Fix Android auto-update: remove --prerelease flag

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -113,6 +113,5 @@ jobs:
 
           Built from commit: ${{ github.sha }}
           Version code: ${{ steps.version.outputs.VERSION_CODE }}" \
-            --prerelease \
             apps/android/app/build/outputs/apk/release/aurboda.apk \
             apps/android/app/build/outputs/apk/release/version.json


### PR DESCRIPTION
## Summary

- The GitHub release for Android APK was created with `--prerelease`, but GitHub's `/releases/latest/download/` URL pattern **only resolves for non-prerelease releases**
- This caused the `version.json` fetch to return **HTTP 404**, silently preventing the app from ever detecting available updates
- Fix: remove the `--prerelease` flag from `gh release create` in the Android workflow

## Root cause

```
$ curl -sI "https://github.com/fiddur/aurboda/releases/latest/download/version.json"
HTTP/2 404
```

GitHub's "latest release" API endpoint excludes prereleases. The release exists at tag `latest`, but the `/releases/latest/download/` URL pattern used by the Android app resolves through GitHub's "latest release" feature, not by tag name.

## Test plan

- [ ] After merge, the next Android workflow run will create a non-prerelease release
- [ ] Verify `https://github.com/fiddur/aurboda/releases/latest/download/version.json` returns 200
- [ ] Install an older APK and verify the update dialog appears on launch

🤖 Generated with [Claude Code](https://claude.ai/code)