### PR TITLE
Fix day view: merge leeway, sleep/meditation HRV in tooltips

### DIFF
--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -1168,7 +1168,29 @@ describe('mergeProductivitySpans', () => {
     expect(result).toHaveLength(2)
   })
 
-  test('does not merge spans with a gap between them', () => {
+  test('merges spans with a small gap (within 2 min leeway)', () => {
+    const result = mergeProductivitySpans([
+      {
+        activity: 'emacs',
+        duration_sec: 299,
+        end_time: new Date('2024-01-15T10:04:59Z'),
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity: 'emacs',
+        duration_sec: 300,
+        end_time: new Date('2024-01-15T10:10:00Z'),
+        start_time: new Date('2024-01-15T10:05:00Z'),
+      },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].start_time).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].end_time).toEqual(new Date('2024-01-15T10:10:00Z'))
+    expect(result[0].duration_sec).toBe(599)
+  })
+
+  test('does not merge spans with a large gap between them', () => {
     const result = mergeProductivitySpans([
       {
         activity: 'emacs',

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -800,9 +800,32 @@ export interface ActivityResult {
   duration?: number // minutes
   activity_type: string
   title?: string
+  notes?: string
   source: string
   data?: Record<string, unknown>
   hr_zone_secs?: HrZoneSecs
+  avg_hrv?: number
+}
+
+/**
+ * Get average HRV for an activity, using embedded Oura data or time series.
+ */
+async function getAvgHrvForActivity(
+  user: string,
+  activity: { data?: Record<string, unknown>; start_time: Date; end_time?: Date },
+): Promise<number | undefined> {
+  // Try embedded Oura HRV data first (meditation sessions have hrv.items)
+  const hrv = activity.data?.hrv as { items?: (number | null)[] } | undefined
+  const items = hrv?.items?.filter((v): v is number => v !== null && v > 0)
+  if (items && items.length > 0) {
+    return Math.round(items.reduce((sum, v) => sum + v, 0) / items.length)
+  }
+
+  // Fall back to time series HRV data
+  if (!activity.end_time) return undefined
+  const hrvData = await getTimeSeries(user, 'hrv_rmssd', activity.start_time, activity.end_time)
+  if (hrvData.length === 0) return undefined
+  return Math.round(hrvData.reduce((sum, [, v]) => sum + v, 0) / hrvData.length)
 }
 
 /**
@@ -835,6 +858,7 @@ export async function queryActivities(
         duration:
           a.end_time ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60) : undefined,
         end_time: a.end_time?.toISOString(),
+        notes: a.notes,
         source: a.source,
         start_time: a.start_time.toISOString(),
         title: a.title,
@@ -846,6 +870,11 @@ export async function queryActivities(
         if (hrData.length > 0) {
           result.hr_zone_secs = computeHrZoneSecs(hrData, hrZones)
         }
+      }
+
+      // Compute average HRV for sleep and meditation
+      if ((a.activity_type === 'sleep' || a.activity_type === 'meditation') && a.end_time) {
+        result.avg_hrv = await getAvgHrvForActivity(user, a)
       }
 
       return result
@@ -867,9 +896,16 @@ export interface ProductivityResult {
 }
 
 /**
+ * Maximum gap (ms) between spans that still counts as "consecutive".
+ * RescueTime often has small gaps (e.g. end 06:39:59, next start 06:40:00).
+ * 2 minutes covers these gaps without merging truly separate sessions.
+ */
+const MERGE_GAP_MS = 2 * 60 * 1000
+
+/**
  * Merge consecutive productivity spans for the same activity/is_mobile.
- * Two spans are merged when the second starts exactly when the first ends
- * and they share the same activity name and is_mobile flag.
+ * Two spans are merged when the gap between prev.end_time and current.start_time
+ * is at most MERGE_GAP_MS and they share the same activity name and is_mobile flag.
  */
 export function mergeProductivitySpans(records: ProductivityRecord[]): ProductivityRecord[] {
   if (records.length === 0) return []
@@ -882,9 +918,10 @@ export function mergeProductivitySpans(records: ProductivityRecord[]): Productiv
 
     const sameActivity = current.activity === prev.activity
     const sameMobile = (current.is_mobile ?? false) === (prev.is_mobile ?? false)
-    const consecutive = prev.end_time.getTime() === current.start_time.getTime()
+    const gap = current.start_time.getTime() - prev.end_time.getTime()
+    const closeEnough = gap >= 0 && gap <= MERGE_GAP_MS
 
-    if (sameActivity && sameMobile && consecutive) {
+    if (sameActivity && sameMobile && closeEnough) {
       prev.end_time = current.end_time
       prev.duration_sec += current.duration_sec
     } else {

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -41,13 +41,15 @@ const hrZoneColors: Record<number, string> = {
   5: '#ef4444',
 }
 
+const TAG_COLOR = '#8b5cf6'
+
 const tagSourceColors: Record<string, string> = {
   calendar: '#f59e0b',
-  default: '#9ca3af',
+  default: TAG_COLOR,
   lastfm: '#ec4899',
   'lastfm-auto': '#ec4899',
-  manual: '#8b5cf6',
-  oura: '#06b6d4',
+  manual: TAG_COLOR,
+  oura: TAG_COLOR,
 }
 
 const productivityColors: Record<number, string> = {
@@ -632,12 +634,8 @@ export const DayView = () => {
           Calendar
         </span>
         <span class="legend-item">
-          <span class="legend-dot" style={{ background: tagSourceColors.manual }} />
-          Manual
-        </span>
-        <span class="legend-item">
-          <span class="legend-dot" style={{ background: tagSourceColors.oura }} />
-          Oura
+          <span class="legend-dot" style={{ background: TAG_COLOR }} />
+          Tags
         </span>
       </div>
 

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -166,7 +166,7 @@ interface TooltipContent {
 }
 
 // Categorization per column
-const categorizeSleepRest = (activities: Activity[]): ChartItem[] =>
+const categorizeSleepRest = (activities: Activity[], tags: Tag[]): ChartItem[] =>
   activities
     .filter(
       (a) => a.activity_type === 'sleep' || a.activity_type === 'nap' || a.activity_type === 'meditation',
@@ -177,6 +177,22 @@ const categorizeSleepRest = (activities: Activity[]): ChartItem[] =>
         a.activity_type === 'sleep' ? 'Sleep'
         : a.activity_type === 'nap' ? 'Nap'
         : 'Meditation'
+      const details: string[] = [formatDuration(a.start_time, end)]
+      if (a.avg_hrv) details.push(`Avg HRV: ${a.avg_hrv} ms`)
+      if (a.notes) details.push(a.notes)
+
+      // For meditation, show overlapping last.fm tags
+      if (a.activity_type === 'meditation') {
+        const music = tags
+          .filter((t) => t.source === 'lastfm' || t.source === 'lastfm-auto')
+          .filter((t) => {
+            const tagEnd = t.end_time ?? new Date(t.start_time.getTime() + 4 * 60000)
+            return t.start_time < end && tagEnd > a.start_time
+          })
+          .map((t) => t.tag)
+        if (music.length > 0) details.push(`♪ ${music.slice(0, 3).join(', ')}`)
+      }
+
       return {
         color: activityColors[a.activity_type] ?? '#3b82f6',
         column: 'Sleep / Rest' as Column,
@@ -185,7 +201,7 @@ const categorizeSleepRest = (activities: Activity[]): ChartItem[] =>
         label,
         start: a.start_time,
         tooltip: {
-          details: [formatDuration(a.start_time, end)],
+          details,
           time: `${formatTime(a.start_time)} – ${formatTime(end)}`,
           title: label,
         },
@@ -395,7 +411,7 @@ export const DayView = () => {
 
   const uniquePlaceNames = [...new Set(places.map((p) => p.region))].filter(Boolean).sort()
   const chartItems = [
-    ...categorizeSleepRest(activities),
+    ...categorizeSleepRest(activities, tags),
     ...categorizeExercise(activities),
     ...categorizeLocations(places, uniquePlaceNames),
     ...categorizeTags(tags),

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -126,6 +126,7 @@ export const getExerciseTypeValue = (name: ExerciseTypeName): number => exercise
 export const activitySchema = z
   .object({
     activity_type: z.string().meta({ description: 'Activity type' }),
+    avg_hrv: z.number().optional().meta({ description: 'Average HRV (ms) during the activity' }),
     data: z.record(z.string(), z.unknown()).optional(),
     duration: durationMinutesSchema.optional(),
     end_time: iso8601DateTimeSchema.optional(),


### PR DESCRIPTION
## Summary
- Add 2-minute leeway to productivity span merging (RescueTime has 1-second gaps between 5-min blocks)
- Compute and return `avg_hrv` for sleep and meditation activities in the backend
- Enhance DayView tooltips to show average HRV and overlapping last.fm tracks for meditation
- Add `avg_hrv` field to api-spec Activity schema

## Test plan
- [x] Backend unit tests pass (638 passed)
- [x] TypeScript check passes for backend, web, and api-spec
- [x] ESLint passes
- [ ] Verify productivity spans are fully merged in day view
- [ ] Verify sleep tooltip shows average HRV
- [ ] Verify meditation tooltip shows HRV and last.fm track

🤖 Generated with [Claude Code](https://claude.com/claude-code)