### PR TITLE
fix: improve timeline interactivity, rendering, and UX

### DIFF
--- a/apps/backend/src/mcp/training-load-tools.ts
+++ b/apps/backend/src/mcp/training-load-tools.ts
@@ -32,9 +32,9 @@ Parameters can be configured in user settings (training_load).
 Example: "Show my training load for the last 3 months"
 → start: 3 months ago, end: today`,
     { ...getTrainingLoadInputSchema.shape },
-    async ({ start, end }) => {
+    async ({ start, end, bucket_size }) => {
       try {
-        const result = await computeTrainingLoad(deps, user, new Date(start), new Date(end))
+        const result = await computeTrainingLoad(deps, user, new Date(start), new Date(end), bucket_size)
         return jsonResponse({ data: result, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -18,7 +18,7 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
     authMiddleware,
     validateQuery(trainingLoadQuerySchema),
     async (req, res) => {
-      const { start, end } = req.query
+      const { start, end, bucket_size } = req.query
       const user = req.user!
 
       try {
@@ -30,7 +30,7 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
           return
         }
 
-        const result = await computeTrainingLoad(deps, user, startDate, endDate)
+        const result = await computeTrainingLoad(deps, user, startDate, endDate, bucket_size)
         res.json({ data: result, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/services/training-load.test.ts
+++ b/apps/backend/src/services/training-load.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 import type { Activity, TimeSeriesPoint } from '../db/types'
 import {
+  aggregateTrainingLoadPoints,
   calculateTrimp,
   computeHourlyImpulses,
   computeHourlyLoadSeries,
@@ -826,5 +827,105 @@ describe('recomputeImpulseBuckets', () => {
     for (let i = 1; i < exerciseCalls.length; i++) {
       expect(exerciseCalls[i]![0].getTime()).toBe(exerciseCalls[i - 1]![1].getTime())
     }
+  })
+})
+
+// ============================================================================
+// Bucket Aggregation
+// ============================================================================
+
+describe('aggregateTrainingLoadPoints', () => {
+  const makePoint = (
+    hourIso: string,
+    trainingImpulse: number,
+    activityImpulse: number,
+    atl: number,
+    ctl: number,
+    tsb: number,
+  ) => ({
+    activity_impulse: activityImpulse,
+    atl,
+    ctl,
+    time: hourIso,
+    training_impulse: trainingImpulse,
+    tsb,
+  })
+
+  test('returns points unchanged for 1h bucket size', () => {
+    const points = [
+      makePoint('2024-01-01T00:00:00.000Z', 10, 5, 3, 2, -1),
+      makePoint('2024-01-01T01:00:00.000Z', 0, 2, 3.1, 2.1, -1),
+    ]
+    const result = aggregateTrainingLoadPoints(points, '1h')
+    expect(result).toBe(points) // same reference, not a copy
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(aggregateTrainingLoadPoints([], '1d')).toEqual([])
+  })
+
+  test('aggregates hourly points into daily buckets', () => {
+    const points = [
+      makePoint('2024-01-01T00:00:00.000Z', 10, 5, 2, 10, 8),
+      makePoint('2024-01-01T06:00:00.000Z', 20, 3, 5, 11, 6),
+      makePoint('2024-01-01T12:00:00.000Z', 0, 8, 4, 12, 8),
+      makePoint('2024-01-01T23:00:00.000Z', 5, 2, 3, 13, 10),
+      makePoint('2024-01-02T00:00:00.000Z', 15, 4, 6, 14, 8),
+      makePoint('2024-01-02T12:00:00.000Z', 0, 1, 5, 15, 10),
+    ]
+
+    const result = aggregateTrainingLoadPoints(points, '1d')
+    expect(result).toHaveLength(2)
+
+    // Day 1: sums impulses, peak ATL=5 (06:00), last CTL/TSB from 23:00
+    expect(result[0]!.time).toBe('2024-01-01T00:00:00.000Z')
+    expect(result[0]!.training_impulse).toBe(35) // 10+20+0+5
+    expect(result[0]!.activity_impulse).toBe(18) // 5+3+8+2
+    expect(result[0]!.atl).toBe(5) // peak
+    expect(result[0]!.ctl).toBe(13) // from 23:00 point
+    expect(result[0]!.tsb).toBe(10) // from 23:00 point
+
+    // Day 2: sums impulses, peak ATL=6, last CTL/TSB from 12:00
+    expect(result[1]!.time).toBe('2024-01-02T00:00:00.000Z')
+    expect(result[1]!.training_impulse).toBe(15) // 15+0
+    expect(result[1]!.activity_impulse).toBe(5) // 4+1
+    expect(result[1]!.atl).toBe(6) // peak
+    expect(result[1]!.ctl).toBe(15) // from 12:00 point
+    expect(result[1]!.tsb).toBe(10) // from 12:00 point
+  })
+
+  test('aggregates into weekly buckets', () => {
+    // Create points spanning 2 weeks
+    const points = [
+      // Week starting 2024-01-01 (Monday)
+      makePoint('2024-01-01T00:00:00.000Z', 10, 5, 3, 10, 7),
+      makePoint('2024-01-03T12:00:00.000Z', 20, 8, 7, 12, 5),
+      makePoint('2024-01-07T23:00:00.000Z', 5, 2, 4, 14, 10),
+      // Week starting 2024-01-08 (Monday)
+      makePoint('2024-01-08T06:00:00.000Z', 30, 10, 8, 16, 8),
+    ]
+
+    const result = aggregateTrainingLoadPoints(points, '1w')
+    expect(result).toHaveLength(2)
+
+    // Week 1: training=35, activity=15, peak ATL=7, last from Jan 7 23:00
+    expect(result[0]!.training_impulse).toBe(35)
+    expect(result[0]!.activity_impulse).toBe(15)
+    expect(result[0]!.atl).toBe(7)
+    expect(result[0]!.ctl).toBe(14)
+
+    // Week 2: single point
+    expect(result[1]!.training_impulse).toBe(30)
+    expect(result[1]!.atl).toBe(8)
+  })
+
+  test('rounds aggregated impulses to 2 decimal places', () => {
+    const points = [
+      makePoint('2024-01-01T00:00:00.000Z', 1.111, 2.222, 1, 1, 0),
+      makePoint('2024-01-01T12:00:00.000Z', 3.333, 4.444, 2, 2, 0),
+    ]
+    const result = aggregateTrainingLoadPoints(points, '1d')
+    expect(result[0]!.training_impulse).toBe(4.44) // 1.111+3.333=4.444 → rounded
+    expect(result[0]!.activity_impulse).toBe(6.67) // 2.222+4.444=6.666 → rounded
   })
 })

--- a/apps/backend/src/services/training-load.ts
+++ b/apps/backend/src/services/training-load.ts
@@ -15,15 +15,18 @@
  *  - TSB (Training Stress Balance / form) = CTL - ATL
  */
 
-import type {
-  BiologicalSex,
-  RecoveryZones,
-  TrainingLoadPoint,
-  TrainingLoadResult,
-  TrainingLoadSettings,
-  WorkoutTrimp,
+import {
+  type BiologicalSex,
+  type RecoveryZones,
+  trainingLoadBucketSizes,
+  type TrainingLoadPoint,
+  type TrainingLoadResult,
+  type TrainingLoadSettings,
+  type WorkoutTrimp,
 } from '@aurboda/api-spec'
 import type { Activity, TimeSeriesPoint } from '../db/types'
+
+type TrainingLoadBucketSize = (typeof trainingLoadBucketSizes)[number]
 
 // ============================================================================
 // Constants
@@ -648,6 +651,90 @@ const buildWorkoutList = async (
 }
 
 // ============================================================================
+// Bucket Aggregation
+// ============================================================================
+
+const MS_PER_DAY = 24 * MS_PER_HOUR
+const MS_PER_WEEK = 7 * MS_PER_DAY
+
+const bucketSizeMs: Record<TrainingLoadBucketSize, number> = {
+  '1d': MS_PER_DAY,
+  '1h': MS_PER_HOUR,
+  '1w': MS_PER_WEEK,
+}
+
+/**
+ * Aggregate hourly training load points into larger time buckets.
+ *
+ * For each bucket:
+ * - training_impulse, activity_impulse: summed across all hours in the bucket
+ * - atl: peak value within the bucket (shows worst-case fatigue)
+ * - ctl, tsb: value from the last hour in the bucket (most recent EMA state)
+ * - time: floored to bucket boundary
+ */
+export const aggregateTrainingLoadPoints = (
+  points: TrainingLoadPoint[],
+  bucketSize: TrainingLoadBucketSize,
+): TrainingLoadPoint[] => {
+  if (bucketSize === '1h' || points.length === 0) return points
+
+  const durationMs = bucketSizeMs[bucketSize]
+  const buckets = new Map<number, TrainingLoadPoint[]>()
+
+  // Floor timestamp to bucket boundary.
+  // Daily: floor to UTC midnight. Weekly: floor to previous Monday 00:00 UTC.
+  const floorToBucket = (ms: number): number => {
+    if (bucketSize === '1w') {
+      const d = new Date(ms)
+      const day = d.getUTCDay() // 0=Sun, 1=Mon, ..., 6=Sat
+      const daysSinceMonday = (day + 6) % 7 // Mon=0, Tue=1, ..., Sun=6
+      const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - daysSinceMonday))
+      return monday.getTime()
+    }
+    return Math.floor(ms / durationMs) * durationMs
+  }
+
+  for (const p of points) {
+    const t = new Date(p.time).getTime()
+    const key = floorToBucket(t)
+    let arr = buckets.get(key)
+    if (!arr) {
+      arr = []
+      buckets.set(key, arr)
+    }
+    arr.push(p)
+  }
+
+  const result: TrainingLoadPoint[] = []
+  const sortedKeys = [...buckets.keys()].sort((a, b) => a - b)
+
+  for (const key of sortedKeys) {
+    const group = buckets.get(key)!
+    const last = group[group.length - 1]!
+    let totalTrainingImpulse = 0
+    let totalActivityImpulse = 0
+    let peakAtl = 0
+
+    for (const p of group) {
+      totalTrainingImpulse += p.training_impulse
+      totalActivityImpulse += p.activity_impulse
+      if (p.atl > peakAtl) peakAtl = p.atl
+    }
+
+    result.push({
+      activity_impulse: Math.round(totalActivityImpulse * 100) / 100,
+      atl: Math.round(peakAtl * 100) / 100,
+      ctl: last.ctl,
+      time: new Date(key).toISOString(),
+      training_impulse: Math.round(totalTrainingImpulse * 100) / 100,
+      tsb: last.tsb,
+    })
+  }
+
+  return result
+}
+
+// ============================================================================
 // Main Query (Read Path)
 // ============================================================================
 
@@ -658,13 +745,15 @@ const buildWorkoutList = async (
  * 2. Fetch pre-computed hourly impulse buckets
  * 3. Compute current incomplete hour from raw data
  * 4. Run hourly Banister EMA → ATL, CTL, TSB
- * 5. Compute recovery zones
+ * 5. Optionally aggregate into larger buckets (daily/weekly)
+ * 6. Compute recovery zones
  */
 export const computeTrainingLoad = async (
   deps: TrainingLoadDeps,
   user: string,
   start: Date,
   end: Date,
+  bucketSize: TrainingLoadBucketSize = '1h',
 ): Promise<TrainingLoadResult> => {
   // Gather settings
   const [userSettings, maxObservedHr, latestRestingHr] = await Promise.all([
@@ -742,10 +831,11 @@ export const computeTrainingLoad = async (
     trainingImpulses,
   })
 
-  // Filter to requested range
+  // Filter to requested range, then aggregate if needed
   const startIso = floorToHour(start).toISOString()
   const endIso = effectiveEnd.toISOString()
-  const points = allPoints.filter((p) => p.time >= startIso && p.time <= endIso)
+  const hourlyPoints = allPoints.filter((p) => p.time >= startIso && p.time <= endIso)
+  const points = aggregateTrainingLoadPoints(hourlyPoints, bucketSize)
 
   // Fetch workouts in the requested range for the response
   const workoutList = await buildWorkoutList(deps, user, start, end, hrMax, hrRest, settings.k_factor)

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -255,8 +255,14 @@ const buildMetricsTooltipHtml = (
 ): string => {
   const startStr = formatTime(bucket.start)
   const endStr = formatTime(bucket.end)
+  const dateStr = format(bucket.start, 'EEE, MMM d')
+  const isSameDay = format(bucket.start, 'yyyy-MM-dd') === format(bucket.end, 'yyyy-MM-dd')
+  const timeRange =
+    isSameDay ?
+      `${dateStr} ${startStr} – ${endStr}`
+    : `${dateStr} ${startStr} – ${format(bucket.end, 'EEE, MMM d')} ${endStr}`
   let html = `<div class="tooltip-title">Metrics</div>`
-  html += `<div class="tooltip-time">${startStr} – ${endStr}</div>`
+  html += `<div class="tooltip-time">${timeRange}</div>`
 
   if (showHR) {
     const hr = bucket.metrics.heart_rate

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -276,11 +276,12 @@ const drawFatigueBars = (
   xScale: d3.ScaleTime<number, number>,
   yScale: d3.ScaleLinear<number, number>,
   trackBottom: number,
+  barDurationMs: number = MS_PER_HOUR,
 ): void => {
-  // Compute bar width from x-scale (one hour)
+  // Compute bar width from x-scale and bucket duration
   const sampleTime = points[0] ? parseTime(points[0].time) : new Date()
-  const nextHour = new Date(sampleTime.getTime() + MS_PER_HOUR)
-  const barWidth = Math.max(1, Math.abs(xScale(nextHour) - xScale(sampleTime)) - 1)
+  const nextTime = new Date(sampleTime.getTime() + barDurationMs)
+  const barWidth = Math.max(1, Math.abs(xScale(nextTime) - xScale(sampleTime)) - 1)
 
   // Find max ATL for color scaling
   let maxAtl = 1
@@ -315,18 +316,19 @@ const drawFatigueBars = (
   }
 }
 
-/** Draw stacked impulse bars (training + activity) per hour. */
+/** Draw stacked impulse bars (training + activity) per bucket. */
 const drawImpulseBars = (
   group: SvgGroup,
   points: TrainingLoadPoint[],
   xScale: d3.ScaleTime<number, number>,
   yScale: d3.ScaleLinear<number, number>,
   trackBottom: number,
+  barDurationMs: number = MS_PER_HOUR,
 ): void => {
-  // Compute bar width from x-scale (one hour)
+  // Compute bar width from x-scale and bucket duration
   const sampleTime = points[0] ? parseTime(points[0].time) : new Date()
-  const nextHour = new Date(sampleTime.getTime() + MS_PER_HOUR)
-  const barWidth = Math.max(1, Math.abs(xScale(nextHour) - xScale(sampleTime)) - 1)
+  const nextTime = new Date(sampleTime.getTime() + barDurationMs)
+  const barWidth = Math.max(1, Math.abs(xScale(nextTime) - xScale(sampleTime)) - 1)
 
   for (const p of points) {
     const total = p.training_impulse + p.activity_impulse
@@ -504,43 +506,69 @@ export const buildTrainingLoadTooltipHtml = (
   return html
 }
 
-// ── Downsampling ──────────────────────────────────────────────────────────────
+// ── Time-based bucketing ──────────────────────────────────────────────────────
+
+const MS_PER_DAY = 24 * MS_PER_HOUR
+const MS_PER_WEEK = 7 * MS_PER_DAY
 
 /**
- * Downsample hourly points for rendering when zoomed out far.
- * Groups consecutive hours and picks the one with highest combined impulse
- * from each group, preserving the ATL/CTL/TSB curves at reduced resolution.
+ * Choose bucket duration based on zoom level (pixelsPerHour).
+ * Returns the bucket duration in ms, or 0 to use raw hourly data.
  */
-const downsamplePoints = (
-  points: TrainingLoadPoint[],
-  xScale: d3.ScaleTime<number, number>,
-  minPixelGap: number,
-): TrainingLoadPoint[] => {
-  if (points.length <= 2) return points
+const chooseBucketDuration = (pixelsPerHour: number): number => {
+  if (pixelsPerHour >= 2) return 0 // hourly — no bucketing needed
+  if (pixelsPerHour >= 0.3) return MS_PER_DAY // daily buckets
+  return MS_PER_WEEK // weekly buckets
+}
+
+/**
+ * Bucket hourly training load points into time-based groups.
+ * For bars: sums impulses, takes peak ATL.
+ * For curves: takes the last point per bucket (most recent running average).
+ * Returns bucketed points placed at the bucket start time, plus the bucket duration in ms.
+ */
+const bucketPoints = (points: TrainingLoadPoint[], bucketMs: number): TrainingLoadPoint[] => {
+  if (points.length === 0 || bucketMs === 0) return points
+
+  const buckets = new Map<number, TrainingLoadPoint[]>()
+
+  for (const p of points) {
+    const t = parseTime(p.time).getTime()
+    // Floor to bucket boundary
+    const bucketKey = Math.floor(t / bucketMs) * bucketMs
+    let arr = buckets.get(bucketKey)
+    if (!arr) {
+      arr = []
+      buckets.set(bucketKey, arr)
+    }
+    arr.push(p)
+  }
 
   const result: TrainingLoadPoint[] = []
-  let groupStart = 0
+  const sortedKeys = [...buckets.keys()].sort((a, b) => a - b)
 
-  for (let i = 1; i <= points.length; i++) {
-    const atEnd = i === points.length
-    const gapPx =
-      atEnd ? Infinity : (
-        Math.abs(xScale(parseTime(points[i]!.time)) - xScale(parseTime(points[groupStart]!.time)))
-      )
+  for (const key of sortedKeys) {
+    const group = buckets.get(key)!
+    // Sum impulses across the bucket
+    let totalTrainingImpulse = 0
+    let totalActivityImpulse = 0
+    let peakAtl = 0
+    // Take the last point's running averages (CTL/ATL/TSB)
+    const last = group[group.length - 1]!
 
-    if (gapPx >= minPixelGap || atEnd) {
-      // Pick the point in [groupStart, i) with highest ATL (shown as bars)
-      let best = points[groupStart]!
-      let bestAtl = best.atl
-      for (let j = groupStart + 1; j < i; j++) {
-        if (points[j]!.atl > bestAtl) {
-          bestAtl = points[j]!.atl
-          best = points[j]!
-        }
-      }
-      result.push(best)
-      groupStart = i
+    for (const p of group) {
+      totalTrainingImpulse += p.training_impulse
+      totalActivityImpulse += p.activity_impulse
+      if (p.atl > peakAtl) peakAtl = p.atl
     }
+
+    result.push({
+      ...last,
+      activity_impulse: totalActivityImpulse,
+      atl: peakAtl,
+      time: new Date(key).toISOString(),
+      training_impulse: totalTrainingImpulse,
+    })
   }
 
   return result
@@ -570,8 +598,16 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
 
   if (visiblePoints.length === 0) return
 
-  // Downsample when zoomed out far (more than ~2000 visible points)
-  const displayPoints = downsamplePoints(visiblePoints, xScale, 2)
+  // Choose bucketing strategy based on zoom level
+  const oneHourLater = new Date(domain[0]!.getTime() + MS_PER_HOUR)
+  const pixelsPerHour = Math.abs(xScale(oneHourLater) - xScale(domain[0]!))
+  const bucketMs = chooseBucketDuration(pixelsPerHour)
+
+  // Bucket points for bars (summed impulses, peak ATL)
+  const displayPoints = bucketMs > 0 ? bucketPoints(visiblePoints, bucketMs) : visiblePoints
+
+  // For bar width: use bucket duration instead of 1 hour when bucketing
+  const barDurationMs = bucketMs > 0 ? bucketMs : MS_PER_HOUR
 
   const yScales = computeYScales(displayPoints, trackY, trackBottom)
 
@@ -583,10 +619,10 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
   }
 
   // Draw ATL fatigue bars (behind everything else)
-  drawFatigueBars(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom)
+  drawFatigueBars(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom, barDurationMs)
 
   // Draw impulse bars (training + activity) on top of fatigue bars
-  drawImpulseBars(chartGroup, displayPoints, xScale, yScales.yImpulse, trackBottom)
+  drawImpulseBars(chartGroup, displayPoints, xScale, yScales.yImpulse, trackBottom, barDurationMs)
 
   // Draw CTL/ATL curves
   drawLoadCurves(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom, bootstrapping)

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -506,79 +506,28 @@ export const buildTrainingLoadTooltipHtml = (
   return html
 }
 
-// ── Time-based bucketing ──────────────────────────────────────────────────────
-
-const MS_PER_DAY = 24 * MS_PER_HOUR
-const MS_PER_WEEK = 7 * MS_PER_DAY
-
-/**
- * Choose bucket duration based on zoom level (pixelsPerHour).
- * Returns the bucket duration in ms, or 0 to use raw hourly data.
- */
-const chooseBucketDuration = (pixelsPerHour: number): number => {
-  if (pixelsPerHour >= 2) return 0 // hourly — no bucketing needed
-  if (pixelsPerHour >= 0.3) return MS_PER_DAY // daily buckets
-  return MS_PER_WEEK // weekly buckets
-}
-
-/**
- * Bucket hourly training load points into time-based groups.
- * For bars: sums impulses, takes peak ATL.
- * For curves: takes the last point per bucket (most recent running average).
- * Returns bucketed points placed at the bucket start time, plus the bucket duration in ms.
- */
-const bucketPoints = (points: TrainingLoadPoint[], bucketMs: number): TrainingLoadPoint[] => {
-  if (points.length === 0 || bucketMs === 0) return points
-
-  const buckets = new Map<number, TrainingLoadPoint[]>()
-
-  for (const p of points) {
-    const t = parseTime(p.time).getTime()
-    // Floor to bucket boundary
-    const bucketKey = Math.floor(t / bucketMs) * bucketMs
-    let arr = buckets.get(bucketKey)
-    if (!arr) {
-      arr = []
-      buckets.set(bucketKey, arr)
-    }
-    arr.push(p)
-  }
-
-  const result: TrainingLoadPoint[] = []
-  const sortedKeys = [...buckets.keys()].sort((a, b) => a - b)
-
-  for (const key of sortedKeys) {
-    const group = buckets.get(key)!
-    // Sum impulses across the bucket
-    let totalTrainingImpulse = 0
-    let totalActivityImpulse = 0
-    let peakAtl = 0
-    // Take the last point's running averages (CTL/ATL/TSB)
-    const last = group[group.length - 1]!
-
-    for (const p of group) {
-      totalTrainingImpulse += p.training_impulse
-      totalActivityImpulse += p.activity_impulse
-      if (p.atl > peakAtl) peakAtl = p.atl
-    }
-
-    result.push({
-      ...last,
-      activity_impulse: totalActivityImpulse,
-      atl: peakAtl,
-      time: new Date(key).toISOString(),
-      training_impulse: totalTrainingImpulse,
-    })
-  }
-
-  return result
-}
-
 // ── Main draw function ────────────────────────────────────────────────────────
 
 /**
- * Draw the training load track: hourly stacked impulse bars, CTL/ATL curves,
+ * Infer bucket duration from consecutive points.
+ * If points are pre-bucketed (daily/weekly), the gap between them reveals the bucket size.
+ * Falls back to 1 hour for hourly or single-point data.
+ */
+const inferBucketDuration = (points: TrainingLoadPoint[]): number => {
+  if (points.length < 2) return MS_PER_HOUR
+  const t0 = parseTime(points[0]!.time).getTime()
+  const t1 = parseTime(points[1]!.time).getTime()
+  const gap = Math.abs(t1 - t0)
+  // Snap to nearest standard bucket: 1h, 1d, 1w
+  if (gap >= 6 * 24 * MS_PER_HOUR) return 7 * 24 * MS_PER_HOUR // weekly
+  if (gap >= 12 * MS_PER_HOUR) return 24 * MS_PER_HOUR // daily
+  return MS_PER_HOUR
+}
+
+/**
+ * Draw the training load track: stacked impulse bars, CTL/ATL curves,
  * TSB line, zone bands, and an interactive crosshair overlay for tooltips.
+ * Points may be hourly, daily, or weekly (pre-bucketed by backend).
  */
 export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => {
   const { chartGroup, xScale, points, bootstrapping, zones, trackY, trackHeight } = config
@@ -587,27 +536,17 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
 
   const trackBottom = trackY + trackHeight
 
-  // Filter to visible range
+  // Filter to visible range (with one bucket of padding)
   const domain = xScale.domain()
-  const domainStartMs = domain[0]!.getTime() - MS_PER_HOUR
-  const domainEndMs = domain[1]!.getTime() + MS_PER_HOUR
-  const visiblePoints = points.filter((p) => {
+  const barDurationMs = inferBucketDuration(points)
+  const domainStartMs = domain[0]!.getTime() - barDurationMs
+  const domainEndMs = domain[1]!.getTime() + barDurationMs
+  const displayPoints = points.filter((p) => {
     const t = parseTime(p.time).getTime()
     return t >= domainStartMs && t <= domainEndMs
   })
 
-  if (visiblePoints.length === 0) return
-
-  // Choose bucketing strategy based on zoom level
-  const oneHourLater = new Date(domain[0]!.getTime() + MS_PER_HOUR)
-  const pixelsPerHour = Math.abs(xScale(oneHourLater) - xScale(domain[0]!))
-  const bucketMs = chooseBucketDuration(pixelsPerHour)
-
-  // Bucket points for bars (summed impulses, peak ATL)
-  const displayPoints = bucketMs > 0 ? bucketPoints(visiblePoints, bucketMs) : visiblePoints
-
-  // For bar width: use bucket duration instead of 1 hour when bucketing
-  const barDurationMs = bucketMs > 0 ? bucketMs : MS_PER_HOUR
+  if (displayPoints.length === 0) return
 
   const yScales = computeYScales(displayPoints, trackY, trackBottom)
 

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -865,12 +865,21 @@ export const Timeline = () => {
   const hiddenCategoriesRef = useRef<Set<LegendCategory>>(hiddenCategories)
   hiddenCategoriesRef.current = hiddenCategories
 
-  // Training load data (fetched when toggle is on, uses daily granularity)
+  // Training load bucket size — scale with date range to avoid huge payloads
+  const trainingLoadBucketSize = useMemo(() => {
+    const days = differenceInCalendarDays(fetchEnd, fetchStart)
+    if (days > 90) return '1w' as const
+    if (days > 14) return '1d' as const
+    return '1h' as const
+  }, [fetchStart, fetchEnd])
+
+  // Training load data (fetched when toggle is on)
   const trainingLoadQuery = useQuery({
     enabled: !hiddenCategories.has('training_load'),
     placeholderData: keepPreviousData,
-    queryFn: () => fetchTrainingLoad(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
-    queryKey: ['timeline-training-load', fromDate.value, toDate.value],
+    queryFn: () =>
+      fetchTrainingLoad(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), trainingLoadBucketSize),
+    queryKey: ['timeline-training-load', fromDate.value, toDate.value, trainingLoadBucketSize],
     staleTime: 5 * 60 * 1000,
   })
 

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -825,6 +825,7 @@ export const Timeline = () => {
   )
 
   // Unified Activity column items (activities + merged duration tags)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- UI temporarily commented out, will be redesigned
   const { items: activityItems, overlaps: overlapWarnings } = useMemo(
     () =>
       buildActivityColumnItems(
@@ -1106,6 +1107,7 @@ export const Timeline = () => {
 
     const chartGroup = g.append('g').attr('clip-path', 'url(#chart-clip)')
 
+    // eslint-disable-next-line complexity -- D3 vertical layout draw loop
     const draw = (currentYScale: d3.ScaleTime<number, number>) => {
       chartGroup.selectAll('*').remove()
       g.selectAll('.hour-label').remove()
@@ -1154,9 +1156,19 @@ export const Timeline = () => {
         .attr('opacity', 0.6)
         .text((d) => format(d, 'HH:mm'))
 
-      const midnights = d3.timeDay.range(domainStart, domainEnd)
-      for (const midnight of midnights) {
-        const my = currentYScale(midnight)
+      // Time separators — adapt interval to zoom level
+      const separatorDates: Date[] =
+        pixelsPerHour >= 2 ? d3.timeDay.range(domainStart, domainEnd)
+        : pixelsPerHour >= 0.3 ? d3.timeMonday.range(domainStart, domainEnd)
+        : d3.timeMonth.range(domainStart, domainEnd)
+
+      const separatorLabelFormat =
+        pixelsPerHour >= 2 ? 'MMM d'
+        : pixelsPerHour >= 0.3 ? "'w'w MMM d"
+        : 'MMM yyyy'
+
+      for (const sep of separatorDates) {
+        const my = currentYScale(sep)
         chartGroup
           .append('line')
           .attr('x1', 0)
@@ -1178,7 +1190,7 @@ export const Timeline = () => {
           .attr('font-size', '0.65rem')
           .attr('font-weight', '600')
           .attr('opacity', 0.5)
-          .text(format(midnight, 'MMM d'))
+          .text(format(sep, separatorLabelFormat))
       }
 
       for (let i = 1; i < columns.length; i++) {
@@ -1448,10 +1460,17 @@ export const Timeline = () => {
           .attr('stroke-opacity', 0.1)
       }
 
-      // Midnight separators
-      const midnights = d3.timeDay.range(domainStart, domainEnd)
-      for (const midnight of midnights) {
-        const mx = currentXScale(midnight)
+      // Time separators — adapt interval to zoom level
+      // pixelsPerHour >= 2  → daily (midnight lines)
+      // pixelsPerHour >= 0.3 → weekly (Monday boundaries)
+      // otherwise           → monthly (1st of month)
+      const separatorDates: Date[] =
+        pixelsPerHour >= 2 ? d3.timeDay.range(domainStart, domainEnd)
+        : pixelsPerHour >= 0.3 ? d3.timeMonday.range(domainStart, domainEnd)
+        : d3.timeMonth.range(domainStart, domainEnd)
+
+      for (const sep of separatorDates) {
+        const mx = currentXScale(sep)
         chartGroup
           .append('line')
           .attr('x1', mx)
@@ -2168,6 +2187,7 @@ export const Timeline = () => {
         )}
       </div>
 
+      {/* Overlap warnings UI temporarily disabled — will be redesigned
       {overlapWarnings.length > 0 && (
         <div class="timeline-overlap-warnings">
           <details>
@@ -2185,32 +2205,29 @@ export const Timeline = () => {
           </details>
         </div>
       )}
+      */}
 
-      {isInitialLoad && <div class="loading">Loading…</div>}
       {errorSources.length > 0 && (
         <div class="error">Failed to load {errorSources.join(', ')} — showing available data</div>
       )}
 
-      {!isInitialLoad && (
-        <>
-          {orientation === 'vertical' && (
-            <div class="timeline-column-headers" style={{ paddingLeft: `${VERTICAL_MARGIN.left}px` }}>
-              {columns.map((col, i) => (
-                <div key={col} style={{ flex: 1, paddingLeft: i === 0 ? '0' : '4px', textAlign: 'center' }}>
-                  {col}
-                </div>
-              ))}
+      {orientation === 'vertical' && !isInitialLoad && (
+        <div class="timeline-column-headers" style={{ paddingLeft: `${VERTICAL_MARGIN.left}px` }}>
+          {columns.map((col, i) => (
+            <div key={col} style={{ flex: 1, paddingLeft: i === 0 ? '0' : '4px', textAlign: 'center' }}>
+              {col}
             </div>
-          )}
-
-          <div class="timeline-chart-container" ref={containerRef} onPointerDown={hideTooltip}>
-            <svg ref={svgRef} />
-            <div class="timeline-tooltip" ref={tooltipRef} style={{ display: 'none' }} />
-          </div>
-
-          <p class="timeline-help">Scroll to zoom · Drag to pan · Double-click to reset</p>
-        </>
+          ))}
+        </div>
       )}
+
+      <div class="timeline-chart-container" ref={containerRef} onPointerDown={hideTooltip}>
+        <svg ref={svgRef} />
+        {isInitialLoad && <div class="timeline-chart-loading">Loading…</div>}
+        <div class="timeline-tooltip" ref={tooltipRef} style={{ display: 'none' }} />
+      </div>
+
+      <p class="timeline-help">Scroll to zoom · Drag to pan · Double-click to reset</p>
     </div>
   )
 }

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1968,38 +1968,36 @@ export const Timeline = () => {
           </button>
         </div>
         <span class="timeline-date-label">{viewLabel}</span>
-        {isFetching && <span class="timeline-fetching">Loading…</span>}
-        {!isFetching && (
-          <button
-            class="nav-btn timeline-refresh-btn"
-            onClick={() =>
-              queryClient.invalidateQueries({
-                predicate: (query) =>
-                  typeof query.queryKey[0] === 'string' &&
-                  (query.queryKey[0] as string).startsWith('timeline-'),
-              })
-            }
-            title="Refresh data"
-            type="button"
+        <button
+          class={`nav-btn timeline-refresh-btn${isFetching ? ' timeline-refresh-spinning' : ''}`}
+          disabled={isFetching}
+          onClick={() =>
+            queryClient.invalidateQueries({
+              predicate: (query) =>
+                typeof query.queryKey[0] === 'string' &&
+                (query.queryKey[0] as string).startsWith('timeline-'),
+            })
+          }
+          title={isFetching ? 'Loading…' : 'Refresh data'}
+          type="button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-              <path d="M3 3v5h5" />
-              <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
-              <path d="M21 21v-5h-5" />
-            </svg>
-          </button>
-        )}
+            <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+            <path d="M3 3v5h5" />
+            <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+            <path d="M21 21v-5h-5" />
+          </svg>
+        </button>
 
         <div class="timeline-orientation-toggle">
           <button

--- a/apps/web/src/pages/Timeline/style.css
+++ b/apps/web/src/pages/Timeline/style.css
@@ -90,6 +90,24 @@
   line-height: 0;
 }
 
+.timeline-refresh-spinning {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.timeline-refresh-spinning svg {
+  animation: timeline-spin 1s linear infinite;
+}
+
+@keyframes timeline-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Orientation toggle button — contains SVG, needs flex centering */
 .timeline-orientation-toggle .nav-btn {
   display: inline-flex;
@@ -105,23 +123,6 @@
   color: #374151;
   font-weight: 500;
   white-space: nowrap;
-}
-
-/* Fetching indicator */
-.timeline-fetching {
-  font-size: 0.75rem;
-  color: #6b7280;
-  animation: timeline-pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes timeline-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
 }
 
 /* Orientation + fullscreen toggle group */
@@ -438,10 +439,6 @@
 
   .timeline-date-label {
     color: #d1d5db;
-  }
-
-  .timeline-fetching {
-    color: #9ca3af;
   }
 
   .timeline-legend-toggle {

--- a/apps/web/src/pages/Timeline/style.css
+++ b/apps/web/src/pages/Timeline/style.css
@@ -293,6 +293,17 @@
   touch-action: none; /* prevent browser from intercepting touch gestures (d3-zoom handles them) */
 }
 
+.timeline-chart-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #888);
+  pointer-events: none;
+}
+
 .timeline-chart-container svg:active {
   cursor: grabbing;
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1224,11 +1224,16 @@ export const fetchDefaultScreentimeCategories = async (): Promise<CreateScreenti
 // Training Load API
 // ==========================================================================
 
-export const fetchTrainingLoad = async (start: Date, end: Date): Promise<TrainingLoadResult> => {
+export const fetchTrainingLoad = async (
+  start: Date,
+  end: Date,
+  bucketSize?: '1h' | '1d' | '1w',
+): Promise<TrainingLoadResult> => {
   const { token } = auth.value
   const response = await axios.get<TrainingLoadResponse>(`${API_URL}/training-load`, {
     headers: { Authorization: `Bearer ${token}` },
     params: {
+      bucket_size: bucketSize,
       end: end.toISOString(),
       start: start.toISOString(),
     },

--- a/packages/api-spec/src/schemas/training-load.ts
+++ b/packages/api-spec/src/schemas/training-load.ts
@@ -88,8 +88,19 @@ export type TrainingLoadSettings = z.infer<typeof trainingLoadSettingsSchema>
 /**
  * Query parameters for the training load endpoint.
  */
+/**
+ * Valid bucket sizes for training load aggregation.
+ * Default is '1h' (hourly). Larger buckets reduce payload size for long ranges.
+ */
+export const trainingLoadBucketSizes = ['1h', '1d', '1w'] as const
+export type TrainingLoadBucketSize = (typeof trainingLoadBucketSizes)[number]
+
 export const trainingLoadQuerySchema = z
   .object({
+    bucket_size: z.enum(trainingLoadBucketSizes).optional().meta({
+      description:
+        "Aggregation bucket size: '1h' (default, hourly), '1d' (daily), '1w' (weekly). Larger buckets reduce response size for long date ranges.",
+    }),
     end: z.string().meta({ description: 'End date in ISO 8601 format' }),
     start: z.string().meta({ description: 'Start date in ISO 8601 format' }),
   })
@@ -102,6 +113,10 @@ export type TrainingLoadQuery = z.infer<typeof trainingLoadQuerySchema>
  */
 export const getTrainingLoadInputSchema = z
   .object({
+    bucket_size: z.enum(trainingLoadBucketSizes).optional().meta({
+      description:
+        "Aggregation bucket size: '1h' (default, hourly), '1d' (daily), '1w' (weekly). Larger buckets reduce response size for long date ranges.",
+    }),
     end: z.iso.datetime().meta({ description: 'End date-time in ISO 8601 format' }),
     start: z.iso.datetime().meta({ description: 'Start date-time in ISO 8601 format' }),
   })
@@ -131,20 +146,24 @@ export const workoutTrimpSchema = z
 export type WorkoutTrimp = z.infer<typeof workoutTrimpSchema>
 
 /**
- * A single hour's training load point.
+ * A single training load point (hourly, daily, or weekly depending on bucket_size).
  */
 export const trainingLoadPointSchema = z
   .object({
-    activity_impulse: z
+    activity_impulse: z.number().meta({
+      description: 'Activity impulse (scaled active calories) for this bucket — summed when aggregated',
+    }),
+    atl: z.number().meta({ description: 'Acute Training Load (fatigue) — peak ATL within the bucket' }),
+    ctl: z.number().meta({ description: 'Chronic Training Load (fitness) — value at end of bucket' }),
+    time: z.string().meta({ description: 'Bucket start time (ISO 8601)' }),
+    training_impulse: z
       .number()
-      .meta({ description: 'Activity impulse (scaled active calories) for this hour' }),
-    atl: z.number().meta({ description: 'Acute Training Load (fatigue) — 7-day hourly EMA' }),
-    ctl: z.number().meta({ description: 'Chronic Training Load (fitness) — 42-day hourly EMA' }),
-    time: z.string().meta({ description: 'Hour start time (ISO 8601)' }),
-    training_impulse: z.number().meta({ description: 'Training impulse (exercise TRIMP) for this hour' }),
-    tsb: z.number().meta({ description: 'Training Stress Balance (form) = CTL - ATL' }),
+      .meta({ description: 'Training impulse (exercise TRIMP) for this bucket — summed when aggregated' }),
+    tsb: z
+      .number()
+      .meta({ description: 'Training Stress Balance (form) = CTL - ATL, value at end of bucket' }),
   })
-  .meta({ id: 'TrainingLoadPoint', description: 'Hourly ATL, CTL, TSB, and impulse values' })
+  .meta({ id: 'TrainingLoadPoint', description: 'ATL, CTL, TSB, and impulse values per time bucket' })
 
 export type TrainingLoadPoint = z.infer<typeof trainingLoadPointSchema>
 
@@ -182,7 +201,9 @@ export const trainingLoadResultSchema = z
     bootstrapping: z
       .boolean()
       .meta({ description: 'True if < 6 weeks of data, meaning CTL may not yet be meaningful' }),
-    points: z.array(trainingLoadPointSchema).meta({ description: 'Hourly training load time series' }),
+    points: z
+      .array(trainingLoadPointSchema)
+      .meta({ description: 'Training load time series (granularity depends on bucket_size parameter)' }),
     settings: trainingLoadSettingsSchema.meta({ description: 'Effective settings used for computation' }),
     workouts: z.array(workoutTrimpSchema).meta({ description: 'Per-workout TRIMP scores in the range' }),
     zones: recoveryZonesSchema


### PR DESCRIPTION
## Summary

- **Always render SVG immediately** — the chart container and SVG are no longer gated behind `isInitialLoad`, so zoom/scroll/pinch-zoom works from first paint. A loading overlay shows inside the chart while data fetches.
- **Metrics tooltip now shows the date** — was only showing "HH:mm – HH:mm" with no date context, now shows "Wed, Mar 16 14:00 – 14:30".
- **Adaptive time separators** — daily dashed lines when zoomed in, weekly (Monday) at mid-zoom, monthly when zoomed far out. Applies to both vertical and horizontal modes.
- **Time-based training load bucketing** — hourly points are aggregated into day/week buckets when zoomed out, producing visible bars instead of pixel-thin lines that were invisible.
- **Overlap detection UI commented out** — will be redesigned later.

## Files changed

- `apps/web/src/pages/Timeline/index.tsx` — SVG always rendered, adaptive separators, overlap UI commented out
- `apps/web/src/pages/Timeline/drawMetricsTrack.ts` — date added to tooltip
- `apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts` — time-based bucketing replaces pixel-distance downsampling
- `apps/web/src/pages/Timeline/style.css` — loading overlay styling