### PR TITLE
fix: make sync-on-read non-blocking to prevent query timeouts

### DIFF
--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -520,9 +520,10 @@ export async function getDailySummary(
   date: Date,
   sync?: SyncProvider,
 ): Promise<DailySummaryResult> {
-  // Auto-sync data sources if sync provider is available
+  // Fire-and-forget: trigger background sync so data is fresh for the next request,
+  // but return current data immediately to avoid blocking on slow external APIs
   if (sync) {
-    await Promise.all([
+    void Promise.all([
       sync.syncOuraIfNeeded(user, 'tags'),
       sync.syncOuraIfNeeded(user, 'sessions'),
       sync.syncRescueTimeIfNeeded(user),
@@ -936,8 +937,9 @@ export async function queryTags(
   end: Date,
   sync?: SyncProvider,
 ): Promise<TagSummary[]> {
+  // Fire-and-forget: trigger background sync so data is fresh for the next request
   if (sync) {
-    await Promise.all([
+    void Promise.all([
       sync.syncOuraIfNeeded(user, 'tags'),
       sync.syncCalendarsIfNeeded(user),
       sync.syncLastFmIfNeeded(user),
@@ -1060,9 +1062,9 @@ export async function queryActivities(
   end: Date,
   sync?: SyncProvider,
 ): Promise<ActivityResult[]> {
-  // Auto-sync Oura sessions if meditation is requested
+  // Fire-and-forget: trigger background sync so meditation data is fresh for the next request
   if (sync && types.includes('meditation')) {
-    await sync.syncOuraIfNeeded(user, 'sessions')
+    void sync.syncOuraIfNeeded(user, 'sessions')
   }
 
   const activities = await getActivities(user, types, start, end)
@@ -1198,8 +1200,9 @@ export async function queryProductivity(
   end: Date,
   sync?: SyncProvider,
 ): Promise<ProductivityResult[]> {
+  // Fire-and-forget: trigger background sync so data is fresh for the next request
   if (sync) {
-    await sync.syncRescueTimeIfNeeded(user)
+    void sync.syncRescueTimeIfNeeded(user)
   }
 
   const productivity = await getProductivity(user, start, end)


### PR DESCRIPTION
## Summary

- External API syncs (Oura, calendars, Last.fm, RescueTime) in query functions (`queryTags`, `queryActivities`, `queryProductivity`, `getDailySummary`) were `await`ed before returning data. When external APIs are slow or unreachable, this blocked the entire HTTP request — causing 502 timeouts (e.g., on `/api/tags`).
- Changed all sync calls to **fire-and-forget** (`void Promise.all([...])`). Queries now return current DB data immediately while syncs complete in the background. Data stays fresh for the next request (30-minute staleness threshold unchanged).
- The sync functions already catch their own errors and log them, so unhandled rejection is not a concern.

## Impact

The Timeline page fires ~25+ requests on load. Previously, if Oura/Last.fm/calendar APIs were slow, multiple endpoints would block simultaneously, causing cascading timeouts. Now all query endpoints respond instantly with cached data.