### PR TITLE
Fix trend chart Y-axis scaling for high-value metrics

### DIFF
--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -69,7 +69,7 @@ const calculateTagTrend = async (
           date_trunc('day', start_time AT TIME ZONE 'UTC')::date as day,
           count(*) as cnt
         FROM tags
-        WHERE tag ~ $1
+        WHERE tag ~* $1
           AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
         GROUP BY 1
       ) t ON d.day = t.day

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -71,8 +71,9 @@ function TagMappingRow({
         <span class="tag-count" title={`Used ${tag.count} time${tag.count !== 1 ? 's' : ''}`}>
           {tag.count} uses
         </span>
-        <span class="tag-latest" title={date.toLocaleString()}>
-          Last: {date.toLocaleDateString()}
+        <span class="tag-latest">
+          Last: {date.toLocaleDateString()}{' '}
+          {date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
         </span>
       </div>
 

--- a/apps/web/src/components/widgets/TrendChartWidget.tsx
+++ b/apps/web/src/components/widgets/TrendChartWidget.tsx
@@ -53,10 +53,13 @@ function TrendChart({
       .domain(d3.extent(parsedData, (d) => d.date) as [Date, Date])
       .range([0, innerWidth])
 
-    const maxValue = d3.max(parsedData, (d) => d.value) ?? 0
+    const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
+    const yRange = yExtent[1] - yExtent[0]
+    const yPadding = yRange * 0.1 || 1
     const y = d3
       .scaleLinear()
-      .domain([0, maxValue * 1.1])
+      .domain([yExtent[0] - yPadding, yExtent[1] + yPadding])
+      .nice()
       .range([innerHeight, 0])
 
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -47,11 +47,12 @@ function TrendChart({ data, color }: { data: { date: string; value: number }[]; 
       .range([0, innerWidth])
 
     const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
-    const yMin = Math.min(0, yExtent[0])
-    const yPadding = (yExtent[1] - yMin) * 0.1 || 1
+    const yRange = yExtent[1] - yExtent[0]
+    const yPadding = yRange * 0.1 || 1
     const y = d3
       .scaleLinear()
-      .domain([yMin, yExtent[1] + yPadding])
+      .domain([yExtent[0] - yPadding, yExtent[1] + yPadding])
+      .nice()
       .range([innerHeight, 0])
 
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)


### PR DESCRIPTION
## Summary
- **Y-axis scaling**: The trend chart Y-axis was forced to start at 0, making metrics like weight (~100 kg) appear as completely flat lines since the ~1 kg variation occupied only ~1% of the chart height. Changed both `TrendChart` (Trends page) and `TrendChartWidget` (dashboard) to use the actual data extent with 10% padding and `d3.nice()` for clean axis ticks.
- **Case-sensitive tag matching**: Tag trend regex used case-sensitive matching (`~`), so a pattern like `coffee|FatCoffee` would miss `Coffee` tags (capital C). Changed to case-insensitive matching (`~*`) since tag names from different sources have inconsistent casing (e.g. `tag_generic_coffee` from Oura vs `Coffee` from manual entry).

## Test plan
- [ ] Check the Trends page with a weight metric — chart should show visible variation instead of a flat line
- [ ] Check the coffee trend — value should be close to 2/day instead of ~0.6
- [ ] Check tag count trends still work for other tags
- [ ] Check a dashboard trend chart widget renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)