### PR TITLE
Scope codecov to backend only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,8 @@ jobs:
           flags: backend
           fail_ci_if_error: false
 
-      - name: Run web tests with coverage
-        run: pnpm --filter aurboda-web test run --coverage
-
-      - name: Upload web coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: apps/web/coverage/coverage-final.json
-          flags: web
-          fail_ci_if_error: false
+      - name: Run web tests
+        run: pnpm --filter aurboda-web test run
 
       - name: Build web
         run: pnpm --filter aurboda-web build
@@ -108,16 +100,8 @@ jobs:
           echo "sdk.dir=$ANDROID_HOME" > local.properties
           echo "aurbodaApiToken=${{ secrets.AURBODA_API_TOKEN }}" >> local.properties
 
-      - name: Run unit tests with coverage
-        run: ./gradlew testDebugUnitTest jacocoTestReport
-
-      - name: Upload Android coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: apps/android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
-          flags: android
-          fail_ci_if_error: false
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
 
       - name: Build debug APK
         run: ./gradlew assembleDebug

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -15,44 +15,6 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22"
-    id("jacoco")
-}
-
-jacoco {
-    toolVersion = "0.8.12"
-}
-
-tasks.register<JacocoReport>("jacocoTestReport") {
-    dependsOn("testDebugUnitTest")
-
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
-
-    val fileFilter = listOf(
-        "**/R.class",
-        "**/R$*.class",
-        "**/BuildConfig.*",
-        "**/Manifest*.*",
-        "**/*Test*.*",
-        "android/**/*.*",
-        "**/ComposableSingletons*.*",
-        "**/*\$Lambda$*.*",
-        "**/*\$inlined$*.*"
-    )
-
-    val debugTree = fileTree("${layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
-        exclude(fileFilter)
-    }
-
-    val mainSrc = "${project.projectDir}/src/main/java"
-
-    sourceDirectories.setFrom(files(mainSrc))
-    classDirectories.setFrom(files(debugTree))
-    executionData.setFrom(fileTree(layout.buildDirectory) {
-        include("jacoco/testDebugUnitTest.exec")
-    })
 }
 
 // Function to load properties from local.properties

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,6 @@
     "@preact/preset-vite": "^2.10.2",
     "@types/d3": "^7.4.3",
     "@types/leaflet": "^1.9.21",
-    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.36.0",
     "eslint-config-preact": "^2.0.0",
     "eslint-plugin-prettier": "^5.5.4",

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,13 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        flags:
+          - backend
     patch:
       default:
         target: auto
+        flags:
+          - backend
 
 flag_management:
   default_rules:
@@ -16,14 +20,4 @@ flag_management:
     - name: backend
       paths:
         - apps/backend/
-      carryforward: true
-
-    - name: web
-      paths:
-        - apps/web/
-      carryforward: true
-
-    - name: android
-      paths:
-        - apps/android/
       carryforward: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,9 +199,6 @@ importers:
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21
-      '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^9.36.0
         version: 9.39.2(jiti@2.6.1)


### PR DESCRIPTION
## Summary

- Remove codecov coverage tracking for web and android apps, keeping it focused on backend only
- Remove associated coverage tooling: `@vitest/coverage-v8` from web, JaCoCo plugin from android
- Scope codecov project and patch status checks to the `backend` flag so the check can be made blocking without noise from web/android coverage fluctuations