### PR TITLE
Support custom metrics in dashboard and trend views

### DIFF
--- a/apps/web/src/components/DashboardEditor/index.tsx
+++ b/apps/web/src/components/DashboardEditor/index.tsx
@@ -4,6 +4,8 @@
 
 import type { DashboardWidget, SectionType } from '@aurboda/api-spec'
 import { useState } from 'preact/hooks'
+import { getMetricDisplayName } from '../../utils/metricLabels'
+import { MetricPicker } from '../MetricPicker'
 
 import './style.css'
 
@@ -95,20 +97,6 @@ const widgetTemplates: WidgetTemplate[] = [
   },
 ]
 
-// Metric options for metric widgets
-const metricOptions = [
-  { label: 'HRV (7-day)', value: 'hrv_7day' },
-  { label: 'HRV (30-day)', value: 'hrv_30day' },
-  { label: 'Resting HR (7-day)', value: 'rhr_7day' },
-  { label: 'Resting HR (30-day)', value: 'rhr_30day' },
-  { label: 'Sleep Score', value: 'sleep_score' },
-  { label: 'Readiness Score', value: 'readiness_score' },
-  { label: 'Steps', value: 'steps' },
-  { label: 'Zone 2 (Weekly)', value: 'zone2_weekly' },
-  { label: 'Weight', value: 'weight' },
-  { label: 'Body Fat', value: 'body_fat' },
-]
-
 // Link options for quick link widgets
 const linkOptions = [
   { icon: 'timeline', label: 'Timeline', value: '/timeline' },
@@ -160,21 +148,13 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
           <div class="config-form">
             <div class="form-group">
               <label>Metric</label>
-              <select
+              <MetricPicker
                 value={(configValues.metric as string) ?? 'hrv_7day'}
-                onChange={(e) => {
-                  const metric = (e.target as HTMLSelectElement).value
-                  const option = metricOptions.find((o) => o.value === metric)
+                onChange={(metric) => {
                   updateConfig('metric', metric)
-                  updateConfig('title', option?.label ?? metric)
+                  updateConfig('title', getMetricDisplayName(metric))
                 }}
-              >
-                {metricOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
+              />
             </div>
             <div class="form-group">
               <label>Title</label>
@@ -201,16 +181,10 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
           <div class="config-form">
             <div class="form-group">
               <label>Metric</label>
-              <select
+              <MetricPicker
                 value={(configValues.metric as string) ?? 'sleep_score'}
-                onChange={(e) => updateConfig('metric', (e.target as HTMLSelectElement).value)}
-              >
-                {metricOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
+                onChange={(metric) => updateConfig('metric', metric)}
+              />
             </div>
             <div class="form-group">
               <label>Lookback Days</label>
@@ -267,13 +241,20 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
               </select>
             </div>
             <div class="form-group">
-              <label>Pattern</label>
-              <input
-                type="text"
-                value={(configValues.pattern as string) ?? ''}
-                onChange={(e) => updateConfig('pattern', (e.target as HTMLInputElement).value)}
-                placeholder="e.g., coffee, exercise"
-              />
+              <label>{(configValues.source_type as string) === 'metric' ? 'Metric' : 'Pattern'}</label>
+              {(configValues.source_type as string) === 'metric' ?
+                <MetricPicker
+                  value={(configValues.pattern as string) ?? ''}
+                  onChange={(metric) => updateConfig('pattern', metric)}
+                  placeholder="Search metrics..."
+                />
+              : <input
+                  type="text"
+                  value={(configValues.pattern as string) ?? ''}
+                  onChange={(e) => updateConfig('pattern', (e.target as HTMLInputElement).value)}
+                  placeholder="e.g., coffee, exercise"
+                />
+              }
             </div>
             <div class="form-group">
               <label>Display Period</label>

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -2,6 +2,7 @@ import { metricUnits, validMetrics } from '@aurboda/api-spec'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 import { type Goal, updateUserSettings } from '../state/api'
+import { metricLabels } from '../utils/metricLabels'
 
 import './GoalsSettings.css'
 
@@ -18,31 +19,6 @@ const durationUnits = [
   { description: 'weeks', unit: 'w' },
   { description: 'months', unit: 'M' },
 ]
-
-// Friendly names for metrics
-const metricLabels: Record<string, string> = {
-  calories_active: 'Active Calories',
-  calories_basal: 'Basal Calories',
-  calories_total: 'Total Calories',
-  distance: 'Distance',
-  floors_climbed: 'Floors Climbed',
-  heart_rate: 'Heart Rate',
-  hr_zone_0_sec: 'Zone 0 (Below Z1)',
-  hr_zone_1_sec: 'Zone 1',
-  hr_zone_2_sec: 'Zone 2',
-  hr_zone_3_sec: 'Zone 3',
-  hr_zone_4_sec: 'Zone 4',
-  hr_zone_5_sec: 'Zone 5',
-  hrv_rmssd: 'HRV (RMSSD)',
-  readiness_score: 'Readiness Score',
-  resilience_score: 'Resilience Score',
-  resting_heart_rate: 'Resting HR',
-  sleep_score: 'Sleep Score',
-  spo2: 'SpO2',
-  steps: 'Steps',
-  vo2_max: 'VO2 Max',
-  weight: 'Weight',
-}
 
 // Get display unit for a metric (e.g., 'sec' -> 'min' for HR zones)
 const getDisplayUnit = (metric: string): string => {

--- a/apps/web/src/components/MetricPicker.css
+++ b/apps/web/src/components/MetricPicker.css
@@ -1,0 +1,120 @@
+.metric-picker {
+  position: relative;
+}
+
+.metric-picker-input {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 0.875rem;
+  color: #1f2937;
+  min-height: 38px;
+  box-sizing: border-box;
+}
+
+.metric-picker-input:focus {
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+  outline: none;
+}
+
+.metric-picker-input::placeholder {
+  color: #9ca3af;
+}
+
+.metric-picker-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 0.25rem 0 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 50;
+}
+
+.metric-picker-group-header {
+  padding: 0.375rem 0.75rem 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #9ca3af;
+  cursor: default;
+}
+
+.metric-picker-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.metric-picker-option:hover,
+.metric-picker-option.highlighted {
+  background: #f3f0ff;
+}
+
+.metric-picker-option.selected {
+  font-weight: 500;
+}
+
+.metric-option-label {
+  color: #1f2937;
+}
+
+.metric-option-key {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .metric-picker-input {
+    background: #111827;
+    border-color: #4b5563;
+    color: #f9fafb;
+  }
+
+  .metric-picker-input::placeholder {
+    color: #6b7280;
+  }
+
+  .metric-picker-dropdown {
+    background: #1f2937;
+    border-color: #4b5563;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .metric-picker-group-header {
+    color: #6b7280;
+  }
+
+  .metric-picker-option:hover,
+  .metric-picker-option.highlighted {
+    background: #374151;
+  }
+
+  .metric-option-label {
+    color: #f9fafb;
+  }
+
+  .metric-option-key {
+    color: #6b7280;
+  }
+}

--- a/apps/web/src/components/MetricPicker.tsx
+++ b/apps/web/src/components/MetricPicker.tsx
@@ -1,0 +1,168 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { fetchCustomMetrics, type CustomMetricDefinition } from '../state/api'
+import { builtinDashboardMetricOptions, getMetricDisplayName } from '../utils/metricLabels'
+
+import './MetricPicker.css'
+
+interface MetricEntry {
+  value: string
+  label: string
+  group: 'builtin' | 'custom'
+}
+
+const buildEntries = (customMetrics: CustomMetricDefinition[]): MetricEntry[] => {
+  const builtin: MetricEntry[] = builtinDashboardMetricOptions.map((m) => ({
+    group: 'builtin',
+    label: m.label,
+    value: m.value,
+  }))
+
+  const custom: MetricEntry[] = customMetrics.map((m) => ({
+    group: 'custom',
+    label: m.description ?? m.name,
+    value: m.name,
+  }))
+
+  return [...builtin, ...custom]
+}
+
+interface MetricPickerProps {
+  value: string
+  onChange: (metric: string) => void
+  placeholder?: string
+}
+
+export function MetricPicker({ value, onChange, placeholder = 'Search metrics...' }: MetricPickerProps) {
+  const [inputValue, setInputValue] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { data: customMetrics } = useQuery({
+    queryFn: fetchCustomMetrics,
+    queryKey: ['customMetrics'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const entries = buildEntries(customMetrics ?? [])
+
+  const filtered = entries.filter(
+    (entry) =>
+      entry.label.toLowerCase().includes(inputValue.toLowerCase()) ||
+      entry.value.toLowerCase().includes(inputValue.toLowerCase()),
+  )
+
+  // Group filtered entries for display
+  const builtinEntries = filtered.filter((e) => e.group === 'builtin')
+  const customEntries = filtered.filter((e) => e.group === 'custom')
+  const flatFiltered = [...builtinEntries, ...customEntries]
+
+  useEffect(() => {
+    setHighlightedIndex(0)
+  }, [inputValue])
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+        setInputValue('')
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const selectMetric = (metricValue: string) => {
+    onChange(metricValue)
+    setInputValue('')
+    setIsOpen(false)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setIsOpen(true)
+      setHighlightedIndex((i) => Math.min(i + 1, flatFiltered.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter' && isOpen && flatFiltered.length > 0) {
+      e.preventDefault()
+      selectMetric(flatFiltered[highlightedIndex].value)
+    } else if (e.key === 'Escape') {
+      setIsOpen(false)
+      setInputValue('')
+    }
+  }
+
+  const displayValue = value ? getMetricDisplayName(value) : ''
+  // Check custom metrics for display name too
+  const customDisplayValue =
+    value && !displayValue.includes(value) ?
+      displayValue
+    : ((customMetrics ?? []).find((m) => m.name === value)?.description ?? displayValue)
+  const shownValue = isOpen ? inputValue : customDisplayValue || value
+
+  return (
+    <div class="metric-picker" ref={containerRef}>
+      <input
+        ref={inputRef}
+        type="text"
+        class="metric-picker-input"
+        value={shownValue}
+        onInput={(e) => {
+          setInputValue((e.target as HTMLInputElement).value)
+          setIsOpen(true)
+        }}
+        onFocus={() => {
+          setInputValue('')
+          setIsOpen(true)
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+      />
+      {isOpen && flatFiltered.length > 0 && (
+        <ul class="metric-picker-dropdown">
+          {builtinEntries.length > 0 && <li class="metric-picker-group-header">Built-in</li>}
+          {builtinEntries.map((entry) => {
+            const idx = flatFiltered.indexOf(entry)
+            return (
+              <li
+                key={entry.value}
+                class={`metric-picker-option ${idx === highlightedIndex ? 'highlighted' : ''} ${entry.value === value ? 'selected' : ''}`}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  selectMetric(entry.value)
+                }}
+                onMouseEnter={() => setHighlightedIndex(idx)}
+              >
+                <span class="metric-option-label">{entry.label}</span>
+                {entry.label !== entry.value && <span class="metric-option-key">{entry.value}</span>}
+              </li>
+            )
+          })}
+          {customEntries.length > 0 && <li class="metric-picker-group-header">Custom</li>}
+          {customEntries.map((entry) => {
+            const idx = flatFiltered.indexOf(entry)
+            return (
+              <li
+                key={entry.value}
+                class={`metric-picker-option ${idx === highlightedIndex ? 'highlighted' : ''} ${entry.value === value ? 'selected' : ''}`}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  selectMetric(entry.value)
+                }}
+                onMouseEnter={() => setHighlightedIndex(idx)}
+              >
+                <span class="metric-option-label">{entry.label}</span>
+                {entry.label !== entry.value && <span class="metric-option-key">{entry.value}</span>}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/widgets/MetricCardWidget.tsx
+++ b/apps/web/src/components/widgets/MetricCardWidget.tsx
@@ -75,8 +75,8 @@ const extractPeriodValue = (
 ): { value: number | string | null; trend: number | null; subtitle: string | undefined } => {
   if (!periodSummary) return { subtitle: undefined, trend: null, value: null }
 
-  const apiMetric = metricToApiMetric[metric]
-  const stats = apiMetric ? periodSummary[apiMetric] : null
+  const apiMetric = metricToApiMetric[metric] ?? metric
+  const stats = periodSummary[apiMetric]
 
   if (!stats) return { subtitle: undefined, trend: null, value: null }
 
@@ -119,11 +119,11 @@ export function MetricCardWidget({ config }: MetricCardWidgetProps) {
   // Fetch period summary for other metrics
   const end = endOfDay(new Date())
   const start30days = startOfDay(subDays(new Date(), 30))
-  const apiMetric = metricToApiMetric[metric]
+  const apiMetric = metricToApiMetric[metric] ?? metric
 
   const periodSummaryQuery = useQuery({
-    enabled: !isBaseline && !!apiMetric,
-    queryFn: () => fetchPeriodSummary(start30days, end, apiMetric ? [apiMetric] : []),
+    enabled: !isBaseline,
+    queryFn: () => fetchPeriodSummary(start30days, end, [apiMetric]),
     queryKey: ['periodSummary', metric],
     staleTime: 5 * 60 * 1000,
   })

--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -9,6 +9,7 @@ import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 import { useEffect, useRef } from 'preact/hooks'
 import {
   fetchHrv,
+  fetchMetricTimeSeries,
   fetchPeriodSummary,
   fetchReadinessScores,
   fetchRestingHeartRate,
@@ -152,19 +153,17 @@ export function SparklineCardWidget({ config }: SparklineCardWidgetProps) {
   const start = startOfDay(subDays(new Date(), lookback_days))
 
   // Fetch time series data for sparkline
-  const fetcher = metricFetchers[metric]
+  const fetcher = metricFetchers[metric] ?? ((s: Date, e: Date) => fetchMetricTimeSeries(metric, s, e))
   const timeSeriesQuery = useQuery({
-    enabled: !!fetcher,
-    queryFn: () => (fetcher ? fetcher(start, end) : Promise.resolve([])),
+    queryFn: () => fetcher(start, end),
     queryKey: ['sparkline', metric, formatISO(start, { representation: 'date' })],
     staleTime: 5 * 60 * 1000,
   })
 
   // Fetch period summary for the value and trend
-  const apiMetric = metricToApiMetric[metric]
+  const apiMetric = metricToApiMetric[metric] ?? metric
   const periodSummaryQuery = useQuery({
-    enabled: !!apiMetric,
-    queryFn: () => fetchPeriodSummary(start, end, apiMetric ? [apiMetric] : []),
+    queryFn: () => fetchPeriodSummary(start, end, [apiMetric]),
     queryKey: ['periodSummary', metric, formatISO(start, { representation: 'date' })],
     staleTime: 5 * 60 * 1000,
   })
@@ -180,7 +179,7 @@ export function SparklineCardWidget({ config }: SparklineCardWidgetProps) {
     for (const m of metricsArray) {
       periodSummary[m.metric] = m
     }
-    const stats = apiMetric ? periodSummary[apiMetric] : null
+    const stats = periodSummary[apiMetric]
     if (stats) {
       value = stats.avg ?? null
       trend = stats.change_from_previous_period_percent ?? null

--- a/apps/web/src/pages/Goals/index.tsx
+++ b/apps/web/src/pages/Goals/index.tsx
@@ -2,33 +2,9 @@ import { metricUnits } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 import { fetchGoalsProgress, fetchUserSettings, type GoalProgress } from '../../state/api'
 import { auth } from '../../state/auth'
+import { metricLabels } from '../../utils/metricLabels'
 
 import './style.css'
-
-// Friendly names for metrics
-const metricLabels: Record<string, string> = {
-  calories_active: 'Active Calories',
-  calories_basal: 'Basal Calories',
-  calories_total: 'Total Calories',
-  distance: 'Distance',
-  floors_climbed: 'Floors Climbed',
-  heart_rate: 'Heart Rate',
-  hr_zone_0_sec: 'Zone 0 (Below Z1)',
-  hr_zone_1_sec: 'Zone 1',
-  hr_zone_2_sec: 'Zone 2',
-  hr_zone_3_sec: 'Zone 3',
-  hr_zone_4_sec: 'Zone 4',
-  hr_zone_5_sec: 'Zone 5',
-  hrv_rmssd: 'HRV (RMSSD)',
-  readiness_score: 'Readiness Score',
-  resilience_score: 'Resilience Score',
-  resting_heart_rate: 'Resting HR',
-  sleep_score: 'Sleep Score',
-  spo2: 'SpO2',
-  steps: 'Steps',
-  vo2_max: 'VO2 Max',
-  weight: 'Weight',
-}
 
 // Format value for display (e.g., seconds to hours:minutes)
 const formatValue = (metric: string, value: number): string => {

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable max-lines -- chart tooltip interaction adds lines */
 import { useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
 import { useEffect, useRef, useState } from 'preact/hooks'
+import { MetricPicker } from '../../components/MetricPicker'
 import { TagPicker } from '../../components/TagPicker'
 import { fetchTrend, type FetchTrendParams, type TrendDisplayPeriod, type TrendResult } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -312,13 +312,8 @@ function TrendConfigForm({
             />
           </label>
         : <label class="pattern-input">
-            Metric Name
-            <input
-              type="text"
-              value={pattern}
-              onInput={(e) => setPattern((e.target as HTMLInputElement).value)}
-              placeholder="e.g., weight"
-            />
+            Metric
+            <MetricPicker value={pattern} onChange={setPattern} placeholder="Search metrics..." />
           </label>
         }
       </div>

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -19,6 +19,8 @@ import type {
   Tag as ApiTag,
   BaselineData,
   BaselineResponse,
+  CustomMetricDefinition,
+  CustomMetricsListResponse,
   DashboardConfig,
   DashboardResponse,
   Goal,
@@ -130,6 +132,7 @@ export type {
   ActivityImpactType,
   AddLastFmTagRuleBody,
   BaselineData,
+  CustomMetricDefinition,
   DashboardConfig,
   Goal,
   GoalProgress,
@@ -660,6 +663,39 @@ export const fetchSteps = async (start: Date, end: Date): Promise<[Date, number]
     start: start.toISOString(),
   }
   const response = await axios.get<QueryMetricsResponse>(`${API_URL}/metrics/steps`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+
+  return (response.data.data ?? []).map(({ time, value }) => [new Date(time), value])
+}
+
+// ==========================================================================
+// Custom Metrics API
+// ==========================================================================
+
+// Fetch user's custom metric definitions
+export const fetchCustomMetrics = async (): Promise<CustomMetricDefinition[]> => {
+  const { token } = auth.value
+  const response = await axios.get<CustomMetricsListResponse>(`${API_URL}/metrics/custom`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  return response.data.data ?? []
+}
+
+// Fetch time series data for any metric (built-in or custom)
+export const fetchMetricTimeSeries = async (
+  metric: string,
+  start: Date,
+  end: Date,
+): Promise<[Date, number][]> => {
+  const { token } = auth.value
+  const params: QueryMetricsQuery = {
+    end: end.toISOString(),
+    start: start.toISOString(),
+  }
+  const response = await axios.get<QueryMetricsResponse>(`${API_URL}/metrics/${encodeURIComponent(metric)}`, {
     headers: { Authorization: `Bearer ${token}` },
     params,
   })

--- a/apps/web/src/utils/metricLabels.ts
+++ b/apps/web/src/utils/metricLabels.ts
@@ -1,0 +1,47 @@
+import { builtinDashboardMetrics } from '@aurboda/api-spec'
+
+/**
+ * Friendly display names for built-in metrics.
+ */
+export const metricLabels: Record<string, string> = {
+  body_fat: 'Body Fat',
+  calories_active: 'Active Calories',
+  calories_basal: 'Basal Calories',
+  calories_total: 'Total Calories',
+  distance: 'Distance',
+  floors_climbed: 'Floors Climbed',
+  heart_rate: 'Heart Rate',
+  hr_zone_0_sec: 'Zone 0 (Below Z1)',
+  hr_zone_1_sec: 'Zone 1',
+  hr_zone_2_sec: 'Zone 2',
+  hr_zone_3_sec: 'Zone 3',
+  hr_zone_4_sec: 'Zone 4',
+  hr_zone_5_sec: 'Zone 5',
+  hrv_7day: 'HRV (7-day)',
+  hrv_30day: 'HRV (30-day)',
+  hrv_rmssd: 'HRV (RMSSD)',
+  readiness_score: 'Readiness Score',
+  resilience_score: 'Resilience Score',
+  resting_heart_rate: 'Resting HR',
+  rhr_7day: 'Resting HR (7-day)',
+  rhr_30day: 'Resting HR (30-day)',
+  sleep_score: 'Sleep Score',
+  spo2: 'SpO2',
+  steps: 'Steps',
+  vo2_max: 'VO2 Max',
+  weight: 'Weight',
+  zone2_weekly: 'Zone 2 (Weekly)',
+}
+
+/**
+ * Get a display name for any metric, falling back to the raw name.
+ */
+export const getMetricDisplayName = (metric: string): string => metricLabels[metric] ?? metric
+
+/**
+ * Built-in dashboard metrics with their display names.
+ */
+export const builtinDashboardMetricOptions = builtinDashboardMetrics.map((m) => ({
+  label: metricLabels[m] ?? m,
+  value: m,
+}))

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -10,9 +10,9 @@ import { baseResponseSchema } from './common.js'
 // =============================================================================
 
 /**
- * Metric types available for metric widgets.
+ * Built-in metric names available for dashboard widgets.
  */
-export const dashboardMetricSchema = z.enum([
+export const builtinDashboardMetrics = [
   // Baseline metrics
   'hrv_7day',
   'hrv_30day',
@@ -29,7 +29,17 @@ export const dashboardMetricSchema = z.enum([
   'hrv_rmssd',
   'resting_heart_rate',
   'hr_zone_2_sec',
-])
+] as const
+
+export type BuiltinDashboardMetric = (typeof builtinDashboardMetrics)[number]
+
+/**
+ * Metric types available for metric widgets.
+ * Accepts any non-empty string to support custom metrics.
+ */
+export const dashboardMetricSchema = z.string().min(1).meta({
+  description: 'Metric name (built-in or custom)',
+})
 
 export type DashboardMetric = z.infer<typeof dashboardMetricSchema>
 


### PR DESCRIPTION
## Summary

- **Loosen `dashboardMetricSchema`** from `z.enum([...])` to `z.string().min(1)` so dashboard widgets accept custom metric names alongside built-in ones. Export `builtinDashboardMetrics` const array.
- **Add `MetricPicker` component** — searchable dropdown combining built-in and user's custom metrics (fetched via `GET /metrics/custom`), with grouped display and keyboard navigation
- **Dashboard Editor** now uses `MetricPicker` for metric_card, sparkline_card, and trend_chart (when source_type is 'metric')
- **MetricCardWidget & SparklineCardWidget** fall through to the raw metric name for unknown metrics, enabling custom metric rendering without code changes
- **Trends view** uses `MetricPicker` instead of plain text input for metric source type
- **Extract shared `metricLabels`** utility from duplicated definitions in Goals and GoalsSettings

## Test plan

- [ ] `pnpm --filter @aurboda/api-spec build` passes
- [ ] `pnpm fix` and `pnpm check` pass (only pre-existing warnings)
- [ ] Unit tests pass
- [ ] Dashboard Editor: Add metric_card → MetricPicker shows built-in + custom metrics
- [ ] Dashboard Editor: Add sparkline_card → MetricPicker works
- [ ] Dashboard Editor: Add trend_chart with source_type=metric → MetricPicker shown
- [ ] Trends page: metric source shows MetricPicker with autocomplete
- [ ] Goals page still renders correctly with shared metricLabels

🤖 Generated with [Claude Code](https://claude.com/claude-code)