### PR TITLE
feat: add bulk metric insert endpoint (POST /metrics/bulk)

### DIFF
--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -4,6 +4,7 @@
 import {
   addCustomMetricBodySchema,
   addMetricBodySchema,
+  bulkMetricItemSchema,
   customMetricDefinitionSchema,
   recalculateCaloriesBodySchema,
   updateCustomMetricBodySchema,
@@ -13,6 +14,7 @@ import { computeAndStoreCalories } from '../services/calorie-computation'
 import {
   addCustomMetric,
   addMetric,
+  bulkAddMetrics,
   deleteCustomMetric,
   deleteMetric,
   deleteMetricData,
@@ -37,6 +39,37 @@ export const registerMetricTools = (server: McpServer, user: string) => {
       if (!result.success) {
         return errorResponse(result.error ?? 'Failed to add metric')
       }
+      return jsonResponse(result)
+    },
+  )
+
+  // Tool: add_metrics_bulk
+  server.tool(
+    'add_metrics_bulk',
+    'Bulk insert metric data points for efficient batch imports. Accepts up to 10,000 items per call. Each item requires metric, value, and time. Items with validation errors are skipped (not inserted), and their errors are returned separately.',
+    {
+      data: z.array(bulkMetricItemSchema).min(1).max(10_000).describe('Array of metric data points'),
+      source: z
+        .string()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe('Default data source for all items (defaults to "aurboda")'),
+    },
+    async ({ data, source }) => {
+      const items = data.map((item) => ({
+        metric: item.metric,
+        source: item.source,
+        time: parseOptionalDate(item.time) ?? new Date(),
+        value: item.value,
+      }))
+
+      const invalidTime = data.findIndex((item) => parseOptionalDate(item.time) === null)
+      if (invalidTime !== -1) {
+        return errorResponse(`Invalid time format at index ${invalidTime}. Use ISO 8601 format.`)
+      }
+
+      const result = await bulkAddMetrics(user, items, source)
       return jsonResponse(result)
     },
   )

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -10,6 +10,9 @@ import {
   addMetricBodySchema,
   type AddMetricResponse,
   type BucketSize,
+  type BulkMetricsBody,
+  bulkMetricsBodySchema,
+  type BulkMetricsResponse,
   type CustomMetricResponse,
   type CustomMetricsListResponse,
   type DailySummaryQuery,
@@ -40,6 +43,7 @@ import { computeAndStoreCalories } from '../services/calorie-computation'
 import {
   addCustomMetric,
   addMetric,
+  bulkAddMetrics,
   deleteCustomMetric,
   deleteMetric,
   deleteMetricData,
@@ -168,6 +172,27 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
 
       const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
       res.json({ ...result, success: true })
+    },
+  )
+
+  // POST /metrics/bulk - Bulk insert metric data points
+  router.post<Record<string, never>, BulkMetricsResponse, BulkMetricsBody>(
+    '/metrics/bulk',
+    authMiddleware,
+    validateBody(bulkMetricsBodySchema),
+    async (req, res) => {
+      const { data, source } = req.body
+      const user = req.user!
+
+      const items = data.map((item) => ({
+        metric: item.metric,
+        source: item.source,
+        time: new Date(item.time),
+        value: item.value,
+      }))
+
+      const result = await bulkAddMetrics(user, items, source)
+      res.json(result)
     },
   )
 

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -6,6 +6,7 @@ import {
   addCustomMetric,
   addMetric,
   addTag,
+  bulkAddMetrics,
   deleteActivity,
   deleteCustomMetric,
   deleteMetric,
@@ -683,6 +684,168 @@ describe('addMetric with custom metrics', () => {
     expect(result.success).toBe(false)
     expect(result.error).toContain('below minimum')
     expect(db.insertTimeSeries).not.toHaveBeenCalled()
+  })
+})
+
+describe('bulkAddMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('inserts multiple built-in metrics in a single batch', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    const result = await bulkAddMetrics('testuser', [
+      { metric: 'heart_rate', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+      { metric: 'heart_rate', time: new Date('2024-01-15T10:05:00Z'), value: 75 },
+      { metric: 'weight', time: new Date('2024-01-15T08:00:00Z'), value: 75.5 },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(result.inserted).toBe(3)
+    expect(result.errors).toHaveLength(0)
+
+    expect(db.insertTimeSeries).toHaveBeenCalledTimes(1)
+    expect(db.insertTimeSeries).toHaveBeenCalledWith('testuser', [
+      {
+        metric: 'heart_rate',
+        source: 'aurboda',
+        time: new Date('2024-01-15T10:00:00Z'),
+        unit: 'bpm',
+        value: 72,
+      },
+      {
+        metric: 'heart_rate',
+        source: 'aurboda',
+        time: new Date('2024-01-15T10:05:00Z'),
+        unit: 'bpm',
+        value: 75,
+      },
+      {
+        metric: 'weight',
+        source: 'aurboda',
+        time: new Date('2024-01-15T08:00:00Z'),
+        unit: 'kg',
+        value: 75.5,
+      },
+    ])
+  })
+
+  test('collects per-item errors without failing the batch', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue({ custom_metrics: [] })
+
+    const result = await bulkAddMetrics('testuser', [
+      { metric: 'heart_rate', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+      { metric: 'invalid_metric', time: new Date('2024-01-15T10:05:00Z'), value: 42 },
+      { metric: 'weight', time: new Date('2024-01-15T08:00:00Z'), value: 75.5 },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(result.inserted).toBe(2)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toEqual({
+      error: 'Invalid metric "invalid_metric"',
+      index: 1,
+    })
+  })
+
+  test('validates custom metric ranges', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      custom_metrics: [{ max_value: 10, min_value: 1, name: 'mood', unit: 'score' }],
+    })
+
+    const result = await bulkAddMetrics('testuser', [
+      { metric: 'mood', time: new Date('2024-01-15T10:00:00Z'), value: 5 },
+      { metric: 'mood', time: new Date('2024-01-15T11:00:00Z'), value: 15 },
+      { metric: 'mood', time: new Date('2024-01-15T12:00:00Z'), value: 0 },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(result.inserted).toBe(1)
+    expect(result.errors).toHaveLength(2)
+    expect(result.errors[0].index).toBe(1)
+    expect(result.errors[0].error).toContain('exceeds maximum')
+    expect(result.errors[1].index).toBe(2)
+    expect(result.errors[1].error).toContain('below minimum')
+  })
+
+  test('uses default source when no per-item source specified', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    await bulkAddMetrics(
+      'testuser',
+      [{ metric: 'heart_rate', time: new Date('2024-01-15T10:00:00Z'), value: 72 }],
+      'oura',
+    )
+
+    expect(db.insertTimeSeries).toHaveBeenCalledWith('testuser', [
+      expect.objectContaining({ source: 'oura' }),
+    ])
+  })
+
+  test('per-item source overrides default source', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    await bulkAddMetrics(
+      'testuser',
+      [
+        { metric: 'heart_rate', source: 'garmin', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+        { metric: 'heart_rate', time: new Date('2024-01-15T10:05:00Z'), value: 75 },
+      ],
+      'oura',
+    )
+
+    expect(db.insertTimeSeries).toHaveBeenCalledWith('testuser', [
+      expect.objectContaining({ source: 'garmin' }),
+      expect.objectContaining({ source: 'oura' }),
+    ])
+  })
+
+  test('defaults source to aurboda when not specified', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue(null)
+
+    await bulkAddMetrics('testuser', [
+      { metric: 'heart_rate', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+    ])
+
+    expect(db.insertTimeSeries).toHaveBeenCalledWith('testuser', [
+      expect.objectContaining({ source: 'aurboda' }),
+    ])
+  })
+
+  test('does not call insertTimeSeries when all items are invalid', async () => {
+    vi.mocked(db.getUserSettings).mockResolvedValue({ custom_metrics: [] })
+
+    const result = await bulkAddMetrics('testuser', [
+      { metric: 'unknown1', time: new Date('2024-01-15T10:00:00Z'), value: 1 },
+      { metric: 'unknown2', time: new Date('2024-01-15T10:05:00Z'), value: 2 },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(result.inserted).toBe(0)
+    expect(result.errors).toHaveLength(2)
+    expect(db.insertTimeSeries).not.toHaveBeenCalled()
+  })
+
+  test('calls getUserSettings only once for the entire batch', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getUserSettings).mockResolvedValue({
+      custom_metrics: [{ name: 'mood', unit: 'score' }],
+    })
+
+    await bulkAddMetrics('testuser', [
+      { metric: 'mood', time: new Date('2024-01-15T10:00:00Z'), value: 5 },
+      { metric: 'mood', time: new Date('2024-01-15T11:00:00Z'), value: 7 },
+      { metric: 'heart_rate', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+    ])
+
+    expect(db.getUserSettings).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -5,7 +5,7 @@
  * They are used by both the MCP tools and the REST API.
  */
 
-import type { ActivityType, CustomMetricDefinition } from '@aurboda/api-spec'
+import type { ActivityType, CustomMetricDefinition, DataSource } from '@aurboda/api-spec'
 import { randomUUID } from 'crypto'
 import {
   deleteActivity as dbDeleteActivity,
@@ -19,6 +19,7 @@ import {
   getUserSettings,
   insertTag,
   insertTimeSeries,
+  type TimeSeriesPoint,
   updateTagEndTime,
 } from '../db'
 import {
@@ -93,6 +94,24 @@ export interface AddActivityResult {
   title?: string
   notes?: string
   error?: string
+}
+
+export interface BulkMetricItem {
+  metric: string
+  value: number
+  time: Date
+  source?: string
+}
+
+export interface BulkMetricError {
+  index: number
+  error: string
+}
+
+export interface BulkAddMetricsResult {
+  success: boolean
+  inserted: number
+  errors: BulkMetricError[]
 }
 
 export interface DeleteActivityResult {
@@ -273,6 +292,62 @@ export async function addMetric(user: string, input: AddMetricInput): Promise<Ad
     time: storedTime,
     unit: unit ?? '',
     value: input.value,
+  }
+}
+
+/**
+ * Bulk insert metric data points.
+ *
+ * Validates all items against built-in and custom metrics, collects per-item errors,
+ * and inserts all valid items in a single batch call to insertTimeSeries.
+ * Skips outbound Health Connect sync for bulk imports (historical data).
+ */
+export async function bulkAddMetrics(
+  user: string,
+  items: BulkMetricItem[],
+  defaultSource?: string,
+): Promise<BulkAddMetricsResult> {
+  const settings = await getUserSettings(user)
+  const customMetrics = settings?.custom_metrics ?? []
+
+  const errors: BulkMetricError[] = []
+  const validPoints: TimeSeriesPoint[] = []
+  const resolvedDefaultSource: DataSource = (defaultSource as DataSource) ?? 'aurboda'
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+
+    if (!isValidMetricOrCustom(item.metric, customMetrics)) {
+      errors.push({ error: `Invalid metric "${item.metric}"`, index: i })
+      continue
+    }
+
+    const rangeError = validateCustomMetricRange(customMetrics, item.metric, item.value)
+    if (rangeError) {
+      errors.push({ error: rangeError, index: i })
+      continue
+    }
+
+    const unit = getMetricUnit(item.metric, customMetrics)
+    const source: DataSource = (item.source as DataSource) ?? resolvedDefaultSource
+
+    validPoints.push({
+      metric: item.metric,
+      source,
+      time: item.time,
+      unit,
+      value: item.value,
+    })
+  }
+
+  if (validPoints.length > 0) {
+    await insertTimeSeries(user, validPoints)
+  }
+
+  return {
+    errors,
+    inserted: validPoints.length,
+    success: true,
   }
 }
 

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -101,6 +101,73 @@ export const addMetricResponseSchema = baseResponseSchema
 export type AddMetricResponse = z.infer<typeof addMetricResponseSchema>
 
 // ============================================================================
+// Bulk Metric Insert
+// ============================================================================
+
+/**
+ * Single item within a bulk metric insert request.
+ */
+export const bulkMetricItemSchema = z
+  .object({
+    metric: metricNameSchema,
+    source: z.string().min(1).max(50).optional().meta({ description: 'Data source (defaults to "aurboda")' }),
+    time: iso8601DateTimeSchema.meta({ description: 'Measurement time (required for bulk inserts)' }),
+    value: metricValueSchema.meta({ example: 36.03 }),
+  })
+  .meta({ id: 'BulkMetricItem' })
+
+export type BulkMetricItem = z.infer<typeof bulkMetricItemSchema>
+
+/**
+ * Bulk metric insert request body.
+ * Accepts up to 10,000 metric data points per request.
+ */
+export const bulkMetricsBodySchema = z
+  .object({
+    data: z
+      .array(bulkMetricItemSchema)
+      .min(1)
+      .max(10_000)
+      .meta({ description: 'Array of metric data points (max 10,000 per request)' }),
+    source: z
+      .string()
+      .min(1)
+      .max(50)
+      .optional()
+      .meta({ description: 'Default data source for all items (defaults to "aurboda")' }),
+  })
+  .meta({
+    description: 'Bulk insert metric data points for efficient batch imports.',
+    id: 'BulkMetricsBody',
+  })
+
+export type BulkMetricsBody = z.infer<typeof bulkMetricsBodySchema>
+
+/**
+ * Per-item error in bulk insert response.
+ */
+export const bulkMetricErrorSchema = z
+  .object({
+    error: z.string().meta({ description: 'Error message' }),
+    index: z.number().int().meta({ description: 'Zero-based index of the failed item' }),
+  })
+  .meta({ id: 'BulkMetricError' })
+
+export type BulkMetricError = z.infer<typeof bulkMetricErrorSchema>
+
+/**
+ * Bulk metric insert response.
+ */
+export const bulkMetricsResponseSchema = baseResponseSchema
+  .extend({
+    errors: z.array(bulkMetricErrorSchema).optional().meta({ description: 'Per-item validation errors' }),
+    inserted: z.number().int().optional().meta({ description: 'Number of successfully inserted items' }),
+  })
+  .meta({ id: 'BulkMetricsResponse' })
+
+export type BulkMetricsResponse = z.infer<typeof bulkMetricsResponseSchema>
+
+// ============================================================================
 // Custom Metric Management
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Adds a bulk metric insertion endpoint to support efficient batch imports of historical health data (e.g., Oura Ring takeout exports with ~1.5M skin temperature readings).

- **`POST /metrics/bulk`** REST endpoint accepting up to 10,000 items per request
- **`add_metrics_bulk`** MCP tool with the same capabilities
- **Schema**: `bulkMetricsBodySchema` in `@aurboda/api-spec` with per-item and default `source` fields
- **Service**: `bulkAddMetrics` — single `getUserSettings()` call, per-item metric/range validation, single `insertTimeSeries` batch call
- Source defaults to `'aurboda'` but can be overridden per-item or via a default `source` field (useful for imports from specific data sources)
- Per-item validation errors are collected and returned without failing the entire batch
- Skips outbound Health Connect sync for bulk imports (historical data)
- 8 new unit tests covering batch insert, error collection, source handling, and custom metric validation

Closes #320