### PR TITLE
Include comments in entity query responses

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -123,7 +123,14 @@ export {
 } from './productivity'
 
 // Notes
-export { deleteNote, getNoteById, getNotesForEntity, insertNote, updateNote } from './notes'
+export {
+  deleteNote,
+  getNoteById,
+  getNotesByEntityIds,
+  getNotesForEntity,
+  insertNote,
+  updateNote,
+} from './notes'
 
 // Lab results
 export { getLabResults, insertLabResult } from './lab-results'

--- a/apps/backend/src/db/notes.integration.test.ts
+++ b/apps/backend/src/db/notes.integration.test.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
-import { deleteNote, getNoteById, getNotesForEntity, insertNote, updateNote } from './notes'
+import {
+  deleteNote,
+  getNoteById,
+  getNotesByEntityIds,
+  getNotesForEntity,
+  insertNote,
+  updateNote,
+} from './notes'
 
 const CONTAINER_TIMEOUT = 60_000
 
@@ -107,6 +114,61 @@ describe('Notes Integration Tests', () => {
       const user = getTestUser()
       const updated = await updateNote(user, randomUUID(), 'New content')
       expect(updated).toBeNull()
+    })
+  })
+
+  describe('getNotesByEntityIds', () => {
+    test('returns empty map for empty IDs array', async () => {
+      const user = getTestUser()
+      const result = await getNotesByEntityIds(user, 'activity', [])
+      expect(result.size).toBe(0)
+    })
+
+    test('returns notes grouped by entity ID', async () => {
+      const user = getTestUser()
+      const entityId1 = randomUUID()
+      const entityId2 = randomUUID()
+
+      await insertNote(user, 'activity', entityId1, 'Note 1a')
+      await insertNote(user, 'activity', entityId1, 'Note 1b')
+      await insertNote(user, 'activity', entityId2, 'Note 2a')
+
+      const result = await getNotesByEntityIds(user, 'activity', [entityId1, entityId2])
+
+      expect(result.size).toBe(2)
+      expect(result.get(entityId1)).toHaveLength(2)
+      expect(result.get(entityId1)![0].content).toBe('Note 1a')
+      expect(result.get(entityId1)![1].content).toBe('Note 1b')
+      expect(result.get(entityId2)).toHaveLength(1)
+      expect(result.get(entityId2)![0].content).toBe('Note 2a')
+    })
+
+    test('only returns notes for the requested entity type', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+
+      await insertNote(user, 'activity', entityId, 'Activity note')
+      await insertNote(user, 'tag', entityId, 'Tag note')
+
+      const result = await getNotesByEntityIds(user, 'activity', [entityId])
+
+      expect(result.size).toBe(1)
+      expect(result.get(entityId)).toHaveLength(1)
+      expect(result.get(entityId)![0].content).toBe('Activity note')
+    })
+
+    test('entities without notes are absent from the map', async () => {
+      const user = getTestUser()
+      const entityId1 = randomUUID()
+      const entityId2 = randomUUID()
+
+      await insertNote(user, 'activity', entityId1, 'Only entity 1 has a note')
+
+      const result = await getNotesByEntityIds(user, 'activity', [entityId1, entityId2])
+
+      expect(result.size).toBe(1)
+      expect(result.has(entityId1)).toBe(true)
+      expect(result.has(entityId2)).toBe(false)
     })
   })
 

--- a/apps/backend/src/db/notes.ts
+++ b/apps/backend/src/db/notes.ts
@@ -60,6 +60,29 @@ export const updateNote = async (user: string, id: string, content: string): Pro
   return mapNoteRow(result.rows[0])
 }
 
+export const getNotesByEntityIds = async (
+  user: string,
+  entityType: EntityType,
+  entityIds: string[],
+): Promise<Map<string, Note[]>> => {
+  if (entityIds.length === 0) return new Map()
+  const result = await query(
+    user,
+    `SELECT ${NOTE_COLUMNS} FROM notes
+     WHERE entity_type = $1 AND entity_id = ANY($2)
+     ORDER BY created_at ASC`,
+    [entityType, entityIds],
+  )
+  const map = new Map<string, Note[]>()
+  for (const row of result.rows) {
+    const note = mapNoteRow(row)
+    const existing = map.get(note.entity_id) ?? []
+    existing.push(note)
+    map.set(note.entity_id, existing)
+  }
+  return map
+}
+
 export const deleteNote = async (user: string, id: string): Promise<boolean> => {
   const result = await query(user, `DELETE FROM notes WHERE id = $1`, [id])
   return (result.rowCount ?? 0) > 0

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -551,10 +551,12 @@ describe('MCP Server', () => {
 
       vi.mocked(queries.queryTags).mockResolvedValue([
         {
+          comments: [],
           start_time: '2024-01-15T14:30:00Z',
           tag: 'coffee',
         },
         {
+          comments: [],
           end_time: '2024-01-15T16:00:00Z',
           start_time: '2024-01-15T15:00:00Z',
           tag: 'meeting',
@@ -647,6 +649,7 @@ describe('MCP Server', () => {
       vi.mocked(queries.queryActivities).mockResolvedValue([
         {
           activity_type: 'sleep',
+          comments: [],
           duration: 480,
           end_time: '2024-01-15T07:00:00Z',
           source: 'health_connect',
@@ -655,6 +658,7 @@ describe('MCP Server', () => {
         },
         {
           activity_type: 'exercise',
+          comments: [],
           duration: 45,
           end_time: '2024-01-15T09:45:00Z',
           hr_zone_secs: { 0: 60, 1: 300, 2: 900, 3: 1200, 4: 240, 5: 0 },
@@ -685,6 +689,7 @@ describe('MCP Server', () => {
       vi.mocked(queries.queryActivities).mockResolvedValue([
         {
           activity_type: 'exercise',
+          comments: [],
           duration: 45,
           end_time: '2024-01-15T09:45:00Z',
           source: 'health_connect',
@@ -762,6 +767,7 @@ describe('MCP Server', () => {
         {
           activity: 'Visual Studio Code',
           category: 'Software Development',
+          comments: [],
           duration_sec: 7200,
           end_time: '2024-01-15T17:00:00Z',
           productivity: 2,
@@ -770,6 +776,7 @@ describe('MCP Server', () => {
         {
           activity: 'Twitter',
           category: 'Social Networking',
+          comments: [],
           duration_sec: 1800,
           end_time: '2024-01-15T18:00:00Z',
           productivity: -2,

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -6,8 +6,11 @@ import {
   getDailySummary,
   getPeriodSummary,
   mergeProductivitySpans,
+  queryActivities,
   queryMetrics,
   queryMetricsBucketed,
+  queryProductivity,
+  queryTags,
 } from './queries'
 
 // Mock the db module
@@ -16,6 +19,7 @@ vi.mock('../db', () => ({
   getDailyAggregateValue: vi.fn(),
   getDailyAggregates: vi.fn(),
   getLocations: vi.fn(),
+  getNotesByEntityIds: vi.fn(),
   getProductivity: vi.fn(),
   getSleepSessions: vi.fn(),
   getTags: vi.fn(),
@@ -1374,5 +1378,184 @@ describe('queryMetrics with contextual HRV', () => {
     // Only samples during exercise should be included
     expect(result.count).toBe(2)
     expect(result.data.map((d) => d.value)).toEqual([22, 18])
+  })
+})
+
+describe('queryTags with comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('attaches comments when notes exist', async () => {
+    const tagId = 'tag-id-1'
+    vi.mocked(db.getTags).mockResolvedValue([
+      { id: tagId, source: 'manual', start_time: new Date('2024-01-15T08:00:00Z'), tag: 'coffee' },
+    ])
+
+    const notesMap = new Map([
+      [
+        tagId,
+        [
+          {
+            content: 'Morning coffee',
+            created_at: new Date('2024-01-15T08:01:00Z'),
+            entity_id: tagId,
+            entity_type: 'tag' as const,
+            id: 'note-1',
+            updated_at: new Date('2024-01-15T08:01:00Z'),
+          },
+        ],
+      ],
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(notesMap)
+
+    const result = await queryTags('testuser', new Date('2024-01-15'), new Date('2024-01-16'))
+
+    expect(result).toHaveLength(1)
+    expect(result[0].comments).toHaveLength(1)
+    expect(result[0].comments[0].content).toBe('Morning coffee')
+    expect(result[0].comments[0].id).toBe('note-1')
+  })
+
+  test('returns empty comments array when no notes exist', async () => {
+    vi.mocked(db.getTags).mockResolvedValue([
+      { id: 'tag-1', source: 'manual', start_time: new Date('2024-01-15T08:00:00Z'), tag: 'coffee' },
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
+
+    const result = await queryTags('testuser', new Date('2024-01-15'), new Date('2024-01-16'))
+
+    expect(result[0].comments).toEqual([])
+  })
+})
+
+describe('queryActivities with comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+  })
+
+  test('attaches comments to activities', async () => {
+    const activityId = 'activity-id-1'
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: activityId,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+    ])
+
+    const notesMap = new Map([
+      [
+        activityId,
+        [
+          {
+            content: 'Felt great!',
+            created_at: new Date('2024-01-15T11:00:00Z'),
+            entity_id: activityId,
+            entity_type: 'activity' as const,
+            id: 'note-1',
+            updated_at: new Date('2024-01-15T11:00:00Z'),
+          },
+        ],
+      ],
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(notesMap)
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+
+    const result = await queryActivities(
+      'testuser',
+      ['exercise'],
+      new Date('2024-01-15'),
+      new Date('2024-01-16'),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0].comments).toHaveLength(1)
+    expect(result[0].comments[0].content).toBe('Felt great!')
+  })
+
+  test('returns empty comments array when no notes exist', async () => {
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        id: 'activity-1',
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
+
+    const result = await queryActivities(
+      'testuser',
+      ['exercise'],
+      new Date('2024-01-15'),
+      new Date('2024-01-16'),
+    )
+
+    expect(result[0].comments).toEqual([])
+  })
+})
+
+describe('queryProductivity with comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('attaches comments to productivity records', async () => {
+    const prodId = 'prod-id-1'
+    vi.mocked(db.getProductivity).mockResolvedValue([
+      {
+        activity: 'VS Code',
+        duration_sec: 3600,
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: prodId,
+        productivity: 2,
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+    ])
+
+    const notesMap = new Map([
+      [
+        prodId,
+        [
+          {
+            content: 'Deep focus session',
+            created_at: new Date('2024-01-15T11:01:00Z'),
+            entity_id: prodId,
+            entity_type: 'productivity' as const,
+            id: 'note-1',
+            updated_at: new Date('2024-01-15T11:01:00Z'),
+          },
+        ],
+      ],
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(notesMap)
+
+    const result = await queryProductivity('testuser', new Date('2024-01-15'), new Date('2024-01-16'))
+
+    expect(result).toHaveLength(1)
+    expect(result[0].comments).toHaveLength(1)
+    expect(result[0].comments[0].content).toBe('Deep focus session')
+  })
+
+  test('returns empty comments array when no notes exist', async () => {
+    vi.mocked(db.getProductivity).mockResolvedValue([
+      {
+        activity: 'VS Code',
+        duration_sec: 3600,
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'prod-1',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
+
+    const result = await queryProductivity('testuser', new Date('2024-01-15'), new Date('2024-01-16'))
+
+    expect(result[0].comments).toEqual([])
   })
 })

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -11,6 +11,7 @@ import {
   getActivities,
   getDailyAggregates,
   getDailyAggregateValue,
+  getNotesByEntityIds,
   getProductivity,
   getSleepSessions,
   getTags,
@@ -118,6 +119,7 @@ export interface TagSummary {
   start_time: string
   end_time?: string
   source?: DataSource
+  comments: CommentSummary[]
 }
 
 export interface PlaceSummary {
@@ -177,6 +179,34 @@ export interface PeriodSummaryResult {
   end: string
   period_days: number
   metrics: PeriodMetricStats[]
+}
+
+export interface CommentSummary {
+  id: string
+  content: string
+  created_at: string
+  updated_at: string
+}
+
+const getCommentsMap = async (
+  user: string,
+  entityType: 'activity' | 'tag' | 'productivity',
+  ids: string[],
+): Promise<Map<string, CommentSummary[]>> => {
+  const notesMap = await getNotesByEntityIds(user, entityType, ids)
+  const result = new Map<string, CommentSummary[]>()
+  for (const [entityId, notes] of notesMap) {
+    result.set(
+      entityId,
+      notes.map((n) => ({
+        content: n.content,
+        created_at: n.created_at.toISOString(),
+        id: n.id,
+        updated_at: n.updated_at.toISOString(),
+      })),
+    )
+  }
+  return result
 }
 
 // ============================================================================
@@ -605,6 +635,7 @@ export async function getDailySummary(
     }),
     steps: { total: totalSteps },
     tags: tags.map((t) => ({
+      comments: [],
       end_time: t.end_time?.toISOString(),
       start_time: t.start_time.toISOString(),
       tag: t.tag,
@@ -793,7 +824,10 @@ export async function queryTags(
   }
 
   const tags = await getTags(user, start, end)
+  const ids = tags.map((t) => t.id).filter((id): id is string => id !== undefined)
+  const commentsMap = await getCommentsMap(user, 'tag', ids)
   return tags.map((t) => ({
+    comments: t.id ? (commentsMap.get(t.id) ?? []) : [],
     end_time: t.end_time?.toISOString(),
     id: t.id,
     source: t.source,
@@ -819,6 +853,7 @@ export interface ActivityResult {
   data?: Record<string, unknown>
   hr_zone_secs?: HrZoneSecs
   avg_hrv?: number
+  comments: CommentSummary[]
 }
 
 /**
@@ -864,6 +899,10 @@ export async function queryActivities(
   const includesExercise = types.includes('exercise')
   const hrZones = includesExercise ? (await getEffectiveHrZones(user)).zones : null
 
+  // Fetch comments for all activities
+  const activityIds = activities.map((a) => a.id).filter((id): id is string => id !== undefined)
+  const commentsMap = await getCommentsMap(user, 'activity', activityIds)
+
   return Promise.all(
     activities.map(async (a) => {
       const timeInBedMinutes =
@@ -871,6 +910,7 @@ export async function queryActivities(
 
       const result: ActivityResult = {
         activity_type: a.activity_type,
+        comments: a.id ? (commentsMap.get(a.id) ?? []) : [],
         data: a.data,
         duration: timeInBedMinutes,
         end_time: a.end_time?.toISOString(),
@@ -921,6 +961,7 @@ export interface ProductivityResult {
   productivity?: number
   duration_sec: number
   is_mobile?: boolean
+  comments: CommentSummary[]
 }
 
 /**
@@ -977,9 +1018,12 @@ export async function queryProductivity(
 
   const productivity = await getProductivity(user, start, end)
   const merged = mergeProductivitySpans(productivity)
+  const prodIds = merged.map((p) => p.id).filter((id): id is string => id !== undefined)
+  const commentsMap = await getCommentsMap(user, 'productivity', prodIds)
   return merged.map((p) => ({
     activity: p.activity,
     category: p.category,
+    comments: p.id ? (commentsMap.get(p.id) ?? []) : [],
     duration_sec: p.duration_sec,
     end_time: p.end_time.toISOString(),
     id: p.id,

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -11,6 +11,7 @@ import {
   iso8601DateTimeSchema,
   timeRangeQuerySchema,
 } from './common.js'
+import { commentSchema } from './notes.js'
 import { hrZoneSecsSchema } from './settings.js'
 
 /**
@@ -127,6 +128,7 @@ export const activitySchema = z
   .object({
     activity_type: z.string().meta({ description: 'Activity type' }),
     avg_hrv: z.number().optional().meta({ description: 'Average HRV (ms) during the activity' }),
+    comments: z.array(commentSchema).optional().meta({ description: 'Attached comments' }),
     data: z.record(z.string(), z.unknown()).optional(),
     deleted_at: iso8601DateTimeSchema.optional().meta({ description: 'Soft-delete timestamp' }),
     duration: durationMinutesSchema.optional(),

--- a/packages/api-spec/src/schemas/notes.ts
+++ b/packages/api-spec/src/schemas/notes.ts
@@ -40,6 +40,20 @@ export const noteSchema = z
 export type Note = z.infer<typeof noteSchema>
 
 /**
+ * Embedded comment schema (without entity_type/entity_id since those are implicit).
+ */
+export const commentSchema = z
+  .object({
+    content: z.string().meta({ description: 'Comment content (markdown)' }),
+    created_at: iso8601DateTimeSchema.optional(),
+    id: z.string().uuid().optional().meta({ description: 'Comment/note ID' }),
+    updated_at: iso8601DateTimeSchema.optional(),
+  })
+  .meta({ id: 'Comment', description: 'A comment attached to an entity' })
+
+export type Comment = z.infer<typeof commentSchema>
+
+/**
  * Add note request body.
  */
 export const addNoteBodySchema = z

--- a/packages/api-spec/src/schemas/productivity.ts
+++ b/packages/api-spec/src/schemas/productivity.ts
@@ -9,6 +9,7 @@ import {
   iso8601DateTimeSchema,
   timeRangeQuerySchema,
 } from './common.js'
+import { commentSchema } from './notes.js'
 
 /**
  * Productivity record schema.
@@ -17,6 +18,7 @@ export const productivityRecordSchema = z
   .object({
     activity: z.string().meta({ description: 'Activity/application name' }),
     category: z.string().optional().meta({ description: 'Activity category' }),
+    comments: z.array(commentSchema).optional().meta({ description: 'Attached comments' }),
     deleted_at: iso8601DateTimeSchema.optional().meta({ description: 'Soft-delete timestamp' }),
     duration_sec: z.number().int().meta({ description: 'Duration in seconds' }),
     end_time: iso8601DateTimeSchema,

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -11,12 +11,14 @@ import {
   tagTextSchema,
   timeRangeQuerySchema,
 } from './common.js'
+import { commentSchema } from './notes.js'
 
 /**
  * Tag schema.
  */
 export const tagSchema = z
   .object({
+    comments: z.array(commentSchema).optional().meta({ description: 'Attached comments' }),
     deleted_at: iso8601DateTimeSchema.optional().meta({ description: 'Soft-delete timestamp' }),
     end_time: iso8601DateTimeSchema.optional(),
     external_id: z.string().optional().meta({ description: 'External ID from source' }),


### PR DESCRIPTION
## Summary

- Add `commentSchema` to `@aurboda/api-spec` and optional `comments` field to activity, tag, and productivity schemas
- Add `getNotesByEntityIds` bulk DB function that fetches notes for multiple entities in a single query
- Attach `comments` array to `queryTags`, `queryActivities`, and `queryProductivity` results via a shared `getCommentsMap` helper
- MCP tools and REST API endpoints automatically include comments — no route changes needed

## Test plan

- [x] Unit tests for `queryTags`, `queryActivities`, `queryProductivity` verify comments are attached when notes exist and empty `[]` when they don't
- [x] Integration tests for `getNotesByEntityIds` cover empty input, grouping by entity ID, entity type filtering, and missing entities
- [x] Existing MCP and service tests updated with `comments` field
- [x] `pnpm fix` and `pnpm --filter aurboda-backend check` pass clean
- [ ] Integration tests pass (require Docker/testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)