### PR TITLE
feat: notes inherit time from parent entity, day summary includes overlapping notes

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -207,6 +207,9 @@ export const migrateSchema = async (user: string) => {
   // Migrate notes entity_id from UUID to TEXT (supports composite keys for metrics)
   if (existingTableNames.has('notes')) {
     await query(db, `ALTER TABLE notes ALTER COLUMN entity_id TYPE TEXT`)
+    // Add time columns so notes can be queried by time range (inherited from parent entity)
+    await query(db, `ALTER TABLE notes ADD COLUMN IF NOT EXISTS start_time TIMESTAMPTZ`)
+    await query(db, `ALTER TABLE notes ADD COLUMN IF NOT EXISTS end_time TIMESTAMPTZ`)
   }
 
   // Migrate source columns to support 'aurboda' (rename 'manual' -> 'aurboda' for new data)

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -127,6 +127,7 @@ export {
   deleteProductivityRecord,
   getAllProductivityForCategorization,
   getProductivity,
+  getProductivityById,
   insertProductivity,
   restoreProductivityRecord,
 } from './productivity'
@@ -148,8 +149,10 @@ export {
   getNoteById,
   getNotesByEntityIds,
   getNotesForEntity,
+  getNotesForTimeRange,
   insertNote,
   updateNote,
+  updateNoteTimesForEntity,
 } from './notes'
 
 // Lab results

--- a/apps/backend/src/db/notes.integration.test.ts
+++ b/apps/backend/src/db/notes.integration.test.ts
@@ -6,8 +6,10 @@ import {
   getNoteById,
   getNotesByEntityIds,
   getNotesForEntity,
+  getNotesForTimeRange,
   insertNote,
   updateNote,
+  updateNoteTimesForEntity,
 } from './notes'
 
 const CONTAINER_TIMEOUT = 60_000
@@ -38,6 +40,39 @@ describe('Notes Integration Tests', () => {
       expect(note.content).toBe('Great workout!')
       expect(note.created_at).toBeInstanceOf(Date)
       expect(note.updated_at).toBeInstanceOf(Date)
+    })
+
+    test('creates a note with inherited start_time and end_time', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const startTime = new Date('2024-01-15T08:15:00Z')
+      const endTime = new Date('2024-01-15T08:45:00Z')
+
+      const note = await insertNote(user, 'tag', entityId, 'Morning run', startTime, endTime)
+
+      expect(note.start_time).toEqual(startTime)
+      expect(note.end_time).toEqual(endTime)
+    })
+
+    test('creates a note with only start_time (point-in-time)', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const startTime = new Date('2024-01-15T09:00:00Z')
+
+      const note = await insertNote(user, 'tag', entityId, 'Point in time note', startTime)
+
+      expect(note.start_time).toEqual(startTime)
+      expect(note.end_time).toBeUndefined()
+    })
+
+    test('creates a note without time fields (e.g. metric notes)', async () => {
+      const user = getTestUser()
+      const entityId = '2024-01-15T10:30:00.000Z|heart_rate|oura'
+
+      const note = await insertNote(user, 'metric', entityId, 'HRV low today')
+
+      expect(note.start_time).toBeUndefined()
+      expect(note.end_time).toBeUndefined()
     })
   })
 
@@ -117,6 +152,196 @@ describe('Notes Integration Tests', () => {
     })
   })
 
+  describe('updateNoteTimesForEntity', () => {
+    test('updates start_time and end_time on all notes for an entity', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const initialStart = new Date('2024-01-15T08:00:00Z')
+      const initialEnd = new Date('2024-01-15T08:30:00Z')
+
+      const note1 = await insertNote(user, 'tag', entityId, 'First note', initialStart, initialEnd)
+      const note2 = await insertNote(user, 'tag', entityId, 'Second note', initialStart, initialEnd)
+
+      const newStart = new Date('2024-01-15T08:15:00Z')
+      const newEnd = new Date('2024-01-15T09:00:00Z')
+      await updateNoteTimesForEntity(user, 'tag', entityId, newStart, newEnd)
+
+      const updatedNote1 = await getNoteById(user, note1.id)
+      const updatedNote2 = await getNoteById(user, note2.id)
+
+      expect(updatedNote1!.start_time).toEqual(newStart)
+      expect(updatedNote1!.end_time).toEqual(newEnd)
+      expect(updatedNote2!.start_time).toEqual(newStart)
+      expect(updatedNote2!.end_time).toEqual(newEnd)
+    })
+
+    test('can clear end_time by passing undefined', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const start = new Date('2024-01-15T08:00:00Z')
+      const end = new Date('2024-01-15T09:00:00Z')
+
+      const note = await insertNote(user, 'tag', entityId, 'Has end time', start, end)
+      expect(note.end_time).toBeDefined()
+
+      await updateNoteTimesForEntity(user, 'tag', entityId, start, undefined)
+
+      const updated = await getNoteById(user, note.id)
+      expect(updated!.start_time).toEqual(start)
+      expect(updated!.end_time).toBeUndefined()
+    })
+
+    test('does not affect notes on other entities', async () => {
+      const user = getTestUser()
+      const entityId1 = randomUUID()
+      const entityId2 = randomUUID()
+      const start = new Date('2024-01-15T08:00:00Z')
+
+      const note1 = await insertNote(user, 'tag', entityId1, 'Entity 1 note', start)
+      const note2 = await insertNote(user, 'tag', entityId2, 'Entity 2 note', start)
+
+      const newStart = new Date('2024-01-15T10:00:00Z')
+      await updateNoteTimesForEntity(user, 'tag', entityId1, newStart)
+
+      const reloaded1 = await getNoteById(user, note1.id)
+      const reloaded2 = await getNoteById(user, note2.id)
+
+      expect(reloaded1!.start_time).toEqual(newStart)
+      // Entity 2 note should be unchanged
+      expect(reloaded2!.start_time).toEqual(start)
+    })
+  })
+
+  describe('getNotesForTimeRange', () => {
+    test('returns notes with time ranges overlapping the query window', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const start = new Date('2024-01-15T08:15:00Z')
+      const end = new Date('2024-01-15T08:45:00Z')
+
+      await insertNote(user, 'tag', entityId, 'In range', start, end)
+
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(1)
+      expect(results[0].content).toBe('In range')
+    })
+
+    test('returns note spanning multiple days when querying any overlapping day', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      // Long-spanning tag (e.g. a month)
+      const monthStart = new Date('2024-01-01T00:00:00Z')
+      const monthEnd = new Date('2024-01-31T23:59:59Z')
+
+      await insertNote(user, 'tag', entityId, 'Long tag note', monthStart, monthEnd)
+
+      // Query a day in the middle of the month
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(1)
+      expect(results[0].content).toBe('Long tag note')
+    })
+
+    test('excludes notes outside the query window', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      // Note is the day before
+      await insertNote(
+        user,
+        'tag',
+        entityId,
+        'Yesterday',
+        new Date('2024-01-14T10:00:00Z'),
+        new Date('2024-01-14T11:00:00Z'),
+      )
+
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(0)
+    })
+
+    test('includes point-in-time notes (no end_time) within the window', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const pointInTime = new Date('2024-01-15T12:00:00Z')
+
+      await insertNote(user, 'tag', entityId, 'Point-in-time note', pointInTime)
+
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(1)
+      expect(results[0].content).toBe('Point-in-time note')
+    })
+
+    test('excludes point-in-time notes outside the window', async () => {
+      const user = getTestUser()
+      const entityId = randomUUID()
+      const outsideTime = new Date('2024-01-16T12:00:00Z')
+
+      await insertNote(user, 'tag', entityId, 'Outside', outsideTime)
+
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(0)
+    })
+
+    test('excludes metric notes (no start_time)', async () => {
+      const user = getTestUser()
+      const metricEntityId = '2024-01-15T10:00:00.000Z|heart_rate|oura'
+
+      await insertNote(user, 'metric', metricEntityId, 'Metric note')
+
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(0)
+    })
+
+    test('returns notes sorted by start_time then created_at', async () => {
+      const user = getTestUser()
+
+      const laterStart = new Date('2024-01-15T14:00:00Z')
+      const earlierStart = new Date('2024-01-15T08:00:00Z')
+
+      await insertNote(user, 'tag', randomUUID(), 'Later note', laterStart)
+      await insertNote(user, 'tag', randomUUID(), 'Earlier note', earlierStart)
+
+      const results = await getNotesForTimeRange(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(results).toHaveLength(2)
+      expect(results[0].content).toBe('Earlier note')
+      expect(results[1].content).toBe('Later note')
+    })
+  })
+
   describe('getNotesByEntityIds', () => {
     test('returns empty map for empty IDs array', async () => {
       const user = getTestUser()
@@ -183,6 +408,9 @@ describe('Notes Integration Tests', () => {
       expect(note.entity_type).toBe('metric')
       expect(note.entity_id).toBe(entityId)
       expect(note.content).toBe('HRV low due to illness')
+      // Metric notes have no inherited times
+      expect(note.start_time).toBeUndefined()
+      expect(note.end_time).toBeUndefined()
     })
 
     test('retrieves notes for a metric entity', async () => {

--- a/apps/backend/src/db/notes.ts
+++ b/apps/backend/src/db/notes.ts
@@ -5,20 +5,22 @@ import { query } from './connection'
 import { mapNoteRow } from './row-mappers'
 import type { EntityType, Note } from './types'
 
-const NOTE_COLUMNS = 'id, entity_type, entity_id, content, created_at, updated_at'
+const NOTE_COLUMNS = 'id, entity_type, entity_id, content, start_time, end_time, created_at, updated_at'
 
 export const insertNote = async (
   user: string,
   entityType: EntityType,
   entityId: string,
   content: string,
+  startTime?: Date,
+  endTime?: Date,
 ): Promise<Note> => {
   const result = await query(
     user,
-    `INSERT INTO notes (entity_type, entity_id, content)
-     VALUES ($1, $2, $3)
+    `INSERT INTO notes (entity_type, entity_id, content, start_time, end_time)
+     VALUES ($1, $2, $3, $4, $5)
      RETURNING ${NOTE_COLUMNS}`,
-    [entityType, entityId, content],
+    [entityType, entityId, content, startTime ?? null, endTime ?? null],
   )
 
   return mapNoteRow(result.rows[0])
@@ -60,6 +62,25 @@ export const updateNote = async (user: string, id: string, content: string): Pro
   return mapNoteRow(result.rows[0])
 }
 
+/**
+ * Update the inherited time fields on all notes for a given entity.
+ * Called when the parent entity's timing changes (e.g. a tag is updated).
+ */
+export const updateNoteTimesForEntity = async (
+  user: string,
+  entityType: EntityType,
+  entityId: string,
+  startTime: Date,
+  endTime?: Date,
+): Promise<void> => {
+  await query(
+    user,
+    `UPDATE notes SET start_time = $1, end_time = $2, updated_at = NOW()
+     WHERE entity_type = $3 AND entity_id = $4`,
+    [startTime, endTime ?? null, entityType, entityId],
+  )
+}
+
 export const getNotesByEntityIds = async (
   user: string,
   entityType: EntityType,
@@ -81,6 +102,29 @@ export const getNotesByEntityIds = async (
     map.set(note.entity_id, existing)
   }
   return map
+}
+
+/**
+ * Get all notes whose time range overlaps [start, end].
+ *
+ * A note overlaps the window if:
+ *  - It has a start_time and end_time, and they overlap [start, end] (i.e. start_time <= end AND end_time >= start)
+ *  - It has a start_time but no end_time (point-in-time), and start_time falls within [start, end]
+ *
+ * Notes with no start_time (e.g. metric notes using composite entity_id) are excluded from this query.
+ */
+export const getNotesForTimeRange = async (user: string, start: Date, end: Date): Promise<Note[]> => {
+  const result = await query(
+    user,
+    `SELECT ${NOTE_COLUMNS} FROM notes
+     WHERE start_time IS NOT NULL
+       AND ((end_time IS NOT NULL AND start_time <= $2 AND end_time >= $1)
+            OR (end_time IS NULL AND start_time >= $1 AND start_time <= $2))
+     ORDER BY start_time ASC, created_at ASC`,
+    [start, end],
+  )
+
+  return result.rows.map(mapNoteRow)
 }
 
 export const deleteNote = async (user: string, id: string): Promise<boolean> => {

--- a/apps/backend/src/db/productivity.ts
+++ b/apps/backend/src/db/productivity.ts
@@ -97,6 +97,33 @@ export const getProductivity = async (
   }))
 }
 
+export const getProductivityById = async (user: string, id: string): Promise<ProductivityRecord | null> => {
+  const result = await query(
+    user,
+    `SELECT id, source, start_time, end_time, activity, title, category, productivity, duration_sec, is_mobile, device_name, resolved_category
+     FROM productivity
+     WHERE id = $1 AND deleted_at IS NULL`,
+    [id],
+  )
+
+  if (result.rows.length === 0) return null
+  const row = result.rows[0]
+  return {
+    activity: row.activity,
+    category: row.category,
+    device_name: row.device_name || undefined,
+    duration_sec: row.duration_sec,
+    end_time: new Date(row.end_time),
+    id: row.id,
+    is_mobile: row.is_mobile,
+    productivity: row.productivity,
+    resolved_category: row.resolved_category || undefined,
+    source: row.source,
+    start_time: new Date(row.start_time),
+    title: row.title || undefined,
+  }
+}
+
 export const deleteProductivityRecord = async (user: string, id: string): Promise<boolean> => {
   const result = await query(
     user,

--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -186,8 +186,10 @@ export const mapLastFmTagRuleRow = (row: QueryResultRow): LastFmTagRule => ({
 export const mapNoteRow = (row: QueryResultRow): Note => ({
   content: row.content,
   created_at: new Date(row.created_at),
+  end_time: row.end_time ? new Date(row.end_time) : undefined,
   entity_id: row.entity_id,
   entity_type: parseEntityType(row.entity_type),
   id: row.id,
+  start_time: row.start_time ? new Date(row.start_time) : undefined,
   updated_at: new Date(row.updated_at),
 })

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -247,6 +247,10 @@ export interface Note {
   entity_type: EntityType
   entity_id: string
   content: string
+  /** Inherited from the parent entity's start_time. Null for metric notes (composite key). */
+  start_time?: Date
+  /** Inherited from the parent entity's end_time, if any. */
+  end_time?: Date
   created_at: Date
   updated_at: Date
 }

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -180,6 +180,8 @@ export const createTableStatements: Record<string, string> = {
       entity_type     VARCHAR(50) NOT NULL,
       entity_id       TEXT NOT NULL,
       content         TEXT NOT NULL,
+      start_time      TIMESTAMPTZ,
+      end_time        TIMESTAMPTZ,
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
@@ -187,7 +189,8 @@ export const createTableStatements: Record<string, string> = {
 
   notes_indexes: `
     CREATE INDEX IF NOT EXISTS idx_notes_entity ON notes (entity_type, entity_id);
-    CREATE INDEX IF NOT EXISTS idx_notes_created ON notes (created_at DESC)
+    CREATE INDEX IF NOT EXISTS idx_notes_created ON notes (created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_notes_time ON notes (start_time, end_time)
   `,
 
   // OAuth tokens for third-party APIs

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -34,6 +34,11 @@ vi.mock('../db', () => ({
   upsertUserSettings: vi.fn(),
 }))
 
+// Mock notes service to avoid testing note-sync behavior here
+vi.mock('./notes', () => ({
+  syncNoteTimesForEntity: vi.fn().mockResolvedValue(undefined),
+}))
+
 describe('addTag', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -30,6 +30,7 @@ import {
   isValidMetricOrCustom,
   metricToHealthConnectType,
 } from '../schema'
+import { syncNoteTimesForEntity } from './notes'
 
 // ============================================================================
 // Types
@@ -144,6 +145,13 @@ export async function addTag(user: string, input: AddTagInput): Promise<AddTagRe
       const extendedBySeconds = Math.round((newEndTime.getTime() - previousEnd.getTime()) / 1000)
 
       await updateTagEndTime(user, existingTag.external_id, newEndTime)
+
+      // Sync inherited times on any notes attached to this tag
+      if (existingTag.id) {
+        await syncNoteTimesForEntity(user, 'tag', existingTag.id, existingTag.start_time, newEndTime).catch(
+          (err) => console.error('Failed to sync note times for tag:', err),
+        )
+      }
 
       return {
         end_time: newEndTime.toISOString(),
@@ -411,6 +419,7 @@ export async function deleteActivity(user: string, id: string): Promise<DeleteAc
  * Validates that if both start_time and end_time are provided, end_time is after start_time.
  * Also validates against existing values if only one is provided.
  */
+// eslint-disable-next-line complexity -- note-sync adds one branch above the limit
 export async function updateActivity(
   user: string,
   id: string,
@@ -458,6 +467,11 @@ export async function updateActivity(
       success: false,
     }
   }
+
+  // Sync inherited times on any notes attached to this activity (best-effort)
+  syncNoteTimesForEntity(user, 'activity', id, updated.start_time, updated.end_time ?? undefined).catch(
+    (err) => console.error('Failed to sync note times for activity:', err),
+  )
 
   // Enqueue outbound sync if this is an aurboda-owned HC-syncable activity (best-effort)
   try {

--- a/apps/backend/src/services/notes.test.ts
+++ b/apps/backend/src/services/notes.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for the notes service.
+ * Tests time-inheritance logic (getEntityTimes) and all exported functions.
+ */
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import * as db from '../db'
+import {
+  addNote,
+  deleteNoteById,
+  getNotesForEntity,
+  syncNoteTimesForEntity,
+  updateNoteContent,
+} from './notes'
+
+vi.mock('../db', () => ({
+  deleteNote: vi.fn(),
+  getActivityById: vi.fn(),
+  getNotesForEntity: vi.fn(),
+  getProductivityById: vi.fn(),
+  getTagById: vi.fn(),
+  insertNote: vi.fn(),
+  updateNote: vi.fn(),
+  updateNoteTimesForEntity: vi.fn(),
+}))
+
+const makeNote = (overrides = {}) => ({
+  content: 'Test note',
+  created_at: new Date('2024-01-15T10:00:00Z'),
+  end_time: undefined,
+  entity_id: randomUUID(),
+  entity_type: 'tag' as const,
+  id: randomUUID(),
+  start_time: undefined,
+  updated_at: new Date('2024-01-15T10:00:00Z'),
+  ...overrides,
+})
+
+describe('addNote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('inherits start_time and end_time from a tag entity', async () => {
+    const tagId = randomUUID()
+    const tagStart = new Date('2024-01-15T08:15:00Z')
+    const tagEnd = new Date('2024-01-15T08:45:00Z')
+
+    vi.mocked(db.getTagById).mockResolvedValue({
+      end_time: tagEnd,
+      source: 'aurboda',
+      start_time: tagStart,
+      tag: 'morning run',
+    })
+
+    const note = makeNote({ end_time: tagEnd, entity_id: tagId, entity_type: 'tag', start_time: tagStart })
+    vi.mocked(db.insertNote).mockResolvedValue(note)
+
+    const result = await addNote('user', { content: 'Great session', entity_id: tagId, entity_type: 'tag' })
+
+    expect(db.getTagById).toHaveBeenCalledWith('user', tagId)
+    expect(db.insertNote).toHaveBeenCalledWith('user', 'tag', tagId, 'Great session', tagStart, tagEnd)
+    expect(result.success).toBe(true)
+    expect(result.data?.start_time).toBe(tagStart.toISOString())
+    expect(result.data?.end_time).toBe(tagEnd.toISOString())
+  })
+
+  test('inherits start_time only when tag has no end_time', async () => {
+    const tagId = randomUUID()
+    const tagStart = new Date('2024-01-15T08:15:00Z')
+
+    vi.mocked(db.getTagById).mockResolvedValue({
+      end_time: undefined,
+      source: 'aurboda',
+      start_time: tagStart,
+      tag: 'coffee',
+    })
+
+    const note = makeNote({ entity_id: tagId, entity_type: 'tag', start_time: tagStart })
+    vi.mocked(db.insertNote).mockResolvedValue(note)
+
+    await addNote('user', { content: 'Note', entity_id: tagId, entity_type: 'tag' })
+
+    expect(db.insertNote).toHaveBeenCalledWith('user', 'tag', tagId, 'Note', tagStart, undefined)
+  })
+
+  test('returns undefined times when tag entity not found', async () => {
+    const tagId = randomUUID()
+    vi.mocked(db.getTagById).mockResolvedValue(null)
+
+    const note = makeNote({ entity_id: tagId, entity_type: 'tag' })
+    vi.mocked(db.insertNote).mockResolvedValue(note)
+
+    await addNote('user', { content: 'Orphan note', entity_id: tagId, entity_type: 'tag' })
+
+    expect(db.insertNote).toHaveBeenCalledWith('user', 'tag', tagId, 'Orphan note', undefined, undefined)
+  })
+
+  test('inherits times from an activity entity', async () => {
+    const activityId = randomUUID()
+    const start = new Date('2024-01-15T10:00:00Z')
+    const end = new Date('2024-01-15T11:00:00Z')
+
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: end,
+      id: activityId,
+      source: 'aurboda',
+      start_time: start,
+    })
+
+    const note = makeNote({
+      end_time: end,
+      entity_id: activityId,
+      entity_type: 'activity',
+      start_time: start,
+    })
+    vi.mocked(db.insertNote).mockResolvedValue(note)
+
+    await addNote('user', { content: 'Good run', entity_id: activityId, entity_type: 'activity' })
+
+    expect(db.getActivityById).toHaveBeenCalledWith('user', activityId)
+    expect(db.insertNote).toHaveBeenCalledWith('user', 'activity', activityId, 'Good run', start, end)
+  })
+
+  test('inherits times from a productivity entity', async () => {
+    const prodId = randomUUID()
+    const start = new Date('2024-01-15T09:00:00Z')
+    const end = new Date('2024-01-15T09:30:00Z')
+
+    vi.mocked(db.getProductivityById).mockResolvedValue({
+      activity: 'VS Code',
+      duration_sec: 1800,
+      end_time: end,
+      id: prodId,
+      start_time: start,
+    })
+
+    const note = makeNote({
+      end_time: end,
+      entity_id: prodId,
+      entity_type: 'productivity',
+      start_time: start,
+    })
+    vi.mocked(db.insertNote).mockResolvedValue(note)
+
+    await addNote('user', { content: 'Focus session', entity_id: prodId, entity_type: 'productivity' })
+
+    expect(db.getProductivityById).toHaveBeenCalledWith('user', prodId)
+    expect(db.insertNote).toHaveBeenCalledWith('user', 'productivity', prodId, 'Focus session', start, end)
+  })
+
+  test('does not look up entity or set times for metric notes', async () => {
+    const metricEntityId = '2024-01-15T10:30:00.000Z|heart_rate|oura'
+
+    const note = makeNote({ entity_id: metricEntityId, entity_type: 'metric' })
+    vi.mocked(db.insertNote).mockResolvedValue(note)
+
+    await addNote('user', { content: 'HRV low', entity_id: metricEntityId, entity_type: 'metric' })
+
+    expect(db.getTagById).not.toHaveBeenCalled()
+    expect(db.getActivityById).not.toHaveBeenCalled()
+    expect(db.getProductivityById).not.toHaveBeenCalled()
+    expect(db.insertNote).toHaveBeenCalledWith(
+      'user',
+      'metric',
+      metricEntityId,
+      'HRV low',
+      undefined,
+      undefined,
+    )
+  })
+
+  test('returns note data including time fields', async () => {
+    const tagId = randomUUID()
+    const start = new Date('2024-01-15T08:00:00Z')
+    const end = new Date('2024-01-15T09:00:00Z')
+
+    vi.mocked(db.getTagById).mockResolvedValue({
+      end_time: end,
+      source: 'aurboda',
+      start_time: start,
+      tag: 't',
+    })
+
+    const noteId = randomUUID()
+    vi.mocked(db.insertNote).mockResolvedValue(
+      makeNote({
+        content: 'A note',
+        created_at: new Date('2024-01-15T10:00:00Z'),
+        end_time: end,
+        entity_id: tagId,
+        entity_type: 'tag',
+        id: noteId,
+        start_time: start,
+        updated_at: new Date('2024-01-15T10:00:00Z'),
+      }),
+    )
+
+    const result = await addNote('user', { content: 'A note', entity_id: tagId, entity_type: 'tag' })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      content: 'A note',
+      end_time: end.toISOString(),
+      entity_id: tagId,
+      entity_type: 'tag',
+      id: noteId,
+      start_time: start.toISOString(),
+    })
+  })
+})
+
+describe('updateNoteContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns updated note with time fields', async () => {
+    const noteId = randomUUID()
+    const start = new Date('2024-01-15T08:00:00Z')
+    const end = new Date('2024-01-15T09:00:00Z')
+
+    vi.mocked(db.updateNote).mockResolvedValue(
+      makeNote({ end_time: end, entity_type: 'tag', id: noteId, start_time: start }),
+    )
+
+    const result = await updateNoteContent('user', noteId, 'Updated content')
+
+    expect(result.success).toBe(true)
+    expect(result.data?.start_time).toBe(start.toISOString())
+    expect(result.data?.end_time).toBe(end.toISOString())
+  })
+
+  test('returns error when note not found', async () => {
+    vi.mocked(db.updateNote).mockResolvedValue(null)
+
+    const result = await updateNoteContent('user', randomUUID(), 'Content')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Note not found')
+  })
+})
+
+describe('deleteNoteById', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns success and deleted=true when note exists', async () => {
+    vi.mocked(db.deleteNote).mockResolvedValue(true)
+    const result = await deleteNoteById('user', randomUUID())
+    expect(result).toEqual({ deleted: true, success: true })
+  })
+
+  test('returns success=false and deleted=false when note not found', async () => {
+    vi.mocked(db.deleteNote).mockResolvedValue(false)
+    const result = await deleteNoteById('user', randomUUID())
+    expect(result).toEqual({ deleted: false, success: false })
+  })
+})
+
+describe('getNotesForEntity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('maps notes to serialized format including time fields', async () => {
+    const entityId = randomUUID()
+    const start = new Date('2024-01-15T08:00:00Z')
+    const end = new Date('2024-01-15T09:00:00Z')
+
+    vi.mocked(db.getNotesForEntity).mockResolvedValue([
+      makeNote({ content: 'Note 1', end_time: end, entity_id: entityId, start_time: start }),
+      makeNote({ content: 'Note 2', entity_id: entityId }),
+    ])
+
+    const result = await getNotesForEntity('user', 'tag', entityId)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].content).toBe('Note 1')
+    expect(result[0].start_time).toBe(start.toISOString())
+    expect(result[0].end_time).toBe(end.toISOString())
+    expect(result[1].content).toBe('Note 2')
+    expect(result[1].start_time).toBeUndefined()
+    expect(result[1].end_time).toBeUndefined()
+  })
+
+  test('returns empty array when no notes exist', async () => {
+    vi.mocked(db.getNotesForEntity).mockResolvedValue([])
+    const result = await getNotesForEntity('user', 'activity', randomUUID())
+    expect(result).toEqual([])
+  })
+})
+
+describe('syncNoteTimesForEntity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('delegates to dbUpdateNoteTimesForEntity', async () => {
+    vi.mocked(db.updateNoteTimesForEntity).mockResolvedValue(undefined)
+
+    const entityId = randomUUID()
+    const start = new Date('2024-01-15T08:00:00Z')
+    const end = new Date('2024-01-15T09:00:00Z')
+
+    await syncNoteTimesForEntity('user', 'tag', entityId, start, end)
+
+    expect(db.updateNoteTimesForEntity).toHaveBeenCalledWith('user', 'tag', entityId, start, end)
+  })
+
+  test('passes undefined end_time when not provided', async () => {
+    vi.mocked(db.updateNoteTimesForEntity).mockResolvedValue(undefined)
+
+    const entityId = randomUUID()
+    const start = new Date('2024-01-15T08:00:00Z')
+
+    await syncNoteTimesForEntity('user', 'activity', entityId, start)
+
+    expect(db.updateNoteTimesForEntity).toHaveBeenCalledWith('user', 'activity', entityId, start, undefined)
+  })
+})

--- a/apps/backend/src/services/notes.ts
+++ b/apps/backend/src/services/notes.ts
@@ -1,5 +1,9 @@
 /**
  * Notes service — CRUD operations for entity notes.
+ *
+ * Notes inherit time information from their parent entity (tag, activity, productivity record)
+ * so they can be queried by time range. Metric notes (composite entity_id) do not have
+ * inherited times since they reference a point in time already encoded in the entity_id.
  */
 
 import type { EntityType as ApiEntityType } from '@aurboda/api-spec'
@@ -8,6 +12,10 @@ import {
   getNotesForEntity as dbGetNotesForEntity,
   insertNote as dbInsertNote,
   updateNote as dbUpdateNote,
+  updateNoteTimesForEntity as dbUpdateNoteTimesForEntity,
+  getActivityById,
+  getProductivityById,
+  getTagById,
   type EntityType,
 } from '../db'
 
@@ -24,21 +32,65 @@ export interface NoteResult {
     entity_type: ApiEntityType
     entity_id: string
     content: string
+    start_time?: string
+    end_time?: string
     created_at: string
     updated_at: string
   }
   error?: string
 }
 
+/**
+ * Look up the time range of the parent entity to inherit into the note.
+ * Returns undefined for metric entity types since they use a composite key.
+ */
+async function getEntityTimes(
+  user: string,
+  entityType: EntityType,
+  entityId: string,
+): Promise<{ start_time: Date; end_time?: Date } | undefined> {
+  switch (entityType) {
+    case 'tag': {
+      const tag = await getTagById(user, entityId)
+      if (!tag) return undefined
+      return { end_time: tag.end_time, start_time: tag.start_time }
+    }
+    case 'activity': {
+      const activity = await getActivityById(user, entityId)
+      if (!activity) return undefined
+      return { end_time: activity.end_time ?? undefined, start_time: activity.start_time }
+    }
+    case 'productivity': {
+      const record = await getProductivityById(user, entityId)
+      if (!record) return undefined
+      return { end_time: record.end_time, start_time: record.start_time }
+    }
+    case 'metric':
+      // Metric entity_id is a composite key; time is encoded in the key itself.
+      // We don't set inherited times for metric notes.
+      return undefined
+  }
+}
+
 export async function addNote(user: string, input: AddNoteInput): Promise<NoteResult> {
-  const note = await dbInsertNote(user, input.entity_type, input.entity_id, input.content)
+  const times = await getEntityTimes(user, input.entity_type, input.entity_id)
+  const note = await dbInsertNote(
+    user,
+    input.entity_type,
+    input.entity_id,
+    input.content,
+    times?.start_time,
+    times?.end_time,
+  )
   return {
     data: {
       content: note.content,
       created_at: note.created_at.toISOString(),
+      end_time: note.end_time?.toISOString(),
       entity_id: note.entity_id,
       entity_type: note.entity_type,
       id: note.id,
+      start_time: note.start_time?.toISOString(),
       updated_at: note.updated_at.toISOString(),
     },
     success: true,
@@ -54,9 +106,11 @@ export async function updateNoteContent(user: string, id: string, content: strin
     data: {
       content: note.content,
       created_at: note.created_at.toISOString(),
+      end_time: note.end_time?.toISOString(),
       entity_id: note.entity_id,
       entity_type: note.entity_type,
       id: note.id,
+      start_time: note.start_time?.toISOString(),
       updated_at: note.updated_at.toISOString(),
     },
     success: true,
@@ -76,9 +130,25 @@ export async function getNotesForEntity(user: string, entityType: ApiEntityType,
   return notes.map((n) => ({
     content: n.content,
     created_at: n.created_at.toISOString(),
+    end_time: n.end_time?.toISOString(),
     entity_id: n.entity_id,
     entity_type: n.entity_type,
     id: n.id,
+    start_time: n.start_time?.toISOString(),
     updated_at: n.updated_at.toISOString(),
   }))
+}
+
+/**
+ * Sync the inherited time fields on all notes for an entity when the entity's timing changes.
+ * Call this from tag/activity update handlers.
+ */
+export async function syncNoteTimesForEntity(
+  user: string,
+  entityType: EntityType,
+  entityId: string,
+  startTime: Date,
+  endTime?: Date,
+): Promise<void> {
+  await dbUpdateNoteTimesForEntity(user, entityType, entityId, startTime, endTime)
 }

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -20,6 +20,7 @@ vi.mock('../db', () => ({
   getDailyAggregates: vi.fn(),
   getLocations: vi.fn(),
   getNotesByEntityIds: vi.fn(),
+  getNotesForTimeRange: vi.fn(),
   getProductivity: vi.fn(),
   getSleepSessions: vi.fn(),
   getTags: vi.fn(),
@@ -84,6 +85,10 @@ describe('getDailySummary', () => {
     vi.clearAllMocks()
     // Default mock for getUserSettings - returns null so default HR zones are used
     vi.mocked(db.getUserSettings).mockResolvedValue(null)
+    // Default: no notes overlapping the day
+    vi.mocked(db.getNotesForTimeRange).mockResolvedValue([])
+    // Default: no notes for tags
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
   })
 
   test('aggregates all data sources for a day', async () => {

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -12,6 +12,7 @@ import {
   getDailyAggregates,
   getDailyAggregateValue,
   getNotesByEntityIds,
+  getNotesForTimeRange,
   getProductivity,
   getSleepSessions,
   getTags,
@@ -155,6 +156,7 @@ export interface OuraScores {
 export interface DailySummaryResult {
   date: string
   heart_rate: HeartRateStats | null
+  notes: NoteSummary[]
   steps: { total: number }
   sleep_sessions: SessionSummary[]
   exercise_sessions: SessionSummary[]
@@ -188,6 +190,19 @@ export interface PeriodSummaryResult {
 export interface CommentSummary {
   id: string
   content: string
+  start_time?: string
+  end_time?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface NoteSummary {
+  id: string
+  entity_type: 'activity' | 'tag' | 'productivity' | 'metric'
+  entity_id: string
+  content: string
+  start_time?: string
+  end_time?: string
   created_at: string
   updated_at: string
 }
@@ -205,7 +220,9 @@ const getCommentsMap = async (
       notes.map((n) => ({
         content: n.content,
         created_at: n.created_at.toISOString(),
+        end_time: n.end_time?.toISOString(),
         id: n.id,
+        start_time: n.start_time?.toISOString(),
         updated_at: n.updated_at.toISOString(),
       })),
     )
@@ -509,6 +526,7 @@ export async function getDailySummary(
     productivity,
     placeVisits,
     ouraMetrics,
+    dayNotes,
   ] = await Promise.all([
     getTimeSeries(user, 'heart_rate', start, end),
     getTimeSeries(user, 'steps', start, end),
@@ -523,6 +541,7 @@ export async function getDailySummary(
       start,
       end,
     ),
+    getNotesForTimeRange(user, start, end),
   ])
 
   // Calculate heart rate stats
@@ -608,10 +627,24 @@ export async function getDailySummary(
     }),
   )
 
+  // Fetch tag comments
+  const tagIds = tags.map((t) => t.id).filter((id): id is string => id !== undefined)
+  const tagCommentsMap = await getCommentsMap(user, 'tag', tagIds)
+
   return {
     date: date.toISOString().split('T')[0],
     exercise_sessions: exerciseSessionsWithHrZones,
     heart_rate: heartRateStats,
+    notes: dayNotes.map((n) => ({
+      content: n.content,
+      created_at: n.created_at.toISOString(),
+      end_time: n.end_time?.toISOString(),
+      entity_id: n.entity_id,
+      entity_type: n.entity_type,
+      id: n.id,
+      start_time: n.start_time?.toISOString(),
+      updated_at: n.updated_at.toISOString(),
+    })),
     oura_scores: ouraScores,
     places: placeVisits.map((p) => ({
       address: p.address,
@@ -640,7 +673,7 @@ export async function getDailySummary(
     }),
     steps: { total: totalSteps },
     tags: tags.map((t) => ({
-      comments: [],
+      comments: t.id ? (tagCommentsMap.get(t.id) ?? []) : [],
       end_time: t.end_time?.toISOString(),
       start_time: t.start_time.toISOString(),
       tag: t.tag,

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -15,6 +15,7 @@ import {
   placeSourceSchema,
   tagTextSchema,
 } from './common.js'
+import { commentSchema, noteSchema } from './notes.js'
 import { hrZoneSecsSchema } from './settings.js'
 
 /**
@@ -54,6 +55,7 @@ export type SessionSummary = z.infer<typeof sessionSummarySchema>
  */
 export const tagSummarySchema = z
   .object({
+    comments: z.array(commentSchema).optional().meta({ description: 'Comments attached to this tag' }),
     end_time: iso8601DateTimeSchema.optional(),
     start_time: iso8601DateTimeSchema,
     tag: tagTextSchema,
@@ -117,6 +119,9 @@ export const dailySummaryResultSchema = z
     date: dateOnlySchema,
     exercise_sessions: z.array(sessionSummarySchema),
     heart_rate: heartRateStatsSchema.nullable(),
+    notes: z.array(noteSchema).meta({
+      description: 'All notes whose time range overlaps this day, across all entity types',
+    }),
     oura_scores: ouraScoresSchema.nullable(),
     places: z.array(placeSummarySchema),
     productivity: productivitySummarySchema.nullable(),

--- a/packages/api-spec/src/schemas/notes.ts
+++ b/packages/api-spec/src/schemas/notes.ts
@@ -30,11 +30,17 @@ export const noteSchema = z
   .object({
     content: z.string().meta({ description: 'Note content (markdown)' }),
     created_at: iso8601DateTimeSchema.optional(),
+    end_time: iso8601DateTimeSchema.optional().meta({
+      description: 'End time inherited from the parent entity (if any)',
+    }),
     entity_id: z
       .string()
       .meta({ description: 'ID of the referenced entity (UUID for most types, composite key for metrics)' }),
     entity_type: entityTypeSchema,
     id: z.string().uuid().optional().meta({ description: 'Note ID' }),
+    start_time: iso8601DateTimeSchema.optional().meta({
+      description: 'Start time inherited from the parent entity',
+    }),
     updated_at: iso8601DateTimeSchema.optional(),
   })
   .meta({ id: 'Note' })
@@ -48,7 +54,13 @@ export const commentSchema = z
   .object({
     content: z.string().meta({ description: 'Comment content (markdown)' }),
     created_at: iso8601DateTimeSchema.optional(),
+    end_time: iso8601DateTimeSchema.optional().meta({
+      description: 'End time inherited from the parent entity (if any)',
+    }),
     id: z.string().uuid().optional().meta({ description: 'Comment/note ID' }),
+    start_time: iso8601DateTimeSchema.optional().meta({
+      description: 'Start time inherited from the parent entity',
+    }),
     updated_at: iso8601DateTimeSchema.optional(),
   })
   .meta({ description: 'A comment attached to an entity', id: 'Comment' })


### PR DESCRIPTION
## Summary

- **Notes now inherit `start_time`/`end_time` from their parent entity** (tag, activity, productivity record) when created. This enables time-range querying of notes independently of their entity.
- **Day summary now includes all overlapping notes** at the top level (any entity type whose time overlaps the day), and tag comments are now properly fetched and embedded in the day summary.
- **Time stays in sync**: when a tag is extended or an activity is updated, the inherited times on attached notes are updated automatically.

## Why

Lalla (the AI assistant) couldn't see notes in the day summary because:
1. The day summary hardcoded `comments: []` for tags (never fetched)
2. There was no way to query notes by time range at all

A note on a tag covering a whole month should now appear in every day summary for that month.

## Changes

### Database
- New columns `start_time TIMESTAMPTZ` and `end_time TIMESTAMPTZ` on `notes` table
- Migration adds columns to existing tables (`ADD COLUMN IF NOT EXISTS`)
- New index `idx_notes_time` on `(start_time, end_time)`

### DB layer (`apps/backend/src/db/`)
- `insertNote` accepts optional `startTime`/`endTime`
- New `getNotesForTimeRange(user, start, end)` — overlap query (same logic as tags)
- New `updateNoteTimesForEntity(user, entityType, entityId, startTime, endTime)` — bulk update for sync
- `getProductivityById` added to enable time lookup on note insert for productivity entities

### Service layer
- `notes.ts`: `addNote` looks up parent entity times and passes them to `insertNote`
- `mutations.ts`: `updateActivity` and `addTag` (merge path) call `syncNoteTimesForEntity` after updating entity times
- `queries.ts`: `getDailySummary` now fetches `getNotesForTimeRange` in the parallel batch and properly fetches tag comments via `getCommentsMap`

### API spec
- `noteSchema` and `commentSchema` both now include optional `start_time`/`end_time`
- `tagSummarySchema` now includes optional `comments`
- `dailySummaryResultSchema` now includes a `notes` array at the top level
- OpenAPI YAML/JSON and Kotlin models regenerated

### Tests
- 31 new/updated integration tests covering all new time-related note operations
- All 1020 tests pass