### PR TITLE
fix: persist sex field in upsertUserSettings

### DIFF
--- a/apps/backend/src/db/settings.integration.test.ts
+++ b/apps/backend/src/db/settings.integration.test.ts
@@ -245,4 +245,37 @@ describe('Settings Integration Tests', () => {
       expect(settings?.dashboard?.sections[1].collapsed).toBe(true)
     })
   })
+
+  describe('User Settings with sex', () => {
+    test('stores and retrieves sex', async () => {
+      const user = getTestUser()
+
+      await upsertUserSettings(user, { sex: 'male' })
+
+      const settings = await getUserSettings(user)
+      expect(settings?.sex).toBe('male')
+    })
+
+    test('updates sex while preserving other settings', async () => {
+      const user = getTestUser()
+
+      await upsertUserSettings(user, { birth_date: '1990-01-15' })
+      await upsertUserSettings(user, { sex: 'female' })
+
+      const settings = await getUserSettings(user)
+      expect(settings?.birth_date).toBe('1990-01-15')
+      expect(settings?.sex).toBe('female')
+    })
+
+    test('preserves sex when update does not include sex', async () => {
+      const user = getTestUser()
+
+      await upsertUserSettings(user, { sex: 'male' })
+      await upsertUserSettings(user, { birth_date: '2000-01-01' })
+
+      const settings = await getUserSettings(user)
+      expect(settings?.sex).toBe('male')
+      expect(settings?.birth_date).toBe('2000-01-01')
+    })
+  })
 })

--- a/apps/backend/src/db/settings.ts
+++ b/apps/backend/src/db/settings.ts
@@ -121,44 +121,29 @@ export const upsertUserSettings = async (
   // Get existing settings
   const existing = (await getUserSettings(user)) ?? {}
 
-  // Merge updates
+  // Merge updates — simple fields are copied directly when present
   const merged: UserSettings = { ...existing }
-  if (updates.birth_date !== undefined) {
-    merged.birth_date = updates.birth_date
+  const simpleFields = [
+    'birth_date',
+    'calendars',
+    'custom_metrics',
+    'dashboard',
+    'goals',
+    'hr_zone_start',
+    'item_icons',
+    'lastfm_username',
+    'rescue_time_key',
+    'sex',
+    'tag_mappings',
+  ] as const
+  for (const field of simpleFields) {
+    if (updates[field] !== undefined) {
+      ;(merged as Record<string, unknown>)[field] = updates[field]
+    }
   }
-  if (updates.calendars !== undefined) {
-    merged.calendars = updates.calendars
-  }
-  if (updates.custom_metrics !== undefined) {
-    merged.custom_metrics = updates.custom_metrics
-  }
-  if (updates.dashboard !== undefined) {
-    merged.dashboard = updates.dashboard
-  }
-  if (updates.goals !== undefined) {
-    merged.goals = updates.goals
-  }
-  if (updates.hr_zone_start !== undefined) {
-    merged.hr_zone_start = updates.hr_zone_start
-  }
-  if (updates.lastfm_username !== undefined) {
-    merged.lastfm_username = updates.lastfm_username
-  }
-  if (updates.rescue_time_key !== undefined) {
-    merged.rescue_time_key = updates.rescue_time_key
-  }
-  if (updates.sex !== undefined) {
-    merged.sex = updates.sex
-  }
-  if (updates.item_icons !== undefined) {
-    merged.item_icons = updates.item_icons
-  }
+  // Deprecated: merge tag_icons into item_icons for backwards compatibility
   if (updates.tag_icons !== undefined) {
-    // Deprecated: merge tag_icons into item_icons for backwards compatibility
     merged.item_icons = { ...(merged.item_icons ?? {}), ...updates.tag_icons }
-  }
-  if (updates.tag_mappings !== undefined) {
-    merged.tag_mappings = updates.tag_mappings
   }
 
   // Check if settings row exists

--- a/apps/backend/src/db/settings.ts
+++ b/apps/backend/src/db/settings.ts
@@ -147,6 +147,9 @@ export const upsertUserSettings = async (
   if (updates.rescue_time_key !== undefined) {
     merged.rescue_time_key = updates.rescue_time_key
   }
+  if (updates.sex !== undefined) {
+    merged.sex = updates.sex
+  }
   if (updates.item_icons !== undefined) {
     merged.item_icons = updates.item_icons
   }


### PR DESCRIPTION
## Summary
- The `sex` field was missing from the explicit merge logic in `upsertUserSettings`, causing it to be silently dropped when saving settings
- Added 3 integration tests for the sex settings field (store/retrieve, preserve on other updates, update while preserving other fields)

Fixes the calorie computation opt-in — without this fix, setting `sex` via the API or MCP had no effect.