### PR TITLE
fix: add daily aggregate sync to foreground and improve cumulative metric fallback

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/DailyAggregateSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DailyAggregateSync.kt
@@ -1,0 +1,151 @@
+package net.aurboda
+
+import android.util.Log
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.aggregate.AggregateMetric
+import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
+import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.FloorsClimbedRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import net.aurboda.api.models.DailyAggregate
+import net.aurboda.api.models.DailyAggregatesBody
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.reflect.KClass
+
+private const val TAG = "DailyAggregateSync"
+
+/** Describes a cumulative metric that can be aggregated from Health Connect. */
+data class AggregatableMetric(
+  val aggregateMetric: AggregateMetric<*>,
+  val dailyMetric: DailyAggregate.Metric,
+  val recordClass: KClass<out Record>,
+)
+
+/** All cumulative metrics we aggregate from Health Connect. */
+val allAggregatableMetrics: List<AggregatableMetric> =
+  listOf(
+    AggregatableMetric(StepsRecord.COUNT_TOTAL, DailyAggregate.Metric.steps, StepsRecord::class),
+    AggregatableMetric(DistanceRecord.DISTANCE_TOTAL, DailyAggregate.Metric.distance, DistanceRecord::class),
+    AggregatableMetric(
+      ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL,
+      DailyAggregate.Metric.calories_active,
+      ActiveCaloriesBurnedRecord::class,
+    ),
+    AggregatableMetric(TotalCaloriesBurnedRecord.ENERGY_TOTAL, DailyAggregate.Metric.calories_total, TotalCaloriesBurnedRecord::class),
+    AggregatableMetric(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL, DailyAggregate.Metric.floors_climbed, FloorsClimbedRecord::class),
+  )
+
+/**
+ * Fetch daily aggregates for cumulative metrics using Health Connect's aggregate() API.
+ * Only fetches for metrics whose record classes are in [grantedTypes].
+ */
+suspend fun fetchDailyAggregates(
+  healthConnectClient: HealthConnectClient,
+  grantedTypes: Set<KClass<out Record>>,
+  days: Int = 7,
+): List<DailyAggregate> {
+  val activeMetrics = allAggregatableMetrics.filter { it.recordClass in grantedTypes }
+  if (activeMetrics.isEmpty()) {
+    Log.d(TAG, "No aggregatable metrics have granted permissions")
+    return emptyList()
+  }
+
+  val aggregates = mutableListOf<DailyAggregate>()
+  val today = LocalDate.now()
+  val zoneId = ZoneId.systemDefault()
+
+  for (dayOffset in 0 until days) {
+    val date = today.minusDays(dayOffset.toLong())
+    val startTime = date.atStartOfDay(zoneId).toInstant()
+    val endTime = date.plusDays(1).atStartOfDay(zoneId).toInstant()
+
+    for ((metric, metricType, _) in activeMetrics) {
+      try {
+        val request =
+          AggregateRequest(
+            metrics = setOf(metric),
+            timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
+          )
+        val result = healthConnectClient.aggregate(request)
+
+        // Extract value based on metric type
+        val value: Double? =
+          when (metric) {
+            StepsRecord.COUNT_TOTAL -> result[StepsRecord.COUNT_TOTAL]?.toDouble()
+            DistanceRecord.DISTANCE_TOTAL -> result[DistanceRecord.DISTANCE_TOTAL]?.inMeters
+            ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL ->
+              result[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
+            TotalCaloriesBurnedRecord.ENERGY_TOTAL ->
+              result[TotalCaloriesBurnedRecord.ENERGY_TOTAL]?.inKilocalories
+            FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL ->
+              result[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL]
+            else -> null
+          }
+
+        if (value != null && value > 0) {
+          val dataOrigins = result.dataOrigins.map { it.packageName }
+          aggregates.add(
+            DailyAggregate(
+              date = date.toString(), // YYYY-MM-DD format
+              metric = metricType,
+              value = value,
+              dataOrigins = dataOrigins,
+            ),
+          )
+          Log.d(TAG, "Aggregate for $metricType on $date: $value from ${dataOrigins.size} sources")
+        } else {
+          Log.d(TAG, "No data for $metricType on $date (value=$value)")
+        }
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to fetch aggregate for $metricType on $date: ${e.message}", e)
+      }
+    }
+  }
+
+  Log.d(TAG, "Fetched ${aggregates.size} aggregates for ${activeMetrics.size} metrics over $days days")
+  return aggregates
+}
+
+/**
+ * Send daily aggregates to the backend.
+ * @return true if successful (including when there's nothing to send), false on failure.
+ */
+suspend fun sendDailyAggregates(
+  aggregates: List<DailyAggregate>,
+  serverUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+): Boolean {
+  if (aggregates.isEmpty()) {
+    Log.d(TAG, "No aggregates to send")
+    return true
+  }
+
+  val postData = DailyAggregatesBody(data = aggregates)
+  return try {
+    val response =
+      httpClient.post("$serverUrl/sync/daily-aggregates") {
+        contentType(ContentType.Application.Json)
+        headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        setBody(postData)
+      }
+    Log.d(TAG, "Daily aggregates response: ${response.status} (${aggregates.size} aggregates)")
+    response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+  } catch (e: Exception) {
+    Log.e(TAG, "Error posting daily aggregates: ${e.message}", e)
+    false
+  }
+}

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -1014,6 +1014,26 @@ fun HealthConnectScreen(
 
   /** Perform fetch + send in one step, then process outbound sync (backend -> HC). */
   suspend fun syncNow(currentContext: Context) {
+    // Fetch and send daily aggregates for cumulative metrics (steps, distance, etc.)
+    try {
+      val aggregates = fetchDailyAggregates(healthConnectClient, grantedRecordTypes.toSet(), days = 7)
+      if (aggregates.isNotEmpty()) {
+        val success = sendDailyAggregates(aggregates, apiUrl, authToken, ktorHttpClient)
+        if (success) {
+          Log.d("SyncNow", "Sent ${aggregates.size} daily aggregates")
+          statusMessage = "Sent ${aggregates.size} daily aggregates."
+        } else {
+          Log.w("SyncNow", "Failed to send daily aggregates")
+          statusMessage = "Failed to send daily aggregates."
+        }
+      } else {
+        Log.d("SyncNow", "No daily aggregates to send")
+      }
+    } catch (e: Exception) {
+      Log.w("SyncNow", "Daily aggregate sync failed: ${e.message}", e)
+      statusMessage = "Daily aggregate sync error: ${e.message}"
+    }
+
     fetchHealthData(currentContext)
     if (healthRecords.isNotEmpty() || pendingDeletionIds.isNotEmpty()) {
       sendPendingDataToServer(currentContext)

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -3,12 +3,9 @@ package net.aurboda
 import android.content.Context
 import android.util.Log
 import androidx.health.connect.client.HealthConnectClient
-import androidx.health.connect.client.aggregate.AggregateMetric
 import androidx.health.connect.client.changes.DeletionChange
 import androidx.health.connect.client.changes.UpsertionChange
 import androidx.health.connect.client.records.*
-import androidx.health.connect.client.request.AggregateRequest
-import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -28,11 +25,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.KSerializer
-import net.aurboda.api.models.DailyAggregate
-import net.aurboda.api.models.DailyAggregatesBody
 import net.aurboda.widget.HrZoneWidgetProvider
-import java.time.LocalDate
-import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
@@ -52,26 +45,6 @@ class SyncWorker(
       install(ContentNegotiation) { json(appJson) }
     }
   }
-
-  // Cumulative metrics with the record class they require permission for
-  private data class AggregatableMetric(
-    val aggregateMetric: AggregateMetric<*>,
-    val dailyMetric: DailyAggregate.Metric,
-    val recordClass: KClass<out Record>,
-  )
-
-  private val allAggregatableMetrics: List<AggregatableMetric> =
-    listOf(
-      AggregatableMetric(StepsRecord.COUNT_TOTAL, DailyAggregate.Metric.steps, StepsRecord::class),
-      AggregatableMetric(DistanceRecord.DISTANCE_TOTAL, DailyAggregate.Metric.distance, DistanceRecord::class),
-      AggregatableMetric(
-        ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL,
-        DailyAggregate.Metric.calories_active,
-        ActiveCaloriesBurnedRecord::class,
-      ),
-      AggregatableMetric(TotalCaloriesBurnedRecord.ENERGY_TOTAL, DailyAggregate.Metric.calories_total, TotalCaloriesBurnedRecord::class),
-      AggregatableMetric(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL, DailyAggregate.Metric.floors_climbed, FloorsClimbedRecord::class),
-    )
 
   override suspend fun doWork(): Result {
     Log.d(TAG, "Starting background sync")
@@ -94,15 +67,11 @@ class SyncWorker(
     // Invalidate token if granted types changed since last sync
     invalidateTokenIfGrantedTypesChanged(grantedTypes)
 
-    // Filter aggregatable metrics to only those with granted permissions
-    val grantedTypeSet = grantedTypes.toSet()
-    val activeAggregateMetrics = allAggregatableMetrics.filter { it.recordClass in grantedTypeSet }
-
     return try {
       // Step 1: Fetch and send daily aggregates for cumulative metrics (deduplicated)
-      val aggregates = fetchDailyAggregates(activeAggregateMetrics, days = 7)
+      val aggregates = fetchDailyAggregates(healthConnectClient, grantedTypes.toSet(), days = 7)
       if (aggregates.isNotEmpty()) {
-        val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken)
+        val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken, httpClient)
         if (!aggregateSuccess) {
           Log.w(TAG, "Failed to send daily aggregates, will retry")
           return Result.retry()
@@ -517,98 +486,6 @@ class SyncWorker(
         .apply()
     } else {
       prefs.edit().putString(GRANTED_TYPES_KEY, currentNames).apply()
-    }
-  }
-
-  /**
-   * Fetch daily aggregates for cumulative metrics using Health Connect's aggregate() API.
-   * Only fetches for metrics that have granted permissions.
-   */
-  private suspend fun fetchDailyAggregates(
-    metrics: List<AggregatableMetric>,
-    days: Int = 7,
-  ): List<DailyAggregate> {
-    if (metrics.isEmpty()) return emptyList()
-
-    val aggregates = mutableListOf<DailyAggregate>()
-    val today = LocalDate.now()
-    val zoneId = ZoneId.systemDefault()
-
-    for (dayOffset in 0 until days) {
-      val date = today.minusDays(dayOffset.toLong())
-      val startTime = date.atStartOfDay(zoneId).toInstant()
-      val endTime = date.plusDays(1).atStartOfDay(zoneId).toInstant()
-
-      for ((metric, metricType, _) in metrics) {
-        try {
-          val request =
-            AggregateRequest(
-              metrics = setOf(metric),
-              timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
-            )
-          val result = healthConnectClient.aggregate(request)
-
-          // Extract value based on metric type
-          val value: Double? =
-            when (metric) {
-              StepsRecord.COUNT_TOTAL -> result[StepsRecord.COUNT_TOTAL]?.toDouble()
-              DistanceRecord.DISTANCE_TOTAL -> result[DistanceRecord.DISTANCE_TOTAL]?.inMeters
-              ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL ->
-                result[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
-              TotalCaloriesBurnedRecord.ENERGY_TOTAL ->
-                result[TotalCaloriesBurnedRecord.ENERGY_TOTAL]?.inKilocalories
-              FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL ->
-                result[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL]
-              else -> null
-            }
-
-          if (value != null && value > 0) {
-            val dataOrigins = result.dataOrigins.map { it.packageName }
-            aggregates.add(
-              DailyAggregate(
-                date = date.toString(), // YYYY-MM-DD format
-                metric = metricType,
-                value = value,
-                dataOrigins = dataOrigins,
-              ),
-            )
-            Log.d(TAG, "Aggregate for $metricType on $date: $value from ${dataOrigins.size} sources")
-          }
-        } catch (e: Exception) {
-          Log.w(TAG, "Failed to fetch aggregate for $metricType on $date", e)
-        }
-      }
-    }
-
-    return aggregates
-  }
-
-  /**
-   * Send daily aggregates to the backend.
-   */
-  private suspend fun sendDailyAggregates(
-    aggregates: List<DailyAggregate>,
-    serverUrl: String,
-    authToken: String,
-  ): Boolean {
-    if (aggregates.isEmpty()) {
-      Log.d(TAG, "No aggregates to send")
-      return true
-    }
-
-    val postData = DailyAggregatesBody(data = aggregates)
-    return try {
-      val response =
-        httpClient.post("$serverUrl/sync/daily-aggregates") {
-          contentType(ContentType.Application.Json)
-          headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-          setBody(postData)
-        }
-      Log.d(TAG, "Daily aggregates response: ${response.status}")
-      response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
-    } catch (e: Exception) {
-      Log.e(TAG, "Error posting daily aggregates", e)
-      false
     }
   }
 

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -67,6 +67,7 @@ export {
   deleteTimeSeriesMetric,
   deleteTimeSeriesPoint,
   getDailyAggregates,
+  getRawDailySum,
   getTimeSeries,
   getTimeSeriesBucketed,
   getTimeSeriesMultiMetric,

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -89,6 +89,26 @@ export const getTimeSeriesWithSource = async (
   return result.rows.map((row) => ({ source: row.source, time: new Date(row.time), value: row.value }))
 }
 
+/**
+ * Get the sum of a metric across ALL sources for a date range.
+ * This is a last-resort fallback for cumulative metrics when no aggregate data exists.
+ * Note: may double-count if multiple apps contributed to Health Connect.
+ */
+export const getRawDailySum = async (
+  user: string,
+  metric: string,
+  start: Date,
+  end: Date,
+): Promise<number> => {
+  const result = await query(
+    user,
+    `SELECT COALESCE(SUM(value), 0) as total FROM time_series
+     WHERE metric = $1 AND time >= $2 AND time <= $3`,
+    [metric, start, end],
+  )
+  return Number(result.rows[0].total)
+}
+
 export const getTimeSeriesMultiMetric = async (
   user: string,
   metrics: MetricType[],

--- a/apps/backend/src/services/goals.test.ts
+++ b/apps/backend/src/services/goals.test.ts
@@ -7,6 +7,7 @@ import * as settings from './settings'
 vi.mock('../db', () => ({
   getDailyAggregateValue: vi.fn(),
   getDailyAggregates: vi.fn(),
+  getRawDailySum: vi.fn(),
   getTimeSeries: vi.fn(),
 }))
 
@@ -63,7 +64,7 @@ describe('getGoalsProgress', () => {
     expect(db.getDailyAggregates).not.toHaveBeenCalled()
   })
 
-  test('falls back to getDailyAggregates when no aggregate value exists', async () => {
+  test('falls back to getRawDailySum when no aggregate value exists for cumulative metric', async () => {
     vi.mocked(settings.getSettings).mockResolvedValue({})
     vi.mocked(settings.getEffectiveGoals).mockReturnValue([
       { id: 'goal-1', metric: 'steps', min: 10000, window: '1d' },
@@ -71,14 +72,18 @@ describe('getGoalsProgress', () => {
 
     // No aggregate value exists
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
-    vi.mocked(db.getDailyAggregates).mockResolvedValue([
-      { avg: 4672, date: '2026-02-02', metric: 'steps', sum: 4672 },
-    ])
+    // getRawDailySum queries ALL sources as fallback
+    vi.mocked(db.getRawDailySum)
+      .mockResolvedValueOnce(4672) // current window
+      .mockResolvedValueOnce(4672) // losingTomorrow window
 
     const result = await getGoalsProgress('testuser')
 
     expect(result).toHaveLength(1)
     expect(result[0].current).toBe(4672)
+    // Should use getRawDailySum as fallback, not getDailyAggregates
+    expect(db.getRawDailySum).toHaveBeenCalled()
+    expect(db.getDailyAggregates).not.toHaveBeenCalled()
   })
 
   test('sums aggregate values across multiple days for 7d window', async () => {

--- a/apps/backend/src/services/goals.ts
+++ b/apps/backend/src/services/goals.ts
@@ -10,7 +10,7 @@ import {
   type GoalProgress,
   type MetricType,
 } from '@aurboda/api-spec'
-import { getDailyAggregates, getDailyAggregateValue, getTimeSeries } from '../db'
+import { getDailyAggregates, getDailyAggregateValue, getRawDailySum, getTimeSeries } from '../db'
 import { computeHrZoneSecs, getEffectiveGoals, getEffectiveHrZones, getSettings } from './settings'
 
 /**
@@ -66,10 +66,12 @@ const getMetricSum = async (user: string, metric: MetricType, start: Date, end: 
       return values.reduce<number>((sum, v) => sum + (v ?? 0), 0)
     }
 
-    // Fall back to raw data if no aggregates exist
+    // Fall back to raw data from ALL sources if no aggregates exist.
+    // This may double-count but is better than showing 0.
+    return getRawDailySum(user, metric, start, end)
   }
 
-  // For non-cumulative metrics or fallback, use daily aggregates and sum them
+  // For non-cumulative metrics, use daily aggregates and sum them
   const dailyData = await getDailyAggregates(user, [metric], start, end)
   return dailyData.reduce((sum, day) => sum + day.sum, 0)
 }

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -128,6 +128,13 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       const { data } = req.body
       const user = req.user!
 
+      const metrics = [...new Set(data.map((a) => a.metric))]
+      const dates = [...new Set(data.map((a) => a.date))].sort()
+      console.log(
+        `📊 Daily aggregates received: ${data.length} entries for [${metrics.join(', ')}] ` +
+          `dates ${dates[0]}..${dates[dates.length - 1]}`,
+      )
+
       for (const aggregate of data) {
         await deps.processDailyAggregate(user, aggregate)
       }


### PR DESCRIPTION
## Summary

Steps and other cumulative metrics (distance, floors, calories) stopped appearing in Goals and daily summaries around March 3. The root cause is on the Android side — the background `SyncWorker` is the only path that sends daily aggregates, and if it fails silently, the data never reaches the backend.

## Changes

### Android
- **Extract shared `DailyAggregateSync.kt`** — moves `fetchDailyAggregates()` and `sendDailyAggregates()` out of `SyncWorker` into a shared utility, so both foreground and background sync can use them
- **Add daily aggregate sync to `syncNow()`** — the foreground sync button now also fetches and sends daily aggregates, giving the user a way to manually trigger this and see results immediately
- **Improved logging** — logs when aggregate values are null/zero (not just when they're positive), making silent failures visible

### Backend
- **Add diagnostic logging to `/sync/daily-aggregates`** — logs the number of entries, metrics, and date range received, so we can distinguish "not sent" vs "sent empty" vs "sent but rejected"
- **Add `getRawDailySum()` fallback** — when no aggregate data exists for cumulative metrics, goals now fall back to summing raw data from ALL sources (may double-count, but better than showing 0)
- **Update goals test** to cover the new fallback path

## Testing
- All 1104 backend tests pass
- `pnpm check` passes (TypeScript + ESLint)