### PR TITLE
Android: Sync ActivityWatch data from aw-android companion app

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ActivityWatchSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ActivityWatchSync.kt
@@ -1,0 +1,308 @@
+package net.aurboda
+
+import android.content.Context
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val TAG = "ActivityWatchSync"
+private const val PREFS_NAME = "AurbodaAppPrefs"
+private const val AW_SYNC_ENABLED_KEY = "activityWatchSyncEnabled"
+private const val AW_LAST_SYNC_PREFIX = "aw_last_sync_"
+private const val AW_URL = "http://localhost:5600"
+private const val AW_TIMEOUT_MS = 2000L
+
+// ============================================================================
+// Preferences
+// ============================================================================
+
+fun isActivityWatchSyncEnabled(context: Context): Boolean {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  return prefs.getBoolean(AW_SYNC_ENABLED_KEY, false)
+}
+
+fun setActivityWatchSyncEnabled(
+  context: Context,
+  enabled: Boolean,
+) {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  prefs.edit().putBoolean(AW_SYNC_ENABLED_KEY, enabled).apply()
+}
+
+private fun getLastSyncTime(
+  context: Context,
+  bucketId: String,
+): String? {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  return prefs.getString("$AW_LAST_SYNC_PREFIX$bucketId", null)
+}
+
+private fun setLastSyncTime(
+  context: Context,
+  bucketId: String,
+  timestamp: String,
+) {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  prefs.edit().putString("$AW_LAST_SYNC_PREFIX$bucketId", timestamp).apply()
+}
+
+// ============================================================================
+// API Models
+// ============================================================================
+
+@Serializable
+data class AwEvent(
+  val timestamp: String,
+  val duration: Double,
+  val data: JsonObject,
+)
+
+@Serializable
+data class AurbodaAwEvent(
+  val app: String,
+  val duration: Double,
+  val timestamp: String,
+  val title: String? = null,
+)
+
+@Serializable
+data class AurbodaAwSyncBody(
+  val device_name: String,
+  val events: List<AurbodaAwEvent>,
+  val is_mobile: Boolean = true,
+)
+
+@Serializable
+data class AurbodaAwSyncResponse(
+  val success: Boolean,
+  val result: AurbodaAwSyncResult? = null,
+  val error: String? = null,
+)
+
+@Serializable
+data class AurbodaAwSyncResult(
+  val status: String,
+  val records_stored: Int,
+  val device_name: String,
+  val error: String? = null,
+)
+
+// ============================================================================
+// Result
+// ============================================================================
+
+data class ActivityWatchSyncResult(
+  val available: Boolean = false,
+  val bucketsFound: Int = 0,
+  val eventsFetched: Int = 0,
+  val eventsPushed: Int = 0,
+  val error: String? = null,
+)
+
+// ============================================================================
+// AW Local API Client
+// ============================================================================
+
+/**
+ * Check if ActivityWatch is reachable on localhost.
+ */
+suspend fun checkActivityWatchAvailable(httpClient: HttpClient): Boolean =
+  try {
+    val response = httpClient.get("$AW_URL/api/0/info")
+    response.status == HttpStatusCode.OK
+  } catch (_: Exception) {
+    false
+  }
+
+/**
+ * Fetch bucket list from ActivityWatch and filter for app-usage buckets.
+ * Returns a list of (bucketId, bucketType) pairs.
+ *
+ * Desktop: type == "currentwindow" (aw-watcher-window)
+ * Android: bucket ID starts with "aw-android-appevents"
+ */
+suspend fun fetchAppEventBuckets(httpClient: HttpClient): List<Pair<String, String>> =
+  try {
+    val response = httpClient.get("$AW_URL/api/0/buckets/")
+    if (response.status != HttpStatusCode.OK) return emptyList()
+
+    val body = response.bodyAsText()
+    val buckets = appJson.decodeFromString<Map<String, JsonObject>>(body)
+
+    buckets.entries
+      .filter { (id, bucket) ->
+        val type = bucket["type"]?.jsonPrimitive?.contentOrNull
+        type == "currentwindow" || id.startsWith("aw-android-appevents")
+      }.map { (id, bucket) ->
+        val type = bucket["type"]?.jsonPrimitive?.contentOrNull ?: "unknown"
+        id to type
+      }
+  } catch (e: Exception) {
+    Log.e(TAG, "🚫 Error fetching AW buckets: ${e.message}")
+    emptyList()
+  }
+
+/**
+ * Fetch events from a specific bucket since the given timestamp.
+ */
+suspend fun fetchBucketEvents(
+  httpClient: HttpClient,
+  bucketId: String,
+  since: String?,
+): List<AwEvent> =
+  try {
+    val url =
+      buildString {
+        append("$AW_URL/api/0/buckets/$bucketId/events?limit=500")
+        if (since != null) append("&start=$since")
+      }
+    val response = httpClient.get(url)
+    if (response.status != HttpStatusCode.OK) return emptyList()
+
+    val body = response.bodyAsText()
+    appJson.decodeFromString<List<AwEvent>>(body)
+  } catch (e: Exception) {
+    Log.e(TAG, "🚫 Error fetching events from $bucketId: ${e.message}")
+    emptyList()
+  }
+
+/**
+ * Push events to the Aurboda backend.
+ */
+suspend fun pushEventsToAurboda(
+  httpClient: HttpClient,
+  apiUrl: String,
+  authToken: String,
+  events: List<AurbodaAwEvent>,
+  deviceName: String,
+): AurbodaAwSyncResponse =
+  try {
+    val response =
+      httpClient.post("$apiUrl/sync/activitywatch") {
+        contentType(ContentType.Application.Json)
+        headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        setBody(AurbodaAwSyncBody(device_name = deviceName, events = events))
+      }
+    if (response.status == HttpStatusCode.OK) {
+      val body = response.bodyAsText()
+      appJson.decodeFromString<AurbodaAwSyncResponse>(body)
+    } else {
+      AurbodaAwSyncResponse(success = false, error = "HTTP ${response.status.value}")
+    }
+  } catch (e: Exception) {
+    Log.e(TAG, "🚫 Error pushing AW events to Aurboda: ${e.message}")
+    AurbodaAwSyncResponse(success = false, error = e.message)
+  }
+
+// ============================================================================
+// Orchestrator
+// ============================================================================
+
+/**
+ * Full ActivityWatch sync pipeline:
+ * 1. Check if AW is available (skip silently if not)
+ * 2. Fetch app-usage buckets
+ * 3. For each bucket, fetch new events since last sync
+ * 4. Map to Aurboda format and push to backend
+ * 5. Update last sync timestamp on success
+ */
+suspend fun processActivityWatchSync(
+  apiUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+  context: Context,
+): ActivityWatchSyncResult {
+  if (!checkActivityWatchAvailable(httpClient)) {
+    return ActivityWatchSyncResult(available = false)
+  }
+  Log.d(TAG, "📱 ActivityWatch detected, starting sync")
+
+  val buckets = fetchAppEventBuckets(httpClient)
+  if (buckets.isEmpty()) {
+    Log.d(TAG, "📱 No app-usage buckets found")
+    return ActivityWatchSyncResult(available = true, bucketsFound = 0)
+  }
+  Log.d(TAG, "📱 Found ${buckets.size} app-usage bucket(s)")
+
+  val deviceName = android.os.Build.MODEL
+  var totalFetched = 0
+  var totalPushed = 0
+
+  for ((bucketId, _) in buckets) {
+    val since = getLastSyncTime(context, bucketId)
+    val events = fetchBucketEvents(httpClient, bucketId, since)
+    if (events.isEmpty()) {
+      Log.d(TAG, "📱 No new events in $bucketId")
+      continue
+    }
+
+    totalFetched += events.size
+    Log.d(TAG, "📱 Fetched ${events.size} events from $bucketId")
+
+    // Map AW events to Aurboda format
+    val aurbodaEvents =
+      events.mapNotNull { event ->
+        val app = event.data["app"]?.jsonPrimitive?.contentOrNull
+        if (app == null) {
+          Log.w(TAG, "⚠️ Skipping event without 'app' field: ${event.data.keys}")
+          return@mapNotNull null
+        }
+        val title = event.data["title"]?.jsonPrimitive?.contentOrNull
+        AurbodaAwEvent(
+          app = app,
+          duration = event.duration,
+          timestamp = event.timestamp,
+          title = title,
+        )
+      }
+
+    if (aurbodaEvents.isEmpty()) continue
+
+    // Push in chunks of 500 to avoid oversized payloads
+    for (chunk in aurbodaEvents.chunked(500)) {
+      val response = pushEventsToAurboda(httpClient, apiUrl, authToken, chunk, deviceName)
+      if (response.success) {
+        totalPushed += response.result?.records_stored ?: chunk.size
+        Log.d(TAG, "✅ Pushed ${chunk.size} events from $bucketId")
+      } else {
+        Log.e(TAG, "🚫 Failed to push events from $bucketId: ${response.error}")
+        return ActivityWatchSyncResult(
+          available = true,
+          bucketsFound = buckets.size,
+          eventsFetched = totalFetched,
+          eventsPushed = totalPushed,
+          error = response.error,
+        )
+      }
+    }
+
+    // Update last sync time to the latest event timestamp
+    val latestTimestamp = events.maxByOrNull { it.timestamp }?.timestamp
+    if (latestTimestamp != null) {
+      setLastSyncTime(context, bucketId, latestTimestamp)
+    }
+  }
+
+  if (totalFetched > 0) {
+    Log.d(TAG, "✅ ActivityWatch sync complete: $totalPushed events pushed")
+  }
+
+  return ActivityWatchSyncResult(
+    available = true,
+    bucketsFound = buckets.size,
+    eventsFetched = totalFetched,
+    eventsPushed = totalPushed,
+  )
+}

--- a/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
@@ -9,21 +9,21 @@ private const val PREFS_NAME = "AurbodaAppPrefs"
 private const val BACKGROUND_SYNC_ENABLED_KEY = "backgroundSyncEnabled"
 
 class AurbodaApplication : Application() {
-    override fun onCreate() {
-        super.onCreate()
+  override fun onCreate() {
+    super.onCreate()
 
-        // Schedule background sync if it was previously enabled
-        // This ensures sync continues after app restarts, device reboots, etc.
-        if (isBackgroundSyncEnabled(this)) {
-            Log.d(TAG, "Background sync was previously enabled, scheduling worker")
-            HealthConnectSyncWorker.schedule(this)
-        } else {
-            Log.d(TAG, "Background sync is not enabled")
-        }
+    // Schedule background sync if it was previously enabled
+    // This ensures sync continues after app restarts, device reboots, etc.
+    if (isBackgroundSyncEnabled(this)) {
+      Log.d(TAG, "Background sync was previously enabled, scheduling worker")
+      SyncWorker.schedule(this)
+    } else {
+      Log.d(TAG, "Background sync is not enabled")
     }
+  }
 
-    private fun isBackgroundSyncEnabled(context: Context): Boolean {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return prefs.getBoolean(BACKGROUND_SYNC_ENABLED_KEY, false)
-    }
+  private fun isBackgroundSyncEnabled(context: Context): Boolean {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    return prefs.getBoolean(BACKGROUND_SYNC_ENABLED_KEY, false)
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -102,9 +102,9 @@ private fun setBackgroundSyncEnabled(
   val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
   prefs.edit().putBoolean(BACKGROUND_SYNC_ENABLED_KEY, enabled).apply()
   if (enabled) {
-    HealthConnectSyncWorker.schedule(context)
+    SyncWorker.schedule(context)
   } else {
-    HealthConnectSyncWorker.cancel(context)
+    SyncWorker.cancel(context)
   }
 }
 
@@ -505,6 +505,10 @@ fun HealthConnectScreen(
   var statusMessage by remember { mutableStateOf("Checking permissions...") }
   var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
   var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
+
+  // -- ActivityWatch state --
+  var awSyncEnabled by remember { mutableStateOf(isActivityWatchSyncEnabled(context)) }
+  var awSyncResult by remember { mutableStateOf<ActivityWatchSyncResult?>(null) }
 
   val batteryOptimizationLauncher =
     rememberLauncherForActivityResult(
@@ -1032,13 +1036,28 @@ fun HealthConnectScreen(
       Log.w("OutboundSync", "Outbound sync failed in syncNow: ${e.message}", e)
       statusMessage = "Outbound sync error: ${e.message}"
     }
+    // ActivityWatch sync (if enabled)
+    if (awSyncEnabled) {
+      try {
+        awSyncResult =
+          processActivityWatchSync(
+            apiUrl = apiUrl,
+            authToken = authToken,
+            httpClient = ktorHttpClient,
+            context = currentContext,
+          )
+      } catch (e: Exception) {
+        Log.w("ActivityWatch", "AW sync failed in syncNow: ${e.message}", e)
+        awSyncResult = ActivityWatchSyncResult(error = e.message)
+      }
+    }
   }
 
   LaunchedEffect(Unit) {
     Log.d("HealthConnectScreen", "LaunchedEffect: Initial check")
     checkPermissionsAndFetchData(this, context)
     if (backgroundSyncEnabled) {
-      HealthConnectSyncWorker.schedule(context)
+      SyncWorker.schedule(context)
     }
   }
 
@@ -1260,6 +1279,77 @@ fun HealthConnectScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
             modifier = Modifier.align(Alignment.End),
           )
+        }
+      }
+    }
+
+    // -- ActivityWatch Sync Card --
+    item {
+      androidx.compose.material3.Card(
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Column(
+          modifier = Modifier.padding(16.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text(
+            "ActivityWatch",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+          )
+          Text(
+            "Sync app usage data from ActivityWatch for Android.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            Text("ActivityWatch Sync", style = MaterialTheme.typography.bodyMedium)
+            Switch(
+              checked = awSyncEnabled,
+              onCheckedChange = { enabled ->
+                awSyncEnabled = enabled
+                setActivityWatchSyncEnabled(context, enabled)
+              },
+            )
+          }
+
+          if (awSyncEnabled) {
+            val result = awSyncResult
+            val awStatusText =
+              when {
+                result == null -> "Sync on next run"
+                result.error != null -> "Error: ${result.error}"
+                !result.available -> "ActivityWatch not detected"
+                result.eventsPushed > 0 -> "${result.eventsPushed} events synced"
+                result.bucketsFound == 0 -> "No app-usage buckets found"
+                else -> "Up to date"
+              }
+            val awStatusColor =
+              when {
+                result == null -> MaterialTheme.colorScheme.onSurfaceVariant
+                result.error != null -> MaterialTheme.colorScheme.error
+                !result.available -> MaterialTheme.colorScheme.onSurfaceVariant
+                result.eventsPushed > 0 -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+              }
+            Text(
+              awStatusText,
+              style = MaterialTheme.typography.bodySmall,
+              color = awStatusColor,
+            )
+
+            if (result != null && !result.available) {
+              Text(
+                "Install ActivityWatch for Android to sync app usage data.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+          }
         }
       }
     }

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -36,13 +36,13 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
-private const val TAG = "HealthConnectSyncWorker"
+private const val TAG = "SyncWorker"
 private const val PREFS_NAME = "AurbodaAppPrefs"
 private const val CHANGES_TOKEN_KEY = "healthConnectChangesToken"
 private const val GRANTED_TYPES_KEY = "grantedRecordTypeNames"
 private const val WORK_NAME = "health_connect_sync"
 
-class HealthConnectSyncWorker(
+class SyncWorker(
   context: Context,
   params: WorkerParameters,
 ) : CoroutineWorker(context, params) {
@@ -150,6 +150,21 @@ class HealthConnectSyncWorker(
         )
       } catch (e: Exception) {
         Log.w(TAG, "Outbound sync failed: ${e.message}")
+      }
+
+      // Step 5: ActivityWatch sync (if enabled).
+      // Best-effort: failures don't affect overall sync result.
+      if (isActivityWatchSyncEnabled(applicationContext)) {
+        try {
+          processActivityWatchSync(
+            apiUrl = credentials.apiUrl,
+            authToken = credentials.authToken,
+            httpClient = httpClient,
+            context = applicationContext,
+          )
+        } catch (e: Exception) {
+          Log.w(TAG, "ActivityWatch sync failed: ${e.message}")
+        }
       }
 
       HrZoneWidgetProvider.triggerUpdate(applicationContext)
@@ -636,7 +651,7 @@ class HealthConnectSyncWorker(
           .build()
 
       val workRequest =
-        PeriodicWorkRequestBuilder<HealthConnectSyncWorker>(
+        PeriodicWorkRequestBuilder<SyncWorker>(
           15,
           TimeUnit.MINUTES,
         ).setConstraints(constraints)

--- a/apps/android/app/src/test/java/net/aurboda/BackgroundSyncTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/BackgroundSyncTest.kt
@@ -58,7 +58,7 @@ class BackgroundSyncTest {
   @Test
   fun `schedule creates periodic work with network constraint`() {
     // When: We schedule the background sync
-    HealthConnectSyncWorker.schedule(context)
+    SyncWorker.schedule(context)
 
     // Then: Work should be enqueued
     val workInfos =
@@ -79,7 +79,7 @@ class BackgroundSyncTest {
   @Test
   fun `schedule uses UPDATE policy to replace existing work`() {
     // Given: Work is already scheduled
-    HealthConnectSyncWorker.schedule(context)
+    SyncWorker.schedule(context)
 
     val initialWorkInfos =
       WorkManager
@@ -89,7 +89,7 @@ class BackgroundSyncTest {
     assertEquals(1, initialWorkInfos.size)
 
     // When: We schedule again (simulating app restart)
-    HealthConnectSyncWorker.schedule(context)
+    SyncWorker.schedule(context)
 
     // Then: There should still be exactly one work request (UPDATE policy)
     val workInfos =
@@ -104,7 +104,7 @@ class BackgroundSyncTest {
   @Test
   fun `cancel removes scheduled work`() {
     // Given: Work is scheduled
-    HealthConnectSyncWorker.schedule(context)
+    SyncWorker.schedule(context)
 
     val initialWorkInfos =
       WorkManager
@@ -114,7 +114,7 @@ class BackgroundSyncTest {
     assertEquals(1, initialWorkInfos.size)
 
     // When: We cancel the work
-    HealthConnectSyncWorker.cancel(context)
+    SyncWorker.cancel(context)
 
     // Then: Work should be cancelled
     val workInfos =
@@ -171,7 +171,7 @@ class BackgroundSyncTest {
     val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
     val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
     if (isEnabled) {
-      HealthConnectSyncWorker.schedule(context)
+      SyncWorker.schedule(context)
     }
 
     // Then: Work should be scheduled
@@ -197,7 +197,7 @@ class BackgroundSyncTest {
     val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
     val isEnabled = prefs.getBoolean(backgroundSyncEnabledKey, false)
     if (isEnabled) {
-      HealthConnectSyncWorker.schedule(context)
+      SyncWorker.schedule(context)
     }
 
     // Then: No work should be scheduled

--- a/apps/backend/src/activitywatch-sync.ts
+++ b/apps/backend/src/activitywatch-sync.ts
@@ -16,11 +16,13 @@ import type { ProductivityRecord } from './db/types'
  * @param user - The Aurboda username
  * @param events - ActivityWatch events from aw-watcher-window or aw-watcher-android
  * @param deviceName - Hostname or user-configured device name (empty string for single-device setup)
+ * @param isMobile - Whether the events come from a mobile device (default false)
  */
 export const processActivityWatchEvents = async (
   user: string,
   events: ActivityWatchEvent[],
   deviceName: string,
+  isMobile = false,
 ): Promise<ActivityWatchSyncResult> => {
   try {
     const records: ProductivityRecord[] = events.map((event) => {
@@ -34,7 +36,7 @@ export const processActivityWatchEvents = async (
         device_name: deviceName,
         duration_sec: durationSec,
         end_time: endTime,
-        is_mobile: false,
+        is_mobile: isMobile,
         productivity: undefined,
         source: 'activitywatch',
         start_time: startTime,

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -259,4 +259,42 @@ describe('sync router', () => {
       expect(mockDeps.processHealthConnectData).not.toHaveBeenCalled()
     })
   })
+
+  describe('activitywatch endpoint', () => {
+    test('POST /sync/activitywatch passes events and device_name', async () => {
+      const app = createTestApp()
+      const events = [{ app: 'firefox', duration: 120, timestamp: '2024-01-15T10:00:00Z' }]
+      const response = await request(app)
+        .post('/sync/activitywatch')
+        .send({ device_name: 'my-laptop', events })
+
+      expect(response.status).toBe(200)
+      expect(mockDeps.processActivityWatchEvents).toHaveBeenCalledWith(
+        'testuser',
+        events,
+        'my-laptop',
+        undefined,
+      )
+    })
+
+    test('POST /sync/activitywatch passes is_mobile when provided', async () => {
+      const app = createTestApp()
+      const events = [{ app: 'com.example.app', duration: 60, timestamp: '2024-01-15T10:00:00Z' }]
+      const response = await request(app)
+        .post('/sync/activitywatch')
+        .send({ device_name: 'pixel-8', events, is_mobile: true })
+
+      expect(response.status).toBe(200)
+      expect(mockDeps.processActivityWatchEvents).toHaveBeenCalledWith('testuser', events, 'pixel-8', true)
+    })
+
+    test('POST /sync/activitywatch defaults device_name to empty string', async () => {
+      const app = createTestApp()
+      const events = [{ app: 'vim', duration: 300, timestamp: '2024-01-15T10:00:00Z' }]
+      const response = await request(app).post('/sync/activitywatch').send({ events })
+
+      expect(response.status).toBe(200)
+      expect(mockDeps.processActivityWatchEvents).toHaveBeenCalledWith('testuser', events, '', undefined)
+    })
+  })
 })

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -97,6 +97,7 @@ export interface SyncRouterDeps {
     user: string,
     events: SyncActivityWatchBody['events'],
     deviceName: string,
+    isMobile?: boolean,
   ) => Promise<ActivityWatchSyncResult>
   getActivityWatchSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   // Outbound sync (Health Connect write-back)
@@ -370,11 +371,11 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     validateBody(syncActivityWatchBodySchema),
     async (req, res) => {
       const user = req.user!
-      const { events, device_name } = req.body
+      const { events, device_name, is_mobile } = req.body
       const deviceName = device_name ?? ''
 
       try {
-        const result = await deps.processActivityWatchEvents(user, events, deviceName)
+        const result = await deps.processActivityWatchEvents(user, events, deviceName, is_mobile)
         res.json({ result, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/web/src/pages/Help/index.tsx
+++ b/apps/web/src/pages/Help/index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 import {
   fetchActivities,
+  fetchActivityWatchStatus,
   fetchHeartRate,
   fetchPlaces,
   fetchProductivity,
@@ -135,13 +136,22 @@ export function Help() {
     staleTime: 5 * 60 * 1000,
   })
 
+  // Fetch ActivityWatch sync status (distinct from RescueTime)
+  const awStatusQuery = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchActivityWatchStatus,
+    queryKey: ['awStatus'],
+    staleTime: 5 * 60 * 1000,
+  })
+
   const isLoading =
     heartRateQuery.isLoading ||
     sleepQuery.isLoading ||
     exerciseQuery.isLoading ||
     productivityQuery.isLoading ||
     locationsQuery.isLoading ||
-    settingsQuery.isLoading
+    settingsQuery.isLoading ||
+    awStatusQuery.isLoading
 
   const hasHeartRate = (heartRateQuery.data?.length ?? 0) > 0
   const hasSleep = (sleepQuery.data?.length ?? 0) > 0
@@ -150,6 +160,7 @@ export function Help() {
   const hasLocations = (locationsQuery.data?.length ?? 0) > 0
   const isOuraConnected = settingsQuery.data?.oura_connected ?? false
   const isRescueTimeConfigured = !!settingsQuery.data?.rescue_time_key
+  const hasActivityWatch = (awStatusQuery.data?.length ?? 0) > 0
 
   if (!isLoggedIn) {
     return (
@@ -318,20 +329,19 @@ export function Help() {
           <DataSourceCard
             name="ActivityWatch"
             status={{
-              description:
-                hasProductivity ?
-                  'Screen time data detected in the last 7 days.'
-                : 'ActivityWatch not configured.',
-              hasData: hasProductivity,
+              description: hasActivityWatch ? 'ActivityWatch data syncing.' : 'ActivityWatch not set up.',
+              hasData: hasActivityWatch,
             }}
             setupSteps={[
-              'Install ActivityWatch on your computer (activitywatch.net).',
-              'Install the aw-push-agent to push data to Aurboda.',
-              'Generate a push agent token in Settings > Data Sources.',
-              'Configure the push agent with your Aurboda URL and token.',
+              'Desktop: Install ActivityWatch, generate an API token in Settings, and set up the push agent script.',
+              'Android: Install ActivityWatch for Android, then enable "ActivityWatch Sync" in Aurboda\'s Sync tab.',
             ]}
             links={[
               { text: 'Go to Settings', url: '/settings' },
+              {
+                text: 'Setup Guide',
+                url: 'https://github.com/fiddur/aurboda/blob/develop/docs/activitywatch.md',
+              },
               { text: 'ActivityWatch Website', url: 'https://activitywatch.net/' },
             ]}
           />

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -168,6 +168,18 @@ export type {
   UserSettingsResponse,
 }
 
+// Check if ActivityWatch has ever pushed data (returns sync states per device)
+export const fetchActivityWatchStatus = async (): Promise<{ last_sync_time: string | null }[]> => {
+  const { token } = auth.value
+  const response = await axios.get<{
+    success: boolean
+    states?: { last_sync_time: string | null }[]
+  }>(`${API_URL}/sync/activitywatch/status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return response.data.states ?? []
+}
+
 // Generate a fresh API token for the authenticated user (used for push agents like ActivityWatch)
 export const generateApiToken = async (): Promise<string> => {
   const { token } = auth.value

--- a/docs/activitywatch.md
+++ b/docs/activitywatch.md
@@ -24,13 +24,13 @@ ActivityWatch (local)  →  Push Agent (cron/systemd)  →  Aurboda API
 
 Each record contains:
 
-| Field | Description |
-|-------|-------------|
-| `activity` | Application name (e.g., "firefox", "emacs", "alacritty") |
-| `duration_sec` | Time spent in seconds |
-| `start_time` / `end_time` | Precise timestamps |
-| `device_name` | Hostname or configured device name |
-| `source` | Always `activitywatch` |
+| Field                     | Description                                              |
+| ------------------------- | -------------------------------------------------------- |
+| `activity`                | Application name (e.g., "firefox", "emacs", "alacritty") |
+| `duration_sec`            | Time spent in seconds                                    |
+| `start_time` / `end_time` | Precise timestamps                                       |
+| `device_name`             | Hostname or configured device name                       |
+| `source`                  | Always `activitywatch`                                   |
 
 Window titles are available in the raw ActivityWatch data but are not currently stored (to avoid sensitive information leaking into the database). Category and productivity scores are not assigned yet — see the [categorization follow-up](https://github.com/fiddur/aurboda/issues/218).
 
@@ -189,6 +189,7 @@ crontab -e
 ```
 
 Add:
+
 ```
 */5 * * * * AURBODA_URL=https://aurboda.net/api AURBODA_TOKEN=your-token DEVICE_NAME=laptop ~/.local/bin/aw-to-aurboda.sh >> ~/.local/state/aw-aurboda/push.log 2>&1
 ```
@@ -249,12 +250,23 @@ Aurboda stores a separate `device_name` with each productivity record. Existing 
 
 ## Android
 
-The [ActivityWatch Android app](https://github.com/ActivityWatch/aw-android) exposes the same local REST API on the device. Pushing to Aurboda from Android requires either:
+The [ActivityWatch Android app](https://github.com/ActivityWatch/aw-android) runs `aw-server-rust` as a native library, exposing the standard ActivityWatch REST API at `localhost:5600` on the device. The Aurboda Android app queries it directly — no Tasker or Termux needed.
 
-- **Option A**: Tasker automation that calls the push script periodically via Termux
-- **Option B**: A dedicated Android companion app (follow-up work)
+### Setup
 
-For now, set `is_mobile: true` in the payload when pushing from Android.
+1. Install [ActivityWatch for Android](https://github.com/ActivityWatch/aw-android) and ensure it is running.
+2. Open the Aurboda app → **Sync** tab.
+3. Enable the **ActivityWatch Sync** toggle.
+
+That's it. Aurboda will sync app-usage events from ActivityWatch automatically, both during foreground "Sync Now" and in the background (every 15 minutes when background sync is enabled).
+
+### How it works
+
+- Aurboda checks `http://localhost:5600` for ActivityWatch availability (2-second timeout; skips silently if not reachable).
+- It fetches app-usage buckets (`currentwindow` type or `aw-android-appevents-*` buckets).
+- New events since the last sync are mapped to the `ActivityWatchEvent` format and POSTed to the backend with `is_mobile: true`.
+- The `device_name` is set to the Android device model name automatically.
+- Last sync time is tracked per bucket in SharedPreferences to avoid re-sending events.
 
 ## Sync Status
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -4,15 +4,15 @@ Aurboda aggregates health, productivity, and location data from multiple sources
 
 ## Overview
 
-| Source | Data Types | Sync Method | Admin Setup | User Setup |
-|--------|-----------|-------------|-------------|------------|
-| [Oura Ring](./oura.md) | Sleep, readiness, resilience, cardiovascular age, meditation, HRV, tags | Pull (API) + Push (webhook) | OAuth credentials (env vars) | OAuth connect |
-| [Health Connect](./health-connect.md) | HR, HRV, weight, body composition, steps, sleep, exercise, 40+ record types | Push (Android app) | None | Install Android app |
-| [ActivityWatch](./activitywatch.md) | App/window usage, per-device tracking | Push (agent script) | None | Install AW + push agent |
-| [RescueTime](./rescuetime.md) | App/website usage, productivity scores | Pull (API) | None | API key |
-| [Last.fm](./lastfm.md) | Music scrobbles, auto-generated tags | Pull (API) | API key (admin setting) | Last.fm username |
-| [Calendars](./calendars.md) | Calendar events (stored as tags) | Pull (ICS fetch) | None | ICS URL(s) |
-| [OwnTracks](./owntracks.md) | GPS location, geofences | Push (HTTP) | None | OwnTracks app config |
+| Source                                | Data Types                                                                  | Sync Method                             | Admin Setup                  | User Setup                                               |
+| ------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------- | ---------------------------- | -------------------------------------------------------- |
+| [Oura Ring](./oura.md)                | Sleep, readiness, resilience, cardiovascular age, meditation, HRV, tags     | Pull (API) + Push (webhook)             | OAuth credentials (env vars) | OAuth connect                                            |
+| [Health Connect](./health-connect.md) | HR, HRV, weight, body composition, steps, sleep, exercise, 40+ record types | Push (Android app)                      | None                         | Install Android app                                      |
+| [ActivityWatch](./activitywatch.md)   | App/window usage, per-device tracking                                       | Push (agent script / Android companion) | None                         | Install AW + push agent or enable in Aurboda Android app |
+| [RescueTime](./rescuetime.md)         | App/website usage, productivity scores                                      | Pull (API)                              | None                         | API key                                                  |
+| [Last.fm](./lastfm.md)                | Music scrobbles, auto-generated tags                                        | Pull (API)                              | API key (admin setting)      | Last.fm username                                         |
+| [Calendars](./calendars.md)           | Calendar events (stored as tags)                                            | Pull (ICS fetch)                        | None                         | ICS URL(s)                                               |
+| [OwnTracks](./owntracks.md)           | GPS location, geofences                                                     | Push (HTTP)                             | None                         | OwnTracks app config                                     |
 
 ## Sync Behavior
 
@@ -30,6 +30,7 @@ Aurboda aggregates health, productivity, and location data from multiple sources
 - No auto-sync (agent controls the schedule)
 
 Check sync status for all providers:
+
 - REST: `GET /api/sync/status`
 - MCP: `get_sync_status()`
 

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -615,6 +615,9 @@ export const syncActivityWatchBodySchema = z
       description: 'Hostname or user-configured device name. Defaults to empty string (single-device setup).',
     }),
     events: z.array(activityWatchEventSchema).min(1).meta({ description: 'ActivityWatch events to store' }),
+    is_mobile: z.boolean().optional().meta({
+      description: 'Whether the events come from a mobile device. Defaults to false.',
+    }),
   })
   .meta({ id: 'SyncActivityWatchBody' })
 


### PR DESCRIPTION
## Summary

Implements native ActivityWatch sync for the Aurboda Android app, plus backend `is_mobile` support and improved ActivityWatch detection in the Help page.

Closes #259

## Changes

### Backend + API spec
- Added `is_mobile: boolean` (optional) to `syncActivityWatchBodySchema`
- Backend accepts and uses `is_mobile` from request body (previously hardcoded to `false`)
- 3 new sync-router tests for ActivityWatch `is_mobile` passthrough

### Android
- **New `ActivityWatchSync.kt`**: Queries the ActivityWatch local API at `localhost:5600`, fetches app-usage buckets (`currentwindow` or `aw-android-appevents-*`), maps events to the Aurboda format, and pushes with `is_mobile: true`
- **Renamed `HealthConnectSyncWorker` → `SyncWorker`**: Now runs both Health Connect and ActivityWatch sync (AW as step 5, best-effort)
- **Sync screen UI**: New "ActivityWatch" card with toggle and status display (available/not detected/events synced/error)
- Per-bucket last sync time tracked in SharedPreferences

### Web
- `fetchActivityWatchStatus()` API client for `GET /sync/activitywatch/status`
- Help page: ActivityWatch now has its own status detection (separate from RescueTime's `hasProductivity`), with setup steps for both desktop and Android paths
- Links to GitHub docs at `github.com/fiddur/aurboda/blob/develop/docs/activitywatch.md`

### Docs
- `activitywatch.md`: Replaced placeholder Android section with full native integration guide
- `data-sources.md`: Updated ActivityWatch entry to reflect Android companion support

## How it works

1. User installs [ActivityWatch for Android](https://github.com/ActivityWatch/aw-android)
2. Enables "ActivityWatch Sync" toggle in Aurboda's Sync tab
3. Aurboda checks `localhost:5600` for AW availability (2s timeout, skips silently if not reachable)
4. Fetches new events since last sync, pushes to backend with `is_mobile: true` and device model as `device_name`
5. Runs both during foreground "Sync Now" and background sync (every 15min)