### PR TITLE
Fix delete ack validation, improve permission UI in sync page

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -1,6 +1,7 @@
 package net.aurboda
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -477,15 +478,20 @@ fun HealthConnectScreen(
   val hasAnyPermissions by remember(grantedRecordTypes) {
     derivedStateOf { grantedRecordTypes.isNotEmpty() }
   }
-  val hasAllPermissions by remember(grantedPermissions) {
+  val hasAllReadPermissions by remember(grantedPermissions) {
     derivedStateOf {
-      val allPerms =
-        allRecordTypes
-          .flatMap {
-            listOf(HealthPermission.getReadPermission(it), HealthPermission.getWritePermission(it))
-          }.toSet()
-      grantedPermissions.containsAll(allPerms)
+      val readPerms = allRecordTypes.map { HealthPermission.getReadPermission(it) }.toSet()
+      grantedPermissions.containsAll(readPerms)
     }
+  }
+  val hasAllWritePermissions by remember(grantedPermissions) {
+    derivedStateOf {
+      val writePerms = allRecordTypes.map { HealthPermission.getWritePermission(it) }.toSet()
+      grantedPermissions.containsAll(writePerms)
+    }
+  }
+  val hasAllPermissions by remember(hasAllReadPermissions, hasAllWritePermissions) {
+    derivedStateOf { hasAllReadPermissions && hasAllWritePermissions }
   }
   val categoryStatuses by remember(grantedPermissions) {
     derivedStateOf { getCategoryStatuses(grantedPermissions) }
@@ -1167,6 +1173,46 @@ fun HealthConnectScreen(
             Text("Sync Now")
           }
 
+          if (!hasAllPermissions) {
+            if (hasAllReadPermissions && !hasAllWritePermissions) {
+              Text(
+                "Write permissions needed for outbound sync (pushing data to Health Connect).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+              )
+              Text(
+                "If the button below has no effect, open Settings > Health Connect > App permissions > Aurboda and grant write access.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+            androidx.compose.material3.OutlinedButton(
+              onClick = {
+                requestPermissionLauncher.launch(allPermissions.toTypedArray())
+              },
+              modifier = Modifier.fillMaxWidth(),
+            ) {
+              Text(if (hasAllReadPermissions) "Grant Write Permissions" else "Grant All Permissions")
+            }
+            androidx.compose.material3.TextButton(
+              onClick = {
+                val intent =
+                  Intent("androidx.health.ACTION_MANAGE_HEALTH_PERMISSIONS")
+                    .putExtra(Intent.EXTRA_PACKAGE_NAME, context.packageName)
+                try {
+                  context.startActivity(intent)
+                } catch (e: Exception) {
+                  Log.w("HealthConnect", "Could not open HC settings: ${e.message}")
+                }
+              },
+            ) {
+              Text(
+                "Open Health Connect Settings",
+                style = MaterialTheme.typography.bodySmall,
+              )
+            }
+          }
+
           Text(
             "Build ${BuildConfig.BUILD_TIMESTAMP}",
             style = MaterialTheme.typography.labelSmall,
@@ -1236,20 +1282,6 @@ fun HealthConnectScreen(
               Text("Grant")
             }
           }
-        }
-      }
-    }
-
-    // -- Grant All Permissions button --
-    if (!hasAllPermissions) {
-      item {
-        androidx.compose.material3.OutlinedButton(
-          onClick = {
-            requestPermissionLauncher.launch(allPermissions.toTypedArray())
-          },
-          modifier = Modifier.fillMaxWidth(),
-        ) {
-          Text("Grant All Permissions")
         }
       }
     }

--- a/apps/backend/src/db/outbound-sync.ts
+++ b/apps/backend/src/db/outbound-sync.ts
@@ -90,7 +90,11 @@ export const getPendingOutboundSync = async (user: string, limit = 100): Promise
  * Acknowledge that an outbound sync entry was successfully written to Health Connect.
  * Updates the status and stores the HC-assigned record ID.
  */
-export const ackOutboundSync = async (user: string, id: string, hcRecordId?: string): Promise<boolean> => {
+export const ackOutboundSync = async (
+  user: string,
+  id: string,
+  hcRecordId?: string | null,
+): Promise<boolean> => {
   const result = await query(
     user,
     `UPDATE outbound_sync_queue

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -101,7 +101,7 @@ export interface SyncRouterDeps {
   getActivityWatchSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   // Outbound sync (Health Connect write-back)
   getPendingOutboundSync: (user: string, limit?: number) => Promise<OutboundSyncEntry[]>
-  ackOutboundSync: (user: string, id: string, hcRecordId?: string) => Promise<boolean>
+  ackOutboundSync: (user: string, id: string, hcRecordId?: string | null) => Promise<boolean>
 }
 
 /**

--- a/packages/api-spec/src/schemas/outbound-sync.ts
+++ b/packages/api-spec/src/schemas/outbound-sync.ts
@@ -80,8 +80,8 @@ export const outboundSyncAckItemSchema = z
   .object({
     hc_record_id: z
       .string()
-      .optional()
-      .meta({ description: 'Health Connect record ID assigned after writing' }),
+      .nullish()
+      .meta({ description: 'Health Connect record ID assigned after writing (null for deletes)' }),
     id: z.string().uuid().meta({ description: 'Sync queue entry ID to acknowledge' }),
   })
   .meta({ id: 'OutboundSyncAckItem' })


### PR DESCRIPTION
## Summary
- **Fix**: Outbound sync delete acknowledgement was rejected because Zod `.optional()` doesn't accept `null` — changed to `.nullish()` so `{ id: '...', hc_record_id: null }` passes validation
- **UI**: Moved "Grant All/Write Permissions" button into the Sync Status Card right after "Sync Now" so it's visible without scrolling
- When reads are all granted but writes are missing, shows explanatory text about write permissions being needed for outbound sync
- Added "Open Health Connect Settings" link as fallback when HC's one-shot permission dialog can't be re-triggered
- Split `hasAllPermissions` into `hasAllReadPermissions` + `hasAllWritePermissions` for granular feedback

## Testing
- Backend: `pnpm check` passes, schema change is backward compatible
- Android: `assembleDebug` + `testDebugUnitTest` pass