### PR TITLE
Fix Day View click: exclude items from zoom handler

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -775,11 +775,17 @@ export const DayView = () => {
       return d3.zoomIdentity.translate(0, ty).scale(k)
     }
 
-    // D3 zoom
+    // D3 zoom — only on background, not on clickable items
     const zoom = d3
       .zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.1, 20])
-      .filter((event) => event.type !== 'dblclick')
+      .filter((event) => {
+        if (event.type === 'dblclick') return false
+        // Don't capture drag/scroll on clickable chart items
+        const target = event.target as SVGElement | null
+        if (target?.classList?.contains('chart-item-clickable')) return false
+        return true
+      })
       .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
         if (isProgrammaticZoom.current) return
         cancelAnimationFrame(zoomRafRef.current)
@@ -1126,7 +1132,8 @@ const drawItem = (
       .attr('opacity', 0.85)
       .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
       .on('mouseleave', hideTooltip)
-    if (handleClick) point.style('cursor', 'pointer').on('click', handleClick)
+    if (handleClick)
+      point.classed('chart-item-clickable', true).style('cursor', 'pointer').on('click', handleClick)
     return
   }
 
@@ -1149,7 +1156,8 @@ const drawItem = (
       d3.select(this).attr('opacity', 0.75)
       hideTooltip()
     })
-  if (handleClick) rect.style('cursor', 'pointer').on('click', handleClick)
+  if (handleClick)
+    rect.classed('chart-item-clickable', true).style('cursor', 'pointer').on('click', handleClick)
 
   // Text label inside if tall enough
   if (blockHeight > 30) {


### PR DESCRIPTION
## Summary
- D3 zoom behavior was capturing `mousedown` on chart items, preventing click events from firing
- Clickable items now get a `chart-item-clickable` CSS class
- The zoom filter excludes events targeting elements with that class
- Clicks on items navigate to the detail page; drag/scroll still works on the background

## Test plan
- [ ] Click an activity/tag/productivity item in Day View → navigates to `/detail/:type/:id`
- [ ] Ctrl/meta-click → opens in new tab
- [ ] Drag on background → still pans as before
- [ ] Scroll on background → still zooms as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)