### PR TITLE
Send raw records for cumulative metrics

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -64,15 +64,6 @@ class HealthConnectSyncWorker(
         Pair(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL, DailyAggregate.Metric.floors_climbed)
     )
 
-    // Record types that are handled by aggregates (to filter from raw records)
-    private val aggregatedRecordTypes = setOf(
-        StepsRecord::class,
-        DistanceRecord::class,
-        ActiveCaloriesBurnedRecord::class,
-        TotalCaloriesBurnedRecord::class,
-        FloorsClimbedRecord::class
-    )
-
     override suspend fun doWork(): Result {
         Log.d(TAG, "Starting background sync")
 
@@ -116,28 +107,14 @@ class HealthConnectSyncWorker(
             }
 
             if (records.isNotEmpty()) {
-                // Filter out records that are handled by aggregates
-                val filteredRecords = records.filter { record ->
-                    record::class !in aggregatedRecordTypes
-                }
-                Log.d(TAG, "Filtered ${records.size} records to ${filteredRecords.size} (excluded aggregated types)")
-
-                if (filteredRecords.isNotEmpty()) {
-                    val success = sendDataToServer(filteredRecords, credentials.apiUrl, credentials.authToken)
-                    if (success) {
-                        Log.d(TAG, "Background sync completed successfully")
-                        HrZoneWidgetProvider.triggerUpdate(applicationContext)
-                        Result.success()
-                    } else {
-                        Log.w(TAG, "Background sync failed to send data")
-                        Result.retry()
-                    }
-                } else {
-                    Log.d(TAG, "No filtered records to sync (all were aggregated types)")
-                    // Still save token since we successfully processed the records
-                    pendingToken?.let { saveChangesToken(it) }
+                val success = sendDataToServer(records, credentials.apiUrl, credentials.authToken)
+                if (success) {
+                    Log.d(TAG, "Background sync completed successfully")
                     HrZoneWidgetProvider.triggerUpdate(applicationContext)
                     Result.success()
+                } else {
+                    Log.w(TAG, "Background sync failed to send data")
+                    Result.retry()
                 }
             } else {
                 // If we had deletions but no records, save token
@@ -214,14 +191,14 @@ class HealthConnectSyncWorker(
         serverUrl: String,
         authToken: String
     ): Boolean {
-        // Note: StepsRecord, DistanceRecord, ActiveCaloriesBurnedRecord, TotalCaloriesBurnedRecord,
-        // and FloorsClimbedRecord are excluded here as they are handled by daily aggregates
         val recordsWithKnownSerializers = records.filter {
             when (it) {
                 is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
                 is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
                 is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
-                is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord -> true
+                is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
+                is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
+                is TotalCaloriesBurnedRecord, is FloorsClimbedRecord -> true
                 else -> false
             }
         }
@@ -240,8 +217,6 @@ class HealthConnectSyncWorker(
             val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
             val apiUrl = "$serverUrl/sync/$recordTypeSimpleName"
 
-            // Note: StepsRecord, DistanceRecord, ActiveCaloriesBurnedRecord, TotalCaloriesBurnedRecord
-            // are now handled by daily aggregates and excluded from raw record sync
             val postSuccessful = when (recordClass) {
                 HeartRateVariabilityRmssdRecord::class -> postData(
                     HrvRecordSerializable.fromRecordsList(classRecords),
@@ -311,6 +286,31 @@ class HealthConnectSyncWorker(
                 RestingHeartRateRecord::class -> postData(
                     RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
                     RestingHeartRateRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                StepsRecord::class -> postData(
+                    StepsRecordSerializable.fromRecordsList(classRecords),
+                    StepsRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                DistanceRecord::class -> postData(
+                    DistanceRecordSerializable.fromRecordsList(classRecords),
+                    DistanceRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                ActiveCaloriesBurnedRecord::class -> postData(
+                    ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+                    ActiveCaloriesBurnedRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                TotalCaloriesBurnedRecord::class -> postData(
+                    TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+                    TotalCaloriesBurnedRecordSerializable.serializer(),
+                    apiUrl, recordTypeSimpleName, authToken
+                )
+                FloorsClimbedRecord::class -> postData(
+                    FloorsClimbedRecordSerializable.fromRecordsList(classRecords),
+                    FloorsClimbedRecordSerializable.serializer(),
                     apiUrl, recordTypeSimpleName, authToken
                 )
                 else -> {

--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -568,6 +568,28 @@ data class SpeedRecordSerializable(
     }
 }
 
+// --- Floors Climbed Record ---
+@Serializable
+data class FloorsClimbedRecordSerializable(
+    val startTime: String,
+    val endTime: String,
+    val floors: Double,
+    val metadata: HealthConnectRecordMetadata
+) {
+    companion object {
+        fun fromRecordsList(classRecords: List<Record>): List<FloorsClimbedRecordSerializable> {
+            return classRecords.filterIsInstance<FloorsClimbedRecord>().map { record ->
+                FloorsClimbedRecordSerializable(
+                    startTime = record.startTime.toIsoString(),
+                    endTime = record.endTime.toIsoString(),
+                    floors = record.floors,
+                    metadata = record.metadata.toSerializable()
+                )
+            }
+        }
+    }
+}
+
 // --- Steps Record ---
 @Serializable
 data class StepsRecordSerializable(

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -580,15 +580,6 @@ fun HealthConnectScreen(
         }
     }
 
-    // Record types handled by daily aggregates (should not be sent as raw records)
-    val aggregatedRecordTypes = setOf(
-        StepsRecord::class,
-        DistanceRecord::class,
-        ActiveCaloriesBurnedRecord::class,
-        TotalCaloriesBurnedRecord::class,
-        FloorsClimbedRecord::class
-    )
-
     suspend fun sendPendingDataToServer(currentActiveContext: Context) {
         if (healthRecords.isEmpty() && pendingDeletionIds.isEmpty()) {
             statusMessage = "No records to send."
@@ -627,15 +618,16 @@ fun HealthConnectScreen(
             }
         }
 
-        // Step 2: Send raw records (excluding aggregated types handled by daily aggregates)
+        // Step 2: Send raw records
         if (allPostsSuccessful && healthRecords.isNotEmpty()) {
-            // Filter out aggregated types (steps, distance, etc.) - these are handled by daily aggregates
             val recordsWithKnownSerializers = healthRecords.filter {
-                it::class !in aggregatedRecordTypes && when (it) {
+                when (it) {
                     is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
                     is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
                     is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
-                    is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord -> true
+                    is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
+                    is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
+                    is TotalCaloriesBurnedRecord, is FloorsClimbedRecord -> true
                     else -> false
                 }
             }
@@ -643,9 +635,9 @@ fun HealthConnectScreen(
             statusMessage = "Sending ${recordsWithKnownSerializers.size} records to server..."
 
             if (recordsWithKnownSerializers.isEmpty()) {
-                Log.d("SendData", "No records with known serializers to send (aggregated types excluded).")
+                Log.d("SendData", "No records with known serializers to send.")
             } else {
-                Log.d("SendData", "Attempting to send ${recordsWithKnownSerializers.size} records (excluded ${healthRecords.size - recordsWithKnownSerializers.size} aggregated/unsupported types).")
+                Log.d("SendData", "Attempting to send ${recordsWithKnownSerializers.size} records (${healthRecords.size - recordsWithKnownSerializers.size} unsupported types excluded).")
 
                 val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
                 for ((recordClass, classRecords) in groupedRecords) {
@@ -668,6 +660,11 @@ fun HealthConnectScreen(
                         BodyWaterMassRecord::class -> handlePostData(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), BodyWaterMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                         HeightRecord::class -> handlePostData(HeightRecordSerializable.fromRecordsList(classRecords), HeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                         RestingHeartRateRecord::class -> handlePostData(RestingHeartRateRecordSerializable.fromRecordsList(classRecords), RestingHeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        StepsRecord::class -> handlePostData(StepsRecordSerializable.fromRecordsList(classRecords), StepsRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        DistanceRecord::class -> handlePostData(DistanceRecordSerializable.fromRecordsList(classRecords), DistanceRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        ActiveCaloriesBurnedRecord::class -> handlePostData(ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords), ActiveCaloriesBurnedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        TotalCaloriesBurnedRecord::class -> handlePostData(TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords), TotalCaloriesBurnedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
+                        FloorsClimbedRecord::class -> handlePostData(FloorsClimbedRecordSerializable.fromRecordsList(classRecords), FloorsClimbedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
                         else -> { Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping."); PostResult.Success }
                     }
                     if (!postResult.isSuccess) {
@@ -816,11 +813,13 @@ fun HealthConnectScreen(
                 Button(
                     onClick = { scope.launch { sendPendingDataToServer(context) } },
                     enabled = (pendingDeletionIds.isNotEmpty() || healthRecords.any { record ->
-                        record::class !in aggregatedRecordTypes && when (record) {
+                        when (record) {
                             is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
                             is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
                             is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
-                            is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord -> true
+                            is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
+                            is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
+                            is TotalCaloriesBurnedRecord, is FloorsClimbedRecord -> true
                             else -> false
                         }
                     }) && !isProcessing


### PR DESCRIPTION
## Summary
- Remove filter that excluded StepsRecord, DistanceRecord, ActiveCaloriesBurnedRecord, TotalCaloriesBurnedRecord, and FloorsClimbedRecord from raw record sync
- Add `FloorsClimbedRecordSerializable` (was missing)
- Add serializer cases for all 5 cumulative record types in both background sync worker and foreground UI
- Both raw records AND daily aggregates are now sent, enabling proper Health Connect deletion support

No double-counting: backend cumulative metric queries already filter to `source='health_connect_aggregate'` only.

## Test plan
- [x] Backend tests pass (746/746)
- [x] Android build errors are pre-existing (generated API client code), unrelated to these changes
- [ ] Install updated app, verify StepsRecord appears in raw_records table
- [ ] Verify daily aggregates still populate time_series correctly
- [ ] Verify deletion of a steps record removes the raw_record entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)