### PR TITLE
fix(productivity): merge interleaved same-app spans within 2-minute window

### DIFF
--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -1131,6 +1131,7 @@ describe('mergeProductivitySpans', () => {
         category: 'Software Development',
         duration_sec: 300,
         end_time: new Date('2024-01-15T10:05:00Z'),
+        id: 'id-1',
         productivity: 2,
         start_time: new Date('2024-01-15T10:00:00Z'),
       },
@@ -1139,6 +1140,7 @@ describe('mergeProductivitySpans', () => {
         category: 'Software Development',
         duration_sec: 300,
         end_time: new Date('2024-01-15T10:10:00Z'),
+        id: 'id-2',
         productivity: 2,
         start_time: new Date('2024-01-15T10:05:00Z'),
       },
@@ -1147,16 +1149,18 @@ describe('mergeProductivitySpans', () => {
         category: 'Software Development',
         duration_sec: 300,
         end_time: new Date('2024-01-15T10:15:00Z'),
+        id: 'id-3',
         productivity: 2,
         start_time: new Date('2024-01-15T10:10:00Z'),
       },
     ])
 
     expect(result).toHaveLength(1)
-    expect(result[0].activity).toBe('emacs')
-    expect(result[0].start_time).toEqual(new Date('2024-01-15T10:00:00Z'))
-    expect(result[0].end_time).toEqual(new Date('2024-01-15T10:15:00Z'))
-    expect(result[0].duration_sec).toBe(900)
+    expect(result[0]!.activity).toBe('emacs')
+    expect(result[0]!.start_time).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0]!.end_time).toEqual(new Date('2024-01-15T10:15:00Z'))
+    expect(result[0]!.duration_sec).toBe(900)
+    expect(result[0]!.source_ids).toEqual(['id-1', 'id-2', 'id-3'])
   })
 
   test('does not merge spans for different activities', () => {
@@ -1223,7 +1227,43 @@ describe('mergeProductivitySpans', () => {
     expect(result).toHaveLength(2)
   })
 
-  test('merges interleaved activities separately', () => {
+  test('merges interleaved same-activity spans within gap threshold', () => {
+    // emacs → firefox (30s) → emacs: the two emacs spans are within 2 min of each other
+    const result = mergeProductivitySpans([
+      {
+        activity: 'emacs',
+        duration_sec: 300,
+        end_time: new Date('2024-01-15T10:05:00Z'),
+        id: 'id-emacs-1',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity: 'firefox',
+        duration_sec: 30,
+        end_time: new Date('2024-01-15T10:05:30Z'),
+        id: 'id-firefox-1',
+        start_time: new Date('2024-01-15T10:05:00Z'),
+      },
+      {
+        activity: 'emacs',
+        duration_sec: 300,
+        end_time: new Date('2024-01-15T10:10:30Z'),
+        id: 'id-emacs-2',
+        start_time: new Date('2024-01-15T10:05:30Z'),
+      },
+    ])
+
+    // emacs spans merge (gap = 30s < 2min); firefox stays separate
+    expect(result).toHaveLength(2)
+    const emacs = result.find((r) => r.activity === 'emacs')!
+    expect(emacs.start_time).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(emacs.end_time).toEqual(new Date('2024-01-15T10:10:30Z'))
+    expect(emacs.duration_sec).toBe(600) // only actual emacs time, not the firefox gap
+    expect(emacs.source_ids).toEqual(['id-emacs-1', 'id-emacs-2'])
+  })
+
+  test('does not merge interleaved same-activity spans when gap exceeds threshold', () => {
+    // emacs → firefox (5 min) → emacs: gap too large, stays as 2 separate emacs spans
     const result = mergeProductivitySpans([
       {
         activity: 'emacs',
@@ -1245,8 +1285,161 @@ describe('mergeProductivitySpans', () => {
       },
     ])
 
-    // emacs-firefox-emacs should remain 3 separate spans since emacs is not consecutive
     expect(result).toHaveLength(3)
+  })
+
+  test('real-world ActivityWatch pattern: rapid Alacritty/firefox interleaving', () => {
+    // Derived from actual MCP data: 06:00-07:10 on 2026-02-27
+    // Sub-second granularity, lots of 3-30s switches between terminal and browser
+    const records = [
+      {
+        activity: 'Alacritty',
+        duration_sec: 257,
+        end_time: new Date('2026-02-27T06:04:18Z'),
+        id: 'a1',
+        start_time: new Date('2026-02-27T06:00:01Z'),
+      },
+      {
+        activity: 'firefox',
+        duration_sec: 3,
+        end_time: new Date('2026-02-27T06:04:22Z'),
+        id: 'f1',
+        start_time: new Date('2026-02-27T06:04:18Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 11,
+        end_time: new Date('2026-02-27T06:04:34Z'),
+        id: 'a2',
+        start_time: new Date('2026-02-27T06:04:23Z'),
+      },
+      {
+        activity: 'firefox',
+        duration_sec: 7,
+        end_time: new Date('2026-02-27T06:04:42Z'),
+        id: 'f2',
+        start_time: new Date('2026-02-27T06:04:35Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 0,
+        end_time: new Date('2026-02-27T06:04:43Z'),
+        id: 'a3',
+        start_time: new Date('2026-02-27T06:04:43Z'),
+      },
+      {
+        activity: 'firefox',
+        duration_sec: 13,
+        end_time: new Date('2026-02-27T06:04:58Z'),
+        id: 'f3',
+        start_time: new Date('2026-02-27T06:04:44Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 66,
+        end_time: new Date('2026-02-27T06:06:06Z'),
+        id: 'a4',
+        start_time: new Date('2026-02-27T06:04:59Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 3,
+        end_time: new Date('2026-02-27T06:06:10Z'),
+        id: 'a5',
+        start_time: new Date('2026-02-27T06:06:07Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 21,
+        end_time: new Date('2026-02-27T06:06:35Z'),
+        id: 'a6',
+        start_time: new Date('2026-02-27T06:06:14Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 1,
+        end_time: new Date('2026-02-27T06:06:39Z'),
+        id: 'a7',
+        start_time: new Date('2026-02-27T06:06:38Z'),
+      },
+      {
+        activity: 'firefox',
+        duration_sec: 16,
+        end_time: new Date('2026-02-27T06:07:02Z'),
+        id: 'f4',
+        start_time: new Date('2026-02-27T06:06:40Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 3,
+        end_time: new Date('2026-02-27T06:07:06Z'),
+        id: 'a8',
+        start_time: new Date('2026-02-27T06:07:03Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 173,
+        end_time: new Date('2026-02-27T06:10:01Z'),
+        id: 'a9',
+        start_time: new Date('2026-02-27T06:07:08Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 241,
+        end_time: new Date('2026-02-27T06:14:02Z'),
+        id: 'a10',
+        start_time: new Date('2026-02-27T06:10:01Z'),
+      },
+    ]
+
+    const result = mergeProductivitySpans(records)
+
+    // All Alacritty spans should merge into one (max gap between consecutive Alacritty ≤ 2min)
+    const alacrittySpans = result.filter((r) => r.activity === 'Alacritty')
+    expect(alacrittySpans).toHaveLength(1)
+    expect(alacrittySpans[0]!.start_time).toEqual(new Date('2026-02-27T06:00:01Z'))
+    expect(alacrittySpans[0]!.end_time).toEqual(new Date('2026-02-27T06:14:02Z'))
+    // duration_sec is the sum of actual Alacritty time only (not firefox gaps)
+    expect(alacrittySpans[0]!.duration_sec).toBe(257 + 11 + 0 + 66 + 3 + 21 + 1 + 3 + 173 + 241)
+    expect(alacrittySpans[0]!.source_ids).toContain('a1')
+    expect(alacrittySpans[0]!.source_ids).toContain('a10')
+
+    // All firefox spans merge into one (all gaps ≤ 2min)
+    const firefoxSpans = result.filter((r) => r.activity === 'firefox')
+    expect(firefoxSpans).toHaveLength(1)
+    expect(firefoxSpans[0]!.duration_sec).toBe(3 + 7 + 13 + 16)
+  })
+
+  test('zero-duration blip records are absorbed into the surrounding span', () => {
+    // A 0-second focus event (e.g. system notification stealing focus briefly)
+    const result = mergeProductivitySpans([
+      {
+        activity: 'Alacritty',
+        duration_sec: 60,
+        end_time: new Date('2024-01-15T10:01:00Z'),
+        id: 'a1',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity: 'plasmashell',
+        duration_sec: 0,
+        end_time: new Date('2024-01-15T10:01:00Z'),
+        id: 'p1',
+        start_time: new Date('2024-01-15T10:01:00Z'),
+      },
+      {
+        activity: 'Alacritty',
+        duration_sec: 60,
+        end_time: new Date('2024-01-15T10:02:00Z'),
+        id: 'a2',
+        start_time: new Date('2024-01-15T10:01:00Z'),
+      },
+    ])
+
+    // Alacritty spans on either side of a 0-sec plasmashell event should merge
+    const alacritty = result.find((r) => r.activity === 'Alacritty')!
+    expect(alacritty.duration_sec).toBe(120)
+    expect(alacritty.source_ids).toEqual(['a1', 'a2'])
   })
 
   test('handles empty input', () => {
@@ -1262,7 +1455,8 @@ describe('mergeProductivitySpans', () => {
     }
     const result = mergeProductivitySpans([record])
     expect(result).toHaveLength(1)
-    expect(result[0]).toEqual(record)
+    expect(result[0]).toMatchObject(record)
+    expect(result[0]!.source_ids).toEqual([]) // no id on input record, so no source_ids collected
   })
 
   test('does not merge desktop and mobile spans for same activity', () => {

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -960,9 +960,11 @@ export async function queryActivities(
 
 /**
  * Productivity record with formatted timestamps.
+ * source_ids lists all original record IDs that were merged into this span.
  */
 export interface ProductivityResult {
   id?: string
+  source_ids?: string[]
   start_time: string
   end_time: string
   activity: string
@@ -974,25 +976,41 @@ export interface ProductivityResult {
 }
 
 /**
- * Maximum gap (ms) between spans that still counts as "consecutive".
- * RescueTime often has small gaps (e.g. end 06:39:59, next start 06:40:00).
- * 2 minutes covers these gaps without merging truly separate sessions.
+ * Maximum gap (ms) between spans of the same activity that are still merged.
+ * Applies both to directly consecutive spans and to spans separated by other
+ * activities (interleave merging). 2 minutes covers RescueTime rounding gaps
+ * and typical rapid window switches (e.g. terminal → browser → terminal).
  */
 const MERGE_GAP_MS = 2 * 60 * 1000
 
+/** Internal type that tracks source IDs through the merge pipeline. */
+type MergeRecord = ProductivityRecord & { source_ids: string[] }
+
 /**
- * Merge consecutive productivity spans for the same activity/is_mobile.
- * Two spans are merged when the gap between prev.end_time and current.start_time
- * is at most MERGE_GAP_MS and they share the same activity name and is_mobile flag.
+ * Merge productivity spans for the same activity/is_mobile, in two phases:
+ *
+ * Phase 1 — sequential: adjacent spans of the same activity within MERGE_GAP_MS
+ * are collapsed (handles RescueTime minute-boundary rounding).
+ *
+ * Phase 2 — interleave: spans of the same activity separated only by short
+ * bursts of other apps (total interleaved gap ≤ MERGE_GAP_MS) are merged into
+ * a single span. duration_sec accumulates only the actual time in that app;
+ * source_ids tracks all original record IDs that were consolidated.
+ *
+ * Records must arrive sorted by start_time (the DB query guarantees this).
  */
-export function mergeProductivitySpans(records: ProductivityRecord[]): ProductivityRecord[] {
+// eslint-disable-next-line complexity -- two-phase merge algorithm is inherently branchy
+export function mergeProductivitySpans(
+  records: ProductivityRecord[],
+): (ProductivityRecord & { source_ids: string[] })[] {
   if (records.length === 0) return []
 
-  const merged: ProductivityRecord[] = [{ ...records[0] }]
+  // --- Phase 1: sequential merge (same as before) ---
+  const phase1: MergeRecord[] = [{ ...records[0]!, source_ids: records[0]!.id ? [records[0]!.id] : [] }]
 
   for (let i = 1; i < records.length; i++) {
-    const current = records[i]
-    const prev = merged[merged.length - 1]
+    const current = records[i]!
+    const prev = phase1[phase1.length - 1]!
 
     const sameActivity = current.activity === prev.activity
     const sameMobile = (current.is_mobile ?? false) === (prev.is_mobile ?? false)
@@ -1002,12 +1020,48 @@ export function mergeProductivitySpans(records: ProductivityRecord[]): Productiv
     if (sameActivity && sameMobile && closeEnough) {
       prev.end_time = current.end_time
       prev.duration_sec += current.duration_sec
+      if (current.id) prev.source_ids.push(current.id)
     } else {
-      merged.push({ ...current })
+      phase1.push({ ...current, source_ids: current.id ? [current.id] : [] })
     }
   }
 
-  return merged
+  // --- Phase 2: interleave merge ---
+  // Walk forward; for each span check whether the most-recent span of the same
+  // activity ended within MERGE_GAP_MS. If so, extend that earlier span and
+  // drop the current one from the output.
+  const phase2: MergeRecord[] = []
+  // Maps "activity|is_mobile" → index in phase2 of the last span for that key
+  const lastIndexFor = new Map<string, number>()
+
+  for (const span of phase1) {
+    const key = `${span.activity}|${span.is_mobile ?? false}`
+    const prevIdx = lastIndexFor.get(key)
+
+    if (prevIdx !== undefined) {
+      const prev = phase2[prevIdx]!
+      const gap = span.start_time.getTime() - prev.end_time.getTime()
+
+      if (gap >= 0 && gap <= MERGE_GAP_MS) {
+        // Extend the earlier span; add this span's duration and source IDs
+        prev.end_time = span.end_time
+        prev.duration_sec += span.duration_sec
+        prev.source_ids.push(...span.source_ids)
+        // Update the index so future same-activity spans compare against the
+        // latest end_time (which is now in the same slot prevIdx)
+        lastIndexFor.set(key, prevIdx)
+        continue
+      }
+    }
+
+    // No mergeable predecessor — emit as a new span
+    lastIndexFor.set(key, phase2.length)
+    phase2.push({ ...span })
+  }
+
+  // Re-sort by start_time (interleave merging preserves the first-span position
+  // but later spans may slot earlier ones after others are skipped)
+  return phase2.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
 }
 
 /**
@@ -1027,19 +1081,29 @@ export async function queryProductivity(
 
   const productivity = await getProductivity(user, start, end)
   const merged = mergeProductivitySpans(productivity)
-  const prodIds = merged.map((p) => p.id).filter((id): id is string => id !== undefined)
-  const commentsMap = await getCommentsMap(user, 'productivity', prodIds)
-  return merged.map((p) => ({
-    activity: p.activity,
-    category: p.category,
-    comments: p.id ? (commentsMap.get(p.id) ?? []) : [],
-    duration_sec: p.duration_sec,
-    end_time: p.end_time.toISOString(),
-    id: p.id,
-    is_mobile: p.is_mobile,
-    productivity: p.productivity,
-    start_time: p.start_time.toISOString(),
-  }))
+  // Fetch comments for all source IDs so comments on any constituent record surface
+  const allIds = merged.flatMap((p) =>
+    p.source_ids.length > 0 ? p.source_ids
+    : p.id ? [p.id]
+    : [],
+  )
+  const commentsMap = await getCommentsMap(user, 'productivity', allIds)
+  return merged.map((p) => {
+    // Collect comments from all source IDs for this merged span
+    const comments = p.source_ids.flatMap((sid) => commentsMap.get(sid) ?? [])
+    return {
+      activity: p.activity,
+      category: p.category,
+      comments,
+      duration_sec: p.duration_sec,
+      end_time: p.end_time.toISOString(),
+      id: p.id,
+      is_mobile: p.is_mobile,
+      productivity: p.productivity,
+      source_ids: p.source_ids.length > 1 ? p.source_ids : undefined,
+      start_time: p.start_time.toISOString(),
+    }
+  })
 }
 
 /**

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -18,11 +18,15 @@ import {
   fetchActivityById,
   fetchCustomMetrics,
   fetchMetricTimeSeriesWithSource,
+  fetchProductivity,
   fetchTagById,
   type MetricDataPointWithSource,
+  type ProductivityRecord,
   restoreActivity,
+  restoreProductivity,
   restoreTag,
   softDeleteActivity,
+  softDeleteProductivity,
   softDeleteTag,
   SourceRecord,
   Tag,
@@ -287,9 +291,67 @@ const MetricDetail = ({ entityId }: { entityId: string }) => {
   )
 }
 
+const productivityScoreLabel = (score: number | undefined | null): string => {
+  switch (score) {
+    case 2:
+      return 'Very Productive'
+    case 1:
+      return 'Productive'
+    case 0:
+      return 'Neutral'
+    case -1:
+      return 'Distracting'
+    case -2:
+      return 'Very Distracting'
+    default:
+      return 'Uncategorized'
+  }
+}
+
+const ProductivityDetail = ({ record }: { record: ProductivityRecord }) => (
+  <div class="entity-info">
+    <div class="entity-meta">
+      <span class="entity-type-badge">screen time</span>
+      {record.is_mobile && <span class="entity-source">Mobile</span>}
+    </div>
+
+    <h2>{record.activity}</h2>
+
+    <div class="entity-fields">
+      <div class="field-row">
+        <span class="field-label">Time</span>
+        <span class="field-value">
+          {formatTime(record.start_time)} – {formatTime(record.end_time)}
+        </span>
+      </div>
+      <div class="field-row">
+        <span class="field-label">Duration</span>
+        <span class="field-value">{formatDuration(record.start_time, record.end_time)}</span>
+      </div>
+      {record.category && (
+        <div class="field-row">
+          <span class="field-label">Category</span>
+          <span class="field-value">{record.category}</span>
+        </div>
+      )}
+      <div class="field-row">
+        <span class="field-label">Productivity</span>
+        <span class="field-value">{productivityScoreLabel(record.productivity)}</span>
+      </div>
+      {record.source_ids && record.source_ids.length > 1 && (
+        <div class="field-row">
+          <span class="field-label">Merged spans</span>
+          <span class="field-value">{record.source_ids.length}</span>
+        </div>
+      )}
+    </div>
+  </div>
+)
+
 const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> => {
   if (entityType === 'activity') return softDeleteActivity(entityId)
   if (entityType === 'tag') return softDeleteTag(entityId)
+  if (entityType === 'productivity') return softDeleteProductivity(entityId)
   if (entityType === 'metric') {
     const parsed = parseMetricEntityId(entityId)
     if (!parsed) return Promise.reject(new Error('Invalid metric entity ID'))
@@ -301,6 +363,7 @@ const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> =
 const restoreEntity = (entityType: EntityType, entityId: string): Promise<void> => {
   if (entityType === 'activity') return restoreActivity(entityId)
   if (entityType === 'tag') return restoreTag(entityId)
+  if (entityType === 'productivity') return restoreProductivity(entityId)
   return Promise.reject(new Error('Unsupported entity type for restore'))
 }
 
@@ -436,6 +499,25 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     staleTime: 60_000,
   })
 
+  // Productivity: fetch a 1-second window around the record start_time to locate it.
+  // We use a broad 24h window keyed on the id; the matching record is found by id.
+  const productivityQuery = useQuery({
+    enabled: entityType === 'productivity',
+    queryFn: async () => {
+      // Fetch a full day's worth of data and find the record by id
+      const now = new Date()
+      const dayStart = new Date(now)
+      dayStart.setHours(0, 0, 0, 0)
+      const dayEnd = new Date(now)
+      dayEnd.setHours(23, 59, 59, 999)
+      // Try today first, then fall back to a wider 7-day window
+      const records = await fetchProductivity(new Date(Date.now() - 7 * 86400000), dayEnd)
+      return records.find((r) => r.id === entityId || r.source_ids?.includes(entityId)) ?? null
+    },
+    queryKey: ['entity-detail', 'productivity', entityId],
+    staleTime: 60_000,
+  })
+
   const invalidateEntity = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ['entity-detail', entityType, entityId] })
   }, [queryClient, entityType, entityId])
@@ -443,14 +525,17 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
   const isLoading =
     entityType === 'activity' ? activityQuery.isLoading
     : entityType === 'tag' ? tagQuery.isLoading
+    : entityType === 'productivity' ? productivityQuery.isLoading
     : false // metric detail handles its own loading
   const isError =
     entityType === 'activity' ? activityQuery.isError
     : entityType === 'tag' ? tagQuery.isError
+    : entityType === 'productivity' ? productivityQuery.isError
     : false
 
   const activity = activityQuery.data
   const tag = tagQuery.data
+  const productivityRecord = productivityQuery.data
 
   const isDeleted =
     entityType === 'activity' ? Boolean(activity?.deleted_at)
@@ -511,10 +596,10 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
     saveMutation.mutate()
   }, [saveMutation])
 
-  // Collect all entity IDs for notes (primary + source records for merged activities)
+  // Collect all entity IDs for notes (primary + source records for merged activities/productivity)
   const allEntityIds =
-    entityType === 'activity' && activity?.source_records ?
-      activity.source_records.map((r) => r.id)
+    entityType === 'activity' && activity?.source_records ? activity.source_records.map((r) => r.id)
+    : entityType === 'productivity' && productivityRecord?.source_ids ? productivityRecord.source_ids
     : undefined
 
   if (isLoading) return <p class="loading">Loading…</p>
@@ -548,6 +633,9 @@ const EntityContent = ({ entityType, entityId }: { entityType: EntityType; entit
         />
       )}
       {entityType === 'tag' && tag && <TagDetail tag={tag} />}
+      {entityType === 'productivity' && productivityRecord && (
+        <ProductivityDetail record={productivityRecord} />
+      )}
       {entityType === 'metric' && <MetricDetail entityId={entityId} />}
 
       <NotesSection entityType={entityType} entityId={rawEntityId} allEntityIds={allEntityIds} />

--- a/packages/api-spec/src/schemas/productivity.ts
+++ b/packages/api-spec/src/schemas/productivity.ts
@@ -24,6 +24,10 @@ export const productivityRecordSchema = z
     end_time: iso8601DateTimeSchema,
     id: z.string().uuid().optional().meta({ description: 'Productivity record ID' }),
     is_mobile: z.boolean().optional().meta({ description: 'Whether activity was on mobile' }),
+    source_ids: z
+      .array(z.string().uuid())
+      .optional()
+      .meta({ description: 'IDs of all constituent records when spans were merged' }),
     productivity: z.number().int().optional().meta({
       description: 'Productivity score (-2 to 2)',
       example: 2,


### PR DESCRIPTION
## Problem

ActivityWatch tracks every window-focus switch at sub-second granularity, so a session at the terminal alternating with the browser produces dozens of records like:

```
06:00:01–06:04:18  Alacritty (257s)
06:04:18–06:04:22  firefox   (3s)     ← 3-second focus switch
06:04:23–06:04:34  Alacritty (11s)
06:04:35–06:04:42  firefox   (7s)
06:04:43–06:04:43  Alacritty (0s)     ← zero-duration blip
...
```

The existing `mergeProductivitySpans` only merged **strictly consecutive** same-activity spans. `Alacritty → firefox → Alacritty` stayed as 3 items because the two Alacritty spans weren't adjacent.

Verified with MCP: the first hour of today's data had ~110 records where Alacritty/firefox/Emacs rapidly alternated every 3–30 seconds.

## Changes

### Backend — `mergeProductivitySpans` (two-phase algorithm)

**Phase 1** (unchanged): sequential merge of adjacent same-activity spans within 2-minute gap (handles RescueTime minute-boundary rounding).

**Phase 2** (new): interleave merge — for each span, check whether the most-recent span of the same app ended within `MERGE_GAP_MS` (2 min). If so, extend that earlier span regardless of what apps appear in between. `duration_sec` accumulates only actual time in that app (not the interleaved time). `source_ids` tracks all original record IDs in the merged span.

### api-spec

Add optional `source_ids: string[]` to `ProductivityRecord` schema. Regenerate OpenAPI YAML/JSON and Kotlin models.

### `queryProductivity`

Collect comments from all `source_ids` so a comment attached to any constituent record surfaces on the merged span.

### Tests

New test cases based on real MCP data:
- Rapid Alacritty/firefox interleaving (3–30s spans) → all Alacritty merge, all firefox merge
- Zero-duration blip records absorbed into surrounding span
- Same-app spans separated by >2 min gap remain separate
- Updated existing tests to assert `source_ids`

### Frontend — EntityDetail

- `ProductivityDetail` component: shows activity, time range, duration, category, productivity score, and merged-span count
- `deleteEntity` / `restoreEntity` now handle `'productivity'` (endpoints already existed)
- `allEntityIds` passes `source_ids` to `NotesSection` so comments on any source record are displayed