### PR TITLE
feat: persist DayView state in URL hash, remove Back button, navigate to metric detail

### DIFF
--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -78,6 +78,7 @@ export interface AddMetricResult {
   value: number
   unit: string
   time: string
+  entity_id?: string
 }
 
 export interface DeleteTagResult {
@@ -304,10 +305,12 @@ export async function addMetric(user: string, input: AddMetricInput): Promise<Ad
     console.error('Failed to enqueue outbound sync for metric:', err)
   }
 
+  const storedTime = input.time.toISOString()
   return {
+    entity_id: `${storedTime}|${input.metric}|aurboda`,
     metric: input.metric,
     success: true,
-    time: input.time.toISOString(),
+    time: storedTime,
     unit: unit ?? '',
     value: input.value,
   }

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -354,12 +354,9 @@ const AddMetricForm = ({ onCreated }: FormProps) => {
         time: metricTimeISO,
         value: parseFloat(value),
       })
-      if (comment.trim() && result.success) {
-        // Backend returns stored time; fall back to the submitted time
-        const storedTime = (result as unknown as { time?: string }).time ?? metricTimeISO
-        const entityId = `${storedTime}|${metric}|aurboda`
+      if (comment.trim() && result.success && result.entity_id) {
         try {
-          await addNote('metric', entityId, comment.trim())
+          await addNote('metric', result.entity_id, comment.trim())
         } catch {
           // Metric was recorded successfully; comment save failed silently
         }
@@ -370,8 +367,8 @@ const AddMetricForm = ({ onCreated }: FormProps) => {
       setError(err.message)
       setSuccess('')
     },
-    onSuccess: () => {
-      if (onCreated('metric', undefined)) return
+    onSuccess: (result) => {
+      if (onCreated('metric', result.entity_id)) return
       setSuccess(`Metric "${metric}" recorded`)
       setError('')
       setValue('')
@@ -459,8 +456,7 @@ export const AddData = () => {
   const handleCreated = useCallback(
     (entityType: string, entityId: string | undefined): boolean => {
       if (addMore) return false
-      if (entityType === 'metric' || !entityId) {
-        // No detail page for metrics; navigate to day view instead
+      if (!entityId) {
         route('/day')
         return true
       }

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- large visualization component */
 import { metricUnits as builtinMetricUnits } from '@aurboda/api-spec'
-import { signal } from '@preact/signals'
+import { signal, useSignalEffect } from '@preact/signals'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import * as d3 from 'd3'
 import { addDays, endOfDay, format, formatISO, startOfDay, subDays } from 'date-fns'
@@ -38,6 +38,54 @@ const viewEnd = signal<Date | null>(null)
 // Default view: start of today to end of today
 const getDefaultViewStart = () => startOfDay(new Date())
 const getDefaultViewEnd = () => endOfDay(new Date())
+
+// ── URL hash helpers ──────────────────────────────────────────────────────────
+// Hash format: #from=2026-02-27T06:00&to=2026-02-27T18:00&hide=sleep,music
+// The router (preact-iso) completely ignores hash fragments, so replaceState
+// with a hash update never triggers a re-render or route change.
+
+/** Parse window.location.hash into view state. */
+const parseViewHash = (): { from: Date | null; to: Date | null; hide: LegendCategory[] } => {
+  const hash = window.location.hash.slice(1) // remove leading '#'
+  if (!hash) return { from: null, hide: [], to: null }
+  const params = new URLSearchParams(hash)
+  const fromStr = params.get('from')
+  const toStr = params.get('to')
+  const hideStr = params.get('hide')
+  const from = fromStr ? new Date(fromStr) : null
+  const to = toStr ? new Date(toStr) : null
+  const hide = hideStr ? (hideStr.split(',').filter(Boolean) as LegendCategory[]) : []
+  return {
+    from: from && !isNaN(from.getTime()) ? from : null,
+    hide,
+    to: to && !isNaN(to.getTime()) ? to : null,
+  }
+}
+
+/** Build hash string from current view state. Returns '' if everything is default (today). */
+const buildViewHash = (start: Date | null, end: Date | null, hidden: ReadonlySet<string>): string => {
+  const params = new URLSearchParams()
+  if (start) params.set('from', start.toISOString())
+  if (end) params.set('to', end.toISOString())
+  if (hidden.size > 0) params.set('hide', [...hidden].join(','))
+  const str = params.toString()
+  return str ? `#${str}` : ''
+}
+
+// Initialise signals from hash on page load (runs once when module is first loaded).
+// Because these are module-level signals they persist across SPA navigations.
+const _initialHash = parseViewHash()
+if (_initialHash.from) {
+  viewStart.value = _initialHash.from
+  viewEnd.value = _initialHash.to
+  // Expand fetch range to cover the hashed viewport
+  const fetchFrom = _initialHash.from
+  const fetchTo = _initialHash.to ?? _initialHash.from
+  fromDate.value = formatISO(subDays(fetchFrom, 1), { representation: 'date' })
+  const todayStr = formatISO(new Date(), { representation: 'date' })
+  const expandedTo = formatISO(addDays(fetchTo, 1), { representation: 'date' })
+  toDate.value = expandedTo > todayStr ? todayStr : expandedTo
+}
 
 // Column definitions
 const BASE_COLUMNS: Column[] = ['Sleep / Rest', 'Exercise', 'Location', 'Tags / Events', 'Screen Time']
@@ -680,7 +728,25 @@ export const DayView = () => {
     toDate.value = formatISO(new Date(), { representation: 'date' })
   }, [])
 
-  const [hiddenCategories, setHiddenCategories] = useState<Set<LegendCategory>>(new Set())
+  const [hiddenCategories, setHiddenCategories] = useState<Set<LegendCategory>>(
+    () => new Set(_initialHash.hide),
+  )
+
+  // Keep a ref so useSignalEffect can read the latest hiddenCategories without re-subscribing
+  const hiddenCategoriesRef = useRef<Set<LegendCategory>>(hiddenCategories)
+  hiddenCategoriesRef.current = hiddenCategories
+
+  // Sync view state → URL hash whenever viewStart or viewEnd signals change
+  useSignalEffect(() => {
+    const hash = buildViewHash(viewStart.value, viewEnd.value, hiddenCategoriesRef.current)
+    history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
+  })
+
+  // Also sync when hiddenCategories changes (toggling legend items)
+  useEffect(() => {
+    const hash = buildViewHash(viewStart.value, viewEnd.value, hiddenCategories)
+    history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
+  }, [hiddenCategories])
 
   const toggleCategory = useCallback((cat: LegendCategory) => {
     setHiddenCategories((prev) => {

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -660,11 +660,6 @@ export const EntityDetail = () => {
 
   return (
     <div class="entity-detail-page">
-      <div class="entity-detail-header">
-        <button type="button" class="back-link back-link-btn" onClick={() => history.back()}>
-          Back
-        </button>
-      </div>
       <EntityContent entityType={entityType} entityId={entityId} />
     </div>
   )

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -5,29 +5,6 @@
   padding: 2rem;
 }
 
-.entity-detail-header {
-  margin-bottom: 1.5rem;
-}
-
-.back-link {
-  color: #673ab8;
-  text-decoration: none;
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-
-.back-link:hover {
-  text-decoration: underline;
-}
-
-.back-link-btn {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  font: inherit;
-}
-
 /* Deleted banner */
 .deleted-banner {
   display: flex;
@@ -665,10 +642,6 @@
 
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
-  .back-link {
-    color: #a78bfa;
-  }
-
   .deleted-banner {
     background: #450a0a;
     border-color: #7f1d1d;

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -90,7 +90,13 @@ export type AddMetricBody = z.infer<typeof addMetricBodySchema>
 /**
  * Add metric response.
  */
-export const addMetricResponseSchema = baseResponseSchema.meta({ id: 'AddMetricResponse' })
+export const addMetricResponseSchema = baseResponseSchema
+  .extend({
+    entity_id: z.string().optional().meta({
+      description: 'Composite entity ID for the created metric point (format: time|metric|source)',
+    }),
+  })
+  .meta({ id: 'AddMetricResponse' })
 
 export type AddMetricResponse = z.infer<typeof addMetricResponseSchema>
 


### PR DESCRIPTION
## Summary

- **DayView URL hash state**: Viewport position (`from`/`to`) and hidden legend categories (`hide`) are now encoded in the URL hash fragment (e.g. `/day#from=...&to=...&hide=sleep,music`). Uses `history.replaceState` so it never triggers a router re-render. Parsed on module load to restore the same view when navigating back from a detail page. All navigation buttons (`<<`, `<`, Today, `>`, `>>`) and D3 zoom/pan update the hash automatically since they all go through `handleZoom`/`handleResetToToday`. Category toggles are synced via a `useEffect`.

- **Remove Back button from EntityDetail**: The Back button was redundant — browser/OS/gesture back navigation works perfectly now that DayView state is in the URL. Removed button and associated CSS.

- **Metric post-add navigation**: Backend `addMetric` now returns `entity_id` in the response (format: `time|metric|aurboda`). Frontend `AddMetricForm` uses this to navigate to `/detail/metric/{entity_id}` when "Add more" is off — consistent with how activities and tags work. Also fixes metric comment notes to use the server-returned `entity_id` instead of a client-composed string.