### PR TITLE
Include entity IDs in query responses for Day View clicks

### DIFF
--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -6,7 +6,7 @@
  * They are used by both the MCP tools and the REST API.
  */
 
-import type { CustomMetricDefinition } from '@aurboda/api-spec'
+import type { CustomMetricDefinition, DataSource } from '@aurboda/api-spec'
 import {
   getActivities,
   getDailyAggregates,
@@ -112,9 +112,11 @@ export interface SessionSummary {
 }
 
 export interface TagSummary {
+  id?: string
   tag: string
   start_time: string
   end_time?: string
+  source?: DataSource
 }
 
 export interface PlaceSummary {
@@ -786,6 +788,8 @@ export async function queryTags(
   const tags = await getTags(user, start, end)
   return tags.map((t) => ({
     end_time: t.end_time?.toISOString(),
+    id: t.id,
+    source: t.source,
     start_time: t.start_time.toISOString(),
     tag: t.tag,
   }))
@@ -795,6 +799,7 @@ export async function queryTags(
  * Activity query result with formatted timestamps.
  */
 export interface ActivityResult {
+  id?: string
   start_time: string
   end_time?: string
   duration?: number // minutes
@@ -858,6 +863,7 @@ export async function queryActivities(
         duration:
           a.end_time ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60) : undefined,
         end_time: a.end_time?.toISOString(),
+        id: a.id,
         notes: a.notes,
         source: a.source,
         start_time: a.start_time.toISOString(),
@@ -886,6 +892,7 @@ export async function queryActivities(
  * Productivity record with formatted timestamps.
  */
 export interface ProductivityResult {
+  id?: string
   start_time: string
   end_time: string
   activity: string
@@ -954,6 +961,7 @@ export async function queryProductivity(
     category: p.category,
     duration_sec: p.duration_sec,
     end_time: p.end_time.toISOString(),
+    id: p.id,
     is_mobile: p.is_mobile,
     productivity: p.productivity,
     start_time: p.start_time.toISOString(),


### PR DESCRIPTION
## Summary
**Root cause found**: The backend query functions (`queryTags`, `queryActivities`, `queryProductivity`) were stripping the `id` field when mapping DB rows to response objects. The frontend never received entity IDs, so `detailUrl` was always `undefined`, and `attachClickNav` returned early — no cursor change, no click handler, nothing.

### Changes
- `TagSummary`: added `id?` and `source?` fields
- `ActivityResult`: added `id?` field  
- `ProductivityResult`: added `id?` field
- All three query `map()` functions now include `id` in their output

### Why all the zoom fixes didn't help
The zoom/click interaction was never the problem. The items never had click handlers or cursor styles attached because `attachClickNav` bailed out at the first line: `if (!detailUrl) return`. And `detailUrl` was always undefined because `item.entity_id` was always undefined because the API never sent IDs.

## Test plan
- [ ] Click activity in Day View → navigates to `/detail/activity/:id`
- [ ] Click tag → navigates to `/detail/tag/:id`
- [ ] Hover on items → shows pointer cursor
- [ ] All 777 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)