### PR TITLE
fix: snap crosshair to exact hovered hour in training load chart

### DIFF
--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -453,10 +453,20 @@ const drawCrosshairOverlay = (
       const [mx] = d3.pointer(event)
       const hoverTime = xScale.invert(mx!)
 
-      // Find nearest hourly point
+      // Snap to the hour that contains the hover time (floor to hour)
+      const hoveredHourMs = hoverTime.getTime()
+      const flooredHour = new Date(hoveredHourMs - (hoveredHourMs % MS_PER_HOUR))
+      const flooredIso = flooredHour.toISOString()
+
+      // Find exact match for the floored hour, fall back to nearest
       let nearest: TrainingLoadPoint | null = null
       let bestDist = Infinity
       for (const p of points) {
+        if (p.time === flooredIso) {
+          nearest = p
+          bestDist = 0
+          break
+        }
         const dist = Math.abs(hoverTime.getTime() - parseTime(p.time).getTime())
         if (dist < bestDist) {
           bestDist = dist


### PR DESCRIPTION
## Summary

- Crosshair now floors hover time to hour start (1:30 → 1:00) instead of rounding to nearest point
- Ensures impulse spikes at any hour are visible in the tooltip
- Previously could skip odd hours, making it impossible to inspect data at those times

Follow-up to #330.