### PR TITLE
fix: serialize TEXT[] columns as PostgreSQL array literals in pg-format

### DIFF
--- a/apps/backend/src/db/productivity.integration.test.ts
+++ b/apps/backend/src/db/productivity.integration.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Productivity database integration tests using testcontainers.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import {
+  batchUpdateResolvedCategory,
+  deleteProductivityRecord,
+  getAllProductivityForCategorization,
+  getProductivity,
+  insertProductivity,
+  restoreProductivityRecord,
+} from '../db'
+import type { ProductivityRecord } from '../db/types'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
+
+const CONTAINER_TIMEOUT = 60_000
+
+const makeRecord = (
+  partial: Partial<ProductivityRecord> & Pick<ProductivityRecord, 'activity'>,
+): ProductivityRecord => ({
+  device_name: '',
+  duration_sec: 300,
+  end_time: new Date('2024-01-15T10:05:00Z'),
+  source: 'activitywatch' as const,
+  start_time: new Date('2024-01-15T10:00:00Z'),
+  ...partial,
+})
+
+describe('Productivity Integration Tests', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  // ==========================================================================
+  // insertProductivity
+  // ==========================================================================
+
+  describe('insertProductivity', () => {
+    test('inserts records and retrieves them', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode', title: 'main.ts — myproject' })])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].activity).toBe('vscode')
+      expect(records[0].title).toBe('main.ts — myproject')
+    })
+
+    test('inserts records with resolved_category as string array', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          resolved_category: ['Work', 'Programming'],
+        }),
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].resolved_category).toEqual(['Work', 'Programming'])
+    })
+
+    test('inserts records with single-element resolved_category', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'netflix',
+          resolved_category: ['TV'],
+        }),
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].resolved_category).toEqual(['TV'])
+    })
+
+    test('inserts records with no resolved_category', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'unknown-app' })])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].resolved_category).toBeUndefined()
+    })
+
+    test('inserts multiple records at once', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          end_time: new Date('2024-01-15T10:05:00Z'),
+          resolved_category: ['Work', 'Programming'],
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+        makeRecord({
+          activity: 'firefox',
+          end_time: new Date('2024-01-15T10:10:00Z'),
+          resolved_category: ['Media', 'Social Media'],
+          start_time: new Date('2024-01-15T10:05:00Z'),
+        }),
+        makeRecord({
+          activity: 'slack',
+          end_time: new Date('2024-01-15T10:15:00Z'),
+          start_time: new Date('2024-01-15T10:10:00Z'),
+        }),
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(3)
+      expect(records[0].resolved_category).toEqual(['Work', 'Programming'])
+      expect(records[1].resolved_category).toEqual(['Media', 'Social Media'])
+      expect(records[2].resolved_category).toBeUndefined()
+    })
+
+    test('handles resolved_category with special characters', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'test-app',
+          resolved_category: ['Category "A"', 'Sub,category'],
+        }),
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].resolved_category).toEqual(['Category "A"', 'Sub,category'])
+    })
+
+    test('does nothing for empty array', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(0)
+    })
+
+    test('upserts on conflict', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode', title: 'old title' })])
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          resolved_category: ['Work'],
+          title: 'new title',
+        }),
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0].title).toBe('new title')
+      expect(records[0].resolved_category).toEqual(['Work'])
+    })
+  })
+
+  // ==========================================================================
+  // batchUpdateResolvedCategory
+  // ==========================================================================
+
+  describe('batchUpdateResolvedCategory', () => {
+    test('updates resolved_category for existing records', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode' })])
+
+      const all = await getAllProductivityForCategorization(user)
+      expect(all).toHaveLength(1)
+
+      await batchUpdateResolvedCategory(user, [{ id: all[0].id, resolved_category: ['Work', 'Programming'] }])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records[0].resolved_category).toEqual(['Work', 'Programming'])
+    })
+
+    test('updates single-element category (the original bug case)', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'netflix' })])
+
+      const all = await getAllProductivityForCategorization(user)
+      await batchUpdateResolvedCategory(user, [{ id: all[0].id, resolved_category: ['TV'] }])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records[0].resolved_category).toEqual(['TV'])
+    })
+
+    test('updates deeply nested category path', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'aw-watcher' })])
+
+      const all = await getAllProductivityForCategorization(user)
+      await batchUpdateResolvedCategory(user, [
+        { id: all[0].id, resolved_category: ['Work', 'Programming', 'ActivityWatch'] },
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records[0].resolved_category).toEqual(['Work', 'Programming', 'ActivityWatch'])
+    })
+
+    test('sets resolved_category to null', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode', resolved_category: ['Work'] })])
+
+      const all = await getAllProductivityForCategorization(user)
+      await batchUpdateResolvedCategory(user, [{ id: all[0].id, resolved_category: null }])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records[0].resolved_category).toBeUndefined()
+    })
+
+    test('updates multiple records in a batch', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          end_time: new Date('2024-01-15T10:05:00Z'),
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+        makeRecord({
+          activity: 'netflix',
+          end_time: new Date('2024-01-15T10:10:00Z'),
+          start_time: new Date('2024-01-15T10:05:00Z'),
+        }),
+        makeRecord({
+          activity: 'slack',
+          end_time: new Date('2024-01-15T10:15:00Z'),
+          start_time: new Date('2024-01-15T10:10:00Z'),
+        }),
+      ])
+
+      const all = await getAllProductivityForCategorization(user)
+      expect(all).toHaveLength(3)
+
+      await batchUpdateResolvedCategory(user, [
+        { id: all.find((r) => r.activity === 'vscode')!.id, resolved_category: ['Work', 'Programming'] },
+        { id: all.find((r) => r.activity === 'netflix')!.id, resolved_category: ['TV'] },
+        { id: all.find((r) => r.activity === 'slack')!.id, resolved_category: null },
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      const byActivity = Object.fromEntries(records.map((r) => [r.activity, r]))
+      expect(byActivity['vscode'].resolved_category).toEqual(['Work', 'Programming'])
+      expect(byActivity['netflix'].resolved_category).toEqual(['TV'])
+      expect(byActivity['slack'].resolved_category).toBeUndefined()
+    })
+
+    test('handles category with spaces in name', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'reddit' })])
+
+      const all = await getAllProductivityForCategorization(user)
+      await batchUpdateResolvedCategory(user, [
+        { id: all[0].id, resolved_category: ['Media', 'Social Media'] },
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(records[0].resolved_category).toEqual(['Media', 'Social Media'])
+    })
+
+    test('does nothing for empty updates array', async () => {
+      const user = getTestUser()
+      await batchUpdateResolvedCategory(user, [])
+      // Should not throw
+    })
+  })
+
+  // ==========================================================================
+  // getAllProductivityForCategorization
+  // ==========================================================================
+
+  describe('getAllProductivityForCategorization', () => {
+    test('returns only id, activity, and title', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode', title: 'main.ts' })])
+
+      const records = await getAllProductivityForCategorization(user)
+      expect(records).toHaveLength(1)
+      expect(records[0]).toHaveProperty('id')
+      expect(records[0]).toHaveProperty('activity', 'vscode')
+      expect(records[0]).toHaveProperty('title', 'main.ts')
+    })
+
+    test('excludes soft-deleted records', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode' })])
+
+      const all = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      await deleteProductivityRecord(user, all[0].id!)
+
+      const forCategorization = await getAllProductivityForCategorization(user)
+      expect(forCategorization).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // deleteProductivityRecord / restoreProductivityRecord
+  // ==========================================================================
+
+  describe('deleteProductivityRecord', () => {
+    test('soft-deletes a record', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode' })])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      const deleted = await deleteProductivityRecord(user, records[0].id!)
+      expect(deleted).toBe(true)
+
+      const after = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(after).toHaveLength(0)
+    })
+
+    test('returns false for non-existent id', async () => {
+      const user = getTestUser()
+      const result = await deleteProductivityRecord(user, '00000000-0000-0000-0000-000000000000')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('restoreProductivityRecord', () => {
+    test('restores a soft-deleted record', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode' })])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      await deleteProductivityRecord(user, records[0].id!)
+      const restored = await restoreProductivityRecord(user, records[0].id!)
+      expect(restored).toBe(true)
+
+      const after = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(after).toHaveLength(1)
+    })
+
+    test('returns false for non-deleted record', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode' })])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      const result = await restoreProductivityRecord(user, records[0].id!)
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/db/productivity.test.ts
+++ b/apps/backend/src/db/productivity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest'
+import { toPgArray } from './productivity'
+
+describe('toPgArray', () => {
+  test('converts single-element array', () => {
+    expect(toPgArray(['TV'])).toBe('{TV}')
+  })
+
+  test('converts multi-element array (hierarchical category path)', () => {
+    expect(toPgArray(['Work', 'Programming'])).toBe('{Work,Programming}')
+  })
+
+  test('converts deeply nested category path', () => {
+    expect(toPgArray(['Work', 'Programming', 'ActivityWatch'])).toBe('{Work,Programming,ActivityWatch}')
+  })
+
+  test('returns null for null input', () => {
+    expect(toPgArray(null)).toBeNull()
+  })
+
+  test('returns null for undefined input', () => {
+    expect(toPgArray(undefined)).toBeNull()
+  })
+
+  test('quotes elements containing commas', () => {
+    expect(toPgArray(['a,b', 'c'])).toBe('{"a,b",c}')
+  })
+
+  test('quotes elements containing double quotes', () => {
+    expect(toPgArray(['has "quotes"'])).toBe('{"has \\"quotes\\""}')
+  })
+
+  test('quotes elements containing backslashes', () => {
+    expect(toPgArray(['back\\slash'])).toBe('{"back\\\\slash"}')
+  })
+
+  test('quotes elements containing spaces', () => {
+    expect(toPgArray(['Social Media'])).toBe('{"Social Media"}')
+  })
+
+  test('quotes empty string elements', () => {
+    expect(toPgArray([''])).toBe('{""}')
+  })
+
+  test('quotes elements containing curly braces', () => {
+    expect(toPgArray(['{nested}'])).toBe('{"{nested}"}')
+  })
+
+  test('quotes NULL keyword to avoid ambiguity', () => {
+    expect(toPgArray(['NULL'])).toBe('{"NULL"}')
+  })
+
+  test('handles empty array', () => {
+    expect(toPgArray([])).toBe('{}')
+  })
+
+  test('handles mixed simple and complex elements', () => {
+    expect(toPgArray(['Media', 'Social Media'])).toBe('{Media,"Social Media"}')
+  })
+})

--- a/apps/backend/src/db/productivity.ts
+++ b/apps/backend/src/db/productivity.ts
@@ -5,6 +5,32 @@ import format from 'pg-format'
 import { query } from './connection'
 import type { ProductivityRecord } from './types'
 
+/**
+ * Convert a JS string array to a PostgreSQL array literal.
+ *
+ * pg-format's %L treats JS arrays as sub-tuples for multi-row VALUES,
+ * so we must serialize TEXT[] columns ourselves before formatting.
+ *
+ * Examples:
+ *   ['TV']                       → '{TV}'
+ *   ['Work', 'Programming']      → '{Work,Programming}'
+ *   ['has "quotes"', 'a,comma']  → '{"has \\"quotes\\"","a,comma"}'
+ *   null / undefined              → null
+ */
+export const toPgArray = (arr: string[] | null | undefined): string | null => {
+  if (arr == null) return null
+
+  const escaped = arr.map((s) => {
+    // Quote the element if it contains special chars, is empty, or looks like a keyword
+    if (s === '' || /[{},"\\\s]/.test(s) || s.toUpperCase() === 'NULL') {
+      return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+    }
+    return s
+  })
+
+  return '{' + escaped.join(',') + '}'
+}
+
 export const insertProductivity = async (user: string, records: ProductivityRecord[]) => {
   if (records.length === 0) return
 
@@ -19,7 +45,7 @@ export const insertProductivity = async (user: string, records: ProductivityReco
     r.duration_sec,
     r.is_mobile || false,
     r.device_name ?? '',
-    r.resolved_category || null,
+    toPgArray(r.resolved_category) ?? null,
   ])
 
   await query(
@@ -102,7 +128,9 @@ export const batchUpdateResolvedCategory = async (
   if (updates.length === 0) return
 
   // Use a CTE with VALUES for efficient batch update
-  const values = updates.map((u) => [u.id, u.resolved_category])
+  // Convert JS arrays to PostgreSQL array literals; pg-format %L treats
+  // JS arrays as sub-tuples, which produces invalid TEXT[] values.
+  const values = updates.map((u) => [u.id, toPgArray(u.resolved_category)])
 
   await query(
     user,


### PR DESCRIPTION
## Summary

- Fixes 500 error when creating/importing screentime categories (and during recategorization)
- `pg-format`'s `%L` treats JS arrays as sub-tuples in multi-row VALUES, producing `'TV'` instead of the required PostgreSQL array literal `'{TV}'` for `TEXT[]` columns
- Adds `toPgArray()` helper that properly serializes `string[]` to PostgreSQL array literal format (with proper escaping of special characters)
- Fixes both `batchUpdateResolvedCategory` and `insertProductivity` which had the same issue
- Includes 14 unit tests covering simple arrays, hierarchical paths, special characters, null handling, and edge cases