### PR TITLE
feat: gap-fill calories from HC aggregate for minutes without HR coverage

### DIFF
--- a/apps/backend/coverage-baseline.json
+++ b/apps/backend/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "statements": 60.74,
+  "statements": 60.44,
   "branches": 86.63,
-  "functions": 78.67
+  "functions": 78.26
 }

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -100,6 +100,24 @@ export const getTimeSeriesWithSource = async (
   return result.rows.map((row) => ({ source: row.source, time: new Date(row.time), value: row.value }))
 }
 
+/** Get time series data for a specific metric and source, bypassing the cumulative source filter. */
+export const getTimeSeriesBySource = async (
+  user: string,
+  metric: string,
+  source: string,
+  start: Date,
+  end: Date,
+): Promise<[Date, number][]> => {
+  const result = await query(
+    user,
+    `SELECT time, value FROM time_series
+     WHERE metric = $1 AND source = $2 AND time >= $3 AND time <= $4
+     ORDER BY time`,
+    [metric, source, start, end],
+  )
+  return result.rows.map((row) => [new Date(row.time), row.value])
+}
+
 /**
  * Get the sum of a metric across ALL sources for a date range.
  * This is a last-resort fallback for cumulative metrics when no aggregate data exists.

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -12,12 +12,18 @@ import {
   deleteTimeSeriesBySource,
   getMetricTimeRange,
   getTimeSeries,
+  getTimeSeriesBySource,
   getTimeSeriesWithSource,
   insertTimeSeries,
 } from '../db/time-series'
 import type { TimeSeriesPoint } from '../db/types'
 import { isHealthConnectSyncableMetric, metricToHealthConnectType } from '../schema'
-import { computeCaloriesPerMinute, getVo2MaxFallback } from './calories'
+import {
+  type CalorieDataPoint,
+  computeCaloriesPerMinute,
+  computeGapFillPoints,
+  getVo2MaxFallback,
+} from './calories'
 
 /**
  * Calculate age from birth date string.
@@ -189,6 +195,117 @@ export const computeAndStoreCalories = async (
   }
 }
 
+export interface GapFillDayResult {
+  gap_minutes: number
+  residual_kcal: number
+  points_stored: number
+}
+
+/**
+ * Gap-fill calories for a single calendar day (UTC).
+ *
+ * After aurboda per-minute calories are computed from HR data, some minutes
+ * may have no HR coverage (e.g., Oura wrist off, no HR monitor worn).
+ * Oura/Health Connect may still capture movement-based calories for those periods.
+ *
+ * This function:
+ * 1. Reads the HC aggregate for the day
+ * 2. Reads existing aurboda calorie points for the day
+ * 3. Computes the residual (HC total - aurboda sum)
+ * 4. Distributes it evenly across minutes without HR coverage
+ * 5. Stores gap-fill points with source 'aurboda'
+ */
+export const gapFillCaloriesForDay = async (user: string, dayStartUtc: Date): Promise<GapFillDayResult> => {
+  const dayEndUtc = new Date(dayStartUtc.getTime() + 24 * 60 * 60 * 1000 - 1)
+
+  // 1. Get HC aggregate for this day (stored at midnight UTC with source 'health_connect_aggregate')
+  const hcData = await getTimeSeriesBySource(
+    user,
+    'calories_active',
+    'health_connect_aggregate',
+    dayStartUtc,
+    dayEndUtc,
+  )
+  if (hcData.length === 0) return { gap_minutes: 0, points_stored: 0, residual_kcal: 0 }
+
+  const hcAggregateKcal = hcData.reduce((sum, [, value]) => sum + value, 0)
+
+  // 2. Get existing aurboda calorie points for this day
+  const existingData = await getTimeSeriesBySource(user, 'calories_active', 'aurboda', dayStartUtc, dayEndUtc)
+  const aurbodaPoints: CalorieDataPoint[] = existingData.map(([time, value]) => ({
+    end_time: new Date(time.getTime() + 60_000),
+    kcal: value,
+    time,
+  }))
+
+  // 3. Compute gap-fill points
+  const result = computeGapFillPoints({
+    aurboda_points: aurbodaPoints,
+    day_start: dayStartUtc,
+    hc_aggregate_kcal: hcAggregateKcal,
+  })
+
+  if (result.points.length === 0) return { gap_minutes: 0, points_stored: 0, residual_kcal: 0 }
+
+  // 4. Store gap-fill points as aurboda source
+  const timeSeriesPoints: TimeSeriesPoint[] = result.points.map((p) => ({
+    metric: 'calories_active',
+    source: 'aurboda' as const,
+    time: p.time,
+    unit: 'kcal',
+    value: p.kcal,
+  }))
+  await insertTimeSeries(user, timeSeriesPoints)
+
+  return {
+    gap_minutes: result.gap_minutes,
+    points_stored: result.points.length,
+    residual_kcal: result.residual_kcal,
+  }
+}
+
+/**
+ * Gap-fill calories for all calendar days within a time range.
+ * Iterates day by day (UTC) and runs gap-fill for each.
+ */
+export const gapFillCaloriesForRange = async (
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<{
+  days_processed: number
+  total_gap_minutes: number
+  total_points_stored: number
+  total_residual_kcal: number
+}> => {
+  // Align to UTC day boundaries
+  const dayMs = 24 * 60 * 60 * 1000
+  const firstDay = new Date(Math.floor(start.getTime() / dayMs) * dayMs)
+  const lastDay = new Date(Math.floor(end.getTime() / dayMs) * dayMs)
+
+  let daysProcessed = 0
+  let totalGapMinutes = 0
+  let totalPointsStored = 0
+  let totalResidualKcal = 0
+
+  for (let dayStart = firstDay.getTime(); dayStart <= lastDay.getTime(); dayStart += dayMs) {
+    const result = await gapFillCaloriesForDay(user, new Date(dayStart))
+    if (result.points_stored > 0) {
+      daysProcessed++
+      totalGapMinutes += result.gap_minutes
+      totalPointsStored += result.points_stored
+      totalResidualKcal += result.residual_kcal
+    }
+  }
+
+  return {
+    days_processed: daysProcessed,
+    total_gap_minutes: totalGapMinutes,
+    total_points_stored: totalPointsStored,
+    total_residual_kcal: totalResidualKcal,
+  }
+}
+
 /**
  * Recompute all calories_active data from scratch using the full HR data range.
  * Processes in daily chunks to avoid memory issues. Deletes existing aurboda
@@ -229,7 +346,16 @@ export const computeAndStoreCaloriesAll = async (
     chunkStart = chunkEnd
   }
 
-  console.log(`🔥 Full recompute: ${totalStored} calorie points across ${daysProcessed} days for ${user}`)
+  // Gap-fill from HC aggregate data for minutes without HR coverage
+  const gapFill = await gapFillCaloriesForRange(user, range.min, range.max)
+  totalStored += gapFill.total_points_stored
+
+  console.log(
+    `🔥 Full recompute: ${totalStored} calorie points across ${daysProcessed} days for ${user}` +
+      (gapFill.total_points_stored > 0 ?
+        ` (${gapFill.total_points_stored} gap-filled from HC aggregate)`
+      : ''),
+  )
 
   return {
     days_processed: daysProcessed,
@@ -242,6 +368,7 @@ export const computeAndStoreCaloriesAll = async (
 /**
  * Trigger calorie computation for a time range after HR data ingestion.
  * This is a best-effort operation that never throws.
+ * Also runs gap-filling to distribute HC aggregate residual into uncovered minutes.
  */
 export const triggerCalorieComputation = async (user: string, start: Date, end: Date): Promise<void> => {
   try {
@@ -250,6 +377,14 @@ export const triggerCalorieComputation = async (user: string, start: Date, end: 
       console.log(
         `🔥 Computed ${result.points_stored} calorie data points for ${user} ` +
           `(VO2max: ${result.vo2_max_source})`,
+      )
+    }
+    // Gap-fill from HC aggregate for days in the range
+    const gapFill = await gapFillCaloriesForRange(user, start, end)
+    if (gapFill.total_points_stored > 0) {
+      console.log(
+        `🔥 Gap-filled ${gapFill.total_points_stored} calorie points for ${user} ` +
+          `(${gapFill.total_residual_kcal.toFixed(0)} kcal residual across ${gapFill.days_processed} days)`,
       )
     }
   } catch (err) {

--- a/apps/backend/src/services/calories.test.ts
+++ b/apps/backend/src/services/calories.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from 'vitest'
 
 import {
   BASELINE_HR_MULTIPLIER,
-  DEFAULT_RESTING_HR,
-  MAX_HOLD_MINUTES,
+  type CalorieDataPoint,
   computeCaloriesForMinute,
   computeCaloriesPerMinute,
+  computeGapFillPoints,
   computeTotalCaloriesForMinute,
+  DEFAULT_RESTING_HR,
   getVo2MaxFallback,
+  MAX_HOLD_MINUTES,
 } from './calories'
 
 describe('getVo2MaxFallback', () => {
@@ -286,5 +288,166 @@ describe('computeCaloriesPerMinute', () => {
       resting_hr: undefined,
     })
     expect(withResting[0].kcal).toBeCloseTo(withoutResting[0].kcal, 4)
+  })
+})
+
+describe('computeGapFillPoints', () => {
+  const dayStart = new Date('2024-01-15T00:00:00Z')
+
+  /** Helper to create a CalorieDataPoint at a given minute offset from day start. */
+  const makePoint = (minuteOffset: number, kcal: number): CalorieDataPoint => ({
+    end_time: new Date(dayStart.getTime() + (minuteOffset + 1) * 60_000),
+    kcal,
+    time: new Date(dayStart.getTime() + minuteOffset * 60_000),
+  })
+
+  test('returns empty result when HC aggregate is 0', () => {
+    const result = computeGapFillPoints({
+      aurboda_points: [makePoint(600, 5)],
+      day_start: dayStart,
+      hc_aggregate_kcal: 0,
+    })
+    expect(result.points).toHaveLength(0)
+    expect(result.gap_minutes).toBe(0)
+    expect(result.residual_kcal).toBe(0)
+  })
+
+  test('returns empty result when aurboda sum >= HC aggregate', () => {
+    // Aurboda computed more than HC thinks — nothing to distribute
+    const result = computeGapFillPoints({
+      aurboda_points: [makePoint(600, 10), makePoint(601, 10)],
+      day_start: dayStart,
+      hc_aggregate_kcal: 15,
+    })
+    expect(result.points).toHaveLength(0)
+    expect(result.residual_kcal).toBe(0)
+  })
+
+  test('returns empty result when no gap minutes exist (full coverage)', () => {
+    // 1440 points covering every minute of the day
+    const points = Array.from({ length: 1440 }, (_, i) => makePoint(i, 0.5))
+    const aurbodaSum = 1440 * 0.5 // 720 kcal
+
+    const result = computeGapFillPoints({
+      aurboda_points: points,
+      day_start: dayStart,
+      hc_aggregate_kcal: aurbodaSum + 100, // HC has more, but no gaps
+    })
+    expect(result.points).toHaveLength(0)
+    expect(result.gap_minutes).toBe(0)
+  })
+
+  test('distributes residual evenly across gap minutes', () => {
+    // 60 minutes of HR data (10:00-10:59), total 120 kcal
+    const points = Array.from({ length: 60 }, (_, i) => makePoint(600 + i, 2))
+
+    // HC says 220 kcal total, aurboda sum = 120, residual = 100 kcal
+    const result = computeGapFillPoints({
+      aurboda_points: points,
+      day_start: dayStart,
+      hc_aggregate_kcal: 220,
+    })
+
+    // 1440 - 60 = 1380 gap minutes
+    expect(result.gap_minutes).toBe(1380)
+    expect(result.residual_kcal).toBeCloseTo(100, 4)
+    expect(result.per_minute_kcal).toBeCloseTo(100 / 1380, 4)
+    expect(result.points).toHaveLength(1380)
+
+    // Total of gap-fill points should equal the residual
+    const gapTotal = result.points.reduce((sum, p) => sum + p.kcal, 0)
+    expect(gapTotal).toBeCloseTo(100, 2)
+  })
+
+  test('gap-fill points have correct time boundaries', () => {
+    // Single aurboda point at 10:00
+    const result = computeGapFillPoints({
+      aurboda_points: [makePoint(600, 5)],
+      day_start: dayStart,
+      hc_aggregate_kcal: 100,
+    })
+
+    // 1439 gap minutes (all except minute 600)
+    expect(result.gap_minutes).toBe(1439)
+
+    // Each point should be exactly 1 minute long
+    for (const p of result.points) {
+      expect(p.end_time.getTime() - p.time.getTime()).toBe(60_000)
+    }
+
+    // First gap point is at midnight
+    expect(result.points[0].time).toEqual(dayStart)
+
+    // Last gap point is at 23:59
+    const lastPoint = result.points[result.points.length - 1]
+    expect(lastPoint.time).toEqual(new Date('2024-01-15T23:59:00Z'))
+
+    // Minute 600 (10:00) should NOT be in gap-fill points
+    const gap600 = result.points.find((p) => p.time.getTime() === dayStart.getTime() + 600 * 60_000)
+    expect(gap600).toBeUndefined()
+  })
+
+  test('gap-fill points do not overlap with aurboda points', () => {
+    // Aurboda covers 08:00-08:59 and 17:00-17:29
+    const points = [
+      ...Array.from({ length: 60 }, (_, i) => makePoint(480 + i, 3)),
+      ...Array.from({ length: 30 }, (_, i) => makePoint(1020 + i, 4)),
+    ]
+
+    const result = computeGapFillPoints({
+      aurboda_points: points,
+      day_start: dayStart,
+      hc_aggregate_kcal: 500,
+    })
+
+    // 1440 - 60 - 30 = 1350 gap minutes
+    expect(result.gap_minutes).toBe(1350)
+
+    // No gap point should have the same minute as an aurboda point
+    const aurbodaMinutes = new Set(points.map((p) => p.time.getTime()))
+    for (const gapPoint of result.points) {
+      expect(aurbodaMinutes.has(gapPoint.time.getTime())).toBe(false)
+    }
+  })
+
+  test('realistic scenario: 8h sleep + 1h exercise, HC has movement data too', () => {
+    // Sleep 23:00 prev day → 07:00 (covered by HR, but 0 active kcal since below baseline)
+    // Exercise 17:00-17:59 (covered by HR, high active kcal)
+    // HC aggregate = 400 kcal (includes movement during uncovered hours)
+    const sleepPoints = Array.from({ length: 420 }, (_, i) => makePoint(i, 0)) // 00:00-06:59, 0 kcal each
+    const exercisePoints = Array.from({ length: 60 }, (_, i) => makePoint(1020 + i, 5)) // 17:00-17:59, 5 kcal each
+    const allPoints = [...sleepPoints, ...exercisePoints]
+    const aurbodaSum = 60 * 5 // 300 kcal (only exercise contributes)
+
+    const result = computeGapFillPoints({
+      aurboda_points: allPoints,
+      day_start: dayStart,
+      hc_aggregate_kcal: 400,
+    })
+
+    // 1440 - 420 - 60 = 960 gap minutes
+    expect(result.gap_minutes).toBe(960)
+    expect(result.residual_kcal).toBeCloseTo(100, 4) // 400 - 300 = 100 kcal
+    expect(result.per_minute_kcal).toBeCloseTo(100 / 960, 4)
+
+    // Total gap-fill + aurboda should approximate HC aggregate
+    const gapTotal = result.points.reduce((sum, p) => sum + p.kcal, 0)
+    expect(gapTotal + aurbodaSum).toBeCloseTo(400, 1)
+  })
+
+  test('handles very small residual correctly', () => {
+    // Only 1 kcal residual across 1000 gap minutes
+    const points = Array.from({ length: 440 }, (_, i) => makePoint(i, 0.1))
+    const aurbodaSum = 440 * 0.1 // 44 kcal
+
+    const result = computeGapFillPoints({
+      aurboda_points: points,
+      day_start: dayStart,
+      hc_aggregate_kcal: aurbodaSum + 1,
+    })
+
+    expect(result.gap_minutes).toBe(1000)
+    expect(result.residual_kcal).toBeCloseTo(1, 4)
+    expect(result.per_minute_kcal).toBeCloseTo(0.001, 4)
   })
 })

--- a/apps/backend/src/services/calories.ts
+++ b/apps/backend/src/services/calories.ts
@@ -99,6 +99,89 @@ export interface CalorieDataPoint {
   kcal: number
 }
 
+export interface GapFillInput {
+  /** Start of the calendar day (midnight UTC) */
+  day_start: Date
+  /** Per-minute aurboda calorie points already computed for this day */
+  aurboda_points: CalorieDataPoint[]
+  /** HC aggregate total active calories for this day (from health_connect_aggregate source) */
+  hc_aggregate_kcal: number
+}
+
+export interface GapFillResult {
+  /** Gap-fill calorie points to store */
+  points: CalorieDataPoint[]
+  /** Number of gap minutes identified */
+  gap_minutes: number
+  /** Residual kcal distributed (hc_aggregate - aurboda_sum) */
+  residual_kcal: number
+  /** Per-minute kcal value used for gap-filling */
+  per_minute_kcal: number
+}
+
+/**
+ * Compute gap-fill calorie points for minutes without HR data.
+ *
+ * After computing per-minute active calories from HR data (aurboda source),
+ * some minutes in the day have no HR coverage (e.g., wrist off, no HR monitor).
+ * Oura/Health Connect may still capture movement-based calories for those periods.
+ *
+ * This function:
+ * 1. Finds the residual: HC aggregate total - sum of aurboda points
+ * 2. Identifies gap minutes in the day (no aurboda point exists)
+ * 3. Distributes the residual evenly across gap minutes
+ *
+ * Returns empty points if:
+ * - HC aggregate is not higher than aurboda sum (nothing to distribute)
+ * - No gap minutes exist (full HR coverage)
+ */
+export const computeGapFillPoints = (input: GapFillInput): GapFillResult => {
+  const { day_start, aurboda_points, hc_aggregate_kcal } = input
+  const emptyResult: GapFillResult = { gap_minutes: 0, per_minute_kcal: 0, points: [], residual_kcal: 0 }
+
+  // Sum of aurboda-computed calories for this day
+  const aurbodaSum = aurboda_points.reduce((sum, p) => sum + p.kcal, 0)
+
+  // Residual = what HC captured that we didn't
+  const residual = hc_aggregate_kcal - aurbodaSum
+  if (residual <= 0) return emptyResult
+
+  // Build a set of minutes already covered by aurboda
+  const coveredMinutes = new Set<number>()
+  for (const p of aurboda_points) {
+    coveredMinutes.add(Math.floor(p.time.getTime() / 60_000))
+  }
+
+  // Find gap minutes in the day (0..1439)
+  const dayStartMs = day_start.getTime()
+  const gapMinutes: number[] = []
+  for (let m = 0; m < 1440; m++) {
+    const minuteMs = dayStartMs + m * 60_000
+    const minuteKey = Math.floor(minuteMs / 60_000)
+    if (!coveredMinutes.has(minuteKey)) {
+      gapMinutes.push(minuteMs)
+    }
+  }
+
+  if (gapMinutes.length === 0) return emptyResult
+
+  // Distribute residual evenly across gap minutes
+  const perMinuteKcal = residual / gapMinutes.length
+
+  const points: CalorieDataPoint[] = gapMinutes.map((ms) => ({
+    end_time: new Date(ms + 60_000),
+    kcal: perMinuteKcal,
+    time: new Date(ms),
+  }))
+
+  return {
+    gap_minutes: gapMinutes.length,
+    per_minute_kcal: perMinuteKcal,
+    points,
+    residual_kcal: residual,
+  }
+}
+
 /**
  * Compute per-minute calorie burn from heart rate samples.
  *


### PR DESCRIPTION
## Summary

After computing per-minute active calories from HR data (aurboda source), minutes without HR coverage get no calorie data. But Oura/Health Connect may still capture movement-based calories for those uncovered periods via wrist accelerometer data.

This PR adds **gap-filling**: after the HR-based computation, it reads the Health Connect daily aggregate and distributes any residual (HC total - aurboda sum) evenly across minutes that had no HR data.

## How it works

1. After storing aurboda per-minute calories, look up HC aggregate for the calendar day
2. Compute residual = HC total - aurboda sum
3. If residual > 0, distribute evenly across uncovered minutes
4. Store gap-fill points with source `aurboda` (same source filter applies)

**Key properties:**
- No midnight spike: residual is spread across actual gap minutes
- HR-based where available, HC-estimated elsewhere
- Gap-filling runs automatically after HR ingestion and during full recompute
- If HC aggregate <= aurboda sum, nothing happens (no negative fill)

## Example

A day with 8h sleep (HR covered, 0 active kcal) + 1h exercise (HR covered, 300 kcal) + 15h uncovered:
- HC aggregate says 400 kcal total
- Residual = 400 - 300 = 100 kcal
- 960 uncovered gap minutes get 100/960 ≈ 0.104 kcal/min each

## Test coverage
- 8 new unit tests for `computeGapFillPoints` pure function (32 total calorie tests)
- All 926 backend unit tests pass
- `pnpm check` and `pnpm fix` pass clean