### PR TITLE
feat: render music as sheet notation in horizontal timeline

### DIFF
--- a/apps/web/src/pages/Timeline/drawMusicStaff.test.ts
+++ b/apps/web/src/pages/Timeline/drawMusicStaff.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from 'vitest'
+import type { Scrobble } from '../../state/api'
+import {
+  buildMusicTooltipHtml,
+  getMergeGapMs,
+  MELODY,
+  mergeScrobblesIntoSessions,
+  MUSIC_STAFF_HEIGHT,
+  staffPositionToY,
+} from './drawMusicStaff'
+
+const makeScrobble = (time: string, artist = 'Artist', track = 'Track', album = 'Album'): Scrobble => ({
+  album,
+  artist,
+  recorded_at: new Date(time),
+  track,
+})
+
+describe('mergeScrobblesIntoSessions', () => {
+  test('returns empty array for no scrobbles', () => {
+    expect(mergeScrobblesIntoSessions([], 600_000)).toEqual([])
+  })
+
+  test('single scrobble becomes a single session', () => {
+    const scrobbles = [makeScrobble('2024-06-15T10:00:00Z')]
+    const sessions = mergeScrobblesIntoSessions(scrobbles, 600_000)
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.start).toEqual(new Date('2024-06-15T10:00:00Z'))
+    // end = recorded_at + 3.5min (210000ms)
+    expect(sessions[0]!.end.getTime()).toBe(new Date('2024-06-15T10:00:00Z').getTime() + 210_000)
+    expect(sessions[0]!.scrobbles).toHaveLength(1)
+  })
+
+  test('merges scrobbles within the gap', () => {
+    const scrobbles = [
+      makeScrobble('2024-06-15T10:00:00Z', 'A', 'T1'),
+      makeScrobble('2024-06-15T10:03:00Z', 'B', 'T2'), // 3min after start, well within track+gap
+      makeScrobble('2024-06-15T10:06:00Z', 'C', 'T3'), // 3min after second
+    ]
+    const sessions = mergeScrobblesIntoSessions(scrobbles, 600_000) // 10min gap
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.scrobbles).toHaveLength(3)
+    expect(sessions[0]!.start).toEqual(new Date('2024-06-15T10:00:00Z'))
+    // end = last scrobble + 3.5min
+    expect(sessions[0]!.end.getTime()).toBe(new Date('2024-06-15T10:06:00Z').getTime() + 210_000)
+  })
+
+  test('splits sessions when gap exceeds threshold', () => {
+    const scrobbles = [
+      makeScrobble('2024-06-15T10:00:00Z', 'A', 'T1'),
+      makeScrobble('2024-06-15T10:03:00Z', 'A', 'T2'),
+      // Big gap: next scrobble at 11:00, well beyond 10min gap
+      makeScrobble('2024-06-15T11:00:00Z', 'B', 'T3'),
+    ]
+    const sessions = mergeScrobblesIntoSessions(scrobbles, 600_000) // 10min gap
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0]!.scrobbles).toHaveLength(2)
+    expect(sessions[1]!.scrobbles).toHaveLength(1)
+    expect(sessions[1]!.start).toEqual(new Date('2024-06-15T11:00:00Z'))
+  })
+
+  test('gap is measured from end of previous track to start of next', () => {
+    // Track duration = 3.5min = 210000ms
+    // Scrobble 1 ends at 10:03:30
+    // Scrobble 2 starts at 10:13:00 → gap = 9.5 min (570000ms)
+    // With 10min (600000ms) merge gap, they should merge
+    const scrobbles = [makeScrobble('2024-06-15T10:00:00Z'), makeScrobble('2024-06-15T10:13:00Z')]
+    const sessions = mergeScrobblesIntoSessions(scrobbles, 600_000)
+    expect(sessions).toHaveLength(1)
+
+    // But with a 9min gap (540000ms), they should split
+    const sessions2 = mergeScrobblesIntoSessions(scrobbles, 540_000)
+    expect(sessions2).toHaveLength(2)
+  })
+
+  test('handles many sessions', () => {
+    const scrobbles = [
+      makeScrobble('2024-06-15T10:00:00Z'),
+      makeScrobble('2024-06-15T12:00:00Z'),
+      makeScrobble('2024-06-15T14:00:00Z'),
+    ]
+    const sessions = mergeScrobblesIntoSessions(scrobbles, 600_000) // 10min
+
+    expect(sessions).toHaveLength(3)
+  })
+})
+
+describe('getMergeGapMs', () => {
+  test('returns 10 min for zoomed in (>100 px/hr)', () => {
+    expect(getMergeGapMs(150)).toBe(10 * 60 * 1000)
+    expect(getMergeGapMs(200)).toBe(10 * 60 * 1000)
+  })
+
+  test('returns 30 min for medium zoom (20-100 px/hr)', () => {
+    expect(getMergeGapMs(50)).toBe(30 * 60 * 1000)
+    expect(getMergeGapMs(21)).toBe(30 * 60 * 1000)
+  })
+
+  test('returns 2 hours for zoomed out (<= 20 px/hr)', () => {
+    expect(getMergeGapMs(20)).toBe(2 * 60 * 60 * 1000)
+    expect(getMergeGapMs(5)).toBe(2 * 60 * 60 * 1000)
+  })
+
+  test('boundary: exactly 100 px/hr is medium', () => {
+    expect(getMergeGapMs(100)).toBe(30 * 60 * 1000)
+  })
+})
+
+describe('staffPositionToY', () => {
+  const staffY = 0
+
+  test('position 0 maps to the middle (3rd) staff line', () => {
+    const y = staffPositionToY(staffY, 0)
+    // Middle line = staffY + STAFF_TOP_PADDING + 2 * STAFF_LINE_SPACING
+    // = 0 + 4 + 12 = 16
+    expect(y).toBe(16)
+  })
+
+  test('positive positions move upward (lower y)', () => {
+    const y0 = staffPositionToY(staffY, 0)
+    const y1 = staffPositionToY(staffY, 1)
+    const y2 = staffPositionToY(staffY, 2)
+
+    expect(y1).toBeLessThan(y0)
+    expect(y2).toBeLessThan(y1)
+  })
+
+  test('negative positions move downward (higher y)', () => {
+    const y0 = staffPositionToY(staffY, 0)
+    const yNeg1 = staffPositionToY(staffY, -1)
+    const yNeg2 = staffPositionToY(staffY, -2)
+
+    expect(yNeg1).toBeGreaterThan(y0)
+    expect(yNeg2).toBeGreaterThan(yNeg1)
+  })
+
+  test('each step moves half a line spacing', () => {
+    const y0 = staffPositionToY(staffY, 0)
+    const y1 = staffPositionToY(staffY, 1)
+
+    // STAFF_LINE_SPACING = 6, so half = 3
+    expect(y0 - y1).toBe(3)
+  })
+
+  test('position +4 lands on the top staff line', () => {
+    const y = staffPositionToY(staffY, 4)
+    // Top line = staffY + STAFF_TOP_PADDING = 0 + 4 = 4
+    expect(y).toBe(4)
+  })
+
+  test('position -4 lands on the bottom staff line', () => {
+    const y = staffPositionToY(staffY, -4)
+    // Bottom line = staffY + STAFF_TOP_PADDING + 4 * STAFF_LINE_SPACING = 0 + 4 + 24 = 28
+    expect(y).toBe(28)
+  })
+
+  test('even positions land on lines, odd positions between lines', () => {
+    // Staff lines are at positions -4, -2, 0, +2, +4
+    const linePositions = [-4, -2, 0, 2, 4]
+    const topLine = staffPositionToY(staffY, 4)
+
+    for (const pos of linePositions) {
+      const y = staffPositionToY(staffY, pos)
+      // Should be exactly on a staff line (integer multiple of line spacing from top)
+      expect((y - topLine) % 6).toBe(0)
+    }
+
+    // Odd positions (spaces between lines) should be at half-spacing
+    const spacePositions = [-3, -1, 1, 3]
+    for (const pos of spacePositions) {
+      const y = staffPositionToY(staffY, pos)
+      expect((y - topLine) % 6).toBe(3) // half a line spacing off
+    }
+  })
+
+  test('works with non-zero staffY offset', () => {
+    const offset = 50
+    const y0base = staffPositionToY(0, 0)
+    const y0offset = staffPositionToY(offset, 0)
+
+    expect(y0offset - y0base).toBe(offset)
+  })
+})
+
+describe('MELODY', () => {
+  test('has at least 20 notes', () => {
+    expect(MELODY.length).toBeGreaterThanOrEqual(20)
+  })
+
+  test('all positions are within reasonable staff range', () => {
+    // Should be within [-6, +6] to avoid excessive ledger lines
+    for (const pos of MELODY) {
+      expect(pos).toBeGreaterThanOrEqual(-6)
+      expect(pos).toBeLessThanOrEqual(6)
+    }
+  })
+})
+
+describe('MUSIC_STAFF_HEIGHT', () => {
+  test('is large enough for 5 lines plus padding', () => {
+    // 5 lines = 4 gaps * 6px + padding above and below
+    expect(MUSIC_STAFF_HEIGHT).toBeGreaterThanOrEqual(24 + 4) // at minimum
+  })
+})
+
+describe('buildMusicTooltipHtml', () => {
+  test('includes session time range', () => {
+    const html = buildMusicTooltipHtml({
+      end: new Date('2024-06-15T11:30:00Z'),
+      scrobbles: [makeScrobble('2024-06-15T10:00:00Z')],
+      start: new Date('2024-06-15T10:00:00Z'),
+    })
+
+    expect(html).toContain('♪ Music')
+    expect(html).toContain('1 track')
+  })
+
+  test('pluralizes track count', () => {
+    const html = buildMusicTooltipHtml({
+      end: new Date('2024-06-15T11:30:00Z'),
+      scrobbles: [
+        makeScrobble('2024-06-15T10:00:00Z', 'A', 'T1'),
+        makeScrobble('2024-06-15T10:03:00Z', 'B', 'T2'),
+      ],
+      start: new Date('2024-06-15T10:00:00Z'),
+    })
+
+    expect(html).toContain('2 tracks')
+  })
+
+  test('lists all tracks', () => {
+    const html = buildMusicTooltipHtml({
+      end: new Date('2024-06-15T11:30:00Z'),
+      scrobbles: [
+        makeScrobble('2024-06-15T10:00:00Z', 'Radiohead', 'Creep'),
+        makeScrobble('2024-06-15T10:03:00Z', 'ABBA', 'I Let the Music Speak'),
+      ],
+      start: new Date('2024-06-15T10:00:00Z'),
+    })
+
+    expect(html).toContain('Radiohead – Creep')
+    expect(html).toContain('ABBA – I Let the Music Speak')
+  })
+
+  test('escapes HTML in track names', () => {
+    const html = buildMusicTooltipHtml({
+      end: new Date('2024-06-15T11:30:00Z'),
+      scrobbles: [makeScrobble('2024-06-15T10:00:00Z', 'AC/DC', '<script>alert("xss")</script>')],
+      start: new Date('2024-06-15T10:00:00Z'),
+    })
+
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})

--- a/apps/web/src/pages/Timeline/drawMusicStaff.ts
+++ b/apps/web/src/pages/Timeline/drawMusicStaff.ts
@@ -1,0 +1,349 @@
+import * as d3 from 'd3'
+import { format } from 'date-fns'
+import type { Scrobble } from '../../state/api'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const TRACK_DURATION_MS = 3.5 * 60 * 1000 // ~3.5 minutes per scrobble
+
+/** Total pixel height of the music staff track */
+export const MUSIC_STAFF_HEIGHT = 34
+
+/** Spacing between adjacent staff lines */
+const STAFF_LINE_SPACING = 6
+
+/** Padding above the top staff line */
+const STAFF_TOP_PADDING = 4
+
+/** Pixels between note centers (constant regardless of zoom) */
+const NOTE_SPACING_PX = 20
+
+/** Note head ellipse x-radius */
+const NOTE_HEAD_RX = 3.2
+
+/** Note head ellipse y-radius */
+const NOTE_HEAD_RY = 2.4
+
+/** Stem length in pixels */
+const STEM_HEIGHT = 14
+
+/** Pixels reserved for the treble clef at session start */
+const CLEF_WIDTH = 18
+
+/** Staff line color opacity */
+const STAFF_LINE_OPACITY = 0.2
+
+/** Note / stem opacity */
+const NOTE_OPACITY = 0.45
+
+// ── Melody data ───────────────────────────────────────────────────────────────
+// Approximate opening of "I Let the Music Speak" (ABBA), mapped to staff
+// positions relative to the middle (3rd) line.  0 = 3rd line (B4 in treble
+// clef), +1 = one half-space up (C5 space), +2 = next line (D5), etc.
+// Negative values go below the middle line.
+
+export const MELODY: number[] = [
+  0,
+  2,
+  4,
+  3,
+  2,
+  1,
+  0,
+  -1, // "I let the mu-sic speak..."
+  0,
+  1,
+  2,
+  1,
+  0,
+  -1,
+  -2,
+  -1, // continuing phrase
+  0,
+  2,
+  3,
+  4,
+  3,
+  2,
+  1,
+  2, // second phrase ascending
+  0,
+  -1,
+  -2,
+  -1,
+  0,
+  1, // resolution
+]
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface MusicSession {
+  start: Date
+  end: Date
+  scrobbles: Scrobble[]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SvgParent = d3.Selection<any, unknown, null, undefined>
+
+// ── Session merging ───────────────────────────────────────────────────────────
+
+/**
+ * Merge scrobbles into listening sessions.  Scrobbles within `mergeGapMs` of
+ * each other (measured from one scrobble's end to the next's start) are grouped
+ * into the same session.
+ *
+ * Expects scrobbles to be sorted ascending by `recorded_at`.
+ */
+export const mergeScrobblesIntoSessions = (scrobbles: Scrobble[], mergeGapMs: number): MusicSession[] => {
+  if (scrobbles.length === 0) return []
+
+  const sessions: MusicSession[] = []
+  let sessionScrobbles: Scrobble[] = [scrobbles[0]!]
+  let sessionStart = scrobbles[0]!.recorded_at
+  let lastEnd = new Date(sessionStart.getTime() + TRACK_DURATION_MS)
+
+  for (let i = 1; i < scrobbles.length; i++) {
+    const s = scrobbles[i]!
+    const gap = s.recorded_at.getTime() - lastEnd.getTime()
+
+    if (gap <= mergeGapMs) {
+      // Continue current session
+      sessionScrobbles.push(s)
+      lastEnd = new Date(s.recorded_at.getTime() + TRACK_DURATION_MS)
+    } else {
+      // Finalize previous session, start new one
+      sessions.push({ end: lastEnd, scrobbles: sessionScrobbles, start: sessionStart })
+      sessionScrobbles = [s]
+      sessionStart = s.recorded_at
+      lastEnd = new Date(s.recorded_at.getTime() + TRACK_DURATION_MS)
+    }
+  }
+
+  // Finalize last session
+  sessions.push({ end: lastEnd, scrobbles: sessionScrobbles, start: sessionStart })
+  return sessions
+}
+
+// ── Merge gap selection ───────────────────────────────────────────────────────
+
+/** Pick a merge gap based on the current zoom level (pixels per hour). */
+export const getMergeGapMs = (pixelsPerHour: number): number => {
+  if (pixelsPerHour > 100) return 10 * 60 * 1000 // 10 min — zoomed in
+  if (pixelsPerHour > 20) return 30 * 60 * 1000 // 30 min — medium
+  return 2 * 60 * 60 * 1000 // 2 hours — zoomed out
+}
+
+// ── Staff position → y-coordinate ─────────────────────────────────────────────
+
+/**
+ * Convert a melody position to a y-coordinate on the staff.
+ * Position 0 = middle (3rd) staff line.
+ * Each +1 moves half a line-spacing up (alternating line/space).
+ */
+export const staffPositionToY = (staffY: number, position: number): number => {
+  const middleLineY = staffY + STAFF_TOP_PADDING + 2 * STAFF_LINE_SPACING
+  return middleLineY - position * (STAFF_LINE_SPACING / 2)
+}
+
+// ── Drawing ───────────────────────────────────────────────────────────────────
+
+const formatTime = (date: Date): string => format(date, 'HH:mm')
+
+/** Draw ledger lines for notes that extend above or below the 5-line staff. */
+const drawLedgerLines = (g: SvgParent, staffY: number, noteX: number, position: number): void => {
+  if (position > 4) {
+    // Notes above top line: draw ledger lines at even positions (6, 8, ...)
+    for (let p = 5; p <= position; p++) {
+      if (p % 2 !== 0) continue
+      const ledgerY = staffPositionToY(staffY, p)
+      g.append('line')
+        .attr('x1', noteX - NOTE_HEAD_RX - 2)
+        .attr('x2', noteX + NOTE_HEAD_RX + 2)
+        .attr('y1', ledgerY)
+        .attr('y2', ledgerY)
+        .attr('stroke', 'currentColor')
+        .attr('stroke-opacity', STAFF_LINE_OPACITY)
+        .attr('stroke-width', 0.75)
+        .attr('pointer-events', 'none')
+    }
+  } else if (position < -4) {
+    // Notes below bottom line: draw ledger lines at even positions (-6, -8, ...)
+    for (let p = -5; p >= position; p--) {
+      if (p % 2 !== 0) continue
+      const ledgerY = staffPositionToY(staffY, p)
+      g.append('line')
+        .attr('x1', noteX - NOTE_HEAD_RX - 2)
+        .attr('x2', noteX + NOTE_HEAD_RX + 2)
+        .attr('y1', ledgerY)
+        .attr('y2', ledgerY)
+        .attr('stroke', 'currentColor')
+        .attr('stroke-opacity', STAFF_LINE_OPACITY)
+        .attr('stroke-width', 0.75)
+        .attr('pointer-events', 'none')
+    }
+  }
+}
+
+/** Draw all music sessions as sheet-music notation onto `chartGroup`. */
+export const drawMusicSessions = (
+  chartGroup: SvgParent,
+  sessions: MusicSession[],
+  currentXScale: d3.ScaleTime<number, number>,
+  staffY: number,
+  showTooltip: (event: MouseEvent, session: MusicSession) => void,
+  hideTooltip: () => void,
+): void => {
+  const topLineY = staffY + STAFF_TOP_PADDING
+  const bottomLineY = topLineY + 4 * STAFF_LINE_SPACING
+
+  for (const session of sessions) {
+    const sx = currentXScale(session.start)
+    const ex = currentXScale(session.end)
+    const sw = ex - sx
+
+    if (sw < 2) continue // too small to render
+
+    const g = chartGroup.append('g').attr('class', 'music-session')
+
+    // ── Invisible hover target ──
+    g.append('rect')
+      .attr('x', sx)
+      .attr('y', staffY)
+      .attr('width', sw)
+      .attr('height', MUSIC_STAFF_HEIGHT)
+      .attr('fill', 'transparent')
+      .attr('cursor', 'default')
+      .on('mouseenter', (event: MouseEvent) => showTooltip(event, session))
+      .on('mouseleave', hideTooltip)
+
+    // ── Staff lines (5 lines) ──
+    for (let i = 0; i < 5; i++) {
+      const ly = topLineY + i * STAFF_LINE_SPACING
+      g.append('line')
+        .attr('x1', sx)
+        .attr('x2', ex)
+        .attr('y1', ly)
+        .attr('y2', ly)
+        .attr('stroke', 'currentColor')
+        .attr('stroke-opacity', STAFF_LINE_OPACITY)
+        .attr('stroke-width', 0.75)
+        .attr('pointer-events', 'none')
+    }
+
+    // ── Left barline ──
+    g.append('line')
+      .attr('x1', sx)
+      .attr('x2', sx)
+      .attr('y1', topLineY)
+      .attr('y2', bottomLineY)
+      .attr('stroke', 'currentColor')
+      .attr('stroke-opacity', 0.35)
+      .attr('stroke-width', 1)
+      .attr('pointer-events', 'none')
+
+    // ── Treble clef (𝄞) ──
+    g.append('text')
+      .attr('x', sx + 3)
+      .attr('y', staffY + MUSIC_STAFF_HEIGHT / 2 + 1)
+      .attr('dy', '0.35em')
+      .attr('font-size', '20px')
+      .attr('fill', 'currentColor')
+      .attr('opacity', 0.35)
+      .attr('pointer-events', 'none')
+      .text('𝄞')
+
+    // ── Right barline ──
+    g.append('line')
+      .attr('x1', ex)
+      .attr('x2', ex)
+      .attr('y1', topLineY)
+      .attr('y2', bottomLineY)
+      .attr('stroke', 'currentColor')
+      .attr('stroke-opacity', 0.35)
+      .attr('stroke-width', 1)
+      .attr('pointer-events', 'none')
+
+    // ── Notes ──
+    const noteStartX = sx + CLEF_WIDTH
+    const availableWidth = sw - CLEF_WIDTH - 4 // 4px padding before right barline
+    if (availableWidth <= 0) continue
+
+    const noteCount = Math.floor(availableWidth / NOTE_SPACING_PX)
+
+    // Global offset: use absolute pixel position to keep melody continuous
+    // across sessions and stable within a zoom frame.
+    const globalOffset = Math.floor(sx / NOTE_SPACING_PX)
+
+    for (let i = 0; i < noteCount; i++) {
+      const noteX = noteStartX + i * NOTE_SPACING_PX + NOTE_SPACING_PX / 2
+      const melodyIdx = (((globalOffset + i) % MELODY.length) + MELODY.length) % MELODY.length
+      const position = MELODY[melodyIdx]!
+      const noteY = staffPositionToY(staffY, position)
+
+      // Note head (tilted ellipse)
+      g.append('ellipse')
+        .attr('cx', noteX)
+        .attr('cy', noteY)
+        .attr('rx', NOTE_HEAD_RX)
+        .attr('ry', NOTE_HEAD_RY)
+        .attr('transform', `rotate(-15, ${noteX}, ${noteY})`)
+        .attr('fill', 'currentColor')
+        .attr('opacity', NOTE_OPACITY)
+        .attr('pointer-events', 'none')
+
+      // Stem: notes at/above middle → stem goes down from right;
+      //        notes below middle → stem goes up from left
+      if (position >= 0) {
+        // Stem down from right side of note head
+        const stemX = noteX + NOTE_HEAD_RX * 0.8
+        g.append('line')
+          .attr('x1', stemX)
+          .attr('x2', stemX)
+          .attr('y1', noteY)
+          .attr('y2', noteY + STEM_HEIGHT)
+          .attr('stroke', 'currentColor')
+          .attr('stroke-opacity', NOTE_OPACITY)
+          .attr('stroke-width', 0.8)
+          .attr('pointer-events', 'none')
+      } else {
+        // Stem up from left side of note head
+        const stemX = noteX - NOTE_HEAD_RX * 0.8
+        g.append('line')
+          .attr('x1', stemX)
+          .attr('x2', stemX)
+          .attr('y1', noteY)
+          .attr('y2', noteY - STEM_HEIGHT)
+          .attr('stroke', 'currentColor')
+          .attr('stroke-opacity', NOTE_OPACITY)
+          .attr('stroke-width', 0.8)
+          .attr('pointer-events', 'none')
+      }
+
+      // Ledger lines for notes above or below the staff
+      drawLedgerLines(g, staffY, noteX, position)
+    }
+  }
+}
+
+// ── Tooltip builder ───────────────────────────────────────────────────────────
+
+const escapeHtml = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+/** Build tooltip HTML for a music session. */
+export const buildMusicTooltipHtml = (session: MusicSession): string => {
+  const startStr = formatTime(session.start)
+  const endStr = formatTime(session.end)
+  const count = session.scrobbles.length
+
+  let html = `<div class="tooltip-title">♪ Music</div>`
+  html += `<div class="tooltip-time">${escapeHtml(startStr)} – ${escapeHtml(endStr)}</div>`
+  html += `<div class="tooltip-detail">${count} track${count !== 1 ? 's' : ''}</div>`
+  html += `<div class="tooltip-tracks">`
+  for (const s of session.scrobbles) {
+    html += `<div>${escapeHtml(s.artist)} – ${escapeHtml(s.track)}</div>`
+  }
+  html += `</div>`
+  return html
+}

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -31,6 +31,13 @@ import { packLanes } from '../../utils/lanePacking'
 import { buildActivityColumnItems, EXCLUDED_TAG_PREFIXES, EXCLUDED_TAG_SOURCES } from './activityMerge'
 import { categorizeMusic } from './categorizeMusic'
 import { drawActivitySparklines, parseBucketedData } from './drawActivitySparklines'
+import {
+  buildMusicTooltipHtml,
+  drawMusicSessions,
+  getMergeGapMs,
+  mergeScrobblesIntoSessions,
+  MUSIC_STAFF_HEIGHT,
+} from './drawMusicStaff'
 import { findOverlappingScrobbles } from './findOverlappingScrobbles'
 import type { ChartItem, Column, Orientation } from './types'
 
@@ -986,6 +993,27 @@ export const Timeline = () => {
     if (tooltipRef.current) tooltipRef.current.style.display = 'none'
   }, [])
 
+  const showMusicTooltip = useCallback(
+    (
+      event: MouseEvent,
+      session: { start: Date; end: Date; scrobbles: { artist: string; track: string }[] },
+    ) => {
+      if (!tooltipRef.current || !containerRef.current) return
+      const tip = tooltipRef.current
+      const containerRect = containerRef.current.getBoundingClientRect()
+      tip.innerHTML = buildMusicTooltipHtml(session as Parameters<typeof buildMusicTooltipHtml>[0])
+      tip.style.display = 'block'
+      const x = event.clientX - containerRect.left + 12
+      const yRaw = event.clientY - containerRect.top - 10
+      const tipH = tip.scrollHeight
+      const yMax = containerRect.height - tipH - 4
+      const y = Math.min(yRaw, Math.max(yMax, 4))
+      tip.style.left = `${Math.min(x, containerRect.width - 320)}px`
+      tip.style.top = `${y}px`
+    },
+    [],
+  )
+
   // ── Vertical chart rendering ───────────────────────────────────────────────
 
   const renderVerticalChart = useCallback(() => {
@@ -1178,6 +1206,7 @@ export const Timeline = () => {
 
   // ── Horizontal chart rendering ─────────────────────────────────────────────
 
+  // eslint-disable-next-line complexity -- D3 visualization setup
   const renderHorizontalChart = useCallback(() => {
     if (!svgRef.current || !containerRef.current) return
 
@@ -1187,10 +1216,14 @@ export const Timeline = () => {
     const chartWidth = containerWidth - margin.left - margin.right
     const chartHeight = Math.max(150, containerHeight - margin.top - margin.bottom)
 
+    const hasMusic = scrobbles.length > 0
+    const musicTrackHeight = hasMusic ? MUSIC_STAFF_HEIGHT : 0
     const TRACK_COUNT = 2
-    const trackHeight = chartHeight / TRACK_COUNT
-    const trackActivity = 0
-    const trackPlaces = trackHeight
+    const remainingHeight = chartHeight - musicTrackHeight
+    const trackHeight = remainingHeight / TRACK_COUNT
+    const trackMusic = 0
+    const trackActivity = musicTrackHeight
+    const trackPlaces = musicTrackHeight + trackHeight
     const ICON_SIZE = 18
 
     const svg = d3.select(svgRef.current)
@@ -1218,7 +1251,7 @@ export const Timeline = () => {
     const heartRates = heartRateQuery.data ?? []
     const hrvData = hrvQuery.data ?? []
 
-    const yHr = d3.scaleLinear().domain([40, 200]).range([chartHeight, 0])
+    const yHr = d3.scaleLinear().domain([40, 200]).range([chartHeight, musicTrackHeight])
     const hrvExtent = d3.extent(hrvData, ([, v]) => v) as [number, number]
     const hrvMin = hrvExtent[0] ?? 0
     const hrvMax = hrvExtent[1] ?? 150
@@ -1227,7 +1260,7 @@ export const Timeline = () => {
       .scaleLinear()
       .domain([Math.max(0, hrvMin - hrvPadding), hrvMax + hrvPadding])
       .nice()
-      .range([chartHeight, 0])
+      .range([chartHeight, musicTrackHeight])
 
     // Combine activity items and all non-hidden tags (point and duration) into the activity lane
     const visibleActivityItems = activityItems.filter((i) => !isItemHidden(i))
@@ -1249,24 +1282,36 @@ export const Timeline = () => {
       .attr('transform', `translate(${margin.left},${margin.top})`)
 
     // Static lane labels and separators (not affected by zoom/pan)
+    if (hasMusic) {
+      outerG
+        .append('line')
+        .attr('x1', 0)
+        .attr('x2', chartWidth)
+        .attr('y1', musicTrackHeight)
+        .attr('y2', musicTrackHeight)
+        .attr('stroke', 'currentColor')
+        .attr('stroke-opacity', 0.2)
+    }
     outerG
       .append('line')
       .attr('x1', 0)
       .attr('x2', chartWidth)
-      .attr('y1', trackHeight)
-      .attr('y2', trackHeight)
+      .attr('y1', trackPlaces)
+      .attr('y2', trackPlaces)
       .attr('stroke', 'currentColor')
       .attr('stroke-opacity', 0.2)
 
     const laneLabels = [
+      ...(hasMusic ? [{ label: 'Music', y: trackMusic }] : []),
       { label: 'Activity', y: trackActivity },
       { label: 'Location', y: trackPlaces },
     ]
     for (const { label, y } of laneLabels) {
+      const laneHeight = label === 'Music' ? musicTrackHeight : trackHeight
       outerG
         .append('text')
         .attr('x', -margin.left + 4)
-        .attr('y', y + trackHeight / 2)
+        .attr('y', y + laneHeight / 2)
         .attr('dy', '0.35em')
         .attr('fill', 'currentColor')
         .attr('font-size', '0.65rem')
@@ -1353,6 +1398,13 @@ export const Timeline = () => {
           .attr('stroke-opacity', 0.3)
           .attr('stroke-width', 1.5)
           .attr('stroke-dasharray', '6,3')
+      }
+
+      // ── Music staff (sheet-music notation) ──
+      if (hasMusic) {
+        const mergeGapMs = getMergeGapMs(pixelsPerHour)
+        const sessions = mergeScrobblesIntoSessions(scrobbles, mergeGapMs)
+        drawMusicSessions(chartGroup, sessions, currentXScale, trackMusic, showMusicTooltip, hideTooltip)
       }
 
       // ── Helper: build detail URL for an item ──
@@ -1574,6 +1626,8 @@ export const Timeline = () => {
     heartRateQuery.data,
     hrvQuery.data,
     isItemHidden,
+    scrobbles,
+    showMusicTooltip,
     showTooltip,
     hideTooltip,
   ])

--- a/apps/web/src/pages/Timeline/style.css
+++ b/apps/web/src/pages/Timeline/style.css
@@ -326,6 +326,16 @@
   font-style: italic;
 }
 
+.timeline-tooltip .tooltip-tracks {
+  max-height: 200px;
+  overflow-y: auto;
+  color: #ec4899;
+  font-style: italic;
+  margin-top: 0.3rem;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
 .timeline-tooltip .hr-zone-bar {
   display: flex;
   height: 8px;


### PR DESCRIPTION
## Summary

- Scrobbles are merged into listening sessions with zoom-dependent gap thresholds (10min zoomed in / 30min medium / 2h zoomed out)
- Sessions rendered as 5-line staff with treble clef (𝄞), barlines, and notes from the "I Let the Music Speak" melody
- Music track sits at the top of the horizontal chart, above Activity and Location lanes
- Hover tooltip shows session time range and full scrollable track list
- HR/HRV overlay scales adjusted to not overlap the music track

## New files

- `drawMusicStaff.ts` — session merging, staff/note SVG drawing, tooltip builder
- `drawMusicStaff.test.ts` — 25 unit tests covering merging, positioning, melody, tooltips

## Visual design

- 5 staff lines with proper note placement (on lines and in spaces)
- Tilted note heads with stems (down for notes at/above middle, up for below)
- Treble clef at session start, barlines at both edges
- Fixed note density regardless of zoom (melody is continuous across sessions via global pixel offset)
- Ledger lines for notes extending beyond the staff