### PR TITLE
feat: add Last.fm tag rule editing (full CRUD)

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -186,7 +186,12 @@ export {
 export { getUserSettings, upsertUserSettings } from './settings'
 
 // Last.fm tag rules
-export { deleteLastFmTagRule, getLastFmTagRules, insertLastFmTagRule } from './lastfm-rules'
+export {
+  deleteLastFmTagRule,
+  getLastFmTagRules,
+  insertLastFmTagRule,
+  updateLastFmTagRule,
+} from './lastfm-rules'
 
 // MCP sessions
 export {

--- a/apps/backend/src/db/lastfm-rules.integration.test.ts
+++ b/apps/backend/src/db/lastfm-rules.integration.test.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'crypto'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
-import { deleteLastFmTagRule, getLastFmTagRules, insertLastFmTagRule } from './lastfm-rules'
+import {
+  deleteLastFmTagRule,
+  getLastFmTagRules,
+  insertLastFmTagRule,
+  updateLastFmTagRule,
+} from './lastfm-rules'
 
 const CONTAINER_TIMEOUT = 60_000
 
@@ -257,5 +262,158 @@ describe('Last.fm Tag Rules Integration Tests', () => {
     })
 
     expect(rule.match_mode).toBe('exact')
+  })
+
+  test('updateLastFmTagRule updates rule_name', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      match_mode: 'exact',
+      match_type: 'track',
+      rule_name: 'Original',
+      tag_name: 'Tag1',
+      track_name: 'Track 1',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, { rule_name: 'Updated Name' })
+
+    expect(updated).not.toBeNull()
+    expect(updated!.rule_name).toBe('Updated Name')
+    expect(updated!.tag_name).toBe('Tag1')
+    expect(updated!.track_name).toBe('Track 1')
+  })
+
+  test('updateLastFmTagRule updates multiple fields', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      match_mode: 'exact',
+      match_type: 'track',
+      rule_name: 'Original',
+      tag_name: 'Tag1',
+      track_name: 'Track 1',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, {
+      match_mode: 'contains',
+      rule_name: 'New Name',
+      tag_name: 'NewTag',
+      track_name: 'New Track',
+    })
+
+    expect(updated).not.toBeNull()
+    expect(updated!.rule_name).toBe('New Name')
+    expect(updated!.tag_name).toBe('NewTag')
+    expect(updated!.track_name).toBe('New Track')
+    expect(updated!.match_mode).toBe('contains')
+  })
+
+  test('updateLastFmTagRule updates merge_gap_seconds', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      artist_name: 'Some Artist',
+      match_mode: 'exact',
+      match_type: 'artist',
+      merge_gap_seconds: 300,
+      rule_name: 'Gap Rule',
+      tag_name: 'GapTag',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, { merge_gap_seconds: 600 })
+
+    expect(updated!.merge_gap_seconds).toBe(600)
+  })
+
+  test('updateLastFmTagRule clears merge_gap_seconds with null', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      artist_name: 'Some Artist',
+      match_mode: 'exact',
+      match_type: 'artist',
+      merge_gap_seconds: 300,
+      rule_name: 'Gap Rule',
+      tag_name: 'GapTag',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, { merge_gap_seconds: null })
+
+    expect(updated!.merge_gap_seconds).toBeUndefined()
+  })
+
+  test('updateLastFmTagRule updates artist_names', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      artist_names: ['Artist A'],
+      match_mode: 'exact',
+      match_type: 'artist',
+      rule_name: 'Multi Artist',
+      tag_name: 'MultiTag',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, {
+      artist_names: ['Artist A', 'Artist B', 'Artist C'],
+    })
+
+    expect(updated!.artist_names).toEqual(['Artist A', 'Artist B', 'Artist C'])
+  })
+
+  test('updateLastFmTagRule returns null for non-existent rule', async () => {
+    const user = getTestUser()
+
+    const updated = await updateLastFmTagRule(user, randomUUID(), { rule_name: 'Nope' })
+
+    expect(updated).toBeNull()
+  })
+
+  test('updateLastFmTagRule returns null when no fields provided', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      match_mode: 'exact',
+      match_type: 'track',
+      rule_name: 'No Update',
+      tag_name: 'Tag1',
+      track_name: 'Track 1',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, {})
+
+    expect(updated).toBeNull()
+  })
+
+  test('updateLastFmTagRule changes match_type from track to artist', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      match_mode: 'exact',
+      match_type: 'track',
+      rule_name: 'Type Change',
+      tag_name: 'TypeTag',
+      track_name: 'Old Track',
+    })
+
+    const updated = await updateLastFmTagRule(user, rule.id, {
+      artist_name: 'New Artist',
+      match_type: 'artist',
+    })
+
+    expect(updated!.match_type).toBe('artist')
+    expect(updated!.artist_name).toBe('New Artist')
+    // track_name remains from the original insert (DB doesn't clear it automatically)
+    expect(updated!.track_name).toBe('Old Track')
+  })
+
+  test('updateLastFmTagRule persists changes in database', async () => {
+    const user = getTestUser()
+    const rule = await insertLastFmTagRule(user, {
+      match_mode: 'exact',
+      match_type: 'track',
+      rule_name: 'Persist Test',
+      tag_name: 'PersistTag',
+      track_name: 'Some Track',
+    })
+
+    await updateLastFmTagRule(user, rule.id, { rule_name: 'Persisted Name' })
+
+    const rules = await getLastFmTagRules(user)
+    const found = rules.find((r) => r.id === rule.id)
+    expect(found).toBeDefined()
+    expect(found!.rule_name).toBe('Persisted Name')
   })
 })

--- a/apps/backend/src/db/lastfm-rules.ts
+++ b/apps/backend/src/db/lastfm-rules.ts
@@ -48,6 +48,72 @@ export const insertLastFmTagRule = async (user: string, rule: LastFmTagRuleInput
 }
 
 /**
+ * Update a Last.fm tag rule by ID.
+ */
+type UpdateLastFmTagRuleInput = Omit<Partial<LastFmTagRuleInput>, 'merge_gap_seconds'> & {
+  merge_gap_seconds?: number | null
+}
+
+export const updateLastFmTagRule = async (
+  user: string,
+  ruleId: string,
+  rule: UpdateLastFmTagRuleInput,
+): Promise<LastFmTagRule | null> => {
+  const setClauses: string[] = []
+  const values: unknown[] = []
+  let paramIndex = 1
+
+  if (rule.rule_name !== undefined) {
+    setClauses.push(`rule_name = $${paramIndex++}`)
+    values.push(rule.rule_name)
+  }
+  if (rule.match_type !== undefined) {
+    setClauses.push(`match_type = $${paramIndex++}`)
+    values.push(rule.match_type)
+  }
+  if (rule.track_name !== undefined) {
+    setClauses.push(`track_name = $${paramIndex++}`)
+    values.push(rule.track_name || null)
+  }
+  if (rule.artist_name !== undefined) {
+    setClauses.push(`artist_name = $${paramIndex++}`)
+    values.push(rule.artist_name || null)
+  }
+  if (rule.artist_names !== undefined) {
+    setClauses.push(`artist_names = $${paramIndex++}`)
+    values.push(rule.artist_names ? JSON.stringify(rule.artist_names) : null)
+  }
+  if (rule.match_mode !== undefined) {
+    setClauses.push(`match_mode = $${paramIndex++}`)
+    values.push(rule.match_mode)
+  }
+  if (rule.tag_name !== undefined) {
+    setClauses.push(`tag_name = $${paramIndex++}`)
+    values.push(rule.tag_name)
+  }
+  if (rule.merge_gap_seconds !== undefined) {
+    setClauses.push(`merge_gap_seconds = $${paramIndex++}`)
+    values.push(rule.merge_gap_seconds ?? null)
+  }
+
+  if (setClauses.length === 0) return null
+
+  values.push(ruleId)
+
+  const result = await query(
+    user,
+    `UPDATE lastfm_tag_rules
+     SET ${setClauses.join(', ')}
+     WHERE id = $${paramIndex}
+     RETURNING ${LASTFM_RULE_COLUMNS}`,
+    values,
+  )
+
+  if (result.rows.length === 0) return null
+  return mapLastFmTagRuleRow(result.rows[0])
+}
+
+/**
  * Delete a Last.fm tag rule by ID.
  */
 export const deleteLastFmTagRule = async (user: string, ruleId: string): Promise<boolean> => {

--- a/apps/backend/src/lastfm-router.ts
+++ b/apps/backend/src/lastfm-router.ts
@@ -6,12 +6,15 @@
 
 import {
   addLastFmTagRuleBodySchema,
+  updateLastFmTagRuleBodySchema,
   type AddLastFmTagRuleBody,
   type AddLastFmTagRuleResponse,
   type DeleteLastFmTagRuleResponse,
   type LastFmTagRulesResponse,
   type RetagLastFmResponse,
   type ScrobblesResponse,
+  type UpdateLastFmTagRuleBody,
+  type UpdateLastFmTagRuleResponse,
 } from '@aurboda/api-spec'
 import { RequestHandler, Router } from 'express'
 import type { ParamsDictionary } from 'express-serve-static-core'
@@ -20,6 +23,7 @@ import {
   getLastFmTagRules,
   getScrobbles,
   insertLastFmTagRule,
+  updateLastFmTagRule,
   type LastFmMatchMode,
   type LastFmMatchType,
 } from './db'
@@ -147,6 +151,65 @@ export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         // Check for unique constraint violation
+        if (message.includes('unique_rule')) {
+          return res
+            .status(409)
+            .json({ error: 'A rule with the same match criteria and tag already exists', success: false })
+        }
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
+
+  // PUT /lastfm/tag-rules/:id - Update a tag rule
+  router.put<{ id: string }, UpdateLastFmTagRuleResponse, UpdateLastFmTagRuleBody>(
+    '/tag-rules/:id',
+    authMiddleware,
+    validateBody(updateLastFmTagRuleBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const { id } = req.params
+
+      try {
+        // Clean up old auto-tags before updating
+        await cleanupRuleTags(user, id)
+
+        const updated = await updateLastFmTagRule(user, id, {
+          artist_name: req.body.artist_name,
+          artist_names: req.body.artist_names,
+          match_mode: req.body.match_mode as LastFmMatchMode | undefined,
+          match_type: req.body.match_type as LastFmMatchType | undefined,
+          merge_gap_seconds: req.body.merge_gap_seconds ?? undefined,
+          rule_name: req.body.rule_name,
+          tag_name: req.body.tag_name,
+          track_name: req.body.track_name,
+        })
+
+        if (!updated) {
+          return res.status(404).json({ error: 'Rule not found', success: false })
+        }
+
+        // Re-apply the updated rule retroactively
+        const tagsApplied = await applyRuleRetroactively(user, updated)
+
+        res.json({
+          data: {
+            artist_name: updated.artist_name,
+            artist_names: updated.artist_names,
+            created_at: updated.created_at.toISOString(),
+            id: updated.id,
+            match_mode: updated.match_mode,
+            match_type: updated.match_type,
+            merge_gap_seconds: updated.merge_gap_seconds ?? null,
+            rule_name: updated.rule_name,
+            tag_name: updated.tag_name,
+            tags_applied: tagsApplied,
+            track_name: updated.track_name,
+          },
+          success: true,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
         if (message.includes('unique_rule')) {
           return res
             .status(409)

--- a/apps/backend/src/mcp/lastfm-tools.ts
+++ b/apps/backend/src/mcp/lastfm-tools.ts
@@ -1,13 +1,18 @@
 /**
  * MCP Last.fm tools: scrobble queries and tag rule management.
  */
-import { addLastFmTagRuleBodySchema, scrobblesQuerySchema } from '@aurboda/api-spec'
+import {
+  addLastFmTagRuleBodySchema,
+  scrobblesQuerySchema,
+  updateLastFmTagRuleBodySchema,
+} from '@aurboda/api-spec'
 import { z } from 'zod'
 import {
   deleteLastFmTagRule,
   getLastFmTagRules,
   getScrobbles,
   insertLastFmTagRule,
+  updateLastFmTagRule,
   type LastFmMatchMode,
   type LastFmMatchType,
 } from '../db'
@@ -89,6 +94,64 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
           data: {
             ...rule,
             created_at: rule.created_at.toISOString(),
+            tags_applied: tagsApplied,
+          },
+          success: true,
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        if (message.includes('unique_rule')) {
+          return errorResponse('A rule with the same match criteria and tag already exists')
+        }
+        return jsonResponse({ error: message, success: false })
+      }
+    },
+  )
+
+  // Tool: update_lastfm_tag_rule
+  server.tool(
+    'update_lastfm_tag_rule',
+    'Update an existing Last.fm auto-tagging rule. Only provided fields are updated. Old auto-tags are removed and the updated rule is re-applied retroactively.',
+    {
+      id: z.string().uuid().describe('The ID of the rule to update'),
+      ...updateLastFmTagRuleBodySchema.shape,
+    },
+    async ({
+      id,
+      artist_name,
+      artist_names,
+      match_mode,
+      match_type,
+      merge_gap_seconds,
+      rule_name,
+      tag_name,
+      track_name,
+    }) => {
+      try {
+        // Clean up old auto-tags before updating
+        await cleanupRuleTags(user, id)
+
+        const updated = await updateLastFmTagRule(user, id, {
+          artist_name,
+          artist_names,
+          match_mode: match_mode as LastFmMatchMode | undefined,
+          match_type: match_type as LastFmMatchType | undefined,
+          merge_gap_seconds: merge_gap_seconds ?? undefined,
+          rule_name,
+          tag_name,
+          track_name,
+        })
+
+        if (!updated) {
+          return jsonResponse({ error: 'Rule not found', success: false })
+        }
+
+        const tagsApplied = await applyRuleRetroactively(user, updated)
+
+        return jsonResponse({
+          data: {
+            ...updated,
+            created_at: updated.created_at.toISOString(),
             tags_applied: tagsApplied,
           },
           success: true,

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -1,14 +1,16 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 import {
   createLastFmTagRule,
   deleteLastFmTagRule,
   fetchLastFmTagRules,
   fetchUserSettings,
+  updateLastFmTagRule,
   type AddLastFmTagRuleBody,
   type LastFmMatchMode,
   type LastFmMatchType,
   type LastFmTagRule,
+  type UpdateLastFmTagRuleBody,
 } from '../../state/api'
 import { auth } from '../../state/auth'
 
@@ -22,7 +24,7 @@ function SaveIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
   if (saveStatus.status === 'idle') return null
   const messages: Record<string, string> = {
     error: saveStatus.error ?? 'Error',
-    saved: 'Rule created',
+    saved: 'Rule saved',
     saving: 'Saving...',
   }
   return <span class={`save-indicator ${saveStatus.status}`}>{messages[saveStatus.status]}</span>
@@ -82,6 +84,289 @@ const buildRule = (
     rule.merge_gap_seconds = Math.round(gapMinutes * 60)
   }
   return rule
+}
+
+function EditableRuleRow({
+  rule,
+  onDeleted,
+  onUpdated,
+}: {
+  rule: LastFmTagRule
+  onDeleted: () => void
+  onUpdated: () => void
+}) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editRuleName, setEditRuleName] = useState(rule.rule_name)
+  const [editTagName, setEditTagName] = useState(rule.tag_name)
+  const [editMatchType, setEditMatchType] = useState<LastFmMatchType>(rule.match_type)
+  const [editMatchMode, setEditMatchMode] = useState<LastFmMatchMode>(rule.match_mode)
+  const [editTrackName, setEditTrackName] = useState(rule.track_name ?? '')
+  const [editArtistName, setEditArtistName] = useState(rule.artist_name ?? '')
+  const [editArtistNames, setEditArtistNames] = useState<string[]>(rule.artist_names ?? [])
+  const [editNewArtistInput, setEditNewArtistInput] = useState('')
+  const [editMergeGapMinutes, setEditMergeGapMinutes] = useState(
+    rule.merge_gap_seconds ? String(Math.round(rule.merge_gap_seconds / 60)) : '',
+  )
+
+  const resetForm = () => {
+    setEditRuleName(rule.rule_name)
+    setEditTagName(rule.tag_name)
+    setEditMatchType(rule.match_type)
+    setEditMatchMode(rule.match_mode)
+    setEditTrackName(rule.track_name ?? '')
+    setEditArtistName(rule.artist_name ?? '')
+    setEditArtistNames(rule.artist_names ?? [])
+    setEditNewArtistInput('')
+    setEditMergeGapMinutes(rule.merge_gap_seconds ? String(Math.round(rule.merge_gap_seconds / 60)) : '')
+  }
+
+  const handleEditAddArtist = () => {
+    const name = editNewArtistInput.trim()
+    if (name && !editArtistNames.includes(name)) {
+      setEditArtistNames([...editArtistNames, name])
+      setEditNewArtistInput('')
+    }
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: () => {
+      const body: UpdateLastFmTagRuleBody = {}
+
+      if (editRuleName.trim() !== rule.rule_name) body.rule_name = editRuleName.trim()
+      if (editTagName.trim() !== rule.tag_name) body.tag_name = editTagName.trim()
+      if (editMatchType !== rule.match_type) body.match_type = editMatchType
+      if (editMatchMode !== rule.match_mode) body.match_mode = editMatchMode
+
+      if (needsTrack(editMatchType)) {
+        if (editTrackName.trim() !== (rule.track_name ?? '')) body.track_name = editTrackName.trim()
+      }
+      if (needsArtist(editMatchType)) {
+        if (editArtistNames.length > 0) {
+          const original = rule.artist_names ?? []
+          if (
+            editArtistNames.length !== original.length ||
+            editArtistNames.some((n, i) => n !== original[i])
+          ) {
+            body.artist_names = editArtistNames
+          }
+        } else if (editArtistName.trim() !== (rule.artist_name ?? '')) {
+          body.artist_name = editArtistName.trim()
+        }
+      }
+
+      const gapMinutes = parseFloat(editMergeGapMinutes)
+      const newGapSeconds = gapMinutes > 0 ? Math.round(gapMinutes * 60) : null
+      if (newGapSeconds !== (rule.merge_gap_seconds ?? null)) {
+        body.merge_gap_seconds = newGapSeconds
+      }
+
+      return updateLastFmTagRule(rule.id, body)
+    },
+    onSuccess: () => {
+      setIsEditing(false)
+      onUpdated()
+    },
+  })
+
+  const handleDelete = async () => {
+    if (!confirm(`Delete rule "${rule.rule_name}"?`)) return
+    try {
+      await deleteLastFmTagRule(rule.id)
+      onDeleted()
+    } catch {
+      // Error will be visible via the parent's status
+    }
+  }
+
+  if (isEditing) {
+    const validationError = validateRuleForm(editMatchType, editTrackName, editArtistName, editArtistNames)
+    const canSave = editRuleName.trim() && editTagName.trim() && !validationError
+
+    return (
+      <div class="rule-item editing">
+        <div class="rule-edit-fields">
+          <div class="form-row">
+            <div class="form-field">
+              <label>Rule Name</label>
+              <input
+                type="text"
+                value={editRuleName}
+                onInput={(e) => setEditRuleName((e.target as HTMLInputElement).value)}
+              />
+            </div>
+            <div class="form-field">
+              <label>Tag to Create</label>
+              <input
+                type="text"
+                value={editTagName}
+                onInput={(e) => setEditTagName((e.target as HTMLInputElement).value)}
+              />
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-field">
+              <label>Match Type</label>
+              <select
+                value={editMatchType}
+                onChange={(e) => setEditMatchType((e.target as HTMLSelectElement).value as LastFmMatchType)}
+              >
+                <option value="track">Track Name (any artist)</option>
+                <option value="artist">Artist Name (any track)</option>
+                <option value="track_artist">Track + Artist (exact)</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label>Match Mode</label>
+              <select
+                value={editMatchMode}
+                onChange={(e) => setEditMatchMode((e.target as HTMLSelectElement).value as LastFmMatchMode)}
+              >
+                <option value="exact">Exact (case-insensitive)</option>
+                <option value="contains">Contains (substring)</option>
+              </select>
+            </div>
+          </div>
+
+          {needsTrack(editMatchType) && (
+            <div class="form-field">
+              <label>Track Name</label>
+              <input
+                type="text"
+                value={editTrackName}
+                onInput={(e) => setEditTrackName((e.target as HTMLInputElement).value)}
+              />
+            </div>
+          )}
+
+          {needsArtist(editMatchType) && (
+            <div class="form-field">
+              <label>Artists</label>
+              {editArtistNames.length > 0 && (
+                <div class="artist-names-list">
+                  {editArtistNames.map((name, idx) => (
+                    <span class="artist-name-chip" key={name}>
+                      {name}
+                      <button
+                        type="button"
+                        class="remove-artist-button"
+                        onClick={() => setEditArtistNames(editArtistNames.filter((_, i) => i !== idx))}
+                      >
+                        x
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div class="artist-input-row">
+                <input
+                  type="text"
+                  value={editArtistNames.length > 0 ? editNewArtistInput : editArtistName}
+                  onInput={(e) => {
+                    const val = (e.target as HTMLInputElement).value
+                    if (editArtistNames.length > 0) {
+                      setEditNewArtistInput(val)
+                    } else {
+                      setEditArtistName(val)
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && editArtistNames.length > 0) {
+                      e.preventDefault()
+                      handleEditAddArtist()
+                    }
+                  }}
+                  placeholder={editArtistNames.length > 0 ? 'Add another artist...' : 'Artist name'}
+                />
+                <button
+                  type="button"
+                  class="add-artist-button"
+                  onClick={() => {
+                    if (editArtistNames.length === 0 && editArtistName.trim()) {
+                      setEditArtistNames([editArtistName.trim()])
+                      setEditArtistName('')
+                    } else {
+                      handleEditAddArtist()
+                    }
+                  }}
+                >
+                  +
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div class="form-field">
+            <label>Session merge gap (minutes)</label>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={editMergeGapMinutes}
+              onInput={(e) => setEditMergeGapMinutes((e.target as HTMLInputElement).value)}
+              placeholder="Leave empty for one tag per scrobble"
+            />
+          </div>
+        </div>
+
+        <div class="rule-edit-actions">
+          <button
+            type="button"
+            class="connect-button"
+            onClick={() => updateMutation.mutate()}
+            disabled={!canSave || updateMutation.isPending}
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            type="button"
+            class="cancel-button"
+            onClick={() => {
+              resetForm()
+              setIsEditing(false)
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+        {updateMutation.isError && <p class="rule-edit-error">{getErrorMessage(updateMutation.error)}</p>}
+      </div>
+    )
+  }
+
+  return (
+    <div class="rule-item" key={rule.id}>
+      <div class="rule-info">
+        <span class="rule-name">{rule.rule_name}</span>
+        <span class="rule-details">
+          {formatRuleDescription(rule)}
+          {' → '}
+          <strong>{rule.tag_name}</strong>
+          {rule.merge_gap_seconds && (
+            <span class="rule-merge-info">
+              {' '}
+              (session merge: {Math.round(rule.merge_gap_seconds / 60)}min)
+            </span>
+          )}
+        </span>
+      </div>
+      <div class="rule-actions">
+        <button
+          type="button"
+          class="edit-rule-button"
+          onClick={() => {
+            resetForm()
+            setIsEditing(true)
+          }}
+        >
+          Edit
+        </button>
+        <button type="button" class="remove-rule-button" onClick={handleDelete}>
+          Delete
+        </button>
+      </div>
+    </div>
+  )
 }
 
 export function LastFmTagRulesSettings() {
@@ -163,16 +448,7 @@ export function LastFmTagRulesSettings() {
     }
   }
 
-  const handleDeleteRule = async (rule: LastFmTagRule) => {
-    if (!confirm(`Delete rule "${rule.rule_name}"?`)) return
-
-    try {
-      await deleteLastFmTagRule(rule.id)
-      queryClient.invalidateQueries({ queryKey: ['lastfmTagRules'] })
-    } catch (err) {
-      setSaveStatus({ error: getErrorMessage(err), status: 'error' })
-    }
-  }
+  const invalidateRules = () => queryClient.invalidateQueries({ queryKey: ['lastfmTagRules'] })
 
   // Don't show if Last.fm is not configured
   if (!userSettings?.lastfm_username) {
@@ -199,25 +475,12 @@ export function LastFmTagRulesSettings() {
           {rulesList.length > 0 && (
             <div class="rules-list">
               {rulesList.map((rule) => (
-                <div class="rule-item" key={rule.id}>
-                  <div class="rule-info">
-                    <span class="rule-name">{rule.rule_name}</span>
-                    <span class="rule-details">
-                      {formatRuleDescription(rule)}
-                      {' → '}
-                      <strong>{rule.tag_name}</strong>
-                      {rule.merge_gap_seconds && (
-                        <span class="rule-merge-info">
-                          {' '}
-                          (session merge: {Math.round(rule.merge_gap_seconds / 60)}min)
-                        </span>
-                      )}
-                    </span>
-                  </div>
-                  <button type="button" class="remove-rule-button" onClick={() => handleDeleteRule(rule)}>
-                    Delete
-                  </button>
-                </div>
+                <EditableRuleRow
+                  key={rule.id}
+                  rule={rule}
+                  onDeleted={invalidateRules}
+                  onUpdated={invalidateRules}
+                />
               ))}
             </div>
           )}

--- a/apps/web/src/components/LastFmTagRulesSettings/style.css
+++ b/apps/web/src/components/LastFmTagRulesSettings/style.css
@@ -38,6 +38,27 @@
   white-space: nowrap;
 }
 
+.rule-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.edit-rule-button {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  background: transparent;
+  border: 1px solid #1976d2;
+  color: #1976d2;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.edit-rule-button:hover {
+  background: #1976d2;
+  color: white;
+}
+
 .remove-rule-button {
   padding: 0.25rem 0.5rem;
   font-size: 0.8rem;
@@ -52,6 +73,63 @@
 .remove-rule-button:hover {
   background: #f44336;
   color: white;
+}
+
+/* Edit mode for rule items */
+.rule-item.editing {
+  flex-direction: column;
+  align-items: stretch;
+  background: #fafafa;
+}
+
+.rule-edit-fields {
+  width: 100%;
+}
+
+.rule-edit-fields .form-field {
+  margin-bottom: 0.75rem;
+}
+
+.rule-edit-fields .form-field label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.rule-edit-fields .form-field input,
+.rule-edit-fields .form-field select {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.rule-edit-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.cancel-button {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: transparent;
+  border: 1px solid #999;
+  color: #666;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cancel-button:hover {
+  background: #e0e0e0;
+}
+
+.rule-edit-error {
+  color: #f44336;
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0 0;
 }
 
 .add-rule-form {
@@ -215,6 +293,36 @@
   .rule-merge-info {
     color: #64b5f6;
   }
+
+  .edit-rule-button {
+    border-color: #64b5f6;
+    color: #64b5f6;
+  }
+
+  .edit-rule-button:hover {
+    background: #1976d2;
+    color: white;
+  }
+
+  .rule-item.editing {
+    background: #1e1e1e;
+  }
+
+  .rule-edit-fields .form-field input,
+  .rule-edit-fields .form-field select {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+
+  .cancel-button {
+    border-color: #666;
+    color: #aaa;
+  }
+
+  .cancel-button:hover {
+    background: #444;
+  }
 }
 
 @media (max-width: 639px) {
@@ -229,7 +337,7 @@
     gap: 0.5rem;
   }
 
-  .remove-rule-button {
+  .rule-actions {
     align-self: flex-end;
   }
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -81,6 +81,8 @@ import type {
   UniqueTagsResponse,
   UpdateActivityBody,
   UpdateCustomMetricBody,
+  UpdateLastFmTagRuleBody,
+  UpdateLastFmTagRuleResponse,
   UpdateScreentimeCategoryBody,
   UpdateSettingsInput,
   UserSettingsResponse,
@@ -169,6 +171,7 @@ export type {
   TrendDisplayPeriod,
   TrendResult,
   TrendSourceType,
+  UpdateLastFmTagRuleBody,
   UpdateSettingsInput,
   UserSettingsResponse,
 }
@@ -886,6 +889,21 @@ export const createLastFmTagRule = async (rule: AddLastFmTagRuleBody): Promise<L
   const response = await axios.post<AddLastFmTagRuleResponse>(`${API_URL}/lastfm/tag-rules`, rule, {
     headers: { Authorization: `Bearer ${token}` },
   })
+
+  return response.data.data!
+}
+
+// Update an existing Last.fm tag rule
+export const updateLastFmTagRule = async (
+  ruleId: string,
+  body: UpdateLastFmTagRuleBody,
+): Promise<LastFmTagRule> => {
+  const { token } = auth.value
+  const response = await axios.put<UpdateLastFmTagRuleResponse>(
+    `${API_URL}/lastfm/tag-rules/${ruleId}`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
 
   return response.data.data!
 }

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -508,6 +508,59 @@ export const addLastFmTagRuleBodySchema = z
 export type AddLastFmTagRuleBody = z.infer<typeof addLastFmTagRuleBodySchema>
 
 /**
+ * Update Last.fm tag rule body schema.
+ * All fields are optional — only provided fields are updated.
+ */
+export const updateLastFmTagRuleBodySchema = z
+  .object({
+    artist_name: z
+      .string()
+      .optional()
+      .meta({ description: 'Artist name to match (for artist or track_artist match type)' }),
+    artist_names: z
+      .array(z.string())
+      .optional()
+      .meta({ description: 'Multiple artist names to match (takes precedence over artist_name when set)' }),
+    match_mode: lastFmMatchModeSchema.optional().meta({ description: 'Match mode' }),
+    match_type: lastFmMatchTypeSchema.optional().meta({ description: 'Type of match' }),
+    merge_gap_seconds: z.number().int().positive().nullable().optional().meta({
+      description: 'Session merge gap in seconds. Set to null to remove.',
+    }),
+    rule_name: z.string().min(1).optional().meta({ description: 'Human-readable name for the rule' }),
+    tag_name: z.string().min(1).optional().meta({ description: 'Tag to create when rule matches' }),
+    track_name: z
+      .string()
+      .optional()
+      .meta({ description: 'Track name to match (for track or track_artist match type)' }),
+  })
+  .meta({
+    id: 'UpdateLastFmTagRuleBody',
+    description: 'Partial update body for a Last.fm tag rule. Only provided fields are updated.',
+  })
+
+export type UpdateLastFmTagRuleBody = z.infer<typeof updateLastFmTagRuleBodySchema>
+
+/**
+ * Update Last.fm tag rule response.
+ */
+export const updateLastFmTagRuleResponseSchema = baseResponseSchema
+  .extend({
+    data: lastFmTagRuleSchema
+      .extend({
+        tags_applied: z
+          .number()
+          .int()
+          .optional()
+          .meta({ description: 'Number of tags retroactively created after re-applying the updated rule' }),
+      })
+      .optional()
+      .meta({ description: 'Updated tag rule' }),
+  })
+  .meta({ id: 'UpdateLastFmTagRuleResponse' })
+
+export type UpdateLastFmTagRuleResponse = z.infer<typeof updateLastFmTagRuleResponseSchema>
+
+/**
  * Last.fm tag rules response.
  */
 export const lastFmTagRulesResponseSchema = baseResponseSchema


### PR DESCRIPTION
## Summary

- Adds **update capability** for Last.fm auto-tagging rules end-to-end — previously only create and delete existed
- Adds **inline edit UI** to the Last.fm tag rules component on the data sources page
- Includes **9 integration tests** for the new `updateLastFmTagRule` DB function

## Changes

### api-spec
- `updateLastFmTagRuleBodySchema` and `updateLastFmTagRuleResponseSchema` with all fields optional for partial updates

### Backend
- `updateLastFmTagRule` DB function with dynamic SQL SET clause (only updates provided fields)
- `PUT /lastfm/tag-rules/:id` REST route with tag cleanup + retroactive reapplication
- `update_lastfm_tag_rule` MCP tool
- 9 new integration tests covering: single field update, multi-field update, merge gap update/clear, artist_names update, non-existent rule, empty update, match type change, persistence verification

### Frontend
- `EditableRuleRow` component with inline edit mode (same pattern as ScreentimeCategoriesSettings)
- Edit/Cancel/Save buttons with `useMutation` for optimistic flow
- Full form with all rule fields: name, tag, match type/mode, track, artists (with chip UI), merge gap
- Dark mode and mobile responsive CSS