### PR TITLE
Throttle zoom scroll events with requestAnimationFrame

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -409,6 +409,7 @@ export const DayView = () => {
   const zoomBehaviorRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown>>()
   const isProgrammaticZoom = useRef(false)
   const baseScaleRef = useRef<d3.ScaleTime<number, number>>()
+  const zoomRafRef = useRef<number>(0)
 
   // Handle zoom - update view range and expand data fetch if needed
   const handleZoom = useCallback((zoomStart: Date, zoomEnd: Date) => {
@@ -668,10 +669,13 @@ export const DayView = () => {
       .filter((event) => event.type !== 'dblclick')
       .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
         if (isProgrammaticZoom.current) return
-        const newY = event.transform.rescaleY(baseScale)
-        const newDomain = newY.domain()
-        draw(d3.scaleTime().domain(newDomain).range([0, CHART_HEIGHT]))
-        handleZoom(newDomain[0], newDomain[1])
+        cancelAnimationFrame(zoomRafRef.current)
+        zoomRafRef.current = requestAnimationFrame(() => {
+          const newY = event.transform.rescaleY(baseScale)
+          const newDomain = newY.domain()
+          draw(d3.scaleTime().domain(newDomain).range([0, CHART_HEIGHT]))
+          handleZoom(newDomain[0], newDomain[1])
+        })
       })
 
     svg.call(zoom)

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -534,6 +534,7 @@ function TimelineChart({
   const xAxisRef = useRef<SVGGElement>(null)
   const zoomBehaviorRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown>>()
   const isProgrammaticZoom = useRef(false)
+  const zoomRafRef = useRef<number>(0)
 
   const [tooltip, setTooltip] = useState<TooltipState>({
     content: { time: '', title: '' },
@@ -642,9 +643,12 @@ function TimelineChart({
       })
       .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
         if (isProgrammaticZoom.current) return
-        const newX = event.transform.rescaleX(baseScale)
-        const domain = newX.domain()
-        onZoom(domain[0], domain[1])
+        cancelAnimationFrame(zoomRafRef.current)
+        zoomRafRef.current = requestAnimationFrame(() => {
+          const newX = event.transform.rescaleX(baseScale)
+          const domain = newX.domain()
+          onZoom(domain[0], domain[1])
+        })
       })
 
     svg.call(zoom)
@@ -661,6 +665,7 @@ function TimelineChart({
     zoomBehaviorRef.current = zoom
 
     return () => {
+      cancelAnimationFrame(zoomRafRef.current)
       svg.on('.zoom', null)
     }
   }, [baseScale, onZoom])


### PR DESCRIPTION
## Summary
- Trackpad two-finger scrolling fires many more wheel events than a mouse wheel, causing browser freezes on Day View and Timeline
- Wraps D3 zoom callbacks in `requestAnimationFrame` to coalesce rapid scroll events into at most one update per frame (~60fps)
- Applies to both DayView (vertical zoom) and Timeline (horizontal zoom)

## Test plan
- [ ] Test two-finger trackpad zoom on Day View - should be smooth, no freezing
- [ ] Test two-finger trackpad zoom on Timeline - should be smooth, no freezing
- [ ] Test mouse wheel zoom still works normally on both views
- [ ] Test drag-to-pan still works on both views
- [ ] Test double-click reset still works on both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)