### PR TITLE
Add 'Add more' toggle to AddData page

### DIFF
--- a/apps/backend/src/oura-sync.test.ts
+++ b/apps/backend/src/oura-sync.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import * as db from './db'
-import { calculateRetryAfter, isRateLimited, processOuraData } from './oura-sync'
+import { calculateRetryAfter, isRateLimited, processOuraData, syncOuraDataType } from './oura-sync'
 
 // Mock the db module
 vi.mock('./db', () => ({
   getSyncState: vi.fn(),
+  getUserSettings: vi.fn(),
   insertActivity: vi.fn(),
   insertRawRecord: vi.fn(),
   insertTag: vi.fn(),
@@ -564,5 +565,130 @@ describe('processOuraData', () => {
 
       expect(db.insertTag).toHaveBeenCalledWith(user, data[0])
     })
+  })
+})
+
+describe('syncOuraDataType', () => {
+  const user = 'testuser'
+  const accessToken = 'test-token'
+
+  const createMockOura = () => ({
+    authCb: vi.fn(),
+    getAccessToken: vi.fn(),
+    getDailyCardiovascularAge: vi.fn().mockResolvedValue([]),
+    getDailyReadiness: vi.fn().mockResolvedValue([]),
+    getDailyResilience: vi.fn().mockResolvedValue([]),
+    getDailySleep: vi.fn().mockResolvedValue([]),
+    getPersonalInfo: vi.fn(),
+    getSessions: vi.fn().mockResolvedValue([]),
+    getTags: vi.fn().mockResolvedValue([]),
+    getUserId: vi.fn(),
+    storeAccessToken: vi.fn(),
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-15T12:00:00Z'))
+  })
+
+  test('incremental sync uses 2-day overlap from last_sync_time', async () => {
+    const lastSyncTime = new Date('2025-01-14T10:00:00Z')
+    vi.mocked(db.getSyncState).mockResolvedValue({
+      data_type: 'dailyReadiness',
+      last_sync_time: lastSyncTime,
+      provider: 'oura',
+      status: 'idle',
+    })
+
+    const mockOura = createMockOura()
+    await syncOuraDataType(user, mockOura as never, 'dailyReadiness', accessToken)
+
+    // Should have been called with start = lastSyncTime - 2 days
+    const expectedStart = new Date('2025-01-12T10:00:00Z')
+    expect(mockOura.getDailyReadiness).toHaveBeenCalledWith(expectedStart, expect.any(Date), accessToken)
+  })
+
+  test('full resync uses 90-day history', async () => {
+    vi.mocked(db.getSyncState).mockResolvedValue({
+      data_type: 'dailyReadiness',
+      last_sync_time: new Date('2025-01-14T10:00:00Z'),
+      provider: 'oura',
+      status: 'idle',
+    })
+
+    const mockOura = createMockOura()
+    await syncOuraDataType(user, mockOura as never, 'dailyReadiness', accessToken, {
+      fullResync: true,
+    })
+
+    // Should have been called with start ~90 days back from now
+    const [start] = mockOura.getDailyReadiness.mock.calls[0]! as [Date]
+    const daysDiff = (new Date('2025-01-15T12:00:00Z').getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    expect(daysDiff).toBeCloseTo(90, 0)
+  })
+
+  test('first sync (no sync state) uses 90-day history', async () => {
+    vi.mocked(db.getSyncState).mockResolvedValue(null)
+
+    const mockOura = createMockOura()
+    await syncOuraDataType(user, mockOura as never, 'dailyReadiness', accessToken)
+
+    // Should have been called with start ~90 days back from now
+    const [start] = mockOura.getDailyReadiness.mock.calls[0]! as [Date]
+    const daysDiff = (new Date('2025-01-15T12:00:00Z').getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    expect(daysDiff).toBeCloseTo(90, 0)
+  })
+
+  test('first sync (no sync state) uses 90-day history', async () => {
+    vi.mocked(db.getSyncState).mockResolvedValue(null)
+
+    const mockOura = createMockOura()
+    await syncOuraDataType(user, mockOura as never, 'dailyReadiness', accessToken)
+
+    // Should have been called with start ~90 days back from now
+    const [start] = mockOura.getDailyReadiness.mock.calls[0]! as [Date]
+    const daysDiff = (new Date('2025-01-15T12:00:00Z').getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    expect(daysDiff).toBeCloseTo(90, 0)
+  })
+
+  test('skips sync when rate limited', async () => {
+    vi.mocked(db.getSyncState).mockResolvedValue({
+      data_type: 'dailyReadiness',
+      provider: 'oura',
+      retry_after: new Date('2025-01-15T13:00:00Z'),
+      status: 'rate_limited',
+    })
+
+    const mockOura = createMockOura()
+    const result = await syncOuraDataType(user, mockOura as never, 'dailyReadiness', accessToken)
+
+    expect(result.status).toBe('skipped')
+    expect(mockOura.getDailyReadiness).not.toHaveBeenCalled()
+  })
+
+  test('updates sync state on success', async () => {
+    vi.mocked(db.getSyncState).mockResolvedValue({
+      data_type: 'dailySleep',
+      last_sync_time: new Date('2025-01-14T10:00:00Z'),
+      provider: 'oura',
+      status: 'idle',
+    })
+
+    const mockOura = createMockOura()
+    mockOura.getDailySleep.mockResolvedValue([{ id: 'sl-1', score: 85, timestamp: '2025-01-15T07:00:00Z' }])
+
+    const result = await syncOuraDataType(user, mockOura as never, 'dailySleep', accessToken)
+
+    expect(result.status).toBe('success')
+    expect(result.records_processed).toBe(1)
+
+    // Should mark as syncing, then idle
+    expect(db.upsertSyncState).toHaveBeenCalledTimes(2)
+    expect(db.upsertSyncState).toHaveBeenCalledWith(user, expect.objectContaining({ status: 'syncing' }))
+    expect(db.upsertSyncState).toHaveBeenCalledWith(
+      user,
+      expect.objectContaining({ last_sync_time: expect.any(Date), status: 'idle' }),
+    )
   })
 })

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -33,6 +33,9 @@ export type OuraDataType =
 /** Default start date for historical sync (90 days back) */
 const DEFAULT_SYNC_HISTORY_DAYS = 90
 
+/** Overlap buffer for incremental syncs to catch retroactive edits (in days). */
+const INCREMENTAL_SYNC_OVERLAP_DAYS = 2
+
 /** Backoff intervals for rate limiting (in minutes) */
 const RATE_LIMIT_BACKOFF = [1, 5, 15, 60]
 
@@ -435,7 +438,8 @@ export const syncOuraDataType = async (
   if (options.fullResync || !syncState?.last_sync_time) {
     start = options.startDate || subDays(end, DEFAULT_SYNC_HISTORY_DAYS)
   } else {
-    start = syncState.last_sync_time
+    // Add overlap buffer to catch retroactive edits in Oura
+    start = subDays(syncState.last_sync_time, INCREMENTAL_SYNC_OVERLAP_DAYS)
   }
 
   // Mark as syncing

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -1,6 +1,7 @@
 import { exerciseTypeNames, type ExerciseTypeName } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
+import { useLocation } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 import { MetricPicker } from '../../components/MetricPicker'
 import { addActivity, addMetric, addNote, addTag, fetchUniqueTags, type ActivityType } from '../../state/api'
@@ -9,9 +10,18 @@ import './style.css'
 
 type Tab = 'activity' | 'tag' | 'metric'
 
+const STORAGE_KEY = 'addData.addMore'
+const getAddMore = (): boolean => localStorage.getItem(STORAGE_KEY) !== 'false'
+const setAddMore = (value: boolean): void => localStorage.setItem(STORAGE_KEY, String(value))
+
 const nowLocal = () => format(new Date(), "yyyy-MM-dd'T'HH:mm")
 
-const AddActivityForm = () => {
+interface FormProps {
+  /** Called after successful creation. If it returns true, the form was navigated away. */
+  onCreated: (entityType: string, entityId: string | undefined) => boolean
+}
+
+const AddActivityForm = ({ onCreated }: FormProps) => {
   const queryClient = useQueryClient()
   const [activityType, setActivityType] = useState<ActivityType>('exercise')
   const [exerciseType, setExerciseType] = useState<ExerciseTypeName>('other_workout')
@@ -46,7 +56,9 @@ const AddActivityForm = () => {
       setError(err.message)
       setSuccess('')
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['dayview-activities'] })
+      if (onCreated('activity', result.data?.id)) return
       setSuccess('Activity added')
       setError('')
       setTitle('')
@@ -54,7 +66,6 @@ const AddActivityForm = () => {
       setComment('')
       setStartTime(nowLocal())
       setEndTime(nowLocal())
-      queryClient.invalidateQueries({ queryKey: ['dayview-activities'] })
     },
   })
 
@@ -160,7 +171,7 @@ const AddActivityForm = () => {
   )
 }
 
-const AddTagForm = () => {
+const AddTagForm = ({ onCreated }: FormProps) => {
   const queryClient = useQueryClient()
   const [tagName, setTagName] = useState('')
   const [startTime, setStartTime] = useState(nowLocal())
@@ -205,7 +216,11 @@ const AddTagForm = () => {
       setError(err.message)
       setSuccess('')
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['dayview-tags'] })
+      queryClient.invalidateQueries({ queryKey: ['uniqueTags'] })
+      const tagId = result.data?.id ?? (result as unknown as { id?: string }).id
+      if (onCreated('tag', tagId)) return
       setSuccess(`Tag "${tagName}" added`)
       setError('')
       setTagName('')
@@ -213,8 +228,6 @@ const AddTagForm = () => {
       setStartTime(nowLocal())
       setHasEndTime(false)
       setMergeSpan('')
-      queryClient.invalidateQueries({ queryKey: ['dayview-tags'] })
-      queryClient.invalidateQueries({ queryKey: ['uniqueTags'] })
     },
   })
 
@@ -325,7 +338,7 @@ const AddTagForm = () => {
   )
 }
 
-const AddMetricForm = () => {
+const AddMetricForm = ({ onCreated }: FormProps) => {
   const [metric, setMetric] = useState('')
   const [value, setValue] = useState('')
   const [time, setTime] = useState(nowLocal())
@@ -358,6 +371,7 @@ const AddMetricForm = () => {
       setSuccess('')
     },
     onSuccess: () => {
+      if (onCreated('metric', undefined)) return
       setSuccess(`Metric "${metric}" recorded`)
       setError('')
       setValue('')
@@ -422,15 +436,51 @@ const AddMetricForm = () => {
 }
 
 export const AddData = () => {
+  const { route } = useLocation()
   const [activeTab, setActiveTab] = useState<Tab>('activity')
+  const [addMore, setAddMoreState] = useState(getAddMore)
 
   const handleTabClick = useCallback((tab: Tab) => {
     setActiveTab(tab)
   }, [])
 
+  const toggleAddMore = useCallback(() => {
+    setAddMoreState((prev) => {
+      const next = !prev
+      setAddMore(next)
+      return next
+    })
+  }, [])
+
+  /**
+   * Called after successful creation.
+   * Returns true if navigation happened (form should not reset).
+   */
+  const handleCreated = useCallback(
+    (entityType: string, entityId: string | undefined): boolean => {
+      if (addMore) return false
+      if (entityType === 'metric' || !entityId) {
+        // No detail page for metrics; navigate to day view instead
+        route('/day')
+        return true
+      }
+      route(`/detail/${entityType}/${entityId}`)
+      return true
+    },
+    [addMore, route],
+  )
+
   return (
     <div class="add-data-page">
-      <h1>Add Data</h1>
+      <div class="add-data-header">
+        <h1>Add Data</h1>
+        <label class="add-more-toggle" title="Keep form open to add more data">
+          <span class="add-more-label">Add more</span>
+          <span class={`toggle-switch ${addMore ? 'active' : ''}`} onClick={toggleAddMore}>
+            <span class="toggle-knob" />
+          </span>
+        </label>
+      </div>
 
       <div class="add-data-tabs">
         <button
@@ -456,9 +506,9 @@ export const AddData = () => {
         </button>
       </div>
 
-      {activeTab === 'activity' && <AddActivityForm />}
-      {activeTab === 'tag' && <AddTagForm />}
-      {activeTab === 'metric' && <AddMetricForm />}
+      {activeTab === 'activity' && <AddActivityForm onCreated={handleCreated} />}
+      {activeTab === 'tag' && <AddTagForm onCreated={handleCreated} />}
+      {activeTab === 'metric' && <AddMetricForm onCreated={handleCreated} />}
     </div>
   )
 }

--- a/apps/web/src/pages/AddData/style.css
+++ b/apps/web/src/pages/AddData/style.css
@@ -4,9 +4,61 @@
   padding: 2rem;
 }
 
+.add-data-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
 .add-data-page h1 {
   font-size: 1.75rem;
-  margin-bottom: 1.5rem;
+  margin: 0;
+}
+
+.add-more-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.add-more-label {
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  background: #d1d5db;
+  border-radius: 10px;
+  transition: background 0.2s ease;
+  cursor: pointer;
+}
+
+.toggle-switch.active {
+  background: #673ab8;
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch.active .toggle-knob {
+  transform: translateX(16px);
 }
 
 .add-data-tabs {
@@ -128,7 +180,7 @@
   gap: 0.5rem;
 }
 
-.add-form .form-check input[type="checkbox"] {
+.add-form .form-check input[type='checkbox'] {
   width: auto;
 }
 
@@ -164,6 +216,18 @@
 
   .add-data-tab {
     color: #9ca3af;
+  }
+
+  .add-more-label {
+    color: #9ca3af;
+  }
+
+  .toggle-switch {
+    background: #4b5563;
+  }
+
+  .toggle-switch.active {
+    background: #8b5cf6;
   }
 
   .add-data-tab:hover {

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -5,7 +5,7 @@
  * Activities dispatch to type-specific detail components:
  * - sleep/nap → SleepDetail (hypnogram, Oura metrics, HR/HRV)
  * - exercise  → ExerciseDetail (HR chart, HR zones)
- * - other     → generic ActivityDetail
+ * - other     → generic ActivityDetail (HR/HRV chart)
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
@@ -23,6 +23,7 @@ import {
   Tag,
   updateActivity,
 } from '../../state/api'
+import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { ExerciseDetail } from './ExerciseDetail'
 import { formatDateTime, formatDateTimeLocal, formatDuration, formatTime } from './format-utils'
@@ -96,6 +97,8 @@ const GenericActivityDetail = ({
           </div>
         </div>
       )}
+
+      <ActivityChart start={displayStart} end={displayEnd} showHrDefault={true} showHrvDefault={true} />
     </div>
   )
 }

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -10,6 +10,7 @@ import {
   fetchUserSettings,
   generateApiToken,
   HrZoneThresholds,
+  syncOura,
   UpdateSettingsInput,
   updateUserSettings,
 } from '../../state/api'
@@ -222,6 +223,25 @@ export function Settings() {
     window.location.href = `${API_URL}/auth/connectOura`
   }
 
+  const [ouraSyncStatus, setOuraSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
+  const [ouraSyncMessage, setOuraSyncMessage] = useState<string>('')
+
+  const handleOuraFullResync = useCallback(async () => {
+    setOuraSyncStatus('syncing')
+    setOuraSyncMessage('')
+    try {
+      const response = await syncOura(true)
+      const totalRecords = (response.results ?? []).reduce((sum, r) => sum + (r.records_processed ?? 0), 0)
+      setOuraSyncStatus('done')
+      setOuraSyncMessage(`Synced ${totalRecords} records`)
+      // Invalidate queries that depend on Oura data
+      await queryClient.invalidateQueries()
+    } catch (err) {
+      setOuraSyncStatus('error')
+      setOuraSyncMessage(err instanceof Error ? err.message : 'Sync failed')
+    }
+  }, [queryClient])
+
   if (!isLoggedIn) {
     return (
       <div class="settings-page">
@@ -275,7 +295,20 @@ export function Settings() {
         <div class="form-field">
           <label>Oura Ring</label>
           {userSettings?.oura_connected ?
-            <p class="connected-status">Connected</p>
+            <div class="oura-connected-row">
+              <p class="connected-status">Connected</p>
+              <button
+                type="button"
+                class="connect-button oura-resync-button"
+                disabled={ouraSyncStatus === 'syncing'}
+                onClick={handleOuraFullResync}
+              >
+                {ouraSyncStatus === 'syncing' ? 'Syncing...' : 'Full Re-sync'}
+              </button>
+              {ouraSyncMessage && (
+                <span class={`oura-sync-message ${ouraSyncStatus}`}>{ouraSyncMessage}</span>
+              )}
+            </div>
           : userSettings?.oura_configured === false ?
             <button type="button" class="connect-button" disabled>
               Connect Oura

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -89,9 +89,9 @@
   margin-bottom: 0;
 }
 
-.form-field input[type="date"],
-.form-field input[type="password"],
-.form-field input[type="text"] {
+.form-field input[type='date'],
+.form-field input[type='password'],
+.form-field input[type='text'] {
   padding: 0.5rem;
   font-size: 1rem;
   border: 1px solid #ccc;
@@ -100,7 +100,7 @@
   max-width: 300px;
 }
 
-.form-field input[type="date"] {
+.form-field input[type='date'] {
   max-width: 200px;
 }
 
@@ -127,6 +127,30 @@
 .connect-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.oura-connected-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.oura-resync-button {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+}
+
+.oura-sync-message {
+  font-size: 0.8rem;
+}
+
+.oura-sync-message.done {
+  color: #4caf50;
+}
+
+.oura-sync-message.error {
+  color: #f44336;
 }
 
 .field-description {
@@ -195,8 +219,8 @@
   margin-bottom: 0.5rem;
 }
 
-.add-calendar-form .form-field input[type="text"],
-.add-calendar-form .form-field input[type="url"] {
+.add-calendar-form .form-field input[type='text'],
+.add-calendar-form .form-field input[type='url'] {
   padding: 0.5rem;
   font-size: 1rem;
   border: 1px solid #ccc;
@@ -227,7 +251,7 @@
   gap: 0.5rem;
 }
 
-.zone-input input[type="number"] {
+.zone-input input[type='number'] {
   width: 80px;
   padding: 0.5rem;
   font-size: 1rem;
@@ -424,24 +448,24 @@
     color: #aaa;
   }
 
-  .add-calendar-form .form-field input[type="text"],
-  .add-calendar-form .form-field input[type="url"] {
+  .add-calendar-form .form-field input[type='text'],
+  .add-calendar-form .form-field input[type='url'] {
     background: #333;
     border-color: #555;
     color: #fff;
   }
 
-  .form-field input[type="date"],
-  .form-field input[type="password"],
-  .form-field input[type="text"],
-  .zone-input input[type="number"] {
+  .form-field input[type='date'],
+  .form-field input[type='password'],
+  .form-field input[type='text'],
+  .zone-input input[type='number'] {
     background: #333;
     border-color: #555;
     color: #fff;
   }
 
-  .form-field input[type="password"]::placeholder,
-  .form-field input[type="text"]::placeholder {
+  .form-field input[type='password']::placeholder,
+  .form-field input[type='text']::placeholder {
     color: #888;
   }
 

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -48,6 +48,7 @@ import type {
   LocationsResponse,
   NamedLocation,
   NamedLocationsResponse,
+  OuraSyncResponse,
   PeriodMetricStats,
   PeriodSummaryQuery,
   PeriodSummaryResponse,
@@ -416,6 +417,17 @@ export const updateUserSettings = async (params: UpdateSettingsInput): Promise<U
     headers: { Authorization: `Bearer ${token}` },
   })
 
+  return response.data
+}
+
+// Trigger Oura sync
+export const syncOura = async (fullResync?: boolean): Promise<OuraSyncResponse> => {
+  const { token } = auth.value
+  const response = await axios.post<OuraSyncResponse>(
+    `${API_URL}/sync/oura`,
+    { full_resync: fullResync },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
   return response.data
 }
 


### PR DESCRIPTION
## Summary

- Adds an "Add more" toggle switch to the top-right of the Add Data page header
- **Toggle on (default):** Current behavior - form clears and stays on page for adding more entries
- **Toggle off:** After successful creation, navigates to the entity detail page (`/detail/activity/:id` or `/detail/tag/:id`). For metrics (no detail page), navigates to the day view instead.
- Toggle state is persisted in `localStorage` so it remembers the user's preference across sessions
- Includes dark mode styles for the toggle switch