### PR TITLE
Add tag_key column to preserve original Oura tag identifiers

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -85,6 +85,38 @@ export const initializeSchema = async (user: string) => {
 }
 
 /**
+ * Backfill tag_key for Oura tags that were already mapped via tag_mappings in user settings.
+ * Reverses the mapping (display name -> programmatic key) to populate tag_key.
+ */
+const backfillTagKeysFromMappings = async (db: Client, existingTableNames: Set<string>) => {
+  if (!existingTableNames.has('user_settings')) return
+
+  const settingsResult = await query(db, `SELECT settings FROM user_settings LIMIT 1`)
+  if (settingsResult.rows.length === 0) return
+
+  const settings = settingsResult.rows[0].settings as Record<string, unknown>
+  const tagMappings = (settings.tag_mappings ?? settings.tagMappings) as Record<string, string> | undefined
+  if (!tagMappings) return
+
+  for (const [tagKey, displayName] of Object.entries(tagMappings)) {
+    // Match tags stored with the mapped display name
+    await query(
+      db,
+      `UPDATE tags SET tag_key = $1, tag = $2
+       WHERE tag_key IS NULL AND source = 'oura' AND tag = $3`,
+      [tagKey, displayName, displayName],
+    )
+    // Also catch tags still stored with the raw programmatic key as tag name
+    await query(
+      db,
+      `UPDATE tags SET tag_key = $1, tag = $2
+       WHERE tag_key IS NULL AND source = 'oura' AND tag = $3`,
+      [tagKey, displayName, tagKey],
+    )
+  }
+}
+
+/**
  * Run database migrations for a user.
  * Checks which tables exist and creates missing ones.
  */
@@ -114,6 +146,24 @@ export const migrateSchema = async (user: string) => {
   if (existingTableNames.has('lastfm_tag_rules')) {
     await query(db, `ALTER TABLE lastfm_tag_rules ADD COLUMN IF NOT EXISTS merge_gap_seconds INTEGER`)
     await query(db, `ALTER TABLE lastfm_tag_rules ADD COLUMN IF NOT EXISTS artist_names JSONB`)
+  }
+
+  if (existingTableNames.has('tags')) {
+    // Add tag_key column to preserve original Oura tag_type_code
+    await query(db, `ALTER TABLE tags ADD COLUMN IF NOT EXISTS tag_key VARCHAR(255)`)
+    await query(db, `CREATE INDEX IF NOT EXISTS idx_tags_tag_key ON tags (tag_key) WHERE tag_key IS NOT NULL`)
+
+    // Backfill: tags that still have programmatic names (UUID/tag_*) get tag_key = tag
+    await query(
+      db,
+      `UPDATE tags SET tag_key = tag
+       WHERE tag_key IS NULL
+         AND (tag ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              OR tag LIKE 'tag\\_%')`,
+    )
+
+    // Backfill: tags that were already mapped (tag = display name) — reverse-lookup from tag_mappings
+    await backfillTagKeysFromMappings(db, existingTableNames)
   }
 }
 

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -104,6 +104,7 @@ export {
   insertTag,
   isProgrammaticTag,
   updateTagEndTime,
+  updateTagNameByKey,
 } from './tags'
 
 // Productivity

--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -147,6 +147,7 @@ export const mapTagRow = (row: QueryResultRow): Tag => ({
   source: row.source,
   start_time: new Date(row.start_time),
   tag: row.tag,
+  tag_key: row.tag_key ?? undefined,
 })
 
 export const mapMcpSessionRow = (row: QueryResultRow): McpSessionRecord => ({

--- a/apps/backend/src/db/tags.integration.test.ts
+++ b/apps/backend/src/db/tags.integration.test.ts
@@ -12,6 +12,7 @@ import {
   insertTag,
   isProgrammaticTag,
   updateTagEndTime,
+  updateTagNameByKey,
 } from '../db'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
 
@@ -86,6 +87,50 @@ describe('Tags Integration Tests', () => {
       expect(tags).toHaveLength(1)
       expect(tags[0].tag).toBe('tea')
       expect(tags[0].start_time).toEqual(new Date('2024-01-15T11:00:00Z'))
+    })
+
+    test('inserts a tag with tag_key', async () => {
+      const user = getTestUser()
+      const tagKey = '067e2862-8cf8-4307-a621-0636dd379cda'
+
+      await insertTag(user, {
+        external_id: 'oura-tag-1',
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        tag: 'Food',
+        tag_key: tagKey,
+      })
+
+      const tags = await getTags(user, new Date('2024-01-15T00:00:00Z'), new Date('2024-01-15T23:59:59Z'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].tag).toBe('Food')
+      expect(tags[0].tag_key).toBe(tagKey)
+    })
+
+    test('preserves tag_key on upsert when new value is undefined', async () => {
+      const user = getTestUser()
+      const tagKey = '067e2862-8cf8-4307-a621-0636dd379cda'
+
+      await insertTag(user, {
+        external_id: 'oura-tag-2',
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        tag: 'Food',
+        tag_key: tagKey,
+      })
+
+      // Upsert without tag_key should preserve existing tag_key
+      await insertTag(user, {
+        external_id: 'oura-tag-2',
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        tag: 'Snack',
+      })
+
+      const tags = await getTags(user, new Date('2024-01-15T00:00:00Z'), new Date('2024-01-15T23:59:59Z'))
+      expect(tags).toHaveLength(1)
+      expect(tags[0].tag).toBe('Snack')
+      expect(tags[0].tag_key).toBe(tagKey)
     })
   })
 
@@ -354,6 +399,51 @@ describe('Tags Integration Tests', () => {
     })
   })
 
+  describe('updateTagNameByKey', () => {
+    test('updates all tags with matching tag_key', async () => {
+      const user = getTestUser()
+      const tagKey = '067e2862-8cf8-4307-a621-0636dd379cda'
+
+      await insertTag(user, {
+        external_id: 'oura-1',
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        tag: 'YinYoga',
+        tag_key: tagKey,
+      })
+      await insertTag(user, {
+        external_id: 'oura-2',
+        source: 'oura',
+        start_time: new Date('2024-01-16T10:00:00Z'),
+        tag: 'YinYoga',
+        tag_key: tagKey,
+      })
+      await insertTag(user, {
+        external_id: 'oura-3',
+        source: 'oura',
+        start_time: new Date('2024-01-17T10:00:00Z'),
+        tag: 'coffee',
+        tag_key: 'tag_generic_coffee',
+      })
+
+      const updated = await updateTagNameByKey(user, tagKey, 'Food')
+      expect(updated).toBe(2)
+
+      const tags = await getTags(user, new Date('2024-01-15T00:00:00Z'), new Date('2024-01-17T23:59:59Z'))
+      const foodTags = tags.filter((t) => t.tag === 'Food')
+      const coffeeTags = tags.filter((t) => t.tag === 'coffee')
+      expect(foodTags).toHaveLength(2)
+      expect(coffeeTags).toHaveLength(1)
+    })
+
+    test('returns 0 when no tags match', async () => {
+      const user = getTestUser()
+
+      const updated = await updateTagNameByKey(user, 'nonexistent-key', 'NewName')
+      expect(updated).toBe(0)
+    })
+  })
+
   describe('getUniqueTags', () => {
     test('returns empty array when no tags exist', async () => {
       const user = getTestUser()
@@ -426,29 +516,32 @@ describe('Tags Integration Tests', () => {
       expect(tags).toEqual([])
     })
 
-    test('returns UUID tags with counts from tags table', async () => {
+    test('returns tags with tag_key set (mapped tags)', async () => {
       const user = getTestUser()
       const uuid1 = '067e2862-8cf8-4307-a621-0636dd379cda'
       const uuid2 = '4ddc8bc2-911d-467d-8c9d-dac2ece87d0a'
 
-      // Insert tags directly to tags table (simulating how Oura sync stores them)
+      // Tags with tag_key set (post-migration: tag has display name, tag_key has original)
       await insertTag(user, {
         external_id: 'tag-1',
         source: 'oura',
         start_time: new Date('2024-01-15T10:00:00Z'),
-        tag: uuid1,
+        tag: 'Food',
+        tag_key: uuid1,
       })
       await insertTag(user, {
         external_id: 'tag-2',
         source: 'oura',
         start_time: new Date('2024-01-15T11:00:00Z'),
-        tag: uuid1, // same tag, counted twice
+        tag: 'Food',
+        tag_key: uuid1, // same tag_key, counted twice
       })
       await insertTag(user, {
         external_id: 'tag-3',
         source: 'oura',
         start_time: new Date('2024-01-15T12:00:00Z'),
-        tag: uuid2,
+        tag: 'Sauna',
+        tag_key: uuid2,
       })
 
       const tags = await getProgrammaticTags(user)
@@ -461,14 +554,16 @@ describe('Tags Integration Tests', () => {
       expect(tags[1].count).toBe(2)
     })
 
-    test('returns tag_* prefixed tags', async () => {
+    test('falls back to programmatic tag names without tag_key (pre-migration)', async () => {
       const user = getTestUser()
+      const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
 
+      // Pre-migration tag: no tag_key, tag has the UUID directly
       await insertTag(user, {
         external_id: 'tag-1',
         source: 'oura',
         start_time: new Date('2024-01-15T10:00:00Z'),
-        tag: 'tag_generic_coffee',
+        tag: uuid,
       })
       await insertTag(user, {
         external_id: 'tag-2',
@@ -480,7 +575,7 @@ describe('Tags Integration Tests', () => {
       const tags = await getProgrammaticTags(user)
 
       expect(tags).toHaveLength(2)
-      expect(tags.map((t) => t.tagKey).sort()).toEqual(['tag_generic_coffee', 'tag_sleep_sauna'])
+      expect(tags.map((t) => t.tagKey).sort()).toEqual([uuid, 'tag_sleep_sauna'])
     })
 
     test('excludes regular human-readable tags', async () => {
@@ -491,25 +586,53 @@ describe('Tags Integration Tests', () => {
         external_id: 'tag-1',
         source: 'oura',
         start_time: new Date('2024-01-15T10:00:00Z'),
-        tag: uuid, // should be included
+        tag: 'Food',
+        tag_key: uuid, // should be included (has tag_key)
       })
       await insertTag(user, {
         external_id: 'tag-2',
         source: 'manual',
         start_time: new Date('2024-01-15T11:00:00Z'),
-        tag: 'coffee', // should be excluded
+        tag: 'coffee', // should be excluded (no tag_key, not programmatic)
       })
       await insertTag(user, {
         external_id: 'tag-3',
         source: 'manual',
         start_time: new Date('2024-01-15T12:00:00Z'),
-        tag: 'Food', // should be excluded
+        tag: 'Food', // should be excluded (no tag_key, not programmatic)
       })
 
       const tags = await getProgrammaticTags(user)
 
       expect(tags).toHaveLength(1)
       expect(tags[0].tagKey).toBe(uuid)
+    })
+
+    test('deduplicates between tag_key and fallback results', async () => {
+      const user = getTestUser()
+      const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
+
+      // Tag with tag_key set
+      await insertTag(user, {
+        external_id: 'tag-1',
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        tag: 'Food',
+        tag_key: uuid,
+      })
+      // Pre-migration tag with same UUID as tag name (no tag_key)
+      await insertTag(user, {
+        external_id: 'tag-2',
+        source: 'oura',
+        start_time: new Date('2024-01-15T11:00:00Z'),
+        tag: uuid,
+      })
+
+      const tags = await getProgrammaticTags(user)
+
+      // Should not duplicate - tag_key result should take precedence
+      const uuidEntries = tags.filter((t) => t.tagKey === uuid)
+      expect(uuidEntries).toHaveLength(1)
     })
   })
 })

--- a/apps/backend/src/db/tags.ts
+++ b/apps/backend/src/db/tags.ts
@@ -8,20 +8,21 @@ import type { Tag } from './types'
 export const insertTag = async (user: string, tag: Tag) => {
   await query(
     user,
-    `INSERT INTO tags (source, external_id, tag, start_time, end_time)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO tags (source, external_id, tag, tag_key, start_time, end_time)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (source, external_id) DO UPDATE SET
        tag = EXCLUDED.tag,
+       tag_key = COALESCE(EXCLUDED.tag_key, tags.tag_key),
        start_time = EXCLUDED.start_time,
        end_time = EXCLUDED.end_time`,
-    [tag.source, tag.external_id, tag.tag, tag.start_time, tag.end_time],
+    [tag.source, tag.external_id, tag.tag, tag.tag_key, tag.start_time, tag.end_time],
   )
 }
 
 export const getTags = async (user: string, start: Date, end: Date): Promise<Tag[]> => {
   const result = await query(
     user,
-    `SELECT id, source, external_id, tag, start_time, end_time
+    `SELECT id, source, external_id, tag, tag_key, start_time, end_time
      FROM tags
      WHERE (end_time IS NOT NULL AND start_time <= $2 AND end_time >= $1)
         OR (end_time IS NULL AND start_time >= $1 AND start_time <= $2)
@@ -58,7 +59,7 @@ export const findMergeableTag = async (
 
   const result = await query(
     user,
-    `SELECT id, source, external_id, tag, start_time, end_time
+    `SELECT id, source, external_id, tag, tag_key, start_time, end_time
      FROM tags
      WHERE tag = $1
        AND source = $4
@@ -86,6 +87,15 @@ export const updateTagEndTime = async (user: string, externalId: string, endTime
   ])
 
   return (result.rowCount ?? 0) > 0
+}
+
+/**
+ * Update the display name (tag column) for all tags with a given tag_key.
+ * Used when a user changes a tag mapping to retroactively rename existing tags.
+ */
+export const updateTagNameByKey = async (user: string, tagKey: string, newName: string): Promise<number> => {
+  const result = await query(user, `UPDATE tags SET tag = $1 WHERE tag_key = $2`, [newName, tagKey])
+  return result.rowCount ?? 0
 }
 
 /**
@@ -118,27 +128,53 @@ export const isProgrammaticTag = (tag: string): boolean =>
  * Get programmatic tags from the tags table.
  * Returns tags that look like they need human-readable names (UUIDs, tag_* prefixes, etc.)
  * along with usage counts and last seen times.
+ *
+ * Uses tag_key column when available (populated by Oura sync), falling back to
+ * checking the tag column for programmatic patterns (for pre-migration data).
  */
 export const getProgrammaticTags = async (
   user: string,
 ): Promise<{ tagKey: string; count: number; latestTime: Date }[]> => {
-  // Query all unique tags with counts - we filter in JS for pattern matching flexibility
-  const result = await query(
+  // Query tags with tag_key set (the canonical source)
+  const tagKeyResult = await query(
+    user,
+    `SELECT
+       tag_key,
+       COUNT(*) as count,
+       MAX(start_time) as latest_time
+     FROM tags
+     WHERE tag_key IS NOT NULL
+     GROUP BY tag_key
+     ORDER BY MAX(start_time) DESC`,
+  )
+
+  const fromTagKey = tagKeyResult.rows.map((row) => ({
+    count: parseInt(row.count, 10),
+    latestTime: new Date(row.latest_time),
+    tagKey: row.tag_key as string,
+  }))
+
+  // Also check for programmatic tag names without tag_key (pre-migration data)
+  const tagKeyValues = new Set(fromTagKey.map((t) => t.tagKey))
+  const fallbackResult = await query(
     user,
     `SELECT
        tag,
        COUNT(*) as count,
        MAX(start_time) as latest_time
      FROM tags
+     WHERE tag_key IS NULL
      GROUP BY tag
      ORDER BY MAX(start_time) DESC`,
   )
 
-  return result.rows
-    .filter((row) => isProgrammaticTag(row.tag))
+  const fromTag = fallbackResult.rows
+    .filter((row) => isProgrammaticTag(row.tag) && !tagKeyValues.has(row.tag))
     .map((row) => ({
       count: parseInt(row.count, 10),
       latestTime: new Date(row.latest_time),
-      tagKey: row.tag,
+      tagKey: row.tag as string,
     }))
+
+  return [...fromTagKey, ...fromTag].sort((a, b) => b.latestTime.getTime() - a.latestTime.getTime())
 }

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -177,6 +177,7 @@ export interface Tag {
   source: DataSource
   external_id?: string
   tag: string
+  tag_key?: string
   start_time: Date
   end_time?: Date
 }

--- a/apps/backend/src/mcp/settings-tools.ts
+++ b/apps/backend/src/mcp/settings-tools.ts
@@ -2,7 +2,13 @@
  * MCP user settings and tag mapping tools.
  */
 import { setTagMappingBodySchema, updateSettingsInputSchema } from '@aurboda/api-spec'
-import { getProgrammaticTags, getUniqueTags, getUserSettings, upsertUserSettings } from '../db'
+import {
+  getProgrammaticTags,
+  getUniqueTags,
+  getUserSettings,
+  updateTagNameByKey,
+  upsertUserSettings,
+} from '../db'
 import { getGoalsProgress } from '../services/goals'
 import { getSettingsResponse, validateAndUpdateSettings } from '../services/settings'
 import { jsonResponse, type McpServer } from './helpers'
@@ -73,6 +79,7 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
       const newMappings = { ...currentMappings, [tag_key]: name }
 
       await upsertUserSettings(user, { tag_mappings: newMappings })
+      await updateTagNameByKey(user, tag_key, name)
 
       return jsonResponse({ mapping: newMappings, success: true })
     },

--- a/apps/backend/src/oura.ts
+++ b/apps/backend/src/oura.ts
@@ -196,6 +196,7 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
               tag.tag_type_code && tagMappings && tag.tag_type_code in tagMappings ?
                 tagMappings[tag.tag_type_code]
               : tag.custom_name || tag.tag_type_code || 'unknown',
+            tag_key: tag.tag_type_code ?? undefined,
           }),
         )
         .filter(

--- a/apps/backend/src/routes/tags-router.ts
+++ b/apps/backend/src/routes/tags-router.ts
@@ -19,7 +19,13 @@ import {
   type UniqueTagsResponse,
 } from '@aurboda/api-spec'
 import { RequestHandler, Router } from 'express'
-import { getProgrammaticTags, getUniqueTags, getUserSettings, upsertUserSettings } from '../db'
+import {
+  getProgrammaticTags,
+  getUniqueTags,
+  getUserSettings,
+  updateTagNameByKey,
+  upsertUserSettings,
+} from '../db'
 import { addTag, deleteTag } from '../services/mutations'
 import { queryTags, type SyncProvider } from '../services/queries'
 import { validateBody, validateQuery } from '../validation'
@@ -118,6 +124,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
       const newMappings = { ...currentMappings, [tag_key]: name }
 
       await upsertUserSettings(user, { tag_mappings: newMappings })
+      await updateTagNameByKey(user, tag_key, name)
 
       res.json({ mapping: newMappings, success: true })
     },

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -267,6 +267,7 @@ export const createTableStatements: Record<string, string> = {
       source          VARCHAR(50) NOT NULL,
       external_id     VARCHAR(255),
       tag             VARCHAR(100) NOT NULL,
+      tag_key         VARCHAR(255),
       start_time      TIMESTAMPTZ NOT NULL,
       end_time        TIMESTAMPTZ,
       CONSTRAINT unique_tag UNIQUE (source, external_id)
@@ -274,7 +275,8 @@ export const createTableStatements: Record<string, string> = {
   `,
   tags_indexes: `
     CREATE INDEX IF NOT EXISTS idx_tags_time ON tags (start_time DESC);
-    CREATE INDEX IF NOT EXISTS idx_tags_tag_time ON tags (tag, start_time DESC)
+    CREATE INDEX IF NOT EXISTS idx_tags_tag_time ON tags (tag, start_time DESC);
+    CREATE INDEX IF NOT EXISTS idx_tags_tag_key ON tags (tag_key) WHERE tag_key IS NOT NULL
   `,
 
   // Normalized time-series metrics for fast charting queries

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -23,6 +23,7 @@ export const tagSchema = z
     source: dataSourceSchema.optional(),
     start_time: iso8601DateTimeSchema,
     tag: tagTextSchema,
+    tag_key: z.string().optional().meta({ description: 'Original programmatic identifier (e.g. Oura tag_type_code)' }),
   })
   .meta({ id: 'Tag' })
 


### PR DESCRIPTION
## Summary

- Adds `tag_key` column to the `tags` table to preserve the original Oura `tag_type_code` (UUID or `tag_*` prefix)
- When a user changes a tag mapping via `set_tag_mapping` (REST API or MCP), all existing tags with that `tag_key` are retroactively bulk-updated
- Migration backfills `tag_key` from existing data: programmatic tag names get `tag_key = tag`, already-mapped tags get reversed from `tag_mappings` in user settings
- `getProgrammaticTags` now uses `tag_key` column with fallback to pattern matching for pre-migration data

## Test plan

- [x] `pnpm check` passes (TypeScript + linting)
- [x] `pnpm fix` passes (no warnings)
- [x] All 765 backend tests pass (including new integration tests for `tag_key` insert/upsert, `updateTagNameByKey`, and `getProgrammaticTags` with `tag_key`)
- [x] Web tests pass
- [x] Android Kotlin compilation succeeds
- [ ] Manual test: sync Oura tags, verify `tag_key` populated, change mapping, verify old tags updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)