### PR TITLE
fix: extend VO2 max lookback to 2 years for calorie computation

### DIFF
--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -39,9 +39,9 @@ const getLatestMetricValue = async (
   user: string,
   metric: string,
   beforeTime: Date,
+  lookbackDays = 90,
 ): Promise<number | null> => {
-  // Look back up to 90 days for the latest value
-  const lookbackStart = new Date(beforeTime.getTime() - 90 * 24 * 60 * 60 * 1000)
+  const lookbackStart = new Date(beforeTime.getTime() - lookbackDays * 24 * 60 * 60 * 1000)
   const data = await getTimeSeries(user, metric, lookbackStart, beforeTime)
   if (data.length === 0) return null
   // Return the most recent value
@@ -101,8 +101,8 @@ export const computeAndStoreCalories = async (
     }
   }
 
-  // 3. Get VO2 max (measured or fallback)
-  const measuredVo2Max = await getLatestMetricValue(user, 'vo2_max', end)
+  // 3. Get VO2 max (measured or fallback) — use 2-year lookback since VO2 max is measured infrequently
+  const measuredVo2Max = await getLatestMetricValue(user, 'vo2_max', end, 730)
   const vo2Max = measuredVo2Max ?? getVo2MaxFallback(sex, age)
   const vo2MaxSource = measuredVo2Max !== null ? 'measured' : 'fallback'
 


### PR DESCRIPTION
## Summary

- Extends the VO2 max lookback window from 90 days to 2 years (730 days) in calorie computation
- Weight lookback stays at 90 days since it's recorded frequently
- A measured VO2 max from a year ago is more accurate than a population average fallback

Fixes calorie backfill using fallback values when a real VO2 max measurement existed but was outside the 90-day window.