### PR TITLE
Add comments to AddData forms and show occasional metrics in DayView

### DIFF
--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useCallback, useState } from 'preact/hooks'
 import { MetricPicker } from '../../components/MetricPicker'
-import { addActivity, addMetric, addTag, fetchUniqueTags, type ActivityType } from '../../state/api'
+import { addActivity, addMetric, addNote, addTag, fetchUniqueTags, type ActivityType } from '../../state/api'
 
 import './style.css'
 
@@ -19,19 +19,29 @@ const AddActivityForm = () => {
   const [startTime, setStartTime] = useState(nowLocal())
   const [endTime, setEndTime] = useState(nowLocal())
   const [notes, setNotes] = useState('')
+  const [comment, setComment] = useState('')
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')
 
   const mutation = useMutation({
-    mutationFn: () =>
-      addActivity({
+    mutationFn: async () => {
+      const result = await addActivity({
         activity_type: activityType,
         end_time: new Date(endTime).toISOString(),
         ...(activityType === 'exercise' ? { exercise_type: exerciseType } : {}),
         ...(notes ? { notes } : {}),
         start_time: new Date(startTime).toISOString(),
         ...(title ? { title } : {}),
-      }),
+      })
+      if (comment.trim() && result.data?.id) {
+        try {
+          await addNote('activity', result.data.id, comment.trim())
+        } catch {
+          // Activity was created successfully; comment save failed silently
+        }
+      }
+      return result
+    },
     onError: (err: Error) => {
       setError(err.message)
       setSuccess('')
@@ -41,6 +51,7 @@ const AddActivityForm = () => {
       setError('')
       setTitle('')
       setNotes('')
+      setComment('')
       setStartTime(nowLocal())
       setEndTime(nowLocal())
       queryClient.invalidateQueries({ queryKey: ['dayview-activities'] })
@@ -125,6 +136,16 @@ const AddActivityForm = () => {
         )}
       </div>
 
+      <div class="form-field">
+        <label>Comment</label>
+        <textarea
+          value={comment}
+          onInput={(e) => setComment((e.target as HTMLTextAreaElement).value)}
+          placeholder="Optional comment"
+          rows={2}
+        />
+      </div>
+
       <div class="add-form-actions">
         <button
           class="btn-primary"
@@ -146,6 +167,7 @@ const AddTagForm = () => {
   const [hasEndTime, setHasEndTime] = useState(false)
   const [endTime, setEndTime] = useState(nowLocal())
   const [mergeSpan, setMergeSpan] = useState('')
+  const [comment, setComment] = useState('')
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')
 
@@ -161,13 +183,24 @@ const AddTagForm = () => {
   )
 
   const mutation = useMutation({
-    mutationFn: () =>
-      addTag({
+    mutationFn: async () => {
+      const result = await addTag({
         ...(hasEndTime ? { end_time: new Date(endTime).toISOString() } : {}),
         ...(mergeSpan ? { merge_span: parseInt(mergeSpan, 10) } : {}),
         start_time: new Date(startTime).toISOString(),
         tag: tagName,
-      }),
+      })
+      // Backend returns id at top level (not wrapped in data)
+      const tagId = result.data?.id ?? (result as unknown as { id?: string }).id
+      if (comment.trim() && tagId) {
+        try {
+          await addNote('tag', tagId, comment.trim())
+        } catch {
+          // Tag was created successfully; comment save failed silently
+        }
+      }
+      return result
+    },
     onError: (err: Error) => {
       setError(err.message)
       setSuccess('')
@@ -176,6 +209,7 @@ const AddTagForm = () => {
       setSuccess(`Tag "${tagName}" added`)
       setError('')
       setTagName('')
+      setComment('')
       setStartTime(nowLocal())
       setHasEndTime(false)
       setMergeSpan('')
@@ -267,6 +301,16 @@ const AddTagForm = () => {
         <span class="form-hint">If set, extends an existing tag if it ended within this many seconds</span>
       </div>
 
+      <div class="form-field">
+        <label>Comment</label>
+        <textarea
+          value={comment}
+          onInput={(e) => setComment((e.target as HTMLTextAreaElement).value)}
+          placeholder="Optional comment"
+          rows={2}
+        />
+      </div>
+
       <div class="add-form-actions">
         <button
           class="btn-primary"
@@ -285,16 +329,30 @@ const AddMetricForm = () => {
   const [metric, setMetric] = useState('')
   const [value, setValue] = useState('')
   const [time, setTime] = useState(nowLocal())
+  const [comment, setComment] = useState('')
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')
 
   const mutation = useMutation({
-    mutationFn: () =>
-      addMetric({
+    mutationFn: async () => {
+      const metricTimeISO = new Date(time).toISOString()
+      const result = await addMetric({
         metric,
-        time: new Date(time).toISOString(),
+        time: metricTimeISO,
         value: parseFloat(value),
-      }),
+      })
+      if (comment.trim() && result.success) {
+        // Backend returns stored time; fall back to the submitted time
+        const storedTime = (result as unknown as { time?: string }).time ?? metricTimeISO
+        const entityId = `${storedTime}|${metric}|manual`
+        try {
+          await addNote('metric', entityId, comment.trim())
+        } catch {
+          // Metric was recorded successfully; comment save failed silently
+        }
+      }
+      return result
+    },
     onError: (err: Error) => {
       setError(err.message)
       setSuccess('')
@@ -303,6 +361,7 @@ const AddMetricForm = () => {
       setSuccess(`Metric "${metric}" recorded`)
       setError('')
       setValue('')
+      setComment('')
       setTime(nowLocal())
     },
   })
@@ -336,6 +395,16 @@ const AddMetricForm = () => {
             onInput={(e) => setTime((e.target as HTMLInputElement).value)}
           />
         </div>
+      </div>
+
+      <div class="form-field">
+        <label>Comment</label>
+        <textarea
+          value={comment}
+          onInput={(e) => setComment((e.target as HTMLTextAreaElement).value)}
+          placeholder="Optional comment"
+          rows={2}
+        />
       </div>
 
       <div class="add-form-actions">

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable max-lines -- large visualization component */
+import { metricUnits as builtinMetricUnits } from '@aurboda/api-spec'
 import { signal } from '@preact/signals'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
 import { addDays, endOfDay, format, formatISO, startOfDay, subDays } from 'date-fns'
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   Activity,
   fetchActivities,
   fetchBucketedMetrics,
+  fetchCustomMetrics,
   fetchPlaces,
   fetchProductivity,
   fetchScrobbles,
@@ -56,6 +58,27 @@ const hrZoneColors: Record<number, string> = {
 }
 
 const TAG_COLOR = '#8b5cf6'
+const METRIC_COLOR = '#14b8a6' // teal for metrics
+
+/** Built-in metrics that are measured occasionally (not continuously streamed from a wearable). */
+const OCCASIONAL_BUILTIN_METRICS = [
+  'weight',
+  'body_fat',
+  'bone_mass',
+  'lean_body_mass',
+  'body_water_mass',
+  'height',
+  'blood_glucose',
+  'blood_pressure_systolic',
+  'blood_pressure_diastolic',
+  'body_temperature',
+  'basal_body_temperature',
+  'spo2',
+  'vo2_max',
+]
+
+/** Maximum data points per metric per day to still show in the day view. */
+const OCCASIONAL_METRIC_MAX_COUNT = 10
 
 const tagSourceColors: Record<string, string> = {
   calendar: '#f59e0b',
@@ -94,6 +117,7 @@ type LegendCategory =
   | 'exercise'
   | 'calendar'
   | 'tags'
+  | 'metrics'
   | 'music'
   | 'location'
   | 'screentime'
@@ -103,11 +127,13 @@ const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = 
   exercise: (item) => item.column === 'Exercise',
   location: (item) => item.column === 'Location',
   meditation: (item) => item.column === 'Sleep / Rest' && item.label === 'Meditation',
+  metrics: (item) => item.column === 'Tags / Events' && item.color === METRIC_COLOR,
   music: (item) => item.column === 'Music',
   nap: (item) => item.column === 'Sleep / Rest' && item.label === 'Nap',
   screentime: (item) => item.column === 'Screen Time',
   sleep: (item) => item.column === 'Sleep / Rest' && item.label === 'Sleep',
-  tags: (item) => item.column === 'Tags / Events' && item.color !== tagSourceColors.calendar,
+  tags: (item) =>
+    item.column === 'Tags / Events' && item.color !== tagSourceColors.calendar && item.color !== METRIC_COLOR,
 }
 
 // Helpers
@@ -344,6 +370,74 @@ const categorizeTags = (tags: Tag[]): ChartItem[] =>
       }
     })
 
+/** Map metric name to human-readable display label. */
+const formatMetricLabel = (metric: string): string =>
+  metric.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+
+/**
+ * Categorize bucketed metric data into chart items for the Tags / Events lane.
+ * Only includes metrics with <= OCCASIONAL_METRIC_MAX_COUNT data points per day.
+ */
+interface MetricBucketData {
+  start: string
+  end: string
+  metrics: Record<string, { avg: number; min: number; max: number; count: number }>
+}
+
+const categorizeOccasionalMetrics = (
+  buckets: MetricBucketData[],
+  metricUnits: Record<string, string>,
+): ChartItem[] => {
+  if (!buckets || buckets.length === 0) return []
+
+  // Count total data points per metric across all buckets
+  const metricCounts: Record<string, number> = {}
+  for (const bucket of buckets) {
+    for (const [metric, stats] of Object.entries(bucket.metrics)) {
+      metricCounts[metric] = (metricCounts[metric] ?? 0) + stats.count
+    }
+  }
+
+  // Only include metrics that are truly "occasional"
+  const occasionalMetrics = new Set(
+    Object.entries(metricCounts)
+      .filter(([, count]) => count <= OCCASIONAL_METRIC_MAX_COUNT)
+      .map(([metric]) => metric),
+  )
+
+  if (occasionalMetrics.size === 0) return []
+
+  const items: ChartItem[] = []
+  for (const bucket of buckets) {
+    for (const [metric, stats] of Object.entries(bucket.metrics)) {
+      if (!occasionalMetrics.has(metric)) continue
+
+      const time = new Date(bucket.start)
+      const end = new Date(time.getTime() + 15 * 60000)
+      const unit = metricUnits[metric] ?? ''
+      const displayValue = Number(stats.avg.toFixed(2))
+      const valueStr = `${displayValue}${unit ? ` ${unit}` : ''}`
+      const metricLabel = formatMetricLabel(metric)
+
+      items.push({
+        color: METRIC_COLOR,
+        column: 'Tags / Events' as Column,
+        end,
+        isPoint: true,
+        label: `${metricLabel}: ${valueStr}`,
+        start: time,
+        tooltip: {
+          details: [`Value: ${valueStr}`, 'Metric measurement'],
+          time: formatTime(time),
+          title: metricLabel,
+        },
+      })
+    }
+  }
+
+  return items
+}
+
 const categorizeProductivity = (productivity: ProductivityRecord[]): ChartItem[] =>
   productivity.map((p) => ({
     color: getProductivityColor(p.productivity),
@@ -472,6 +566,38 @@ export const DayView = () => {
     staleTime: 5 * 60 * 1000,
   })
 
+  // Fetch custom metric definitions to know which custom metrics to show
+  const customMetricsQuery = useQuery({
+    queryFn: fetchCustomMetrics,
+    queryKey: ['custom-metrics'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  // Build list of all occasional metric names (built-in + custom)
+  const occasionalMetricNames = useMemo(() => {
+    const customNames = (customMetricsQuery.data ?? []).map((m) => m.name)
+    return [...OCCASIONAL_BUILTIN_METRICS, ...customNames]
+  }, [customMetricsQuery.data])
+
+  // Build metric units map (built-in + custom)
+  const allMetricUnits = useMemo(() => {
+    const units: Record<string, string> = { ...builtinMetricUnits }
+    for (const m of customMetricsQuery.data ?? []) {
+      units[m.name] = m.unit
+    }
+    return units
+  }, [customMetricsQuery.data])
+
+  // Fetch occasional metric data with 5-minute buckets for the day view
+  const occasionalMetricsQuery = useQuery({
+    enabled: occasionalMetricNames.length > 0,
+    placeholderData: keepPreviousData,
+    queryFn: () =>
+      fetchBucketedMetrics(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), occasionalMetricNames, '5m'),
+    queryKey: ['dayview-occasional-metrics', fromDate.value, toDate.value, occasionalMetricNames],
+    staleTime: 5 * 60 * 1000,
+  })
+
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
@@ -575,6 +701,11 @@ export const DayView = () => {
   const musicItems = hasLastFm ? categorizeMusic(scrobbles) : []
   const showMusicColumn = musicItems.length > 0
 
+  const occasionalMetricItems = categorizeOccasionalMetrics(
+    (occasionalMetricsQuery.data?.buckets ?? []) as MetricBucketData[],
+    allMetricUnits,
+  )
+
   const allColumns: Column[] = showMusicColumn ? [...BASE_COLUMNS, 'Music'] : BASE_COLUMNS
 
   const uniquePlaceNames = [...new Set(places.map((p) => p.region))].filter(Boolean).sort()
@@ -584,6 +715,7 @@ export const DayView = () => {
     ...categorizeLocations(places, uniquePlaceNames),
     ...categorizeTags(tags),
     ...categorizeProductivity(productivity),
+    ...occasionalMetricItems,
     ...musicItems,
   ].filter((item) => !isItemHidden(item))
 
@@ -606,7 +738,8 @@ export const DayView = () => {
     placesQuery.isFetching ||
     tagsQuery.isFetching ||
     productivityQuery.isFetching ||
-    scrobblesQuery.isFetching
+    scrobblesQuery.isFetching ||
+    occasionalMetricsQuery.isFetching
 
   // Render SVG chart
   const renderChart = useCallback(() => {
@@ -888,6 +1021,9 @@ export const DayView = () => {
             { cat: 'location' as LegendCategory, color: placeColorPalette[0]!, label: 'Location' },
             { cat: 'calendar' as LegendCategory, color: tagSourceColors.calendar!, label: 'Calendar' },
             { cat: 'tags' as LegendCategory, color: TAG_COLOR, label: 'Tags' },
+            ...(occasionalMetricItems.length > 0 ?
+              [{ cat: 'metrics' as LegendCategory, color: METRIC_COLOR, label: 'Metrics' }]
+            : []),
             { cat: 'screentime' as LegendCategory, color: productivityColors[1]!, label: 'Screen Time' },
             ...(showMusicColumn ?
               [{ cat: 'music' as LegendCategory, color: MUSIC_COLOR, label: 'Music' }]

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -13,9 +13,11 @@ import type {
   AddLastFmTagRuleBody,
   AddLastFmTagRuleResponse,
   AddMetricBody,
+  AddMetricResponse,
   AddNamedLocationBody,
   AddNamedLocationResponse,
   AddTagBody,
+  AddTagResponse,
   Activity as ApiActivity,
   DetectedLocation as ApiDetectedLocation,
   PlaceVisit as ApiPlaceVisit,
@@ -976,18 +978,20 @@ export const addActivity = async (body: AddActivityBody): Promise<AddActivityRes
   return response.data
 }
 
-export const addTag = async (body: AddTagBody): Promise<void> => {
+export const addTag = async (body: AddTagBody): Promise<AddTagResponse> => {
   const { token } = auth.value
-  await axios.post(`${API_URL}/tags`, body, {
+  const response = await axios.post<AddTagResponse>(`${API_URL}/tags`, body, {
     headers: { Authorization: `Bearer ${token}` },
   })
+  return response.data
 }
 
-export const addMetric = async (body: AddMetricBody): Promise<void> => {
+export const addMetric = async (body: AddMetricBody): Promise<AddMetricResponse> => {
   const { token } = auth.value
-  await axios.post(`${API_URL}/metrics`, body, {
+  const response = await axios.post<AddMetricResponse>(`${API_URL}/metrics`, body, {
     headers: { Authorization: `Bearer ${token}` },
   })
+  return response.data
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Add comment fields to AddData page**: All three forms (Activity, Tag, Metric) now include an optional "Comment" textarea. On submission, a note is created via the existing notes API after the primary entity is created. Note creation failures are caught silently to avoid losing the successfully created entity.
- **Show occasional metrics in DayView**: Custom metrics and occasional built-in metrics (weight, body_fat, blood_glucose, etc.) are now displayed as teal diamond point items in the Tags/Events lane. Metrics with >10 data points per day are automatically excluded to avoid cluttering the view with continuous metrics. A "Metrics" toggle is added to the legend for visibility control.
- **API return types**: `addTag` and `addMetric` frontend functions now return their response data (previously void) to support extracting entity IDs for note creation.

### Known caveats

- The `AddTagResponse` schema defines `data.id` but the backend returns `id` at the top level. The frontend handles both formats with a fallback.
- The `AddMetricResponse` schema is minimal (`baseResponseSchema`). The frontend uses the response's `time` field (if present) for the metric entity ID composite key to match what the backend stored.
- Occasional metrics are fetched with 5-minute bucketed queries. For truly occasional metrics this is fine, but it means the displayed time is the bucket start, not the exact measurement time (off by up to 5 minutes).