### PR TITLE
fix: prevent outbound sync queue starvation from bulk calorie entries

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -522,6 +522,10 @@ suspend fun processOutboundSync(
         val reason = "${entry.hc_record_type}: ${result.reason}"
         skipReasons.add(reason)
         Log.w(TAG, "⚠️ Skipped entry ${entry.id} (${entry.hc_record_type}/${entry.operation}): ${result.reason}")
+        // Acknowledge skipped entries so they don't block the queue permanently.
+        // These are unrecoverable failures (missing permission, bad payload, unsupported type)
+        // that will never succeed on retry.
+        ackItems.add(OutboundSyncAckItemApi(id = entry.id))
       }
     }
   }

--- a/apps/backend/src/db/outbound-sync.integration.test.ts
+++ b/apps/backend/src/db/outbound-sync.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { query } from './connection.ts'
 import {
   ackOutboundSync,
   enqueueOutboundSync,
@@ -33,7 +34,10 @@ describe('Outbound Sync Queue Integration Tests', () => {
         entity_type: 'activity',
         hc_record_type: 'ExerciseSessionRecord',
         operation: 'insert',
-        payload: { activity_type: 'exercise', start_time: '2024-01-15T10:00:00Z' },
+        payload: {
+          activity_type: 'exercise',
+          start_time: '2024-01-15T10:00:00Z',
+        },
       })
 
       expect(id).toBeDefined()
@@ -98,7 +102,7 @@ describe('Outbound Sync Queue Integration Tests', () => {
   })
 
   describe('getPendingOutboundSync', () => {
-    test('returns entries ordered by creation time', async () => {
+    test('returns entries ordered newest-first', async () => {
       const user = getTestUser()
 
       await enqueueOutboundSync(user, {
@@ -119,8 +123,8 @@ describe('Outbound Sync Queue Integration Tests', () => {
 
       const pending = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(2)
-      expect(pending[0].entity_id).toBe('first')
-      expect(pending[1].entity_id).toBe('second')
+      expect(pending[0].entity_id).toBe('second')
+      expect(pending[1].entity_id).toBe('first')
     })
 
     test('respects limit', async () => {
@@ -144,6 +148,38 @@ describe('Outbound Sync Queue Integration Tests', () => {
       const user = getTestUser()
       const pending = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(0)
+    })
+
+    test('auto-expires entries older than 90 days', async () => {
+      const user = getTestUser()
+
+      // Create an entry and backdate it to 91 days ago
+      const oldId = await enqueueOutboundSync(user, {
+        entity_id: 'old-calorie',
+        entity_type: 'time_series',
+        hc_record_type: 'ActiveCaloriesBurnedRecord',
+        operation: 'insert',
+        payload: { value: 5.0 },
+      })
+      await query(
+        user,
+        `UPDATE outbound_sync_queue SET created_at = NOW() - INTERVAL '91 days' WHERE id = $1`,
+        [oldId],
+      )
+
+      // Create a recent entry
+      await enqueueOutboundSync(user, {
+        entity_id: 'recent-exercise',
+        entity_type: 'activity',
+        hc_record_type: 'ExerciseSessionRecord',
+        operation: 'insert',
+        payload: {},
+      })
+
+      const pending = await getPendingOutboundSync(user)
+      // Only the recent entry should be returned; the old one should be auto-expired
+      expect(pending).toHaveLength(1)
+      expect(pending[0].entity_id).toBe('recent-exercise')
     })
   })
 

--- a/apps/backend/src/db/outbound-sync.ts
+++ b/apps/backend/src/db/outbound-sync.ts
@@ -68,17 +68,31 @@ export const enqueueOutboundSync = async (user: string, input: EnqueueOutboundSy
 }
 
 /**
- * Get all pending outbound sync entries.
- * Ordered by creation time (oldest first).
+ * Get pending outbound sync entries.
+ *
+ * Ordered newest-first so recent user actions (exercises, weight entries) are
+ * synced immediately instead of being starved by bulk historical data.
+ *
+ * Entries older than 90 days are auto-expired (marked 'failed') since Health
+ * Connect typically ignores data that old.
  */
 export const getPendingOutboundSync = async (user: string, limit = 100): Promise<OutboundSyncEntry[]> => {
+  // Auto-expire entries older than 90 days — HC won't accept them anyway
+  await query(
+    user,
+    `UPDATE outbound_sync_queue
+     SET status = 'failed'
+     WHERE status = 'pending' AND created_at < NOW() - INTERVAL '90 days'`,
+    [],
+  )
+
   const result = await query(
     user,
     `SELECT id, entity_type, entity_id, operation, hc_record_type, payload,
             hc_record_id, status, created_at, synced_at
      FROM outbound_sync_queue
      WHERE status = 'pending'
-     ORDER BY created_at ASC
+     ORDER BY created_at DESC
      LIMIT $1`,
     [limit],
   )

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -58,7 +58,13 @@ const getLatestMetricValue = async (
   return data[data.length - 1][1]
 }
 
-/** Queue outbound sync entries for calorie data points (best-effort). */
+/**
+ * Queue outbound sync entries for calorie data points (best-effort).
+ *
+ * Only enqueues points from the last 24 hours to avoid flooding the outbound
+ * queue with historical recalculations. Health Connect benefits from recent
+ * calorie data but historical backfills would starve other outbound entries.
+ */
 const enqueueCalorieSync = async (
   user: string,
   points: { time: Date; end_time: Date; kcal: number }[],
@@ -67,7 +73,12 @@ const enqueueCalorieSync = async (
     if (!isHealthConnectSyncableMetric('calories_active')) return
     const hcRecordType = metricToHealthConnectType.calories_active
     if (!hcRecordType) return
-    for (const p of points) {
+
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const recentPoints = points.filter((p) => p.time >= cutoff)
+    if (recentPoints.length === 0) return
+
+    for (const p of recentPoints) {
       await enqueueOutboundSync(user, {
         entity_id: `calories_active|${p.time.toISOString()}`,
         entity_type: 'time_series',
@@ -101,7 +112,10 @@ const invalidateTrainingLoadImpulses = async (user: string, fromTime: Date): Pro
     const existingTime = existingWatermark ? new Date(existingWatermark) : null
     const effectiveTime = existingTime && existingTime < fromTime ? existingTime : fromTime
     await upsertUserSettings(user, {
-      training_load: { ...settings.training_load, impulse_watermark: effectiveTime.toISOString() },
+      training_load: {
+        ...settings.training_load,
+        impulse_watermark: effectiveTime.toISOString(),
+      },
     })
   } catch (err) {
     console.error('Failed to invalidate training load impulses:', err)
@@ -366,7 +380,9 @@ export const computeAndStoreCaloriesAll = async (
 
   while (chunkStart < range.max) {
     const chunkEnd = new Date(Math.min(chunkStart.getTime() + dayMs, range.max.getTime() + 60_000))
-    const result = await computeAndStoreCalories(user, chunkStart, chunkEnd, { force: true })
+    const result = await computeAndStoreCalories(user, chunkStart, chunkEnd, {
+      force: true,
+    })
 
     totalComputed += result.points_computed
     totalStored += result.points_stored


### PR DESCRIPTION
## Summary

The outbound sync queue (backend -> Health Connect) was being flooded with thousands of per-minute `ActiveCaloriesBurnedRecord` entries from the calorie computation feature, starving higher-value entries like manually added exercises from ever being synced.

## Changes

- **Android: Ack skipped entries** — Entries skipped due to missing permissions or bad payloads are now acknowledged so they don't permanently block the queue
- **Backend: Newest-first ordering** — Queue now returns entries `DESC` by `created_at`, so recent user actions (exercises, weight) sync immediately instead of waiting behind historical bulk data
- **Backend: 90-day auto-expiry** — Pending entries older than 90 days are automatically marked as failed, since Health Connect typically ignores data that old
- **Backend: 24h calorie sync limit** — `enqueueCalorieSync` now only enqueues calorie data points from the last 24 hours, preventing historical recalculations from flooding the queue

## Testing

- Updated integration test for newest-first ordering
- Added integration test for 90-day auto-expiry
- All 14 outbound sync integration tests pass