### PR TITLE
Fix HRV right y-axis scale on Timeline chart

### DIFF
--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -583,8 +583,16 @@ function TimelineChart({
   // Heart rate y scale (left axis)
   const yHr = d3.scaleLinear().domain([40, 200]).range([chartHeight, 0])
 
-  // HRV y scale (right axis) - typical RMSSD values range from 10-100ms
-  const yHrv = d3.scaleLinear().domain([0, 150]).range([chartHeight, 0])
+  // HRV y scale (right axis) - dynamic domain based on actual data
+  const hrvExtent = d3.extent(hrvData, ([, v]) => v) as [number, number]
+  const hrvMin = hrvExtent[0] ?? 0
+  const hrvMax = hrvExtent[1] ?? 150
+  const hrvPadding = Math.max((hrvMax - hrvMin) * 0.2, 5)
+  const yHrv = d3
+    .scaleLinear()
+    .domain([Math.max(0, hrvMin - hrvPadding), hrvMax + hrvPadding])
+    .nice()
+    .range([chartHeight, 0])
 
   // Filter activities by type
   const sleepSessions =
@@ -1108,7 +1116,7 @@ function TimelineChart({
           <g
             transform={`translate(${chartWidth},0)`}
             ref={(g) => {
-              if (g) d3.select(g).call(d3.axisRight(yHrv)).selectAll('text').style('fill', colors.hrv)
+              if (g) d3.select(g).call(d3.axisRight(yHrv).ticks(6)).selectAll('text').style('fill', colors.hrv)
             }}
           />
 

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1116,7 +1116,8 @@ function TimelineChart({
           <g
             transform={`translate(${chartWidth},0)`}
             ref={(g) => {
-              if (g) d3.select(g).call(d3.axisRight(yHrv).ticks(6)).selectAll('text').style('fill', colors.hrv)
+              if (g)
+                d3.select(g).call(d3.axisRight(yHrv).ticks(6)).selectAll('text').style('fill', colors.hrv)
             }}
           />
 


### PR DESCRIPTION
## Summary
- Fixed the HRV right y-axis on the Timeline chart which had a hardcoded domain `[0, 150]` producing useless tick labels when actual data was in a narrower range (e.g. 9-30ms during exercise)
- The axis now dynamically computes its domain from the actual HRV data extent with 20% padding and `.nice()` for clean tick values
- Added explicit `.ticks(6)` to prevent D3 from generating too many or confusing tick labels

## Test plan
- [ ] Open the Timeline page with HRV enabled
- [ ] Zoom into an exercise session and verify the right y-axis ticks match the visible HRV data range
- [ ] Verify the axis shows sensible labels when HRV data ranges are narrow (e.g. 9-30ms) or wide (e.g. 10-100ms)
- [ ] Verify fallback works when no HRV data is loaded (should default to 0-150 range)

🤖 Generated with [Claude Code](https://claude.ai/code)