### PR TITLE
feat: add 'rest' activity type for Oura short sleep detection

### DIFF
--- a/apps/backend/scripts/migrate-phantom-naps-to-rest.sql
+++ b/apps/backend/scripts/migrate-phantom-naps-to-rest.sql
@@ -1,0 +1,68 @@
+-- One-time migration: Convert Oura-sourced nap activities to 'rest' where the
+-- total non-awake sleep stage time is less than 15 minutes.
+--
+-- Background: Oura's API returns type "sleep" for short detected sleep periods.
+-- Aurboda previously mapped all of these to activity_type='nap'. Oura's own app
+-- only shows them as naps if there are >= 15 minutes of actual sleep stages
+-- (light, deep, or REM). Shorter detections are shown as "restorative time".
+--
+-- This migration reclassifies existing phantom naps to match the new threshold logic.
+--
+-- The stages are stored in HC encoding: 1=awake, 4=light, 5=deep, 6=REM.
+-- We sum the duration of all non-awake stages and compare to 15 minutes.
+--
+-- Run with: psql -U <user> -d <database> -f migrate-phantom-naps-to-rest.sql
+-- Or for a specific schema: psql -U <user> -d <database> -c "SET search_path TO <schema>" -f ...
+--
+-- DRY RUN first (shows what would be updated):
+-- Uncomment the SELECT and comment the UPDATE.
+
+-- Dry run: see which activities would be affected
+SELECT
+  id,
+  title,
+  start_time,
+  end_time,
+  data->>'ouraType' AS oura_type,
+  (
+    SELECT COALESCE(SUM(
+      EXTRACT(EPOCH FROM (
+        (s->>'endTime')::timestamptz - (s->>'startTime')::timestamptz
+      )) / 60.0
+    ), 0)
+    FROM jsonb_array_elements(data->'stages') AS s
+    WHERE (s->>'stage')::int != 1  -- exclude awake
+  ) AS sleep_minutes
+FROM activities
+WHERE source = 'oura'
+  AND activity_type = 'nap'
+  AND deleted_at IS NULL
+  AND (
+    SELECT COALESCE(SUM(
+      EXTRACT(EPOCH FROM (
+        (s->>'endTime')::timestamptz - (s->>'startTime')::timestamptz
+      )) / 60.0
+    ), 0)
+    FROM jsonb_array_elements(data->'stages') AS s
+    WHERE (s->>'stage')::int != 1
+  ) < 15
+ORDER BY start_time;
+
+-- Actual migration: uncomment below and comment out the SELECT above
+/*
+UPDATE activities
+SET activity_type = 'rest',
+    title = 'Rest'
+WHERE source = 'oura'
+  AND activity_type = 'nap'
+  AND deleted_at IS NULL
+  AND (
+    SELECT COALESCE(SUM(
+      EXTRACT(EPOCH FROM (
+        (s->>'endTime')::timestamptz - (s->>'startTime')::timestamptz
+      )) / 60.0
+    ), 0)
+    FROM jsonb_array_elements(data->'stages') AS s
+    WHERE (s->>'stage')::int != 1
+  ) < 15;
+*/

--- a/apps/backend/src/db/row-mappers.test.ts
+++ b/apps/backend/src/db/row-mappers.test.ts
@@ -19,6 +19,7 @@ describe('type guards', () => {
     expect(parseActivityType('exercise')).toBe('exercise')
     expect(parseActivityType('meditation')).toBe('meditation')
     expect(parseActivityType('nap')).toBe('nap')
+    expect(parseActivityType('rest')).toBe('rest')
   })
 
   test('parseActivityType throws on invalid type', () => {

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -17,7 +17,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
   // Tool: add_activity
   server.tool(
     'add_activity',
-    'Add an activity session (exercise, meditation, nap). Use this to log workouts or other activities.',
+    'Add an activity session (exercise, meditation, nap, rest). Use this to log workouts or other activities.',
     {
       ...addActivityBodySchema.shape,
       // Override enum with z.string() to allow handler-level validation with friendlier error message

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -148,13 +148,15 @@ Use cases:
   // Tool: query_activities
   server.tool(
     'query_activities',
-    'Query activities (sleep, exercise, meditation, nap) for a time range. Returns activity sessions with duration, HR zones for exercise, and other metadata.',
+    'Query activities (sleep, exercise, meditation, nap, rest) for a time range. Returns activity sessions with duration, HR zones for exercise, and other metadata.',
     {
       ...timeRangeQuerySchema.shape,
       types: z
         .array(activityTypeSchema)
         .optional()
-        .describe('Activity types to include. Defaults to all types (sleep, exercise, meditation, nap).'),
+        .describe(
+          'Activity types to include. Defaults to all types (sleep, exercise, meditation, nap, rest).',
+        ),
     },
     async ({ end, start, types }) => {
       const requestedTypes = types ?? [...activityTypes]

--- a/apps/backend/src/oura-process.ts
+++ b/apps/backend/src/oura-process.ts
@@ -371,11 +371,29 @@ export const convertOuraSleepPhases = (phases: string | null, bedtimeStart: Date
   return stages
 }
 
-/** Map Oura sleep period type to Aurboda activity type. */
-const OURA_SLEEP_TYPE_MAP: Record<string, 'sleep' | 'nap' | 'meditation'> = {
+/** Minimum minutes of actual sleep stages (non-awake) for Oura short sleep to qualify as a nap. */
+const NAP_SLEEP_MINUTES_THRESHOLD = 15
+
+/** HC stage number for "awake". */
+const HC_STAGE_AWAKE = 1
+
+/**
+ * Compute total non-awake sleep time in minutes from HC-encoded sleep stages.
+ *
+ * Stages use Health Connect encoding where 1 = awake. All other stages
+ * (light=4, deep=5, REM=6, sleeping/unknown=2) count as actual sleep.
+ */
+export const computeSleepMinutes = (stages: SleepStage[]): number =>
+  stages.reduce((total, s) => {
+    if (s.stage === HC_STAGE_AWAKE) return total
+    const ms = new Date(s.endTime).getTime() - new Date(s.startTime).getTime()
+    return total + ms / 60_000
+  }, 0)
+
+/** Map Oura sleep period type to Aurboda activity type (for non-short-sleep types). */
+const OURA_SLEEP_TYPE_MAP: Record<string, 'sleep' | 'meditation'> = {
   long_sleep: 'sleep',
   rest: 'meditation',
-  sleep: 'nap',
 }
 
 /**
@@ -394,14 +412,27 @@ const processSleep = async (user: string, data: OuraSleepPeriodRaw[]) => {
       source: 'oura',
     })
 
-    const activityType = OURA_SLEEP_TYPE_MAP[record.type] ?? 'sleep'
     const stages = convertOuraSleepPhases(record.sleep_phase_5_min, bedtimeStart)
+
+    // For Oura short sleep (type "sleep"), classify based on actual sleep time:
+    // >= 15 min of sleep stages → nap, otherwise → rest.
+    const activityType =
+      record.type === 'sleep' ?
+        computeSleepMinutes(stages) >= NAP_SLEEP_MINUTES_THRESHOLD ?
+          'nap'
+        : 'rest'
+      : (OURA_SLEEP_TYPE_MAP[record.type] ?? 'sleep')
 
     const titleMap: Record<string, string> = {
       long_sleep: 'Sleep',
       rest: 'Rest',
-      sleep: 'Nap',
     }
+    const title =
+      record.type === 'sleep' ?
+        activityType === 'nap' ?
+          'Nap'
+        : 'Rest'
+      : (titleMap[record.type] ?? record.type)
 
     await insertActivity(user, {
       activity_type: activityType,
@@ -415,7 +446,7 @@ const processSleep = async (user: string, data: OuraSleepPeriodRaw[]) => {
       end_time: bedtimeEnd,
       source: 'oura',
       start_time: bedtimeStart,
-      title: titleMap[record.type] ?? record.type,
+      title,
     })
 
     // Extract HR and HRV interval data to time series

--- a/apps/backend/src/oura-sync.test.ts
+++ b/apps/backend/src/oura-sync.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import * as db from './db'
 import {
   calculateRetryAfter,
+  computeSleepMinutes,
   convertOuraSleepPhases,
   isRateLimited,
   processOuraData,
@@ -150,6 +151,41 @@ describe('convertOuraSleepPhases', () => {
       { endTime: '2025-01-15T23:25:00.000Z', stage: 6, startTime: '2025-01-15T23:20:00.000Z' }, // REM 5min
       { endTime: '2025-01-15T23:30:00.000Z', stage: 1, startTime: '2025-01-15T23:25:00.000Z' }, // awake 5min
     ])
+  })
+})
+
+describe('computeSleepMinutes', () => {
+  test('returns 0 for empty stages', () => {
+    expect(computeSleepMinutes([])).toBe(0)
+  })
+
+  test('returns 0 when all stages are awake', () => {
+    expect(
+      computeSleepMinutes([
+        { endTime: '2025-01-15T23:10:00.000Z', stage: 1, startTime: '2025-01-15T23:00:00.000Z' },
+        { endTime: '2025-01-15T23:20:00.000Z', stage: 1, startTime: '2025-01-15T23:10:00.000Z' },
+      ]),
+    ).toBe(0)
+  })
+
+  test('sums non-awake stages correctly', () => {
+    expect(
+      computeSleepMinutes([
+        { endTime: '2025-01-15T23:10:00.000Z', stage: 1, startTime: '2025-01-15T23:00:00.000Z' }, // awake 10min
+        { endTime: '2025-01-15T23:25:00.000Z', stage: 4, startTime: '2025-01-15T23:10:00.000Z' }, // light 15min
+        { endTime: '2025-01-15T23:30:00.000Z', stage: 1, startTime: '2025-01-15T23:25:00.000Z' }, // awake 5min
+      ]),
+    ).toBe(15)
+  })
+
+  test('counts all sleep stage types (light, deep, REM)', () => {
+    expect(
+      computeSleepMinutes([
+        { endTime: '2025-01-15T23:10:00.000Z', stage: 4, startTime: '2025-01-15T23:00:00.000Z' }, // light 10min
+        { endTime: '2025-01-15T23:15:00.000Z', stage: 5, startTime: '2025-01-15T23:10:00.000Z' }, // deep 5min
+        { endTime: '2025-01-15T23:20:00.000Z', stage: 6, startTime: '2025-01-15T23:15:00.000Z' }, // REM 5min
+      ]),
+    ).toBe(20)
   })
 })
 
@@ -611,14 +647,34 @@ describe('processOuraData', () => {
       })
     })
 
-    test('processes short sleep as nap activity', async () => {
-      await processOuraData(user, 'sleep', [makeSleepRecord({ id: 'nap-1', type: 'sleep' })])
+    test('processes short sleep with >= 15 min of sleep stages as nap', async () => {
+      // Oura phases: '4422244' → awake, awake, light, light, light, awake, awake
+      // = 3 light epochs × 5 min = 15 min of actual sleep → qualifies as nap
+      await processOuraData(user, 'sleep', [
+        makeSleepRecord({ id: 'nap-1', sleep_phase_5_min: '4422244', type: 'sleep' }),
+      ])
 
       expect(db.insertActivity).toHaveBeenCalledWith(
         user,
         expect.objectContaining({
           activity_type: 'nap',
           title: 'Nap',
+        }),
+      )
+    })
+
+    test('processes short sleep with < 15 min of sleep stages as rest', async () => {
+      // Oura phases: '44124' → awake, awake, deep, light, awake
+      // = 2 sleep epochs × 5 min = 10 min of actual sleep → classified as rest
+      await processOuraData(user, 'sleep', [
+        makeSleepRecord({ id: 'rest-short-1', sleep_phase_5_min: '44124', type: 'sleep' }),
+      ])
+
+      expect(db.insertActivity).toHaveBeenCalledWith(
+        user,
+        expect.objectContaining({
+          activity_type: 'rest',
+          title: 'Rest',
         }),
       )
     })

--- a/apps/backend/src/oura-sync.ts
+++ b/apps/backend/src/oura-sync.ts
@@ -14,7 +14,12 @@ import { type OuraDataType, processOuraData } from './oura-process'
 import { triggerCalorieComputation } from './services/calorie-computation'
 
 // Re-export for consumers that import from oura-sync
-export { convertOuraSleepPhases, processOuraData, type OuraDataType } from './oura-process'
+export {
+  computeSleepMinutes,
+  convertOuraSleepPhases,
+  processOuraData,
+  type OuraDataType,
+} from './oura-process'
 
 /** Default start date for historical sync (90 days back) */
 const DEFAULT_SYNC_HISTORY_DAYS = 90

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -83,6 +83,7 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
           <option value="exercise">Exercise</option>
           <option value="meditation">Meditation</option>
           <option value="nap">Nap</option>
+          <option value="rest">Rest</option>
           <option value="sleep">Sleep</option>
         </select>
       </div>

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -34,6 +34,7 @@ const ACTIVITY_COLORS: Record<string, string> = {
   exercise: '#10b981',
   meditation: '#a855f7',
   nap: '#60a5fa',
+  rest: '#86efac',
   sleep: '#3b82f6',
 }
 
@@ -58,6 +59,7 @@ const activityToItem = (a: Activity): DataItem => {
     a.activity_type === 'exercise' ? (a.title ?? 'Exercise')
     : a.activity_type === 'meditation' ? (a.title ?? 'Meditation')
     : a.activity_type === 'sleep' ? 'Sleep'
+    : a.activity_type === 'rest' ? 'Rest'
     : 'Nap'
   return {
     color: ACTIVITY_COLORS[a.activity_type] ?? '#6b7280',
@@ -154,7 +156,7 @@ export const Data = () => {
 
   const activitiesQuery = useQuery({
     placeholderData: keepPreviousData,
-    queryFn: () => fetchActivities(start, end, ['sleep', 'exercise', 'meditation', 'nap']),
+    queryFn: () => fetchActivities(start, end, ['sleep', 'exercise', 'meditation', 'nap', 'rest']),
     queryKey: ['data-activities', dateStr],
     staleTime: 5 * 60 * 1000,
   })

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -118,7 +118,10 @@ const ActivityDetailDispatch = ({
   const musicEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
 
-  const isSleep = activity.activity_type === 'sleep' || activity.activity_type === 'nap'
+  const isSleep =
+    activity.activity_type === 'sleep' ||
+    activity.activity_type === 'nap' ||
+    activity.activity_type === 'rest'
   const isExercise = activity.activity_type === 'exercise'
   const hasSourceRecords = activity.source_records && activity.source_records.length > 1
 

--- a/apps/web/src/pages/Timeline/activityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.test.ts
@@ -150,6 +150,7 @@ describe('buildActivityColumnItems', () => {
     exercise: '#10b981',
     meditation: '#a855f7',
     nap: '#60a5fa',
+    rest: '#86efac',
     sleep: '#3b82f6',
   }
   const itemIcons: Record<string, string> = {}

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -156,7 +156,7 @@ export const createDurationTagItem = (
 type ActivityMeta = {
   label: string
   color: string
-  actType: 'sleep' | 'nap' | 'meditation' | 'exercise'
+  actType: 'sleep' | 'nap' | 'rest' | 'meditation' | 'exercise'
 }
 
 /** Extract label, color, and activity type from an Activity. Returns null for unknown types. */
@@ -171,6 +171,8 @@ const getActivityMeta = (
       return { actType: 'sleep', color: activityColors.sleep ?? '#3b82f6', label: 'Sleep' }
     case 'nap':
       return { actType: 'nap', color: activityColors.nap ?? '#60a5fa', label: 'Nap' }
+    case 'rest':
+      return { actType: 'rest', color: activityColors.rest ?? '#86efac', label: a.title || 'Rest' }
     case 'meditation':
       return {
         actType: 'meditation',

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -66,6 +66,7 @@ const getDefaultViewEnd = () => endOfDay(new Date())
 type LegendCategory =
   | 'sleep'
   | 'nap'
+  | 'rest'
   | 'meditation'
   | 'exercise'
   | 'calendar'
@@ -148,6 +149,7 @@ const MUSIC_COLOR = '#ec4899'
 const activityColors: Record<string, string> = {
   meditation: '#a855f7',
   nap: '#60a5fa',
+  rest: '#86efac',
   sleep: '#3b82f6',
 }
 
@@ -324,6 +326,7 @@ const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = 
   metrics: (item) => item.column === 'Tags / Events' && item.color === METRIC_COLOR,
   music: (item) => item.column === 'Music',
   nap: (item) => item.column === 'Activity' && item.activity_type === 'nap',
+  rest: (item) => item.column === 'Activity' && item.activity_type === 'rest',
   screentime: (item) => item.column === 'Screen Time',
   sleep: (item) => item.column === 'Activity' && item.activity_type === 'sleep',
   tags: (item) =>
@@ -591,6 +594,7 @@ export const Timeline = () => {
         'exercise',
         'meditation',
         'nap',
+        'rest',
       ]),
     queryKey: ['timeline-activities', fromDate.value, toDate.value],
     staleTime: 5 * 60 * 1000,
@@ -1930,6 +1934,7 @@ export const Timeline = () => {
               [
                 { cat: 'sleep' as LegendCategory, color: activityColors.sleep!, label: 'Sleep' },
                 { cat: 'nap' as LegendCategory, color: activityColors.nap!, label: 'Nap' },
+                { cat: 'rest' as LegendCategory, color: activityColors.rest!, label: 'Rest' },
                 {
                   cat: 'meditation' as LegendCategory,
                   color: activityColors.meditation!,

--- a/apps/web/src/pages/Timeline/types.ts
+++ b/apps/web/src/pages/Timeline/types.ts
@@ -27,7 +27,7 @@ export interface ChartItem {
   entity_type?: 'activity' | 'tag' | 'productivity' | 'metric'
   href?: string
   /** Activity type for sparkline overlay targeting */
-  activity_type?: 'sleep' | 'nap' | 'meditation' | 'exercise'
+  activity_type?: 'sleep' | 'nap' | 'meditation' | 'exercise' | 'rest'
   /** Emoji or icon URL to render instead of the default point marker */
   icon?: string
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -92,7 +92,7 @@ import { API_URL } from '../config'
 import { auth } from './auth'
 
 // Frontend types with Date objects (converted from API string types)
-export type ActivityType = 'sleep' | 'exercise' | 'meditation' | 'nap'
+export type ActivityType = 'sleep' | 'exercise' | 'meditation' | 'nap' | 'rest'
 
 export interface SourceRecord {
   id: string

--- a/apps/web/src/utils/emojiLookup.ts
+++ b/apps/web/src/utils/emojiLookup.ts
@@ -10,6 +10,7 @@ export const DEFAULT_ITEM_ICONS: Record<string, string> = {
   // Activity types
   'activity:meditation': '🧘',
   'activity:nap': '💤',
+  'activity:rest': '😌',
   'activity:sleep': '😴',
 
   // Exercise types (keyed by display name from exerciseTypeNames)
@@ -128,6 +129,7 @@ const WORD_TO_EMOJI: Record<string, string> = {
   poop: '💩',
   rain: '🌧️',
   reading: '📖',
+  rest: '😌',
   restaurant: '🍽️',
   rice: '🍚',
   run: '🏃',

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -105,7 +105,7 @@ export const isContextualHrvMetric = (metric: MetricType): boolean =>
 /**
  * Valid activity types.
  */
-export const activityTypes = ['sleep', 'exercise', 'meditation', 'nap'] as const
+export const activityTypes = ['sleep', 'exercise', 'meditation', 'nap', 'rest'] as const
 
 /**
  * Activity types for activities table.


### PR DESCRIPTION
## Summary

- Adds a new `rest` activity type to distinguish Oura's phantom sleep detections from real naps
- Oura short sleep (`type: "sleep"`) is now classified based on actual sleep stage time: >= 15 min of non-awake stages → `nap`, otherwise → `rest`
- This matches [Oura's own nap detection criteria](https://support.ouraring.com/hc/en-us/articles/1500009653181-Nap-Detection): *"For Oura to detect sleep as a nap, it must be between 15 minutes and three hours in length, and your body must fall into at least one sleep stage"*

## Changes

### API Spec
- Added `rest` to `activityTypes` enum, regenerated OpenAPI + Kotlin models

### Backend
- `oura-process.ts`: Added `computeSleepMinutes()` helper that sums non-awake stage durations from HC-encoded stages. Updated `processSleep` to classify Oura `type: "sleep"` dynamically based on the 15-minute threshold
- `oura-sync.ts`: Re-exported `computeSleepMinutes`
- MCP tool descriptions updated to include `rest`

### Frontend
- Timeline: rest category with soft green color (`#86efac`), legend entry, category matcher
- Data page: rest color, label, included in fetch
- AddData: rest option in activity type dropdown
- EntityDetail: rest treated as sleep-like (shows stages)
- Emoji: `😌` for `activity:rest`

### Tests
- `computeSleepMinutes` unit tests (empty, all-awake, mixed stages)
- Updated nap classification test to use explicit phases with >= 15 min sleep
- New test for short sleep with < 15 min sleep stages → rest
- `parseActivityType('rest')` test
- Frontend activityColors fixture updated

### Migration
- `apps/backend/scripts/migrate-phantom-naps-to-rest.sql`: One-time SQL script to reclassify existing Oura-sourced nap activities with < 15 min of actual sleep stages to `rest`

## Not synced to Health Connect
`rest` has no Health Connect mapping (like `meditation`), so rest activities won't sync to/from HC.