### PR TITLE
Android UX: sensor descriptions, auto-send on foreground, widget refresh

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -761,9 +761,12 @@ fun HealthConnectScreen(
                         // Re-check permissions in case user changed them in system settings
                         refreshPermissions()
                         fetchHealthData(context)
-                        if (backgroundSyncEnabled && (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty())) {
+                        // Always send pending data when app comes to foreground
+                        if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
                             sendPendingDataToServer(context)
                         }
+                        // Refresh widget with latest data
+                        net.aurboda.widget.HrZoneWidgetProvider.triggerUpdate(context)
                     }
                 }
             }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -357,6 +357,9 @@ fun LiveScreen(
                 isScanning = false
             },
             onConnectDevice = { device ->
+                // Stop scanning once a device is being connected
+                isScanning = false
+
                 // Check Health Connect write permission based on device type
                 val hasPermission = when (device.sensorType) {
                     SensorType.HEART_RATE -> hasHrWritePermission
@@ -745,10 +748,76 @@ private fun ScannerSection(
             }
         } else if (!isScanning && discoveredDevices.isEmpty()) {
             Text(
-                text = "Tap 'Scan for Devices' to find heart rate monitors and step sensors.",
+                text = "Tap 'Scan for Devices' to find nearby Bluetooth sensors.",
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Card(
+                    modifier = Modifier.weight(1f),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Favorite,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "Heart Rate Monitor",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center
+                        )
+                        Text(
+                            text = "Tracks heart rate and HRV in real time",
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Card(
+                    modifier = Modifier.weight(1f),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "Step Sensor",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center
+                        )
+                        Text(
+                            text = "Tracks cadence and steps from a footpod",
+                            style = MaterialTheme.typography.bodySmall,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Live Sensors clarity**: Added descriptive cards explaining what HR monitors (track heart rate and HRV in real time) and step sensors (track cadence and steps from a footpod) are for. Stops BLE scanning when a device is connected.
- **Foreground sync**: Pending Health Connect data is now always sent when the app comes to foreground, regardless of the background sync toggle.
- **Widget refresh**: The goals widget now refreshes its data whenever the app is brought to foreground.

## Test plan
- [ ] Open Live Sensors tab with no devices connected — verify descriptive cards appear
- [ ] Scan for devices and connect one — verify scanning stops
- [ ] Collect some Health Connect data, close the app, re-open and go to Sync tab — verify data is sent automatically
- [ ] Check the goals widget updates after bringing the app to foreground

🤖 Generated with [Claude Code](https://claude.com/claude-code)