### PR TITLE
Use sleep HRV for baseline instead of all-day HRV (#226)

### DIFF
--- a/apps/backend/src/services/correlations.test.ts
+++ b/apps/backend/src/services/correlations.test.ts
@@ -87,10 +87,19 @@ describe('correlations service', () => {
 
       const result = await getBaseline('testuser')
 
-      expect(result.hrv.avg7day).toBe(45.5)
-      expect(result.hrv.avg30day).toBe(44.2)
+      // Verify HRV is fetched via queryMetrics('hrv_sleep'), not getTimeSeriesStats('hrv_rmssd')
+      expect(queries.queryMetrics).toHaveBeenCalledTimes(3)
+      for (const [, metric] of vi.mocked(queries.queryMetrics).mock.calls) {
+        expect(metric).toBe('hrv_sleep')
+      }
+
+      // Verify averages are computed correctly from the data points
+      expect(result.hrv.avg7day).toBe(45.5) // (40 + 46 + 50.5) / 3
+      expect(result.hrv.avg30day).toBe(44.2) // (42 + 46.4) / 2
       expect(result.resting_hr.avg7day).toBe(60.3)
       expect(result.resting_hr.avg30day).toBe(61.1)
+
+      // Verify trends are calculated (30-day vs previous 30-day)
       expect(result.hrv.trend_percent).not.toBeNull()
       expect(result.resting_hr.trend_percent).not.toBeNull()
       expect(result.period.start).toBeDefined()
@@ -102,6 +111,9 @@ describe('correlations service', () => {
       vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
 
       const result = await getBaseline('testuser')
+
+      // Should still call queryMetrics for sleep HRV even when empty
+      expect(queries.queryMetrics).toHaveBeenCalledTimes(3)
 
       expect(result.hrv.avg7day).toBeNull()
       expect(result.hrv.avg30day).toBeNull()

--- a/apps/backend/src/services/correlations.test.ts
+++ b/apps/backend/src/services/correlations.test.ts
@@ -8,6 +8,7 @@ import {
   getHrvActivitiesCorrelation,
 } from './correlations'
 import * as locations from './locations'
+import * as queries from './queries'
 
 // Mock db module
 vi.mock('../db', () => ({
@@ -23,24 +24,57 @@ vi.mock('./locations', () => ({
   getPlaceVisits: vi.fn(),
 }))
 
+// Mock queries module (for queryMetrics used by getBaseline)
+vi.mock('./queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof queries>()
+  return {
+    ...actual,
+    queryMetrics: vi.fn(),
+  }
+})
+
 describe('correlations service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe('getBaseline', () => {
-    test('returns HRV and resting HR baseline statistics', async () => {
-      // Mock stats - order: HRV 7-day, HRV 30-day, HRV prev-30, HR 7-day, HR 30-day, HR prev-30
+    const emptyHrvResult = { count: 0, data: [], metric: 'hrv_sleep', unit: 'ms' }
+
+    test('returns sleep HRV and resting HR baseline statistics', async () => {
+      // Mock queryMetrics for sleep HRV (3 calls: 7-day, 30-day, prev-30)
+      vi.mocked(queries.queryMetrics)
+        .mockResolvedValueOnce({
+          count: 3,
+          data: [
+            { time: '2024-01-13T02:00:00Z', value: 40 },
+            { time: '2024-01-14T02:00:00Z', value: 46 },
+            { time: '2024-01-15T02:00:00Z', value: 50.5 },
+          ],
+          metric: 'hrv_sleep',
+          unit: 'ms',
+        }) // 7-day sleep HRV (avg = 45.5)
+        .mockResolvedValueOnce({
+          count: 2,
+          data: [
+            { time: '2024-01-01T02:00:00Z', value: 42 },
+            { time: '2024-01-10T02:00:00Z', value: 46.4 },
+          ],
+          metric: 'hrv_sleep',
+          unit: 'ms',
+        }) // 30-day sleep HRV (avg = 44.2)
+        .mockResolvedValueOnce({
+          count: 2,
+          data: [
+            { time: '2023-12-01T02:00:00Z', value: 41 },
+            { time: '2023-12-15T02:00:00Z', value: 45 },
+          ],
+          metric: 'hrv_sleep',
+          unit: 'ms',
+        }) // previous 30-day sleep HRV (avg = 43.0)
+
+      // Mock resting HR stats (3 calls: 7-day, 30-day, prev-30)
       vi.mocked(db.getTimeSeriesStats)
-        .mockResolvedValueOnce([
-          { avg: 45.5, count: 100, max: 80, metric: 'hrv_rmssd', min: 20, stddev: 5, unit: 'ms' },
-        ]) // 7-day HRV
-        .mockResolvedValueOnce([
-          { avg: 44.2, count: 400, max: 85, metric: 'hrv_rmssd', min: 18, stddev: 6, unit: 'ms' },
-        ]) // 30-day HRV
-        .mockResolvedValueOnce([
-          { avg: 43.0, count: 400, max: 82, metric: 'hrv_rmssd', min: 17, stddev: 5, unit: 'ms' },
-        ]) // previous 30-day HRV
         .mockResolvedValueOnce([
           { avg: 60.3, count: 100, max: 70, metric: 'resting_heart_rate', min: 52, stddev: 3, unit: 'bpm' },
         ]) // 7-day resting HR
@@ -64,6 +98,7 @@ describe('correlations service', () => {
     })
 
     test('handles missing data gracefully', async () => {
+      vi.mocked(queries.queryMetrics).mockResolvedValue(emptyHrvResult)
       vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
 
       const result = await getBaseline('testuser')
@@ -75,17 +110,25 @@ describe('correlations service', () => {
     })
 
     test('uses reference date when provided', async () => {
+      vi.mocked(queries.queryMetrics).mockResolvedValue(emptyHrvResult)
       vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
 
       const referenceDate = new Date('2024-01-15T12:00:00Z')
       await getBaseline('testuser', referenceDate)
 
-      // Should be called with dates calculated from reference date
+      // queryMetrics called for sleep HRV with dates from reference date
+      expect(queries.queryMetrics).toHaveBeenCalled()
+      const hrvCalls = vi.mocked(queries.queryMetrics).mock.calls
+      // First call: 7-day sleep HRV ending on reference date
+      const [, metric, , endDate] = hrvCalls[0]
+      expect(metric).toBe('hrv_sleep')
+      expect(endDate.toISOString().split('T')[0]).toBe('2024-01-15')
+
+      // getTimeSeriesStats called for resting HR with dates from reference date
       expect(db.getTimeSeriesStats).toHaveBeenCalled()
-      const calls = vi.mocked(db.getTimeSeriesStats).mock.calls
-      // First call should be for 7-day HRV ending on reference date
-      const [, , , endDate] = calls[0]
-      expect(new Date(endDate).toISOString().split('T')[0]).toBe('2024-01-15')
+      const hrCalls = vi.mocked(db.getTimeSeriesStats).mock.calls
+      const [, , , hrEndDate] = hrCalls[0]
+      expect(new Date(hrEndDate).toISOString().split('T')[0]).toBe('2024-01-15')
     })
   })
 

--- a/apps/backend/src/services/correlations.ts
+++ b/apps/backend/src/services/correlations.ts
@@ -9,7 +9,7 @@
 import { type MetricType } from '@aurboda/api-spec'
 import { getActivities, getProductivity, getTags, getTimeSeries, getTimeSeriesStats } from '../db'
 import { getPlaceVisits } from './locations'
-import { SyncProvider } from './queries'
+import { queryMetrics, SyncProvider } from './queries'
 
 // ============================================================================
 // Types
@@ -420,12 +420,20 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
   const prevEnd30day = new Date(start30day)
   prevEnd30day.setMilliseconds(-1)
 
-  // Fetch all stats in parallel
-  const [hrvStats7day, hrvStats30day, hrvStatsPrev30day, hrStats7day, hrStats30day, hrStatsPrev30day] =
+  // Compute average from sleep HRV data (contextual metric, not stored directly)
+  const getSleepHrvAvg = async (start: Date, end: Date): Promise<number | null> => {
+    const result = await queryMetrics(user, 'hrv_sleep', start, end)
+    if (result.count === 0) return null
+    const sum = result.data.reduce((acc, d) => acc + d.value, 0)
+    return sum / result.count
+  }
+
+  // Fetch sleep HRV and resting HR stats in parallel
+  const [hrvAvg7day, hrvAvg30day, hrvAvgPrev30day, hrStats7day, hrStats30day, hrStatsPrev30day] =
     await Promise.all([
-      getTimeSeriesStats(user, ['hrv_rmssd'], start7day, end7day),
-      getTimeSeriesStats(user, ['hrv_rmssd'], start30day, end30day),
-      getTimeSeriesStats(user, ['hrv_rmssd'], prevStart30day, prevEnd30day),
+      getSleepHrvAvg(start7day, end7day),
+      getSleepHrvAvg(start30day, end30day),
+      getSleepHrvAvg(prevStart30day, prevEnd30day),
       getTimeSeriesStats(user, ['resting_heart_rate'], start7day, end7day),
       getTimeSeriesStats(user, ['resting_heart_rate'], start30day, end30day),
       getTimeSeriesStats(user, ['resting_heart_rate'], prevStart30day, prevEnd30day),
@@ -433,8 +441,8 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
 
   // Calculate trends
   const hrvTrend =
-    hrvStats30day[0]?.avg && hrvStatsPrev30day[0]?.avg ?
-      ((hrvStats30day[0].avg - hrvStatsPrev30day[0].avg) / hrvStatsPrev30day[0].avg) * 100
+    hrvAvg30day !== null && hrvAvgPrev30day !== null ?
+      ((hrvAvg30day - hrvAvgPrev30day) / hrvAvgPrev30day) * 100
     : null
 
   const hrTrend =
@@ -444,8 +452,8 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
 
   return {
     hrv: {
-      avg7day: hrvStats7day[0]?.avg ? Math.round(hrvStats7day[0].avg * 10) / 10 : null,
-      avg30day: hrvStats30day[0]?.avg ? Math.round(hrvStats30day[0].avg * 10) / 10 : null,
+      avg7day: hrvAvg7day !== null ? Math.round(hrvAvg7day * 10) / 10 : null,
+      avg30day: hrvAvg30day !== null ? Math.round(hrvAvg30day * 10) / 10 : null,
       trend_percent: hrvTrend !== null ? Math.round(hrvTrend * 10) / 10 : null,
     },
     period: {


### PR DESCRIPTION
## Summary

- Switch `getBaseline()` to use `queryMetrics('hrv_sleep', ...)` instead of `getTimeSeriesStats(['hrv_rmssd'], ...)` for the 7-day, 30-day, and trend HRV values
- All-day HRV includes active daytime readings that naturally lower the average and distort the recovery picture; sleep HRV is the meaningful autonomic indicator
- Resting HR continues to use `getTimeSeriesStats` as before (it's a stored metric, not contextual)

Closes #226

## Test plan

- [x] Updated 3 baseline tests to mock `queryMetrics` for sleep HRV instead of `getTimeSeriesStats` for `hrv_rmssd`
- [x] All 790 backend tests pass
- [x] `pnpm check` passes
- [ ] Manual: verify `/correlations/baseline` API returns sleep-filtered HRV averages
- [ ] Manual: verify dashboard HRV metric cards reflect sleep HRV values

🤖 Generated with [Claude Code](https://claude.com/claude-code)