### PR TITLE
Fix #229: Multi-source activity display, sleep chart defaults, chart tooltip

### DIFF
--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -5,6 +5,7 @@ import {
   deleteActivity,
   getActivities,
   getActivityById,
+  getOverlappingActivities,
   getSleepSessions,
   insertActivity,
   updateActivity,
@@ -288,6 +289,123 @@ describe('Activities Integration Tests', () => {
 
       const result = await deleteActivity(user, nonExistentId)
       expect(result).toBe(false)
+    })
+  })
+
+  describe('getOverlappingActivities', () => {
+    test('returns overlapping activities of the same type', async () => {
+      const user = getTestUser()
+      const id1 = randomUUID()
+      const id2 = randomUUID()
+
+      // Two overlapping exercises from different sources
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: id1,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'From Gravl',
+      })
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:45:00Z'),
+        id: id2,
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:05:00Z'),
+        title: 'From Fitbit',
+      })
+
+      const activity = await getActivityById(user, id1)
+      expect(activity).not.toBeNull()
+
+      const overlapping = await getOverlappingActivities(user, activity!)
+      expect(overlapping).toHaveLength(2)
+      expect(overlapping.map((a) => a.id).sort()).toEqual([id1, id2].sort())
+    })
+
+    test('does not return non-overlapping activities', async () => {
+      const user = getTestUser()
+      const id1 = randomUUID()
+      const id2 = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: id1,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T15:00:00Z'),
+        id: id2,
+        source: 'garmin',
+        start_time: new Date('2024-01-15T14:00:00Z'),
+      })
+
+      const activity = await getActivityById(user, id1)
+      const overlapping = await getOverlappingActivities(user, activity!)
+      expect(overlapping).toHaveLength(1)
+      expect(overlapping[0]!.id).toBe(id1)
+    })
+
+    test('does not return activities of a different type', async () => {
+      const user = getTestUser()
+      const id1 = randomUUID()
+      const id2 = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: id1,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      await insertActivity(user, {
+        activity_type: 'sleep',
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: id2,
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const activity = await getActivityById(user, id1)
+      const overlapping = await getOverlappingActivities(user, activity!)
+      expect(overlapping).toHaveLength(1)
+      expect(overlapping[0]!.id).toBe(id1)
+    })
+
+    test('excludes deleted activities', async () => {
+      const user = getTestUser()
+      const id1 = randomUUID()
+      const id2 = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: id1,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:45:00Z'),
+        id: id2,
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:05:00Z'),
+      })
+
+      await deleteActivity(user, id2)
+
+      const activity = await getActivityById(user, id1)
+      const overlapping = await getOverlappingActivities(user, activity!)
+      expect(overlapping).toHaveLength(1)
+      expect(overlapping[0]!.id).toBe(id1)
     })
   })
 

--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -88,6 +88,27 @@ export const mergeOverlappingActivities = (activities: Activity[]): Activity[] =
   return result.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
 }
 
+/**
+ * Find all non-deleted activities of the same type that overlap in time with the given activity.
+ * Returns raw DB rows (no merge) including the activity itself.
+ */
+export const getOverlappingActivities = async (user: string, activity: Activity): Promise<Activity[]> => {
+  const endTime = activity.end_time ?? activity.start_time
+  const result = await query(
+    user,
+    `SELECT id, source, activity_type, start_time, end_time, title, notes, data, deleted_at
+     FROM activities
+     WHERE activity_type = $1
+       AND deleted_at IS NULL
+       AND start_time <= $3
+       AND (end_time >= $2 OR end_time IS NULL)
+     ORDER BY start_time`,
+    [activity.activity_type, activity.start_time, endTime],
+  )
+
+  return result.rows.map(mapActivityRow)
+}
+
 export const insertActivity = async (user: string, activity: Activity) => {
   await query(
     user,

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -71,6 +71,7 @@ export {
   deleteActivity,
   getActivities,
   getActivityById,
+  getOverlappingActivities,
   getSleepSessions,
   insertActivity,
   mergeOverlappingActivities,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -21,7 +21,7 @@ import {
   type UpdateActivityResponse,
 } from '@aurboda/api-spec'
 import { RequestHandler, Router } from 'express'
-import { getActivityById } from '../db'
+import { getActivityById, getOverlappingActivities } from '../db'
 import {
   addActivity,
   deleteActivity,
@@ -179,6 +179,31 @@ export const createActivitiesRouter = (
       return res.status(404).json({ error: 'Activity not found', success: false })
     }
 
+    // Check for overlapping activities from other sources
+    const overlapping = activity.deleted_at ? [] : await getOverlappingActivities(user, activity)
+
+    const hasMultipleSources = overlapping.length > 1
+    const sourceRecords =
+      hasMultipleSources ?
+        overlapping.map((a) => ({
+          data_origin: (a.data as Record<string, unknown> | undefined)?.dataOrigin as string | undefined,
+          end_time: a.end_time?.toISOString(),
+          id: a.id!,
+          source: a.source,
+          start_time: a.start_time.toISOString(),
+          title: a.title,
+        }))
+      : undefined
+
+    const mergedStartTime =
+      hasMultipleSources ?
+        new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))).toISOString()
+      : undefined
+    const mergedEndTime =
+      hasMultipleSources ?
+        new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))).toISOString()
+      : undefined
+
     res.json({
       data: {
         activity_type: activity.activity_type,
@@ -186,8 +211,11 @@ export const createActivitiesRouter = (
         deleted_at: activity.deleted_at?.toISOString(),
         end_time: activity.end_time?.toISOString(),
         id: activity.id,
+        merged_end_time: mergedEndTime,
+        merged_start_time: mergedStartTime,
         notes: activity.notes,
         source: activity.source,
+        source_records: sourceRecords,
         start_time: activity.start_time.toISOString(),
         title: activity.title,
       },

--- a/apps/web/src/pages/EntityDetail/ActivityChart.tsx
+++ b/apps/web/src/pages/EntityDetail/ActivityChart.tsx
@@ -5,12 +5,14 @@
  * - Sleep hypnogram (colored bands by sleep stage)
  * - Heart rate line overlay
  * - HRV line overlay
+ * - Hover tooltip with crosshair
  */
 import { useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
 import { format } from 'date-fns'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchHeartRate, fetchHrv } from '../../state/api'
+import { findNearest, findStageAtTime } from './chart-utils'
 import { STAGE_COLORS, STAGE_LABELS, STAGE_Y_ORDER, type SleepStage } from './sleep-utils'
 
 interface ActivityChartProps {
@@ -151,6 +153,7 @@ export const ActivityChart = ({
 }: ActivityChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
   const [showHr, setShowHr] = useState(showHrDefault)
   const [showHrv, setShowHrv] = useState(showHrvDefault)
 
@@ -222,6 +225,68 @@ export const ActivityChart = ({
       const offset = axisSide === 'right' && hrVisible ? 45 : 0
       drawLineOverlay(g, xScale, innerWidth, innerHeight, hrvData, '#14b8a6', 'ms', axisSide, offset)
     }
+
+    // Tooltip crosshair and interaction overlay
+    const crosshair = g
+      .append('line')
+      .attr('y1', 0)
+      .attr('y2', innerHeight)
+      .attr('stroke', 'currentColor')
+      .attr('stroke-opacity', 0.4)
+      .attr('stroke-dasharray', '4 3')
+      .attr('pointer-events', 'none')
+      .style('display', 'none')
+
+    const tooltip = tooltipRef.current
+
+    g.append('rect')
+      .attr('width', innerWidth)
+      .attr('height', innerHeight)
+      .attr('fill', 'transparent')
+      .attr('pointer-events', 'all')
+      .on('mousemove', (event: MouseEvent) => {
+        const [mx] = d3.pointer(event)
+        const time = xScale.invert(mx)
+
+        crosshair.attr('x1', mx).attr('x2', mx).style('display', null)
+
+        const lines: string[] = [format(time, 'HH:mm:ss')]
+
+        if (hasData(hrData)) {
+          const nearest = findNearest(hrData, time)
+          if (nearest) lines.push(`HR: ${Math.round(nearest[1])} bpm`)
+        }
+        if (hasData(hrvData)) {
+          const nearest = findNearest(hrvData, time)
+          if (nearest) lines.push(`HRV: ${Math.round(nearest[1])} ms`)
+        }
+        if (hasHypnogram && stages) {
+          const stage = findStageAtTime(stages, time)
+          if (stage) lines.push(`Stage: ${stage}`)
+        }
+
+        if (tooltip) {
+          tooltip.textContent = lines.join('\n')
+          tooltip.style.display = 'block'
+
+          // Position relative to container
+          const containerRect = containerRef.current!.getBoundingClientRect()
+          const svgRect = svgRef.current!.getBoundingClientRect()
+          const tooltipX = mx + MARGIN.left + (svgRect.left - containerRect.left)
+          const tooltipWidth = tooltip.offsetWidth
+          const availableWidth = containerRect.width
+
+          // Flip to left side if too close to right edge
+          const left =
+            tooltipX + tooltipWidth + 12 > availableWidth ? tooltipX - tooltipWidth - 12 : tooltipX + 12
+          tooltip.style.left = `${left}px`
+          tooltip.style.top = `${MARGIN.top + 8}px`
+        }
+      })
+      .on('mouseleave', () => {
+        crosshair.style('display', 'none')
+        if (tooltip) tooltip.style.display = 'none'
+      })
   }, [start, end, stages, hasHypnogram, hrData, hrvData])
 
   return (
@@ -246,6 +311,7 @@ export const ActivityChart = ({
       </div>
       <div class="chart-svg-container" ref={containerRef}>
         <svg ref={svgRef} />
+        <div class="chart-tooltip" ref={tooltipRef} />
       </div>
     </div>
   )

--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -59,7 +59,9 @@ const HrZoneBar = ({ zones }: { zones: Record<number, number> }) => {
 }
 
 export const ExerciseDetail = ({ activity }: { activity: Activity }) => {
-  const end = activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  const displayStart = activity.merged_start_time ?? activity.start_time
+  const displayEnd =
+    activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
   const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseTypeName as
     | string
     | undefined
@@ -78,12 +80,12 @@ export const ExerciseDetail = ({ activity }: { activity: Activity }) => {
           <div class="field-row">
             <span class="field-label">Time</span>
             <span class="field-value">
-              {formatDateTime(activity.start_time)} – {formatTime(end)}
+              {formatDateTime(displayStart)} – {formatTime(displayEnd)}
             </span>
           </div>
           <div class="field-row">
             <span class="field-label">Duration</span>
-            <span class="field-value">{formatDuration(activity.start_time, end)}</span>
+            <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
           </div>
           {activity.avg_hrv !== undefined && (
             <div class="field-row">
@@ -104,7 +106,7 @@ export const ExerciseDetail = ({ activity }: { activity: Activity }) => {
 
       {/* HR chart with overlays */}
       <div class="detail-grid-full">
-        <ActivityChart start={activity.start_time} end={end} showHrDefault={true} />
+        <ActivityChart start={displayStart} end={displayEnd} showHrDefault={true} />
       </div>
     </>
   )

--- a/apps/web/src/pages/EntityDetail/SleepDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/SleepDetail.tsx
@@ -75,10 +75,12 @@ const OuraMetricsCards = ({ metrics }: { metrics: Partial<Record<OuraSleepMetric
 
 export const SleepDetail = ({ activity }: { activity: Activity }) => {
   const end = activity.end_time ?? new Date(activity.start_time.getTime() + 8 * 60 * 60000)
+  const displayStart = activity.merged_start_time ?? activity.start_time
+  const displayEnd = activity.merged_end_time ?? end
   const stages = parseSleepStages(activity.data as Record<string, unknown> | undefined)
   const sleepMinutes = resolveSleepMinutes(activity.total_sleep, stages)
 
-  const endDateStr = format(end, 'yyyy-MM-dd')
+  const endDateStr = format(displayEnd, 'yyyy-MM-dd')
   const ouraQuery = useQuery({
     queryFn: () => {
       const dayStart = new Date(`${endDateStr}T00:00:00`)
@@ -106,12 +108,12 @@ export const SleepDetail = ({ activity }: { activity: Activity }) => {
           <div class="field-row">
             <span class="field-label">Time</span>
             <span class="field-value">
-              {formatDateTime(activity.start_time)} – {formatTime(end)}
+              {formatDateTime(displayStart)} – {formatTime(displayEnd)}
             </span>
           </div>
           <div class="field-row">
             <span class="field-label">In Bed</span>
-            <span class="field-value">{formatDuration(activity.start_time, end)}</span>
+            <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
           </div>
           {sleepMinutes !== undefined && (
             <div class="field-row">
@@ -138,9 +140,11 @@ export const SleepDetail = ({ activity }: { activity: Activity }) => {
 
       <div class="detail-grid-full">
         <ActivityChart
-          start={activity.start_time}
-          end={end}
+          start={displayStart}
+          end={displayEnd}
           stages={stages.length > 0 ? stages : undefined}
+          showHrDefault={true}
+          showHrvDefault={true}
         />
       </div>
     </>

--- a/apps/web/src/pages/EntityDetail/chart-utils.test.ts
+++ b/apps/web/src/pages/EntityDetail/chart-utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest'
+import { findNearest, findStageAtTime } from './chart-utils'
+
+describe('findNearest', () => {
+  test('returns undefined for empty data', () => {
+    expect(findNearest([], new Date('2024-01-15T10:00:00Z'))).toBeUndefined()
+  })
+
+  test('returns single element for single-element array', () => {
+    const data: [Date, number][] = [[new Date('2024-01-15T10:00:00Z'), 72]]
+    expect(findNearest(data, new Date('2024-01-15T12:00:00Z'))).toEqual(data[0])
+  })
+
+  test('returns exact match', () => {
+    const data: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 70],
+      [new Date('2024-01-15T10:05:00Z'), 72],
+      [new Date('2024-01-15T10:10:00Z'), 68],
+    ]
+    expect(findNearest(data, new Date('2024-01-15T10:05:00Z'))).toEqual(data[1])
+  })
+
+  test('returns closest point when between two points', () => {
+    const data: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 70],
+      [new Date('2024-01-15T10:10:00Z'), 72],
+    ]
+    // 10:03 is closer to 10:00
+    expect(findNearest(data, new Date('2024-01-15T10:03:00Z'))).toEqual(data[0])
+    // 10:08 is closer to 10:10
+    expect(findNearest(data, new Date('2024-01-15T10:08:00Z'))).toEqual(data[1])
+  })
+
+  test('returns first point when target is before all data', () => {
+    const data: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 70],
+      [new Date('2024-01-15T10:10:00Z'), 72],
+    ]
+    expect(findNearest(data, new Date('2024-01-15T09:00:00Z'))).toEqual(data[0])
+  })
+
+  test('returns last point when target is after all data', () => {
+    const data: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 70],
+      [new Date('2024-01-15T10:10:00Z'), 72],
+    ]
+    expect(findNearest(data, new Date('2024-01-15T11:00:00Z'))).toEqual(data[1])
+  })
+
+  test('handles large dataset with binary search', () => {
+    const data: [Date, number][] = Array.from({ length: 1000 }, (_, i) => [
+      new Date(new Date('2024-01-15T00:00:00Z').getTime() + i * 60000),
+      60 + Math.sin(i) * 10,
+    ])
+    // Target at 500 minutes in
+    const target = new Date(new Date('2024-01-15T00:00:00Z').getTime() + 500 * 60000)
+    const result = findNearest(data, target)
+    expect(result).toEqual(data[500])
+  })
+})
+
+describe('findStageAtTime', () => {
+  const stages = [
+    { endTime: '2024-01-15T00:30:00Z', stage: 4, startTime: '2024-01-15T00:00:00Z' },
+    { endTime: '2024-01-15T01:00:00Z', stage: 5, startTime: '2024-01-15T00:30:00Z' },
+    { endTime: '2024-01-15T01:30:00Z', stage: 6, startTime: '2024-01-15T01:00:00Z' },
+    { endTime: '2024-01-15T01:35:00Z', stage: 1, startTime: '2024-01-15T01:30:00Z' },
+  ]
+
+  test('returns correct stage label when time falls within a stage', () => {
+    expect(findStageAtTime(stages, new Date('2024-01-15T00:15:00Z'))).toBe('Light')
+    expect(findStageAtTime(stages, new Date('2024-01-15T00:45:00Z'))).toBe('Deep')
+    expect(findStageAtTime(stages, new Date('2024-01-15T01:15:00Z'))).toBe('REM')
+    expect(findStageAtTime(stages, new Date('2024-01-15T01:32:00Z'))).toBe('Awake')
+  })
+
+  test('returns undefined when time is outside all stages', () => {
+    expect(findStageAtTime(stages, new Date('2024-01-14T23:00:00Z'))).toBeUndefined()
+    expect(findStageAtTime(stages, new Date('2024-01-15T02:00:00Z'))).toBeUndefined()
+  })
+
+  test('returns stage at exact start boundary (inclusive)', () => {
+    expect(findStageAtTime(stages, new Date('2024-01-15T00:00:00Z'))).toBe('Light')
+  })
+
+  test('returns undefined at exact end boundary (exclusive)', () => {
+    // End of last stage should not match
+    expect(findStageAtTime(stages, new Date('2024-01-15T01:35:00Z'))).toBeUndefined()
+  })
+
+  test('returns undefined for empty stages', () => {
+    expect(findStageAtTime([], new Date('2024-01-15T00:15:00Z'))).toBeUndefined()
+  })
+})

--- a/apps/web/src/pages/EntityDetail/chart-utils.ts
+++ b/apps/web/src/pages/EntityDetail/chart-utils.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure utility functions for chart tooltip interactions.
+ */
+import type { SleepStage } from './sleep-utils'
+import { STAGE_LABELS } from './sleep-utils'
+
+/**
+ * Find the nearest data point to a given time using binary search.
+ * Returns the [Date, number] tuple closest to `targetTime`, or undefined if data is empty.
+ */
+export const findNearest = (data: [Date, number][], targetTime: Date): [Date, number] | undefined => {
+  if (data.length === 0) return undefined
+  if (data.length === 1) return data[0]
+
+  const t = targetTime.getTime()
+
+  let lo = 0
+  let hi = data.length - 1
+
+  while (lo < hi - 1) {
+    const mid = (lo + hi) >> 1
+    if (data[mid]![0].getTime() <= t) {
+      lo = mid
+    } else {
+      hi = mid
+    }
+  }
+
+  const dLo = Math.abs(data[lo]![0].getTime() - t)
+  const dHi = Math.abs(data[hi]![0].getTime() - t)
+  return dLo <= dHi ? data[lo] : data[hi]
+}
+
+/**
+ * Find the sleep stage active at a given time.
+ * Returns the stage label string, or undefined if no stage covers that time.
+ */
+export const findStageAtTime = (stages: SleepStage[], time: Date): string | undefined => {
+  const t = time.getTime()
+  for (const stage of stages) {
+    const start = new Date(stage.startTime).getTime()
+    const end = new Date(stage.endTime).getTime()
+    if (t >= start && t < end) {
+      return STAGE_LABELS[stage.stage]
+    }
+  }
+  return undefined
+}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -25,6 +25,7 @@ import {
   restoreTag,
   softDeleteActivity,
   softDeleteTag,
+  SourceRecord,
   Tag,
   updateNote,
 } from '../../state/api'
@@ -51,9 +52,27 @@ const formatDuration = (start: Date, end: Date): string => {
   return m > 0 ? `${h}h ${m}m` : `${h}h`
 }
 
+const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
+  <div class="source-records">
+    <h3>Sources ({records.length})</h3>
+    {records.map((record) => (
+      <a key={record.id} href={`/detail/activity/${record.id}`} class="source-record">
+        <span class="source-record-source">{record.data_origin ?? record.source}</span>
+        <span class="source-record-time">
+          {format(new Date(record.start_time), 'HH:mm')}
+          {record.end_time ? ` – ${format(new Date(record.end_time), 'HH:mm')}` : ''}
+        </span>
+        {record.title && <span class="source-record-title">{record.title}</span>}
+      </a>
+    ))}
+  </div>
+)
+
 /** Generic activity detail for types other than sleep/exercise. */
 const GenericActivityDetail = ({ activity }: { activity: Activity }) => {
-  const end = activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  const displayStart = activity.merged_start_time ?? activity.start_time
+  const displayEnd =
+    activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
   const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseTypeName as
     | string
     | undefined
@@ -71,12 +90,12 @@ const GenericActivityDetail = ({ activity }: { activity: Activity }) => {
         <div class="field-row">
           <span class="field-label">Time</span>
           <span class="field-value">
-            {formatDateTime(activity.start_time)} – {formatTime(end)}
+            {formatDateTime(displayStart)} – {formatTime(displayEnd)}
           </span>
         </div>
         <div class="field-row">
           <span class="field-label">Duration</span>
-          <span class="field-value">{formatDuration(activity.start_time, end)}</span>
+          <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
         </div>
         {activity.avg_hrv !== undefined && (
           <div class="field-row">
@@ -101,12 +120,19 @@ const ActivityDetailDispatch = ({ activity }: { activity: Activity }) => {
 
   const isSleep = activity.activity_type === 'sleep' || activity.activity_type === 'nap'
   const isExercise = activity.activity_type === 'exercise'
+  const hasSourceRecords = activity.source_records && activity.source_records.length > 1
 
   return (
     <>
+      {hasSourceRecords && (
+        <div class="merged-indicator">Merged from {activity.source_records!.length} sources</div>
+      )}
+
       {isSleep && <SleepDetail activity={activity} />}
       {isExercise && <ExerciseDetail activity={activity} />}
       {!isSleep && !isExercise && <GenericActivityDetail activity={activity} />}
+
+      {hasSourceRecords && <SourceRecordsSection records={activity.source_records!} />}
 
       <div class="detail-grid">
         <MusicPlaylist start={activity.start_time} end={end} />

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -157,6 +157,69 @@
   color: #9ca3af;
 }
 
+/* Merged activity indicator */
+.merged-indicator {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  margin-bottom: 1rem;
+  background: #ede9fe;
+  color: #5b21b6;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+/* Source records */
+.source-records {
+  margin-top: 1.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.source-records h3 {
+  font-size: 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.source-record {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s ease;
+}
+
+.source-record:last-child {
+  margin-bottom: 0;
+}
+
+.source-record:hover {
+  background: #f3f4f6;
+}
+
+.source-record-source {
+  font-weight: 500;
+  font-size: 0.85rem;
+  min-width: 100px;
+}
+
+.source-record-time {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.source-record-title {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-left: auto;
+}
+
 /* Activity chart */
 .activity-chart-container {
   position: relative;
@@ -196,8 +259,24 @@
 }
 
 .chart-svg-container {
+  position: relative;
   width: 100%;
   overflow: hidden;
+}
+
+.chart-tooltip {
+  display: none;
+  position: absolute;
+  padding: 0.375rem 0.5rem;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  white-space: pre;
+  pointer-events: none;
+  z-index: 10;
+  color: #374151;
 }
 
 .chart-svg-container svg {
@@ -584,6 +663,35 @@
     border-color: #374151;
   }
 
+  .merged-indicator {
+    background: #2e1065;
+    color: #c4b5fd;
+  }
+
+  .source-records {
+    border-color: #374151;
+  }
+
+  .source-record {
+    border-color: #374151;
+  }
+
+  .source-record:hover {
+    background: #1f2937;
+  }
+
+  .source-record-source {
+    color: #d1d5db;
+  }
+
+  .source-record-time {
+    color: #9ca3af;
+  }
+
+  .source-record-title {
+    color: #9ca3af;
+  }
+
   .chart-toggle {
     border-color: #4b5563;
     color: #9ca3af;
@@ -592,6 +700,12 @@
   .chart-toggle.active {
     background: #374151;
     border-color: #6b7280;
+    color: #d1d5db;
+  }
+
+  .chart-tooltip {
+    background: rgba(31, 41, 55, 0.95);
+    border-color: #4b5563;
     color: #d1d5db;
   }
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -74,9 +74,21 @@ import { auth } from './auth'
 // Frontend types with Date objects (converted from API string types)
 export type ActivityType = 'sleep' | 'exercise' | 'meditation' | 'nap'
 
+export interface SourceRecord {
+  id: string
+  source: string
+  start_time: string
+  end_time?: string
+  title?: string
+  data_origin?: string
+}
+
 export interface Activity extends Omit<ApiActivity, 'start_time' | 'end_time'> {
   start_time: Date
   end_time?: Date
+  source_records?: SourceRecord[]
+  merged_start_time?: Date
+  merged_end_time?: Date
 }
 
 export interface ProductivityRecord extends Omit<ApiProductivityRecord, 'start_time' | 'end_time'> {
@@ -826,6 +838,9 @@ export const fetchActivityById = async (id: string): Promise<Activity> => {
   return {
     ...d,
     end_time: d.end_time ? new Date(d.end_time) : undefined,
+    merged_end_time: d.merged_end_time ? new Date(d.merged_end_time) : undefined,
+    merged_start_time: d.merged_start_time ? new Date(d.merged_start_time) : undefined,
+    source_records: d.source_records,
     start_time: new Date(d.start_time),
   }
 }

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -152,6 +152,42 @@ export const activitySchema = z
 export type Activity = z.infer<typeof activitySchema>
 
 /**
+ * Source record schema for multi-source merged activities.
+ */
+export const sourceRecordSchema = z
+  .object({
+    data_origin: z.string().optional().meta({ description: 'Health Connect data origin package' }),
+    end_time: iso8601DateTimeSchema.optional(),
+    id: z.string().uuid().meta({ description: 'Activity ID' }),
+    source: z.string().meta({ description: 'Data source' }),
+    start_time: iso8601DateTimeSchema,
+    title: z.string().optional().meta({ description: 'Activity title' }),
+  })
+  .meta({ id: 'SourceRecord', description: 'Individual source record within a merged activity' })
+
+export type SourceRecord = z.infer<typeof sourceRecordSchema>
+
+/**
+ * Activity detail response schema (single activity with optional merge info).
+ */
+export const activityDetailSchema = activitySchema
+  .extend({
+    merged_end_time: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: 'Merged end time across all overlapping sources' }),
+    merged_start_time: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: 'Merged start time across all overlapping sources' }),
+    source_records: z
+      .array(sourceRecordSchema)
+      .optional()
+      .meta({ description: 'Individual source records when activity is merged from multiple sources' }),
+  })
+  .meta({ id: 'ActivityDetail' })
+
+export type ActivityDetail = z.infer<typeof activityDetailSchema>
+
+/**
  * Activities query schema.
  */
 export const activitiesQuerySchema = timeRangeQuerySchema


### PR DESCRIPTION
## Summary
- **Multi-source merged activity display**: When activities are logged from multiple sources (e.g., Gravl + Fitbit), the detail page now shows the merged time range and lists individual source records with links to each source's detail page
- **Sleep chart HR/HRV defaults**: Sleep detail charts now show HR and HRV overlays by default
- **Chart hover tooltip**: All activity charts now show a crosshair and tooltip on hover displaying time, HR, HRV, and sleep stage values

## Changes
- New `getOverlappingActivities` DB function to find overlapping activities of the same type
- Enhanced `GET /activities/:id` to return `source_records`, `merged_start_time`, `merged_end_time` when multiple sources overlap
- Added `SourceRecord` and `ActivityDetail` schemas to api-spec
- New `SourceRecordsSection` component and merged time display in detail views
- D3 tooltip with bisector-based nearest-value lookup via `findNearest` and `findStageAtTime` pure functions
- Dark mode support for all new UI elements

## Test plan
- [x] `pnpm check` passes (TypeScript + lint)
- [x] `pnpm fix` passes
- [x] Backend unit tests pass (794 tests)
- [x] Web unit tests pass (88 tests, including new chart-utils tests)
- [x] Integration tests for `getOverlappingActivities` (overlapping, non-overlapping, different type, deleted)
- [ ] Manual: open a sleep detail page → HR and HRV should load by default
- [ ] Manual: hover over any activity chart → crosshair + tooltip should appear
- [ ] Manual: open a multi-source exercise detail → source records should be listed

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)