### PR TITLE
Add web UI for creating data and editing exercise types

### DIFF
--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -526,5 +526,93 @@ describe('Activities Integration Tests', () => {
       expect(updated).not.toBeNull()
       expect(updated?.title).toBe('Morning meditation')
     })
+
+    test('updates data field on activity', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const updated = await updateActivity(user, activityId, {
+        data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.data).toEqual({ exerciseType: 81, exerciseTypeName: 'weightlifting' })
+    })
+
+    test('replaces entire data field (no partial merge at db level)', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        data: { calories: 300, exerciseType: 70, exerciseTypeName: 'strength_training' },
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      // DB layer replaces data entirely; merging is done in the service layer
+      const updated = await updateActivity(user, activityId, {
+        data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.data).toEqual({ exerciseType: 81, exerciseTypeName: 'weightlifting' })
+    })
+
+    test('preserves data when updating other fields', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const updated = await updateActivity(user, activityId, {
+        title: 'Heavy lifting session',
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.title).toBe('Heavy lifting session')
+      expect(updated?.data).toEqual({ exerciseType: 81, exerciseTypeName: 'weightlifting' })
+    })
+
+    test('updates data and other fields together', async () => {
+      const user = getTestUser()
+      const activityId = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: activityId,
+        source: 'manual',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      })
+
+      const updated = await updateActivity(user, activityId, {
+        data: { exerciseType: 56, exerciseTypeName: 'running' },
+        notes: 'Morning run in the park',
+        title: 'Morning Run',
+      })
+
+      expect(updated).not.toBeNull()
+      expect(updated?.title).toBe('Morning Run')
+      expect(updated?.notes).toBe('Morning run in the park')
+      expect(updated?.data).toEqual({ exerciseType: 56, exerciseTypeName: 'running' })
+    })
   })
 })

--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -232,6 +232,7 @@ export const updateActivity = async (
   if (updates.end_time !== undefined) fields.push({ column: 'end_time', value: updates.end_time })
   if (updates.title !== undefined) fields.push({ column: 'title', value: updates.title })
   if (updates.notes !== undefined) fields.push({ column: 'notes', value: updates.notes })
+  if (updates.data !== undefined) fields.push({ column: 'data', value: JSON.stringify(updates.data) })
 
   if (fields.length === 0) return getActivityById(user, id)
 

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -89,6 +89,7 @@ export interface ActivityUpdate {
   end_time?: Date
   title?: string
   notes?: string
+  data?: Record<string, unknown>
 }
 
 // ============================================================================

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -24,9 +24,12 @@ vi.mock('./services/mutations', () => ({
   addCustomMetric: vi.fn(),
   addMetric: vi.fn(),
   addTag: vi.fn(),
+  deleteActivity: vi.fn(),
   deleteCustomMetric: vi.fn(),
   deleteTag: vi.fn(),
   getCustomMetrics: vi.fn().mockResolvedValue([]),
+  restoreActivity: vi.fn(),
+  updateActivity: vi.fn(),
 }))
 
 // Mock db for sync status and stored detected locations
@@ -1179,6 +1182,202 @@ describe('MCP Server', () => {
       expect(response.status).toBe(200)
       const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
       expect(parsed.result.content[0].text).toContain('end_time must be after start_time')
+    })
+  })
+
+  describe('Tool: update_activity', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    const testActivityId = '00000000-0000-4000-a000-000000000001'
+
+    test('updates activity with exercise_type', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.updateActivity).mockResolvedValue({
+        activity_type: 'exercise',
+        end_time: '2024-03-15T11:00:00.000Z',
+        id: testActivityId,
+        start_time: '2024-03-15T10:00:00.000Z',
+        success: true,
+        title: 'Workout',
+      })
+
+      const response = await callTool(app, token, sessionId, 'update_activity', {
+        exercise_type: 'weightlifting',
+        id: testActivityId,
+        title: 'Workout',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(mutations.updateActivity).toHaveBeenCalledWith('testuser', testActivityId, {
+        data: {
+          exerciseType: 81,
+          exerciseTypeName: 'weightlifting',
+        },
+        end_time: undefined,
+        notes: undefined,
+        start_time: undefined,
+        title: 'Workout',
+      })
+    })
+
+    test('updates activity without exercise_type', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.updateActivity).mockResolvedValue({
+        activity_type: 'exercise',
+        end_time: '2024-03-15T11:00:00.000Z',
+        id: testActivityId,
+        notes: 'Great session',
+        start_time: '2024-03-15T10:00:00.000Z',
+        success: true,
+      })
+
+      const response = await callTool(app, token, sessionId, 'update_activity', {
+        id: testActivityId,
+        notes: 'Great session',
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(mutations.updateActivity).toHaveBeenCalledWith('testuser', testActivityId, {
+        data: undefined,
+        end_time: undefined,
+        notes: 'Great session',
+        start_time: undefined,
+        title: undefined,
+      })
+    })
+
+    test('returns error for invalid exercise_type', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            arguments: {
+              exercise_type: 'not_a_real_exercise',
+              id: testActivityId,
+            },
+            name: 'update_activity',
+          },
+        })
+
+      expect(response.status).toBe(200)
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      expect(parsed.result.content[0].text).toContain('Invalid exercise_type')
+      expect(mutations.updateActivity).not.toHaveBeenCalled()
+    })
+
+    test('passes time updates as Date objects', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.updateActivity).mockResolvedValue({
+        activity_type: 'exercise',
+        end_time: '2024-03-15T12:00:00.000Z',
+        id: testActivityId,
+        start_time: '2024-03-15T09:00:00.000Z',
+        success: true,
+      })
+
+      await callTool(app, token, sessionId, 'update_activity', {
+        end_time: '2024-03-15T12:00:00Z',
+        id: testActivityId,
+        start_time: '2024-03-15T09:00:00Z',
+      })
+
+      expect(mutations.updateActivity).toHaveBeenCalledWith('testuser', testActivityId, {
+        data: undefined,
+        end_time: expect.any(Date),
+        notes: undefined,
+        start_time: expect.any(Date),
+        title: undefined,
+      })
+    })
+
+    test('returns error from service on failure', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(mutations.updateActivity).mockResolvedValue({
+        error: 'Activity not found',
+        id: testActivityId,
+        success: false,
+      })
+
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            arguments: {
+              id: testActivityId,
+              title: 'New title',
+            },
+            name: 'update_activity',
+          },
+        })
+
+      expect(response.status).toBe(200)
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      expect(parsed.result.content[0].text).toContain('Activity not found')
     })
   })
 

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -87,13 +87,34 @@ export const registerActivityTools = (server: McpServer, user: string) => {
   // Tool: update_activity
   server.tool(
     'update_activity',
-    'Update an existing activity. Can modify start_time, end_time, title, and notes. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
+    'Update an existing activity. Can modify start_time, end_time, title, notes, and exercise_type. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
     {
       id: z.string().uuid().describe('The ID of the activity to update'),
       ...updateActivityBodySchema.shape,
+      // Override enum with z.string() to allow handler-level validation with friendlier error message
+      exercise_type: z
+        .string()
+        .optional()
+        .describe(
+          `New exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
+        ),
     },
-    async ({ id, start_time, end_time, title, notes }) => {
+    async ({ id, start_time, end_time, title, notes, exercise_type }) => {
+      let data: Record<string, unknown> | undefined
+      if (exercise_type !== undefined) {
+        if (!isValidExerciseType(exercise_type)) {
+          return errorResponse(
+            `Invalid exercise_type "${exercise_type}". Valid types include: ${exerciseTypeNames.slice(0, 15).join(', ')}...`,
+          )
+        }
+        data = {
+          exerciseType: getExerciseTypeValue(exercise_type),
+          exerciseTypeName: exercise_type,
+        }
+      }
+
       const result = await updateActivity(user, id, {
+        data,
         end_time: end_time ? new Date(end_time) : undefined,
         notes,
         start_time: start_time ? new Date(start_time) : undefined,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -140,10 +140,26 @@ export const createActivitiesRouter = (
     validateBody(updateActivityBodySchema),
     async (req, res) => {
       const { id } = req.params
-      const { start_time, end_time, title, notes } = req.body
+      const { start_time, end_time, title, notes, exercise_type } = req.body
       const user = req.user!
 
+      // Convert exercise_type name to data object if provided
+      let data: Record<string, unknown> | undefined
+      if (exercise_type !== undefined) {
+        if (!isValidExerciseType(exercise_type)) {
+          return res.status(400).json({
+            error: `Invalid exercise_type "${exercise_type}"`,
+            success: false,
+          })
+        }
+        data = {
+          exerciseType: getExerciseTypeValue(exercise_type),
+          exerciseTypeName: exercise_type,
+        }
+      }
+
       const result = await updateActivity(user, id, {
+        data,
         end_time: end_time ? new Date(end_time) : undefined,
         notes,
         start_time: start_time ? new Date(start_time) : undefined,

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -839,6 +839,166 @@ describe('updateActivity', () => {
     expect(result.error).toBe('end_time must be after start_time')
     expect(db.updateActivity).not.toHaveBeenCalled()
   })
+
+  test('merges data with existing activity data', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { exerciseType: 70, exerciseTypeName: 'strength_training' },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    await updateActivity('testuser', 'activity-123', {
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+    })
+
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      end_time: undefined,
+      notes: undefined,
+      start_time: undefined,
+      title: undefined,
+    })
+  })
+
+  test('merges new data fields while preserving existing ones', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { calories: 300, exerciseType: 70, exerciseTypeName: 'strength_training' },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { calories: 300, exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    await updateActivity('testuser', 'activity-123', {
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+    })
+
+    // Should merge: existing {calories, exerciseType, exerciseTypeName} + new {exerciseType, exerciseTypeName}
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      data: { calories: 300, exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      end_time: undefined,
+      notes: undefined,
+      start_time: undefined,
+      title: undefined,
+    })
+  })
+
+  test('sets data on activity with no existing data', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { exerciseType: 56, exerciseTypeName: 'running' },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    await updateActivity('testuser', 'activity-123', {
+      data: { exerciseType: 56, exerciseTypeName: 'running' },
+    })
+
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      data: { exerciseType: 56, exerciseTypeName: 'running' },
+      end_time: undefined,
+      notes: undefined,
+      start_time: undefined,
+      title: undefined,
+    })
+  })
+
+  test('does not pass data when input has no data field', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { exerciseType: 70 },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { exerciseType: 70 },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      notes: 'Updated notes',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    await updateActivity('testuser', 'activity-123', {
+      notes: 'Updated notes',
+    })
+
+    // data should be undefined (not touched) when not provided in input
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      data: undefined,
+      end_time: undefined,
+      notes: 'Updated notes',
+      start_time: undefined,
+      title: undefined,
+    })
+  })
+
+  test('updates data and other fields together', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'manual',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+      title: 'Heavy lifting',
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      title: 'Heavy lifting',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.title).toBe('Heavy lifting')
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
+      end_time: undefined,
+      notes: undefined,
+      start_time: undefined,
+      title: 'Heavy lifting',
+    })
+  })
 })
 
 describe('updateCustomMetric', () => {

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -145,6 +145,7 @@ export interface UpdateActivityInput {
   end_time?: Date
   title?: string
   notes?: string
+  data?: Record<string, unknown>
 }
 
 export interface UpdateActivityResult {
@@ -514,7 +515,12 @@ export async function updateActivity(
     }
   }
 
+  // Merge new data fields into existing data (preserving fields not being updated)
+  const mergedData =
+    input.data ? { ...((existing.data as Record<string, unknown>) ?? {}), ...input.data } : undefined
+
   const updated = await dbUpdateActivity(user, id, {
+    data: mergedData,
     end_time: input.end_time,
     notes: input.notes,
     start_time: input.start_time,

--- a/apps/web/src/components/CustomMetricsSettings.tsx
+++ b/apps/web/src/components/CustomMetricsSettings.tsx
@@ -1,0 +1,241 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+import {
+  addCustomMetric,
+  deleteCustomMetric,
+  fetchCustomMetrics,
+  updateCustomMetric,
+  type CustomMetricDefinition,
+} from '../state/api'
+
+const CustomMetricRow = ({
+  metric,
+  onDeleted,
+  onUpdated,
+}: {
+  metric: CustomMetricDefinition
+  onDeleted: () => void
+  onUpdated: () => void
+}) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [unit, setUnit] = useState(metric.unit)
+  const [description, setDescription] = useState(metric.description ?? '')
+  const [minValue, setMinValue] = useState(metric.min_value?.toString() ?? '')
+  const [maxValue, setMaxValue] = useState(metric.max_value?.toString() ?? '')
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      updateCustomMetric(metric.name, {
+        description: description || undefined,
+        max_value: maxValue ? parseFloat(maxValue) : null,
+        min_value: minValue ? parseFloat(minValue) : null,
+        unit,
+      }),
+    onSuccess: () => {
+      setIsEditing(false)
+      onUpdated()
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteCustomMetric(metric.name),
+    onSuccess: onDeleted,
+  })
+
+  if (isEditing) {
+    return (
+      <div class="custom-metric-item editing">
+        <div class="custom-metric-fields">
+          <span class="custom-metric-name">{metric.name}</span>
+          <div class="custom-metric-edit-row">
+            <input
+              type="text"
+              value={unit}
+              onInput={(e) => setUnit((e.target as HTMLInputElement).value)}
+              placeholder="Unit"
+              class="custom-metric-input"
+            />
+            <input
+              type="text"
+              value={description}
+              onInput={(e) => setDescription((e.target as HTMLInputElement).value)}
+              placeholder="Description"
+              class="custom-metric-input wide"
+            />
+          </div>
+          <div class="custom-metric-edit-row">
+            <input
+              type="number"
+              step="any"
+              value={minValue}
+              onInput={(e) => setMinValue((e.target as HTMLInputElement).value)}
+              placeholder="Min"
+              class="custom-metric-input"
+            />
+            <input
+              type="number"
+              step="any"
+              value={maxValue}
+              onInput={(e) => setMaxValue((e.target as HTMLInputElement).value)}
+              placeholder="Max"
+              class="custom-metric-input"
+            />
+          </div>
+        </div>
+        <div class="custom-metric-actions">
+          <button
+            type="button"
+            class="note-action-btn"
+            onClick={() => updateMutation.mutate()}
+            disabled={updateMutation.isPending || !unit.trim()}
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save'}
+          </button>
+          <button type="button" class="note-action-btn" onClick={() => setIsEditing(false)}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div class="custom-metric-item">
+      <div class="custom-metric-fields">
+        <span class="custom-metric-name">{metric.name}</span>
+        <span class="custom-metric-unit">{metric.unit}</span>
+        {metric.description && <span class="custom-metric-desc">{metric.description}</span>}
+        {(metric.min_value !== undefined || metric.max_value !== undefined) && (
+          <span class="custom-metric-range">
+            Range: {metric.min_value ?? '—'} – {metric.max_value ?? '—'}
+          </span>
+        )}
+      </div>
+      <div class="custom-metric-actions">
+        <button type="button" class="note-action-btn" onClick={() => setIsEditing(true)}>
+          Edit
+        </button>
+        <button
+          type="button"
+          class="note-action-btn danger"
+          onClick={() => deleteMutation.mutate()}
+          disabled={deleteMutation.isPending}
+        >
+          {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function CustomMetricsSettings() {
+  const queryClient = useQueryClient()
+  const [newName, setNewName] = useState('')
+  const [newUnit, setNewUnit] = useState('')
+  const [newDescription, setNewDescription] = useState('')
+  const [newMinValue, setNewMinValue] = useState('')
+  const [newMaxValue, setNewMaxValue] = useState('')
+
+  const { data: metrics } = useQuery({
+    queryFn: fetchCustomMetrics,
+    queryKey: ['customMetrics'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['customMetrics'] })
+  }
+
+  const addMutation = useMutation({
+    mutationFn: () =>
+      addCustomMetric({
+        ...(newDescription ? { description: newDescription } : {}),
+        ...(newMaxValue ? { max_value: parseFloat(newMaxValue) } : {}),
+        ...(newMinValue ? { min_value: parseFloat(newMinValue) } : {}),
+        name: newName,
+        unit: newUnit,
+      }),
+    onSuccess: () => {
+      setNewName('')
+      setNewUnit('')
+      setNewDescription('')
+      setNewMinValue('')
+      setNewMaxValue('')
+      invalidate()
+    },
+  })
+
+  return (
+    <section class="settings-section">
+      <h2>Custom Metrics</h2>
+      <p class="section-description">
+        Define custom metrics to track any numeric data. Custom metrics appear in the metric picker and can be
+        used in trends and dashboards.
+      </p>
+
+      {(metrics ?? []).length > 0 && (
+        <div class="custom-metrics-list">
+          {(metrics ?? []).map((m) => (
+            <CustomMetricRow key={m.name} metric={m} onDeleted={invalidate} onUpdated={invalidate} />
+          ))}
+        </div>
+      )}
+
+      <div class="custom-metric-add-form">
+        <h3>Add Custom Metric</h3>
+        <div class="custom-metric-add-row">
+          <input
+            type="text"
+            value={newName}
+            onInput={(e) => setNewName((e.target as HTMLInputElement).value)}
+            placeholder="name (snake_case)"
+            class="custom-metric-input"
+          />
+          <input
+            type="text"
+            value={newUnit}
+            onInput={(e) => setNewUnit((e.target as HTMLInputElement).value)}
+            placeholder="unit (e.g. kg, mg, count)"
+            class="custom-metric-input"
+          />
+        </div>
+        <div class="custom-metric-add-row">
+          <input
+            type="text"
+            value={newDescription}
+            onInput={(e) => setNewDescription((e.target as HTMLInputElement).value)}
+            placeholder="Description (optional)"
+            class="custom-metric-input wide"
+          />
+        </div>
+        <div class="custom-metric-add-row">
+          <input
+            type="number"
+            step="any"
+            value={newMinValue}
+            onInput={(e) => setNewMinValue((e.target as HTMLInputElement).value)}
+            placeholder="Min value (optional)"
+            class="custom-metric-input"
+          />
+          <input
+            type="number"
+            step="any"
+            value={newMaxValue}
+            onInput={(e) => setNewMaxValue((e.target as HTMLInputElement).value)}
+            placeholder="Max value (optional)"
+            class="custom-metric-input"
+          />
+        </div>
+        {addMutation.isError && <p class="custom-metric-error">{(addMutation.error as Error).message}</p>}
+        <button
+          type="button"
+          class="connect-button"
+          onClick={() => addMutation.mutate()}
+          disabled={addMutation.isPending || !newName.trim() || !newUnit.trim()}
+        >
+          {addMutation.isPending ? 'Adding...' : 'Add Metric'}
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -31,6 +31,9 @@ export function Header() {
             <a href="/day" class={url == '/day' && 'active'}>
               Day
             </a>
+            <a href="/add" class={url == '/add' && 'active'}>
+              + Add
+            </a>
             <a href="/trends" class={url == '/trends' && 'active'}>
               Trends
             </a>

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { LocationProvider, Route, Router } from 'preact-iso'
 import { Footer } from './components/Footer.jsx'
 import { Header } from './components/Header.jsx'
+import { AddData } from './pages/AddData/index.jsx'
 import { AdminSettings } from './pages/AdminSettings/index.jsx'
 import { Correlations } from './pages/Correlations/index.jsx'
 import { DayView } from './pages/DayView/index.jsx'
@@ -37,6 +38,7 @@ export function App() {
             <Route path="/hr-zones" component={HrZones} />
             <Route path="/timeline" component={Timeline} />
             <Route path="/day" component={DayView} />
+            <Route path="/add" component={AddData} />
             <Route path="/detail/:type/:id" component={EntityDetail} />
             <Route path="/sleep" component={Sleep} />
             <Route path="/correlations" component={Correlations} />

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -1,0 +1,395 @@
+import { exerciseTypeNames, type ExerciseTypeName } from '@aurboda/api-spec'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { useCallback, useState } from 'preact/hooks'
+import { MetricPicker } from '../../components/MetricPicker'
+import { addActivity, addMetric, addTag, fetchUniqueTags, type ActivityType } from '../../state/api'
+
+import './style.css'
+
+type Tab = 'activity' | 'tag' | 'metric'
+
+const nowLocal = () => format(new Date(), "yyyy-MM-dd'T'HH:mm")
+
+const AddActivityForm = () => {
+  const queryClient = useQueryClient()
+  const [activityType, setActivityType] = useState<ActivityType>('exercise')
+  const [exerciseType, setExerciseType] = useState<ExerciseTypeName>('other_workout')
+  const [title, setTitle] = useState('')
+  const [startTime, setStartTime] = useState(nowLocal())
+  const [endTime, setEndTime] = useState(nowLocal())
+  const [notes, setNotes] = useState('')
+  const [success, setSuccess] = useState('')
+  const [error, setError] = useState('')
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      addActivity({
+        activity_type: activityType,
+        end_time: new Date(endTime).toISOString(),
+        ...(activityType === 'exercise' ? { exercise_type: exerciseType } : {}),
+        ...(notes ? { notes } : {}),
+        start_time: new Date(startTime).toISOString(),
+        ...(title ? { title } : {}),
+      }),
+    onError: (err: Error) => {
+      setError(err.message)
+      setSuccess('')
+    },
+    onSuccess: () => {
+      setSuccess('Activity added')
+      setError('')
+      setTitle('')
+      setNotes('')
+      setStartTime(nowLocal())
+      setEndTime(nowLocal())
+      queryClient.invalidateQueries({ queryKey: ['dayview-activities'] })
+    },
+  })
+
+  return (
+    <div class="add-form">
+      {success && <div class="add-success">{success}</div>}
+      {error && <div class="add-error">{error}</div>}
+
+      <div class="form-field">
+        <label>Activity Type</label>
+        <select
+          value={activityType}
+          onChange={(e) => setActivityType((e.target as HTMLSelectElement).value as ActivityType)}
+        >
+          <option value="exercise">Exercise</option>
+          <option value="meditation">Meditation</option>
+          <option value="nap">Nap</option>
+          <option value="sleep">Sleep</option>
+        </select>
+      </div>
+
+      {activityType === 'exercise' && (
+        <div class="form-field">
+          <label>Exercise Type</label>
+          <select
+            value={exerciseType}
+            onChange={(e) => setExerciseType((e.target as HTMLSelectElement).value as ExerciseTypeName)}
+          >
+            {exerciseTypeNames.map((name) => (
+              <option key={name} value={name}>
+                {name.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div class="form-field">
+        <label>Title</label>
+        <input
+          type="text"
+          value={title}
+          onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+          placeholder={activityType === 'exercise' ? 'e.g. Morning run' : 'Optional title'}
+        />
+      </div>
+
+      <div class="form-row">
+        <div class="form-field">
+          <label>Start</label>
+          <input
+            type="datetime-local"
+            value={startTime}
+            onInput={(e) => setStartTime((e.target as HTMLInputElement).value)}
+          />
+        </div>
+        <div class="form-field">
+          <label>End</label>
+          <input
+            type="datetime-local"
+            value={endTime}
+            onInput={(e) => setEndTime((e.target as HTMLInputElement).value)}
+          />
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label>Notes</label>
+        <textarea
+          value={notes}
+          onInput={(e) => setNotes((e.target as HTMLTextAreaElement).value)}
+          placeholder={
+            activityType === 'exercise' ? 'e.g. Bench press: 10x80, 8x85\nSquat: 5x100' : 'Optional notes'
+          }
+          rows={3}
+        />
+        {activityType === 'exercise' && (
+          <span class="form-hint">For workouts: "Exercise: reps x weight" per line</span>
+        )}
+      </div>
+
+      <div class="add-form-actions">
+        <button
+          class="btn-primary"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending || !startTime || !endTime}
+          type="button"
+        >
+          {mutation.isPending ? 'Adding...' : 'Add Activity'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const AddTagForm = () => {
+  const queryClient = useQueryClient()
+  const [tagName, setTagName] = useState('')
+  const [startTime, setStartTime] = useState(nowLocal())
+  const [hasEndTime, setHasEndTime] = useState(false)
+  const [endTime, setEndTime] = useState(nowLocal())
+  const [mergeSpan, setMergeSpan] = useState('')
+  const [success, setSuccess] = useState('')
+  const [error, setError] = useState('')
+
+  const { data: uniqueTags } = useQuery({
+    queryFn: fetchUniqueTags,
+    queryKey: ['uniqueTags'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const filteredTags = (uniqueTags ?? []).filter(
+    (t) => tagName && t.toLowerCase().includes(tagName.toLowerCase()) && t !== tagName,
+  )
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      addTag({
+        ...(hasEndTime ? { end_time: new Date(endTime).toISOString() } : {}),
+        ...(mergeSpan ? { merge_span: parseInt(mergeSpan, 10) } : {}),
+        start_time: new Date(startTime).toISOString(),
+        tag: tagName,
+      }),
+    onError: (err: Error) => {
+      setError(err.message)
+      setSuccess('')
+    },
+    onSuccess: () => {
+      setSuccess(`Tag "${tagName}" added`)
+      setError('')
+      setTagName('')
+      setStartTime(nowLocal())
+      setHasEndTime(false)
+      setMergeSpan('')
+      queryClient.invalidateQueries({ queryKey: ['dayview-tags'] })
+      queryClient.invalidateQueries({ queryKey: ['uniqueTags'] })
+    },
+  })
+
+  return (
+    <div class="add-form">
+      {success && <div class="add-success">{success}</div>}
+      {error && <div class="add-error">{error}</div>}
+
+      <div class="form-field" style={{ position: 'relative' }}>
+        <label>Tag Name</label>
+        <input
+          type="text"
+          value={tagName}
+          onInput={(e) => {
+            setTagName((e.target as HTMLInputElement).value)
+            setShowSuggestions(true)
+          }}
+          onFocus={() => setShowSuggestions(true)}
+          onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+          placeholder="e.g. coffee, gym, meeting"
+        />
+        {showSuggestions && filteredTags.length > 0 && (
+          <ul
+            class="tag-picker-dropdown"
+            style={{ left: 0, position: 'absolute', right: 0, top: '100%', zIndex: 10 }}
+          >
+            {filteredTags.slice(0, 8).map((t) => (
+              <li
+                key={t}
+                class="tag-picker-option"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  setTagName(t)
+                  setShowSuggestions(false)
+                }}
+              >
+                <span class="tag-option-display">{t}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div class="form-field">
+        <label>Start Time</label>
+        <input
+          type="datetime-local"
+          value={startTime}
+          onInput={(e) => setStartTime((e.target as HTMLInputElement).value)}
+        />
+      </div>
+
+      <div class="form-check">
+        <input
+          type="checkbox"
+          id="has-end-time"
+          checked={hasEndTime}
+          onChange={(e) => setHasEndTime((e.target as HTMLInputElement).checked)}
+        />
+        <label for="has-end-time">Has end time (span tag)</label>
+      </div>
+
+      {hasEndTime && (
+        <div class="form-field">
+          <label>End Time</label>
+          <input
+            type="datetime-local"
+            value={endTime}
+            onInput={(e) => setEndTime((e.target as HTMLInputElement).value)}
+          />
+        </div>
+      )}
+
+      <div class="form-field">
+        <label>Merge Span (seconds)</label>
+        <input
+          type="number"
+          value={mergeSpan}
+          onInput={(e) => setMergeSpan((e.target as HTMLInputElement).value)}
+          placeholder="Optional (1-3600)"
+          min="1"
+          max="3600"
+        />
+        <span class="form-hint">If set, extends an existing tag if it ended within this many seconds</span>
+      </div>
+
+      <div class="add-form-actions">
+        <button
+          class="btn-primary"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending || !tagName.trim() || !startTime}
+          type="button"
+        >
+          {mutation.isPending ? 'Adding...' : 'Add Tag'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const AddMetricForm = () => {
+  const [metric, setMetric] = useState('')
+  const [value, setValue] = useState('')
+  const [time, setTime] = useState(nowLocal())
+  const [success, setSuccess] = useState('')
+  const [error, setError] = useState('')
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      addMetric({
+        metric,
+        time: new Date(time).toISOString(),
+        value: parseFloat(value),
+      }),
+    onError: (err: Error) => {
+      setError(err.message)
+      setSuccess('')
+    },
+    onSuccess: () => {
+      setSuccess(`Metric "${metric}" recorded`)
+      setError('')
+      setValue('')
+      setTime(nowLocal())
+    },
+  })
+
+  return (
+    <div class="add-form">
+      {success && <div class="add-success">{success}</div>}
+      {error && <div class="add-error">{error}</div>}
+
+      <div class="form-field">
+        <label>Metric</label>
+        <MetricPicker value={metric} onChange={setMetric} placeholder="Select a metric..." />
+      </div>
+
+      <div class="form-row">
+        <div class="form-field">
+          <label>Value</label>
+          <input
+            type="number"
+            step="any"
+            value={value}
+            onInput={(e) => setValue((e.target as HTMLInputElement).value)}
+            placeholder="e.g. 72.5"
+          />
+        </div>
+        <div class="form-field">
+          <label>Time</label>
+          <input
+            type="datetime-local"
+            value={time}
+            onInput={(e) => setTime((e.target as HTMLInputElement).value)}
+          />
+        </div>
+      </div>
+
+      <div class="add-form-actions">
+        <button
+          class="btn-primary"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending || !metric || !value}
+          type="button"
+        >
+          {mutation.isPending ? 'Adding...' : 'Add Metric'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export const AddData = () => {
+  const [activeTab, setActiveTab] = useState<Tab>('activity')
+
+  const handleTabClick = useCallback((tab: Tab) => {
+    setActiveTab(tab)
+  }, [])
+
+  return (
+    <div class="add-data-page">
+      <h1>Add Data</h1>
+
+      <div class="add-data-tabs">
+        <button
+          class={`add-data-tab ${activeTab === 'activity' ? 'active' : ''}`}
+          onClick={() => handleTabClick('activity')}
+          type="button"
+        >
+          Activity
+        </button>
+        <button
+          class={`add-data-tab ${activeTab === 'tag' ? 'active' : ''}`}
+          onClick={() => handleTabClick('tag')}
+          type="button"
+        >
+          Tag
+        </button>
+        <button
+          class={`add-data-tab ${activeTab === 'metric' ? 'active' : ''}`}
+          onClick={() => handleTabClick('metric')}
+          type="button"
+        >
+          Metric
+        </button>
+      </div>
+
+      {activeTab === 'activity' && <AddActivityForm />}
+      {activeTab === 'tag' && <AddTagForm />}
+      {activeTab === 'metric' && <AddMetricForm />}
+    </div>
+  )
+}

--- a/apps/web/src/pages/AddData/style.css
+++ b/apps/web/src/pages/AddData/style.css
@@ -1,0 +1,221 @@
+.add-data-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.add-data-page h1 {
+  font-size: 1.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.add-data-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.add-data-tab {
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  color: #6b7280;
+  transition: all 0.15s ease;
+}
+
+.add-data-tab:hover {
+  color: #374151;
+}
+
+.add-data-tab.active {
+  color: #673ab8;
+  border-bottom-color: #673ab8;
+}
+
+.add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.add-form .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.add-form .form-field label {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.add-form .form-field input,
+.add-form .form-field select,
+.add-form .form-field textarea {
+  padding: 0.5rem;
+  font-size: 0.95rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+}
+
+.add-form .form-field input:focus,
+.add-form .form-field select:focus,
+.add-form .form-field textarea:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.add-form .form-field textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.add-form .form-row {
+  display: flex;
+  gap: 1rem;
+}
+
+.add-form .form-row .form-field {
+  flex: 1;
+}
+
+.add-form-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.add-form-actions .btn-primary {
+  padding: 0.5rem 1.5rem;
+  font-size: 0.9rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.add-form-actions .btn-primary:hover:not(:disabled) {
+  background: #5e35b1;
+}
+
+.add-form-actions .btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.add-form .form-hint {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  margin-top: -0.125rem;
+}
+
+.add-form .form-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.add-form .form-check input[type="checkbox"] {
+  width: auto;
+}
+
+.add-form .form-check label {
+  font-weight: 400;
+}
+
+.add-success {
+  padding: 0.75rem 1rem;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  color: #166534;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.add-error {
+  padding: 0.75rem 1rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  color: #991b1b;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .add-data-tabs {
+    border-color: #374151;
+  }
+
+  .add-data-tab {
+    color: #9ca3af;
+  }
+
+  .add-data-tab:hover {
+    color: #d1d5db;
+  }
+
+  .add-data-tab.active {
+    color: #a78bfa;
+    border-bottom-color: #a78bfa;
+  }
+
+  .add-form .form-field label {
+    color: #d1d5db;
+  }
+
+  .add-form .form-field input,
+  .add-form .form-field select,
+  .add-form .form-field textarea {
+    border-color: #4b5563;
+  }
+
+  .add-form .form-field input:focus,
+  .add-form .form-field select:focus,
+  .add-form .form-field textarea:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .add-form .form-hint {
+    color: #6b7280;
+  }
+
+  .add-success {
+    background: #052e16;
+    border-color: #166534;
+    color: #86efac;
+  }
+
+  .add-error {
+    background: #450a0a;
+    border-color: #7f1d1d;
+    color: #fca5a5;
+  }
+}
+
+@media (max-width: 639px) {
+  .add-data-page {
+    padding: 1rem;
+  }
+
+  .add-form .form-row {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -9,6 +9,7 @@ export interface ActivityDraft {
   start_time: string // yyyy-MM-ddTHH:mm for datetime-local
   end_time: string
   notes: string
+  exercise_type?: string
 }
 
 interface EditableActivityFieldsProps {

--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -1,6 +1,7 @@
 /**
  * Exercise-specific detail view with HR chart and HR zone bar.
  */
+import { exerciseTypeNames } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 import { Activity, fetchMetricTimeSeries } from '../../state/api'
 import { ActivityChart } from './ActivityChart'
@@ -46,6 +47,8 @@ const HrZoneBar = ({ zones }: { zones: Record<number, number> }) => {
     </div>
   )
 }
+
+const formatExerciseTypeName = (name: string): string => name.replace(/_/g, ' ')
 
 export const ExerciseDetail = ({
   activity,
@@ -93,6 +96,39 @@ export const ExerciseDetail = ({
           draft={draft}
           onDraftChange={onDraftChange}
         />
+
+        {isEditing && (
+          <div class="entity-fields" style={{ marginTop: '0.5rem' }}>
+            <div class="field-row">
+              <span class="field-label">Exercise Type</span>
+              <span class="field-value">
+                <select
+                  class="edit-datetime-input"
+                  value={draft.exercise_type ?? exerciseType ?? ''}
+                  onChange={(e) =>
+                    onDraftChange({ ...draft, exercise_type: (e.target as HTMLSelectElement).value })
+                  }
+                >
+                  <option value="">-- Select --</option>
+                  {exerciseTypeNames.map((name) => (
+                    <option key={name} value={name}>
+                      {formatExerciseTypeName(name)}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </div>
+          </div>
+        )}
+
+        {!isEditing && exerciseType && (
+          <div class="entity-fields">
+            <div class="field-row">
+              <span class="field-label">Exercise Type</span>
+              <span class="field-value">{formatExerciseTypeName(exerciseType)}</span>
+            </div>
+          </div>
+        )}
 
         {!isEditing && totalCalories !== undefined && (
           <div class="entity-fields">

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -12,6 +12,7 @@ import { useRoute } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 import {
   Activity,
+  type ExerciseTypeName,
   fetchActivityById,
   fetchTagById,
   restoreActivity,
@@ -304,8 +305,12 @@ const makeDraft = (activity: Activity): ActivityDraft => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseTypeName as
+    | string
+    | undefined
   return {
     end_time: formatDateTimeLocal(displayEnd),
+    exercise_type: exerciseType,
     notes: activity.notes ?? '',
     start_time: formatDateTimeLocal(displayStart),
     title: activity.title ?? '',
@@ -371,13 +376,21 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
   const saveMutation = useMutation({
     mutationFn: () => {
       if (!activity) return Promise.resolve()
-      const body: Record<string, string> = {}
+      const body: {
+        start_time?: string
+        end_time?: string
+        title?: string
+        notes?: string
+        exercise_type?: ExerciseTypeName
+      } = {}
       const originalDraft = makeDraft(activity)
       if (draft.title !== originalDraft.title) body.title = draft.title
       if (draft.start_time !== originalDraft.start_time)
         body.start_time = new Date(draft.start_time).toISOString()
       if (draft.end_time !== originalDraft.end_time) body.end_time = new Date(draft.end_time).toISOString()
       if (draft.notes !== originalDraft.notes) body.notes = draft.notes
+      if (draft.exercise_type !== originalDraft.exercise_type && draft.exercise_type)
+        body.exercise_type = draft.exercise_type as ExerciseTypeName
       if (Object.keys(body).length === 0) return Promise.resolve()
       return updateActivity(rawEntityId, body)
     },

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,6 +1,7 @@
 import type { CalendarConfig } from '@aurboda/api-spec'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
+import { CustomMetricsSettings } from '../../components/CustomMetricsSettings'
 import { GoalsSettings } from '../../components/GoalsSettings'
 import { LastFmTagRulesSettings } from '../../components/LastFmTagRulesSettings'
 import { TagMappingsSettings } from '../../components/TagMappingsSettings'
@@ -503,6 +504,8 @@ export function Settings() {
           <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
         )}
       </section>
+
+      <CustomMetricsSettings />
 
       <LastFmTagRulesSettings />
 

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -279,9 +279,135 @@
   background: #f5f5f5;
 }
 
+/* Custom metrics */
+.custom-metrics-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.custom-metric-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.custom-metric-item.editing {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.custom-metric-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.custom-metric-name {
+  font-weight: 600;
+  font-family: monospace;
+  font-size: 0.9rem;
+}
+
+.custom-metric-unit {
+  font-size: 0.85rem;
+  color: #6b7280;
+  padding: 0.125rem 0.5rem;
+  background: #f3f4f6;
+  border-radius: 4px;
+}
+
+.custom-metric-desc {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.custom-metric-range {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.custom-metric-actions {
+  display: flex;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.custom-metric-edit-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.custom-metric-input {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  min-width: 0;
+  flex: 1;
+}
+
+.custom-metric-input.wide {
+  flex: 2;
+}
+
+.custom-metric-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.custom-metric-add-form {
+  margin-top: 0.75rem;
+}
+
+.custom-metric-add-form h3 {
+  font-size: 0.95rem;
+  margin: 0 0 0.5rem;
+}
+
+.custom-metric-add-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.custom-metric-error {
+  color: #ef4444;
+  font-size: 0.85rem;
+  margin: 0.25rem 0;
+}
+
 @media (prefers-color-scheme: dark) {
   .settings-section {
     border-bottom-color: #444;
+  }
+
+  .custom-metric-item {
+    border-color: #444;
+  }
+
+  .custom-metric-unit {
+    background: #374151;
+    color: #9ca3af;
+  }
+
+  .custom-metric-input {
+    border-color: #4b5563;
+  }
+
+  .custom-metric-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
   }
 
   .section-description,

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -9,11 +9,13 @@ import type {
   ActivityImpactType,
   AddActivityBody,
   AddActivityResponse,
+  AddCustomMetricBody,
   AddLastFmTagRuleBody,
   AddLastFmTagRuleResponse,
   AddMetricBody,
   AddNamedLocationBody,
   AddNamedLocationResponse,
+  AddTagBody,
   Activity as ApiActivity,
   DetectedLocation as ApiDetectedLocation,
   PlaceVisit as ApiPlaceVisit,
@@ -70,6 +72,8 @@ import type {
   TrendResult,
   TrendSourceType,
   UniqueTagsResponse,
+  UpdateActivityBody,
+  UpdateCustomMetricBody,
   UpdateSettingsInput,
   UserSettingsResponse,
 } from '@aurboda/api-spec'
@@ -819,16 +823,7 @@ export const softDeleteActivity = async (id: string): Promise<void> => {
   })
 }
 
-export const updateActivity = async (
-  id: string,
-  body: {
-    start_time?: string
-    end_time?: string
-    title?: string
-    notes?: string
-    exercise_type?: ExerciseTypeName
-  },
-): Promise<void> => {
+export const updateActivity = async (id: string, body: UpdateActivityBody): Promise<void> => {
   const { token } = auth.value
   await axios.patch(`${API_URL}/activities/${id}`, body, {
     headers: { Authorization: `Bearer ${token}` },
@@ -981,12 +976,7 @@ export const addActivity = async (body: AddActivityBody): Promise<AddActivityRes
   return response.data
 }
 
-export const addTag = async (body: {
-  tag: string
-  start_time: string
-  end_time?: string
-  merge_span?: number
-}): Promise<void> => {
+export const addTag = async (body: AddTagBody): Promise<void> => {
   const { token } = auth.value
   await axios.post(`${API_URL}/tags`, body, {
     headers: { Authorization: `Bearer ${token}` },
@@ -1004,13 +994,7 @@ export const addMetric = async (body: AddMetricBody): Promise<void> => {
 // Custom Metrics Management
 // ============================================================================
 
-export const addCustomMetric = async (body: {
-  name: string
-  unit: string
-  description?: string
-  min_value?: number
-  max_value?: number
-}): Promise<CustomMetricDefinition> => {
+export const addCustomMetric = async (body: AddCustomMetricBody): Promise<CustomMetricDefinition> => {
   const { token } = auth.value
   const response = await axios.post<{ success: boolean; data: CustomMetricDefinition }>(
     `${API_URL}/metrics/custom`,
@@ -1022,7 +1006,7 @@ export const addCustomMetric = async (body: {
 
 export const updateCustomMetric = async (
   name: string,
-  body: { description?: string; unit?: string; min_value?: number | null; max_value?: number | null },
+  body: UpdateCustomMetricBody,
 ): Promise<CustomMetricDefinition> => {
   const { token } = auth.value
   const response = await axios.patch<{ success: boolean; data: CustomMetricDefinition }>(

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -7,8 +7,11 @@ import type {
   ActivityImpactQuery,
   ActivityImpactResponse,
   ActivityImpactType,
+  AddActivityBody,
+  AddActivityResponse,
   AddLastFmTagRuleBody,
   AddLastFmTagRuleResponse,
+  AddMetricBody,
   AddNamedLocationBody,
   AddNamedLocationResponse,
   Activity as ApiActivity,
@@ -23,6 +26,7 @@ import type {
   CustomMetricsListResponse,
   DashboardConfig,
   DashboardResponse,
+  ExerciseTypeName,
   Goal,
   GoalProgress,
   GoalsProgressResponse,
@@ -134,6 +138,7 @@ export type {
   BaselineData,
   CustomMetricDefinition,
   DashboardConfig,
+  ExerciseTypeName,
   Goal,
   GoalProgress,
   HrvActivitiesData,
@@ -816,7 +821,13 @@ export const softDeleteActivity = async (id: string): Promise<void> => {
 
 export const updateActivity = async (
   id: string,
-  body: { start_time?: string; end_time?: string; title?: string; notes?: string },
+  body: {
+    start_time?: string
+    end_time?: string
+    title?: string
+    notes?: string
+    exercise_type?: ExerciseTypeName
+  },
 ): Promise<void> => {
   const { token } = auth.value
   await axios.patch(`${API_URL}/activities/${id}`, body, {
@@ -954,6 +965,77 @@ export const updateNote = async (id: string, content: string): Promise<NoteData>
 export const deleteNote = async (id: string): Promise<void> => {
   const { token } = auth.value
   await axios.delete(`${API_URL}/notes/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+// ============================================================================
+// Add Data (Activity, Tag, Metric)
+// ============================================================================
+
+export const addActivity = async (body: AddActivityBody): Promise<AddActivityResponse> => {
+  const { token } = auth.value
+  const response = await axios.post<AddActivityResponse>(`${API_URL}/activities`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return response.data
+}
+
+export const addTag = async (body: {
+  tag: string
+  start_time: string
+  end_time?: string
+  merge_span?: number
+}): Promise<void> => {
+  const { token } = auth.value
+  await axios.post(`${API_URL}/tags`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export const addMetric = async (body: AddMetricBody): Promise<void> => {
+  const { token } = auth.value
+  await axios.post(`${API_URL}/metrics`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+// ============================================================================
+// Custom Metrics Management
+// ============================================================================
+
+export const addCustomMetric = async (body: {
+  name: string
+  unit: string
+  description?: string
+  min_value?: number
+  max_value?: number
+}): Promise<CustomMetricDefinition> => {
+  const { token } = auth.value
+  const response = await axios.post<{ success: boolean; data: CustomMetricDefinition }>(
+    `${API_URL}/metrics/custom`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data
+}
+
+export const updateCustomMetric = async (
+  name: string,
+  body: { description?: string; unit?: string; min_value?: number | null; max_value?: number | null },
+): Promise<CustomMetricDefinition> => {
+  const { token } = auth.value
+  const response = await axios.patch<{ success: boolean; data: CustomMetricDefinition }>(
+    `${API_URL}/metrics/custom/${encodeURIComponent(name)}`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data
+}
+
+export const deleteCustomMetric = async (name: string): Promise<void> => {
+  const { token } = auth.value
+  await axios.delete(`${API_URL}/metrics/custom/${encodeURIComponent(name)}`, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -285,6 +285,9 @@ export type DeleteActivityResponse = z.infer<typeof deleteActivityResponseSchema
 export const updateActivityBodySchema = z
   .object({
     end_time: iso8601DateTimeSchema.optional().meta({ description: 'New end time of the activity' }),
+    exercise_type: exerciseTypeSchema.optional().meta({
+      description: 'New exercise type name (only for exercise activities)',
+    }),
     notes: z.string().optional().meta({ description: 'New activity notes' }),
     start_time: iso8601DateTimeSchema.optional().meta({ description: 'New start time of the activity' }),
     title: z.string().optional().meta({ description: 'New activity title' }),


### PR DESCRIPTION
## Summary
- **Add Data page** (`/add`): New page with tabbed forms for creating activities, tags, and metrics directly from the web UI
- **Custom Metrics management**: CRUD interface in Settings page for managing custom metric definitions (name, unit, description, min/max)
- **Exercise type editing**: Exercise type is now visible in exercise detail view and editable via a dropdown selector
- **Backend support**: Added `exercise_type` to the update activity API (REST + MCP) with proper validation and data merging

## Test plan
- [ ] Navigate to `/add` and verify all three tabs (Activity, Tag, Metric) work
- [ ] Create an activity with exercise type, verify it appears in timeline
- [ ] Create a tag with autocomplete suggestions, verify it appears
- [ ] Create a metric entry, verify it saves
- [ ] Go to Settings, add/edit/delete a custom metric definition
- [ ] Open an exercise activity detail, verify exercise type is shown
- [ ] Edit an exercise activity, change exercise type via dropdown, save
- [ ] Verify dark mode styling on all new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)