### PR TITLE
Use optional (not null) for absent fields, set explicitNulls=false

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -57,6 +57,7 @@ val appJson =
     isLenient = true
     ignoreUnknownKeys = true
     encodeDefaults = true // Important if you have default values and want them in the JSON
+    explicitNulls = false // Omit null fields from JSON; null means "not provided", not "set to null"
   }
 
 // Generic wrapper for POST requests

--- a/apps/backend/src/db/outbound-sync.ts
+++ b/apps/backend/src/db/outbound-sync.ts
@@ -90,11 +90,7 @@ export const getPendingOutboundSync = async (user: string, limit = 100): Promise
  * Acknowledge that an outbound sync entry was successfully written to Health Connect.
  * Updates the status and stores the HC-assigned record ID.
  */
-export const ackOutboundSync = async (
-  user: string,
-  id: string,
-  hcRecordId?: string | null,
-): Promise<boolean> => {
+export const ackOutboundSync = async (user: string, id: string, hcRecordId?: string): Promise<boolean> => {
   const result = await query(
     user,
     `UPDATE outbound_sync_queue

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -101,7 +101,7 @@ export interface SyncRouterDeps {
   getActivityWatchSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   // Outbound sync (Health Connect write-back)
   getPendingOutboundSync: (user: string, limit?: number) => Promise<OutboundSyncEntry[]>
-  ackOutboundSync: (user: string, id: string, hcRecordId?: string | null) => Promise<boolean>
+  ackOutboundSync: (user: string, id: string, hcRecordId?: string) => Promise<boolean>
 }
 
 /**

--- a/packages/api-spec/src/schemas/outbound-sync.ts
+++ b/packages/api-spec/src/schemas/outbound-sync.ts
@@ -80,8 +80,8 @@ export const outboundSyncAckItemSchema = z
   .object({
     hc_record_id: z
       .string()
-      .nullish()
-      .meta({ description: 'Health Connect record ID assigned after writing (null for deletes)' }),
+      .optional()
+      .meta({ description: 'Health Connect record ID assigned after writing' }),
     id: z.string().uuid().meta({ description: 'Sync queue entry ID to acknowledge' }),
   })
   .meta({ id: 'OutboundSyncAckItem' })


### PR DESCRIPTION
## Summary
- Revert `hc_record_id` in outbound sync ack schema from `.nullish()` back to `.optional()` — null means "set to empty", absent means "not provided"
- Set `explicitNulls = false` in Android `kotlinx.serialization` config so null fields are omitted from JSON payloads instead of sent as explicit `null`
- This aligns Kotlin serialization with the backend's optional field semantics
- Bonus: reduces payload size (e.g. NutritionRecord's 40+ null nutrient fields are no longer sent)

## Breaking change
Old APK sending `hc_record_id: null` will be rejected by the backend. Users need to install the updated APK.