### PR TITLE
Fix trends 400 error: migrate localStorage camelCase params

### DIFF
--- a/apps/web/src/state/savedTrends.ts
+++ b/apps/web/src/state/savedTrends.ts
@@ -47,11 +47,41 @@ export const DEFAULT_TRENDS: SavedTrend[] = [
 
 const STORAGE_KEY = 'savedTrends'
 
+// Migrate old camelCase params from before the snake_case standardization.
+interface LegacyParams {
+  sourceType?: string
+  halfLifeDays?: number
+  lookbackDays?: number
+  displayPeriod?: string
+}
+
+const migrateParams = (params: FetchTrendParams & LegacyParams): FetchTrendParams => {
+  const { sourceType, halfLifeDays, lookbackDays, displayPeriod, ...rest } = params
+  return {
+    ...rest,
+    source_type: rest.source_type ?? (sourceType as FetchTrendParams['source_type']),
+    ...(rest.half_life_days == null && halfLifeDays != null ? { half_life_days: halfLifeDays } : {}),
+    ...(rest.lookback_days == null && lookbackDays != null ? { lookback_days: lookbackDays } : {}),
+    ...(rest.display_period == null && displayPeriod != null
+      ? { display_period: displayPeriod as FetchTrendParams['display_period'] }
+      : {}),
+  }
+}
+
 const loadSavedTrends = (): SavedTrend[] => {
   const saved = localStorage.getItem(STORAGE_KEY)
   if (saved) {
     try {
-      return JSON.parse(saved) as SavedTrend[]
+      const parsed = JSON.parse(saved) as Array<SavedTrend & { params: FetchTrendParams & LegacyParams }>
+      const needsMigration = parsed.some(
+        (t) => 'sourceType' in t.params || 'halfLifeDays' in t.params || 'lookbackDays' in t.params || 'displayPeriod' in t.params,
+      )
+      if (needsMigration) {
+        const migrated = parsed.map((t) => ({ ...t, params: migrateParams(t.params) }))
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(migrated))
+        return migrated
+      }
+      return parsed
     } catch {
       return DEFAULT_TRENDS
     }

--- a/apps/web/src/state/savedTrends.ts
+++ b/apps/web/src/state/savedTrends.ts
@@ -62,9 +62,9 @@ const migrateParams = (params: FetchTrendParams & LegacyParams): FetchTrendParam
     source_type: rest.source_type ?? (sourceType as FetchTrendParams['source_type']),
     ...(rest.half_life_days == null && halfLifeDays != null ? { half_life_days: halfLifeDays } : {}),
     ...(rest.lookback_days == null && lookbackDays != null ? { lookback_days: lookbackDays } : {}),
-    ...(rest.display_period == null && displayPeriod != null
-      ? { display_period: displayPeriod as FetchTrendParams['display_period'] }
-      : {}),
+    ...(rest.display_period == null && displayPeriod != null ?
+      { display_period: displayPeriod as FetchTrendParams['display_period'] }
+    : {}),
   }
 }
 
@@ -74,7 +74,11 @@ const loadSavedTrends = (): SavedTrend[] => {
     try {
       const parsed = JSON.parse(saved) as Array<SavedTrend & { params: FetchTrendParams & LegacyParams }>
       const needsMigration = parsed.some(
-        (t) => 'sourceType' in t.params || 'halfLifeDays' in t.params || 'lookbackDays' in t.params || 'displayPeriod' in t.params,
+        (t) =>
+          'sourceType' in t.params ||
+          'halfLifeDays' in t.params ||
+          'lookbackDays' in t.params ||
+          'displayPeriod' in t.params,
       )
       if (needsMigration) {
         const migrated = parsed.map((t) => ({ ...t, params: migrateParams(t.params) }))


### PR DESCRIPTION
## Summary
- The snake_case standardization (59d350d) renamed fields in `FetchTrendParams` (e.g., `sourceType` → `source_type`) but saved trends in `localStorage` still had the old camelCase keys
- When loading old data, `source_type` was `undefined`, causing the backend to reject requests with 400 (missing required field)
- Added a migration in `loadSavedTrends()` that detects old camelCase keys and converts them to snake_case, persisting the fix back to localStorage

## Test plan
- [ ] Clear localStorage `savedTrends` key and verify default trends load correctly
- [ ] Set localStorage to old camelCase format and verify migration runs on page load
- [ ] Verify trends page loads and displays data after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)