### PR TITLE
feat: add /version endpoint and switch MCP to stateless mode

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,5 +55,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: BUILD_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,9 @@ COPY nginx.conf /etc/nginx/http.d/default.conf
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+ARG BUILD_SHA=unknown
 ENV NODE_ENV=production
+ENV BUILD_SHA=${BUILD_SHA}
 EXPOSE 80
 
 CMD ["/entrypoint.sh"]

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -34,7 +34,6 @@ import { syncAllCalendars } from './ical-sync'
 import { createLastFmRouter } from './lastfm-router'
 import { syncLastFmData } from './lastfm-sync'
 import { createMcpRouter } from './mcp'
-import { createDbSessionStore } from './mcp-session-store'
 import { ouraClient } from './oura'
 import type { OuraDataType } from './oura-sync'
 import { syncAllOuraData, syncOuraDataType } from './oura-sync'
@@ -106,8 +105,8 @@ const main = async () => {
   httpd.use(cors({ origin: true }))
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
-  // Use database-backed session store for persistence across restarts
-  httpd.use('/mcp', createMcpRouter(auth, oura, syncProvider, { sessionStore: createDbSessionStore() }))
+  // Stateless mode — no session tracking needed (tools only, no subscriptions)
+  httpd.use('/mcp', createMcpRouter(auth, oura, syncProvider))
 
   httpd.use(json({ limit: '10mb' }))
 
@@ -149,6 +148,13 @@ const main = async () => {
   // ==========================================================================
   // Auth routes (stay here - tightly coupled to server setup)
   // ==========================================================================
+
+  httpd.get('/version', (_req, res) => {
+    res.json({
+      build_sha: process.env.BUILD_SHA ?? 'dev',
+      success: true,
+    })
+  })
 
   httpd.get<Record<string, never>, ServerStatusResponse>('/status', async (_req, res) => {
     const signupMode = await centralDb.getSignupMode()

--- a/apps/backend/src/mcp.integration.test.ts
+++ b/apps/backend/src/mcp.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * MCP Integration tests with real PostgreSQL.
  *
- * Tests the full MCP session persistence flow using a real database.
+ * Tests the stateless MCP server against a real database.
  */
 
 import express from 'express'
@@ -9,7 +9,6 @@ import request from 'supertest'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { createAuth } from './auth'
 import { createMcpRouter } from './mcp'
-import { createDbSessionStore } from './mcp-session-store'
 import { cleanTestDb, startTestDb, stopTestDb } from './test/db-test-helper'
 
 // Increase timeout for container startup
@@ -19,16 +18,25 @@ const auth = createAuth('very very secretvery very secret') // 32 bytes for AES-
 
 function createTestApp() {
   const app = express()
-  // Use database-backed session store
-  const sessionStore = createDbSessionStore()
-  app.use('/mcp', createMcpRouter(auth, undefined, undefined, { sessionStore }))
+  // Stateless MCP — no session tracking
+  app.use('/mcp', createMcpRouter(auth))
   return app
 }
 
 const mcpPost = (app: ReturnType<typeof createTestApp>) =>
   request(app).post('/mcp').set('Accept', 'application/json, text/event-stream')
 
-describe('MCP Database Integration Tests', () => {
+function parseSSEResponse(text: string): unknown {
+  const lines = text.split('\n')
+  for (const line of lines) {
+    if (line.startsWith('data: ')) {
+      return JSON.parse(line.slice(6))
+    }
+  }
+  throw new Error('No data line found in SSE response')
+}
+
+describe('MCP Database Integration Tests (Stateless)', () => {
   beforeAll(async () => {
     await startTestDb()
   }, CONTAINER_TIMEOUT)
@@ -41,139 +49,113 @@ describe('MCP Database Integration Tests', () => {
     await cleanTestDb()
   })
 
-  test('session persists in database and survives app restart', async () => {
-    const token = auth.createToken('testuser')
-
-    // Create first app instance
-    const app1 = createTestApp()
-
-    // Initialize a session
-    const initResponse = await mcpPost(app1)
-      .set('Authorization', `Bearer ${token}`)
-      .send({
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'initialize',
-        params: {
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-          protocolVersion: '2024-11-05',
-        },
-      })
-
-    expect(initResponse.status).toBe(200)
-    const sessionId = initResponse.headers['mcp-session-id'] as string
-    expect(sessionId).toBeDefined()
-    console.log('Got session ID:', sessionId)
-
-    // Simulate restart by creating a new app instance
-    // This creates a fresh in-memory sessions map but uses the same database
-    const app2 = createTestApp()
-
-    // Try to use the same session ID on the new app instance
-    const response = await mcpPost(app2)
-      .set('Authorization', `Bearer ${token}`)
-      .set('Mcp-Session-Id', sessionId)
-      .send({
-        id: 2,
-        jsonrpc: '2.0',
-        method: 'initialize',
-        params: {
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-          protocolVersion: '2024-11-05',
-        },
-      })
-
-    expect(response.status).toBe(200)
-    // The session ID should be preserved
-    expect(response.headers['mcp-session-id']).toBe(sessionId)
-  })
-
-  test('session is saved to database on creation', async () => {
+  test('stateless tool call works without initialize', async () => {
     const token = auth.createToken('testuser')
     const app = createTestApp()
 
-    const initResponse = await mcpPost(app)
+    // Call a tool directly — no initialize needed in stateless mode
+    const response = await mcpPost(app)
       .set('Authorization', `Bearer ${token}`)
       .send({
         id: 1,
         jsonrpc: '2.0',
-        method: 'initialize',
+        method: 'tools/call',
         params: {
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-          protocolVersion: '2024-11-05',
+          arguments: {
+            end: '2024-01-31T23:59:59Z',
+            start: '2024-01-01T00:00:00Z',
+          },
+          name: 'query_tags',
         },
       })
 
-    expect(initResponse.status).toBe(200)
-    const sessionId = initResponse.headers['mcp-session-id'] as string
-
-    // Verify session was saved to database by creating a new app and restoring
-    const app2 = createTestApp()
-
-    // After restart, we need to re-initialize (but the session ID is preserved)
-    const response = await mcpPost(app2)
-      .set('Authorization', `Bearer ${token}`)
-      .set('Mcp-Session-Id', sessionId)
-      .send({
-        id: 2,
-        jsonrpc: '2.0',
-        method: 'initialize',
-        params: {
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-          protocolVersion: '2024-11-05',
-        },
-      })
-
-    // If the session was restored, we should get a 200 response with the same session ID
     expect(response.status).toBe(200)
-    expect(response.headers['mcp-session-id']).toBe(sessionId)
+    // No session ID in stateless mode
+    expect(response.headers['mcp-session-id']).toBeUndefined()
+
+    const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+    const result = JSON.parse(parsed.result.content[0].text)
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual([])
   })
 
-  test('session for different user cannot be restored', async () => {
+  test('each request is independent (no shared state)', async () => {
+    const token = auth.createToken('testuser')
+    const app = createTestApp()
+
+    // First request
+    const response1 = await mcpPost(app)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: {
+          arguments: {
+            end: '2024-01-31T23:59:59Z',
+            start: '2024-01-01T00:00:00Z',
+          },
+          name: 'query_tags',
+        },
+      })
+
+    // Second request — completely independent
+    const response2 = await mcpPost(app)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: {
+          arguments: {
+            end: '2024-02-28T23:59:59Z',
+            start: '2024-02-01T00:00:00Z',
+          },
+          name: 'query_tags',
+        },
+      })
+
+    expect(response1.status).toBe(200)
+    expect(response2.status).toBe(200)
+  })
+
+  test('different users get isolated data', async () => {
     const token1 = auth.createToken('user1')
     const token2 = auth.createToken('user2')
+    const app = createTestApp()
 
-    const app1 = createTestApp()
-
-    // Create session for user1
-    const initResponse = await mcpPost(app1)
+    // Both users can make independent requests
+    const response1 = await mcpPost(app)
       .set('Authorization', `Bearer ${token1}`)
       .send({
         id: 1,
         jsonrpc: '2.0',
-        method: 'initialize',
+        method: 'tools/call',
         params: {
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-          protocolVersion: '2024-11-05',
+          arguments: {
+            end: '2024-01-31T23:59:59Z',
+            start: '2024-01-01T00:00:00Z',
+          },
+          name: 'query_tags',
         },
       })
 
-    const sessionId = initResponse.headers['mcp-session-id'] as string
-
-    // Create new app instance and try to use user1's session as user2
-    const app2 = createTestApp()
-
-    const response = await mcpPost(app2)
+    const response2 = await mcpPost(app)
       .set('Authorization', `Bearer ${token2}`)
-      .set('Mcp-Session-Id', sessionId)
       .send({
-        id: 2,
+        id: 1,
         jsonrpc: '2.0',
-        method: 'initialize',
+        method: 'tools/call',
         params: {
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-          protocolVersion: '2024-11-05',
+          arguments: {
+            end: '2024-01-31T23:59:59Z',
+            start: '2024-01-01T00:00:00Z',
+          },
+          name: 'query_tags',
         },
       })
 
-    // Should get a 200 response but with a NEW session ID (not the old one)
-    expect(response.status).toBe(200)
-    expect(response.headers['mcp-session-id']).not.toBe(sessionId)
+    expect(response1.status).toBe(200)
+    expect(response2.status).toBe(200)
   })
 })

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createAuth } from './auth'
 import * as db from './db'
 import { createMcpRouter } from './mcp'
-import { createInMemorySessionStore, McpSessionStore } from './mcp-session-store'
 import * as mutations from './services/mutations'
 import * as queries from './services/queries'
 
@@ -55,7 +54,7 @@ const auth = createAuth('very very secretvery very secret') // 32 bytes for AES-
 
 function createTestApp() {
   const app = express()
-  // MCP router must be mounted BEFORE body-parser, as the MCP SDK handles its own body parsing
+  // MCP router must be mounted BEFORE body-parser — stateless mode (no sessions)
   app.use('/mcp', createMcpRouter(auth))
   return app
 }
@@ -113,7 +112,7 @@ describe('MCP Server', () => {
       expect(response.body.error).toBe('Unauthorized')
     })
 
-    test('accepts valid bearer token and returns session ID', async () => {
+    test('accepts valid bearer token in stateless mode', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
 
@@ -131,113 +130,42 @@ describe('MCP Server', () => {
         })
 
       expect(response.status).toBe(200)
-      expect(response.headers['mcp-session-id']).toBeDefined()
+      // Stateless mode: no session ID in response
+      expect(response.headers['mcp-session-id']).toBeUndefined()
     })
   })
 
-  describe('Authentication - GET /mcp (SSE endpoint)', () => {
-    test('returns 401 without authorization header', async () => {
+  describe('Stateless mode - GET /mcp (SSE not supported)', () => {
+    test('returns 405 for GET requests', async () => {
       const app = createTestApp()
-      const response = await request(app)
-        .get('/mcp')
-        .set('Accept', 'text/event-stream')
-        .set('Mcp-Session-Id', 'some-session-id')
+      const response = await request(app).get('/mcp').set('Accept', 'text/event-stream')
 
-      expect(response.status).toBe(401)
-      expect(response.body.error).toBe('Unauthorized')
-    })
-
-    test('returns 400 for missing session ID', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
-      const response = await request(app).get('/mcp').set('Authorization', `Bearer ${token}`)
-
-      expect(response.status).toBe(400)
-      expect(response.body.error).toBe('Invalid or missing session ID')
-    })
-
-    test('returns 400 for invalid session ID', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
-      const response = await request(app)
-        .get('/mcp')
-        .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', 'nonexistent-session')
-
-      expect(response.status).toBe(400)
-      expect(response.body.error).toBe('Invalid or missing session ID')
+      expect(response.status).toBe(405)
+      expect(response.body.error).toBe('SSE not supported in stateless mode')
     })
   })
 
-  describe('Authentication - DELETE /mcp (end session)', () => {
-    test('returns 401 without authorization header', async () => {
+  describe('Stateless mode - DELETE /mcp (no sessions)', () => {
+    test('returns 405 for DELETE requests', async () => {
       const app = createTestApp()
-      const response = await mcpDelete(app).set('Mcp-Session-Id', 'some-session-id')
-
-      expect(response.status).toBe(401)
-      expect(response.body.error).toBe('Unauthorized')
-    })
-
-    test('returns 400 for missing session ID', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
-      const response = await mcpDelete(app).set('Authorization', `Bearer ${token}`)
-
-      expect(response.status).toBe(400)
-      expect(response.body.error).toBe('Invalid or missing session ID')
-    })
-
-    test('returns 400 for invalid session ID', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
       const response = await mcpDelete(app)
-        .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', 'invalid-session-id')
 
-      expect(response.status).toBe(400)
-      expect(response.body.error).toBe('Invalid or missing session ID')
+      expect(response.status).toBe(405)
+      expect(response.body.error).toBe('No sessions in stateless mode')
     })
   })
-
-  // Note: Session isolation via POST is handled by checking session.user !== user
-  // in mcp.ts POST handler. Due to complexity of MCP SDK's internal session state,
-  // full integration testing of session isolation requires using a real MCP client.
-  // The GET and DELETE endpoints' session isolation is tested via the "returns 400
-  // for invalid session ID" tests which verify sessions are properly scoped.
 
   describe('Tool: query_period_summary', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -245,17 +173,23 @@ describe('MCP Server', () => {
 
       // Parse SSE response
       const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let toolResult: any = null
+      try {
+        toolResult = JSON.parse(parsed.result.content[0].text)
+      } catch {
+        // Error responses may contain plain text instead of JSON
+      }
       return {
         ...response,
         parsed,
-        toolResult: JSON.parse(parsed.result.content[0].text),
+        toolResult,
       }
     }
 
     test('returns aggregated stats for valid metrics', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       // Mock service response
       vi.mocked(queries.getPeriodSummary).mockResolvedValue({
@@ -278,7 +212,7 @@ describe('MCP Server', () => {
         start: '2024-01-01T00:00:00.000Z',
       })
 
-      const response = await callTool(app, token, sessionId, 'query_period_summary', {
+      const response = await callTool(app, token, 'query_period_summary', {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
@@ -307,63 +241,34 @@ describe('MCP Server', () => {
     test('returns error for invalid date format', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
-        .send({
-          id: 2,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            arguments: {
-              end: 'not-a-date',
-              metrics: ['hrv_rmssd'],
-              start: '2024-01-01T00:00:00Z',
-            },
-            name: 'query_period_summary',
-          },
-        })
+      const response = await callTool(app, token, 'query_period_summary', {
+        end: 'not-a-date',
+        metrics: ['hrv_rmssd'],
+        start: '2024-01-01T00:00:00Z',
+      })
 
-      expect(response.status).toBe(200)
-      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
       // Schema validation catches invalid dates before our handler runs
-      expect(parsed.result.content[0].text).toMatch(/Invalid (date|ISO datetime)/i)
+      expect(response.parsed.result.content[0].text).toMatch(/Invalid (date|ISO datetime)/i)
     })
 
     test('returns error for invalid metrics', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
-        .send({
-          id: 2,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            arguments: {
-              end: '2024-01-31T23:59:59Z',
-              metrics: ['invalid_metric', 'hrv_rmssd'],
-              start: '2024-01-01T00:00:00Z',
-            },
-            name: 'query_period_summary',
-          },
-        })
+      const response = await callTool(app, token, 'query_period_summary', {
+        end: '2024-01-31T23:59:59Z',
+        metrics: ['invalid_metric', 'hrv_rmssd'],
+        start: '2024-01-01T00:00:00Z',
+      })
 
-      expect(response.status).toBe(200)
-      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
-      expect(parsed.result.content[0].text).toContain('Invalid metrics')
-      expect(parsed.result.content[0].text).toContain('invalid_metric')
+      expect(response.parsed.result.content[0].text).toContain('Invalid metrics')
+      expect(response.parsed.result.content[0].text).toContain('invalid_metric')
     })
 
     test('calculates change from previous period', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.getPeriodSummary).mockResolvedValue({
         end: '2024-01-31T23:59:59.000Z',
@@ -385,7 +290,7 @@ describe('MCP Server', () => {
         start: '2024-01-01T00:00:00.000Z',
       })
 
-      const response = await callTool(app, token, sessionId, 'query_period_summary', {
+      const response = await callTool(app, token, 'query_period_summary', {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
@@ -398,7 +303,6 @@ describe('MCP Server', () => {
     test('identifies outliers beyond 2 stddev', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.getPeriodSummary).mockResolvedValue({
         end: '2024-01-31T23:59:59.000Z',
@@ -421,7 +325,7 @@ describe('MCP Server', () => {
         start: '2024-01-01T00:00:00.000Z',
       })
 
-      const response = await callTool(app, token, sessionId, 'query_period_summary', {
+      const response = await callTool(app, token, 'query_period_summary', {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
@@ -435,7 +339,6 @@ describe('MCP Server', () => {
     test('handles metrics with no data', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.getPeriodSummary).mockResolvedValue({
         end: '2024-01-31T23:59:59.000Z',
@@ -457,7 +360,7 @@ describe('MCP Server', () => {
         start: '2024-01-01T00:00:00.000Z',
       })
 
-      const response = await callTool(app, token, sessionId, 'query_period_summary', {
+      const response = await callTool(app, token, 'query_period_summary', {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
@@ -472,8 +375,6 @@ describe('MCP Server', () => {
     test('calculates completeness percentage correctly', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
-
       vi.mocked(queries.getPeriodSummary).mockResolvedValue({
         end: '2024-01-31T23:59:59.000Z',
         metrics: [
@@ -494,7 +395,7 @@ describe('MCP Server', () => {
         start: '2024-01-01T00:00:00.000Z',
       })
 
-      const response = await callTool(app, token, sessionId, 'query_period_summary', {
+      const response = await callTool(app, token, 'query_period_summary', {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
@@ -506,34 +407,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: query_tags', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -550,7 +433,6 @@ describe('MCP Server', () => {
     test('returns tags for valid time range', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryTags).mockResolvedValue([
         {
@@ -566,7 +448,7 @@ describe('MCP Server', () => {
         },
       ])
 
-      const response = await callTool(app, token, sessionId, 'query_tags', {
+      const response = await callTool(app, token, 'query_tags', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
       })
@@ -587,11 +469,10 @@ describe('MCP Server', () => {
     test('returns empty array when no tags exist', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryTags).mockResolvedValue([])
 
-      const response = await callTool(app, token, sessionId, 'query_tags', {
+      const response = await callTool(app, token, 'query_tags', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
       })
@@ -603,34 +484,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: get_programmatic_tags', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -647,7 +510,6 @@ describe('MCP Server', () => {
     test('returns programmatic tags with is_programmatic flag and mapped name', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
       vi.mocked(db.getProgrammaticTags).mockResolvedValue([
@@ -657,7 +519,7 @@ describe('MCP Server', () => {
         tag_mappings: { [uuid]: 'Food' },
       })
 
-      const response = await callTool(app, token, sessionId, 'get_programmatic_tags', {})
+      const response = await callTool(app, token, 'get_programmatic_tags', {})
 
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
@@ -674,7 +536,6 @@ describe('MCP Server', () => {
     test('returns non-programmatic tags with current_name set to tag name', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(db.getProgrammaticTags).mockResolvedValue([
         {
@@ -687,7 +548,7 @@ describe('MCP Server', () => {
       ])
       vi.mocked(db.getUserSettings).mockResolvedValue(null)
 
-      const response = await callTool(app, token, sessionId, 'get_programmatic_tags', {})
+      const response = await callTool(app, token, 'get_programmatic_tags', {})
 
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
@@ -712,7 +573,6 @@ describe('MCP Server', () => {
     test('returns mixed programmatic and non-programmatic tags', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       const uuid = '067e2862-8cf8-4307-a621-0636dd379cda'
       vi.mocked(db.getProgrammaticTags).mockResolvedValue([
@@ -721,7 +581,7 @@ describe('MCP Server', () => {
       ])
       vi.mocked(db.getUserSettings).mockResolvedValue(null)
 
-      const response = await callTool(app, token, sessionId, 'get_programmatic_tags', {})
+      const response = await callTool(app, token, 'get_programmatic_tags', {})
 
       expect(response.toolResult.data).toHaveLength(2)
       // Programmatic tag without mapping has null current_name
@@ -734,34 +594,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: query_activities', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -778,7 +620,6 @@ describe('MCP Server', () => {
     test('returns activities for valid time range', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryActivities).mockResolvedValue([
         {
@@ -802,7 +643,7 @@ describe('MCP Server', () => {
         },
       ])
 
-      const response = await callTool(app, token, sessionId, 'query_activities', {
+      const response = await callTool(app, token, 'query_activities', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
       })
@@ -818,7 +659,6 @@ describe('MCP Server', () => {
     test('filters by activity types when provided', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryActivities).mockResolvedValue([
         {
@@ -832,7 +672,7 @@ describe('MCP Server', () => {
         },
       ])
 
-      const response = await callTool(app, token, sessionId, 'query_activities', {
+      const response = await callTool(app, token, 'query_activities', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
         types: ['exercise'],
@@ -851,34 +691,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: query_productivity', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -895,7 +717,6 @@ describe('MCP Server', () => {
     test('returns productivity data for valid time range', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryProductivity).mockResolvedValue([
         {
@@ -918,7 +739,7 @@ describe('MCP Server', () => {
         },
       ])
 
-      const response = await callTool(app, token, sessionId, 'query_productivity', {
+      const response = await callTool(app, token, 'query_productivity', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
       })
@@ -938,34 +759,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: query_locations', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -982,7 +785,6 @@ describe('MCP Server', () => {
     test('returns location visits for valid time range', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryLocations).mockResolvedValue([
         {
@@ -1005,7 +807,7 @@ describe('MCP Server', () => {
         },
       ])
 
-      const response = await callTool(app, token, sessionId, 'query_locations', {
+      const response = await callTool(app, token, 'query_locations', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
       })
@@ -1022,11 +824,10 @@ describe('MCP Server', () => {
     test('returns empty array when no visits exist', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(queries.queryLocations).mockResolvedValue([])
 
-      const response = await callTool(app, token, sessionId, 'query_locations', {
+      const response = await callTool(app, token, 'query_locations', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
       })
@@ -1038,34 +839,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: get_stored_detected_locations', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -1082,7 +865,6 @@ describe('MCP Server', () => {
     test('returns stored detected locations with addresses', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(db.getDetectedLocations).mockResolvedValue([
         {
@@ -1115,7 +897,7 @@ describe('MCP Server', () => {
         },
       ])
 
-      const response = await callTool(app, token, sessionId, 'get_stored_detected_locations', {})
+      const response = await callTool(app, token, 'get_stored_detected_locations', {})
 
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
@@ -1129,11 +911,10 @@ describe('MCP Server', () => {
     test('returns empty array when no stored locations exist', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(db.getDetectedLocations).mockResolvedValue([])
 
-      const response = await callTool(app, token, sessionId, 'get_stored_detected_locations', {})
+      const response = await callTool(app, token, 'get_stored_detected_locations', {})
 
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
@@ -1142,34 +923,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: add_activity', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -1186,7 +949,6 @@ describe('MCP Server', () => {
     test('creates exercise activity with exercise_type name', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.addActivity).mockResolvedValue({
         activity_type: 'exercise',
@@ -1197,7 +959,7 @@ describe('MCP Server', () => {
         title: 'Upper body',
       })
 
-      const response = await callTool(app, token, sessionId, 'add_activity', {
+      const response = await callTool(app, token, 'add_activity', {
         activity_type: 'exercise',
         end_time: '2024-03-15T11:45:00Z',
         exercise_type: 'weightlifting',
@@ -1224,7 +986,6 @@ describe('MCP Server', () => {
     test('creates activity without exercise_type', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.addActivity).mockResolvedValue({
         activity_type: 'meditation',
@@ -1235,7 +996,7 @@ describe('MCP Server', () => {
         title: 'Morning meditation',
       })
 
-      const response = await callTool(app, token, sessionId, 'add_activity', {
+      const response = await callTool(app, token, 'add_activity', {
         activity_type: 'meditation',
         end_time: '2024-03-15T07:30:00Z',
         start_time: '2024-03-15T07:00:00Z',
@@ -1257,13 +1018,11 @@ describe('MCP Server', () => {
     test('returns error for invalid exercise_type name', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
@@ -1286,7 +1045,6 @@ describe('MCP Server', () => {
     test('returns error when end_time is before start_time', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.addActivity).mockResolvedValue({
         error: 'end_time must be after start_time',
@@ -1295,9 +1053,8 @@ describe('MCP Server', () => {
 
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
@@ -1317,34 +1074,16 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: update_activity', () => {
-    async function initializeSession(app: express.Express, token: string) {
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-      return response.headers['mcp-session-id'] as string
-    }
-
     async function callTool(
       app: express.Express,
       token: string,
-      sessionId: string,
       toolName: string,
       args: Record<string, unknown>,
     ) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: { arguments: args, name: toolName },
@@ -1363,7 +1102,6 @@ describe('MCP Server', () => {
     test('updates activity with exercise_type', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.updateActivity).mockResolvedValue({
         activity_type: 'exercise',
@@ -1374,7 +1112,7 @@ describe('MCP Server', () => {
         title: 'Workout',
       })
 
-      const response = await callTool(app, token, sessionId, 'update_activity', {
+      const response = await callTool(app, token, 'update_activity', {
         exercise_type: 'weightlifting',
         id: testActivityId,
         title: 'Workout',
@@ -1397,7 +1135,6 @@ describe('MCP Server', () => {
     test('updates activity without exercise_type', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.updateActivity).mockResolvedValue({
         activity_type: 'exercise',
@@ -1408,7 +1145,7 @@ describe('MCP Server', () => {
         success: true,
       })
 
-      const response = await callTool(app, token, sessionId, 'update_activity', {
+      const response = await callTool(app, token, 'update_activity', {
         id: testActivityId,
         notes: 'Great session',
       })
@@ -1427,13 +1164,11 @@ describe('MCP Server', () => {
     test('returns error for invalid exercise_type', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
@@ -1454,7 +1189,6 @@ describe('MCP Server', () => {
     test('passes time updates as Date objects', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.updateActivity).mockResolvedValue({
         activity_type: 'exercise',
@@ -1464,7 +1198,7 @@ describe('MCP Server', () => {
         success: true,
       })
 
-      await callTool(app, token, sessionId, 'update_activity', {
+      await callTool(app, token, 'update_activity', {
         end_time: '2024-03-15T12:00:00Z',
         id: testActivityId,
         start_time: '2024-03-15T09:00:00Z',
@@ -1482,7 +1216,6 @@ describe('MCP Server', () => {
     test('returns error from service on failure', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
-      const sessionId = await initializeSession(app, token)
 
       vi.mocked(mutations.updateActivity).mockResolvedValue({
         error: 'Activity not found',
@@ -1492,9 +1225,8 @@ describe('MCP Server', () => {
 
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
         .send({
-          id: 2,
+          id: 1,
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
@@ -1509,180 +1241,6 @@ describe('MCP Server', () => {
       expect(response.status).toBe(200)
       const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
       expect(parsed.result.content[0].text).toContain('Activity not found')
-    })
-  })
-
-  describe('Session Persistence', () => {
-    function createTestAppWithStore(sessionStore: McpSessionStore) {
-      const app = express()
-      app.use('/mcp', createMcpRouter(auth, undefined, undefined, { sessionStore }))
-      return app
-    }
-
-    test('session can be restored after simulated restart', async () => {
-      const sessionStore = createInMemorySessionStore()
-      const app1 = createTestAppWithStore(sessionStore)
-      const token = auth.createToken('testuser')
-
-      // Create session on first "instance"
-      const initResponse = await mcpPost(app1)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-
-      expect(initResponse.status).toBe(200)
-      const sessionId = initResponse.headers['mcp-session-id'] as string
-      expect(sessionId).toBeDefined()
-
-      // Simulate restart by creating a new app instance (fresh in-memory sessions)
-      // but using the same session store
-      const app2 = createTestAppWithStore(sessionStore)
-
-      // Use the same session ID - it should be restored from store
-      // Note: The McpServer instance is recreated, so we need to re-initialize
-      // but the session ID is preserved (the key benefit of persistence)
-      const response = await mcpPost(app2)
-        .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
-        .send({
-          id: 2,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-
-      expect(response.status).toBe(200)
-      // The session ID should be preserved (same as before)
-      expect(response.headers['mcp-session-id']).toBe(sessionId)
-    })
-
-    test('session store saves new sessions', async () => {
-      const sessionStore = createInMemorySessionStore()
-      const app = createTestAppWithStore(sessionStore)
-      const token = auth.createToken('testuser')
-
-      const initResponse = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-
-      expect(initResponse.status).toBe(200)
-      const sessionId = initResponse.headers['mcp-session-id'] as string
-
-      // Verify session was saved to store
-      const record = await sessionStore.get('testuser', sessionId)
-      expect(record).not.toBeNull()
-      expect(record!.username).toBe('testuser')
-      expect(record!.session_id).toBe(sessionId)
-    })
-
-    test('session is deleted from store on DELETE', async () => {
-      const sessionStore = createInMemorySessionStore()
-      const app = createTestAppWithStore(sessionStore)
-      const token = auth.createToken('testuser')
-
-      // Create session
-      const initResponse = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-
-      const sessionId = initResponse.headers['mcp-session-id'] as string
-
-      // Delete session
-      await mcpDelete(app).set('Authorization', `Bearer ${token}`).set('Mcp-Session-Id', sessionId)
-
-      // Verify session was removed from store
-      const record = await sessionStore.get('testuser', sessionId)
-      expect(record).toBeNull()
-    })
-
-    test('expired sessions are not restored', async () => {
-      vi.useFakeTimers()
-      const sessionStore = createInMemorySessionStore()
-
-      // Create session at "time zero"
-      const day1 = new Date('2024-01-01T10:00:00Z')
-      vi.setSystemTime(day1)
-
-      const app1 = createTestAppWithStore(sessionStore)
-      const token = auth.createToken('testuser')
-
-      const initResponse = await mcpPost(app1)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-
-      expect(initResponse.status).toBe(200)
-      const sessionId = initResponse.headers['mcp-session-id'] as string
-
-      // Jump forward 8 days (past the 7-day expiry)
-      const day9 = new Date('2024-01-09T10:00:00Z')
-      vi.setSystemTime(day9)
-
-      // Simulate restart with fresh app
-      const app2 = createTestAppWithStore(sessionStore)
-
-      // Try to use the old session - should fail because it's expired
-      // Since the session can't be restored, the system will create a new one
-      // So the response will succeed but with a DIFFERENT session ID
-      const response = await mcpPost(app2)
-        .set('Authorization', `Bearer ${token}`)
-        .set('Mcp-Session-Id', sessionId)
-        .send({
-          id: 2,
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            capabilities: {},
-            clientInfo: { name: 'test-client', version: '1.0.0' },
-            protocolVersion: '2024-11-05',
-          },
-        })
-
-      expect(response.status).toBe(200)
-      // A new session should have been created
-      const newSessionId = response.headers['mcp-session-id'] as string
-      expect(newSessionId).toBeDefined()
-      expect(newSessionId).not.toBe(sessionId)
-
-      vi.useRealTimers()
     })
   })
 })

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -1,14 +1,16 @@
 /**
- * MCP server router with session management.
+ * Stateless MCP server router.
+ *
+ * Each request creates a fresh McpServer + transport pair. No session tracking
+ * is needed since the server only exposes tools (no resources, subscriptions,
+ * or server-initiated notifications).
  *
  * Tool registrations are split into focused modules under mcp/.
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { randomUUID } from 'crypto'
 import { Request, Response, Router } from 'express'
 import { Auth } from './auth'
-import { DEFAULT_SESSION_INACTIVITY_MS, McpSessionStore } from './mcp-session-store'
 import { registerActivityTools } from './mcp/activity-tools'
 import { registerCorrelationTools } from './mcp/correlation-tools'
 import { registerLastFmTools } from './mcp/lastfm-tools'
@@ -27,31 +29,42 @@ import { registerTrendTools } from './mcp/trend-tools'
 import { ouraClient } from './oura'
 import { SyncProvider } from './services/queries'
 
-interface McpSession {
-  transport: StreamableHTTPServerTransport
-  server: McpServer
-  user: string
-}
-
 type OuraClientType = ReturnType<typeof ouraClient>
 
+const createMcpServer = (user: string, oura?: OuraClientType, sync?: SyncProvider): McpServer => {
+  const server = new McpServer({
+    name: 'aurboda',
+    version: '1.0.0',
+  })
+
+  registerQueryTools(server, user, sync)
+  registerTagTools(server, user)
+  registerMetricTools(server, user)
+  registerActivityTools(server, user)
+  registerSyncTools(server, user, oura)
+  registerLastFmTools(server, user)
+  registerSettingsTools(server, user)
+  registerLocationTools(server, user)
+  registerCorrelationTools(server, user, sync)
+  registerTrainingLoadTools(server, user)
+  registerTrendTools(server, user)
+  registerNoteTools(server, user)
+  registerMealTools(server, user)
+  registerReportTools(server, user)
+  registerScreentimeCategoryTools(server, user)
+
+  return server
+}
+
 /**
- * Create an MCP router with optional session persistence.
+ * Create a stateless MCP router.
  *
- * When a sessionStore is provided, sessions are persisted to the database
- * and can survive backend restarts. When a client reconnects with a
- * previously-issued session ID, the session is lazily restored.
+ * Each POST request creates a fresh McpServer and transport. No session
+ * persistence or tracking is needed — the server only exposes tools with
+ * no server-initiated notifications.
  */
-export function createMcpRouter(
-  auth: Auth,
-  oura?: OuraClientType,
-  sync?: SyncProvider,
-  options?: { sessionStore?: McpSessionStore; cleanupIntervalMs?: number },
-): Router {
+export function createMcpRouter(auth: Auth, oura?: OuraClientType, sync?: SyncProvider): Router {
   const router = Router()
-  const sessions = new Map<string, McpSession>()
-  const sessionStore = options?.sessionStore
-  const cleanupIntervalMs = options?.cleanupIntervalMs ?? 60 * 60 * 1000 // Default: 1 hour
 
   const getAuthenticatedUser = (req: Request): string | null => {
     const authHeader = req.headers.authorization
@@ -66,106 +79,7 @@ export function createMcpRouter(
     }
   }
 
-  const createMcpServer = (user: string): McpServer => {
-    const server = new McpServer({
-      name: 'aurboda',
-      version: '1.0.0',
-    })
-
-    registerQueryTools(server, user, sync)
-    registerTagTools(server, user)
-    registerMetricTools(server, user)
-    registerActivityTools(server, user)
-    registerSyncTools(server, user, oura)
-    registerLastFmTools(server, user)
-    registerSettingsTools(server, user)
-    registerLocationTools(server, user)
-    registerCorrelationTools(server, user, sync)
-    registerTrainingLoadTools(server, user)
-    registerTrendTools(server, user)
-    registerNoteTools(server, user)
-    registerMealTools(server, user)
-    registerReportTools(server, user)
-    registerScreentimeCategoryTools(server, user)
-
-    return server
-  }
-
-  // Helper to restore a session from the store (lazy restoration after restart)
-  const restoreSessionFromStore = async (user: string, sessionId: string): Promise<McpSession | null> => {
-    if (!sessionStore) {
-      console.log('[MCP] restoreSessionFromStore: no sessionStore configured')
-      return null
-    }
-
-    console.log(`[MCP] restoreSessionFromStore: attempting to restore session ${sessionId} for user ${user}`)
-    const record = await sessionStore.get(user, sessionId)
-    if (!record) {
-      console.log(`[MCP] restoreSessionFromStore: session ${sessionId} not found in store`)
-      return null
-    }
-    if (record.username !== user) {
-      console.log(
-        `[MCP] restoreSessionFromStore: session ${sessionId} belongs to ${record.username}, not ${user}`,
-      )
-      return null
-    }
-
-    // Check if session is expired (older than 7 days by default)
-    const maxAge = DEFAULT_SESSION_INACTIVITY_MS
-    const age = Date.now() - record.last_activity.getTime()
-    console.log(
-      `[MCP] restoreSessionFromStore: session ${sessionId} age=${age}ms, maxAge=${maxAge}ms, lastActivity=${record.last_activity.toISOString()}`,
-    )
-    if (age > maxAge) {
-      // Session expired - clean it up
-      console.log(`[MCP] restoreSessionFromStore: session ${sessionId} expired, deleting`)
-      await sessionStore.delete(user, sessionId)
-      return null
-    }
-
-    // Recreate the McpServer and transport
-    console.log(`[MCP] restoreSessionFromStore: recreating McpServer for session ${sessionId}`)
-    const server = createMcpServer(user)
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => sessionId,
-    })
-
-    await server.connect(transport)
-
-    const session: McpSession = { server, transport, user }
-    sessions.set(sessionId, session)
-
-    console.log(`[MCP] restoreSessionFromStore: session ${sessionId} restored successfully`)
-    return session
-  }
-
-  // Periodic cleanup of in-memory sessions that have no recent activity
-  // This runs on an interval to free memory from abandoned sessions
-  let cleanupTimer: ReturnType<typeof setInterval> | undefined
-  if (sessionStore) {
-    cleanupTimer = setInterval(async () => {
-      const now = Date.now()
-      for (const [sessionId, session] of sessions) {
-        // Check store for last activity
-        const record = await sessionStore.get(session.user, sessionId)
-        if (!record || now - record.last_activity.getTime() > DEFAULT_SESSION_INACTIVITY_MS) {
-          // Close and remove stale session
-          await session.server.close()
-          sessions.delete(sessionId)
-          if (record) {
-            await sessionStore.delete(session.user, sessionId)
-          }
-        }
-      }
-    }, cleanupIntervalMs)
-
-    // Don't let the timer prevent process exit
-    cleanupTimer.unref()
-  }
-
-  // POST /mcp - Handle JSON-RPC requests
-  // eslint-disable-next-line complexity -- TODO: refactor
+  // POST /mcp - Handle JSON-RPC requests (stateless: fresh server per request)
   router.post('/', async (req: Request, res: Response) => {
     const user = getAuthenticatedUser(req)
     if (!user) {
@@ -173,153 +87,24 @@ export function createMcpRouter(
       return
     }
 
-    const sessionId = req.headers['mcp-session-id'] as string | undefined
-    console.log(
-      `[MCP] POST request: user=${user}, sessionId=${sessionId ?? 'none'}, hasStore=${!!sessionStore}`,
-    )
+    const server = createMcpServer(user, oura, sync)
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    })
 
-    let session: McpSession | undefined
-
-    if (sessionId && sessions.has(sessionId)) {
-      // Session is in memory
-      console.log(`[MCP] POST: session ${sessionId} found in memory`)
-      session = sessions.get(sessionId)!
-      if (session.user !== user) {
-        res.status(403).json({ error: 'Session belongs to different user' })
-        return
-      }
-    } else if (sessionId && sessionStore) {
-      // Session not in memory - try to restore from store
-      console.log(`[MCP] POST: session ${sessionId} not in memory, attempting restore from store`)
-      try {
-        const restored = await restoreSessionFromStore(user, sessionId)
-        if (restored) {
-          session = restored
-        }
-      } catch (err) {
-        console.error(`[MCP] POST: error restoring session ${sessionId}:`, err)
-        // Continue to create new session
-      }
-    }
-
-    if (!session) {
-      // Create new session - generate ID first so transport and our map use the same one
-      const newSessionId = randomUUID()
-      console.log(`[MCP] POST: creating new session ${newSessionId} for user ${user}`)
-      const server = createMcpServer(user)
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => newSessionId,
-      })
-
-      await server.connect(transport)
-
-      session = { server, transport, user }
-      sessions.set(newSessionId, session)
-
-      // Persist to store if available
-      if (sessionStore) {
-        console.log(`[MCP] POST: saving new session ${newSessionId} to store`)
-        try {
-          await sessionStore.save(user, newSessionId)
-        } catch (err) {
-          console.error(`[MCP] POST: error saving session ${newSessionId}:`, err)
-          // Continue without persistence
-        }
-      }
-    }
-
-    await session.transport.handleRequest(req, res)
-
-    // Update last activity in store
-    if (sessionStore && sessionId) {
-      try {
-        await sessionStore.touch(user, sessionId)
-      } catch (err) {
-        console.error(`[MCP] POST: error touching session ${sessionId}:`, err)
-      }
-    }
+    await server.connect(transport)
+    await transport.handleRequest(req, res)
+    await server.close()
   })
 
-  // GET /mcp - SSE stream for server notifications
-  router.get('/', async (req: Request, res: Response) => {
-    const user = getAuthenticatedUser(req)
-    if (!user) {
-      res.status(401).json({ error: 'Unauthorized' })
-      return
-    }
-
-    const sessionId = req.headers['mcp-session-id'] as string | undefined
-
-    if (!sessionId) {
-      res.status(400).json({ error: 'Invalid or missing session ID' })
-      return
-    }
-
-    let session = sessions.get(sessionId)
-
-    // Try to restore from store if not in memory
-    if (!session && sessionStore) {
-      session = (await restoreSessionFromStore(user, sessionId)) ?? undefined
-    }
-
-    if (!session) {
-      res.status(400).json({ error: 'Invalid or missing session ID' })
-      return
-    }
-
-    if (session.user !== user) {
-      res.status(403).json({ error: 'Session belongs to different user' })
-      return
-    }
-
-    await session.transport.handleRequest(req, res)
-
-    // Update last activity in store
-    if (sessionStore) {
-      await sessionStore.touch(user, sessionId)
-    }
+  // GET /mcp - Not used in stateless mode (no SSE notifications)
+  router.get('/', (_req: Request, res: Response) => {
+    res.status(405).json({ error: 'SSE not supported in stateless mode' })
   })
 
-  // DELETE /mcp - End session
-  router.delete('/', async (req: Request, res: Response) => {
-    const user = getAuthenticatedUser(req)
-    if (!user) {
-      res.status(401).json({ error: 'Unauthorized' })
-      return
-    }
-
-    const sessionId = req.headers['mcp-session-id'] as string | undefined
-
-    if (!sessionId) {
-      res.status(400).json({ error: 'Invalid or missing session ID' })
-      return
-    }
-
-    let session = sessions.get(sessionId)
-
-    // Try to restore from store if not in memory (so we can properly close it)
-    if (!session && sessionStore) {
-      session = (await restoreSessionFromStore(user, sessionId)) ?? undefined
-    }
-
-    if (!session) {
-      res.status(400).json({ error: 'Invalid or missing session ID' })
-      return
-    }
-
-    if (session.user !== user) {
-      res.status(403).json({ error: 'Session belongs to different user' })
-      return
-    }
-
-    await session.transport.handleRequest(req, res)
-    await session.server.close()
-    sessions.delete(sessionId)
-
-    // Also delete from store
-    if (sessionStore) {
-      await sessionStore.delete(user, sessionId)
-    }
+  // DELETE /mcp - Not used in stateless mode (no sessions)
+  router.delete('/', (_req: Request, res: Response) => {
+    res.status(405).json({ error: 'No sessions in stateless mode' })
   })
 
   return router


### PR DESCRIPTION
## Summary

- Add `GET /version` endpoint returning `{ build_sha, success }` (unauthenticated) for deploy polling
- Inject git SHA as `BUILD_SHA` into Docker image via build arg in CI workflow
- Switch MCP server to stateless mode (`sessionIdGenerator: undefined`) — each POST creates a fresh McpServer+transport pair, eliminating reconnection issues after deploys
- Remove session persistence code (DB session store, session map, cleanup timer, session restoration)
- Update all MCP tests: remove session ID handling, remove Session Persistence test suite, rewrite integration tests for stateless mode

## Why

After a deploy, MCP clients had to reconnect because sessions were invalidated. The session persistence via DB was ineffective (new `McpServer` always has `_initialized = false`). Since the MCP server only exposes tools (no resources, subscriptions, or server-initiated notifications), sessions are unnecessary. Stateless mode makes deploys seamless.

The `/version` endpoint lets an agent poll to detect when a new Docker image has been deployed by Watchtower.

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add `ARG BUILD_SHA=unknown` and `ENV BUILD_SHA` |
| `.github/workflows/docker.yml` | Pass `BUILD_SHA=${{ github.sha }}` as build arg |
| `apps/backend/src/api.ts` | Add `GET /version` route, remove DB session store import, simplify MCP mount |
| `apps/backend/src/mcp.ts` | Complete rewrite: stateless per-request servers, no session tracking |
| `apps/backend/src/mcp.test.ts` | Remove session handling from all tests (-580 lines of session boilerplate) |
| `apps/backend/src/mcp.integration.test.ts` | Rewrite for stateless mode (verify tool calls work without initialize) |

## Testing

- All 33 MCP unit tests pass
- 3 MCP integration tests pass (stateless tool calls, request independence, user isolation)
- `pnpm check` passes (types + lint)