### PR TITLE
fix: replace CJS named imports for Node 25 ESM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "25"
-          cache: "pnpm"
+          node-version: '25'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install
@@ -92,8 +92,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
@@ -107,8 +107,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "25"
-          cache: "pnpm"
+          node-version: '25'
+          cache: 'pnpm'
 
       - name: Install api-spec dependencies
         run: pnpm --filter @aurboda/api-spec install

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,7 +18,6 @@
     "@js-temporal/polyfill": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "axios": "^1.11.0",
-    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
@@ -33,7 +32,6 @@
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^11.11.0",
-    "@types/body-parser": "^1.19.6",
     "@types/cors": "^2.8.19",
     "@types/d3": "^7.4.3",
     "@types/express": "^5.0.3",

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -6,9 +6,8 @@
  */
 import type { LoginResponse, ServerStatusResponse, SignupResponse } from '@aurboda/api-spec'
 
-import { json } from 'body-parser'
 import cors from 'cors'
-import express, { type RequestHandler } from 'express'
+import express, { json, type RequestHandler } from 'express'
 import { Client } from 'pg'
 
 import type { OuraDataType } from './oura-sync.ts'

--- a/apps/backend/src/garmin.test.ts
+++ b/apps/backend/src/garmin.test.ts
@@ -2,300 +2,340 @@
  * Garmin Connect API client tests.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the GarminConnect class from the library
 const mockGarminConnect = vi.hoisted(() => ({
-  exportToken: vi.fn().mockReturnValue({ oauth1: 'token1', oauth2: 'token2' }),
+  exportToken: vi.fn().mockReturnValue({ oauth1: "token1", oauth2: "token2" }),
   get: vi.fn().mockResolvedValue({}),
   getActivities: vi.fn().mockResolvedValue([]),
   getHeartRate: vi.fn().mockResolvedValue({}),
   getSleepData: vi.fn().mockResolvedValue({}),
-  getUserProfile: vi.fn().mockResolvedValue({ displayName: 'user123' }),
+  getUserProfile: vi.fn().mockResolvedValue({ displayName: "user123" }),
   getUserSettings: vi.fn().mockResolvedValue({ userData: {} }),
   loadToken: vi.fn(),
   login: vi.fn().mockResolvedValue(undefined),
-}))
+}));
 
-vi.mock('@flow-js/garmin-connect', () => {
-  const MockGarminConnect = vi.fn()
-  Object.assign(MockGarminConnect.prototype, mockGarminConnect)
-  return { GarminConnect: MockGarminConnect }
-})
+vi.mock("@flow-js/garmin-connect", () => {
+  const MockGarminConnect = vi.fn();
+  Object.assign(MockGarminConnect.prototype, mockGarminConnect);
+  return {
+    default: { GarminConnect: MockGarminConnect },
+    GarminConnect: MockGarminConnect,
+  };
+});
 
-import { GarminConnect } from '@flow-js/garmin-connect'
+import garminConnectPkg from "@flow-js/garmin-connect";
+const { GarminConnect } = garminConnectPkg;
 
-import { garminClient, type GarminClientDeps } from './garmin.ts'
+import { garminClient, type GarminClientDeps } from "./garmin.ts";
 
-const testUser = 'test-user'
-const storedTokens = { oauth1: 'stored-token1', oauth2: 'stored-token2' }
+const testUser = "test-user";
+const storedTokens = { oauth1: "stored-token1", oauth2: "stored-token2" };
 
 const createMockDeps = (): GarminClientDeps => ({
   getOAuthToken: vi.fn().mockResolvedValue({
     access_token: JSON.stringify(storedTokens),
-    provider: 'garmin',
+    provider: "garmin",
   }),
   upsertOAuthToken: vi.fn().mockResolvedValue(undefined),
-})
+});
 
-describe('garminClient', () => {
-  let deps: GarminClientDeps
+describe("garminClient", () => {
+  let deps: GarminClientDeps;
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    deps = createMockDeps()
-  })
+    vi.clearAllMocks();
+    deps = createMockDeps();
+  });
 
-  describe('login', () => {
-    it('creates GarminConnect with credentials and logs in', async () => {
-      const client = garminClient(deps)
-      const result = await client.login(testUser, 'user@example.com', 'secret')
+  describe("login", () => {
+    it("creates GarminConnect with credentials and logs in", async () => {
+      const client = garminClient(deps);
+      const result = await client.login(testUser, "user@example.com", "secret");
 
       expect(GarminConnect).toHaveBeenCalledWith({
-        password: 'secret',
-        username: 'user@example.com',
-      })
-      expect(mockGarminConnect.login).toHaveBeenCalled()
+        password: "secret",
+        username: "user@example.com",
+      });
+      expect(mockGarminConnect.login).toHaveBeenCalled();
       expect(result).toEqual({
         success: true,
-        tokens: { oauth1: 'token1', oauth2: 'token2' },
-      })
-    })
+        tokens: { oauth1: "token1", oauth2: "token2" },
+      });
+    });
 
-    it('stores tokens after successful login', async () => {
-      const client = garminClient(deps)
-      await client.login(testUser, 'user@example.com', 'secret')
-
-      expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
-        provider: 'garmin',
-      })
-    })
-  })
-
-  describe('disconnect', () => {
-    it('clears stored tokens', async () => {
-      const client = garminClient(deps)
-      await client.disconnect(testUser)
+    it("stores tokens after successful login", async () => {
+      const client = garminClient(deps);
+      await client.login(testUser, "user@example.com", "secret");
 
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: '',
-        provider: 'garmin',
-      })
-    })
-  })
+        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
+        provider: "garmin",
+      });
+    });
+  });
 
-  describe('restoreSession (via data methods)', () => {
-    it('throws when no token is stored', async () => {
-      vi.mocked(deps.getOAuthToken).mockResolvedValue(null)
+  describe("disconnect", () => {
+    it("clears stored tokens", async () => {
+      const client = garminClient(deps);
+      await client.disconnect(testUser);
 
-      const client = garminClient(deps)
+      expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
+        access_token: "",
+        provider: "garmin",
+      });
+    });
+  });
+
+  describe("restoreSession (via data methods)", () => {
+    it("throws when no token is stored", async () => {
+      vi.mocked(deps.getOAuthToken).mockResolvedValue(null);
+
+      const client = garminClient(deps);
       await expect(client.getHeartRate(testUser, new Date())).rejects.toThrow(
-        'User has no Garmin session. Please connect Garmin first.',
-      )
-    })
+        "User has no Garmin session. Please connect Garmin first.",
+      );
+    });
 
-    it('loads stored tokens into GarminConnect', async () => {
-      const client = garminClient(deps)
-      await client.getHeartRate(testUser, new Date('2024-06-15'))
+    it("loads stored tokens into GarminConnect", async () => {
+      const client = garminClient(deps);
+      await client.getHeartRate(testUser, new Date("2024-06-15"));
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
-    })
-  })
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
+        "stored-token1",
+        "stored-token2",
+      );
+    });
+  });
 
-  describe('getDailySummary', () => {
-    it('restores session, fetches summary via get, and saves session', async () => {
-      const summaryData = { calendarDate: '2024-06-15', totalSteps: 10000 }
-      mockGarminConnect.get.mockResolvedValueOnce(summaryData)
+  describe("getDailySummary", () => {
+    it("restores session, fetches summary via get, and saves session", async () => {
+      const summaryData = { calendarDate: "2024-06-15", totalSteps: 10000 };
+      mockGarminConnect.get.mockResolvedValueOnce(summaryData);
 
-      const client = garminClient(deps)
-      const result = await client.getDailySummary(testUser, new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getDailySummary(
+        testUser,
+        new Date("2024-06-15"),
+      );
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
-      expect(mockGarminConnect.getUserProfile).toHaveBeenCalled()
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
+        "stored-token1",
+        "stored-token2",
+      );
+      expect(mockGarminConnect.getUserProfile).toHaveBeenCalled();
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/usersummary-service/usersummary/daily/user123?calendarDate=2024-06-15',
-      )
-      expect(result).toEqual(summaryData)
+        "/usersummary-service/usersummary/daily/user123?calendarDate=2024-06-15",
+      );
+      expect(result).toEqual(summaryData);
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
-        provider: 'garmin',
-      })
-    })
-  })
+        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
+        provider: "garmin",
+      });
+    });
+  });
 
-  describe('getHeartRate', () => {
-    it('restores session, calls getHeartRate, and saves session', async () => {
-      const hrData = { heartRateValues: [[1000, 72]] }
-      mockGarminConnect.getHeartRate.mockResolvedValueOnce(hrData)
+  describe("getHeartRate", () => {
+    it("restores session, calls getHeartRate, and saves session", async () => {
+      const hrData = { heartRateValues: [[1000, 72]] };
+      mockGarminConnect.getHeartRate.mockResolvedValueOnce(hrData);
 
-      const client = garminClient(deps)
-      const date = new Date('2024-06-15')
-      const result = await client.getHeartRate(testUser, date)
+      const client = garminClient(deps);
+      const date = new Date("2024-06-15");
+      const result = await client.getHeartRate(testUser, date);
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
-      expect(mockGarminConnect.getHeartRate).toHaveBeenCalledWith(date)
-      expect(result).toEqual(hrData)
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
+        "stored-token1",
+        "stored-token2",
+      );
+      expect(mockGarminConnect.getHeartRate).toHaveBeenCalledWith(date);
+      expect(result).toEqual(hrData);
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
-        provider: 'garmin',
-      })
-    })
-  })
+        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
+        provider: "garmin",
+      });
+    });
+  });
 
-  describe('getStress', () => {
-    it('restores session, fetches stress via get, and saves session', async () => {
-      const stressData = { calendarDate: '2024-06-15', overallStressLevel: 42 }
-      mockGarminConnect.get.mockResolvedValueOnce(stressData)
+  describe("getStress", () => {
+    it("restores session, fetches stress via get, and saves session", async () => {
+      const stressData = { calendarDate: "2024-06-15", overallStressLevel: 42 };
+      mockGarminConnect.get.mockResolvedValueOnce(stressData);
 
-      const client = garminClient(deps)
-      const result = await client.getStress(testUser, new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getStress(testUser, new Date("2024-06-15"));
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/dailyStress/2024-06-15')
-      expect(result).toEqual(stressData)
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
+        "stored-token1",
+        "stored-token2",
+      );
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        "/wellness-service/wellness/dailyStress/2024-06-15",
+      );
+      expect(result).toEqual(stressData);
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
-        provider: 'garmin',
-      })
-    })
-  })
+        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
+        provider: "garmin",
+      });
+    });
+  });
 
-  describe('getHrv', () => {
-    it('restores session, fetches HRV via get, and saves session', async () => {
+  describe("getHrv", () => {
+    it("restores session, fetches HRV via get, and saves session", async () => {
       const hrvData = {
-        calendarDate: '2024-06-15',
+        calendarDate: "2024-06-15",
         lastNightAvg: 42,
         weeklyAvg: 45,
-      }
-      mockGarminConnect.get.mockResolvedValueOnce(hrvData)
+      };
+      mockGarminConnect.get.mockResolvedValueOnce(hrvData);
 
-      const client = garminClient(deps)
-      const result = await client.getHrv(testUser, new Date('2024-06-15'))
-
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/hrv-service/hrv/2024-06-15')
-      expect(result).toEqual(hrvData)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
-
-  describe('getSleep', () => {
-    it('restores session, calls getSleepData, and saves session', async () => {
-      const sleepData = { dailySleepDTO: { calendarDate: '2024-06-15' } }
-      mockGarminConnect.getSleepData.mockResolvedValueOnce(sleepData)
-
-      const client = garminClient(deps)
-      const date = new Date('2024-06-15')
-      const result = await client.getSleep(testUser, date)
-
-      expect(mockGarminConnect.getSleepData).toHaveBeenCalledWith(date)
-      expect(result).toEqual(sleepData)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
-
-  describe('getBodyBattery', () => {
-    it('restores session, fetches body battery with date range, and saves session', async () => {
-      const bbData = [{ charged: 80, date: '2024-06-15', drained: 60 }]
-      mockGarminConnect.get.mockResolvedValueOnce(bbData)
-
-      const client = garminClient(deps)
-      const result = await client.getBodyBattery(testUser, new Date('2024-06-14'), new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getHrv(testUser, new Date("2024-06-15"));
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/wellness-service/wellness/bodyBattery/reports/daily?startDate=2024-06-14&endDate=2024-06-15',
-      )
-      expect(result).toEqual(bbData)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
+        "/hrv-service/hrv/2024-06-15",
+      );
+      expect(result).toEqual(hrvData);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
 
-  describe('getActivities', () => {
-    it('restores session, calls getActivities with start and limit, and saves session', async () => {
-      const activities = [{ activityId: 1 }, { activityId: 2 }]
-      mockGarminConnect.getActivities.mockResolvedValueOnce(activities)
+  describe("getSleep", () => {
+    it("restores session, calls getSleepData, and saves session", async () => {
+      const sleepData = { dailySleepDTO: { calendarDate: "2024-06-15" } };
+      mockGarminConnect.getSleepData.mockResolvedValueOnce(sleepData);
 
-      const client = garminClient(deps)
-      const result = await client.getActivities(testUser, 0, 10)
+      const client = garminClient(deps);
+      const date = new Date("2024-06-15");
+      const result = await client.getSleep(testUser, date);
 
-      expect(mockGarminConnect.getActivities).toHaveBeenCalledWith(0, 10)
-      expect(result).toEqual(activities)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
+      expect(mockGarminConnect.getSleepData).toHaveBeenCalledWith(date);
+      expect(result).toEqual(sleepData);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
 
-  describe('getSpo2', () => {
-    it('restores session, fetches SpO2 via get, and saves session', async () => {
-      const spo2Data = { averageSpO2: 97, calendarDate: '2024-06-15' }
-      mockGarminConnect.get.mockResolvedValueOnce(spo2Data)
+  describe("getBodyBattery", () => {
+    it("restores session, fetches body battery with date range, and saves session", async () => {
+      const bbData = [{ charged: 80, date: "2024-06-15", drained: 60 }];
+      mockGarminConnect.get.mockResolvedValueOnce(bbData);
 
-      const client = garminClient(deps)
-      const result = await client.getSpo2(testUser, new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getBodyBattery(
+        testUser,
+        new Date("2024-06-14"),
+        new Date("2024-06-15"),
+      );
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/daily/spo2/2024-06-15')
-      expect(result).toEqual(spo2Data)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        "/wellness-service/wellness/bodyBattery/reports/daily?startDate=2024-06-14&endDate=2024-06-15",
+      );
+      expect(result).toEqual(bbData);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
 
-  describe('getRespiration', () => {
-    it('restores session, fetches respiration via get, and saves session', async () => {
+  describe("getActivities", () => {
+    it("restores session, calls getActivities with start and limit, and saves session", async () => {
+      const activities = [{ activityId: 1 }, { activityId: 2 }];
+      mockGarminConnect.getActivities.mockResolvedValueOnce(activities);
+
+      const client = garminClient(deps);
+      const result = await client.getActivities(testUser, 0, 10);
+
+      expect(mockGarminConnect.getActivities).toHaveBeenCalledWith(0, 10);
+      expect(result).toEqual(activities);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
+
+  describe("getSpo2", () => {
+    it("restores session, fetches SpO2 via get, and saves session", async () => {
+      const spo2Data = { averageSpO2: 97, calendarDate: "2024-06-15" };
+      mockGarminConnect.get.mockResolvedValueOnce(spo2Data);
+
+      const client = garminClient(deps);
+      const result = await client.getSpo2(testUser, new Date("2024-06-15"));
+
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        "/wellness-service/wellness/daily/spo2/2024-06-15",
+      );
+      expect(result).toEqual(spo2Data);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
+
+  describe("getRespiration", () => {
+    it("restores session, fetches respiration via get, and saves session", async () => {
       const respData = {
         avgWakingRespirationValue: 16,
-        calendarDate: '2024-06-15',
-      }
-      mockGarminConnect.get.mockResolvedValueOnce(respData)
+        calendarDate: "2024-06-15",
+      };
+      mockGarminConnect.get.mockResolvedValueOnce(respData);
 
-      const client = garminClient(deps)
-      const result = await client.getRespiration(testUser, new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getRespiration(
+        testUser,
+        new Date("2024-06-15"),
+      );
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/wellness-service/wellness/daily/respiration/2024-06-15',
-      )
-      expect(result).toEqual(respData)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
+        "/wellness-service/wellness/daily/respiration/2024-06-15",
+      );
+      expect(result).toEqual(respData);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
 
-  describe('getTrainingReadiness', () => {
-    it('restores session, fetches training readiness via get, and saves session', async () => {
+  describe("getTrainingReadiness", () => {
+    it("restores session, fetches training readiness via get, and saves session", async () => {
       const trData = {
-        calendarDate: '2024-06-15',
-        level: 'HIGH',
+        calendarDate: "2024-06-15",
+        level: "HIGH",
         overallScore: 75,
-      }
-      mockGarminConnect.get.mockResolvedValueOnce(trData)
+      };
+      mockGarminConnect.get.mockResolvedValueOnce(trData);
 
-      const client = garminClient(deps)
-      const result = await client.getTrainingReadiness(testUser, new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getTrainingReadiness(
+        testUser,
+        new Date("2024-06-15"),
+      );
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/metrics-service/metrics/trainingreadiness/2024-06-15',
-      )
-      expect(result).toEqual(trData)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
+        "/metrics-service/metrics/trainingreadiness/2024-06-15",
+      );
+      expect(result).toEqual(trData);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
 
-  describe('getIntensityMinutes', () => {
-    it('restores session, fetches intensity minutes via get, and saves session', async () => {
+  describe("getIntensityMinutes", () => {
+    it("restores session, fetches intensity minutes via get, and saves session", async () => {
       const imData = {
-        calendarDate: '2024-06-15',
+        calendarDate: "2024-06-15",
         moderateIntensityMinutes: 30,
         vigorousIntensityMinutes: 15,
-      }
-      mockGarminConnect.get.mockResolvedValueOnce(imData)
+      };
+      mockGarminConnect.get.mockResolvedValueOnce(imData);
 
-      const client = garminClient(deps)
-      const result = await client.getIntensityMinutes(testUser, new Date('2024-06-15'))
+      const client = garminClient(deps);
+      const result = await client.getIntensityMinutes(
+        testUser,
+        new Date("2024-06-15"),
+      );
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/daily/im/2024-06-15')
-      expect(result).toEqual(imData)
-      expect(deps.upsertOAuthToken).toHaveBeenCalled()
-    })
-  })
-})
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        "/wellness-service/wellness/daily/im/2024-06-15",
+      );
+      expect(result).toEqual(imData);
+      expect(deps.upsertOAuthToken).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -8,7 +8,10 @@
  * blob in oauth_tokens. Credentials are never stored.
  */
 
-import { GarminConnect, type IGarminTokens } from '@flow-js/garmin-connect'
+import type { IGarminTokens } from '@flow-js/garmin-connect'
+
+import garminConnectPkg from '@flow-js/garmin-connect'
+const { GarminConnect } = garminConnectPkg
 
 import { getOAuthToken, upsertOAuthToken } from './db/index.ts'
 
@@ -165,7 +168,7 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
    * Restore a GarminConnect instance from stored tokens for a user.
    * Throws if no tokens are stored.
    */
-  const restoreSession = async (user: string): Promise<GarminConnect> => {
+  const restoreSession = async (user: string): Promise<InstanceType<typeof GarminConnect>> => {
     const stored = await deps.getOAuthToken(user, 'garmin')
     if (!stored) throw new Error('User has no Garmin session. Please connect Garmin first.')
 
@@ -176,7 +179,7 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
   }
 
   /** Persist the current GarminConnect session tokens for a user. */
-  const saveSession = async (user: string, gc: GarminConnect): Promise<void> => {
+  const saveSession = async (user: string, gc: InstanceType<typeof GarminConnect>): Promise<void> => {
     const tokens = gc.exportToken()
     await deps.upsertOAuthToken(user, {
       access_token: JSON.stringify(tokens),

--- a/apps/backend/src/oura-webhook-router.test.ts
+++ b/apps/backend/src/oura-webhook-router.test.ts
@@ -1,5 +1,4 @@
-import { json } from 'body-parser'
-import express from 'express'
+import express, { json } from 'express'
 import request from 'supertest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 

--- a/apps/backend/src/owntracks.test.ts
+++ b/apps/backend/src/owntracks.test.ts
@@ -1,5 +1,4 @@
-import { json } from 'body-parser'
-import express from 'express'
+import express, { json } from 'express'
 import request from 'supertest'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -48,13 +47,22 @@ describe('parseBasicAuth', () => {
   test('handles special characters in credentials', () => {
     const encoded = Buffer.from('user@domain.com:p@$$w0rd!').toString('base64')
     const result = parseBasicAuth(`Basic ${encoded}`)
-    expect(result).toEqual({ password: 'p@$$w0rd!', username: 'user@domain.com' })
+    expect(result).toEqual({
+      password: 'p@$$w0rd!',
+      username: 'user@domain.com',
+    })
   })
 
   test('handles case-insensitive Basic prefix', () => {
     const encoded = Buffer.from('user:pass').toString('base64')
-    expect(parseBasicAuth(`basic ${encoded}`)).toEqual({ password: 'pass', username: 'user' })
-    expect(parseBasicAuth(`BASIC ${encoded}`)).toEqual({ password: 'pass', username: 'user' })
+    expect(parseBasicAuth(`basic ${encoded}`)).toEqual({
+      password: 'pass',
+      username: 'user',
+    })
+    expect(parseBasicAuth(`BASIC ${encoded}`)).toEqual({
+      password: 'pass',
+      username: 'user',
+    })
   })
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       axios:
         specifier: ^1.11.0
         version: 1.13.3
-      body-parser:
-        specifier: ^1.20.3
-        version: 1.20.4
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -81,9 +78,6 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^11.11.0
         version: 11.11.0
-      '@types/body-parser':
-        specifier: ^1.19.6
-        version: 1.19.6
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
@@ -1554,10 +1548,6 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -1914,14 +1904,6 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1957,10 +1939,6 @@ packages:
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
-
-  destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -2314,10 +2292,6 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -2510,10 +2484,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
-
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -2592,9 +2562,6 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2884,10 +2851,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  raw-body@2.5.3:
-    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
-    engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -3262,10 +3225,6 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
-
-  type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -4783,23 +4742,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@1.20.4:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.14.1
-      raw-body: 2.5.3
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -5180,10 +5122,6 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -5211,8 +5149,6 @@ snapshots:
   depd@2.0.0: {}
 
   destr@2.0.5: {}
-
-  destroy@1.2.0: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -5630,10 +5566,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -5803,8 +5735,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
     optional: true
 
@@ -5821,8 +5753,6 @@ snapshots:
   marked@17.0.3: {}
 
   math-intrinsics@1.1.0: {}
-
-  media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
 
@@ -5883,8 +5813,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
-
-  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -6208,13 +6136,6 @@ snapshots:
       side-channel: 1.1.0
 
   range-parser@1.2.1: {}
-
-  raw-body@2.5.3:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -6691,11 +6612,6 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
-
-  type-is@1.6.18:
-    dependencies:
-      media-typer: 0.3.0
-      mime-types: 2.1.35
 
   type-is@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Replace `body-parser` named import with Express built-in `json()` middleware (Node 25 rejects CJS named exports)
- Switch `@flow-js/garmin-connect` to default import pattern (`import pkg from '...'` + destructure)
- Fix garmin test mock to export `default` matching the new import style
- Remove `body-parser` and `@types/body-parser` dependencies

Fixes the production startup crash:
```
SyntaxError: Named export 'json' not found. The requested module 'body-parser' is a CommonJS module
```

Verified: Docker image builds and server starts successfully on Node 25.8.1.