### PR TITLE
fix: include source field in productivity response + docs update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,23 @@
 ## Repository structure
 
-See README.md for general setup.  Specific docs in docs/ directory.
+See README.md for general setup. Specific docs in docs/ directory.
 
-* Backend API and MCP: apps/backend (typescript)
-* Frontend Web: apps/web (typescript)
-* Android App: apps/android (kotlin)
-* Shared typing and OpenAPI spec: packages/api-spec (typescript and generated yaml/kotlin)
-* Database: PostgreSQL
-
+- Backend API and MCP: apps/backend (typescript)
+- Frontend Web: apps/web (typescript)
+- Android App: apps/android (kotlin)
+- Shared typing and OpenAPI spec: packages/api-spec (typescript and generated yaml/kotlin)
+- Database: PostgreSQL
 
 ## API and MCP Parity
 
 The REST API and MCP tools should have the same capabilities:
 
-* Every MCP tool should have a corresponding REST API endpoint
-* REST API follows RESTful conventions (GET for queries, POST for mutations, etc.)
-* Shared business logic lives in `apps/backend/src/services/` and is used by both API and MCP
-* Type definitions and schemas live in `packages/api-spec/`
+- Every MCP tool should have a corresponding REST API endpoint
+- REST API follows RESTful conventions (GET for queries, POST for mutations, etc.)
+- Shared business logic lives in `apps/backend/src/services/` and is used by both API and MCP
+- Type definitions and schemas live in `packages/api-spec/`
 
 When adding new features, implement both the MCP tool and REST API endpoint.
-
 
 ## Shared Schemas and Types (`packages/api-spec`)
 
@@ -38,6 +36,7 @@ All field names use **snake_case** everywhere: schemas, REST API, MCP tools, DB 
 ### How each layer uses api-spec
 
 **REST API routers** (`apps/backend/src/routes/`) — import schemas for request validation:
+
 ```typescript
 import { addTagBodySchema, type AddTagBody } from '@aurboda/api-spec'
 // Use with validation middleware:
@@ -45,19 +44,24 @@ router.post('/', authMiddleware, validateBody(addTagBodySchema), async (req, res
 ```
 
 **MCP tools** (`apps/backend/src/mcp/`) — use `.shape` to extract the flat field record that `server.tool()` expects:
+
 ```typescript
 import { addTagBodySchema } from '@aurboda/api-spec'
 server.tool('add_tag', 'Description', { ...addTagBodySchema.shape }, async (params) => { ... })
 // To add extra fields: { id: z.string().uuid(), ...updateBodySchema.shape }
 // To override a field: { ...bodySchema.shape, field: z.string().optional() }
 ```
+
 Keep simple 1-field tools (delete by id) inline — import overhead exceeds duplication savings.
 
 **Web frontend** (`apps/web/src/`) — import types only (no runtime schemas):
+
 ```typescript
 import type { Tag, TagsQuery, TagsResponse } from '@aurboda/api-spec'
 ```
+
 The frontend extends API types where Date objects are needed (API uses ISO strings):
+
 ```typescript
 export interface Tag extends Omit<ApiTag, 'start_time' | 'end_time'> {
   start_time: Date
@@ -66,6 +70,7 @@ export interface Tag extends Omit<ApiTag, 'start_time' | 'end_time'> {
 ```
 
 **Android app** (`apps/android/`) — uses generated Kotlin models from OpenAPI:
+
 ```kotlin
 // Generated at packages/api-spec/generated/kotlin/src/main/kotlin/net/aurboda/api/models/
 @Serializable
@@ -76,9 +81,11 @@ data class Tag(
 ```
 
 **DB layer** (`apps/backend/src/db/`) — imports types for type safety, not schemas:
+
 ```typescript
 import type { ActivityType, MetricType, DataSource } from '@aurboda/api-spec'
 ```
+
 Row mappers in `db/row-mappers.ts` use type guards with api-spec constants (e.g. `activityTypes`).
 
 **Services** (`apps/backend/src/services/`) — import types for function signatures. Services contain the shared business logic used by both REST API and MCP.
@@ -92,42 +99,37 @@ Row mappers in `db/row-mappers.ts` use type guards with api-spec constants (e.g.
 5. Regenerate: `cd packages/api-spec && pnpm generate` (updates OpenAPI YAML/JSON, TypeScript types, and Kotlin models).
 6. Use the generated Kotlin models in the Android app.
 
-
 ## Work flow
 
-* NEVER alter already pushed commits.  No amend if the commit is pushed.  No force push.
-* Always make a PR of suggested changes.
-
+- NEVER alter already pushed commits. No amend if the commit is pushed. No force push.
+- Always make a PR of suggested changes.
 
 ## Code style
 
-* Prefer code that is testable without heavy mocking.
-* Prefer functional style, no classes.
-
+- Prefer code that is testable without heavy mocking.
+- Prefer functional style, no classes.
 
 ## Testing
 
-* Make unit test first (when reasonable), prompting a more testable code with clear dependency injection.
-* Backend should be well covered with tests.
-* All database functions in `apps/backend/src/db.ts` must have integration tests in `db.integration.test.ts`.
-* Integration tests use testcontainers to run against a real PostgreSQL instance.
-
+- Make unit test first (when reasonable), prompting a more testable code with clear dependency injection.
+- Backend should be well covered with tests.
+- All database functions in `apps/backend/src/db.ts` must have integration tests in `db.integration.test.ts`.
+- Integration tests use testcontainers to run against a real PostgreSQL instance.
 
 For typescript:
 
-* `pnpm fix` to make code prettier and handle linting rules
-* `pnpm check` to check typescript etc
-
+- `pnpm fix` to make code prettier and handle linting rules
+- `pnpm check` to check typescript etc
+- Nothing is merged to `develop` without passing CI checks. If you see errors after merging from `origin/develop`, dependencies need to be reinstalled and packages rebuilt — do NOT assume they are pre-existing.
 
 ## Documentation
 
-* Keep documentation in `docs/` up to date when changing related code.
-* When adding or modifying a data source, update `docs/data-sources.md` and the relevant per-source doc (e.g., `docs/oura.md`).
-* When changing APIs, sync behavior, admin/user setup, or data models, update the corresponding docs to reflect the new behavior.
-* Documentation should stay well structured: the overview page (`docs/data-sources.md`) links to per-topic docs, each covering what data is synced, admin setup, user setup, and how sync works.
-
+- Keep documentation in `docs/` up to date when changing related code.
+- When adding or modifying a data source, update `docs/data-sources.md` and the relevant per-source doc (e.g., `docs/oura.md`).
+- When changing APIs, sync behavior, admin/user setup, or data models, update the corresponding docs to reflect the new behavior.
+- Documentation should stay well structured: the overview page (`docs/data-sources.md`) links to per-topic docs, each covering what data is synced, admin setup, user setup, and how sync works.
 
 ## Deployment
 
-* aurboda-backend is automatically deployed to https://aurboda.net/api on merge to `develop`.
-* aurboda-web is automatically deployed to https://aurboda.net/ on merge to `develop`.
+- aurboda-backend is automatically deployed to https://aurboda.net/api on merge to `develop`.
+- aurboda-web is automatically deployed to https://aurboda.net/ on merge to `develop`.

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -972,6 +972,7 @@ export interface ProductivityResult {
   productivity?: number
   duration_sec: number
   is_mobile?: boolean
+  source?: DataSource
   comments: CommentSummary[]
 }
 
@@ -1100,6 +1101,7 @@ export async function queryProductivity(
       id: p.id,
       is_mobile: p.is_mobile,
       productivity: p.productivity,
+      source: p.source,
       source_ids: p.source_ids.length > 1 ? p.source_ids : undefined,
       start_time: p.start_time.toISOString(),
     }


### PR DESCRIPTION
## Summary

- **Bug fix**: The `queryProductivity` response was missing the `source` field, so the Help page couldn't distinguish ActivityWatch from RescueTime records for the desktop/mobile card split
- **Docs**: Added note to AGENTS.md that errors after merging from develop require `pnpm install` + rebuild, not assuming pre-existing