### PR TITLE
fix: save emoji immediately when clicking suggestion in tag mapper

### DIFF
--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -87,10 +87,22 @@ function TagMappingRow({
     }
   }
 
-  const handleAcceptSuggestion = () => {
-    if (suggestedEmoji) {
+  const handleAcceptSuggestion = async () => {
+    if (!suggestedEmoji) return
+
+    const name = (localValue ?? tag.current_name ?? '').trim()
+    if (!name) return
+
+    setSuggestedEmoji(undefined)
+    setStatus('saving')
+    try {
+      await onSave(tag.tag_key, name, suggestedEmoji)
+      setLocalValue(undefined)
+      setLocalIcon(undefined)
+      setStatus('saved')
+    } catch {
       setLocalIcon(suggestedEmoji)
-      setSuggestedEmoji(undefined)
+      setStatus('error')
     }
   }
 


### PR DESCRIPTION
## Summary

- Clicking a suggested emoji in the tag mapper settings only set local state but never saved to the backend
- The save-on-blur pattern requires focusing and leaving an input field, which doesn't happen when clicking a button
- Now the suggestion click saves directly to the backend, with proper loading/error states