### PR TITLE
feat: auto-bootstrap training load and show by default

### DIFF
--- a/apps/backend/src/services/training-load.ts
+++ b/apps/backend/src/services/training-load.ts
@@ -677,13 +677,6 @@ export const computeTrainingLoad = async (
   const hrMax = resolveHrMax(settings.hr_max, maxObservedHr, userSettings.birth_date)
   const hrRest = resolveHrRest(settings.hr_rest, latestRestingHr)
 
-  // Check watermark — if dirty, recompute before querying
-  const watermark = userSettings.training_load?.impulse_watermark
-  if (watermark) {
-    const fromHour = floorToHour(new Date(watermark))
-    await recomputeImpulseBuckets(deps, user, fromHour)
-  }
-
   // Extended range for EMA bootstrapping (3 × tau_chronic in hours)
   const lookbackHours = Math.ceil(settings.tau_chronic * 3 * HOURS_PER_DAY)
   const extendedStart = new Date(start.getTime() - lookbackHours * MS_PER_HOUR)
@@ -692,11 +685,28 @@ export const computeTrainingLoad = async (
   const currentHour = getCurrentHourStart()
   const effectiveEnd = end > currentHour ? currentHour : floorToHour(end)
 
+  // Check watermark — if dirty, recompute before querying
+  const watermark = userSettings.training_load?.impulse_watermark
+  if (watermark) {
+    const fromHour = floorToHour(new Date(watermark))
+    await recomputeImpulseBuckets(deps, user, fromHour)
+  }
+
   // Fetch pre-computed impulse buckets for the extended range
-  const [trainingBuckets, activityBuckets] = await Promise.all([
+  let [trainingBuckets, activityBuckets] = await Promise.all([
     deps.getImpulseBuckets(user, 'training_impulse', extendedStartHour, effectiveEnd),
     deps.getImpulseBuckets(user, 'activity_impulse', extendedStartHour, effectiveEnd),
   ])
+
+  // Auto-bootstrap: if no watermark was set and no impulse buckets exist,
+  // trigger a full recompute from the extended start range
+  if (!watermark && trainingBuckets.length === 0 && activityBuckets.length === 0) {
+    await recomputeImpulseBuckets(deps, user, extendedStartHour)
+    ;[trainingBuckets, activityBuckets] = await Promise.all([
+      deps.getImpulseBuckets(user, 'training_impulse', extendedStartHour, effectiveEnd),
+      deps.getImpulseBuckets(user, 'activity_impulse', extendedStartHour, effectiveEnd),
+    ])
+  }
 
   // Build maps from stored buckets
   const trainingImpulses = new Map<string, number>()

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -828,7 +828,7 @@ export const Timeline = () => {
   const [showMetricsHRV, setShowMetricsHRV] = useState(true)
   const [showMetricsSteps, setShowMetricsSteps] = useState(true)
   const [showMetricsCalories, setShowMetricsCalories] = useState(true)
-  const [showTrainingLoad, setShowTrainingLoad] = useState(false)
+  const [showTrainingLoad, setShowTrainingLoad] = useState(true)
 
   // Training load data (fetched when toggle is on, uses daily granularity)
   const trainingLoadQuery = useQuery({


### PR DESCRIPTION
## Summary

- **Auto-bootstrap impulse buckets**: When `computeTrainingLoad` finds no stored impulse buckets and no watermark, it automatically triggers a full `recomputeImpulseBuckets` from the extended lookback range. The first query self-bootstraps without needing a manual backfill endpoint.
- **Training load on by default**: Set `showTrainingLoad` initial state to `true` in the Timeline.

Follow-up to #328.