### PR TITLE
Use SVG <a> elements for Day View item links

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -1103,25 +1103,15 @@ const drawItem = (
   const detailUrl =
     item.entity_id && item.entity_type ? `/detail/${item.entity_type}/${item.entity_id}` : undefined
 
-  // Clickable items: d3-zoom lets click events through for stationary clicks
-  // (within clickDistance). We use data-clickable for CSS cursor override.
-  const attachClickNav = (el: d3.Selection<SVGElement, unknown, null, undefined>) => {
-    if (!detailUrl) return
-    el.attr('data-clickable', 'true')
-      .style('cursor', 'pointer')
-      .on('click.nav', (event: MouseEvent) => {
-        if (event.ctrlKey || event.metaKey) {
-          window.open(detailUrl, '_blank')
-        } else {
-          window.location.href = detailUrl
-        }
-      })
-  }
+  // Wrap clickable items in an SVG <a> so the browser handles middle-click,
+  // right-click context menu, ctrl+click etc. natively.
+  const parent =
+    detailUrl ? chartGroup.append('a').attr('href', detailUrl).attr('data-clickable', 'true') : chartGroup
 
   if (item.isPoint) {
     const cy = y1
     const size = Math.min(laneWidth / 2, 6)
-    const point = chartGroup
+    parent
       .append('polygon')
       .attr(
         'points',
@@ -1131,12 +1121,11 @@ const drawItem = (
       .attr('opacity', 0.85)
       .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
       .on('mouseleave', hideTooltip)
-    attachClickNav(point as unknown as d3.Selection<SVGElement, unknown, null, undefined>)
     return
   }
 
   // Rectangle block
-  const rect = chartGroup
+  parent
     .append('rect')
     .attr('x', x)
     .attr('y', y1)
@@ -1154,7 +1143,6 @@ const drawItem = (
       d3.select(this).attr('opacity', 0.75)
       hideTooltip()
     })
-  attachClickNav(rect as unknown as d3.Selection<SVGElement, unknown, null, undefined>)
 
   // Text label inside if tall enough
   if (blockHeight > 30) {
@@ -1162,7 +1150,7 @@ const drawItem = (
     const charWidth = laneWidth > 100 ? 7.5 : 6
     const maxChars = Math.floor(laneWidth / charWidth)
     const text = item.label.length > maxChars ? item.label.slice(0, maxChars) + '…' : item.label
-    chartGroup
+    parent
       .append('text')
       .attr('x', x + 4)
       .attr('y', y1 + 14)


### PR DESCRIPTION
## Summary
Replace JS click handlers with native SVG `<a>` element wrapping for Day View items. This gives the browser standard link behavior:
- Left click → navigate to detail page
- Middle click → open in new tab
- Right click → context menu (Open in New Tab, Copy Link, etc.)
- Ctrl/Cmd+click → open in new tab

Clickable items are wrapped in `<a href="/detail/:type/:id">` instead of having JavaScript click handlers attached.

## Test plan
- [ ] Left click → navigates to detail page
- [ ] Middle click → opens in new tab
- [ ] Right click → shows browser context menu with link options
- [ ] Ctrl+click → opens in new tab
- [ ] Drag on background → still pans normally
- [ ] Tooltip still shows on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)