### PR TITLE
feat: improve DayView tag icons - stack, sort, and show on duration tags

### DIFF
--- a/apps/backend/src/lastfm-sync.test.ts
+++ b/apps/backend/src/lastfm-sync.test.ts
@@ -329,8 +329,9 @@ describe('applyTagRules', () => {
 
     expect(tagsCreated).toBe(1)
     expect(insertTag).toHaveBeenCalledTimes(1)
+    // End time is the last scrobble (10:08) + merge_gap_seconds (10min) = 10:18.
     expect(insertTag).toHaveBeenCalledWith('testuser', {
-      end_time: new Date('2024-01-01T10:08:00Z'),
+      end_time: new Date('2024-01-01T10:18:00Z'),
       external_id: expect.stringMatching(/^lastfm-session-rule-1-/),
       source: 'lastfm-auto',
       start_time: new Date('2024-01-01T10:00:00Z'),
@@ -398,18 +399,18 @@ describe('applyTagRules', () => {
     expect(tagsCreated).toBe(2)
     expect(insertTag).toHaveBeenCalledTimes(2)
 
-    // First session: Jan 9
+    // First session: Jan 9 (11:00–11:04) + merge_gap 10min = 11:14.
     expect(insertTag).toHaveBeenCalledWith('testuser', {
-      end_time: new Date('2024-01-09T11:04:00Z'),
+      end_time: new Date('2024-01-09T11:14:00Z'),
       external_id: expect.stringContaining('rule-1'),
       source: 'lastfm-auto',
       start_time: new Date('2024-01-09T11:00:00Z'),
       tag: 'VocalExercise',
     })
 
-    // Second session: Jan 17
+    // Second session: Jan 17 (10:00–10:08) + merge_gap 10min = 10:18.
     expect(insertTag).toHaveBeenCalledWith('testuser', {
-      end_time: new Date('2024-01-17T10:08:00Z'),
+      end_time: new Date('2024-01-17T10:18:00Z'),
       external_id: expect.stringContaining('rule-1'),
       source: 'lastfm-auto',
       start_time: new Date('2024-01-17T10:00:00Z'),
@@ -448,13 +449,48 @@ describe('applyTagRules', () => {
 
     const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
 
+    // End extended by merge_gap_seconds: 10:06 + 10min = 10:16.
     expect(tagsCreated).toBe(1)
     expect(updateTagEndTime).toHaveBeenCalledWith(
       'testuser',
       'lastfm-session-rule-1-existing',
-      new Date('2024-01-01T10:06:00Z'),
+      new Date('2024-01-01T10:16:00Z'),
     )
     expect(insertTag).not.toHaveBeenCalled()
+  })
+
+  it('extends single-scrobble session by merge_gap_seconds', async () => {
+    vi.mocked(findMergeableTag).mockResolvedValue(undefined)
+
+    // Single matching scrobble — merge_gap_seconds used as duration estimate
+    const scrobbles: Scrobble[] = [
+      { artist: 'Holosync', timestamp: new Date('2024-01-01T14:36:00Z'), track: 'Dive' },
+    ]
+
+    const rules: LastFmTagRule[] = [
+      {
+        artist_name: 'Holosync',
+        created_at: new Date(),
+        id: 'rule-1',
+        match_mode: 'exact',
+        match_type: 'artist',
+        merge_gap_seconds: 1860, // 31 minutes
+        rule_name: 'Holosync',
+        tag_name: 'Holosync',
+      },
+    ]
+
+    const tagsCreated = await applyTagRules('testuser', scrobbles, rules)
+
+    expect(tagsCreated).toBe(1)
+    expect(insertTag).toHaveBeenCalledWith('testuser', {
+      // End = 14:36 + 31min = 15:07
+      end_time: new Date('2024-01-01T15:07:00Z'),
+      external_id: expect.stringMatching(/^lastfm-session-rule-1-/),
+      source: 'lastfm-auto',
+      start_time: new Date('2024-01-01T14:36:00Z'),
+      tag: 'Holosync',
+    })
   })
 
   it('handles mix of point-in-time and session rules', async () => {

--- a/apps/backend/src/lastfm-sync.ts
+++ b/apps/backend/src/lastfm-sync.ts
@@ -133,6 +133,11 @@ interface ScrobbleEvent extends TimestampedEvent {
 /**
  * Apply session rules (rules with mergeGapSeconds) to scrobbles.
  * Groups matching scrobbles into sessions and creates span tags.
+ *
+ * The session end time is extended by merge_gap_seconds to account for the
+ * last track's duration, so that a single-scrobble session (e.g. a 30-minute
+ * meditation track with merge_gap_seconds=1860) gets a meaningful span rather
+ * than start_time === end_time.
  */
 const applySessionRules = async (
   user: string,
@@ -155,6 +160,11 @@ const applySessionRules = async (
     for (let i = 0; i < sessions.length; i++) {
       const session = sessions[i]
 
+      // Extend session end by merge_gap_seconds to account for last track duration.
+      // The merge gap is configured per-rule and represents the expected track/session
+      // length, so it serves as a reasonable duration estimate.
+      const sessionEnd = new Date(session.endTime.getTime() + gapMs)
+
       // For the first session, try cross-sync merging
       if (i === 0) {
         const existingTag = await findMergeableTag(
@@ -166,7 +176,7 @@ const applySessionRules = async (
         )
 
         if (existingTag) {
-          await updateTagEndTime(user, existingTag.external_id!, session.endTime)
+          await updateTagEndTime(user, existingTag.external_id!, sessionEnd)
           tagsCreated++
           continue
         }
@@ -174,7 +184,7 @@ const applySessionRules = async (
 
       const externalId = `lastfm-session-${rule.id}-${session.startTime.getTime()}`
       await insertTag(user, {
-        end_time: session.endTime,
+        end_time: sessionEnd,
         external_id: externalId,
         source: 'lastfm-auto',
         start_time: session.startTime,

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -1486,6 +1486,50 @@ const mergeSmallItems = (
   return result
 }
 
+/**
+ * Stack icon-bearing point items vertically instead of spreading across sub-lanes.
+ * Groups items at the same start time that have icons, forces them to lane 0,
+ * and assigns a vertical pixel offset so they sit below each other.
+ * Non-icon items and duration items keep their original lanes.
+ */
+const stackIconPoints = (
+  items: { item: ChartItem; lane: number }[],
+): { item: ChartItem; lane: number; yOffset: number }[] => {
+  // Separate icon points from everything else
+  const iconPoints = items.filter((p) => p.item.isPoint && p.item.icon)
+  if (iconPoints.length <= 1) return items.map((p) => ({ ...p, yOffset: 0 }))
+
+  // Group icon points by start time
+  const byTime = new Map<number, { item: ChartItem; lane: number }[]>()
+  for (const p of iconPoints) {
+    const t = p.item.start.getTime()
+    const group = byTime.get(t) ?? []
+    group.push(p)
+    byTime.set(t, group)
+  }
+
+  // Build a set of items that are stacked (have siblings at the same time)
+  const stackedSet = new Set<ChartItem>()
+  const offsetMap = new Map<ChartItem, number>()
+  const ICON_STEP = 18 // vertical spacing between stacked icons
+
+  for (const group of byTime.values()) {
+    // Sort by label for consistent ordering
+    group.sort((a, b) => a.item.label.localeCompare(b.item.label))
+    for (let i = 0; i < group.length; i++) {
+      stackedSet.add(group[i]!.item)
+      offsetMap.set(group[i]!.item, i * ICON_STEP)
+    }
+  }
+
+  return items.map((p) => {
+    if (stackedSet.has(p.item)) {
+      return { item: p.item, lane: 0, yOffset: offsetMap.get(p.item) ?? 0 }
+    }
+    return { ...p, yOffset: 0 }
+  })
+}
+
 const drawColumnItems = (
   chartGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
   columnData: ColumnDataEntry[],
@@ -1503,16 +1547,37 @@ const drawColumnItems = (
     const mergedItems = mergeSmallItems(packedItems, yScale)
     const hasMerged = mergedItems.some((m) => m.item.label.endsWith(' items'))
 
+    // Stack icon points vertically instead of sub-lanes
+    const stackedItems = stackIconPoints(mergedItems)
+
     const colX = colIdx * colWidth + colGap
     const usableWidth = colWidth - colGap * 2
+
+    // Determine effective lane count: icon-stacked items don't need extra lanes
+    const hasStacked = stackedItems.some((s) => s.yOffset > 0)
+    const nonStackedLanes =
+      hasStacked ?
+        Math.max(1, ...stackedItems.filter((s) => s.yOffset === 0 && !s.item.isPoint).map((s) => s.lane + 1))
+      : laneCount
     // If merging happened, use full column width for merged blocks
-    const effectiveLanes = hasMerged ? 1 : Math.max(laneCount, 1)
+    const effectiveLanes = hasMerged ? 1 : Math.max(nonStackedLanes, 1)
     const lanes = effectiveLanes
     const laneWidth = (usableWidth - (lanes - 1) * colPadding) / lanes
 
-    for (const { item, lane } of mergedItems) {
+    for (const { item, lane, yOffset } of stackedItems) {
       const effectiveLane = hasMerged ? 0 : lane
-      drawItem(chartGroup, item, effectiveLane, colX, laneWidth, colPadding, yScale, showTooltip, hideTooltip)
+      drawItem(
+        chartGroup,
+        item,
+        effectiveLane,
+        colX,
+        laneWidth,
+        colPadding,
+        yScale,
+        showTooltip,
+        hideTooltip,
+        yOffset,
+      )
     }
   }
 }
@@ -1527,9 +1592,10 @@ const drawItem = (
   yScale: d3.ScaleTime<number, number>,
   showTooltip: (event: MouseEvent, item: ChartItem) => void,
   hideTooltip: () => void,
+  yOffset = 0,
 ) => {
-  const y1 = yScale(item.start)
-  const y2 = yScale(item.end)
+  const y1 = yScale(item.start) + yOffset
+  const y2 = yScale(item.end) + yOffset
   const x = colX + lane * (laneWidth + colPadding)
   const blockHeight = Math.max(y2 - y1, 2)
 
@@ -1629,8 +1695,30 @@ const drawItem = (
       hideTooltip()
     })
 
-  // Text label inside if tall enough
-  if (blockHeight > 30) {
+  // Icon overlay for duration blocks
+  if (item.icon && isEmoji(item.icon)) {
+    const emojiSize = 14
+    parent
+      .append('text')
+      .attr('x', x + laneWidth / 2)
+      .attr('y', y1 + blockHeight / 2)
+      .attr('dy', '0.35em')
+      .attr('text-anchor', 'middle')
+      .attr('font-size', `${emojiSize}px`)
+      .attr('pointer-events', 'none')
+      .text(item.icon)
+  } else if (item.icon && isUrl(item.icon)) {
+    const imgSize = 14
+    parent
+      .append('image')
+      .attr('href', item.icon)
+      .attr('x', x + laneWidth / 2 - imgSize / 2)
+      .attr('y', y1 + blockHeight / 2 - imgSize / 2)
+      .attr('width', imgSize)
+      .attr('height', imgSize)
+      .attr('pointer-events', 'none')
+  } else if (blockHeight > 30) {
+    // Text label inside if tall enough (only when no icon)
     const fontSize = laneWidth > 100 ? '0.8rem' : '0.65rem'
     const charWidth = laneWidth > 100 ? 7.5 : 6
     const maxChars = Math.floor(laneWidth / charWidth)

--- a/apps/web/src/pages/DayView/index.tsx
+++ b/apps/web/src/pages/DayView/index.tsx
@@ -1457,8 +1457,9 @@ const mergeSmallItems = (
 
   for (const packed of sorted) {
     const h = Math.abs(yScale(packed.item.end) - yScale(packed.item.start))
-    if (h >= MIN_ITEM_HEIGHT) {
-      // Large item: flush pending cluster then add as-is
+    if (h >= MIN_ITEM_HEIGHT || (packed.item.isPoint && packed.item.icon)) {
+      // Large item or icon point: flush pending cluster then add as-is
+      // Icon points are handled by stackIconPoints instead of merging
       flushCluster()
       result.push(packed)
       continue


### PR DESCRIPTION
## Summary

- **Duration tag icons**: Show emoji/image icons centered on duration (span) tag blocks. Previously icons were only rendered for point-in-time tags.
- **Stacked icons**: Simultaneous point tags with icons now stack vertically (☕ above 🍽️) instead of being spread across sub-lanes that waste horizontal space.
- **Consistent ordering**: Stacked icons are sorted by label name so coffee/food always appear in the same order.
- **Lane optimization**: Recalculates effective lane count when icons are stacked to avoid unnecessarily narrow sub-lanes.

## Notes

- URL-based icons (PNG, SVG) already work — just paste an `https://` URL into the icon field in Tag Mappings settings.
- The 18px vertical step between stacked icons may need tuning based on real-world usage.