### PR TITLE
fix: calorie computation bugs affecting training load accuracy

### DIFF
--- a/apps/backend/coverage-baseline.json
+++ b/apps/backend/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "statements": 60.83,
+  "statements": 60.74,
   "branches": 86.63,
-  "functions": 79.19
+  "functions": 78.67
 }

--- a/apps/backend/src/db/cumulative-query.ts
+++ b/apps/backend/src/db/cumulative-query.ts
@@ -1,19 +1,31 @@
 /**
  * Helper for splitting metric queries by cumulative/non-cumulative type.
  *
- * Cumulative metrics (steps, distance, etc.) use only the aggregate source
+ * Cumulative metrics (steps, distance, etc.) use only trusted sources
  * to avoid mixing raw readings with deduplicated daily totals.
+ *
+ * Some cumulative metrics (like calories_active) are "aurboda-only":
+ * when aurboda computes per-minute values, the health_connect_aggregate
+ * daily totals must be excluded to avoid nonsense averages.
  */
-import { cumulativeMetrics, type MetricType } from '@aurboda/api-spec'
+import { aurbodaOnlyMetrics, cumulativeMetrics, type MetricType } from '@aurboda/api-spec'
 import type { QueryResultRow } from 'pg'
 
 /**
- * Split a list of metric names into cumulative and non-cumulative groups.
+ * Split a list of metric names into three groups:
+ * - aurbodaOnly: cumulative metrics that should use only the 'aurboda' source
+ * - cumulative: other cumulative metrics that use standard cumulativeSources
+ * - nonCumulative: metrics that use all sources
  */
 export const splitMetricsByCumulative = (
   metrics: string[],
-): { cumulative: string[]; nonCumulative: string[] } => ({
-  cumulative: metrics.filter((m) => cumulativeMetrics.includes(m as MetricType)),
+): { aurbodaOnly: string[]; cumulative: string[]; nonCumulative: string[] } => ({
+  aurbodaOnly: metrics.filter(
+    (m) => cumulativeMetrics.includes(m as MetricType) && aurbodaOnlyMetrics.includes(m as MetricType),
+  ),
+  cumulative: metrics.filter(
+    (m) => cumulativeMetrics.includes(m as MetricType) && !aurbodaOnlyMetrics.includes(m as MetricType),
+  ),
   nonCumulative: metrics.filter((m) => !cumulativeMetrics.includes(m as MetricType)),
 })
 
@@ -40,9 +52,12 @@ interface SplitQueryOptions<T> {
  * The SQL templates should use $1 for the metrics array, with remaining placeholders
  * for the additional params (e.g. $2 for start, $3 for end). The cumulative SQL can
  * reference additional placeholders for cumulativeExtraParams.
+ *
+ * Aurboda-only metrics reuse the cumulative SQL template but with ['aurboda'] as the
+ * source filter instead of the standard cumulativeSources.
  */
 export const querySplitByCumulative = async <T>(options: SplitQueryOptions<T>): Promise<T[]> => {
-  const { cumulative, nonCumulative } = splitMetricsByCumulative(options.metrics)
+  const { aurbodaOnly, cumulative, nonCumulative } = splitMetricsByCumulative(options.metrics)
   const results: T[] = []
 
   if (cumulative.length > 0) {
@@ -51,6 +66,20 @@ export const querySplitByCumulative = async <T>(options: SplitQueryOptions<T>): 
       cumulative,
       ...options.params,
       ...extraParams,
+    ])
+    results.push(...result.rows.map(options.mapRow))
+  }
+
+  if (aurbodaOnly.length > 0) {
+    // Use the same cumulative SQL template but with 'aurboda' as the only source
+    const extraParams = options.cumulativeExtraParams ?? []
+    // Replace the cumulativeSources param with just ['aurboda']
+    // The cumulativeExtraParams[0] is the sources array, so we override it
+    const aurbodaExtraParams = extraParams.length > 0 ? [['aurboda'], ...extraParams.slice(1)] : [['aurboda']]
+    const result = await options.queryFn(options.sqlCumulative, [
+      aurbodaOnly,
+      ...options.params,
+      ...aurbodaExtraParams,
     ])
     results.push(...result.rows.map(options.mapRow))
   }

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -2,11 +2,24 @@
  * Time series data CRUD, bucketed aggregation, and statistics.
  */
 import format from 'pg-format'
-import { cumulativeMetrics, cumulativeSources, type MetricType, metricUnits } from '../schema'
+import {
+  aurbodaOnlyMetrics,
+  cumulativeMetrics,
+  cumulativeSources,
+  type MetricType,
+  metricUnits,
+} from '../schema'
 import { query } from './connection'
 import { querySplitByCumulative } from './cumulative-query'
 import { parseMetricType } from './row-mappers'
 import type { BucketedMetricData, DailyMetricAggregate, MetricStats, TimeSeriesPoint } from './types'
+
+/** Get the source filter for a single metric: aurboda-only, cumulative sources, or all sources (null). */
+const getSourceFilter = (metric: string): string[] | null => {
+  if (aurbodaOnlyMetrics.includes(metric as MetricType)) return ['aurboda']
+  if (cumulativeMetrics.includes(metric as MetricType)) return cumulativeSources
+  return null
+}
 
 export const insertTimeSeries = async (user: string, points: TimeSeriesPoint[]) => {
   if (points.length === 0) return
@@ -44,13 +57,11 @@ export const getTimeSeries = async (
   start: Date,
   end: Date,
 ): Promise<[Date, number][]> => {
-  // For cumulative metrics (steps, distance, etc.), only use aggregate source
-  // to avoid mixing raw readings with deduplicated daily totals
-  const isCumulative = cumulativeMetrics.includes(metric as MetricType)
+  const sources = getSourceFilter(metric)
 
   const result = await query(
     user,
-    isCumulative ?
+    sources ?
       `SELECT time, value FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
          AND source = ANY($4)
@@ -58,7 +69,7 @@ export const getTimeSeries = async (
     : `SELECT time, value FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
        ORDER BY time`,
-    isCumulative ? [metric, start, end, cumulativeSources] : [metric, start, end],
+    sources ? [metric, start, end, sources] : [metric, start, end],
   )
 
   return result.rows.map((row) => [new Date(row.time), row.value])
@@ -71,11 +82,11 @@ export const getTimeSeriesWithSource = async (
   start: Date,
   end: Date,
 ): Promise<{ time: Date; value: number; source: string }[]> => {
-  const isCumulative = cumulativeMetrics.includes(metric as MetricType)
+  const sources = getSourceFilter(metric)
 
   const result = await query(
     user,
-    isCumulative ?
+    sources ?
       `SELECT time, value, source FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
          AND source = ANY($4)
@@ -83,7 +94,7 @@ export const getTimeSeriesWithSource = async (
     : `SELECT time, value, source FROM time_series
        WHERE metric = $1 AND time >= $2 AND time <= $3
        ORDER BY time`,
-    isCumulative ? [metric, start, end, cumulativeSources] : [metric, start, end],
+    sources ? [metric, start, end, sources] : [metric, start, end],
   )
 
   return result.rows.map((row) => ({ source: row.source, time: new Date(row.time), value: row.value }))
@@ -249,6 +260,24 @@ export const getDailyAggregates = async (
  * @param end - End of time range
  * @param bucketMinutes - Bucket size in minutes (e.g., 5, 15, 30, 60, 1440 for 1 day)
  */
+// ============================================================================
+// Time Range Discovery
+// ============================================================================
+
+/** Get the min and max time for a metric (across all sources). Returns null if no data exists. */
+export const getMetricTimeRange = async (
+  user: string,
+  metric: string,
+): Promise<{ min: Date; max: Date } | null> => {
+  const result = await query(
+    user,
+    `SELECT MIN(time) as min_time, MAX(time) as max_time FROM time_series WHERE metric = $1`,
+    [metric],
+  )
+  if (result.rows.length === 0 || result.rows[0].min_time === null) return null
+  return { max: new Date(result.rows[0].max_time), min: new Date(result.rows[0].min_time) }
+}
+
 // ============================================================================
 // Time Series Deletion (manual source only)
 // ============================================================================

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -10,7 +10,7 @@ import {
   updateCustomMetricBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
-import { computeAndStoreCalories } from '../services/calorie-computation'
+import { computeAndStoreCalories, computeAndStoreCaloriesAll } from '../services/calorie-computation'
 import {
   addCustomMetric,
   addMetric,
@@ -184,9 +184,13 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   // Tool: recalculate_calories
   server.tool(
     'recalculate_calories',
-    'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback).',
-    { ...recalculateCaloriesBodySchema.shape },
+    'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback). Omit start/end to recompute all historical data.',
+    { ...recalculateCaloriesBodySchema.shape, end: z.string().optional(), start: z.string().optional() },
     async ({ start, end }) => {
+      if (!start || !end) {
+        const result = await computeAndStoreCaloriesAll(user)
+        return jsonResponse({ ...result, success: true })
+      }
       const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
       return jsonResponse({ ...result, success: true })
     },

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -7,6 +7,7 @@
 
 // Re-export common types from shared api-spec package
 export {
+  aurbodaOnlyMetrics,
   contextualHrvMetrics,
   cumulativeMetrics,
   cumulativeSources,

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -10,6 +10,7 @@ import type { BiologicalSex } from '@aurboda/api-spec'
 import { enqueueOutboundSync, getUserSettings } from '../db'
 import {
   deleteTimeSeriesBySource,
+  getMetricTimeRange,
   getTimeSeries,
   getTimeSeriesWithSource,
   insertTimeSeries,
@@ -48,6 +49,45 @@ const getLatestMetricValue = async (
   return data[data.length - 1][1]
 }
 
+/** Queue outbound sync entries for calorie data points (best-effort). */
+const enqueueCalorieSync = async (
+  user: string,
+  points: { time: Date; end_time: Date; kcal: number }[],
+): Promise<void> => {
+  try {
+    if (!isHealthConnectSyncableMetric('calories_active')) return
+    const hcRecordType = metricToHealthConnectType.calories_active
+    if (!hcRecordType) return
+    for (const p of points) {
+      await enqueueOutboundSync(user, {
+        entity_id: `calories_active|${p.time.toISOString()}`,
+        entity_type: 'time_series',
+        hc_record_type: hcRecordType,
+        operation: 'insert',
+        payload: {
+          end_time: p.end_time.toISOString(),
+          metric: 'calories_active',
+          time: p.time.toISOString(),
+          unit: 'kcal',
+          value: p.kcal,
+        },
+      })
+    }
+  } catch (err) {
+    console.error('Failed to enqueue calorie outbound sync:', err)
+  }
+}
+
+const skippedResult = (
+  reason: string,
+  vo2MaxSource: 'measured' | 'fallback' = 'fallback',
+): CalorieComputationResult => ({
+  points_computed: 0,
+  points_stored: 0,
+  skipped_reason: reason,
+  vo2_max_source: vo2MaxSource,
+})
+
 export interface CalorieComputationResult {
   points_computed: number
   points_stored: number
@@ -68,76 +108,54 @@ export const computeAndStoreCalories = async (
   end: Date,
   options?: { force?: boolean },
 ): Promise<CalorieComputationResult> => {
-  // 1. Get user settings
+  // 1. Get user settings and validate required fields
   const settings = await getUserSettings(user)
-  if (!settings) {
-    return { points_computed: 0, points_stored: 0, skipped_reason: 'no settings', vo2_max_source: 'fallback' }
-  }
+  if (!settings) return skippedResult('no settings')
 
   const sex = settings.sex as BiologicalSex | undefined
-  if (!sex) {
-    return { points_computed: 0, points_stored: 0, skipped_reason: 'sex not set', vo2_max_source: 'fallback' }
-  }
-
-  if (!settings.birth_date) {
-    return {
-      points_computed: 0,
-      points_stored: 0,
-      skipped_reason: 'birth_date not set',
-      vo2_max_source: 'fallback',
-    }
-  }
+  if (!sex) return skippedResult('sex not set')
+  if (!settings.birth_date) return skippedResult('birth_date not set')
 
   const age = calculateAge(settings.birth_date)
 
   // 2. Get latest weight
   const weight = await getLatestMetricValue(user, 'weight', end)
-  if (weight === null) {
-    return {
-      points_computed: 0,
-      points_stored: 0,
-      skipped_reason: 'no weight data',
-      vo2_max_source: 'fallback',
-    }
-  }
+  if (weight === null) return skippedResult('no weight data')
 
   // 3. Get VO2 max (measured or fallback) — use 2-year lookback since VO2 max is measured infrequently
   const measuredVo2Max = await getLatestMetricValue(user, 'vo2_max', end, 730)
   const vo2Max = measuredVo2Max ?? getVo2MaxFallback(sex, age)
   const vo2MaxSource = measuredVo2Max !== null ? 'measured' : 'fallback'
 
-  // 4. Get HR data for the time range
-  const hrData = await getTimeSeries(user, 'heart_rate', start, end)
-  if (hrData.length === 0) {
-    return {
-      points_computed: 0,
-      points_stored: 0,
-      skipped_reason: 'no HR data',
-      vo2_max_source: vo2MaxSource,
-    }
-  }
+  // 4. Get resting HR (for baseline subtraction)
+  const restingHr = await getLatestMetricValue(user, 'resting_heart_rate', end)
 
-  // 5. Delete existing aurboda calories if force-recomputing
+  // 5. Get HR data for the time range
+  const hrData = await getTimeSeries(user, 'heart_rate', start, end)
+  if (hrData.length === 0) return skippedResult('no HR data', vo2MaxSource)
+
+  // 6. Delete existing aurboda calories if force-recomputing
   if (options?.force) {
     await deleteTimeSeriesBySource(user, 'calories_active', 'aurboda', start, end)
   }
 
-  // 6. Check if aurboda calories already exist for this range to avoid recomputing
+  // 7. Check if aurboda calories already exist for this range to avoid recomputing
   const existingCalories = await getTimeSeriesWithSource(user, 'calories_active', start, end)
   const existingAurbodaMinutes = new Set(
     existingCalories.filter((p) => p.source === 'aurboda').map((p) => Math.floor(p.time.getTime() / 60_000)),
   )
 
-  // 6. Compute per-minute calories
+  // 8. Compute per-minute calories (active only, with baseline subtraction)
   const caloriePoints = computeCaloriesPerMinute({
     age_years: age,
     hr_samples: hrData,
+    resting_hr: restingHr ?? undefined,
     sex,
     vo2_max: vo2Max,
     weight_kg: weight,
   })
 
-  // 7. Filter out already-computed minutes
+  // 9. Filter out already-computed minutes
   const newPoints = caloriePoints.filter(
     (p) => !existingAurbodaMinutes.has(Math.floor(p.time.getTime() / 60_000)),
   )
@@ -151,7 +169,7 @@ export const computeAndStoreCalories = async (
     }
   }
 
-  // 8. Store as time_series
+  // 10. Store as time_series
   const timeSeriesPoints: TimeSeriesPoint[] = newPoints.map((p) => ({
     metric: 'calories_active',
     source: 'aurboda' as const,
@@ -161,35 +179,62 @@ export const computeAndStoreCalories = async (
   }))
   await insertTimeSeries(user, timeSeriesPoints)
 
-  // 9. Queue outbound sync for each point (best-effort)
-  try {
-    if (isHealthConnectSyncableMetric('calories_active')) {
-      const hcRecordType = metricToHealthConnectType.calories_active
-      if (hcRecordType) {
-        for (const p of newPoints) {
-          await enqueueOutboundSync(user, {
-            entity_id: `calories_active|${p.time.toISOString()}`,
-            entity_type: 'time_series',
-            hc_record_type: hcRecordType,
-            operation: 'insert',
-            payload: {
-              end_time: p.end_time.toISOString(),
-              metric: 'calories_active',
-              time: p.time.toISOString(),
-              unit: 'kcal',
-              value: p.kcal,
-            },
-          })
-        }
-      }
-    }
-  } catch (err) {
-    console.error('Failed to enqueue calorie outbound sync:', err)
-  }
+  // 11. Queue outbound sync (best-effort)
+  await enqueueCalorieSync(user, newPoints)
 
   return {
     points_computed: caloriePoints.length,
     points_stored: newPoints.length,
+    vo2_max_source: vo2MaxSource,
+  }
+}
+
+/**
+ * Recompute all calories_active data from scratch using the full HR data range.
+ * Processes in daily chunks to avoid memory issues. Deletes existing aurboda
+ * calorie data for each chunk before recomputing.
+ */
+export const computeAndStoreCaloriesAll = async (
+  user: string,
+): Promise<CalorieComputationResult & { days_processed: number }> => {
+  const range = await getMetricTimeRange(user, 'heart_rate')
+  if (!range) {
+    return {
+      days_processed: 0,
+      points_computed: 0,
+      points_stored: 0,
+      skipped_reason: 'no HR data found',
+      vo2_max_source: 'fallback',
+    }
+  }
+
+  let totalComputed = 0
+  let totalStored = 0
+  let daysProcessed = 0
+  let vo2MaxSource: 'measured' | 'fallback' = 'fallback'
+
+  // Process in daily chunks
+  const dayMs = 24 * 60 * 60 * 1000
+  let chunkStart = new Date(range.min)
+
+  while (chunkStart < range.max) {
+    const chunkEnd = new Date(Math.min(chunkStart.getTime() + dayMs, range.max.getTime() + 60_000))
+    const result = await computeAndStoreCalories(user, chunkStart, chunkEnd, { force: true })
+
+    totalComputed += result.points_computed
+    totalStored += result.points_stored
+    if (result.vo2_max_source === 'measured') vo2MaxSource = 'measured'
+    daysProcessed++
+
+    chunkStart = chunkEnd
+  }
+
+  console.log(`🔥 Full recompute: ${totalStored} calorie points across ${daysProcessed} days for ${user}`)
+
+  return {
+    days_processed: daysProcessed,
+    points_computed: totalComputed,
+    points_stored: totalStored,
     vo2_max_source: vo2MaxSource,
   }
 }

--- a/apps/backend/src/services/calories.test.ts
+++ b/apps/backend/src/services/calories.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  BASELINE_HR_MULTIPLIER,
+  DEFAULT_RESTING_HR,
   MAX_HOLD_MINUTES,
   computeCaloriesForMinute,
   computeCaloriesPerMinute,
+  computeTotalCaloriesForMinute,
   getVo2MaxFallback,
 } from './calories'
 
@@ -23,42 +26,102 @@ describe('getVo2MaxFallback', () => {
   })
 })
 
-describe('computeCaloriesForMinute', () => {
-  test('computes calories for a male', () => {
+describe('computeTotalCaloriesForMinute', () => {
+  test('computes total calories for a male (including BMR)', () => {
     // Man, 50 years old, 100 kg, VO2max 40, HR 120
     // CB = (0.634*120 + 0.404*40 + 0.394*100 + 0.271*50 - 95.7735) / 4.184
     // = (76.08 + 16.16 + 39.4 + 13.55 - 95.7735) / 4.184
     // = 49.4165 / 4.184
     // ≈ 11.811
-    const result = computeCaloriesForMinute(120, 40, 100, 50, 'male')
+    const result = computeTotalCaloriesForMinute(120, 40, 100, 50, 'male')
     expect(result).toBeCloseTo(11.811, 2)
   })
 
-  test('computes calories for a female', () => {
+  test('computes total calories for a female', () => {
     // Woman, 35 years old, 65 kg, VO2max 35, HR 130
     // CB = (0.45*130 + 0.380*35 + 0.103*65 + 0.274*35 - 59.3954) / 4.184
     // = (58.5 + 13.3 + 6.695 + 9.59 - 59.3954) / 4.184
     // = 28.6896 / 4.184
     // ≈ 6.858
-    const result = computeCaloriesForMinute(130, 35, 65, 35, 'female')
+    const result = computeTotalCaloriesForMinute(130, 35, 65, 35, 'female')
     expect(result).toBeCloseTo(6.858, 2)
   })
 
   test('clamps to 0 for very low heart rate', () => {
-    // Very low HR where formula would go negative
-    const result = computeCaloriesForMinute(40, 30, 50, 20, 'male')
+    const result = computeTotalCaloriesForMinute(40, 30, 50, 20, 'male')
     expect(result).toBe(0)
   })
 
   test('returns positive value for moderate exercise', () => {
-    const result = computeCaloriesForMinute(150, 45, 80, 40, 'male')
+    const result = computeTotalCaloriesForMinute(150, 45, 80, 40, 'male')
     expect(result).toBeGreaterThan(0)
+  })
+})
+
+describe('computeCaloriesForMinute (active-only with baseline subtraction)', () => {
+  test('returns 0 at resting HR (below baseline threshold)', () => {
+    // At resting HR 55, baseline HR = 55 * 1.2 = 66
+    // HR 55 is below the baseline, so active calories should be 0
+    const result = computeCaloriesForMinute(55, 40, 100, 50, 'male', 55)
+    expect(result).toBe(0)
+  })
+
+  test('returns 0 at sleep HR (at or below baseline threshold)', () => {
+    // Resting HR 55, baseline HR = 66
+    // Sleep HR of 60 is below baseline
+    const result = computeCaloriesForMinute(60, 40, 100, 50, 'male', 55)
+    expect(result).toBe(0)
+  })
+
+  test('returns 0 exactly at the baseline HR threshold', () => {
+    // Resting HR 55, baseline HR = 66
+    const result = computeCaloriesForMinute(66, 40, 100, 50, 'male', 55)
+    expect(result).toBe(0)
+  })
+
+  test('returns small positive value just above baseline threshold', () => {
+    // Resting HR 55, baseline HR = 66
+    // HR 70 is slightly above baseline
+    const result = computeCaloriesForMinute(70, 40, 100, 50, 'male', 55)
+    expect(result).toBeGreaterThan(0)
+    expect(result).toBeLessThan(1) // should be small
+  })
+
+  test('returns active calories for exercise HR', () => {
+    // Resting HR 55, baseline HR = 66
+    const restingHr = 55
+    const baselineHr = restingHr * BASELINE_HR_MULTIPLIER
+    const total = computeTotalCaloriesForMinute(120, 40, 100, 50, 'male')
+    const baseline = computeTotalCaloriesForMinute(baselineHr, 40, 100, 50, 'male')
+    const expected = total - baseline
+
+    const result = computeCaloriesForMinute(120, 40, 100, 50, 'male', restingHr)
+    expect(result).toBeCloseTo(expected, 4)
+    expect(result).toBeGreaterThan(5) // substantial active calories at HR 120
+  })
+
+  test('uses DEFAULT_RESTING_HR when resting HR not provided', () => {
+    const baselineHr = DEFAULT_RESTING_HR * BASELINE_HR_MULTIPLIER
+    const total = computeTotalCaloriesForMinute(120, 40, 100, 50, 'male')
+    const baseline = computeTotalCaloriesForMinute(baselineHr, 40, 100, 50, 'male')
+    const expected = total - baseline
+
+    const result = computeCaloriesForMinute(120, 40, 100, 50, 'male')
+    expect(result).toBeCloseTo(expected, 4)
+  })
+
+  test('active calories are less than total calories', () => {
+    const active = computeCaloriesForMinute(150, 45, 80, 40, 'male', 55)
+    const total = computeTotalCaloriesForMinute(150, 45, 80, 40, 'male')
+    expect(active).toBeGreaterThan(0)
+    expect(active).toBeLessThan(total)
   })
 })
 
 describe('computeCaloriesPerMinute', () => {
   const baseParams = {
     age_years: 50,
+    resting_hr: 55,
     sex: 'male' as const,
     vo2_max: 40,
     weight_kg: 100,
@@ -80,6 +143,16 @@ describe('computeCaloriesPerMinute', () => {
     expect(result[0].kcal).toBeGreaterThan(0)
   })
 
+  test('returns 0 kcal for sleep-range HR', () => {
+    // HR 60 with resting HR 55 → baseline HR 66 → should be 0
+    const result = computeCaloriesPerMinute({
+      ...baseParams,
+      hr_samples: [[new Date('2024-01-15T23:00:00Z'), 60]],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].kcal).toBe(0)
+  })
+
   test('produces per-minute buckets for dense HR data', () => {
     // 5 samples over 4 minutes (every 60 seconds)
     const samples: [Date, number][] = [
@@ -93,14 +166,17 @@ describe('computeCaloriesPerMinute', () => {
     expect(result).toHaveLength(5)
 
     // Each minute should have the corresponding HR value
-    // First minute: HR 120, no other samples in [10:00, 10:01)
     expect(result[0].time).toEqual(new Date('2024-01-15T10:00:00Z'))
     expect(result[0].end_time).toEqual(new Date('2024-01-15T10:01:00Z'))
+
+    // All should have positive active calories (HR > 66 threshold)
+    for (const point of result) {
+      expect(point.kcal).toBeGreaterThan(0)
+    }
   })
 
   test('hold-last-value fills sparse data (5-minute intervals like Oura)', () => {
     // Oura sleep HR: one sample every 5 minutes
-    // Each sample holds for up to MAX_HOLD_MINUTES minutes
     const samples: [Date, number][] = [
       [new Date('2024-01-15T23:00:00Z'), 60],
       [new Date('2024-01-15T23:05:00Z'), 58],
@@ -112,15 +188,10 @@ describe('computeCaloriesPerMinute', () => {
     // 23:10 from third (1 bucket) = 11 total
     expect(result).toHaveLength(11)
 
-    // First minute uses HR 60
-    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(60, 40, 100, 50, 'male'), 4)
-
-    // Minutes 1-4 (23:01-23:04) also use HR 60 (hold-last-value within MAX_HOLD_MINUTES)
-    expect(result[1].kcal).toBeCloseTo(result[0].kcal, 4)
-    expect(result[4].kcal).toBeCloseTo(result[0].kcal, 4)
-
-    // Minute 5 (23:05) uses HR 58
-    expect(result[5].kcal).toBeCloseTo(computeCaloriesForMinute(58, 40, 100, 50, 'male'), 4)
+    // All sleep-range HR values should produce 0 active calories
+    for (const point of result) {
+      expect(point.kcal).toBe(0)
+    }
   })
 
   test('skips minutes beyond MAX_HOLD_MINUTES gap', () => {
@@ -132,15 +203,10 @@ describe('computeCaloriesPerMinute', () => {
     const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
 
     // 10:00-10:04 from first sample (5 buckets) + 10:20 from second (1 bucket) = 6 total
-    // Minutes 10:05-10:19 are skipped (gap > MAX_HOLD_MINUTES)
     expect(result).toHaveLength(MAX_HOLD_MINUTES + 1)
     expect(result[0].time).toEqual(new Date('2024-01-15T10:00:00Z'))
     expect(result[MAX_HOLD_MINUTES - 1].time).toEqual(new Date('2024-01-15T10:04:00Z'))
     expect(result[MAX_HOLD_MINUTES].time).toEqual(new Date('2024-01-15T10:20:00Z'))
-
-    // First bucket uses HR 120, last uses HR 130
-    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(120, 40, 100, 50, 'male'), 4)
-    expect(result[MAX_HOLD_MINUTES].kcal).toBeCloseTo(computeCaloriesForMinute(130, 40, 100, 50, 'male'), 4)
   })
 
   test('does not produce stale data for hours-long gaps', () => {
@@ -154,10 +220,11 @@ describe('computeCaloriesPerMinute', () => {
     // Only MAX_HOLD_MINUTES from the first sample + 1 from the second
     expect(result).toHaveLength(MAX_HOLD_MINUTES + 1)
 
-    // No stale 150bpm calories in the evening gap
-    const lastBeforeGap = result[MAX_HOLD_MINUTES - 1]
-    expect(lastBeforeGap.time).toEqual(new Date('2024-01-15T18:04:00Z'))
-    expect(result[MAX_HOLD_MINUTES].time).toEqual(new Date('2024-01-15T23:00:00Z'))
+    // Exercise HR should produce positive active calories
+    expect(result[0].kcal).toBeGreaterThan(0)
+
+    // Sleep HR (55, below baseline 66) should produce 0
+    expect(result[MAX_HOLD_MINUTES].kcal).toBe(0)
   })
 
   test('averages multiple HR samples within same minute', () => {
@@ -170,7 +237,7 @@ describe('computeCaloriesPerMinute', () => {
     expect(result).toHaveLength(1)
 
     // Average of 100 and 120 = 110
-    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(110, 40, 100, 50, 'male'), 4)
+    expect(result[0].kcal).toBeCloseTo(computeCaloriesForMinute(110, 40, 100, 50, 'male', 55), 4)
   })
 
   test('all data points have 60-second intervals', () => {
@@ -186,24 +253,38 @@ describe('computeCaloriesPerMinute', () => {
     }
   })
 
-  test('total calories for a 30-minute run match formula', () => {
-    // 30 minutes of constant 150bpm running
+  test('total active calories for a 30-minute run are less than total burn', () => {
+    // 31 minutes of constant 150bpm running
     const samples: [Date, number][] = Array.from(
       { length: 31 },
       (_, i) => [new Date(`2024-01-15T10:${String(i).padStart(2, '0')}:00Z`), 150] as [Date, number],
     )
 
     const result = computeCaloriesPerMinute({ ...baseParams, hr_samples: samples })
-    const totalKcal = result.reduce((sum, p) => sum + p.kcal, 0)
+    const totalActiveKcal = result.reduce((sum, p) => sum + p.kcal, 0)
 
-    // Formula: CB = T * (0.634*150 + 0.404*40 + 0.394*100 + 0.271*50 - 95.7735) / 4.184
-    //            = 30 * (95.1 + 16.16 + 39.4 + 13.55 - 95.7735) / 4.184
-    //            = 30 * 68.4365 / 4.184
-    //            = 30 * 16.3579...
-    //            ≈ 490.74
-    const expectedPerMinute = (0.634 * 150 + 0.404 * 40 + 0.394 * 100 + 0.271 * 50 - 95.7735) / 4.184
-    const expectedTotal = 31 * expectedPerMinute
+    // The active calories should be less than the total formula output
+    const totalPerMinute = computeTotalCaloriesForMinute(150, 40, 100, 50, 'male')
+    const totalBurn = 31 * totalPerMinute
+    expect(totalActiveKcal).toBeLessThan(totalBurn)
 
-    expect(totalKcal).toBeCloseTo(expectedTotal, 0)
+    // But still substantial (most of the burn at HR 150 is active)
+    const activePerMinute = computeCaloriesForMinute(150, 40, 100, 50, 'male', 55)
+    const expectedActive = 31 * activePerMinute
+    expect(totalActiveKcal).toBeCloseTo(expectedActive, 0)
+  })
+
+  test('uses default resting HR when not provided', () => {
+    const withResting = computeCaloriesPerMinute({
+      ...baseParams,
+      hr_samples: [[new Date('2024-01-15T10:00:00Z'), 120]],
+      resting_hr: DEFAULT_RESTING_HR,
+    })
+    const withoutResting = computeCaloriesPerMinute({
+      ...baseParams,
+      hr_samples: [[new Date('2024-01-15T10:00:00Z'), 120]],
+      resting_hr: undefined,
+    })
+    expect(withResting[0].kcal).toBeCloseTo(withoutResting[0].kcal, 4)
   })
 })

--- a/apps/backend/src/services/calories.ts
+++ b/apps/backend/src/services/calories.ts
@@ -13,6 +13,15 @@
  *   V  = VO2 max (mL/kg/min)
  *   W  = Weight (kg)
  *   A  = Age (years)
+ *
+ * The formula computes TOTAL caloric burn including BMR. To get active-only
+ * calories, we subtract a baseline computed at resting_hr * BASELINE_HR_MULTIPLIER
+ * using the same formula. This naturally zeroes out sleep and rest periods.
+ *
+ * The 1.2x multiplier was empirically validated against Oura sleep HR data:
+ * during actual sleep stages (light/deep/REM, excluding awake periods with
+ * 5-min margins), HR stays at or below resting_hr * 1.2, so this threshold
+ * produces 0 active calories during sleep.
  */
 
 import type { BiologicalSex } from '@aurboda/api-spec'
@@ -23,6 +32,17 @@ import type { BiologicalSex } from '@aurboda/api-spec'
  * the threshold are skipped (no calorie data rather than stale data).
  */
 export const MAX_HOLD_MINUTES = 5
+
+/**
+ * Multiplier applied to resting HR to compute the baseline HR threshold.
+ * The formula's output at this HR is subtracted from each minute's result
+ * to yield active-only calories. Empirically validated against sleep data:
+ * during actual sleep stages, HR stays at or below this threshold.
+ */
+export const BASELINE_HR_MULTIPLIER = 1.2
+
+/** Default resting HR when no measured value is available. */
+export const DEFAULT_RESTING_HR = 60
 
 /** Default VO2 max fallback values by sex and age group (mL/kg/min). */
 const VO2_MAX_FALLBACK: Record<BiologicalSex, { age: number; value: number }[]> = {
@@ -66,6 +86,8 @@ export interface CalorieCalcParams {
   age_years: number
   /** Biological sex */
   sex: BiologicalSex
+  /** Resting heart rate (bpm). Used to compute the baseline subtraction. */
+  resting_hr?: number
 }
 
 export interface CalorieDataPoint {
@@ -86,8 +108,14 @@ export interface CalorieDataPoint {
  */
 export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieDataPoint[] => {
   const { hr_samples, vo2_max, weight_kg, age_years, sex } = params
+  const restingHr = params.resting_hr ?? DEFAULT_RESTING_HR
 
   if (hr_samples.length === 0) return []
+
+  // Compute the baseline: formula output at resting_hr * multiplier.
+  // This is subtracted from every minute to yield active-only calories.
+  const baselineHr = restingHr * BASELINE_HR_MULTIPLIER
+  const baselineKcal = computeTotalCaloriesForMinute(baselineHr, vo2_max, weight_kg, age_years, sex)
 
   // Determine time range
   const firstTime = hr_samples[0][0].getTime()
@@ -140,8 +168,9 @@ export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieData
     // Average HR for this minute
     const avgHr = hrValues.reduce((a, b) => a + b, 0) / hrValues.length
 
-    // Apply formula (T = 1 minute)
-    const kcal = computeCaloriesForMinute(avgHr, vo2_max, weight_kg, age_years, sex)
+    // Active calories = total formula output minus baseline
+    const totalKcal = computeTotalCaloriesForMinute(avgHr, vo2_max, weight_kg, age_years, sex)
+    const kcal = Math.max(0, totalKcal - baselineKcal)
 
     results.push({
       end_time: new Date(bucketEnd),
@@ -154,10 +183,11 @@ export const computeCaloriesPerMinute = (params: CalorieCalcParams): CalorieData
 }
 
 /**
- * Compute calories burned in one minute given average HR and other parameters.
+ * Compute TOTAL calories burned in one minute (including BMR) given HR and parameters.
  * Returns 0 if the formula yields a negative value (very low HR).
+ * This is the raw formula — use computeCaloriesForMinute for active-only calories.
  */
-export const computeCaloriesForMinute = (
+export const computeTotalCaloriesForMinute = (
   avgHr: number,
   vo2Max: number,
   weightKg: number,
@@ -171,4 +201,24 @@ export const computeCaloriesForMinute = (
     raw = (0.45 * avgHr + 0.38 * vo2Max + 0.103 * weightKg + 0.274 * ageYears - 59.3954) / 4.184
   }
   return Math.max(0, raw)
+}
+
+/**
+ * Compute ACTIVE calories burned in one minute given HR, resting HR, and other parameters.
+ * Subtracts the formula's output at resting_hr * BASELINE_HR_MULTIPLIER as the zero-point.
+ * Returns 0 for HR at or below the baseline threshold (sleep, rest).
+ */
+export const computeCaloriesForMinute = (
+  avgHr: number,
+  vo2Max: number,
+  weightKg: number,
+  ageYears: number,
+  sex: BiologicalSex,
+  restingHr?: number,
+): number => {
+  const rhr = restingHr ?? DEFAULT_RESTING_HR
+  const baselineHr = rhr * BASELINE_HR_MULTIPLIER
+  const total = computeTotalCaloriesForMinute(avgHr, vo2Max, weightKg, ageYears, sex)
+  const baseline = computeTotalCaloriesForMinute(baselineHr, vo2Max, weightKg, ageYears, sex)
+  return Math.max(0, total - baseline)
 }

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -255,8 +255,6 @@ const buildMetricsTooltipHtml = (
 ): string => {
   const startStr = formatTime(bucket.start)
   const endStr = formatTime(bucket.end)
-  const bucketMinutes = (bucket.end.getTime() - bucket.start.getTime()) / 60_000
-
   let html = `<div class="tooltip-title">Metrics</div>`
   html += `<div class="tooltip-time">${startStr} – ${endStr}</div>`
 
@@ -275,15 +273,13 @@ const buildMetricsTooltipHtml = (
   if (showSteps) {
     const steps = bucket.metrics.steps
     if (steps) {
-      const perMin = bucketMinutes > 0 ? steps.avg / bucketMinutes : 0
-      html += `<div class="tooltip-detail" style="color:${STEPS_COLOR}">🚶 Steps: ${perMin.toFixed(1)}/min</div>`
+      html += `<div class="tooltip-detail" style="color:${STEPS_COLOR}">🚶 Steps: ${steps.avg.toFixed(1)}/min</div>`
     }
   }
   if (showCalories) {
     const cal = bucket.metrics.calories_active
     if (cal) {
-      const perMin = bucketMinutes > 0 ? cal.avg / bucketMinutes : 0
-      html += `<div class="tooltip-detail" style="color:${CALORIES_COLOR}">🔥 Calories: ${perMin.toFixed(1)} kcal/min</div>`
+      html += `<div class="tooltip-detail" style="color:${CALORIES_COLOR}">🔥 Calories: ${cal.avg.toFixed(1)} kcal/min</div>`
     }
   }
 

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -290,6 +290,16 @@ export const cumulativeMetrics: MetricType[] = [
 export const cumulativeSources: DataSource[] = ['health_connect_aggregate', 'aurboda']
 
 /**
+ * Metrics where 'aurboda' per-minute data should be used exclusively
+ * instead of mixing with 'health_connect_aggregate' daily totals.
+ *
+ * When aurboda computes per-minute values (e.g., calories from HR data),
+ * the daily aggregate from Health Connect is redundant and would produce
+ * nonsense if AVG'd with per-minute values in the same bucket.
+ */
+export const aurbodaOnlyMetrics: MetricType[] = ['calories_active']
+
+/**
  * Place visit source schema.
  */
 export const placeSourceSchema = z.enum(['named', 'detected', 'owntracks', 'unknown']).meta({


### PR DESCRIPTION
## Summary

Fixes four calorie computation bugs that caused incorrect training load (ATL/CTL/TSB) curves:

- **Formula gives total, not active calories**: Subtract resting baseline (formula output at resting_hr × 1.2) so sleep/rest → 0 kcal. Multiplier validated against Oura sleep HR data.
- **Midnight aggregate spike**: `health_connect_aggregate` dumps full day's calories at 00:00, inflating overnight fatigue. Now `calories_active` uses only per-minute `aurboda` source.
- **Tooltip double-division**: `cal.avg / bucketMinutes` divided an already-per-minute value by minutes again, showing values ~15x too small.
- **Full recompute**: `recalculate_calories` MCP tool now supports omitting start/end to recompute all historical data.

## Expected values after fixes
- 36-min strength session (avg HR ~111): 356 → **247 kcal active**
- Sleep (HR ~60): 128 kcal/hr → **0 kcal/hr**
- Light walking (HR 80): → **~127 kcal/hr**

## Test coverage
- 24 unit tests covering baseline subtraction, sleep → 0, edge cases
- All 918 backend unit tests pass
- `pnpm check` and `pnpm fix` pass clean