### PR TITLE
Fix Day View click: zoom filter excludes clickable items

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -779,7 +779,15 @@ export const DayView = () => {
     const zoom = d3
       .zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.1, 20])
-      .filter((event) => event.type !== 'dblclick')
+      .clickDistance(5)
+      .filter((event: Event) => {
+        if (event.type === 'dblclick') return false
+        // Don't let zoom capture mousedown on clickable chart items
+        if (event.type === 'mousedown' || event.type === 'touchstart') {
+          if ((event.target as Element).closest?.('[data-clickable]')) return false
+        }
+        return true
+      })
       .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
         if (isProgrammaticZoom.current) return
         cancelAnimationFrame(zoomRafRef.current)
@@ -1101,30 +1109,17 @@ const drawItem = (
   const detailUrl =
     item.entity_id && item.entity_type ? `/detail/${item.entity_type}/${item.entity_id}` : undefined
 
-  // Attach click-navigation via mousedown/mouseup. d3-zoom v3 uses mousedown
-  // (not pointerdown), so we must stop mousedown propagation to prevent zoom
-  // from capturing the drag. On mouseup we check movement to distinguish click.
+  // Mark items as clickable via data attribute. The zoom filter above skips
+  // mousedown events on [data-clickable] elements, so a plain click fires.
   const attachClickNav = (el: d3.Selection<SVGElement, unknown, null, undefined>) => {
     if (!detailUrl) return
-    let downX = 0
-    let downY = 0
-    el.style('cursor', 'pointer')
-      .on('mousedown.nav', (event: MouseEvent) => {
-        if (event.button !== 0) return
-        downX = event.clientX
-        downY = event.clientY
-        event.stopPropagation()
-      })
-      .on('mouseup.nav', (event: MouseEvent) => {
-        if (event.button !== 0) return
-        const dx = Math.abs(event.clientX - downX)
-        const dy = Math.abs(event.clientY - downY)
-        if (dx < 5 && dy < 5) {
-          if (event.ctrlKey || event.metaKey) {
-            window.open(detailUrl, '_blank')
-          } else {
-            window.location.href = detailUrl
-          }
+    el.attr('data-clickable', 'true')
+      .style('cursor', 'pointer')
+      .on('click.nav', (event: MouseEvent) => {
+        if (event.ctrlKey || event.metaKey) {
+          window.open(detailUrl, '_blank')
+        } else {
+          window.location.href = detailUrl
         }
       })
   }

--- a/apps/web/src/pages/DayView/style.css
+++ b/apps/web/src/pages/DayView/style.css
@@ -118,6 +118,10 @@
   cursor: grabbing;
 }
 
+.day-view-chart-container svg [data-clickable] {
+  cursor: pointer;
+}
+
 /* Tooltip */
 .day-view-tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- Previous attempts used `stopPropagation()` on mousedown/pointerdown, but d3-zoom's capture-phase handlers on `window` still interfered with mouseup/click
- New approach: the **zoom filter** returns `false` for mousedown/touchstart events on `[data-clickable]` elements, so d3-zoom completely ignores them
- Items use a simple `click` handler for navigation — no mousedown/mouseup dance needed
- Added CSS `cursor: pointer` rule for `[data-clickable]` elements in SVG
- Added `zoom.clickDistance(5)` for tolerance on minor mouse movement

## Why previous fixes failed
1. **PR #212** (zoom filter + CSS class): filter checked `classList.contains()` but unclear why it failed — possibly deployment timing
2. **PR #213** (pointerdown stopPropagation): d3-zoom v3 uses `mousedown`, not `pointerdown` — wrong event type
3. **PR #214** (mousedown stopPropagation): even though propagation was stopped, d3-zoom's `mouseupped` handler (attached in capture phase on window) called `stopImmediatePropagation` on mouseup, preventing the mouseup.nav handler from firing

This fix avoids all event interception issues by using the zoom filter — d3-zoom never processes the event at all.

## Test plan
- [ ] Click an activity/tag in Day View → navigates to detail page
- [ ] Ctrl+click → opens in new tab
- [ ] Hover on items → shows pointer cursor (not grab)
- [ ] Drag on background → still pans normally
- [ ] Scroll wheel → still zooms normally (even when cursor is over an item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)