### PR TITLE
perf: fix O(n²) preprocessData — replace spread with push

### DIFF
--- a/apps/web/src/utils/chart.ts
+++ b/apps/web/src/utils/chart.ts
@@ -10,11 +10,16 @@ export const preprocessData = (
   data: [Date, number][],
   gapThresholdMinutes: number,
 ): ([Date, number] | null)[] => {
+  if (data.length === 0) return []
   const thresholdMs = gapThresholdMinutes * 60 * 1000
-  return data.reduce<([Date, number] | null)[]>((acc, curr) => {
-    const last = acc.at(-1)
-    return last && curr[0].getTime() - (last as [Date, number])[0].getTime() > thresholdMs ?
-        [...acc, null, curr]
-      : [...acc, curr]
-  }, [])
+  const result: ([Date, number] | null)[] = [data[0]!]
+  for (let i = 1; i < data.length; i++) {
+    const prev = data[i - 1]!
+    const curr = data[i]!
+    if (curr[0].getTime() - prev[0].getTime() > thresholdMs) {
+      result.push(null)
+    }
+    result.push(curr)
+  }
+  return result
 }


### PR DESCRIPTION
## Summary

- `preprocessData` used `Array.reduce` with spread operators (`[...acc, null, curr]` / `[...acc, curr]`) which copies the entire accumulated array on every iteration. For 5,000 HR data points this means ~12.5 million element copies — showing up as **56% of CPU time** in Firefox profiling (`reduce` → `ig/<` → `next`).

- Replaced with a simple `for` loop using `push()` — O(n) instead of O(n²). All existing tests pass unchanged.

This was the root cause of the timeline freezing on data load/refetch in both orientations.