### PR TITLE
Fix merged activity navigation: separate merged vs raw views

### DIFF
--- a/apps/backend/src/activities.test.ts
+++ b/apps/backend/src/activities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { mergeOverlappingActivities, type Activity } from './db'
+import { mergeOverlappingActivities, type Activity, type MergedActivity } from './db'
 
 describe('mergeOverlappingActivities', () => {
   const makeActivity = (overrides: Partial<Activity>): Activity => ({
@@ -340,5 +340,86 @@ describe('mergeOverlappingActivities', () => {
     const result = mergeOverlappingActivities(activities)
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe('first-id')
+  })
+
+  test('single activity has no source_ids', () => {
+    const activity = makeActivity({
+      end_time: new Date('2024-01-15T11:00:00Z'),
+      id: 'only-id',
+      title: 'Solo workout',
+    })
+    const result = mergeOverlappingActivities([activity]) as MergedActivity[]
+    expect(result).toHaveLength(1)
+    expect(result[0].source_ids).toBeUndefined()
+  })
+
+  test('two merged activities have source_ids with both IDs', () => {
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'first-id',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T11:30:00Z'),
+        id: 'second-id',
+        start_time: new Date('2024-01-15T10:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities) as MergedActivity[]
+    expect(result).toHaveLength(1)
+    expect(result[0].source_ids).toEqual(['first-id', 'second-id'])
+  })
+
+  test('two separate groups each track source_ids independently', () => {
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T08:00:00Z'),
+        id: 'morning-a',
+        start_time: new Date('2024-01-15T07:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T08:30:00Z'),
+        id: 'morning-b',
+        start_time: new Date('2024-01-15T07:30:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T19:00:00Z'),
+        id: 'evening-a',
+        start_time: new Date('2024-01-15T18:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T19:30:00Z'),
+        id: 'evening-b',
+        start_time: new Date('2024-01-15T18:30:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities) as MergedActivity[]
+    expect(result).toHaveLength(2)
+    expect(result[0].source_ids).toEqual(['morning-a', 'morning-b'])
+    expect(result[1].source_ids).toEqual(['evening-a', 'evening-b'])
+  })
+
+  test('three merged activities track all source_ids', () => {
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: 'id-1',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'id-2',
+        start_time: new Date('2024-01-15T10:15:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T11:30:00Z'),
+        id: 'id-3',
+        start_time: new Date('2024-01-15T10:45:00Z'),
+      }),
+    ]
+    const result = mergeOverlappingActivities(activities) as MergedActivity[]
+    expect(result).toHaveLength(1)
+    expect(result[0].source_ids).toEqual(['id-1', 'id-2', 'id-3'])
   })
 })

--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -5,7 +5,7 @@ import type { ActivityType } from '../schema'
 import { query } from './connection'
 import { buildDynamicUpdate, type UpdateEntry } from './dynamic-update'
 import { mapActivityRow } from './row-mappers'
-import type { Activity, ActivityUpdate } from './types'
+import type { Activity, ActivityUpdate, MergedActivity } from './types'
 
 /**
  * Merge overlapping activities of the same type.
@@ -24,7 +24,7 @@ import type { Activity, ActivityUpdate } from './types'
  * - Data objects are merged (later values override earlier for same keys)
  */
 // eslint-disable-next-line complexity -- TODO: refactor
-export const mergeOverlappingActivities = (activities: Activity[]): Activity[] => {
+export const mergeOverlappingActivities = (activities: Activity[]): MergedActivity[] => {
   if (activities.length === 0) return []
 
   // Group by activity type
@@ -35,13 +35,14 @@ export const mergeOverlappingActivities = (activities: Activity[]): Activity[] =
     byType.set(a.activity_type, group)
   }
 
-  const result: Activity[] = []
+  const result: MergedActivity[] = []
 
   for (const [, typeActivities] of byType) {
     // Sort by start time
     const sorted = [...typeActivities].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
 
-    let current = { ...sorted[0] }
+    let current: MergedActivity = { ...sorted[0] }
+    let currentSourceIds: string[] = sorted[0].id ? [sorted[0].id] : []
 
     for (let i = 1; i < sorted.length; i++) {
       const next = sorted[i]
@@ -73,14 +74,26 @@ export const mergeOverlappingActivities = (activities: Activity[]): Activity[] =
         if (next.data) {
           current.data = { ...current.data, ...next.data }
         }
+
+        // Track source IDs
+        if (next.id) {
+          currentSourceIds.push(next.id)
+        }
       } else {
         // No overlap, save current and start new
+        if (currentSourceIds.length > 1) {
+          current.source_ids = currentSourceIds
+        }
         result.push(current)
         current = { ...next }
+        currentSourceIds = next.id ? [next.id] : []
       }
     }
 
     // Don't forget the last one
+    if (currentSourceIds.length > 1) {
+      current.source_ids = currentSourceIds
+    }
     result.push(current)
   }
 
@@ -202,7 +215,7 @@ export const getActivities = async (
   activityType: ActivityType | ActivityType[],
   start: Date,
   end: Date,
-): Promise<Activity[]> => {
+): Promise<MergedActivity[]> => {
   const types = Array.isArray(activityType) ? activityType : [activityType]
 
   const result = await query(
@@ -225,7 +238,7 @@ export const getActivities = async (
  * Uses date overlap logic so overnight sleep (starting 11pm, ending 7am)
  * appears on the wake-up day rather than the start day.
  */
-export const getSleepSessions = async (user: string, start: Date, end: Date): Promise<Activity[]> => {
+export const getSleepSessions = async (user: string, start: Date, end: Date): Promise<MergedActivity[]> => {
   const result = await query(
     user,
     `SELECT id, source, activity_type, start_time, end_time, title, notes, data, deleted_at

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -24,6 +24,7 @@ export type {
   LastFmTagRuleInput,
   Location,
   McpSessionRecord,
+  MergedActivity,
   MetricStats,
   NamedLocation,
   NamedLocationInput,

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -80,6 +80,10 @@ export interface Activity {
   deleted_at?: Date
 }
 
+export interface MergedActivity extends Activity {
+  source_ids?: string[] // only set when 2+ activities were merged
+}
+
 export interface ActivityUpdate {
   start_time?: Date
   end_time?: Date

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -170,40 +170,68 @@ export const createActivitiesRouter = (
   )
 
   // GET /activities/:id - Get a single activity by ID (for detail page)
+  // Supports merged: prefix — merged:<uuid> returns merged view, plain uuid returns raw activity
   router.get<{ id: string }>('/activities/:id', authMiddleware, async (req, res) => {
-    const { id } = req.params
+    const rawId = req.params.id
     const user = req.user!
 
-    const activity = await getActivityById(user, id, true)
+    const isMerged = rawId.startsWith('merged:')
+    const realId = isMerged ? rawId.slice('merged:'.length) : rawId
+
+    const activity = await getActivityById(user, realId, true)
     if (!activity) {
       return res.status(404).json({ error: 'Activity not found', success: false })
     }
 
-    // Check for overlapping activities from other sources
-    const overlapping = activity.deleted_at ? [] : await getOverlappingActivities(user, activity)
+    // For merged: prefix, fetch overlapping activities and return merged view
+    if (isMerged && !activity.deleted_at) {
+      const overlapping = await getOverlappingActivities(user, activity)
+      const hasMultipleSources = overlapping.length > 1
 
-    const hasMultipleSources = overlapping.length > 1
-    const sourceRecords =
-      hasMultipleSources ?
-        overlapping.map((a) => ({
-          data_origin: (a.data as Record<string, unknown> | undefined)?.dataOrigin as string | undefined,
-          end_time: a.end_time?.toISOString(),
-          id: a.id!,
-          source: a.source,
-          start_time: a.start_time.toISOString(),
-          title: a.title,
-        }))
-      : undefined
+      const sourceRecords =
+        hasMultipleSources ?
+          overlapping.map((a) => {
+            const data = a.data as Record<string, unknown> | undefined
+            return {
+              data_origin: data?.dataOrigin as string | undefined,
+              end_time: a.end_time?.toISOString(),
+              exercise_type_name: data?.exerciseTypeName as string | undefined,
+              id: a.id!,
+              source: a.source,
+              start_time: a.start_time.toISOString(),
+              title: a.title,
+            }
+          })
+        : undefined
 
-    const mergedStartTime =
-      hasMultipleSources ?
-        new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))).toISOString()
-      : undefined
-    const mergedEndTime =
-      hasMultipleSources ?
-        new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))).toISOString()
-      : undefined
+      const mergedStartTime =
+        hasMultipleSources ?
+          new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))).toISOString()
+        : undefined
+      const mergedEndTime =
+        hasMultipleSources ?
+          new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))).toISOString()
+        : undefined
 
+      return res.json({
+        data: {
+          activity_type: activity.activity_type,
+          data: activity.data,
+          end_time: activity.end_time?.toISOString(),
+          id: activity.id,
+          merged_end_time: mergedEndTime,
+          merged_start_time: mergedStartTime,
+          notes: activity.notes,
+          source: activity.source,
+          source_records: sourceRecords,
+          start_time: activity.start_time.toISOString(),
+          title: activity.title,
+        },
+        success: true,
+      })
+    }
+
+    // Plain UUID: return raw single activity (no overlap lookup)
     res.json({
       data: {
         activity_type: activity.activity_type,
@@ -211,11 +239,8 @@ export const createActivitiesRouter = (
         deleted_at: activity.deleted_at?.toISOString(),
         end_time: activity.end_time?.toISOString(),
         id: activity.id,
-        merged_end_time: mergedEndTime,
-        merged_start_time: mergedStartTime,
         notes: activity.notes,
         source: activity.source,
-        source_records: sourceRecords,
         start_time: activity.start_time.toISOString(),
         title: activity.title,
       },

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -874,7 +874,7 @@ export async function queryActivities(
         data: a.data,
         duration: timeInBedMinutes,
         end_time: a.end_time?.toISOString(),
-        id: a.id,
+        id: 'source_ids' in a && a.source_ids ? `merged:${a.id}` : a.id,
         notes: a.notes,
         source: a.source,
         start_time: a.start_time.toISOString(),

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -57,12 +57,14 @@ const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
     <h3>Sources ({records.length})</h3>
     {records.map((record) => (
       <a key={record.id} href={`/detail/activity/${record.id}`} class="source-record">
-        <span class="source-record-source">{record.data_origin ?? record.source}</span>
+        <span class="source-record-source">
+          {record.title ?? record.exercise_type_name ?? record.data_origin ?? record.source}
+        </span>
         <span class="source-record-time">
           {format(new Date(record.start_time), 'HH:mm')}
           {record.end_time ? ` – ${format(new Date(record.end_time), 'HH:mm')}` : ''}
         </span>
-        {record.title && <span class="source-record-title">{record.title}</span>}
+        {record.title && record.data_origin && <span class="source-record-title">{record.data_origin}</span>}
       </a>
     ))}
   </div>
@@ -180,21 +182,36 @@ const TagDetail = ({ tag }: { tag: Tag }) => {
   )
 }
 
-const NotesSection = ({ entityType, entityId }: { entityType: EntityType; entityId: string }) => {
+const NotesSection = ({
+  entityType,
+  entityId,
+  allEntityIds,
+}: {
+  entityType: EntityType
+  entityId: string
+  allEntityIds?: string[]
+}) => {
   const queryClient = useQueryClient()
   const [newNote, setNewNote] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editContent, setEditContent] = useState('')
 
+  // Fetch notes for all source entity IDs (merged activity) or just the one
+  const idsToFetch = allEntityIds ?? [entityId]
   const notesQuery = useQuery({
-    queryFn: () => fetchNotes(entityType, entityId),
-    queryKey: ['notes', entityType, entityId],
+    queryFn: async () => {
+      const results = await Promise.all(idsToFetch.map((id) => fetchNotes(entityType, id)))
+      return results
+        .flat()
+        .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    },
+    queryKey: ['notes', entityType, ...idsToFetch],
     staleTime: 30_000,
   })
 
   const invalidateNotes = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: ['notes', entityType, entityId] }),
-    [queryClient, entityType, entityId],
+    () => queryClient.invalidateQueries({ queryKey: ['notes', entityType, ...idsToFetch] }),
+    [queryClient, entityType, ...idsToFetch],
   )
 
   const addMutation = useMutation({
@@ -375,6 +392,10 @@ const EntityActions = ({
 const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entityId: string }) => {
   const queryClient = useQueryClient()
 
+  // Strip merged: prefix for raw operations (delete/restore/notes write)
+  const isMerged = entityId.startsWith('merged:')
+  const rawEntityId = isMerged ? entityId.slice('merged:'.length) : entityId
+
   const activityQuery = useQuery({
     enabled: entityType === 'activity',
     queryFn: () => fetchActivityById(entityId),
@@ -404,6 +425,12 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     : entityType === 'tag' ? Boolean(tag?.deleted_at)
     : false
 
+  // Collect all entity IDs for notes (primary + source records for merged activities)
+  const allEntityIds =
+    entityType === 'activity' && activity?.source_records ?
+      activity.source_records.map((r) => r.id)
+    : undefined
+
   if (isLoading) return <p class="loading">Loading…</p>
   if (isError) return <p class="error">Failed to load {entityType}</p>
 
@@ -411,7 +438,7 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     <>
       <EntityActions
         entityType={entityType}
-        entityId={entityId}
+        entityId={rawEntityId}
         isDeleted={isDeleted}
         onMutationSuccess={invalidateEntity}
       />
@@ -419,7 +446,7 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
       {entityType === 'activity' && activity && <ActivityDetailDispatch activity={activity} />}
       {entityType === 'tag' && tag && <TagDetail tag={tag} />}
 
-      <NotesSection entityType={entityType} entityId={entityId} />
+      <NotesSection entityType={entityType} entityId={rawEntityId} allEntityIds={allEntityIds} />
     </>
   )
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -81,6 +81,7 @@ export interface SourceRecord {
   end_time?: string
   title?: string
   data_origin?: string
+  exercise_type_name?: string
 }
 
 export interface Activity extends Omit<ApiActivity, 'start_time' | 'end_time'> {

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -158,6 +158,7 @@ export const sourceRecordSchema = z
   .object({
     data_origin: z.string().optional().meta({ description: 'Health Connect data origin package' }),
     end_time: iso8601DateTimeSchema.optional(),
+    exercise_type_name: z.string().optional().meta({ description: 'Exercise type name (e.g. weightlifting)' }),
     id: z.string().uuid().meta({ description: 'Activity ID' }),
     source: z.string().meta({ description: 'Data source' }),
     start_time: iso8601DateTimeSchema,


### PR DESCRIPTION
## Summary

- List endpoints return `merged:<uuid>` as the ID when activities were merged from multiple sources
- `GET /activities/merged:<uuid>` fetches overlaps, returns merged view with source_records
- `GET /activities/<uuid>` returns just that one raw activity (no overlap lookup)
- Source record links use plain UUIDs so clicking shows the individual raw record
- Better source record display labels (title > exercise_type_name > data_origin > source)
- Notes section on merged views aggregates notes from all source activity IDs
- Delete/restore actions operate on the real UUID (stripped `merged:` prefix)

## Test plan

- [x] Backend tests: 798 passed (4 new source_ids tracking tests)
- [x] Web tests: 88 passed
- [x] TypeScript type checking passes
- [ ] Manual: day view exercise with multiple sources links to `merged:` URL, shows merged view with source records
- [ ] Manual: click individual source record shows raw single activity without merged banner
- [ ] Manual: notes on merged view work (stored against raw UUID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)