### PR TITLE
Fix DayView Last.fm display and enable refetch on focus

### DIFF
--- a/apps/web/src/pages/DayView/findOverlappingScrobbles.test.ts
+++ b/apps/web/src/pages/DayView/findOverlappingScrobbles.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'vitest'
+import type { Scrobble } from '../../state/api'
+import { findOverlappingScrobbles } from './findOverlappingScrobbles'
+
+describe('findOverlappingScrobbles', () => {
+  test('returns empty array when no scrobbles', () => {
+    expect(
+      findOverlappingScrobbles([], new Date('2024-06-15T10:00:00Z'), new Date('2024-06-15T11:00:00Z')),
+    ).toEqual([])
+  })
+
+  test('returns artist – track for overlapping scrobble', () => {
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'Kid A',
+        artist: 'Radiohead',
+        recorded_at: new Date('2024-06-15T10:30:00Z'),
+        track: 'Idioteque',
+      },
+    ]
+
+    const result = findOverlappingScrobbles(
+      scrobbles,
+      new Date('2024-06-15T10:00:00Z'),
+      new Date('2024-06-15T11:00:00Z'),
+    )
+
+    expect(result).toEqual(['Radiohead – Idioteque'])
+  })
+
+  test('excludes scrobbles outside the time range', () => {
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'Album',
+        artist: 'Artist',
+        recorded_at: new Date('2024-06-15T09:00:00Z'),
+        track: 'Early Track',
+      },
+      {
+        album: 'Album',
+        artist: 'Artist',
+        recorded_at: new Date('2024-06-15T12:00:00Z'),
+        track: 'Late Track',
+      },
+    ]
+
+    const result = findOverlappingScrobbles(
+      scrobbles,
+      new Date('2024-06-15T10:00:00Z'),
+      new Date('2024-06-15T11:00:00Z'),
+    )
+
+    expect(result).toEqual([])
+  })
+
+  test('includes scrobble that starts just before range but track duration overlaps', () => {
+    // Track starts at 09:58, duration ~3.5 min, so ends at ~10:01:30 — overlaps with range starting at 10:00
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'Album',
+        artist: 'Artist',
+        recorded_at: new Date('2024-06-15T09:58:00Z'),
+        track: 'Overlap Track',
+      },
+    ]
+
+    const result = findOverlappingScrobbles(
+      scrobbles,
+      new Date('2024-06-15T10:00:00Z'),
+      new Date('2024-06-15T11:00:00Z'),
+    )
+
+    expect(result).toEqual(['Artist – Overlap Track'])
+  })
+
+  test('excludes scrobble whose duration ends before range starts', () => {
+    // Track starts at 09:50, duration ~3.5 min, ends at ~09:53:30 — no overlap with 10:00+
+    const scrobbles: Scrobble[] = [
+      {
+        album: 'Album',
+        artist: 'Artist',
+        recorded_at: new Date('2024-06-15T09:50:00Z'),
+        track: 'No Overlap',
+      },
+    ]
+
+    const result = findOverlappingScrobbles(
+      scrobbles,
+      new Date('2024-06-15T10:00:00Z'),
+      new Date('2024-06-15T11:00:00Z'),
+    )
+
+    expect(result).toEqual([])
+  })
+
+  test('returns multiple overlapping scrobbles', () => {
+    const scrobbles: Scrobble[] = [
+      { album: 'A1', artist: 'Artist A', recorded_at: new Date('2024-06-15T10:10:00Z'), track: 'Track 1' },
+      { album: 'A2', artist: 'Artist B', recorded_at: new Date('2024-06-15T10:20:00Z'), track: 'Track 2' },
+      { album: 'A3', artist: 'Artist C', recorded_at: new Date('2024-06-15T12:00:00Z'), track: 'Track 3' },
+    ]
+
+    const result = findOverlappingScrobbles(
+      scrobbles,
+      new Date('2024-06-15T10:00:00Z'),
+      new Date('2024-06-15T11:00:00Z'),
+    )
+
+    expect(result).toEqual(['Artist A – Track 1', 'Artist B – Track 2'])
+  })
+})

--- a/apps/web/src/pages/DayView/findOverlappingScrobbles.ts
+++ b/apps/web/src/pages/DayView/findOverlappingScrobbles.ts
@@ -1,0 +1,15 @@
+import type { Scrobble } from '../../state/api'
+
+const TRACK_DURATION_MS = 3.5 * 60 * 1000 // ~3.5 minutes
+
+/** Find scrobbles that overlap a given time range, returning "artist – track" strings. */
+export const findOverlappingScrobbles = (scrobbles: Scrobble[], start: Date, end: Date): string[] => {
+  const result: string[] = []
+  for (const s of scrobbles) {
+    const trackEnd = new Date(s.recorded_at.getTime() + TRACK_DURATION_MS)
+    if (s.recorded_at < end && trackEnd > start) {
+      result.push(`${s.artist} – ${s.track}`)
+    }
+  }
+  return result
+}

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -15,10 +15,12 @@ import {
   fetchUserSettings,
   Place,
   ProductivityRecord,
+  Scrobble,
   Tag,
 } from '../../state/api'
 import { packLanes } from '../../utils/lanePacking'
 import { categorizeMusic } from './categorizeMusic'
+import { findOverlappingScrobbles } from './findOverlappingScrobbles'
 import type { ChartItem, Column } from './types'
 
 import './style.css'
@@ -204,7 +206,11 @@ const buildSleepDetails = (a: Activity, end: Date, ouraByDate: OuraSleepByDate):
 }
 
 // Categorization per column
-const categorizeSleepRest = (activities: Activity[], tags: Tag[], ouraByDate: OuraSleepByDate): ChartItem[] =>
+const categorizeSleepRest = (
+  activities: Activity[],
+  scrobbles: Scrobble[],
+  ouraByDate: OuraSleepByDate,
+): ChartItem[] =>
   activities
     .filter(
       (a) => a.activity_type === 'sleep' || a.activity_type === 'nap' || a.activity_type === 'meditation',
@@ -223,15 +229,9 @@ const categorizeSleepRest = (activities: Activity[], tags: Tag[], ouraByDate: Ou
 
       if (a.notes) details.push(a.notes)
 
-      // For meditation, show overlapping last.fm tags
+      // For meditation, show overlapping scrobbles (artist – track)
       if (a.activity_type === 'meditation') {
-        const music = tags
-          .filter((t) => t.source === 'lastfm' || t.source === 'lastfm-auto')
-          .filter((t) => {
-            const tagEnd = t.end_time ?? new Date(t.start_time.getTime() + 4 * 60000)
-            return t.start_time < end && tagEnd > a.start_time
-          })
-          .map((t) => t.tag)
+        const music = findOverlappingScrobbles(scrobbles, a.start_time, end)
         if (music.length > 0) details.push(`♪ ${music.slice(0, 3).join(', ')}`)
       }
 
@@ -310,7 +310,7 @@ const categorizeLocations = (places: Place[], uniquePlaceNames: string[]): Chart
 
 const categorizeTags = (tags: Tag[]): ChartItem[] =>
   tags
-    .filter((t) => t.source !== 'lastfm' && t.source !== 'lastfm-auto')
+    .filter((t) => t.source !== 'lastfm')
     .map((t) => {
       const isPoint = !t.end_time
       const end = t.end_time ?? new Date(t.start_time.getTime() + 15 * 60000)
@@ -353,19 +353,6 @@ const categorizeProductivity = (productivity: ProductivityRecord[]): ChartItem[]
       title: p.activity,
     },
   }))
-
-// Find overlapping lastfm tags for a given time range
-const findOverlappingMusic = (tags: Tag[], start: Date, end: Date): string[] => {
-  const music: string[] = []
-  for (const t of tags) {
-    if (t.source !== 'lastfm' && t.source !== 'lastfm-auto') continue
-    const tagEnd = t.end_time ?? new Date(t.start_time.getTime() + 4 * 60000)
-    if (t.start_time < end && tagEnd > start) {
-      music.push(t.tag)
-    }
-  }
-  return music
-}
 
 // Build HR zone bar HTML for exercise tooltips
 const buildHrZoneBarHtml = (zones: Record<number, number>): string => {
@@ -421,28 +408,28 @@ export const DayView = () => {
     placeholderData: keepPreviousData,
     queryFn: () => fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['dayview-activities', fromDate.value, toDate.value],
-    staleTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 
   const placesQuery = useQuery({
     placeholderData: keepPreviousData,
     queryFn: () => fetchPlaces(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['dayview-places', fromDate.value, toDate.value],
-    staleTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 
   const tagsQuery = useQuery({
     placeholderData: keepPreviousData,
     queryFn: () => fetchTags(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['dayview-tags', fromDate.value, toDate.value],
-    staleTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 
   const productivityQuery = useQuery({
     placeholderData: keepPreviousData,
     queryFn: () => fetchProductivity(fetchStart, fetchEnd),
     queryKey: ['dayview-productivity', fromDate.value, toDate.value],
-    staleTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 
   const settingsQuery = useQuery({
@@ -461,7 +448,7 @@ export const DayView = () => {
         '1d',
       ),
     queryKey: ['dayview-oura-sleep', fromDate.value, toDate.value],
-    staleTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 
   const hasLastFm = Boolean(settingsQuery.data?.lastfm_username)
@@ -471,7 +458,7 @@ export const DayView = () => {
     placeholderData: keepPreviousData,
     queryFn: () => fetchScrobbles(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['dayview-scrobbles', fromDate.value, toDate.value],
-    staleTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
   })
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -581,7 +568,7 @@ export const DayView = () => {
 
   const uniquePlaceNames = [...new Set(places.map((p) => p.region))].filter(Boolean).sort()
   const chartItems = [
-    ...categorizeSleepRest(activities, tags, ouraByDate),
+    ...categorizeSleepRest(activities, scrobbles, ouraByDate),
     ...categorizeExercise(activities),
     ...categorizeLocations(places, uniquePlaceNames),
     ...categorizeTags(tags),
@@ -653,7 +640,7 @@ export const DayView = () => {
 
     const showTooltip = (event: MouseEvent, item: ChartItem) => {
       if (!tooltipRef.current || !containerRef.current) return
-      const music = findOverlappingMusic(tags, item.start, item.end)
+      const music = findOverlappingScrobbles(scrobbles, item.start, item.end)
       const tip = tooltipRef.current
       const containerRect = containerRef.current.getBoundingClientRect()
 
@@ -831,7 +818,7 @@ export const DayView = () => {
     effectiveViewStart,
     handleResetToToday,
     handleZoom,
-    tags,
+    scrobbles,
   ])
 
   // Re-render on data change and resize

--- a/apps/web/src/state/queryClient.ts
+++ b/apps/web/src/state/queryClient.ts
@@ -5,7 +5,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       gcTime: 30 * 60 * 1000, // How long unused data stays cached
-      refetchOnWindowFocus: false, // Disabled to prevent unnecessary reloads on focus
+      refetchOnWindowFocus: true, // Refetch stale data when window regains focus
       retry: 2, // Number of retries for failed queries
       staleTime: 5 * 60 * 1000, // Default cache validity: 5 minutes
     },


### PR DESCRIPTION
## Summary

- **Show lastfm-auto tags in Tags/Events lane**: Removed the filter that excluded `lastfm-auto` source tags (like "Vocal training") from the Tags/Events column. They now render with the music-pink color already defined in `tagSourceColors`.
- **Tooltip music overlay shows actual tracks**: Replaced `findOverlappingMusic` (which showed auto-tag names) with `findOverlappingScrobbles` (shows "Artist – Track" from actual scrobble data). Affects both general tooltip overlays and meditation-specific tooltips.
- **Enable refetch on window focus**: Changed `refetchOnWindowFocus` from `false` to `true` globally, so stale data refreshes when the tab regains focus. Lowered DayView query staleTime from 10 to 5 minutes to match the global default.

## Changes

| File | Change |
|------|--------|
| `DayView/findOverlappingScrobbles.ts` | New extracted module: finds scrobbles overlapping a time range, returns "artist – track" strings |
| `DayView/findOverlappingScrobbles.test.ts` | Unit tests for the new module (6 tests) |
| `DayView/index.tsx` | Use `findOverlappingScrobbles` in tooltips and meditation details; show `lastfm-auto` tags in Tags/Events; lower staleTime to 5 min |
| `state/queryClient.ts` | Enable `refetchOnWindowFocus: true` |