### PR TITLE
Add nap to outbound Health Connect sync

### DIFF
--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -450,6 +450,7 @@ export const metricToHealthConnectType: Partial<Record<MetricType, string>> = {
  */
 export const activityTypeToHealthConnectType: Partial<Record<ActivityType, string>> = {
   exercise: 'ExerciseSessionRecord',
+  nap: 'SleepSessionRecord',
   sleep: 'SleepSessionRecord',
 }
 


### PR DESCRIPTION
## Summary
- Map `nap` activity type to `SleepSessionRecord` in `activityTypeToHealthConnectType`
- Naps created in Aurboda (via web UI or MCP) will now be enqueued for outbound sync and written to Health Connect as sleep sessions
- No Android code changes needed — `SleepSessionRecord` is already handled in `OutboundSync.kt`