### PR TITLE
perf: rewrite horizontal timeline to match vertical clear-and-redraw pattern

### DIFF
--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -719,8 +719,7 @@ export const Timeline = () => {
   const baseScaleRef = useRef<d3.ScaleTime<number, number>>()
   const zoomRafRef = useRef<number>(0)
   const drawRef = useRef<((scale: d3.ScaleTime<number, number>) => void) | null>(null)
-  // Horizontal chart: stable references to avoid DOM rebuild during pan/zoom
-  const hContentGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null)
+  // Horizontal chart: stable reference for x-axis (updated in place, never rebuilt)
   const hAxisGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null)
 
   // ── Derived data ───────────────────────────────────────────────────────────
@@ -1178,7 +1177,6 @@ export const Timeline = () => {
 
   // ── Horizontal chart rendering ─────────────────────────────────────────────
 
-  // eslint-disable-next-line complexity -- D3 drawing function; splitting would obscure data flow
   const renderHorizontalChart = useCallback(() => {
     if (!svgRef.current || !containerRef.current) return
 
@@ -1309,242 +1307,211 @@ export const Timeline = () => {
       .attr('transform', `translate(0,${chartHeight})`)
     hAxisGroupRef.current = xAxisGroup
 
-    // Clipped content group — items rendered at base-scale positions;
-    // a transform is applied during zoom/pan instead of recreating DOM nodes.
+    // Clipped content group — cleared and redrawn each frame (like vertical mode)
     const clipped = outerG.append('g').attr('clip-path', 'url(#h-chart-clip)')
-    const contentGroup = clipped.append('g').attr('class', 'h-content')
-    hContentGroupRef.current = contentGroup
+    const chartGroup = clipped.append('g').attr('class', 'h-content')
 
-    // Build all items — DOM nodes are created once, then repositioned in draw()
-    // Each element stores its source time as data-start / data-end attributes
-    // so draw() can reposition using the current x-scale without a group transform.
-
-    // ── Activity lane ──
-    for (const { item, lane } of packedActivityItems.items) {
-      const laneY = trackActivity + lane * activitySubLaneHeight
-      const laneH = activitySubLaneHeight - 1
-      const startMs = item.start.getTime()
-      const endMs = item.end.getTime()
-
-      contentGroup
-        .append('rect')
-        .attr('class', 'h-span')
-        .attr('data-start', startMs)
-        .attr('data-end', endMs)
-        .attr('y', laneY)
-        .attr('height', laneH)
-        .attr('fill', item.color)
-        .attr('opacity', 0.7)
-        .attr('rx', 2)
-        .attr('cursor', 'pointer')
-        .on('mouseenter', function (event: MouseEvent) {
-          d3.select(this).attr('opacity', 0.9)
-          showTooltip(event, item)
-        })
-        .on('mouseleave', function () {
-          d3.select(this).attr('opacity', 0.7)
-          hideTooltip()
-        })
-
-      if (item.icon && isEmoji(item.icon)) {
-        contentGroup
-          .append('text')
-          .attr('class', 'h-span-mid')
-          .attr('data-start', startMs)
-          .attr('data-end', endMs)
-          .attr('y', laneY + laneH / 2)
-          .attr('dy', '0.35em')
-          .attr('text-anchor', 'middle')
-          .attr('font-size', '12px')
-          .attr('pointer-events', 'none')
-          .text(item.icon)
-      } else if (item.icon && isUrl(item.icon)) {
-        const imgSize = 12
-        contentGroup
-          .append('image')
-          .attr('class', 'h-span-mid')
-          .attr('data-start', startMs)
-          .attr('data-end', endMs)
-          .attr('data-offset', -imgSize / 2)
-          .attr('href', item.icon)
-          .attr('y', laneY + laneH / 2 - imgSize / 2)
-          .attr('width', imgSize)
-          .attr('height', imgSize)
-          .attr('pointer-events', 'none')
-      } else {
-        contentGroup
-          .append('text')
-          .attr('class', 'h-span-label')
-          .attr('data-start', startMs)
-          .attr('data-end', endMs)
-          .attr('y', laneY + Math.min(laneH * 0.6, 14))
-          .attr('fill', 'white')
-          .attr('font-size', '0.65rem')
-          .attr('pointer-events', 'none')
-          .attr('data-label', item.label)
-      }
-    }
-
-    // ── Places lane ──
-    const placeItems = chartItems.filter((i) => i.column === 'Location')
-    for (const place of placeItems) {
-      const startMs = place.start.getTime()
-      const endMs = place.end.getTime()
-      contentGroup
-        .append('rect')
-        .attr('class', 'h-span')
-        .attr('data-start', startMs)
-        .attr('data-end', endMs)
-        .attr('y', trackPlaces)
-        .attr('height', trackHeight)
-        .attr('fill', place.color)
-        .attr('opacity', 0.7)
-        .attr('cursor', 'pointer')
-        .on('mouseenter', function (event: MouseEvent) {
-          d3.select(this).attr('opacity', 0.9)
-          showTooltip(event, place)
-        })
-        .on('mouseleave', function () {
-          d3.select(this).attr('opacity', 0.7)
-          hideTooltip()
-        })
-    }
-
-    // ── Tags lane: stacked icons ──
-    for (const { item: tag, lane } of packedPointTags.items) {
-      const icon = tag.icon
-      const startMs = tag.start.getTime()
-      const tagY = trackTags + 4 + lane * (TAG_ICON_SIZE + 2)
-
-      if (icon && isEmoji(icon)) {
-        contentGroup
-          .append('text')
-          .attr('class', 'h-point')
-          .attr('data-start', startMs)
-          .attr('y', tagY + TAG_ICON_SIZE * 0.8)
-          .attr('font-size', TAG_ICON_SIZE)
-          .attr('text-anchor', 'middle')
-          .attr('cursor', 'pointer')
-          .text(icon)
-          .on('mouseenter', (event: MouseEvent) => showTooltip(event, tag))
-          .on('mouseleave', hideTooltip)
-      } else if (icon && isUrl(icon)) {
-        contentGroup
-          .append('image')
-          .attr('class', 'h-point')
-          .attr('data-start', startMs)
-          .attr('data-offset', -TAG_ICON_SIZE / 2)
-          .attr('href', icon)
-          .attr('y', tagY)
-          .attr('width', TAG_ICON_SIZE)
-          .attr('height', TAG_ICON_SIZE)
-          .attr('cursor', 'pointer')
-          .on('mouseenter', (event: MouseEvent) => showTooltip(event, tag))
-          .on('mouseleave', hideTooltip)
-      } else {
-        contentGroup
-          .append('line')
-          .attr('class', 'h-point-line')
-          .attr('data-start', startMs)
-          .attr('y1', trackTags)
-          .attr('y2', trackTags + trackHeight)
-          .attr('stroke', tag.color)
-          .attr('stroke-width', 1.5)
-          .attr('stroke-dasharray', '3,2')
-          .attr('opacity', 0.6)
-          .attr('cursor', 'pointer')
-          .on('mouseenter', (event: MouseEvent) => showTooltip(event, tag))
-          .on('mouseleave', hideTooltip)
-      }
-    }
-
-    // ── HR/HRV paths — store processed data for redraw ──
+    // Pre-process HR/HRV data once (expensive — don't repeat per frame)
     const hrProcessed = heartRates.length > 0 ? preprocessData(heartRates, 10) : null
     const hrvProcessed = hrvData.length > 0 ? preprocessData(hrvData, 10) : null
 
-    if (hrProcessed) {
-      contentGroup
-        .append('path')
-        .attr('class', 'h-hr-path')
-        .attr('fill', 'none')
-        .attr('stroke', HR_COLOR)
-        .attr('stroke-width', 1.5)
-        .attr('pointer-events', 'none')
-    }
-
-    if (hrvProcessed) {
-      contentGroup
-        .append('path')
-        .attr('class', 'h-hrv-path')
-        .attr('fill', 'none')
-        .attr('stroke', HRV_COLOR)
-        .attr('stroke-width', 1.5)
-        .attr('pointer-events', 'none')
-    }
-
-    // draw() repositions all elements using the current x-scale — no group transform
+    // draw() clears and redraws all content using the current x-scale.
+    // This is fast because the browser batches DOM mutations into a single paint.
+    // eslint-disable-next-line complexity -- D3 visualization draw loop
     const draw = (currentXScale: d3.ScaleTime<number, number>) => {
-      const cg = hContentGroupRef.current
+      chartGroup.selectAll('*').remove()
       const ag = hAxisGroupRef.current
-      if (!cg || !ag) return
+      if (!ag) return
 
-      // Span elements (rects): update x and width
-      cg.selectAll<SVGRectElement, unknown>('.h-span').each(function () {
-        const el = d3.select(this)
-        const x = currentXScale(new Date(+el.attr('data-start')!))
-        const w = Math.max(0, currentXScale(new Date(+el.attr('data-end')!)) - x)
-        el.attr('x', x).attr('width', w)
-      })
+      const domain = currentXScale.domain()
+      const domainStart = domain[0]!
+      const domainEnd = domain[1]!
 
-      // Span midpoint elements (emoji text, images): position at center of span
-      cg.selectAll<SVGElement, unknown>('.h-span-mid').each(function () {
-        const el = d3.select(this)
-        const x0 = currentXScale(new Date(+el.attr('data-start')!))
-        const x1 = currentXScale(new Date(+el.attr('data-end')!))
-        const mid = (x0 + x1) / 2
-        const offset = +(el.attr('data-offset') ?? '0')
-        el.attr('x', mid + offset)
-      })
+      // ── Time grid lines ──
+      const oneHourLater = new Date(domainStart.getTime() + 3600000)
+      const pixelsPerHour = Math.abs(currentXScale(oneHourLater) - currentXScale(domainStart))
+      let hourIntervalHours: number
+      if (pixelsPerHour >= 60) hourIntervalHours = 1
+      else if (pixelsPerHour >= 30) hourIntervalHours = 2
+      else if (pixelsPerHour >= 15) hourIntervalHours = 4
+      else if (pixelsPerHour >= 8) hourIntervalHours = 6
+      else if (pixelsPerHour >= 4) hourIntervalHours = 12
+      else hourIntervalHours = 24
 
-      // Span labels (text): position at start + 4, truncate to fit
-      cg.selectAll<SVGTextElement, unknown>('.h-span-label').each(function () {
-        const el = d3.select(this)
-        const x0 = currentXScale(new Date(+el.attr('data-start')!))
-        const x1 = currentXScale(new Date(+el.attr('data-end')!))
-        const w = x1 - x0
-        el.attr('x', x0 + 4)
-        const label = el.attr('data-label') ?? ''
-        if (w > 40) {
-          const maxChars = Math.floor(w / 6)
-          el.text(label.length > maxChars ? label.slice(0, maxChars) + '…' : label).style('display', null)
-        } else {
-          el.style('display', 'none')
+      const hours = d3.timeHour.range(domainStart, domainEnd)
+      const gridHours = hours.filter((d) => d.getHours() % hourIntervalHours === 0)
+      for (const h of gridHours) {
+        const hx = currentXScale(h)
+        chartGroup
+          .append('line')
+          .attr('x1', hx)
+          .attr('x2', hx)
+          .attr('y1', 0)
+          .attr('y2', chartHeight)
+          .attr('stroke', 'currentColor')
+          .attr('stroke-opacity', 0.1)
+      }
+
+      // Midnight separators
+      const midnights = d3.timeDay.range(domainStart, domainEnd)
+      for (const midnight of midnights) {
+        const mx = currentXScale(midnight)
+        chartGroup
+          .append('line')
+          .attr('x1', mx)
+          .attr('x2', mx)
+          .attr('y1', 0)
+          .attr('y2', chartHeight)
+          .attr('stroke', 'currentColor')
+          .attr('stroke-opacity', 0.3)
+          .attr('stroke-width', 1.5)
+          .attr('stroke-dasharray', '6,3')
+      }
+
+      // ── Activity lane ──
+      for (const { item, lane } of packedActivityItems.items) {
+        const laneY = trackActivity + lane * activitySubLaneHeight
+        const laneH = activitySubLaneHeight - 1
+        const rx = currentXScale(item.start)
+        const rw = Math.max(0, currentXScale(item.end) - rx)
+
+        chartGroup
+          .append('rect')
+          .attr('x', rx)
+          .attr('y', laneY)
+          .attr('width', rw)
+          .attr('height', laneH)
+          .attr('fill', item.color)
+          .attr('opacity', 0.7)
+          .attr('rx', 2)
+          .attr('cursor', 'pointer')
+          .on('mouseenter', function (event: MouseEvent) {
+            d3.select(this).attr('opacity', 0.9)
+            showTooltip(event, item)
+          })
+          .on('mouseleave', function () {
+            d3.select(this).attr('opacity', 0.7)
+            hideTooltip()
+          })
+
+        if (item.icon && isEmoji(item.icon)) {
+          chartGroup
+            .append('text')
+            .attr('x', rx + rw / 2)
+            .attr('y', laneY + laneH / 2)
+            .attr('dy', '0.35em')
+            .attr('text-anchor', 'middle')
+            .attr('font-size', '12px')
+            .attr('pointer-events', 'none')
+            .text(item.icon)
+        } else if (item.icon && isUrl(item.icon)) {
+          const imgSize = 12
+          chartGroup
+            .append('image')
+            .attr('href', item.icon)
+            .attr('x', rx + rw / 2 - imgSize / 2)
+            .attr('y', laneY + laneH / 2 - imgSize / 2)
+            .attr('width', imgSize)
+            .attr('height', imgSize)
+            .attr('pointer-events', 'none')
+        } else if (rw > 40) {
+          const maxChars = Math.floor(rw / 6)
+          const text = item.label.length > maxChars ? item.label.slice(0, maxChars) + '…' : item.label
+          chartGroup
+            .append('text')
+            .attr('x', rx + 4)
+            .attr('y', laneY + Math.min(laneH * 0.6, 14))
+            .attr('fill', 'white')
+            .attr('font-size', '0.65rem')
+            .attr('pointer-events', 'none')
+            .text(text)
         }
-      })
+      }
 
-      // Point elements (emoji text, images): position at start time
-      cg.selectAll<SVGElement, unknown>('.h-point').each(function () {
-        const el = d3.select(this)
-        const x = currentXScale(new Date(+el.attr('data-start')!))
-        const offset = +(el.attr('data-offset') ?? '0')
-        el.attr('x', x + offset)
-      })
+      // ── Places lane ──
+      const placeItems = chartItems.filter((i) => i.column === 'Location')
+      for (const place of placeItems) {
+        const px = currentXScale(place.start)
+        const pw = Math.max(0, currentXScale(place.end) - px)
+        chartGroup
+          .append('rect')
+          .attr('x', px)
+          .attr('y', trackPlaces)
+          .attr('width', pw)
+          .attr('height', trackHeight)
+          .attr('fill', place.color)
+          .attr('opacity', 0.7)
+          .attr('cursor', 'pointer')
+          .on('mouseenter', function (event: MouseEvent) {
+            d3.select(this).attr('opacity', 0.9)
+            showTooltip(event, place)
+          })
+          .on('mouseleave', function () {
+            d3.select(this).attr('opacity', 0.7)
+            hideTooltip()
+          })
+      }
 
-      // Point lines: update x1 and x2
-      cg.selectAll<SVGLineElement, unknown>('.h-point-line').each(function () {
-        const el = d3.select(this)
-        const x = currentXScale(new Date(+el.attr('data-start')!))
-        el.attr('x1', x).attr('x2', x)
-      })
+      // ── Tags lane: stacked icons ──
+      for (const { item: tag, lane } of packedPointTags.items) {
+        const icon = tag.icon
+        const tx = currentXScale(tag.start)
+        const tagY = trackTags + 4 + lane * (TAG_ICON_SIZE + 2)
 
-      // HR/HRV paths: regenerate path data with current scale
+        if (icon && isEmoji(icon)) {
+          chartGroup
+            .append('text')
+            .attr('x', tx)
+            .attr('y', tagY + TAG_ICON_SIZE * 0.8)
+            .attr('font-size', TAG_ICON_SIZE)
+            .attr('text-anchor', 'middle')
+            .attr('cursor', 'pointer')
+            .text(icon)
+            .on('mouseenter', (event: MouseEvent) => showTooltip(event, tag))
+            .on('mouseleave', hideTooltip)
+        } else if (icon && isUrl(icon)) {
+          chartGroup
+            .append('image')
+            .attr('href', icon)
+            .attr('x', tx - TAG_ICON_SIZE / 2)
+            .attr('y', tagY)
+            .attr('width', TAG_ICON_SIZE)
+            .attr('height', TAG_ICON_SIZE)
+            .attr('cursor', 'pointer')
+            .on('mouseenter', (event: MouseEvent) => showTooltip(event, tag))
+            .on('mouseleave', hideTooltip)
+        } else {
+          chartGroup
+            .append('line')
+            .attr('x1', tx)
+            .attr('x2', tx)
+            .attr('y1', trackTags)
+            .attr('y2', trackTags + trackHeight)
+            .attr('stroke', tag.color)
+            .attr('stroke-width', 1.5)
+            .attr('stroke-dasharray', '3,2')
+            .attr('opacity', 0.6)
+            .attr('cursor', 'pointer')
+            .on('mouseenter', (event: MouseEvent) => showTooltip(event, tag))
+            .on('mouseleave', hideTooltip)
+        }
+      }
+
+      // ── HR/HRV paths ──
       if (hrProcessed) {
         const hrLine = d3
           .line<[Date, number] | null>()
           .defined(Boolean)
           .x(([time]) => currentXScale(time))
           .y(([, rate]) => yHr(rate))
-        cg.select('.h-hr-path').attr('d', hrLine(hrProcessed) as never)
+        chartGroup
+          .append('path')
+          .datum(hrProcessed)
+          .attr('fill', 'none')
+          .attr('stroke', HR_COLOR)
+          .attr('stroke-width', 1.5)
+          .attr('pointer-events', 'none')
+          .attr('d', hrLine as never)
       }
       if (hrvProcessed) {
         const hrvLine = d3
@@ -1552,8 +1519,18 @@ export const Timeline = () => {
           .defined(Boolean)
           .x(([time]) => currentXScale(time))
           .y(([, value]) => yHrv(value))
-        cg.select('.h-hrv-path').attr('d', hrvLine(hrvProcessed) as never)
+        chartGroup
+          .append('path')
+          .datum(hrvProcessed)
+          .attr('fill', 'none')
+          .attr('stroke', HRV_COLOR)
+          .attr('stroke-width', 1.5)
+          .attr('pointer-events', 'none')
+          .attr('d', hrvLine as never)
       }
+
+      // ── Now line ──
+      drawHorizontalNowLine(chartGroup, chartHeight, currentXScale)
 
       // Update x-axis in place
       ag.call(d3.axisBottom(currentXScale).ticks(8) as never)
@@ -2312,6 +2289,36 @@ const drawNowLine = (
     .attr('x', chartWidth + 4)
     .attr('y', nowY)
     .attr('dy', '0.35em')
+    .attr('fill', NOW_COLOR)
+    .attr('font-size', '0.65rem')
+    .attr('font-weight', '600')
+    .text('Now')
+}
+
+const drawHorizontalNowLine = (
+  chartGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  chartHeight: number,
+  xScale: d3.ScaleTime<number, number>,
+) => {
+  const now = new Date()
+  const domain = xScale.domain()
+  if (now < domain[0]! || now > domain[1]!) return
+
+  const nowX = xScale(now)
+  chartGroup
+    .append('line')
+    .attr('x1', nowX)
+    .attr('x2', nowX)
+    .attr('y1', 0)
+    .attr('y2', chartHeight)
+    .attr('stroke', NOW_COLOR)
+    .attr('stroke-width', 1.5)
+    .attr('stroke-dasharray', '6,3')
+  chartGroup
+    .append('text')
+    .attr('x', nowX)
+    .attr('y', -4)
+    .attr('text-anchor', 'middle')
     .attr('fill', NOW_COLOR)
     .attr('font-size', '0.65rem')
     .attr('font-weight', '600')


### PR DESCRIPTION
## Summary

- **Horizontal chart now uses clear-and-redraw** like vertical mode. Previously it used per-element repositioning via `data-*` attributes and `.each()` loops during zoom/pan, which caused layout thrashing (interleaved DOM reads/writes) and regenerated HR/HRV path strings every frame. Now `draw()` clears the content group and redraws everything with the current time scale — the browser batches all DOM mutations into a single paint.

- **Pre-process HR/HRV data once** per render (`preprocessData` called once in the render function), reused across draw frames without regeneration.

- **Added time grid lines**, midnight separators, and a now-line to horizontal mode (parity with vertical).

- **Resize loop fix** from PR #295 retained: skips redraws when container dimensions haven't changed.

- **Cleaned up unused refs**: `hContentGroupRef`, `hBaseScaleRef`, `hChartGroupRef`.

Both orientations now follow the same architecture: `render*Chart()` builds the SVG skeleton + static elements, `draw(timeScale)` clears and redraws all dynamic content.