### PR TITLE
Widen Day view for desktop readability

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -579,6 +579,7 @@ export const DayView = () => {
         .attr('stroke-opacity', 0.1)
 
       // Hour labels on left
+      const hourFontSize = chartWidth > 1200 ? '0.85rem' : '0.7rem'
       g.selectAll('.hour-label')
         .data(hours)
         .enter()
@@ -589,7 +590,7 @@ export const DayView = () => {
         .attr('dy', '0.35em')
         .attr('text-anchor', 'end')
         .attr('fill', 'currentColor')
-        .attr('font-size', '0.7rem')
+        .attr('font-size', hourFontSize)
         .attr('opacity', 0.6)
         .text((d) => format(d, 'HH:mm'))
 
@@ -912,14 +913,16 @@ const drawItem = (
 
   // Text label inside if tall enough
   if (blockHeight > 30) {
-    const maxChars = Math.floor(laneWidth / 6)
+    const fontSize = laneWidth > 100 ? '0.8rem' : '0.65rem'
+    const charWidth = laneWidth > 100 ? 7.5 : 6
+    const maxChars = Math.floor(laneWidth / charWidth)
     const text = item.label.length > maxChars ? item.label.slice(0, maxChars) + '…' : item.label
     chartGroup
       .append('text')
       .attr('x', x + 4)
       .attr('y', y1 + 14)
       .attr('fill', 'white')
-      .attr('font-size', '0.65rem')
+      .attr('font-size', fontSize)
       .attr('font-weight', '500')
       .attr('pointer-events', 'none')
       .text(text)

--- a/apps/web/src/pages/DayView/style.css
+++ b/apps/web/src/pages/DayView/style.css
@@ -1,5 +1,5 @@
 .day-view {
-  max-width: 1100px;
+  max-width: 1800px;
   margin: 0 auto;
   padding: 2rem;
 }


### PR DESCRIPTION
## Summary
- Increase `.day-view` max-width from 1100px to 1800px so the chart fills more of the screen on wide monitors
- Scale up block label font (0.65rem → 0.8rem) and hour label font (0.7rem → 0.85rem) when there is enough space
- Text labels inside blocks show more characters on wider lanes

## Test plan
- [ ] Open Day view on a wide desktop browser (1400px+) — chart should fill more horizontal space
- [ ] Verify text labels in blocks are larger and more readable
- [ ] Verify mobile view (<768px) is unchanged (falls back to list view)
- [ ] Check that zooming/panning still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)