### PR TITLE
feat: show all tags in tag mapper for icon setting

### DIFF
--- a/apps/backend/src/db/tags.integration.test.ts
+++ b/apps/backend/src/db/tags.integration.test.ts
@@ -536,7 +536,7 @@ describe('Tags Integration Tests', () => {
       expect(tags).toEqual([])
     })
 
-    test('returns tags with tag_key set (mapped tags)', async () => {
+    test('returns tags with tag_key set as programmatic', async () => {
       const user = getTestUser()
       const uuid1 = '067e2862-8cf8-4307-a621-0636dd379cda'
       const uuid2 = '4ddc8bc2-911d-467d-8c9d-dac2ece87d0a'
@@ -565,13 +565,15 @@ describe('Tags Integration Tests', () => {
       })
 
       const tags = await getProgrammaticTags(user)
+      const programmatic = tags.filter((t) => t.isProgrammatic)
 
-      expect(tags).toHaveLength(2)
+      expect(programmatic).toHaveLength(2)
       // Sorted by latest time descending
-      expect(tags[0].tagKey).toBe(uuid2)
-      expect(tags[0].count).toBe(1)
-      expect(tags[1].tagKey).toBe(uuid1)
-      expect(tags[1].count).toBe(2)
+      expect(programmatic[0].tagKey).toBe(uuid2)
+      expect(programmatic[0].count).toBe(1)
+      expect(programmatic[0].isProgrammatic).toBe(true)
+      expect(programmatic[1].tagKey).toBe(uuid1)
+      expect(programmatic[1].count).toBe(2)
     })
 
     test('falls back to programmatic tag names without tag_key (pre-migration)', async () => {
@@ -593,12 +595,14 @@ describe('Tags Integration Tests', () => {
       })
 
       const tags = await getProgrammaticTags(user)
+      const programmatic = tags.filter((t) => t.isProgrammatic)
 
-      expect(tags).toHaveLength(2)
-      expect(tags.map((t) => t.tagKey).sort()).toEqual([uuid, 'tag_sleep_sauna'])
+      expect(programmatic).toHaveLength(2)
+      expect(programmatic.map((t) => t.tagKey).sort()).toEqual([uuid, 'tag_sleep_sauna'])
+      expect(programmatic.every((t) => t.isProgrammatic)).toBe(true)
     })
 
-    test('excludes regular human-readable tags', async () => {
+    test('includes regular human-readable tags as non-programmatic', async () => {
       const user = getTestUser()
       const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
 
@@ -607,25 +611,57 @@ describe('Tags Integration Tests', () => {
         source: 'oura',
         start_time: new Date('2024-01-15T10:00:00Z'),
         tag: 'Food',
-        tag_key: uuid, // should be included (has tag_key)
+        tag_key: uuid,
       })
       await insertTag(user, {
         external_id: 'tag-2',
         source: 'aurboda',
         start_time: new Date('2024-01-15T11:00:00Z'),
-        tag: 'coffee', // should be excluded (no tag_key, not programmatic)
+        tag: 'coffee',
       })
       await insertTag(user, {
         external_id: 'tag-3',
-        source: 'aurboda',
+        source: 'lastfm-auto',
         start_time: new Date('2024-01-15T12:00:00Z'),
-        tag: 'Food', // should be excluded (no tag_key, not programmatic)
+        tag: 'VocalExercise',
+      })
+
+      const tags = await getProgrammaticTags(user)
+
+      // All tags should be returned
+      expect(tags).toHaveLength(3)
+
+      // Programmatic tag (has tag_key)
+      const ouraTag = tags.find((t) => t.tagKey === uuid)
+      expect(ouraTag).toBeDefined()
+      expect(ouraTag!.isProgrammatic).toBe(true)
+
+      // Non-programmatic tags (manual and lastfm-auto)
+      const coffeeTag = tags.find((t) => t.tagKey === 'coffee')
+      expect(coffeeTag).toBeDefined()
+      expect(coffeeTag!.isProgrammatic).toBe(false)
+
+      const vocalTag = tags.find((t) => t.tagKey === 'VocalExercise')
+      expect(vocalTag).toBeDefined()
+      expect(vocalTag!.isProgrammatic).toBe(false)
+    })
+
+    test('includes calendar tags as non-programmatic', async () => {
+      const user = getTestUser()
+
+      await insertTag(user, {
+        external_id: 'cal-1',
+        source: 'calendar',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        tag: '[Work] Standup',
       })
 
       const tags = await getProgrammaticTags(user)
 
       expect(tags).toHaveLength(1)
-      expect(tags[0].tagKey).toBe(uuid)
+      expect(tags[0].tagKey).toBe('[Work] Standup')
+      expect(tags[0].isProgrammatic).toBe(false)
+      expect(tags[0].count).toBe(1)
     })
 
     test('deduplicates between tag_key and fallback results', async () => {

--- a/apps/backend/src/db/tags.ts
+++ b/apps/backend/src/db/tags.ts
@@ -186,17 +186,18 @@ export const isProgrammaticTag = (tag: string): boolean =>
   PROGRAMMATIC_TAG_PATTERNS.some((pattern) => pattern.test(tag))
 
 /**
- * Get programmatic tags from the tags table.
- * Returns tags that look like they need human-readable names (UUIDs, tag_* prefixes, etc.)
- * along with usage counts and last seen times.
+ * Get all tags for the tag mapper.
+ * Returns programmatic tags (UUIDs, tag_* prefixes) that need human-readable names,
+ * plus all other tags so users can set icons on any tag.
  *
  * Uses tag_key column when available (populated by Oura sync), falling back to
  * checking the tag column for programmatic patterns (for pre-migration data).
+ * Also includes non-programmatic tags grouped by display name.
  */
 export const getProgrammaticTags = async (
   user: string,
-): Promise<{ tagKey: string; count: number; latestTime: Date }[]> => {
-  // Query tags with tag_key set (the canonical source)
+): Promise<{ tagKey: string; count: number; latestTime: Date; isProgrammatic: boolean }[]> => {
+  // Query tags with tag_key set (the canonical source — Oura tags)
   const tagKeyResult = await query(
     user,
     `SELECT
@@ -211,11 +212,12 @@ export const getProgrammaticTags = async (
 
   const fromTagKey = tagKeyResult.rows.map((row) => ({
     count: parseInt(row.count, 10),
+    isProgrammatic: true,
     latestTime: new Date(row.latest_time),
     tagKey: row.tag_key as string,
   }))
 
-  // Also check for programmatic tag names without tag_key (pre-migration data)
+  // Also check tags without tag_key, grouped by tag name
   const tagKeyValues = new Set(fromTagKey.map((t) => t.tagKey))
   const fallbackResult = await query(
     user,
@@ -230,9 +232,10 @@ export const getProgrammaticTags = async (
   )
 
   const fromTag = fallbackResult.rows
-    .filter((row) => isProgrammaticTag(row.tag) && !tagKeyValues.has(row.tag))
+    .filter((row) => !tagKeyValues.has(row.tag))
     .map((row) => ({
       count: parseInt(row.count, 10),
+      isProgrammatic: isProgrammaticTag(row.tag),
       latestTime: new Date(row.latest_time),
       tagKey: row.tag as string,
     }))

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -602,6 +602,137 @@ describe('MCP Server', () => {
     })
   })
 
+  describe('Tool: get_programmatic_tags', () => {
+    async function initializeSession(app: express.Express, token: string) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+            protocolVersion: '2024-11-05',
+          },
+        })
+      return response.headers['mcp-session-id'] as string
+    }
+
+    async function callTool(
+      app: express.Express,
+      token: string,
+      sessionId: string,
+      toolName: string,
+      args: Record<string, unknown>,
+    ) {
+      const response = await mcpPost(app)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Mcp-Session-Id', sessionId)
+        .send({
+          id: 2,
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { arguments: args, name: toolName },
+        })
+
+      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      return {
+        ...response,
+        parsed,
+        toolResult: JSON.parse(parsed.result.content[0].text),
+      }
+    }
+
+    test('returns programmatic tags with is_programmatic flag and mapped name', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
+      vi.mocked(db.getProgrammaticTags).mockResolvedValue([
+        { count: 5, isProgrammatic: true, latestTime: new Date('2024-01-15T12:00:00Z'), tagKey: uuid },
+      ])
+      vi.mocked(db.getUserSettings).mockResolvedValue({
+        tag_mappings: { [uuid]: 'Food' },
+      })
+
+      const response = await callTool(app, token, sessionId, 'get_programmatic_tags', {})
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(1)
+      expect(response.toolResult.data[0]).toEqual({
+        count: 5,
+        current_name: 'Food',
+        is_programmatic: true,
+        latest_time: '2024-01-15T12:00:00.000Z',
+        tag_key: uuid,
+      })
+    })
+
+    test('returns non-programmatic tags with current_name set to tag name', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      vi.mocked(db.getProgrammaticTags).mockResolvedValue([
+        {
+          count: 3,
+          isProgrammatic: false,
+          latestTime: new Date('2024-01-15T14:00:00Z'),
+          tagKey: 'VocalExercise',
+        },
+        { count: 10, isProgrammatic: false, latestTime: new Date('2024-01-15T16:00:00Z'), tagKey: 'coffee' },
+      ])
+      vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+      const response = await callTool(app, token, sessionId, 'get_programmatic_tags', {})
+
+      expect(response.status).toBe(200)
+      expect(response.toolResult.success).toBe(true)
+      expect(response.toolResult.data).toHaveLength(2)
+      // Non-programmatic tags use their tag name as current_name
+      expect(response.toolResult.data[0]).toEqual({
+        count: 3,
+        current_name: 'VocalExercise',
+        is_programmatic: false,
+        latest_time: '2024-01-15T14:00:00.000Z',
+        tag_key: 'VocalExercise',
+      })
+      expect(response.toolResult.data[1]).toEqual({
+        count: 10,
+        current_name: 'coffee',
+        is_programmatic: false,
+        latest_time: '2024-01-15T16:00:00.000Z',
+        tag_key: 'coffee',
+      })
+    })
+
+    test('returns mixed programmatic and non-programmatic tags', async () => {
+      const app = createTestApp()
+      const token = auth.createToken('testuser')
+      const sessionId = await initializeSession(app, token)
+
+      const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
+      vi.mocked(db.getProgrammaticTags).mockResolvedValue([
+        { count: 2, isProgrammatic: true, latestTime: new Date('2024-01-15T10:00:00Z'), tagKey: uuid },
+        { count: 7, isProgrammatic: false, latestTime: new Date('2024-01-15T12:00:00Z'), tagKey: 'coffee' },
+      ])
+      vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+      const response = await callTool(app, token, sessionId, 'get_programmatic_tags', {})
+
+      expect(response.toolResult.data).toHaveLength(2)
+      // Programmatic tag without mapping has null current_name
+      expect(response.toolResult.data[0].is_programmatic).toBe(true)
+      expect(response.toolResult.data[0].current_name).toBeNull()
+      // Non-programmatic tag always has current_name = tag name
+      expect(response.toolResult.data[1].is_programmatic).toBe(false)
+      expect(response.toolResult.data[1].current_name).toBe('coffee')
+    })
+  })
+
   describe('Tool: query_activities', () => {
     async function initializeSession(app: express.Express, token: string) {
       const response = await mcpPost(app)

--- a/apps/backend/src/mcp/settings-tools.ts
+++ b/apps/backend/src/mcp/settings-tools.ts
@@ -50,7 +50,7 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
   // Tool: get_programmatic_tags
   server.tool(
     'get_programmatic_tags',
-    'Get all programmatic tags (UUIDs, tag_* prefixes) with their current mapped names. These are tags that look like they need human-readable display names. Tags without a currentName are unmapped.',
+    'Get all tags available for mapping. Includes programmatic tags (UUIDs, tag_* prefixes) that need human-readable display names, plus all other tags so icons can be set on any tag. Tags with is_programmatic=true and no current_name are unmapped.',
     {},
     async () => {
       const tags = await getProgrammaticTags(user)
@@ -59,7 +59,8 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
 
       const data = tags.map((tag) => ({
         count: tag.count,
-        current_name: mappings[tag.tagKey] ?? null,
+        current_name: tag.isProgrammatic ? (mappings[tag.tagKey] ?? null) : tag.tagKey,
+        is_programmatic: tag.isProgrammatic,
         latest_time: tag.latestTime.toISOString(),
         tag_key: tag.tagKey,
       }))

--- a/apps/backend/src/routes/tags-router.ts
+++ b/apps/backend/src/routes/tags-router.ts
@@ -141,7 +141,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
     res.json({ data: tags, success: true })
   })
 
-  // GET /tags/programmatic - Get all programmatic tags with their current mappings
+  // GET /tags/programmatic - Get all tags with their current mappings (for tag mapper)
   router.get<Record<string, never>, ProgrammaticTagsResponse>(
     '/programmatic',
     authMiddleware,
@@ -153,7 +153,9 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
 
       const data = tags.map((tag) => ({
         count: tag.count,
-        current_name: mappings[tag.tagKey] ?? null,
+        // For programmatic tags, look up the mapped name; for regular tags, the tag name IS the name
+        current_name: tag.isProgrammatic ? (mappings[tag.tagKey] ?? null) : tag.tagKey,
+        is_programmatic: tag.isProgrammatic,
         latest_time: tag.latestTime.toISOString(),
         tag_key: tag.tagKey,
       }))

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -34,6 +34,8 @@ function TagMappingRow({
   const [status, setStatus] = useState<RowStatus>('idle')
   const [suggestedEmoji, setSuggestedEmoji] = useState<string | undefined>(undefined)
 
+  const isProgrammatic = tag.is_programmatic
+
   // Clear saved indicator after 3 seconds
   useEffect(() => {
     if (status !== 'saved') return
@@ -43,7 +45,7 @@ function TagMappingRow({
 
   const displayValue = localValue ?? tag.current_name ?? ''
   const displayIcon = localIcon ?? currentIcon ?? ''
-  const isUnmapped = !tag.current_name
+  const isUnmapped = isProgrammatic && !tag.current_name
 
   // Auto-suggest emoji when name changes
   useEffect(() => {
@@ -126,9 +128,10 @@ function TagMappingRow({
           value={displayValue}
           onInput={(e) => setLocalValue((e.target as HTMLInputElement).value)}
           onBlur={() => void handleBlur()}
-          placeholder="Enter display name..."
+          placeholder={isProgrammatic ? 'Enter display name...' : undefined}
           class={isUnmapped ? 'unmapped' : ''}
-          disabled={status === 'saving'}
+          disabled={status === 'saving' || !isProgrammatic}
+          readOnly={!isProgrammatic}
         />
         <span class="row-status">
           {status === 'saving' && <span class="status-saving" title="Saving..." />}
@@ -173,9 +176,11 @@ function TagMappingRow({
         )}
       </div>
 
-      <div class="tag-uuid" title={tag.tag_key}>
-        {formatTagKey(tag.tag_key)}
-      </div>
+      {isProgrammatic && (
+        <div class="tag-uuid" title={tag.tag_key}>
+          {formatTagKey(tag.tag_key)}
+        </div>
+      )}
     </div>
   )
 }
@@ -217,7 +222,7 @@ export function TagMappingsSettings() {
     )
   }
 
-  const unmappedCount = tags?.filter((t) => !t.current_name).length ?? 0
+  const unmappedCount = tags?.filter((t) => t.is_programmatic && !t.current_name).length ?? 0
   const icons = mappingsData?.icons ?? {}
 
   return (
@@ -228,12 +233,12 @@ export function TagMappingsSettings() {
       </div>
 
       <p class="section-description">
-        Set display names and icons for programmatic tags. Icons can be emoji characters or image URLs.
-        Changes save automatically when you leave the field.
+        Set display names for programmatic tags and icons for any tag. Icons can be emoji characters or image
+        URLs. Changes save automatically when you leave the field.
       </p>
 
       {!tags || tags.length === 0 ?
-        <p class="no-tags">No programmatic tags found. Tags will appear here after syncing data.</p>
+        <p class="no-tags">No tags found. Tags will appear here after syncing data.</p>
       : <div class="tag-mappings-list">
           {tags.map((tag) => (
             <TagMappingRow

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -126,15 +126,19 @@ export const uniqueTagsResponseSchema = baseResponseSchema
 export type UniqueTagsResponse = z.infer<typeof uniqueTagsResponseSchema>
 
 /**
- * Programmatic tag info - tags that look like they need human-readable names.
- * Includes UUIDs (Oura custom tags), tag_* prefixes (Oura presets), etc.
+ * Programmatic tag info - tags that can be configured in the tag mapper.
+ * Includes programmatic tags (UUIDs, tag_* prefixes) that need human-readable names,
+ * as well as all other tags so users can set icons on any tag.
  */
 export const programmaticTagSchema = z
   .object({
     count: z.number().int().meta({ description: 'Number of occurrences' }),
     current_name: z.string().nullable().meta({ description: 'Current mapped name (null if unmapped)' }),
+    is_programmatic: z
+      .boolean()
+      .meta({ description: 'Whether this tag needs a name mapping (true for UUIDs/tag_* prefixes)' }),
     latest_time: iso8601DateTimeSchema.meta({ description: 'Most recent occurrence' }),
-    tag_key: z.string().meta({ description: 'The programmatic tag identifier (UUID, tag_* prefix, etc.)' }),
+    tag_key: z.string().meta({ description: 'The tag identifier (programmatic key or tag name)' }),
   })
   .meta({ id: 'ProgrammaticTag' })
 


### PR DESCRIPTION
## Summary

- **Tag mapper now shows all tags**, not just Oura programmatic tags (UUIDs/`tag_*` prefixes)
- Manual, lastfm-auto, and calendar tags appear in the mapper so users can set icons on any tag
- Non-programmatic tags have their name field read-only (they already have human-readable names) but the icon field is editable

## Changes

- **`packages/api-spec`**: Added `is_programmatic` boolean to `programmaticTagSchema` to distinguish tags needing name mapping vs icon-only
- **`apps/backend/src/db/tags.ts`**: `getProgrammaticTags()` now returns all tags — programmatic ones (with `tag_key` or matching UUID/`tag_*` patterns) and regular ones (grouped by tag name with `isProgrammatic: false`)
- **`apps/backend/src/routes/tags-router.ts`**: GET `/tags/programmatic` passes `is_programmatic` flag and sets `current_name` to the tag name for non-programmatic tags
- **`apps/backend/src/mcp/settings-tools.ts`**: MCP `get_programmatic_tags` tool updated with matching logic
- **`apps/web/src/components/TagMappingsSettings.tsx`**: 
  - Name input is read-only for non-programmatic tags
  - "Unmapped" highlighting only applies to programmatic tags without a name
  - Tag key column hidden for non-programmatic tags
  - Description updated to reflect broader scope
- **Integration tests**: Updated existing tests and added new ones for non-programmatic tag inclusion