### PR TITLE
Add scrobble query endpoint to REST API and MCP

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -50,7 +50,7 @@ export {
 } from './connection'
 
 // Raw records
-export { insertRawRecord } from './raw-records'
+export { getScrobbles, insertRawRecord, type ScrobbleRecord } from './raw-records'
 
 // Time series
 export {

--- a/apps/backend/src/db/raw-records.integration.test.ts
+++ b/apps/backend/src/db/raw-records.integration.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
+import { getScrobbles, insertRawRecord } from './raw-records'
+
+const CONTAINER_TIMEOUT = 60_000
+
+describe('Raw Records Integration Tests', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  describe('getScrobbles', () => {
+    test('returns scrobbles within time range', async () => {
+      const user = getTestUser()
+
+      await insertRawRecord(user, {
+        data: { album: 'Album A', artist: 'Artist A', track: 'Track A' },
+        external_id: '1-Track A-Artist A',
+        record_type: 'scrobble',
+        recorded_at: new Date('2026-02-17T10:05:00Z'),
+        source: 'lastfm',
+      })
+      await insertRawRecord(user, {
+        data: { album: 'Album B', artist: 'Artist B', track: 'Track B' },
+        external_id: '2-Track B-Artist B',
+        record_type: 'scrobble',
+        recorded_at: new Date('2026-02-17T10:10:00Z'),
+        source: 'lastfm',
+      })
+      // Outside range
+      await insertRawRecord(user, {
+        data: { album: 'Album C', artist: 'Artist C', track: 'Track C' },
+        external_id: '3-Track C-Artist C',
+        record_type: 'scrobble',
+        recorded_at: new Date('2026-02-17T11:00:00Z'),
+        source: 'lastfm',
+      })
+
+      const result = await getScrobbles(
+        user,
+        new Date('2026-02-17T10:00:00Z'),
+        new Date('2026-02-17T10:15:00Z'),
+      )
+
+      expect(result).toHaveLength(2)
+      expect(result[0].track).toBe('Track A')
+      expect(result[0].artist).toBe('Artist A')
+      expect(result[0].album).toBe('Album A')
+      expect(result[1].track).toBe('Track B')
+    })
+
+    test('returns empty array when no scrobbles in range', async () => {
+      const user = getTestUser()
+      const result = await getScrobbles(
+        user,
+        new Date('2026-02-17T10:00:00Z'),
+        new Date('2026-02-17T11:00:00Z'),
+      )
+      expect(result).toEqual([])
+    })
+
+    test('only returns lastfm scrobbles, not other raw records', async () => {
+      const user = getTestUser()
+
+      await insertRawRecord(user, {
+        data: { album: 'Album', artist: 'Artist', track: 'Track' },
+        external_id: '1-Track-Artist',
+        record_type: 'scrobble',
+        recorded_at: new Date('2026-02-17T10:05:00Z'),
+        source: 'lastfm',
+      })
+      await insertRawRecord(user, {
+        data: { some: 'data' },
+        external_id: 'other-record',
+        record_type: 'heartrate',
+        recorded_at: new Date('2026-02-17T10:05:00Z'),
+        source: 'health_connect',
+      })
+
+      const result = await getScrobbles(
+        user,
+        new Date('2026-02-17T10:00:00Z'),
+        new Date('2026-02-17T11:00:00Z'),
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].track).toBe('Track')
+    })
+
+    test('returns results ordered by recorded_at ascending', async () => {
+      const user = getTestUser()
+
+      await insertRawRecord(user, {
+        data: { album: '', artist: 'A', track: 'Second' },
+        external_id: '2-Second-A',
+        record_type: 'scrobble',
+        recorded_at: new Date('2026-02-17T10:10:00Z'),
+        source: 'lastfm',
+      })
+      await insertRawRecord(user, {
+        data: { album: '', artist: 'A', track: 'First' },
+        external_id: '1-First-A',
+        record_type: 'scrobble',
+        recorded_at: new Date('2026-02-17T10:05:00Z'),
+        source: 'lastfm',
+      })
+
+      const result = await getScrobbles(
+        user,
+        new Date('2026-02-17T10:00:00Z'),
+        new Date('2026-02-17T11:00:00Z'),
+      )
+      expect(result[0].track).toBe('First')
+      expect(result[1].track).toBe('Second')
+    })
+  })
+})

--- a/apps/backend/src/db/raw-records.ts
+++ b/apps/backend/src/db/raw-records.ts
@@ -15,3 +15,32 @@ export const insertRawRecord = async (user: string, record: RawRecord) => {
     [record.source, record.record_type, record.external_id, record.recorded_at, record.data],
   )
 }
+
+export interface ScrobbleRecord {
+  recorded_at: Date
+  track: string
+  artist: string
+  album: string
+}
+
+/**
+ * Query Last.fm scrobbles from raw_records within a time range.
+ */
+export const getScrobbles = async (user: string, start: Date, end: Date): Promise<ScrobbleRecord[]> => {
+  const result = await query(
+    user,
+    `SELECT recorded_at, data
+     FROM raw_records
+     WHERE source = 'lastfm' AND record_type = 'scrobble'
+       AND recorded_at >= $1 AND recorded_at < $2
+     ORDER BY recorded_at ASC`,
+    [start, end],
+  )
+
+  return result.rows.map((row) => ({
+    album: (row.data.album as string) ?? '',
+    artist: (row.data.artist as string) ?? '',
+    recorded_at: row.recorded_at as Date,
+    track: (row.data.track as string) ?? '',
+  }))
+}

--- a/apps/backend/src/lastfm-router.ts
+++ b/apps/backend/src/lastfm-router.ts
@@ -9,6 +9,7 @@ import {
   type AddLastFmTagRuleBody,
   type AddLastFmTagRuleResponse,
   type LastFmTagRulesResponse,
+  type ScrobblesResponse,
   type SyncResponse,
 } from '@aurboda/api-spec'
 import { RequestHandler, Router } from 'express'
@@ -16,6 +17,7 @@ import type { ParamsDictionary } from 'express-serve-static-core'
 import {
   deleteLastFmTagRule,
   getLastFmTagRules,
+  getScrobbles,
   insertLastFmTagRule,
   type LastFmMatchMode,
   type LastFmMatchType,
@@ -27,6 +29,30 @@ import { validateBody } from './validation'
  */
 export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
   const router = Router()
+
+  // GET /lastfm/scrobbles - Query scrobbles by time range
+  router.get<ParamsDictionary, ScrobblesResponse>('/scrobbles', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { start, end } = req.query as { start?: string; end?: string }
+
+    if (!start || !end) {
+      return res.status(400).json({ error: 'start and end query parameters are required', success: false })
+    }
+
+    try {
+      const scrobbles = await getScrobbles(user, new Date(start), new Date(end))
+      const serialized = scrobbles.map((s) => ({
+        album: s.album,
+        artist: s.artist,
+        recorded_at: s.recorded_at.toISOString(),
+        track: s.track,
+      }))
+      res.json({ data: serialized, success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
 
   // GET /lastfm/tag-rules - List all tag rules
   router.get<ParamsDictionary, LastFmTagRulesResponse>('/tag-rules', authMiddleware, async (req, res) => {

--- a/apps/backend/src/mcp/lastfm-tools.ts
+++ b/apps/backend/src/mcp/lastfm-tools.ts
@@ -1,11 +1,12 @@
 /**
- * MCP Last.fm tag rule tools.
+ * MCP Last.fm tools: scrobble queries and tag rule management.
  */
-import { addLastFmTagRuleBodySchema } from '@aurboda/api-spec'
+import { addLastFmTagRuleBodySchema, scrobblesQuerySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 import {
   deleteLastFmTagRule,
   getLastFmTagRules,
+  getScrobbles,
   insertLastFmTagRule,
   type LastFmMatchMode,
   type LastFmMatchType,
@@ -13,6 +14,23 @@ import {
 import { errorResponse, jsonResponse, type McpServer } from './helpers'
 
 export const registerLastFmTools = (server: McpServer, user: string) => {
+  // Tool: query_scrobbles
+  server.tool(
+    'query_scrobbles',
+    'Query Last.fm scrobbles for a time range. Returns tracks played with artist, album, and timestamp.',
+    { ...scrobblesQuerySchema.shape },
+    async ({ start, end }) => {
+      const scrobbles = await getScrobbles(user, new Date(start), new Date(end))
+      const serialized = scrobbles.map((s) => ({
+        album: s.album,
+        artist: s.artist,
+        recorded_at: s.recorded_at.toISOString(),
+        track: s.track,
+      }))
+      return jsonResponse({ data: serialized, success: true })
+    },
+  )
+
   // Tool: get_lastfm_tag_rules
   server.tool(
     'get_lastfm_tag_rules',

--- a/docs/lastfm.md
+++ b/docs/lastfm.md
@@ -9,7 +9,7 @@ Scrobbles are stored as raw records with:
 - MusicBrainz IDs (when available)
 - Timestamp
 
-Scrobbles themselves are not directly visible in the timeline. Instead, the **auto-tagging rules** system creates tags from matching scrobbles, which appear on the timeline and can be used in correlations.
+Scrobbles can be queried directly via API or MCP. The **auto-tagging rules** system creates tags from matching scrobbles, which appear on the timeline and can be used in correlations.
 
 ## Admin Setup
 
@@ -63,6 +63,15 @@ Rules can be managed in **Settings > Last.fm Tag Rules** or via MCP tools:
 - `get_lastfm_tag_rules()` -- List all rules
 - `add_lastfm_tag_rule(...)` -- Create a rule
 - `delete_lastfm_tag_rule(rule_id)` -- Delete a rule
+
+## Querying Scrobbles
+
+Raw scrobbles can be queried by time range:
+
+- **REST:** `GET /api/lastfm/scrobbles?start=...&end=...`
+- **MCP:** `query_scrobbles(start, end)`
+
+Returns track name, artist, album, and timestamp for each scrobble in the time range.
 
 ## Sync
 

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -10,6 +10,7 @@ import {
   dateOnlySchema,
   iso8601DateTimeSchema,
   syncStatusSchema,
+  timeRangeQuerySchema,
 } from './common.js'
 
 // Shared sync options fields
@@ -517,3 +518,37 @@ export const addLastFmTagRuleResponseSchema = baseResponseSchema
   .meta({ id: 'AddLastFmTagRuleResponse' })
 
 export type AddLastFmTagRuleResponse = z.infer<typeof addLastFmTagRuleResponseSchema>
+
+// ============================================================================
+// Last.fm scrobbles query schemas
+// ============================================================================
+
+/**
+ * Scrobble record schema.
+ */
+export const scrobbleSchema = z
+  .object({
+    album: z.string().meta({ description: 'Album name' }),
+    artist: z.string().meta({ description: 'Artist name' }),
+    recorded_at: iso8601DateTimeSchema.meta({ description: 'When the track was played' }),
+    track: z.string().meta({ description: 'Track name' }),
+  })
+  .meta({ id: 'Scrobble' })
+
+export type Scrobble = z.infer<typeof scrobbleSchema>
+
+/**
+ * Scrobbles query schema.
+ */
+export const scrobblesQuerySchema = timeRangeQuerySchema.meta({ id: 'ScrobblesQuery' })
+
+export type ScrobblesQuery = z.infer<typeof scrobblesQuerySchema>
+
+/**
+ * Scrobbles response schema.
+ */
+export const scrobblesResponseSchema = createDataArrayResponseSchema(scrobbleSchema).meta({
+  id: 'ScrobblesResponse',
+})
+
+export type ScrobblesResponse = z.infer<typeof scrobblesResponseSchema>


### PR DESCRIPTION
## Summary
- Added `getScrobbles` db function to query Last.fm scrobbles from `raw_records` table by time range
- Added `GET /api/lastfm/scrobbles?start=...&end=...` REST endpoint
- Added `query_scrobbles` MCP tool for querying scrobbles via MCP
- Added scrobble schemas (`Scrobble`, `ScrobblesQuery`, `ScrobblesResponse`) to `@aurboda/api-spec`
- Added integration tests for the db function
- Updated Last.fm docs

## Test plan
- [x] Integration tests pass for getScrobbles (time range filtering, ordering, source filtering)
- [x] All 758 existing tests still pass
- [x] `pnpm fix` and `pnpm check` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)