### PR TITLE
Fix metric comment lost when adding metric+comment together

### DIFF
--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -357,7 +357,7 @@ const AddMetricForm = ({ onCreated }: FormProps) => {
       if (comment.trim() && result.success) {
         // Backend returns stored time; fall back to the submitted time
         const storedTime = (result as unknown as { time?: string }).time ?? metricTimeISO
-        const entityId = `${storedTime}|${metric}|manual`
+        const entityId = `${storedTime}|${metric}|aurboda`
         try {
           await addNote('metric', entityId, comment.trim())
         } catch {


### PR DESCRIPTION
## Summary
- The AddMetricForm constructed the note entity_id with source `manual`, but `addMetric` stores metrics with source `aurboda`
- This caused notes/comments to be saved with a mismatched entity_id, making them orphaned — they could never be found when looking up notes for the metric
- One-line fix: changed `manual` to `aurboda` in the entity_id construction

## Test plan
- [ ] Add a metric with a comment in the web UI
- [ ] Verify the comment appears on the metric detail page
- [ ] Verify the comment appears in the DayView

🤖 Generated with [Claude Code](https://claude.com/claude-code)