### PR TITLE
Fix daily aggregate sync: use snake_case data_origins

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -43,6 +43,7 @@ import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.records.WheelchairPushesRecord
 import androidx.health.connect.client.records.metadata.Metadata
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.time.Instant
@@ -68,6 +69,7 @@ data class DailyAggregate(
     val date: String,           // "2024-01-15"
     val metric: String,         // "steps", "distance", etc.
     val value: Double,
+    @SerialName("data_origins")
     val dataOrigins: List<String>  // Contributing app package names
 )
 


### PR DESCRIPTION
## Summary
- The `DailyAggregate` Kotlin class serialized `dataOrigins` as camelCase, but the backend `dailyAggregateSchema` expects `data_origins` (snake_case)
- This caused Zod validation to reject all daily aggregate POST requests with 400, blocking sync of steps, distance, calories_active, calories_total, and floors_climbed since the snake_case standardization in #177 (deployed ~Feb 15)
- Additionally, the background sync worker aborts entirely when aggregates fail, meaning raw record sync was also blocked for background syncs

## Fix
Added `@SerialName("data_origins")` to the `DailyAggregate` data class so Kotlin serialization outputs the snake_case field name the backend expects.

## Test plan
- [x] Android debug build compiles
- [x] Android debug unit tests pass
- [x] Backend tests pass (746/746)
- [ ] After merging: verify daily aggregates appear in `time_series` table with source `health_connect_aggregate`
- [ ] After deploying new APK: verify steps/distance/calories data resumes syncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)