### PR TITLE
Make metrics clickable in Day view with detail page and notes support

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -64,6 +64,7 @@ export {
   getTimeSeriesBucketed,
   getTimeSeriesMultiMetric,
   getTimeSeriesStats,
+  getTimeSeriesWithSource,
   insertTimeSeries,
 } from './time-series'
 

--- a/apps/backend/src/db/time-series.integration.test.ts
+++ b/apps/backend/src/db/time-series.integration.test.ts
@@ -12,6 +12,7 @@ import {
   deleteTimeSeriesPoint,
   getTimeSeries,
   getTimeSeriesBucketed,
+  getTimeSeriesWithSource,
   insertTimeSeries,
 } from './time-series'
 
@@ -214,6 +215,65 @@ describe('Time Series Integration Tests', () => {
       )
 
       expect(data).toHaveLength(2)
+    })
+  })
+
+  // ==========================================================================
+  // Time Series With Source
+  // ==========================================================================
+
+  describe('getTimeSeriesWithSource', () => {
+    test('returns time, value, and source for each data point', async () => {
+      const user = getTestUser()
+
+      await insertTimeSeries(user, [
+        { metric: 'weight', source: 'manual', time: new Date('2024-01-15T08:00:00Z'), value: 75.5 },
+        { metric: 'weight', source: 'health_connect', time: new Date('2024-01-15T09:00:00Z'), value: 75.3 },
+      ])
+
+      const data = await getTimeSeriesWithSource(
+        user,
+        'weight',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(data).toHaveLength(2)
+      expect(data[0]).toEqual({
+        source: 'manual',
+        time: new Date('2024-01-15T08:00:00Z'),
+        value: 75.5,
+      })
+      expect(data[1]).toEqual({
+        source: 'health_connect',
+        time: new Date('2024-01-15T09:00:00Z'),
+        value: 75.3,
+      })
+    })
+
+    test('filters cumulative metrics to aggregate source only', async () => {
+      const user = getTestUser()
+
+      await insertTimeSeries(user, [
+        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T10:00:00Z'), value: 100 },
+        {
+          metric: 'steps',
+          source: 'health_connect_aggregate',
+          time: new Date('2024-01-15T00:00:00Z'),
+          value: 8500,
+        },
+      ])
+
+      const data = await getTimeSeriesWithSource(
+        user,
+        'steps',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(data).toHaveLength(1)
+      expect(data[0].source).toBe('health_connect_aggregate')
+      expect(data[0].value).toBe(8500)
     })
   })
 

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -64,6 +64,31 @@ export const getTimeSeries = async (
   return result.rows.map((row) => [new Date(row.time), row.value])
 }
 
+/** Like getTimeSeries but also returns the source field for each data point. */
+export const getTimeSeriesWithSource = async (
+  user: string,
+  metric: string,
+  start: Date,
+  end: Date,
+): Promise<{ time: Date; value: number; source: string }[]> => {
+  const isCumulative = cumulativeMetrics.includes(metric as MetricType)
+
+  const result = await query(
+    user,
+    isCumulative ?
+      `SELECT time, value, source FROM time_series
+       WHERE metric = $1 AND time >= $2 AND time <= $3
+         AND source = 'health_connect_aggregate'
+       ORDER BY time`
+    : `SELECT time, value, source FROM time_series
+       WHERE metric = $1 AND time >= $2 AND time <= $3
+       ORDER BY time`,
+    [metric, start, end],
+  )
+
+  return result.rows.map((row) => ({ source: row.source, time: new Date(row.time), value: row.value }))
+}
+
 export const getTimeSeriesMultiMetric = async (
   user: string,
   metrics: MetricType[],

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -89,13 +89,21 @@ describe('getDailySummary', () => {
   test('aggregates all data sources for a day', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([
+        // Daily heart rate data
         [new Date('2024-01-15T10:00:00Z'), 72],
         [new Date('2024-01-15T11:00:00Z'), 80],
         [new Date('2024-01-15T12:00:00Z'), 65],
       ])
       .mockResolvedValueOnce([
+        // Daily steps data
         [new Date('2024-01-15T08:00:00Z'), 5000],
         [new Date('2024-01-15T12:00:00Z'), 3000],
+      ])
+      .mockResolvedValueOnce([
+        // Exercise session HR data (for HR zone calculation)
+        [new Date('2024-01-15T10:00:00Z'), 72],
+        [new Date('2024-01-15T10:15:00Z'), 80],
+        [new Date('2024-01-15T10:30:00Z'), 75],
       ])
 
     // Sleep sessions now use getSleepSessions with date overlap logic

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -27,6 +27,7 @@ vi.mock('../db', () => ({
   getTimeSeriesBucketed: vi.fn(),
   getTimeSeriesMultiMetric: vi.fn(),
   getTimeSeriesStats: vi.fn(),
+  getTimeSeriesWithSource: vi.fn(),
   getUserSettings: vi.fn(),
 }))
 
@@ -40,13 +41,13 @@ describe('queryMetrics', () => {
     vi.clearAllMocks()
   })
 
-  test('returns formatted time series data', async () => {
-    const mockData: [Date, number][] = [
-      [new Date('2024-01-01T10:00:00Z'), 72],
-      [new Date('2024-01-01T11:00:00Z'), 75],
-      [new Date('2024-01-01T12:00:00Z'), 68],
+  test('returns formatted time series data with source', async () => {
+    const mockData = [
+      { source: 'oura', time: new Date('2024-01-01T10:00:00Z'), value: 72 },
+      { source: 'oura', time: new Date('2024-01-01T11:00:00Z'), value: 75 },
+      { source: 'manual', time: new Date('2024-01-01T12:00:00Z'), value: 68 },
     ]
-    vi.mocked(db.getTimeSeries).mockResolvedValue(mockData)
+    vi.mocked(db.getTimeSeriesWithSource).mockResolvedValue(mockData)
 
     const result = await queryMetrics(
       'testuser',
@@ -59,11 +60,12 @@ describe('queryMetrics', () => {
     expect(result.unit).toBe('bpm')
     expect(result.count).toBe(3)
     expect(result.data).toHaveLength(3)
-    expect(result.data[0]).toEqual({ time: '2024-01-01T10:00:00.000Z', value: 72 })
+    expect(result.data[0]).toEqual({ source: 'oura', time: '2024-01-01T10:00:00.000Z', value: 72 })
+    expect(result.data[2]).toEqual({ source: 'manual', time: '2024-01-01T12:00:00.000Z', value: 68 })
   })
 
   test('returns empty data when no records', async () => {
-    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getTimeSeriesWithSource).mockResolvedValue([])
 
     const result = await queryMetrics(
       'testuser',

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -19,6 +19,7 @@ import {
   getTimeSeriesBucketed,
   getTimeSeriesMultiMetric,
   getTimeSeriesStats,
+  getTimeSeriesWithSource,
   type ProductivityRecord,
 } from '../db'
 import {
@@ -54,6 +55,7 @@ export interface SyncProvider {
 }
 
 export interface MetricDataPoint {
+  source?: string
   time: string
   value: number
 }
@@ -242,11 +244,11 @@ export async function queryMetrics(
     }
   }
 
-  const data = await getTimeSeries(user, metric, start, end)
+  const data = await getTimeSeriesWithSource(user, metric, start, end)
 
   return {
     count: data.length,
-    data: data.map(([time, value]) => ({ time: time.toISOString(), value })),
+    data: data.map((d) => ({ source: d.source, time: d.time.toISOString(), value: d.value })),
     metric,
     unit,
   }

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -10,6 +10,7 @@ import {
   fetchActivities,
   fetchBucketedMetrics,
   fetchCustomMetrics,
+  fetchMetricTimeSeriesWithSource,
   fetchPlaces,
   fetchProductivity,
   fetchScrobbles,
@@ -19,6 +20,7 @@ import {
   ProductivityRecord,
   Scrobble,
   Tag,
+  type MetricDataPointWithSource,
 } from '../../state/api'
 import { packLanes } from '../../utils/lanePacking'
 import { categorizeMusic } from './categorizeMusic'
@@ -375,27 +377,19 @@ const formatMetricLabel = (metric: string): string =>
   metric.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 
 /**
- * Categorize bucketed metric data into chart items for the Tags / Events lane.
+ * Categorize metric data points into chart items for the Tags / Events lane.
  * Only includes metrics with <= OCCASIONAL_METRIC_MAX_COUNT data points per day.
  */
-interface MetricBucketData {
-  start: string
-  end: string
-  metrics: Record<string, { avg: number; min: number; max: number; count: number }>
-}
-
 const categorizeOccasionalMetrics = (
-  buckets: MetricBucketData[],
+  dataPoints: MetricDataPointWithSource[],
   metricUnits: Record<string, string>,
 ): ChartItem[] => {
-  if (!buckets || buckets.length === 0) return []
+  if (!dataPoints || dataPoints.length === 0) return []
 
-  // Count total data points per metric across all buckets
+  // Count total data points per metric
   const metricCounts: Record<string, number> = {}
-  for (const bucket of buckets) {
-    for (const [metric, stats] of Object.entries(bucket.metrics)) {
-      metricCounts[metric] = (metricCounts[metric] ?? 0) + stats.count
-    }
+  for (const dp of dataPoints) {
+    metricCounts[dp.metric] = (metricCounts[dp.metric] ?? 0) + 1
   }
 
   // Only include metrics that are truly "occasional"
@@ -407,35 +401,32 @@ const categorizeOccasionalMetrics = (
 
   if (occasionalMetrics.size === 0) return []
 
-  const items: ChartItem[] = []
-  for (const bucket of buckets) {
-    for (const [metric, stats] of Object.entries(bucket.metrics)) {
-      if (!occasionalMetrics.has(metric)) continue
-
-      const time = new Date(bucket.start)
-      const end = new Date(time.getTime() + 15 * 60000)
-      const unit = metricUnits[metric] ?? ''
-      const displayValue = Number(stats.avg.toFixed(2))
+  return dataPoints
+    .filter((dp) => occasionalMetrics.has(dp.metric))
+    .map((dp) => {
+      const unit = metricUnits[dp.metric] ?? ''
+      const displayValue = Number(dp.value.toFixed(2))
       const valueStr = `${displayValue}${unit ? ` ${unit}` : ''}`
-      const metricLabel = formatMetricLabel(metric)
+      const metricLabel = formatMetricLabel(dp.metric)
+      const end = new Date(dp.time.getTime() + 15 * 60000)
+      const entityId = `${dp.time.toISOString()}|${dp.metric}|${dp.source}`
 
-      items.push({
+      return {
         color: METRIC_COLOR,
         column: 'Tags / Events' as Column,
         end,
+        entity_id: entityId,
+        entity_type: 'metric' as const,
         isPoint: true,
         label: `${metricLabel}: ${valueStr}`,
-        start: time,
+        start: dp.time,
         tooltip: {
-          details: [`Value: ${valueStr}`, 'Metric measurement'],
-          time: formatTime(time),
+          details: [`Value: ${valueStr}`, `Source: ${dp.source}`, 'Metric measurement'],
+          time: formatTime(dp.time),
           title: metricLabel,
         },
-      })
-    }
-  }
-
-  return items
+      }
+    })
 }
 
 const categorizeProductivity = (productivity: ProductivityRecord[]): ChartItem[] =>
@@ -588,12 +579,18 @@ export const DayView = () => {
     return units
   }, [customMetricsQuery.data])
 
-  // Fetch occasional metric data with 5-minute buckets for the day view
+  // Fetch occasional metric data with source info for entity linking
   const occasionalMetricsQuery = useQuery({
     enabled: occasionalMetricNames.length > 0,
     placeholderData: keepPreviousData,
-    queryFn: () =>
-      fetchBucketedMetrics(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), occasionalMetricNames, '5m'),
+    queryFn: async () => {
+      const start = subDays(fetchStart, 0.5)
+      const end = addDays(fetchEnd, 0.5)
+      const results = await Promise.all(
+        occasionalMetricNames.map((metric) => fetchMetricTimeSeriesWithSource(metric, start, end)),
+      )
+      return results.flat()
+    },
     queryKey: ['dayview-occasional-metrics', fromDate.value, toDate.value, occasionalMetricNames],
     staleTime: 5 * 60 * 1000,
   })
@@ -701,10 +698,7 @@ export const DayView = () => {
   const musicItems = hasLastFm ? categorizeMusic(scrobbles) : []
   const showMusicColumn = musicItems.length > 0
 
-  const occasionalMetricItems = categorizeOccasionalMetrics(
-    (occasionalMetricsQuery.data?.buckets ?? []) as MetricBucketData[],
-    allMetricUnits,
-  )
+  const occasionalMetricItems = categorizeOccasionalMetrics(occasionalMetricsQuery.data ?? [], allMetricUnits)
 
   const allColumns: Column[] = showMusicColumn ? [...BASE_COLUMNS, 'Music'] : BASE_COLUMNS
 
@@ -1074,7 +1068,7 @@ export const DayView = () => {
             {mobileItems.map((item, idx) => {
               const href =
                 item.entity_id && item.entity_type ?
-                  `/detail/${item.entity_type}/${item.entity_id}`
+                  `/detail/${item.entity_type}/${encodeURIComponent(item.entity_id)}`
                 : (item.href ?? undefined)
               const Wrapper = href ? 'a' : 'div'
               return (
@@ -1246,7 +1240,7 @@ const drawItem = (
 
   const detailUrl =
     item.entity_id && item.entity_type ?
-      `/detail/${item.entity_type}/${item.entity_id}`
+      `/detail/${item.entity_type}/${encodeURIComponent(item.entity_id)}`
     : (item.href ?? undefined)
 
   // Wrap clickable items in an SVG <a> so the browser handles middle-click,

--- a/apps/web/src/pages/DayView/types.ts
+++ b/apps/web/src/pages/DayView/types.ts
@@ -15,6 +15,6 @@ export interface ChartItem {
   tooltip: TooltipContent
   isPoint: boolean
   entity_id?: string
-  entity_type?: 'activity' | 'tag' | 'productivity'
+  entity_type?: 'activity' | 'tag' | 'productivity' | 'metric'
   href?: string
 }

--- a/apps/web/src/pages/EntityDetail/NotesSection.tsx
+++ b/apps/web/src/pages/EntityDetail/NotesSection.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'preact/hooks'
 import { MarkdownEditor } from '../../components/MarkdownEditor/index.jsx'
 import { addNote, deleteNote, fetchNotes, type NoteData, updateNote } from '../../state/api'
 
-type EntityType = 'activity' | 'tag' | 'productivity'
+type EntityType = 'activity' | 'tag' | 'productivity' | 'metric'
 
 export const NotesSection = ({
   entityType,

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Entity detail page — shows an activity, tag, or productivity record
+ * Entity detail page — shows an activity, tag, productivity record, or metric data point
  * with notes and action buttons (delete / restore).
  *
  * Activities dispatch to type-specific detail components:
@@ -7,14 +7,19 @@
  * - exercise  → ExerciseDetail (HR chart, HR zones)
  * - other     → generic ActivityDetail
  */
+import { metricUnits as builtinMetricUnits } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 import {
   Activity,
+  deleteMetricPoint,
   type ExerciseTypeName,
   fetchActivityById,
+  fetchCustomMetrics,
+  fetchMetricTimeSeriesWithSource,
   fetchTagById,
+  type MetricDataPointWithSource,
   restoreActivity,
   restoreTag,
   softDeleteActivity,
@@ -32,7 +37,7 @@ import { SleepDetail } from './SleepDetail'
 
 import './style.css'
 
-type EntityType = 'activity' | 'tag' | 'productivity'
+type EntityType = 'activity' | 'tag' | 'productivity' | 'metric'
 
 const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
   <div class="source-records">
@@ -194,9 +199,99 @@ const TagDetail = ({ tag }: { tag: Tag }) => {
   )
 }
 
+/** Parse a metric entity ID (format: "iso_time|metric_name|source"). */
+const parseMetricEntityId = (entityId: string): { time: string; metric: string; source: string } | null => {
+  const parts = entityId.split('|')
+  if (parts.length !== 3) return null
+  const [time, metric, source] = parts
+  if (!time || !metric || !source) return null
+  const d = new Date(time)
+  if (isNaN(d.getTime())) return null
+  return { metric, source, time }
+}
+
+/** Map metric name to human-readable display label. */
+const formatMetricLabel = (metric: string): string =>
+  metric.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+
+const MetricDetail = ({ entityId }: { entityId: string }) => {
+  const parsed = parseMetricEntityId(entityId)
+
+  // Look up the data point to get current value (in case it was updated)
+  const customMetricsQuery = useQuery({
+    queryFn: fetchCustomMetrics,
+    queryKey: ['custom-metrics'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const pointQuery = useQuery({
+    enabled: parsed !== null,
+    queryFn: async (): Promise<MetricDataPointWithSource | null> => {
+      if (!parsed) return null
+      const time = new Date(parsed.time)
+      // Narrow query: 1 second window around the exact time
+      const start = new Date(time.getTime() - 500)
+      const end = new Date(time.getTime() + 500)
+      const points = await fetchMetricTimeSeriesWithSource(parsed.metric, start, end)
+      // Find exact match by source
+      return points.find((p) => p.source === parsed.source) ?? points[0] ?? null
+    },
+    queryKey: ['metric-point', entityId],
+    staleTime: 60_000,
+  })
+
+  if (!parsed) {
+    return <p class="error">Invalid metric reference</p>
+  }
+
+  const metricLabel = formatMetricLabel(parsed.metric)
+  const customUnit = customMetricsQuery.data?.find((m) => m.name === parsed.metric)?.unit
+  const unit = customUnit ?? (builtinMetricUnits as Record<string, string>)[parsed.metric] ?? ''
+  const point = pointQuery.data
+  const time = new Date(parsed.time)
+  const displayValue = point ? Number(point.value.toFixed(2)) : null
+
+  return (
+    <div class="entity-info">
+      <div class="entity-meta">
+        <span class="entity-type-badge">metric</span>
+        <span class="entity-source">Source: {parsed.source}</span>
+      </div>
+
+      <h2>{metricLabel}</h2>
+
+      <div class="entity-fields">
+        <div class="field-row">
+          <span class="field-label">Time</span>
+          <span class="field-value">{formatDateTime(time)}</span>
+        </div>
+        <div class="field-row">
+          <span class="field-label">Value</span>
+          <span class="field-value">
+            {pointQuery.isLoading ?
+              'Loading...'
+            : displayValue !== null ?
+              `${displayValue}${unit ? ` ${unit}` : ''}`
+            : 'Not found'}
+          </span>
+        </div>
+        <div class="field-row">
+          <span class="field-label">Metric</span>
+          <span class="field-value">{parsed.metric}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> => {
   if (entityType === 'activity') return softDeleteActivity(entityId)
   if (entityType === 'tag') return softDeleteTag(entityId)
+  if (entityType === 'metric') {
+    const parsed = parseMetricEntityId(entityId)
+    if (!parsed) return Promise.reject(new Error('Invalid metric entity ID'))
+    return deleteMetricPoint(parsed.metric, parsed.time)
+  }
   return Promise.reject(new Error('Unsupported entity type for delete'))
 }
 
@@ -342,8 +437,14 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     queryClient.invalidateQueries({ queryKey: ['entity-detail', entityType, entityId] })
   }, [queryClient, entityType, entityId])
 
-  const isLoading = entityType === 'activity' ? activityQuery.isLoading : tagQuery.isLoading
-  const isError = entityType === 'activity' ? activityQuery.isError : tagQuery.isError
+  const isLoading =
+    entityType === 'activity' ? activityQuery.isLoading
+    : entityType === 'tag' ? tagQuery.isLoading
+    : false // metric detail handles its own loading
+  const isError =
+    entityType === 'activity' ? activityQuery.isError
+    : entityType === 'tag' ? tagQuery.isError
+    : false
 
   const activity = activityQuery.data
   const tag = tagQuery.data
@@ -352,6 +453,9 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     entityType === 'activity' ? Boolean(activity?.deleted_at)
     : entityType === 'tag' ? Boolean(tag?.deleted_at)
     : false
+
+  // For metrics, only manual entries can be deleted
+  const isManualMetric = entityType === 'metric' && parseMetricEntityId(entityId)?.source === 'manual'
 
   // Edit state
   const [isEditing, setIsEditing] = useState(false)
@@ -415,19 +519,22 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
 
   return (
     <>
-      <EntityActions
-        entityType={entityType}
-        entityId={rawEntityId}
-        isDeleted={isDeleted}
-        onMutationSuccess={invalidateEntity}
-        canEdit={entityType === 'activity'}
-        isMerged={isMergedActivity}
-        isEditing={isEditing}
-        onStartEditing={startEditing}
-        onCancelEditing={cancelEditing}
-        onSave={handleSave}
-        isSaving={saveMutation.isPending}
-      />
+      {/* Metrics only support delete for manual entries; hide actions for non-manual metrics */}
+      {entityType !== 'metric' || isManualMetric ?
+        <EntityActions
+          entityType={entityType}
+          entityId={rawEntityId}
+          isDeleted={isDeleted}
+          onMutationSuccess={entityType === 'metric' ? () => history.back() : invalidateEntity}
+          canEdit={entityType === 'activity'}
+          isMerged={isMergedActivity}
+          isEditing={isEditing}
+          onStartEditing={startEditing}
+          onCancelEditing={cancelEditing}
+          onSave={handleSave}
+          isSaving={saveMutation.isPending}
+        />
+      : null}
 
       {entityType === 'activity' && activity && (
         <ActivityDetailDispatch
@@ -438,18 +545,19 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
         />
       )}
       {entityType === 'tag' && tag && <TagDetail tag={tag} />}
+      {entityType === 'metric' && <MetricDetail entityId={entityId} />}
 
       <NotesSection entityType={entityType} entityId={rawEntityId} allEntityIds={allEntityIds} />
     </>
   )
 }
 
-const VALID_ENTITY_TYPES = new Set<string>(['activity', 'tag', 'productivity'])
+const VALID_ENTITY_TYPES = new Set<string>(['activity', 'tag', 'productivity', 'metric'])
 
 export const EntityDetail = () => {
   const { params } = useRoute()
   const entityType = params.type as EntityType
-  const entityId = params.id as string
+  const entityId = decodeURIComponent(params.id as string)
 
   if (!VALID_ENTITY_TYPES.has(entityType)) {
     return (

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -714,6 +714,38 @@ export const fetchMetricTimeSeries = async (
   return (response.data.data ?? []).map(({ time, value }) => [new Date(time), value])
 }
 
+/** Metric data point with source info for linking to detail views. */
+export interface MetricDataPointWithSource {
+  time: Date
+  value: number
+  source: string
+  metric: string
+}
+
+/** Fetch time series data for a metric including source (for entity linking). */
+export const fetchMetricTimeSeriesWithSource = async (
+  metric: string,
+  start: Date,
+  end: Date,
+): Promise<MetricDataPointWithSource[]> => {
+  const { token } = auth.value
+  const params: QueryMetricsQuery = {
+    end: end.toISOString(),
+    start: start.toISOString(),
+  }
+  const response = await axios.get<QueryMetricsResponse>(`${API_URL}/metrics/${encodeURIComponent(metric)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+
+  return (response.data.data ?? []).map((d) => ({
+    metric,
+    source: d.source ?? 'manual',
+    time: new Date(d.time),
+    value: d.value,
+  }))
+}
+
 // ==========================================================================
 // Trends API
 // ==========================================================================
@@ -992,6 +1024,15 @@ export const addMetric = async (body: AddMetricBody): Promise<AddMetricResponse>
     headers: { Authorization: `Bearer ${token}` },
   })
   return response.data
+}
+
+/** Delete a single manual metric measurement. */
+export const deleteMetricPoint = async (metric: string, time: string): Promise<void> => {
+  const { token } = auth.value
+  await axios.delete(`${API_URL}/metrics/${encodeURIComponent(metric)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { time },
+  })
 }
 
 // ============================================================================

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -28,6 +28,10 @@ const metricNameSchema = z.string().min(1).max(50).meta({
  */
 export const metricDataPointSchema = z
   .object({
+    source: z
+      .string()
+      .optional()
+      .meta({ description: 'Data source (e.g., "manual", "oura", "health_connect")' }),
     time: iso8601DateTimeSchema,
     value: metricValueSchema,
   })


### PR DESCRIPTION
## Summary

- **Metrics in the Day view are now clickable**, linking to a new MetricDetail component in the EntityDetail page
- Users can **view metric details** (value, source, time) and **add/edit notes** on metric data points
- Manual metric measurements can be **deleted** from the detail page
- The metric `source` field is now included in the `GET /metrics/:metric` API response

## Changes

### Backend
- Added `getTimeSeriesWithSource()` DB function that returns `source` alongside time/value
- Updated `queryMetrics()` service to use the new function and include `source` in responses
- Added `source` field to `MetricDataPoint` schema in `@aurboda/api-spec`

### Frontend - Day View
- Switched occasional metrics from bucketed to non-bucketed API to get `source` info
- Each metric data point now has `entity_id` (composite key: `time|metric|source`) and `entity_type: 'metric'`
- URL-encoded entity IDs in all detail links (needed for pipe-delimited metric keys)

### Frontend - Entity Detail
- Added `MetricDetail` component showing metric name, value, unit, time, and source
- Added `'metric'` to valid entity types in EntityDetail and NotesSection
- Delete button shown only for manual-source metrics (non-manual metrics hide actions)
- After deleting a metric, navigates back instead of showing deleted state

### Tests
- Added integration tests for `getTimeSeriesWithSource` (with source, cumulative filtering)
- Updated `queryMetrics` unit tests to mock `getTimeSeriesWithSource` and assert `source` in output

## Other unlinked data reviewed
- **Music/scrobbles**: These are Last.fm raw records without entity IDs in our data model - no natural detail page exists for them, so they remain unlinked for now