### PR TITLE
Fix sleep duration to exclude awake time (#37)

### DIFF
--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -31,6 +31,7 @@ import {
 import { classifyHrvByContext, getHrvContextWindows, HrvContext } from './hrv-context'
 import { getPlaceVisits } from './locations'
 import { computeHrZoneSecs, getEffectiveHrZones, HrZoneSecs } from './settings'
+import { computeSleepMinutes } from './sleep-duration'
 
 // ============================================================================
 // Types
@@ -589,13 +590,19 @@ export async function getDailySummary(
       start_time: p.start_time.toISOString(),
     })),
     productivity: productivitySummary,
-    sleep_sessions: sleepSessions.map((s) => ({
-      data: s.data,
-      duration:
-        s.end_time ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60) : undefined,
-      end_time: s.end_time?.toISOString(),
-      start_time: s.start_time.toISOString(),
-    })),
+    sleep_sessions: sleepSessions.map((s) => {
+      const timeInBed =
+        s.end_time ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60) : undefined
+      const totalSleep = computeSleepMinutes(s.data as Record<string, unknown> | undefined)
+      return {
+        data: s.data,
+        duration: totalSleep ?? timeInBed,
+        end_time: s.end_time?.toISOString(),
+        start_time: s.start_time.toISOString(),
+        time_in_bed: timeInBed,
+        total_sleep: totalSleep,
+      }
+    }),
     steps: { total: totalSteps },
     tags: tags.map((t) => ({
       end_time: t.end_time?.toISOString(),
@@ -803,6 +810,8 @@ export interface ActivityResult {
   start_time: string
   end_time?: string
   duration?: number // minutes
+  time_in_bed?: number // minutes (end_time - start_time, sleep only)
+  total_sleep?: number // minutes (actual sleep excluding awake, sleep only)
   activity_type: string
   title?: string
   notes?: string
@@ -857,17 +866,29 @@ export async function queryActivities(
 
   return Promise.all(
     activities.map(async (a) => {
+      const timeInBedMinutes =
+        a.end_time ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60) : undefined
+
       const result: ActivityResult = {
         activity_type: a.activity_type,
         data: a.data,
-        duration:
-          a.end_time ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60) : undefined,
+        duration: timeInBedMinutes,
         end_time: a.end_time?.toISOString(),
         id: a.id,
         notes: a.notes,
         source: a.source,
         start_time: a.start_time.toISOString(),
         title: a.title,
+      }
+
+      // For sleep activities: compute actual sleep time from stage data
+      if (a.activity_type === 'sleep') {
+        result.time_in_bed = timeInBedMinutes
+        const sleepMinutes = computeSleepMinutes(a.data as Record<string, unknown> | undefined)
+        if (sleepMinutes !== undefined) {
+          result.total_sleep = sleepMinutes
+          result.duration = sleepMinutes
+        }
       }
 
       // Compute HR zones for exercise activities with end time

--- a/apps/backend/src/services/sleep-duration.test.ts
+++ b/apps/backend/src/services/sleep-duration.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest'
+import { computeSleepMinutes } from './sleep-duration'
+
+describe('computeSleepMinutes', () => {
+  test('returns undefined when data is undefined', () => {
+    expect(computeSleepMinutes(undefined)).toBeUndefined()
+  })
+
+  test('returns undefined when data has no stage info', () => {
+    expect(computeSleepMinutes({ some_field: 'value' })).toBeUndefined()
+  })
+
+  test('returns undefined when stages is not an array', () => {
+    expect(computeSleepMinutes({ stages: 'not-an-array' })).toBeUndefined()
+  })
+
+  test('returns undefined when stages is empty', () => {
+    expect(computeSleepMinutes({ stages: [] })).toBeUndefined()
+  })
+
+  describe('Health Connect stages format', () => {
+    // Stage values: 1=Awake, 2=Sleeping, 3=Out of bed, 4=Light, 5=Deep, 6=REM
+
+    test('sums only sleep stages (2, 4, 5, 6), excluding awake (1) and out of bed (3)', () => {
+      const data = {
+        stages: [
+          { endTime: '2025-01-21T00:30:00Z', stage: 1, startTime: '2025-01-21T00:00:00Z' }, // 30m awake
+          { endTime: '2025-01-21T02:30:00Z', stage: 4, startTime: '2025-01-21T00:30:00Z' }, // 120m light
+          { endTime: '2025-01-21T03:30:00Z', stage: 5, startTime: '2025-01-21T02:30:00Z' }, // 60m deep
+          { endTime: '2025-01-21T04:00:00Z', stage: 1, startTime: '2025-01-21T03:30:00Z' }, // 30m awake
+          { endTime: '2025-01-21T05:00:00Z', stage: 6, startTime: '2025-01-21T04:00:00Z' }, // 60m REM
+          { endTime: '2025-01-21T06:00:00Z', stage: 2, startTime: '2025-01-21T05:00:00Z' }, // 60m sleeping
+        ],
+      }
+      // Total sleep: 120 + 60 + 60 + 60 = 300 minutes
+      expect(computeSleepMinutes(data)).toBe(300)
+    })
+
+    test('returns undefined when all stages are awake', () => {
+      const data = {
+        stages: [
+          { endTime: '2025-01-21T01:00:00Z', stage: 1, startTime: '2025-01-21T00:00:00Z' },
+          { endTime: '2025-01-21T02:00:00Z', stage: 3, startTime: '2025-01-21T01:00:00Z' },
+        ],
+      }
+      expect(computeSleepMinutes(data)).toBeUndefined()
+    })
+
+    test('handles stages with only deep and REM', () => {
+      const data = {
+        stages: [
+          { endTime: '2025-01-21T02:00:00Z', stage: 5, startTime: '2025-01-21T00:00:00Z' }, // 120m deep
+          { endTime: '2025-01-21T03:30:00Z', stage: 6, startTime: '2025-01-21T02:00:00Z' }, // 90m REM
+        ],
+      }
+      expect(computeSleepMinutes(data)).toBe(210)
+    })
+
+    test('skips stages with missing or invalid fields', () => {
+      const data = {
+        stages: [
+          { endTime: '2025-01-21T02:00:00Z', stage: 4, startTime: '2025-01-21T00:00:00Z' }, // 120m light
+          { stage: 5, startTime: '2025-01-21T02:00:00Z' }, // missing endTime
+          { endTime: '2025-01-21T04:00:00Z', stage: 6 }, // missing startTime
+          { endTime: '2025-01-21T05:00:00Z', startTime: '2025-01-21T04:00:00Z' }, // missing stage
+        ],
+      }
+      expect(computeSleepMinutes(data)).toBe(120)
+    })
+
+    test('rounds to nearest minute', () => {
+      const data = {
+        stages: [
+          // 90.5 minutes (90 min + 30 sec)
+          { endTime: '2025-01-21T01:30:30Z', stage: 4, startTime: '2025-01-21T00:00:00Z' },
+        ],
+      }
+      expect(computeSleepMinutes(data)).toBe(91)
+    })
+  })
+
+  describe('Oura total_sleep_duration format', () => {
+    test('converts seconds to minutes', () => {
+      const data = { total_sleep_duration: 21600 } // 360 minutes = 6 hours
+      expect(computeSleepMinutes(data)).toBe(360)
+    })
+
+    test('rounds to nearest minute', () => {
+      const data = { total_sleep_duration: 21630 } // 360.5 minutes
+      expect(computeSleepMinutes(data)).toBe(361)
+    })
+
+    test('returns undefined for zero duration', () => {
+      const data = { total_sleep_duration: 0 }
+      expect(computeSleepMinutes(data)).toBeUndefined()
+    })
+  })
+
+  describe('priority', () => {
+    test('prefers Health Connect stages over Oura total_sleep_duration', () => {
+      const data = {
+        stages: [
+          { endTime: '2025-01-21T02:00:00Z', stage: 5, startTime: '2025-01-21T00:00:00Z' }, // 120m deep
+        ],
+        total_sleep_duration: 21600, // 360 minutes
+      }
+      expect(computeSleepMinutes(data)).toBe(120)
+    })
+  })
+})

--- a/apps/backend/src/services/sleep-duration.ts
+++ b/apps/backend/src/services/sleep-duration.ts
@@ -1,0 +1,57 @@
+/**
+ * Sleep duration computation from stage data.
+ *
+ * Computes actual sleep time (excluding awake periods) from sleep stage data
+ * stored in the activity's JSONB `data` field.
+ */
+
+/**
+ * Health Connect sleep stage values that count as actual sleep.
+ * 1=Awake, 2=Sleeping, 3=Out of bed, 4=Light, 5=Deep, 6=REM
+ */
+const SLEEP_STAGES = new Set([2, 4, 5, 6])
+
+interface SleepStage {
+  startTime?: string
+  endTime?: string
+  stage?: number
+}
+
+/**
+ * Compute actual sleep minutes from activity data.
+ *
+ * Supports two formats:
+ * - Health Connect: `data.stages` array with `{startTime, endTime, stage}` entries
+ * - Oura: `data.total_sleep_duration` in seconds
+ *
+ * Health Connect stages take priority when both are present.
+ *
+ * @returns Actual sleep duration in minutes, or undefined if no stage data available.
+ */
+export const computeSleepMinutes = (data: Record<string, unknown> | undefined): number | undefined => {
+  if (!data) return undefined
+
+  // Health Connect stages format
+  const stages = data.stages
+  if (Array.isArray(stages)) {
+    let ms = 0
+    for (const stage of stages as SleepStage[]) {
+      if (
+        SLEEP_STAGES.has(stage.stage ?? -1) &&
+        typeof stage.startTime === 'string' &&
+        typeof stage.endTime === 'string'
+      ) {
+        ms += new Date(stage.endTime).getTime() - new Date(stage.startTime).getTime()
+      }
+    }
+    return ms > 0 ? Math.round(ms / 60000) : undefined
+  }
+
+  // Oura total_sleep_duration format (in seconds)
+  const totalSleepDuration = data.total_sleep_duration
+  if (typeof totalSleepDuration === 'number' && totalSleepDuration > 0) {
+    return Math.round(totalSleepDuration / 60)
+  }
+
+  return undefined
+}

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -166,36 +166,13 @@ const escapeHtml = (str: string): string =>
 type OuraSleepMetrics = Record<string, number>
 type OuraSleepByDate = Map<string, OuraSleepMetrics>
 
-/**
- * Health Connect sleep stage values.
- * AWAKE=1, SLEEPING=2, OUT_OF_BED=3, LIGHT=4, DEEP=5, REM=6
- */
-const HC_SLEEP_STAGES = new Set([2, 4, 5, 6])
-
-const computeHcSleepMinutes = (data: Record<string, unknown> | undefined): number | undefined => {
-  const stages = data?.stages
-  if (!Array.isArray(stages)) return undefined
-  let ms = 0
-  for (const stage of stages as { startTime?: string; endTime?: string; stage?: number }[]) {
-    if (
-      HC_SLEEP_STAGES.has(stage.stage ?? -1) &&
-      typeof stage.startTime === 'string' &&
-      typeof stage.endTime === 'string'
-    ) {
-      ms += new Date(stage.endTime).getTime() - new Date(stage.startTime).getTime()
-    }
-  }
-  return ms > 0 ? Math.round(ms / 60000) : undefined
-}
-
 const buildSleepDetails = (a: Activity, end: Date, ouraByDate: OuraSleepByDate): string[] => {
   const details: string[] = []
   details.push(`Bed: ${formatDuration(a.start_time, end)}`)
 
-  const sleepMin = computeHcSleepMinutes(a.data as Record<string, unknown> | undefined)
-  if (sleepMin !== undefined) {
-    const h = Math.floor(sleepMin / 60)
-    const m = sleepMin % 60
+  if (a.total_sleep !== undefined) {
+    const h = Math.floor(a.total_sleep / 60)
+    const m = a.total_sleep % 60
     details.push(`Sleep: ${m > 0 ? `${h}h ${m}m` : `${h}h`}`)
   }
 

--- a/apps/web/src/pages/Sleep/index.tsx
+++ b/apps/web/src/pages/Sleep/index.tsx
@@ -161,7 +161,7 @@ function SleepDurationChart({ sleepSessions, height = 180 }: { sleepSessions: Ac
       .filter((s) => s.end_time)
       .map((s) => ({
         date: s.start_time,
-        hours: (s.end_time!.getTime() - s.start_time.getTime()) / 3600000,
+        hours: (s.duration ?? (s.end_time!.getTime() - s.start_time.getTime()) / 60000) / 60,
       }))
       .sort((a, b) => a.date.getTime() - b.date.getTime())
 
@@ -372,13 +372,14 @@ export function Sleep() {
 
   const isLoading = sleepScoresQuery.isLoading || periodSummaryQuery.isLoading || activitiesQuery.isLoading
 
-  // Calculate average sleep duration
+  // Calculate average sleep duration (using total_sleep from API when available)
+  const sessionsWithDuration = sleepSessions.filter((s) => s.end_time)
   const avgSleepDuration =
-    sleepSessions.length > 0 ?
-      sleepSessions.reduce((sum, s) => {
-        if (!s.end_time) return sum
-        return sum + (s.end_time.getTime() - s.start_time.getTime()) / 3600000
-      }, 0) / sleepSessions.length
+    sessionsWithDuration.length > 0 ?
+      sessionsWithDuration.reduce(
+        (sum, s) => sum + (s.duration ?? (s.end_time!.getTime() - s.start_time.getTime()) / 60000) / 60,
+        0,
+      ) / sessionsWithDuration.length
     : null
 
   const handleDaysChange = (e: Event) => {

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -138,7 +138,14 @@ export const activitySchema = z
     notes: z.string().optional().meta({ description: 'Activity notes' }),
     source: z.string().optional().meta({ description: 'Data source' }),
     start_time: iso8601DateTimeSchema,
+    time_in_bed: durationMinutesSchema.optional().meta({
+      description: 'Time in bed in minutes (end_time - start_time). Only present for sleep activities.',
+    }),
     title: z.string().optional().meta({ description: 'Activity title' }),
+    total_sleep: durationMinutesSchema.optional().meta({
+      description:
+        'Actual sleep time in minutes, excluding awake periods. Only present for sleep activities with stage data.',
+    }),
   })
   .meta({ id: 'Activity' })
 


### PR DESCRIPTION
## Summary
- Sleep duration was calculated as `end_time - start_time` (time in bed), inflating values by including awake periods
- Now computes actual sleep time from Health Connect stage data (stages 2=Sleeping, 4=Light, 5=Deep, 6=REM), excluding awake (1) and out-of-bed (3)
- Adds `time_in_bed` and `total_sleep` fields to the Activity API response for sleep activities
- Frontend Sleep page and DayView now display actual sleep duration

## Test plan
- [x] 13 unit tests for `computeSleepMinutes` covering HC stages, Oura format, edge cases
- [ ] Verify Sleep page shows actual sleep time (shorter than time in bed) for sessions with stage data
- [ ] Verify DayView shows "Bed: Xh Ym" and "Sleep: Xh Ym" correctly
- [ ] Verify MCP `query_activities` returns `total_sleep` and `time_in_bed` for sleep activities
- [ ] Verify non-sleep activities are unaffected

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)