### PR TITLE
Fix merged activity detail: transitive overlap, merged fields, music range

### DIFF
--- a/apps/backend/src/activities.test.ts
+++ b/apps/backend/src/activities.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest'
-import { mergeOverlappingActivities, type Activity, type MergedActivity } from './db'
+import {
+  findMergedGroupForActivity,
+  mergeOverlappingActivities,
+  type Activity,
+  type MergedActivity,
+} from './db'
 
 describe('mergeOverlappingActivities', () => {
   const makeActivity = (overrides: Partial<Activity>): Activity => ({
@@ -421,5 +426,148 @@ describe('mergeOverlappingActivities', () => {
     const result = mergeOverlappingActivities(activities) as MergedActivity[]
     expect(result).toHaveLength(1)
     expect(result[0].source_ids).toEqual(['id-1', 'id-2', 'id-3'])
+  })
+})
+
+describe('findMergedGroupForActivity', () => {
+  const makeActivity = (overrides: Partial<Activity>): Activity => ({
+    activity_type: 'exercise',
+    source: 'health_connect',
+    start_time: new Date('2024-01-15T10:00:00Z'),
+    ...overrides,
+  })
+
+  test('returns the single activity when no merge group exists', () => {
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'solo-id',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      }),
+    ]
+    const merged = mergeOverlappingActivities(activities)
+    const group = findMergedGroupForActivity(merged, activities, 'solo-id')
+    expect(group).toHaveLength(1)
+    expect(group[0].id).toBe('solo-id')
+  })
+
+  test('returns empty array for non-existent activity ID', () => {
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'real-id',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      }),
+    ]
+    const merged = mergeOverlappingActivities(activities)
+    const group = findMergedGroupForActivity(merged, activities, 'non-existent')
+    expect(group).toHaveLength(0)
+  })
+
+  test('finds transitive chain: A overlaps B, B overlaps C, but A does not overlap C', () => {
+    // A: 10:00-10:30, B: 10:20-11:00, C: 10:50-11:30
+    // A overlaps B (10:30 >= 10:20), B overlaps C (11:00 >= 10:50), A does NOT directly overlap C
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: 'A',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'B',
+        start_time: new Date('2024-01-15T10:20:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T11:30:00Z'),
+        id: 'C',
+        start_time: new Date('2024-01-15T10:50:00Z'),
+      }),
+    ]
+    const merged = mergeOverlappingActivities(activities)
+    expect(merged).toHaveLength(1) // all merged transitively
+
+    const group = findMergedGroupForActivity(merged, activities, 'A')
+    expect(group).toHaveLength(3)
+    expect(group.map((a) => a.id).sort()).toEqual(['A', 'B', 'C'])
+  })
+
+  test('returns only the correct group when there are separate groups', () => {
+    const activities = [
+      // Morning group
+      makeActivity({
+        end_time: new Date('2024-01-15T08:00:00Z'),
+        id: 'morning-a',
+        start_time: new Date('2024-01-15T07:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T08:30:00Z'),
+        id: 'morning-b',
+        start_time: new Date('2024-01-15T07:30:00Z'),
+      }),
+      // Evening group
+      makeActivity({
+        end_time: new Date('2024-01-15T19:00:00Z'),
+        id: 'evening-a',
+        start_time: new Date('2024-01-15T18:00:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T19:30:00Z'),
+        id: 'evening-b',
+        start_time: new Date('2024-01-15T18:30:00Z'),
+      }),
+    ]
+    const merged = mergeOverlappingActivities(activities)
+
+    const morningGroup = findMergedGroupForActivity(merged, activities, 'morning-a')
+    expect(morningGroup).toHaveLength(2)
+    expect(morningGroup.map((a) => a.id).sort()).toEqual(['morning-a', 'morning-b'])
+
+    const eveningGroup = findMergedGroupForActivity(merged, activities, 'evening-b')
+    expect(eveningGroup).toHaveLength(2)
+    expect(eveningGroup.map((a) => a.id).sort()).toEqual(['evening-a', 'evening-b'])
+  })
+
+  test('real-world scenario: 4 activities with transitive chaining', () => {
+    // Simulates: Health Connect 10:27-11:37, Gravl 10:27-10:40, Polar 10:27-11:32, Manual 11:32-12:37
+    // HC overlaps Gravl, HC overlaps Polar, Polar overlaps Manual
+    // HC does NOT directly overlap Manual (11:37 >= 11:32 — actually it does in this case)
+    // Let's make it so HC ends at 11:30 and Manual starts at 11:32 to be truly transitive
+    const activities = [
+      makeActivity({
+        end_time: new Date('2024-01-15T10:40:00Z'),
+        id: 'gravl',
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:27:00Z'),
+        title: 'Weightlifting',
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T11:30:00Z'),
+        id: 'hc',
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:27:00Z'),
+      }),
+      makeActivity({
+        data: { exerciseTypeName: 'Strength training' },
+        end_time: new Date('2024-01-15T11:32:00Z'),
+        id: 'polar',
+        source: 'oura',
+        start_time: new Date('2024-01-15T10:27:00Z'),
+      }),
+      makeActivity({
+        end_time: new Date('2024-01-15T12:37:00Z'),
+        id: 'manual',
+        source: 'manual',
+        start_time: new Date('2024-01-15T11:32:00Z'),
+        title: 'Extra sets',
+      }),
+    ]
+    const merged = mergeOverlappingActivities(activities)
+    expect(merged).toHaveLength(1)
+
+    // Looking up any activity in the group should return all 4
+    const group = findMergedGroupForActivity(merged, activities, 'gravl')
+    expect(group).toHaveLength(4)
+    expect(group.map((a) => a.id).sort()).toEqual(['gravl', 'hc', 'manual', 'polar'])
   })
 })

--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -407,6 +407,49 @@ describe('Activities Integration Tests', () => {
       expect(overlapping).toHaveLength(1)
       expect(overlapping[0]!.id).toBe(id1)
     })
+
+    test('finds transitively connected activities', async () => {
+      const user = getTestUser()
+      const idA = randomUUID()
+      const idB = randomUUID()
+      const idC = randomUUID()
+
+      // A: 10:00-10:30, B: 10:20-11:00, C: 10:50-11:30
+      // A overlaps B, B overlaps C, but A does NOT directly overlap C
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: idA,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Part A',
+      })
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: idB,
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:20:00Z'),
+        title: 'Part B',
+      })
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:30:00Z'),
+        id: idC,
+        source: 'manual',
+        start_time: new Date('2024-01-15T10:50:00Z'),
+        title: 'Part C',
+      })
+
+      const activity = await getActivityById(user, idA)
+      expect(activity).not.toBeNull()
+
+      const overlapping = await getOverlappingActivities(user, activity!)
+      expect(overlapping).toHaveLength(3)
+      expect(overlapping.map((a) => a.id).sort()).toEqual([idA, idB, idC].sort())
+    })
   })
 
   describe('updateActivity', () => {

--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -102,24 +102,59 @@ export const mergeOverlappingActivities = (activities: Activity[]): MergedActivi
 }
 
 /**
- * Find all non-deleted activities of the same type that overlap in time with the given activity.
- * Returns raw DB rows (no merge) including the activity itself.
+ * Given merged results and the original raw activities, find all raw activities
+ * belonging to the same merge group as the given activity ID.
+ *
+ * Pure function — no DB access, easy to unit test.
+ */
+export const findMergedGroupForActivity = (
+  mergedResults: MergedActivity[],
+  rawActivities: Activity[],
+  activityId: string,
+): Activity[] => {
+  // Find which merged result contains the target activity ID
+  const mergedGroup = mergedResults.find((m) => m.id === activityId || m.source_ids?.includes(activityId))
+  if (!mergedGroup) return []
+
+  // Collect all IDs in this merge group
+  const groupIds = new Set(mergedGroup.source_ids ?? (mergedGroup.id ? [mergedGroup.id] : []))
+
+  // Return the raw activities that belong to this group, sorted by start_time
+  return rawActivities
+    .filter((a) => a.id !== undefined && groupIds.has(a.id))
+    .sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+}
+
+/**
+ * Find all non-deleted activities of the same type that belong to the same merge group
+ * as the given activity. Uses transitive merge logic (via mergeOverlappingActivities +
+ * findMergedGroupForActivity) to guarantee consistency with the day view.
+ *
+ * Queries a wide time window (activity's day +/- 12h) and runs the merge algorithm
+ * to find the full transitive chain.
  */
 export const getOverlappingActivities = async (user: string, activity: Activity): Promise<Activity[]> => {
-  const endTime = activity.end_time ?? activity.start_time
+  // Query a wide window around the activity to catch all transitively-connected activities
+  const activityTime = activity.start_time.getTime()
+  const windowStart = new Date(activityTime - 12 * 60 * 60 * 1000)
+  const windowEnd = new Date(activityTime + 24 * 60 * 60 * 1000)
+
   const result = await query(
     user,
     `SELECT id, source, activity_type, start_time, end_time, title, notes, data, deleted_at
      FROM activities
      WHERE activity_type = $1
        AND deleted_at IS NULL
+       AND start_time >= $2
        AND start_time <= $3
-       AND (end_time >= $2 OR end_time IS NULL)
      ORDER BY start_time`,
-    [activity.activity_type, activity.start_time, endTime],
+    [activity.activity_type, windowStart, windowEnd],
   )
 
-  return result.rows.map(mapActivityRow)
+  const rawActivities = result.rows.map(mapActivityRow)
+  const merged = mergeOverlappingActivities(rawActivities)
+
+  return findMergedGroupForActivity(merged, rawActivities, activity.id!)
 }
 
 export const insertActivity = async (user: string, activity: Activity) => {

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -70,6 +70,7 @@ export {
 // Activities
 export {
   deleteActivity,
+  findMergedGroupForActivity,
   getActivities,
   getActivityById,
   getOverlappingActivities,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -213,19 +213,32 @@ export const createActivitiesRouter = (
           new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))).toISOString()
         : undefined
 
+      // Compute merged fields from all sources (same rules as mergeOverlappingActivities)
+      const sorted = [...overlapping].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+      const mergedTitle = sorted.find((a) => a.title)?.title ?? activity.title
+      const mergedNotes =
+        sorted
+          .map((a) => a.notes)
+          .filter(Boolean)
+          .join('\n') || activity.notes
+      const mergedData = sorted.reduce<Record<string, unknown>>(
+        (acc, a) => (a.data ? { ...acc, ...a.data } : acc),
+        {},
+      )
+
       return res.json({
         data: {
           activity_type: activity.activity_type,
-          data: activity.data,
+          data: Object.keys(mergedData).length > 0 ? mergedData : activity.data,
           end_time: activity.end_time?.toISOString(),
           id: activity.id,
           merged_end_time: mergedEndTime,
           merged_start_time: mergedStartTime,
-          notes: activity.notes,
+          notes: mergedNotes,
           source: activity.source,
           source_records: sourceRecords,
           start_time: activity.start_time.toISOString(),
-          title: activity.title,
+          title: mergedTitle,
         },
         success: true,
       })

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -118,7 +118,9 @@ const GenericActivityDetail = ({ activity }: { activity: Activity }) => {
 
 /** Dispatch to type-specific activity detail component. */
 const ActivityDetailDispatch = ({ activity }: { activity: Activity }) => {
-  const end = activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  const musicStart = activity.merged_start_time ?? activity.start_time
+  const musicEnd =
+    activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
 
   const isSleep = activity.activity_type === 'sleep' || activity.activity_type === 'nap'
   const isExercise = activity.activity_type === 'exercise'
@@ -137,7 +139,7 @@ const ActivityDetailDispatch = ({ activity }: { activity: Activity }) => {
       {hasSourceRecords && <SourceRecordsSection records={activity.source_records!} />}
 
       <div class="detail-grid">
-        <MusicPlaylist start={activity.start_time} end={end} />
+        <MusicPlaylist start={musicStart} end={musicEnd} />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

- **Transitive overlap lookup**: `getOverlappingActivities` now uses `mergeOverlappingActivities` + new `findMergedGroupForActivity` pure function to find the full transitive chain, guaranteeing consistency with the day view. Previously, only directly overlapping activities were found, missing transitively-connected sources.
- **Merged fields in detail response**: The detail endpoint now computes merged `title`, `data`, and `notes` from all source activities (using the same merge rules as the day view) instead of returning the primary activity's raw fields.
- **Music playlist time range**: Frontend now uses `merged_start_time`/`merged_end_time` for the music playlist component instead of the raw activity times, so music covers the full merged duration.

## Test plan

- [x] Unit tests for `findMergedGroupForActivity`: transitive chain, separate groups, single activity, non-existent ID, real-world 4-activity scenario
- [x] Integration test: 3 transitively connected activities (A↔B, B↔C, not A↔C) all found via `getOverlappingActivities`
- [x] All 814 existing + new tests pass
- [x] `pnpm fix` and `pnpm check` pass (no new warnings/errors)
- [ ] Manual: verify merged detail view shows all sources, correct time range, correct title, and full music playlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)