### PR TITLE
Fix Day View click: use mousedown to match d3-zoom v3

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -1101,21 +1101,21 @@ const drawItem = (
   const detailUrl =
     item.entity_id && item.entity_type ? `/detail/${item.entity_type}/${item.entity_id}` : undefined
 
-  // Attach click-navigation via pointerdown/pointerup. We stop propagation on
-  // pointerdown so D3 zoom (on the SVG) never sees the event and doesn't
-  // interfere. On pointerup we check movement to distinguish click from drag.
+  // Attach click-navigation via mousedown/mouseup. d3-zoom v3 uses mousedown
+  // (not pointerdown), so we must stop mousedown propagation to prevent zoom
+  // from capturing the drag. On mouseup we check movement to distinguish click.
   const attachClickNav = (el: d3.Selection<SVGElement, unknown, null, undefined>) => {
     if (!detailUrl) return
     let downX = 0
     let downY = 0
     el.style('cursor', 'pointer')
-      .on('pointerdown.nav', (event: PointerEvent) => {
+      .on('mousedown.nav', (event: MouseEvent) => {
         if (event.button !== 0) return
         downX = event.clientX
         downY = event.clientY
         event.stopPropagation()
       })
-      .on('pointerup.nav', (event: PointerEvent) => {
+      .on('mouseup.nav', (event: MouseEvent) => {
         if (event.button !== 0) return
         const dx = Math.abs(event.clientX - downX)
         const dy = Math.abs(event.clientY - downY)


### PR DESCRIPTION
## Summary
- d3-zoom v3.0.0 listens on `mousedown.zoom`, NOT `pointerdown.zoom`
- Previous fix (PR #213) used `pointerdown.nav`/`pointerup.nav` which had zero effect since d3-zoom uses a completely different event type
- Changed to `mousedown.nav`/`mouseup.nav` so `stopPropagation()` actually prevents zoom from capturing the event on clickable items

## Root cause
Reading the actual d3-zoom v3.0.0 source (`node_modules/.pnpm/d3-zoom@3.0.0/node_modules/d3-zoom/src/zoom.js` line 76) reveals:
```js
.on("mousedown.zoom", mousedowned)
```
Not `pointerdown.zoom`.

## Test plan
- [ ] Click an activity/tag in Day View → navigates to detail page
- [ ] Ctrl+click → opens in new tab
- [ ] Drag on background → still scrolls/pans normally
- [ ] Hover on items → shows pointer cursor, not grab cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)