### PR TITLE
DayView: rename Screen Time, add toggles, fix OS-level focus refetch

### DIFF
--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -36,7 +36,7 @@ const getDefaultViewStart = () => startOfDay(new Date())
 const getDefaultViewEnd = () => endOfDay(new Date())
 
 // Column definitions
-const BASE_COLUMNS: Column[] = ['Sleep / Rest', 'Exercise', 'Location', 'Tags / Events', 'Productivity']
+const BASE_COLUMNS: Column[] = ['Sleep / Rest', 'Exercise', 'Location', 'Tags / Events', 'Screen Time']
 const MUSIC_COLOR = '#ec4899'
 
 // Colors
@@ -87,14 +87,25 @@ const placeColorPalette = [
 
 const NOW_COLOR = '#ef4444'
 
-type LegendCategory = 'sleep' | 'nap' | 'meditation' | 'exercise' | 'calendar' | 'tags' | 'music'
+type LegendCategory =
+  | 'sleep'
+  | 'nap'
+  | 'meditation'
+  | 'exercise'
+  | 'calendar'
+  | 'tags'
+  | 'music'
+  | 'location'
+  | 'screentime'
 
 const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = {
   calendar: (item) => item.column === 'Tags / Events' && item.color === tagSourceColors.calendar,
   exercise: (item) => item.column === 'Exercise',
+  location: (item) => item.column === 'Location',
   meditation: (item) => item.column === 'Sleep / Rest' && item.label === 'Meditation',
   music: (item) => item.column === 'Music',
   nap: (item) => item.column === 'Sleep / Rest' && item.label === 'Nap',
+  screentime: (item) => item.column === 'Screen Time',
   sleep: (item) => item.column === 'Sleep / Rest' && item.label === 'Sleep',
   tags: (item) => item.column === 'Tags / Events' && item.color !== tagSourceColors.calendar,
 }
@@ -336,7 +347,7 @@ const categorizeTags = (tags: Tag[]): ChartItem[] =>
 const categorizeProductivity = (productivity: ProductivityRecord[]): ChartItem[] =>
   productivity.map((p) => ({
     color: getProductivityColor(p.productivity),
-    column: 'Productivity' as Column,
+    column: 'Screen Time' as Column,
     end: p.end_time,
     entity_id: p.id,
     entity_type: 'productivity' as const,
@@ -576,10 +587,8 @@ export const DayView = () => {
     ...musicItems,
   ].filter((item) => !isItemHidden(item))
 
-  // Only show columns that have visible items (plus always keep Productivity/Location since they don't toggle)
-  const columns = allColumns.filter(
-    (col) => col === 'Productivity' || col === 'Location' || chartItems.some((item) => item.column === col),
-  )
+  // Only show columns that have visible items
+  const columns = allColumns.filter((col) => chartItems.some((item) => item.column === col))
 
   // Group by column and pack lanes
   const columnData = columns.map((col) => {
@@ -876,8 +885,10 @@ export const DayView = () => {
             { cat: 'nap' as LegendCategory, color: activityColors.nap!, label: 'Nap' },
             { cat: 'meditation' as LegendCategory, color: activityColors.meditation!, label: 'Meditation' },
             { cat: 'exercise' as LegendCategory, color: hrZoneColors[2]!, label: 'Exercise' },
+            { cat: 'location' as LegendCategory, color: placeColorPalette[0]!, label: 'Location' },
             { cat: 'calendar' as LegendCategory, color: tagSourceColors.calendar!, label: 'Calendar' },
             { cat: 'tags' as LegendCategory, color: TAG_COLOR, label: 'Tags' },
+            { cat: 'screentime' as LegendCategory, color: productivityColors[1]!, label: 'Screen Time' },
             ...(showMusicColumn ?
               [{ cat: 'music' as LegendCategory, color: MUSIC_COLOR, label: 'Music' }]
             : []),

--- a/apps/web/src/pages/DayView/types.ts
+++ b/apps/web/src/pages/DayView/types.ts
@@ -1,4 +1,4 @@
-export type Column = 'Sleep / Rest' | 'Exercise' | 'Location' | 'Tags / Events' | 'Productivity' | 'Music'
+export type Column = 'Sleep / Rest' | 'Exercise' | 'Location' | 'Tags / Events' | 'Screen Time' | 'Music'
 
 export interface TooltipContent {
   title: string

--- a/apps/web/src/pages/Help/index.tsx
+++ b/apps/web/src/pages/Help/index.tsx
@@ -165,13 +165,13 @@ export function Help() {
 
   return (
     <div class="help-page">
-      <header class="page-header">
+      <div class="page-header">
         <h1>Getting Started</h1>
         <p class="page-subtitle">
           Connect your data sources to start tracking. Below you can see which sources are active and how to
           set up any that are missing.
         </p>
-      </header>
+      </div>
 
       {isLoading && <div class="loading">Checking your data sources...</div>}
 
@@ -261,27 +261,6 @@ export function Help() {
           />
 
           <DataSourceCard
-            name="RescueTime (Productivity)"
-            status={{
-              description:
-                hasProductivity ? 'Productivity data detected in the last 7 days.'
-                : isRescueTimeConfigured ? 'RescueTime configured but no recent data synced.'
-                : 'RescueTime not configured.',
-              hasData: hasProductivity,
-              isConfigured: isRescueTimeConfigured,
-            }}
-            setupSteps={[
-              'Sign up for RescueTime and install their app on your devices.',
-              'Get your API key from RescueTime API settings.',
-              'Enter the API key in Settings > Data Sources.',
-            ]}
-            links={[
-              { text: 'Go to Settings', url: '/settings' },
-              { text: 'RescueTime API Settings', url: 'https://www.rescuetime.com/anapi/manage' },
-            ]}
-          />
-
-          <DataSourceCard
             name="Location Tracking (OwnTracks)"
             status={{
               description:
@@ -302,6 +281,58 @@ export function Help() {
                 url: 'https://github.com/fiddur/aurboda/blob/develop/docs/owntracks.md',
               },
               { text: 'OwnTracks Website', url: 'https://owntracks.org/' },
+            ]}
+          />
+        </div>
+      </section>
+
+      <section class="data-sources">
+        <h2>Screen Time</h2>
+        <p class="section-description">
+          Track which apps and websites you use. Data from both sources is combined into the Screen Time
+          column in the Day view.
+        </p>
+
+        <div class="sources-grid">
+          <DataSourceCard
+            name="RescueTime"
+            status={{
+              description:
+                isRescueTimeConfigured && hasProductivity ? 'Screen time data detected in the last 7 days.'
+                : isRescueTimeConfigured ? 'RescueTime configured but no recent data synced.'
+                : 'RescueTime not configured.',
+              hasData: isRescueTimeConfigured && hasProductivity,
+              isConfigured: isRescueTimeConfigured,
+            }}
+            setupSteps={[
+              'Sign up for RescueTime and install their app on your devices.',
+              'Get your API key from RescueTime API settings.',
+              'Enter the API key in Settings > Data Sources.',
+            ]}
+            links={[
+              { text: 'Go to Settings', url: '/settings' },
+              { text: 'RescueTime API Settings', url: 'https://www.rescuetime.com/anapi/manage' },
+            ]}
+          />
+
+          <DataSourceCard
+            name="ActivityWatch"
+            status={{
+              description:
+                hasProductivity ?
+                  'Screen time data detected in the last 7 days.'
+                : 'ActivityWatch not configured.',
+              hasData: hasProductivity,
+            }}
+            setupSteps={[
+              'Install ActivityWatch on your computer (activitywatch.net).',
+              'Install the aw-push-agent to push data to Aurboda.',
+              'Generate a push agent token in Settings > Data Sources.',
+              'Configure the push agent with your Aurboda URL and token.',
+            ]}
+            links={[
+              { text: 'Go to Settings', url: '/settings' },
+              { text: 'ActivityWatch Website', url: 'https://activitywatch.net/' },
             ]}
           />
         </div>

--- a/apps/web/src/pages/Help/style.css
+++ b/apps/web/src/pages/Help/style.css
@@ -63,6 +63,14 @@
   margin-bottom: 3rem;
 }
 
+.help-page .section-description {
+  color: #4b5563;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: -1rem 0 1.5rem 0;
+  max-width: 700px;
+}
+
 .help-page .sources-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
@@ -217,7 +225,8 @@
     color: #f9fafb;
   }
 
-  .help-page .page-subtitle {
+  .help-page .page-subtitle,
+  .help-page .section-description {
     color: #9ca3af;
   }
 

--- a/apps/web/src/state/queryClient.ts
+++ b/apps/web/src/state/queryClient.ts
@@ -1,4 +1,21 @@
-import { QueryClient } from '@tanstack/react-query'
+import { focusManager, QueryClient } from '@tanstack/react-query'
+
+// TanStack Query's default focusManager only listens to `visibilitychange`,
+// which fires when switching browser tabs but NOT when alt-tabbing between
+// applications (e.g. terminal ↔ browser on Linux). Add a `focus` listener
+// so stale queries also refetch when the browser window regains OS-level focus.
+focusManager.setEventListener((handleFocus) => {
+  const onVisibilityChange = () => handleFocus()
+  const onFocus = () => handleFocus()
+
+  window.addEventListener('visibilitychange', onVisibilityChange, false)
+  window.addEventListener('focus', onFocus, false)
+
+  return () => {
+    window.removeEventListener('visibilitychange', onVisibilityChange)
+    window.removeEventListener('focus', onFocus)
+  }
+})
 
 // Create and export a singleton QueryClient instance
 export const queryClient = new QueryClient({


### PR DESCRIPTION
## Summary

- **Rename Productivity → Screen Time**: The column label and internal type now reflect that it's about tracking what apps/sites are active, not "productivity" scoring.
- **Location & Screen Time toggleable**: Added both to the legend toggle system so they can be hidden like all other categories. Removed the always-show override.
- **Fix refetchOnWindowFocus for OS-level focus**: TanStack Query's default `focusManager` only listens to `visibilitychange` (which fires on tab switches within the browser). Alt-tabbing between applications (e.g. terminal ↔ browser on Linux) doesn't trigger it. Added a `focus` event listener so stale data refetches on OS-level window focus too.

## Changes

| File | Change |
|------|--------|
| `DayView/types.ts` | Rename `'Productivity'` → `'Screen Time'` in Column type |
| `DayView/index.tsx` | Rename column references; add `location` and `screentime` legend categories with toggle support; remove always-show override |
| `state/queryClient.ts` | Custom `focusManager.setEventListener` that listens to both `visibilitychange` and `focus` events |