### PR TITLE
Widen Day view and add Music lane for Last.fm scrobbles

### DIFF
--- a/apps/web/src/pages/DayView/categorizeMusic.test.ts
+++ b/apps/web/src/pages/DayView/categorizeMusic.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest'
+import type { Scrobble } from '../../state/api'
+import { categorizeMusic } from './categorizeMusic'
+
+describe('categorizeMusic', () => {
+  test('returns empty array for empty scrobbles', () => {
+    expect(categorizeMusic([])).toEqual([])
+  })
+
+  test('converts a scrobble to a chart item with artist – track label', () => {
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'Kid A',
+        artist: 'Radiohead',
+        recorded_at: new Date('2024-06-15T10:00:00Z'),
+        track: 'Everything In Its Right Place',
+      },
+    ]
+
+    const result = categorizeMusic(scrobbles)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.label).toBe('Radiohead – Everything In Its Right Place')
+    expect(result[0]!.column).toBe('Music')
+    expect(result[0]!.color).toBe('#ec4899')
+    expect(result[0]!.isPoint).toBe(false)
+    expect(result[0]!.start).toEqual(new Date('2024-06-15T10:00:00Z'))
+    // ~3.5 min = 210000ms
+    expect(result[0]!.end.getTime() - result[0]!.start.getTime()).toBe(210000)
+  })
+
+  test('creates tooltip with time and album info', () => {
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'The Campfire Headphase',
+        artist: 'Boards of Canada',
+        recorded_at: new Date('2024-06-15T14:30:00Z'),
+        track: 'Dayvan Cowboy',
+      },
+    ]
+
+    const result = categorizeMusic(scrobbles)
+
+    expect(result[0]!.tooltip.title).toBe('Boards of Canada – Dayvan Cowboy')
+    expect(result[0]!.tooltip.details).toContain('The Campfire Headphase')
+  })
+
+  test('handles scrobble without album', () => {
+    const scrobbles: Scrobble[] = [
+      {
+        album: '',
+        artist: 'Unknown Artist',
+        recorded_at: new Date('2024-06-15T10:00:00Z'),
+        track: 'Some Track',
+      },
+    ]
+
+    const result = categorizeMusic(scrobbles)
+
+    expect(result[0]!.tooltip.details).not.toContain('')
+  })
+
+  test('handles multiple scrobbles', () => {
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'Album 1',
+        artist: 'Artist A',
+        recorded_at: new Date('2024-06-15T10:00:00Z'),
+        track: 'Track 1',
+      },
+      {
+        album: 'Album 2',
+        artist: 'Artist B',
+        recorded_at: new Date('2024-06-15T10:05:00Z'),
+        track: 'Track 2',
+      },
+    ]
+
+    const result = categorizeMusic(scrobbles)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]!.label).toBe('Artist A – Track 1')
+    expect(result[1]!.label).toBe('Artist B – Track 2')
+  })
+})

--- a/apps/web/src/pages/DayView/categorizeMusic.ts
+++ b/apps/web/src/pages/DayView/categorizeMusic.ts
@@ -1,0 +1,27 @@
+import { format } from 'date-fns'
+import type { Scrobble } from '../../state/api'
+import type { ChartItem } from './types'
+
+const MUSIC_COLOR = '#ec4899'
+const TRACK_DURATION_MS = 3.5 * 60 * 1000 // ~3.5 minutes
+
+const formatTime = (date: Date): string => format(date, 'HH:mm')
+
+export const categorizeMusic = (scrobbles: Scrobble[]): ChartItem[] =>
+  scrobbles.map((s) => {
+    const label = `${s.artist} – ${s.track}`
+    const end = new Date(s.recorded_at.getTime() + TRACK_DURATION_MS)
+    return {
+      color: MUSIC_COLOR,
+      column: 'Music',
+      end,
+      isPoint: false,
+      label,
+      start: s.recorded_at,
+      tooltip: {
+        details: [s.album].filter(Boolean),
+        time: formatTime(s.recorded_at),
+        title: label,
+      },
+    }
+  })

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -9,12 +9,16 @@ import {
   fetchActivities,
   fetchPlaces,
   fetchProductivity,
+  fetchScrobbles,
   fetchTags,
+  fetchUserSettings,
   Place,
   ProductivityRecord,
   Tag,
 } from '../../state/api'
 import { packLanes } from '../../utils/lanePacking'
+import { categorizeMusic } from './categorizeMusic'
+import type { ChartItem, Column } from './types'
 
 import './style.css'
 
@@ -29,8 +33,8 @@ const getDefaultViewStart = () => startOfDay(new Date())
 const getDefaultViewEnd = () => endOfDay(new Date())
 
 // Column definitions
-const COLUMNS = ['Sleep / Rest', 'Exercise', 'Location', 'Tags / Events', 'Productivity'] as const
-type Column = (typeof COLUMNS)[number]
+const BASE_COLUMNS: Column[] = ['Sleep / Rest', 'Exercise', 'Location', 'Tags / Events', 'Productivity']
+const MUSIC_COLOR = '#ec4899'
 
 // Colors
 const activityColors: Record<string, string> = {
@@ -156,23 +160,6 @@ const formatDuration = (start: Date, end: Date): string => {
 
 const escapeHtml = (str: string): string =>
   str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-
-// Categorized item for the chart
-interface ChartItem {
-  column: Column
-  start: Date
-  end: Date
-  label: string
-  color: string
-  tooltip: TooltipContent
-  isPoint: boolean
-}
-
-interface TooltipContent {
-  title: string
-  time: string
-  details: string[]
-}
 
 // Categorization per column
 const categorizeSleepRest = (activities: Activity[], tags: Tag[]): ChartItem[] =>
@@ -403,6 +390,22 @@ export const DayView = () => {
     staleTime: 10 * 60 * 1000,
   })
 
+  const settingsQuery = useQuery({
+    queryFn: fetchUserSettings,
+    queryKey: ['user-settings'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const hasLastFm = Boolean(settingsQuery.data?.lastfm_username)
+
+  const scrobblesQuery = useQuery({
+    enabled: hasLastFm,
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchScrobbles(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
+    queryKey: ['dayview-scrobbles', fromDate.value, toDate.value],
+    staleTime: 10 * 60 * 1000,
+  })
+
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
@@ -469,6 +472,12 @@ export const DayView = () => {
   const places = placesQuery.data ?? []
   const tags = tagsQuery.data ?? []
   const productivity = productivityQuery.data ?? []
+  const scrobbles = scrobblesQuery.data ?? []
+
+  const musicItems = hasLastFm ? categorizeMusic(scrobbles) : []
+  const showMusicColumn = musicItems.length > 0
+
+  const columns: Column[] = showMusicColumn ? [...BASE_COLUMNS, 'Music'] : BASE_COLUMNS
 
   const uniquePlaceNames = [...new Set(places.map((p) => p.region))].filter(Boolean).sort()
   const chartItems = [
@@ -477,10 +486,11 @@ export const DayView = () => {
     ...categorizeLocations(places, uniquePlaceNames),
     ...categorizeTags(tags),
     ...categorizeProductivity(productivity),
+    ...musicItems,
   ]
 
   // Group by column and pack lanes
-  const columnData = COLUMNS.map((col) => {
+  const columnData = columns.map((col) => {
     const colItems = chartItems.filter((i) => i.column === col)
     const packed = packLanes(
       colItems,
@@ -494,7 +504,8 @@ export const DayView = () => {
     activitiesQuery.isFetching ||
     placesQuery.isFetching ||
     tagsQuery.isFetching ||
-    productivityQuery.isFetching
+    productivityQuery.isFetching ||
+    scrobblesQuery.isFetching
 
   // Render SVG chart
   const renderChart = useCallback(() => {
@@ -520,7 +531,7 @@ export const DayView = () => {
     const yScale = d3.scaleTime().domain([effectiveViewStart, effectiveViewEnd]).range([0, CHART_HEIGHT])
 
     // Column layout
-    const colWidth = chartWidth / COLUMNS.length
+    const colWidth = chartWidth / columns.length
     const colGap = 4
     const colPadding = 2
 
@@ -624,7 +635,7 @@ export const DayView = () => {
       }
 
       // Column separators
-      for (let i = 1; i < COLUMNS.length; i++) {
+      for (let i = 1; i < columns.length; i++) {
         chartGroup
           .append('line')
           .attr('x1', i * colWidth)
@@ -695,6 +706,7 @@ export const DayView = () => {
   }, [
     activities,
     chartItems,
+    columns,
     columnData,
     effectiveViewEnd,
     effectiveViewStart,
@@ -776,6 +788,12 @@ export const DayView = () => {
           <span class="legend-dot" style={{ background: TAG_COLOR }} />
           Tags
         </span>
+        {showMusicColumn && (
+          <span class="legend-item">
+            <span class="legend-dot" style={{ background: MUSIC_COLOR }} />
+            Music
+          </span>
+        )}
       </div>
 
       {isLoading && <div class="loading">Loading…</div>}
@@ -784,7 +802,7 @@ export const DayView = () => {
       {!isLoading && !isError && (
         <>
           <div class="day-view-column-headers" style={{ paddingLeft: `${margin.left}px` }}>
-            {COLUMNS.map((col, i) => (
+            {columns.map((col, i) => (
               <div
                 key={col}
                 style={{
@@ -831,7 +849,7 @@ export const DayView = () => {
 // D3 drawing helpers extracted to reduce component complexity
 
 type ColumnDataEntry = {
-  column: (typeof COLUMNS)[number]
+  column: Column
   items: { item: ChartItem; lane: number }[]
   laneCount: number
 }

--- a/apps/web/src/pages/DayView/style.css
+++ b/apps/web/src/pages/DayView/style.css
@@ -1,5 +1,4 @@
 .day-view {
-  max-width: 1800px;
   margin: 0 auto;
   padding: 2rem;
 }

--- a/apps/web/src/pages/DayView/types.ts
+++ b/apps/web/src/pages/DayView/types.ts
@@ -1,0 +1,17 @@
+export type Column = 'Sleep / Rest' | 'Exercise' | 'Location' | 'Tags / Events' | 'Productivity' | 'Music'
+
+export interface TooltipContent {
+  title: string
+  time: string
+  details: string[]
+}
+
+export interface ChartItem {
+  column: Column
+  start: Date
+  end: Date
+  label: string
+  color: string
+  tooltip: TooltipContent
+  isPoint: boolean
+}

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -15,6 +15,7 @@ import type {
   DetectedLocation as ApiDetectedLocation,
   PlaceVisit as ApiPlaceVisit,
   ProductivityRecord as ApiProductivityRecord,
+  Scrobble as ApiScrobble,
   Tag as ApiTag,
   BaselineData,
   BaselineResponse,
@@ -48,6 +49,7 @@ import type {
   PromoteDetectedLocationBody,
   QueryMetricsQuery,
   QueryMetricsResponse,
+  ScrobblesResponse,
   SetTagMappingResponse,
   SyncResponse,
   TagCorrelation,
@@ -100,6 +102,10 @@ export interface StoredDetectedLocation extends Omit<ApiDetectedLocation, 'first
 export interface Tag extends Omit<ApiTag, 'start_time' | 'end_time'> {
   start_time: Date
   end_time?: Date
+}
+
+export interface Scrobble extends Omit<ApiScrobble, 'recorded_at'> {
+  recorded_at: Date
 }
 
 // Re-export API types that don't need Date conversion
@@ -241,6 +247,24 @@ export const fetchTags = async (start: Date, end: Date): Promise<Tag[]> => {
     ...tag,
     end_time: tag.end_time ? new Date(tag.end_time) : undefined,
     start_time: new Date(tag.start_time),
+  }))
+}
+
+// Fetch Last.fm scrobbles for the specified date range
+export const fetchScrobbles = async (start: Date, end: Date): Promise<Scrobble[]> => {
+  const { token } = auth.value
+  const params = {
+    end: end.toISOString(),
+    start: start.toISOString(),
+  }
+  const response = await axios.get<ScrobblesResponse>(`${API_URL}/lastfm/scrobbles`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+
+  return (response.data.data ?? []).map((scrobble) => ({
+    ...scrobble,
+    recorded_at: new Date(scrobble.recorded_at),
   }))
 }
 


### PR DESCRIPTION
## Summary

- Removed `max-width: 1800px` constraint from Day view so it fills the full browser width on desktop
- Added a conditional "Music" column that shows Last.fm scrobbles when the user has Last.fm configured
- Each scrobble displays as a ~3.5min block showing "Artist – Track" with pink (#ec4899) color coding
- Music column only appears when there is scrobble data for the viewed time range
- Added `fetchScrobbles` API function and `Scrobble` frontend type
- Extracted `ChartItem`/`Column` types to shared `types.ts` for testability

## Test plan

- [x] `pnpm --filter aurboda-web check` passes
- [x] `pnpm --filter aurboda-web test` passes (5 new categorizeMusic tests)
- [ ] Visual: Day view fills browser width on desktop
- [ ] Visual: Music lane appears for users with Last.fm configured
- [ ] Visual: Music lane is absent when Last.fm is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)