### PR TITLE
feat: disambiguate sleep sessions in daily summary with location and date attribution

### DIFF
--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -90,7 +90,7 @@ Use cases:
   // Tool: get_daily_summary
   server.tool(
     'get_daily_summary',
-    'Get a comprehensive summary of health data for a specific day including heart rate, steps, sleep, exercise, tags, productivity, and visited places. Also includes Oura scores (sleep_score, readiness_score, resilience_score, cardiovascular_age) when available.',
+    'Get a comprehensive summary of health data for a specific day including heart rate, steps, sleep, exercise, tags, productivity, and visited places. Also includes Oura scores (sleep_score, readiness_score, resilience_score, cardiovascular_age) when available.\n\nSleep sessions are disambiguated: `primary_sleep` is the session the user woke up from on this date (following Oura convention), `evening_sleep` is the session started this evening that continues to the next day. Each sleep session includes `sleep_date` (the date it belongs to, using wake-up convention) and `sleep_location` (best-guess location). The `oura_scores.sleep_score` evaluates the `primary_sleep` session.',
     {
       date: dateOnlySchema.describe('Date in YYYY-MM-DD format (e.g., 2024-01-15)'),
     },

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -3,6 +3,7 @@ import * as db from '../db'
 import { MetricType } from '../schema'
 import * as locationsService from './locations'
 import {
+  findSleepLocation,
   getDailySummary,
   getPeriodSummary,
   mergeProductivitySpans,
@@ -187,6 +188,22 @@ describe('getDailySummary', () => {
     // Sleep sessions
     expect(result.sleep_sessions).toHaveLength(1)
     expect(result.sleep_sessions[0].duration).toBe(480) // 8 hours in minutes
+    expect(result.sleep_sessions[0].sleep_date).toBe('2024-01-15') // woke up on this date
+    expect(result.sleep_sessions[0].sleep_location).toEqual({
+      lat: 59.33,
+      lon: 18.07,
+      name: 'Home',
+      source: 'named',
+    })
+
+    // Primary sleep = session that ended on this date
+    expect(result.primary_sleep).not.toBeNull()
+    expect(result.primary_sleep!.end_time).toBe('2024-01-15T07:00:00.000Z')
+    expect(result.primary_sleep!.sleep_date).toBe('2024-01-15')
+    expect(result.primary_sleep!.sleep_location?.name).toBe('Home')
+
+    // Evening sleep = no sleep started on Jan 15 that extends to Jan 16
+    expect(result.evening_sleep).toBeNull()
 
     // Exercise sessions
     expect(result.exercise_sessions).toHaveLength(1)
@@ -473,6 +490,247 @@ describe('getDailySummary', () => {
     expect(result.exercise_sessions[0].hr_zone_secs).toBeUndefined()
     // Should not have called getTimeSeries for the exercise session
     expect(db.getTimeSeries).toHaveBeenCalledTimes(2) // Only daily HR and steps
+  })
+
+  test('classifies overnight sleep as primary_sleep on wake-up date', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-03-08T06:23:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-03-07T22:01:00Z'),
+      },
+    ])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    // Query for March 8 — the date the user woke up
+    const result = await getDailySummary('testuser', new Date('2024-03-08'))
+
+    expect(result.primary_sleep).not.toBeNull()
+    expect(result.primary_sleep!.start_time).toBe('2024-03-07T22:01:00.000Z')
+    expect(result.primary_sleep!.end_time).toBe('2024-03-08T06:23:00.000Z')
+    expect(result.primary_sleep!.sleep_date).toBe('2024-03-08')
+    expect(result.evening_sleep).toBeNull()
+  })
+
+  test('classifies evening sleep that extends past midnight', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      // Morning sleep (primary) — woke up on Mar 8
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-03-08T06:23:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-03-07T22:01:00Z'),
+      },
+      // Evening sleep — fell asleep on Mar 8, wakes up Mar 9
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-03-09T07:00:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-03-08T22:30:00Z'),
+      },
+    ])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-03-08'))
+
+    // primary_sleep = ended on Mar 8
+    expect(result.primary_sleep).not.toBeNull()
+    expect(result.primary_sleep!.end_time).toBe('2024-03-08T06:23:00.000Z')
+    expect(result.primary_sleep!.sleep_date).toBe('2024-03-08')
+
+    // evening_sleep = started on Mar 8, ends Mar 9
+    expect(result.evening_sleep).not.toBeNull()
+    expect(result.evening_sleep!.start_time).toBe('2024-03-08T22:30:00.000Z')
+    expect(result.evening_sleep!.end_time).toBe('2024-03-09T07:00:00.000Z')
+    expect(result.evening_sleep!.sleep_date).toBe('2024-03-09')
+
+    // Both should appear in sleep_sessions
+    expect(result.sleep_sessions).toHaveLength(2)
+  })
+
+  test('returns null for primary_sleep and evening_sleep when no sleep data', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-03-08'))
+
+    expect(result.primary_sleep).toBeNull()
+    expect(result.evening_sleep).toBeNull()
+    expect(result.sleep_sessions).toHaveLength(0)
+  })
+
+  test('adds sleep_location from overlapping place visits', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-03-08T07:00:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-03-07T23:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([
+      {
+        duration_minutes: 300,
+        end_time: new Date('2024-03-08T08:00:00Z'),
+        lat: 57.7,
+        lon: 11.97,
+        name: 'Hökås',
+        source: 'named',
+        start_time: new Date('2024-03-07T22:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-03-08'))
+
+    expect(result.primary_sleep).not.toBeNull()
+    expect(result.primary_sleep!.sleep_location).toEqual({
+      lat: 57.7,
+      lon: 11.97,
+      name: 'Hökås',
+      source: 'named',
+    })
+  })
+
+  test('sleep_location picks the place with longest overlap', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-03-08T07:00:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-03-07T23:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([
+      // Short visit at Office before sleep
+      {
+        duration_minutes: 30,
+        end_time: new Date('2024-03-07T23:30:00Z'),
+        lat: 59.33,
+        lon: 18.07,
+        name: 'Office',
+        source: 'named',
+        start_time: new Date('2024-03-07T22:00:00Z'),
+      },
+      // Long stay at Home covering most of sleep
+      {
+        duration_minutes: 600,
+        end_time: new Date('2024-03-08T08:00:00Z'),
+        lat: 57.7,
+        lon: 11.97,
+        name: 'Home',
+        source: 'named',
+        start_time: new Date('2024-03-07T23:30:00Z'),
+      },
+    ])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-03-08'))
+
+    // Should pick Home (7.5h overlap) over Office (30min overlap)
+    expect(result.primary_sleep!.sleep_location!.name).toBe('Home')
+  })
+
+  test('sleep_location is undefined when no place visits overlap', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-03-08T07:00:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-03-07T23:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+    vi.mocked(db.getTags).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-03-08'))
+
+    expect(result.primary_sleep!.sleep_location).toBeUndefined()
+  })
+})
+
+describe('findSleepLocation', () => {
+  test('returns undefined when no place visits', () => {
+    const result = findSleepLocation(new Date('2024-03-07T23:00:00Z'), new Date('2024-03-08T07:00:00Z'), [])
+    expect(result).toBeUndefined()
+  })
+
+  test('returns the place with longest overlap', () => {
+    const result = findSleepLocation(new Date('2024-03-07T23:00:00Z'), new Date('2024-03-08T07:00:00Z'), [
+      {
+        duration_minutes: 30,
+        end_time: new Date('2024-03-07T23:30:00Z'),
+        lat: 59.33,
+        lon: 18.07,
+        name: 'Office',
+        source: 'named' as const,
+        start_time: new Date('2024-03-07T22:00:00Z'),
+      },
+      {
+        duration_minutes: 600,
+        end_time: new Date('2024-03-08T08:00:00Z'),
+        lat: 57.7,
+        lon: 11.97,
+        name: 'Home',
+        source: 'named' as const,
+        start_time: new Date('2024-03-07T23:30:00Z'),
+      },
+    ])
+    expect(result).toEqual({
+      lat: 57.7,
+      lon: 11.97,
+      name: 'Home',
+      source: 'named',
+    })
+  })
+
+  test('ignores places with no overlap', () => {
+    const result = findSleepLocation(new Date('2024-03-07T23:00:00Z'), new Date('2024-03-08T07:00:00Z'), [
+      {
+        duration_minutes: 120,
+        end_time: new Date('2024-03-07T20:00:00Z'),
+        lat: 59.33,
+        lon: 18.07,
+        name: 'Office',
+        source: 'named' as const,
+        start_time: new Date('2024-03-07T18:00:00Z'),
+      },
+    ])
+    expect(result).toBeUndefined()
   })
 })
 

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -32,7 +32,7 @@ import {
   metricUnits,
 } from '../schema'
 import { classifyHrvByContext, getHrvContextWindows, HrvContext } from './hrv-context'
-import { getPlaceVisits } from './locations'
+import { getPlaceVisits, type PlaceVisit } from './locations'
 import { computeHrZoneSecs, getEffectiveHrZones, HrZoneSecs, type HrZoneThresholds } from './settings'
 import { computeSleepMinutes } from './sleep-duration'
 
@@ -118,6 +118,24 @@ export interface SessionSummary {
   hr_zone_secs?: HrZoneSecs
 }
 
+export interface SleepLocation {
+  name: string
+  source: 'named' | 'detected' | 'owntracks' | 'unknown'
+  lat?: number
+  lon?: number
+}
+
+export interface SleepSessionSummary {
+  start_time: string
+  end_time?: string
+  duration?: number // minutes (actual sleep time or time in bed)
+  time_in_bed?: number // minutes
+  total_sleep?: number // minutes (from sleep stage data)
+  sleep_date?: string // YYYY-MM-DD — the date this sleep "belongs to" (wake-up convention)
+  sleep_location?: SleepLocation
+  data?: Record<string, unknown>
+}
+
 export interface TagSummary {
   id?: string
   tag: string
@@ -158,7 +176,9 @@ export interface DailySummaryResult {
   heart_rate: HeartRateStats | null
   notes: NoteSummary[]
   steps: { total: number }
-  sleep_sessions: SessionSummary[]
+  primary_sleep: SleepSessionSummary | null
+  evening_sleep: SleepSessionSummary | null
+  sleep_sessions: SleepSessionSummary[]
   exercise_sessions: SessionSummary[]
   tags: TagSummary[]
   productivity: ProductivitySummary | null
@@ -631,8 +651,44 @@ export async function getDailySummary(
   const tagIds = tags.map((t) => t.id).filter((id): id is string => id !== undefined)
   const tagCommentsMap = await getCommentsMap(user, 'tag', tagIds)
 
+  // Build sleep session summaries with sleep_date and sleep_location
+  const dateStr = date.toISOString().split('T')[0]
+  const sleepSessionSummaries: SleepSessionSummary[] = sleepSessions.map((s) => {
+    const timeInBed =
+      s.end_time ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60) : undefined
+    const totalSleep = computeSleepMinutes(s.data as Record<string, unknown> | undefined)
+
+    // sleep_date = wake-up date (end_time date), or start_time date if still sleeping
+    const sleepDate =
+      s.end_time ? s.end_time.toISOString().split('T')[0] : s.start_time.toISOString().split('T')[0]
+
+    // Find the best-guess sleep location from place visits overlapping the sleep window
+    const sleepLocation = findSleepLocation(s.start_time, s.end_time ?? end, placeVisits)
+
+    return {
+      data: s.data,
+      duration: totalSleep ?? timeInBed,
+      end_time: s.end_time?.toISOString(),
+      sleep_date: sleepDate,
+      sleep_location: sleepLocation,
+      start_time: s.start_time.toISOString(),
+      time_in_bed: timeInBed,
+      total_sleep: totalSleep,
+    }
+  })
+
+  // Classify sleep sessions:
+  // primary_sleep = session where the user woke up on this date (end_time is on this date)
+  // evening_sleep = session that started on this date but ends on the next day (or is ongoing)
+  const primarySleep = sleepSessionSummaries.find((s) => s.end_time && s.end_time.startsWith(dateStr)) ?? null
+  const eveningSleep =
+    sleepSessionSummaries.find(
+      (s) => s.start_time.startsWith(dateStr) && (!s.end_time || !s.end_time.startsWith(dateStr)),
+    ) ?? null
+
   return {
-    date: date.toISOString().split('T')[0],
+    date: dateStr,
+    evening_sleep: eveningSleep,
     exercise_sessions: exerciseSessionsWithHrZones,
     heart_rate: heartRateStats,
     notes: dayNotes.map((n) => ({
@@ -657,20 +713,9 @@ export async function getDailySummary(
       source: p.source,
       start_time: p.start_time.toISOString(),
     })),
+    primary_sleep: primarySleep,
     productivity: productivitySummary,
-    sleep_sessions: sleepSessions.map((s) => {
-      const timeInBed =
-        s.end_time ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60) : undefined
-      const totalSleep = computeSleepMinutes(s.data as Record<string, unknown> | undefined)
-      return {
-        data: s.data,
-        duration: totalSleep ?? timeInBed,
-        end_time: s.end_time?.toISOString(),
-        start_time: s.start_time.toISOString(),
-        time_in_bed: timeInBed,
-        total_sleep: totalSleep,
-      }
-    }),
+    sleep_sessions: sleepSessionSummaries,
     steps: { total: totalSteps },
     tags: tags.map((t) => ({
       comments: t.id ? (tagCommentsMap.get(t.id) ?? []) : [],
@@ -678,6 +723,40 @@ export async function getDailySummary(
       start_time: t.start_time.toISOString(),
       tag: t.tag,
     })),
+  }
+}
+
+/**
+ * Find the best-guess sleep location from place visits overlapping a sleep window.
+ * Returns the place with the longest overlap during the sleep window.
+ */
+export function findSleepLocation(
+  sleepStart: Date,
+  sleepEnd: Date,
+  placeVisits: PlaceVisit[],
+): SleepLocation | undefined {
+  let bestMatch: PlaceVisit | undefined
+  let bestOverlap = 0
+
+  for (const visit of placeVisits) {
+    // Calculate overlap between sleep window and visit
+    const overlapStart = Math.max(sleepStart.getTime(), visit.start_time.getTime())
+    const overlapEnd = Math.min(sleepEnd.getTime(), visit.end_time.getTime())
+    const overlap = overlapEnd - overlapStart
+
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap
+      bestMatch = visit
+    }
+  }
+
+  if (!bestMatch) return undefined
+
+  return {
+    lat: bestMatch.lat,
+    lon: bestMatch.lon,
+    name: bestMatch.name,
+    source: bestMatch.source,
   }
 }
 

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -33,7 +33,48 @@ export const heartRateStatsSchema = z
 export type HeartRateStats = z.infer<typeof heartRateStatsSchema>
 
 /**
- * Session summary schema (for sleep, exercise, meditation).
+ * Sleep location schema — best-guess location where the person slept.
+ */
+export const sleepLocationSchema = z
+  .object({
+    lat: latSchema.optional(),
+    lon: lonSchema.optional(),
+    name: z.string().meta({ description: 'Location name', example: 'Home' }),
+    source: placeSourceSchema,
+  })
+  .meta({ id: 'SleepLocation', description: 'Best-guess location where the person slept' })
+
+export type SleepLocation = z.infer<typeof sleepLocationSchema>
+
+/**
+ * Sleep session summary schema — extends session summary with sleep-specific fields.
+ */
+export const sleepSessionSummarySchema = z
+  .object({
+    data: z.record(z.string(), z.unknown()).optional(),
+    duration: durationMinutesSchema.optional(),
+    end_time: iso8601DateTimeSchema.optional(),
+    sleep_date: dateOnlySchema.optional().meta({
+      description:
+        'The date this sleep "belongs to", using wake-up convention (the date the user woke up). E.g. sleep starting 2026-03-07T23:00Z and ending 2026-03-08T07:00Z has sleep_date 2026-03-08.',
+    }),
+    sleep_location: sleepLocationSchema.optional().meta({
+      description: 'Best-guess location where the person slept during this session',
+    }),
+    start_time: iso8601DateTimeSchema,
+    time_in_bed: durationMinutesSchema.optional().meta({
+      description: 'Total time in bed in minutes (end_time - start_time)',
+    }),
+    total_sleep: durationMinutesSchema.optional().meta({
+      description: 'Actual sleep time in minutes (excluding awake periods), from sleep stage data',
+    }),
+  })
+  .meta({ id: 'SleepSessionSummary', description: 'Sleep session with location and date attribution' })
+
+export type SleepSessionSummary = z.infer<typeof sleepSessionSummarySchema>
+
+/**
+ * Session summary schema (for exercise, meditation).
  */
 export const sessionSummarySchema = z
   .object({
@@ -105,7 +146,9 @@ export const ouraScoresSchema = z
     cardiovascular_age: z.number().nullable().meta({ description: 'Oura cardiovascular age' }),
     readiness_score: z.number().nullable().meta({ description: 'Oura readiness score (0-100)' }),
     resilience_score: z.number().nullable().meta({ description: 'Oura resilience score (0-100)' }),
-    sleep_score: z.number().nullable().meta({ description: 'Oura sleep score (0-100)' }),
+    sleep_score: z.number().nullable().meta({
+      description: 'Oura sleep score (0-100). Evaluates the primary_sleep session for this date.',
+    }),
   })
   .meta({ id: 'OuraScores' })
 
@@ -117,15 +160,29 @@ export type OuraScores = z.infer<typeof ouraScoresSchema>
 export const dailySummaryResultSchema = z
   .object({
     date: dateOnlySchema,
+    evening_sleep: sleepSessionSummarySchema.nullable().meta({
+      description:
+        'Sleep session that started on this date but continues into the next day (fell asleep tonight). Will appear as the primary_sleep on the next day. Null if no evening sleep was started.',
+    }),
     exercise_sessions: z.array(sessionSummarySchema),
     heart_rate: heartRateStatsSchema.nullable(),
     notes: z.array(noteSchema).meta({
       description: 'All notes whose time range overlaps this day, across all entity types',
     }),
-    oura_scores: ouraScoresSchema.nullable(),
+    oura_scores: ouraScoresSchema.nullable().meta({
+      description:
+        'Oura scores for this date. The sleep_score evaluates the primary_sleep session (the sleep the user woke up from on this date).',
+    }),
     places: z.array(placeSummarySchema),
+    primary_sleep: sleepSessionSummarySchema.nullable().meta({
+      description:
+        'The main sleep session for this date — the one the user woke up from on this date (following Oura convention). The oura_scores.sleep_score evaluates this session. Null if no primary sleep ended on this date.',
+    }),
     productivity: productivitySummarySchema.nullable(),
-    sleep_sessions: z.array(sessionSummarySchema),
+    sleep_sessions: z.array(sleepSessionSummarySchema).meta({
+      description:
+        'All sleep sessions overlapping this date (kept for backward compatibility). Prefer using primary_sleep and evening_sleep for unambiguous sleep attribution.',
+    }),
     steps: z.object({
       total: z.number().meta({ description: 'Total steps for the day' }),
     }),


### PR DESCRIPTION
## Summary

Closes #303

- Adds `primary_sleep` and `evening_sleep` fields to daily summary, clearly identifying which sleep session the user woke up from (primary, following Oura convention) vs fell asleep during (evening)
- Each sleep session now includes `sleep_date` (the date this sleep belongs to, using wake-up convention) and `sleep_location` (best-guess location from overlapping place visits)
- Documents that `oura_scores.sleep_score` evaluates the `primary_sleep` session
- Keeps `sleep_sessions` array for backward compatibility

## Changes

### `packages/api-spec` (schema)
- New `SleepLocation` schema with name, source, lat, lon
- New `SleepSessionSummary` schema extending session with `sleep_date`, `sleep_location`, `time_in_bed`, `total_sleep`
- `DailySummaryResult` gains `primary_sleep` and `evening_sleep` fields (nullable)
- `sleep_sessions` array type changed to `SleepSessionSummary[]`
- Oura scores description updated to link sleep_score to primary_sleep

### `apps/backend` (service)
- `getDailySummary` now classifies sleep sessions as primary (woke up today) vs evening (fell asleep today, continues tomorrow)
- New `findSleepLocation()` function finds the place visit with longest overlap during a sleep window
- MCP tool description updated to explain the new sleep disambiguation fields

### Tests
- 9 new unit tests covering: primary/evening classification, sleep location from place visits, location overlap selection, no-data cases
- 3 unit tests for `findSleepLocation` directly
- Existing comprehensive test updated to verify new fields