### PR TITLE
Add inline edit for activity detail page

### DIFF
--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -1,0 +1,118 @@
+/**
+ * Shared component that renders activity title, time, duration, and notes
+ * in either read mode (plain text) or edit mode (input fields).
+ */
+import { formatDateTime, formatDuration, formatTime } from './format-utils'
+
+export interface ActivityDraft {
+  title: string
+  start_time: string // yyyy-MM-ddTHH:mm for datetime-local
+  end_time: string
+  notes: string
+}
+
+interface EditableActivityFieldsProps {
+  title: string
+  displayStart: Date
+  displayEnd: Date
+  notes?: string
+  isEditing: boolean
+  draft: ActivityDraft
+  onDraftChange: (draft: ActivityDraft) => void
+  /** Label for the duration row (e.g. "In Bed" for sleep). Defaults to "Duration". */
+  durationLabel?: string
+}
+
+export const EditableActivityFields = ({
+  title,
+  displayStart,
+  displayEnd,
+  notes,
+  isEditing,
+  draft,
+  onDraftChange,
+  durationLabel = 'Duration',
+}: EditableActivityFieldsProps) => {
+  if (isEditing) {
+    const draftStart = new Date(draft.start_time)
+    const draftEnd = new Date(draft.end_time)
+    const draftDuration =
+      isNaN(draftStart.getTime()) || isNaN(draftEnd.getTime()) ? '—' : formatDuration(draftStart, draftEnd)
+
+    return (
+      <>
+        <input
+          type="text"
+          class="edit-title-input"
+          value={draft.title}
+          onInput={(e) => onDraftChange({ ...draft, title: (e.target as HTMLInputElement).value })}
+        />
+
+        <div class="entity-fields">
+          <div class="field-row">
+            <span class="field-label">Start</span>
+            <span class="field-value">
+              <input
+                type="datetime-local"
+                class="edit-datetime-input"
+                value={draft.start_time}
+                onInput={(e) => onDraftChange({ ...draft, start_time: (e.target as HTMLInputElement).value })}
+              />
+            </span>
+          </div>
+          <div class="field-row">
+            <span class="field-label">End</span>
+            <span class="field-value">
+              <input
+                type="datetime-local"
+                class="edit-datetime-input"
+                value={draft.end_time}
+                onInput={(e) => onDraftChange({ ...draft, end_time: (e.target as HTMLInputElement).value })}
+              />
+            </span>
+          </div>
+          <div class="field-row">
+            <span class="field-label">{durationLabel}</span>
+            <span class="field-value">{draftDuration}</span>
+          </div>
+          <div class="field-row">
+            <span class="field-label">Notes</span>
+            <span class="field-value">
+              <textarea
+                class="edit-notes-input"
+                value={draft.notes}
+                onInput={(e) => onDraftChange({ ...draft, notes: (e.target as HTMLTextAreaElement).value })}
+                rows={3}
+              />
+            </span>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <h2>{title}</h2>
+
+      <div class="entity-fields">
+        <div class="field-row">
+          <span class="field-label">Time</span>
+          <span class="field-value">
+            {formatDateTime(displayStart)} – {formatTime(displayEnd)}
+          </span>
+        </div>
+        <div class="field-row">
+          <span class="field-label">{durationLabel}</span>
+          <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
+        </div>
+        {notes && (
+          <div class="field-row">
+            <span class="field-label">Notes</span>
+            <span class="field-value">{notes}</span>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -1,21 +1,9 @@
 /**
  * Exercise-specific detail view with HR chart and HR zone bar.
  */
-import { format } from 'date-fns'
 import { Activity } from '../../state/api'
 import { ActivityChart } from './ActivityChart'
-
-const formatTime = (d: Date) => format(d, 'HH:mm')
-const formatDateTime = (d: Date) => format(d, 'yyyy-MM-dd HH:mm')
-
-const formatDuration = (start: Date, end: Date): string => {
-  const ms = end.getTime() - start.getTime()
-  const totalMin = Math.round(ms / 60000)
-  if (totalMin < 60) return `${totalMin}m`
-  const h = Math.floor(totalMin / 60)
-  const m = totalMin % 60
-  return m > 0 ? `${h}h ${m}m` : `${h}h`
-}
+import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 
 const hrZoneLabels = ['Rest', 'Zone 1', 'Zone 2', 'Zone 3', 'Zone 4', 'Zone 5']
 const hrZoneColors = ['#22c55e', '#22c55e', '#3b82f6', '#f59e0b', '#f97316', '#ef4444']
@@ -58,7 +46,17 @@ const HrZoneBar = ({ zones }: { zones: Record<number, number> }) => {
   )
 }
 
-export const ExerciseDetail = ({ activity }: { activity: Activity }) => {
+export const ExerciseDetail = ({
+  activity,
+  isEditing,
+  draft,
+  onDraftChange,
+}: {
+  activity: Activity
+  isEditing: boolean
+  draft: ActivityDraft
+  onDraftChange: (d: ActivityDraft) => void
+}) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
@@ -74,32 +72,24 @@ export const ExerciseDetail = ({ activity }: { activity: Activity }) => {
           {activity.source && <span class="entity-source">Source: {activity.source}</span>}
         </div>
 
-        <h2>{activity.title || exerciseType || 'Exercise'}</h2>
+        <EditableActivityFields
+          title={activity.title || exerciseType || 'Exercise'}
+          displayStart={displayStart}
+          displayEnd={displayEnd}
+          notes={activity.notes}
+          isEditing={isEditing}
+          draft={draft}
+          onDraftChange={onDraftChange}
+        />
 
-        <div class="entity-fields">
-          <div class="field-row">
-            <span class="field-label">Time</span>
-            <span class="field-value">
-              {formatDateTime(displayStart)} – {formatTime(displayEnd)}
-            </span>
-          </div>
-          <div class="field-row">
-            <span class="field-label">Duration</span>
-            <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
-          </div>
-          {activity.avg_hrv !== undefined && (
+        {!isEditing && activity.avg_hrv !== undefined && (
+          <div class="entity-fields">
             <div class="field-row">
               <span class="field-label">Avg HRV</span>
               <span class="field-value">{activity.avg_hrv} ms</span>
             </div>
-          )}
-          {activity.notes && (
-            <div class="field-row">
-              <span class="field-label">Notes</span>
-              <span class="field-value">{activity.notes}</span>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {activity.hr_zone_secs && <HrZoneBar zones={activity.hr_zone_secs as Record<number, number>} />}
       </div>

--- a/apps/web/src/pages/EntityDetail/NotesSection.tsx
+++ b/apps/web/src/pages/EntityDetail/NotesSection.tsx
@@ -1,0 +1,152 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { marked } from 'marked'
+import { useCallback, useState } from 'preact/hooks'
+import { MarkdownEditor } from '../../components/MarkdownEditor/index.jsx'
+import { addNote, deleteNote, fetchNotes, type NoteData, updateNote } from '../../state/api'
+
+type EntityType = 'activity' | 'tag' | 'productivity'
+
+export const NotesSection = ({
+  entityType,
+  entityId,
+  allEntityIds,
+}: {
+  entityType: EntityType
+  entityId: string
+  allEntityIds?: string[]
+}) => {
+  const queryClient = useQueryClient()
+  const [newNote, setNewNote] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editContent, setEditContent] = useState('')
+
+  // Fetch notes for all source entity IDs (merged activity) or just the one
+  const idsToFetch = allEntityIds ?? [entityId]
+  const notesQuery = useQuery({
+    queryFn: async () => {
+      const results = await Promise.all(idsToFetch.map((id) => fetchNotes(entityType, id)))
+      return results
+        .flat()
+        .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    },
+    queryKey: ['notes', entityType, ...idsToFetch],
+    staleTime: 30_000,
+  })
+
+  const invalidateNotes = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: ['notes', entityType, ...idsToFetch] }),
+    [queryClient, entityType, ...idsToFetch],
+  )
+
+  const addMutation = useMutation({
+    mutationFn: () => addNote(entityType, entityId, newNote),
+    onSuccess: () => {
+      setNewNote('')
+      invalidateNotes()
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, content }: { id: string; content: string }) => updateNote(id, content),
+    onSuccess: () => {
+      setEditingId(null)
+      invalidateNotes()
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteNote(id),
+    onSuccess: invalidateNotes,
+  })
+
+  const handleAdd = useCallback(
+    (e: Event) => {
+      e.preventDefault()
+      if (!newNote.trim()) return
+      addMutation.mutate()
+    },
+    [newNote, addMutation],
+  )
+
+  const startEdit = useCallback((note: NoteData) => {
+    setEditingId(note.id)
+    setEditContent(note.content)
+  }, [])
+
+  const handleUpdate = useCallback(
+    (e: Event) => {
+      e.preventDefault()
+      if (!editingId || !editContent.trim()) return
+      updateMutation.mutate({ content: editContent, id: editingId })
+    },
+    [editingId, editContent, updateMutation],
+  )
+
+  const notes = notesQuery.data ?? []
+
+  return (
+    <div class="notes-section">
+      <h3>Notes</h3>
+
+      {notesQuery.isLoading && <p class="notes-loading">Loading notes…</p>}
+
+      {notes.length > 0 && (
+        <div class="notes-list">
+          {notes.map((note) => (
+            <div key={note.id} class="note-item">
+              {editingId === note.id ?
+                <form onSubmit={handleUpdate} class="note-edit-form">
+                  <MarkdownEditor value={editContent} onChange={setEditContent} rows={3} />
+                  <div class="note-edit-actions">
+                    <button type="submit" class="btn-primary" disabled={updateMutation.isPending}>
+                      Save
+                    </button>
+                    <button type="button" class="btn-secondary" onClick={() => setEditingId(null)}>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              : <>
+                  <div
+                    class="note-content"
+                    dangerouslySetInnerHTML={{ __html: marked.parse(note.content) as string }}
+                  />
+                  <div class="note-footer">
+                    <span class="note-date">{format(new Date(note.created_at), 'yyyy-MM-dd HH:mm')}</span>
+                    <div class="note-actions">
+                      <button
+                        class="note-action-btn"
+                        onClick={() => startEdit(note)}
+                        title="Edit note"
+                        type="button"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        class="note-action-btn danger"
+                        onClick={() => deleteMutation.mutate(note.id)}
+                        title="Delete note"
+                        type="button"
+                        disabled={deleteMutation.isPending}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                </>
+              }
+            </div>
+          ))}
+        </div>
+      )}
+
+      <form onSubmit={handleAdd} class="note-add-form">
+        <MarkdownEditor value={newNote} onChange={setNewNote} placeholder="Add a note…" rows={3} />
+        <button type="submit" class="btn-primary" disabled={!newNote.trim() || addMutation.isPending}>
+          {addMutation.isPending ? 'Adding…' : 'Add Note'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/src/pages/EntityDetail/SleepDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/SleepDetail.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { Activity, fetchBucketedMetrics } from '../../state/api'
 import { ActivityChart } from './ActivityChart'
+import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import {
   computeSleepMinutesFromStages,
   formatMinutesAsHM,
@@ -14,18 +15,6 @@ import {
   type OuraSleepMetricKey,
   parseSleepStages,
 } from './sleep-utils'
-
-const formatTime = (d: Date) => format(d, 'HH:mm')
-const formatDateTime = (d: Date) => format(d, 'yyyy-MM-dd HH:mm')
-
-const formatDuration = (start: Date, end: Date): string => {
-  const ms = end.getTime() - start.getTime()
-  const totalMin = Math.round(ms / 60000)
-  if (totalMin < 60) return `${totalMin}m`
-  const h = Math.floor(totalMin / 60)
-  const m = totalMin % 60
-  return m > 0 ? `${h}h ${m}m` : `${h}h`
-}
 
 /** Extract Oura metric values from bucketed query response. */
 const extractOuraMetrics = (
@@ -73,7 +62,17 @@ const OuraMetricsCards = ({ metrics }: { metrics: Partial<Record<OuraSleepMetric
   </div>
 )
 
-export const SleepDetail = ({ activity }: { activity: Activity }) => {
+export const SleepDetail = ({
+  activity,
+  isEditing,
+  draft,
+  onDraftChange,
+}: {
+  activity: Activity
+  isEditing: boolean
+  draft: ActivityDraft
+  onDraftChange: (d: ActivityDraft) => void
+}) => {
   const end = activity.end_time ?? new Date(activity.start_time.getTime() + 8 * 60 * 60000)
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd = activity.merged_end_time ?? end
@@ -102,38 +101,33 @@ export const SleepDetail = ({ activity }: { activity: Activity }) => {
           {activity.source && <span class="entity-source">Source: {activity.source}</span>}
         </div>
 
-        <h2>{activity.title || (activity.activity_type === 'nap' ? 'Nap' : 'Sleep')}</h2>
+        <EditableActivityFields
+          title={activity.title || (activity.activity_type === 'nap' ? 'Nap' : 'Sleep')}
+          displayStart={displayStart}
+          displayEnd={displayEnd}
+          notes={activity.notes}
+          isEditing={isEditing}
+          draft={draft}
+          onDraftChange={onDraftChange}
+          durationLabel="In Bed"
+        />
 
-        <div class="entity-fields">
-          <div class="field-row">
-            <span class="field-label">Time</span>
-            <span class="field-value">
-              {formatDateTime(displayStart)} – {formatTime(displayEnd)}
-            </span>
+        {!isEditing && (
+          <div class="entity-fields">
+            {sleepMinutes !== undefined && (
+              <div class="field-row">
+                <span class="field-label">Asleep</span>
+                <span class="field-value">{formatMinutesAsHM(sleepMinutes)}</span>
+              </div>
+            )}
+            {activity.avg_hrv !== undefined && (
+              <div class="field-row">
+                <span class="field-label">Avg HRV</span>
+                <span class="field-value">{activity.avg_hrv} ms</span>
+              </div>
+            )}
           </div>
-          <div class="field-row">
-            <span class="field-label">In Bed</span>
-            <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
-          </div>
-          {sleepMinutes !== undefined && (
-            <div class="field-row">
-              <span class="field-label">Asleep</span>
-              <span class="field-value">{formatMinutesAsHM(sleepMinutes)}</span>
-            </div>
-          )}
-          {activity.avg_hrv !== undefined && (
-            <div class="field-row">
-              <span class="field-label">Avg HRV</span>
-              <span class="field-value">{activity.avg_hrv} ms</span>
-            </div>
-          )}
-          {activity.notes && (
-            <div class="field-row">
-              <span class="field-label">Notes</span>
-              <span class="field-value">{activity.notes}</span>
-            </div>
-          )}
-        </div>
+        )}
       </div>
 
       {hasOuraMetrics && <OuraMetricsCards metrics={ouraMetrics} />}

--- a/apps/web/src/pages/EntityDetail/format-utils.ts
+++ b/apps/web/src/pages/EntityDetail/format-utils.ts
@@ -1,0 +1,17 @@
+import { format } from 'date-fns'
+
+export const formatTime = (d: Date) => format(d, 'HH:mm')
+
+export const formatDateTime = (d: Date) => format(d, 'yyyy-MM-dd HH:mm')
+
+/** Format for <input type="datetime-local"> value binding. */
+export const formatDateTimeLocal = (d: Date) => format(d, "yyyy-MM-dd'T'HH:mm")
+
+export const formatDuration = (start: Date, end: Date): string => {
+  const ms = end.getTime() - start.getTime()
+  const totalMin = Math.round(ms / 60000)
+  if (totalMin < 60) return `${totalMin}m`
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -8,49 +8,30 @@
  * - other     → generic ActivityDetail
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { format } from 'date-fns'
-import { marked } from 'marked'
 import { useRoute } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
-import { MarkdownEditor } from '../../components/MarkdownEditor/index.jsx'
 import {
   Activity,
-  addNote,
-  deleteNote,
   fetchActivityById,
-  fetchNotes,
   fetchTagById,
-  NoteData,
   restoreActivity,
   restoreTag,
   softDeleteActivity,
   softDeleteTag,
   SourceRecord,
   Tag,
-  updateNote,
+  updateActivity,
 } from '../../state/api'
+import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { ExerciseDetail } from './ExerciseDetail'
+import { formatDateTime, formatDateTimeLocal, formatDuration, formatTime } from './format-utils'
 import { MusicPlaylist } from './MusicPlaylist'
+import { NotesSection } from './NotesSection'
 import { SleepDetail } from './SleepDetail'
 
 import './style.css'
 
-marked.setOptions({ breaks: true, gfm: true })
-
 type EntityType = 'activity' | 'tag' | 'productivity'
-
-const formatTime = (d: Date) => format(d, 'HH:mm')
-
-const formatDateTime = (d: Date) => format(d, 'yyyy-MM-dd HH:mm')
-
-const formatDuration = (start: Date, end: Date): string => {
-  const ms = end.getTime() - start.getTime()
-  const totalMin = Math.round(ms / 60000)
-  if (totalMin < 60) return `${totalMin}m`
-  const h = Math.floor(totalMin / 60)
-  const m = totalMin % 60
-  return m > 0 ? `${h}h ${m}m` : `${h}h`
-}
 
 const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
   <div class="source-records">
@@ -61,8 +42,8 @@ const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
           {record.title ?? record.exercise_type_name ?? record.data_origin ?? record.source}
         </span>
         <span class="source-record-time">
-          {format(new Date(record.start_time), 'HH:mm')}
-          {record.end_time ? ` – ${format(new Date(record.end_time), 'HH:mm')}` : ''}
+          {formatTime(new Date(record.start_time))}
+          {record.end_time ? ` – ${formatTime(new Date(record.end_time))}` : ''}
         </span>
         {record.title && record.data_origin && <span class="source-record-title">{record.data_origin}</span>}
       </a>
@@ -71,7 +52,17 @@ const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
 )
 
 /** Generic activity detail for types other than sleep/exercise. */
-const GenericActivityDetail = ({ activity }: { activity: Activity }) => {
+const GenericActivityDetail = ({
+  activity,
+  isEditing,
+  draft,
+  onDraftChange,
+}: {
+  activity: Activity
+  isEditing: boolean
+  draft: ActivityDraft
+  onDraftChange: (d: ActivityDraft) => void
+}) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
@@ -86,38 +77,40 @@ const GenericActivityDetail = ({ activity }: { activity: Activity }) => {
         {activity.source && <span class="entity-source">Source: {activity.source}</span>}
       </div>
 
-      <h2>{activity.title || exerciseType || activity.activity_type}</h2>
+      <EditableActivityFields
+        title={activity.title || exerciseType || activity.activity_type}
+        displayStart={displayStart}
+        displayEnd={displayEnd}
+        notes={activity.notes}
+        isEditing={isEditing}
+        draft={draft}
+        onDraftChange={onDraftChange}
+      />
 
-      <div class="entity-fields">
-        <div class="field-row">
-          <span class="field-label">Time</span>
-          <span class="field-value">
-            {formatDateTime(displayStart)} – {formatTime(displayEnd)}
-          </span>
-        </div>
-        <div class="field-row">
-          <span class="field-label">Duration</span>
-          <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
-        </div>
-        {activity.avg_hrv !== undefined && (
+      {!isEditing && activity.avg_hrv !== undefined && (
+        <div class="entity-fields">
           <div class="field-row">
             <span class="field-label">Avg HRV</span>
             <span class="field-value">{activity.avg_hrv} ms</span>
           </div>
-        )}
-        {activity.notes && (
-          <div class="field-row">
-            <span class="field-label">Notes</span>
-            <span class="field-value">{activity.notes}</span>
-          </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }
 
 /** Dispatch to type-specific activity detail component. */
-const ActivityDetailDispatch = ({ activity }: { activity: Activity }) => {
+const ActivityDetailDispatch = ({
+  activity,
+  isEditing,
+  draft,
+  onDraftChange,
+}: {
+  activity: Activity
+  isEditing: boolean
+  draft: ActivityDraft
+  onDraftChange: (d: ActivityDraft) => void
+}) => {
   const musicStart = activity.merged_start_time ?? activity.start_time
   const musicEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
@@ -132,9 +125,25 @@ const ActivityDetailDispatch = ({ activity }: { activity: Activity }) => {
         <div class="merged-indicator">Merged from {activity.source_records!.length} sources</div>
       )}
 
-      {isSleep && <SleepDetail activity={activity} />}
-      {isExercise && <ExerciseDetail activity={activity} />}
-      {!isSleep && !isExercise && <GenericActivityDetail activity={activity} />}
+      {isSleep && (
+        <SleepDetail activity={activity} isEditing={isEditing} draft={draft} onDraftChange={onDraftChange} />
+      )}
+      {isExercise && (
+        <ExerciseDetail
+          activity={activity}
+          isEditing={isEditing}
+          draft={draft}
+          onDraftChange={onDraftChange}
+        />
+      )}
+      {!isSleep && !isExercise && (
+        <GenericActivityDetail
+          activity={activity}
+          isEditing={isEditing}
+          draft={draft}
+          onDraftChange={onDraftChange}
+        />
+      )}
 
       {hasSourceRecords && <SourceRecordsSection records={activity.source_records!} />}
 
@@ -184,150 +193,6 @@ const TagDetail = ({ tag }: { tag: Tag }) => {
   )
 }
 
-const NotesSection = ({
-  entityType,
-  entityId,
-  allEntityIds,
-}: {
-  entityType: EntityType
-  entityId: string
-  allEntityIds?: string[]
-}) => {
-  const queryClient = useQueryClient()
-  const [newNote, setNewNote] = useState('')
-  const [editingId, setEditingId] = useState<string | null>(null)
-  const [editContent, setEditContent] = useState('')
-
-  // Fetch notes for all source entity IDs (merged activity) or just the one
-  const idsToFetch = allEntityIds ?? [entityId]
-  const notesQuery = useQuery({
-    queryFn: async () => {
-      const results = await Promise.all(idsToFetch.map((id) => fetchNotes(entityType, id)))
-      return results
-        .flat()
-        .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
-    },
-    queryKey: ['notes', entityType, ...idsToFetch],
-    staleTime: 30_000,
-  })
-
-  const invalidateNotes = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: ['notes', entityType, ...idsToFetch] }),
-    [queryClient, entityType, ...idsToFetch],
-  )
-
-  const addMutation = useMutation({
-    mutationFn: () => addNote(entityType, entityId, newNote),
-    onSuccess: () => {
-      setNewNote('')
-      invalidateNotes()
-    },
-  })
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, content }: { id: string; content: string }) => updateNote(id, content),
-    onSuccess: () => {
-      setEditingId(null)
-      invalidateNotes()
-    },
-  })
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteNote(id),
-    onSuccess: invalidateNotes,
-  })
-
-  const handleAdd = useCallback(
-    (e: Event) => {
-      e.preventDefault()
-      if (!newNote.trim()) return
-      addMutation.mutate()
-    },
-    [newNote, addMutation],
-  )
-
-  const startEdit = useCallback((note: NoteData) => {
-    setEditingId(note.id)
-    setEditContent(note.content)
-  }, [])
-
-  const handleUpdate = useCallback(
-    (e: Event) => {
-      e.preventDefault()
-      if (!editingId || !editContent.trim()) return
-      updateMutation.mutate({ content: editContent, id: editingId })
-    },
-    [editingId, editContent, updateMutation],
-  )
-
-  const notes = notesQuery.data ?? []
-
-  return (
-    <div class="notes-section">
-      <h3>Notes</h3>
-
-      {notesQuery.isLoading && <p class="notes-loading">Loading notes…</p>}
-
-      {notes.length > 0 && (
-        <div class="notes-list">
-          {notes.map((note) => (
-            <div key={note.id} class="note-item">
-              {editingId === note.id ?
-                <form onSubmit={handleUpdate} class="note-edit-form">
-                  <MarkdownEditor value={editContent} onChange={setEditContent} rows={3} />
-                  <div class="note-edit-actions">
-                    <button type="submit" class="btn-primary" disabled={updateMutation.isPending}>
-                      Save
-                    </button>
-                    <button type="button" class="btn-secondary" onClick={() => setEditingId(null)}>
-                      Cancel
-                    </button>
-                  </div>
-                </form>
-              : <>
-                  <div
-                    class="note-content"
-                    dangerouslySetInnerHTML={{ __html: marked.parse(note.content) as string }}
-                  />
-                  <div class="note-footer">
-                    <span class="note-date">{format(new Date(note.created_at), 'yyyy-MM-dd HH:mm')}</span>
-                    <div class="note-actions">
-                      <button
-                        class="note-action-btn"
-                        onClick={() => startEdit(note)}
-                        title="Edit note"
-                        type="button"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        class="note-action-btn danger"
-                        onClick={() => deleteMutation.mutate(note.id)}
-                        title="Delete note"
-                        type="button"
-                        disabled={deleteMutation.isPending}
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </div>
-                </>
-              }
-            </div>
-          ))}
-        </div>
-      )}
-
-      <form onSubmit={handleAdd} class="note-add-form">
-        <MarkdownEditor value={newNote} onChange={setNewNote} placeholder="Add a note…" rows={3} />
-        <button type="submit" class="btn-primary" disabled={!newNote.trim() || addMutation.isPending}>
-          {addMutation.isPending ? 'Adding…' : 'Add Note'}
-        </button>
-      </form>
-    </div>
-  )
-}
-
 const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> => {
   if (entityType === 'activity') return softDeleteActivity(entityId)
   if (entityType === 'tag') return softDeleteTag(entityId)
@@ -340,16 +205,37 @@ const restoreEntity = (entityType: EntityType, entityId: string): Promise<void> 
   return Promise.reject(new Error('Unsupported entity type for restore'))
 }
 
+const PencilIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+    <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+  </svg>
+)
+
 const EntityActions = ({
   entityType,
   entityId,
   isDeleted,
   onMutationSuccess,
+  canEdit,
+  isMerged,
+  isEditing,
+  onStartEditing,
+  onCancelEditing,
+  onSave,
+  isSaving,
 }: {
   entityType: EntityType
   entityId: string
   isDeleted: boolean
   onMutationSuccess: () => void
+  canEdit: boolean
+  isMerged: boolean
+  isEditing: boolean
+  onStartEditing: () => void
+  onCancelEditing: () => void
+  onSave: () => void
+  isSaving: boolean
 }) => {
   const deleteMutation = useMutation({
     mutationFn: () => deleteEntity(entityType, entityId),
@@ -379,16 +265,51 @@ const EntityActions = ({
 
   return (
     <div class="entity-actions">
-      <button
-        class="btn-danger"
-        onClick={() => deleteMutation.mutate()}
-        disabled={deleteMutation.isPending}
-        type="button"
-      >
-        {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
-      </button>
+      {canEdit && !isEditing && (
+        <button
+          class="btn-edit"
+          onClick={onStartEditing}
+          disabled={isMerged}
+          title={isMerged ? 'Edit individual sources' : 'Edit activity'}
+          type="button"
+        >
+          <PencilIcon />
+        </button>
+      )}
+      {isEditing && (
+        <>
+          <button class="btn-primary" onClick={onSave} disabled={isSaving} type="button">
+            {isSaving ? 'Saving…' : 'Save'}
+          </button>
+          <button class="btn-secondary" onClick={onCancelEditing} type="button">
+            Cancel
+          </button>
+        </>
+      )}
+      {!isEditing && (
+        <button
+          class="btn-danger"
+          onClick={() => deleteMutation.mutate()}
+          disabled={deleteMutation.isPending}
+          type="button"
+        >
+          {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+        </button>
+      )}
     </div>
   )
+}
+
+const makeDraft = (activity: Activity): ActivityDraft => {
+  const displayStart = activity.merged_start_time ?? activity.start_time
+  const displayEnd =
+    activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  return {
+    end_time: formatDateTimeLocal(displayEnd),
+    notes: activity.notes ?? '',
+    start_time: formatDateTimeLocal(displayStart),
+    title: activity.title ?? '',
+  }
 }
 
 const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entityId: string }) => {
@@ -427,6 +348,49 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     : entityType === 'tag' ? Boolean(tag?.deleted_at)
     : false
 
+  // Edit state
+  const [isEditing, setIsEditing] = useState(false)
+  const emptyDraft: ActivityDraft = { end_time: '', notes: '', start_time: '', title: '' }
+  const [draft, setDraft] = useState<ActivityDraft>(emptyDraft)
+
+  const isMergedActivity = Boolean(
+    entityType === 'activity' && activity?.source_records && activity.source_records.length > 1,
+  )
+
+  const startEditing = useCallback(() => {
+    if (!activity) return
+    setDraft(makeDraft(activity))
+    setIsEditing(true)
+  }, [activity])
+
+  const cancelEditing = useCallback(() => {
+    setIsEditing(false)
+    setDraft(emptyDraft)
+  }, [])
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      if (!activity) return Promise.resolve()
+      const body: Record<string, string> = {}
+      const originalDraft = makeDraft(activity)
+      if (draft.title !== originalDraft.title) body.title = draft.title
+      if (draft.start_time !== originalDraft.start_time)
+        body.start_time = new Date(draft.start_time).toISOString()
+      if (draft.end_time !== originalDraft.end_time) body.end_time = new Date(draft.end_time).toISOString()
+      if (draft.notes !== originalDraft.notes) body.notes = draft.notes
+      if (Object.keys(body).length === 0) return Promise.resolve()
+      return updateActivity(rawEntityId, body)
+    },
+    onSuccess: () => {
+      setIsEditing(false)
+      invalidateEntity()
+    },
+  })
+
+  const handleSave = useCallback(() => {
+    saveMutation.mutate()
+  }, [saveMutation])
+
   // Collect all entity IDs for notes (primary + source records for merged activities)
   const allEntityIds =
     entityType === 'activity' && activity?.source_records ?
@@ -443,9 +407,23 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
         entityId={rawEntityId}
         isDeleted={isDeleted}
         onMutationSuccess={invalidateEntity}
+        canEdit={entityType === 'activity'}
+        isMerged={isMergedActivity}
+        isEditing={isEditing}
+        onStartEditing={startEditing}
+        onCancelEditing={cancelEditing}
+        onSave={handleSave}
+        isSaving={saveMutation.isPending}
       />
 
-      {entityType === 'activity' && activity && <ActivityDetailDispatch activity={activity} />}
+      {entityType === 'activity' && activity && (
+        <ActivityDetailDispatch
+          activity={activity}
+          isEditing={isEditing}
+          draft={draft}
+          onDraftChange={setDraft}
+        />
+      )}
       {entityType === 'tag' && tag && <TagDetail tag={tag} />}
 
       <NotesSection entityType={entityType} entityId={rawEntityId} allEntityIds={allEntityIds} />

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -558,6 +558,84 @@
   background: #f3f4f6;
 }
 
+/* Edit mode */
+.btn-edit {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: #6b7280;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.btn-edit:hover:not(:disabled) {
+  background: #673ab8;
+  border-color: #673ab8;
+  color: white;
+}
+
+.btn-edit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.edit-title-input {
+  display: block;
+  width: 100%;
+  margin: 0 0 1rem;
+  padding: 0.375rem 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.edit-title-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.edit-datetime-input {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.9rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+}
+
+.edit-datetime-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.edit-notes-input {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.9rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  resize: vertical;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.edit-notes-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
 /* Loading & error */
 .entity-detail-page .loading,
 .entity-detail-page .error {
@@ -690,6 +768,45 @@
 
   .source-record-title {
     color: #9ca3af;
+  }
+
+  .btn-edit {
+    background: #374151;
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .btn-edit:hover:not(:disabled) {
+    background: #8b5cf6;
+    border-color: #8b5cf6;
+    color: white;
+  }
+
+  .edit-title-input {
+    border-color: #4b5563;
+  }
+
+  .edit-title-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .edit-datetime-input {
+    border-color: #4b5563;
+  }
+
+  .edit-datetime-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .edit-notes-input {
+    border-color: #4b5563;
+  }
+
+  .edit-notes-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
   }
 
   .chart-toggle {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -778,6 +778,16 @@ export const softDeleteActivity = async (id: string): Promise<void> => {
   })
 }
 
+export const updateActivity = async (
+  id: string,
+  body: { start_time?: string; end_time?: string; title?: string; notes?: string },
+): Promise<void> => {
+  const { token } = auth.value
+  await axios.patch(`${API_URL}/activities/${id}`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
 export const restoreActivity = async (id: string): Promise<void> => {
   const { token } = auth.value
   await axios.post(


### PR DESCRIPTION
## Summary

- Add pencil edit button on activity detail pages to toggle inline editing of title, start/end time, and notes
- For merged activities, the pencil is disabled with tooltip "Edit individual sources"
- Saves via PATCH `/activities/:id` (only sends changed fields)
- Extract shared `EditableActivityFields` component, `format-utils.ts`, and `NotesSection` to reduce duplication and file size

## Test plan

- [ ] Open a single-source activity detail, click pencil, edit title/time/notes, save — verify changes persist on reload
- [ ] Open a merged activity detail, verify pencil is disabled with tooltip "Edit individual sources"
- [ ] Verify Cancel discards changes
- [ ] Verify dark mode styling for edit inputs
- [ ] `pnpm fix && pnpm check` — no lint/type errors
- [ ] `pnpm test` — all backend and web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)