### PR TITLE
fix: limit HR hold-forward to 5 minutes for calorie computation

### DIFF
--- a/apps/backend/coverage-baseline.json
+++ b/apps/backend/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "statements": 59.57,
-  "branches": 85.65,
-  "functions": 79.52
+  "statements": 59.61,
+  "branches": 85.68,
+  "functions": 79.56
 }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -59,6 +59,7 @@ export { getAllScrobbles, getScrobbles, insertRawRecord, type ScrobbleRecord } f
 
 // Time series
 export {
+  deleteTimeSeriesBySource,
   deleteTimeSeriesMetric,
   deleteTimeSeriesPoint,
   getDailyAggregates,

--- a/apps/backend/src/db/time-series.integration.test.ts
+++ b/apps/backend/src/db/time-series.integration.test.ts
@@ -8,6 +8,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper'
 import {
+  deleteTimeSeriesBySource,
   deleteTimeSeriesMetric,
   deleteTimeSeriesPoint,
   getTimeSeries,
@@ -570,6 +571,58 @@ describe('Time Series Integration Tests', () => {
       const result = await deleteTimeSeriesPoint(user, 'weight', new Date('2024-01-15T08:00:00Z'))
 
       expect(result).toBe(false)
+    })
+  })
+
+  describe('deleteTimeSeriesBySource', () => {
+    test('deletes only data matching source and time range', async () => {
+      const user = getTestUser()
+
+      // Use heart_rate (non-cumulative) so getTimeSeriesWithSource returns all sources
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'aurboda', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+        { metric: 'heart_rate', source: 'aurboda', time: new Date('2024-01-15T11:00:00Z'), value: 75 },
+        { metric: 'heart_rate', source: 'aurboda', time: new Date('2024-01-15T12:00:00Z'), value: 68 },
+        { metric: 'heart_rate', source: 'health_connect', time: new Date('2024-01-15T10:30:00Z'), value: 80 },
+      ])
+
+      // Delete only aurboda source within 10:00–12:00 (exclusive end)
+      const count = await deleteTimeSeriesBySource(
+        user,
+        'heart_rate',
+        'aurboda',
+        new Date('2024-01-15T10:00:00Z'),
+        new Date('2024-01-15T12:00:00Z'),
+      )
+
+      expect(count).toBe(2) // 10:00 and 11:00 deleted, 12:00 outside range (end exclusive)
+
+      const data = await getTimeSeriesWithSource(
+        user,
+        'heart_rate',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(data).toHaveLength(2)
+      // health_connect data preserved
+      expect(data.find((d) => d.source === 'health_connect')).toBeDefined()
+      // aurboda at 12:00 preserved (outside delete range)
+      expect(data.find((d) => d.source === 'aurboda' && d.value === 68)).toBeDefined()
+    })
+
+    test('returns 0 when no matching data exists', async () => {
+      const user = getTestUser()
+
+      const count = await deleteTimeSeriesBySource(
+        user,
+        'heart_rate',
+        'aurboda',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(count).toBe(0)
     })
   })
 

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -251,6 +251,21 @@ export const deleteTimeSeriesMetric = async (user: string, metric: string): Prom
   return result.rowCount ?? 0
 }
 
+export const deleteTimeSeriesBySource = async (
+  user: string,
+  metric: string,
+  source: string,
+  start: Date,
+  end: Date,
+): Promise<number> => {
+  const result = await query(
+    user,
+    `DELETE FROM time_series WHERE metric = $1 AND source = $2 AND time >= $3 AND time < $4`,
+    [metric, source, start, end],
+  )
+  return result.rowCount ?? 0
+}
+
 export const getTimeSeriesBucketed = async (
   user: string,
   metrics: MetricType[],

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -154,7 +154,7 @@ export const registerMetricTools = (server: McpServer, user: string) => {
     'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback).',
     { ...recalculateCaloriesBodySchema.shape },
     async ({ start, end }) => {
-      const result = await computeAndStoreCalories(user, new Date(start), new Date(end))
+      const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
       return jsonResponse({ ...result, success: true })
     },
   )

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -164,7 +164,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
       const { start, end } = req.body
       const user = req.user!
 
-      const result = await computeAndStoreCalories(user, new Date(start), new Date(end))
+      const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
       res.json({ ...result, success: true })
     },
   )

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -8,7 +8,12 @@
 
 import type { BiologicalSex } from '@aurboda/api-spec'
 import { enqueueOutboundSync, getUserSettings } from '../db'
-import { getTimeSeries, getTimeSeriesWithSource, insertTimeSeries } from '../db/time-series'
+import {
+  deleteTimeSeriesBySource,
+  getTimeSeries,
+  getTimeSeriesWithSource,
+  insertTimeSeries,
+} from '../db/time-series'
 import type { TimeSeriesPoint } from '../db/types'
 import { isHealthConnectSyncableMetric, metricToHealthConnectType } from '../schema'
 import { computeCaloriesPerMinute, getVo2MaxFallback } from './calories'
@@ -61,6 +66,7 @@ export const computeAndStoreCalories = async (
   user: string,
   start: Date,
   end: Date,
+  options?: { force?: boolean },
 ): Promise<CalorieComputationResult> => {
   // 1. Get user settings
   const settings = await getUserSettings(user)
@@ -111,7 +117,12 @@ export const computeAndStoreCalories = async (
     }
   }
 
-  // 5. Check if aurboda calories already exist for this range to avoid recomputing
+  // 5. Delete existing aurboda calories if force-recomputing
+  if (options?.force) {
+    await deleteTimeSeriesBySource(user, 'calories_active', 'aurboda', start, end)
+  }
+
+  // 6. Check if aurboda calories already exist for this range to avoid recomputing
   const existingCalories = await getTimeSeriesWithSource(user, 'calories_active', start, end)
   const existingAurbodaMinutes = new Set(
     existingCalories.filter((p) => p.source === 'aurboda').map((p) => Math.floor(p.time.getTime() / 60_000)),

--- a/apps/backend/src/services/calories.test.ts
+++ b/apps/backend/src/services/calories.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
-import { computeCaloriesForMinute, computeCaloriesPerMinute, getVo2MaxFallback } from './calories'
+import {
+  MAX_HOLD_MINUTES,
+  computeCaloriesForMinute,
+  computeCaloriesPerMinute,
+  getVo2MaxFallback,
+} from './calories'
 
 describe('getVo2MaxFallback', () => {
   test('returns age-appropriate fallback for male', () => {
@@ -95,6 +100,7 @@ describe('computeCaloriesPerMinute', () => {
 
   test('hold-last-value fills sparse data (5-minute intervals like Oura)', () => {
     // Oura sleep HR: one sample every 5 minutes
+    // Each sample holds for up to MAX_HOLD_MINUTES minutes
     const samples: [Date, number][] = [
       [new Date('2024-01-15T23:00:00Z'), 60],
       [new Date('2024-01-15T23:05:00Z'), 58],
@@ -102,18 +108,56 @@ describe('computeCaloriesPerMinute', () => {
     ]
     const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
 
-    // Should produce 11 minute buckets (23:00 through 23:10)
+    // 23:00-23:04 from first sample (5 buckets), 23:05-23:09 from second (5 buckets),
+    // 23:10 from third (1 bucket) = 11 total
     expect(result).toHaveLength(11)
 
     // First minute uses HR 60
     expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(60, 40, 100, 50, 'male'), 4)
 
-    // Minutes 1-4 (23:01-23:04) also use HR 60 (hold-last-value)
+    // Minutes 1-4 (23:01-23:04) also use HR 60 (hold-last-value within MAX_HOLD_MINUTES)
     expect(result[1].kcal).toBeCloseTo(result[0].kcal, 4)
     expect(result[4].kcal).toBeCloseTo(result[0].kcal, 4)
 
     // Minute 5 (23:05) uses HR 58
     expect(result[5].kcal).toBeCloseTo(computeCaloriesForMinute(58, 40, 100, 50, 'male'), 4)
+  })
+
+  test('skips minutes beyond MAX_HOLD_MINUTES gap', () => {
+    // Two readings 20 minutes apart — only the first MAX_HOLD_MINUTES should be filled
+    const samples: [Date, number][] = [
+      [new Date('2024-01-15T10:00:00Z'), 120],
+      [new Date('2024-01-15T10:20:00Z'), 130],
+    ]
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+
+    // 10:00-10:04 from first sample (5 buckets) + 10:20 from second (1 bucket) = 6 total
+    // Minutes 10:05-10:19 are skipped (gap > MAX_HOLD_MINUTES)
+    expect(result).toHaveLength(MAX_HOLD_MINUTES + 1)
+    expect(result[0].time).toEqual(new Date('2024-01-15T10:00:00Z'))
+    expect(result[MAX_HOLD_MINUTES - 1].time).toEqual(new Date('2024-01-15T10:04:00Z'))
+    expect(result[MAX_HOLD_MINUTES].time).toEqual(new Date('2024-01-15T10:20:00Z'))
+
+    // First bucket uses HR 120, last uses HR 130
+    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(120, 40, 100, 50, 'male'), 4)
+    expect(result[MAX_HOLD_MINUTES].kcal).toBeCloseTo(computeCaloriesForMinute(130, 40, 100, 50, 'male'), 4)
+  })
+
+  test('does not produce stale data for hours-long gaps', () => {
+    // Workout ends at 18:00, next reading at 23:00 (sleep)
+    const samples: [Date, number][] = [
+      [new Date('2024-01-15T18:00:00Z'), 150],
+      [new Date('2024-01-15T23:00:00Z'), 55],
+    ]
+    const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
+
+    // Only MAX_HOLD_MINUTES from the first sample + 1 from the second
+    expect(result).toHaveLength(MAX_HOLD_MINUTES + 1)
+
+    // No stale 150bpm calories in the evening gap
+    const lastBeforeGap = result[MAX_HOLD_MINUTES - 1]
+    expect(lastBeforeGap.time).toEqual(new Date('2024-01-15T18:04:00Z'))
+    expect(result[MAX_HOLD_MINUTES].time).toEqual(new Date('2024-01-15T23:00:00Z'))
   })
 
   test('averages multiple HR samples within same minute', () => {

--- a/apps/backend/src/services/calories.ts
+++ b/apps/backend/src/services/calories.ts
@@ -17,6 +17,13 @@
 
 import type { BiologicalSex } from '@aurboda/api-spec'
 
+/**
+ * Maximum minutes a single HR reading can be held forward.
+ * If the gap between consecutive HR samples exceeds this, minutes beyond
+ * the threshold are skipped (no calorie data rather than stale data).
+ */
+export const MAX_HOLD_MINUTES = 5
+
 /** Default VO2 max fallback values by sex and age group (mL/kg/min). */
 const VO2_MAX_FALLBACK: Record<BiologicalSex, { age: number; value: number }[]> = {
   female: [
@@ -74,8 +81,8 @@ export interface CalorieDataPoint {
  * Compute per-minute calorie burn from heart rate samples.
  *
  * Uses hold-last-value interpolation for sparse data (e.g., Oura 5-minute HR):
- * a sample's HR value is assumed to persist until the next sample arrives.
- * Minutes without any HR coverage are skipped.
+ * a sample's HR value is assumed to persist for up to MAX_HOLD_MINUTES (5 min).
+ * Minutes beyond that gap are skipped — no calorie data rather than stale data.
  */
 export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieDataPoint[] => {
   const { hr_samples, vo2_max, weight_kg, age_years, sex } = params
@@ -97,6 +104,7 @@ export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieData
 
   // For each minute bucket, find the applicable HR (hold-last-value)
   let sampleIdx = 0
+  const maxHoldMs = MAX_HOLD_MINUTES * 60_000
 
   for (let minuteMs = startMinute; minuteMs <= endMinute; minuteMs += 60_000) {
     const bucketStart = minuteMs
@@ -111,7 +119,9 @@ export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieData
     const hrValues: number[] = []
 
     // If the current sample is at or before this bucket, its value applies (hold-last-value)
-    if (hr_samples[sampleIdx][0].getTime() <= bucketStart) {
+    // BUT only if within MAX_HOLD_MINUTES of the bucket start
+    const lastSampleTime = hr_samples[sampleIdx][0].getTime()
+    if (lastSampleTime <= bucketStart && bucketStart - lastSampleTime < maxHoldMs) {
       hrValues.push(hr_samples[sampleIdx][1])
     }
 


### PR DESCRIPTION
## Summary
- HR readings were held forward indefinitely, producing stale calorie data for hours-long gaps (e.g., last workout reading at 18:00 persisted until sleep at 23:00)
- Now limited to `MAX_HOLD_MINUTES` (5 min) — minutes beyond the gap produce no calorie data
- Recalculate endpoint and MCP tool now force-delete existing aurboda calories before recomputing (needed to fix already-stored stale data)
- Added `deleteTimeSeriesBySource` DB function for targeted time-range cleanup

## Testing
- 2 new unit tests: gap skipping behavior and hours-long gap scenario
- All 1077 tests pass