### PR TITLE
feat: unified bucketed metrics — reduce timeline from ~17+N to ~2 requests

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -69,6 +69,7 @@ export {
   deleteTimeSeriesMetric,
   deleteTimeSeriesPoint,
   getDailyAggregates,
+  getDistinctMetrics,
   getRawDailySum,
   getTimeSeries,
   getTimeSeriesBucketed,

--- a/apps/backend/src/db/time-series.integration.test.ts
+++ b/apps/backend/src/db/time-series.integration.test.ts
@@ -11,6 +11,7 @@ import {
   deleteTimeSeriesBySource,
   deleteTimeSeriesMetric,
   deleteTimeSeriesPoint,
+  getDistinctMetrics,
   getTimeSeries,
   getTimeSeriesBucketed,
   getTimeSeriesWithSource,
@@ -678,6 +679,40 @@ describe('Time Series Integration Tests', () => {
       const count = await deleteTimeSeriesMetric(user, 'weight')
 
       expect(count).toBe(0)
+    })
+  })
+
+  describe('getDistinctMetrics', () => {
+    test('returns distinct metric names within time range', async () => {
+      const user = getTestUser()
+
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2024-01-15T06:00:00Z'), value: 72 },
+        { metric: 'heart_rate', source: 'oura', time: new Date('2024-01-15T07:00:00Z'), value: 75 },
+        { metric: 'steps', source: 'health_connect', time: new Date('2024-01-15T06:00:00Z'), value: 100 },
+        { metric: 'weight', source: 'manual', time: new Date('2024-01-15T08:00:00Z'), value: 80 },
+        { metric: 'weight', source: 'manual', time: new Date('2024-01-20T08:00:00Z'), value: 80.5 },
+      ])
+
+      const metrics = await getDistinctMetrics(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-16T00:00:00Z'),
+      )
+
+      expect(metrics).toEqual(['heart_rate', 'steps', 'weight'])
+    })
+
+    test('returns empty array when no data in range', async () => {
+      const user = getTestUser()
+
+      const metrics = await getDistinctMetrics(
+        user,
+        new Date('2024-06-01T00:00:00Z'),
+        new Date('2024-06-02T00:00:00Z'),
+      )
+
+      expect(metrics).toEqual([])
     })
   })
 })

--- a/apps/backend/src/db/time-series.integration.test.ts
+++ b/apps/backend/src/db/time-series.integration.test.ts
@@ -303,7 +303,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T10:30:00Z'),
-        15, // 15-minute buckets
+        '15 minutes',
       )
 
       expect(buckets).toHaveLength(2)
@@ -342,7 +342,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate', 'hrv_rmssd'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T10:15:00Z'),
-        15,
+        '15 minutes',
       )
 
       expect(buckets).toHaveLength(2) // One bucket per metric
@@ -367,7 +367,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T11:00:00Z'),
-        15,
+        '15 minutes',
       )
 
       expect(buckets).toHaveLength(0)
@@ -385,7 +385,7 @@ describe('Time Series Integration Tests', () => {
         [],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T11:00:00Z'),
-        15,
+        '15 minutes',
       )
 
       expect(buckets).toHaveLength(0)
@@ -406,7 +406,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T10:10:00Z'),
-        5, // 5-minute buckets
+        '5 minutes',
       )
 
       expect(buckets).toHaveLength(2)
@@ -431,7 +431,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T12:00:00Z'),
-        60, // 1-hour buckets
+        '60 minutes',
       )
 
       expect(buckets).toHaveLength(2)
@@ -460,7 +460,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T00:00:00Z'),
         new Date('2024-01-17T00:00:00Z'),
-        1440, // 1-day buckets (24*60 minutes)
+        '1 day',
       )
 
       expect(buckets).toHaveLength(2)
@@ -487,7 +487,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T10:45:00Z'),
-        15,
+        '15 minutes',
       )
 
       expect(buckets).toHaveLength(2)
@@ -510,7 +510,7 @@ describe('Time Series Integration Tests', () => {
         ['heart_rate'],
         new Date('2024-01-15T10:00:00Z'),
         new Date('2024-01-15T10:15:00Z'),
-        15,
+        '15 minutes',
       )
 
       expect(buckets).toHaveLength(1)

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -338,7 +338,7 @@ export const getTimeSeriesBucketed = async (
   metrics: MetricType[],
   start: Date,
   end: Date,
-  bucketMinutes: number,
+  interval: string,
 ): Promise<BucketedMetricData[]> => {
   if (metrics.length === 0) return []
 
@@ -348,6 +348,7 @@ export const getTimeSeriesBucketed = async (
        AVG(value) as avg,
        MIN(value) as min,
        MAX(value) as max,
+       SUM(value) as sum,
        COUNT(*)::integer as count
      FROM time_series
      WHERE metric = ANY($1) AND time >= $2 AND time < $3${sourceFilter}
@@ -361,9 +362,9 @@ export const getTimeSeriesBucketed = async (
     max: row.max !== null ? Number(row.max) : 0,
     metric: parseMetricType(row.metric as string),
     min: row.min !== null ? Number(row.min) : 0,
+    sum: row.sum !== null ? Number(row.sum) : 0,
   })
 
-  const interval = `${bucketMinutes} minutes`
   const results = await querySplitByCumulative<BucketedMetricData>({
     cumulativeExtraParams: [cumulativeSources],
     mapRow,
@@ -375,4 +376,13 @@ export const getTimeSeriesBucketed = async (
   })
 
   return results.sort((a, b) => a.bucket_start.getTime() - b.bucket_start.getTime())
+}
+
+/** Get distinct metric names that have data in the given time range. */
+export const getDistinctMetrics = async (user: string, start: Date, end: Date): Promise<string[]> => {
+  const result = await query(user, 'SELECT DISTINCT metric FROM time_series WHERE time >= $1 AND time < $2', [
+    start,
+    end,
+  ])
+  return result.rows.map((row) => row.metric as string).sort()
 }

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -64,6 +64,7 @@ export interface BucketedMetricData {
   min: number
   max: number
   count: number
+  sum: number
 }
 
 // ============================================================================

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -14,7 +14,6 @@ import {
 import { z } from 'zod'
 import { getCustomMetrics } from '../services/mutations'
 import {
-  type BucketSize,
   getDailySummary,
   getPeriodSummary,
   queryActivities,
@@ -53,35 +52,51 @@ export const registerQueryTools = (server: McpServer, user: string, sync?: SyncP
     'query_metrics_bucketed',
     `Query pre-aggregated health metrics in time buckets. Returns buckets with min/max/avg/count for each metric.
 Much more efficient than query_metrics for analysis - returns ~96 buckets for a day (15m intervals) instead of 30,000+ individual samples.
+Cumulative metrics (steps, calories, etc.) also include a 'sum' field.
+
+If metrics is omitted, returns ALL metrics with data in the time range.
+Use exclude to skip specific metrics when fetching all.
+
+Bucket size format: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), M (months).
+Examples: 10s, 5m, 1h, 1d, 1M
 
 Use cases:
 - Daily timeline analysis: "Show me HR/HRV patterns across the day"
 - Sleep quality analysis: "How did my HRV change during sleep?"
 - Exercise response: "Compare pre/during/post exercise HR"
-- Multi-day trends: "What's my average resting HR this week?" (use 1d bucket)`,
+- Multi-day trends: "What's my average resting HR this week?" (use 1d bucket)
+- All metrics overview: Omit metrics param to get everything`,
     {
       ...timeRangeQuerySchema.shape,
       bucket: bucketSizeSchema,
-      metrics: z.array(z.string()).describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
+      exclude: z.array(z.string()).optional().describe('Metrics to exclude (useful when fetching all)'),
+      metrics: z
+        .array(z.string())
+        .optional()
+        .describe(`Metrics to include (omit for all). Valid built-in metrics: ${validMetrics.join(', ')}`),
     },
-    async ({ bucket, end, metrics, start }) => {
+    async ({ bucket, end, exclude, metrics, start }) => {
       const customMetrics = await getCustomMetrics(user)
-      const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
-      if (invalidMetrics.length > 0) {
-        const customNames = customMetrics.map((m) => m.name)
-        const allMetrics = [...validMetrics, ...customNames]
-        return errorResponse(
-          `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${allMetrics.join(', ')}`,
-        )
+
+      // Validate specified metrics if provided
+      if (metrics) {
+        const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
+        if (invalidMetrics.length > 0) {
+          const customNames = customMetrics.map((m) => m.name)
+          const allMetrics = [...validMetrics, ...customNames]
+          return errorResponse(
+            `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${allMetrics.join(', ')}`,
+          )
+        }
       }
 
-      const validatedMetrics = metrics as MetricType[]
       const result = await queryMetricsBucketed(
         user,
-        validatedMetrics,
+        metrics as MetricType[] | undefined,
         new Date(start),
         new Date(end),
-        bucket as BucketSize,
+        bucket,
+        { customMetrics, exclude },
       )
       return jsonResponse(result)
     },

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -9,7 +9,6 @@ import {
   type AddMetricBody,
   addMetricBodySchema,
   type AddMetricResponse,
-  type BucketSize,
   type BulkMetricsBody,
   bulkMetricsBodySchema,
   type BulkMetricsResponse,
@@ -60,8 +59,6 @@ import {
 import { getLatestMetric } from '../services/reports'
 import { validateBody, validateQuery } from '../validation'
 
-const validBucketSizes = ['5m', '15m', '30m', '1h', '1d'] as const
-
 export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider?: SyncProvider): Router => {
   const router = Router()
 
@@ -71,34 +68,34 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     authMiddleware,
     validateQuery(queryMetricsBucketedQuerySchema),
     async (req, res) => {
-      const { start, end, bucket, metrics: metricsParam } = req.query
+      const { start, end, bucket, metrics: metricsParam, exclude: excludeParam } = req.query
       const user = req.user!
 
       const settings = await getUserSettings(user)
       const customMetrics = settings?.custom_metrics ?? []
 
-      const metrics = metricsParam.split(',')
-      const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
-      if (invalidMetrics.length > 0) {
-        return res.status(400).json({
-          error: `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${validMetrics.join(', ')}`,
-          success: false,
-        })
-      }
+      // Parse optional metrics and exclude lists
+      const metrics = metricsParam ? metricsParam.split(',') : undefined
+      const exclude = excludeParam ? excludeParam.split(',') : undefined
 
-      if (!validBucketSizes.includes(bucket)) {
-        return res.status(400).json({
-          error: `Invalid bucket size "${bucket}". Valid sizes are: ${validBucketSizes.join(', ')}`,
-          success: false,
-        })
+      // Validate specified metrics if provided
+      if (metrics) {
+        const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
+        if (invalidMetrics.length > 0) {
+          return res.status(400).json({
+            error: `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${validMetrics.join(', ')}`,
+            success: false,
+          })
+        }
       }
 
       const result = await queryMetricsBucketed(
         user,
-        metrics as MetricType[],
+        metrics as MetricType[] | undefined,
         new Date(start),
         new Date(end),
-        bucket as BucketSize,
+        bucket,
+        { customMetrics, exclude },
       )
       res.json({ ...result, success: true })
     },

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -11,6 +11,7 @@ export {
   contextualHrvMetrics,
   cumulativeMetrics,
   cumulativeSources,
+  getMetricAggregation,
   getMetricUnit,
   hrZoneMetrics,
   isContextualHrvMetric,
@@ -18,10 +19,12 @@ export {
   isValidMetric,
   isValidMetricOrCustom,
   metricUnits,
+  sumMetrics,
   validMetrics,
   type ActivityType,
   type CustomMetricDefinition,
   type DataSource,
+  type MetricAggregation,
   type MetricType,
 } from '@aurboda/api-spec'
 

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -7,6 +7,7 @@ import {
   getDailySummary,
   getPeriodSummary,
   mergeProductivitySpans,
+  parseBucketSize,
   queryActivities,
   queryMetrics,
   queryMetricsBucketed,
@@ -19,6 +20,7 @@ vi.mock('../db', () => ({
   getActivities: vi.fn(),
   getDailyAggregateValue: vi.fn(),
   getDailyAggregates: vi.fn(),
+  getDistinctMetrics: vi.fn(),
   getLocations: vi.fn(),
   getNotesByEntityIds: vi.fn(),
   getNotesForTimeRange: vi.fn(),
@@ -1396,6 +1398,179 @@ describe('queryMetricsBucketed', () => {
     // Should have no hrv_sleep buckets since HRV data is during awake hours
     const hrvSleepBuckets = result.buckets.filter((b) => b.metrics.hrv_sleep)
     expect(hrvSleepBuckets).toHaveLength(0)
+  })
+
+  test('discovers all metrics when metrics param is omitted', async () => {
+    vi.mocked(db.getDistinctMetrics).mockResolvedValue(['heart_rate', 'steps'])
+    vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue([
+      {
+        avg: 72,
+        bucket_start: new Date('2024-01-15T06:00:00Z'),
+        count: 60,
+        max: 80,
+        metric: 'heart_rate',
+        min: 65,
+        sum: 0,
+      },
+      {
+        avg: 100,
+        bucket_start: new Date('2024-01-15T06:00:00Z'),
+        count: 12,
+        max: 200,
+        metric: 'steps',
+        min: 0,
+        sum: 1200,
+      },
+    ])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      undefined,
+      new Date('2024-01-15T06:00:00Z'),
+      new Date('2024-01-15T06:05:00Z'),
+      '5m',
+    )
+
+    expect(db.getDistinctMetrics).toHaveBeenCalledWith('testuser', expect.any(Date), expect.any(Date))
+    expect(result.buckets).toHaveLength(1)
+    expect(result.buckets[0].metrics.heart_rate).toBeDefined()
+    expect(result.buckets[0].metrics.steps).toBeDefined()
+  })
+
+  test('applies exclude filter to discovered metrics', async () => {
+    vi.mocked(db.getDistinctMetrics).mockResolvedValue(['heart_rate', 'steps', 'training_impulse'])
+    vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue([
+      {
+        avg: 72,
+        bucket_start: new Date('2024-01-15T06:00:00Z'),
+        count: 60,
+        max: 80,
+        metric: 'heart_rate',
+        min: 65,
+        sum: 0,
+      },
+    ])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      undefined,
+      new Date('2024-01-15T06:00:00Z'),
+      new Date('2024-01-15T06:05:00Z'),
+      '5m',
+      { exclude: ['training_impulse', 'steps'] },
+    )
+
+    // Only heart_rate should be queried (steps and training_impulse excluded)
+    expect(db.getTimeSeriesBucketed).toHaveBeenCalledWith(
+      'testuser',
+      ['heart_rate'],
+      expect.any(Date),
+      expect.any(Date),
+      '5 minutes',
+    )
+    expect(result.buckets).toHaveLength(1)
+    expect(result.buckets[0].metrics.heart_rate).toBeDefined()
+    expect(result.buckets[0].metrics.training_impulse).toBeUndefined()
+  })
+
+  test('includes sum for cumulative metrics', async () => {
+    vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue([
+      {
+        avg: 100,
+        bucket_start: new Date('2024-01-15T06:00:00Z'),
+        count: 12,
+        max: 200,
+        metric: 'steps',
+        min: 0,
+        sum: 1200,
+      },
+    ])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      ['steps'],
+      new Date('2024-01-15T06:00:00Z'),
+      new Date('2024-01-15T06:05:00Z'),
+      '5m',
+    )
+
+    expect(result.buckets).toHaveLength(1)
+    const steps = result.buckets[0]!.metrics.steps!
+    expect(steps).toBeDefined()
+    expect(steps.sum).toBe(1200)
+    expect(steps.avg).toBe(100)
+  })
+
+  test('omits sum for non-cumulative metrics', async () => {
+    vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue([
+      {
+        avg: 72,
+        bucket_start: new Date('2024-01-15T06:00:00Z'),
+        count: 60,
+        max: 80,
+        metric: 'heart_rate',
+        min: 65,
+        sum: 4320,
+      },
+    ])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      ['heart_rate'],
+      new Date('2024-01-15T06:00:00Z'),
+      new Date('2024-01-15T06:05:00Z'),
+      '5m',
+    )
+
+    expect(result.buckets).toHaveLength(1)
+    const hr = result.buckets[0]!.metrics.heart_rate!
+    expect(hr).toBeDefined()
+    expect(hr.sum).toBeUndefined()
+    expect(hr.avg).toBe(72)
+  })
+
+  test('returns empty buckets when no metrics discovered', async () => {
+    vi.mocked(db.getDistinctMetrics).mockResolvedValue([])
+
+    const result = await queryMetricsBucketed(
+      'testuser',
+      undefined,
+      new Date('2024-01-15T06:00:00Z'),
+      new Date('2024-01-15T06:05:00Z'),
+      '5m',
+    )
+
+    expect(result.buckets).toHaveLength(0)
+  })
+})
+
+describe('parseBucketSize', () => {
+  test('parses seconds', () => {
+    expect(parseBucketSize('30s')).toEqual({ interval: '30 seconds', ms: 30000 })
+  })
+
+  test('parses minutes', () => {
+    expect(parseBucketSize('5m')).toEqual({ interval: '5 minutes', ms: 300000 })
+  })
+
+  test('parses hours', () => {
+    expect(parseBucketSize('1h')).toEqual({ interval: '1 hours', ms: 3600000 })
+  })
+
+  test('parses days', () => {
+    expect(parseBucketSize('1d')).toEqual({ interval: '1 days', ms: 86400000 })
+  })
+
+  test('parses months', () => {
+    expect(parseBucketSize('1M')).toEqual({ interval: '1 months', ms: 30 * 86400000 })
+  })
+
+  test('throws on invalid format', () => {
+    expect(() => parseBucketSize('abc')).toThrow('Invalid bucket size')
+  })
+
+  test('throws on empty string', () => {
+    expect(() => parseBucketSize('')).toThrow('Invalid bucket size')
   })
 })
 

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -1012,6 +1012,7 @@ describe('queryMetricsBucketed', () => {
         max: 80,
         metric: 'heart_rate',
         min: 65,
+        sum: 0,
       },
       {
         avg: 78,
@@ -1020,6 +1021,7 @@ describe('queryMetricsBucketed', () => {
         max: 85,
         metric: 'heart_rate',
         min: 70,
+        sum: 0,
       },
     ]
     vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue(mockBuckets)
@@ -1059,6 +1061,7 @@ describe('queryMetricsBucketed', () => {
         max: 80,
         metric: 'heart_rate',
         min: 65,
+        sum: 0,
       },
       {
         avg: 45,
@@ -1067,6 +1070,7 @@ describe('queryMetricsBucketed', () => {
         max: 60,
         metric: 'hrv_rmssd',
         min: 30,
+        sum: 0,
       },
       {
         avg: 78,
@@ -1075,6 +1079,7 @@ describe('queryMetricsBucketed', () => {
         max: 85,
         metric: 'heart_rate',
         min: 70,
+        sum: 0,
       },
       {
         avg: 42,
@@ -1083,6 +1088,7 @@ describe('queryMetricsBucketed', () => {
         max: 55,
         metric: 'hrv_rmssd',
         min: 28,
+        sum: 0,
       },
     ]
     vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue(mockBuckets)
@@ -1129,6 +1135,7 @@ describe('queryMetricsBucketed', () => {
         max: 80,
         metric: 'heart_rate',
         min: 65,
+        sum: 0,
       },
     ]
     vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue(mockBuckets)
@@ -1148,7 +1155,7 @@ describe('queryMetricsBucketed', () => {
       ['heart_rate'],
       expect.any(Date),
       expect.any(Date),
-      5,
+      '5 minutes',
     )
   })
 
@@ -1161,6 +1168,7 @@ describe('queryMetricsBucketed', () => {
         max: 80,
         metric: 'heart_rate',
         min: 65,
+        sum: 0,
       },
     ]
     vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue(mockBuckets)
@@ -1180,7 +1188,7 @@ describe('queryMetricsBucketed', () => {
       ['heart_rate'],
       expect.any(Date),
       expect.any(Date),
-      60,
+      '1 hours',
     )
   })
 
@@ -1193,6 +1201,7 @@ describe('queryMetricsBucketed', () => {
         max: 120,
         metric: 'heart_rate',
         min: 55,
+        sum: 0,
       },
     ]
     vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue(mockBuckets)
@@ -1212,7 +1221,7 @@ describe('queryMetricsBucketed', () => {
       ['heart_rate'],
       expect.any(Date),
       expect.any(Date),
-      1440,
+      '1 days',
     )
   })
 
@@ -1226,6 +1235,7 @@ describe('queryMetricsBucketed', () => {
         max: 80,
         metric: 'heart_rate',
         min: 65,
+        sum: 0,
       },
       {
         avg: 45,
@@ -1234,6 +1244,7 @@ describe('queryMetricsBucketed', () => {
         max: 60,
         metric: 'hrv_rmssd',
         min: 30,
+        sum: 0,
       },
       {
         avg: 78,
@@ -1242,6 +1253,7 @@ describe('queryMetricsBucketed', () => {
         max: 85,
         metric: 'heart_rate',
         min: 70,
+        sum: 0,
       },
       // No hrv_rmssd data for 06:15 bucket
     ]
@@ -1315,6 +1327,7 @@ describe('queryMetricsBucketed', () => {
         max: 80,
         metric: 'heart_rate' as MetricType,
         min: 65,
+        sum: 0,
       },
     ])
 

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -11,6 +11,7 @@ import {
   getActivities,
   getDailyAggregates,
   getDailyAggregateValue,
+  getDistinctMetrics,
   getNotesByEntityIds,
   getNotesForTimeRange,
   getProductivity,
@@ -25,9 +26,11 @@ import {
 } from '../db'
 import {
   ActivityType,
+  getMetricAggregation,
   getMetricUnit,
   isContextualHrvMetric,
   isHrZoneMetric,
+  isValidMetricOrCustom,
   MetricType,
   metricUnits,
 } from '../schema'
@@ -69,9 +72,9 @@ export interface QueryMetricsResult {
 }
 
 /**
- * Valid bucket sizes for bucketed metrics queries.
+ * Bucket size string in {number}{unit} format (e.g., '5m', '10s', '1h', '1d', '1M').
  */
-export type BucketSize = '5m' | '15m' | '30m' | '1h' | '1d'
+export type BucketSize = string
 
 /**
  * Bucket statistics for a single metric.
@@ -81,6 +84,7 @@ export interface BucketMetricStats {
   min: number
   max: number
   count: number
+  sum?: number
 }
 
 /**
@@ -322,25 +326,40 @@ async function getContextualHrvData(
 }
 
 /**
- * Convert bucket size string to minutes.
+ * Parse a bucket size string like '5m', '10s', '1h', '1d', '1M' into:
+ * - interval: PostgreSQL interval string for date_bin() (e.g., '300 seconds')
+ * - ms: bucket duration in milliseconds (for in-memory bucketing)
  */
-const bucketSizeToMinutes: Record<BucketSize, number> = {
-  '1d': 1440,
-  '1h': 60,
-  '5m': 5,
-  '15m': 15,
-  '30m': 30,
+export const parseBucketSize = (bucket: string): { interval: string; ms: number } => {
+  const match = bucket.match(/^(\d+)([smhdM])$/)
+  if (!match) throw new Error(`Invalid bucket size: ${bucket}`)
+  const n = parseInt(match[1], 10)
+  const unit = match[2]
+  switch (unit) {
+    case 's':
+      return { interval: `${n} seconds`, ms: n * 1000 }
+    case 'm':
+      return { interval: `${n} minutes`, ms: n * 60 * 1000 }
+    case 'h':
+      return { interval: `${n} hours`, ms: n * 60 * 60 * 1000 }
+    case 'd':
+      return { interval: `${n} days`, ms: n * 24 * 60 * 60 * 1000 }
+    case 'M':
+      // Approximate months as 30 days for in-memory bucketing; PostgreSQL handles months properly
+      return { interval: `${n} months`, ms: n * 30 * 24 * 60 * 60 * 1000 }
+    default:
+      throw new Error(`Invalid bucket size unit: ${unit}`)
+  }
 }
 
 /**
  * Compute bucket start time for a given timestamp.
  */
-const getBucketStart = (time: Date, bucketMinutes: number, rangeStart: Date): Date => {
-  const msPerBucket = bucketMinutes * 60 * 1000
+const getBucketStart = (time: Date, bucketMs: number, rangeStart: Date): Date => {
   const startMs = rangeStart.getTime()
   const timeMs = time.getTime()
-  const bucketIndex = Math.floor((timeMs - startMs) / msPerBucket)
-  return new Date(startMs + bucketIndex * msPerBucket)
+  const bucketIndex = Math.floor((timeMs - startMs) / bucketMs)
+  return new Date(startMs + bucketIndex * bucketMs)
 }
 
 /**
@@ -359,15 +378,23 @@ const contextualHrvMetricToContext: Record<string, HrvContext> = {
 const computeContextualHrvBuckets = (
   hrvData: [Date, number][],
   metric: MetricType,
-  bucketMinutes: number,
+  bucketMs: number,
   rangeStart: Date,
-): { bucket_start: Date; metric: MetricType; avg: number; min: number; max: number; count: number }[] => {
+): {
+  bucket_start: Date
+  metric: MetricType
+  avg: number
+  min: number
+  max: number
+  count: number
+  sum: number
+}[] => {
   if (hrvData.length === 0) return []
 
   // Group data by bucket
   const bucketMap = new Map<string, number[]>()
   for (const [time, value] of hrvData) {
-    const bucketStart = getBucketStart(time, bucketMinutes, rangeStart)
+    const bucketStart = getBucketStart(time, bucketMs, rangeStart)
     const key = bucketStart.toISOString()
     if (!bucketMap.has(key)) {
       bucketMap.set(key, [])
@@ -376,50 +403,75 @@ const computeContextualHrvBuckets = (
   }
 
   // Compute aggregations for each bucket
-  return Array.from(bucketMap.entries()).map(([key, values]) => ({
-    avg: values.reduce((a, b) => a + b, 0) / values.length,
-    bucket_start: new Date(key),
-    count: values.length,
-    max: Math.max(...values),
-    metric,
-    min: Math.min(...values),
-  }))
+  return Array.from(bucketMap.entries()).map(([key, values]) => {
+    const sum = values.reduce((a, b) => a + b, 0)
+    return {
+      avg: sum / values.length,
+      bucket_start: new Date(key),
+      count: values.length,
+      max: Math.max(...values),
+      metric,
+      min: Math.min(...values),
+      sum,
+    }
+  })
 }
 
 /**
  * Query bucketed/aggregated time series data for multiple metrics.
  *
- * Returns pre-aggregated buckets with min/max/avg/count for each metric,
+ * Returns pre-aggregated buckets with min/max/avg/count/sum for each metric,
  * significantly reducing data size compared to raw time series queries.
+ * Sum is included for cumulative metrics (steps, calories, etc.).
  *
  * Supports contextual HRV metrics (hrv_sleep, hrv_activity, hrv_awake) which
  * are computed by filtering hrv_rmssd data by overlapping sleep/activity windows.
  *
  * @param user - The username
- * @param metrics - Array of metric types to query
+ * @param metrics - Specific metrics to query (omit for all metrics in range)
  * @param start - Start of time range
  * @param end - End of time range
- * @param bucket - Bucket size: '5m', '15m', '30m', '1h', or '1d'
+ * @param bucket - Bucket size string, e.g. '5m', '10s', '1h', '1d', '1M'
+ * @param options.exclude - Metrics to exclude (useful when fetching all)
+ * @param options.customMetrics - Custom metric definitions for validation
  */
 export async function queryMetricsBucketed(
   user: string,
-  metrics: MetricType[],
+  metrics: MetricType[] | undefined,
   start: Date,
   end: Date,
   bucket: BucketSize,
+  options: { customMetrics?: CustomMetricDefinition[]; exclude?: string[] } = {},
 ): Promise<QueryMetricsBucketedResult> {
-  const bucketMinutes = bucketSizeToMinutes[bucket]
+  const { interval, ms: bucketMs } = parseBucketSize(bucket)
+  const excludeSet = new Set(options.exclude ?? [])
+
+  // Resolve which metrics to query
+  let resolvedMetrics: MetricType[]
+  if (metrics && metrics.length > 0) {
+    resolvedMetrics = metrics.filter((m) => !excludeSet.has(m))
+  } else {
+    // Discover all metrics with data in the range
+    const available = await getDistinctMetrics(user, start, end)
+    resolvedMetrics = available.filter(
+      (m) => !excludeSet.has(m) && isValidMetricOrCustom(m, options.customMetrics),
+    ) as MetricType[]
+  }
+
+  if (resolvedMetrics.length === 0) {
+    return { bucket, buckets: [], end: end.toISOString(), start: start.toISOString() }
+  }
 
   // Separate regular metrics from contextual HRV metrics
-  const regularMetrics = metrics.filter((m) => !isContextualHrvMetric(m))
-  const contextualHrvMetricsRequested = metrics.filter(isContextualHrvMetric)
+  const regularMetrics = resolvedMetrics.filter((m) => !isContextualHrvMetric(m))
+  const contextualHrvMetricsRequested = resolvedMetrics.filter(isContextualHrvMetric)
 
   // Fetch regular bucketed data and contextual HRV data in parallel
   const needsContextualHrv = contextualHrvMetricsRequested.length > 0
   const [regularData, contextualHrvData] = await Promise.all([
-    regularMetrics.length > 0 ? getTimeSeriesBucketed(user, regularMetrics, start, end, bucketMinutes) : [],
+    regularMetrics.length > 0 ? getTimeSeriesBucketed(user, regularMetrics, start, end, interval) : [],
     needsContextualHrv ?
-      computeContextualHrvData(user, contextualHrvMetricsRequested, start, end, bucketMinutes)
+      computeContextualHrvData(user, contextualHrvMetricsRequested, start, end, bucketMs)
     : [],
   ])
 
@@ -431,7 +483,7 @@ export async function queryMetricsBucketed(
 
   for (const row of allData) {
     const bucketKey = row.bucket_start.toISOString()
-    const bucketEndMs = row.bucket_start.getTime() + bucketMinutes * 60 * 1000
+    const bucketEndMs = row.bucket_start.getTime() + bucketMs
     const bucketEnd = new Date(bucketEndMs).toISOString()
 
     if (!bucketMap.has(bucketKey)) {
@@ -443,12 +495,17 @@ export async function queryMetricsBucketed(
     }
 
     const bucketEntry = bucketMap.get(bucketKey)!
-    bucketEntry.metrics[row.metric] = {
+    const stats: BucketMetricStats = {
       avg: row.avg,
       count: row.count,
       max: row.max,
       min: row.min,
     }
+    // Include sum for cumulative metrics
+    if (getMetricAggregation(row.metric) === 'sum') {
+      stats.sum = row.sum
+    }
+    bucketEntry.metrics[row.metric] = stats
   }
 
   // Convert map to sorted array
@@ -473,9 +530,17 @@ async function computeContextualHrvData(
   metrics: MetricType[],
   start: Date,
   end: Date,
-  bucketMinutes: number,
+  bucketMs: number,
 ): Promise<
-  { bucket_start: Date; metric: MetricType; avg: number; min: number; max: number; count: number }[]
+  {
+    bucket_start: Date
+    metric: MetricType
+    avg: number
+    min: number
+    max: number
+    count: number
+    sum: number
+  }[]
 > {
   // Fetch raw HRV data and context windows in parallel
   const [hrvData, { sleepWindows, activityWindows }] = await Promise.all([
@@ -496,13 +561,14 @@ async function computeContextualHrvData(
     min: number
     max: number
     count: number
+    sum: number
   }[] = []
 
   for (const metric of metrics) {
     const context = contextualHrvMetricToContext[metric]
     if (context) {
       const contextData = classified[context]
-      const buckets = computeContextualHrvBuckets(contextData, metric, bucketMinutes, start)
+      const buckets = computeContextualHrvBuckets(contextData, metric, bucketMs, start)
       results.push(...buckets)
     }
   }

--- a/apps/backend/src/services/training-load.ts
+++ b/apps/backend/src/services/training-load.ts
@@ -803,13 +803,12 @@ export const createTrainingLoadDeps = (): TrainingLoadDeps => ({
   },
 
   getHourlyCalorieSums: async (user, start, end) => {
-    const buckets = await getTimeSeriesBucketed(user, ['calories_active'], start, end, 60)
-    // getTimeSeriesBucketed returns avg — we need sum (avg × count)
-    return buckets.map((b) => [b.bucket_start, b.avg * b.count] as [Date, number])
+    const buckets = await getTimeSeriesBucketed(user, ['calories_active'], start, end, '60 minutes')
+    return buckets.map((b) => [b.bucket_start, b.sum] as [Date, number])
   },
 
   getHrSamples: async (user, start, end) => {
-    const buckets = await getTimeSeriesBucketed(user, ['heart_rate'], start, end, 5)
+    const buckets = await getTimeSeriesBucketed(user, ['heart_rate'], start, end, '5 minutes')
     return buckets.map((b) => [b.bucket_start, b.avg] as [Date, number])
   },
 

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -239,7 +239,7 @@ export const buildActivityColumnItems = (
   activityColors: Record<string, string>,
   exerciseColor: (a: Activity) => string,
   getExerciseTypeName: (a: Activity) => string,
-  ouraByDate: Map<string, Record<string, number>>,
+  sleepMetricsByDate: Map<string, Record<string, number>>,
   buildSleepDetails: (a: Activity, end: Date) => string[],
   scrobbles: { artist: string; track: string; recorded_at: Date }[],
 ): { items: ChartItem[]; overlaps: OverlapWarning[] } => {

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable max-lines -- large visualization component */
-import { metricUnits as builtinMetricUnits, type ScreentimeCategory } from '@aurboda/api-spec'
+import {
+  metricUnits as builtinMetricUnits,
+  type QueryMetricsBucketedResponse,
+  type ScreentimeCategory,
+} from '@aurboda/api-spec'
 import { signal, useSignalEffect } from '@preact/signals'
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
 import * as d3 from 'd3'
@@ -10,7 +14,6 @@ import {
   fetchActivities,
   fetchBucketedMetrics,
   fetchCustomMetrics,
-  fetchMetricTimeSeriesWithSource,
   fetchPlaces,
   fetchProductivity,
   fetchScreentimeCategories,
@@ -22,7 +25,6 @@ import {
   Place,
   ProductivityRecord,
   Tag,
-  type MetricDataPointWithSource,
 } from '../../state/api'
 import { parseBucketedResponse } from '../../utils/chart'
 import { isEmoji, isUrl } from '../../utils/emojiLookup'
@@ -193,23 +195,24 @@ const TAG_COLOR = '#8b5cf6'
 const METRIC_COLOR = '#14b8a6'
 const NOW_COLOR = '#ef4444'
 
-const OCCASIONAL_BUILTIN_METRICS = [
-  'weight',
-  'body_fat',
-  'bone_mass',
-  'lean_body_mass',
-  'body_water_mass',
-  'height',
-  'blood_glucose',
-  'blood_pressure_systolic',
-  'blood_pressure_diastolic',
-  'body_temperature',
-  'basal_body_temperature',
-  'spo2',
-  'vo2_max',
-]
-
+/** Max data points per metric across the time range to be treated as "occasional" (shown as point markers). */
 const OCCASIONAL_METRIC_MAX_COUNT = 10
+
+/** Metrics to exclude from the unified bucketed query (fetched via separate endpoints). */
+const TIMELINE_EXCLUDED_METRICS = ['training_impulse', 'activity_impulse']
+
+/** Core metrics used for band/bar charts and sparklines. */
+const CORE_CHART_METRICS = new Set([
+  'heart_rate',
+  'hrv_rmssd',
+  'hrv_sleep',
+  'hrv_awake',
+  'hrv_activity',
+  'steps',
+  'calories_active',
+  'calories_total',
+  'calories_basal',
+])
 
 const tagSourceColors: Record<string, string> = {
   calendar: '#f59e0b',
@@ -317,10 +320,10 @@ const formatDuration = (start: Date, end: Date): string => {
 const escapeHtml = (str: string): string =>
   str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
-type OuraSleepMetrics = Record<string, number>
-type OuraSleepByDate = Map<string, OuraSleepMetrics>
+type SleepMetrics = Record<string, number>
+type SleepMetricsByDate = Map<string, SleepMetrics>
 
-const buildSleepDetails = (a: Activity, end: Date, ouraByDate: OuraSleepByDate): string[] => {
+const buildSleepDetails = (a: Activity, end: Date, sleepByDate: SleepMetricsByDate): string[] => {
   const details: string[] = []
   details.push(`Bed: ${formatDuration(a.start_time, end)}`)
 
@@ -330,15 +333,16 @@ const buildSleepDetails = (a: Activity, end: Date, ouraByDate: OuraSleepByDate):
     details.push(`Sleep: ${m > 0 ? `${h}h ${m}m` : `${h}h`}`)
   }
 
-  const oura = ouraByDate.get(format(end, 'yyyy-MM-dd'))
-  if (oura) {
-    if (oura.sleep_score !== undefined) details.push(`ō score: ${Math.round(oura.sleep_score)}`)
-    if (oura.sleep_efficiency !== undefined)
-      details.push(`ō efficiency: ${Math.round(oura.sleep_efficiency)}%`)
-    if (oura.sleep_restfulness !== undefined)
-      details.push(`ō restfulness: ${Math.round(oura.sleep_restfulness)}`)
-    if (oura.sleep_deep_score !== undefined) details.push(`ō deep: ${Math.round(oura.sleep_deep_score)}`)
-    if (oura.sleep_rem_score !== undefined) details.push(`ō REM: ${Math.round(oura.sleep_rem_score)}`)
+  const sleepData = sleepByDate.get(format(end, 'yyyy-MM-dd'))
+  if (sleepData) {
+    if (sleepData.sleep_score !== undefined) details.push(`Score: ${Math.round(sleepData.sleep_score)}`)
+    if (sleepData.sleep_efficiency !== undefined)
+      details.push(`Efficiency: ${Math.round(sleepData.sleep_efficiency)}%`)
+    if (sleepData.sleep_restfulness !== undefined)
+      details.push(`Restfulness: ${Math.round(sleepData.sleep_restfulness)}`)
+    if (sleepData.sleep_deep_score !== undefined)
+      details.push(`Deep: ${Math.round(sleepData.sleep_deep_score)}`)
+    if (sleepData.sleep_rem_score !== undefined) details.push(`REM: ${Math.round(sleepData.sleep_rem_score)}`)
   }
 
   if (a.avg_hrv) details.push(`Avg HRV: ${a.avg_hrv} ms`)
@@ -420,36 +424,48 @@ const categorizeTags = (tags: Tag[], itemIcons: Record<string, string>): ChartIt
 const formatMetricLabel = (metric: string): string =>
   metric.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 
+/**
+ * Extract occasional (sparse) metrics from bucketed data as point ChartItems.
+ * A metric is "occasional" if it has data in ≤ OCCASIONAL_METRIC_MAX_COUNT buckets
+ * and is not a core chart metric (HR, HRV, steps, calories).
+ */
 const categorizeOccasionalMetrics = (
-  dataPoints: MetricDataPointWithSource[],
+  data: QueryMetricsBucketedResponse | undefined,
   metricUnitsMap: Record<string, string>,
 ): ChartItem[] => {
-  if (!dataPoints || dataPoints.length === 0) return []
+  if (!data?.buckets?.length) return []
 
-  const metricCounts: Record<string, number> = {}
-  for (const dp of dataPoints) {
-    metricCounts[dp.metric] = (metricCounts[dp.metric] ?? 0) + 1
+  // Count how many buckets each metric appears in
+  const metricBucketCounts: Record<string, number> = {}
+  for (const bucket of data.buckets) {
+    for (const metric of Object.keys(bucket.metrics)) {
+      metricBucketCounts[metric] = (metricBucketCounts[metric] ?? 0) + 1
+    }
   }
 
+  // Find occasional metrics: sparse, non-core
   const occasionalMetrics = new Set(
-    Object.entries(metricCounts)
-      .filter(([, count]) => count <= OCCASIONAL_METRIC_MAX_COUNT)
+    Object.entries(metricBucketCounts)
+      .filter(([metric, count]) => count <= OCCASIONAL_METRIC_MAX_COUNT && !CORE_CHART_METRICS.has(metric))
       .map(([metric]) => metric),
   )
 
   if (occasionalMetrics.size === 0) return []
 
-  return dataPoints
-    .filter((dp) => occasionalMetrics.has(dp.metric))
-    .map((dp) => {
-      const unit = metricUnitsMap[dp.metric] ?? ''
-      const displayValue = Number(dp.value.toFixed(2))
-      const valueStr = `${displayValue}${unit ? ` ${unit}` : ''}`
-      const metricLabel = formatMetricLabel(dp.metric)
-      const end = new Date(dp.time.getTime() + 15 * 60000)
-      const entityId = `${dp.time.toISOString()}|${dp.metric}|${dp.source}`
+  const items: ChartItem[] = []
+  for (const bucket of data.buckets) {
+    const bucketStart = new Date(bucket.start)
+    for (const [metric, stats] of Object.entries(bucket.metrics)) {
+      if (!occasionalMetrics.has(metric)) continue
 
-      return {
+      const unit = metricUnitsMap[metric] ?? ''
+      const displayValue = Number(stats.avg.toFixed(2))
+      const valueStr = `${displayValue}${unit ? ` ${unit}` : ''}`
+      const metricLabel = formatMetricLabel(metric)
+      const end = new Date(bucketStart.getTime() + 15 * 60000)
+      const entityId = `${bucketStart.toISOString()}|${metric}`
+
+      items.push({
         color: METRIC_COLOR,
         column: 'Tags / Events' as Column,
         end,
@@ -457,14 +473,16 @@ const categorizeOccasionalMetrics = (
         entity_type: 'metric' as const,
         isPoint: true,
         label: `${metricLabel}: ${valueStr}`,
-        start: dp.time,
+        start: bucketStart,
         tooltip: {
-          details: [`Value: ${valueStr}`, `Source: ${dp.source}`, 'Metric measurement'],
-          time: formatTime(dp.time),
+          details: [`Value: ${valueStr}`, 'Metric measurement'],
+          time: formatTime(bucketStart),
           title: metricLabel,
         },
-      }
-    })
+      })
+    }
+  }
+  return items
 }
 
 const getResolvedColor = (p: ProductivityRecord, categories: ScreentimeCategory[]): string => {
@@ -672,19 +690,6 @@ export const Timeline = () => {
     staleTime: 30 * 60 * 1000,
   })
 
-  const ouraMetricsQuery = useQuery({
-    placeholderData: keepPreviousData,
-    queryFn: () =>
-      fetchBucketedMetrics(
-        subDays(fetchStart, 0.5),
-        addDays(fetchEnd, 0.5),
-        ['sleep_score', 'sleep_efficiency', 'sleep_restfulness', 'sleep_deep_score', 'sleep_rem_score'],
-        '1d',
-      ),
-    queryKey: ['timeline-oura-sleep', fromDate.value, toDate.value],
-    staleTime: 5 * 60 * 1000,
-  })
-
   const hasLastFm = Boolean(settingsQuery.data?.lastfm_username)
 
   const scrobblesQuery = useQuery({
@@ -695,7 +700,7 @@ export const Timeline = () => {
     staleTime: 5 * 60 * 1000,
   })
 
-  // Bucketed metrics: used for sparklines (vertical) and band/bar charts (horizontal)
+  // Unified bucketed metrics: all metrics in one request
   // Scale bucket size with date range to avoid overwhelming the API on large ranges
   const metricBucketSize = useMemo(() => {
     const days = differenceInCalendarDays(fetchEnd, fetchStart)
@@ -711,8 +716,9 @@ export const Timeline = () => {
       fetchBucketedMetrics(
         subDays(fetchStart, 0.5),
         addDays(fetchEnd, 0.5),
-        ['heart_rate', 'hrv_rmssd', 'steps', 'calories_active'],
+        undefined,
         metricBucketSize,
+        TIMELINE_EXCLUDED_METRICS,
       ),
     queryKey: ['timeline-bucketed-metrics', fromDate.value, toDate.value, metricBucketSize],
     staleTime: 5 * 60 * 1000,
@@ -730,11 +736,6 @@ export const Timeline = () => {
     staleTime: 30 * 60 * 1000,
   })
 
-  const occasionalMetricNames = useMemo(() => {
-    const customNames = (customMetricsQuery.data ?? []).map((m) => m.name)
-    return [...OCCASIONAL_BUILTIN_METRICS, ...customNames]
-  }, [customMetricsQuery.data])
-
   const allMetricUnits = useMemo(() => {
     const units: Record<string, string> = { ...builtinMetricUnits }
     for (const m of customMetricsQuery.data ?? []) {
@@ -742,21 +743,6 @@ export const Timeline = () => {
     }
     return units
   }, [customMetricsQuery.data])
-
-  const occasionalMetricsQuery = useQuery({
-    enabled: occasionalMetricNames.length > 0,
-    placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const start = subDays(fetchStart, 0.5)
-      const end = addDays(fetchEnd, 0.5)
-      const results = await Promise.all(
-        occasionalMetricNames.map((metric) => fetchMetricTimeSeriesWithSource(metric, start, end)),
-      )
-      return results.flat()
-    },
-    queryKey: ['timeline-occasional-metrics', fromDate.value, toDate.value, occasionalMetricNames],
-    staleTime: 5 * 60 * 1000,
-  })
 
   // ── Refs ───────────────────────────────────────────────────────────────────
 
@@ -787,18 +773,28 @@ export const Timeline = () => {
   const productivity = productivityQuery.data ?? []
   const scrobbles = scrobblesQuery.data ?? []
 
-  const ouraByDate = useMemo<OuraSleepByDate>(() => {
-    const map: OuraSleepByDate = new Map()
-    for (const bucket of ouraMetricsQuery.data?.buckets ?? []) {
-      const key = format(new Date(bucket.start), 'yyyy-MM-dd')
-      const metrics: OuraSleepMetrics = {}
-      for (const [metric, stats] of Object.entries(bucket.metrics)) {
-        metrics[metric] = stats.avg
+  // Extract sleep score metrics from unified bucketed data, keyed by date
+  const sleepMetricsByDate = useMemo<SleepMetricsByDate>(() => {
+    const map: SleepMetricsByDate = new Map()
+    const sleepMetricNames = [
+      'sleep_score',
+      'sleep_efficiency',
+      'sleep_restfulness',
+      'sleep_deep_score',
+      'sleep_rem_score',
+    ]
+    for (const bucket of bucketedMetricsQuery.data?.buckets ?? []) {
+      for (const name of sleepMetricNames) {
+        const stats = bucket.metrics[name]
+        if (!stats) continue
+        const key = format(new Date(bucket.start), 'yyyy-MM-dd')
+        const existing = map.get(key) ?? {}
+        existing[name] = stats.avg
+        map.set(key, existing)
       }
-      map.set(key, metrics)
     }
     return map
-  }, [ouraMetricsQuery.data])
+  }, [bucketedMetricsQuery.data])
 
   const itemIcons = useMemo<Record<string, string>>(() => {
     return tagMappingsQuery.data?.icons ?? {}
@@ -808,8 +804,8 @@ export const Timeline = () => {
   const showMusicColumn = musicItems.length > 0
 
   const occasionalMetricItems = useMemo(
-    () => categorizeOccasionalMetrics(occasionalMetricsQuery.data ?? [], allMetricUnits),
-    [occasionalMetricsQuery.data, allMetricUnits],
+    () => categorizeOccasionalMetrics(bucketedMetricsQuery.data, allMetricUnits),
+    [bucketedMetricsQuery.data, allMetricUnits],
   )
 
   const sparklineBuckets = useMemo(
@@ -838,11 +834,11 @@ export const Timeline = () => {
         activityColors,
         getExerciseColor,
         getExerciseTypeName,
-        ouraByDate,
-        (a, end) => buildSleepDetails(a, end, ouraByDate),
+        sleepMetricsByDate,
+        (a, end) => buildSleepDetails(a, end, sleepMetricsByDate),
         scrobbles,
       ),
-    [activities, tags, itemIcons, ouraByDate, scrobbles],
+    [activities, tags, itemIcons, sleepMetricsByDate, scrobbles],
   )
 
   // Tags that should stay in the Tags / Events column (not pulled into Activity)
@@ -975,7 +971,6 @@ export const Timeline = () => {
     tagsQuery.isFetching ||
     productivityQuery.isFetching ||
     scrobblesQuery.isFetching ||
-    occasionalMetricsQuery.isFetching ||
     bucketedMetricsQuery.isFetching
 
   // ── Navigation ─────────────────────────────────────────────────────────────

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -664,15 +664,17 @@ export const fetchActivityImpact = async (
 export const fetchBucketedMetrics = async (
   start: Date,
   end: Date,
-  metrics: string[],
+  metrics?: string[],
   bucket: string = '1d',
+  exclude?: string[],
 ): Promise<QueryMetricsBucketedResponse> => {
   const { token } = auth.value
   const params: QueryMetricsBucketedQuery = {
     bucket: bucket as QueryMetricsBucketedQuery['bucket'],
     end: end.toISOString(),
-    metrics: metrics.join(','),
     start: start.toISOString(),
+    ...(metrics && { metrics: metrics.join(',') }),
+    ...(exclude && { exclude: exclude.join(',') }),
   }
   const response = await axios.get<QueryMetricsBucketedResponse>(`${API_URL}/metrics/bucketed`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/apps/web/src/utils/chart.ts
+++ b/apps/web/src/utils/chart.ts
@@ -32,7 +32,7 @@ export const preprocessData = (
 export interface MetricBucketParsed {
   start: Date
   end: Date
-  metrics: Record<string, { avg: number; min: number; max: number; count: number }>
+  metrics: Record<string, { avg: number; min: number; max: number; count: number; sum?: number }>
 }
 
 /**
@@ -80,6 +80,8 @@ export const aggregateBuckets = (buckets: MetricBucketParsed[], factor: number):
     for (const name of metricNames) {
       let totalWeightedAvg = 0
       let totalCount = 0
+      let totalSum = 0
+      let hasSum = false
       let globalMin = Infinity
       let globalMax = -Infinity
 
@@ -88,6 +90,10 @@ export const aggregateBuckets = (buckets: MetricBucketParsed[], factor: number):
         if (!stats) continue
         totalWeightedAvg += stats.avg * stats.count
         totalCount += stats.count
+        if (stats.sum !== undefined) {
+          totalSum += stats.sum
+          hasSum = true
+        }
         if (stats.min < globalMin) globalMin = stats.min
         if (stats.max > globalMax) globalMax = stats.max
       }
@@ -98,6 +104,7 @@ export const aggregateBuckets = (buckets: MetricBucketParsed[], factor: number):
           count: totalCount,
           max: globalMax,
           min: globalMin,
+          ...(hasSum && { sum: totalSum }),
         }
       }
     }

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -272,6 +272,37 @@ export const isValidMetricOrCustom = (
 ): boolean => isValidMetric(metric) || customMetrics.some((m) => m.name === metric)
 
 /**
+ * Aggregation type for metrics: 'sum' for cumulative totals, 'avg' for instantaneous values.
+ * Determines how values are combined in time buckets.
+ */
+export type MetricAggregation = 'avg' | 'sum'
+
+/**
+ * Metrics that should be summed when bucketed (cumulative totals).
+ * All other metrics default to averaging.
+ */
+export const sumMetrics: MetricType[] = [
+  'steps',
+  'distance',
+  'floors_climbed',
+  'calories_active',
+  'calories_total',
+  'calories_basal',
+  'hr_zone_0_sec',
+  'hr_zone_1_sec',
+  'hr_zone_2_sec',
+  'hr_zone_3_sec',
+  'hr_zone_4_sec',
+  'hr_zone_5_sec',
+  'training_impulse',
+  'activity_impulse',
+]
+
+/** Get the aggregation type for a metric (sum or avg). */
+export const getMetricAggregation = (metric: string): MetricAggregation =>
+  (sumMetrics as string[]).includes(metric) ? 'sum' : 'avg'
+
+/**
  * Cumulative metrics that are summed over a day and can have duplicate sources.
  */
 export const cumulativeMetrics: MetricType[] = [

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -244,13 +244,19 @@ export type CustomMetricsListResponse = z.infer<typeof customMetricsListResponse
 // =============================================================================
 
 /**
- * Valid bucket sizes for aggregated queries.
+ * Bucket size for time-based aggregation.
+ * Format: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), M (months).
+ * Examples: '10s', '5m', '1h', '1d', '1M'
  */
-export const bucketSizeSchema = z.enum(['5m', '15m', '30m', '1h', '1d']).meta({
-  description: 'Bucket size for aggregation',
-  example: '15m',
-  id: 'BucketSize',
-})
+export const bucketSizeSchema = z
+  .string()
+  .regex(/^\d+[smhdM]$/, 'Must be {number}{unit} where unit is s, m, h, d, or M')
+  .meta({
+    description:
+      'Bucket size: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), M (months)',
+    example: '15m',
+    id: 'BucketSize',
+  })
 
 export type BucketSize = z.infer<typeof bucketSizeSchema>
 
@@ -263,6 +269,10 @@ export const bucketMetricStatsSchema = z
     count: z.number().int().meta({ description: 'Number of data points' }),
     max: z.number().meta({ description: 'Maximum value in bucket' }),
     min: z.number().meta({ description: 'Minimum value in bucket' }),
+    sum: z
+      .number()
+      .optional()
+      .meta({ description: 'Sum of values in bucket (present for cumulative metrics)' }),
   })
   .meta({ id: 'BucketMetricStats' })
 
@@ -286,12 +296,18 @@ export type MetricBucket = z.infer<typeof metricBucketSchema>
 
 /**
  * Query bucketed metrics request query.
+ * If metrics is omitted, returns all metrics with data in the time range.
+ * Use exclude to skip specific metrics when fetching all.
  */
 export const queryMetricsBucketedQuerySchema = timeRangeQuerySchema
   .extend({
-    bucket: bucketSizeSchema.meta({ description: 'Bucket size: "5m", "15m", "30m", "1h", or "1d"' }),
-    metrics: z.string().meta({
-      description: 'Comma-separated list of metrics',
+    bucket: bucketSizeSchema,
+    exclude: z.string().optional().meta({
+      description: 'Comma-separated list of metrics to exclude (useful when fetching all)',
+      example: 'training_impulse,activity_impulse',
+    }),
+    metrics: z.string().optional().meta({
+      description: 'Comma-separated list of metrics (omit to fetch all metrics with data in the range)',
       example: 'heart_rate,hrv_rmssd',
     }),
   })


### PR DESCRIPTION
## Summary

Extends the `/metrics/bucketed` endpoint to support fetching all metrics in one request, replacing 3 separate Timeline metric queries (~17+N HTTP requests) with a single unified call (~2 total including training load).

### Backend changes

- **api-spec**: Flexible `bucketSizeSchema` (`{number}{unit}` format), optional `metrics`/`exclude` query params, `sum` field in `BucketMetricStats`, `MetricAggregation` type with `sumMetrics` list
- **DB layer**: `getTimeSeriesBucketed` uses PostgreSQL interval strings instead of minutes, adds `SUM(value)` to SQL output. New `getDistinctMetrics()` function for discovering all metrics in a time range
- **Service layer**: `queryMetricsBucketed` auto-discovers metrics when omitted, supports `exclude` param, new `parseBucketSize()` for compact→interval conversion
- **Route + MCP**: Updated handlers for optional `metrics`/`exclude` params

### Frontend changes

- **3 queries → 1**: Replaced `ouraMetricsQuery` + `bucketedMetricsQuery` + `occasionalMetricsQuery` (which fanned out to 13+N individual metric requests) with a single `fetchBucketedMetrics` call that omits the `metrics` param (fetches all) and uses `exclude` for `training_impulse,activity_impulse`
- **Source-agnostic**: Removed Oura-specific naming (`OuraSleepMetrics` → `SleepMetrics`, removed `ō` prefix from sleep detail labels)
- **Sleep tooltip enrichment**: Sleep scores extracted from unified bucketed data by date
- **Occasional metrics**: Sparse metrics (weight, body fat, etc.) extracted from bucketed data and shown as point markers
- **Sum aggregation**: `MetricBucketParsed` and `aggregateBuckets` now support optional `sum` field for cumulative metrics

### Testing

- All backend unit tests pass (62 queries tests, 144 total across key test files)
- Backend type check + lint clean
- Web type check + lint clean
- API-spec builds and regenerates cleanly