### PR TITLE
Fix Oura webhook challenge verification (404 on GET)

### DIFF
--- a/apps/backend/src/oura-webhook-router.test.ts
+++ b/apps/backend/src/oura-webhook-router.test.ts
@@ -27,6 +27,27 @@ describe('oura-webhook-router', () => {
     vi.clearAllMocks()
   })
 
+  describe('GET /webhooks/oura - challenge verification', () => {
+    test('returns 200 with challenge echoed back', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const response = await request(app).get('/webhooks/oura?challenge=abc123')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({ challenge: 'abc123' })
+    })
+
+    test('returns 400 when challenge query param is missing', async () => {
+      const deps = createDeps()
+      const app = createApp(deps)
+
+      const response = await request(app).get('/webhooks/oura')
+
+      expect(response.status).toBe(400)
+    })
+  })
+
   describe('POST /webhooks/oura - notification handling', () => {
     test('returns 200 and triggers sync for valid notification', async () => {
       const deps = createDeps()

--- a/apps/backend/src/oura-webhook-router.ts
+++ b/apps/backend/src/oura-webhook-router.ts
@@ -50,6 +50,15 @@ export const createOuraWebhookRouter = (deps: OuraWebhookRouterDeps): OuraWebhoo
     pendingSyncs.clear()
   }
 
+  router.get('/', (req, res) => {
+    const { challenge } = req.query
+    if (typeof challenge !== 'string') {
+      res.status(400).json({ error: 'Missing challenge' })
+      return
+    }
+    res.json({ challenge })
+  })
+
   router.post('/', async (req, res) => {
     const { data_type, event_type, user_id, verification_token } = req.body ?? {}
 


### PR DESCRIPTION
## Summary

- Oura verifies callback URLs before creating webhook subscriptions by sending a `GET` request with a `challenge` query parameter to the callback URL
- Our router only had a `POST` handler, so the challenge GET returned 404 → Oura rejected the subscription with a 400 error
- Added a `GET /` handler that echoes back the `challenge` query param as `{"challenge": "<value>"}` with status 200
- Added tests for the challenge handler (valid challenge and missing challenge cases)

## Test plan

- [ ] Run `pnpm test` — all tests pass
- [ ] Oura webhook subscriptions should now be created successfully on startup (no more 400 errors in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)