### PR TITLE
Android outbound sync: write backend changes to Health Connect (Phase 2)

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -1,148 +1,147 @@
-import java.util.Properties
-import java.io.FileInputStream
 import java.io.File // Assuming this was added to fix the previous 'Unresolved reference: io'
-
-configurations.all {
-    resolutionStrategy {
-        force("org.jetbrains.kotlin:kotlin-stdlib:1.9.0") // Example version
-        force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0") // If you use jdk8 variant
-        force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0") // If you use jdk7 variant
-    }
-}
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22"
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
+  id("org.jetbrains.kotlin.plugin.serialization") version libs.versions.kotlin.get()
 }
 
 // Function to load properties from local.properties
-fun getLocalProperty(key: String, projectRootDir: File): String { // Assuming changed to File
-    val properties = Properties()
-    val localPropertiesFile = File(projectRootDir, "local.properties") // Assuming changed to File
-    if (localPropertiesFile.exists()) {
-        FileInputStream(localPropertiesFile).use { stream -> properties.load(stream) } // Changed lambda parameter
-    }
-    return properties.getProperty(key) ?: ""
+fun getLocalProperty(
+  key: String,
+  projectRootDir: File,
+): String { // Assuming changed to File
+  val properties = Properties()
+  val localPropertiesFile = File(projectRootDir, "local.properties") // Assuming changed to File
+  if (localPropertiesFile.exists()) {
+    FileInputStream(localPropertiesFile).use { stream -> properties.load(stream) } // Changed lambda parameter
+  }
+  return properties.getProperty(key) ?: ""
 }
 
 // Read version code from environment variable (set by CI) or default to 1 for local builds
 val versionCodeFromEnv = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
 
 android {
-    namespace = "net.aurboda"
-    compileSdk = 36
+  namespace = "net.aurboda"
+  compileSdk = 36
 
-    sourceSets {
-        getByName("main") {
-            java.srcDir("../../../packages/api-spec/generated/kotlin/src/main/kotlin")
-        }
+  sourceSets {
+    getByName("main") {
+      java.srcDir("../../../packages/api-spec/generated/kotlin/src/main/kotlin")
     }
+  }
 
-    defaultConfig {
-        applicationId = "net.aurboda"
-        minSdk = 34
-        targetSdk = 36
-        versionCode = versionCodeFromEnv
-        versionName = "1.0.$versionCodeFromEnv"
+  defaultConfig {
+    applicationId = "net.aurboda"
+    minSdk = 34
+    targetSdk = 36
+    versionCode = versionCodeFromEnv
+    versionName = "1.0.$versionCodeFromEnv"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        // Expose version info to runtime code
-        buildConfigField("int", "VERSION_CODE_INT", "$versionCodeFromEnv")
-    }
+    // Expose version info to runtime code
+    buildConfigField("int", "VERSION_CODE_INT", "$versionCodeFromEnv")
+  }
 
-    signingConfigs {
-        val keystoreFile = getLocalProperty("KEYSTORE_FILE", rootProject.projectDir)
-        val keystorePassword = getLocalProperty("KEYSTORE_PASSWORD", rootProject.projectDir)
-        val keyAlias = getLocalProperty("KEY_ALIAS", rootProject.projectDir)
-        val keyPassword = getLocalProperty("KEY_PASSWORD", rootProject.projectDir)
+  signingConfigs {
+    val keystoreFile = getLocalProperty("KEYSTORE_FILE", rootProject.projectDir)
+    val keystorePassword = getLocalProperty("KEYSTORE_PASSWORD", rootProject.projectDir)
+    val keyAlias = getLocalProperty("KEY_ALIAS", rootProject.projectDir)
+    val keyPassword = getLocalProperty("KEY_PASSWORD", rootProject.projectDir)
 
-        if (keystoreFile.isNotEmpty() && keystorePassword.isNotEmpty()) {
-            create("release") {
-                storeFile = file(keystoreFile)
-                storePassword = keystorePassword
-                this.keyAlias = keyAlias
-                this.keyPassword = keyPassword
-            }
-        }
+    if (keystoreFile.isNotEmpty() && keystorePassword.isNotEmpty()) {
+      create("release") {
+        storeFile = file(keystoreFile)
+        storePassword = keystorePassword
+        this.keyAlias = keyAlias
+        this.keyPassword = keyPassword
+      }
     }
+  }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-            signingConfigs.findByName("release")?.let {
-                signingConfig = it
-            }
-        }
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+      proguardFiles(
+        getDefaultProguardFile("proguard-android-optimize.txt"),
+        "proguard-rules.pro",
+      )
+      signingConfigs.findByName("release")?.let {
+        signingConfig = it
+      }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+  // kotlinOptions moved to top-level kotlin {} block (required by Kotlin 2.3+)
+  buildFeatures {
+    compose = true
+    buildConfig = true
+  }
+  packaging {
+    resources {
+      excludes += "/META-INF/{AL2.0,LGPL2.1}"
     }
-    kotlinOptions {
-        jvmTarget = "11"
+  }
+  testOptions {
+    unitTests {
+      isIncludeAndroidResources = true
     }
-    buildFeatures {
-        compose = true
-        buildConfig = true
-    }
-    packagingOptions {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+    freeCompilerArgs.addAll("-Wextra", "-Werror")
+  }
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.9.0")) // Example version, use your project's Kotlin version
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-    implementation("androidx.health.connect:connect-client:1.2.0-alpha01")
+  implementation("org.jetbrains.kotlin:kotlin-stdlib")
+  implementation(libs.androidx.core.ktx)
+  implementation(libs.androidx.lifecycle.runtime.ktx)
+  implementation(libs.androidx.lifecycle.runtime.compose)
+  implementation(libs.androidx.activity.compose)
+  implementation(platform(libs.androidx.compose.bom))
+  implementation(libs.androidx.compose.ui)
+  implementation(libs.androidx.compose.ui.graphics)
+  implementation(libs.androidx.compose.ui.tooling.preview)
+  implementation(libs.androidx.compose.material3)
+  implementation("androidx.health.connect:connect-client:1.2.0-alpha01")
 
-    implementation("io.ktor:ktor-client-android:2.3.8")
-    implementation("io.ktor:ktor-client-content-negotiation:2.3.8")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.8")
+  implementation("io.ktor:ktor-client-android:2.3.13")
+  implementation("io.ktor:ktor-client-content-negotiation:2.3.13")
+  implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.13")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 
-    // Encrypted SharedPreferences for secure credential storage
-    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+  // Encrypted SharedPreferences for secure credential storage
+  implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
-    // WorkManager for background sync
-    implementation("androidx.work:work-runtime-ktx:2.9.0")
+  // WorkManager for background sync
+  implementation("androidx.work:work-runtime-ktx:2.9.0")
 
-    testImplementation(libs.junit)
-    testImplementation("io.mockk:mockk:1.13.9")
-    testImplementation("androidx.work:work-testing:2.9.0")
-    testImplementation("org.robolectric:robolectric:4.11.1")
-    testImplementation("androidx.test:core:1.5.0")
-    testImplementation(platform(libs.androidx.compose.bom))
-    testImplementation(libs.androidx.compose.ui.test.junit4)
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-    testImplementation("io.ktor:ktor-client-mock:2.3.8")
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
+  testImplementation(libs.junit)
+  testImplementation("io.mockk:mockk:1.13.9")
+  testImplementation("androidx.work:work-testing:2.9.0")
+  testImplementation("org.robolectric:robolectric:4.11.1")
+  testImplementation("androidx.test:core:1.5.0")
+  testImplementation(platform(libs.androidx.compose.bom))
+  testImplementation(libs.androidx.compose.ui.test.junit4)
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+  testImplementation("io.ktor:ktor-client-mock:2.3.13")
+  androidTestImplementation(libs.androidx.junit)
+  androidTestImplementation(libs.androidx.espresso.core)
+  androidTestImplementation(platform(libs.androidx.compose.bom))
+  androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+  debugImplementation(libs.androidx.compose.ui.tooling)
+  debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -61,10 +61,19 @@
     <uses-permission android:name="android.permission.health.READ_WEIGHT"/>
     <uses-permission android:name="android.permission.health.READ_WHEELCHAIR_PUSHES" />
 
-    <!-- Write permissions for BLE sensor data -->
+    <!-- Write permissions for BLE sensor data and outbound sync -->
+    <uses-permission android:name="android.permission.health.WRITE_BODY_FAT" />
+    <uses-permission android:name="android.permission.health.WRITE_BODY_WATER_MASS" />
+    <uses-permission android:name="android.permission.health.WRITE_BONE_MASS" />
+    <uses-permission android:name="android.permission.health.WRITE_EXERCISE" />
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE" />
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE_VARIABILITY" />
+    <uses-permission android:name="android.permission.health.WRITE_HEIGHT" />
+    <uses-permission android:name="android.permission.health.WRITE_LEAN_BODY_MASS" />
+    <uses-permission android:name="android.permission.health.WRITE_RESTING_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.WRITE_SLEEP" />
     <uses-permission android:name="android.permission.health.WRITE_STEPS" />
+    <uses-permission android:name="android.permission.health.WRITE_WEIGHT" />
 
     <application
         android:name=".AurbodaApplication"

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -138,15 +138,19 @@ class HealthConnectSyncWorker(
         Log.d(TAG, "No new inbound data to sync")
       }
 
-      // Step 4: Process outbound sync (backend -> Health Connect)
-      val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-      processOutboundSync(
-        apiUrl = credentials.apiUrl,
-        authToken = credentials.authToken,
-        httpClient = httpClient,
-        healthConnectClient = healthConnectClient,
-        grantedPermissions = grantedPermissions,
-      )
+      // Step 4: Process outbound sync (backend -> Health Connect).
+      // Reuses grantedPermissions from step 0 above — permissions don't change mid-sync.
+      try {
+        processOutboundSync(
+          apiUrl = credentials.apiUrl,
+          authToken = credentials.authToken,
+          httpClient = httpClient,
+          healthConnectClient = healthConnectClient,
+          grantedPermissions = grantedPermissions,
+        )
+      } catch (e: Exception) {
+        Log.w(TAG, "Outbound sync failed: ${e.message}")
+      }
 
       HrZoneWidgetProvider.triggerUpdate(applicationContext)
       Result.success()
@@ -178,23 +182,17 @@ class HealthConnectSyncWorker(
       val changesResponse = healthConnectClient.getChanges(currentToken)
       val upsertions =
         changesResponse.changes
-          .mapNotNull {
-            if (it is UpsertionChange) it.record else null
-          }.filter { record ->
-            // Skip records written by Aurboda's outbound sync to prevent sync loops
+          .mapNotNull { if (it is UpsertionChange) it.record else null }
+          .filter { record ->
+            // Skip records written by Aurboda's outbound sync to prevent sync loops.
+            // This covers both outbound-synced records (clientRecordId prefix) and
+            // BLE sensor writes (same dataOrigin package), which are already sent
+            // directly to the backend and shouldn't be re-ingested via HC.
             val isOwnOrigin = record.metadata.dataOrigin.packageName == "net.aurboda"
             val isOutboundSync =
               record.metadata.clientRecordId
                 ?.startsWith(OUTBOUND_SYNC_CLIENT_ID_PREFIX) == true
-            if (isOwnOrigin || isOutboundSync) {
-              Log.d(
-                TAG,
-                "Skipping own record: ${record::class.simpleName} (origin=${record.metadata.dataOrigin.packageName}, clientId=${record.metadata.clientRecordId})",
-              )
-              false
-            } else {
-              true
-            }
+            !(isOwnOrigin || isOutboundSync)
           }
 
       if (upsertions.isNotEmpty()) {

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectSyncWorker.kt
@@ -8,10 +8,7 @@ import androidx.health.connect.client.changes.DeletionChange
 import androidx.health.connect.client.changes.UpsertionChange
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.request.AggregateRequest
-import androidx.health.connect.client.request.ChangesTokenRequest
 import androidx.health.connect.client.time.TimeRangeFilter
-import java.time.LocalDate
-import java.time.ZoneId
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -34,6 +31,8 @@ import kotlinx.serialization.KSerializer
 import net.aurboda.api.models.DailyAggregate
 import net.aurboda.api.models.DailyAggregatesBody
 import net.aurboda.widget.HrZoneWidgetProvider
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
@@ -44,520 +43,621 @@ private const val GRANTED_TYPES_KEY = "grantedRecordTypeNames"
 private const val WORK_NAME = "health_connect_sync"
 
 class HealthConnectSyncWorker(
-    context: Context,
-    params: WorkerParameters
+  context: Context,
+  params: WorkerParameters,
 ) : CoroutineWorker(context, params) {
-
-    private val healthConnectClient by lazy { HealthConnectClient.getOrCreate(applicationContext) }
-    private val httpClient by lazy {
-        HttpClient(Android) {
-            install(ContentNegotiation) { json(appJson) }
-        }
+  private val healthConnectClient by lazy { HealthConnectClient.getOrCreate(applicationContext) }
+  private val httpClient by lazy {
+    HttpClient(Android) {
+      install(ContentNegotiation) { json(appJson) }
     }
+  }
 
-    // Cumulative metrics with the record class they require permission for
-    private data class AggregatableMetric(
-        val aggregateMetric: AggregateMetric<*>,
-        val dailyMetric: DailyAggregate.Metric,
-        val recordClass: KClass<out Record>
+  // Cumulative metrics with the record class they require permission for
+  private data class AggregatableMetric(
+    val aggregateMetric: AggregateMetric<*>,
+    val dailyMetric: DailyAggregate.Metric,
+    val recordClass: KClass<out Record>,
+  )
+
+  private val allAggregatableMetrics: List<AggregatableMetric> =
+    listOf(
+      AggregatableMetric(StepsRecord.COUNT_TOTAL, DailyAggregate.Metric.steps, StepsRecord::class),
+      AggregatableMetric(DistanceRecord.DISTANCE_TOTAL, DailyAggregate.Metric.distance, DistanceRecord::class),
+      AggregatableMetric(
+        ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL,
+        DailyAggregate.Metric.calories_active,
+        ActiveCaloriesBurnedRecord::class,
+      ),
+      AggregatableMetric(TotalCaloriesBurnedRecord.ENERGY_TOTAL, DailyAggregate.Metric.calories_total, TotalCaloriesBurnedRecord::class),
+      AggregatableMetric(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL, DailyAggregate.Metric.floors_climbed, FloorsClimbedRecord::class),
     )
 
-    private val allAggregatableMetrics: List<AggregatableMetric> = listOf(
-        AggregatableMetric(StepsRecord.COUNT_TOTAL, DailyAggregate.Metric.steps, StepsRecord::class),
-        AggregatableMetric(DistanceRecord.DISTANCE_TOTAL, DailyAggregate.Metric.distance, DistanceRecord::class),
-        AggregatableMetric(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL, DailyAggregate.Metric.calories_active, ActiveCaloriesBurnedRecord::class),
-        AggregatableMetric(TotalCaloriesBurnedRecord.ENERGY_TOTAL, DailyAggregate.Metric.calories_total, TotalCaloriesBurnedRecord::class),
-        AggregatableMetric(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL, DailyAggregate.Metric.floors_climbed, FloorsClimbedRecord::class)
-    )
+  override suspend fun doWork(): Result {
+    Log.d(TAG, "Starting background sync")
 
-    override suspend fun doWork(): Result {
-        Log.d(TAG, "Starting background sync")
-
-        val credentials = CredentialsManager.getCredentials(applicationContext)
-        if (credentials == null) {
-            Log.w(TAG, "No credentials found, skipping sync")
-            return Result.success()
-        }
-
-        // Check permissions — proceed with whatever is granted (partial permissions support)
-        val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-        val grantedTypes = getGrantedRecordTypes(grantedPermissions)
-        if (grantedTypes.isEmpty()) {
-            Log.w(TAG, "No permissions granted, skipping sync")
-            return Result.success()
-        }
-        Log.d(TAG, "Granted ${grantedTypes.size}/${allRecordTypes.size} record types")
-
-        // Invalidate token if granted types changed since last sync
-        invalidateTokenIfGrantedTypesChanged(grantedTypes)
-
-        // Filter aggregatable metrics to only those with granted permissions
-        val grantedTypeSet = grantedTypes.toSet()
-        val activeAggregateMetrics = allAggregatableMetrics.filter { it.recordClass in grantedTypeSet }
-
-        return try {
-            // Step 1: Fetch and send daily aggregates for cumulative metrics (deduplicated)
-            val aggregates = fetchDailyAggregates(activeAggregateMetrics, days = 7)
-            if (aggregates.isNotEmpty()) {
-                val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken)
-                if (!aggregateSuccess) {
-                    Log.w(TAG, "Failed to send daily aggregates, will retry")
-                    return Result.retry()
-                }
-                Log.d(TAG, "Sent ${aggregates.size} daily aggregates")
-            }
-
-            // Step 2: Fetch and send raw records (filtered to exclude aggregated types)
-            val (records, deletionIds) = fetchHealthData()
-
-            // Step 3: Send deletions to backend
-            if (deletionIds.isNotEmpty()) {
-                val deletionSuccess = sendDeletions(deletionIds, credentials.apiUrl, credentials.authToken)
-                if (!deletionSuccess) {
-                    Log.w(TAG, "Failed to send deletions, will retry")
-                    return Result.retry()
-                }
-                Log.d(TAG, "Sent ${deletionIds.size} deletions")
-            }
-
-            if (records.isNotEmpty()) {
-                val success = sendDataToServer(records, credentials.apiUrl, credentials.authToken)
-                if (success) {
-                    Log.d(TAG, "Background sync completed successfully")
-                    HrZoneWidgetProvider.triggerUpdate(applicationContext)
-                    Result.success()
-                } else {
-                    Log.w(TAG, "Background sync failed to send data")
-                    Result.retry()
-                }
-            } else {
-                // If we had deletions but no records, save token
-                if (deletionIds.isNotEmpty()) {
-                    pendingToken?.let { saveChangesToken(it) }
-                }
-                Log.d(TAG, "No new data to sync")
-                HrZoneWidgetProvider.triggerUpdate(applicationContext)
-                Result.success()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Background sync failed", e)
-            Result.retry()
-        }
+    val credentials = CredentialsManager.getCredentials(applicationContext)
+    if (credentials == null) {
+      Log.w(TAG, "No credentials found, skipping sync")
+      return Result.success()
     }
 
-    private data class FetchResult(val records: List<Record>, val deletionIds: List<String>)
+    // Check permissions — proceed with whatever is granted (partial permissions support)
+    val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+    val grantedTypes = getGrantedRecordTypes(grantedPermissions)
+    if (grantedTypes.isEmpty()) {
+      Log.w(TAG, "No permissions granted, skipping sync")
+      return Result.success()
+    }
+    Log.d(TAG, "Granted ${grantedTypes.size}/${allRecordTypes.size} record types")
 
-    private suspend fun fetchHealthData(): FetchResult {
-        val records = mutableListOf<Record>()
-        val deletionIds = mutableListOf<String>()
-        val lastToken = loadChangesToken()
+    // Invalidate token if granted types changed since last sync
+    invalidateTokenIfGrantedTypesChanged(grantedTypes)
 
-        if (lastToken == null) {
-            Log.d(TAG, "No token found, skipping background fetch (initial fetch should be done in foreground)")
-            return FetchResult(emptyList(), emptyList())
+    // Filter aggregatable metrics to only those with granted permissions
+    val grantedTypeSet = grantedTypes.toSet()
+    val activeAggregateMetrics = allAggregatableMetrics.filter { it.recordClass in grantedTypeSet }
+
+    return try {
+      // Step 1: Fetch and send daily aggregates for cumulative metrics (deduplicated)
+      val aggregates = fetchDailyAggregates(activeAggregateMetrics, days = 7)
+      if (aggregates.isNotEmpty()) {
+        val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken)
+        if (!aggregateSuccess) {
+          Log.w(TAG, "Failed to send daily aggregates, will retry")
+          return Result.retry()
         }
+        Log.d(TAG, "Sent ${aggregates.size} daily aggregates")
+      }
 
-        var currentToken: String = lastToken
-        var hasMore = true
+      // Step 2: Fetch and send raw records (filtered to exclude aggregated types)
+      val (records, deletionIds) = fetchHealthData()
 
-        while (hasMore) {
-            val changesResponse = healthConnectClient.getChanges(currentToken)
-            val upsertions = changesResponse.changes.mapNotNull {
-                if (it is UpsertionChange) it.record else null
-            }
-
-            if (upsertions.isNotEmpty()) {
-                Log.d(TAG, "Fetched ${upsertions.size} records")
-                records.addAll(upsertions)
-            }
-
-            changesResponse.changes.forEach {
-                if (it is DeletionChange) {
-                    Log.d(TAG, "Record deleted, ID: ${it.recordId}")
-                    deletionIds.add(it.recordId)
-                }
-            }
-
-            hasMore = changesResponse.hasMore
-            currentToken = changesResponse.nextChangesToken
+      // Step 3: Send deletions to backend
+      if (deletionIds.isNotEmpty()) {
+        val deletionSuccess = sendDeletions(deletionIds, credentials.apiUrl, credentials.authToken)
+        if (!deletionSuccess) {
+          Log.w(TAG, "Failed to send deletions, will retry")
+          return Result.retry()
         }
+        Log.d(TAG, "Sent ${deletionIds.size} deletions")
+      }
 
-        // Save the new token if we have records to send (token will be updated after successful send)
-        // If no records and no deletions, save token now to avoid re-fetching empty changes
-        if (records.isEmpty() && deletionIds.isEmpty()) {
-            saveChangesToken(currentToken)
-        } else {
-            // Store temporarily, will be saved after successful send
-            pendingToken = currentToken
+      if (records.isNotEmpty()) {
+        val success = sendDataToServer(records, credentials.apiUrl, credentials.authToken)
+        if (!success) {
+          Log.w(TAG, "Background sync failed to send data")
+          return Result.retry()
         }
-
+        Log.d(TAG, "Inbound sync completed successfully")
+      } else {
+        // If we had deletions but no records, save token
         if (deletionIds.isNotEmpty()) {
-            Log.d(TAG, "Collected ${deletionIds.size} deletion IDs")
+          pendingToken?.let { saveChangesToken(it) }
         }
+        Log.d(TAG, "No new inbound data to sync")
+      }
 
-        return FetchResult(records, deletionIds)
-    }
-
-    private var pendingToken: String? = null
-
-    private suspend fun sendDataToServer(
-        records: List<Record>,
-        serverUrl: String,
-        authToken: String
-    ): Boolean {
-        val recordsWithKnownSerializers = records.filter {
-            when (it) {
-                is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
-                is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
-                is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
-                is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
-                is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
-                is TotalCaloriesBurnedRecord, is FloorsClimbedRecord -> true
-                else -> false
-            }
-        }
-
-        if (recordsWithKnownSerializers.isEmpty()) {
-            Log.d(TAG, "No records with known serializers to send")
-            pendingToken?.let { saveChangesToken(it) }
-            return true
-        }
-
-        val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
-        var allPostsSuccessful = true
-
-        for ((recordClass, classRecords) in groupedRecords) {
-            if (classRecords.isEmpty()) continue
-            val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
-            val apiUrl = "$serverUrl/sync/$recordTypeSimpleName"
-
-            val postSuccessful = when (recordClass) {
-                HeartRateVariabilityRmssdRecord::class -> postData(
-                    HrvRecordSerializable.fromRecordsList(classRecords),
-                    HrvRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                WeightRecord::class -> postData(
-                    WeightRecordSerializable.fromRecordsList(classRecords),
-                    WeightRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                HeartRateRecord::class -> postDataChunked(
-                    HeartRateRecordSerializable.fromRecordsList(classRecords),
-                    HeartRateRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                ExerciseSessionRecord::class -> postData(
-                    ExerciseSessionRecordSerializable.fromRecordsList(classRecords),
-                    ExerciseSessionRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                SpeedRecord::class -> postData(
-                    SpeedRecordSerializable.fromRecordsList(classRecords),
-                    SpeedRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                PowerRecord::class -> postData(
-                    PowerRecordSerializable.fromRecordsList(classRecords),
-                    PowerRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                NutritionRecord::class -> postData(
-                    NutritionRecordSerializable.fromRecordsList(classRecords),
-                    NutritionRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                LeanBodyMassRecord::class -> postData(
-                    LeanBodyMassRecordSerializable.fromRecordsList(classRecords),
-                    LeanBodyMassRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                BodyFatRecord::class -> postData(
-                    BodyFatRecordSerializable.fromRecordsList(classRecords),
-                    BodyFatRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                SleepSessionRecord::class -> postData(
-                    SleepSessionRecordSerializable.fromRecordsList(classRecords),
-                    SleepSessionRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                BoneMassRecord::class -> postData(
-                    BoneMassRecordSerializable.fromRecordsList(classRecords),
-                    BoneMassRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                BodyWaterMassRecord::class -> postData(
-                    BodyWaterMassRecordSerializable.fromRecordsList(classRecords),
-                    BodyWaterMassRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                HeightRecord::class -> postData(
-                    HeightRecordSerializable.fromRecordsList(classRecords),
-                    HeightRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                RestingHeartRateRecord::class -> postData(
-                    RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
-                    RestingHeartRateRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                StepsRecord::class -> postData(
-                    StepsRecordSerializable.fromRecordsList(classRecords),
-                    StepsRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                DistanceRecord::class -> postData(
-                    DistanceRecordSerializable.fromRecordsList(classRecords),
-                    DistanceRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                ActiveCaloriesBurnedRecord::class -> postData(
-                    ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
-                    ActiveCaloriesBurnedRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                TotalCaloriesBurnedRecord::class -> postData(
-                    TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
-                    TotalCaloriesBurnedRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                FloorsClimbedRecord::class -> postData(
-                    FloorsClimbedRecordSerializable.fromRecordsList(classRecords),
-                    FloorsClimbedRecordSerializable.serializer(),
-                    apiUrl, recordTypeSimpleName, authToken
-                )
-                else -> {
-                    Log.w(TAG, "No specific serialization for $recordTypeSimpleName. Skipping.")
-                    true
-                }
-            }
-
-            if (!postSuccessful) {
-                allPostsSuccessful = false
-                Log.w(TAG, "Post failed for $recordTypeSimpleName")
-                break
-            }
-        }
-
-        if (allPostsSuccessful) {
-            pendingToken?.let { saveChangesToken(it) }
-            Log.d(TAG, "All data sent successfully, token updated")
-        }
-
-        return allPostsSuccessful
-    }
-
-    private suspend inline fun <reified T : Any> postData(
-        dataList: List<T>,
-        itemSerializer: KSerializer<T>,
-        apiUrl: String,
-        recordTypeSimpleName: String,
-        authToken: String
-    ): Boolean {
-        if (dataList.isEmpty()) {
-            Log.d(TAG, "No data to send for $recordTypeSimpleName")
-            return true
-        }
-        Log.d(TAG, "Posting $recordTypeSimpleName: ${dataList.size} records")
-        return postChunk(PostWrapper(dataList), apiUrl, authToken, httpClient, TAG).isSuccess
-    }
-
-    /**
-     * Post data in chunks to avoid 413 Request Entity Too Large errors.
-     * HeartRateRecord can be very large (thousands of samples per record).
-     */
-    private suspend inline fun <reified T : Any> postDataChunked(
-        dataList: List<T>,
-        itemSerializer: KSerializer<T>,
-        apiUrl: String,
-        recordTypeSimpleName: String,
-        authToken: String,
-        chunkSize: Int = 10
-    ): Boolean = postDataChunked(
-        dataList = dataList,
-        apiUrl = apiUrl,
-        authToken = authToken,
+      // Step 4: Process outbound sync (backend -> Health Connect)
+      val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+      processOutboundSync(
+        apiUrl = credentials.apiUrl,
+        authToken = credentials.authToken,
         httpClient = httpClient,
-        chunkSize = chunkSize,
-        recordTypeName = recordTypeSimpleName,
-        logTag = TAG
+        healthConnectClient = healthConnectClient,
+        grantedPermissions = grantedPermissions,
+      )
+
+      HrZoneWidgetProvider.triggerUpdate(applicationContext)
+      Result.success()
+    } catch (e: Exception) {
+      Log.e(TAG, "Background sync failed", e)
+      Result.retry()
+    }
+  }
+
+  private data class FetchResult(
+    val records: List<Record>,
+    val deletionIds: List<String>,
+  )
+
+  private suspend fun fetchHealthData(): FetchResult {
+    val records = mutableListOf<Record>()
+    val deletionIds = mutableListOf<String>()
+    val lastToken = loadChangesToken()
+
+    if (lastToken == null) {
+      Log.d(TAG, "No token found, skipping background fetch (initial fetch should be done in foreground)")
+      return FetchResult(emptyList(), emptyList())
+    }
+
+    var currentToken: String = lastToken
+    var hasMore = true
+
+    while (hasMore) {
+      val changesResponse = healthConnectClient.getChanges(currentToken)
+      val upsertions =
+        changesResponse.changes
+          .mapNotNull {
+            if (it is UpsertionChange) it.record else null
+          }.filter { record ->
+            // Skip records written by Aurboda's outbound sync to prevent sync loops
+            val isOwnOrigin = record.metadata.dataOrigin.packageName == "net.aurboda"
+            val isOutboundSync =
+              record.metadata.clientRecordId
+                ?.startsWith(OUTBOUND_SYNC_CLIENT_ID_PREFIX) == true
+            if (isOwnOrigin || isOutboundSync) {
+              Log.d(
+                TAG,
+                "Skipping own record: ${record::class.simpleName} (origin=${record.metadata.dataOrigin.packageName}, clientId=${record.metadata.clientRecordId})",
+              )
+              false
+            } else {
+              true
+            }
+          }
+
+      if (upsertions.isNotEmpty()) {
+        Log.d(TAG, "Fetched ${upsertions.size} records (after filtering own records)")
+        records.addAll(upsertions)
+      }
+
+      changesResponse.changes.forEach {
+        if (it is DeletionChange) {
+          Log.d(TAG, "Record deleted, ID: ${it.recordId}")
+          deletionIds.add(it.recordId)
+        }
+      }
+
+      hasMore = changesResponse.hasMore
+      currentToken = changesResponse.nextChangesToken
+    }
+
+    // Save the new token if we have records to send (token will be updated after successful send)
+    // If no records and no deletions, save token now to avoid re-fetching empty changes
+    if (records.isEmpty() && deletionIds.isEmpty()) {
+      saveChangesToken(currentToken)
+    } else {
+      // Store temporarily, will be saved after successful send
+      pendingToken = currentToken
+    }
+
+    if (deletionIds.isNotEmpty()) {
+      Log.d(TAG, "Collected ${deletionIds.size} deletion IDs")
+    }
+
+    return FetchResult(records, deletionIds)
+  }
+
+  private var pendingToken: String? = null
+
+  private suspend fun sendDataToServer(
+    records: List<Record>,
+    serverUrl: String,
+    authToken: String,
+  ): Boolean {
+    val recordsWithKnownSerializers =
+      records.filter {
+        when (it) {
+          is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
+          is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
+          is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
+          is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
+          is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
+          is TotalCaloriesBurnedRecord, is FloorsClimbedRecord,
+          -> true
+          else -> false
+        }
+      }
+
+    if (recordsWithKnownSerializers.isEmpty()) {
+      Log.d(TAG, "No records with known serializers to send")
+      pendingToken?.let { saveChangesToken(it) }
+      return true
+    }
+
+    val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
+    var allPostsSuccessful = true
+
+    for ((recordClass, classRecords) in groupedRecords) {
+      if (classRecords.isEmpty()) continue
+      val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
+      val apiUrl = "$serverUrl/sync/$recordTypeSimpleName"
+
+      val postSuccessful =
+        when (recordClass) {
+          HeartRateVariabilityRmssdRecord::class ->
+            postData(
+              HrvRecordSerializable.fromRecordsList(classRecords),
+              HrvRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          WeightRecord::class ->
+            postData(
+              WeightRecordSerializable.fromRecordsList(classRecords),
+              WeightRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          HeartRateRecord::class ->
+            postDataChunked(
+              HeartRateRecordSerializable.fromRecordsList(classRecords),
+              HeartRateRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          ExerciseSessionRecord::class ->
+            postData(
+              ExerciseSessionRecordSerializable.fromRecordsList(classRecords),
+              ExerciseSessionRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          SpeedRecord::class ->
+            postData(
+              SpeedRecordSerializable.fromRecordsList(classRecords),
+              SpeedRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          PowerRecord::class ->
+            postData(
+              PowerRecordSerializable.fromRecordsList(classRecords),
+              PowerRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          NutritionRecord::class ->
+            postData(
+              NutritionRecordSerializable.fromRecordsList(classRecords),
+              NutritionRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          LeanBodyMassRecord::class ->
+            postData(
+              LeanBodyMassRecordSerializable.fromRecordsList(classRecords),
+              LeanBodyMassRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          BodyFatRecord::class ->
+            postData(
+              BodyFatRecordSerializable.fromRecordsList(classRecords),
+              BodyFatRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          SleepSessionRecord::class ->
+            postData(
+              SleepSessionRecordSerializable.fromRecordsList(classRecords),
+              SleepSessionRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          BoneMassRecord::class ->
+            postData(
+              BoneMassRecordSerializable.fromRecordsList(classRecords),
+              BoneMassRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          BodyWaterMassRecord::class ->
+            postData(
+              BodyWaterMassRecordSerializable.fromRecordsList(classRecords),
+              BodyWaterMassRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          HeightRecord::class ->
+            postData(
+              HeightRecordSerializable.fromRecordsList(classRecords),
+              HeightRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          RestingHeartRateRecord::class ->
+            postData(
+              RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
+              RestingHeartRateRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          StepsRecord::class ->
+            postData(
+              StepsRecordSerializable.fromRecordsList(classRecords),
+              StepsRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          DistanceRecord::class ->
+            postData(
+              DistanceRecordSerializable.fromRecordsList(classRecords),
+              DistanceRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          ActiveCaloriesBurnedRecord::class ->
+            postData(
+              ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+              ActiveCaloriesBurnedRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          TotalCaloriesBurnedRecord::class ->
+            postData(
+              TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+              TotalCaloriesBurnedRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          FloorsClimbedRecord::class ->
+            postData(
+              FloorsClimbedRecordSerializable.fromRecordsList(classRecords),
+              FloorsClimbedRecordSerializable.serializer(),
+              apiUrl,
+              recordTypeSimpleName,
+              authToken,
+            )
+          else -> {
+            Log.w(TAG, "No specific serialization for $recordTypeSimpleName. Skipping.")
+            true
+          }
+        }
+
+      if (!postSuccessful) {
+        allPostsSuccessful = false
+        Log.w(TAG, "Post failed for $recordTypeSimpleName")
+        break
+      }
+    }
+
+    if (allPostsSuccessful) {
+      pendingToken?.let { saveChangesToken(it) }
+      Log.d(TAG, "All data sent successfully, token updated")
+    }
+
+    return allPostsSuccessful
+  }
+
+  private suspend inline fun <reified T : Any> postData(
+    dataList: List<T>,
+    itemSerializer: KSerializer<T>,
+    apiUrl: String,
+    recordTypeSimpleName: String,
+    authToken: String,
+  ): Boolean {
+    if (dataList.isEmpty()) {
+      Log.d(TAG, "No data to send for $recordTypeSimpleName")
+      return true
+    }
+    Log.d(TAG, "Posting $recordTypeSimpleName: ${dataList.size} records")
+    return postChunk(PostWrapper(dataList), apiUrl, authToken, httpClient, TAG).isSuccess
+  }
+
+  /**
+   * Post data in chunks to avoid 413 Request Entity Too Large errors.
+   * HeartRateRecord can be very large (thousands of samples per record).
+   */
+  private suspend inline fun <reified T : Any> postDataChunked(
+    dataList: List<T>,
+    itemSerializer: KSerializer<T>,
+    apiUrl: String,
+    recordTypeSimpleName: String,
+    authToken: String,
+    chunkSize: Int = 10,
+  ): Boolean =
+    postDataChunked(
+      dataList = dataList,
+      apiUrl = apiUrl,
+      authToken = authToken,
+      httpClient = httpClient,
+      chunkSize = chunkSize,
+      recordTypeName = recordTypeSimpleName,
+      logTag = TAG,
     ).isSuccess
 
-    private fun saveChangesToken(token: String?) {
-        val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        Log.d(TAG, "Saving token: ${token?.take(10)}...")
-        prefs.edit().putString(CHANGES_TOKEN_KEY, token).apply()
+  private fun saveChangesToken(token: String?) {
+    val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    Log.d(TAG, "Saving token: ${token?.take(10)}...")
+    prefs.edit().putString(CHANGES_TOKEN_KEY, token).apply()
+  }
+
+  private fun loadChangesToken(): String? {
+    val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return prefs.getString(CHANGES_TOKEN_KEY, null)
+  }
+
+  /**
+   * Check if granted types changed and invalidate the changes token if so.
+   */
+  private fun invalidateTokenIfGrantedTypesChanged(currentGrantedTypes: List<KClass<out Record>>) {
+    val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val currentNames = currentGrantedTypes.map { it.simpleName ?: "" }.sorted().joinToString(",")
+    val savedNames = prefs.getString(GRANTED_TYPES_KEY, null)
+
+    if (savedNames != null && savedNames != currentNames) {
+      Log.d(TAG, "Granted types changed, invalidating changes token")
+      prefs
+        .edit()
+        .remove(CHANGES_TOKEN_KEY)
+        .putString(GRANTED_TYPES_KEY, currentNames)
+        .apply()
+    } else {
+      prefs.edit().putString(GRANTED_TYPES_KEY, currentNames).apply()
     }
+  }
 
-    private fun loadChangesToken(): String? {
-        val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return prefs.getString(CHANGES_TOKEN_KEY, null)
-    }
+  /**
+   * Fetch daily aggregates for cumulative metrics using Health Connect's aggregate() API.
+   * Only fetches for metrics that have granted permissions.
+   */
+  private suspend fun fetchDailyAggregates(
+    metrics: List<AggregatableMetric>,
+    days: Int = 7,
+  ): List<DailyAggregate> {
+    if (metrics.isEmpty()) return emptyList()
 
-    /**
-     * Check if granted types changed and invalidate the changes token if so.
-     */
-    private fun invalidateTokenIfGrantedTypesChanged(currentGrantedTypes: List<KClass<out Record>>) {
-        val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val currentNames = currentGrantedTypes.map { it.simpleName ?: "" }.sorted().joinToString(",")
-        val savedNames = prefs.getString(GRANTED_TYPES_KEY, null)
+    val aggregates = mutableListOf<DailyAggregate>()
+    val today = LocalDate.now()
+    val zoneId = ZoneId.systemDefault()
 
-        if (savedNames != null && savedNames != currentNames) {
-            Log.d(TAG, "Granted types changed, invalidating changes token")
-            prefs.edit()
-                .remove(CHANGES_TOKEN_KEY)
-                .putString(GRANTED_TYPES_KEY, currentNames)
-                .apply()
-        } else {
-            prefs.edit().putString(GRANTED_TYPES_KEY, currentNames).apply()
-        }
-    }
+    for (dayOffset in 0 until days) {
+      val date = today.minusDays(dayOffset.toLong())
+      val startTime = date.atStartOfDay(zoneId).toInstant()
+      val endTime = date.plusDays(1).atStartOfDay(zoneId).toInstant()
 
-    /**
-     * Fetch daily aggregates for cumulative metrics using Health Connect's aggregate() API.
-     * Only fetches for metrics that have granted permissions.
-     */
-    private suspend fun fetchDailyAggregates(
-        metrics: List<AggregatableMetric>,
-        days: Int = 7
-    ): List<DailyAggregate> {
-        if (metrics.isEmpty()) return emptyList()
-
-        val aggregates = mutableListOf<DailyAggregate>()
-        val today = LocalDate.now()
-        val zoneId = ZoneId.systemDefault()
-
-        for (dayOffset in 0 until days) {
-            val date = today.minusDays(dayOffset.toLong())
-            val startTime = date.atStartOfDay(zoneId).toInstant()
-            val endTime = date.plusDays(1).atStartOfDay(zoneId).toInstant()
-
-            for ((metric, metricType, _) in metrics) {
-                try {
-                    val request = AggregateRequest(
-                        metrics = setOf(metric),
-                        timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
-                    )
-                    val result = healthConnectClient.aggregate(request)
-
-                    // Extract value based on metric type
-                    val value: Double? = when (metric) {
-                        StepsRecord.COUNT_TOTAL -> result[StepsRecord.COUNT_TOTAL]?.toDouble()
-                        DistanceRecord.DISTANCE_TOTAL -> result[DistanceRecord.DISTANCE_TOTAL]?.inMeters
-                        ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL ->
-                            result[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
-                        TotalCaloriesBurnedRecord.ENERGY_TOTAL ->
-                            result[TotalCaloriesBurnedRecord.ENERGY_TOTAL]?.inKilocalories
-                        FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL ->
-                            result[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL]
-                        else -> null
-                    }
-
-                    if (value != null && value > 0) {
-                        val dataOrigins = result.dataOrigins.map { it.packageName }
-                        aggregates.add(
-                            DailyAggregate(
-                                date = date.toString(), // YYYY-MM-DD format
-                                metric = metricType,
-                                value = value,
-                                dataOrigins = dataOrigins
-                            )
-                        )
-                        Log.d(TAG, "Aggregate for $metricType on $date: $value from ${dataOrigins.size} sources")
-                    }
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to fetch aggregate for $metricType on $date", e)
-                }
-            }
-        }
-
-        return aggregates
-    }
-
-    /**
-     * Send daily aggregates to the backend.
-     */
-    private suspend fun sendDailyAggregates(
-        aggregates: List<DailyAggregate>,
-        serverUrl: String,
-        authToken: String
-    ): Boolean {
-        if (aggregates.isEmpty()) {
-            Log.d(TAG, "No aggregates to send")
-            return true
-        }
-
-        val postData = DailyAggregatesBody(data = aggregates)
-        return try {
-            val response = httpClient.post("$serverUrl/sync/daily-aggregates") {
-                contentType(ContentType.Application.Json)
-                headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-                setBody(postData)
-            }
-            Log.d(TAG, "Daily aggregates response: ${response.status}")
-            response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-        } catch (e: Exception) {
-            Log.e(TAG, "Error posting daily aggregates", e)
-            false
-        }
-    }
-
-    /**
-     * Send Health Connect deletion IDs to the backend.
-     */
-    private suspend fun sendDeletions(
-        deletionIds: List<String>,
-        serverUrl: String,
-        authToken: String
-    ): Boolean {
-        if (deletionIds.isEmpty()) return true
-
-        val postData = PostWrapper(deletionIds)
-        return try {
-            val response = httpClient.post("$serverUrl/sync/deletions") {
-                contentType(ContentType.Application.Json)
-                headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-                setBody(postData)
-            }
-            Log.d(TAG, "Deletions response: ${response.status}")
-            response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-        } catch (e: Exception) {
-            Log.e(TAG, "Error posting deletions", e)
-            false
-        }
-    }
-
-    companion object {
-        /**
-         * Schedule periodic background sync.
-         * Sync runs every 15 minutes (minimum interval for periodic work).
-         */
-        fun schedule(context: Context) {
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
-
-            val workRequest = PeriodicWorkRequestBuilder<HealthConnectSyncWorker>(
-                15, TimeUnit.MINUTES
+      for ((metric, metricType, _) in metrics) {
+        try {
+          val request =
+            AggregateRequest(
+              metrics = setOf(metric),
+              timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
             )
-                .setConstraints(constraints)
-                .build()
+          val result = healthConnectClient.aggregate(request)
 
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                WORK_NAME,
-                ExistingPeriodicWorkPolicy.UPDATE,
-                workRequest
+          // Extract value based on metric type
+          val value: Double? =
+            when (metric) {
+              StepsRecord.COUNT_TOTAL -> result[StepsRecord.COUNT_TOTAL]?.toDouble()
+              DistanceRecord.DISTANCE_TOTAL -> result[DistanceRecord.DISTANCE_TOTAL]?.inMeters
+              ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL ->
+                result[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
+              TotalCaloriesBurnedRecord.ENERGY_TOTAL ->
+                result[TotalCaloriesBurnedRecord.ENERGY_TOTAL]?.inKilocalories
+              FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL ->
+                result[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL]
+              else -> null
+            }
+
+          if (value != null && value > 0) {
+            val dataOrigins = result.dataOrigins.map { it.packageName }
+            aggregates.add(
+              DailyAggregate(
+                date = date.toString(), // YYYY-MM-DD format
+                metric = metricType,
+                value = value,
+                dataOrigins = dataOrigins,
+              ),
             )
-            Log.d(TAG, "Background sync scheduled with network constraint")
+            Log.d(TAG, "Aggregate for $metricType on $date: $value from ${dataOrigins.size} sources")
+          }
+        } catch (e: Exception) {
+          Log.w(TAG, "Failed to fetch aggregate for $metricType on $date", e)
         }
-
-        /**
-         * Cancel scheduled background sync.
-         */
-        fun cancel(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
-            Log.d(TAG, "Background sync cancelled")
-        }
+      }
     }
+
+    return aggregates
+  }
+
+  /**
+   * Send daily aggregates to the backend.
+   */
+  private suspend fun sendDailyAggregates(
+    aggregates: List<DailyAggregate>,
+    serverUrl: String,
+    authToken: String,
+  ): Boolean {
+    if (aggregates.isEmpty()) {
+      Log.d(TAG, "No aggregates to send")
+      return true
+    }
+
+    val postData = DailyAggregatesBody(data = aggregates)
+    return try {
+      val response =
+        httpClient.post("$serverUrl/sync/daily-aggregates") {
+          contentType(ContentType.Application.Json)
+          headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+          setBody(postData)
+        }
+      Log.d(TAG, "Daily aggregates response: ${response.status}")
+      response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+    } catch (e: Exception) {
+      Log.e(TAG, "Error posting daily aggregates", e)
+      false
+    }
+  }
+
+  /**
+   * Send Health Connect deletion IDs to the backend.
+   */
+  private suspend fun sendDeletions(
+    deletionIds: List<String>,
+    serverUrl: String,
+    authToken: String,
+  ): Boolean {
+    if (deletionIds.isEmpty()) return true
+
+    val postData = PostWrapper(deletionIds)
+    return try {
+      val response =
+        httpClient.post("$serverUrl/sync/deletions") {
+          contentType(ContentType.Application.Json)
+          headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+          setBody(postData)
+        }
+      Log.d(TAG, "Deletions response: ${response.status}")
+      response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+    } catch (e: Exception) {
+      Log.e(TAG, "Error posting deletions", e)
+      false
+    }
+  }
+
+  companion object {
+    /**
+     * Schedule periodic background sync.
+     * Sync runs every 15 minutes (minimum interval for periodic work).
+     */
+    fun schedule(context: Context) {
+      val constraints =
+        Constraints
+          .Builder()
+          .setRequiredNetworkType(NetworkType.CONNECTED)
+          .build()
+
+      val workRequest =
+        PeriodicWorkRequestBuilder<HealthConnectSyncWorker>(
+          15,
+          TimeUnit.MINUTES,
+        ).setConstraints(constraints)
+          .build()
+
+      WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+        WORK_NAME,
+        ExistingPeriodicWorkPolicy.UPDATE,
+        workRequest,
+      )
+      Log.d(TAG, "Background sync scheduled with network constraint")
+    }
+
+    /**
+     * Cancel scheduled background sync.
+     */
+    fun cancel(context: Context) {
+      WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+      Log.d(TAG, "Background sync cancelled")
+    }
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -51,675 +51,668 @@ import java.time.format.DateTimeFormatter
 import kotlin.reflect.KClass
 
 // Global JSON configuration instance
-val appJson = Json {
+val appJson =
+  Json {
     prettyPrint = true
     isLenient = true
     ignoreUnknownKeys = true
     encodeDefaults = true // Important if you have default values and want them in the JSON
-}
+  }
 
 // Generic wrapper for POST requests
 @Serializable
-data class PostWrapper<T>(val data: List<T>)
+data class PostWrapper<T>(
+  val data: List<T>,
+)
 
 // --- Base Metadata and Device for Serializable Records ---
 @Serializable
 data class DeviceSerializable(
-    val manufacturer: String?,
-    val model: String?,
-    val type: Int
+  val manufacturer: String?,
+  val model: String?,
+  val type: Int,
 )
 
 @Serializable
 data class HealthConnectRecordMetadata(
-    val id: String,
-    val dataOrigin: String, // package name
-    val lastModifiedTime: String,
-    val clientRecordId: String?,
-    val clientRecordVersion: Long,
-    val device: DeviceSerializable?,
-    val recordingMethod: Int
+  val id: String,
+  val dataOrigin: String, // package name
+  val lastModifiedTime: String,
+  val clientRecordId: String?,
+  val clientRecordVersion: Long,
+  val device: DeviceSerializable?,
+  val recordingMethod: Int,
 )
 
 // --- Active Calories Burned Record ---
 @Serializable
 data class ActiveCaloriesBurnedRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val energyInKilocalories: Double,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val energyInKilocalories: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<ActiveCaloriesBurnedRecordSerializable> {
-            return classRecords.filterIsInstance<ActiveCaloriesBurnedRecord>().map { record ->
-                ActiveCaloriesBurnedRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    energyInKilocalories = record.energy.inKilocalories,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<ActiveCaloriesBurnedRecordSerializable> =
+      classRecords.filterIsInstance<ActiveCaloriesBurnedRecord>().map { record ->
+        ActiveCaloriesBurnedRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          energyInKilocalories = record.energy.inKilocalories,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Body Fat Record ---
 @Serializable
 data class BodyFatRecordSerializable(
-    val time: String,
-    val percentage: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val percentage: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<BodyFatRecordSerializable> {
-            return classRecords.filterIsInstance<BodyFatRecord>().map { record ->
-                BodyFatRecordSerializable(
-                    time = record.time.toIsoString(),
-                    percentage = record.percentage.value, // androidx.health.connect.client.units.Percentage.value is Double
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BodyFatRecordSerializable> =
+      classRecords.filterIsInstance<BodyFatRecord>().map { record ->
+        BodyFatRecordSerializable(
+          time = record.time.toIsoString(),
+          percentage = record.percentage.value, // androidx.health.connect.client.units.Percentage.value is Double
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Body Water Mass Record ---
 @Serializable
 data class BodyWaterMassRecordSerializable(
-    val time: String,
-    val massInKilograms: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val massInKilograms: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<BodyWaterMassRecordSerializable> {
-            return classRecords.filterIsInstance<BodyWaterMassRecord>().map { record ->
-                BodyWaterMassRecordSerializable(
-                    time = record.time.toIsoString(),
-                    massInKilograms = record.mass.inKilograms,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BodyWaterMassRecordSerializable> =
+      classRecords.filterIsInstance<BodyWaterMassRecord>().map { record ->
+        BodyWaterMassRecordSerializable(
+          time = record.time.toIsoString(),
+          massInKilograms = record.mass.inKilograms,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Bone Mass Record ---
 @Serializable
 data class BoneMassRecordSerializable(
-    val time: String,
-    val massInKilograms: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val massInKilograms: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<BoneMassRecordSerializable> {
-            return classRecords.filterIsInstance<BoneMassRecord>().map { record ->
-                BoneMassRecordSerializable(
-                    time = record.time.toIsoString(),
-                    massInKilograms = record.mass.inKilograms,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BoneMassRecordSerializable> =
+      classRecords.filterIsInstance<BoneMassRecord>().map { record ->
+        BoneMassRecordSerializable(
+          time = record.time.toIsoString(),
+          massInKilograms = record.mass.inKilograms,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
-// --- Distance Record --- 
+// --- Distance Record ---
 @Serializable
 data class DistanceRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val distanceInMeters: Double?,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val distanceInMeters: Double?,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<DistanceRecordSerializable> {
-            return classRecords.filterIsInstance<DistanceRecord>().map { record ->
-                DistanceRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    distanceInMeters = record.distance.inMeters,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<DistanceRecordSerializable> =
+      classRecords.filterIsInstance<DistanceRecord>().map { record ->
+        DistanceRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          distanceInMeters = record.distance.inMeters,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Exercise Session Record Helpers ---
 @Serializable
 data class ExerciseSegmentSerializable(
-    val startTime: String,
-    val endTime: String,
-    val segmentType: Int,
-    // val weightInKilograms: Double? = null, // Add if using a library version that supports segment.weight
+  val startTime: String,
+  val endTime: String,
+  val segmentType: Int,
+  // val weightInKilograms: Double? = null, // Add if using a library version that supports segment.weight
 )
 
 @Serializable
 data class ExerciseLapSerializable(
-    val startTime: String,
-    val endTime: String,
-    val lengthInMeters: Double?
+  val startTime: String,
+  val endTime: String,
+  val lengthInMeters: Double?,
 )
 
 @Serializable
 data class ExerciseRouteLocationSerializable(
-    val time: String,
-    val latitude: Double,
-    val longitude: Double,
-    val horizontalAccuracyInMeters: Double?,
-    val verticalAccuracyInMeters: Double?,
-    val altitudeInMeters: Double?
+  val time: String,
+  val latitude: Double,
+  val longitude: Double,
+  val horizontalAccuracyInMeters: Double?,
+  val verticalAccuracyInMeters: Double?,
+  val altitudeInMeters: Double?,
 )
 
 @Serializable
 data class ExerciseRouteSerializable(
-    val route: List<ExerciseRouteLocationSerializable>
+  val route: List<ExerciseRouteLocationSerializable>,
 )
 
 // --- Exercise Session Record ---
 @Serializable
 data class ExerciseSessionRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val exerciseType: Int,
-    val title: String?,
-    val notes: String?,
-    val segments: List<ExerciseSegmentSerializable>? = null,
-    val laps: List<ExerciseLapSerializable>? = null,
-    val route: ExerciseRouteSerializable? = null,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val exerciseType: Int,
+  val title: String?,
+  val notes: String?,
+  val segments: List<ExerciseSegmentSerializable>? = null,
+  val laps: List<ExerciseLapSerializable>? = null,
+  val route: ExerciseRouteSerializable? = null,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<ExerciseSessionRecordSerializable> {
-            return classRecords.filterIsInstance<ExerciseSessionRecord>().map { record: ExerciseSessionRecord ->
-                ExerciseSessionRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    exerciseType = record.exerciseType,
-                    title = record.title,
-                    notes = record.notes,
-                    segments = record.segments.map { segment: ExerciseSegment ->
-                        ExerciseSegmentSerializable(
-                            startTime = segment.startTime.toIsoString(),
-                            endTime = segment.endTime.toIsoString(),
-                            segmentType = segment.segmentType
-                            // weightInKilograms = if (segment.weight != null) segment.weight!!.inKilograms else null // Enable if segment.weight is available
-                        )
-                    }.takeIf { it.isNotEmpty() },
-                    laps = record.laps.map { lap: ExerciseLap ->
-                        ExerciseLapSerializable(
-                            startTime = lap.startTime.toIsoString(),
-                            endTime = lap.endTime.toIsoString(),
-                            lengthInMeters = lap.length?.inMeters
-                        )
-                    }.takeIf { it.isNotEmpty() },
-                    route = if (record.exerciseRouteResult is ExerciseRouteResult.Data) {
-                        (record.exerciseRouteResult as ExerciseRouteResult.Data).exerciseRoute?.let { sdkExerciseRoute: ExerciseRoute ->
-                            ExerciseRouteSerializable(
-                                route = sdkExerciseRoute.route.map { sdkLocation: ExerciseRoute.Location ->
-                                    ExerciseRouteLocationSerializable(
-                                        time = sdkLocation.time.toIsoString(),
-                                        latitude = sdkLocation.latitude,
-                                        longitude = sdkLocation.longitude,
-                                        horizontalAccuracyInMeters = sdkLocation.horizontalAccuracy?.inMeters,
-                                        verticalAccuracyInMeters = sdkLocation.verticalAccuracy?.inMeters,
-                                        altitudeInMeters = sdkLocation.altitude?.inMeters
-                                    )
-                                }
-                            )
-                        }
-                    } else {
-                        null
-                    },
-                    metadata = record.metadata.toSerializable()
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<ExerciseSessionRecordSerializable> =
+      classRecords.filterIsInstance<ExerciseSessionRecord>().map { record: ExerciseSessionRecord ->
+        ExerciseSessionRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          exerciseType = record.exerciseType,
+          title = record.title,
+          notes = record.notes,
+          segments =
+            record.segments
+              .map { segment: ExerciseSegment ->
+                ExerciseSegmentSerializable(
+                  startTime = segment.startTime.toIsoString(),
+                  endTime = segment.endTime.toIsoString(),
+                  segmentType = segment.segmentType,
+                  // weightInKilograms = if (segment.weight != null) segment.weight!!.inKilograms else null // Enable if segment.weight is available
                 )
-            }
-        }
-    }
+              }.takeIf { it.isNotEmpty() },
+          laps =
+            record.laps
+              .map { lap: ExerciseLap ->
+                ExerciseLapSerializable(
+                  startTime = lap.startTime.toIsoString(),
+                  endTime = lap.endTime.toIsoString(),
+                  lengthInMeters = lap.length?.inMeters,
+                )
+              }.takeIf { it.isNotEmpty() },
+          route =
+            if (record.exerciseRouteResult is ExerciseRouteResult.Data) {
+              (record.exerciseRouteResult as ExerciseRouteResult.Data).exerciseRoute.let { sdkExerciseRoute: ExerciseRoute ->
+                ExerciseRouteSerializable(
+                  route =
+                    sdkExerciseRoute.route.map { sdkLocation: ExerciseRoute.Location ->
+                      ExerciseRouteLocationSerializable(
+                        time = sdkLocation.time.toIsoString(),
+                        latitude = sdkLocation.latitude,
+                        longitude = sdkLocation.longitude,
+                        horizontalAccuracyInMeters = sdkLocation.horizontalAccuracy?.inMeters,
+                        verticalAccuracyInMeters = sdkLocation.verticalAccuracy?.inMeters,
+                        altitudeInMeters = sdkLocation.altitude?.inMeters,
+                      )
+                    },
+                )
+              }
+            } else {
+              null
+            },
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Heart Rate Record Helpers ---
 @Serializable
 data class HeartRateSampleSerializable(
-    val time: String,
-    val beatsPerMinute: Long
+  val time: String,
+  val beatsPerMinute: Long,
 )
 
 // --- Heart Rate Record ---
 @Serializable
 data class HeartRateRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val samples: List<HeartRateSampleSerializable>,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val samples: List<HeartRateSampleSerializable>,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<HeartRateRecordSerializable> {
-            return classRecords.filterIsInstance<HeartRateRecord>().map { record ->
-                HeartRateRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    samples = record.samples.map {
-                        HeartRateSampleSerializable(
-                            time = it.time.toIsoString(),
-                            beatsPerMinute = it.beatsPerMinute
-                        )
-                    },
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<HeartRateRecordSerializable> =
+      classRecords.filterIsInstance<HeartRateRecord>().map { record ->
+        HeartRateRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          samples =
+            record.samples.map {
+              HeartRateSampleSerializable(
+                time = it.time.toIsoString(),
+                beatsPerMinute = it.beatsPerMinute,
+              )
+            },
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Heart Rate Variability Record ---
 @Serializable
 data class HrvRecordSerializable(
-    val time: String,
-    val heartRateVariabilityMillis: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val heartRateVariabilityMillis: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<HrvRecordSerializable> {
-            return classRecords.filterIsInstance<HeartRateVariabilityRmssdRecord>().map { record ->
-                HrvRecordSerializable(
-                    time = record.time.toIsoString(),
-                    heartRateVariabilityMillis = record.heartRateVariabilityMillis,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<HrvRecordSerializable> =
+      classRecords.filterIsInstance<HeartRateVariabilityRmssdRecord>().map { record ->
+        HrvRecordSerializable(
+          time = record.time.toIsoString(),
+          heartRateVariabilityMillis = record.heartRateVariabilityMillis,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Lean Body Mass Record ---
 @Serializable
 data class LeanBodyMassRecordSerializable(
-    val time: String,
-    val massInKilograms: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val massInKilograms: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<LeanBodyMassRecordSerializable> {
-            return classRecords.filterIsInstance<LeanBodyMassRecord>().map { record ->
-                LeanBodyMassRecordSerializable(
-                    time = record.time.toIsoString(),
-                    massInKilograms = record.mass.inKilograms,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<LeanBodyMassRecordSerializable> =
+      classRecords.filterIsInstance<LeanBodyMassRecord>().map { record ->
+        LeanBodyMassRecordSerializable(
+          time = record.time.toIsoString(),
+          massInKilograms = record.mass.inKilograms,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Nutrition Record ---
 @Serializable
 data class NutritionRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val biotinInGrams: Double? = null,
-    val caffeineInGrams: Double? = null,
-    val calciumInGrams: Double? = null,
-    val energyInKilocalories: Double? = null,
-    val energyFromFatInKilocalories: Double? = null,
-    val chlorideInGrams: Double? = null,
-    val cholesterolInGrams: Double? = null,
-    val chromiumInGrams: Double? = null,
-    val copperInGrams: Double? = null,
-    val dietaryFiberInGrams: Double? = null,
-    val folateInGrams: Double? = null,
-    val folicAcidInGrams: Double? = null,
-    val iodineInGrams: Double? = null,
-    val ironInGrams: Double? = null,
-    val magnesiumInGrams: Double? = null,
-    val manganeseInGrams: Double? = null,
-    val molybdenumInGrams: Double? = null,
-    val monounsaturatedFatInGrams: Double? = null,
-    val niacinInGrams: Double? = null,
-    val pantothenicAcidInGrams: Double? = null,
-    val phosphorusInGrams: Double? = null,
-    val polyunsaturatedFatInGrams: Double? = null,
-    val potassiumInGrams: Double? = null,
-    val proteinInGrams: Double? = null,
-    val riboflavinInGrams: Double? = null,
-    val saturatedFatInGrams: Double? = null,
-    val seleniumInGrams: Double? = null,
-    val sodiumInGrams: Double? = null,
-    val sugarInGrams: Double? = null,
-    val thiaminInGrams: Double? = null,
-    val totalCarbohydrateInGrams: Double? = null,
-    val totalFatInGrams: Double? = null,
-    val transFatInGrams: Double? = null,
-    val unsaturatedFatInGrams: Double? = null,
-    val vitaminAInGrams: Double? = null,
-    val vitaminB12InGrams: Double? = null,
-    val vitaminB6InGrams: Double? = null,
-    val vitaminCInGrams: Double? = null,
-    val vitaminDInGrams: Double? = null,
-    val vitaminEInGrams: Double? = null,
-    val vitaminKInGrams: Double? = null,
-    val zincInGrams: Double? = null,
-    val mealType: Int,
-    val name: String? = null,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val biotinInGrams: Double? = null,
+  val caffeineInGrams: Double? = null,
+  val calciumInGrams: Double? = null,
+  val energyInKilocalories: Double? = null,
+  val energyFromFatInKilocalories: Double? = null,
+  val chlorideInGrams: Double? = null,
+  val cholesterolInGrams: Double? = null,
+  val chromiumInGrams: Double? = null,
+  val copperInGrams: Double? = null,
+  val dietaryFiberInGrams: Double? = null,
+  val folateInGrams: Double? = null,
+  val folicAcidInGrams: Double? = null,
+  val iodineInGrams: Double? = null,
+  val ironInGrams: Double? = null,
+  val magnesiumInGrams: Double? = null,
+  val manganeseInGrams: Double? = null,
+  val molybdenumInGrams: Double? = null,
+  val monounsaturatedFatInGrams: Double? = null,
+  val niacinInGrams: Double? = null,
+  val pantothenicAcidInGrams: Double? = null,
+  val phosphorusInGrams: Double? = null,
+  val polyunsaturatedFatInGrams: Double? = null,
+  val potassiumInGrams: Double? = null,
+  val proteinInGrams: Double? = null,
+  val riboflavinInGrams: Double? = null,
+  val saturatedFatInGrams: Double? = null,
+  val seleniumInGrams: Double? = null,
+  val sodiumInGrams: Double? = null,
+  val sugarInGrams: Double? = null,
+  val thiaminInGrams: Double? = null,
+  val totalCarbohydrateInGrams: Double? = null,
+  val totalFatInGrams: Double? = null,
+  val transFatInGrams: Double? = null,
+  val unsaturatedFatInGrams: Double? = null,
+  val vitaminAInGrams: Double? = null,
+  val vitaminB12InGrams: Double? = null,
+  val vitaminB6InGrams: Double? = null,
+  val vitaminCInGrams: Double? = null,
+  val vitaminDInGrams: Double? = null,
+  val vitaminEInGrams: Double? = null,
+  val vitaminKInGrams: Double? = null,
+  val zincInGrams: Double? = null,
+  val mealType: Int,
+  val name: String? = null,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<NutritionRecordSerializable> {
-            return classRecords.filterIsInstance<NutritionRecord>().map { record ->
-                NutritionRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    biotinInGrams = record.biotin?.inGrams,
-                    caffeineInGrams = record.caffeine?.inGrams,
-                    calciumInGrams = record.calcium?.inGrams,
-                    energyInKilocalories = record.energy?.inKilocalories,
-                    energyFromFatInKilocalories = record.energyFromFat?.inKilocalories,
-                    chlorideInGrams = record.chloride?.inGrams,
-                    cholesterolInGrams = record.cholesterol?.inGrams,
-                    chromiumInGrams = record.chromium?.inGrams,
-                    copperInGrams = record.copper?.inGrams,
-                    dietaryFiberInGrams = record.dietaryFiber?.inGrams,
-                    folateInGrams = record.folate?.inGrams,
-                    folicAcidInGrams = record.folicAcid?.inGrams,
-                    iodineInGrams = record.iodine?.inGrams,
-                    ironInGrams = record.iron?.inGrams,
-                    magnesiumInGrams = record.magnesium?.inGrams,
-                    manganeseInGrams = record.manganese?.inGrams,
-                    molybdenumInGrams = record.molybdenum?.inGrams,
-                    monounsaturatedFatInGrams = record.monounsaturatedFat?.inGrams,
-                    niacinInGrams = record.niacin?.inGrams,
-                    pantothenicAcidInGrams = record.pantothenicAcid?.inGrams,
-                    phosphorusInGrams = record.phosphorus?.inGrams,
-                    polyunsaturatedFatInGrams = record.polyunsaturatedFat?.inGrams,
-                    potassiumInGrams = record.potassium?.inGrams,
-                    proteinInGrams = record.protein?.inGrams,
-                    riboflavinInGrams = record.riboflavin?.inGrams,
-                    saturatedFatInGrams = record.saturatedFat?.inGrams,
-                    seleniumInGrams = record.selenium?.inGrams,
-                    sodiumInGrams = record.sodium?.inGrams,
-                    sugarInGrams = record.sugar?.inGrams,
-                    thiaminInGrams = record.thiamin?.inGrams,
-                    totalCarbohydrateInGrams = record.totalCarbohydrate?.inGrams,
-                    totalFatInGrams = record.totalFat?.inGrams,
-                    transFatInGrams = record.transFat?.inGrams,
-                    unsaturatedFatInGrams = record.unsaturatedFat?.inGrams,
-                    vitaminAInGrams = record.vitaminA?.inGrams,
-                    vitaminB12InGrams = record.vitaminB12?.inGrams,
-                    vitaminB6InGrams = record.vitaminB6?.inGrams,
-                    vitaminCInGrams = record.vitaminC?.inGrams,
-                    vitaminDInGrams = record.vitaminD?.inGrams,
-                    vitaminEInGrams = record.vitaminE?.inGrams,
-                    vitaminKInGrams = record.vitaminK?.inGrams,
-                    zincInGrams = record.zinc?.inGrams,
-                    mealType = record.mealType,
-                    name = record.name,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<NutritionRecordSerializable> =
+      classRecords.filterIsInstance<NutritionRecord>().map { record ->
+        NutritionRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          biotinInGrams = record.biotin?.inGrams,
+          caffeineInGrams = record.caffeine?.inGrams,
+          calciumInGrams = record.calcium?.inGrams,
+          energyInKilocalories = record.energy?.inKilocalories,
+          energyFromFatInKilocalories = record.energyFromFat?.inKilocalories,
+          chlorideInGrams = record.chloride?.inGrams,
+          cholesterolInGrams = record.cholesterol?.inGrams,
+          chromiumInGrams = record.chromium?.inGrams,
+          copperInGrams = record.copper?.inGrams,
+          dietaryFiberInGrams = record.dietaryFiber?.inGrams,
+          folateInGrams = record.folate?.inGrams,
+          folicAcidInGrams = record.folicAcid?.inGrams,
+          iodineInGrams = record.iodine?.inGrams,
+          ironInGrams = record.iron?.inGrams,
+          magnesiumInGrams = record.magnesium?.inGrams,
+          manganeseInGrams = record.manganese?.inGrams,
+          molybdenumInGrams = record.molybdenum?.inGrams,
+          monounsaturatedFatInGrams = record.monounsaturatedFat?.inGrams,
+          niacinInGrams = record.niacin?.inGrams,
+          pantothenicAcidInGrams = record.pantothenicAcid?.inGrams,
+          phosphorusInGrams = record.phosphorus?.inGrams,
+          polyunsaturatedFatInGrams = record.polyunsaturatedFat?.inGrams,
+          potassiumInGrams = record.potassium?.inGrams,
+          proteinInGrams = record.protein?.inGrams,
+          riboflavinInGrams = record.riboflavin?.inGrams,
+          saturatedFatInGrams = record.saturatedFat?.inGrams,
+          seleniumInGrams = record.selenium?.inGrams,
+          sodiumInGrams = record.sodium?.inGrams,
+          sugarInGrams = record.sugar?.inGrams,
+          thiaminInGrams = record.thiamin?.inGrams,
+          totalCarbohydrateInGrams = record.totalCarbohydrate?.inGrams,
+          totalFatInGrams = record.totalFat?.inGrams,
+          transFatInGrams = record.transFat?.inGrams,
+          unsaturatedFatInGrams = record.unsaturatedFat?.inGrams,
+          vitaminAInGrams = record.vitaminA?.inGrams,
+          vitaminB12InGrams = record.vitaminB12?.inGrams,
+          vitaminB6InGrams = record.vitaminB6?.inGrams,
+          vitaminCInGrams = record.vitaminC?.inGrams,
+          vitaminDInGrams = record.vitaminD?.inGrams,
+          vitaminEInGrams = record.vitaminE?.inGrams,
+          vitaminKInGrams = record.vitaminK?.inGrams,
+          zincInGrams = record.zinc?.inGrams,
+          mealType = record.mealType,
+          name = record.name,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Power Record Helpers ---
 @Serializable
 data class PowerSampleSerializable(
-    val time: String,
-    val powerInWatts: Double
+  val time: String,
+  val powerInWatts: Double,
 )
 
 // --- Power Record ---
 @Serializable
 data class PowerRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val samples: List<PowerSampleSerializable>,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val samples: List<PowerSampleSerializable>,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<PowerRecordSerializable> {
-            return classRecords.filterIsInstance<PowerRecord>().map { record ->
-                PowerRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    samples = record.samples.map {
-                        PowerSampleSerializable(
-                            time = it.time.toIsoString(),
-                            powerInWatts = it.power.inWatts
-                        )
-                    },
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<PowerRecordSerializable> =
+      classRecords.filterIsInstance<PowerRecord>().map { record ->
+        PowerRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          samples =
+            record.samples.map {
+              PowerSampleSerializable(
+                time = it.time.toIsoString(),
+                powerInWatts = it.power.inWatts,
+              )
+            },
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Sleep Session Record Helpers ---
 @Serializable
 data class SleepStageSerializable(
-    val startTime: String,
-    val endTime: String,
-    val stage: Int
+  val startTime: String,
+  val endTime: String,
+  val stage: Int,
 )
 
 // --- Sleep Session Record ---
 @Serializable
 data class SleepSessionRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val stages: List<SleepStageSerializable>,
-    val title: String? = null,
-    val notes: String? = null,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val stages: List<SleepStageSerializable>,
+  val title: String? = null,
+  val notes: String? = null,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<SleepSessionRecordSerializable> {
-            return classRecords.filterIsInstance<SleepSessionRecord>().map { record ->
-                SleepSessionRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    stages = record.stages.map {
-                        SleepStageSerializable(
-                            startTime = it.startTime.toIsoString(),
-                            endTime = it.endTime.toIsoString(),
-                            stage = it.stage
-                        )
-                    },
-                    title = record.title,
-                    notes = record.notes,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<SleepSessionRecordSerializable> =
+      classRecords.filterIsInstance<SleepSessionRecord>().map { record ->
+        SleepSessionRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          stages =
+            record.stages.map {
+              SleepStageSerializable(
+                startTime = it.startTime.toIsoString(),
+                endTime = it.endTime.toIsoString(),
+                stage = it.stage,
+              )
+            },
+          title = record.title,
+          notes = record.notes,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Speed Record Helpers ---
 @Serializable
 data class SpeedSampleSerializable(
-    val time: String,
-    val speedInMetersPerSecond: Double
+  val time: String,
+  val speedInMetersPerSecond: Double,
 )
 
 // --- Speed Record ---
 @Serializable
 data class SpeedRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val samples: List<SpeedSampleSerializable>,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val samples: List<SpeedSampleSerializable>,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<SpeedRecordSerializable> {
-            return classRecords.filterIsInstance<SpeedRecord>().map { record ->
-                SpeedRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    samples = record.samples.map {
-                        SpeedSampleSerializable(
-                            time = it.time.toIsoString(),
-                            speedInMetersPerSecond = it.speed.inMetersPerSecond
-                        )
-                    },
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<SpeedRecordSerializable> =
+      classRecords.filterIsInstance<SpeedRecord>().map { record ->
+        SpeedRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          samples =
+            record.samples.map {
+              SpeedSampleSerializable(
+                time = it.time.toIsoString(),
+                speedInMetersPerSecond = it.speed.inMetersPerSecond,
+              )
+            },
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Floors Climbed Record ---
 @Serializable
 data class FloorsClimbedRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val floors: Double,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val floors: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<FloorsClimbedRecordSerializable> {
-            return classRecords.filterIsInstance<FloorsClimbedRecord>().map { record ->
-                FloorsClimbedRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    floors = record.floors,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<FloorsClimbedRecordSerializable> =
+      classRecords.filterIsInstance<FloorsClimbedRecord>().map { record ->
+        FloorsClimbedRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          floors = record.floors,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Steps Record ---
 @Serializable
 data class StepsRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val count: Long,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val count: Long,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<StepsRecordSerializable> {
-            return classRecords.filterIsInstance<StepsRecord>().map { record ->
-                StepsRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    count = record.count,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<StepsRecordSerializable> =
+      classRecords.filterIsInstance<StepsRecord>().map { record ->
+        StepsRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          count = record.count,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Total Calories Burned Record ---
 @Serializable
 data class TotalCaloriesBurnedRecordSerializable(
-    val startTime: String,
-    val endTime: String,
-    val energyInKilocalories: Double,
-    val metadata: HealthConnectRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val energyInKilocalories: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<TotalCaloriesBurnedRecordSerializable> {
-            return classRecords.filterIsInstance<TotalCaloriesBurnedRecord>().map { record ->
-                TotalCaloriesBurnedRecordSerializable(
-                    startTime = record.startTime.toIsoString(),
-                    endTime = record.endTime.toIsoString(),
-                    energyInKilocalories = record.energy.inKilocalories,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<TotalCaloriesBurnedRecordSerializable> =
+      classRecords.filterIsInstance<TotalCaloriesBurnedRecord>().map { record ->
+        TotalCaloriesBurnedRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          energyInKilocalories = record.energy.inKilocalories,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Weight Record ---
 @Serializable
 data class WeightRecordSerializable(
-    val time: String,
-    val weightInKilograms: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val weightInKilograms: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<WeightRecordSerializable> {
-            return classRecords.filterIsInstance<WeightRecord>().map { record ->
-                WeightRecordSerializable(
-                    time = record.time.toIsoString(),
-                    weightInKilograms = record.weight.inKilograms,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<WeightRecordSerializable> =
+      classRecords.filterIsInstance<WeightRecord>().map { record ->
+        WeightRecordSerializable(
+          time = record.time.toIsoString(),
+          weightInKilograms = record.weight.inKilograms,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Height Record ---
 @Serializable
 data class HeightRecordSerializable(
-    val time: String,
-    val heightInMeters: Double,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val heightInMeters: Double,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<HeightRecordSerializable> {
-            return classRecords.filterIsInstance<HeightRecord>().map { record ->
-                HeightRecordSerializable(
-                    time = record.time.toIsoString(),
-                    heightInMeters = record.height.inMeters,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<HeightRecordSerializable> =
+      classRecords.filterIsInstance<HeightRecord>().map { record ->
+        HeightRecordSerializable(
+          time = record.time.toIsoString(),
+          heightInMeters = record.height.inMeters,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // --- Resting Heart Rate Record ---
 @Serializable
 data class RestingHeartRateRecordSerializable(
-    val time: String,
-    val beatsPerMinute: Long,
-    val metadata: HealthConnectRecordMetadata
+  val time: String,
+  val beatsPerMinute: Long,
+  val metadata: HealthConnectRecordMetadata,
 ) {
-    companion object {
-        fun fromRecordsList(classRecords: List<Record>): List<RestingHeartRateRecordSerializable> {
-            return classRecords.filterIsInstance<RestingHeartRateRecord>().map { record ->
-                RestingHeartRateRecordSerializable(
-                    time = record.time.toIsoString(),
-                    beatsPerMinute = record.beatsPerMinute,
-                    metadata = record.metadata.toSerializable()
-                )
-            }
-        }
-    }
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<RestingHeartRateRecordSerializable> =
+      classRecords.filterIsInstance<RestingHeartRateRecord>().map { record ->
+        RestingHeartRateRecordSerializable(
+          time = record.time.toIsoString(),
+          beatsPerMinute = record.beatsPerMinute,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
 }
 
 // Helper to format Instant to ISO 8601 String
-fun Instant.toIsoString(): String {
-    return this.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-}
+fun Instant.toIsoString(): String = this.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
 // Helper to convert Health Connect Metadata to Serializable Metadata
-fun Metadata.toSerializable(): HealthConnectRecordMetadata {
-    return HealthConnectRecordMetadata(
-        id = this.id,
-        dataOrigin = this.dataOrigin.packageName,
-        lastModifiedTime = this.lastModifiedTime.toIsoString(),
-        clientRecordId = this.clientRecordId,
-        clientRecordVersion = this.clientRecordVersion,
-        device = this.device?.let {
-            DeviceSerializable(
-                manufacturer = it.manufacturer,
-                model = it.model,
-                type = it.type
-            )
-        },
-        recordingMethod = this.recordingMethod
-    )
-}
+fun Metadata.toSerializable(): HealthConnectRecordMetadata =
+  HealthConnectRecordMetadata(
+    id = this.id,
+    dataOrigin = this.dataOrigin.packageName,
+    lastModifiedTime = this.lastModifiedTime.toIsoString(),
+    clientRecordId = this.clientRecordId,
+    clientRecordVersion = this.clientRecordVersion,
+    device =
+      this.device?.let {
+        DeviceSerializable(
+          manufacturer = it.manufacturer,
+          model = it.model,
+          type = it.type,
+        )
+      },
+    recordingMethod = this.recordingMethod,
+  )
 
 // Comprehensive list of all record KClass objects we want to read, sorted alphabetically
-val allRecordTypes: List<KClass<out Record>> = listOf(
+val allRecordTypes: List<KClass<out Record>> =
+  listOf(
     ActiveCaloriesBurnedRecord::class,
     BasalBodyTemperatureRecord::class,
     BasalMetabolicRateRecord::class,
@@ -759,5 +752,5 @@ val allRecordTypes: List<KClass<out Record>> = listOf(
     TotalCaloriesBurnedRecord::class,
     Vo2MaxRecord::class,
     WeightRecord::class,
-    WheelchairPushesRecord::class
-)
+    WheelchairPushesRecord::class,
+  )

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -176,7 +176,7 @@ fun getRecordSummary(record: Record): String =
         ?.power
         ?.inWatts ?: 0.0,
     )}W"
-    is NutritionRecord -> "Nutrition: ${record.name ?: "Unnamed food"} (${record.mealType ?: "Unknown"}, ${String.format(
+    is NutritionRecord -> "Nutrition: ${record.name ?: "Unnamed food"} (mealType=${record.mealType}, ${String.format(
       "%.0f",
       record.energy?.inKilocalories ?: 0.0,
     )} kcal)"
@@ -300,6 +300,7 @@ class MainActivity : ComponentActivity() {
 
 private const val VERSION_JSON_URL = "https://github.com/fiddur/aurboda/releases/latest/download/version.json"
 
+@Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
 @Composable
 fun AurbodaApp(initialTab: MainTab? = null) {
   val appState = rememberAppState(initialTab = initialTab)
@@ -457,6 +458,7 @@ fun AurbodaApp(initialTab: MainTab? = null) {
   }
 }
 
+@Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
 @Composable
 fun HealthConnectScreen(
   apiUrl: String,
@@ -553,7 +555,7 @@ fun HealthConnectScreen(
                 .readRecords(request)
                 .records
                 .filter { record ->
-                  // Skip records written by Aurboda's outbound sync to prevent sync loops
+                  // Skip records written by Aurboda (outbound sync + BLE sensors)
                   val isOwnOrigin = record.metadata.dataOrigin.packageName == "net.aurboda"
                   val isOutboundSync =
                     record.metadata.clientRecordId
@@ -561,10 +563,7 @@ fun HealthConnectScreen(
                   !(isOwnOrigin || isOutboundSync)
                 }
             if (recordsOfType.isNotEmpty()) {
-              Log.d(
-                "FetchData",
-                "Fetched ${recordsOfType.size} records of type ${recordType.simpleName} (after filtering own records)",
-              )
+              Log.d("FetchData", "Fetched ${recordsOfType.size} records of type ${recordType.simpleName} (after filtering)")
               localHealthRecords.addAll(recordsOfType)
             }
           } catch (e: Exception) {
@@ -605,7 +604,7 @@ fun HealthConnectScreen(
             changesResponse.changes
               .mapNotNull { if (it is UpsertionChange) it.record else null }
               .filter { record ->
-                // Skip records written by Aurboda's outbound sync to prevent sync loops
+                // Skip records written by Aurboda (outbound sync + BLE sensors)
                 val isOwnOrigin = record.metadata.dataOrigin.packageName == "net.aurboda"
                 val isOutboundSync =
                   record.metadata.clientRecordId
@@ -613,7 +612,7 @@ fun HealthConnectScreen(
                 !(isOwnOrigin || isOutboundSync)
               }
           if (upsertions.isNotEmpty()) {
-            Log.d("FetchData", "Adding ${upsertions.size} upserted records (after filtering own records).")
+            Log.d("FetchData", "Adding ${upsertions.size} upserted records (after filtering).")
             localHealthRecords.addAll(upsertions)
             totalUpsertions += upsertions.size
           }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -90,98 +89,121 @@ private const val BACKGROUND_SYNC_ENABLED_KEY = "backgroundSyncEnabled"
 private const val GRANTED_TYPES_KEY = "grantedRecordTypeNames"
 
 private fun isBackgroundSyncEnabled(context: Context): Boolean {
-    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    return prefs.getBoolean(BACKGROUND_SYNC_ENABLED_KEY, false)
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  return prefs.getBoolean(BACKGROUND_SYNC_ENABLED_KEY, false)
 }
 
-private fun setBackgroundSyncEnabled(context: Context, enabled: Boolean) {
-    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    prefs.edit().putBoolean(BACKGROUND_SYNC_ENABLED_KEY, enabled).apply()
-    if (enabled) {
-        HealthConnectSyncWorker.schedule(context)
-    } else {
-        HealthConnectSyncWorker.cancel(context)
-    }
+private fun setBackgroundSyncEnabled(
+  context: Context,
+  enabled: Boolean,
+) {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  prefs.edit().putBoolean(BACKGROUND_SYNC_ENABLED_KEY, enabled).apply()
+  if (enabled) {
+    HealthConnectSyncWorker.schedule(context)
+  } else {
+    HealthConnectSyncWorker.cancel(context)
+  }
 }
 
-fun Record.getPrimaryInstant(): Instant {
-    return when (this) {
-        is StepsRecord -> this.endTime
-        is DistanceRecord -> this.endTime
-        is SpeedRecord -> this.endTime
-        is ActiveCaloriesBurnedRecord -> this.endTime
-        is TotalCaloriesBurnedRecord -> this.endTime
-        is PowerRecord -> this.endTime
-        is NutritionRecord -> this.endTime
-        is SleepSessionRecord -> this.startTime
-        is HeartRateVariabilityRmssdRecord -> this.time
-        is WeightRecord -> this.time
-        is LeanBodyMassRecord -> this.time
-        is BodyFatRecord -> this.time
-        is BoneMassRecord -> this.time
-        is ExerciseSessionRecord -> this.startTime
-        is HeartRateRecord -> this.startTime
-        is HeightRecord -> this.time
-        is BodyWaterMassRecord -> this.time
-        is BasalMetabolicRateRecord -> this.time
-        is CervicalMucusRecord -> this.time
-        is IntermenstrualBleedingRecord -> this.time
-        is MenstruationFlowRecord -> this.time
-        is MenstruationPeriodRecord -> this.startTime 
-        is OvulationTestRecord -> this.time
-        is SexualActivityRecord -> this.time
-        is BasalBodyTemperatureRecord -> this.time
-        is HydrationRecord -> this.startTime 
-        is RestingHeartRateRecord -> this.time
-        is BloodPressureRecord -> this.time
-        is BloodGlucoseRecord -> this.time
-        is OxygenSaturationRecord -> this.time
-        is BodyTemperatureRecord -> this.time
-        is RespiratoryRateRecord -> this.time
-        is FloorsClimbedRecord -> this.endTime
-        is CyclingPedalingCadenceRecord -> this.endTime
-        is ElevationGainedRecord -> this.endTime
-        is Vo2MaxRecord -> this.time
-        is WheelchairPushesRecord -> this.endTime
-        else -> this.metadata.lastModifiedTime
-    }
-}
+fun Record.getPrimaryInstant(): Instant =
+  when (this) {
+    is StepsRecord -> this.endTime
+    is DistanceRecord -> this.endTime
+    is SpeedRecord -> this.endTime
+    is ActiveCaloriesBurnedRecord -> this.endTime
+    is TotalCaloriesBurnedRecord -> this.endTime
+    is PowerRecord -> this.endTime
+    is NutritionRecord -> this.endTime
+    is SleepSessionRecord -> this.startTime
+    is HeartRateVariabilityRmssdRecord -> this.time
+    is WeightRecord -> this.time
+    is LeanBodyMassRecord -> this.time
+    is BodyFatRecord -> this.time
+    is BoneMassRecord -> this.time
+    is ExerciseSessionRecord -> this.startTime
+    is HeartRateRecord -> this.startTime
+    is HeightRecord -> this.time
+    is BodyWaterMassRecord -> this.time
+    is BasalMetabolicRateRecord -> this.time
+    is CervicalMucusRecord -> this.time
+    is IntermenstrualBleedingRecord -> this.time
+    is MenstruationFlowRecord -> this.time
+    is MenstruationPeriodRecord -> this.startTime
+    is OvulationTestRecord -> this.time
+    is SexualActivityRecord -> this.time
+    is BasalBodyTemperatureRecord -> this.time
+    is HydrationRecord -> this.startTime
+    is RestingHeartRateRecord -> this.time
+    is BloodPressureRecord -> this.time
+    is BloodGlucoseRecord -> this.time
+    is OxygenSaturationRecord -> this.time
+    is BodyTemperatureRecord -> this.time
+    is RespiratoryRateRecord -> this.time
+    is FloorsClimbedRecord -> this.endTime
+    is CyclingPedalingCadenceRecord -> this.endTime
+    is ElevationGainedRecord -> this.endTime
+    is Vo2MaxRecord -> this.time
+    is WheelchairPushesRecord -> this.endTime
+    else -> this.metadata.lastModifiedTime
+  }
 
-fun getRecordSummary(record: Record): String {
-    return when (record) {
-        is HeartRateVariabilityRmssdRecord -> "HRV: ${record.heartRateVariabilityMillis} ms"
-        is WeightRecord -> "Weight: ${record.weight.inKilograms} kg"
-        is StepsRecord -> "Steps: ${record.count}"
-        is ExerciseSessionRecord -> "Exercise: ${record.title ?: record.exerciseType.toString().lowercase().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }}"
-        is DistanceRecord -> "Distance: ${String.format("%.2f", record.distance.inMeters)}m"
-        is SpeedRecord -> "Speed: First sample ${String.format("%.2f", record.samples.firstOrNull()?.speed?.inMetersPerSecond ?: 0.0)} m/s"
-        is HeartRateRecord -> "HeartRate: ${record.samples.size} samples, first ${record.samples.firstOrNull()?.beatsPerMinute ?: "N/A"}bpm"
-        is ActiveCaloriesBurnedRecord -> "Active Cals: ${String.format("%.2f", record.energy.inKilocalories)} kcal"
-        is TotalCaloriesBurnedRecord -> "Total Cals: ${String.format("%.2f", record.energy.inKilocalories)} kcal"
-        is PowerRecord -> "Power: ${record.samples.size} samples, first ${String.format("%.2f", record.samples.firstOrNull()?.power?.inWatts ?: 0.0)}W"
-        is NutritionRecord -> "Nutrition: ${record.name ?: "Unnamed food"} (${record.mealType ?: "Unknown"}, ${String.format("%.0f",record.energy?.inKilocalories ?: 0.0)} kcal)"
-        is LeanBodyMassRecord -> "Lean Body Mass: ${String.format("%.2f", record.mass.inKilograms)} kg"
-        is BodyFatRecord -> "Body Fat: ${String.format("%.1f", record.percentage.value)}%%"
-        is SleepSessionRecord -> "Sleep: ${record.title ?: "Session"} (Stages: ${record.stages.size})"
-        is BoneMassRecord -> "Bone Mass: ${String.format("%.2f", record.mass.inKilograms)} kg"
-        is BodyWaterMassRecord -> "Body Water: ${String.format("%.2f", record.mass.inKilograms)} kg"
-        is HeightRecord -> "Height: ${String.format("%.2f", record.height.inMeters)} m"
-        is RestingHeartRateRecord -> "Resting HR: ${record.beatsPerMinute} bpm"
-        else -> record::class.simpleName ?: "Record" 
-    }
-}
+fun getRecordSummary(record: Record): String =
+  when (record) {
+    is HeartRateVariabilityRmssdRecord -> "HRV: ${record.heartRateVariabilityMillis} ms"
+    is WeightRecord -> "Weight: ${record.weight.inKilograms} kg"
+    is StepsRecord -> "Steps: ${record.count}"
+    is ExerciseSessionRecord ->
+      "Exercise: ${record.title ?: record.exerciseType
+        .toString()
+        .lowercase()
+        .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }}"
+    is DistanceRecord -> "Distance: ${String.format("%.2f", record.distance.inMeters)}m"
+    is SpeedRecord -> "Speed: First sample ${String.format(
+      "%.2f",
+      record.samples
+        .firstOrNull()
+        ?.speed
+        ?.inMetersPerSecond ?: 0.0,
+    )} m/s"
+    is HeartRateRecord -> "HeartRate: ${record.samples.size} samples, first ${record.samples.firstOrNull()?.beatsPerMinute ?: "N/A"}bpm"
+    is ActiveCaloriesBurnedRecord -> "Active Cals: ${String.format("%.2f", record.energy.inKilocalories)} kcal"
+    is TotalCaloriesBurnedRecord -> "Total Cals: ${String.format("%.2f", record.energy.inKilocalories)} kcal"
+    is PowerRecord -> "Power: ${record.samples.size} samples, first ${String.format(
+      "%.2f",
+      record.samples
+        .firstOrNull()
+        ?.power
+        ?.inWatts ?: 0.0,
+    )}W"
+    is NutritionRecord -> "Nutrition: ${record.name ?: "Unnamed food"} (${record.mealType ?: "Unknown"}, ${String.format(
+      "%.0f",
+      record.energy?.inKilocalories ?: 0.0,
+    )} kcal)"
+    is LeanBodyMassRecord -> "Lean Body Mass: ${String.format("%.2f", record.mass.inKilograms)} kg"
+    is BodyFatRecord -> "Body Fat: ${String.format("%.1f", record.percentage.value)}%%"
+    is SleepSessionRecord -> "Sleep: ${record.title ?: "Session"} (Stages: ${record.stages.size})"
+    is BoneMassRecord -> "Bone Mass: ${String.format("%.2f", record.mass.inKilograms)} kg"
+    is BodyWaterMassRecord -> "Body Water: ${String.format("%.2f", record.mass.inKilograms)} kg"
+    is HeightRecord -> "Height: ${String.format("%.2f", record.height.inMeters)} m"
+    is RestingHeartRateRecord -> "Resting HR: ${record.beatsPerMinute} bpm"
+    else -> record::class.simpleName ?: "Record"
+  }
 
-private fun saveChangesToken(context: Context, token: String?) {
-    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    Log.d("TokenManager", "Saving token: ${token?.take(10)}...")
-    prefs.edit().putString(CHANGES_TOKEN_KEY, token).apply()
+private fun saveChangesToken(
+  context: Context,
+  token: String?,
+) {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  Log.d("TokenManager", "Saving token: ${token?.take(10)}...")
+  prefs.edit().putString(CHANGES_TOKEN_KEY, token).apply()
 }
 
 private fun loadChangesToken(context: Context): String? {
-    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    val token = prefs.getString(CHANGES_TOKEN_KEY, null)
-    Log.d("TokenManager", "Loaded token: ${token?.take(10)}...")
-    return token
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  val token = prefs.getString(CHANGES_TOKEN_KEY, null)
+  Log.d("TokenManager", "Loaded token: ${token?.take(10)}...")
+  return token
 }
 
 /**
@@ -189,41 +211,42 @@ private fun loadChangesToken(context: Context): String? {
  * If changed, invalidate the changes token to force a full re-fetch.
  */
 private fun invalidateTokenIfGrantedTypesChanged(
-    context: Context,
-    currentGrantedTypes: List<KClass<out Record>>
+  context: Context,
+  currentGrantedTypes: List<KClass<out Record>>,
 ) {
-    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    val currentNames = currentGrantedTypes.map { it.simpleName ?: "" }.sorted().joinToString(",")
-    val savedNames = prefs.getString(GRANTED_TYPES_KEY, null)
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  val currentNames = currentGrantedTypes.map { it.simpleName ?: "" }.sorted().joinToString(",")
+  val savedNames = prefs.getString(GRANTED_TYPES_KEY, null)
 
-    if (savedNames != null && savedNames != currentNames) {
-        Log.d("TokenManager", "Granted types changed, invalidating changes token")
-        prefs.edit()
-            .remove(CHANGES_TOKEN_KEY)
-            .putString(GRANTED_TYPES_KEY, currentNames)
-            .apply()
-    } else {
-        prefs.edit().putString(GRANTED_TYPES_KEY, currentNames).apply()
-    }
+  if (savedNames != null && savedNames != currentNames) {
+    Log.d("TokenManager", "Granted types changed, invalidating changes token")
+    prefs
+      .edit()
+      .remove(CHANGES_TOKEN_KEY)
+      .putString(GRANTED_TYPES_KEY, currentNames)
+      .apply()
+  } else {
+    prefs.edit().putString(GRANTED_TYPES_KEY, currentNames).apply()
+  }
 }
 
 private const val SEND_DATA_TAG = "SendData"
 
 private suspend inline fun <reified T : Any> handlePostData(
-    dataList: List<T>,
-    itemSerializer: KSerializer<T>,
-    apiUrl: String,
-    recordTypeSimpleName: String,
-    httpClient: HttpClient,
-    authToken: String
+  dataList: List<T>,
+  itemSerializer: KSerializer<T>,
+  apiUrl: String,
+  recordTypeSimpleName: String,
+  httpClient: HttpClient,
+  authToken: String,
 ): PostResult {
-    if (dataList.isEmpty()) {
-        Log.d(SEND_DATA_TAG, "No data to send for $recordTypeSimpleName")
-        return PostResult.Success
-    }
-    val postData = PostWrapper(dataList)
-    Log.d(SEND_DATA_TAG, "Posting $recordTypeSimpleName: ${dataList.size} records")
-    return postChunk(postData, apiUrl, authToken, httpClient, SEND_DATA_TAG)
+  if (dataList.isEmpty()) {
+    Log.d(SEND_DATA_TAG, "No data to send for $recordTypeSimpleName")
+    return PostResult.Success
+  }
+  val postData = PostWrapper(dataList)
+  Log.d(SEND_DATA_TAG, "Posting $recordTypeSimpleName: ${dataList.size} records")
+  return postChunk(postData, apiUrl, authToken, httpClient, SEND_DATA_TAG)
 }
 
 /**
@@ -231,813 +254,1034 @@ private suspend inline fun <reified T : Any> handlePostData(
  * HeartRateRecord can be very large (thousands of samples per record).
  */
 private suspend inline fun <reified T : Any> handlePostDataChunked(
-    dataList: List<T>,
-    itemSerializer: KSerializer<T>,
-    apiUrl: String,
-    recordTypeSimpleName: String,
-    httpClient: HttpClient,
-    authToken: String,
-    chunkSize: Int = 10
-): PostResult = postDataChunked(
+  dataList: List<T>,
+  itemSerializer: KSerializer<T>,
+  apiUrl: String,
+  recordTypeSimpleName: String,
+  httpClient: HttpClient,
+  authToken: String,
+  chunkSize: Int = 10,
+): PostResult =
+  postDataChunked(
     dataList = dataList,
     apiUrl = apiUrl,
     authToken = authToken,
     httpClient = httpClient,
     chunkSize = chunkSize,
     recordTypeName = recordTypeSimpleName,
-    logTag = SEND_DATA_TAG
-)
+    logTag = SEND_DATA_TAG,
+  )
 
 class MainActivity : ComponentActivity() {
-    companion object {
-        const val EXTRA_OPEN_TAB = "open_tab"
-        const val TAB_DATA = "data"
-    }
+  companion object {
+    const val EXTRA_OPEN_TAB = "open_tab"
+    const val TAB_DATA = "data"
+  }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val initialTab = when (intent?.getStringExtra(EXTRA_OPEN_TAB)) {
-            TAB_DATA -> MainTab.Data
-            else -> null
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val initialTab =
+      when (intent?.getStringExtra(EXTRA_OPEN_TAB)) {
+        TAB_DATA -> MainTab.Data
+        else -> null
+      }
+    setContent {
+      AurbodaAppTheme {
+        Surface(
+          modifier = Modifier.fillMaxSize(),
+          color = MaterialTheme.colorScheme.background,
+        ) {
+          AurbodaApp(initialTab = initialTab)
         }
-        setContent {
-            AurbodaAppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    AurbodaApp(initialTab = initialTab)
-                }
-            }
-        }
+      }
     }
+  }
 }
 
 private const val VERSION_JSON_URL = "https://github.com/fiddur/aurboda/releases/latest/download/version.json"
 
 @Composable
 fun AurbodaApp(initialTab: MainTab? = null) {
-    val appState = rememberAppState(initialTab = initialTab)
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
+  val appState = rememberAppState(initialTab = initialTab)
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
+  val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
 
-    // Update check state
-    var updateAvailable by remember { mutableStateOf<VersionInfo?>(null) }
-    var showUpdateDialog by remember { mutableStateOf(false) }
-    var showDownloadingDialog by remember { mutableStateOf(false) }
-    var showInstallDialog by remember { mutableStateOf(false) }
-    var downloadedApkFile by remember { mutableStateOf<File?>(null) }
-    var updateError by remember { mutableStateOf<String?>(null) }
+  // Update check state
+  var updateAvailable by remember { mutableStateOf<VersionInfo?>(null) }
+  var showUpdateDialog by remember { mutableStateOf(false) }
+  var showDownloadingDialog by remember { mutableStateOf(false) }
+  var showInstallDialog by remember { mutableStateOf(false) }
+  var downloadedApkFile by remember { mutableStateOf<File?>(null) }
+  var updateError by remember { mutableStateOf<String?>(null) }
 
-    // Check for updates on app launch
-    LaunchedEffect(Unit) {
-        val currentVersionCode = BuildConfig.VERSION_CODE_INT
-        Log.d("UpdateChecker", "Checking for updates. Current version code: $currentVersionCode")
-        when (val result = checkForUpdate(ktorHttpClient, VERSION_JSON_URL, currentVersionCode)) {
-            is UpdateCheckResult.UpdateAvailable -> {
-                Log.d("UpdateChecker", "Update available: ${result.versionInfo.versionName}")
-                updateAvailable = result.versionInfo
+  // Check for updates on app launch
+  LaunchedEffect(Unit) {
+    val currentVersionCode = BuildConfig.VERSION_CODE_INT
+    Log.d("UpdateChecker", "Checking for updates. Current version code: $currentVersionCode")
+    when (val result = checkForUpdate(ktorHttpClient, VERSION_JSON_URL, currentVersionCode)) {
+      is UpdateCheckResult.UpdateAvailable -> {
+        Log.d("UpdateChecker", "Update available: ${result.versionInfo.versionName}")
+        updateAvailable = result.versionInfo
 
-                // Check if we already have this download in progress or finished
-                when (val downloadState = getExistingDownloadState(context, result.versionInfo.versionName)) {
-                    is DownloadState.Downloaded -> {
-                        Log.d("UpdateChecker", "APK already downloaded: ${downloadState.apkFile.name}")
-                        downloadedApkFile = downloadState.apkFile
-                        showInstallDialog = true
-                    }
-                    is DownloadState.InProgress -> {
-                        Log.d("UpdateChecker", "Download already in progress")
-                        showDownloadingDialog = true
-                    }
-                    is DownloadState.None -> {
-                        showUpdateDialog = true
-                    }
-                }
-            }
-            is UpdateCheckResult.NoUpdate -> {
-                Log.d("UpdateChecker", "No update available")
-            }
-            is UpdateCheckResult.Error -> {
-                Log.w("UpdateChecker", "Error checking for updates: ${result.message}")
-            }
+        // Check if we already have this download in progress or finished
+        when (val downloadState = getExistingDownloadState(context, result.versionInfo.versionName)) {
+          is DownloadState.Downloaded -> {
+            Log.d("UpdateChecker", "APK already downloaded: ${downloadState.apkFile.name}")
+            downloadedApkFile = downloadState.apkFile
+            showInstallDialog = true
+          }
+          is DownloadState.InProgress -> {
+            Log.d("UpdateChecker", "Download already in progress")
+            showDownloadingDialog = true
+          }
+          is DownloadState.None -> {
+            showUpdateDialog = true
+          }
         }
+      }
+      is UpdateCheckResult.NoUpdate -> {
+        Log.d("UpdateChecker", "No update available")
+      }
+      is UpdateCheckResult.Error -> {
+        Log.w("UpdateChecker", "Error checking for updates: ${result.message}")
+      }
     }
+  }
 
-    // Update dialogs
-    if (showUpdateDialog && updateAvailable != null) {
-        UpdateAvailableDialog(
-            versionInfo = updateAvailable!!,
-            onUpdate = {
-                showUpdateDialog = false
-                showDownloadingDialog = true
-                downloadUpdate(
-                    context = context,
-                    downloadUrl = updateAvailable!!.downloadUrl,
-                    versionName = updateAvailable!!.versionName,
-                    onDownloadComplete = { apkFile ->
-                        scope.launch {
-                            showDownloadingDialog = false
-                            downloadedApkFile = apkFile
-                            showInstallDialog = true
-                        }
-                    },
-                    onDownloadFailed = { error ->
-                        scope.launch {
-                            showDownloadingDialog = false
-                            updateError = error
-                        }
-                    }
-                )
-            },
-            onDismiss = { showUpdateDialog = false }
+  // Update dialogs
+  if (showUpdateDialog && updateAvailable != null) {
+    UpdateAvailableDialog(
+      versionInfo = updateAvailable!!,
+      onUpdate = {
+        showUpdateDialog = false
+        showDownloadingDialog = true
+        downloadUpdate(
+          context = context,
+          downloadUrl = updateAvailable!!.downloadUrl,
+          versionName = updateAvailable!!.versionName,
+          onDownloadComplete = { apkFile ->
+            scope.launch {
+              showDownloadingDialog = false
+              downloadedApkFile = apkFile
+              showInstallDialog = true
+            }
+          },
+          onDownloadFailed = { error ->
+            scope.launch {
+              showDownloadingDialog = false
+              updateError = error
+            }
+          },
         )
-    }
+      },
+      onDismiss = { showUpdateDialog = false },
+    )
+  }
 
-    if (showInstallDialog && updateAvailable != null && downloadedApkFile != null) {
-        UpdateReadyToInstallDialog(
-            versionInfo = updateAvailable!!,
-            onInstall = {
-                showInstallDialog = false
-                installApk(context, downloadedApkFile!!)
-            },
-            onDismiss = { showInstallDialog = false }
-        )
-    }
+  if (showInstallDialog && updateAvailable != null && downloadedApkFile != null) {
+    UpdateReadyToInstallDialog(
+      versionInfo = updateAvailable!!,
+      onInstall = {
+        showInstallDialog = false
+        installApk(context, downloadedApkFile!!)
+      },
+      onDismiss = { showInstallDialog = false },
+    )
+  }
 
-    if (showDownloadingDialog) {
-        UpdateDownloadingDialog(
-            onDismiss = { showDownloadingDialog = false }
-        )
-    }
+  if (showDownloadingDialog) {
+    UpdateDownloadingDialog(
+      onDismiss = { showDownloadingDialog = false },
+    )
+  }
 
-    updateError?.let { error ->
-        UpdateErrorDialog(
-            errorMessage = error,
-            onDismiss = { updateError = null }
-        )
-    }
+  updateError?.let { error ->
+    UpdateErrorDialog(
+      errorMessage = error,
+      onDismiss = { updateError = null },
+    )
+  }
 
-    when (appState.currentScreen) {
-        AppScreen.Login -> {
-            val context = LocalContext.current
-            net.aurboda.ui.screens.LoginScreen(
-                initialServerUrl = appState.pendingServerUrl,
-                onSaveCredentials = { serverUrl, username, token ->
-                    CredentialsManager.saveCredentials(context, serverUrl, username, token)
-                },
-                onLoginSuccess = { appState.onLoginSuccess() }
+  when (appState.currentScreen) {
+    AppScreen.Login -> {
+      val context = LocalContext.current
+      net.aurboda.ui.screens.LoginScreen(
+        initialServerUrl = appState.pendingServerUrl,
+        onSaveCredentials = { serverUrl, username, token ->
+          CredentialsManager.saveCredentials(context, serverUrl, username, token)
+        },
+        onLoginSuccess = { appState.onLoginSuccess() },
+      )
+    }
+    AppScreen.Main -> {
+      val credentials = appState.credentials
+      if (credentials != null) {
+        net.aurboda.ui.screens.MainScreen(
+          currentTab = appState.currentTab,
+          onTabSelected = { appState.selectTab(it) },
+          syncContent = { modifier ->
+            HealthConnectScreen(
+              apiUrl = credentials.apiUrl,
+              authToken = credentials.authToken,
+              modifier = modifier,
             )
-        }
-        AppScreen.Main -> {
-            val credentials = appState.credentials
-            if (credentials != null) {
-                net.aurboda.ui.screens.MainScreen(
-                    currentTab = appState.currentTab,
-                    onTabSelected = { appState.selectTab(it) },
-                    syncContent = { modifier ->
-                        HealthConnectScreen(
-                            apiUrl = credentials.apiUrl,
-                            authToken = credentials.authToken,
-                            modifier = modifier
-                        )
-                    },
-                    dataContent = { modifier ->
-                        net.aurboda.ui.screens.DataScreen(
-                            apiUrl = credentials.apiUrl,
-                            authToken = credentials.authToken,
-                            modifier = modifier
-                        )
-                    },
-                    liveContent = { modifier ->
-                        net.aurboda.ui.screens.LiveScreen(
-                            modifier = modifier
-                        )
-                    },
-                    accountContent = { modifier ->
-                        net.aurboda.ui.screens.AccountScreen(
-                            username = credentials.username,
-                            serverUrl = credentials.serverUrl,
-                            onServerUrlChange = { newUrl -> appState.changeServerUrl(newUrl) },
-                            onLogout = { appState.logout() },
-                            modifier = modifier
-                        )
-                    }
-                )
-            } else {
-                // Should not happen, but handle gracefully
-                appState.logout()
-            }
-        }
+          },
+          dataContent = { modifier ->
+            net.aurboda.ui.screens.DataScreen(
+              apiUrl = credentials.apiUrl,
+              authToken = credentials.authToken,
+              modifier = modifier,
+            )
+          },
+          liveContent = { modifier ->
+            net.aurboda.ui.screens.LiveScreen(
+              modifier = modifier,
+            )
+          },
+          accountContent = { modifier ->
+            net.aurboda.ui.screens.AccountScreen(
+              username = credentials.username,
+              serverUrl = credentials.serverUrl,
+              onServerUrlChange = { newUrl -> appState.changeServerUrl(newUrl) },
+              onLogout = { appState.logout() },
+              modifier = modifier,
+            )
+          },
+        )
+      } else {
+        // Should not happen, but handle gracefully
+        appState.logout()
+      }
     }
+  }
 }
 
 @Composable
 fun HealthConnectScreen(
-    apiUrl: String,
-    authToken: String,
-    modifier: Modifier = Modifier
+  apiUrl: String,
+  authToken: String,
+  modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val healthConnectClient = remember { HealthConnectClient.getOrCreate(context) }
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+  val healthConnectClient = remember { HealthConnectClient.getOrCreate(context) }
 
-    // -- Permission state (partial permissions support) --
-    var grantedPermissions by remember { mutableStateOf<Set<String>>(emptySet()) }
-    val grantedRecordTypes by remember(grantedPermissions) {
-        derivedStateOf { getGrantedRecordTypes(grantedPermissions) }
+  // -- Permission state (partial permissions support) --
+  var grantedPermissions by remember { mutableStateOf<Set<String>>(emptySet()) }
+  val grantedRecordTypes by remember(grantedPermissions) {
+    derivedStateOf { getGrantedRecordTypes(grantedPermissions) }
+  }
+  val hasAnyPermissions by remember(grantedRecordTypes) {
+    derivedStateOf { grantedRecordTypes.isNotEmpty() }
+  }
+  val hasAllPermissions by remember(grantedPermissions) {
+    derivedStateOf {
+      val allPermissions = allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet()
+      grantedPermissions.containsAll(allPermissions)
     }
-    val hasAnyPermissions by remember(grantedRecordTypes) {
-        derivedStateOf { grantedRecordTypes.isNotEmpty() }
-    }
-    val hasAllPermissions by remember(grantedPermissions) {
-        derivedStateOf {
-            val allPermissions = allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet()
-            grantedPermissions.containsAll(allPermissions)
-        }
-    }
-    val categoryStatuses by remember(grantedPermissions) {
-        derivedStateOf { getCategoryStatuses(grantedPermissions) }
-    }
+  }
+  val categoryStatuses by remember(grantedPermissions) {
+    derivedStateOf { getCategoryStatuses(grantedPermissions) }
+  }
 
-    var healthRecords by remember { mutableStateOf<List<Record>>(emptyList()) }
-    var pendingDeletionIds by remember { mutableStateOf<List<String>>(emptyList()) }
-    var isProcessing by remember { mutableStateOf(false) }
-    var pendingTokenToPersist by remember { mutableStateOf<String?>(null) }
-    var statusMessage by remember { mutableStateOf("Checking permissions...") }
-    var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
-    var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
+  var healthRecords by remember { mutableStateOf<List<Record>>(emptyList()) }
+  var pendingDeletionIds by remember { mutableStateOf<List<String>>(emptyList()) }
+  var isProcessing by remember { mutableStateOf(false) }
+  var pendingTokenToPersist by remember { mutableStateOf<String?>(null) }
+  var statusMessage by remember { mutableStateOf("Checking permissions...") }
+  var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
+  var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
 
-    val batteryOptimizationLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
+  val batteryOptimizationLauncher =
+    rememberLauncherForActivityResult(
+      contract = ActivityResultContracts.StartActivityForResult(),
     ) {
-        if (isIgnoringBatteryOptimizations(context)) {
-            Log.d("BatteryOptimization", "Battery optimization exemption granted")
-        } else {
-            Log.d("BatteryOptimization", "Battery optimization exemption was not granted")
-        }
+      if (isIgnoringBatteryOptimizations(context)) {
+        Log.d("BatteryOptimization", "Battery optimization exemption granted")
+      } else {
+        Log.d("BatteryOptimization", "Battery optimization exemption was not granted")
+      }
     }
 
-    val scope = rememberCoroutineScope()
-    val allPermissions = remember(allRecordTypes) { allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet() }
-    val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
+  val scope = rememberCoroutineScope()
+  val allPermissions = remember(allRecordTypes) { allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet() }
+  val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
 
-    suspend fun fetchHealthData(currentActiveContext: Context) {
-        if (grantedRecordTypes.isEmpty()) {
-            statusMessage = "No permissions granted. Cannot fetch data."
-            Log.d("HealthConnectScreen", "fetchHealthData called but no granted types.")
-            return
-        }
-        if (isProcessing) {
-            Log.d("HealthConnectScreen", "fetchHealthData called while already processing. Bailing.")
-            return
-        }
-        isProcessing = true
-        statusMessage = "Fetching data from Health Connect..."
-        val typesToFetch = grantedRecordTypes
-        Log.d("HealthConnectScreen", "Starting data fetch for ${typesToFetch.size} granted types...")
+  suspend fun fetchHealthData(currentActiveContext: Context) {
+    if (grantedRecordTypes.isEmpty()) {
+      statusMessage = "No permissions granted. Cannot fetch data."
+      Log.d("HealthConnectScreen", "fetchHealthData called but no granted types.")
+      return
+    }
+    if (isProcessing) {
+      Log.d("HealthConnectScreen", "fetchHealthData called while already processing. Bailing.")
+      return
+    }
+    isProcessing = true
+    statusMessage = "Fetching data from Health Connect..."
+    val typesToFetch = grantedRecordTypes
+    Log.d("HealthConnectScreen", "Starting data fetch for ${typesToFetch.size} granted types...")
 
-        // Invalidate token if the set of granted types has changed
-        invalidateTokenIfGrantedTypesChanged(currentActiveContext, typesToFetch)
+    // Invalidate token if the set of granted types has changed
+    invalidateTokenIfGrantedTypesChanged(currentActiveContext, typesToFetch)
 
-        val localHealthRecords = mutableListOf<Record>()
-        val localDeletionIds = mutableListOf<String>()
-        var localPendingTokenToPersist: String? = null
-        var fetchSuccessful = true
+    val localHealthRecords = mutableListOf<Record>()
+    val localDeletionIds = mutableListOf<String>()
+    var localPendingTokenToPersist: String? = null
+    var fetchSuccessful = true
 
-        val lastTokenFromPrefs = loadChangesToken(currentActiveContext)
+    val lastTokenFromPrefs = loadChangesToken(currentActiveContext)
 
-        if (lastTokenFromPrefs == null) {
-            Log.d("FetchData", "No token found. Performing initial fetch.")
-            try {
-                val sevenDaysAgo = ZonedDateTime.now().minusDays(7).toInstant()
-                val now = Instant.now()
-                for (recordType: KClass<out Record> in typesToFetch) {
-                    try {
-                        @Suppress("UNCHECKED_CAST")
-                        val specificRecordType = recordType as KClass<Record>
-                        val request = ReadRecordsRequest(
-                            recordType = specificRecordType,
-                            timeRangeFilter = TimeRangeFilter.between(sevenDaysAgo, now),
-                            ascendingOrder = false
-                        )
-                        val recordsOfType = healthConnectClient.readRecords(request).records
-                        if (recordsOfType.isNotEmpty()) {
-                            Log.d("FetchData", "Fetched ${recordsOfType.size} records of type ${recordType.simpleName}")
-                            localHealthRecords.addAll(recordsOfType)
-                        }
-                    } catch (e: Exception) {
-                        Log.w("FetchData", "Error fetching ${recordType.simpleName}: ${e.message}")
-                    }
+    if (lastTokenFromPrefs == null) {
+      Log.d("FetchData", "No token found. Performing initial fetch.")
+      try {
+        val sevenDaysAgo = ZonedDateTime.now().minusDays(7).toInstant()
+        val now = Instant.now()
+        for (recordType: KClass<out Record> in typesToFetch) {
+          try {
+            @Suppress("UNCHECKED_CAST")
+            val specificRecordType = recordType as KClass<Record>
+            val request =
+              ReadRecordsRequest(
+                recordType = specificRecordType,
+                timeRangeFilter = TimeRangeFilter.between(sevenDaysAgo, now),
+                ascendingOrder = false,
+              )
+            val recordsOfType =
+              healthConnectClient
+                .readRecords(request)
+                .records
+                .filter { record ->
+                  // Skip records written by Aurboda's outbound sync to prevent sync loops
+                  val isOwnOrigin = record.metadata.dataOrigin.packageName == "net.aurboda"
+                  val isOutboundSync =
+                    record.metadata.clientRecordId
+                      ?.startsWith(OUTBOUND_SYNC_CLIENT_ID_PREFIX) == true
+                  !(isOwnOrigin || isOutboundSync)
                 }
-                Log.d("FetchData", "Initial fetch complete. Total ${localHealthRecords.size} records.")
-                if (localHealthRecords.isNotEmpty()) {
-                    val initialToken = healthConnectClient.getChangesToken(ChangesTokenRequest(typesToFetch.toSet()))
-                    localPendingTokenToPersist = initialToken
-                    statusMessage = "Fetched ${localHealthRecords.size} initial records. Ready to send."
-                } else {
-                    statusMessage = "No records found during initial fetch."
-                    try {
-                        val initialToken = healthConnectClient.getChangesToken(ChangesTokenRequest(typesToFetch.toSet()))
-                        saveChangesToken(currentActiveContext, initialToken)
-                        Log.d("FetchData", "Saved initial token (no data): ${initialToken.take(10)}...")
-                    } catch (e: Exception) {
-                        Log.e("FetchData", "Failed to get/save initial changes token.", e)
-                        statusMessage = "Error initializing token."
-                    }
-                }
-            } catch (e: Exception) {
-                Log.e("FetchData", "Error during initial data fetch.", e)
-                statusMessage = "Error fetching initial data: ${e.message}"
-                fetchSuccessful = false
+            if (recordsOfType.isNotEmpty()) {
+              Log.d(
+                "FetchData",
+                "Fetched ${recordsOfType.size} records of type ${recordType.simpleName} (after filtering own records)",
+              )
+              localHealthRecords.addAll(recordsOfType)
             }
+          } catch (e: Exception) {
+            Log.w("FetchData", "Error fetching ${recordType.simpleName}: ${e.message}")
+          }
+        }
+        Log.d("FetchData", "Initial fetch complete. Total ${localHealthRecords.size} records.")
+        if (localHealthRecords.isNotEmpty()) {
+          val initialToken = healthConnectClient.getChangesToken(ChangesTokenRequest(typesToFetch.toSet()))
+          localPendingTokenToPersist = initialToken
+          statusMessage = "Fetched ${localHealthRecords.size} initial records. Ready to send."
         } else {
-            Log.d("FetchData", "Token found: ${lastTokenFromPrefs.take(10)}... Fetching changes.")
-            try {
-                var currentToken: String = lastTokenFromPrefs
-                var totalUpsertions = 0
-                var hasMore = true
+          statusMessage = "No records found during initial fetch."
+          try {
+            val initialToken = healthConnectClient.getChangesToken(ChangesTokenRequest(typesToFetch.toSet()))
+            saveChangesToken(currentActiveContext, initialToken)
+            Log.d("FetchData", "Saved initial token (no data): ${initialToken.take(10)}...")
+          } catch (e: Exception) {
+            Log.e("FetchData", "Failed to get/save initial changes token.", e)
+            statusMessage = "Error initializing token."
+          }
+        }
+      } catch (e: Exception) {
+        Log.e("FetchData", "Error during initial data fetch.", e)
+        statusMessage = "Error fetching initial data: ${e.message}"
+        fetchSuccessful = false
+      }
+    } else {
+      Log.d("FetchData", "Token found: ${lastTokenFromPrefs.take(10)}... Fetching changes.")
+      try {
+        var currentToken: String = lastTokenFromPrefs
+        var totalUpsertions = 0
+        var hasMore = true
 
-                while (hasMore) {
-                    val changesResponse = healthConnectClient.getChanges(currentToken)
-                    val upsertions = changesResponse.changes.mapNotNull { if (it is UpsertionChange) it.record else null }
-                    if (upsertions.isNotEmpty()) {
-                        Log.d("FetchData", "Adding ${upsertions.size} upserted records.")
-                        localHealthRecords.addAll(upsertions)
-                        totalUpsertions += upsertions.size
-                    }
-                    changesResponse.changes.forEach {
-                        if (it is DeletionChange) {
-                            localDeletionIds.add(it.recordId)
-                        }
-                    }
-
-                    hasMore = changesResponse.hasMore
-                    currentToken = changesResponse.nextChangesToken
-
-                    if (hasMore) {
-                        statusMessage = "Fetching more data... ($totalUpsertions records so far)"
-                    }
-                }
-
-                localPendingTokenToPersist = currentToken
-                if (totalUpsertions == 0 && localDeletionIds.isEmpty()) {
-                    statusMessage = "No new changes found."
-                    saveChangesToken(currentActiveContext, localPendingTokenToPersist)
-                    localPendingTokenToPersist = null
-                } else {
-                    val parts = mutableListOf<String>()
-                    if (totalUpsertions > 0) parts.add("$totalUpsertions new/updated records")
-                    if (localDeletionIds.isNotEmpty()) parts.add("${localDeletionIds.size} deletions")
-                    statusMessage = "Fetched ${parts.joinToString(", ")}. Ready to send."
-                }
-            } catch (e: Exception) {
-                Log.e("FetchData", "Error fetching changes.", e)
-                statusMessage = "Error fetching changes: ${e.message}"
-                fetchSuccessful = false
+        while (hasMore) {
+          val changesResponse = healthConnectClient.getChanges(currentToken)
+          val upsertions =
+            changesResponse.changes
+              .mapNotNull { if (it is UpsertionChange) it.record else null }
+              .filter { record ->
+                // Skip records written by Aurboda's outbound sync to prevent sync loops
+                val isOwnOrigin = record.metadata.dataOrigin.packageName == "net.aurboda"
+                val isOutboundSync =
+                  record.metadata.clientRecordId
+                    ?.startsWith(OUTBOUND_SYNC_CLIENT_ID_PREFIX) == true
+                !(isOwnOrigin || isOutboundSync)
+              }
+          if (upsertions.isNotEmpty()) {
+            Log.d("FetchData", "Adding ${upsertions.size} upserted records (after filtering own records).")
+            localHealthRecords.addAll(upsertions)
+            totalUpsertions += upsertions.size
+          }
+          changesResponse.changes.forEach {
+            if (it is DeletionChange) {
+              localDeletionIds.add(it.recordId)
             }
+          }
+
+          hasMore = changesResponse.hasMore
+          currentToken = changesResponse.nextChangesToken
+
+          if (hasMore) {
+            statusMessage = "Fetching more data... ($totalUpsertions records so far)"
+          }
         }
 
-        if (fetchSuccessful) {
-            healthRecords = localHealthRecords.sortedByDescending { it.getPrimaryInstant() }
-            pendingDeletionIds = localDeletionIds
-            pendingTokenToPersist = localPendingTokenToPersist
+        localPendingTokenToPersist = currentToken
+        if (totalUpsertions == 0 && localDeletionIds.isEmpty()) {
+          statusMessage = "No new changes found."
+          saveChangesToken(currentActiveContext, localPendingTokenToPersist)
+          localPendingTokenToPersist = null
         } else {
-            if (lastTokenFromPrefs != null) healthRecords = emptyList()
-            pendingDeletionIds = emptyList()
-            pendingTokenToPersist = null
+          val parts = mutableListOf<String>()
+          if (totalUpsertions > 0) parts.add("$totalUpsertions new/updated records")
+          if (localDeletionIds.isNotEmpty()) parts.add("${localDeletionIds.size} deletions")
+          statusMessage = "Fetched ${parts.joinToString(", ")}. Ready to send."
         }
-        Log.d("HealthConnectScreen", "Data fetch finished. status: $statusMessage")
-        isProcessing = false
+      } catch (e: Exception) {
+        Log.e("FetchData", "Error fetching changes.", e)
+        statusMessage = "Error fetching changes: ${e.message}"
+        fetchSuccessful = false
+      }
     }
 
-    /** Re-query actual granted permissions from system after launcher returns. */
-    suspend fun refreshPermissions() {
-        grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-        val count = grantedRecordTypes.size
-        Log.d("HealthConnect", "Permissions refreshed: $count/${allRecordTypes.size} types granted")
-        if (count > 0) {
-            statusMessage = "$count of ${allRecordTypes.size} data types authorized."
-        } else {
-            statusMessage = "No permissions granted."
-        }
+    if (fetchSuccessful) {
+      healthRecords = localHealthRecords.sortedByDescending { it.getPrimaryInstant() }
+      pendingDeletionIds = localDeletionIds
+      pendingTokenToPersist = localPendingTokenToPersist
+    } else {
+      if (lastTokenFromPrefs != null) healthRecords = emptyList()
+      pendingDeletionIds = emptyList()
+      pendingTokenToPersist = null
     }
+    Log.d("HealthConnectScreen", "Data fetch finished. status: $statusMessage")
+    isProcessing = false
+  }
 
-    val requestPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
+  /** Re-query actual granted permissions from system after launcher returns. */
+  suspend fun refreshPermissions() {
+    grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+    val count = grantedRecordTypes.size
+    Log.d("HealthConnect", "Permissions refreshed: $count/${allRecordTypes.size} types granted")
+    if (count > 0) {
+      statusMessage = "$count of ${allRecordTypes.size} data types authorized."
+    } else {
+      statusMessage = "No permissions granted."
+    }
+  }
+
+  val requestPermissionLauncher =
+    rememberLauncherForActivityResult(
+      contract = ActivityResultContracts.RequestMultiplePermissions(),
     ) { _ ->
-        // Don't trust the launcher result — re-query actual permissions from system
-        scope.launch {
-            refreshPermissions()
-            if (grantedRecordTypes.isNotEmpty()) {
-                fetchHealthData(context)
-            } else {
-                isProcessing = false
-            }
+      // Don't trust the launcher result — re-query actual permissions from system
+      scope.launch {
+        refreshPermissions()
+        if (grantedRecordTypes.isNotEmpty()) {
+          fetchHealthData(context)
+        } else {
+          isProcessing = false
         }
+      }
     }
 
-    suspend fun checkPermissionsAndFetchData(coroutineScope: CoroutineScope, currentContext: Context) {
-        grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-        val grantedCount = grantedRecordTypes.size
-        Log.d("HealthConnect", "Permission check: $grantedCount/${allRecordTypes.size} types granted")
+  suspend fun checkPermissionsAndFetchData(
+    coroutineScope: CoroutineScope,
+    currentContext: Context,
+  ) {
+    grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+    val grantedCount = grantedRecordTypes.size
+    Log.d("HealthConnect", "Permission check: $grantedCount/${allRecordTypes.size} types granted")
 
-        if (grantedCount > 0) {
-            statusMessage = "$grantedCount of ${allRecordTypes.size} data types authorized."
-            coroutineScope.launch { fetchHealthData(currentContext) }
-        } else {
-            // No permissions at all — request everything
-            statusMessage = "No permissions granted. Requesting access..."
-            isProcessing = false
+    if (grantedCount > 0) {
+      statusMessage = "$grantedCount of ${allRecordTypes.size} data types authorized."
+      coroutineScope.launch { fetchHealthData(currentContext) }
+    } else {
+      // No permissions at all — request everything
+      statusMessage = "No permissions granted. Requesting access..."
+      isProcessing = false
+      requestPermissionLauncher.launch(allPermissions.toTypedArray())
+    }
+  }
+
+  suspend fun sendPendingDataToServer(currentActiveContext: Context) {
+    if (healthRecords.isEmpty() && pendingDeletionIds.isEmpty()) {
+      statusMessage = "No records to send."
+      Log.d("SendData", "No records or deletions to send.")
+      return
+    }
+    if (isProcessing) {
+      Log.d("SendData", "sendPendingDataToServer called while already processing.")
+      return
+    }
+    isProcessing = true
+    var allPostsSuccessful = true
+
+    // Step 1: Send deletions to backend
+    if (pendingDeletionIds.isNotEmpty()) {
+      statusMessage = "Sending ${pendingDeletionIds.size} deletions..."
+      Log.d("SendData", "Sending ${pendingDeletionIds.size} deletion IDs to server")
+      val deletionResult =
+        try {
+          val response =
+            ktorHttpClient.post("$apiUrl/sync/deletions") {
+              contentType(ContentType.Application.Json)
+              headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+              setBody(PostWrapper(pendingDeletionIds))
+            }
+          response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+        } catch (e: Exception) {
+          Log.e("SendData", "Error posting deletions", e)
+          false
+        }
+      if (!deletionResult) {
+        allPostsSuccessful = false
+        statusMessage = "Failed to send deletions"
+        Log.w("SendData", "Failed to send deletions")
+      } else {
+        Log.d("SendData", "Deletions sent successfully")
+        pendingDeletionIds = emptyList()
+      }
+    }
+
+    // Step 2: Send raw records
+    if (allPostsSuccessful && healthRecords.isNotEmpty()) {
+      val recordsWithKnownSerializers =
+        healthRecords.filter {
+          when (it) {
+            is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
+            is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
+            is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
+            is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
+            is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
+            is TotalCaloriesBurnedRecord, is FloorsClimbedRecord,
+            -> true
+            else -> false
+          }
+        }
+
+      statusMessage = "Sending ${recordsWithKnownSerializers.size} records to server..."
+
+      if (recordsWithKnownSerializers.isEmpty()) {
+        Log.d("SendData", "No records with known serializers to send.")
+      } else {
+        Log.d("SendData", "Sending ${recordsWithKnownSerializers.size} records.")
+
+        val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
+        for ((recordClass, classRecords) in groupedRecords) {
+          if (classRecords.isEmpty()) continue
+          val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
+          val syncUrl = "$apiUrl/sync/$recordTypeSimpleName"
+
+          val postResult =
+            when (recordClass) {
+              HeartRateVariabilityRmssdRecord::class ->
+                handlePostData(
+                  HrvRecordSerializable.fromRecordsList(classRecords),
+                  HrvRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              WeightRecord::class ->
+                handlePostData(
+                  WeightRecordSerializable.fromRecordsList(classRecords),
+                  WeightRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              HeartRateRecord::class ->
+                handlePostDataChunked(
+                  HeartRateRecordSerializable.fromRecordsList(classRecords),
+                  HeartRateRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              ExerciseSessionRecord::class ->
+                handlePostData(
+                  ExerciseSessionRecordSerializable.fromRecordsList(classRecords),
+                  ExerciseSessionRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              SpeedRecord::class ->
+                handlePostData(
+                  SpeedRecordSerializable.fromRecordsList(classRecords),
+                  SpeedRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              PowerRecord::class ->
+                handlePostData(
+                  PowerRecordSerializable.fromRecordsList(classRecords),
+                  PowerRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              NutritionRecord::class ->
+                handlePostData(
+                  NutritionRecordSerializable.fromRecordsList(classRecords),
+                  NutritionRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              LeanBodyMassRecord::class ->
+                handlePostData(
+                  LeanBodyMassRecordSerializable.fromRecordsList(classRecords),
+                  LeanBodyMassRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              BodyFatRecord::class ->
+                handlePostData(
+                  BodyFatRecordSerializable.fromRecordsList(classRecords),
+                  BodyFatRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              SleepSessionRecord::class ->
+                handlePostData(
+                  SleepSessionRecordSerializable.fromRecordsList(classRecords),
+                  SleepSessionRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              BoneMassRecord::class ->
+                handlePostData(
+                  BoneMassRecordSerializable.fromRecordsList(classRecords),
+                  BoneMassRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              BodyWaterMassRecord::class ->
+                handlePostData(
+                  BodyWaterMassRecordSerializable.fromRecordsList(classRecords),
+                  BodyWaterMassRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              HeightRecord::class ->
+                handlePostData(
+                  HeightRecordSerializable.fromRecordsList(classRecords),
+                  HeightRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              RestingHeartRateRecord::class ->
+                handlePostData(
+                  RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
+                  RestingHeartRateRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              StepsRecord::class ->
+                handlePostData(
+                  StepsRecordSerializable.fromRecordsList(classRecords),
+                  StepsRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              DistanceRecord::class ->
+                handlePostData(
+                  DistanceRecordSerializable.fromRecordsList(classRecords),
+                  DistanceRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              ActiveCaloriesBurnedRecord::class ->
+                handlePostData(
+                  ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+                  ActiveCaloriesBurnedRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              TotalCaloriesBurnedRecord::class ->
+                handlePostData(
+                  TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+                  TotalCaloriesBurnedRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              FloorsClimbedRecord::class ->
+                handlePostData(
+                  FloorsClimbedRecordSerializable.fromRecordsList(classRecords),
+                  FloorsClimbedRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
+              else -> {
+                Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping.")
+                PostResult.Success
+              }
+            }
+          if (!postResult.isSuccess) {
+            allPostsSuccessful = false
+            val errorDetail = postResult.errorMessage() ?: "Unknown error"
+            statusMessage = "Failed to send $recordTypeSimpleName: $errorDetail"
+            Log.w("SendData", "Post failed for $recordTypeSimpleName: $errorDetail")
+            break
+          }
+        }
+      }
+    }
+
+    if (allPostsSuccessful) {
+      if (pendingTokenToPersist != null) {
+        saveChangesToken(currentActiveContext, pendingTokenToPersist)
+        statusMessage = "Data sent successfully. Token updated."
+        Log.d("SendData", "All posts successful. Saved token: ${pendingTokenToPersist?.take(10)}...")
+        pendingTokenToPersist = null
+      } else {
+        statusMessage = "Data sent successfully."
+        Log.d("SendData", "All posts successful. No new token was pending to save.")
+      }
+      healthRecords = emptyList()
+      pendingDeletionIds = emptyList()
+    } else {
+      Log.w("SendData", "Not all posts successful. Pending records remain.")
+    }
+    isProcessing = false
+  }
+
+  /** Perform fetch + send in one step, then process outbound sync (backend -> HC). */
+  suspend fun syncNow(currentContext: Context) {
+    fetchHealthData(currentContext)
+    if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
+      sendPendingDataToServer(currentContext)
+    }
+    // Process outbound sync: write backend changes to Health Connect
+    try {
+      processOutboundSync(
+        apiUrl = apiUrl,
+        authToken = authToken,
+        httpClient = ktorHttpClient,
+        healthConnectClient = healthConnectClient,
+        grantedPermissions = grantedPermissions,
+      )
+    } catch (e: Exception) {
+      Log.w("OutboundSync", "Outbound sync failed in syncNow: ${e.message}")
+    }
+  }
+
+  LaunchedEffect(Unit) {
+    Log.d("HealthConnectScreen", "LaunchedEffect: Initial check")
+    checkPermissionsAndFetchData(this, context)
+    if (backgroundSyncEnabled) {
+      HealthConnectSyncWorker.schedule(context)
+    }
+  }
+
+  DisposableEffect(lifecycleOwner) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_RESUME) {
+          Log.d("HealthConnectScreen", "App resumed. HasAny: $hasAnyPermissions, IsProcessing: $isProcessing")
+          if (hasAnyPermissions && !isProcessing) {
+            scope.launch {
+              // Re-check permissions in case user changed them in system settings
+              refreshPermissions()
+              fetchHealthData(context)
+              // Always send pending data when app comes to foreground
+              if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
+                sendPendingDataToServer(context)
+              }
+              // Process outbound sync: write backend changes to Health Connect
+              try {
+                processOutboundSync(
+                  apiUrl = apiUrl,
+                  authToken = authToken,
+                  httpClient = ktorHttpClient,
+                  healthConnectClient = healthConnectClient,
+                  grantedPermissions = grantedPermissions,
+                )
+              } catch (e: Exception) {
+                Log.w("OutboundSync", "Outbound sync failed on resume: ${e.message}")
+              }
+              // Refresh widget with latest data
+              net.aurboda.widget.HrZoneWidgetProvider
+                .triggerUpdate(context)
+            }
+          }
+        }
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+    }
+  }
+
+  // Periodic sync while app is open (when background sync is enabled)
+  LaunchedEffect(backgroundSyncEnabled, hasAnyPermissions) {
+    if (backgroundSyncEnabled && hasAnyPermissions) {
+      Log.d("HealthConnectScreen", "Starting periodic sync loop (60s interval)")
+      while (true) {
+        delay(60_000L)
+        if (!isProcessing) {
+          Log.d("HealthConnectScreen", "Periodic sync: fetching and sending data")
+          syncNow(context)
+        }
+      }
+    }
+  }
+
+  val pendingRecordCount by remember(healthRecords) {
+    derivedStateOf { healthRecords.size + pendingDeletionIds.size }
+  }
+
+  // --- UI ---
+
+  LazyColumn(
+    modifier = modifier.fillMaxSize().padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    // -- Sync Status Card --
+    item {
+      androidx.compose.material3.Card(
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Column(
+          modifier = Modifier.padding(16.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            Text(
+              "Health Connect Sync",
+              style = MaterialTheme.typography.titleMedium,
+              fontWeight = FontWeight.Bold,
+            )
+            if (isProcessing) {
+              androidx.compose.material3.CircularProgressIndicator(
+                modifier = Modifier.height(16.dp).width(16.dp),
+                strokeWidth = 2.dp,
+              )
+            }
+          }
+
+          Text(
+            statusMessage,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+
+          Text(
+            "${grantedRecordTypes.size} of ${allRecordTypes.size} data types authorized",
+            style = MaterialTheme.typography.bodyMedium,
+          )
+
+          if (pendingRecordCount > 0) {
+            Text(
+              "$pendingRecordCount records pending",
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.primary,
+            )
+          }
+
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            Text("Background Sync", style = MaterialTheme.typography.bodyMedium)
+            Switch(
+              checked = backgroundSyncEnabled,
+              onCheckedChange = { enabled ->
+                backgroundSyncEnabled = enabled
+                setBackgroundSyncEnabled(context, enabled)
+                if (enabled && !isIgnoringBatteryOptimizations(context)) {
+                  showBatteryOptimizationDialog = true
+                }
+              },
+            )
+          }
+
+          Button(
+            onClick = { scope.launch { syncNow(context) } },
+            enabled = hasAnyPermissions && !isProcessing,
+            modifier = Modifier.fillMaxWidth(),
+          ) {
+            Text("Sync Now")
+          }
+        }
+      }
+    }
+
+    // -- Data Source Category Cards --
+    items(categoryStatuses.size) { index ->
+      val status = categoryStatuses[index]
+      val iconText =
+        when {
+          status.allGranted -> "\u2705" // green check
+          status.partiallyGranted -> "\u26A0\uFE0F" // amber warning
+          else -> "\u274C" // red X
+        }
+      val iconColor =
+        when {
+          status.allGranted -> MaterialTheme.colorScheme.primary
+          status.partiallyGranted -> MaterialTheme.colorScheme.tertiary
+          else -> MaterialTheme.colorScheme.error
+        }
+
+      androidx.compose.material3.Card(
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Row(
+          modifier = Modifier.padding(12.dp).fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+          Text(iconText, style = MaterialTheme.typography.titleLarge)
+
+          Column(modifier = Modifier.weight(1f)) {
+            Text(
+              status.category.name,
+              style = MaterialTheme.typography.titleSmall,
+              fontWeight = FontWeight.Bold,
+            )
+            Text(
+              status.category.description,
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (!status.allGranted) {
+              Text(
+                "${status.grantedCount}/${status.totalCount} types",
+                style = MaterialTheme.typography.bodySmall,
+                color = iconColor,
+              )
+            }
+          }
+
+          if (!status.allGranted) {
+            androidx.compose.material3.OutlinedButton(
+              onClick = {
+                val categoryPermissions =
+                  status.category.recordTypes
+                    .map { HealthPermission.getReadPermission(it) }
+                    .toTypedArray()
+                requestPermissionLauncher.launch(categoryPermissions)
+              },
+            ) {
+              Text("Grant")
+            }
+          }
+        }
+      }
+    }
+
+    // -- Grant All Permissions button --
+    if (!hasAllPermissions) {
+      item {
+        androidx.compose.material3.OutlinedButton(
+          onClick = {
             requestPermissionLauncher.launch(allPermissions.toTypedArray())
+          },
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          Text("Grant All Permissions")
         }
+      }
     }
 
-    suspend fun sendPendingDataToServer(currentActiveContext: Context) {
-        if (healthRecords.isEmpty() && pendingDeletionIds.isEmpty()) {
-            statusMessage = "No records to send."
-            Log.d("SendData", "No records or deletions to send.")
-            return
-        }
-        if (isProcessing) {
-            Log.d("SendData", "sendPendingDataToServer called while already processing.")
-            return
-        }
-        isProcessing = true
-        var allPostsSuccessful = true
-
-        // Step 1: Send deletions to backend
-        if (pendingDeletionIds.isNotEmpty()) {
-            statusMessage = "Sending ${pendingDeletionIds.size} deletions..."
-            Log.d("SendData", "Sending ${pendingDeletionIds.size} deletion IDs to server")
-            val deletionResult = try {
-                val response = ktorHttpClient.post("$apiUrl/sync/deletions") {
-                    contentType(ContentType.Application.Json)
-                    headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-                    setBody(PostWrapper(pendingDeletionIds))
-                }
-                response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-            } catch (e: Exception) {
-                Log.e("SendData", "Error posting deletions", e)
-                false
-            }
-            if (!deletionResult) {
-                allPostsSuccessful = false
-                statusMessage = "Failed to send deletions"
-                Log.w("SendData", "Failed to send deletions")
-            } else {
-                Log.d("SendData", "Deletions sent successfully")
-                pendingDeletionIds = emptyList()
-            }
-        }
-
-        // Step 2: Send raw records
-        if (allPostsSuccessful && healthRecords.isNotEmpty()) {
-            val recordsWithKnownSerializers = healthRecords.filter {
-                when (it) {
-                    is HeartRateVariabilityRmssdRecord, is WeightRecord, is HeartRateRecord,
-                    is ExerciseSessionRecord, is SpeedRecord, is PowerRecord, is NutritionRecord,
-                    is LeanBodyMassRecord, is BodyFatRecord, is SleepSessionRecord, is BoneMassRecord,
-                    is BodyWaterMassRecord, is HeightRecord, is RestingHeartRateRecord,
-                    is StepsRecord, is DistanceRecord, is ActiveCaloriesBurnedRecord,
-                    is TotalCaloriesBurnedRecord, is FloorsClimbedRecord -> true
-                    else -> false
-                }
-            }
-
-            statusMessage = "Sending ${recordsWithKnownSerializers.size} records to server..."
-
-            if (recordsWithKnownSerializers.isEmpty()) {
-                Log.d("SendData", "No records with known serializers to send.")
-            } else {
-                Log.d("SendData", "Sending ${recordsWithKnownSerializers.size} records.")
-
-                val groupedRecords = recordsWithKnownSerializers.groupBy { it::class }
-                for ((recordClass, classRecords) in groupedRecords) {
-                    if (classRecords.isEmpty()) continue
-                    val recordTypeSimpleName = recordClass.simpleName ?: "UnknownRecordType"
-                    val syncUrl = "$apiUrl/sync/$recordTypeSimpleName"
-
-                    val postResult = when (recordClass) {
-                        HeartRateVariabilityRmssdRecord::class -> handlePostData(HrvRecordSerializable.fromRecordsList(classRecords), HrvRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        WeightRecord::class -> handlePostData(WeightRecordSerializable.fromRecordsList(classRecords), WeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        HeartRateRecord::class -> handlePostDataChunked(HeartRateRecordSerializable.fromRecordsList(classRecords), HeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        ExerciseSessionRecord::class -> handlePostData(ExerciseSessionRecordSerializable.fromRecordsList(classRecords), ExerciseSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        SpeedRecord::class -> handlePostData(SpeedRecordSerializable.fromRecordsList(classRecords), SpeedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        PowerRecord::class -> handlePostData(PowerRecordSerializable.fromRecordsList(classRecords), PowerRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        NutritionRecord::class -> handlePostData(NutritionRecordSerializable.fromRecordsList(classRecords), NutritionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        LeanBodyMassRecord::class -> handlePostData(LeanBodyMassRecordSerializable.fromRecordsList(classRecords), LeanBodyMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        BodyFatRecord::class -> handlePostData(BodyFatRecordSerializable.fromRecordsList(classRecords), BodyFatRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        SleepSessionRecord::class -> handlePostData(SleepSessionRecordSerializable.fromRecordsList(classRecords), SleepSessionRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        BoneMassRecord::class -> handlePostData(BoneMassRecordSerializable.fromRecordsList(classRecords), BoneMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        BodyWaterMassRecord::class -> handlePostData(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), BodyWaterMassRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        HeightRecord::class -> handlePostData(HeightRecordSerializable.fromRecordsList(classRecords), HeightRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        RestingHeartRateRecord::class -> handlePostData(RestingHeartRateRecordSerializable.fromRecordsList(classRecords), RestingHeartRateRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        StepsRecord::class -> handlePostData(StepsRecordSerializable.fromRecordsList(classRecords), StepsRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        DistanceRecord::class -> handlePostData(DistanceRecordSerializable.fromRecordsList(classRecords), DistanceRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        ActiveCaloriesBurnedRecord::class -> handlePostData(ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords), ActiveCaloriesBurnedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        TotalCaloriesBurnedRecord::class -> handlePostData(TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords), TotalCaloriesBurnedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        FloorsClimbedRecord::class -> handlePostData(FloorsClimbedRecordSerializable.fromRecordsList(classRecords), FloorsClimbedRecordSerializable.serializer(), syncUrl, recordTypeSimpleName, ktorHttpClient, authToken)
-                        else -> { Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping."); PostResult.Success }
-                    }
-                    if (!postResult.isSuccess) {
-                        allPostsSuccessful = false
-                        val errorDetail = postResult.errorMessage() ?: "Unknown error"
-                        statusMessage = "Failed to send $recordTypeSimpleName: $errorDetail"
-                        Log.w("SendData", "Post failed for $recordTypeSimpleName: $errorDetail")
-                        break
-                    }
-                }
-            }
-        }
-
-        if (allPostsSuccessful) {
-            if (pendingTokenToPersist != null) {
-                saveChangesToken(currentActiveContext, pendingTokenToPersist)
-                statusMessage = "Data sent successfully. Token updated."
-                Log.d("SendData", "All posts successful. Saved token: ${pendingTokenToPersist?.take(10)}...")
-                pendingTokenToPersist = null
-            } else {
-                statusMessage = "Data sent successfully."
-                Log.d("SendData", "All posts successful. No new token was pending to save.")
-            }
-            healthRecords = emptyList()
-            pendingDeletionIds = emptyList()
-        } else {
-            Log.w("SendData", "Not all posts successful. Pending records remain.")
-        }
-        isProcessing = false
-    }
-
-    /** Perform fetch + send in one step. */
-    suspend fun syncNow(currentContext: Context) {
-        fetchHealthData(currentContext)
-        if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
-            sendPendingDataToServer(currentContext)
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        Log.d("HealthConnectScreen", "LaunchedEffect: Initial check")
-        checkPermissionsAndFetchData(this, context)
-        if (backgroundSyncEnabled) {
-            HealthConnectSyncWorker.schedule(context)
-        }
-    }
-
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                Log.d("HealthConnectScreen", "App resumed. HasAny: $hasAnyPermissions, IsProcessing: $isProcessing")
-                if (hasAnyPermissions && !isProcessing) {
-                    scope.launch {
-                        // Re-check permissions in case user changed them in system settings
-                        refreshPermissions()
-                        fetchHealthData(context)
-                        // Always send pending data when app comes to foreground
-                        if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
-                            sendPendingDataToServer(context)
-                        }
-                        // Refresh widget with latest data
-                        net.aurboda.widget.HrZoneWidgetProvider.triggerUpdate(context)
-                    }
-                }
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
-
-    // Periodic sync while app is open (when background sync is enabled)
-    LaunchedEffect(backgroundSyncEnabled, hasAnyPermissions) {
-        if (backgroundSyncEnabled && hasAnyPermissions) {
-            Log.d("HealthConnectScreen", "Starting periodic sync loop (60s interval)")
-            while (true) {
-                delay(60_000L)
-                if (!isProcessing) {
-                    Log.d("HealthConnectScreen", "Periodic sync: fetching and sending data")
-                    syncNow(context)
-                }
-            }
-        }
-    }
-
-    val pendingRecordCount by remember(healthRecords) {
-        derivedStateOf { healthRecords.size + pendingDeletionIds.size }
-    }
-
-    // --- UI ---
-
-    LazyColumn(
-        modifier = modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        // -- Sync Status Card --
-        item {
-            androidx.compose.material3.Card(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            "Health Connect Sync",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold
-                        )
-                        if (isProcessing) {
-                            androidx.compose.material3.CircularProgressIndicator(
-                                modifier = Modifier.height(16.dp).width(16.dp),
-                                strokeWidth = 2.dp
-                            )
-                        }
-                    }
-
-                    Text(
-                        statusMessage,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-
-                    Text(
-                        "${grantedRecordTypes.size} of ${allRecordTypes.size} data types authorized",
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-
-                    if (pendingRecordCount > 0) {
-                        Text(
-                            "$pendingRecordCount records pending",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text("Background Sync", style = MaterialTheme.typography.bodyMedium)
-                        Switch(
-                            checked = backgroundSyncEnabled,
-                            onCheckedChange = { enabled ->
-                                backgroundSyncEnabled = enabled
-                                setBackgroundSyncEnabled(context, enabled)
-                                if (enabled && !isIgnoringBatteryOptimizations(context)) {
-                                    showBatteryOptimizationDialog = true
-                                }
-                            }
-                        )
-                    }
-
-                    Button(
-                        onClick = { scope.launch { syncNow(context) } },
-                        enabled = hasAnyPermissions && !isProcessing,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Sync Now")
-                    }
-                }
-            }
-        }
-
-        // -- Data Source Category Cards --
-        items(categoryStatuses.size) { index ->
-            val status = categoryStatuses[index]
-            val iconText = when {
-                status.allGranted -> "\u2705"     // green check
-                status.partiallyGranted -> "\u26A0\uFE0F"  // amber warning
-                else -> "\u274C"                  // red X
-            }
-            val iconColor = when {
-                status.allGranted -> MaterialTheme.colorScheme.primary
-                status.partiallyGranted -> MaterialTheme.colorScheme.tertiary
-                else -> MaterialTheme.colorScheme.error
-            }
-
-            androidx.compose.material3.Card(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Row(
-                    modifier = Modifier.padding(12.dp).fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Text(iconText, style = MaterialTheme.typography.titleLarge)
-
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            status.category.name,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.Bold
-                        )
-                        Text(
-                            status.category.description,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        if (!status.allGranted) {
-                            Text(
-                                "${status.grantedCount}/${status.totalCount} types",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = iconColor
-                            )
-                        }
-                    }
-
-                    if (!status.allGranted) {
-                        androidx.compose.material3.OutlinedButton(
-                            onClick = {
-                                val categoryPermissions = status.category.recordTypes
-                                    .map { HealthPermission.getReadPermission(it) }
-                                    .toTypedArray()
-                                requestPermissionLauncher.launch(categoryPermissions)
-                            }
-                        ) {
-                            Text("Grant")
-                        }
-                    }
-                }
-            }
-        }
-
-        // -- Grant All Permissions button --
-        if (!hasAllPermissions) {
-            item {
-                androidx.compose.material3.OutlinedButton(
-                    onClick = {
-                        requestPermissionLauncher.launch(allPermissions.toTypedArray())
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Grant All Permissions")
-                }
-            }
-        }
-
-        // -- Empty state --
-        if (!hasAnyPermissions && !isProcessing) {
-            item {
-                Text(
-                    "Grant at least one data category to start syncing your health data.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(vertical = 16.dp)
-                )
-            }
-        }
-    }
-
-    // Battery optimization dialog
-    if (showBatteryOptimizationDialog) {
-        AlertDialog(
-            onDismissRequest = { showBatteryOptimizationDialog = false },
-            title = { Text("Battery Optimization") },
-            text = {
-                Text(
-                    "For reliable background sync, allow Aurboda to run " +
-                    "without battery restrictions. This helps ensure your " +
-                    "health data syncs even when the app is closed."
-                )
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        showBatteryOptimizationDialog = false
-                        batteryOptimizationLauncher.launch(
-                            createBatteryOptimizationIntent(context)
-                        )
-                    }
-                ) {
-                    Text("Allow")
-                }
-            },
-            dismissButton = {
-                Button(
-                    onClick = { showBatteryOptimizationDialog = false }
-                ) {
-                    Text("Not Now")
-                }
-            }
+    // -- Empty state --
+    if (!hasAnyPermissions && !isProcessing) {
+      item {
+        Text(
+          "Grant at least one data category to start syncing your health data.",
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          textAlign = TextAlign.Center,
+          modifier = Modifier.padding(vertical = 16.dp),
         )
+      }
     }
+  }
+
+  // Battery optimization dialog
+  if (showBatteryOptimizationDialog) {
+    AlertDialog(
+      onDismissRequest = { showBatteryOptimizationDialog = false },
+      title = { Text("Battery Optimization") },
+      text = {
+        Text(
+          "For reliable background sync, allow Aurboda to run " +
+            "without battery restrictions. This helps ensure your " +
+            "health data syncs even when the app is closed.",
+        )
+      },
+      confirmButton = {
+        Button(
+          onClick = {
+            showBatteryOptimizationDialog = false
+            batteryOptimizationLauncher.launch(
+              createBatteryOptimizationIntent(context),
+            )
+          },
+        ) {
+          Text("Allow")
+        }
+      },
+      dismissButton = {
+        Button(
+          onClick = { showBatteryOptimizationDialog = false },
+        ) {
+          Text("Not Now")
+        }
+      },
+    )
+  }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun HealthConnectScreenPreview() {
-    AurbodaAppTheme {
-        HealthConnectScreen(
-            apiUrl = "https://example.com/api",
-            authToken = "preview-token"
-        )
-    }
+  AurbodaAppTheme {
+    HealthConnectScreen(
+      apiUrl = "https://example.com/api",
+      authToken = "preview-token",
+    )
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -1,0 +1,503 @@
+package net.aurboda
+
+import android.util.Log
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.*
+import androidx.health.connect.client.records.metadata.Metadata
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import java.time.Instant
+import java.time.ZoneOffset
+
+private const val TAG = "OutboundSync"
+
+/**
+ * Prefix for clientRecordId on records written by outbound sync.
+ * Used by inbound sync to skip these records and prevent sync loops.
+ */
+const val OUTBOUND_SYNC_CLIENT_ID_PREFIX = "aurboda-sync-"
+
+// ============================================================================
+// API Models (hand-written because the generated models type payload as Map<String, String>)
+// ============================================================================
+
+@Serializable
+data class OutboundSyncEntryApi(
+  val id: String,
+  val entity_type: String,
+  val entity_id: String,
+  val operation: String,
+  val hc_record_type: String,
+  val payload: JsonObject,
+  val hc_record_id: String? = null,
+  val status: String,
+  val created_at: String,
+  val synced_at: String? = null,
+)
+
+@Serializable
+data class OutboundSyncResponseApi(
+  val success: Boolean,
+  val data: List<OutboundSyncEntryApi>? = null,
+  val error: String? = null,
+)
+
+@Serializable
+data class OutboundSyncAckItemApi(
+  val id: String,
+  val hc_record_id: String? = null,
+)
+
+@Serializable
+data class OutboundSyncAckBodyApi(
+  val entries: List<OutboundSyncAckItemApi>,
+)
+
+@Serializable
+data class OutboundSyncAckResponseApi(
+  val success: Boolean,
+  val acknowledged: Int? = null,
+  val error: String? = null,
+)
+
+// ============================================================================
+// API Client
+// ============================================================================
+
+/**
+ * Fetch pending outbound sync entries from the backend.
+ */
+suspend fun fetchOutboundSyncEntries(
+  apiUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+): List<OutboundSyncEntryApi> {
+  return try {
+    val response =
+      httpClient.get("$apiUrl/sync/outbound") {
+        headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+      }
+    if (response.status != HttpStatusCode.OK) {
+      Log.e(TAG, "🚫 Failed to fetch outbound sync: HTTP ${response.status.value}")
+      return emptyList()
+    }
+    val body = response.bodyAsText()
+    val parsed = appJson.decodeFromString<OutboundSyncResponseApi>(body)
+    if (!parsed.success) {
+      Log.e(TAG, "🚫 Outbound sync response error: ${parsed.error}")
+      return emptyList()
+    }
+    val entries = parsed.data ?: emptyList()
+    if (entries.isNotEmpty()) {
+      Log.d(TAG, "📥 Fetched ${entries.size} pending outbound sync entries")
+    }
+    entries
+  } catch (e: Exception) {
+    Log.e(TAG, "🚫 Error fetching outbound sync entries", e)
+    emptyList()
+  }
+}
+
+/**
+ * Acknowledge successfully synced outbound entries to the backend.
+ */
+suspend fun acknowledgeOutboundSync(
+  entries: List<OutboundSyncAckItemApi>,
+  apiUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+): Boolean {
+  if (entries.isEmpty()) return true
+  return try {
+    val response =
+      httpClient.post("$apiUrl/sync/outbound/ack") {
+        contentType(ContentType.Application.Json)
+        headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        setBody(OutboundSyncAckBodyApi(entries = entries))
+      }
+    if (response.status == HttpStatusCode.OK) {
+      Log.d(TAG, "✅ Acknowledged ${entries.size} outbound sync entries")
+      true
+    } else {
+      Log.e(TAG, "🚫 Ack failed: HTTP ${response.status.value}")
+      false
+    }
+  } catch (e: Exception) {
+    Log.e(TAG, "🚫 Error acknowledging outbound sync", e)
+    false
+  }
+}
+
+// ============================================================================
+// Health Connect Record Builder
+// ============================================================================
+
+/**
+ * Write an outbound sync entry to Health Connect.
+ * Returns the Health Connect record ID on success, null on failure.
+ */
+suspend fun writeToHealthConnect(
+  entry: OutboundSyncEntryApi,
+  healthConnectClient: HealthConnectClient,
+  grantedPermissions: Set<String>,
+): String? =
+  try {
+    when (entry.operation) {
+      "insert", "update" -> writeUpsertRecord(entry, healthConnectClient, grantedPermissions)
+      "delete" -> {
+        deleteHealthConnectRecord(entry, healthConnectClient)
+        // Return a marker so ack knows it succeeded (no new record ID for deletes)
+        "deleted"
+      }
+      else -> {
+        Log.w(TAG, "⚠️ Unknown operation: ${entry.operation} for entry ${entry.id}")
+        null
+      }
+    }
+  } catch (e: Exception) {
+    Log.e(TAG, "🚫 Failed to write ${entry.hc_record_type} to Health Connect: ${e.message}", e)
+    null
+  }
+
+/**
+ * Write an insert/update record to Health Connect.
+ * Uses clientRecordId with OUTBOUND_SYNC_CLIENT_ID_PREFIX for loop prevention.
+ */
+private suspend fun writeUpsertRecord(
+  entry: OutboundSyncEntryApi,
+  healthConnectClient: HealthConnectClient,
+  grantedPermissions: Set<String>,
+): String? {
+  val clientRecordId = "$OUTBOUND_SYNC_CLIENT_ID_PREFIX${entry.entity_id}"
+  val payload = entry.payload
+
+  val record: Record =
+    when (entry.hc_record_type) {
+      "WeightRecord" -> {
+        if (!hasWritePermission<WeightRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        WeightRecord(
+          weight =
+            androidx.health.connect.client.units.Mass
+              .kilograms(value),
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "HeightRecord" -> {
+        if (!hasWritePermission<HeightRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        HeightRecord(
+          height =
+            androidx.health.connect.client.units.Length
+              .meters(value),
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "BodyFatRecord" -> {
+        if (!hasWritePermission<BodyFatRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        BodyFatRecord(
+          percentage =
+            androidx.health.connect.client.units
+              .Percentage(value),
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "LeanBodyMassRecord" -> {
+        if (!hasWritePermission<LeanBodyMassRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        LeanBodyMassRecord(
+          mass =
+            androidx.health.connect.client.units.Mass
+              .kilograms(value),
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "BoneMassRecord" -> {
+        if (!hasWritePermission<BoneMassRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        BoneMassRecord(
+          mass =
+            androidx.health.connect.client.units.Mass
+              .kilograms(value),
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "BodyWaterMassRecord" -> {
+        if (!hasWritePermission<BodyWaterMassRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        BodyWaterMassRecord(
+          mass =
+            androidx.health.connect.client.units.Mass
+              .kilograms(value),
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "RestingHeartRateRecord" -> {
+        if (!hasWritePermission<RestingHeartRateRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value")?.toLong() ?: return null
+        val time = payload.getInstant("time") ?: return null
+        RestingHeartRateRecord(
+          beatsPerMinute = value,
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "StepsRecord" -> {
+        if (!hasWritePermission<StepsRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value")?.toLong() ?: return null
+        val startTime = payload.getInstant("time") ?: return null
+        // Steps need a time range; use 1-minute window
+        val endTime = startTime.plusSeconds(60)
+        StepsRecord(
+          count = value,
+          startTime = startTime,
+          startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
+          endTime = endTime,
+          endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "HeartRateRecord" -> {
+        if (!hasWritePermission<HeartRateRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value")?.toLong() ?: return null
+        val time = payload.getInstant("time") ?: return null
+        val endTime = time.plusSeconds(1)
+        HeartRateRecord(
+          startTime = time,
+          startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          endTime = endTime,
+          endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+          samples = listOf(HeartRateRecord.Sample(time = time, beatsPerMinute = value)),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "HeartRateVariabilityRmssdRecord" -> {
+        if (!hasWritePermission<HeartRateVariabilityRmssdRecord>(grantedPermissions)) return null
+        val value = payload.getDouble("value") ?: return null
+        val time = payload.getInstant("time") ?: return null
+        HeartRateVariabilityRmssdRecord(
+          heartRateVariabilityMillis = value,
+          time = time,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(time),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "ExerciseSessionRecord" -> {
+        if (!hasWritePermission<ExerciseSessionRecord>(grantedPermissions)) return null
+        val startTime = payload.getInstant("start_time") ?: return null
+        val endTime = payload.getInstant("end_time") ?: return null
+        val title = payload.getString("title")
+        val notes = payload.getString("notes")
+        ExerciseSessionRecord(
+          startTime = startTime,
+          startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
+          endTime = endTime,
+          endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+          exerciseType = ExerciseSessionRecord.EXERCISE_TYPE_OTHER_WORKOUT,
+          title = title,
+          notes = notes,
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      "SleepSessionRecord" -> {
+        if (!hasWritePermission<SleepSessionRecord>(grantedPermissions)) return null
+        val startTime = payload.getInstant("start_time") ?: return null
+        val endTime = payload.getInstant("end_time") ?: return null
+        val title = payload.getString("title")
+        val notes = payload.getString("notes")
+        SleepSessionRecord(
+          startTime = startTime,
+          startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
+          endTime = endTime,
+          endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+          title = title,
+          notes = notes,
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
+      else -> {
+        Log.w(TAG, "⚠️ Unsupported HC record type: ${entry.hc_record_type}")
+        return null
+      }
+    }
+
+  val result = healthConnectClient.insertRecords(listOf(record))
+  val recordId = result.recordIdsList.firstOrNull()
+  if (recordId != null) {
+    Log.d(TAG, "📝 Wrote ${entry.hc_record_type} to Health Connect: $recordId")
+  }
+  return recordId
+}
+
+/**
+ * Delete a record from Health Connect by its record ID.
+ */
+private suspend fun deleteHealthConnectRecord(
+  entry: OutboundSyncEntryApi,
+  healthConnectClient: HealthConnectClient,
+) {
+  val hcRecordId =
+    entry.payload.getString("hc_record_id")
+      ?: entry.hc_record_id
+  if (hcRecordId == null) {
+    Log.w(TAG, "⚠️ No HC record ID for delete operation on entry ${entry.id}")
+    return
+  }
+
+  // We need to know the record class to delete. Map hc_record_type back to class.
+  val recordClass = hcRecordTypeToClass(entry.hc_record_type)
+  if (recordClass == null) {
+    Log.w(TAG, "⚠️ Unknown record type for delete: ${entry.hc_record_type}")
+    return
+  }
+
+  healthConnectClient.deleteRecords(
+    recordType = recordClass,
+    recordIdsList = listOf(hcRecordId),
+    clientRecordIdsList = emptyList(),
+  )
+  Log.d(TAG, "🗑️ Deleted ${entry.hc_record_type} from Health Connect: $hcRecordId")
+}
+
+// ============================================================================
+// Main Processor
+// ============================================================================
+
+/**
+ * Process all pending outbound sync entries:
+ * 1. Fetch pending entries from backend
+ * 2. Write each to Health Connect
+ * 3. Acknowledge successful writes
+ *
+ * @return true if all entries were processed successfully (or none pending)
+ */
+suspend fun processOutboundSync(
+  apiUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+  healthConnectClient: HealthConnectClient,
+  grantedPermissions: Set<String>,
+): Boolean {
+  val entries = fetchOutboundSyncEntries(apiUrl, authToken, httpClient)
+  if (entries.isEmpty()) return true
+
+  Log.d(TAG, "🔄 Processing ${entries.size} outbound sync entries")
+
+  val ackItems = mutableListOf<OutboundSyncAckItemApi>()
+
+  for (entry in entries) {
+    val hcRecordId = writeToHealthConnect(entry, healthConnectClient, grantedPermissions)
+    if (hcRecordId != null) {
+      ackItems.add(
+        OutboundSyncAckItemApi(
+          id = entry.id,
+          hc_record_id = if (hcRecordId == "deleted") null else hcRecordId,
+        ),
+      )
+    } else {
+      Log.w(TAG, "⚠️ Skipped entry ${entry.id} (${entry.hc_record_type}/${entry.operation})")
+    }
+  }
+
+  if (ackItems.isNotEmpty()) {
+    val ackSuccess = acknowledgeOutboundSync(ackItems, apiUrl, authToken, httpClient)
+    if (ackSuccess) {
+      Log.d(TAG, "✅ Outbound sync complete: ${ackItems.size}/${entries.size} entries synced")
+    } else {
+      Log.w(TAG, "⚠️ Outbound sync: wrote to HC but failed to acknowledge")
+      return false
+    }
+  }
+
+  return true
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Check if write permission is granted for a specific record type. */
+private inline fun <reified T : Record> hasWritePermission(grantedPermissions: Set<String>): Boolean {
+  val permission = HealthPermission.getWritePermission(T::class)
+  val granted = permission in grantedPermissions
+  if (!granted) {
+    Log.d(TAG, "⏭️ No write permission for ${T::class.simpleName}, skipping")
+  }
+  return granted
+}
+
+/** Map HC record type name back to its KClass for deletion. */
+private fun hcRecordTypeToClass(typeName: String): kotlin.reflect.KClass<out Record>? =
+  when (typeName) {
+    "WeightRecord" -> WeightRecord::class
+    "HeightRecord" -> HeightRecord::class
+    "BodyFatRecord" -> BodyFatRecord::class
+    "LeanBodyMassRecord" -> LeanBodyMassRecord::class
+    "BoneMassRecord" -> BoneMassRecord::class
+    "BodyWaterMassRecord" -> BodyWaterMassRecord::class
+    "RestingHeartRateRecord" -> RestingHeartRateRecord::class
+    "HeartRateRecord" -> HeartRateRecord::class
+    "HeartRateVariabilityRmssdRecord" -> HeartRateVariabilityRmssdRecord::class
+    "StepsRecord" -> StepsRecord::class
+    "ExerciseSessionRecord" -> ExerciseSessionRecord::class
+    "SleepSessionRecord" -> SleepSessionRecord::class
+    else -> null
+  }
+
+/** Extract a Double value from a JsonObject field. */
+private fun JsonObject.getDouble(key: String): Double? = this[key]?.jsonPrimitive?.doubleOrNull
+
+/** Extract a String value from a JsonObject field. */
+private fun JsonObject.getString(key: String): String? =
+  this[key]?.let { element ->
+    if (element is JsonPrimitive && !element.isString && element.content == "null") {
+      null
+    } else {
+      element.jsonPrimitive.content
+    }
+  }
+
+/** Parse an ISO-8601 datetime string from a JsonObject field. */
+private fun JsonObject.getInstant(key: String): Instant? =
+  getString(key)?.let {
+    try {
+      Instant.parse(it)
+    } catch (e: Exception) {
+      null
+    }
+  }

--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -16,10 +16,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.time.Instant
 import java.time.ZoneOffset
@@ -158,11 +159,13 @@ suspend fun writeToHealthConnect(
 ): String? =
   try {
     when (entry.operation) {
+      // insertRecords() handles both insert and update: Health Connect deduplicates by
+      // clientRecordId, so re-inserting with the same ID effectively upserts the record.
       "insert", "update" -> writeUpsertRecord(entry, healthConnectClient, grantedPermissions)
       "delete" -> {
-        deleteHealthConnectRecord(entry, healthConnectClient)
+        val success = deleteHealthConnectRecord(entry, healthConnectClient)
         // Return a marker so ack knows it succeeded (no new record ID for deletes)
-        "deleted"
+        if (success) "deleted" else null
       }
       else -> {
         Log.w(TAG, "⚠️ Unknown operation: ${entry.operation} for entry ${entry.id}")
@@ -281,7 +284,9 @@ private suspend fun writeUpsertRecord(
         if (!hasWritePermission<StepsRecord>(grantedPermissions)) return null
         val value = payload.getDouble("value")?.toLong() ?: return null
         val startTime = payload.getInstant("time") ?: return null
-        // Steps need a time range; use 1-minute window
+        // Synthetic time window: StepsRecord requires a time range but the backend only stores a
+        // point-in-time. A 60-second window is acceptable for single-value step entries (e.g.,
+        // manual corrections). Aggregated daily totals come from other apps, not outbound sync.
         val endTime = startTime.plusSeconds(60)
         StepsRecord(
           count = value,
@@ -296,6 +301,8 @@ private suspend fun writeUpsertRecord(
         if (!hasWritePermission<HeartRateRecord>(grantedPermissions)) return null
         val value = payload.getDouble("value")?.toLong() ?: return null
         val time = payload.getInstant("time") ?: return null
+        // Synthetic time window: HeartRateRecord requires a time range but the backend stores a
+        // single sample. A 1-second window wrapping that sample is the minimum valid range.
         val endTime = time.plusSeconds(1)
         HeartRateRecord(
           startTime = time,
@@ -323,12 +330,21 @@ private suspend fun writeUpsertRecord(
         val endTime = payload.getInstant("end_time") ?: return null
         val title = payload.getString("title")
         val notes = payload.getString("notes")
+        // Extract exercise type from the nested data object; falls back to OTHER_WORKOUT.
+        // Backend stores exerciseType as an int matching HC's EXERCISE_TYPE_* constants.
+        val exerciseType =
+          payload["data"]
+            ?.jsonObject
+            ?.get("exerciseType")
+            ?.jsonPrimitive
+            ?.intOrNull
+            ?: ExerciseSessionRecord.EXERCISE_TYPE_OTHER_WORKOUT
         ExerciseSessionRecord(
           startTime = startTime,
           startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
           endTime = endTime,
           endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
-          exerciseType = ExerciseSessionRecord.EXERCISE_TYPE_OTHER_WORKOUT,
+          exerciseType = exerciseType,
           title = title,
           notes = notes,
           metadata = Metadata.manualEntry(clientRecordId),
@@ -366,24 +382,28 @@ private suspend fun writeUpsertRecord(
 
 /**
  * Delete a record from Health Connect by its record ID.
+ * Returns true if the delete succeeded or the entry is unprocessable (should be ack'd to prevent
+ * infinite retry). Returns false only on transient failures that should be retried.
  */
 private suspend fun deleteHealthConnectRecord(
   entry: OutboundSyncEntryApi,
   healthConnectClient: HealthConnectClient,
-) {
+): Boolean {
   val hcRecordId =
     entry.payload.getString("hc_record_id")
       ?: entry.hc_record_id
   if (hcRecordId == null) {
-    Log.w(TAG, "⚠️ No HC record ID for delete operation on entry ${entry.id}")
-    return
+    // No HC record ID available — this entry can never be processed, so ack it to avoid
+    // infinite retry. This can happen if the record was created before outbound sync tracked IDs.
+    Log.w(TAG, "⚠️ No HC record ID for delete on entry ${entry.id}, acknowledging as unprocessable")
+    return true
   }
 
   // We need to know the record class to delete. Map hc_record_type back to class.
   val recordClass = hcRecordTypeToClass(entry.hc_record_type)
   if (recordClass == null) {
-    Log.w(TAG, "⚠️ Unknown record type for delete: ${entry.hc_record_type}")
-    return
+    Log.w(TAG, "⚠️ Unknown record type for delete: ${entry.hc_record_type}, acknowledging as unprocessable")
+    return true
   }
 
   healthConnectClient.deleteRecords(
@@ -392,6 +412,7 @@ private suspend fun deleteHealthConnectRecord(
     clientRecordIdsList = emptyList(),
   )
   Log.d(TAG, "🗑️ Deleted ${entry.hc_record_type} from Health Connect: $hcRecordId")
+  return true
 }
 
 // ============================================================================

--- a/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
@@ -27,358 +27,403 @@ private const val TAG = "BleConnectionManager"
 private const val MAX_STEP_CALCULATION_GAP_SECONDS = 5.0
 private const val RSSI_POLL_INTERVAL_MS = 2000L
 
-class BleConnectionManager(private val context: Context) {
-    private var bluetoothGatt: BluetoothGatt? = null
-    private var connectedDevice: BluetoothDevice? = null
+class BleConnectionManager(
+  private val context: Context,
+) {
+  private var bluetoothGatt: BluetoothGatt? = null
+  private var connectedDevice: BluetoothDevice? = null
 
-    private val _connectionState = MutableStateFlow<BleConnectionState>(BleConnectionState.Disconnected)
-    val connectionState: StateFlow<BleConnectionState> = _connectionState.asStateFlow()
+  private val _connectionState = MutableStateFlow<BleConnectionState>(BleConnectionState.Disconnected)
+  val connectionState: StateFlow<BleConnectionState> = _connectionState.asStateFlow()
 
-    private val _heartRateSamples = MutableSharedFlow<HeartRateSample>(extraBufferCapacity = 64)
-    val heartRateSamples: SharedFlow<HeartRateSample> = _heartRateSamples.asSharedFlow()
+  private val _heartRateSamples = MutableSharedFlow<HeartRateSample>(extraBufferCapacity = 64)
+  val heartRateSamples: SharedFlow<HeartRateSample> = _heartRateSamples.asSharedFlow()
 
-    private val _connectedDeviceInfo = MutableStateFlow<ConnectedDevice?>(null)
-    val connectedDeviceInfo: StateFlow<ConnectedDevice?> = _connectedDeviceInfo.asStateFlow()
+  private val _connectedDeviceInfo = MutableStateFlow<ConnectedDevice?>(null)
+  val connectedDeviceInfo: StateFlow<ConnectedDevice?> = _connectedDeviceInfo.asStateFlow()
 
-    private val _currentHeartRate = MutableStateFlow<Int?>(null)
-    val currentHeartRate: StateFlow<Int?> = _currentHeartRate.asStateFlow()
+  private val _currentHeartRate = MutableStateFlow<Int?>(null)
+  val currentHeartRate: StateFlow<Int?> = _currentHeartRate.asStateFlow()
 
-    private val _batteryLevel = MutableStateFlow<Int?>(null)
-    val batteryLevel: StateFlow<Int?> = _batteryLevel.asStateFlow()
+  private val _batteryLevel = MutableStateFlow<Int?>(null)
+  val batteryLevel: StateFlow<Int?> = _batteryLevel.asStateFlow()
 
-    // RSC (Running Speed and Cadence) data
-    private val _cadenceSamples = MutableSharedFlow<CadenceSample>(extraBufferCapacity = 64)
-    val cadenceSamples: SharedFlow<CadenceSample> = _cadenceSamples.asSharedFlow()
+  // RSC (Running Speed and Cadence) data
+  private val _cadenceSamples = MutableSharedFlow<CadenceSample>(extraBufferCapacity = 64)
+  val cadenceSamples: SharedFlow<CadenceSample> = _cadenceSamples.asSharedFlow()
 
-    private val _currentCadence = MutableStateFlow<Int?>(null)
-    val currentCadence: StateFlow<Int?> = _currentCadence.asStateFlow()
+  private val _currentCadence = MutableStateFlow<Int?>(null)
+  val currentCadence: StateFlow<Int?> = _currentCadence.asStateFlow()
 
-    private val _currentSpeed = MutableStateFlow<Float?>(null)
-    val currentSpeed: StateFlow<Float?> = _currentSpeed.asStateFlow()
+  private val _currentSpeed = MutableStateFlow<Float?>(null)
+  val currentSpeed: StateFlow<Float?> = _currentSpeed.asStateFlow()
 
-    // Step tracking - cumulative steps since connection started
-    private var stepTrackingStartTime: java.time.Instant? = null
-    private var lastCadenceTime: java.time.Instant? = null
-    private var accumulatedSteps: Double = 0.0
+  // Step tracking - cumulative steps since connection started
+  private var stepTrackingStartTime: java.time.Instant? = null
+  private var lastCadenceTime: java.time.Instant? = null
+  private var accumulatedSteps: Double = 0.0
 
-    private val _stepsSinceStart = MutableStateFlow<Int>(0)
-    val stepsSinceStart: StateFlow<Int> = _stepsSinceStart.asStateFlow()
+  private val _stepsSinceStart = MutableStateFlow<Int>(0)
+  val stepsSinceStart: StateFlow<Int> = _stepsSinceStart.asStateFlow()
 
-    // RSSI (signal strength) monitoring
-    private val _rssi = MutableStateFlow<Int?>(null)
-    val rssi: StateFlow<Int?> = _rssi.asStateFlow()
+  // RSSI (signal strength) monitoring
+  private val _rssi = MutableStateFlow<Int?>(null)
+  val rssi: StateFlow<Int?> = _rssi.asStateFlow()
 
-    // Last time we received data from the device
-    private val _lastDataReceivedTime = MutableStateFlow<java.time.Instant?>(null)
-    val lastDataReceivedTime: StateFlow<java.time.Instant?> = _lastDataReceivedTime.asStateFlow()
+  // Last time we received data from the device
+  private val _lastDataReceivedTime = MutableStateFlow<java.time.Instant?>(null)
+  val lastDataReceivedTime: StateFlow<java.time.Instant?> = _lastDataReceivedTime.asStateFlow()
 
-    // Coroutine scope for RSSI polling
-    private val scope = CoroutineScope(Dispatchers.Main)
-    private var rssiPollingJob: Job? = null
+  // Coroutine scope for RSSI polling
+  private val scope = CoroutineScope(Dispatchers.Main)
+  private var rssiPollingJob: Job? = null
 
-    // Queue for characteristics to read after notifications are set up
-    private val pendingReads = mutableListOf<BluetoothGattCharacteristic>()
+  // Queue for characteristics to read after notifications are set up
+  private val pendingReads = mutableListOf<BluetoothGattCharacteristic>()
 
-    private val gattCallback = object : BluetoothGattCallback() {
-        @SuppressLint("MissingPermission")
-        override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
-            when (newState) {
-                BluetoothProfile.STATE_CONNECTED -> {
-                    Log.d(TAG, "Connected to GATT server, discovering services...")
-                    _connectionState.value = BleConnectionState.Connecting
-                    gatt.discoverServices()
-                }
-                BluetoothProfile.STATE_DISCONNECTED -> {
-                    Log.d(TAG, "Disconnected from GATT server")
-                    stopRssiPolling()
-                    _connectionState.value = BleConnectionState.Disconnected
-                    _connectedDeviceInfo.value = null
-                    _currentHeartRate.value = null
-                    _batteryLevel.value = null
-                    _currentCadence.value = null
-                    _currentSpeed.value = null
-                    _stepsSinceStart.value = 0
-                    _lastDataReceivedTime.value = null
-                    stepTrackingStartTime = null
-                    lastCadenceTime = null
-                    accumulatedSteps = 0.0
-                    bluetoothGatt?.close()
-                    bluetoothGatt = null
-                    connectedDevice = null
-                }
-            }
-        }
-
-        @SuppressLint("MissingPermission")
-        override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                Log.d(TAG, "Services discovered successfully")
-
-                // Check for Battery Service (common across devices)
-                val batteryService = gatt.getService(BATTERY_SERVICE_UUID)
-                val batteryCharacteristic = batteryService?.getCharacteristic(BATTERY_LEVEL_UUID)
-                if (batteryCharacteristic != null) {
-                    pendingReads.add(batteryCharacteristic)
-                    Log.d(TAG, "Battery service found, will read after setup")
-                }
-
-                // Look for Heart Rate Service
-                val hrService = gatt.getService(HEART_RATE_SERVICE_UUID)
-                if (hrService != null) {
-                    val hrMeasurement = hrService.getCharacteristic(HEART_RATE_MEASUREMENT_UUID)
-                    if (hrMeasurement != null) {
-                        enableNotifications(gatt, hrMeasurement)
-                        _connectionState.value = BleConnectionState.Connected
-                        _connectedDeviceInfo.value = ConnectedDevice(
-                            address = gatt.device.address,
-                            name = gatt.device.name,
-                            type = SensorType.HEART_RATE
-                        )
-                        startRssiPolling()
-                        Log.d(TAG, "Heart Rate service found and notifications enabled")
-                        return
-                    }
-                }
-
-                // Look for RSC Service if HR not found
-                val rscService = gatt.getService(RUNNING_SPEED_CADENCE_SERVICE_UUID)
-                if (rscService != null) {
-                    val rscMeasurement = rscService.getCharacteristic(RSC_MEASUREMENT_UUID)
-                    if (rscMeasurement != null) {
-                        enableNotifications(gatt, rscMeasurement)
-                        _connectionState.value = BleConnectionState.Connected
-                        _connectedDeviceInfo.value = ConnectedDevice(
-                            address = gatt.device.address,
-                            name = gatt.device.name,
-                            type = SensorType.RUNNING_SPEED_CADENCE
-                        )
-                        // Reset step tracking for new RSC connection
-                        stepTrackingStartTime = java.time.Instant.now()
-                        lastCadenceTime = null
-                        accumulatedSteps = 0.0
-                        _stepsSinceStart.value = 0
-                        startRssiPolling()
-                        Log.d(TAG, "RSC service found and notifications enabled, step tracking started")
-                        return
-                    }
-                }
-
-                Log.w(TAG, "No supported services found on device")
-                _connectionState.value = BleConnectionState.Error("No supported services found")
-                disconnect()
-            } else {
-                Log.e(TAG, "Service discovery failed: $status")
-                _connectionState.value = BleConnectionState.Error("Service discovery failed")
-                disconnect()
-            }
-        }
-
-        override fun onCharacteristicChanged(
-            gatt: BluetoothGatt,
-            characteristic: BluetoothGattCharacteristic,
-            value: ByteArray
-        ) {
-            when (characteristic.uuid) {
-                HEART_RATE_MEASUREMENT_UUID -> {
-                    val sample = parseHeartRateMeasurement(value)
-                    if (sample != null) {
-                        Log.d(TAG, "Heart rate: ${sample.bpm} bpm")
-                        _currentHeartRate.value = sample.bpm
-                        _heartRateSamples.tryEmit(sample)
-                        _lastDataReceivedTime.value = java.time.Instant.now()
-                    }
-                }
-                RSC_MEASUREMENT_UUID -> {
-                    val now = java.time.Instant.now()
-                    val lastTime = lastCadenceTime
-                    val gapMs = if (lastTime != null) java.time.Duration.between(lastTime, now).toMillis() else null
-
-                    val sample = parseRscMeasurement(value)
-                    if (sample != null) {
-                        Log.d(TAG, "RSC: cadence=${sample.cadence} spm, speed=${sample.speed} m/s, gap=${gapMs}ms, steps=${accumulatedSteps.toInt()}")
-                        _currentCadence.value = sample.cadence
-                        _currentSpeed.value = sample.speed
-                        _cadenceSamples.tryEmit(sample)
-                        _lastDataReceivedTime.value = now
-
-                        // Track cumulative steps by integrating cadence over time
-                        if (lastTime != null && sample.cadence > 0) {
-                            val elapsedSeconds = gapMs!! / 1000.0
-                            // Sanity check: ignore gaps larger than threshold to prevent
-                            // huge step jumps when the device stops sending data temporarily
-                            if (elapsedSeconds <= MAX_STEP_CALCULATION_GAP_SECONDS) {
-                                // cadence is steps per minute, convert to steps in elapsed time
-                                val stepsInInterval = sample.cadence * elapsedSeconds / 60.0
-                                accumulatedSteps += stepsInInterval
-                                _stepsSinceStart.value = accumulatedSteps.toInt()
-                                Log.d(TAG, "RSC step calc: +${String.format("%.1f", stepsInInterval)} steps (${elapsedSeconds}s * ${sample.cadence} spm / 60)")
-                            } else {
-                                Log.w(TAG, "RSC: Ignoring step calculation - gap of ${elapsedSeconds}s exceeds ${MAX_STEP_CALCULATION_GAP_SECONDS}s threshold")
-                            }
-                        }
-                        lastCadenceTime = now
-                    } else {
-                        Log.w(TAG, "RSC: Failed to parse data (${value.size} bytes), gap=${gapMs}ms")
-                    }
-                }
-            }
-        }
-
-        override fun onDescriptorWrite(
-            gatt: BluetoothGatt,
-            descriptor: BluetoothGattDescriptor,
-            status: Int
-        ) {
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                Log.d(TAG, "Descriptor write successful")
-                // Process pending reads after notifications are set up
-                processPendingReads(gatt)
-            } else {
-                Log.e(TAG, "Descriptor write failed: $status")
-            }
-        }
-
-        @Suppress("DEPRECATION")
-        override fun onCharacteristicRead(
-            gatt: BluetoothGatt,
-            characteristic: BluetoothGattCharacteristic,
-            status: Int
-        ) {
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                when (characteristic.uuid) {
-                    BATTERY_LEVEL_UUID -> {
-                        val batteryLevel = characteristic.value?.firstOrNull()?.toInt()?.and(0xFF)
-                        if (batteryLevel != null) {
-                            Log.d(TAG, "Battery level: $batteryLevel%")
-                            _batteryLevel.value = batteryLevel
-                        }
-                    }
-                }
-            } else {
-                Log.e(TAG, "Characteristic read failed: $status")
-            }
-            // Continue processing any remaining pending reads
-            processPendingReads(gatt)
-        }
-
-        override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
-            if (status == BluetoothGatt.GATT_SUCCESS) {
-                _rssi.value = rssi
-            }
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun processPendingReads(gatt: BluetoothGatt) {
-        if (pendingReads.isNotEmpty()) {
-            val characteristic = pendingReads.removeAt(0)
-            Log.d(TAG, "Reading characteristic: ${characteristic.uuid}")
-            @Suppress("DEPRECATION")
-            gatt.readCharacteristic(characteristic)
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun startRssiPolling() {
-        rssiPollingJob?.cancel()
-        rssiPollingJob = scope.launch {
-            while (isActive) {
-                bluetoothGatt?.readRemoteRssi()
-                delay(RSSI_POLL_INTERVAL_MS)
-            }
-        }
-    }
-
-    private fun stopRssiPolling() {
-        rssiPollingJob?.cancel()
-        rssiPollingJob = null
-        _rssi.value = null
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun enableNotifications(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
-        gatt.setCharacteristicNotification(characteristic, true)
-
-        val descriptor = characteristic.getDescriptor(CLIENT_CHARACTERISTIC_CONFIG_UUID)
-        if (descriptor != null) {
-            @Suppress("DEPRECATION")
-            descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-            @Suppress("DEPRECATION")
-            gatt.writeDescriptor(descriptor)
-            Log.d(TAG, "Enabling notifications for ${characteristic.uuid}")
-        } else {
-            Log.w(TAG, "No CCCD found for characteristic ${characteristic.uuid}")
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    fun connect(deviceAddress: String) {
-        if (_connectionState.value is BleConnectionState.Connected ||
-            _connectionState.value is BleConnectionState.Connecting) {
-            Log.w(TAG, "Already connected or connecting")
-            return
-        }
-
-        val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
-        val adapter = bluetoothManager?.adapter
-
-        if (adapter == null) {
-            _connectionState.value = BleConnectionState.Error("Bluetooth not available")
-            return
-        }
-
-        try {
-            val device = adapter.getRemoteDevice(deviceAddress)
-            connectedDevice = device
+  private val gattCallback =
+    object : BluetoothGattCallback() {
+      @SuppressLint("MissingPermission")
+      override fun onConnectionStateChange(
+        gatt: BluetoothGatt,
+        status: Int,
+        newState: Int,
+      ) {
+        when (newState) {
+          BluetoothProfile.STATE_CONNECTED -> {
+            Log.d(TAG, "Connected to GATT server, discovering services...")
             _connectionState.value = BleConnectionState.Connecting
-            Log.d(TAG, "Connecting to device: $deviceAddress")
-            bluetoothGatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
-        } catch (e: IllegalArgumentException) {
-            Log.e(TAG, "Invalid device address: $deviceAddress", e)
-            _connectionState.value = BleConnectionState.Error("Invalid device address")
-        } catch (e: SecurityException) {
-            Log.e(TAG, "Security exception connecting to device", e)
-            _connectionState.value = BleConnectionState.Error("Permission denied")
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    fun disconnect() {
-        Log.d(TAG, "Disconnecting...")
-        try {
-            bluetoothGatt?.disconnect()
-        } catch (e: SecurityException) {
-            Log.e(TAG, "Security exception disconnecting", e)
-        }
-        _currentHeartRate.value = null
-        _batteryLevel.value = null
-        _currentCadence.value = null
-        _currentSpeed.value = null
-    }
-
-    @SuppressLint("MissingPermission")
-    fun close() {
-        Log.d(TAG, "Closing connection manager...")
-        stopRssiPolling()
-        try {
+            gatt.discoverServices()
+          }
+          BluetoothProfile.STATE_DISCONNECTED -> {
+            Log.d(TAG, "Disconnected from GATT server")
+            stopRssiPolling()
+            _connectionState.value = BleConnectionState.Disconnected
+            _connectedDeviceInfo.value = null
+            _currentHeartRate.value = null
+            _batteryLevel.value = null
+            _currentCadence.value = null
+            _currentSpeed.value = null
+            _stepsSinceStart.value = 0
+            _lastDataReceivedTime.value = null
+            stepTrackingStartTime = null
+            lastCadenceTime = null
+            accumulatedSteps = 0.0
             bluetoothGatt?.close()
-        } catch (e: SecurityException) {
-            Log.e(TAG, "Security exception closing", e)
+            bluetoothGatt = null
+            connectedDevice = null
+          }
         }
-        bluetoothGatt = null
-        connectedDevice = null
-        pendingReads.clear()
-        _connectionState.value = BleConnectionState.Disconnected
-        _connectedDeviceInfo.value = null
-        _currentHeartRate.value = null
-        _batteryLevel.value = null
-        _currentCadence.value = null
-        _currentSpeed.value = null
-        _stepsSinceStart.value = 0
-        _rssi.value = null
-        _lastDataReceivedTime.value = null
-        stepTrackingStartTime = null
-        lastCadenceTime = null
-        accumulatedSteps = 0.0
+      }
+
+      @SuppressLint("MissingPermission")
+      override fun onServicesDiscovered(
+        gatt: BluetoothGatt,
+        status: Int,
+      ) {
+        if (status == BluetoothGatt.GATT_SUCCESS) {
+          Log.d(TAG, "Services discovered successfully")
+
+          // Check for Battery Service (common across devices)
+          val batteryService = gatt.getService(BATTERY_SERVICE_UUID)
+          val batteryCharacteristic = batteryService?.getCharacteristic(BATTERY_LEVEL_UUID)
+          if (batteryCharacteristic != null) {
+            pendingReads.add(batteryCharacteristic)
+            Log.d(TAG, "Battery service found, will read after setup")
+          }
+
+          // Look for Heart Rate Service
+          val hrService = gatt.getService(HEART_RATE_SERVICE_UUID)
+          if (hrService != null) {
+            val hrMeasurement = hrService.getCharacteristic(HEART_RATE_MEASUREMENT_UUID)
+            if (hrMeasurement != null) {
+              enableNotifications(gatt, hrMeasurement)
+              _connectionState.value = BleConnectionState.Connected
+              _connectedDeviceInfo.value =
+                ConnectedDevice(
+                  address = gatt.device.address,
+                  name = gatt.device.name,
+                  type = SensorType.HEART_RATE,
+                )
+              startRssiPolling()
+              Log.d(TAG, "Heart Rate service found and notifications enabled")
+              return
+            }
+          }
+
+          // Look for RSC Service if HR not found
+          val rscService = gatt.getService(RUNNING_SPEED_CADENCE_SERVICE_UUID)
+          if (rscService != null) {
+            val rscMeasurement = rscService.getCharacteristic(RSC_MEASUREMENT_UUID)
+            if (rscMeasurement != null) {
+              enableNotifications(gatt, rscMeasurement)
+              _connectionState.value = BleConnectionState.Connected
+              _connectedDeviceInfo.value =
+                ConnectedDevice(
+                  address = gatt.device.address,
+                  name = gatt.device.name,
+                  type = SensorType.RUNNING_SPEED_CADENCE,
+                )
+              // Reset step tracking for new RSC connection
+              stepTrackingStartTime = java.time.Instant.now()
+              lastCadenceTime = null
+              accumulatedSteps = 0.0
+              _stepsSinceStart.value = 0
+              startRssiPolling()
+              Log.d(TAG, "RSC service found and notifications enabled, step tracking started")
+              return
+            }
+          }
+
+          Log.w(TAG, "No supported services found on device")
+          _connectionState.value = BleConnectionState.Error("No supported services found")
+          disconnect()
+        } else {
+          Log.e(TAG, "Service discovery failed: $status")
+          _connectionState.value = BleConnectionState.Error("Service discovery failed")
+          disconnect()
+        }
+      }
+
+      override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+      ) {
+        when (characteristic.uuid) {
+          HEART_RATE_MEASUREMENT_UUID -> {
+            val sample = parseHeartRateMeasurement(value)
+            if (sample != null) {
+              Log.d(TAG, "Heart rate: ${sample.bpm} bpm")
+              _currentHeartRate.value = sample.bpm
+              _heartRateSamples.tryEmit(sample)
+              _lastDataReceivedTime.value = java.time.Instant.now()
+            }
+          }
+          RSC_MEASUREMENT_UUID -> {
+            val now = java.time.Instant.now()
+            val lastTime = lastCadenceTime
+            val gapMs =
+              if (lastTime != null) {
+                java.time.Duration
+                  .between(lastTime, now)
+                  .toMillis()
+              } else {
+                null
+              }
+
+            val sample = parseRscMeasurement(value)
+            if (sample != null) {
+              Log.d(
+                TAG,
+                "RSC: cadence=${sample.cadence} spm, speed=${sample.speed} m/s, gap=${gapMs}ms, steps=${accumulatedSteps.toInt()}",
+              )
+              _currentCadence.value = sample.cadence
+              _currentSpeed.value = sample.speed
+              _cadenceSamples.tryEmit(sample)
+              _lastDataReceivedTime.value = now
+
+              // Track cumulative steps by integrating cadence over time
+              if (lastTime != null && sample.cadence > 0) {
+                val elapsedSeconds = gapMs!! / 1000.0
+                // Sanity check: ignore gaps larger than threshold to prevent
+                // huge step jumps when the device stops sending data temporarily
+                if (elapsedSeconds <= MAX_STEP_CALCULATION_GAP_SECONDS) {
+                  // cadence is steps per minute, convert to steps in elapsed time
+                  val stepsInInterval = sample.cadence * elapsedSeconds / 60.0
+                  accumulatedSteps += stepsInInterval
+                  _stepsSinceStart.value = accumulatedSteps.toInt()
+                  Log.d(
+                    TAG,
+                    "RSC step calc: +${String.format(
+                      "%.1f",
+                      stepsInInterval,
+                    )} steps (${elapsedSeconds}s * ${sample.cadence} spm / 60)",
+                  )
+                } else {
+                  Log.w(
+                    TAG,
+                    "RSC: Ignoring step calculation - gap of ${elapsedSeconds}s exceeds ${MAX_STEP_CALCULATION_GAP_SECONDS}s threshold",
+                  )
+                }
+              }
+              lastCadenceTime = now
+            } else {
+              Log.w(TAG, "RSC: Failed to parse data (${value.size} bytes), gap=${gapMs}ms")
+            }
+          }
+        }
+      }
+
+      override fun onDescriptorWrite(
+        gatt: BluetoothGatt,
+        descriptor: BluetoothGattDescriptor,
+        status: Int,
+      ) {
+        if (status == BluetoothGatt.GATT_SUCCESS) {
+          Log.d(TAG, "Descriptor write successful")
+          // Process pending reads after notifications are set up
+          processPendingReads(gatt)
+        } else {
+          Log.e(TAG, "Descriptor write failed: $status")
+        }
+      }
+
+      @Deprecated("Using deprecated overload for API backward compatibility")
+      @Suppress("DEPRECATION")
+      override fun onCharacteristicRead(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        status: Int,
+      ) {
+        if (status == BluetoothGatt.GATT_SUCCESS) {
+          when (characteristic.uuid) {
+            BATTERY_LEVEL_UUID -> {
+              val batteryLevel =
+                characteristic.value
+                  ?.firstOrNull()
+                  ?.toInt()
+                  ?.and(0xFF)
+              if (batteryLevel != null) {
+                Log.d(TAG, "Battery level: $batteryLevel%")
+                _batteryLevel.value = batteryLevel
+              }
+            }
+          }
+        } else {
+          Log.e(TAG, "Characteristic read failed: $status")
+        }
+        // Continue processing any remaining pending reads
+        processPendingReads(gatt)
+      }
+
+      override fun onReadRemoteRssi(
+        gatt: BluetoothGatt,
+        rssi: Int,
+        status: Int,
+      ) {
+        if (status == BluetoothGatt.GATT_SUCCESS) {
+          _rssi.value = rssi
+        }
+      }
     }
+
+  @SuppressLint("MissingPermission")
+  private fun processPendingReads(gatt: BluetoothGatt) {
+    if (pendingReads.isNotEmpty()) {
+      val characteristic = pendingReads.removeAt(0)
+      Log.d(TAG, "Reading characteristic: ${characteristic.uuid}")
+      @Suppress("DEPRECATION")
+      gatt.readCharacteristic(characteristic)
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  private fun startRssiPolling() {
+    rssiPollingJob?.cancel()
+    rssiPollingJob =
+      scope.launch {
+        while (isActive) {
+          bluetoothGatt?.readRemoteRssi()
+          delay(RSSI_POLL_INTERVAL_MS)
+        }
+      }
+  }
+
+  private fun stopRssiPolling() {
+    rssiPollingJob?.cancel()
+    rssiPollingJob = null
+    _rssi.value = null
+  }
+
+  @SuppressLint("MissingPermission")
+  private fun enableNotifications(
+    gatt: BluetoothGatt,
+    characteristic: BluetoothGattCharacteristic,
+  ) {
+    gatt.setCharacteristicNotification(characteristic, true)
+
+    val descriptor = characteristic.getDescriptor(CLIENT_CHARACTERISTIC_CONFIG_UUID)
+    if (descriptor != null) {
+      @Suppress("DEPRECATION")
+      descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+      @Suppress("DEPRECATION")
+      gatt.writeDescriptor(descriptor)
+      Log.d(TAG, "Enabling notifications for ${characteristic.uuid}")
+    } else {
+      Log.w(TAG, "No CCCD found for characteristic ${characteristic.uuid}")
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  fun connect(deviceAddress: String) {
+    if (_connectionState.value is BleConnectionState.Connected ||
+      _connectionState.value is BleConnectionState.Connecting
+    ) {
+      Log.w(TAG, "Already connected or connecting")
+      return
+    }
+
+    val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    val adapter = bluetoothManager?.adapter
+
+    if (adapter == null) {
+      _connectionState.value = BleConnectionState.Error("Bluetooth not available")
+      return
+    }
+
+    try {
+      val device = adapter.getRemoteDevice(deviceAddress)
+      connectedDevice = device
+      _connectionState.value = BleConnectionState.Connecting
+      Log.d(TAG, "Connecting to device: $deviceAddress")
+      bluetoothGatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+    } catch (e: IllegalArgumentException) {
+      Log.e(TAG, "Invalid device address: $deviceAddress", e)
+      _connectionState.value = BleConnectionState.Error("Invalid device address")
+    } catch (e: SecurityException) {
+      Log.e(TAG, "Security exception connecting to device", e)
+      _connectionState.value = BleConnectionState.Error("Permission denied")
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  fun disconnect() {
+    Log.d(TAG, "Disconnecting...")
+    try {
+      bluetoothGatt?.disconnect()
+    } catch (e: SecurityException) {
+      Log.e(TAG, "Security exception disconnecting", e)
+    }
+    _currentHeartRate.value = null
+    _batteryLevel.value = null
+    _currentCadence.value = null
+    _currentSpeed.value = null
+  }
+
+  @SuppressLint("MissingPermission")
+  fun close() {
+    Log.d(TAG, "Closing connection manager...")
+    stopRssiPolling()
+    try {
+      bluetoothGatt?.close()
+    } catch (e: SecurityException) {
+      Log.e(TAG, "Security exception closing", e)
+    }
+    bluetoothGatt = null
+    connectedDevice = null
+    pendingReads.clear()
+    _connectionState.value = BleConnectionState.Disconnected
+    _connectedDeviceInfo.value = null
+    _currentHeartRate.value = null
+    _batteryLevel.value = null
+    _currentCadence.value = null
+    _currentSpeed.value = null
+    _stepsSinceStart.value = 0
+    _rssi.value = null
+    _lastDataReceivedTime.value = null
+    stepTrackingStartTime = null
+    lastCadenceTime = null
+    accumulatedSteps = 0.0
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ble/HeartRateParser.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/HeartRateParser.kt
@@ -7,54 +7,61 @@ import java.time.Instant
  * See: https://www.bluetooth.com/specifications/specs/heart-rate-service-1-0/
  */
 fun parseHeartRateMeasurement(data: ByteArray): HeartRateSample? {
-    if (data.isEmpty()) return null
+  if (data.isEmpty()) return null
 
-    val flags = data[0].toInt() and 0xFF
-    val isHrValueUint16 = (flags and 0x01) != 0
-    val hasSensorContact = (flags and 0x02) != 0
-    val sensorContactSupported = (flags and 0x04) != 0
-    val hasEnergyExpended = (flags and 0x08) != 0
-    val hasRrIntervals = (flags and 0x10) != 0
+  val flags = data[0].toInt() and 0xFF
+  val isHrValueUint16 = (flags and 0x01) != 0
 
-    var offset = 1
+  // Sensor contact bits (0x02, 0x04) are parsed but not currently used
+  @Suppress("UNUSED_VARIABLE")
+  val hasSensorContact = (flags and 0x02) != 0
 
-    // Parse heart rate value
-    val heartRate: Int = if (isHrValueUint16) {
-        if (data.size < offset + 2) return null
-        val hr = (data[offset].toInt() and 0xFF) or ((data[offset + 1].toInt() and 0xFF) shl 8)
-        offset += 2
-        hr
+  @Suppress("UNUSED_VARIABLE")
+  val sensorContactSupported = (flags and 0x04) != 0
+  val hasEnergyExpended = (flags and 0x08) != 0
+  val hasRrIntervals = (flags and 0x10) != 0
+
+  var offset = 1
+
+  // Parse heart rate value
+  val heartRate: Int =
+    if (isHrValueUint16) {
+      if (data.size < offset + 2) return null
+      val hr = (data[offset].toInt() and 0xFF) or ((data[offset + 1].toInt() and 0xFF) shl 8)
+      offset += 2
+      hr
     } else {
-        if (data.size < offset + 1) return null
-        val hr = data[offset].toInt() and 0xFF
-        offset += 1
-        hr
+      if (data.size < offset + 1) return null
+      val hr = data[offset].toInt() and 0xFF
+      offset += 1
+      hr
     }
 
-    // Skip energy expended if present (2 bytes)
-    if (hasEnergyExpended) {
+  // Skip energy expended if present (2 bytes)
+  if (hasEnergyExpended) {
+    offset += 2
+  }
+
+  // Parse RR-Intervals if present
+  val rrIntervals: List<Int>? =
+    if (hasRrIntervals && offset < data.size) {
+      val intervals = mutableListOf<Int>()
+      while (offset + 1 < data.size) {
+        // RR-Interval is in units of 1/1024 seconds
+        val rrRaw = (data[offset].toInt() and 0xFF) or ((data[offset + 1].toInt() and 0xFF) shl 8)
+        // Convert to milliseconds: (rrRaw / 1024) * 1000 = rrRaw * 1000 / 1024
+        val rrMs = (rrRaw * 1000) / 1024
+        intervals.add(rrMs)
         offset += 2
-    }
-
-    // Parse RR-Intervals if present
-    val rrIntervals: List<Int>? = if (hasRrIntervals && offset < data.size) {
-        val intervals = mutableListOf<Int>()
-        while (offset + 1 < data.size) {
-            // RR-Interval is in units of 1/1024 seconds
-            val rrRaw = (data[offset].toInt() and 0xFF) or ((data[offset + 1].toInt() and 0xFF) shl 8)
-            // Convert to milliseconds: (rrRaw / 1024) * 1000 = rrRaw * 1000 / 1024
-            val rrMs = (rrRaw * 1000) / 1024
-            intervals.add(rrMs)
-            offset += 2
-        }
-        intervals.takeIf { it.isNotEmpty() }
+      }
+      intervals.takeIf { it.isNotEmpty() }
     } else {
-        null
+      null
     }
 
-    return HeartRateSample(
-        timestamp = Instant.now(),
-        bpm = heartRate,
-        rrIntervals = rrIntervals
-    )
+  return HeartRateSample(
+    timestamp = Instant.now(),
+    bpm = heartRate,
+    rrIntervals = rrIntervals,
+  )
 }

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -52,34 +52,34 @@ private const val TAG = "SensorService"
 private const val NOTIFICATION_ID = 1001
 private const val CHANNEL_ID = "sensor_service_channel"
 private const val SYNC_INTERVAL_MS = 5000L
-private const val RR_BUFFER_MIN_SIZE = 30   // Minimum intervals for HRV calculation
-private const val RR_BUFFER_MAX_SIZE = 300  // Maximum intervals (~5 minutes at 60bpm)
-private const val CHART_HISTORY_DURATION_MS = 5 * 60 * 1000L  // 5 minutes of chart history
+private const val RR_BUFFER_MIN_SIZE = 30 // Minimum intervals for HRV calculation
+private const val RR_BUFFER_MAX_SIZE = 300 // Maximum intervals (~5 minutes at 60bpm)
+private const val CHART_HISTORY_DURATION_MS = 5 * 60 * 1000L // 5 minutes of chart history
 private const val ONE_MINUTE_MS = 60_000L
 
 /**
  * Data point for chart display with timestamp.
  */
 data class ChartDataPoint(
-    val timestamp: Long,  // epoch millis
-    val value: Float
+  val timestamp: Long, // epoch millis
+  val value: Float,
 )
 
 /**
  * State for an individual connected device.
  */
 data class DeviceState(
-    val device: ConnectedDevice,
-    val connectionState: BleConnectionState = BleConnectionState.Connected,
-    val batteryLevel: Int? = null,
-    val rssi: Int? = null,
-    val lastDataReceivedTime: Instant? = null,
-    // HR device specific
-    val currentHeartRate: Int? = null,
-    // RSC device specific
-    val currentCadence: Int? = null,
-    val currentSpeed: Float? = null,
-    val stepsSinceStart: Int = 0
+  val device: ConnectedDevice,
+  val connectionState: BleConnectionState = BleConnectionState.Connected,
+  val batteryLevel: Int? = null,
+  val rssi: Int? = null,
+  val lastDataReceivedTime: Instant? = null,
+  // HR device specific
+  val currentHeartRate: Int? = null,
+  // RSC device specific
+  val currentCadence: Int? = null,
+  val currentSpeed: Float? = null,
+  val stepsSinceStart: Int = 0,
 )
 
 /**
@@ -87,31 +87,31 @@ data class DeviceState(
  * Supports multiple simultaneously connected devices.
  */
 data class SensorServiceState(
-    val isRunning: Boolean = false,
-    val connectedDevices: Map<String, DeviceState> = emptyMap(),  // keyed by device address
-    val connectingDevices: Set<String> = emptySet(),  // addresses of devices currently connecting
-    val lastSyncTime: Instant? = null,
-    val pendingSamples: Int = 0,
-    val pendingCadenceSamples: Int = 0,
-    val currentHrv: Double? = null,           // Latest RMSSD in ms
-    val hrvReliable: Boolean = false,         // Whether HRV measurement is reliable
-    val rrIntervalCount: Int = 0,             // Number of RR intervals in buffer
-    val hrChartHistory: List<ChartDataPoint> = emptyList(),   // 5 min HR history for chart
-    val hrvChartHistory: List<ChartDataPoint> = emptyList(),  // 5 min HRV history for chart
-    // Phone step counter
-    val phoneStepCounterAvailable: Boolean = false,
-    val phoneStepCounterActive: Boolean = false,
-    val phoneStepsSinceStart: Int = 0,
-    val phoneStepLastUpdateTime: Instant? = null
+  val isRunning: Boolean = false,
+  val connectedDevices: Map<String, DeviceState> = emptyMap(), // keyed by device address
+  val connectingDevices: Set<String> = emptySet(), // addresses of devices currently connecting
+  val lastSyncTime: Instant? = null,
+  val pendingSamples: Int = 0,
+  val pendingCadenceSamples: Int = 0,
+  val currentHrv: Double? = null, // Latest RMSSD in ms
+  val hrvReliable: Boolean = false, // Whether HRV measurement is reliable
+  val rrIntervalCount: Int = 0, // Number of RR intervals in buffer
+  val hrChartHistory: List<ChartDataPoint> = emptyList(), // 5 min HR history for chart
+  val hrvChartHistory: List<ChartDataPoint> = emptyList(), // 5 min HRV history for chart
+  // Phone step counter
+  val phoneStepCounterAvailable: Boolean = false,
+  val phoneStepCounterActive: Boolean = false,
+  val phoneStepsSinceStart: Int = 0,
+  val phoneStepLastUpdateTime: Instant? = null,
 ) {
-    // Convenience accessors for backward compatibility and easy access
-    val hrDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.HEART_RATE }
-    val rscDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.RUNNING_SPEED_CADENCE }
-    val currentHeartRate: Int? get() = hrDevice?.currentHeartRate
-    val currentCadence: Int? get() = rscDevice?.currentCadence
-    val stepsSinceStart: Int get() = rscDevice?.stepsSinceStart ?: 0
-    val hasConnectedDevices: Boolean get() = connectedDevices.isNotEmpty()
-    val isConnecting: Boolean get() = connectingDevices.isNotEmpty()
+  // Convenience accessors for backward compatibility and easy access
+  val hrDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.HEART_RATE }
+  val rscDevice: DeviceState? get() = connectedDevices.values.find { it.device.type == SensorType.RUNNING_SPEED_CADENCE }
+  val currentHeartRate: Int? get() = hrDevice?.currentHeartRate
+  val currentCadence: Int? get() = rscDevice?.currentCadence
+  val stepsSinceStart: Int get() = rscDevice?.stepsSinceStart ?: 0
+  val hasConnectedDevices: Boolean get() = connectedDevices.isNotEmpty()
+  val isConnecting: Boolean get() = connectingDevices.isNotEmpty()
 }
 
 /**
@@ -119,8 +119,8 @@ data class SensorServiceState(
  */
 @Serializable
 data class LiveHeartRateSample(
-    val time: String,
-    val beatsPerMinute: Long
+  val time: String,
+  val beatsPerMinute: Long,
 )
 
 /**
@@ -129,10 +129,10 @@ data class LiveHeartRateSample(
  */
 @Serializable
 data class LiveHeartRateRecord(
-    val startTime: String,
-    val endTime: String,
-    val samples: List<LiveHeartRateSample>,
-    val metadata: LiveRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val samples: List<LiveHeartRateSample>,
+  val metadata: LiveRecordMetadata,
 )
 
 /**
@@ -140,42 +140,46 @@ data class LiveHeartRateRecord(
  */
 @Serializable
 data class LiveRecordMetadata(
-    val id: String,
-    val dataOrigin: String = "net.aurboda",
-    val device: LiveDeviceInfo? = null
+  val id: String,
+  val dataOrigin: String = "net.aurboda",
+  val device: LiveDeviceInfo? = null,
 )
 
 @Serializable
 data class LiveDeviceInfo(
-    val type: Int = 2, // TYPE_CHEST_STRAP
-    val model: String? = null
+  val type: Int = 2, // TYPE_CHEST_STRAP
+  val model: String? = null,
 )
 
 @Serializable
-private data class HeartRateSyncBody(val data: List<LiveHeartRateRecord>)
+private data class HeartRateSyncBody(
+  val data: List<LiveHeartRateRecord>,
+)
 
 /**
  * Steps record in Health Connect format for backend sync.
  */
 @Serializable
 data class LiveStepsRecord(
-    val startTime: String,
-    val endTime: String,
-    val count: Long,
-    val metadata: LiveRecordMetadata
+  val startTime: String,
+  val endTime: String,
+  val count: Long,
+  val metadata: LiveRecordMetadata,
 )
 
 @Serializable
-private data class StepsSyncBody(val data: List<LiveStepsRecord>)
+private data class StepsSyncBody(
+  val data: List<LiveStepsRecord>,
+)
 
 /**
  * Accumulates steps for a specific clock minute.
  * The minute is identified by its start time (truncated to minute boundary).
  */
 data class MinuteStepBucket(
-    val minuteStart: Instant,  // Start of the clock minute (e.g., 11:46:00.000)
-    var totalSteps: Long = 0,
-    var lastCadence: Int = 0   // Last known cadence for ongoing calculation
+  val minuteStart: Instant, // Start of the clock minute (e.g., 11:46:00.000)
+  var totalSteps: Long = 0,
+  var lastCadence: Int = 0, // Last known cadence for ongoing calculation
 )
 
 /**
@@ -183,13 +187,15 @@ data class MinuteStepBucket(
  */
 @Serializable
 data class LiveHrvRecord(
-    val time: String,
-    val heartRateVariabilityMillis: Double,
-    val metadata: LiveRecordMetadata
+  val time: String,
+  val heartRateVariabilityMillis: Double,
+  val metadata: LiveRecordMetadata,
 )
 
 @Serializable
-private data class HrvSyncBody(val data: List<LiveHrvRecord>)
+private data class HrvSyncBody(
+  val data: List<LiveHrvRecord>,
+)
 
 /**
  * Foreground service that manages BLE sensor connections.
@@ -197,1027 +203,1132 @@ private data class HrvSyncBody(val data: List<LiveHrvRecord>)
  * syncs to backend every 5 seconds, and writes to Health Connect.
  */
 class SensorService : Service() {
+  private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+  private val connectionManagers = mutableMapOf<String, BleConnectionManager>()
+  private val deviceJobs = mutableMapOf<String, List<Job>>() // Jobs per device address
+  private var syncJob: Job? = null
+  private var phoneStepJob: Job? = null
 
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val connectionManagers = mutableMapOf<String, BleConnectionManager>()
-    private val deviceJobs = mutableMapOf<String, List<Job>>()  // Jobs per device address
-    private var syncJob: Job? = null
-    private var phoneStepJob: Job? = null
+  // Phone step counter
+  private var phoneStepCounter: PhoneStepCounter? = null
 
-    // Phone step counter
-    private var phoneStepCounter: PhoneStepCounter? = null
+  private val sampleBuffer = mutableListOf<HeartRateSample>()
+  private val cadenceSampleBuffer = mutableListOf<CadenceSample>()
+  private val rrIntervalBuffer = ArrayDeque<Int>(RR_BUFFER_MAX_SIZE)
+  private val hrChartBuffer = mutableListOf<ChartDataPoint>()
+  private val hrvChartBuffer = mutableListOf<ChartDataPoint>()
 
-    private val sampleBuffer = mutableListOf<HeartRateSample>()
-    private val cadenceSampleBuffer = mutableListOf<CadenceSample>()
-    private val rrIntervalBuffer = ArrayDeque<Int>(RR_BUFFER_MAX_SIZE)
-    private val hrChartBuffer = mutableListOf<ChartDataPoint>()
-    private val hrvChartBuffer = mutableListOf<ChartDataPoint>()
-    // Step buckets keyed by minute start time (epoch millis truncated to minute)
-    // Also used for phone step counter data
-    private val stepBuckets = mutableMapOf<Long, MinuteStepBucket>()
-    private val phoneStepBuckets = mutableMapOf<Long, MinuteStepBucket>()
-    private val bufferLock = Any()
+  // Step buckets keyed by minute start time (epoch millis truncated to minute)
+  // Also used for phone step counter data
+  private val stepBuckets = mutableMapOf<Long, MinuteStepBucket>()
+  private val phoneStepBuckets = mutableMapOf<Long, MinuteStepBucket>()
+  private val bufferLock = Any()
 
-    private val httpClient by lazy {
-        HttpClient(Android) {
-            install(ContentNegotiation) { json(appJson) }
-        }
+  private val httpClient by lazy {
+    HttpClient(Android) {
+      install(ContentNegotiation) { json(appJson) }
     }
-
-    private val healthConnectClient by lazy {
-        HealthConnectClient.getOrCreate(applicationContext)
-    }
-
-    override fun onCreate() {
-        super.onCreate()
-        Log.d(TAG, "Service created")
-        createNotificationChannel()
-    }
-
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        when (intent?.action) {
-            ACTION_CONNECT -> {
-                val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
-                if (deviceAddress != null) {
-                    // Start foreground if not already running
-                    if (!_serviceState.value.isRunning) {
-                        startForegroundWithNotification()
-                    }
-                    connectToDevice(deviceAddress)
-                } else {
-                    Log.w(TAG, "No device address provided")
-                    if (!_serviceState.value.hasConnectedDevices) {
-                        stopSelf()
-                    }
-                }
-            }
-            ACTION_DISCONNECT -> {
-                val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
-                if (deviceAddress != null) {
-                    disconnectDevice(deviceAddress)
-                } else {
-                    disconnectAll()
-                }
-            }
-            ACTION_STOP -> {
-                stopSensorService()
-            }
-            ACTION_START_PHONE_STEPS -> {
-                startPhoneStepCounter()
-            }
-            ACTION_STOP_PHONE_STEPS -> {
-                stopPhoneStepCounter()
-            }
-        }
-        return START_NOT_STICKY
-    }
-
-    override fun onBind(intent: Intent?): IBinder? = null
-
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d(TAG, "Service destroyed")
-        cleanup()
-        serviceScope.cancel()
-    }
-
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                "Sensor Service",
-                NotificationManager.IMPORTANCE_LOW
-            ).apply {
-                description = "Keeps BLE sensor connections active"
-                setShowBadge(false)
-            }
-            val notificationManager = getSystemService(NotificationManager::class.java)
-            notificationManager.createNotificationChannel(channel)
-        }
-    }
-
-    @SuppressLint("ForegroundServiceType")
-    private fun startForegroundWithNotification() {
-        val notification = buildNotification(_serviceState.value)
-        startForeground(NOTIFICATION_ID, notification)
-        updateState { it.copy(isRunning = true) }
-    }
-
-    private fun buildNotification(state: SensorServiceState): Notification {
-        val openIntent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-        val openPendingIntent = PendingIntent.getActivity(
-            this, 0, openIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val stopIntent = Intent(this, SensorService::class.java).apply {
-            action = ACTION_STOP
-        }
-        val stopPendingIntent = PendingIntent.getService(
-            this, 1, stopIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val contentText = buildString {
-            val hrText = state.currentHeartRate?.let { "HR: $it BPM" }
-            val cadenceText = state.currentCadence?.let { "Cadence: $it spm • ${state.stepsSinceStart} steps" }
-            val phoneStepsText = if (state.phoneStepCounterActive) "Phone: ${state.phoneStepsSinceStart} steps" else null
-
-            when {
-                hrText != null && cadenceText != null -> append("$hrText • $cadenceText")
-                hrText != null && phoneStepsText != null -> append("$hrText • $phoneStepsText")
-                hrText != null -> append(hrText)
-                cadenceText != null -> append(cadenceText)
-                phoneStepsText != null -> append(phoneStepsText)
-                state.hasConnectedDevices -> append("${state.connectedDevices.size} sensor(s) connected")
-                state.isConnecting -> append("Connecting...")
-                else -> append("Ready")
-            }
-        }
-
-        return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("Aurboda - Sensors Active")
-            .setContentText(contentText)
-            .setSmallIcon(R.mipmap.ic_launcher)
-            .setOngoing(true)
-            .setSilent(true)
-            .setContentIntent(openPendingIntent)
-            .addAction(0, "Stop", stopPendingIntent)
-            .build()
-    }
-
-    private fun updateNotification() {
-        val notification = buildNotification(_serviceState.value)
-        val notificationManager = getSystemService(NotificationManager::class.java)
-        notificationManager.notify(NOTIFICATION_ID, notification)
-    }
-
-    private fun connectToDevice(deviceAddress: String) {
-        // Don't connect if already connected or connecting to this device
-        if (connectionManagers.containsKey(deviceAddress)) {
-            Log.w(TAG, "Already connected to device: $deviceAddress")
-            return
-        }
-        if (_serviceState.value.connectingDevices.contains(deviceAddress)) {
-            Log.w(TAG, "Already connecting to device: $deviceAddress")
-            return
-        }
-
-        Log.d(TAG, "Connecting to device: $deviceAddress")
-        updateState { it.copy(connectingDevices = it.connectingDevices + deviceAddress) }
-
-        val manager = BleConnectionManager(this)
-        val jobs = mutableListOf<Job>()
-
-        // Observe connection state
-        jobs += serviceScope.launch {
-            manager.connectionState.collect { state ->
-                Log.d(TAG, "Connection state for $deviceAddress: $state")
-
-                when (state) {
-                    is BleConnectionState.Connected -> {
-                        updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
-                        startDataCollection(manager, deviceAddress)
-                        startSyncLoop()
-                    }
-                    is BleConnectionState.Disconnected -> {
-                        handleDeviceDisconnected(deviceAddress)
-                    }
-                    is BleConnectionState.Error -> {
-                        Log.e(TAG, "Connection error for $deviceAddress: ${state.message}")
-                        updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
-                    }
-                    else -> {}
-                }
-            }
-        }
-
-        // Observe connected device info
-        jobs += serviceScope.launch {
-            manager.connectedDeviceInfo.collect { device ->
-                if (device != null) {
-                    updateState { state ->
-                        val deviceState = state.connectedDevices[deviceAddress]?.copy(device = device)
-                            ?: DeviceState(device = device)
-                        state.copy(connectedDevices = state.connectedDevices + (deviceAddress to deviceState))
-                    }
-                    updateNotification()
-                }
-            }
-        }
-
-        // Observe battery level
-        jobs += serviceScope.launch {
-            manager.batteryLevel.collect { level ->
-                updateDeviceState(deviceAddress) { it.copy(batteryLevel = level) }
-            }
-        }
-
-        // Observe current heart rate
-        jobs += serviceScope.launch {
-            manager.currentHeartRate.collect { hr ->
-                updateDeviceState(deviceAddress) { it.copy(currentHeartRate = hr) }
-                updateNotification()
-            }
-        }
-
-        // Observe current cadence
-        jobs += serviceScope.launch {
-            manager.currentCadence.collect { cadence ->
-                updateDeviceState(deviceAddress) { it.copy(currentCadence = cadence) }
-                updateNotification()
-            }
-        }
-
-        // Observe current speed
-        jobs += serviceScope.launch {
-            manager.currentSpeed.collect { speed ->
-                updateDeviceState(deviceAddress) { it.copy(currentSpeed = speed) }
-            }
-        }
-
-        // Observe cumulative steps
-        jobs += serviceScope.launch {
-            manager.stepsSinceStart.collect { steps ->
-                updateDeviceState(deviceAddress) { it.copy(stepsSinceStart = steps) }
-                updateNotification()
-            }
-        }
-
-        // Observe RSSI (signal strength)
-        jobs += serviceScope.launch {
-            manager.rssi.collect { rssi ->
-                updateDeviceState(deviceAddress) { it.copy(rssi = rssi) }
-            }
-        }
-
-        // Observe last data received time
-        jobs += serviceScope.launch {
-            manager.lastDataReceivedTime.collect { time ->
-                updateDeviceState(deviceAddress) { it.copy(lastDataReceivedTime = time) }
-            }
-        }
-
-        connectionManagers[deviceAddress] = manager
-        deviceJobs[deviceAddress] = jobs
-
-        manager.connect(deviceAddress)
-    }
-
-    private fun updateDeviceState(deviceAddress: String, update: (DeviceState) -> DeviceState) {
-        updateState { state ->
-            val deviceState = state.connectedDevices[deviceAddress] ?: return@updateState state
-            state.copy(connectedDevices = state.connectedDevices + (deviceAddress to update(deviceState)))
-        }
-    }
-
-    private fun handleDeviceDisconnected(deviceAddress: String) {
-        Log.d(TAG, "Device disconnected: $deviceAddress")
-
-        // Check if this was an HR device and clear RR buffer + HRV state + chart history
-        val wasHrDevice = _serviceState.value.connectedDevices[deviceAddress]?.device?.type == SensorType.HEART_RATE
-        if (wasHrDevice) {
-            synchronized(bufferLock) {
-                rrIntervalBuffer.clear()
-                hrChartBuffer.clear()
-                hrvChartBuffer.clear()
-                Log.d(TAG, "Cleared RR interval buffer and chart history due to HR device disconnect")
-            }
-            updateState { it.copy(
-                currentHrv = null,
-                hrvReliable = false,
-                rrIntervalCount = 0,
-                hrChartHistory = emptyList(),
-                hrvChartHistory = emptyList()
-            ) }
-        }
-
-        // Cancel jobs for this device
-        deviceJobs[deviceAddress]?.forEach { it.cancel() }
-        deviceJobs.remove(deviceAddress)
-
-        // Close and remove connection manager
-        connectionManagers[deviceAddress]?.close()
-        connectionManagers.remove(deviceAddress)
-
-        // Update state
-        updateState { state ->
-            state.copy(
-                connectedDevices = state.connectedDevices - deviceAddress,
-                connectingDevices = state.connectingDevices - deviceAddress
-            )
-        }
-        updateNotification()
-
-        // Stop service if no devices connected
-        if (connectionManagers.isEmpty() && _serviceState.value.connectingDevices.isEmpty()) {
-            Log.d(TAG, "No devices connected, stopping service")
-            stopSensorService()
-        }
-    }
-
-    private fun startDataCollection(manager: BleConnectionManager, deviceAddress: String) {
-        // Add collection jobs to the device's job list
-        val existingJobs = deviceJobs[deviceAddress]?.toMutableList() ?: mutableListOf()
-
-        existingJobs += serviceScope.launch {
-            manager.heartRateSamples.collect { sample ->
-                synchronized(bufferLock) {
-                    sampleBuffer.add(sample)
-
-                    // Add to chart history and prune old data
-                    val now = System.currentTimeMillis()
-                    val cutoff = now - CHART_HISTORY_DURATION_MS
-                    hrChartBuffer.add(ChartDataPoint(now, sample.bpm.toFloat()))
-                    hrChartBuffer.removeAll { it.timestamp < cutoff }
-
-                    updateState { it.copy(
-                        pendingSamples = sampleBuffer.size,
-                        hrChartHistory = hrChartBuffer.toList()
-                    ) }
-
-                    // Collect RR intervals for HRV calculation (rolling window)
-                    sample.rrIntervals?.forEach { rr ->
-                        if (rrIntervalBuffer.size >= RR_BUFFER_MAX_SIZE) {
-                            rrIntervalBuffer.removeFirst()
-                        }
-                        rrIntervalBuffer.addLast(rr)
-                    }
-                }
-            }
-        }
-
-        existingJobs += serviceScope.launch {
-            var lastSampleTime: Instant? = null
-            manager.cadenceSamples.collect { sample ->
-                synchronized(bufferLock) {
-                    cadenceSampleBuffer.add(sample)
-
-                    // Accumulate steps into minute buckets
-                    val sampleTimeMs = sample.timestamp.toEpochMilli()
-                    val minuteStartMs = sampleTimeMs - (sampleTimeMs % ONE_MINUTE_MS)
-                    val minuteStart = Instant.ofEpochMilli(minuteStartMs)
-
-                    val bucket = stepBuckets.getOrPut(minuteStartMs) {
-                        MinuteStepBucket(minuteStart = minuteStart)
-                    }
-
-                    // Calculate steps since last sample using cadence
-                    lastSampleTime?.let { lastTime ->
-                        val elapsedSeconds = java.time.Duration.between(lastTime, sample.timestamp).toMillis() / 1000.0
-                        if (elapsedSeconds > 0 && elapsedSeconds < 30) { // Sanity check
-                            val stepsInInterval = (sample.cadence * elapsedSeconds / 60.0).toLong()
-                            bucket.totalSteps += stepsInInterval
-                        }
-                    }
-                    bucket.lastCadence = sample.cadence
-                    lastSampleTime = sample.timestamp
-
-                    updateState { it.copy(pendingCadenceSamples = cadenceSampleBuffer.size) }
-                }
-            }
-        }
-
-        deviceJobs[deviceAddress] = existingJobs
-    }
-
-    private fun startSyncLoop() {
-        syncJob?.cancel()
-        syncJob = serviceScope.launch {
-            while (true) {
-                delay(SYNC_INTERVAL_MS)
-                syncPendingSamples()
-            }
-        }
-    }
-
-    private suspend fun syncPendingSamples() {
-        val hrSamplesToSync: List<HeartRateSample>
-        val rrIntervalsForHrv: List<Int>
-        val completedStepBuckets: List<MinuteStepBucket>
-        val completedPhoneStepBuckets: List<MinuteStepBucket>
-
-        synchronized(bufferLock) {
-            hrSamplesToSync = sampleBuffer.toList()
-            // Copy RR intervals for HRV calculation (don't clear - rolling window)
-            rrIntervalsForHrv = rrIntervalBuffer.toList()
-
-            // Extract completed minute buckets (all minutes except the current one)
-            val nowMs = System.currentTimeMillis()
-            val currentMinuteStartMs = nowMs - (nowMs % ONE_MINUTE_MS)
-
-            // BLE foot pod step buckets
-            completedStepBuckets = stepBuckets.entries
-                .filter { it.key < currentMinuteStartMs && it.value.totalSteps > 0 }
-                .map { it.value }
-                .sortedBy { it.minuteStart }
-
-            // Remove completed buckets from the map
-            completedStepBuckets.forEach { bucket ->
-                stepBuckets.remove(bucket.minuteStart.toEpochMilli())
-            }
-
-            // Phone step counter buckets
-            completedPhoneStepBuckets = phoneStepBuckets.entries
-                .filter { it.key < currentMinuteStartMs && it.value.totalSteps > 0 }
-                .map { it.value }
-                .sortedBy { it.minuteStart }
-
-            // Remove completed phone step buckets
-            completedPhoneStepBuckets.forEach { bucket ->
-                phoneStepBuckets.remove(bucket.minuteStart.toEpochMilli())
-            }
-
-            // Clear raw cadence samples (they've been accumulated into buckets)
-            cadenceSampleBuffer.clear()
-
-            if (hrSamplesToSync.isEmpty() && completedStepBuckets.isEmpty() && completedPhoneStepBuckets.isEmpty()) return
-            sampleBuffer.clear()
-            updateState { it.copy(pendingSamples = 0, pendingCadenceSamples = 0) }
-        }
-
-        // Sync HR samples if any
-        if (hrSamplesToSync.isNotEmpty()) {
-            Log.d(TAG, "Syncing ${hrSamplesToSync.size} HR samples")
-            val backendSuccess = syncHeartRateToBackend(hrSamplesToSync)
-            if (!backendSuccess) {
-                synchronized(bufferLock) {
-                    sampleBuffer.addAll(0, hrSamplesToSync)
-                    updateState { it.copy(pendingSamples = sampleBuffer.size) }
-                }
-            } else {
-                writeHeartRateToHealthConnect(hrSamplesToSync)
-            }
-        }
-
-        // Sync completed minute step buckets if any (from BLE foot pod)
-        if (completedStepBuckets.isNotEmpty()) {
-            val totalSteps = completedStepBuckets.sumOf { it.totalSteps }
-            Log.d(TAG, "Syncing ${completedStepBuckets.size} BLE step bucket(s) with $totalSteps total steps")
-            val backendSuccess = syncStepBucketsToBackend(completedStepBuckets, "ble-footpod")
-            if (!backendSuccess) {
-                // Re-add buckets on failure
-                synchronized(bufferLock) {
-                    completedStepBuckets.forEach { bucket ->
-                        stepBuckets[bucket.minuteStart.toEpochMilli()] = bucket
-                    }
-                }
-            } else {
-                writeStepBucketsToHealthConnect(completedStepBuckets)
-            }
-        }
-
-        // Sync completed phone step buckets if any
-        if (completedPhoneStepBuckets.isNotEmpty()) {
-            val totalSteps = completedPhoneStepBuckets.sumOf { it.totalSteps }
-            Log.d(TAG, "Syncing ${completedPhoneStepBuckets.size} phone step bucket(s) with $totalSteps total steps")
-            val backendSuccess = syncStepBucketsToBackend(completedPhoneStepBuckets, "phone")
-            if (!backendSuccess) {
-                // Re-add buckets on failure
-                synchronized(bufferLock) {
-                    completedPhoneStepBuckets.forEach { bucket ->
-                        phoneStepBuckets[bucket.minuteStart.toEpochMilli()] = bucket
-                    }
-                }
-            } else {
-                writeStepBucketsToHealthConnect(completedPhoneStepBuckets)
-            }
-        }
-
-        // Calculate and sync HRV if we have enough RR intervals
-        if (rrIntervalsForHrv.size >= RR_BUFFER_MIN_SIZE) {
-            val hrvResult = calculateHrv(rrIntervalsForHrv)
-            Log.d(TAG, "HRV calculation: rmssd=${hrvResult.rmssd}, valid=${hrvResult.validIntervals}, " +
-                    "artifacts=${hrvResult.artifactCount} (${String.format("%.1f", hrvResult.artifactPercentage)}%), " +
-                    "reliable=${hrvResult.isReliable}")
-
-            // Add to HRV chart history if we have a valid value
-            if (hrvResult.rmssd != null) {
-                synchronized(bufferLock) {
-                    val now = System.currentTimeMillis()
-                    val cutoff = now - CHART_HISTORY_DURATION_MS
-                    hrvChartBuffer.add(ChartDataPoint(now, hrvResult.rmssd.toFloat()))
-                    hrvChartBuffer.removeAll { it.timestamp < cutoff }
-                }
-            }
-
-            // Update state for UI display
-            updateState { it.copy(
-                currentHrv = hrvResult.rmssd,
-                hrvReliable = hrvResult.isReliable,
-                rrIntervalCount = rrIntervalsForHrv.size,
-                hrvChartHistory = hrvChartBuffer.toList()
-            ) }
-
-            if (hrvResult.isReliable && hrvResult.rmssd != null) {
-                val timestamp = Instant.now()
-                syncHrvToBackend(hrvResult.rmssd, timestamp)
-                writeHrvToHealthConnect(hrvResult.rmssd, timestamp)
-            }
-        } else {
-            // Update state to show collecting progress
-            updateState { it.copy(
-                currentHrv = null,
-                hrvReliable = false,
-                rrIntervalCount = rrIntervalsForHrv.size
-            ) }
-            if (rrIntervalsForHrv.isNotEmpty()) {
-                Log.d(TAG, "HRV: Collecting RR intervals (${rrIntervalsForHrv.size}/$RR_BUFFER_MIN_SIZE)")
-            }
-        }
-
-        updateState { it.copy(lastSyncTime = Instant.now()) }
-    }
-
-    private suspend fun syncHeartRateToBackend(samples: List<HeartRateSample>): Boolean {
-        val credentials = CredentialsManager.getCredentials(this) ?: run {
-            Log.w(TAG, "No credentials, skipping backend sync")
-            return true // Don't block on missing credentials
-        }
-
-        if (samples.isEmpty()) return true
-
-        // Sort samples and create a single HeartRateRecord in Health Connect format
-        val sortedSamples = samples.sortedBy { it.timestamp }
-        val startTime = sortedSamples.first().timestamp
-        val endTime = sortedSamples.last().timestamp.plusSeconds(1)
-
-        // Generate unique ID for this batch based on start time
-        val recordId = "live-hr-${startTime.epochSecond}-${startTime.nano}"
-
-        // Get device info from HR device if available
-        val hrManager = connectionManagers.values.find {
-            it.connectedDeviceInfo.value?.type == SensorType.HEART_RATE
-        }
-        val deviceInfo = hrManager?.connectedDeviceInfo?.value?.let { device ->
-            LiveDeviceInfo(
-                type = 2, // TYPE_CHEST_STRAP
-                model = device.name
-            )
-        }
-
-        val record = LiveHeartRateRecord(
-            startTime = startTime.toString(),
-            endTime = endTime.toString(),
-            samples = sortedSamples.map { sample ->
-                LiveHeartRateSample(
-                    time = sample.timestamp.toString(),
-                    beatsPerMinute = sample.bpm.toLong()
-                )
-            },
-            metadata = LiveRecordMetadata(
-                id = recordId,
-                device = deviceInfo
-            )
-        )
-
-        return try {
-            val response = httpClient.post("${credentials.apiUrl}/sync/HeartRateRecord") {
-                contentType(ContentType.Application.Json)
-                headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
-                setBody(HeartRateSyncBody(listOf(record)))
-            }
-            val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-            Log.d(TAG, "Backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")
-            success
-        } catch (e: Exception) {
-            Log.e(TAG, "Backend sync error", e)
-            false
-        }
-    }
-
-    private suspend fun writeHeartRateToHealthConnect(samples: List<HeartRateSample>) {
-        if (samples.isEmpty()) return
-
-        try {
-            // Check write permission
-            val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-            val writePermission = HealthPermission.getWritePermission(HeartRateRecord::class)
-            if (writePermission !in grantedPermissions) {
-                Log.w(TAG, "No Health Connect write permission for HeartRateRecord")
-                return
-            }
-
-            // Group samples into 1-second intervals for Health Connect
-            // Health Connect expects HeartRateRecord with a time range and samples
-            val sortedSamples = samples.sortedBy { it.timestamp }
-            val startTime = sortedSamples.first().timestamp
-            val endTime = sortedSamples.last().timestamp.plusSeconds(1)
-
-            val hrSamples = sortedSamples.map { sample ->
-                HeartRateRecord.Sample(
-                    time = sample.timestamp,
-                    beatsPerMinute = sample.bpm.toLong()
-                )
-            }
-
-            val record = HeartRateRecord(
-                startTime = startTime,
-                startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
-                endTime = endTime,
-                endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
-                samples = hrSamples,
-                metadata = Metadata.autoRecorded(
-                    device = Device(type = Device.TYPE_CHEST_STRAP)
-                )
-            )
-
-            healthConnectClient.insertRecords(listOf(record))
-            Log.d(TAG, "Wrote ${samples.size} HR samples to Health Connect")
-        } catch (e: Exception) {
-            Log.e(TAG, "Health Connect write error", e)
-        }
-    }
-
-    /**
-     * Sync step buckets to backend. Each bucket represents one clock minute with
-     * timestamps aligned to minute boundaries (e.g., 11:46:00.000 - 11:46:59.999).
-     */
-    private suspend fun syncStepBucketsToBackend(buckets: List<MinuteStepBucket>, source: String = "ble-footpod"): Boolean {
-        val credentials = CredentialsManager.getCredentials(this) ?: run {
-            Log.w(TAG, "No credentials, skipping backend sync")
-            return true // Don't block on missing credentials
-        }
-
-        if (buckets.isEmpty()) return true
-
-        // Get device info based on source
-        val deviceInfo = when (source) {
-            "phone" -> LiveDeviceInfo(
-                type = 1, // TYPE_PHONE
-                model = android.os.Build.MODEL
-            )
-            else -> {
-                // BLE foot pod - get device info from RSC device if available
-                val rscManager = connectionManagers.values.find {
-                    it.connectedDeviceInfo.value?.type == SensorType.RUNNING_SPEED_CADENCE
-                }
-                rscManager?.connectedDeviceInfo?.value?.let { device ->
-                    LiveDeviceInfo(
-                        type = 4, // TYPE_WATCH or foot pod
-                        model = device.name
-                    )
-                }
-            }
-        }
-
-        // Create one record per minute bucket with clock-minute-aligned timestamps
-        val records = buckets.map { bucket ->
-            val minuteEnd = bucket.minuteStart.plusMillis(ONE_MINUTE_MS - 1) // 11:46:59.999
-            val recordId = "live-steps-$source-${bucket.minuteStart.epochSecond}"
-
-            LiveStepsRecord(
-                startTime = bucket.minuteStart.toString(),
-                endTime = minuteEnd.toString(),
-                count = bucket.totalSteps,
-                metadata = LiveRecordMetadata(
-                    id = recordId,
-                    device = deviceInfo
-                )
-            )
-        }
-
-        return try {
-            val response = httpClient.post("${credentials.apiUrl}/sync/StepsRecord") {
-                contentType(ContentType.Application.Json)
-                headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
-                setBody(StepsSyncBody(records))
-            }
-            val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-            val totalSteps = buckets.sumOf { it.totalSteps }
-            Log.d(TAG, "Steps backend sync (${buckets.size} minutes, $totalSteps steps) ${if (success) "succeeded" else "failed"}: ${response.status}")
-            success
-        } catch (e: Exception) {
-            Log.e(TAG, "Steps backend sync error", e)
-            false
-        }
-    }
-
-    /**
-     * Write step buckets to Health Connect. Each bucket becomes one StepsRecord with
-     * timestamps aligned to minute boundaries for proper aggregation/deduplication.
-     */
-    private suspend fun writeStepBucketsToHealthConnect(buckets: List<MinuteStepBucket>) {
-        if (buckets.isEmpty()) return
-
-        try {
-            // Check write permission
-            val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-            val writePermission = HealthPermission.getWritePermission(StepsRecord::class)
-            if (writePermission !in grantedPermissions) {
-                Log.w(TAG, "No Health Connect write permission for StepsRecord")
-                return
-            }
-
-            // Create one record per minute bucket with clock-minute-aligned timestamps
-            val records = buckets.map { bucket ->
-                val minuteEnd = bucket.minuteStart.plusMillis(ONE_MINUTE_MS - 1) // 11:46:59.999
-
-                StepsRecord(
-                    startTime = bucket.minuteStart,
-                    startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(bucket.minuteStart),
-                    endTime = minuteEnd,
-                    endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(minuteEnd),
-                    count = bucket.totalSteps,
-                    metadata = Metadata.autoRecorded(
-                        device = Device(type = Device.TYPE_WATCH)
-                    )
-                )
-            }
-
-            healthConnectClient.insertRecords(records)
-            val totalSteps = buckets.sumOf { it.totalSteps }
-            Log.d(TAG, "Wrote ${buckets.size} minute bucket(s) with $totalSteps total steps to Health Connect")
-        } catch (e: Exception) {
-            Log.e(TAG, "Health Connect steps write error", e)
-        }
-    }
-
-    private suspend fun syncHrvToBackend(rmssd: Double, timestamp: Instant) {
-        val credentials = CredentialsManager.getCredentials(this) ?: run {
-            Log.w(TAG, "No credentials, skipping HRV backend sync")
-            return
-        }
-
-        val recordId = "live-hrv-${timestamp.epochSecond}-${timestamp.nano}"
-
-        // Get device info from HR device if available
-        val hrManager = connectionManagers.values.find {
-            it.connectedDeviceInfo.value?.type == SensorType.HEART_RATE
-        }
-        val deviceInfo = hrManager?.connectedDeviceInfo?.value?.let { device ->
-            LiveDeviceInfo(
-                type = 2, // TYPE_CHEST_STRAP
-                model = device.name
-            )
-        }
-
-        val record = LiveHrvRecord(
-            time = timestamp.toString(),
-            heartRateVariabilityMillis = rmssd,
-            metadata = LiveRecordMetadata(
-                id = recordId,
-                device = deviceInfo
-            )
-        )
-
-        try {
-            val response = httpClient.post("${credentials.apiUrl}/sync/HeartRateVariabilityRmssdRecord") {
-                contentType(ContentType.Application.Json)
-                headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
-                setBody(HrvSyncBody(listOf(record)))
-            }
-            val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-            Log.d(TAG, "HRV backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")
-        } catch (e: Exception) {
-            Log.e(TAG, "HRV backend sync error", e)
-        }
-    }
-
-    private suspend fun writeHrvToHealthConnect(rmssd: Double, timestamp: Instant) {
-        try {
-            // Check write permission
-            val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
-            val writePermission = HealthPermission.getWritePermission(HeartRateVariabilityRmssdRecord::class)
-            if (writePermission !in grantedPermissions) {
-                Log.w(TAG, "No Health Connect write permission for HeartRateVariabilityRmssdRecord")
-                return
-            }
-
-            val record = HeartRateVariabilityRmssdRecord(
-                time = timestamp,
-                zoneOffset = ZoneOffset.systemDefault().rules.getOffset(timestamp),
-                heartRateVariabilityMillis = rmssd,
-                metadata = Metadata.autoRecorded(
-                    device = Device(type = Device.TYPE_CHEST_STRAP)
-                )
-            )
-
-            healthConnectClient.insertRecords(listOf(record))
-            Log.d(TAG, "Wrote HRV (RMSSD=${String.format("%.1f", rmssd)}ms) to Health Connect")
-        } catch (e: Exception) {
-            Log.e(TAG, "Health Connect HRV write error", e)
-        }
-    }
-
-    private fun disconnectDevice(deviceAddress: String) {
-        Log.d(TAG, "Disconnecting device: $deviceAddress")
-        connectionManagers[deviceAddress]?.disconnect()
-    }
-
-    private fun disconnectAll() {
-        Log.d(TAG, "Disconnecting all devices...")
-        connectionManagers.keys.toList().forEach { address ->
-            connectionManagers[address]?.disconnect()
-        }
-    }
-
-    private fun startPhoneStepCounter() {
-        Log.d(TAG, "Starting phone step counter")
-
-        // Create counter if needed
-        if (phoneStepCounter == null) {
-            phoneStepCounter = PhoneStepCounter(applicationContext)
-        }
-
-        val counter = phoneStepCounter!!
-
-        // Update availability state
-        updateState { it.copy(phoneStepCounterAvailable = counter.isAvailable.value) }
-
-        if (!counter.isAvailable.value) {
-            Log.w(TAG, "Phone step counter not available on this device")
-            return
-        }
-
-        // Start foreground if not already running
-        if (!_serviceState.value.isRunning) {
+  }
+
+  private val healthConnectClient by lazy {
+    HealthConnectClient.getOrCreate(applicationContext)
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    Log.d(TAG, "Service created")
+    createNotificationChannel()
+  }
+
+  override fun onStartCommand(
+    intent: Intent?,
+    flags: Int,
+    startId: Int,
+  ): Int {
+    when (intent?.action) {
+      ACTION_CONNECT -> {
+        val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
+        if (deviceAddress != null) {
+          // Start foreground if not already running
+          if (!_serviceState.value.isRunning) {
             startForegroundWithNotification()
-        }
-
-        // Start monitoring
-        if (counter.startMonitoring()) {
-            updateState { it.copy(phoneStepCounterActive = true) }
-
-            // Start sync loop if not already running
-            if (syncJob == null || syncJob?.isActive != true) {
-                startSyncLoop()
-            }
-
-            // Collect step updates
-            phoneStepJob?.cancel()
-            phoneStepJob = serviceScope.launch {
-                var lastStepCount = 0
-                var lastMinuteStartMs = 0L
-
-                counter.stepsSinceStart.collect { steps ->
-                    updateState { it.copy(phoneStepsSinceStart = steps) }
-
-                    // Accumulate into minute buckets for syncing
-                    val now = Instant.now()
-                    val minuteStartMs = now.toEpochMilli() - (now.toEpochMilli() % ONE_MINUTE_MS)
-
-                    synchronized(bufferLock) {
-                        // Calculate delta since last update
-                        val stepsDelta = steps - lastStepCount
-
-                        if (stepsDelta > 0) {
-                            val bucket = phoneStepBuckets.getOrPut(minuteStartMs) {
-                                MinuteStepBucket(minuteStart = Instant.ofEpochMilli(minuteStartMs))
-                            }
-
-                            // If we're in a new minute, add the delta to the new bucket
-                            // If same minute, add to existing bucket
-                            bucket.totalSteps += stepsDelta
-                            Log.d(TAG, "Phone steps: +$stepsDelta in bucket ${bucket.minuteStart}, total in bucket: ${bucket.totalSteps}")
-                        }
-
-                        lastStepCount = steps
-                        lastMinuteStartMs = minuteStartMs
-                    }
-
-                    updateNotification()
-                }
-            }
-
-            // Also collect last update time
-            serviceScope.launch {
-                counter.lastUpdateTime.collect { time ->
-                    updateState { it.copy(phoneStepLastUpdateTime = time) }
-                }
-            }
-
-            Log.d(TAG, "Phone step counter started")
+          }
+          connectToDevice(deviceAddress)
         } else {
-            Log.e(TAG, "Failed to start phone step counter")
+          Log.w(TAG, "No device address provided")
+          if (!_serviceState.value.hasConnectedDevices) {
+            stopSelf()
+          }
         }
+      }
+      ACTION_DISCONNECT -> {
+        val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
+        if (deviceAddress != null) {
+          disconnectDevice(deviceAddress)
+        } else {
+          disconnectAll()
+        }
+      }
+      ACTION_STOP -> {
+        stopSensorService()
+      }
+      ACTION_START_PHONE_STEPS -> {
+        startPhoneStepCounter()
+      }
+      ACTION_STOP_PHONE_STEPS -> {
+        stopPhoneStepCounter()
+      }
+    }
+    return START_NOT_STICKY
+  }
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  override fun onDestroy() {
+    super.onDestroy()
+    Log.d(TAG, "Service destroyed")
+    cleanup()
+    serviceScope.cancel()
+  }
+
+  private fun createNotificationChannel() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val channel =
+        NotificationChannel(
+          CHANNEL_ID,
+          "Sensor Service",
+          NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+          description = "Keeps BLE sensor connections active"
+          setShowBadge(false)
+        }
+      val notificationManager = getSystemService(NotificationManager::class.java)
+      notificationManager.createNotificationChannel(channel)
+    }
+  }
+
+  @SuppressLint("ForegroundServiceType")
+  private fun startForegroundWithNotification() {
+    val notification = buildNotification(_serviceState.value)
+    startForeground(NOTIFICATION_ID, notification)
+    updateState { it.copy(isRunning = true) }
+  }
+
+  private fun buildNotification(state: SensorServiceState): Notification {
+    val openIntent =
+      Intent(this, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+      }
+    val openPendingIntent =
+      PendingIntent.getActivity(
+        this,
+        0,
+        openIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+
+    val stopIntent =
+      Intent(this, SensorService::class.java).apply {
+        action = ACTION_STOP
+      }
+    val stopPendingIntent =
+      PendingIntent.getService(
+        this,
+        1,
+        stopIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+
+    val contentText =
+      buildString {
+        val hrText = state.currentHeartRate?.let { "HR: $it BPM" }
+        val cadenceText = state.currentCadence?.let { "Cadence: $it spm • ${state.stepsSinceStart} steps" }
+        val phoneStepsText = if (state.phoneStepCounterActive) "Phone: ${state.phoneStepsSinceStart} steps" else null
+
+        when {
+          hrText != null && cadenceText != null -> append("$hrText • $cadenceText")
+          hrText != null && phoneStepsText != null -> append("$hrText • $phoneStepsText")
+          hrText != null -> append(hrText)
+          cadenceText != null -> append(cadenceText)
+          phoneStepsText != null -> append(phoneStepsText)
+          state.hasConnectedDevices -> append("${state.connectedDevices.size} sensor(s) connected")
+          state.isConnecting -> append("Connecting...")
+          else -> append("Ready")
+        }
+      }
+
+    return NotificationCompat
+      .Builder(this, CHANNEL_ID)
+      .setContentTitle("Aurboda - Sensors Active")
+      .setContentText(contentText)
+      .setSmallIcon(R.mipmap.ic_launcher)
+      .setOngoing(true)
+      .setSilent(true)
+      .setContentIntent(openPendingIntent)
+      .addAction(0, "Stop", stopPendingIntent)
+      .build()
+  }
+
+  private fun updateNotification() {
+    val notification = buildNotification(_serviceState.value)
+    val notificationManager = getSystemService(NotificationManager::class.java)
+    notificationManager.notify(NOTIFICATION_ID, notification)
+  }
+
+  private fun connectToDevice(deviceAddress: String) {
+    // Don't connect if already connected or connecting to this device
+    if (connectionManagers.containsKey(deviceAddress)) {
+      Log.w(TAG, "Already connected to device: $deviceAddress")
+      return
+    }
+    if (_serviceState.value.connectingDevices.contains(deviceAddress)) {
+      Log.w(TAG, "Already connecting to device: $deviceAddress")
+      return
     }
 
-    private fun stopPhoneStepCounter() {
-        Log.d(TAG, "Stopping phone step counter")
-        phoneStepJob?.cancel()
-        phoneStepJob = null
-        phoneStepCounter?.stopMonitoring()
-        updateState {
-            it.copy(
-                phoneStepCounterActive = false,
-                phoneStepsSinceStart = 0,
-                phoneStepLastUpdateTime = null
-            )
-        }
-        synchronized(bufferLock) {
-            phoneStepBuckets.clear()
-        }
+    Log.d(TAG, "Connecting to device: $deviceAddress")
+    updateState { it.copy(connectingDevices = it.connectingDevices + deviceAddress) }
 
-        // Stop service if nothing else is running
-        if (!_serviceState.value.hasConnectedDevices && !_serviceState.value.isConnecting) {
-            stopSensorService()
-        } else {
+    val manager = BleConnectionManager(this)
+    val jobs = mutableListOf<Job>()
+
+    // Observe connection state
+    jobs +=
+      serviceScope.launch {
+        manager.connectionState.collect { state ->
+          Log.d(TAG, "Connection state for $deviceAddress: $state")
+
+          when (state) {
+            is BleConnectionState.Connected -> {
+              updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
+              startDataCollection(manager, deviceAddress)
+              startSyncLoop()
+            }
+            is BleConnectionState.Disconnected -> {
+              handleDeviceDisconnected(deviceAddress)
+            }
+            is BleConnectionState.Error -> {
+              Log.e(TAG, "Connection error for $deviceAddress: ${state.message}")
+              updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
+            }
+            else -> {}
+          }
+        }
+      }
+
+    // Observe connected device info
+    jobs +=
+      serviceScope.launch {
+        manager.connectedDeviceInfo.collect { device ->
+          if (device != null) {
+            updateState { state ->
+              val deviceState =
+                state.connectedDevices[deviceAddress]?.copy(device = device)
+                  ?: DeviceState(device = device)
+              state.copy(connectedDevices = state.connectedDevices + (deviceAddress to deviceState))
+            }
             updateNotification()
+          }
         }
+      }
+
+    // Observe battery level
+    jobs +=
+      serviceScope.launch {
+        manager.batteryLevel.collect { level ->
+          updateDeviceState(deviceAddress) { it.copy(batteryLevel = level) }
+        }
+      }
+
+    // Observe current heart rate
+    jobs +=
+      serviceScope.launch {
+        manager.currentHeartRate.collect { hr ->
+          updateDeviceState(deviceAddress) { it.copy(currentHeartRate = hr) }
+          updateNotification()
+        }
+      }
+
+    // Observe current cadence
+    jobs +=
+      serviceScope.launch {
+        manager.currentCadence.collect { cadence ->
+          updateDeviceState(deviceAddress) { it.copy(currentCadence = cadence) }
+          updateNotification()
+        }
+      }
+
+    // Observe current speed
+    jobs +=
+      serviceScope.launch {
+        manager.currentSpeed.collect { speed ->
+          updateDeviceState(deviceAddress) { it.copy(currentSpeed = speed) }
+        }
+      }
+
+    // Observe cumulative steps
+    jobs +=
+      serviceScope.launch {
+        manager.stepsSinceStart.collect { steps ->
+          updateDeviceState(deviceAddress) { it.copy(stepsSinceStart = steps) }
+          updateNotification()
+        }
+      }
+
+    // Observe RSSI (signal strength)
+    jobs +=
+      serviceScope.launch {
+        manager.rssi.collect { rssi ->
+          updateDeviceState(deviceAddress) { it.copy(rssi = rssi) }
+        }
+      }
+
+    // Observe last data received time
+    jobs +=
+      serviceScope.launch {
+        manager.lastDataReceivedTime.collect { time ->
+          updateDeviceState(deviceAddress) { it.copy(lastDataReceivedTime = time) }
+        }
+      }
+
+    connectionManagers[deviceAddress] = manager
+    deviceJobs[deviceAddress] = jobs
+
+    manager.connect(deviceAddress)
+  }
+
+  private fun updateDeviceState(
+    deviceAddress: String,
+    update: (DeviceState) -> DeviceState,
+  ) {
+    updateState { state ->
+      val deviceState = state.connectedDevices[deviceAddress] ?: return@updateState state
+      state.copy(connectedDevices = state.connectedDevices + (deviceAddress to update(deviceState)))
+    }
+  }
+
+  private fun handleDeviceDisconnected(deviceAddress: String) {
+    Log.d(TAG, "Device disconnected: $deviceAddress")
+
+    // Check if this was an HR device and clear RR buffer + HRV state + chart history
+    val wasHrDevice =
+      _serviceState.value.connectedDevices[deviceAddress]
+        ?.device
+        ?.type == SensorType.HEART_RATE
+    if (wasHrDevice) {
+      synchronized(bufferLock) {
+        rrIntervalBuffer.clear()
+        hrChartBuffer.clear()
+        hrvChartBuffer.clear()
+        Log.d(TAG, "Cleared RR interval buffer and chart history due to HR device disconnect")
+      }
+      updateState {
+        it.copy(
+          currentHrv = null,
+          hrvReliable = false,
+          rrIntervalCount = 0,
+          hrChartHistory = emptyList(),
+          hrvChartHistory = emptyList(),
+        )
+      }
     }
 
-    private fun stopSensorService() {
-        Log.d(TAG, "Stopping service...")
-        cleanup()
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        stopSelf()
-        updateState { SensorServiceState() }
+    // Cancel jobs for this device
+    deviceJobs[deviceAddress]?.forEach { it.cancel() }
+    deviceJobs.remove(deviceAddress)
+
+    // Close and remove connection manager
+    connectionManagers[deviceAddress]?.close()
+    connectionManagers.remove(deviceAddress)
+
+    // Update state
+    updateState { state ->
+      state.copy(
+        connectedDevices = state.connectedDevices - deviceAddress,
+        connectingDevices = state.connectingDevices - deviceAddress,
+      )
+    }
+    updateNotification()
+
+    // Stop service if no devices connected
+    if (connectionManagers.isEmpty() && _serviceState.value.connectingDevices.isEmpty()) {
+      Log.d(TAG, "No devices connected, stopping service")
+      stopSensorService()
+    }
+  }
+
+  private fun startDataCollection(
+    manager: BleConnectionManager,
+    deviceAddress: String,
+  ) {
+    // Add collection jobs to the device's job list
+    val existingJobs = deviceJobs[deviceAddress]?.toMutableList() ?: mutableListOf()
+
+    existingJobs +=
+      serviceScope.launch {
+        manager.heartRateSamples.collect { sample ->
+          synchronized(bufferLock) {
+            sampleBuffer.add(sample)
+
+            // Add to chart history and prune old data
+            val now = System.currentTimeMillis()
+            val cutoff = now - CHART_HISTORY_DURATION_MS
+            hrChartBuffer.add(ChartDataPoint(now, sample.bpm.toFloat()))
+            hrChartBuffer.removeAll { it.timestamp < cutoff }
+
+            updateState {
+              it.copy(
+                pendingSamples = sampleBuffer.size,
+                hrChartHistory = hrChartBuffer.toList(),
+              )
+            }
+
+            // Collect RR intervals for HRV calculation (rolling window)
+            sample.rrIntervals?.forEach { rr ->
+              if (rrIntervalBuffer.size >= RR_BUFFER_MAX_SIZE) {
+                rrIntervalBuffer.removeFirst()
+              }
+              rrIntervalBuffer.addLast(rr)
+            }
+          }
+        }
+      }
+
+    existingJobs +=
+      serviceScope.launch {
+        var lastSampleTime: Instant? = null
+        manager.cadenceSamples.collect { sample ->
+          synchronized(bufferLock) {
+            cadenceSampleBuffer.add(sample)
+
+            // Accumulate steps into minute buckets
+            val sampleTimeMs = sample.timestamp.toEpochMilli()
+            val minuteStartMs = sampleTimeMs - (sampleTimeMs % ONE_MINUTE_MS)
+            val minuteStart = Instant.ofEpochMilli(minuteStartMs)
+
+            val bucket =
+              stepBuckets.getOrPut(minuteStartMs) {
+                MinuteStepBucket(minuteStart = minuteStart)
+              }
+
+            // Calculate steps since last sample using cadence
+            lastSampleTime?.let { lastTime ->
+              val elapsedSeconds =
+                java.time.Duration
+                  .between(lastTime, sample.timestamp)
+                  .toMillis() / 1000.0
+              if (elapsedSeconds > 0 && elapsedSeconds < 30) { // Sanity check
+                val stepsInInterval = (sample.cadence * elapsedSeconds / 60.0).toLong()
+                bucket.totalSteps += stepsInInterval
+              }
+            }
+            bucket.lastCadence = sample.cadence
+            lastSampleTime = sample.timestamp
+
+            updateState { it.copy(pendingCadenceSamples = cadenceSampleBuffer.size) }
+          }
+        }
+      }
+
+    deviceJobs[deviceAddress] = existingJobs
+  }
+
+  private fun startSyncLoop() {
+    syncJob?.cancel()
+    syncJob =
+      serviceScope.launch {
+        while (true) {
+          delay(SYNC_INTERVAL_MS)
+          syncPendingSamples()
+        }
+      }
+  }
+
+  private suspend fun syncPendingSamples() {
+    val hrSamplesToSync: List<HeartRateSample>
+    val rrIntervalsForHrv: List<Int>
+    val completedStepBuckets: List<MinuteStepBucket>
+    val completedPhoneStepBuckets: List<MinuteStepBucket>
+
+    synchronized(bufferLock) {
+      hrSamplesToSync = sampleBuffer.toList()
+      // Copy RR intervals for HRV calculation (don't clear - rolling window)
+      rrIntervalsForHrv = rrIntervalBuffer.toList()
+
+      // Extract completed minute buckets (all minutes except the current one)
+      val nowMs = System.currentTimeMillis()
+      val currentMinuteStartMs = nowMs - (nowMs % ONE_MINUTE_MS)
+
+      // BLE foot pod step buckets
+      completedStepBuckets =
+        stepBuckets.entries
+          .filter { it.key < currentMinuteStartMs && it.value.totalSteps > 0 }
+          .map { it.value }
+          .sortedBy { it.minuteStart }
+
+      // Remove completed buckets from the map
+      completedStepBuckets.forEach { bucket ->
+        stepBuckets.remove(bucket.minuteStart.toEpochMilli())
+      }
+
+      // Phone step counter buckets
+      completedPhoneStepBuckets =
+        phoneStepBuckets.entries
+          .filter { it.key < currentMinuteStartMs && it.value.totalSteps > 0 }
+          .map { it.value }
+          .sortedBy { it.minuteStart }
+
+      // Remove completed phone step buckets
+      completedPhoneStepBuckets.forEach { bucket ->
+        phoneStepBuckets.remove(bucket.minuteStart.toEpochMilli())
+      }
+
+      // Clear raw cadence samples (they've been accumulated into buckets)
+      cadenceSampleBuffer.clear()
+
+      if (hrSamplesToSync.isEmpty() && completedStepBuckets.isEmpty() && completedPhoneStepBuckets.isEmpty()) return
+      sampleBuffer.clear()
+      updateState { it.copy(pendingSamples = 0, pendingCadenceSamples = 0) }
     }
 
-    private fun cleanup() {
-        syncJob?.cancel()
-        phoneStepJob?.cancel()
-
-        // Stop phone step counter
-        phoneStepCounter?.stopMonitoring()
-        phoneStepCounter = null
-
-        // Cancel all device jobs
-        deviceJobs.values.forEach { jobs ->
-            jobs.forEach { it.cancel() }
-        }
-        deviceJobs.clear()
-
-        // Close all connection managers
-        connectionManagers.values.forEach { it.close() }
-        connectionManagers.clear()
-
-        // Clear all buffers
+    // Sync HR samples if any
+    if (hrSamplesToSync.isNotEmpty()) {
+      Log.d(TAG, "Syncing ${hrSamplesToSync.size} HR samples")
+      val backendSuccess = syncHeartRateToBackend(hrSamplesToSync)
+      if (!backendSuccess) {
         synchronized(bufferLock) {
-            sampleBuffer.clear()
-            cadenceSampleBuffer.clear()
-            rrIntervalBuffer.clear()
-            hrChartBuffer.clear()
-            hrvChartBuffer.clear()
-            stepBuckets.clear()
-            phoneStepBuckets.clear()
+          sampleBuffer.addAll(0, hrSamplesToSync)
+          updateState { it.copy(pendingSamples = sampleBuffer.size) }
         }
+      } else {
+        writeHeartRateToHealthConnect(hrSamplesToSync)
+      }
     }
 
-    private fun updateState(update: (SensorServiceState) -> SensorServiceState) {
-        _serviceState.value = update(_serviceState.value)
+    // Sync completed minute step buckets if any (from BLE foot pod)
+    if (completedStepBuckets.isNotEmpty()) {
+      val totalSteps = completedStepBuckets.sumOf { it.totalSteps }
+      Log.d(TAG, "Syncing ${completedStepBuckets.size} BLE step bucket(s) with $totalSteps total steps")
+      val backendSuccess = syncStepBucketsToBackend(completedStepBuckets, "ble-footpod")
+      if (!backendSuccess) {
+        // Re-add buckets on failure
+        synchronized(bufferLock) {
+          completedStepBuckets.forEach { bucket ->
+            stepBuckets[bucket.minuteStart.toEpochMilli()] = bucket
+          }
+        }
+      } else {
+        writeStepBucketsToHealthConnect(completedStepBuckets)
+      }
     }
 
-    companion object {
-        const val ACTION_CONNECT = "net.aurboda.action.CONNECT_SENSOR"
-        const val ACTION_DISCONNECT = "net.aurboda.action.DISCONNECT_SENSOR"
-        const val ACTION_STOP = "net.aurboda.action.STOP_SENSOR_SERVICE"
-        const val ACTION_START_PHONE_STEPS = "net.aurboda.action.START_PHONE_STEPS"
-        const val ACTION_STOP_PHONE_STEPS = "net.aurboda.action.STOP_PHONE_STEPS"
-        const val EXTRA_DEVICE_ADDRESS = "device_address"
-
-        private val _serviceState = MutableStateFlow(SensorServiceState())
-        val serviceState: StateFlow<SensorServiceState> = _serviceState.asStateFlow()
-
-        fun connect(context: Context, deviceAddress: String) {
-            val intent = Intent(context, SensorService::class.java).apply {
-                action = ACTION_CONNECT
-                putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
-            }
-            context.startForegroundService(intent)
+    // Sync completed phone step buckets if any
+    if (completedPhoneStepBuckets.isNotEmpty()) {
+      val totalSteps = completedPhoneStepBuckets.sumOf { it.totalSteps }
+      Log.d(TAG, "Syncing ${completedPhoneStepBuckets.size} phone step bucket(s) with $totalSteps total steps")
+      val backendSuccess = syncStepBucketsToBackend(completedPhoneStepBuckets, "phone")
+      if (!backendSuccess) {
+        // Re-add buckets on failure
+        synchronized(bufferLock) {
+          completedPhoneStepBuckets.forEach { bucket ->
+            phoneStepBuckets[bucket.minuteStart.toEpochMilli()] = bucket
+          }
         }
-
-        fun disconnect(context: Context, deviceAddress: String) {
-            val intent = Intent(context, SensorService::class.java).apply {
-                action = ACTION_DISCONNECT
-                putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
-            }
-            context.startService(intent)
-        }
-
-        fun disconnectAll(context: Context) {
-            val intent = Intent(context, SensorService::class.java).apply {
-                action = ACTION_DISCONNECT
-            }
-            context.startService(intent)
-        }
-
-        fun startPhoneStepCounter(context: Context) {
-            val intent = Intent(context, SensorService::class.java).apply {
-                action = ACTION_START_PHONE_STEPS
-            }
-            context.startForegroundService(intent)
-        }
-
-        fun stopPhoneStepCounter(context: Context) {
-            val intent = Intent(context, SensorService::class.java).apply {
-                action = ACTION_STOP_PHONE_STEPS
-            }
-            context.startService(intent)
-        }
-
-        fun stop(context: Context) {
-            val intent = Intent(context, SensorService::class.java).apply {
-                action = ACTION_STOP
-            }
-            context.startService(intent)
-        }
-
-        internal fun updateServiceState(state: SensorServiceState) {
-            _serviceState.value = state
-        }
+      } else {
+        writeStepBucketsToHealthConnect(completedPhoneStepBuckets)
+      }
     }
+
+    // Calculate and sync HRV if we have enough RR intervals
+    if (rrIntervalsForHrv.size >= RR_BUFFER_MIN_SIZE) {
+      val hrvResult = calculateHrv(rrIntervalsForHrv)
+      Log.d(
+        TAG,
+        "HRV calculation: rmssd=${hrvResult.rmssd}, valid=${hrvResult.validIntervals}, " +
+          "artifacts=${hrvResult.artifactCount} (${String.format("%.1f", hrvResult.artifactPercentage)}%), " +
+          "reliable=${hrvResult.isReliable}",
+      )
+
+      // Add to HRV chart history if we have a valid value
+      if (hrvResult.rmssd != null) {
+        synchronized(bufferLock) {
+          val now = System.currentTimeMillis()
+          val cutoff = now - CHART_HISTORY_DURATION_MS
+          hrvChartBuffer.add(ChartDataPoint(now, hrvResult.rmssd.toFloat()))
+          hrvChartBuffer.removeAll { it.timestamp < cutoff }
+        }
+      }
+
+      // Update state for UI display
+      updateState {
+        it.copy(
+          currentHrv = hrvResult.rmssd,
+          hrvReliable = hrvResult.isReliable,
+          rrIntervalCount = rrIntervalsForHrv.size,
+          hrvChartHistory = hrvChartBuffer.toList(),
+        )
+      }
+
+      if (hrvResult.isReliable && hrvResult.rmssd != null) {
+        val timestamp = Instant.now()
+        syncHrvToBackend(hrvResult.rmssd, timestamp)
+        writeHrvToHealthConnect(hrvResult.rmssd, timestamp)
+      }
+    } else {
+      // Update state to show collecting progress
+      updateState {
+        it.copy(
+          currentHrv = null,
+          hrvReliable = false,
+          rrIntervalCount = rrIntervalsForHrv.size,
+        )
+      }
+      if (rrIntervalsForHrv.isNotEmpty()) {
+        Log.d(TAG, "HRV: Collecting RR intervals (${rrIntervalsForHrv.size}/$RR_BUFFER_MIN_SIZE)")
+      }
+    }
+
+    updateState { it.copy(lastSyncTime = Instant.now()) }
+  }
+
+  private suspend fun syncHeartRateToBackend(samples: List<HeartRateSample>): Boolean {
+    val credentials =
+      CredentialsManager.getCredentials(this) ?: run {
+        Log.w(TAG, "No credentials, skipping backend sync")
+        return true // Don't block on missing credentials
+      }
+
+    if (samples.isEmpty()) return true
+
+    // Sort samples and create a single HeartRateRecord in Health Connect format
+    val sortedSamples = samples.sortedBy { it.timestamp }
+    val startTime = sortedSamples.first().timestamp
+    val endTime = sortedSamples.last().timestamp.plusSeconds(1)
+
+    // Generate unique ID for this batch based on start time
+    val recordId = "live-hr-${startTime.epochSecond}-${startTime.nano}"
+
+    // Get device info from HR device if available
+    val hrManager =
+      connectionManagers.values.find {
+        it.connectedDeviceInfo.value?.type == SensorType.HEART_RATE
+      }
+    val deviceInfo =
+      hrManager?.connectedDeviceInfo?.value?.let { device ->
+        LiveDeviceInfo(
+          type = 2, // TYPE_CHEST_STRAP
+          model = device.name,
+        )
+      }
+
+    val record =
+      LiveHeartRateRecord(
+        startTime = startTime.toString(),
+        endTime = endTime.toString(),
+        samples =
+          sortedSamples.map { sample ->
+            LiveHeartRateSample(
+              time = sample.timestamp.toString(),
+              beatsPerMinute = sample.bpm.toLong(),
+            )
+          },
+        metadata =
+          LiveRecordMetadata(
+            id = recordId,
+            device = deviceInfo,
+          ),
+      )
+
+    return try {
+      val response =
+        httpClient.post("${credentials.apiUrl}/sync/HeartRateRecord") {
+          contentType(ContentType.Application.Json)
+          headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
+          setBody(HeartRateSyncBody(listOf(record)))
+        }
+      val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+      Log.d(TAG, "Backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")
+      success
+    } catch (e: Exception) {
+      Log.e(TAG, "Backend sync error", e)
+      false
+    }
+  }
+
+  private suspend fun writeHeartRateToHealthConnect(samples: List<HeartRateSample>) {
+    if (samples.isEmpty()) return
+
+    try {
+      // Check write permission
+      val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+      val writePermission = HealthPermission.getWritePermission(HeartRateRecord::class)
+      if (writePermission !in grantedPermissions) {
+        Log.w(TAG, "No Health Connect write permission for HeartRateRecord")
+        return
+      }
+
+      // Group samples into 1-second intervals for Health Connect
+      // Health Connect expects HeartRateRecord with a time range and samples
+      val sortedSamples = samples.sortedBy { it.timestamp }
+      val startTime = sortedSamples.first().timestamp
+      val endTime = sortedSamples.last().timestamp.plusSeconds(1)
+
+      val hrSamples =
+        sortedSamples.map { sample ->
+          HeartRateRecord.Sample(
+            time = sample.timestamp,
+            beatsPerMinute = sample.bpm.toLong(),
+          )
+        }
+
+      val record =
+        HeartRateRecord(
+          startTime = startTime,
+          startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
+          endTime = endTime,
+          endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+          samples = hrSamples,
+          metadata =
+            Metadata.autoRecorded(
+              device = Device(type = Device.TYPE_CHEST_STRAP),
+            ),
+        )
+
+      healthConnectClient.insertRecords(listOf(record))
+      Log.d(TAG, "Wrote ${samples.size} HR samples to Health Connect")
+    } catch (e: Exception) {
+      Log.e(TAG, "Health Connect write error", e)
+    }
+  }
+
+  /**
+   * Sync step buckets to backend. Each bucket represents one clock minute with
+   * timestamps aligned to minute boundaries (e.g., 11:46:00.000 - 11:46:59.999).
+   */
+  private suspend fun syncStepBucketsToBackend(
+    buckets: List<MinuteStepBucket>,
+    source: String = "ble-footpod",
+  ): Boolean {
+    val credentials =
+      CredentialsManager.getCredentials(this) ?: run {
+        Log.w(TAG, "No credentials, skipping backend sync")
+        return true // Don't block on missing credentials
+      }
+
+    if (buckets.isEmpty()) return true
+
+    // Get device info based on source
+    val deviceInfo =
+      when (source) {
+        "phone" ->
+          LiveDeviceInfo(
+            type = 1, // TYPE_PHONE
+            model = android.os.Build.MODEL,
+          )
+        else -> {
+          // BLE foot pod - get device info from RSC device if available
+          val rscManager =
+            connectionManagers.values.find {
+              it.connectedDeviceInfo.value?.type == SensorType.RUNNING_SPEED_CADENCE
+            }
+          rscManager?.connectedDeviceInfo?.value?.let { device ->
+            LiveDeviceInfo(
+              type = 4, // TYPE_WATCH or foot pod
+              model = device.name,
+            )
+          }
+        }
+      }
+
+    // Create one record per minute bucket with clock-minute-aligned timestamps
+    val records =
+      buckets.map { bucket ->
+        val minuteEnd = bucket.minuteStart.plusMillis(ONE_MINUTE_MS - 1) // 11:46:59.999
+        val recordId = "live-steps-$source-${bucket.minuteStart.epochSecond}"
+
+        LiveStepsRecord(
+          startTime = bucket.minuteStart.toString(),
+          endTime = minuteEnd.toString(),
+          count = bucket.totalSteps,
+          metadata =
+            LiveRecordMetadata(
+              id = recordId,
+              device = deviceInfo,
+            ),
+        )
+      }
+
+    return try {
+      val response =
+        httpClient.post("${credentials.apiUrl}/sync/StepsRecord") {
+          contentType(ContentType.Application.Json)
+          headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
+          setBody(StepsSyncBody(records))
+        }
+      val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+      val totalSteps = buckets.sumOf { it.totalSteps }
+      Log.d(
+        TAG,
+        "Steps backend sync (${buckets.size} minutes, $totalSteps steps) ${if (success) "succeeded" else "failed"}: ${response.status}",
+      )
+      success
+    } catch (e: Exception) {
+      Log.e(TAG, "Steps backend sync error", e)
+      false
+    }
+  }
+
+  /**
+   * Write step buckets to Health Connect. Each bucket becomes one StepsRecord with
+   * timestamps aligned to minute boundaries for proper aggregation/deduplication.
+   */
+  private suspend fun writeStepBucketsToHealthConnect(buckets: List<MinuteStepBucket>) {
+    if (buckets.isEmpty()) return
+
+    try {
+      // Check write permission
+      val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+      val writePermission = HealthPermission.getWritePermission(StepsRecord::class)
+      if (writePermission !in grantedPermissions) {
+        Log.w(TAG, "No Health Connect write permission for StepsRecord")
+        return
+      }
+
+      // Create one record per minute bucket with clock-minute-aligned timestamps
+      val records =
+        buckets.map { bucket ->
+          val minuteEnd = bucket.minuteStart.plusMillis(ONE_MINUTE_MS - 1) // 11:46:59.999
+
+          StepsRecord(
+            startTime = bucket.minuteStart,
+            startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(bucket.minuteStart),
+            endTime = minuteEnd,
+            endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(minuteEnd),
+            count = bucket.totalSteps,
+            metadata =
+              Metadata.autoRecorded(
+                device = Device(type = Device.TYPE_WATCH),
+              ),
+          )
+        }
+
+      healthConnectClient.insertRecords(records)
+      val totalSteps = buckets.sumOf { it.totalSteps }
+      Log.d(TAG, "Wrote ${buckets.size} minute bucket(s) with $totalSteps total steps to Health Connect")
+    } catch (e: Exception) {
+      Log.e(TAG, "Health Connect steps write error", e)
+    }
+  }
+
+  private suspend fun syncHrvToBackend(
+    rmssd: Double,
+    timestamp: Instant,
+  ) {
+    val credentials =
+      CredentialsManager.getCredentials(this) ?: run {
+        Log.w(TAG, "No credentials, skipping HRV backend sync")
+        return
+      }
+
+    val recordId = "live-hrv-${timestamp.epochSecond}-${timestamp.nano}"
+
+    // Get device info from HR device if available
+    val hrManager =
+      connectionManagers.values.find {
+        it.connectedDeviceInfo.value?.type == SensorType.HEART_RATE
+      }
+    val deviceInfo =
+      hrManager?.connectedDeviceInfo?.value?.let { device ->
+        LiveDeviceInfo(
+          type = 2, // TYPE_CHEST_STRAP
+          model = device.name,
+        )
+      }
+
+    val record =
+      LiveHrvRecord(
+        time = timestamp.toString(),
+        heartRateVariabilityMillis = rmssd,
+        metadata =
+          LiveRecordMetadata(
+            id = recordId,
+            device = deviceInfo,
+          ),
+      )
+
+    try {
+      val response =
+        httpClient.post("${credentials.apiUrl}/sync/HeartRateVariabilityRmssdRecord") {
+          contentType(ContentType.Application.Json)
+          headers { append(HttpHeaders.Authorization, "Bearer ${credentials.authToken}") }
+          setBody(HrvSyncBody(listOf(record)))
+        }
+      val success = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+      Log.d(TAG, "HRV backend sync ${if (success) "succeeded" else "failed"}: ${response.status}")
+    } catch (e: Exception) {
+      Log.e(TAG, "HRV backend sync error", e)
+    }
+  }
+
+  private suspend fun writeHrvToHealthConnect(
+    rmssd: Double,
+    timestamp: Instant,
+  ) {
+    try {
+      // Check write permission
+      val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+      val writePermission = HealthPermission.getWritePermission(HeartRateVariabilityRmssdRecord::class)
+      if (writePermission !in grantedPermissions) {
+        Log.w(TAG, "No Health Connect write permission for HeartRateVariabilityRmssdRecord")
+        return
+      }
+
+      val record =
+        HeartRateVariabilityRmssdRecord(
+          time = timestamp,
+          zoneOffset = ZoneOffset.systemDefault().rules.getOffset(timestamp),
+          heartRateVariabilityMillis = rmssd,
+          metadata =
+            Metadata.autoRecorded(
+              device = Device(type = Device.TYPE_CHEST_STRAP),
+            ),
+        )
+
+      healthConnectClient.insertRecords(listOf(record))
+      Log.d(TAG, "Wrote HRV (RMSSD=${String.format("%.1f", rmssd)}ms) to Health Connect")
+    } catch (e: Exception) {
+      Log.e(TAG, "Health Connect HRV write error", e)
+    }
+  }
+
+  private fun disconnectDevice(deviceAddress: String) {
+    Log.d(TAG, "Disconnecting device: $deviceAddress")
+    connectionManagers[deviceAddress]?.disconnect()
+  }
+
+  private fun disconnectAll() {
+    Log.d(TAG, "Disconnecting all devices...")
+    connectionManagers.keys.toList().forEach { address ->
+      connectionManagers[address]?.disconnect()
+    }
+  }
+
+  private fun startPhoneStepCounter() {
+    Log.d(TAG, "Starting phone step counter")
+
+    // Create counter if needed
+    if (phoneStepCounter == null) {
+      phoneStepCounter = PhoneStepCounter(applicationContext)
+    }
+
+    val counter = phoneStepCounter!!
+
+    // Update availability state
+    updateState { it.copy(phoneStepCounterAvailable = counter.isAvailable.value) }
+
+    if (!counter.isAvailable.value) {
+      Log.w(TAG, "Phone step counter not available on this device")
+      return
+    }
+
+    // Start foreground if not already running
+    if (!_serviceState.value.isRunning) {
+      startForegroundWithNotification()
+    }
+
+    // Start monitoring
+    if (counter.startMonitoring()) {
+      updateState { it.copy(phoneStepCounterActive = true) }
+
+      // Start sync loop if not already running
+      if (syncJob == null || syncJob?.isActive != true) {
+        startSyncLoop()
+      }
+
+      // Collect step updates
+      phoneStepJob?.cancel()
+      phoneStepJob =
+        serviceScope.launch {
+          var lastStepCount = 0
+
+          counter.stepsSinceStart.collect { steps ->
+            updateState { it.copy(phoneStepsSinceStart = steps) }
+
+            // Accumulate into minute buckets for syncing
+            val now = Instant.now()
+            val minuteStartMs = now.toEpochMilli() - (now.toEpochMilli() % ONE_MINUTE_MS)
+
+            synchronized(bufferLock) {
+              // Calculate delta since last update
+              val stepsDelta = steps - lastStepCount
+
+              if (stepsDelta > 0) {
+                val bucket =
+                  phoneStepBuckets.getOrPut(minuteStartMs) {
+                    MinuteStepBucket(minuteStart = Instant.ofEpochMilli(minuteStartMs))
+                  }
+
+                // If we're in a new minute, add the delta to the new bucket
+                // If same minute, add to existing bucket
+                bucket.totalSteps += stepsDelta
+                Log.d(TAG, "Phone steps: +$stepsDelta in bucket ${bucket.minuteStart}, total in bucket: ${bucket.totalSteps}")
+              }
+
+              lastStepCount = steps
+            }
+
+            updateNotification()
+          }
+        }
+
+      // Also collect last update time
+      serviceScope.launch {
+        counter.lastUpdateTime.collect { time ->
+          updateState { it.copy(phoneStepLastUpdateTime = time) }
+        }
+      }
+
+      Log.d(TAG, "Phone step counter started")
+    } else {
+      Log.e(TAG, "Failed to start phone step counter")
+    }
+  }
+
+  private fun stopPhoneStepCounter() {
+    Log.d(TAG, "Stopping phone step counter")
+    phoneStepJob?.cancel()
+    phoneStepJob = null
+    phoneStepCounter?.stopMonitoring()
+    updateState {
+      it.copy(
+        phoneStepCounterActive = false,
+        phoneStepsSinceStart = 0,
+        phoneStepLastUpdateTime = null,
+      )
+    }
+    synchronized(bufferLock) {
+      phoneStepBuckets.clear()
+    }
+
+    // Stop service if nothing else is running
+    if (!_serviceState.value.hasConnectedDevices && !_serviceState.value.isConnecting) {
+      stopSensorService()
+    } else {
+      updateNotification()
+    }
+  }
+
+  private fun stopSensorService() {
+    Log.d(TAG, "Stopping service...")
+    cleanup()
+    stopForeground(STOP_FOREGROUND_REMOVE)
+    stopSelf()
+    updateState { SensorServiceState() }
+  }
+
+  private fun cleanup() {
+    syncJob?.cancel()
+    phoneStepJob?.cancel()
+
+    // Stop phone step counter
+    phoneStepCounter?.stopMonitoring()
+    phoneStepCounter = null
+
+    // Cancel all device jobs
+    deviceJobs.values.forEach { jobs ->
+      jobs.forEach { it.cancel() }
+    }
+    deviceJobs.clear()
+
+    // Close all connection managers
+    connectionManagers.values.forEach { it.close() }
+    connectionManagers.clear()
+
+    // Clear all buffers
+    synchronized(bufferLock) {
+      sampleBuffer.clear()
+      cadenceSampleBuffer.clear()
+      rrIntervalBuffer.clear()
+      hrChartBuffer.clear()
+      hrvChartBuffer.clear()
+      stepBuckets.clear()
+      phoneStepBuckets.clear()
+    }
+  }
+
+  private fun updateState(update: (SensorServiceState) -> SensorServiceState) {
+    _serviceState.value = update(_serviceState.value)
+  }
+
+  companion object {
+    const val ACTION_CONNECT = "net.aurboda.action.CONNECT_SENSOR"
+    const val ACTION_DISCONNECT = "net.aurboda.action.DISCONNECT_SENSOR"
+    const val ACTION_STOP = "net.aurboda.action.STOP_SENSOR_SERVICE"
+    const val ACTION_START_PHONE_STEPS = "net.aurboda.action.START_PHONE_STEPS"
+    const val ACTION_STOP_PHONE_STEPS = "net.aurboda.action.STOP_PHONE_STEPS"
+    const val EXTRA_DEVICE_ADDRESS = "device_address"
+
+    private val _serviceState = MutableStateFlow(SensorServiceState())
+    val serviceState: StateFlow<SensorServiceState> = _serviceState.asStateFlow()
+
+    fun connect(
+      context: Context,
+      deviceAddress: String,
+    ) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_CONNECT
+          putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
+        }
+      context.startForegroundService(intent)
+    }
+
+    fun disconnect(
+      context: Context,
+      deviceAddress: String,
+    ) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_DISCONNECT
+          putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
+        }
+      context.startService(intent)
+    }
+
+    fun disconnectAll(context: Context) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_DISCONNECT
+        }
+      context.startService(intent)
+    }
+
+    fun startPhoneStepCounter(context: Context) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_START_PHONE_STEPS
+        }
+      context.startForegroundService(intent)
+    }
+
+    fun stopPhoneStepCounter(context: Context) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_STOP_PHONE_STEPS
+        }
+      context.startService(intent)
+    }
+
+    fun stop(context: Context) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_STOP
+        }
+      context.startService(intent)
+    }
+
+    internal fun updateServiceState(state: SensorServiceState) {
+      _serviceState.value = state
+    }
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LoginScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LoginScreen.kt
@@ -40,153 +40,159 @@ import net.aurboda.LoginResult
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun LoginScreen(
-    initialServerUrl: String? = null,
-    authApi: AuthApi = remember { AuthApi.create() },
-    onSaveCredentials: (serverUrl: String, username: String, token: String) -> Unit = { serverUrl, username, token ->
-        throw IllegalStateException("onSaveCredentials must be provided")
-    },
-    onLoginSuccess: () -> Unit
+  initialServerUrl: String? = null,
+  authApi: AuthApi = remember { AuthApi.create() },
+  onSaveCredentials: (serverUrl: String, username: String, token: String) -> Unit = { _, _, _ ->
+    throw IllegalStateException("onSaveCredentials must be provided")
+  },
+  onLoginSuccess: () -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
-    val autofill = LocalAutofill.current
-    val autofillTree = LocalAutofillTree.current
+  val scope = rememberCoroutineScope()
+  val autofill = LocalAutofill.current
+  val autofillTree = LocalAutofillTree.current
 
-    var serverUrl by remember { mutableStateOf(initialServerUrl ?: "https://aurboda.net") }
-    var username by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
-    var isLoading by remember { mutableStateOf(false) }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
+  var serverUrl by remember { mutableStateOf(initialServerUrl ?: "https://aurboda.net") }
+  var username by remember { mutableStateOf("") }
+  var password by remember { mutableStateOf("") }
+  var isLoading by remember { mutableStateOf(false) }
+  var errorMessage by remember { mutableStateOf<String?>(null) }
 
-    val usernameAutofillNode = remember {
-        AutofillNode(
-            autofillTypes = listOf(AutofillType.Username),
-            onFill = { username = it }
-        )
+  val usernameAutofillNode =
+    remember {
+      AutofillNode(
+        autofillTypes = listOf(AutofillType.Username),
+        onFill = { username = it },
+      )
     }
-    val passwordAutofillNode = remember {
-        AutofillNode(
-            autofillTypes = listOf(AutofillType.Password),
-            onFill = { password = it }
-        )
+  val passwordAutofillNode =
+    remember {
+      AutofillNode(
+        autofillTypes = listOf(AutofillType.Password),
+        onFill = { password = it },
+      )
     }
-    autofillTree += usernameAutofillNode
-    autofillTree += passwordAutofillNode
+  autofillTree += usernameAutofillNode
+  autofillTree += passwordAutofillNode
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Text(
-            text = "Aurboda",
-            style = MaterialTheme.typography.headlineLarge
-        )
+  Column(
+    modifier =
+      Modifier
+        .fillMaxSize()
+        .padding(24.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+  ) {
+    Text(
+      text = "Aurboda",
+      style = MaterialTheme.typography.headlineLarge,
+    )
 
-        Spacer(modifier = Modifier.height(32.dp))
+    Spacer(modifier = Modifier.height(32.dp))
 
-        OutlinedTextField(
-            value = serverUrl,
-            onValueChange = { serverUrl = it },
-            label = { Text("Server URL") },
-            placeholder = { Text("https://aurboda.net") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            enabled = !isLoading
-        )
+    OutlinedTextField(
+      value = serverUrl,
+      onValueChange = { serverUrl = it },
+      label = { Text("Server URL") },
+      placeholder = { Text("https://aurboda.net") },
+      modifier = Modifier.fillMaxWidth(),
+      singleLine = true,
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+      enabled = !isLoading,
+    )
 
-        Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
 
-        OutlinedTextField(
-            value = username,
-            onValueChange = { username = it },
-            label = { Text("Username") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .onGloballyPositioned { coordinates ->
-                    usernameAutofillNode.boundingBox = coordinates.boundsInWindow()
-                }
-                .onFocusChanged { focusState ->
-                    if (focusState.isFocused) {
-                        autofill?.requestAutofillForNode(usernameAutofillNode)
-                    } else {
-                        autofill?.cancelAutofillForNode(usernameAutofillNode)
-                    }
-                },
-            singleLine = true,
-            enabled = !isLoading
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Password") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .onGloballyPositioned { coordinates ->
-                    passwordAutofillNode.boundingBox = coordinates.boundsInWindow()
-                }
-                .onFocusChanged { focusState ->
-                    if (focusState.isFocused) {
-                        autofill?.requestAutofillForNode(passwordAutofillNode)
-                    } else {
-                        autofill?.cancelAutofillForNode(passwordAutofillNode)
-                    }
-                },
-            singleLine = true,
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            enabled = !isLoading
-        )
-
-        if (errorMessage != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = errorMessage!!,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall
-            )
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Button(
-            onClick = {
-                scope.launch {
-                    isLoading = true
-                    errorMessage = null
-
-                    // Normalize server URL
-                    val normalizedUrl = serverUrl.trimEnd('/')
-
-                    when (val result = authApi.login(normalizedUrl, username, password)) {
-                        is LoginResult.Success -> {
-                            onSaveCredentials(normalizedUrl, username, result.token)
-                            onLoginSuccess()
-                        }
-                        is LoginResult.Error -> {
-                            errorMessage = result.message
-                        }
-                    }
-                    isLoading = false
-                }
-            },
-            modifier = Modifier.fillMaxWidth(),
-            enabled = !isLoading && serverUrl.isNotBlank() &&
-                    username.isNotBlank() && password.isNotBlank()
-        ) {
-            if (isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(20.dp),
-                    strokeWidth = 2.dp
-                )
+    OutlinedTextField(
+      value = username,
+      onValueChange = { username = it },
+      label = { Text("Username") },
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .onGloballyPositioned { coordinates ->
+            usernameAutofillNode.boundingBox = coordinates.boundsInWindow()
+          }.onFocusChanged { focusState ->
+            if (focusState.isFocused) {
+              autofill?.requestAutofillForNode(usernameAutofillNode)
             } else {
-                Text("Login")
+              autofill?.cancelAutofillForNode(usernameAutofillNode)
             }
-        }
+          },
+      singleLine = true,
+      enabled = !isLoading,
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    OutlinedTextField(
+      value = password,
+      onValueChange = { password = it },
+      label = { Text("Password") },
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .onGloballyPositioned { coordinates ->
+            passwordAutofillNode.boundingBox = coordinates.boundsInWindow()
+          }.onFocusChanged { focusState ->
+            if (focusState.isFocused) {
+              autofill?.requestAutofillForNode(passwordAutofillNode)
+            } else {
+              autofill?.cancelAutofillForNode(passwordAutofillNode)
+            }
+          },
+      singleLine = true,
+      visualTransformation = PasswordVisualTransformation(),
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+      enabled = !isLoading,
+    )
+
+    if (errorMessage != null) {
+      Spacer(modifier = Modifier.height(8.dp))
+      Text(
+        text = errorMessage!!,
+        color = MaterialTheme.colorScheme.error,
+        style = MaterialTheme.typography.bodySmall,
+      )
     }
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Button(
+      onClick = {
+        scope.launch {
+          isLoading = true
+          errorMessage = null
+
+          // Normalize server URL
+          val normalizedUrl = serverUrl.trimEnd('/')
+
+          when (val result = authApi.login(normalizedUrl, username, password)) {
+            is LoginResult.Success -> {
+              onSaveCredentials(normalizedUrl, username, result.token)
+              onLoginSuccess()
+            }
+            is LoginResult.Error -> {
+              errorMessage = result.message
+            }
+          }
+          isLoading = false
+        }
+      },
+      modifier = Modifier.fillMaxWidth(),
+      enabled =
+        !isLoading &&
+          serverUrl.isNotBlank() &&
+          username.isNotBlank() &&
+          password.isNotBlank(),
+    ) {
+      if (isLoading) {
+        CircularProgressIndicator(
+          modifier = Modifier.size(20.dp),
+          strokeWidth = 2.dp,
+        )
+      } else {
+        Text("Login")
+      }
+    }
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
-import android.view.View
 import android.widget.RemoteViews
 import net.aurboda.MainActivity
 import net.aurboda.R
@@ -16,81 +15,90 @@ import net.aurboda.R
 private const val TAG = "HrZoneWidgetProvider"
 
 class HrZoneWidgetProvider : AppWidgetProvider() {
-
-    override fun onUpdate(
-        context: Context,
-        appWidgetManager: AppWidgetManager,
-        appWidgetIds: IntArray
-    ) {
-        Log.d(TAG, "onUpdate called for ${appWidgetIds.size} widgets")
-        for (appWidgetId in appWidgetIds) {
-            updateWidget(context, appWidgetManager, appWidgetId)
-        }
+  override fun onUpdate(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetIds: IntArray,
+  ) {
+    Log.d(TAG, "onUpdate called for ${appWidgetIds.size} widgets")
+    for (appWidgetId in appWidgetIds) {
+      updateWidget(context, appWidgetManager, appWidgetId)
     }
+  }
 
-    override fun onReceive(context: Context, intent: Intent) {
-        super.onReceive(context, intent)
-        if (intent.action == ACTION_UPDATE_WIDGETS) {
-            Log.d(TAG, "Received update broadcast")
-            val appWidgetManager = AppWidgetManager.getInstance(context)
-            val componentName = ComponentName(context, HrZoneWidgetProvider::class.java)
-            val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+  override fun onReceive(
+    context: Context,
+    intent: Intent,
+  ) {
+    super.onReceive(context, intent)
+    if (intent.action == ACTION_UPDATE_WIDGETS) {
+      Log.d(TAG, "Received update broadcast")
+      val appWidgetManager = AppWidgetManager.getInstance(context)
+      val componentName = ComponentName(context, HrZoneWidgetProvider::class.java)
+      val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
 
-            // Notify the ListView adapter to refresh data
-            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.goals_list)
-        }
+      // Notify the ListView adapter to refresh data
+      @Suppress("DEPRECATION")
+      appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.goals_list)
     }
+  }
 
-    private fun updateWidget(
-        context: Context,
-        appWidgetManager: AppWidgetManager,
-        appWidgetId: Int
-    ) {
-        val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
+  private fun updateWidget(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int,
+  ) {
+    val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
 
-        // Set up click handler to open the app on the Data tab
-        val openAppIntent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_DATA)
+    // Set up click handler to open the app on the Data tab
+    val openAppIntent =
+      Intent(context, MainActivity::class.java).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_DATA)
+      }
+    val pendingIntent =
+      PendingIntent.getActivity(
+        context,
+        appWidgetId,
+        openAppIntent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+    views.setPendingIntentTemplate(R.id.goals_list, pendingIntent)
+    views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
+
+    // Set up the RemoteViews adapter for the ListView
+    val serviceIntent =
+      Intent(context, GoalsWidgetService::class.java).apply {
+        putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        // Unique data URI to ensure fresh adapter per widget
+        data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
+      }
+    @Suppress("DEPRECATION")
+    views.setRemoteAdapter(R.id.goals_list, serviceIntent)
+
+    // Set empty view
+    views.setEmptyView(R.id.goals_list, R.id.empty_view)
+
+    appWidgetManager.updateAppWidget(appWidgetId, views)
+
+    // Trigger data refresh
+    @Suppress("DEPRECATION")
+    appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.goals_list)
+  }
+
+  companion object {
+    const val ACTION_UPDATE_WIDGETS = "net.aurboda.ACTION_UPDATE_HR_ZONE_WIDGETS"
+
+    /**
+     * Trigger an update of all HR Zone widgets.
+     * Call this after background sync completes.
+     */
+    fun triggerUpdate(context: Context) {
+      val intent =
+        Intent(context, HrZoneWidgetProvider::class.java).apply {
+          action = ACTION_UPDATE_WIDGETS
         }
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            appWidgetId,
-            openAppIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        views.setPendingIntentTemplate(R.id.goals_list, pendingIntent)
-        views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
-
-        // Set up the RemoteViews adapter for the ListView
-        val serviceIntent = Intent(context, GoalsWidgetService::class.java).apply {
-            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            // Unique data URI to ensure fresh adapter per widget
-            data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
-        }
-        views.setRemoteAdapter(R.id.goals_list, serviceIntent)
-
-        // Set empty view
-        views.setEmptyView(R.id.goals_list, R.id.empty_view)
-
-        appWidgetManager.updateAppWidget(appWidgetId, views)
-
-        // Trigger data refresh
-        appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.goals_list)
+      context.sendBroadcast(intent)
     }
-
-    companion object {
-        const val ACTION_UPDATE_WIDGETS = "net.aurboda.ACTION_UPDATE_HR_ZONE_WIDGETS"
-
-        /**
-         * Trigger an update of all HR Zone widgets.
-         * Call this after background sync completes.
-         */
-        fun triggerUpdate(context: Context) {
-            val intent = Intent(context, HrZoneWidgetProvider::class.java).apply {
-                action = ACTION_UPDATE_WIDGETS
-            }
-            context.sendBroadcast(intent)
-        }
-    }
+  }
 }

--- a/apps/android/app/src/test/java/net/aurboda/BackgroundSyncTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/BackgroundSyncTest.kt
@@ -3,7 +3,6 @@ package net.aurboda
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
-import androidx.work.NetworkType
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -26,178 +25,196 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = android.app.Application::class)
 class BackgroundSyncTest {
+  private lateinit var context: Context
+  private val prefsName = "AurbodaAppPrefs"
+  private val backgroundSyncEnabledKey = "backgroundSyncEnabled"
 
-    private lateinit var context: Context
-    private val prefsName = "AurbodaAppPrefs"
-    private val backgroundSyncEnabledKey = "backgroundSyncEnabled"
+  @Before
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
 
-    @Before
-    fun setup() {
-        context = ApplicationProvider.getApplicationContext()
+    // Initialize WorkManager for testing
+    val config =
+      Configuration
+        .Builder()
+        .setMinimumLoggingLevel(android.util.Log.DEBUG)
+        .build()
+    WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+  }
 
-        // Initialize WorkManager for testing
-        val config = Configuration.Builder()
-            .setMinimumLoggingLevel(android.util.Log.DEBUG)
-            .build()
-        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+  @After
+  fun teardown() {
+    // Clear preferences after each test
+    context
+      .getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+      .edit()
+      .clear()
+      .apply()
+
+    // Cancel all work
+    WorkManager.getInstance(context).cancelAllWork()
+  }
+
+  @Test
+  fun `schedule creates periodic work with network constraint`() {
+    // When: We schedule the background sync
+    HealthConnectSyncWorker.schedule(context)
+
+    // Then: Work should be enqueued
+    val workInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
+
+    assertEquals("Should have exactly one work request", 1, workInfos.size)
+
+    val workInfo = workInfos[0]
+    assertTrue(
+      "Work should be enqueued or running",
+      workInfo.state == WorkInfo.State.ENQUEUED || workInfo.state == WorkInfo.State.RUNNING,
+    )
+  }
+
+  @Test
+  fun `schedule uses UPDATE policy to replace existing work`() {
+    // Given: Work is already scheduled
+    HealthConnectSyncWorker.schedule(context)
+
+    val initialWorkInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
+    assertEquals(1, initialWorkInfos.size)
+
+    // When: We schedule again (simulating app restart)
+    HealthConnectSyncWorker.schedule(context)
+
+    // Then: There should still be exactly one work request (UPDATE policy)
+    val workInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
+
+    assertEquals("Should still have exactly one work request after re-scheduling", 1, workInfos.size)
+  }
+
+  @Test
+  fun `cancel removes scheduled work`() {
+    // Given: Work is scheduled
+    HealthConnectSyncWorker.schedule(context)
+
+    val initialWorkInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
+    assertEquals(1, initialWorkInfos.size)
+
+    // When: We cancel the work
+    HealthConnectSyncWorker.cancel(context)
+
+    // Then: Work should be cancelled
+    val workInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
+
+    assertTrue(
+      "Work should be cancelled or empty",
+      workInfos.isEmpty() || workInfos[0].state == WorkInfo.State.CANCELLED,
+    )
+  }
+
+  @Test
+  fun `background sync preference defaults to false`() {
+    // Given: No preference has been set
+
+    // When: We read the preference
+    val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+    val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
+
+    // Then: It should default to false
+    assertFalse("Background sync should default to false", isEnabled)
+  }
+
+  @Test
+  fun `background sync preference can be enabled`() {
+    // Given: We enable background sync
+    context
+      .getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+      .edit()
+      .putBoolean(backgroundSyncEnabledKey, true)
+      .apply()
+
+    // When: We read the preference
+    val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+    val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
+
+    // Then: It should be true
+    assertTrue("Background sync should be enabled", isEnabled)
+  }
+
+  @Test
+  fun `AurbodaApplication schedules worker when background sync was previously enabled`() {
+    // Given: Background sync is enabled in preferences
+    context
+      .getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+      .edit()
+      .putBoolean(backgroundSyncEnabledKey, true)
+      .apply()
+
+    // When: Application starts (simulated by calling the scheduling logic)
+    val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+    val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
+    if (isEnabled) {
+      HealthConnectSyncWorker.schedule(context)
     }
 
-    @After
-    fun teardown() {
-        // Clear preferences after each test
-        context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-            .edit()
-            .clear()
-            .apply()
+    // Then: Work should be scheduled
+    val workInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
 
-        // Cancel all work
-        WorkManager.getInstance(context).cancelAllWork()
+    assertEquals("Should have scheduled work", 1, workInfos.size)
+  }
+
+  @Test
+  fun `AurbodaApplication does not schedule worker when background sync is disabled`() {
+    // Given: Background sync is disabled (default)
+    context
+      .getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+      .edit()
+      .putBoolean(backgroundSyncEnabledKey, false)
+      .apply()
+
+    // When: Application starts (simulated by calling the scheduling logic)
+    val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+    val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
+    if (isEnabled) {
+      HealthConnectSyncWorker.schedule(context)
     }
 
-    @Test
-    fun `schedule creates periodic work with network constraint`() {
-        // When: We schedule the background sync
-        HealthConnectSyncWorker.schedule(context)
+    // Then: No work should be scheduled
+    val workInfos =
+      WorkManager
+        .getInstance(context)
+        .getWorkInfosForUniqueWork("health_connect_sync")
+        .get()
 
-        // Then: Work should be enqueued
-        val workInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
+    assertTrue("Should not have scheduled work", workInfos.isEmpty())
+  }
 
-        assertEquals("Should have exactly one work request", 1, workInfos.size)
-
-        val workInfo = workInfos[0]
-        assertTrue(
-            "Work should be enqueued or running",
-            workInfo.state == WorkInfo.State.ENQUEUED || workInfo.state == WorkInfo.State.RUNNING
-        )
-    }
-
-    @Test
-    fun `schedule uses UPDATE policy to replace existing work`() {
-        // Given: Work is already scheduled
-        HealthConnectSyncWorker.schedule(context)
-
-        val initialWorkInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
-        assertEquals(1, initialWorkInfos.size)
-        val initialWorkId = initialWorkInfos[0].id
-
-        // When: We schedule again (simulating app restart)
-        HealthConnectSyncWorker.schedule(context)
-
-        // Then: There should still be exactly one work request (UPDATE policy)
-        val workInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
-
-        assertEquals("Should still have exactly one work request after re-scheduling", 1, workInfos.size)
-    }
-
-    @Test
-    fun `cancel removes scheduled work`() {
-        // Given: Work is scheduled
-        HealthConnectSyncWorker.schedule(context)
-
-        val initialWorkInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
-        assertEquals(1, initialWorkInfos.size)
-
-        // When: We cancel the work
-        HealthConnectSyncWorker.cancel(context)
-
-        // Then: Work should be cancelled
-        val workInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
-
-        assertTrue(
-            "Work should be cancelled or empty",
-            workInfos.isEmpty() || workInfos[0].state == WorkInfo.State.CANCELLED
-        )
-    }
-
-    @Test
-    fun `background sync preference defaults to false`() {
-        // Given: No preference has been set
-
-        // When: We read the preference
-        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
-
-        // Then: It should default to false
-        assertFalse("Background sync should default to false", isEnabled)
-    }
-
-    @Test
-    fun `background sync preference can be enabled`() {
-        // Given: We enable background sync
-        context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-            .edit()
-            .putBoolean(backgroundSyncEnabledKey, true)
-            .apply()
-
-        // When: We read the preference
-        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
-
-        // Then: It should be true
-        assertTrue("Background sync should be enabled", isEnabled)
-    }
-
-    @Test
-    fun `AurbodaApplication schedules worker when background sync was previously enabled`() {
-        // Given: Background sync is enabled in preferences
-        context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-            .edit()
-            .putBoolean(backgroundSyncEnabledKey, true)
-            .apply()
-
-        // When: Application starts (simulated by calling the scheduling logic)
-        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
-        if (isEnabled) {
-            HealthConnectSyncWorker.schedule(context)
-        }
-
-        // Then: Work should be scheduled
-        val workInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
-
-        assertEquals("Should have scheduled work", 1, workInfos.size)
-    }
-
-    @Test
-    fun `AurbodaApplication does not schedule worker when background sync is disabled`() {
-        // Given: Background sync is disabled (default)
-        context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-            .edit()
-            .putBoolean(backgroundSyncEnabledKey, false)
-            .apply()
-
-        // When: Application starts (simulated by calling the scheduling logic)
-        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-        val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
-        if (isEnabled) {
-            HealthConnectSyncWorker.schedule(context)
-        }
-
-        // Then: No work should be scheduled
-        val workInfos = WorkManager.getInstance(context)
-            .getWorkInfosForUniqueWork("health_connect_sync")
-            .get()
-
-        assertTrue("Should not have scheduled work", workInfos.isEmpty())
-    }
-
-    @Test
-    fun `preference key constants are consistent`() {
-        // This test documents and verifies the preference keys used across the app
-        // If these change, both AurbodaApplication and MainActivity need to be updated
-        assertEquals("AurbodaAppPrefs", prefsName)
-        assertEquals("backgroundSyncEnabled", backgroundSyncEnabledKey)
-    }
+  @Test
+  fun `preference key constants are consistent`() {
+    // This test documents and verifies the preference keys used across the app
+    // If these change, both AurbodaApplication and MainActivity need to be updated
+    assertEquals("AurbodaAppPrefs", prefsName)
+    assertEquals("backgroundSyncEnabled", backgroundSyncEnabledKey)
+  }
 }

--- a/apps/android/app/src/test/java/net/aurboda/HeartRateParserTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/HeartRateParserTest.kt
@@ -7,119 +7,121 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class HeartRateParserTest {
+  @Test
+  fun `parse 8-bit heart rate without RR intervals`() {
+    // Flags: 0x00 = 8-bit HR, no other fields
+    // HR: 72 bpm
+    val data = byteArrayOf(0x00, 72)
 
-    @Test
-    fun `parse 8-bit heart rate without RR intervals`() {
-        // Flags: 0x00 = 8-bit HR, no other fields
-        // HR: 72 bpm
-        val data = byteArrayOf(0x00, 72)
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNotNull(sample)
+    assertEquals(72, sample!!.bpm)
+    assertNull(sample.rrIntervals)
+  }
 
-        assertNotNull(sample)
-        assertEquals(72, sample!!.bpm)
-        assertNull(sample.rrIntervals)
-    }
+  @Test
+  fun `parse 16-bit heart rate without RR intervals`() {
+    // Flags: 0x01 = 16-bit HR
+    // HR: 150 bpm (0x0096 in little-endian: 0x96, 0x00)
+    val data = byteArrayOf(0x01, 0x96.toByte(), 0x00)
 
-    @Test
-    fun `parse 16-bit heart rate without RR intervals`() {
-        // Flags: 0x01 = 16-bit HR
-        // HR: 150 bpm (0x0096 in little-endian: 0x96, 0x00)
-        val data = byteArrayOf(0x01, 0x96.toByte(), 0x00)
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNotNull(sample)
+    assertEquals(150, sample!!.bpm)
+    assertNull(sample.rrIntervals)
+  }
 
-        assertNotNull(sample)
-        assertEquals(150, sample!!.bpm)
-        assertNull(sample.rrIntervals)
-    }
+  @Test
+  fun `parse 8-bit heart rate with RR intervals`() {
+    // Flags: 0x10 = 8-bit HR + RR intervals present
+    // HR: 85 bpm
+    // RR interval: 0x02C8 (712 in units of 1/1024 sec = ~695 ms)
+    val data = byteArrayOf(0x10, 85, 0xC8.toByte(), 0x02)
 
-    @Test
-    fun `parse 8-bit heart rate with RR intervals`() {
-        // Flags: 0x10 = 8-bit HR + RR intervals present
-        // HR: 85 bpm
-        // RR interval: 0x02C8 (712 in units of 1/1024 sec = ~695 ms)
-        val data = byteArrayOf(0x10, 85, 0xC8.toByte(), 0x02)
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNotNull(sample)
+    assertEquals(85, sample!!.bpm)
+    assertNotNull(sample.rrIntervals)
+    assertEquals(1, sample.rrIntervals!!.size)
+    // (712 * 1000) / 1024 = 695.3125, truncated to 695
+    assertEquals(695, sample.rrIntervals[0])
+  }
 
-        assertNotNull(sample)
-        assertEquals(85, sample!!.bpm)
-        assertNotNull(sample.rrIntervals)
-        assertEquals(1, sample.rrIntervals!!.size)
-        // (712 * 1000) / 1024 = 695.3125, truncated to 695
-        assertEquals(695, sample.rrIntervals!![0])
-    }
+  @Test
+  fun `parse heart rate with multiple RR intervals`() {
+    // Flags: 0x10 = 8-bit HR + RR intervals present
+    // HR: 80 bpm
+    // Two RR intervals
+    val data =
+      byteArrayOf(
+        0x10,
+        80,
+        0x00,
+        0x03, // First RR: 768 units = 750 ms
+        0x00,
+        0x04, // Second RR: 1024 units = 1000 ms
+      )
 
-    @Test
-    fun `parse heart rate with multiple RR intervals`() {
-        // Flags: 0x10 = 8-bit HR + RR intervals present
-        // HR: 80 bpm
-        // Two RR intervals
-        val data = byteArrayOf(
-            0x10,
-            80,
-            0x00, 0x03,  // First RR: 768 units = 750 ms
-            0x00, 0x04   // Second RR: 1024 units = 1000 ms
-        )
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNotNull(sample)
+    assertEquals(80, sample!!.bpm)
+    assertNotNull(sample.rrIntervals)
+    assertEquals(2, sample.rrIntervals!!.size)
+    assertEquals(750, sample.rrIntervals[0])
+    assertEquals(1000, sample.rrIntervals[1])
+  }
 
-        assertNotNull(sample)
-        assertEquals(80, sample!!.bpm)
-        assertNotNull(sample.rrIntervals)
-        assertEquals(2, sample.rrIntervals!!.size)
-        assertEquals(750, sample.rrIntervals!![0])
-        assertEquals(1000, sample.rrIntervals!![1])
-    }
+  @Test
+  fun `parse heart rate with energy expended skipped`() {
+    // Flags: 0x08 = energy expended present (but no RR)
+    // HR: 100 bpm
+    // Energy expended: 2 bytes (skipped in our parser)
+    val data = byteArrayOf(0x08, 100, 0x50, 0x00)
 
-    @Test
-    fun `parse heart rate with energy expended skipped`() {
-        // Flags: 0x08 = energy expended present (but no RR)
-        // HR: 100 bpm
-        // Energy expended: 2 bytes (skipped in our parser)
-        val data = byteArrayOf(0x08, 100, 0x50, 0x00)
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNotNull(sample)
+    assertEquals(100, sample!!.bpm)
+    assertNull(sample.rrIntervals)
+  }
 
-        assertNotNull(sample)
-        assertEquals(100, sample!!.bpm)
-        assertNull(sample.rrIntervals)
-    }
+  @Test
+  fun `parse empty data returns null`() {
+    val data = byteArrayOf()
 
-    @Test
-    fun `parse empty data returns null`() {
-        val data = byteArrayOf()
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNull(sample)
+  }
 
-        assertNull(sample)
-    }
+  @Test
+  fun `parse truncated 16-bit data returns null`() {
+    // Flags indicate 16-bit but only 1 byte of HR data
+    val data = byteArrayOf(0x01, 0x50)
 
-    @Test
-    fun `parse truncated 16-bit data returns null`() {
-        // Flags indicate 16-bit but only 1 byte of HR data
-        val data = byteArrayOf(0x01, 0x50)
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
+    assertNull(sample)
+  }
 
-        assertNull(sample)
-    }
+  @Test
+  fun `parse typical Polar H10 data`() {
+    // Typical Polar H10 format: 8-bit HR with RR intervals
+    // Flags: 0x16 = sensor contact supported & detected + RR intervals
+    // HR: 65 bpm
+    // RR: ~923 ms
+    val data = byteArrayOf(0x16, 65, 0xB6.toByte(), 0x03)
 
-    @Test
-    fun `parse typical Polar H10 data`() {
-        // Typical Polar H10 format: 8-bit HR with RR intervals
-        // Flags: 0x16 = sensor contact supported & detected + RR intervals
-        // HR: 65 bpm
-        // RR: ~923 ms
-        val data = byteArrayOf(0x16, 65, 0xB6.toByte(), 0x03)
+    val sample = parseHeartRateMeasurement(data)
 
-        val sample = parseHeartRateMeasurement(data)
-
-        assertNotNull(sample)
-        assertEquals(65, sample!!.bpm)
-        assertNotNull(sample.rrIntervals)
-        // (950 * 1000) / 1024 = 927
-        assertEquals(927, sample.rrIntervals!![0])
-    }
+    assertNotNull(sample)
+    assertEquals(65, sample!!.bpm)
+    assertNotNull(sample.rrIntervals)
+    // (950 * 1000) / 1024 = 927
+    assertEquals(927, sample.rrIntervals!![0])
+  }
 }

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.0"
-kotlin = "2.0.21"
+kotlin = "2.3.10"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"

--- a/packages/api-spec/src/openapi.ts
+++ b/packages/api-spec/src/openapi.ts
@@ -63,6 +63,12 @@ import { productivityResponseSchema } from './schemas/productivity.js'
 
 import { goalsProgressResponseSchema } from './schemas/goals.js'
 
+import {
+  outboundSyncAckBodySchema,
+  outboundSyncAckResponseSchema,
+  outboundSyncResponseSchema,
+} from './schemas/outbound-sync.js'
+
 // Error response
 const errorResponseSchema = z
   .object({
@@ -568,6 +574,42 @@ const openApiDocument = createDocument({
         },
         security: [{ bearerAuth: [] }],
         summary: 'Sync RescueTime data',
+        tags: ['Sync'],
+      },
+    },
+
+    // --- Sync: Outbound (backend -> Health Connect) ---
+
+    '/sync/outbound': {
+      get: {
+        description:
+          'Get pending outbound sync entries. The Android app polls this to discover changes that need to be written to Health Connect.',
+        responses: {
+          200: {
+            content: { 'application/json': { schema: outboundSyncResponseSchema } },
+            description: 'Pending outbound sync entries',
+          },
+        },
+        security: [{ bearerAuth: [] }],
+        summary: 'Get pending outbound sync entries',
+        tags: ['Sync'],
+      },
+    },
+    '/sync/outbound/ack': {
+      post: {
+        description:
+          'Acknowledge that outbound sync entries have been written to Health Connect. Optionally includes the Health Connect record ID for future reference.',
+        requestBody: {
+          content: { 'application/json': { schema: outboundSyncAckBodySchema } },
+        },
+        responses: {
+          200: {
+            content: { 'application/json': { schema: outboundSyncAckResponseSchema } },
+            description: 'Acknowledgement result',
+          },
+        },
+        security: [{ bearerAuth: [] }],
+        summary: 'Acknowledge outbound sync entries',
         tags: ['Sync'],
       },
     },


### PR DESCRIPTION
## Summary

Phase 2 of bidirectional Health Connect sync (#248). When data changes in Aurboda (via web UI, MCP, or another source), the Android app now writes those changes to Health Connect.

- **OutboundSync.kt** — Complete outbound sync pipeline: fetch pending entries from backend (`GET /sync/outbound`), build and insert HC records, acknowledge writes (`POST /sync/outbound/ack`)
- **12 HC record types** supported: Weight, Height, BodyFat, LeanBodyMass, BoneMass, BodyWaterMass, RestingHeartRate, Steps, HeartRate, HRV, ExerciseSession, SleepSession
- **Loop prevention** — Records written by outbound sync use `clientRecordId` prefix `"aurboda-sync-"`. Both inbound sync paths (HealthConnectSyncWorker and MainActivity) now filter out records with `dataOrigin=net.aurboda` or the sync prefix
- **Three sync triggers** — Background WorkManager (15min), ON_RESUME, and manual "Sync Now" button all run outbound sync after inbound sync completes
- **9 new WRITE permissions** added to AndroidManifest.xml
- **OpenAPI spec** updated with outbound sync endpoint paths

Builds on Phase 1 (PR #256, merged) which added the backend outbound sync queue, REST endpoints, and MCP tools.

## Testing

- Android app builds successfully (`./gradlew assembleDebug`)
- All 627 backend tests pass
- TypeScript type checks pass for both backend and web