### PR TITLE
feat: enable source maps in production build

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vite'
 import preact from '@preact/preset-vite'
+import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   envDir: '../..',
   plugins: [preact()],
+  build: {
+    sourcemap: true,
+  },
 })


### PR DESCRIPTION
## Summary

- Enables `build.sourcemap: true` in Vite config so `.map` files are generated alongside the JS bundle.
- Nginx already serves all files under `/assets/` with immutable caching — no config change needed.
- DevTools and Firefox Profiler will automatically load source maps, showing original TypeScript source instead of minified names like `Z3/<`, `ig`, `hu`.

**Impact**: ~3MB added to Docker image. Zero runtime cost (maps only fetched when DevTools is open). Build time unchanged (~2.4s).