### PR TITLE
fix: merge training load and metrics into a single combined tooltip

### DIFF
--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -5,9 +5,20 @@
  * - Steps and calories as bar charts behind the lines
  * - Crosshair tooltip on mouseover showing all metric values at that time
  */
+import type { RecoveryZones, TrainingLoadPoint, WorkoutTrimp } from '@aurboda/api-spec'
 import * as d3 from 'd3'
 import { format } from 'date-fns'
 import { type MetricBucketParsed, aggregateBuckets } from '../../utils/chart'
+import {
+  ACTIVITY_IMPULSE_COLOR,
+  ATL_COLOR,
+  CTL_COLOR,
+  findNearbyWorkouts,
+  findTrainingLoadPoint,
+  TRAINING_IMPULSE_COLOR,
+  TSB_FATIGUED_COLOR,
+  TSB_FRESH_COLOR,
+} from './drawTrainingLoadTrack'
 
 // ── Colors ────────────────────────────────────────────────────────────────────
 
@@ -48,6 +59,12 @@ export interface MetricsTrackConfig {
   /** Tooltip callback — receives HTML content and mouse event. */
   showTooltipHtml: (event: MouseEvent, html: string) => void
   hideTooltip: () => void
+  /** Optional: training load points for combined tooltip. */
+  trainingLoadPoints?: TrainingLoadPoint[]
+  /** Optional: per-workout TRIMP scores for combined tooltip. */
+  trainingLoadWorkouts?: WorkoutTrimp[]
+  /** Optional: recovery zone thresholds for combined tooltip. */
+  trainingLoadZones?: RecoveryZones
 }
 
 // ── Bucket aggregation by zoom ────────────────────────────────────────────────
@@ -179,12 +196,62 @@ const drawBarChart = (
 
 const formatTime = (date: Date): string => format(date, 'HH:mm')
 
+/** Build training load section for the combined tooltip. */
+const buildTrainingLoadSection = (
+  bucketMid: Date,
+  points: TrainingLoadPoint[],
+  workouts?: WorkoutTrimp[],
+  zones?: RecoveryZones,
+): string => {
+  const point = findTrainingLoadPoint(points, bucketMid)
+  if (!point) return ''
+
+  let html = `<div class="tooltip-separator" style="border-top:1px solid rgba(128,128,128,0.3);margin:4px 0"></div>`
+  html += `<div class="tooltip-detail" style="color:${CTL_COLOR}">Fitness (CTL): ${point.ctl.toFixed(1)}</div>`
+  html += `<div class="tooltip-detail" style="color:${ATL_COLOR}">Fatigue (ATL): ${point.atl.toFixed(1)}</div>`
+
+  const tsbColor = point.tsb >= 0 ? TSB_FRESH_COLOR : TSB_FATIGUED_COLOR
+  const tsbLabel = point.tsb >= 0 ? 'Fresh' : 'Fatigued'
+  html += `<div class="tooltip-detail" style="color:${tsbColor}">Form (TSB): ${point.tsb >= 0 ? '+' : ''}${point.tsb.toFixed(1)} — ${tsbLabel}</div>`
+
+  if (point.training_impulse > 0) {
+    html += `<div class="tooltip-detail" style="color:${TRAINING_IMPULSE_COLOR}">Training: ${point.training_impulse.toFixed(1)}</div>`
+  }
+  if (point.activity_impulse > 0) {
+    html += `<div class="tooltip-detail" style="color:${ACTIVITY_IMPULSE_COLOR}">Activity: ${point.activity_impulse.toFixed(1)}</div>`
+  }
+
+  if (zones) {
+    let zoneName: string
+    if (point.atl < zones.balanced_min) zoneName = 'Undertrained'
+    else if (point.atl <= zones.balanced_max) zoneName = 'Balanced'
+    else if (point.atl <= zones.strained_max) zoneName = 'Strained'
+    else zoneName = 'Very Strained'
+    html += `<div class="tooltip-detail" style="opacity:0.7">Zone: ${zoneName}</div>`
+  }
+
+  if (workouts) {
+    const hourTime = new Date(point.time)
+    const nearbyWorkouts = findNearbyWorkouts(workouts, hourTime)
+    for (const w of nearbyWorkouts) {
+      const title = w.title ?? 'Workout'
+      const hrStr = w.avg_hr ? ` (${Math.round(w.avg_hr)} bpm avg)` : ''
+      html += `<div class="tooltip-detail" style="opacity:0.7">${title}: ${w.duration_minutes.toFixed(0)}min, TRIMP ${w.trimp.toFixed(0)}${hrStr}</div>`
+    }
+  }
+
+  return html
+}
+
 const buildMetricsTooltipHtml = (
   bucket: MetricBucketParsed,
   showHR: boolean,
   showHRV: boolean,
   showSteps: boolean,
   showCalories: boolean,
+  trainingLoadPoints?: TrainingLoadPoint[],
+  trainingLoadWorkouts?: WorkoutTrimp[],
+  trainingLoadZones?: RecoveryZones,
 ): string => {
   const startStr = formatTime(bucket.start)
   const endStr = formatTime(bucket.end)
@@ -218,6 +285,12 @@ const buildMetricsTooltipHtml = (
       const perMin = bucketMinutes > 0 ? cal.avg / bucketMinutes : 0
       html += `<div class="tooltip-detail" style="color:${CALORIES_COLOR}">🔥 Calories: ${perMin.toFixed(1)} kcal/min</div>`
     }
+  }
+
+  // Append training load section if available
+  if (trainingLoadPoints && trainingLoadPoints.length > 0) {
+    const bucketMid = new Date((bucket.start.getTime() + bucket.end.getTime()) / 2)
+    html += buildTrainingLoadSection(bucketMid, trainingLoadPoints, trainingLoadWorkouts, trainingLoadZones)
   }
 
   return html
@@ -300,6 +373,9 @@ const drawCrosshairOverlay = (
   showCalories: boolean,
   showTooltipHtml: (event: MouseEvent, html: string) => void,
   hideTooltip: () => void,
+  trainingLoadPoints?: TrainingLoadPoint[],
+  trainingLoadWorkouts?: WorkoutTrimp[],
+  trainingLoadZones?: RecoveryZones,
 ): void => {
   outerG.selectAll('.metrics-crosshair').remove()
 
@@ -354,7 +430,16 @@ const drawCrosshairOverlay = (
       }
 
       hairline.attr('x1', mx!).attr('x2', mx!).style('display', null)
-      const html = buildMetricsTooltipHtml(nearest, showHR, showHRV, showSteps, showCalories)
+      const html = buildMetricsTooltipHtml(
+        nearest,
+        showHR,
+        showHRV,
+        showSteps,
+        showCalories,
+        trainingLoadPoints,
+        trainingLoadWorkouts,
+        trainingLoadZones,
+      )
       showTooltipHtml(event, html)
     })
     .on('mouseleave', () => {
@@ -390,8 +475,10 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     hideTooltip,
   } = config
 
-  if (rawBuckets.length === 0) return
-  if (!showHR && !showHRV && !showSteps && !showCalories) return
+  const hasMetrics = showHR || showHRV || showSteps || showCalories
+  const hasTrainingLoad = config.trainingLoadPoints && config.trainingLoadPoints.length > 0
+  if (rawBuckets.length === 0 && !hasTrainingLoad) return
+  if (!hasMetrics && !hasTrainingLoad) return
 
   const factor = getAggregationFactor(pixelsPerHour)
   const buckets = aggregateBuckets(rawBuckets, factor)
@@ -417,7 +504,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     if (hrvBand.length > 1) drawBandChart(chartGroup, hrvBand, xScale, yHrv, HRV_COLOR)
   }
 
-  // Crosshair tooltip overlay
+  // Crosshair tooltip overlay (includes training load data in combined tooltip)
   drawCrosshairOverlay(
     outerG,
     xScale,
@@ -431,5 +518,8 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     showCalories,
     showTooltipHtml,
     hideTooltip,
+    config.trainingLoadPoints,
+    config.trainingLoadWorkouts,
+    config.trainingLoadZones,
   )
 }

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- D3 visualization with multiple drawing functions */
 /**
  * Draws the training load track in horizontal timeline mode.
  *
@@ -42,8 +41,6 @@ type SvgGroup = d3.Selection<any, unknown, null, undefined>
 export interface TrainingLoadTrackConfig {
   /** The SVG group to draw into (already clipped). */
   chartGroup: SvgGroup
-  /** The outer (static) group for crosshair overlay. */
-  outerG: SvgGroup
   /** Current x-scale (time -> pixels). */
   xScale: d3.ScaleTime<number, number>
   /** Hourly training load points. */
@@ -58,11 +55,6 @@ export interface TrainingLoadTrackConfig {
   trackY: number
   /** Height of the track in pixels. */
   trackHeight: number
-  /** Chart width in pixels. */
-  chartWidth: number
-  /** Tooltip callback. */
-  showTooltipHtml: (event: MouseEvent, html: string) => void
-  hideTooltip: () => void
 }
 
 // ── Y-scale computation ───────────────────────────────────────────────────────
@@ -122,9 +114,49 @@ const computeYScales = (
 
 // ── Drawing ───────────────────────────────────────────────────────────────────
 
-const MS_PER_HOUR = 3600_000
+export const MS_PER_HOUR = 3600_000
 
 const parseTime = (timeStr: string): Date => new Date(timeStr)
+
+/**
+ * Find the training load point whose hour contains the given time.
+ * Floors the time to the hour, then looks for an exact match or nearest within 2 hours.
+ */
+export const findTrainingLoadPoint = (points: TrainingLoadPoint[], time: Date): TrainingLoadPoint | null => {
+  const timeMs = time.getTime()
+  const flooredHour = new Date(timeMs - (timeMs % MS_PER_HOUR))
+  const flooredIso = flooredHour.toISOString()
+
+  // Exact match first
+  for (const p of points) {
+    if (p.time === flooredIso) return p
+  }
+
+  // Fall back to nearest within 2 hours
+  let nearest: TrainingLoadPoint | null = null
+  let bestDist = Infinity
+  for (const p of points) {
+    const dist = Math.abs(timeMs - parseTime(p.time).getTime())
+    if (dist < bestDist) {
+      bestDist = dist
+      nearest = p
+    }
+  }
+
+  return nearest && bestDist <= 2 * MS_PER_HOUR ? nearest : null
+}
+
+/**
+ * Find workouts that overlap with a given hour.
+ */
+export const findNearbyWorkouts = (workouts: WorkoutTrimp[], hourTime: Date): WorkoutTrimp[] => {
+  const hourMs = hourTime.getTime()
+  return workouts.filter((w) => {
+    const wStart = new Date(w.start_time).getTime()
+    const wEnd = new Date(w.end_time).getTime()
+    return wStart <= hourMs + MS_PER_HOUR && wEnd >= hourMs
+  })
+}
 
 /** Draw recovery zone bands (horizontal stripes). */
 const drawZoneBands = (
@@ -439,7 +471,7 @@ const drawTsbLine = (
 
 // ── Tooltip ───────────────────────────────────────────────────────────────────
 
-const buildTrainingLoadTooltipHtml = (
+export const buildTrainingLoadTooltipHtml = (
   point: TrainingLoadPoint,
   workoutsNearby: WorkoutTrimp[],
   zones?: RecoveryZones,
@@ -480,94 +512,6 @@ const buildTrainingLoadTooltipHtml = (
   }
 
   return html
-}
-
-// ── Crosshair overlay ─────────────────────────────────────────────────────────
-
-const drawCrosshairOverlay = (
-  outerG: SvgGroup,
-  xScale: d3.ScaleTime<number, number>,
-  points: TrainingLoadPoint[],
-  workouts: WorkoutTrimp[],
-  zones: RecoveryZones | undefined,
-  trackY: number,
-  trackHeight: number,
-  chartWidth: number,
-  showTooltipHtml: (event: MouseEvent, html: string) => void,
-  hideTooltip: () => void,
-): void => {
-  outerG.selectAll('.training-load-crosshair').remove()
-
-  const crosshairGroup = outerG.append('g').attr('class', 'training-load-crosshair')
-  const trackBottom = trackY + trackHeight
-
-  const hairline = crosshairGroup
-    .append('line')
-    .attr('y1', trackY)
-    .attr('y2', trackBottom)
-    .attr('stroke', 'currentColor')
-    .attr('stroke-opacity', 0.4)
-    .attr('stroke-width', 0.75)
-    .attr('stroke-dasharray', '3,2')
-    .attr('pointer-events', 'none')
-    .style('display', 'none')
-
-  crosshairGroup
-    .append('rect')
-    .attr('x', 0)
-    .attr('y', trackY)
-    .attr('width', chartWidth)
-    .attr('height', trackHeight)
-    .attr('fill', 'transparent')
-    .attr('cursor', 'crosshair')
-    .on('mousemove', (event: MouseEvent) => {
-      const [mx] = d3.pointer(event)
-      const hoverTime = xScale.invert(mx!)
-
-      // Snap to the hour that contains the hover time (floor to hour)
-      const hoveredHourMs = hoverTime.getTime()
-      const flooredHour = new Date(hoveredHourMs - (hoveredHourMs % MS_PER_HOUR))
-      const flooredIso = flooredHour.toISOString()
-
-      // Find exact match for the floored hour, fall back to nearest
-      let nearest: TrainingLoadPoint | null = null
-      let bestDist = Infinity
-      for (const p of points) {
-        if (p.time === flooredIso) {
-          nearest = p
-          bestDist = 0
-          break
-        }
-        const dist = Math.abs(hoverTime.getTime() - parseTime(p.time).getTime())
-        if (dist < bestDist) {
-          bestDist = dist
-          nearest = p
-        }
-      }
-
-      if (!nearest || bestDist > 2 * MS_PER_HOUR) {
-        hairline.style('display', 'none')
-        hideTooltip()
-        return
-      }
-
-      hairline.attr('x1', mx!).attr('x2', mx!).style('display', null)
-
-      // Find workouts near this hour (within 1 hour)
-      const nearestTime = parseTime(nearest.time).getTime()
-      const nearbyWorkouts = workouts.filter((w) => {
-        const wStart = new Date(w.start_time).getTime()
-        const wEnd = new Date(w.end_time).getTime()
-        return wStart <= nearestTime + MS_PER_HOUR && wEnd >= nearestTime
-      })
-
-      const html = buildTrainingLoadTooltipHtml(nearest, nearbyWorkouts, zones)
-      showTooltipHtml(event, html)
-    })
-    .on('mouseleave', () => {
-      hairline.style('display', 'none')
-      hideTooltip()
-    })
 }
 
 // ── Downsampling ──────────────────────────────────────────────────────────────
@@ -619,20 +563,7 @@ const downsamplePoints = (
  * TSB line, zone bands, and an interactive crosshair overlay for tooltips.
  */
 export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => {
-  const {
-    chartGroup,
-    outerG,
-    xScale,
-    points,
-    workouts,
-    bootstrapping,
-    zones,
-    trackY,
-    trackHeight,
-    chartWidth,
-    showTooltipHtml,
-    hideTooltip,
-  } = config
+  const { chartGroup, xScale, points, bootstrapping, zones, trackY, trackHeight } = config
 
   if (points.length === 0) return
 
@@ -672,18 +603,4 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
 
   // Draw TSB line on top
   drawTsbLine(chartGroup, displayPoints, xScale, yScales.yTsb)
-
-  // Crosshair tooltip overlay (uses full points for accurate snapping)
-  drawCrosshairOverlay(
-    outerG,
-    xScale,
-    visiblePoints,
-    workouts,
-    zones,
-    trackY,
-    trackHeight,
-    chartWidth,
-    showTooltipHtml,
-    hideTooltip,
-  )
 }

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1591,8 +1591,8 @@ export const Timeline = () => {
         }
       }
 
-      // ── Metrics track (HR/HRV band charts + steps/calories bars) ──
-      if (metricsYScales) {
+      // ── Metrics track (HR/HRV band charts + steps/calories bars + combined tooltip) ──
+      if (metricsYScales || (showTrainingLoad && trainingLoadData)) {
         drawMetricsTrack({
           buckets: metricBuckets,
           chartGroup,
@@ -1620,8 +1620,17 @@ export const Timeline = () => {
           },
           trackHeight: metricsTrackHeight,
           trackY: trackMetrics,
+          ...(metricsYScales ?
+            { yScales: metricsYScales }
+          : { yScales: computeYScales([], trackMetrics, trackMetrics + metricsTrackHeight) }),
           xScale: currentXScale,
-          yScales: metricsYScales,
+          ...(showTrainingLoad && trainingLoadData ?
+            {
+              trainingLoadPoints: trainingLoadData.points,
+              trainingLoadWorkouts: trainingLoadData.workouts,
+              trainingLoadZones: trainingLoadData.zones ?? undefined,
+            }
+          : {}),
         })
       }
 
@@ -1630,24 +1639,7 @@ export const Timeline = () => {
         drawTrainingLoadTrack({
           bootstrapping: trainingLoadData.bootstrapping,
           chartGroup,
-          chartWidth,
-          hideTooltip,
-          outerG,
           points: trainingLoadData.points,
-          showTooltipHtml: (event: MouseEvent, html: string) => {
-            if (!tooltipRef.current || !containerRef.current) return
-            const tip = tooltipRef.current
-            const containerRect = containerRef.current.getBoundingClientRect()
-            tip.innerHTML = html
-            tip.style.display = 'block'
-            const x = event.clientX - containerRect.left + 12
-            const yRaw = event.clientY - containerRect.top - 10
-            const tipH = tip.scrollHeight
-            const yMax = containerRect.height - tipH - 4
-            const y = Math.min(yRaw, Math.max(yMax, 4))
-            tip.style.left = `${Math.min(x, containerRect.width - 320)}px`
-            tip.style.top = `${y}px`
-          },
           trackHeight: metricsTrackHeight,
           trackY: trackMetrics,
           workouts: trainingLoadData.workouts,


### PR DESCRIPTION
## Summary

Fixes the tooltip blocking issue where the training load crosshair overlay (drawn after metrics in SVG) sat on top and captured all mouse events, completely blocking the metrics tooltip (HR, HRV, calories, steps).

- **Removed** the training load crosshair overlay from `drawTrainingLoadTrack.ts` entirely
- **Extended** the metrics crosshair in `drawMetricsTrack.ts` to include training load data (CTL/ATL/TSB/zone/impulses/nearby workouts) in a combined tooltip
- **Refactored** tooltip builder to stay within ESLint complexity limits by extracting `buildTrainingLoadSection` helper
- Training load visuals (fatigue bars, impulse bars, CTL/ATL curves, TSB line, zone bands) are unchanged — only the tooltip overlay was removed

The combined tooltip shows metrics at fine granularity (5m/15m/30m depending on zoom) with training load data from the containing hour, separated by a horizontal line.

Closes the tooltip blocking issue identified in the hourly training load feature (#309).