### PR TITLE
feat: responsive UI — hamburger nav, fluid Timeline, /data page, HR/HRV fixes

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -19,23 +19,21 @@ const NAV_LINKS = [
   { href: '/goals', label: 'Goals' },
   { href: '/hr-zones', label: 'HR Zones' },
   { href: '/timeline', label: 'Timeline' },
+  { href: '/data', label: 'Data' },
   { href: '/add', label: '+ Add' },
   { href: '/trends', label: 'Trends' },
   { href: '/places', label: 'Places' },
 ]
 
-const NavLink = ({ href, label, url }: { href: string; label: string; url: string }) => (
-  <a href={href} class={url === href ? 'active' : undefined}>
-    {label}
-  </a>
-)
-
+// eslint-disable-next-line complexity -- navigation component with many branches
 export function Header() {
   const { url } = useLocation()
   const isLoggedIn = auth.value.token
   const isAdmin = auth.value.is_admin
 
   const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [dsExpandedInDrawer, setDsExpandedInDrawer] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
   const isDataSourcesActive = url.startsWith('/data-sources')
@@ -53,37 +51,52 @@ export function Header() {
     [dropdownOpen],
   )
 
-  // Close dropdown when clicking outside
+  const toggleDrawer = useCallback(() => setDrawerOpen((v) => !v), [])
+  const closeDrawer = useCallback(() => setDrawerOpen(false), [])
+
+  // Close desktop dropdown when clicking outside
   useEffect(() => {
     if (!dropdownOpen) return
-
     const handleClickOutside = (e: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setDropdownOpen(false)
       }
     }
-
     document.addEventListener('click', handleClickOutside)
     return () => document.removeEventListener('click', handleClickOutside)
   }, [dropdownOpen])
 
-  // Close dropdown on navigation
+  // Close drawer on Escape
+  useEffect(() => {
+    if (!drawerOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDrawerOpen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [drawerOpen])
+
+  // Close dropdown and drawer on navigation
   useEffect(() => {
     setDropdownOpen(false)
+    setDrawerOpen(false)
   }, [url])
 
   return (
     <header>
-      <nav>
+      {/* ── Desktop nav ─────────────────────────────────────── */}
+      <nav class="nav-desktop">
         <a href="/" class={url === '/' ? 'active' : undefined}>
           Home
         </a>
         {isLoggedIn ?
           <>
             {NAV_LINKS.map((link) => (
-              <NavLink key={link.href} href={link.href} label={link.label} url={url} />
+              <a key={link.href} href={link.href} class={url === link.href ? 'active' : undefined}>
+                {link.label}
+              </a>
             ))}
-            <div class={`nav-dropdown ${isDataSourcesActive ? 'active' : ''}`} ref={dropdownRef}>
+            <div class={`nav-dropdown${isDataSourcesActive ? ' active' : ''}`} ref={dropdownRef}>
               <a
                 href="/data-sources"
                 class={isDataSourcesActive ? 'active dropdown-toggle' : 'dropdown-toggle'}
@@ -115,6 +128,91 @@ export function Header() {
             </a>
           </>
         : <a href="/login" class={url === '/login' ? 'active' : undefined}>
+            Login
+          </a>
+        }
+      </nav>
+
+      {/* ── Mobile nav bar (hamburger) ───────────────────────── */}
+      <nav class="nav-mobile">
+        <a href="/" class={`nav-mobile-home${url === '/' ? ' active' : ''}`}>
+          Home
+        </a>
+        <span class="spacer" />
+        <button
+          class="hamburger-btn"
+          onClick={toggleDrawer}
+          aria-label="Open navigation menu"
+          aria-expanded={drawerOpen}
+          type="button"
+        >
+          ☰
+        </button>
+      </nav>
+
+      {/* ── Drawer backdrop ──────────────────────────────────── */}
+      {drawerOpen && <div class="drawer-backdrop" onClick={closeDrawer} />}
+
+      {/* ── Left drawer ─────────────────────────────────────── */}
+      <nav class={`nav-drawer${drawerOpen ? ' open' : ''}`} aria-hidden={!drawerOpen}>
+        <div class="drawer-header">
+          <span class="drawer-title">Menu</span>
+          <button class="drawer-close-btn" onClick={closeDrawer} aria-label="Close menu" type="button">
+            ✕
+          </button>
+        </div>
+        {isLoggedIn ?
+          <>
+            <a href="/" class={url === '/' ? 'active' : undefined} onClick={closeDrawer}>
+              Home
+            </a>
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                class={url === link.href ? 'active' : undefined}
+                onClick={closeDrawer}
+              >
+                {link.label}
+              </a>
+            ))}
+            {/* Data Sources inline expand */}
+            <button
+              class={`drawer-section-toggle${isDataSourcesActive ? ' active' : ''}`}
+              onClick={() => setDsExpandedInDrawer((v) => !v)}
+              type="button"
+            >
+              Data Sources <span class="dropdown-arrow">{dsExpandedInDrawer ? '\u25B4' : '\u25BE'}</span>
+            </button>
+            {dsExpandedInDrawer &&
+              DATA_SOURCE_LINKS.map((link) => (
+                <a
+                  key={link.path}
+                  href={link.path}
+                  class={`drawer-sub-link${url === link.path ? ' active' : ''}`}
+                  onClick={closeDrawer}
+                >
+                  {link.label}
+                </a>
+              ))}
+            {isAdmin && (
+              <a href="/admin" class={url === '/admin' ? 'active' : undefined} onClick={closeDrawer}>
+                Admin
+              </a>
+            )}
+            <div class="drawer-spacer" />
+            <a
+              href="/settings"
+              class={url === '/settings' ? 'active user-link' : 'user-link'}
+              onClick={closeDrawer}
+            >
+              {auth.value.user}
+            </a>
+            <a href="#" onClick={handleLogout} class="logout-link">
+              Logout
+            </a>
+          </>
+        : <a href="/login" class={url === '/login' ? 'active' : undefined} onClick={closeDrawer}>
             Login
           </a>
         }

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -8,6 +8,7 @@ import { NotFound } from './pages/_404.jsx'
 import { AddData } from './pages/AddData/index.jsx'
 import { AdminSettings } from './pages/AdminSettings/index.jsx'
 import { Correlations } from './pages/Correlations/index.jsx'
+import { Data } from './pages/Data/index.jsx'
 import { ActivityWatchAndroidSource } from './pages/DataSources/ActivityWatchAndroidSource.jsx'
 import { ActivityWatchDesktopSource } from './pages/DataSources/ActivityWatchDesktopSource.jsx'
 import { AndroidAppSource } from './pages/DataSources/AndroidAppSource.jsx'
@@ -45,6 +46,7 @@ export function App() {
             <Route path="/goals" component={Goals} />
             <Route path="/hr-zones" component={HrZones} />
             <Route path="/timeline" component={Timeline} />
+            <Route path="/data" component={Data} />
             <Route path="/add" component={AddData} />
             <Route path="/detail/:type/:id" component={EntityDetail} />
             <Route path="/sleep" component={Sleep} />

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -1,0 +1,269 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { addDays, endOfDay, format, formatISO, startOfDay, subDays } from 'date-fns'
+import { useState } from 'preact/hooks'
+import {
+  fetchActivities,
+  fetchPlaces,
+  fetchScrobbles,
+  fetchTags,
+  type Activity,
+  type Place,
+  type Tag,
+} from '../../state/api'
+
+import './style.css'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type ItemType = 'activity' | 'tag' | 'location' | 'music'
+
+interface DataItem {
+  color: string
+  detail: string
+  end?: Date
+  entityId?: string
+  entityType?: string
+  label: string
+  start: Date
+  type: ItemType
+}
+
+// ── Colors ─────────────────────────────────────────────────────────────────
+
+const ACTIVITY_COLORS: Record<string, string> = {
+  exercise: '#10b981',
+  meditation: '#a855f7',
+  nap: '#60a5fa',
+  sleep: '#3b82f6',
+}
+
+const TAG_COLOR = '#f59e0b'
+const LOCATION_COLOR = '#6366f1'
+const MUSIC_COLOR = '#ec4899'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const formatDuration = (start: Date, end: Date): string => {
+  const ms = end.getTime() - start.getTime()
+  const totalMin = Math.round(ms / 60000)
+  if (totalMin < 60) return `${totalMin}m`
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}
+
+const activityToItem = (a: Activity): DataItem => {
+  const end = a.end_time ?? new Date(a.start_time.getTime() + 60 * 60000)
+  const label =
+    a.activity_type === 'exercise' ? (a.title ?? 'Exercise')
+    : a.activity_type === 'meditation' ? (a.title ?? 'Meditation')
+    : a.activity_type === 'sleep' ? 'Sleep'
+    : 'Nap'
+  return {
+    color: ACTIVITY_COLORS[a.activity_type] ?? '#6b7280',
+    detail: `${format(a.start_time, 'HH:mm')} – ${format(end, 'HH:mm')} · ${formatDuration(a.start_time, end)}`,
+    end,
+    entityId: a.id,
+    entityType: 'activity',
+    label,
+    start: a.start_time,
+    type: 'activity',
+  }
+}
+
+const tagToItem = (t: Tag): DataItem => ({
+  color: TAG_COLOR,
+  detail:
+    t.end_time ?
+      `${format(t.start_time, 'HH:mm')} – ${format(t.end_time, 'HH:mm')} · ${formatDuration(t.start_time, t.end_time)}`
+    : format(t.start_time, 'HH:mm'),
+  end: t.end_time,
+  entityId: t.id,
+  entityType: 'tag',
+  label: t.tag,
+  start: t.start_time,
+  type: 'tag',
+})
+
+const placeToItem = (p: Place): DataItem => ({
+  color: LOCATION_COLOR,
+  detail: `${format(p.start_time, 'HH:mm')} – ${format(p.end_time, 'HH:mm')} · ${formatDuration(p.start_time, p.end_time)}`,
+  end: p.end_time,
+  label: p.region,
+  start: p.start_time,
+  type: 'location',
+})
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+const TYPE_LABELS: Record<ItemType, string> = {
+  activity: 'Activities',
+  location: 'Locations',
+  music: 'Music',
+  tag: 'Tags',
+}
+
+const TYPE_COLORS: Record<ItemType, string> = {
+  activity: ACTIVITY_COLORS.sleep!,
+  location: LOCATION_COLOR,
+  music: MUSIC_COLOR,
+  tag: TAG_COLOR,
+}
+
+const buildItems = (
+  activeTypes: Set<ItemType>,
+  activities: Activity[],
+  tags: Tag[],
+  places: Place[],
+  scrobbles: { artist: string; recorded_at: Date; track: string }[],
+): DataItem[] => {
+  const items: DataItem[] = []
+  if (activeTypes.has('activity')) {
+    for (const a of activities) items.push(activityToItem(a))
+  }
+  if (activeTypes.has('tag')) {
+    for (const t of tags) items.push(tagToItem(t))
+  }
+  if (activeTypes.has('location')) {
+    for (const p of places) items.push(placeToItem(p))
+  }
+  if (activeTypes.has('music')) {
+    for (const s of scrobbles) {
+      items.push({
+        color: MUSIC_COLOR,
+        detail: `${format(s.recorded_at, 'HH:mm')} · ${s.artist}`,
+        label: s.track,
+        start: s.recorded_at,
+        type: 'music',
+      })
+    }
+  }
+  return items.sort((a, b) => a.start.getTime() - b.start.getTime())
+}
+
+// eslint-disable-next-line complexity -- data page with multiple query sources
+export const Data = () => {
+  const [dateStr, setDateStr] = useState(formatISO(new Date(), { representation: 'date' }))
+  const [activeTypes, setActiveTypes] = useState<Set<ItemType>>(
+    new Set(['activity', 'tag', 'location', 'music']),
+  )
+
+  const date = new Date(dateStr)
+  const start = subDays(startOfDay(date), 0.5)
+  const end = addDays(endOfDay(date), 0.5)
+
+  const activitiesQuery = useQuery({
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchActivities(start, end, ['sleep', 'exercise', 'meditation', 'nap']),
+    queryKey: ['data-activities', dateStr],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const tagsQuery = useQuery({
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchTags(start, end),
+    queryKey: ['data-tags', dateStr],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const placesQuery = useQuery({
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchPlaces(start, end),
+    queryKey: ['data-places', dateStr],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const scrobblesQuery = useQuery({
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchScrobbles(start, end),
+    queryKey: ['data-scrobbles', dateStr],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const isLoading =
+    activitiesQuery.isLoading || tagsQuery.isLoading || placesQuery.isLoading || scrobblesQuery.isLoading
+  const isError =
+    activitiesQuery.isError || tagsQuery.isError || placesQuery.isError || scrobblesQuery.isError
+
+  const toggleType = (t: ItemType) => {
+    setActiveTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
+
+  const allItems = buildItems(
+    activeTypes,
+    activitiesQuery.data ?? [],
+    tagsQuery.data ?? [],
+    placesQuery.data ?? [],
+    scrobblesQuery.data ?? [],
+  )
+
+  const prevDay = () => setDateStr(formatISO(subDays(new Date(dateStr), 1), { representation: 'date' }))
+  const nextDay = () => setDateStr(formatISO(addDays(new Date(dateStr), 1), { representation: 'date' }))
+  const goToday = () => setDateStr(formatISO(new Date(), { representation: 'date' }))
+
+  return (
+    <div class="data-page">
+      <div class="data-controls">
+        <div class="data-nav">
+          <button class="nav-btn" onClick={prevDay} title="Previous day" type="button">
+            {'<'}
+          </button>
+          <button class="nav-btn nav-today" onClick={goToday} type="button">
+            Today
+          </button>
+          <button class="nav-btn" onClick={nextDay} title="Next day" type="button">
+            {'>'}
+          </button>
+        </div>
+        <span class="data-date-label">{format(date, 'EEE MMM d, yyyy')}</span>
+        <div class="data-type-filters">
+          {(Object.entries(TYPE_LABELS) as [ItemType, string][]).map(([t, label]) => (
+            <button
+              key={t}
+              class={`data-type-btn${activeTypes.has(t) ? ' active' : ''}`}
+              onClick={() => toggleType(t)}
+              type="button"
+              style={activeTypes.has(t) ? { borderColor: TYPE_COLORS[t] } : undefined}
+            >
+              <span
+                class="data-type-dot"
+                style={{ background: activeTypes.has(t) ? TYPE_COLORS[t] : '#d1d5db' }}
+              />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && <p class="data-status">Loading…</p>}
+      {isError && <p class="data-status data-error">Error loading data</p>}
+
+      {!isLoading && !isError && (
+        <div class="data-list">
+          {allItems.length === 0 && <p class="data-status">No data for this day</p>}
+          {allItems.map((item, i) => {
+            const href =
+              item.entityId && item.entityType ?
+                `/detail/${item.entityType}/${encodeURIComponent(item.entityId)}`
+              : undefined
+            const El = href ? 'a' : 'div'
+            return (
+              <El key={i} class={`data-item${href ? ' clickable' : ''}`} {...(href ? { href } : {})}>
+                <span class="data-dot" style={{ background: item.color }} />
+                <div class="data-item-content">
+                  <span class="data-item-label">{item.label}</span>
+                  <span class="data-item-detail">{item.detail}</span>
+                </div>
+              </El>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Data/style.css
+++ b/apps/web/src/pages/Data/style.css
@@ -1,0 +1,212 @@
+.data-page {
+  width: 100%;
+  padding: 1.5rem;
+  box-sizing: border-box;
+}
+
+/* Controls */
+.data-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 0.625rem 0.75rem;
+  background: #f9fafb;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+}
+
+.data-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.data-nav .nav-btn {
+  background: transparent;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #374151;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.data-nav .nav-btn:hover {
+  background: #e5e7eb;
+  border-color: #9ca3af;
+}
+
+.data-nav .nav-today {
+  font-weight: 500;
+  padding: 0.3rem 0.75rem;
+}
+
+.data-date-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #374151;
+  white-space: nowrap;
+}
+
+/* Type filter buttons */
+.data-type-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-left: auto;
+}
+
+.data-type-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: transparent;
+  border: 1px solid #d1d5db;
+  border-radius: 20px;
+  padding: 0.2rem 0.625rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  color: #6b7280;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.data-type-btn:hover {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.data-type-btn.active {
+  color: #374151;
+  background: #f9fafb;
+}
+
+.data-type-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* List */
+.data-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.data-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.625rem 0.25rem;
+  border-bottom: 1px solid #e5e7eb;
+  text-decoration: none;
+  color: inherit;
+}
+
+.data-item.clickable {
+  cursor: pointer;
+}
+
+.data-item.clickable:hover {
+  background: #f9fafb;
+  border-radius: 6px;
+  margin: 0 -0.25rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.data-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  margin-top: 0.3rem;
+}
+
+.data-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.data-item-label {
+  font-weight: 500;
+  color: #1f2937;
+  font-size: 0.9rem;
+}
+
+.data-item-detail {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.data-status {
+  text-align: center;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+.data-error {
+  color: #dc2626;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .data-controls {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .data-nav .nav-btn {
+    color: #d1d5db;
+    border-color: #4b5563;
+  }
+
+  .data-nav .nav-btn:hover {
+    background: #374151;
+    border-color: #6b7280;
+  }
+
+  .data-date-label {
+    color: #d1d5db;
+  }
+
+  .data-type-btn {
+    color: #9ca3af;
+    border-color: #4b5563;
+  }
+
+  .data-type-btn:hover {
+    background: #374151;
+    color: #d1d5db;
+  }
+
+  .data-type-btn.active {
+    color: #d1d5db;
+    background: #1f2937;
+  }
+
+  .data-item {
+    border-color: #374151;
+  }
+
+  .data-item.clickable:hover {
+    background: #1f2937;
+  }
+
+  .data-item-label {
+    color: #e5e7eb;
+  }
+
+  .data-item-detail {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -497,8 +497,6 @@ export const buildTooltipHtml = (item: ChartItem, music: string[], activities: A
 
 // ── Chart layout constants ────────────────────────────────────────────────────
 
-const VERTICAL_CHART_HEIGHT = 800
-const HORIZONTAL_CHART_HEIGHT = 500
 const HORIZONTAL_MARGIN = { bottom: 30, left: 60, right: 60, top: 10 }
 const VERTICAL_MARGIN = { bottom: 10, left: 60, right: 10, top: 30 }
 
@@ -506,10 +504,11 @@ const computeVerticalZoomTransform = (
   baseScale: d3.ScaleTime<number, number>,
   vStart: Date,
   vEnd: Date,
+  chartHeight: number,
 ): d3.ZoomTransform => {
   const by0 = baseScale(vStart)
   const by1 = baseScale(vEnd)
-  const k = VERTICAL_CHART_HEIGHT / (by1 - by0)
+  const k = chartHeight / (by1 - by0)
   return d3.zoomIdentity.translate(0, -k * by0).scale(k)
 }
 
@@ -542,6 +541,33 @@ export const Timeline = () => {
 
   const orientationRef = useRef(orientation)
   orientationRef.current = orientation
+
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [legendCollapsed, setLegendCollapsed] = useState(false)
+  const legendRef = useRef<HTMLDivElement>(null)
+
+  // Auto-collapse legend if it wraps to more than one row
+  useEffect(() => {
+    const el = legendRef.current
+    if (!el) return
+    // First render: measure if content height exceeds one-row height
+    const firstChild = el.firstElementChild as HTMLElement | null
+    if (!firstChild) return
+    const oneRowHeight = firstChild.getBoundingClientRect().height || 36
+    if (el.scrollHeight > oneRowHeight + 8) {
+      setLegendCollapsed(true)
+    }
+  }, []) // run once after mount
+
+  // Escape key exits fullscreen
+  useEffect(() => {
+    if (!isFullscreen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsFullscreen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [isFullscreen])
 
   // ── Data queries ───────────────────────────────────────────────────────────
 
@@ -630,7 +656,7 @@ export const Timeline = () => {
   const heartRateQuery = useQuery({
     enabled: orientation === 'horizontal',
     placeholderData: keepPreviousData,
-    queryFn: () => fetchHeartRate(new Date(fromDate.value), new Date(toDate.value)),
+    queryFn: () => fetchHeartRate(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['timeline-hr', fromDate.value, toDate.value],
     staleTime: 5 * 60 * 1000,
   })
@@ -638,7 +664,7 @@ export const Timeline = () => {
   const hrvQuery = useQuery({
     enabled: orientation === 'horizontal',
     placeholderData: keepPreviousData,
-    queryFn: () => fetchHrv(new Date(fromDate.value), new Date(toDate.value)),
+    queryFn: () => fetchHrv(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['timeline-hrv', fromDate.value, toDate.value],
     staleTime: 5 * 60 * 1000,
   })
@@ -959,22 +985,21 @@ export const Timeline = () => {
     if (!svgRef.current || !containerRef.current) return
 
     const containerWidth = containerRef.current.clientWidth
+    const containerHeight = containerRef.current.clientHeight
     const margin = VERTICAL_MARGIN
     const chartWidth = containerWidth - margin.left - margin.right
+    const chartHeight = Math.max(200, containerHeight - margin.top - margin.bottom)
 
     const svg = d3.select(svgRef.current)
     svg.selectAll('*').remove()
-    svg.attr('width', containerWidth).attr('height', VERTICAL_CHART_HEIGHT + margin.top + margin.bottom)
+    svg.attr('width', containerWidth).attr('height', containerHeight)
 
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
 
-    const baseScale = d3.scaleTime().domain(baseScaleDomain).range([0, VERTICAL_CHART_HEIGHT])
+    const baseScale = d3.scaleTime().domain(baseScaleDomain).range([0, chartHeight])
     baseScaleRef.current = baseScale
 
-    const yScale = d3
-      .scaleTime()
-      .domain([effectiveViewStart, effectiveViewEnd])
-      .range([0, VERTICAL_CHART_HEIGHT])
+    const yScale = d3.scaleTime().domain([effectiveViewStart, effectiveViewEnd]).range([0, chartHeight])
 
     const colWidth = chartWidth / columns.length
     const colGap = 4
@@ -986,7 +1011,7 @@ export const Timeline = () => {
       .attr('id', 'chart-clip')
       .append('rect')
       .attr('width', chartWidth)
-      .attr('height', VERTICAL_CHART_HEIGHT)
+      .attr('height', chartHeight)
 
     const chartGroup = g.append('g').attr('clip-path', 'url(#chart-clip)')
 
@@ -1126,7 +1151,7 @@ export const Timeline = () => {
       svg.call(zoomBehaviorRef.current)
       svg.call(
         zoomBehaviorRef.current.transform,
-        computeVerticalZoomTransform(baseScale, effectiveViewStart, effectiveViewEnd),
+        computeVerticalZoomTransform(baseScale, effectiveViewStart, effectiveViewEnd, chartHeight),
       )
       isProgrammaticZoom.current = false
     }
@@ -1150,9 +1175,10 @@ export const Timeline = () => {
     if (!svgRef.current || !containerRef.current) return
 
     const containerWidth = containerRef.current.clientWidth
+    const containerHeight = containerRef.current.clientHeight
     const margin = HORIZONTAL_MARGIN
     const chartWidth = containerWidth - margin.left - margin.right
-    const chartHeight = HORIZONTAL_CHART_HEIGHT - margin.top - margin.bottom
+    const chartHeight = Math.max(150, containerHeight - margin.top - margin.bottom)
 
     const TRACK_COUNT = 3
     const trackHeight = chartHeight / TRACK_COUNT
@@ -1163,7 +1189,7 @@ export const Timeline = () => {
 
     const svg = d3.select(svgRef.current)
     svg.selectAll('*').remove()
-    svg.attr('width', containerWidth).attr('height', HORIZONTAL_CHART_HEIGHT)
+    svg.attr('width', containerWidth).attr('height', containerHeight)
 
     // Add defs once
     const defs = svg.append('defs')
@@ -1407,7 +1433,8 @@ export const Timeline = () => {
           .defined(Boolean)
           .x(([time]) => currentXScale(time))
           .y(([, rate]) => yHr(rate))
-        g.append('path')
+        clipped
+          .append('path')
           .datum(preprocessData(heartRates, 10))
           .attr('fill', 'none')
           .attr('stroke', HR_COLOR)
@@ -1422,7 +1449,8 @@ export const Timeline = () => {
           .defined(Boolean)
           .x(([time]) => currentXScale(time))
           .y(([, value]) => yHrv(value))
-        g.append('path')
+        clipped
+          .append('path')
           .datum(preprocessData(hrvData, 10))
           .attr('fill', 'none')
           .attr('stroke', HRV_COLOR)
@@ -1514,7 +1542,14 @@ export const Timeline = () => {
             if (!baseScale) return
             const newY = event.transform.rescaleY(baseScale)
             const newDomain = newY.domain() as [Date, Date]
-            drawRef.current?.(d3.scaleTime().domain(newDomain).range([0, VERTICAL_CHART_HEIGHT]))
+            const h =
+              containerRef.current ?
+                Math.max(
+                  200,
+                  containerRef.current.clientHeight - VERTICAL_MARGIN.top - VERTICAL_MARGIN.bottom,
+                )
+              : 800
+            drawRef.current?.(d3.scaleTime().domain(newDomain).range([0, h]))
           })
         })
         .on('end', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
@@ -1531,7 +1566,11 @@ export const Timeline = () => {
 
       const baseScale = baseScaleRef.current
       if (baseScale) {
-        const t = computeVerticalZoomTransform(baseScale, effectiveViewStart, effectiveViewEnd)
+        const hForZoom =
+          containerRef.current ?
+            Math.max(200, containerRef.current.clientHeight - VERTICAL_MARGIN.top - VERTICAL_MARGIN.bottom)
+          : 800
+        const t = computeVerticalZoomTransform(baseScale, effectiveViewStart, effectiveViewEnd, hForZoom)
         isProgrammaticZoom.current = true
         svg.call(zoom.transform, t)
         isProgrammaticZoom.current = false
@@ -1591,8 +1630,6 @@ export const Timeline = () => {
   const isError =
     activitiesQuery.isError || placesQuery.isError || tagsQuery.isError || productivityQuery.isError
 
-  const mobileItems = [...chartItems].sort((a, b) => a.start.getTime() - b.start.getTime())
-
   const viewLabel =
     format(effectiveViewStart, 'MMM d') === format(effectiveViewEnd, 'MMM d') ?
       format(effectiveViewStart, 'MMM d, yyyy')
@@ -1600,10 +1637,10 @@ export const Timeline = () => {
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
-  return (
-    <div class="timeline-view">
-      <h1>Timeline</h1>
+  const hiddenCount = hiddenCategories.size
 
+  return (
+    <div class={`timeline-view${isFullscreen ? ' timeline-fullscreen' : ''}`}>
       <div class="timeline-controls">
         <div class="timeline-nav">
           <button class="nav-btn" onClick={() => handleJumpDays(-30)} title="Back 1 month">
@@ -1627,7 +1664,7 @@ export const Timeline = () => {
 
         <div class="timeline-orientation-toggle">
           <button
-            class={`orientation-btn${orientation === 'vertical' ? ' active' : ''}`}
+            class={`nav-btn${orientation === 'vertical' ? ' active' : ''}`}
             onClick={() => setOrientation('vertical')}
             title="Vertical (columns)"
             type="button"
@@ -1635,67 +1672,100 @@ export const Timeline = () => {
             ☰
           </button>
           <button
-            class={`orientation-btn${orientation === 'horizontal' ? ' active' : ''}`}
+            class={`nav-btn${orientation === 'horizontal' ? ' active' : ''}`}
             onClick={() => setOrientation('horizontal')}
             title="Horizontal (timeline)"
             type="button"
           >
             ≡
           </button>
+          <button
+            class="nav-btn timeline-fullscreen-btn"
+            onClick={() => setIsFullscreen((v) => !v)}
+            title={isFullscreen ? 'Exit full screen (Esc)' : 'Full screen'}
+            type="button"
+          >
+            {isFullscreen ? '⛶' : '⛶'}
+          </button>
         </div>
       </div>
 
-      <div class="timeline-legend">
-        {(
-          [
-            { cat: 'sleep' as LegendCategory, color: activityColors.sleep!, label: 'Sleep' },
-            { cat: 'nap' as LegendCategory, color: activityColors.nap!, label: 'Nap' },
-            { cat: 'meditation' as LegendCategory, color: activityColors.meditation!, label: 'Meditation' },
-            { cat: 'exercise' as LegendCategory, color: hrZoneColors[2]!, label: 'Exercise' },
-            { cat: 'location' as LegendCategory, color: placeColorPalette[0]!, label: 'Location' },
-            { cat: 'calendar' as LegendCategory, color: tagSourceColors.calendar!, label: 'Calendar' },
-            { cat: 'tags' as LegendCategory, color: TAG_COLOR, label: 'Tags' },
-            ...(occasionalMetricItems.length > 0 ?
-              [{ cat: 'metrics' as LegendCategory, color: METRIC_COLOR, label: 'Metrics' }]
-            : []),
-            { cat: 'screentime' as LegendCategory, color: productivityColors[1]!, label: 'Screen Time' },
-            ...(showMusicColumn ?
-              [{ cat: 'music' as LegendCategory, color: MUSIC_COLOR, label: 'Music' }]
-            : []),
-          ] as { cat: LegendCategory; color: string; label: string }[]
-        ).map(({ cat, color, label }) => (
-          <button
-            key={cat}
-            class={`legend-item${hiddenCategories.has(cat) ? ' legend-item-hidden' : ''}`}
-            onClick={() => toggleCategory(cat)}
-            type="button"
-          >
-            <span class="legend-dot" style={{ background: color }} />
-            {label}
-          </button>
-        ))}
-        <span class="legend-separator" />
-        {orientation === 'vertical' && (
-          <>
-            <button
-              class={`legend-item${!showSparklineHR ? ' legend-item-hidden' : ''}`}
-              onClick={() => setShowSparklineHR((v) => !v)}
-              type="button"
-              title="Toggle HR sparklines on activities"
-            >
-              <span class="legend-dot" style={{ background: HR_COLOR }} />
-              HR
-            </button>
-            <button
-              class={`legend-item${!showSparklineHRV ? ' legend-item-hidden' : ''}`}
-              onClick={() => setShowSparklineHRV((v) => !v)}
-              type="button"
-              title="Toggle HRV sparklines on activities"
-            >
-              <span class="legend-dot" style={{ background: HRV_COLOR }} />
-              HRV
-            </button>
-          </>
+      <div class={`timeline-legend-wrapper${legendCollapsed ? ' collapsed' : ''}`}>
+        <button
+          class="timeline-legend-toggle"
+          onClick={() => setLegendCollapsed((v) => !v)}
+          type="button"
+          title={legendCollapsed ? 'Show legend' : 'Hide legend'}
+        >
+          Legend{hiddenCount > 0 ? ` (${hiddenCount} hidden)` : ''}{' '}
+          <span class="dropdown-arrow">{legendCollapsed ? '▾' : '▴'}</span>
+        </button>
+        {!legendCollapsed && (
+          <div class="timeline-legend" ref={legendRef}>
+            {(
+              [
+                { cat: 'sleep' as LegendCategory, color: activityColors.sleep!, label: 'Sleep' },
+                { cat: 'nap' as LegendCategory, color: activityColors.nap!, label: 'Nap' },
+                {
+                  cat: 'meditation' as LegendCategory,
+                  color: activityColors.meditation!,
+                  label: 'Meditation',
+                },
+                { cat: 'exercise' as LegendCategory, color: hrZoneColors[2]!, label: 'Exercise' },
+                { cat: 'location' as LegendCategory, color: placeColorPalette[0]!, label: 'Location' },
+                {
+                  cat: 'calendar' as LegendCategory,
+                  color: tagSourceColors.calendar!,
+                  label: 'Calendar',
+                },
+                { cat: 'tags' as LegendCategory, color: TAG_COLOR, label: 'Tags' },
+                ...(occasionalMetricItems.length > 0 ?
+                  [{ cat: 'metrics' as LegendCategory, color: METRIC_COLOR, label: 'Metrics' }]
+                : []),
+                {
+                  cat: 'screentime' as LegendCategory,
+                  color: productivityColors[1]!,
+                  label: 'Screen Time',
+                },
+                ...(showMusicColumn ?
+                  [{ cat: 'music' as LegendCategory, color: MUSIC_COLOR, label: 'Music' }]
+                : []),
+              ] as { cat: LegendCategory; color: string; label: string }[]
+            ).map(({ cat, color, label }) => (
+              <button
+                key={cat}
+                class={`legend-item${hiddenCategories.has(cat) ? ' legend-item-hidden' : ''}`}
+                onClick={() => toggleCategory(cat)}
+                type="button"
+              >
+                <span class="legend-dot" style={{ background: color }} />
+                {label}
+              </button>
+            ))}
+            <span class="legend-separator" />
+            {orientation === 'vertical' && (
+              <>
+                <button
+                  class={`legend-item${!showSparklineHR ? ' legend-item-hidden' : ''}`}
+                  onClick={() => setShowSparklineHR((v) => !v)}
+                  type="button"
+                  title="Toggle HR sparklines on activities"
+                >
+                  <span class="legend-dot" style={{ background: HR_COLOR }} />
+                  HR
+                </button>
+                <button
+                  class={`legend-item${!showSparklineHRV ? ' legend-item-hidden' : ''}`}
+                  onClick={() => setShowSparklineHRV((v) => !v)}
+                  type="button"
+                  title="Toggle HRV sparklines on activities"
+                >
+                  <span class="legend-dot" style={{ background: HRV_COLOR }} />
+                  HRV
+                </button>
+              </>
+            )}
+          </div>
         )}
       </div>
 
@@ -1738,35 +1808,6 @@ export const Timeline = () => {
           </div>
 
           <p class="timeline-help">Scroll to zoom · Drag to pan · Double-click to reset</p>
-
-          <div class="timeline-list">
-            {mobileItems.length === 0 && <p class="loading">No data for this period</p>}
-            {mobileItems.map((item, idx) => {
-              const href =
-                item.entity_id && item.entity_type ?
-                  `/detail/${item.entity_type}/${encodeURIComponent(item.entity_id)}`
-                : (item.href ?? undefined)
-              const Wrapper = href ? 'a' : 'div'
-              return (
-                <Wrapper
-                  class={`timeline-list-item${href ? ' clickable' : ''}`}
-                  key={idx}
-                  {...(href ? { href } : {})}
-                >
-                  <span class="list-dot" style={{ background: item.color }} />
-                  <span class="list-time">{item.tooltip.time}</span>
-                  <div class="list-content">
-                    <div class="list-title">{item.label}</div>
-                    {item.tooltip.details.map((d, i) => (
-                      <div class="list-detail" key={i}>
-                        {d}
-                      </div>
-                    ))}
-                  </div>
-                </Wrapper>
-              )
-            })}
-          </div>
         </>
       )}
     </div>

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1664,20 +1664,51 @@ export const Timeline = () => {
 
         <div class="timeline-orientation-toggle">
           <button
-            class={`nav-btn${orientation === 'vertical' ? ' active' : ''}`}
-            onClick={() => setOrientation('vertical')}
-            title="Vertical (columns)"
+            class="nav-btn"
+            onClick={() => setOrientation(orientation === 'vertical' ? 'horizontal' : 'vertical')}
+            title={orientation === 'vertical' ? 'Switch to horizontal layout' : 'Switch to vertical layout'}
             type="button"
           >
-            ☰
-          </button>
-          <button
-            class={`nav-btn${orientation === 'horizontal' ? ' active' : ''}`}
-            onClick={() => setOrientation('horizontal')}
-            title="Horizontal (timeline)"
-            type="button"
-          >
-            ≡
+            {
+              orientation === 'vertical' ?
+                // Portrait screen → rotate to landscape
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  {/* Portrait screen */}
+                  <rect x="7" y="2" width="10" height="14" rx="2" />
+                  {/* Rotation arrow (clockwise, bottom-right) */}
+                  <path d="M19 17a7 7 0 0 1-7 5" />
+                  <polyline points="16 21 19 17 23 19" />
+                </svg>
+                // Landscape screen → rotate to portrait
+              : <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  {/* Landscape screen */}
+                  <rect x="2" y="7" width="14" height="10" rx="2" />
+                  {/* Rotation arrow (counter-clockwise, bottom-right) */}
+                  <path d="M17 19a7 7 0 0 1-5 -7" />
+                  <polyline points="21 16 17 19 19 23" />
+                </svg>
+
+            }
           </button>
           <button
             class="nav-btn timeline-fullscreen-btn"

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1682,10 +1682,10 @@ export const Timeline = () => {
           <button
             class="nav-btn timeline-fullscreen-btn"
             onClick={() => setIsFullscreen((v) => !v)}
-            title={isFullscreen ? 'Exit full screen (Esc)' : 'Full screen'}
+            title={isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
             type="button"
           >
-            {isFullscreen ? '⛶' : '⛶'}
+            {isFullscreen ? '⤡' : '⛶'}
           </button>
         </div>
       </div>

--- a/apps/web/src/pages/Timeline/style.css
+++ b/apps/web/src/pages/Timeline/style.css
@@ -81,11 +81,13 @@
   font-weight: 500;
 }
 
-/* Active orientation button */
-.timeline-orientation-toggle .nav-btn.active {
-  background: #374151;
-  color: #fff;
-  border-color: #374151;
+/* Orientation toggle button — contains SVG, needs flex centering */
+.timeline-orientation-toggle .nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.4rem;
+  line-height: 0;
 }
 
 /* Date label */
@@ -376,12 +378,6 @@
   .timeline-nav .nav-btn:active,
   .timeline-orientation-toggle .nav-btn:active {
     background: #4b5563;
-  }
-
-  .timeline-orientation-toggle .nav-btn.active {
-    background: #d1d5db;
-    color: #111827;
-    border-color: #d1d5db;
   }
 
   .timeline-date-label {

--- a/apps/web/src/pages/Timeline/style.css
+++ b/apps/web/src/pages/Timeline/style.css
@@ -1,26 +1,43 @@
+/* ── Timeline page layout ──────────────────────────────────────── */
+
 .timeline-view {
-  margin: 0 auto;
-  padding: 2rem;
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  height: 100%;
+  padding: 0.5rem 0.75rem 0;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
-.timeline-view h1 {
-  font-size: 2rem;
-  margin: 0 0 1.5rem 0;
-  color: #1f2937;
+/* Full-screen mode: cover everything including the nav bar */
+.timeline-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  background: var(--bg, #fff);
+  padding: 0.5rem 0.75rem 0;
 }
 
-/* Controls */
+@media (prefers-color-scheme: dark) {
+  .timeline-fullscreen {
+    background: #1a1a1a;
+  }
+}
+
+/* ── Controls bar ─────────────────────────────────────────────── */
+
 .timeline-controls {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+  padding: 0.375rem 0.5rem;
   background: #f9fafb;
   border-radius: 8px;
   border: 1px solid #e5e7eb;
+  flex-shrink: 0;
 }
 
 /* Navigation buttons */
@@ -30,11 +47,12 @@
   gap: 0.25rem;
 }
 
-.timeline-nav .nav-btn {
+.timeline-nav .nav-btn,
+.timeline-orientation-toggle .nav-btn {
   background: transparent;
   border: 1px solid #d1d5db;
   border-radius: 4px;
-  padding: 0.375rem 0.625rem;
+  padding: 0.25rem 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
@@ -42,48 +60,45 @@
   transition:
     background 0.15s,
     border-color 0.15s;
-  min-width: 2rem;
+  min-width: 1.75rem;
   text-align: center;
+  line-height: 1.4;
 }
 
-.timeline-nav .nav-btn:hover {
+.timeline-nav .nav-btn:hover,
+.timeline-orientation-toggle .nav-btn:hover {
   background: #e5e7eb;
   border-color: #9ca3af;
 }
 
-.timeline-nav .nav-btn:active {
+.timeline-nav .nav-btn:active,
+.timeline-orientation-toggle .nav-btn:active {
   background: #d1d5db;
 }
 
 .timeline-nav .nav-today {
-  padding: 0.375rem 0.75rem;
+  padding: 0.25rem 0.625rem;
   font-weight: 500;
 }
 
-/* Date label */
-.timeline-date-label {
-  font-size: 0.9rem;
-  color: #374151;
-  font-weight: 500;
-}
-
-/* Orientation toggle */
-.timeline-orientation-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  margin-left: auto;
-}
-
+/* Active orientation button */
 .timeline-orientation-toggle .nav-btn.active {
   background: #374151;
   color: #fff;
   border-color: #374151;
 }
 
+/* Date label */
+.timeline-date-label {
+  font-size: 0.875rem;
+  color: #374151;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
 /* Fetching indicator */
 .timeline-fetching {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: #6b7280;
   animation: timeline-pulse 1.5s ease-in-out infinite;
 }
@@ -98,30 +113,70 @@
   }
 }
 
-/* Legend */
+/* Orientation + fullscreen toggle group */
+.timeline-orientation-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.timeline-fullscreen-btn {
+  font-size: 1rem;
+  padding: 0.2rem 0.4rem !important;
+}
+
+/* ── Legend ────────────────────────────────────────────────────── */
+
+.timeline-legend-wrapper {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.375rem;
+  flex-shrink: 0;
+}
+
+.timeline-legend-toggle {
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  color: #6b7280;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.timeline-legend-toggle:hover {
+  background: #f3f4f6;
+  color: #374151;
+}
+
 .timeline-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
   background: #f9fafb;
   border-radius: 8px;
   border: 1px solid #e5e7eb;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
+  flex: 1;
 }
 
 .timeline-legend .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.3rem;
   cursor: pointer;
   background: none;
   border: none;
-  padding: 0.25rem 0.5rem;
+  padding: 0.15rem 0.4rem;
   border-radius: 4px;
   font: inherit;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: inherit;
   transition:
     opacity 0.15s,
@@ -138,29 +193,32 @@
 }
 
 .timeline-legend .legend-dot {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 3px;
   flex-shrink: 0;
 }
 
 .timeline-legend .legend-separator {
   width: 1px;
-  height: 20px;
+  height: 18px;
   background: #d1d5db;
-  margin: 0 0.25rem;
+  margin: 0 0.125rem;
   flex-shrink: 0;
+  align-self: center;
 }
 
-/* Overlap warnings */
+/* ── Overlap warnings ──────────────────────────────────────────── */
+
 .timeline-overlap-warnings {
-  margin-bottom: 1rem;
-  padding: 0.5rem 1rem;
+  margin-bottom: 0.375rem;
+  padding: 0.375rem 0.75rem;
   background: #fefce8;
   border: 1px solid #fbbf24;
   border-radius: 8px;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: #92400e;
+  flex-shrink: 0;
 }
 
 .timeline-overlap-warnings summary {
@@ -174,7 +232,7 @@
 }
 
 .timeline-overlap-warnings ul {
-  margin: 0.5rem 0;
+  margin: 0.375rem 0;
   padding-left: 1.25rem;
 }
 
@@ -182,21 +240,19 @@
   margin-bottom: 0.25rem;
 }
 
-.timeline-overlap-warnings .overlap-hint {
-  margin: 0.5rem 0 0;
-  font-size: 0.8rem;
-  color: #a16207;
-  font-style: italic;
-}
+/* ── Chart container — fills remaining space ─────────────────── */
 
-/* Chart container */
 .timeline-chart-container {
   position: relative;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 
 .timeline-chart-container svg {
   display: block;
+  width: 100%;
+  height: 100%;
   cursor: grab;
 }
 
@@ -208,15 +264,31 @@
   cursor: pointer;
 }
 
-/* Tooltip */
+/* ── Column headers ────────────────────────────────────────────── */
+
+.timeline-column-headers {
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.125rem;
+  padding: 0 0 0.25rem 0;
+  border-bottom: 1px solid #e5e7eb;
+  flex-shrink: 0;
+}
+
+/* ── Tooltip ───────────────────────────────────────────────────── */
+
 .timeline-tooltip {
   position: absolute;
   pointer-events: none;
   background: rgba(0, 0, 0, 0.9);
   color: white;
-  padding: 0.625rem 0.875rem;
+  padding: 0.5rem 0.75rem;
   border-radius: 6px;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   line-height: 1.5;
   max-width: 300px;
   z-index: 1000;
@@ -231,17 +303,17 @@
 
 .timeline-tooltip .tooltip-time {
   color: #9ca3af;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
 }
 
 .timeline-tooltip .tooltip-detail {
   color: #d1d5db;
-  margin-top: 0.25rem;
+  margin-top: 0.2rem;
 }
 
 .timeline-tooltip .tooltip-music {
   color: #ec4899;
-  margin-top: 0.375rem;
+  margin-top: 0.3rem;
   font-style: italic;
 }
 
@@ -250,7 +322,7 @@
   height: 8px;
   border-radius: 4px;
   overflow: hidden;
-  margin-top: 0.375rem;
+  margin-top: 0.3rem;
 }
 
 .timeline-tooltip .hr-zone-bar span {
@@ -258,15 +330,18 @@
   height: 100%;
 }
 
-/* Help text */
+/* ── Help text ─────────────────────────────────────────────────── */
+
 .timeline-help {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: #9ca3af;
-  margin-top: 0.5rem;
+  margin: 0.25rem 0 0;
   text-align: center;
+  flex-shrink: 0;
 }
 
-/* Loading and error states */
+/* ── Loading / error states ────────────────────────────────────── */
+
 .timeline-view .loading,
 .timeline-view .error {
   text-align: center;
@@ -278,94 +353,28 @@
   color: #dc2626;
 }
 
-/* Mobile list fallback */
-.timeline-list {
-  display: none;
-}
+/* ── Dark mode ─────────────────────────────────────────────────── */
 
-.timeline-list-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.75rem 0;
-  border-bottom: 1px solid #e5e7eb;
-  text-decoration: none;
-  color: inherit;
-}
-
-.timeline-list-item.clickable {
-  cursor: pointer;
-}
-
-.timeline-list-item.clickable:hover {
-  background: #f9fafb;
-}
-
-.timeline-list-item .list-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 3px;
-  flex-shrink: 0;
-  margin-top: 0.375rem;
-}
-
-.timeline-list-item .list-time {
-  font-size: 0.8rem;
-  color: #6b7280;
-  min-width: 90px;
-  flex-shrink: 0;
-}
-
-.timeline-list-item .list-content {
-  flex: 1;
-}
-
-.timeline-list-item .list-title {
-  font-weight: 500;
-  color: #374151;
-}
-
-.timeline-list-item .list-detail {
-  font-size: 0.85rem;
-  color: #6b7280;
-}
-
-/* Column headers */
-.timeline-column-headers {
-  display: flex;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.25rem;
-  padding: 0 0 0.5rem 0;
-  border-bottom: 1px solid #e5e7eb;
-}
-
-/* Dark mode */
 @media (prefers-color-scheme: dark) {
-  .timeline-view h1 {
-    color: #f3f4f6;
-  }
-
   .timeline-controls {
     background: #1f2937;
     border-color: #374151;
   }
 
-  .timeline-nav .nav-btn {
+  .timeline-nav .nav-btn,
+  .timeline-orientation-toggle .nav-btn {
     color: #d1d5db;
     border-color: #4b5563;
-    background: transparent;
   }
 
-  .timeline-nav .nav-btn:hover {
+  .timeline-nav .nav-btn:hover,
+  .timeline-orientation-toggle .nav-btn:hover {
     background: #374151;
     border-color: #6b7280;
   }
 
-  .timeline-nav .nav-btn:active {
+  .timeline-nav .nav-btn:active,
+  .timeline-orientation-toggle .nav-btn:active {
     background: #4b5563;
   }
 
@@ -383,6 +392,16 @@
     color: #9ca3af;
   }
 
+  .timeline-legend-toggle {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .timeline-legend-toggle:hover {
+    background: #374151;
+    color: #d1d5db;
+  }
+
   .timeline-legend {
     background: #1f2937;
     border-color: #374151;
@@ -396,29 +415,13 @@
     background: #4b5563;
   }
 
-  .timeline-tooltip {
-    background: rgba(17, 24, 39, 0.95);
-  }
-
   .timeline-column-headers {
     color: #9ca3af;
     border-color: #374151;
   }
 
-  .timeline-list-item {
-    border-color: #374151;
-  }
-
-  .timeline-list-item .list-title {
-    color: #d1d5db;
-  }
-
-  .timeline-list-item .list-detail {
-    color: #9ca3af;
-  }
-
-  .timeline-list-item.clickable:hover {
-    background: #1f2937;
+  .timeline-tooltip {
+    background: rgba(17, 24, 39, 0.95);
   }
 
   .timeline-overlap-warnings {
@@ -429,36 +432,5 @@
 
   .timeline-overlap-warnings summary {
     color: #fbbf24;
-  }
-
-  .timeline-overlap-warnings .overlap-hint {
-    color: #fcd34d;
-  }
-}
-
-/* Responsive */
-@media (max-width: 768px) {
-  .timeline-view {
-    padding: 1rem;
-  }
-
-  .timeline-view h1 {
-    font-size: 1.5rem;
-  }
-
-  .timeline-chart-container {
-    display: none;
-  }
-
-  .timeline-column-headers {
-    display: none;
-  }
-
-  .timeline-help {
-    display: none;
-  }
-
-  .timeline-list {
-    display: block;
   }
 }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -23,40 +23,49 @@ body {
   min-height: 100vh;
 }
 
+/* ── Header ────────────────────────────────────────────────── */
+
 header {
   background-color: #673ab8;
 }
 
-header nav {
+/* Desktop nav — shown by default, hidden on narrow screens */
+.nav-desktop {
   display: flex;
+  align-items: center;
 }
 
-header nav .spacer {
+.nav-desktop .spacer {
   flex: 1;
 }
 
-header a {
+.nav-desktop a {
   color: #fff;
   padding: 0.75rem;
   text-decoration: none;
+  white-space: nowrap;
 }
 
-header a.active {
+.nav-desktop a.active {
   background-color: #0005;
 }
 
-header a:hover {
+.nav-desktop a:hover {
   background-color: #0008;
 }
 
-/* Nav dropdown for Data Sources */
+/* Nav dropdown for Data Sources — desktop */
 .nav-dropdown {
   position: relative;
+  display: flex;
+  align-items: stretch;
 }
 
 .nav-dropdown .dropdown-toggle {
   cursor: pointer;
   user-select: none;
+  display: flex;
+  align-items: center;
 }
 
 .dropdown-arrow {
@@ -93,6 +102,165 @@ header a:hover {
   background-color: #0005;
 }
 
+/* Mobile nav bar — hidden by default, shown on narrow screens */
+.nav-mobile {
+  display: none;
+  align-items: center;
+  padding: 0 0.5rem;
+}
+
+.nav-mobile .spacer {
+  flex: 1;
+}
+
+.nav-mobile-home {
+  color: #fff;
+  padding: 0.75rem;
+  text-decoration: none;
+}
+
+.nav-mobile-home.active {
+  background-color: #0005;
+}
+
+.hamburger-btn {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1.4rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.hamburger-btn:hover {
+  background-color: #0008;
+}
+
+/* Drawer backdrop */
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 200;
+}
+
+/* Left drawer */
+.nav-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  background: #673ab8;
+  z-index: 300;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+  overflow-y: auto;
+}
+
+.nav-drawer.open {
+  transform: translateX(0);
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.drawer-title {
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.drawer-close-btn {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+}
+
+.drawer-close-btn:hover {
+  background-color: #0008;
+  border-radius: 4px;
+}
+
+.nav-drawer a {
+  color: #fff;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  display: block;
+}
+
+.nav-drawer a.active {
+  background-color: #0005;
+}
+
+.nav-drawer a:hover {
+  background-color: #0008;
+}
+
+.drawer-section-toggle {
+  background: transparent;
+  border: none;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  width: 100%;
+  font: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.drawer-section-toggle:hover {
+  background-color: #0008;
+}
+
+.drawer-section-toggle.active {
+  background-color: #0005;
+}
+
+.drawer-sub-link {
+  padding-left: 2rem !important;
+  font-size: 0.9rem !important;
+  opacity: 0.9;
+}
+
+.drawer-spacer {
+  flex: 1;
+  min-height: 1rem;
+}
+
+/* ── Responsive: which nav to show ───────────────────────── */
+
+/*
+ * Switch to hamburger when the desktop nav would be too cramped.
+ * ~60em covers the approximate character width of all nav items.
+ */
+@media (max-width: 60em) {
+  .nav-desktop {
+    display: none;
+  }
+
+  .nav-mobile {
+    display: flex;
+  }
+}
+
+/* ── Main content ─────────────────────────────────────────── */
+
 main {
   flex: auto;
   display: flex;
@@ -100,11 +268,7 @@ main {
   text-align: left;
 }
 
-@media (max-width: 639px) {
-  main {
-    margin: 2rem;
-  }
-}
+/* ── Footer ───────────────────────────────────────────────── */
 
 .site-footer {
   text-align: right;


### PR DESCRIPTION
## Summary

### Bugfixes
- **HR/HRV lines outside Y-axis** — paths were appended to the unclipped `g` group; moved to `clipped` group
- **HR/HRV missing start of sleep** — fetch range was midnight-to-midnight with no padding; now uses `±12h` like all other queries

### Header / nav
- **Hamburger menu** on narrow screens (<60em): replaces top nav with a left-side slide-in drawer
- **Data Sources** in drawer expands inline (no absolute-positioned dropdown)
- **Desktop dropdown alignment fix** — `nav-dropdown` wrapper now uses `display:flex; align-items:stretch` so it sits flush with other nav links
- **Data** link added to nav

### Timeline
- **Fluid chart height** — removed hardcoded 800px/500px constants; chart fills remaining viewport height via `flex:1` on the container
- **Fullscreen toggle** (⛶) — CSS `position:fixed; inset:0` covers entire screen including nav; Escape to exit
- **Collapsible legend** — toggle button shows/hides legend; auto-collapses on mount if legend wraps to >1 row; shows hidden-count in toggle label
- **Orientation toggle CSS fix** — buttons were using class `orientation-btn` but CSS targeted `nav-btn`; unified
- **Remove h1** heading (redundant with nav)
- **Remove mobile list fallback** (replaced by /data page)

### New `/data` page
- Chronological list of all data for a given day
- Type filter: Activities / Tags / Locations / Music (pill buttons)
- Day navigation with prev/next/today