### PR TITLE
feat: generate calories burned from HR data

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -62,6 +62,7 @@
     <uses-permission android:name="android.permission.health.READ_WHEELCHAIR_PUSHES" />
 
     <!-- Write permissions for BLE sensor data and outbound sync -->
+    <uses-permission android:name="android.permission.health.WRITE_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.WRITE_BODY_FAT" />
     <uses-permission android:name="android.permission.health.WRITE_BODY_WATER_MASS" />
     <uses-permission android:name="android.permission.health.WRITE_BONE_MASS" />

--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -689,6 +689,25 @@ data class RestingHeartRateRecordSerializable(
   }
 }
 
+// --- VO2 Max Record ---
+@Serializable
+data class Vo2MaxRecordSerializable(
+  val time: String,
+  val vo2MillilitersPerMinuteKilogram: Double,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<Vo2MaxRecordSerializable> =
+      classRecords.filterIsInstance<Vo2MaxRecord>().map { record ->
+        Vo2MaxRecordSerializable(
+          time = record.time.toIsoString(),
+          vo2MillilitersPerMinuteKilogram = record.vo2MillilitersPerMinuteKilogram,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
 // Helper to format Instant to ISO 8601 String
 fun Instant.toIsoString(): String = this.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
@@ -718,6 +737,7 @@ fun Metadata.toSerializable(): HealthConnectRecordMetadata =
  */
 val writableRecordTypes: Set<KClass<out Record>> =
   setOf(
+    ActiveCaloriesBurnedRecord::class,
     BodyFatRecord::class,
     BodyWaterMassRecord::class,
     BoneMassRecord::class,

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -969,6 +969,15 @@ fun HealthConnectScreen(
                   ktorHttpClient,
                   authToken,
                 )
+              Vo2MaxRecord::class ->
+                handlePostData(
+                  Vo2MaxRecordSerializable.fromRecordsList(classRecords),
+                  Vo2MaxRecordSerializable.serializer(),
+                  syncUrl,
+                  recordTypeSimpleName,
+                  ktorHttpClient,
+                  authToken,
+                )
               else -> {
                 Log.w("SendData", "No specific serialization for $recordTypeSimpleName. Skipping.")
                 PostResult.Success

--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -204,6 +204,29 @@ private suspend fun writeUpsertRecord(
 
   val record: Record =
     when (entry.hc_record_type) {
+      "ActiveCaloriesBurnedRecord" -> {
+        if (!hasWritePermission<ActiveCaloriesBurnedRecord>(
+            grantedPermissions,
+          )
+        ) {
+          return WriteResult.Skipped("no WRITE_ACTIVE_CALORIES_BURNED permission")
+        }
+        val value = payload.getDouble("value") ?: return WriteResult.Skipped("missing/invalid 'value' in payload: ${payload.keys}")
+        val startTime = payload.getInstant("time") ?: return WriteResult.Skipped("missing/invalid 'time' in payload: ${payload["time"]}")
+        // Per-minute calorie data: each record covers a 60-second window.
+        // If end_time is provided, use it; otherwise default to start + 60s.
+        val endTime = payload.getInstant("end_time") ?: startTime.plusSeconds(60)
+        ActiveCaloriesBurnedRecord(
+          energy =
+            androidx.health.connect.client.units.Energy
+              .kilocalories(value),
+          startTime = startTime,
+          startZoneOffset = ZoneOffset.systemDefault().rules.getOffset(startTime),
+          endTime = endTime,
+          endZoneOffset = ZoneOffset.systemDefault().rules.getOffset(endTime),
+          metadata = Metadata.manualEntry(clientRecordId),
+        )
+      }
       "WeightRecord" -> {
         if (!hasWritePermission<WeightRecord>(grantedPermissions)) return WriteResult.Skipped("no WRITE_WEIGHT permission")
         val value = payload.getDouble("value") ?: return WriteResult.Skipped("missing/invalid 'value' in payload: ${payload.keys}")

--- a/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
@@ -188,6 +188,7 @@ class HealthDataModelsTest {
     // These are the record types handled in OutboundSync.kt writeUpsertRecord()
     val expectedTypes =
       setOf(
+        "ActiveCaloriesBurnedRecord",
         "BodyFatRecord",
         "BodyWaterMassRecord",
         "BoneMassRecord",

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -51,6 +51,7 @@ import { createScreentimeCategoriesRouter } from './routes/screentime-categories
 import { createSettingsRouter } from './routes/settings-router'
 import { createTagsRouter } from './routes/tags-router'
 import { createTrendsRouter } from './routes/trends-router'
+import { triggerCalorieComputation } from './services/calorie-computation'
 import { getCentralDb, initializeCentralDb } from './services/central-db'
 import { createDetectionTrigger, DetectionTrigger } from './services/detection-trigger'
 import { runDetectionForUser } from './services/detection-worker'
@@ -354,6 +355,8 @@ const main = async () => {
         syncLastFm: transformLastFmSyncResult,
         syncOura: transformOuraSyncResults,
         syncRescueTime: transformRescueTimeSyncResult,
+        triggerCalorieComputation: (user: string, start: Date, end: Date) =>
+          triggerCalorieComputation(user, start, end),
       },
       authMiddleware,
     ),

--- a/apps/backend/src/db/cumulative-query.ts
+++ b/apps/backend/src/db/cumulative-query.ts
@@ -20,9 +20,11 @@ export const splitMetricsByCumulative = (
 interface SplitQueryOptions<T> {
   /** The metric names to query */
   metrics: string[]
-  /** Additional query parameters after the metrics array (e.g. start, end dates) */
+  /** Shared query parameters after the metrics array (e.g. start, end dates) */
   params: unknown[]
-  /** SQL for cumulative metrics (with source filter). $1 = metrics array, remaining = params */
+  /** Extra parameters appended only to the cumulative query (e.g. source filter values) */
+  cumulativeExtraParams?: unknown[]
+  /** SQL for cumulative metrics (with source filter). $1 = metrics array, remaining = params + cumulativeExtraParams */
   sqlCumulative: string
   /** SQL for non-cumulative metrics (all sources). $1 = metrics array, remaining = params */
   sqlNonCumulative: string
@@ -36,14 +38,20 @@ interface SplitQueryOptions<T> {
  * Run split queries for cumulative and non-cumulative metrics, combining results.
  *
  * The SQL templates should use $1 for the metrics array, with remaining placeholders
- * for the additional params (e.g. $2 for start, $3 for end).
+ * for the additional params (e.g. $2 for start, $3 for end). The cumulative SQL can
+ * reference additional placeholders for cumulativeExtraParams.
  */
 export const querySplitByCumulative = async <T>(options: SplitQueryOptions<T>): Promise<T[]> => {
   const { cumulative, nonCumulative } = splitMetricsByCumulative(options.metrics)
   const results: T[] = []
 
   if (cumulative.length > 0) {
-    const result = await options.queryFn(options.sqlCumulative, [cumulative, ...options.params])
+    const extraParams = options.cumulativeExtraParams ?? []
+    const result = await options.queryFn(options.sqlCumulative, [
+      cumulative,
+      ...options.params,
+      ...extraParams,
+    ])
     results.push(...result.rows.map(options.mapRow))
   }
 

--- a/apps/backend/src/db/health-connect.ts
+++ b/apps/backend/src/db/health-connect.ts
@@ -4,6 +4,7 @@
 import type { DataSource, MetricType } from '@aurboda/api-spec'
 import {
   cumulativeMetrics,
+  cumulativeSources,
   healthConnectActivityMapping,
   healthConnectMetricMapping,
   isValidMetric,
@@ -295,10 +296,10 @@ export const getDailyAggregateValue = async (
   const result = await query(
     user,
     `SELECT value FROM time_series
-     WHERE metric = $1 AND source = 'health_connect_aggregate'
+     WHERE metric = $1 AND source = ANY($4)
      AND time >= $2 AND time < $3
      LIMIT 1`,
-    [metric, start, end],
+    [metric, start, end, cumulativeSources],
   )
 
   if (result.rows.length === 0) return null

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -2,7 +2,7 @@
  * Time series data CRUD, bucketed aggregation, and statistics.
  */
 import format from 'pg-format'
-import { cumulativeMetrics, type MetricType, metricUnits } from '../schema'
+import { cumulativeMetrics, cumulativeSources, type MetricType, metricUnits } from '../schema'
 import { query } from './connection'
 import { querySplitByCumulative } from './cumulative-query'
 import { parseMetricType } from './row-mappers'
@@ -53,12 +53,12 @@ export const getTimeSeries = async (
     isCumulative ?
       `SELECT time, value FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
-         AND source = 'health_connect_aggregate'
+         AND source = ANY($4)
        ORDER BY time`
     : `SELECT time, value FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
        ORDER BY time`,
-    [metric, start, end],
+    isCumulative ? [metric, start, end, cumulativeSources] : [metric, start, end],
   )
 
   return result.rows.map((row) => [new Date(row.time), row.value])
@@ -78,12 +78,12 @@ export const getTimeSeriesWithSource = async (
     isCumulative ?
       `SELECT time, value, source FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
-         AND source = 'health_connect_aggregate'
+         AND source = ANY($4)
        ORDER BY time`
     : `SELECT time, value, source FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
        ORDER BY time`,
-    [metric, start, end],
+    isCumulative ? [metric, start, end, cumulativeSources] : [metric, start, end],
   )
 
   return result.rows.map((row) => ({ source: row.source, time: new Date(row.time), value: row.value }))
@@ -98,13 +98,14 @@ export const getTimeSeriesMultiMetric = async (
   if (metrics.length === 0) return {} as Record<MetricType, [Date, number][]>
 
   const rows = await querySplitByCumulative<{ metric: string; time: Date; value: number }>({
+    cumulativeExtraParams: [cumulativeSources],
     mapRow: (row) => ({ metric: row.metric as string, time: new Date(row.time), value: row.value as number }),
     metrics,
     params: [start, end],
     queryFn: (sql, params) => query(user, sql, params),
     sqlCumulative: `SELECT time, metric, value FROM time_series
        WHERE metric = ANY($1) AND time >= $2 AND time <= $3
-         AND source = 'health_connect_aggregate'
+         AND source = ANY($4)
        ORDER BY metric, time`,
     sqlNonCumulative: `SELECT time, metric, value FROM time_series
        WHERE metric = ANY($1) AND time >= $2 AND time <= $3
@@ -156,11 +157,12 @@ export const getTimeSeriesStats = async (
   })
 
   const results = await querySplitByCumulative<MetricStats>({
+    cumulativeExtraParams: [cumulativeSources],
     mapRow,
     metrics,
     params: [start, end],
     queryFn: (sql, params) => query(user, sql, params),
-    sqlCumulative: statsSql(`\n         AND source = 'health_connect_aggregate'`),
+    sqlCumulative: statsSql(`\n         AND source = ANY($4)`),
     sqlNonCumulative: statsSql(''),
   })
 
@@ -194,11 +196,12 @@ export const getDailyAggregates = async (
   })
 
   const results = await querySplitByCumulative<DailyMetricAggregate>({
+    cumulativeExtraParams: [cumulativeSources],
     mapRow,
     metrics,
     params: [start, end],
     queryFn: (sql, params) => query(user, sql, params),
-    sqlCumulative: dailySql(`\n         AND source = 'health_connect_aggregate'`),
+    sqlCumulative: dailySql(`\n         AND source = ANY($4)`),
     sqlNonCumulative: dailySql(''),
   })
 
@@ -257,9 +260,7 @@ export const getTimeSeriesBucketed = async (
 ): Promise<BucketedMetricData[]> => {
   if (metrics.length === 0) return []
 
-  const result = await query(
-    user,
-    `SELECT
+  const bucketedSql = (sourceFilter: string) => `SELECT
        date_bin($4::interval, time, $2) as bucket_start,
        metric,
        AVG(value) as avg,
@@ -267,18 +268,29 @@ export const getTimeSeriesBucketed = async (
        MAX(value) as max,
        COUNT(*)::integer as count
      FROM time_series
-     WHERE metric = ANY($1) AND time >= $2 AND time < $3
+     WHERE metric = ANY($1) AND time >= $2 AND time < $3${sourceFilter}
      GROUP BY bucket_start, metric
-     ORDER BY bucket_start, metric`,
-    [metrics, start, end, `${bucketMinutes} minutes`],
-  )
+     ORDER BY bucket_start, metric`
 
-  return result.rows.map((row) => ({
+  const mapRow = (row: { [key: string]: unknown }): BucketedMetricData => ({
     avg: row.avg !== null ? Number(row.avg) : 0,
-    bucket_start: new Date(row.bucket_start),
-    count: row.count,
+    bucket_start: new Date(row.bucket_start as string),
+    count: row.count as number,
     max: row.max !== null ? Number(row.max) : 0,
-    metric: parseMetricType(row.metric),
+    metric: parseMetricType(row.metric as string),
     min: row.min !== null ? Number(row.min) : 0,
-  }))
+  })
+
+  const interval = `${bucketMinutes} minutes`
+  const results = await querySplitByCumulative<BucketedMetricData>({
+    cumulativeExtraParams: [cumulativeSources],
+    mapRow,
+    metrics,
+    params: [start, end, interval],
+    queryFn: (sql, params) => query(user, sql, params),
+    sqlCumulative: bucketedSql(`\n     AND source = ANY($5)`),
+    sqlNonCumulative: bucketedSql(''),
+  })
+
+  return results.sort((a, b) => a.bucket_start.getTime() - b.bucket_start.getTime())
 }

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -6,6 +6,7 @@
  */
 import type {
   ActivityType,
+  BiologicalSex,
   CustomMetricDefinition,
   DashboardConfig,
   DataSource,
@@ -332,6 +333,7 @@ export interface UserSettings {
   hr_zone_start?: { 1: number; 2: number; 3: number; 4: number; 5: number }
   lastfm_username?: string // Last.fm username for scrobble sync
   rescue_time_key?: string // RescueTime API key (personal token)
+  sex?: BiologicalSex // Biological sex for calorie calculation
   item_icons?: Record<string, string> // Unified icon mappings for all timeline items (tags, activities, exercise types)
   tag_icons?: Record<string, string> // Deprecated: tag-only icons (migrated to item_icons)
   tag_mappings?: Record<string, string> // Tag name mappings from UUIDs to display names

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -5,9 +5,11 @@ import {
   addCustomMetricBodySchema,
   addMetricBodySchema,
   customMetricDefinitionSchema,
+  recalculateCaloriesBodySchema,
   updateCustomMetricBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
+import { computeAndStoreCalories } from '../services/calorie-computation'
 import {
   addCustomMetric,
   addMetric,
@@ -143,6 +145,17 @@ export const registerMetricTools = (server: McpServer, user: string) => {
     async ({ metric }) => {
       const result = await deleteMetricData(user, metric)
       return jsonResponse(result)
+    },
+  )
+
+  // Tool: recalculate_calories
+  server.tool(
+    'recalculate_calories',
+    'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback).',
+    { ...recalculateCaloriesBodySchema.shape },
+    async ({ start, end }) => {
+      const result = await computeAndStoreCalories(user, new Date(start), new Date(end))
+      return jsonResponse({ ...result, success: true })
     },
   )
 }

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -11,6 +11,7 @@ import { addMinutes, isFuture, subDays } from 'date-fns'
 import { getSyncState, getUserSettings, SyncState, upsertSyncState } from './db'
 import { ouraClient } from './oura'
 import { type OuraDataType, processOuraData } from './oura-process'
+import { triggerCalorieComputation } from './services/calorie-computation'
 
 // Re-export for consumers that import from oura-sync
 export { convertOuraSleepPhases, processOuraData, type OuraDataType } from './oura-process'
@@ -129,6 +130,11 @@ export const syncOuraDataType = async (
     }
 
     await processOuraData(user, dataType, data)
+
+    // Trigger calorie computation for data types that include HR samples
+    if ((dataType === 'sleep' || dataType === 'sessions') && data.length > 0) {
+      await triggerCalorieComputation(user, start, end)
+    }
 
     // Update sync state on success
     await upsertSyncState(user, {

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -26,12 +26,16 @@ import {
   type QueryMetricsQuery,
   queryMetricsQuerySchema,
   type QueryMetricsResponse,
+  type RecalculateCaloriesBody,
+  recalculateCaloriesBodySchema,
+  type RecalculateCaloriesResponse,
   type UpdateCustomMetricBody,
   updateCustomMetricBodySchema,
 } from '@aurboda/api-spec'
 import { RequestHandler, Router } from 'express'
 import { getUserSettings } from '../db'
 import { isValidMetricOrCustom, type MetricType, validMetrics } from '../schema'
+import { computeAndStoreCalories } from '../services/calorie-computation'
 import {
   addCustomMetric,
   addMetric,
@@ -148,6 +152,20 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
         return res.status(404).json({ error: result.error, success: false })
       }
       res.json({ data: result.data, success: true })
+    },
+  )
+
+  // POST /metrics/recalculate-calories - Recalculate calorie burn from HR data
+  router.post<Record<string, never>, RecalculateCaloriesResponse, RecalculateCaloriesBody>(
+    '/metrics/recalculate-calories',
+    authMiddleware,
+    validateBody(recalculateCaloriesBodySchema),
+    async (req, res) => {
+      const { start, end } = req.body
+      const user = req.user!
+
+      const result = await computeAndStoreCalories(user, new Date(start), new Date(end))
+      res.json({ ...result, success: true })
     },
   )
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -9,6 +9,7 @@
 export {
   contextualHrvMetrics,
   cumulativeMetrics,
+  cumulativeSources,
   getMetricUnit,
   hrZoneMetrics,
   isContextualHrvMetric,
@@ -463,6 +464,7 @@ export const metricToHealthConnectType: Partial<Record<MetricType, string>> = {
   body_fat: 'BodyFatRecord',
   body_water_mass: 'BodyWaterMassRecord',
   bone_mass: 'BoneMassRecord',
+  calories_active: 'ActiveCaloriesBurnedRecord',
   heart_rate: 'HeartRateRecord',
   height: 'HeightRecord',
   hrv_rmssd: 'HeartRateVariabilityRmssdRecord',

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -1,0 +1,202 @@
+/**
+ * Service for automatic calorie computation from HR data.
+ *
+ * Triggered after HR data is ingested (from Health Connect or Oura).
+ * Computes per-minute calories using the HR-based formula and stores them
+ * as calories_active with source 'aurboda', plus queues outbound sync.
+ */
+
+import type { BiologicalSex } from '@aurboda/api-spec'
+import { enqueueOutboundSync, getUserSettings } from '../db'
+import { getTimeSeries, getTimeSeriesWithSource, insertTimeSeries } from '../db/time-series'
+import type { TimeSeriesPoint } from '../db/types'
+import { isHealthConnectSyncableMetric, metricToHealthConnectType } from '../schema'
+import { computeCaloriesPerMinute, getVo2MaxFallback } from './calories'
+
+/**
+ * Calculate age from birth date string.
+ */
+const calculateAge = (birthDate: string): number => {
+  const birth = new Date(birthDate)
+  const today = new Date()
+  let age = today.getFullYear() - birth.getFullYear()
+  const monthDiff = today.getMonth() - birth.getMonth()
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--
+  }
+  return age
+}
+
+/**
+ * Get the most recent value for a metric before or at the given time.
+ */
+const getLatestMetricValue = async (
+  user: string,
+  metric: string,
+  beforeTime: Date,
+): Promise<number | null> => {
+  // Look back up to 90 days for the latest value
+  const lookbackStart = new Date(beforeTime.getTime() - 90 * 24 * 60 * 60 * 1000)
+  const data = await getTimeSeries(user, metric, lookbackStart, beforeTime)
+  if (data.length === 0) return null
+  // Return the most recent value
+  return data[data.length - 1][1]
+}
+
+export interface CalorieComputationResult {
+  points_computed: number
+  points_stored: number
+  vo2_max_source: 'measured' | 'fallback'
+  skipped_reason?: string
+}
+
+/**
+ * Compute and store calories for a time range where HR data exists.
+ *
+ * This is the main entry point called after HR data ingestion.
+ * It gathers all required inputs, computes per-minute calories,
+ * stores them, and queues outbound sync.
+ */
+export const computeAndStoreCalories = async (
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<CalorieComputationResult> => {
+  // 1. Get user settings
+  const settings = await getUserSettings(user)
+  if (!settings) {
+    return { points_computed: 0, points_stored: 0, skipped_reason: 'no settings', vo2_max_source: 'fallback' }
+  }
+
+  const sex = settings.sex as BiologicalSex | undefined
+  if (!sex) {
+    return { points_computed: 0, points_stored: 0, skipped_reason: 'sex not set', vo2_max_source: 'fallback' }
+  }
+
+  if (!settings.birth_date) {
+    return {
+      points_computed: 0,
+      points_stored: 0,
+      skipped_reason: 'birth_date not set',
+      vo2_max_source: 'fallback',
+    }
+  }
+
+  const age = calculateAge(settings.birth_date)
+
+  // 2. Get latest weight
+  const weight = await getLatestMetricValue(user, 'weight', end)
+  if (weight === null) {
+    return {
+      points_computed: 0,
+      points_stored: 0,
+      skipped_reason: 'no weight data',
+      vo2_max_source: 'fallback',
+    }
+  }
+
+  // 3. Get VO2 max (measured or fallback)
+  const measuredVo2Max = await getLatestMetricValue(user, 'vo2_max', end)
+  const vo2Max = measuredVo2Max ?? getVo2MaxFallback(sex, age)
+  const vo2MaxSource = measuredVo2Max !== null ? 'measured' : 'fallback'
+
+  // 4. Get HR data for the time range
+  const hrData = await getTimeSeries(user, 'heart_rate', start, end)
+  if (hrData.length === 0) {
+    return {
+      points_computed: 0,
+      points_stored: 0,
+      skipped_reason: 'no HR data',
+      vo2_max_source: vo2MaxSource,
+    }
+  }
+
+  // 5. Check if aurboda calories already exist for this range to avoid recomputing
+  const existingCalories = await getTimeSeriesWithSource(user, 'calories_active', start, end)
+  const existingAurbodaMinutes = new Set(
+    existingCalories.filter((p) => p.source === 'aurboda').map((p) => Math.floor(p.time.getTime() / 60_000)),
+  )
+
+  // 6. Compute per-minute calories
+  const caloriePoints = computeCaloriesPerMinute({
+    age_years: age,
+    hr_samples: hrData,
+    sex,
+    vo2_max: vo2Max,
+    weight_kg: weight,
+  })
+
+  // 7. Filter out already-computed minutes
+  const newPoints = caloriePoints.filter(
+    (p) => !existingAurbodaMinutes.has(Math.floor(p.time.getTime() / 60_000)),
+  )
+
+  if (newPoints.length === 0) {
+    return {
+      points_computed: caloriePoints.length,
+      points_stored: 0,
+      skipped_reason: 'all minutes already computed',
+      vo2_max_source: vo2MaxSource,
+    }
+  }
+
+  // 8. Store as time_series
+  const timeSeriesPoints: TimeSeriesPoint[] = newPoints.map((p) => ({
+    metric: 'calories_active',
+    source: 'aurboda' as const,
+    time: p.time,
+    unit: 'kcal',
+    value: p.kcal,
+  }))
+  await insertTimeSeries(user, timeSeriesPoints)
+
+  // 9. Queue outbound sync for each point (best-effort)
+  try {
+    if (isHealthConnectSyncableMetric('calories_active')) {
+      const hcRecordType = metricToHealthConnectType.calories_active
+      if (hcRecordType) {
+        for (const p of newPoints) {
+          await enqueueOutboundSync(user, {
+            entity_id: `calories_active|${p.time.toISOString()}`,
+            entity_type: 'time_series',
+            hc_record_type: hcRecordType,
+            operation: 'insert',
+            payload: {
+              end_time: p.end_time.toISOString(),
+              metric: 'calories_active',
+              time: p.time.toISOString(),
+              unit: 'kcal',
+              value: p.kcal,
+            },
+          })
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Failed to enqueue calorie outbound sync:', err)
+  }
+
+  return {
+    points_computed: caloriePoints.length,
+    points_stored: newPoints.length,
+    vo2_max_source: vo2MaxSource,
+  }
+}
+
+/**
+ * Trigger calorie computation for a time range after HR data ingestion.
+ * This is a best-effort operation that never throws.
+ */
+export const triggerCalorieComputation = async (user: string, start: Date, end: Date): Promise<void> => {
+  try {
+    const result = await computeAndStoreCalories(user, start, end)
+    if (result.points_stored > 0) {
+      console.log(
+        `🔥 Computed ${result.points_stored} calorie data points for ${user} ` +
+          `(VO2max: ${result.vo2_max_source})`,
+      )
+    }
+  } catch (err) {
+    console.error('Calorie computation failed (non-fatal):', err)
+  }
+}

--- a/apps/backend/src/services/calories.test.ts
+++ b/apps/backend/src/services/calories.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from 'vitest'
+
+import { computeCaloriesForMinute, computeCaloriesPerMinute, getVo2MaxFallback } from './calories'
+
+describe('getVo2MaxFallback', () => {
+  test('returns age-appropriate fallback for male', () => {
+    expect(getVo2MaxFallback('male', 25)).toBe(42) // < 30
+    expect(getVo2MaxFallback('male', 35)).toBe(40) // < 40
+    expect(getVo2MaxFallback('male', 49)).toBe(37) // < 50
+    expect(getVo2MaxFallback('male', 55)).toBe(34) // < 60
+    expect(getVo2MaxFallback('male', 75)).toBe(28) // >= 70
+  })
+
+  test('returns age-appropriate fallback for female', () => {
+    expect(getVo2MaxFallback('female', 25)).toBe(36) // < 30
+    expect(getVo2MaxFallback('female', 45)).toBe(31) // < 50
+    expect(getVo2MaxFallback('female', 80)).toBe(23) // >= 70
+  })
+})
+
+describe('computeCaloriesForMinute', () => {
+  test('computes calories for a male', () => {
+    // Man, 50 years old, 100 kg, VO2max 40, HR 120
+    // CB = (0.634*120 + 0.404*40 + 0.394*100 + 0.271*50 - 95.7735) / 4.184
+    // = (76.08 + 16.16 + 39.4 + 13.55 - 95.7735) / 4.184
+    // = 49.4165 / 4.184
+    // ≈ 11.811
+    const result = computeCaloriesForMinute(120, 40, 100, 50, 'male')
+    expect(result).toBeCloseTo(11.811, 2)
+  })
+
+  test('computes calories for a female', () => {
+    // Woman, 35 years old, 65 kg, VO2max 35, HR 130
+    // CB = (0.45*130 + 0.380*35 + 0.103*65 + 0.274*35 - 59.3954) / 4.184
+    // = (58.5 + 13.3 + 6.695 + 9.59 - 59.3954) / 4.184
+    // = 28.6896 / 4.184
+    // ≈ 6.858
+    const result = computeCaloriesForMinute(130, 35, 65, 35, 'female')
+    expect(result).toBeCloseTo(6.858, 2)
+  })
+
+  test('clamps to 0 for very low heart rate', () => {
+    // Very low HR where formula would go negative
+    const result = computeCaloriesForMinute(40, 30, 50, 20, 'male')
+    expect(result).toBe(0)
+  })
+
+  test('returns positive value for moderate exercise', () => {
+    const result = computeCaloriesForMinute(150, 45, 80, 40, 'male')
+    expect(result).toBeGreaterThan(0)
+  })
+})
+
+describe('computeCaloriesPerMinute', () => {
+  const baseParams = {
+    age_years: 50,
+    sex: 'male' as const,
+    vo2_max: 40,
+    weight_kg: 100,
+  }
+
+  test('returns empty array for no HR samples', () => {
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: [] })
+    expect(result).toEqual([])
+  })
+
+  test('returns one data point for a single HR sample', () => {
+    const result = computeCaloriesPerMinute({
+      ...baseParams,
+      hr_samples: [[new Date('2024-01-15T10:00:00Z'), 120]],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].time).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].end_time).toEqual(new Date('2024-01-15T10:01:00Z'))
+    expect(result[0].kcal).toBeGreaterThan(0)
+  })
+
+  test('produces per-minute buckets for dense HR data', () => {
+    // 5 samples over 4 minutes (every 60 seconds)
+    const samples: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 120],
+      [new Date('2024-01-15T10:01:00Z'), 125],
+      [new Date('2024-01-15T10:02:00Z'), 130],
+      [new Date('2024-01-15T10:03:00Z'), 128],
+      [new Date('2024-01-15T10:04:00Z'), 122],
+    ]
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+    expect(result).toHaveLength(5)
+
+    // Each minute should have the corresponding HR value
+    // First minute: HR 120, no other samples in [10:00, 10:01)
+    expect(result[0].time).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[0].end_time).toEqual(new Date('2024-01-15T10:01:00Z'))
+  })
+
+  test('hold-last-value fills sparse data (5-minute intervals like Oura)', () => {
+    // Oura sleep HR: one sample every 5 minutes
+    const samples: [Date, number][] = [
+      [new Date('2024-01-15T23:00:00Z'), 60],
+      [new Date('2024-01-15T23:05:00Z'), 58],
+      [new Date('2024-01-15T23:10:00Z'), 55],
+    ]
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+
+    // Should produce 11 minute buckets (23:00 through 23:10)
+    expect(result).toHaveLength(11)
+
+    // First minute uses HR 60
+    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(60, 40, 100, 50, 'male'), 4)
+
+    // Minutes 1-4 (23:01-23:04) also use HR 60 (hold-last-value)
+    expect(result[1].kcal).toBeCloseTo(result[0].kcal, 4)
+    expect(result[4].kcal).toBeCloseTo(result[0].kcal, 4)
+
+    // Minute 5 (23:05) uses HR 58
+    expect(result[5].kcal).toBeCloseTo(computeCaloriesForMinute(58, 40, 100, 50, 'male'), 4)
+  })
+
+  test('averages multiple HR samples within same minute', () => {
+    // Two samples in the same minute
+    const samples: [Date, number][] = [
+      [new Date('2024-01-15T10:00:10Z'), 100],
+      [new Date('2024-01-15T10:00:40Z'), 120],
+    ]
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+    expect(result).toHaveLength(1)
+
+    // Average of 100 and 120 = 110
+    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(110, 40, 100, 50, 'male'), 4)
+  })
+
+  test('all data points have 60-second intervals', () => {
+    const samples: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 120],
+      [new Date('2024-01-15T10:05:00Z'), 130],
+    ]
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+
+    for (const point of result) {
+      const diffMs = point.end_time.getTime() - point.time.getTime()
+      expect(diffMs).toBe(60_000)
+    }
+  })
+
+  test('total calories for a 30-minute run match formula', () => {
+    // 30 minutes of constant 150bpm running
+    const samples: [Date, number][] = Array.from(
+      { length: 31 },
+      (_, i) => [new Date(`2024-01-15T10:${String(i).padStart(2, '0')}:00Z`), 150] as [Date, number],
+    )
+
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+    const totalKcal = result.reduce((sum, p) => sum + p.kcal, 0)
+
+    // Formula: CB = T * (0.634*150 + 0.404*40 + 0.394*100 + 0.271*50 - 95.7735) / 4.184
+    //            = 30 * (95.1 + 16.16 + 39.4 + 13.55 - 95.7735) / 4.184
+    //            = 30 * 68.4365 / 4.184
+    //            = 30 * 16.3579...
+    //            ≈ 490.74
+    const expectedPerMinute = (0.634 * 150 + 0.404 * 40 + 0.394 * 100 + 0.271 * 50 - 95.7735) / 4.184
+    const expectedTotal = 31 * expectedPerMinute
+
+    expect(totalKcal).toBeCloseTo(expectedTotal, 0)
+  })
+})

--- a/apps/backend/src/services/calories.ts
+++ b/apps/backend/src/services/calories.ts
@@ -1,0 +1,164 @@
+/**
+ * Calorie calculation from heart rate data.
+ *
+ * Uses the formulas from https://www.omnicalculator.com/sports/calories-burned-by-heart-rate
+ *
+ * Men:   CB = T * (0.634*H + 0.404*V + 0.394*W + 0.271*A - 95.7735) / 4.184
+ * Women: CB = T * (0.45*H  + 0.380*V + 0.103*W + 0.274*A - 59.3954) / 4.184
+ *
+ * where:
+ *   CB = Calories burned (kcal)
+ *   T  = Duration in minutes
+ *   H  = Average heart rate (bpm)
+ *   V  = VO2 max (mL/kg/min)
+ *   W  = Weight (kg)
+ *   A  = Age (years)
+ */
+
+import type { BiologicalSex } from '@aurboda/api-spec'
+
+/** Default VO2 max fallback values by sex and age group (mL/kg/min). */
+const VO2_MAX_FALLBACK: Record<BiologicalSex, { age: number; value: number }[]> = {
+  female: [
+    { age: 30, value: 36 },
+    { age: 40, value: 34 },
+    { age: 50, value: 31 },
+    { age: 60, value: 28 },
+    { age: 70, value: 25 },
+    { age: 999, value: 23 },
+  ],
+  male: [
+    { age: 30, value: 42 },
+    { age: 40, value: 40 },
+    { age: 50, value: 37 },
+    { age: 60, value: 34 },
+    { age: 70, value: 31 },
+    { age: 999, value: 28 },
+  ],
+}
+
+/**
+ * Get a population-average VO2 max estimate based on sex and age.
+ */
+export const getVo2MaxFallback = (sex: BiologicalSex, age: number): number => {
+  const brackets = VO2_MAX_FALLBACK[sex]
+  for (const bracket of brackets) {
+    if (age < bracket.age) return bracket.value
+  }
+  return brackets[brackets.length - 1].value
+}
+
+export interface CalorieCalcParams {
+  /** Sorted HR samples: [timestamp, bpm] */
+  hr_samples: [Date, number][]
+  /** VO2 max in mL/kg/min */
+  vo2_max: number
+  /** Weight in kg */
+  weight_kg: number
+  /** Age in years */
+  age_years: number
+  /** Biological sex */
+  sex: BiologicalSex
+}
+
+export interface CalorieDataPoint {
+  /** Start of the minute bucket */
+  time: Date
+  /** End of the minute bucket (time + 60s) */
+  end_time: Date
+  /** Calories burned in this minute (kcal) */
+  kcal: number
+}
+
+/**
+ * Compute per-minute calorie burn from heart rate samples.
+ *
+ * Uses hold-last-value interpolation for sparse data (e.g., Oura 5-minute HR):
+ * a sample's HR value is assumed to persist until the next sample arrives.
+ * Minutes without any HR coverage are skipped.
+ */
+export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieDataPoint[] => {
+  const { hr_samples, vo2_max, weight_kg, age_years, sex } = params
+
+  if (hr_samples.length === 0) return []
+
+  // Determine time range
+  const firstTime = hr_samples[0][0].getTime()
+  const lastTime = hr_samples[hr_samples.length - 1][0].getTime()
+
+  // For a single sample, it covers just the one minute bucket it falls in
+  const endTime = hr_samples.length === 1 ? firstTime : lastTime
+
+  // Align start to the beginning of its minute
+  const startMinute = Math.floor(firstTime / 60_000) * 60_000
+  const endMinute = Math.floor(endTime / 60_000) * 60_000
+
+  const results: CalorieDataPoint[] = []
+
+  // For each minute bucket, find the applicable HR (hold-last-value)
+  let sampleIdx = 0
+
+  for (let minuteMs = startMinute; minuteMs <= endMinute; minuteMs += 60_000) {
+    const bucketStart = minuteMs
+    const bucketEnd = minuteMs + 60_000
+
+    // Advance sampleIdx to the last sample at or before bucketEnd
+    while (sampleIdx < hr_samples.length - 1 && hr_samples[sampleIdx + 1][0].getTime() <= bucketStart) {
+      sampleIdx++
+    }
+
+    // Collect all HR values that fall within or apply to this bucket
+    const hrValues: number[] = []
+
+    // If the current sample is at or before this bucket, its value applies (hold-last-value)
+    if (hr_samples[sampleIdx][0].getTime() <= bucketStart) {
+      hrValues.push(hr_samples[sampleIdx][1])
+    }
+
+    // Also include any samples that fall within this bucket
+    for (let i = sampleIdx; i < hr_samples.length; i++) {
+      const sampleTime = hr_samples[i][0].getTime()
+      if (sampleTime > bucketStart && sampleTime < bucketEnd) {
+        hrValues.push(hr_samples[i][1])
+      }
+      if (sampleTime >= bucketEnd) break
+    }
+
+    // Skip this minute if we have no HR data
+    if (hrValues.length === 0) continue
+
+    // Average HR for this minute
+    const avgHr = hrValues.reduce((a, b) => a + b, 0) / hrValues.length
+
+    // Apply formula (T = 1 minute)
+    const kcal = computeCaloriesForMinute(avgHr, vo2_max, weight_kg, age_years, sex)
+
+    results.push({
+      end_time: new Date(bucketEnd),
+      kcal,
+      time: new Date(bucketStart),
+    })
+  }
+
+  return results
+}
+
+/**
+ * Compute calories burned in one minute given average HR and other parameters.
+ * Returns 0 if the formula yields a negative value (very low HR).
+ */
+export const computeCaloriesForMinute = (
+  avgHr: number,
+  vo2Max: number,
+  weightKg: number,
+  ageYears: number,
+  sex: BiologicalSex,
+): number => {
+  let raw: number
+  if (sex === 'male') {
+    raw = (0.634 * avgHr + 0.404 * vo2Max + 0.394 * weightKg + 0.271 * ageYears - 95.7735) / 4.184
+  } else {
+    raw = (0.45 * avgHr + 0.38 * vo2Max + 0.103 * weightKg + 0.274 * ageYears - 59.3954) / 4.184
+  }
+  return Math.max(0, raw)
+}

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -213,6 +213,7 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
     oura_configured: ouraConfigured,
     oura_connected: ouraToken !== null,
     rescue_time_key: settings.rescue_time_key ?? null,
+    sex: settings.sex ?? null,
     success: true,
     tag_icons: settings.item_icons ?? {},
     tag_mappings: settings.tag_mappings ?? {},
@@ -242,6 +243,7 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
       oura_configured: !!(process.env.OURA_CLIENT && process.env.OURA_SECRET),
       oura_connected: false,
       rescue_time_key: null,
+      sex: null,
       success: false,
       tag_icons: {},
       tag_mappings: {},
@@ -258,6 +260,7 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
     'item_icons',
     'lastfm_username',
     'rescue_time_key',
+    'sex',
     'tag_icons',
     'tag_mappings',
   ] as const

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -28,6 +28,7 @@ describe('sync router', () => {
     syncLastFm: vi.fn().mockResolvedValue({ scrobbles_processed: 0, status: 'success', tags_created: 0 }),
     syncOura: vi.fn().mockResolvedValue({ success: true }),
     syncRescueTime: vi.fn().mockResolvedValue({ success: true }),
+    triggerCalorieComputation: vi.fn().mockResolvedValue(undefined),
   }
 
   // Simple auth middleware that sets req.user for tests

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -64,6 +64,7 @@ export interface SyncRouterDeps {
   deleteHealthConnectRecords: (user: string, externalIds: string[]) => Promise<number>
   processDailyAggregate: (user: string, aggregate: DailyAggregate) => Promise<void>
   processHealthConnectData: (user: string, recordType: string, data: HealthConnectRecord) => Promise<void>
+  triggerCalorieComputation: (user: string, start: Date, end: Date) => Promise<void>
   syncOura: (user: string, options: { fullResync?: boolean; startDate?: Date }) => Promise<OuraSyncResult[]>
   getOuraSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   resetOuraSyncState: (user: string, dataType?: string) => Promise<void>
@@ -476,6 +477,21 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       // Process each Health Connect record through the new schema
       for (const item of records) {
         await deps.processHealthConnectData(user, recordType, item)
+      }
+
+      // Trigger calorie computation when HR data is ingested
+      if (recordType === 'HeartRateRecord' && records.length > 0) {
+        const timestamps = records.flatMap((r) => {
+          const samples = r.samples as Array<{ time: string }> | undefined
+          if (samples) return samples.map((s) => new Date(s.time).getTime())
+          const t = r.startTime || r.time
+          return t ? [new Date(t as string).getTime()] : []
+        })
+        if (timestamps.length > 0) {
+          const start = new Date(Math.min(...timestamps))
+          const end = new Date(Math.max(...timestamps))
+          await deps.triggerCalorieComputation(user, start, end)
+        }
       }
 
       res.json({ success: true })

--- a/apps/web/src/pages/DataSources/AurbodaSource.tsx
+++ b/apps/web/src/pages/DataSources/AurbodaSource.tsx
@@ -2,12 +2,55 @@ import { useQuery } from '@tanstack/react-query'
 import { CustomMetricsSettings } from '../../components/CustomMetricsSettings'
 import { GoalsSettings } from '../../components/GoalsSettings'
 import { TagMappingsSettings } from '../../components/TagMappingsSettings'
-import { fetchUserSettings } from '../../state/api'
+import { fetchMetricTimeSeries, fetchUserSettings } from '../../state/api'
 import { auth } from '../../state/auth'
 
 import './style.css'
 
-const DATA_TYPES = ['Tags', 'Custom metrics', 'Manual data entry', 'Goals', 'Notes']
+const DATA_TYPES = ['Tags', 'Custom metrics', 'Manual data entry', 'Goals', 'Notes', 'Calories (computed)']
+
+function CalorieEstimationStatus({
+  hasBirthDate,
+  hasSex,
+  hasVo2Max,
+}: {
+  hasBirthDate: boolean
+  hasSex: boolean
+  hasVo2Max: boolean
+}) {
+  if (!hasSex) {
+    return (
+      <div class="status-banner not-connected">
+        <span class="status-dot not-connected" />
+        Calorie estimation is disabled — set your biological sex in <a href="/settings">Settings</a> to enable
+        it.
+      </div>
+    )
+  }
+  if (!hasBirthDate) {
+    return (
+      <div class="status-banner not-connected">
+        <span class="status-dot not-connected" />
+        Birth date is required for calorie estimation — set it in <a href="/settings">Settings</a>.
+      </div>
+    )
+  }
+  if (!hasVo2Max) {
+    return (
+      <div class="status-banner not-connected">
+        <span class="status-dot not-connected" />
+        No VO2 max data found — using age/sex-based population averages for calorie estimation. Sync VO2 max
+        from a fitness watch via Health Connect for more accurate results.
+      </div>
+    )
+  }
+  return (
+    <div class="status-banner connected">
+      <span class="status-dot connected" />
+      Calorie estimation is active with measured VO2 max data.
+    </div>
+  )
+}
 
 export function AurbodaSource() {
   const isLoggedIn = auth.value.token
@@ -17,6 +60,21 @@ export function AurbodaSource() {
     queryFn: fetchUserSettings,
     queryKey: ['userSettings'],
   })
+
+  // Check if VO2 max data exists (look back 90 days, matching calorie computation service)
+  const { data: vo2MaxData } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () => {
+      const lookbackStart = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+      return fetchMetricTimeSeries('vo2_max', lookbackStart, new Date())
+    },
+    queryKey: ['vo2max_check'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const hasVo2Max = (vo2MaxData?.length ?? 0) > 0
+  const hasSex = !!userSettings?.sex
+  const hasBirthDate = !!userSettings?.birth_date
 
   if (!isLoggedIn) {
     return (
@@ -55,6 +113,15 @@ export function AurbodaSource() {
           <span class="status-dot connected" /> Always available — no setup required
         </div>
       </div>
+
+      <section class="settings-section">
+        <h2>Calorie Estimation</h2>
+        <p class="section-description">
+          Aurboda computes per-minute active calorie burn from heart rate data using a metabolic formula. This
+          applies to all HR data — sleep, exercise, and continuous monitoring.
+        </p>
+        <CalorieEstimationStatus hasBirthDate={hasBirthDate} hasSex={hasSex} hasVo2Max={hasVo2Max} />
+      </section>
 
       <TagMappingsSettings />
 

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -1,7 +1,13 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
 import { TimelineIconsSettings } from '../../components/TimelineIconsSettings'
-import { fetchUserSettings, HrZoneThresholds, UpdateSettingsInput, updateUserSettings } from '../../state/api'
+import {
+  BiologicalSex,
+  fetchUserSettings,
+  HrZoneThresholds,
+  UpdateSettingsInput,
+  updateUserSettings,
+} from '../../state/api'
 import { auth } from '../../state/auth'
 import { defaultHrZoneThresholds } from '../../utils/hrZones'
 import { parseZoneValue, updateZoneThreshold, validateHrZoneThresholds } from '../../utils/settings'
@@ -43,15 +49,17 @@ export function Settings() {
 
   // Form state
   const [birthDate, setBirthDate] = useState<string>('')
+  const [sex, setSex] = useState<BiologicalSex | null>(null)
   const [hrZones, setHrZones] = useState<HrZoneThresholds | null>(null)
 
   // Save status for each section
-  const [birthDateStatus, setBirthDateStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [personalInfoStatus, setPersonalInfoStatus] = useState<SaveStatus>({ status: 'idle' })
   const [hrZonesStatus, setHrZonesStatus] = useState<SaveStatus>({ status: 'idle' })
 
   // Initialize form when data loads
   const initializeForm = () => {
     setBirthDate(userSettings?.birth_date ?? '')
+    setSex(userSettings?.sex ?? null)
     setHrZones(userSettings?.hr_zone_start ?? null)
   }
 
@@ -91,11 +99,18 @@ export function Settings() {
 
     // Validate format if not empty
     if (birthDate && !/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
-      setBirthDateStatus({ error: 'Invalid date format', status: 'error' })
+      setPersonalInfoStatus({ error: 'Invalid date format', status: 'error' })
       return
     }
 
-    saveSection({ birth_date: birthDate || null }, setBirthDateStatus)
+    saveSection({ birth_date: birthDate || null }, setPersonalInfoStatus)
+  }
+
+  const handleSexChange = (e: Event) => {
+    const value = (e.target as HTMLSelectElement).value
+    const newSex = value === '' ? null : (value as BiologicalSex)
+    setSex(newSex)
+    saveSection({ sex: newSex }, setPersonalInfoStatus)
   }
 
   const handleZoneChange = (zone: keyof HrZoneThresholds, value: string) => {
@@ -153,7 +168,7 @@ export function Settings() {
       <section class="settings-section">
         <div class="section-header-row">
           <h2>Personal Information</h2>
-          <SaveStatusIndicator saveStatus={birthDateStatus} />
+          <SaveStatusIndicator saveStatus={personalInfoStatus} />
         </div>
         <div class="form-field">
           <label for="birth-date">Birth Date</label>
@@ -166,6 +181,19 @@ export function Settings() {
           />
           <p class="field-description">
             Used to calculate age-based HR zone thresholds if custom zones are not set.
+          </p>
+        </div>
+
+        <div class="form-field">
+          <label for="sex">Biological Sex</label>
+          <select id="sex" value={sex ?? ''} onChange={handleSexChange}>
+            <option value="">Not set</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+          </select>
+          <p class="field-description">
+            Required for calorie burn estimation from heart rate data. Setting this enables automatic calorie
+            computation.
           </p>
         </div>
       </section>

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -91,7 +91,8 @@
 
 .form-field input[type='date'],
 .form-field input[type='password'],
-.form-field input[type='text'] {
+.form-field input[type='text'],
+.form-field select {
   padding: 0.5rem;
   font-size: 1rem;
   border: 1px solid #ccc;
@@ -100,7 +101,8 @@
   max-width: 300px;
 }
 
-.form-field input[type='date'] {
+.form-field input[type='date'],
+.form-field select {
   max-width: 200px;
 }
 
@@ -458,6 +460,7 @@
   .form-field input[type='date'],
   .form-field input[type='password'],
   .form-field input[type='text'],
+  .form-field select,
   .zone-input input[type='number'] {
     background: #333;
     border-color: #555;

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -143,6 +143,9 @@ export interface Scrobble extends Omit<ApiScrobble, 'recorded_at'> {
   recorded_at: Date
 }
 
+// Defined locally to avoid Zod type resolution issues with api-spec's z.infer<z.ZodEnum>
+export type BiologicalSex = 'male' | 'female'
+
 // Re-export API types that don't need Date conversion
 export type {
   ActivityCorrelation,

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -278,6 +278,13 @@ export const cumulativeMetrics: MetricType[] = [
 ]
 
 /**
+ * Trusted sources for cumulative metrics.
+ * health_connect_aggregate: deduplicated daily totals from Health Connect
+ * aurboda: computed values (e.g., calorie calculation from HR data)
+ */
+export const cumulativeSources: DataSource[] = ['health_connect_aggregate', 'aurboda']
+
+/**
  * Place visit source schema.
  */
 export const placeSourceSchema = z.enum(['named', 'detected', 'owntracks', 'unknown']).meta({

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -245,3 +245,48 @@ export const queryMetricsBucketedResponseSchema = baseResponseSchema
   .meta({ id: 'QueryMetricsBucketedResponse' })
 
 export type QueryMetricsBucketedResponse = z.infer<typeof queryMetricsBucketedResponseSchema>
+
+// =============================================================================
+// Calorie Recalculation
+// =============================================================================
+
+/**
+ * Recalculate calories request body.
+ * Computes calorie burn from HR data for the given time range.
+ */
+export const recalculateCaloriesBodySchema = z
+  .object({
+    end: iso8601DateTimeSchema.meta({ description: 'End date/time' }),
+    start: iso8601DateTimeSchema.meta({ description: 'Start date/time' }),
+  })
+  .meta({
+    id: 'RecalculateCaloriesBody',
+    description: 'Recalculate calories burned from HR data for a time range.',
+  })
+
+export type RecalculateCaloriesBody = z.infer<typeof recalculateCaloriesBodySchema>
+
+/**
+ * Recalculate calories response.
+ */
+export const recalculateCaloriesResponseSchema = baseResponseSchema
+  .extend({
+    points_computed: z
+      .number()
+      .int()
+      .optional()
+      .meta({ description: 'Total per-minute calorie points computed' }),
+    points_stored: z
+      .number()
+      .int()
+      .optional()
+      .meta({ description: 'New points stored (excluding already-computed)' }),
+    skipped_reason: z.string().optional().meta({ description: 'Reason computation was skipped, if any' }),
+    vo2_max_source: z
+      .enum(['measured', 'fallback'])
+      .optional()
+      .meta({ description: 'Whether measured VO2 max was used or age/sex fallback' }),
+  })
+  .meta({ id: 'RecalculateCaloriesResponse' })
+
+export type RecalculateCaloriesResponse = z.infer<typeof recalculateCaloriesResponseSchema>

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -48,6 +48,17 @@ export const hrZoneSecsSchema = z
 export type HrZoneSecs = z.infer<typeof hrZoneSecsSchema>
 
 /**
+ * Biological sex schema (used for calorie calculation formulas).
+ */
+export const biologicalSexSchema = z.enum(['male', 'female']).meta({
+  description: 'Biological sex (used for calorie calculation formulas)',
+  example: 'male',
+  id: 'BiologicalSex',
+})
+
+export type BiologicalSex = z.infer<typeof biologicalSexSchema>
+
+/**
  * Birth date schema (YYYY-MM-DD format).
  */
 export const birthDateSchema = z.iso.date().meta({
@@ -132,6 +143,9 @@ export const updateSettingsInputSchema = z
     birth_date: birthDateSchema.nullable().optional().meta({
       description: 'Birth date (set to null to clear)',
     }),
+    sex: biologicalSexSchema.nullable().optional().meta({
+      description: 'Biological sex for calorie calculation (set to null to clear)',
+    }),
     calendars: calendarsSchema.nullable().optional().meta({
       description: 'Calendar ICS URL configurations (set to null to clear all)',
     }),
@@ -185,6 +199,7 @@ export const userSettingsResponseSchema = baseResponseSchema
     oura_configured: z.boolean().meta({ description: 'Whether Oura OAuth is configured on server' }),
     oura_connected: z.boolean().meta({ description: 'Whether Oura is connected via OAuth' }),
     rescue_time_key: z.string().nullable().meta({ description: 'RescueTime API key' }),
+    sex: biologicalSexSchema.nullable().meta({ description: 'Biological sex for calorie calculation' }),
     item_icons: itemIconsSchema.meta({
       description:
         'Unified icon mappings for all timeline items — tags, activities, exercise types (tag key or name -> emoji/URL)',


### PR DESCRIPTION
## Summary

Implements GitHub issue #240: **Generate calories burned from HR data**.

Computes per-minute active calorie burn from heart rate data using the Keytel et al. metabolic formula. Calories are computed automatically whenever HR data is ingested from any source (Health Connect, Oura, BLE chest strap). The `sex` setting acts as the effective opt-in — no sex set, no computation.

## Key Changes

### API Spec (`packages/api-spec`)
- Add `biologicalSexSchema` and `BiologicalSex` type to settings schemas
- Add `cumulativeSources` constant (`['health_connect_aggregate', 'aurboda']`) for cumulative metric queries
- Add `recalculateCaloriesBodySchema` / `RecalculateCaloriesResponse` for manual recalculation endpoint

### Backend
- **Pure calorie functions** (`services/calories.ts`): `computeCaloriesPerMinute()`, `computeCaloriesForMinute()`, `getVo2MaxFallback()` — 13 unit tests
- **Calorie computation service** (`services/calorie-computation.ts`): Gathers inputs (settings, weight, VO2 max, HR data), computes per-minute calories, stores as `calories_active` with `source='aurboda'`, queues outbound sync
- **Post-ingestion hooks**: Triggers calorie computation after HC HeartRateRecord processing (sync-router) and after Oura sleep/session HR data (oura-sync)
- **REST endpoint**: `POST /metrics/recalculate-calories` for manual recalculation
- **MCP tool**: `recalculate_calories` with start/end params
- **Cumulative query fix**: `querySplitByCumulative` now uses `cumulativeExtraParams` to avoid PostgreSQL parameter count mismatch when non-cumulative queries don't need the source filter
- **Settings**: Add `sex` field to user settings (response, update, error response)

### Android
- **Fix VO2 Max sync**: Add `Vo2MaxRecordSerializable` and serialization branch (records were silently skipped)
- **Outbound sync**: Add `ActiveCaloriesBurnedRecord` case in `writeUpsertRecord()`, add to `writableRecordTypes`, add `WRITE_ACTIVE_CALORIES_BURNED` permission

### Frontend
- **Settings page**: Biological sex selector in Personal Information section
- **Data Sources page**: Calorie estimation status section on Aurboda source page, showing whether calorie estimation is active, missing VO2 max (using fallback), or disabled (missing sex/birth_date)

## Formula

From Keytel et al.:
- **Men**: `CB = T × (0.634×H + 0.404×V + 0.394×W + 0.271×A - 95.7735) / 4.184`
- **Women**: `CB = T × (0.450×H + 0.380×V + 0.103×W + 0.274×A - 59.3954) / 4.184`

Where T=minutes, H=avg HR, V=VO2max, W=weight(kg), A=age(years).

Closes #240