### PR TITLE
Fix Oura tag sync: use correct snake_case field names

### DIFF
--- a/apps/backend/src/oura-sync.test.ts
+++ b/apps/backend/src/oura-sync.test.ts
@@ -507,13 +507,13 @@ describe('processOuraData', () => {
 
   describe('tags', () => {
     test('processes tag data with custom name', async () => {
-      // Data is pre-transformed by oura.ts getTags()
+      // Data is pre-transformed by oura.ts getTags() which returns DB Tag type (snake_case)
       const data = [
         {
-          endTime: new Date('2025-01-01T08:05:00Z'),
-          externalId: 'tag-1',
-          source: 'oura',
-          startTime: new Date('2025-01-01T08:00:00Z'),
+          end_time: new Date('2025-01-01T08:05:00Z'),
+          external_id: 'tag-1',
+          source: 'oura' as const,
+          start_time: new Date('2025-01-01T08:00:00Z'),
           tag: 'Morning Coffee',
         },
       ]
@@ -528,59 +528,41 @@ describe('processOuraData', () => {
         source: 'oura',
       })
 
-      expect(db.insertTag).toHaveBeenCalledWith(user, {
-        end_time: new Date('2025-01-01T08:05:00Z'),
-        external_id: 'tag-1',
-        source: 'oura',
-        start_time: new Date('2025-01-01T08:00:00Z'),
-        tag: 'Morning Coffee',
-      })
+      expect(db.insertTag).toHaveBeenCalledWith(user, data[0])
     })
 
-    test('processes tag data without endTime', async () => {
-      // Data is pre-transformed by oura.ts getTags()
+    test('processes tag data without end_time', async () => {
+      // Data is pre-transformed by oura.ts getTags() which returns DB Tag type (snake_case)
       const data = [
         {
-          endTime: undefined,
-          externalId: 'tag-2',
-          source: 'oura',
-          startTime: new Date('2025-01-01T14:00:00Z'),
+          end_time: undefined,
+          external_id: 'tag-2',
+          source: 'oura' as const,
+          start_time: new Date('2025-01-01T14:00:00Z'),
           tag: 'stress_high',
         },
       ]
 
       await processOuraData(user, 'tags', data)
 
-      expect(db.insertTag).toHaveBeenCalledWith(user, {
-        end_time: undefined,
-        external_id: 'tag-2',
-        source: 'oura',
-        start_time: new Date('2025-01-01T14:00:00Z'),
-        tag: 'stress_high',
-      })
+      expect(db.insertTag).toHaveBeenCalledWith(user, data[0])
     })
 
     test('handles tag with unknown type', async () => {
       // Data is pre-transformed by oura.ts getTags() - 'unknown' is set by oura.ts when tag_type_code is null
       const data = [
         {
-          endTime: undefined,
-          externalId: 'tag-3',
-          source: 'oura',
-          startTime: new Date('2025-01-01T14:00:00Z'),
+          end_time: undefined,
+          external_id: 'tag-3',
+          source: 'oura' as const,
+          start_time: new Date('2025-01-01T14:00:00Z'),
           tag: 'unknown',
         },
       ]
 
       await processOuraData(user, 'tags', data)
 
-      expect(db.insertTag).toHaveBeenCalledWith(user, {
-        end_time: undefined,
-        external_id: 'tag-3',
-        source: 'oura',
-        start_time: new Date('2025-01-01T14:00:00Z'),
-        tag: 'unknown',
-      })
+      expect(db.insertTag).toHaveBeenCalledWith(user, data[0])
     })
   })
 })

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -14,6 +14,7 @@ import {
   insertTag,
   insertTimeSeries,
   SyncState,
+  Tag,
   TimeSeriesPoint,
   upsertSyncState,
 } from './db'
@@ -89,14 +90,6 @@ interface OuraSession {
   heartRate?: OuraIntervalData
   hrv?: OuraIntervalData
   motion?: unknown
-}
-
-interface OuraTag {
-  startTime: Date
-  endTime?: Date
-  tag: string
-  externalId: string
-  source: string
 }
 
 /**
@@ -352,23 +345,17 @@ const processSessions = async (user: string, data: OuraSession[]) => {
 /**
  * Process Oura tag data.
  */
-const processTags = async (user: string, data: OuraTag[]) => {
+const processTags = async (user: string, data: Tag[]) => {
   for (const record of data) {
     await insertRawRecord(user, {
       data: record as unknown as Record<string, unknown>,
-      external_id: record.externalId,
+      external_id: record.external_id,
       record_type: 'enhanced_tag',
-      recorded_at: record.startTime,
+      recorded_at: record.start_time,
       source: 'oura',
     })
 
-    await insertTag(user, {
-      end_time: record.endTime,
-      external_id: record.externalId,
-      source: 'oura',
-      start_time: record.startTime,
-      tag: record.tag,
-    })
+    await insertTag(user, record)
   }
 }
 
@@ -403,7 +390,7 @@ export const processOuraData = async (
       await processSessions(user, data as OuraSession[])
       break
     case 'tags':
-      await processTags(user, data as OuraTag[])
+      await processTags(user, data as Tag[])
       break
   }
 }


### PR DESCRIPTION
## Summary
- Fix broken Oura tag sync that has been failing since Feb 15 with "null value in column recorded_at" error
- The `processTags` function used an `OuraTag` interface with camelCase fields (`startTime`, `endTime`, `externalId`) but `oura.getTags()` returns DB `Tag` type objects with snake_case fields (`start_time`, `end_time`, `external_id`)
- This caused `record.startTime` to be `undefined`, breaking the `insertRawRecord` call
- Replace the incorrect `OuraTag` interface with the DB `Tag` type and pass the record directly to `insertTag`

## Test plan
- [x] Updated existing unit tests to use correct snake_case field format
- [x] All 760 backend tests pass
- [ ] After deploy, trigger Oura sync and verify tags appear in both Day View and Timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)