### PR TITLE
fix: include nap in default activity types and DayView fetch

### DIFF
--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -48,7 +48,7 @@ export const createActivitiesRouter = (
       const { start, end, types: typesParam } = req.query
       const user = req.user!
 
-      const types = (typesParam?.split(',') || ['sleep', 'exercise', 'meditation']) as (
+      const types = (typesParam?.split(',') || ['sleep', 'exercise', 'meditation', 'nap']) as (
         | 'sleep'
         | 'exercise'
         | 'meditation'

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -514,7 +514,13 @@ export const DayView = () => {
 
   const activitiesQuery = useQuery({
     placeholderData: keepPreviousData,
-    queryFn: () => fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
+    queryFn: () =>
+      fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), [
+        'sleep',
+        'exercise',
+        'meditation',
+        'nap',
+      ]),
     queryKey: ['dayview-activities', fromDate.value, toDate.value],
     staleTime: 5 * 60 * 1000,
   })


### PR DESCRIPTION
## Problem

Nap activities were not shown in the Day View timeline even when the Nap toggle was enabled.

## Root Cause

Two gaps combined to cause the issue:

1. **Backend default** (`apps/backend/src/routes/activities-router.ts`): When `GET /activities` is called without a `types` parameter, the default list was `['sleep', 'exercise', 'meditation']` — `'nap'` was missing.

2. **Frontend DayView** (`apps/web/src/pages/DayView/index.tsx`): The `fetchActivities` call did not pass a `types` argument, so it relied entirely on the backend default — which excluded naps.

## Fix

- Added `'nap'` to the backend default types list.
- Explicitly pass all four activity types (`sleep`, `exercise`, `meditation`, `nap`) in the DayView query for clarity and resilience against future backend default changes.