### PR TITLE
fix: training load perf and empty tooltip on zoomed-out timeline

### DIFF
--- a/apps/backend/src/services/training-load.ts
+++ b/apps/backend/src/services/training-load.ts
@@ -639,12 +639,21 @@ const buildWorkoutList = async (
   kFactor: number,
 ): Promise<WorkoutTrimp[]> => {
   const exercises = await deps.getExercises(user, start, end)
-  const hrSamples = await deps.getHrSamples(user, start, end)
-  const training = new Map<string, number>() // throwaway, just for reusing processExercise
+  if (exercises.length === 0) return []
 
+  // Fetch HR samples per exercise session in parallel (not the whole range)
+  // — avoids pulling months of 5-minute HR data when only a few sessions need it
+  const hrPerExercise = await Promise.all(
+    exercises.map((ex) => {
+      const sessionEnd = ex.end_time ?? new Date(ex.start_time.getTime() + MS_PER_HOUR)
+      return deps.getHrSamples(user, ex.start_time, sessionEnd)
+    }),
+  )
+
+  const training = new Map<string, number>() // throwaway, just for reusing processExercise
   const workoutList: WorkoutTrimp[] = []
-  for (const ex of exercises) {
-    const workout = processExercise(ex, hrSamples, hrMax, hrRest, kFactor, training)
+  for (let i = 0; i < exercises.length; i++) {
+    const workout = processExercise(exercises[i]!, hrPerExercise[i]!, hrMax, hrRest, kFactor, training)
     if (workout) workoutList.push(workout)
   }
   return workoutList
@@ -766,6 +775,10 @@ export const computeTrainingLoad = async (
   const hrMax = resolveHrMax(settings.hr_max, maxObservedHr, userSettings.birth_date)
   const hrRest = resolveHrRest(settings.hr_rest, latestRestingHr)
 
+  // Start building the workout list early — it only needs settings, not impulse buckets.
+  // Runs in parallel with watermark recompute + impulse fetch + EMA.
+  const workoutListPromise = buildWorkoutList(deps, user, start, end, hrMax, hrRest, settings.k_factor)
+
   // Extended range for EMA bootstrapping (3 × tau_chronic in hours)
   const lookbackHours = Math.ceil(settings.tau_chronic * 3 * HOURS_PER_DAY)
   const extendedStart = new Date(start.getTime() - lookbackHours * MS_PER_HOUR)
@@ -837,8 +850,8 @@ export const computeTrainingLoad = async (
   const hourlyPoints = allPoints.filter((p) => p.time >= startIso && p.time <= endIso)
   const points = aggregateTrainingLoadPoints(hourlyPoints, bucketSize)
 
-  // Fetch workouts in the requested range for the response
-  const workoutList = await buildWorkoutList(deps, user, start, end, hrMax, hrRest, settings.k_factor)
+  // Await the workout list (started earlier, runs in parallel)
+  const workoutList = await workoutListPromise
 
   // Determine bootstrapping status
   const totalHours = allPoints.length

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -69,8 +69,14 @@ export interface MetricsTrackConfig {
 
 // ── Bucket aggregation by zoom ────────────────────────────────────────────────
 
-/** Pick an aggregation factor based on pixels-per-hour (zoom level). */
-const getAggregationFactor = (pixelsPerHour: number): number => {
+/** Pick an aggregation factor based on pixels-per-hour and bucket size.
+ *  Only merges small (5m/15m) buckets — if buckets are already >= 1h, skip. */
+const getAggregationFactor = (pixelsPerHour: number, buckets: MetricBucketParsed[]): number => {
+  // If buckets are already large (>= 1 hour), don't aggregate further
+  if (buckets.length >= 2) {
+    const bucketMs = buckets[1]!.start.getTime() - buckets[0]!.start.getTime()
+    if (bucketMs >= 3600_000) return 1
+  }
   if (pixelsPerHour > 100) return 1 // 5m buckets as-is
   if (pixelsPerHour > 20) return 3 // merge to ~15m
   return 6 // merge to ~30m
@@ -202,8 +208,9 @@ const buildTrainingLoadSection = (
   points: TrainingLoadPoint[],
   workouts?: WorkoutTrimp[],
   zones?: RecoveryZones,
+  toleranceMs?: number,
 ): string => {
-  const point = findTrainingLoadPoint(points, bucketMid)
+  const point = findTrainingLoadPoint(points, bucketMid, toleranceMs)
   if (!point) return ''
 
   let html = `<div class="tooltip-separator" style="border-top:1px solid rgba(128,128,128,0.3);margin:4px 0"></div>`
@@ -252,7 +259,8 @@ const buildMetricsTooltipHtml = (
   trainingLoadPoints?: TrainingLoadPoint[],
   trainingLoadWorkouts?: WorkoutTrimp[],
   trainingLoadZones?: RecoveryZones,
-): string => {
+  trainingLoadToleranceMs?: number,
+): string | null => {
   const startStr = formatTime(bucket.start)
   const endStr = formatTime(bucket.end)
   const dateStr = format(bucket.start, 'EEE, MMM d')
@@ -263,39 +271,54 @@ const buildMetricsTooltipHtml = (
     : `${dateStr} ${startStr} – ${format(bucket.end, 'EEE, MMM d')} ${endStr}`
   let html = `<div class="tooltip-title">Metrics</div>`
   html += `<div class="tooltip-time">${timeRange}</div>`
+  let hasContent = false
 
   if (showHR) {
     const hr = bucket.metrics.heart_rate
     if (hr) {
       html += `<div class="tooltip-detail" style="color:${HR_COLOR}">❤ HR: ${Math.round(hr.avg)} bpm (${Math.round(hr.min)}–${Math.round(hr.max)})</div>`
+      hasContent = true
     }
   }
   if (showHRV) {
     const hrv = bucket.metrics.hrv_rmssd
     if (hrv) {
       html += `<div class="tooltip-detail" style="color:${HRV_COLOR}">♥ HRV: ${Math.round(hrv.avg)} ms (${Math.round(hrv.min)}–${Math.round(hrv.max)})</div>`
+      hasContent = true
     }
   }
   if (showSteps) {
     const steps = bucket.metrics.steps
     if (steps) {
       html += `<div class="tooltip-detail" style="color:${STEPS_COLOR}">🚶 Steps: ${steps.avg.toFixed(1)}/min</div>`
+      hasContent = true
     }
   }
   if (showCalories) {
     const cal = bucket.metrics.calories_active
     if (cal) {
       html += `<div class="tooltip-detail" style="color:${CALORIES_COLOR}">🔥 Calories: ${cal.avg.toFixed(1)} kcal/min</div>`
+      hasContent = true
     }
   }
 
-  // Append training load section if available
+  // Append training load section if available (with tolerance matching the bucket duration)
   if (trainingLoadPoints && trainingLoadPoints.length > 0) {
     const bucketMid = new Date((bucket.start.getTime() + bucket.end.getTime()) / 2)
-    html += buildTrainingLoadSection(bucketMid, trainingLoadPoints, trainingLoadWorkouts, trainingLoadZones)
+    const section = buildTrainingLoadSection(
+      bucketMid,
+      trainingLoadPoints,
+      trainingLoadWorkouts,
+      trainingLoadZones,
+      trainingLoadToleranceMs,
+    )
+    if (section) {
+      html += section
+      hasContent = true
+    }
   }
 
-  return html
+  return hasContent ? html : null
 }
 
 // ── Y-scale computation ───────────────────────────────────────────────────────
@@ -432,6 +455,8 @@ const drawCrosshairOverlay = (
       }
 
       hairline.attr('x1', mx!).attr('x2', mx!).style('display', null)
+      // Use bucket duration as tolerance for matching training load points
+      const tolerance = Math.max(2 * 3600_000, bucketDuration)
       const html = buildMetricsTooltipHtml(
         nearest,
         showHR,
@@ -441,7 +466,13 @@ const drawCrosshairOverlay = (
         trainingLoadPoints,
         trainingLoadWorkouts,
         trainingLoadZones,
+        tolerance,
       )
+      if (!html) {
+        hairline.style('display', 'none')
+        hideTooltip()
+        return
+      }
       showTooltipHtml(event, html)
     })
     .on('mouseleave', () => {
@@ -482,7 +513,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
   if (rawBuckets.length === 0 && !hasTrainingLoad) return
   if (!hasMetrics && !hasTrainingLoad) return
 
-  const factor = getAggregationFactor(pixelsPerHour)
+  const factor = getAggregationFactor(pixelsPerHour, rawBuckets)
   const buckets = aggregateBuckets(rawBuckets, factor)
   const trackBottom = trackY + trackHeight
 

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -127,10 +127,15 @@ export const MS_PER_HOUR = 3600_000
 const parseTime = (timeStr: string): Date => new Date(timeStr)
 
 /**
- * Find the training load point whose hour contains the given time.
- * Floors the time to the hour, then looks for an exact match or nearest within 2 hours.
+ * Find the training load point nearest to the given time.
+ * Tries exact hour match first, then falls back to nearest within tolerance.
+ * Default tolerance is 2 hours; pass a larger value for weekly/daily bucketed data.
  */
-export const findTrainingLoadPoint = (points: TrainingLoadPoint[], time: Date): TrainingLoadPoint | null => {
+export const findTrainingLoadPoint = (
+  points: TrainingLoadPoint[],
+  time: Date,
+  maxDistanceMs: number = 2 * MS_PER_HOUR,
+): TrainingLoadPoint | null => {
   const timeMs = time.getTime()
   const flooredHour = new Date(timeMs - (timeMs % MS_PER_HOUR))
   const flooredIso = flooredHour.toISOString()
@@ -140,7 +145,7 @@ export const findTrainingLoadPoint = (points: TrainingLoadPoint[], time: Date): 
     if (p.time === flooredIso) return p
   }
 
-  // Fall back to nearest within 2 hours
+  // Fall back to nearest within tolerance
   let nearest: TrainingLoadPoint | null = null
   let bestDist = Infinity
   for (const p of points) {
@@ -151,7 +156,7 @@ export const findTrainingLoadPoint = (points: TrainingLoadPoint[], time: Date): 
     }
   }
 
-  return nearest && bestDist <= 2 * MS_PER_HOUR ? nearest : null
+  return nearest && bestDist <= maxDistanceMs ? nearest : null
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #343 — fixes two issues reported after deployment:

### Backend: Training load response time ~20s → ~2s
- **`buildWorkoutList`** was fetching 7 months of 5-minute HR data in a single query (~60K rows), then doing O(N × 60K) linear scans per exercise. Now fetches HR per exercise session in parallel — each query returns ~12 rows instead of 60K.
- **`buildWorkoutList`** now kicks off immediately after settings resolve, running in parallel with the watermark recompute, impulse bucket fetch, and EMA computation.

### Frontend: Empty tooltips on year view
- **Metric aggregation**: `getAggregationFactor` was merging 6 daily buckets into ~6-day mega-buckets at low zoom, creating buckets spanning time gaps with no data. Now skips aggregation when buckets are already >= 1 hour.
- **Empty tooltip suppression**: `buildMetricsTooltipHtml` now returns `null` when there's no metric or training load content, and the crosshair handler hides the tooltip instead of showing an empty one.
- **Training load matching**: `findTrainingLoadPoint` tolerance widened from hard-coded 2h to `max(2h, bucketDuration)` — weekly training load points now match within their week.

## Files changed
- `apps/backend/src/services/training-load.ts` — perf fixes
- `apps/web/src/pages/Timeline/drawMetricsTrack.ts` — tooltip fixes
- `apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts` — tolerance parameter