### PR TITLE
fix: remove SVG CSS scaling that stretched timeline icons, text, and HR/HRV lines

### DIFF
--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1533,15 +1533,22 @@ export const Timeline = () => {
     } else {
       renderHorizontalChart()
     }
+    let resizeRaf = 0
     const resizeObserver = new ResizeObserver(() => {
-      if (orientationRef.current === 'vertical') {
-        renderVerticalChart()
-      } else {
-        renderHorizontalChart()
-      }
+      cancelAnimationFrame(resizeRaf)
+      resizeRaf = requestAnimationFrame(() => {
+        if (orientationRef.current === 'vertical') {
+          renderVerticalChart()
+        } else {
+          renderHorizontalChart()
+        }
+      })
     })
     if (containerRef.current) resizeObserver.observe(containerRef.current)
-    return () => resizeObserver.disconnect()
+    return () => {
+      cancelAnimationFrame(resizeRaf)
+      resizeObserver.disconnect()
+    }
   }, [orientation, renderVerticalChart, renderHorizontalChart])
 
   // ── Zoom behavior — set up once per orientation ────────────────────────────

--- a/apps/web/src/pages/Timeline/style.css
+++ b/apps/web/src/pages/Timeline/style.css
@@ -253,8 +253,6 @@
 
 .timeline-chart-container svg {
   display: block;
-  width: 100%;
-  height: 100%;
   cursor: grab;
 }
 


### PR DESCRIPTION
## Summary

- Removes `width: 100%` / `height: 100%` from `.timeline-chart-container svg` — these caused the browser to scale the SVG element to fill its container, but without a `viewBox` the SVG coordinate system stayed at its drawn pixel dimensions, stretching content horizontally at wider viewports and squeezing it when zoomed out. D3 already sets correct pixel `width`/`height` attributes directly on the element.
- Debounces `ResizeObserver` redraws via `requestAnimationFrame` (with `cancelAnimationFrame` cleanup) to prevent excessive full redraws — and potential freezing — during window resize.