### PR TITLE
feat: add Garmin Connect data source UI

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -14,6 +14,7 @@ import { ActivityWatchDesktopSource } from './pages/DataSources/ActivityWatchDes
 import { AndroidAppSource } from './pages/DataSources/AndroidAppSource.jsx'
 import { AurbodaSource } from './pages/DataSources/AurbodaSource.jsx'
 import { CalendarsSource } from './pages/DataSources/CalendarsSource.jsx'
+import { GarminSource } from './pages/DataSources/GarminSource.jsx'
 import { DataSources } from './pages/DataSources/index.jsx'
 import { LastFmSource } from './pages/DataSources/LastFmSource.jsx'
 import { OuraSource } from './pages/DataSources/OuraSource.jsx'
@@ -57,6 +58,7 @@ export function App() {
             <Route path="/data-sources/aurboda" component={AurbodaSource} />
             <Route path="/data-sources/android-app" component={AndroidAppSource} />
             <Route path="/data-sources/oura" component={OuraSource} />
+            <Route path="/data-sources/garmin" component={GarminSource} />
             <Route path="/data-sources/activitywatch-desktop" component={ActivityWatchDesktopSource} />
             <Route path="/data-sources/activitywatch-android" component={ActivityWatchAndroidSource} />
             <Route path="/data-sources/rescue-time" component={RescueTimeSource} />

--- a/apps/web/src/pages/DataSources/GarminSource.tsx
+++ b/apps/web/src/pages/DataSources/GarminSource.tsx
@@ -1,0 +1,214 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useState } from 'preact/hooks'
+import { connectGarmin, disconnectGarmin, fetchUserSettings, syncGarmin } from '../../state/api'
+import { auth } from '../../state/auth'
+import { DataTypesList, LoginRequired, StatusBanner } from './shared'
+
+import './style.css'
+
+const DATA_TYPES = [
+  'Daily summary (steps, distance, calories, floors)',
+  'Heart rate (resting + samples)',
+  'HRV (last night average)',
+  'Sleep (duration, stages, score)',
+  'Stress level',
+  'Body Battery',
+  'Activities (exercise with HR, VO2 max)',
+  'SpO2 (blood oxygen)',
+  'Respiration rate',
+  'Training readiness',
+  'Intensity minutes',
+]
+
+export function GarminSource() {
+  const isLoggedIn = auth.value.token
+  const queryClient = useQueryClient()
+
+  const { data: userSettings, isLoading } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+  })
+
+  const isConnected = userSettings?.garmin_connected ?? false
+
+  // Login form state
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loginStatus, setLoginStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [loginError, setLoginError] = useState('')
+
+  // Disconnect state
+  const [disconnecting, setDisconnecting] = useState(false)
+
+  // Sync state
+  const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
+  const [syncMessage, setSyncMessage] = useState('')
+
+  const handleLogin = useCallback(
+    async (e: Event) => {
+      e.preventDefault()
+      if (!email || !password) return
+
+      setLoginStatus('loading')
+      setLoginError('')
+      try {
+        const result = await connectGarmin(email, password)
+        if (result.success) {
+          setEmail('')
+          setPassword('')
+          setLoginStatus('idle')
+          await queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+        } else if (result.mfa_required) {
+          setLoginStatus('error')
+          setLoginError('Garmin requires multi-factor authentication, which is not yet supported.')
+        } else {
+          setLoginStatus('error')
+          setLoginError(result.error ?? 'Login failed')
+        }
+      } catch (err) {
+        setLoginStatus('error')
+        setLoginError(err instanceof Error ? err.message : 'Login failed')
+      }
+    },
+    [email, password, queryClient],
+  )
+
+  const handleDisconnect = useCallback(async () => {
+    setDisconnecting(true)
+    try {
+      await disconnectGarmin()
+      await queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+    } catch {
+      // Silently handle — the user can try again
+    } finally {
+      setDisconnecting(false)
+    }
+  }, [queryClient])
+
+  const handleFullResync = useCallback(async () => {
+    setSyncStatus('syncing')
+    setSyncMessage('')
+    try {
+      const response = await syncGarmin(true)
+      const totalRecords = (response.results ?? []).reduce((sum, r) => sum + (r.records_processed ?? 0), 0)
+      setSyncStatus('done')
+      setSyncMessage(`Synced ${totalRecords} records`)
+      await queryClient.invalidateQueries()
+    } catch (err) {
+      setSyncStatus('error')
+      setSyncMessage(err instanceof Error ? err.message : 'Sync failed')
+    }
+  }, [queryClient])
+
+  if (!isLoggedIn) return <LoginRequired />
+
+  return (
+    <div class="data-sources-page">
+      <div class="page-header">
+        <h1>Garmin Connect</h1>
+      </div>
+
+      <div class="data-source-detail">
+        <p class="source-description">
+          <a href="https://connect.garmin.com/" target="_blank" rel="noopener noreferrer">
+            Garmin Connect
+          </a>{' '}
+          provides fitness and health data from Garmin wearable devices. Aurboda syncs data by connecting to
+          your Garmin account. Your credentials are used only for the initial login and are never stored —
+          only session tokens are persisted.
+        </p>
+
+        <DataTypesList types={DATA_TYPES} />
+
+        {isLoading ?
+          <div class="loading">Loading...</div>
+        : <>
+            <StatusBanner
+              connected={isConnected}
+              label={isConnected ? 'Garmin Connect is connected' : 'Garmin Connect not connected'}
+            />
+
+            <div class="links-row">
+              <a
+                href="https://github.com/fiddur/aurboda/blob/develop/docs/garmin.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="doc-link"
+              >
+                Garmin integration documentation
+              </a>
+            </div>
+
+            <section class="settings-section">
+              <h2>Connection</h2>
+
+              {isConnected ?
+                <div class="garmin-connected-actions">
+                  <p class="connected-status">Connected</p>
+                  <div class="garmin-button-row">
+                    <button
+                      type="button"
+                      class="connect-button"
+                      disabled={syncStatus === 'syncing'}
+                      onClick={handleFullResync}
+                    >
+                      {syncStatus === 'syncing' ? 'Syncing...' : 'Full Re-sync'}
+                    </button>
+                    <button
+                      type="button"
+                      class="connect-button disconnect-button"
+                      disabled={disconnecting}
+                      onClick={handleDisconnect}
+                    >
+                      {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+                    </button>
+                  </div>
+                  {syncMessage && <p class={`garmin-sync-message ${syncStatus}`}>{syncMessage}</p>}
+                </div>
+              : <form class="garmin-login-form" onSubmit={handleLogin}>
+                  <div class="form-field">
+                    <label for="garmin-email">Garmin Connect Email</label>
+                    <input
+                      id="garmin-email"
+                      type="email"
+                      value={email}
+                      onInput={(e) => setEmail((e.target as HTMLInputElement).value)}
+                      placeholder="your-email@example.com"
+                      required
+                      disabled={loginStatus === 'loading'}
+                    />
+                  </div>
+                  <div class="form-field">
+                    <label for="garmin-password">Password</label>
+                    <input
+                      id="garmin-password"
+                      type="password"
+                      value={password}
+                      onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
+                      placeholder="Your Garmin password"
+                      required
+                      disabled={loginStatus === 'loading'}
+                    />
+                  </div>
+                  <button
+                    type="submit"
+                    class="connect-button"
+                    disabled={loginStatus === 'loading' || !email || !password}
+                  >
+                    {loginStatus === 'loading' ? 'Connecting...' : 'Connect Garmin'}
+                  </button>
+                  <p class="field-description">
+                    Your credentials are used only to authenticate with Garmin and are never stored on the
+                    server. Only session tokens are saved.
+                  </p>
+                  {loginError && <p class="garmin-login-error">{loginError}</p>}
+                </form>
+              }
+            </section>
+          </>
+        }
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/DataSources/index.tsx
+++ b/apps/web/src/pages/DataSources/index.tsx
@@ -106,6 +106,7 @@ export function DataSources() {
   const hasProductivity = (productivityQuery.data?.length ?? 0) > 0
   const hasLocations = (locationsQuery.data?.length ?? 0) > 0
   const isOuraConnected = settingsQuery.data?.oura_connected ?? false
+  const isGarminConnected = settingsQuery.data?.garmin_connected ?? false
   const isRescueTimeConfigured = !!settingsQuery.data?.rescue_time_key
   const hasLastfm = !!settingsQuery.data?.lastfm_username
   const hasCalendars = (settingsQuery.data?.calendars ?? []).length > 0
@@ -149,6 +150,13 @@ export function DataSources() {
       name: 'Oura Ring',
       path: '/data-sources/oura',
       statusText: isOuraConnected ? 'Connected' : 'Not connected',
+    },
+    {
+      dataTypes: 'Sleep, stress, body battery, HR, HRV, activities, SpO2, training readiness',
+      isConnected: isGarminConnected,
+      name: 'Garmin Connect',
+      path: '/data-sources/garmin',
+      statusText: isGarminConnected ? 'Connected' : 'Not connected',
     },
     {
       dataTypes: 'App and window usage on desktop',

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -324,6 +324,7 @@
 }
 
 .data-sources-page .form-field input[type='date'],
+.data-sources-page .form-field input[type='email'],
 .data-sources-page .form-field input[type='password'],
 .data-sources-page .form-field input[type='text'],
 .data-sources-page .form-field input[type='url'] {
@@ -431,6 +432,55 @@
 
 .data-sources-page .oura-sync-message.error {
   color: #f44336;
+}
+
+/* Garmin specific */
+.data-sources-page .garmin-connected-actions .connected-status {
+  margin-bottom: 0.75rem;
+}
+
+.data-sources-page .garmin-button-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.data-sources-page .disconnect-button {
+  background: transparent;
+  color: #f44336;
+  border: 1px solid #f44336;
+}
+
+.data-sources-page .disconnect-button:hover:not(:disabled) {
+  background: #f44336;
+  color: white;
+}
+
+.data-sources-page .garmin-sync-message {
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.data-sources-page .garmin-sync-message.done {
+  color: #4caf50;
+}
+
+.data-sources-page .garmin-sync-message.error {
+  color: #f44336;
+}
+
+.data-sources-page .garmin-login-form {
+  max-width: 400px;
+}
+
+.data-sources-page .garmin-login-form .connect-button {
+  margin-top: 0.5rem;
+}
+
+.data-sources-page .garmin-login-error {
+  color: #f44336;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
 }
 
 /* AW token */
@@ -648,6 +698,7 @@
   }
 
   .data-sources-page .form-field input[type='date'],
+  .data-sources-page .form-field input[type='email'],
   .data-sources-page .form-field input[type='password'],
   .data-sources-page .form-field input[type='text'],
   .data-sources-page .form-field input[type='url'] {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -32,6 +32,7 @@ import type {
   DashboardConfig,
   DashboardResponse,
   ExerciseTypeName,
+  GarminSyncResponse,
   Goal,
   GoalProgress,
   GoalsProgressResponse,
@@ -450,6 +451,40 @@ export const syncOura = async (fullResync?: boolean): Promise<OuraSyncResponse> 
   const { token } = auth.value
   const response = await axios.post<OuraSyncResponse>(
     `${API_URL}/sync/oura`,
+    { full_resync: fullResync },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}
+
+// Garmin Connect auth + sync
+export const connectGarmin = async (
+  email: string,
+  password: string,
+): Promise<{ success: boolean; mfa_required?: boolean; error?: string }> => {
+  const { token } = auth.value
+  const response = await axios.post(
+    `${API_URL}/auth/garmin/login`,
+    { email, password },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}
+
+export const disconnectGarmin = async (): Promise<{ success: boolean }> => {
+  const { token } = auth.value
+  const response = await axios.post(
+    `${API_URL}/auth/garmin/disconnect`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}
+
+export const syncGarmin = async (fullResync?: boolean): Promise<GarminSyncResponse> => {
+  const { token } = auth.value
+  const response = await axios.post<GarminSyncResponse>(
+    `${API_URL}/sync/garmin`,
     { full_resync: fullResync },
     { headers: { Authorization: `Bearer ${token}` } },
   )


### PR DESCRIPTION
## Summary

- Add frontend UI for connecting/disconnecting Garmin Connect in the Data Sources page
- Garmin card appears in the data sources grid showing connection status
- Login form with email/password, full re-sync and disconnect buttons when connected

## Changes

| File | Change |
|------|--------|
| `GarminSource.tsx` | New page: login form, disconnect, re-sync, status banner, data types list |
| `DataSources/index.tsx` | Added Garmin card to sources grid using `garmin_connected` |
| `state/api.ts` | Added `connectGarmin()`, `disconnectGarmin()`, `syncGarmin()` API functions |
| `index.tsx` | Route registration for `/data-sources/garmin` |
| `style.css` | Garmin styles + `input[type='email']` support in form fields |

Follows the existing data source page pattern (shared components, status banner, data type badges).

Follow-up to #348 (backend Garmin integration).