### PR TITLE
fix: zone bands squished + tooltip missing on weekly training load view

### DIFF
--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -15,6 +15,7 @@ import {
   CTL_COLOR,
   findNearbyWorkouts,
   findTrainingLoadPoint,
+  inferBucketDuration,
   TRAINING_IMPULSE_COLOR,
   TSB_FATIGUED_COLOR,
   TSB_FRESH_COLOR,
@@ -321,6 +322,44 @@ const buildMetricsTooltipHtml = (
   return hasContent ? html : null
 }
 
+/**
+ * Build a standalone training-load tooltip (no metric data).
+ * Used when metric buckets are empty but training load points exist.
+ */
+const buildTrainingLoadOnlyTooltipHtml = (
+  hoverTime: Date,
+  trainingLoadPoints: TrainingLoadPoint[],
+  trainingLoadWorkouts?: WorkoutTrimp[],
+  trainingLoadZones?: RecoveryZones,
+  toleranceMs?: number,
+): string | null => {
+  const point = findTrainingLoadPoint(trainingLoadPoints, hoverTime, toleranceMs)
+  if (!point) return null
+
+  // Build date header from the training load point's own time + bucket duration
+  const pointTime = new Date(point.time)
+  const bucketDuration = inferBucketDuration(trainingLoadPoints)
+  const bucketEnd = new Date(pointTime.getTime() + bucketDuration)
+  const dateStr = format(pointTime, 'EEE, MMM d')
+  const isSameDay = format(pointTime, 'yyyy-MM-dd') === format(bucketEnd, 'yyyy-MM-dd')
+  const timeRange =
+    isSameDay ?
+      `${dateStr} ${formatTime(pointTime)} – ${formatTime(bucketEnd)}`
+    : `${dateStr} – ${format(bucketEnd, 'EEE, MMM d')}`
+
+  let html = `<div class="tooltip-title">Training Load</div>`
+  html += `<div class="tooltip-time">${timeRange}</div>`
+
+  const section = buildTrainingLoadSection(
+    hoverTime,
+    trainingLoadPoints,
+    trainingLoadWorkouts,
+    trainingLoadZones,
+    toleranceMs,
+  )
+  return section ? html + section : null
+}
+
 // ── Y-scale computation ───────────────────────────────────────────────────────
 
 /** Extract maximum avg value from buckets for a given metric. */
@@ -430,6 +469,7 @@ const drawCrosshairOverlay = (
       const [mx] = d3.pointer(event)
       const hoverTime = xScale.invert(mx!)
 
+      // Try to find the nearest metric bucket
       let nearest: MetricBucketParsed | null = null
       let bestDist = Infinity
       for (const b of buckets) {
@@ -441,38 +481,49 @@ const drawCrosshairOverlay = (
         }
       }
 
-      if (!nearest) {
-        hairline.style('display', 'none')
-        hideTooltip()
-        return
+      // If we have a metric bucket match, check distance threshold
+      if (nearest) {
+        const bucketDuration = nearest.end.getTime() - nearest.start.getTime()
+        if (bestDist > bucketDuration * 2) {
+          nearest = null
+        }
       }
 
-      const bucketDuration = nearest.end.getTime() - nearest.start.getTime()
-      if (bestDist > bucketDuration * 2) {
-        hairline.style('display', 'none')
-        hideTooltip()
-        return
+      // Build tooltip: use metric bucket if available, otherwise training-load-only
+      let html: string | null = null
+      if (nearest) {
+        const bucketDuration = nearest.end.getTime() - nearest.start.getTime()
+        const tolerance = Math.max(2 * 3600_000, bucketDuration)
+        html = buildMetricsTooltipHtml(
+          nearest,
+          showHR,
+          showHRV,
+          showSteps,
+          showCalories,
+          trainingLoadPoints,
+          trainingLoadWorkouts,
+          trainingLoadZones,
+          tolerance,
+        )
+      } else if (trainingLoadPoints && trainingLoadPoints.length > 0) {
+        // No metric bucket — build a standalone training load tooltip
+        const tlBucketDuration = inferBucketDuration(trainingLoadPoints)
+        const tolerance = Math.max(2 * 3600_000, tlBucketDuration)
+        html = buildTrainingLoadOnlyTooltipHtml(
+          hoverTime,
+          trainingLoadPoints,
+          trainingLoadWorkouts,
+          trainingLoadZones,
+          tolerance,
+        )
       }
 
-      hairline.attr('x1', mx!).attr('x2', mx!).style('display', null)
-      // Use bucket duration as tolerance for matching training load points
-      const tolerance = Math.max(2 * 3600_000, bucketDuration)
-      const html = buildMetricsTooltipHtml(
-        nearest,
-        showHR,
-        showHRV,
-        showSteps,
-        showCalories,
-        trainingLoadPoints,
-        trainingLoadWorkouts,
-        trainingLoadZones,
-        tolerance,
-      )
       if (!html) {
         hairline.style('display', 'none')
         hideTooltip()
         return
       }
+      hairline.attr('x1', mx!).attr('x2', mx!).style('display', null)
       showTooltipHtml(event, html)
     })
     .on('mouseleave', () => {

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -72,10 +72,12 @@ const computeYScales = (
   points: TrainingLoadPoint[],
   trackY: number,
   trackBottom: number,
+  zones?: RecoveryZones,
 ): TrainingLoadYScales => {
   // Load scale: tight domain around actual ATL/CTL range for better visual resolution.
   // With a zero-anchored domain the curves compress into ~10% of the track when values
   // are close (e.g. CTL 5.9–6.8).  A tight domain lets small variations fill the track.
+  // Zone thresholds are also included so zone bands are always visible, not squished.
   let minLoad = Infinity
   let maxLoad = -Infinity
   for (const p of points) {
@@ -83,6 +85,11 @@ const computeYScales = (
     if (p.ctl < minLoad) minLoad = p.ctl
     if (p.atl > maxLoad) maxLoad = p.atl
     if (p.ctl > maxLoad) maxLoad = p.ctl
+  }
+  // Include zone thresholds in domain so zone bands are always visible
+  if (zones) {
+    if (zones.balanced_min < minLoad) minLoad = zones.balanced_min
+    if (zones.strained_max > maxLoad) maxLoad = zones.strained_max
   }
   if (minLoad === Infinity) minLoad = 0
   if (maxLoad === -Infinity) maxLoad = 10
@@ -518,7 +525,7 @@ export const buildTrainingLoadTooltipHtml = (
  * If points are pre-bucketed (daily/weekly), the gap between them reveals the bucket size.
  * Falls back to 1 hour for hourly or single-point data.
  */
-const inferBucketDuration = (points: TrainingLoadPoint[]): number => {
+export const inferBucketDuration = (points: TrainingLoadPoint[]): number => {
   if (points.length < 2) return MS_PER_HOUR
   const t0 = parseTime(points[0]!.time).getTime()
   const t1 = parseTime(points[1]!.time).getTime()
@@ -553,7 +560,7 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
 
   if (displayPoints.length === 0) return
 
-  const yScales = computeYScales(displayPoints, trackY, trackBottom)
+  const yScales = computeYScales(displayPoints, trackY, trackBottom, zones)
 
   // Draw zone bands first (behind everything)
   if (zones) {


### PR DESCRIPTION
## Summary

- **Zone bands squished to bottom**: `computeYScales` in `drawTrainingLoadTrack.ts` now includes zone thresholds (`balanced_min`, `strained_max`) in the y-domain. Previously, when peak ATL >> zone thresholds, the zone bands compressed into the bottom few pixels of the track. Now zones are always visible with proper proportional height.

- **Tooltip missing on weekly training load bars**: The crosshair overlay in `drawMetricsTrack.ts` would bail out early when metric buckets were empty (e.g. all metrics hidden but training load visible). Now it falls back to building a standalone training-load-only tooltip matched directly against training load points.

- **Tooltip date range incorrect for weekly bars**: When showing training load without metrics, the tooltip now derives its date header from the training load point's bucket duration (weekly/daily) instead of inheriting a metric bucket's narrower date range.

## Changes

- `drawTrainingLoadTrack.ts`: `computeYScales` accepts optional `zones` param, extends domain to include zone thresholds. `inferBucketDuration` now exported.
- `drawMetricsTrack.ts`: New `buildTrainingLoadOnlyTooltipHtml` function for standalone training load tooltips. `drawCrosshairOverlay` mousemove handler restructured to fall back to training-load-only tooltip when metric buckets are empty.