### PR TITLE
feat: unified timezone-aware metrics bucketing with improved tooltips

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@aurboda/api-spec": "workspace:*",
     "@flow-js/garmin-connect": "^1.6.7",
+    "@js-temporal/polyfill": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "axios": "^1.11.0",
     "body-parser": "^1.20.3",

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -339,11 +339,15 @@ export const getTimeSeriesBucketed = async (
   start: Date,
   end: Date,
   interval: string,
+  tz: string = 'UTC',
 ): Promise<BucketedMetricData[]> => {
   if (metrics.length === 0) return []
 
+  // For timezone-aware bucketing, convert timestamps to local time before binning,
+  // then convert back. This ensures daily buckets align to local midnight (and
+  // handles DST correctly — spring-forward days are 23h, fall-back days are 25h).
   const bucketedSql = (sourceFilter: string) => `SELECT
-       date_bin($4::interval, time, $2) as bucket_start,
+       date_bin($4::interval, time AT TIME ZONE $5, ($2 AT TIME ZONE $5)::timestamp) AT TIME ZONE $5 as bucket_start,
        metric,
        AVG(value) as avg,
        MIN(value) as min,
@@ -369,9 +373,9 @@ export const getTimeSeriesBucketed = async (
     cumulativeExtraParams: [cumulativeSources],
     mapRow,
     metrics,
-    params: [start, end, interval],
+    params: [start, end, interval, tz],
     queryFn: (sql, params) => query(user, sql, params),
-    sqlCumulative: bucketedSql(`\n     AND source = ANY($5)`),
+    sqlCumulative: bucketedSql(`\n     AND source = ANY($6)`),
     sqlNonCumulative: bucketedSql(''),
   })
 

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -74,8 +74,12 @@ Use cases:
         .array(z.string())
         .optional()
         .describe(`Metrics to include (omit for all). Valid built-in metrics: ${validMetrics.join(', ')}`),
+      tz: z
+        .string()
+        .optional()
+        .describe('IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). Defaults to UTC.'),
     },
-    async ({ bucket, end, exclude, metrics, start }) => {
+    async ({ bucket, end, exclude, metrics, start, tz }) => {
       const customMetrics = await getCustomMetrics(user)
 
       // Validate specified metrics if provided
@@ -96,7 +100,7 @@ Use cases:
         new Date(start),
         new Date(end),
         bucket,
-        { customMetrics, exclude },
+        { customMetrics, exclude, tz },
       )
       return jsonResponse(result)
     },

--- a/apps/backend/src/mcp/training-load-tools.ts
+++ b/apps/backend/src/mcp/training-load-tools.ts
@@ -32,9 +32,9 @@ Parameters can be configured in user settings (training_load).
 Example: "Show my training load for the last 3 months"
 → start: 3 months ago, end: today`,
     { ...getTrainingLoadInputSchema.shape },
-    async ({ start, end, bucket_size }) => {
+    async ({ start, end, bucket_size, tz }) => {
       try {
-        const result = await computeTrainingLoad(deps, user, new Date(start), new Date(end), bucket_size)
+        const result = await computeTrainingLoad(deps, user, new Date(start), new Date(end), bucket_size, tz)
         return jsonResponse({ data: result, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -68,7 +68,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     authMiddleware,
     validateQuery(queryMetricsBucketedQuerySchema),
     async (req, res) => {
-      const { start, end, bucket, metrics: metricsParam, exclude: excludeParam } = req.query
+      const { start, end, bucket, metrics: metricsParam, exclude: excludeParam, tz } = req.query
       const user = req.user!
 
       const settings = await getUserSettings(user)
@@ -95,7 +95,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
         new Date(start),
         new Date(end),
         bucket,
-        { customMetrics, exclude },
+        { customMetrics, exclude, tz },
       )
       res.json({ ...result, success: true })
     },

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -18,7 +18,7 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
     authMiddleware,
     validateQuery(trainingLoadQuerySchema),
     async (req, res) => {
-      const { start, end, bucket_size } = req.query
+      const { start, end, bucket_size, tz } = req.query
       const user = req.user!
 
       try {
@@ -30,7 +30,7 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
           return
         }
 
-        const result = await computeTrainingLoad(deps, user, startDate, endDate, bucket_size)
+        const result = await computeTrainingLoad(deps, user, startDate, endDate, bucket_size, tz)
         res.json({ data: result, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -1158,6 +1158,7 @@ describe('queryMetricsBucketed', () => {
       expect.any(Date),
       expect.any(Date),
       '5 minutes',
+      'UTC',
     )
   })
 
@@ -1191,6 +1192,7 @@ describe('queryMetricsBucketed', () => {
       expect.any(Date),
       expect.any(Date),
       '1 hours',
+      'UTC',
     )
   })
 
@@ -1224,6 +1226,7 @@ describe('queryMetricsBucketed', () => {
       expect.any(Date),
       expect.any(Date),
       '1 days',
+      'UTC',
     )
   })
 
@@ -1467,6 +1470,7 @@ describe('queryMetricsBucketed', () => {
       expect.any(Date),
       expect.any(Date),
       '5 minutes',
+      'UTC',
     )
     expect(result.buckets).toHaveLength(1)
     expect(result.buckets[0].metrics.heart_rate).toBeDefined()

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CustomMetricDefinition, DataSource } from '@aurboda/api-spec'
+import { Temporal } from '@js-temporal/polyfill'
 import {
   getActivities,
   getDailyAggregates,
@@ -356,8 +357,17 @@ export const parseBucketSize = (bucket: string): { interval: string; ms: number 
 
 /**
  * Compute bucket start time for a given timestamp.
+ * For buckets >= 1 day, uses Temporal for timezone-aware flooring (DST-correct).
  */
-const getBucketStart = (time: Date, bucketMs: number, rangeStart: Date): Date => {
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const getBucketStart = (time: Date, bucketMs: number, rangeStart: Date, tz: string = 'UTC'): Date => {
+  // For daily+ buckets, floor to local midnight using Temporal (DST-correct)
+  if (bucketMs >= MS_PER_DAY) {
+    const instant = Temporal.Instant.fromEpochMilliseconds(time.getTime())
+    const localMidnight = instant.toZonedDateTimeISO(tz).startOfDay()
+    return new Date(localMidnight.epochMilliseconds)
+  }
+  // For sub-day buckets, use fixed-interval arithmetic (TZ doesn't affect sub-day boundaries)
   const startMs = rangeStart.getTime()
   const timeMs = time.getTime()
   const bucketIndex = Math.floor((timeMs - startMs) / bucketMs)
@@ -382,6 +392,7 @@ const computeContextualHrvBuckets = (
   metric: MetricType,
   bucketMs: number,
   rangeStart: Date,
+  tz: string = 'UTC',
 ): {
   bucket_start: Date
   metric: MetricType
@@ -396,7 +407,7 @@ const computeContextualHrvBuckets = (
   // Group data by bucket
   const bucketMap = new Map<string, number[]>()
   for (const [time, value] of hrvData) {
-    const bucketStart = getBucketStart(time, bucketMs, rangeStart)
+    const bucketStart = getBucketStart(time, bucketMs, rangeStart, tz)
     const key = bucketStart.toISOString()
     if (!bucketMap.has(key)) {
       bucketMap.set(key, [])
@@ -443,7 +454,7 @@ export async function queryMetricsBucketed(
   start: Date,
   end: Date,
   bucket: BucketSize,
-  options: { customMetrics?: CustomMetricDefinition[]; exclude?: string[] } = {},
+  options: { customMetrics?: CustomMetricDefinition[]; exclude?: string[]; tz?: string } = {},
 ): Promise<QueryMetricsBucketedResult> {
   const { interval, ms: bucketMs } = parseBucketSize(bucket)
   const excludeSet = new Set(options.exclude ?? [])
@@ -469,11 +480,12 @@ export async function queryMetricsBucketed(
   const contextualHrvMetricsRequested = resolvedMetrics.filter(isContextualHrvMetric)
 
   // Fetch regular bucketed data and contextual HRV data in parallel
+  const tz = options.tz ?? 'UTC'
   const needsContextualHrv = contextualHrvMetricsRequested.length > 0
   const [regularData, contextualHrvData] = await Promise.all([
-    regularMetrics.length > 0 ? getTimeSeriesBucketed(user, regularMetrics, start, end, interval) : [],
+    regularMetrics.length > 0 ? getTimeSeriesBucketed(user, regularMetrics, start, end, interval, tz) : [],
     needsContextualHrv ?
-      computeContextualHrvData(user, contextualHrvMetricsRequested, start, end, bucketMs)
+      computeContextualHrvData(user, contextualHrvMetricsRequested, start, end, bucketMs, tz)
     : [],
   ])
 
@@ -533,6 +545,7 @@ async function computeContextualHrvData(
   start: Date,
   end: Date,
   bucketMs: number,
+  tz: string = 'UTC',
 ): Promise<
   {
     bucket_start: Date
@@ -570,7 +583,7 @@ async function computeContextualHrvData(
     const context = contextualHrvMetricToContext[metric]
     if (context) {
       const contextData = classified[context]
-      const buckets = computeContextualHrvBuckets(contextData, metric, bucketMs, start)
+      const buckets = computeContextualHrvBuckets(contextData, metric, bucketMs, start, tz)
       results.push(...buckets)
     }
   }

--- a/apps/backend/src/services/training-load.ts
+++ b/apps/backend/src/services/training-load.ts
@@ -24,6 +24,7 @@ import {
   type TrainingLoadSettings,
   type WorkoutTrimp,
 } from '@aurboda/api-spec'
+import { Temporal } from '@js-temporal/polyfill'
 import type { Activity, TimeSeriesPoint } from '../db/types'
 
 type TrainingLoadBucketSize = (typeof trainingLoadBucketSizes)[number]
@@ -666,15 +667,6 @@ const buildWorkoutList = async (
 // Bucket Aggregation
 // ============================================================================
 
-const MS_PER_DAY = 24 * MS_PER_HOUR
-const MS_PER_WEEK = 7 * MS_PER_DAY
-
-const bucketSizeMs: Record<TrainingLoadBucketSize, number> = {
-  '1d': MS_PER_DAY,
-  '1h': MS_PER_HOUR,
-  '1w': MS_PER_WEEK,
-}
-
 /**
  * Aggregate hourly training load points into larger time buckets.
  *
@@ -684,31 +676,39 @@ const bucketSizeMs: Record<TrainingLoadBucketSize, number> = {
  * - ctl, tsb: value from the last hour in the bucket (most recent EMA state)
  * - time: floored to bucket boundary
  */
+/**
+ * Floor a UTC epoch millisecond to the start of the local day or local Monday
+ * in the given IANA timezone. Uses Temporal for DST-correct bucketing
+ * (spring-forward days = 23h, fall-back days = 25h).
+ */
+export const floorToLocalBucket = (ms: number, bucketSize: '1d' | '1w', tz: string): number => {
+  const instant = Temporal.Instant.fromEpochMilliseconds(ms)
+  const zoned = instant.toZonedDateTimeISO(tz)
+
+  if (bucketSize === '1w') {
+    // Floor to local Monday 00:00
+    const dayOfWeek = zoned.dayOfWeek // 1=Mon, 7=Sun
+    const daysBack = dayOfWeek - 1
+    const monday = zoned.subtract({ days: daysBack }).startOfDay()
+    return monday.epochMilliseconds
+  }
+
+  // Floor to local midnight
+  return zoned.startOfDay().epochMilliseconds
+}
+
 export const aggregateTrainingLoadPoints = (
   points: TrainingLoadPoint[],
   bucketSize: TrainingLoadBucketSize,
+  tz: string = 'UTC',
 ): TrainingLoadPoint[] => {
   if (bucketSize === '1h' || points.length === 0) return points
 
-  const durationMs = bucketSizeMs[bucketSize]
   const buckets = new Map<number, TrainingLoadPoint[]>()
-
-  // Floor timestamp to bucket boundary.
-  // Daily: floor to UTC midnight. Weekly: floor to previous Monday 00:00 UTC.
-  const floorToBucket = (ms: number): number => {
-    if (bucketSize === '1w') {
-      const d = new Date(ms)
-      const day = d.getUTCDay() // 0=Sun, 1=Mon, ..., 6=Sat
-      const daysSinceMonday = (day + 6) % 7 // Mon=0, Tue=1, ..., Sun=6
-      const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - daysSinceMonday))
-      return monday.getTime()
-    }
-    return Math.floor(ms / durationMs) * durationMs
-  }
 
   for (const p of points) {
     const t = new Date(p.time).getTime()
-    const key = floorToBucket(t)
+    const key = floorToLocalBucket(t, bucketSize, tz)
     let arr = buckets.get(key)
     if (!arr) {
       arr = []
@@ -791,6 +791,7 @@ export const computeTrainingLoad = async (
   start: Date,
   end: Date,
   bucketSize: TrainingLoadBucketSize = '1h',
+  tz: string = 'UTC',
 ): Promise<TrainingLoadResult> => {
   // Gather settings and latest resting HR in parallel.
   const [userSettings, latestRestingHr] = await Promise.all([
@@ -877,7 +878,7 @@ export const computeTrainingLoad = async (
   const startIso = floorToHour(start).toISOString()
   const endIso = effectiveEnd.toISOString()
   const hourlyPoints = allPoints.filter((p) => p.time >= startIso && p.time <= endIso)
-  const points = aggregateTrainingLoadPoints(hourlyPoints, bucketSize)
+  const points = aggregateTrainingLoadPoints(hourlyPoints, bucketSize, tz)
 
   // Await the workout list (started earlier, runs in parallel)
   const workoutList = await workoutListPromise

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -468,24 +468,24 @@ const drawCrosshairOverlay = (
     .on('mousemove', (event: MouseEvent) => {
       const [mx] = d3.pointer(event)
       const hoverTime = xScale.invert(mx!)
+      const hoverMs = hoverTime.getTime()
 
-      // Try to find the nearest metric bucket
+      // Binary search for the bucket containing hoverTime (start <= hoverTime < end)
       let nearest: MetricBucketParsed | null = null
-      let bestDist = Infinity
-      for (const b of buckets) {
-        const mid = (b.start.getTime() + b.end.getTime()) / 2
-        const dist = Math.abs(hoverTime.getTime() - mid)
-        if (dist < bestDist) {
-          bestDist = dist
-          nearest = b
-        }
-      }
-
-      // If we have a metric bucket match, check distance threshold
-      if (nearest) {
-        const bucketDuration = nearest.end.getTime() - nearest.start.getTime()
-        if (bestDist > bucketDuration * 2) {
-          nearest = null
+      if (buckets.length > 0) {
+        let lo = 0
+        let hi = buckets.length - 1
+        while (lo <= hi) {
+          const mid = (lo + hi) >>> 1
+          const b = buckets[mid]!
+          if (hoverMs < b.start.getTime()) {
+            hi = mid - 1
+          } else if (hoverMs >= b.end.getTime()) {
+            lo = mid + 1
+          } else {
+            nearest = b
+            break
+          }
         }
       }
 

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -385,7 +385,8 @@ const drawImpulseBars = (
   }
 }
 
-/** Draw CTL (fitness) area and ATL (fatigue) line. */
+/** Draw CTL (fitness) area and ATL (fatigue) line.
+ *  Points are anchored at the bucket midpoint for correct visual alignment. */
 const drawLoadCurves = (
   group: SvgGroup,
   points: TrainingLoadPoint[],
@@ -393,13 +394,17 @@ const drawLoadCurves = (
   yScale: d3.ScaleLinear<number, number>,
   trackBottom: number,
   bootstrapping: boolean,
+  barDurationMs: number,
 ): void => {
   if (points.length < 2) return
+
+  const halfBucket = barDurationMs / 2
+  const midX = (d: TrainingLoadPoint) => xScale(new Date(parseTime(d.time).getTime() + halfBucket))
 
   // CTL area (fitness) - filled below the line
   const ctlArea = d3
     .area<TrainingLoadPoint>()
-    .x((d) => xScale(parseTime(d.time)))
+    .x(midX)
     .y0(trackBottom)
     .y1((d) => yScale(d.ctl))
     .curve(d3.curveMonotoneX)
@@ -415,7 +420,7 @@ const drawLoadCurves = (
   // CTL line
   const ctlLine = d3
     .line<TrainingLoadPoint>()
-    .x((d) => xScale(parseTime(d.time)))
+    .x(midX)
     .y((d) => yScale(d.ctl))
     .curve(d3.curveMonotoneX)
 
@@ -431,21 +436,26 @@ const drawLoadCurves = (
     .attr('stroke-dasharray', bootstrapping ? '4,3' : 'none')
 }
 
-/** Draw TSB (form) as a color-coded line. */
+/** Draw TSB (form) as a color-coded line.
+ *  Points are anchored at the bucket midpoint for correct visual alignment. */
 const drawTsbLine = (
   group: SvgGroup,
   points: TrainingLoadPoint[],
   xScale: d3.ScaleTime<number, number>,
   yScale: d3.ScaleLinear<number, number>,
+  barDurationMs: number,
 ): void => {
   if (points.length < 2) return
+
+  const halfBucket = barDurationMs / 2
+  const midTime = (p: TrainingLoadPoint) => new Date(parseTime(p.time).getTime() + halfBucket)
 
   // Zero reference line
   const zeroY = yScale(0)
   group
     .append('line')
-    .attr('x1', xScale(parseTime(points[0]!.time)))
-    .attr('x2', xScale(parseTime(points[points.length - 1]!.time)))
+    .attr('x1', xScale(midTime(points[0]!)))
+    .attr('x2', xScale(midTime(points[points.length - 1]!)))
     .attr('y1', zeroY)
     .attr('y2', zeroY)
     .attr('stroke', 'currentColor')
@@ -462,9 +472,9 @@ const drawTsbLine = (
 
     group
       .append('line')
-      .attr('x1', xScale(parseTime(prev.time)))
+      .attr('x1', xScale(midTime(prev)))
       .attr('y1', yScale(prev.tsb))
-      .attr('x2', xScale(parseTime(curr.time)))
+      .attr('x2', xScale(midTime(curr)))
       .attr('y2', yScale(curr.tsb))
       .attr('stroke', color)
       .attr('stroke-width', 2)
@@ -575,9 +585,9 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
   // Draw impulse bars (training + activity) on top of fatigue bars
   drawImpulseBars(chartGroup, displayPoints, xScale, yScales.yImpulse, trackBottom, barDurationMs)
 
-  // Draw CTL/ATL curves
-  drawLoadCurves(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom, bootstrapping)
+  // Draw CTL/ATL curves (anchored at bucket midpoints)
+  drawLoadCurves(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom, bootstrapping, barDurationMs)
 
-  // Draw TSB line on top
-  drawTsbLine(chartGroup, displayPoints, xScale, yScales.yTsb)
+  // Draw TSB line on top (anchored at bucket midpoints)
+  drawTsbLine(chartGroup, displayPoints, xScale, yScales.yTsb, barDurationMs)
 }

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -711,15 +711,16 @@ export const Timeline = () => {
     staleTime: 5 * 60 * 1000,
   })
 
-  // Unified bucketed metrics: all metrics in one request
-  // Scale bucket size with date range to avoid overwhelming the API on large ranges
-  const metricBucketSize = useMemo(() => {
-    const days = differenceInCalendarDays(fetchEnd, fetchStart)
+  // Unified bucket size for all metrics + training load, derived from the visible view range
+  // (not the fetch range). This ensures zooming in gives finer-grained data.
+  const bucketSize = useMemo(() => {
+    const days = differenceInCalendarDays(effectiveViewEnd, effectiveViewStart)
+    if (days > 365) return '1w'
     if (days > 90) return '1d'
     if (days > 30) return '1h'
     if (days > 7) return '15m'
     return '5m'
-  }, [fetchStart, fetchEnd])
+  }, [effectiveViewStart, effectiveViewEnd])
 
   const bucketedMetricsQuery = useQuery({
     enabled: !hiddenCategories.has('metrics'),
@@ -729,10 +730,10 @@ export const Timeline = () => {
         subDays(fetchStart, 0.5),
         addDays(fetchEnd, 0.5),
         undefined,
-        metricBucketSize,
+        bucketSize,
         TIMELINE_EXCLUDED_METRICS,
       ),
-    queryKey: ['timeline-bucketed-metrics', fromDate.value, toDate.value, metricBucketSize],
+    queryKey: ['timeline-bucketed-metrics', fromDate.value, toDate.value, bucketSize],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -871,13 +872,14 @@ export const Timeline = () => {
 
   // ── Legend / filtering ─────────────────────────────────────────────────────
 
-  // Training load bucket size — scale with date range to avoid huge payloads
-  const trainingLoadBucketSize = useMemo(() => {
-    const days = differenceInCalendarDays(fetchEnd, fetchStart)
-    if (days > 90) return '1w' as const
-    if (days > 14) return '1d' as const
-    return '1h' as const
-  }, [fetchStart, fetchEnd])
+  // Training load uses the same unified bucket size as general metrics.
+  // The training load backend accepts '1h', '1d', '1w' — map the unified size accordingly.
+  const trainingLoadBucketSize = useMemo((): '1h' | '1d' | '1w' => {
+    if (bucketSize === '1w') return '1w'
+    if (bucketSize === '1d') return '1d'
+    // For sub-day metric buckets (5m, 15m, 1h), use hourly training load
+    return '1h'
+  }, [bucketSize])
 
   // Training load data (fetched when toggle is on)
   const trainingLoadQuery = useQuery({

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -695,6 +695,9 @@ export const fetchActivityImpact = async (
   return response.data.data!
 }
 
+/** Browser's IANA timezone (e.g. "Europe/Stockholm"), sent to the backend for TZ-aware bucketing. */
+const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone
+
 // Fetch multiple metrics in time buckets (e.g. 1d for daily Oura scores)
 export const fetchBucketedMetrics = async (
   start: Date,
@@ -708,6 +711,7 @@ export const fetchBucketedMetrics = async (
     bucket: bucket as QueryMetricsBucketedQuery['bucket'],
     end: end.toISOString(),
     start: start.toISOString(),
+    tz: browserTz,
     ...(metrics && { metrics: metrics.join(',') }),
     ...(exclude && { exclude: exclude.join(',') }),
   }
@@ -1271,6 +1275,7 @@ export const fetchTrainingLoad = async (
       bucket_size: bucketSize,
       end: end.toISOString(),
       start: start.toISOString(),
+      tz: browserTz,
     },
   })
   return response.data.data!

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -310,6 +310,15 @@ export const queryMetricsBucketedQuerySchema = timeRangeQuerySchema
       description: 'Comma-separated list of metrics (omit to fetch all metrics with data in the range)',
       example: 'heart_rate,hrv_rmssd',
     }),
+    tz: z
+      .string()
+      .optional()
+      .meta({
+        description:
+          'IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). ' +
+          'Daily+ buckets align to local midnight. Defaults to UTC.',
+        example: 'Europe/Stockholm',
+      }),
   })
   .meta({ id: 'QueryMetricsBucketedQuery' })
 

--- a/packages/api-spec/src/schemas/training-load.ts
+++ b/packages/api-spec/src/schemas/training-load.ts
@@ -107,6 +107,15 @@ export const trainingLoadQuerySchema = z
     }),
     end: z.string().meta({ description: 'End date in ISO 8601 format' }),
     start: z.string().meta({ description: 'Start date in ISO 8601 format' }),
+    tz: z
+      .string()
+      .optional()
+      .meta({
+        description:
+          'IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). ' +
+          'Daily/weekly buckets align to local midnight/Monday. Defaults to UTC.',
+        example: 'Europe/Stockholm',
+      }),
   })
   .meta({ description: 'Query parameters for training load time series', id: 'TrainingLoadQuery' })
 
@@ -123,6 +132,15 @@ export const getTrainingLoadInputSchema = z
     }),
     end: z.iso.datetime().meta({ description: 'End date-time in ISO 8601 format' }),
     start: z.iso.datetime().meta({ description: 'Start date-time in ISO 8601 format' }),
+    tz: z
+      .string()
+      .optional()
+      .meta({
+        description:
+          'IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). ' +
+          'Daily/weekly buckets align to local midnight/Monday. Defaults to UTC.',
+        example: 'Europe/Stockholm',
+      }),
   })
   .meta({ description: 'Input for computing training load time series', id: 'GetTrainingLoadInput' })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@flow-js/garmin-connect':
         specifier: ^1.6.7
         version: 1.6.7
+      '@js-temporal/polyfill':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
         version: 1.25.3(hono@4.11.6)(zod@4.3.6)


### PR DESCRIPTION
## Summary

- **Timezone-aware bucketing**: Add `tz` query parameter to bucketed metrics and training load APIs. Backend uses `@js-temporal/polyfill` for DST-correct local midnight/Monday flooring (23h spring-forward, 25h fall-back days), and PostgreSQL `date_bin` with `AT TIME ZONE` for SQL-level alignment.
- **Unified bucket size**: Single bucket size derived from the visible view range (not the wider fetch range), used for both general metrics and training load. Training load maps the unified size to its supported `'1h' | '1d' | '1w'` values.
- **Binary-search tooltip**: Replace distance-heuristic tooltip detection with exact binary search (`start <= hoverTime < end`), fixing tooltip failures in the middle of wide bars.
- **Midpoint-anchored line charts**: CTL area, CTL line, and TSB line points are now anchored at bucket midpoints instead of bucket start (midnight), improving visual alignment.

## Changes

### API Spec (`packages/api-spec`)
- Added `tz` field (IANA timezone, defaults to `'UTC'`) to `queryMetricsBucketedQuerySchema`, `trainingLoadQuerySchema`, and `getTrainingLoadInputSchema`

### Backend
- `db/time-series.ts`: `getTimeSeriesBucketed` accepts `tz` param; SQL uses `AT TIME ZONE $5`
- `services/queries.ts`: `queryMetricsBucketed`, `getBucketStart`, `computeContextualHrvBuckets` accept `tz`; Temporal polyfill for daily+ buckets
- `services/training-load.ts`: `floorToLocalBucket()` using Temporal; `aggregateTrainingLoadPoints` and `computeTrainingLoad` accept `tz`; removed unused `bucketSizeMs`
- Routes and MCP tools: wire `tz` through to service functions
- Tests: updated `getTimeSeriesBucketed` mock expectations to include `'UTC'` arg

### Frontend
- `state/api.ts`: sends `browserTz` (`Intl.DateTimeFormat().resolvedOptions().timeZone`) on API calls
- `Timeline/index.tsx`: unified `bucketSize` memo from view range; single size for both tracks
- `drawMetricsTrack.ts`: binary-search tooltip
- `drawTrainingLoadTrack.ts`: `barDurationMs` param for midpoint-anchored lines