### PR TITLE
Fix write permissions check to only verify manifest-declared types

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -711,6 +711,27 @@ fun Metadata.toSerializable(): HealthConnectRecordMetadata =
     recordingMethod = this.recordingMethod,
   )
 
+/**
+ * Record types for which we have WRITE permissions in the manifest.
+ * These are the types used for outbound sync (backend → Health Connect).
+ * Must match the WRITE_* permissions declared in AndroidManifest.xml.
+ */
+val writableRecordTypes: Set<KClass<out Record>> =
+  setOf(
+    BodyFatRecord::class,
+    BodyWaterMassRecord::class,
+    BoneMassRecord::class,
+    ExerciseSessionRecord::class,
+    HeartRateRecord::class,
+    HeartRateVariabilityRmssdRecord::class,
+    HeightRecord::class,
+    LeanBodyMassRecord::class,
+    RestingHeartRateRecord::class,
+    SleepSessionRecord::class,
+    StepsRecord::class,
+    WeightRecord::class,
+  )
+
 // Comprehensive list of all record KClass objects we want to read, sorted alphabetically
 val allRecordTypes: List<KClass<out Record>> =
   listOf(

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -77,8 +77,9 @@ import net.aurboda.update.checkForUpdate
 import net.aurboda.update.downloadUpdate
 import net.aurboda.update.getExistingDownloadState
 import net.aurboda.update.installApk
-// Import allRecordTypes from HealthDataModels
+// Import record type lists from HealthDataModels
 import net.aurboda.allRecordTypes
+import net.aurboda.writableRecordTypes
 import java.io.File
 import java.time.Instant
 import java.time.ZonedDateTime
@@ -486,7 +487,7 @@ fun HealthConnectScreen(
   }
   val hasAllWritePermissions by remember(grantedPermissions) {
     derivedStateOf {
-      val writePerms = allRecordTypes.map { HealthPermission.getWritePermission(it) }.toSet()
+      val writePerms = writableRecordTypes.map { HealthPermission.getWritePermission(it) }.toSet()
       grantedPermissions.containsAll(writePerms)
     }
   }
@@ -519,7 +520,9 @@ fun HealthConnectScreen(
   val scope = rememberCoroutineScope()
   val allPermissions =
     remember(allRecordTypes) {
-      allRecordTypes.flatMap { listOf(HealthPermission.getReadPermission(it), HealthPermission.getWritePermission(it)) }.toSet()
+      val readPerms = allRecordTypes.map { HealthPermission.getReadPermission(it) }
+      val writePerms = writableRecordTypes.map { HealthPermission.getWritePermission(it) }
+      (readPerms + writePerms).toSet()
     }
   val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
 
@@ -1174,42 +1177,80 @@ fun HealthConnectScreen(
           }
 
           if (!hasAllPermissions) {
-            if (hasAllReadPermissions && !hasAllWritePermissions) {
-              Text(
-                "Write permissions needed for outbound sync (pushing data to Health Connect).",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.error,
-              )
-              Text(
-                "If the button below has no effect, open Settings > Health Connect > App permissions > Aurboda and grant write access.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-              )
-            }
-            androidx.compose.material3.OutlinedButton(
-              onClick = {
-                requestPermissionLauncher.launch(allPermissions.toTypedArray())
-              },
+            var permissionsExpanded by remember { mutableStateOf(false) }
+            val missingLabel =
+              if (!hasAllReadPermissions && !hasAllWritePermissions) {
+                "Read & write permissions pending"
+              } else if (!hasAllReadPermissions) {
+                "Read permissions pending"
+              } else {
+                "Write permissions pending"
+              }
+
+            androidx.compose.material3.Surface(
+              onClick = { permissionsExpanded = !permissionsExpanded },
+              shape = MaterialTheme.shapes.small,
+              color = MaterialTheme.colorScheme.surfaceVariant,
               modifier = Modifier.fillMaxWidth(),
             ) {
-              Text(if (hasAllReadPermissions) "Grant Write Permissions" else "Grant All Permissions")
-            }
-            androidx.compose.material3.TextButton(
-              onClick = {
-                val intent =
-                  Intent("androidx.health.ACTION_MANAGE_HEALTH_PERMISSIONS")
-                    .putExtra(Intent.EXTRA_PACKAGE_NAME, context.packageName)
-                try {
-                  context.startActivity(intent)
-                } catch (e: Exception) {
-                  Log.w("HealthConnect", "Could not open HC settings: ${e.message}")
+              Column(modifier = Modifier.padding(12.dp)) {
+                Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.SpaceBetween,
+                  modifier = Modifier.fillMaxWidth(),
+                ) {
+                  Text(
+                    missingLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                  )
+                  Text(
+                    if (permissionsExpanded) "\u25B2" else "\u25BC",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                  )
                 }
-              },
-            ) {
-              Text(
-                "Open Health Connect Settings",
-                style = MaterialTheme.typography.bodySmall,
-              )
+
+                if (permissionsExpanded) {
+                  androidx.compose.foundation.layout
+                    .Spacer(modifier = Modifier.height(8.dp))
+                  if (hasAllReadPermissions && !hasAllWritePermissions) {
+                    Text(
+                      "Write access allows outbound sync (pushing data to Health Connect). " +
+                        "If the button has no effect, use Health Connect Settings.",
+                      style = MaterialTheme.typography.bodySmall,
+                      color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    androidx.compose.foundation.layout
+                      .Spacer(modifier = Modifier.height(8.dp))
+                  }
+                  androidx.compose.material3.OutlinedButton(
+                    onClick = {
+                      requestPermissionLauncher.launch(allPermissions.toTypedArray())
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                  ) {
+                    Text(if (hasAllReadPermissions) "Grant Write Permissions" else "Grant All Permissions")
+                  }
+                  androidx.compose.material3.TextButton(
+                    onClick = {
+                      val intent =
+                        Intent("androidx.health.ACTION_MANAGE_HEALTH_PERMISSIONS")
+                          .putExtra(Intent.EXTRA_PACKAGE_NAME, context.packageName)
+                      try {
+                        context.startActivity(intent)
+                      } catch (e: Exception) {
+                        Log.w("HealthConnect", "Could not open HC settings: ${e.message}")
+                      }
+                    },
+                  ) {
+                    Text(
+                      "Open Health Connect Settings",
+                      style = MaterialTheme.typography.bodySmall,
+                    )
+                  }
+                }
+              }
             }
           }
 
@@ -1274,8 +1315,12 @@ fun HealthConnectScreen(
               onClick = {
                 val categoryPermissions =
                   status.category.recordTypes
-                    .flatMap { listOf(HealthPermission.getReadPermission(it), HealthPermission.getWritePermission(it)) }
-                    .toTypedArray()
+                    .flatMap { type ->
+                      buildList {
+                        add(HealthPermission.getReadPermission(type))
+                        if (type in writableRecordTypes) add(HealthPermission.getWritePermission(type))
+                      }
+                    }.toTypedArray()
                 requestPermissionLauncher.launch(categoryPermissions)
               },
             ) {

--- a/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
@@ -1,165 +1,207 @@
 package net.aurboda
 
-import org.junit.Test
 import org.junit.Assert.*
+import org.junit.Test
 import java.time.Instant
-import java.time.ZoneOffset
 
 /**
  * Unit tests for HealthDataModels utilities
  */
 class HealthDataModelsTest {
+  @Test
+  fun `toIsoString formats instant correctly in UTC`() {
+    val instant = Instant.parse("2024-01-15T10:30:00Z")
+    assertEquals("2024-01-15T10:30:00Z", instant.toIsoString())
+  }
 
-    @Test
-    fun `toIsoString formats instant correctly in UTC`() {
-        val instant = Instant.parse("2024-01-15T10:30:00Z")
-        assertEquals("2024-01-15T10:30:00Z", instant.toIsoString())
+  @Test
+  fun `toIsoString handles epoch instant`() {
+    val instant = Instant.EPOCH
+    assertEquals("1970-01-01T00:00:00Z", instant.toIsoString())
+  }
+
+  @Test
+  fun `toIsoString handles milliseconds`() {
+    val instant = Instant.parse("2024-06-20T14:25:30.123Z")
+    // The formatter should include milliseconds
+    assertTrue(instant.toIsoString().startsWith("2024-06-20T14:25:30"))
+  }
+
+  @Test
+  fun `appJson configuration is lenient`() {
+    // Test that the JSON configuration can parse with unknown keys
+    val jsonString = """{"known": "value", "unknown": "ignored"}"""
+
+    @kotlinx.serialization.Serializable
+    data class TestData(
+      val known: String,
+    )
+
+    val result = appJson.decodeFromString<TestData>(jsonString)
+    assertEquals("value", result.known)
+  }
+
+  @Test
+  fun `appJson encodes defaults`() {
+    @kotlinx.serialization.Serializable
+    data class TestWithDefault(
+      val value: String = "default",
+    )
+
+    val result = appJson.encodeToString(kotlinx.serialization.serializer(), TestWithDefault())
+    assertTrue(result.contains("default"))
+  }
+
+  @Test
+  fun `DeviceSerializable holds device info correctly`() {
+    val device =
+      DeviceSerializable(
+        manufacturer = "Samsung",
+        model = "Galaxy Watch 5",
+        type = 1,
+      )
+
+    assertEquals("Samsung", device.manufacturer)
+    assertEquals("Galaxy Watch 5", device.model)
+    assertEquals(1, device.type)
+  }
+
+  @Test
+  fun `DeviceSerializable handles null manufacturer and model`() {
+    val device =
+      DeviceSerializable(
+        manufacturer = null,
+        model = null,
+        type = 0,
+      )
+
+    assertNull(device.manufacturer)
+    assertNull(device.model)
+    assertEquals(0, device.type)
+  }
+
+  @Test
+  fun `HealthConnectRecordMetadata stores all fields`() {
+    val metadata =
+      HealthConnectRecordMetadata(
+        id = "test-id-123",
+        dataOrigin = "com.example.app",
+        lastModifiedTime = "2024-01-15T10:30:00Z",
+        clientRecordId = "client-123",
+        clientRecordVersion = 1L,
+        device = DeviceSerializable("Test", "Model", 1),
+        recordingMethod = 2,
+      )
+
+    assertEquals("test-id-123", metadata.id)
+    assertEquals("com.example.app", metadata.dataOrigin)
+    assertEquals("2024-01-15T10:30:00Z", metadata.lastModifiedTime)
+    assertEquals("client-123", metadata.clientRecordId)
+    assertEquals(1L, metadata.clientRecordVersion)
+    assertNotNull(metadata.device)
+    assertEquals(2, metadata.recordingMethod)
+  }
+
+  @Test
+  fun `HeartRateSampleSerializable stores sample data`() {
+    val sample =
+      HeartRateSampleSerializable(
+        time = "2024-01-15T10:30:00Z",
+        beatsPerMinute = 72L,
+      )
+
+    assertEquals("2024-01-15T10:30:00Z", sample.time)
+    assertEquals(72L, sample.beatsPerMinute)
+  }
+
+  @Test
+  fun `StepsRecordSerializable stores step count`() {
+    val metadata =
+      HealthConnectRecordMetadata(
+        id = "steps-1",
+        dataOrigin = "com.google.android.apps.fitness",
+        lastModifiedTime = "2024-01-15T10:30:00Z",
+        clientRecordId = null,
+        clientRecordVersion = 0L,
+        device = null,
+        recordingMethod = 1,
+      )
+
+    val record =
+      StepsRecordSerializable(
+        startTime = "2024-01-15T08:00:00Z",
+        endTime = "2024-01-15T09:00:00Z",
+        count = 5432L,
+        metadata = metadata,
+      )
+
+    assertEquals(5432L, record.count)
+    assertEquals("2024-01-15T08:00:00Z", record.startTime)
+    assertEquals("2024-01-15T09:00:00Z", record.endTime)
+  }
+
+  @Test
+  fun `SleepStageSerializable stores stage info`() {
+    val stage =
+      SleepStageSerializable(
+        startTime = "2024-01-15T23:00:00Z",
+        endTime = "2024-01-16T01:00:00Z",
+        stage = 4, // Deep sleep
+      )
+
+    assertEquals(4, stage.stage)
+    assertEquals("2024-01-15T23:00:00Z", stage.startTime)
+    assertEquals("2024-01-16T01:00:00Z", stage.endTime)
+  }
+
+  @Test
+  fun `allRecordTypes contains expected record classes`() {
+    // Verify the list contains key health record types
+    val typeNames = allRecordTypes.map { it.simpleName }
+
+    assertTrue("Should contain HeartRateRecord", typeNames.contains("HeartRateRecord"))
+    assertTrue("Should contain StepsRecord", typeNames.contains("StepsRecord"))
+    assertTrue("Should contain SleepSessionRecord", typeNames.contains("SleepSessionRecord"))
+    assertTrue("Should contain WeightRecord", typeNames.contains("WeightRecord"))
+    assertTrue("Should contain ExerciseSessionRecord", typeNames.contains("ExerciseSessionRecord"))
+  }
+
+  @Test
+  fun `allRecordTypes has no duplicates`() {
+    val uniqueTypes = allRecordTypes.toSet()
+    assertEquals(allRecordTypes.size, uniqueTypes.size)
+  }
+
+  @Test
+  fun `writableRecordTypes is a subset of allRecordTypes`() {
+    val allSet = allRecordTypes.toSet()
+    for (type in writableRecordTypes) {
+      assertTrue(
+        "${type.simpleName} is in writableRecordTypes but not in allRecordTypes",
+        type in allSet,
+      )
     }
+  }
 
-    @Test
-    fun `toIsoString handles epoch instant`() {
-        val instant = Instant.EPOCH
-        assertEquals("1970-01-01T00:00:00Z", instant.toIsoString())
-    }
-
-    @Test
-    fun `toIsoString handles milliseconds`() {
-        val instant = Instant.parse("2024-06-20T14:25:30.123Z")
-        // The formatter should include milliseconds
-        assertTrue(instant.toIsoString().startsWith("2024-06-20T14:25:30"))
-    }
-
-    @Test
-    fun `appJson configuration is lenient`() {
-        // Test that the JSON configuration can parse with unknown keys
-        val jsonString = """{"known": "value", "unknown": "ignored"}"""
-
-        @kotlinx.serialization.Serializable
-        data class TestData(val known: String)
-
-        val result = appJson.decodeFromString<TestData>(jsonString)
-        assertEquals("value", result.known)
-    }
-
-    @Test
-    fun `appJson encodes defaults`() {
-        @kotlinx.serialization.Serializable
-        data class TestWithDefault(val value: String = "default")
-
-        val result = appJson.encodeToString(kotlinx.serialization.serializer(), TestWithDefault())
-        assertTrue(result.contains("default"))
-    }
-
-    @Test
-    fun `DeviceSerializable holds device info correctly`() {
-        val device = DeviceSerializable(
-            manufacturer = "Samsung",
-            model = "Galaxy Watch 5",
-            type = 1
-        )
-
-        assertEquals("Samsung", device.manufacturer)
-        assertEquals("Galaxy Watch 5", device.model)
-        assertEquals(1, device.type)
-    }
-
-    @Test
-    fun `DeviceSerializable handles null manufacturer and model`() {
-        val device = DeviceSerializable(
-            manufacturer = null,
-            model = null,
-            type = 0
-        )
-
-        assertNull(device.manufacturer)
-        assertNull(device.model)
-        assertEquals(0, device.type)
-    }
-
-    @Test
-    fun `HealthConnectRecordMetadata stores all fields`() {
-        val metadata = HealthConnectRecordMetadata(
-            id = "test-id-123",
-            dataOrigin = "com.example.app",
-            lastModifiedTime = "2024-01-15T10:30:00Z",
-            clientRecordId = "client-123",
-            clientRecordVersion = 1L,
-            device = DeviceSerializable("Test", "Model", 1),
-            recordingMethod = 2
-        )
-
-        assertEquals("test-id-123", metadata.id)
-        assertEquals("com.example.app", metadata.dataOrigin)
-        assertEquals("2024-01-15T10:30:00Z", metadata.lastModifiedTime)
-        assertEquals("client-123", metadata.clientRecordId)
-        assertEquals(1L, metadata.clientRecordVersion)
-        assertNotNull(metadata.device)
-        assertEquals(2, metadata.recordingMethod)
-    }
-
-    @Test
-    fun `HeartRateSampleSerializable stores sample data`() {
-        val sample = HeartRateSampleSerializable(
-            time = "2024-01-15T10:30:00Z",
-            beatsPerMinute = 72L
-        )
-
-        assertEquals("2024-01-15T10:30:00Z", sample.time)
-        assertEquals(72L, sample.beatsPerMinute)
-    }
-
-    @Test
-    fun `StepsRecordSerializable stores step count`() {
-        val metadata = HealthConnectRecordMetadata(
-            id = "steps-1",
-            dataOrigin = "com.google.android.apps.fitness",
-            lastModifiedTime = "2024-01-15T10:30:00Z",
-            clientRecordId = null,
-            clientRecordVersion = 0L,
-            device = null,
-            recordingMethod = 1
-        )
-
-        val record = StepsRecordSerializable(
-            startTime = "2024-01-15T08:00:00Z",
-            endTime = "2024-01-15T09:00:00Z",
-            count = 5432L,
-            metadata = metadata
-        )
-
-        assertEquals(5432L, record.count)
-        assertEquals("2024-01-15T08:00:00Z", record.startTime)
-        assertEquals("2024-01-15T09:00:00Z", record.endTime)
-    }
-
-    @Test
-    fun `SleepStageSerializable stores stage info`() {
-        val stage = SleepStageSerializable(
-            startTime = "2024-01-15T23:00:00Z",
-            endTime = "2024-01-16T01:00:00Z",
-            stage = 4 // Deep sleep
-        )
-
-        assertEquals(4, stage.stage)
-        assertEquals("2024-01-15T23:00:00Z", stage.startTime)
-        assertEquals("2024-01-16T01:00:00Z", stage.endTime)
-    }
-
-    @Test
-    fun `allRecordTypes contains expected record classes`() {
-        // Verify the list contains key health record types
-        val typeNames = allRecordTypes.map { it.simpleName }
-
-        assertTrue("Should contain HeartRateRecord", typeNames.contains("HeartRateRecord"))
-        assertTrue("Should contain StepsRecord", typeNames.contains("StepsRecord"))
-        assertTrue("Should contain SleepSessionRecord", typeNames.contains("SleepSessionRecord"))
-        assertTrue("Should contain WeightRecord", typeNames.contains("WeightRecord"))
-        assertTrue("Should contain ExerciseSessionRecord", typeNames.contains("ExerciseSessionRecord"))
-    }
-
-    @Test
-    fun `allRecordTypes has no duplicates`() {
-        val uniqueTypes = allRecordTypes.toSet()
-        assertEquals(allRecordTypes.size, uniqueTypes.size)
-    }
+  @Test
+  fun `writableRecordTypes matches outbound sync record types`() {
+    // These are the record types handled in OutboundSync.kt writeUpsertRecord()
+    val expectedTypes =
+      setOf(
+        "BodyFatRecord",
+        "BodyWaterMassRecord",
+        "BoneMassRecord",
+        "ExerciseSessionRecord",
+        "HeartRateRecord",
+        "HeartRateVariabilityRmssdRecord",
+        "HeightRecord",
+        "LeanBodyMassRecord",
+        "RestingHeartRateRecord",
+        "SleepSessionRecord",
+        "StepsRecord",
+        "WeightRecord",
+      )
+    val actualTypes = writableRecordTypes.map { it.simpleName }.toSet()
+    assertEquals(expectedTypes, actualTypes)
+  }
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `hasAllWritePermissions` was checking write permissions for all ~37 record types, but only 12 have WRITE permissions declared in the manifest. This caused the "Write permissions pending" warning to show permanently, even when the user had granted all available write permissions.
- **New `writableRecordTypes` set** in `HealthDataModels.kt` — the 12 record types matching `WRITE_*` permissions in `AndroidManifest.xml`.
- **Permission requests now correct**: `allPermissions` requests READ for all types, WRITE only for writable types. Category "Grant" buttons likewise.
- **UI improvement**: Replaced error-colored warning text with a neutral expandable `Surface` block ("Write permissions pending" / "Read & write permissions pending") that expands to show the grant button and HC settings link.
- **Tests**: Added `writableRecordTypes is a subset of allRecordTypes` and `writableRecordTypes matches outbound sync record types`.

Fixes the "Write permissions needed" false alarm from #262.