### PR TITLE
fix: debounce timeline zoom with rAF and remove ATL line

### DIFF
--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -407,24 +407,6 @@ const drawLoadCurves = (
     .attr('stroke-opacity', bootstrapping ? 0.4 : 0.8)
     .attr('pointer-events', 'none')
     .attr('stroke-dasharray', bootstrapping ? '4,3' : 'none')
-
-  // ATL line (fatigue) - just a line, no area fill
-  const atlLine = d3
-    .line<TrainingLoadPoint>()
-    .x((d) => xScale(parseTime(d.time)))
-    .y((d) => yScale(d.atl))
-    .curve(d3.curveMonotoneX)
-
-  group
-    .append('path')
-    .datum(points)
-    .attr('d', atlLine)
-    .attr('fill', 'none')
-    .attr('stroke', ATL_COLOR)
-    .attr('stroke-width', 1.5)
-    .attr('stroke-opacity', bootstrapping ? 0.4 : 0.8)
-    .attr('pointer-events', 'none')
-    .attr('stroke-dasharray', bootstrapping ? '4,3' : 'none')
 }
 
 /** Draw TSB (form) as a color-coded line. */

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -722,6 +722,8 @@ export const Timeline = () => {
   const baseScaleRef = useRef<d3.ScaleTime<number, number>>()
 
   const drawRef = useRef<((scale: d3.ScaleTime<number, number>) => void) | null>(null)
+  /** rAF handle for coalescing rapid zoom events into a single draw per frame. */
+  const zoomRafRef = useRef<number>(0)
   // Horizontal chart: stable reference for x-axis (updated in place, never rebuilt)
   const hAxisGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null)
 
@@ -1763,7 +1765,10 @@ export const Timeline = () => {
             containerRef.current ?
               Math.max(200, containerRef.current.clientHeight - VERTICAL_MARGIN.top - VERTICAL_MARGIN.bottom)
             : 800
-          drawRef.current?.(d3.scaleTime().domain(newDomain).range([0, h]))
+          cancelAnimationFrame(zoomRafRef.current)
+          zoomRafRef.current = requestAnimationFrame(() => {
+            drawRef.current?.(d3.scaleTime().domain(newDomain).range([0, h]))
+          })
         })
         .on('end', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
           if (isProgrammaticZoom.current) return
@@ -1803,7 +1808,10 @@ export const Timeline = () => {
           if (!baseScale) return
           const newX = event.transform.rescaleX(baseScale)
           const newDomain = newX.domain() as [Date, Date]
-          drawRef.current?.(d3.scaleTime().domain(newDomain).range([0, chartWidth]))
+          cancelAnimationFrame(zoomRafRef.current)
+          zoomRafRef.current = requestAnimationFrame(() => {
+            drawRef.current?.(d3.scaleTime().domain(newDomain).range([0, chartWidth]))
+          })
         })
         .on('end', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
           if (isProgrammaticZoom.current) return
@@ -1827,6 +1835,10 @@ export const Timeline = () => {
     }
 
     svg.on('dblclick.zoom', () => handleResetToToday())
+
+    return () => {
+      cancelAnimationFrame(zoomRafRef.current)
+    }
   }, [orientation, handleZoom, handleResetToToday, effectiveViewStart, effectiveViewEnd])
 
   // ── UI state ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two timeline UI fixes:

- **Zoom debounce**: Two-finger trackpad scrolling caused slow, lingering zoom because `draw()` was called synchronously on every wheel event. Now uses `requestAnimationFrame` to coalesce rapid zoom events — only the latest transform is drawn per animation frame, making zoom responsive again.

- **Remove ATL line**: Fatigue (ATL) was rendered as both colored bars AND a smooth line on top. Removed the redundant ATL line from `drawLoadCurves()`; the bars already convey fatigue level with their blue-orange-red color gradient.