### PR TITLE
fix: add outbound sync pagination and fix calorie queue cutoff

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -56,6 +56,7 @@ data class OutboundSyncResponseApi(
   val success: Boolean,
   val data: List<OutboundSyncEntryApi>? = null,
   val error: String? = null,
+  val total_pending: Int? = null,
 )
 
 @Serializable
@@ -80,6 +81,11 @@ data class OutboundSyncAckResponseApi(
 // API Client
 // ============================================================================
 
+data class OutboundSyncFetchResult(
+  val entries: List<OutboundSyncEntryApi> = emptyList(),
+  val totalPending: Int = 0,
+)
+
 /**
  * Fetch pending outbound sync entries from the backend.
  */
@@ -87,7 +93,7 @@ suspend fun fetchOutboundSyncEntries(
   apiUrl: String,
   authToken: String,
   httpClient: HttpClient,
-): List<OutboundSyncEntryApi> {
+): OutboundSyncFetchResult {
   return try {
     val response =
       httpClient.get("$apiUrl/sync/outbound") {
@@ -95,22 +101,23 @@ suspend fun fetchOutboundSyncEntries(
       }
     if (response.status != HttpStatusCode.OK) {
       Log.e(TAG, "🚫 Failed to fetch outbound sync: HTTP ${response.status.value}")
-      return emptyList()
+      return OutboundSyncFetchResult()
     }
     val body = response.bodyAsText()
     val parsed = appJson.decodeFromString<OutboundSyncResponseApi>(body)
     if (!parsed.success) {
       Log.e(TAG, "🚫 Outbound sync response error: ${parsed.error}")
-      return emptyList()
+      return OutboundSyncFetchResult()
     }
     val entries = parsed.data ?: emptyList()
+    val totalPending = parsed.total_pending ?: entries.size
     if (entries.isNotEmpty()) {
-      Log.d(TAG, "📥 Fetched ${entries.size} pending outbound sync entries")
+      Log.d(TAG, "📥 Fetched ${entries.size} pending outbound sync entries ($totalPending total in queue)")
     }
-    entries
+    OutboundSyncFetchResult(entries = entries, totalPending = totalPending)
   } catch (e: Exception) {
     Log.e(TAG, "🚫 Error fetching outbound sync entries", e)
-    emptyList()
+    OutboundSyncFetchResult()
   }
 }
 
@@ -476,11 +483,12 @@ private suspend fun deleteHealthConnectRecord(
 
 /**
  * Process all pending outbound sync entries:
- * 1. Fetch pending entries from backend
+ * 1. Fetch pending entries from backend (page by page)
  * 2. Write each to Health Connect
  * 3. Acknowledge successful writes
+ * 4. Repeat until queue is drained
  *
- * @return true if all entries were processed successfully (or none pending)
+ * @return cumulative result across all pages
  */
 data class OutboundSyncResult(
   val fetched: Int = 0,
@@ -489,7 +497,11 @@ data class OutboundSyncResult(
   val acknowledged: Boolean = true,
   val error: String? = null,
   val skipReasons: List<String> = emptyList(),
+  val pagesProcessed: Int = 0,
 )
+
+/** Maximum number of pages to process in a single sync pass to avoid runaway loops. */
+private const val MAX_OUTBOUND_SYNC_PAGES = 50
 
 suspend fun processOutboundSync(
   apiUrl: String,
@@ -498,60 +510,79 @@ suspend fun processOutboundSync(
   healthConnectClient: HealthConnectClient,
   grantedPermissions: Set<String>,
 ): OutboundSyncResult {
-  val entries = fetchOutboundSyncEntries(apiUrl, authToken, httpClient)
-  if (entries.isEmpty()) return OutboundSyncResult()
+  var totalFetched = 0
+  var totalWritten = 0
+  var totalSkipped = 0
+  var allAcknowledged = true
+  val allSkipReasons = mutableListOf<String>()
+  var pagesProcessed = 0
 
-  Log.d(TAG, "🔄 Processing ${entries.size} outbound sync entries")
+  for (page in 1..MAX_OUTBOUND_SYNC_PAGES) {
+    val fetchResult = fetchOutboundSyncEntries(apiUrl, authToken, httpClient)
+    val entries = fetchResult.entries
+    if (entries.isEmpty()) break
 
-  val ackItems = mutableListOf<OutboundSyncAckItemApi>()
-  var skipped = 0
-  val skipReasons = mutableListOf<String>()
+    pagesProcessed++
+    totalFetched += entries.size
+    Log.d(TAG, "🔄 Processing page $page: ${entries.size} entries (${fetchResult.totalPending} total pending)")
 
-  for (entry in entries) {
-    when (val result = writeToHealthConnect(entry, healthConnectClient, grantedPermissions)) {
-      is WriteResult.Success -> {
-        ackItems.add(
-          OutboundSyncAckItemApi(
-            id = entry.id,
-            hc_record_id = if (result.recordId == "deleted") null else result.recordId,
-          ),
-        )
-      }
-      is WriteResult.Skipped -> {
-        skipped++
-        val reason = "${entry.hc_record_type}: ${result.reason}"
-        skipReasons.add(reason)
-        Log.w(TAG, "⚠️ Skipped entry ${entry.id} (${entry.hc_record_type}/${entry.operation}): ${result.reason}")
-        // Acknowledge skipped entries so they don't block the queue permanently.
-        // These are unrecoverable failures (missing permission, bad payload, unsupported type)
-        // that will never succeed on retry.
-        ackItems.add(OutboundSyncAckItemApi(id = entry.id))
+    val ackItems = mutableListOf<OutboundSyncAckItemApi>()
+    var pageSkipped = 0
+
+    for (entry in entries) {
+      when (val result = writeToHealthConnect(entry, healthConnectClient, grantedPermissions)) {
+        is WriteResult.Success -> {
+          ackItems.add(
+            OutboundSyncAckItemApi(
+              id = entry.id,
+              hc_record_id = if (result.recordId == "deleted") null else result.recordId,
+            ),
+          )
+        }
+        is WriteResult.Skipped -> {
+          pageSkipped++
+          val reason = "${entry.hc_record_type}: ${result.reason}"
+          allSkipReasons.add(reason)
+          Log.w(TAG, "⚠️ Skipped entry ${entry.id} (${entry.hc_record_type}/${entry.operation}): ${result.reason}")
+          // Acknowledge skipped entries so they don't block the queue permanently.
+          // These are unrecoverable failures (missing permission, bad payload, unsupported type)
+          // that will never succeed on retry.
+          ackItems.add(OutboundSyncAckItemApi(id = entry.id))
+        }
       }
     }
+
+    totalWritten += ackItems.size - pageSkipped
+    totalSkipped += pageSkipped
+
+    if (ackItems.isNotEmpty()) {
+      val ackSuccess = acknowledgeOutboundSync(ackItems, apiUrl, authToken, httpClient)
+      if (ackSuccess) {
+        Log.d(TAG, "✅ Page $page complete: ${ackItems.size}/${entries.size} entries synced")
+      } else {
+        Log.w(TAG, "⚠️ Outbound sync page $page: wrote to HC but failed to acknowledge")
+        allAcknowledged = false
+        break
+      }
+    }
+
+    // If we processed fewer entries than the total pending, there are more pages
+    val remaining = fetchResult.totalPending - entries.size
+    if (remaining <= 0) break
+    Log.d(TAG, "📋 $remaining more entries remaining in queue, fetching next page...")
   }
 
-  if (ackItems.isNotEmpty()) {
-    val ackSuccess = acknowledgeOutboundSync(ackItems, apiUrl, authToken, httpClient)
-    if (ackSuccess) {
-      Log.d(TAG, "✅ Outbound sync complete: ${ackItems.size}/${entries.size} entries synced")
-    } else {
-      Log.w(TAG, "⚠️ Outbound sync: wrote to HC but failed to acknowledge")
-      return OutboundSyncResult(
-        fetched = entries.size,
-        written = ackItems.size,
-        skipped = skipped,
-        acknowledged = false,
-        skipReasons = skipReasons,
-      )
-    }
+  if (pagesProcessed > 0) {
+    Log.d(TAG, "✅ Outbound sync finished: $totalWritten written, $totalSkipped skipped across $pagesProcessed pages")
   }
 
   return OutboundSyncResult(
-    fetched = entries.size,
-    written = ackItems.size,
-    skipped = skipped,
-    acknowledged = true,
-    skipReasons = skipReasons,
+    fetched = totalFetched,
+    written = totalWritten,
+    skipped = totalSkipped,
+    acknowledged = allAcknowledged,
+    skipReasons = allSkipReasons,
+    pagesProcessed = pagesProcessed,
   )
 }
 

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -206,6 +206,7 @@ export {
   type OutboundSyncEntry,
   type OutboundSyncOperation,
   type OutboundSyncStatus,
+  type PendingOutboundSyncResult,
 } from './outbound-sync.ts'
 
 // Settings

--- a/apps/backend/src/db/outbound-sync.integration.test.ts
+++ b/apps/backend/src/db/outbound-sync.integration.test.ts
@@ -43,7 +43,7 @@ describe('Outbound Sync Queue Integration Tests', () => {
       expect(id).toBeDefined()
       expect(typeof id).toBe('string')
 
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(1)
       expect(pending[0].entity_id).toBe('activity-123')
       expect(pending[0].operation).toBe('insert')
@@ -71,7 +71,7 @@ describe('Outbound Sync Queue Integration Tests', () => {
         payload: { start_time: '2024-01-15T10:30:00Z' },
       })
 
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(1)
       expect(pending[0].operation).toBe('update')
     })
@@ -95,7 +95,7 @@ describe('Outbound Sync Queue Integration Tests', () => {
         payload: {},
       })
 
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(1)
       expect(pending[0].operation).toBe('delete')
     })
@@ -121,13 +121,13 @@ describe('Outbound Sync Queue Integration Tests', () => {
         payload: {},
       })
 
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(2)
       expect(pending[0].entity_id).toBe('second')
       expect(pending[1].entity_id).toBe('first')
     })
 
-    test('respects limit', async () => {
+    test('respects limit and returns total_pending', async () => {
       const user = getTestUser()
 
       for (let i = 0; i < 5; i++) {
@@ -140,14 +140,16 @@ describe('Outbound Sync Queue Integration Tests', () => {
         })
       }
 
-      const pending = await getPendingOutboundSync(user, 3)
+      const { entries: pending, total_pending } = await getPendingOutboundSync(user, 3)
       expect(pending).toHaveLength(3)
+      expect(total_pending).toBe(5)
     })
 
     test('returns empty array when no pending entries', async () => {
       const user = getTestUser()
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending, total_pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(0)
+      expect(total_pending).toBe(0)
     })
 
     test('auto-expires entries older than 90 days', async () => {
@@ -176,10 +178,50 @@ describe('Outbound Sync Queue Integration Tests', () => {
         payload: {},
       })
 
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       // Only the recent entry should be returned; the old one should be auto-expired
       expect(pending).toHaveLength(1)
       expect(pending[0].entity_id).toBe('recent-exercise')
+    })
+
+    test('total_pending reflects count after auto-expiry', async () => {
+      const user = getTestUser()
+
+      // Create an entry and backdate it to 91 days ago
+      const oldId = await enqueueOutboundSync(user, {
+        entity_id: 'old-entry',
+        entity_type: 'time_series',
+        hc_record_type: 'ActiveCaloriesBurnedRecord',
+        operation: 'insert',
+        payload: { value: 5.0 },
+      })
+      await query(
+        user,
+        `UPDATE outbound_sync_queue SET created_at = NOW() - INTERVAL '91 days' WHERE id = $1`,
+        [oldId],
+      )
+
+      // Create two recent entries
+      await enqueueOutboundSync(user, {
+        entity_id: 'recent-1',
+        entity_type: 'activity',
+        hc_record_type: 'ExerciseSessionRecord',
+        operation: 'insert',
+        payload: {},
+      })
+      await enqueueOutboundSync(user, {
+        entity_id: 'recent-2',
+        entity_type: 'activity',
+        hc_record_type: 'ExerciseSessionRecord',
+        operation: 'insert',
+        payload: {},
+      })
+
+      const { entries, total_pending } = await getPendingOutboundSync(user, 1)
+      // Should only return 1 due to limit, but total_pending should be 2
+      // (the old entry was auto-expired)
+      expect(entries).toHaveLength(1)
+      expect(total_pending).toBe(2)
     })
   })
 
@@ -199,7 +241,7 @@ describe('Outbound Sync Queue Integration Tests', () => {
       expect(ok).toBe(true)
 
       // Should no longer be in pending
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(0)
     })
 
@@ -242,7 +284,7 @@ describe('Outbound Sync Queue Integration Tests', () => {
       expect(ok).toBe(true)
 
       // Should no longer be in pending
-      const pending = await getPendingOutboundSync(user)
+      const { entries: pending } = await getPendingOutboundSync(user)
       expect(pending).toHaveLength(0)
     })
   })

--- a/apps/backend/src/db/outbound-sync.ts
+++ b/apps/backend/src/db/outbound-sync.ts
@@ -76,7 +76,15 @@ export const enqueueOutboundSync = async (user: string, input: EnqueueOutboundSy
  * Entries older than 90 days are auto-expired (marked 'failed') since Health
  * Connect typically ignores data that old.
  */
-export const getPendingOutboundSync = async (user: string, limit = 100): Promise<OutboundSyncEntry[]> => {
+export interface PendingOutboundSyncResult {
+  entries: OutboundSyncEntry[]
+  total_pending: number
+}
+
+export const getPendingOutboundSync = async (
+  user: string,
+  limit = 100,
+): Promise<PendingOutboundSyncResult> => {
   // Auto-expire entries older than 90 days — HC won't accept them anyway
   await query(
     user,
@@ -85,6 +93,14 @@ export const getPendingOutboundSync = async (user: string, limit = 100): Promise
      WHERE status = 'pending' AND created_at < NOW() - INTERVAL '90 days'`,
     [],
   )
+
+  // Get total pending count and entries in a single round-trip
+  const countResult = await query(
+    user,
+    `SELECT COUNT(*)::int AS total FROM outbound_sync_queue WHERE status = 'pending'`,
+    [],
+  )
+  const total_pending = (countResult.rows[0]?.total as number) ?? 0
 
   const result = await query(
     user,
@@ -97,7 +113,10 @@ export const getPendingOutboundSync = async (user: string, limit = 100): Promise
     [limit],
   )
 
-  return result.rows.map(mapOutboundSyncRow)
+  return {
+    entries: result.rows.map(mapOutboundSyncRow),
+    total_pending,
+  }
 }
 
 /**

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -231,7 +231,7 @@ export const registerSyncTools = (
     },
     async ({ limit }) => {
       try {
-        const entries = await getPendingOutboundSync(user, limit)
+        const { entries, total_pending } = await getPendingOutboundSync(user, limit)
         return jsonResponse({
           count: entries.length,
           data: entries.map((e) => ({
@@ -240,6 +240,7 @@ export const registerSyncTools = (
             synced_at: e.synced_at?.toISOString(),
           })),
           success: true,
+          total_pending,
         })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/services/calorie-computation.test.ts
+++ b/apps/backend/src/services/calorie-computation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { enqueueCalorieSync } from './calorie-computation.ts'
+
+// Mock the DB layer — enqueueCalorieSync depends on enqueueOutboundSync
+const mockEnqueueOutboundSync = vi.fn().mockResolvedValue('mock-id')
+vi.mock('../db/index.ts', () => ({
+  enqueueOutboundSync: (...args: unknown[]) => mockEnqueueOutboundSync(...args),
+  getUserSettings: vi.fn(),
+  upsertUserSettings: vi.fn(),
+}))
+
+describe('enqueueCalorieSync', () => {
+  test('does nothing for empty points array', async () => {
+    await enqueueCalorieSync('test-user', [])
+    expect(mockEnqueueOutboundSync).not.toHaveBeenCalled()
+  })
+
+  test('enqueues all points regardless of age', async () => {
+    const oldPoint = {
+      end_time: new Date('2024-01-01T10:01:00Z'),
+      kcal: 5.5,
+      time: new Date('2024-01-01T10:00:00Z'),
+    }
+    const recentPoint = {
+      end_time: new Date('2026-03-17T10:01:00Z'),
+      kcal: 12.3,
+      time: new Date('2026-03-17T10:00:00Z'),
+    }
+
+    mockEnqueueOutboundSync.mockClear()
+    await enqueueCalorieSync('test-user', [oldPoint, recentPoint])
+
+    // Both points should be enqueued — no timestamp cutoff
+    expect(mockEnqueueOutboundSync).toHaveBeenCalledTimes(2)
+    expect(mockEnqueueOutboundSync).toHaveBeenCalledWith(
+      'test-user',
+      expect.objectContaining({
+        entity_id: `calories_active|${oldPoint.time.toISOString()}`,
+        hc_record_type: 'ActiveCaloriesBurnedRecord',
+        operation: 'insert',
+      }),
+    )
+    expect(mockEnqueueOutboundSync).toHaveBeenCalledWith(
+      'test-user',
+      expect.objectContaining({
+        entity_id: `calories_active|${recentPoint.time.toISOString()}`,
+      }),
+    )
+  })
+
+  test('swallows errors without throwing', async () => {
+    mockEnqueueOutboundSync.mockClear()
+    mockEnqueueOutboundSync.mockRejectedValueOnce(new Error('db error'))
+
+    // Should not throw
+    await expect(
+      enqueueCalorieSync('test-user', [{ end_time: new Date(), kcal: 1, time: new Date() }]),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -61,24 +61,24 @@ const getLatestMetricValue = async (
 /**
  * Queue outbound sync entries for calorie data points (best-effort).
  *
- * Only enqueues points from the last 24 hours to avoid flooding the outbound
- * queue with historical recalculations. Health Connect benefits from recent
- * calorie data but historical backfills would starve other outbound entries.
+ * When `skipSync` is true (used during full historical recomputes), no entries
+ * are queued to avoid flooding the outbound queue with thousands of old data
+ * points that would starve more important entries (exercises, weight, etc.).
+ *
+ * For normal incremental computation (triggered by new HR data), all new
+ * calorie points are queued regardless of their timestamp.
  */
-const enqueueCalorieSync = async (
+export const enqueueCalorieSync = async (
   user: string,
   points: { time: Date; end_time: Date; kcal: number }[],
 ): Promise<void> => {
   try {
+    if (points.length === 0) return
     if (!isHealthConnectSyncableMetric('calories_active')) return
     const hcRecordType = metricToHealthConnectType.calories_active
     if (!hcRecordType) return
 
-    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000)
-    const recentPoints = points.filter((p) => p.time >= cutoff)
-    if (recentPoints.length === 0) return
-
-    for (const p of recentPoints) {
+    for (const p of points) {
       await enqueueOutboundSync(user, {
         entity_id: `calories_active|${p.time.toISOString()}`,
         entity_type: 'time_series',
@@ -150,7 +150,7 @@ export const computeAndStoreCalories = async (
   user: string,
   start: Date,
   end: Date,
-  options?: { force?: boolean },
+  options?: { force?: boolean; skipSync?: boolean },
 ): Promise<CalorieComputationResult> => {
   // 1. Get user settings and validate required fields
   const settings = await getUserSettings(user)
@@ -223,8 +223,10 @@ export const computeAndStoreCalories = async (
   }))
   await insertTimeSeries(user, timeSeriesPoints)
 
-  // 11. Queue outbound sync (best-effort)
-  await enqueueCalorieSync(user, newPoints)
+  // 11. Queue outbound sync (best-effort, skipped during full historical recomputes)
+  if (!options?.skipSync) {
+    await enqueueCalorieSync(user, newPoints)
+  }
 
   // 12. Invalidate training load impulse buckets so they recompute from new calorie data
   await invalidateTrainingLoadImpulses(user, start)
@@ -382,6 +384,7 @@ export const computeAndStoreCaloriesAll = async (
     const chunkEnd = new Date(Math.min(chunkStart.getTime() + dayMs, range.max.getTime() + 60_000))
     const result = await computeAndStoreCalories(user, chunkStart, chunkEnd, {
       force: true,
+      skipSync: true,
     })
 
     totalComputed += result.points_computed

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -14,7 +14,7 @@ describe('sync router', () => {
     getLastFmApiKey: vi.fn().mockResolvedValue('test-lastfm-key'),
     getLastFmSyncStates: vi.fn().mockResolvedValue([]),
     getOuraSyncStates: vi.fn().mockResolvedValue([]),
-    getPendingOutboundSync: vi.fn().mockResolvedValue([]),
+    getPendingOutboundSync: vi.fn().mockResolvedValue({ entries: [], total_pending: 0 }),
     getRescueTimeSyncStates: vi.fn().mockResolvedValue([]),
     getSettings: vi.fn().mockResolvedValue({ rescue_time_key: 'test-key' }),
     processActivityWatchEvents: vi

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -67,6 +67,11 @@ interface OutboundSyncEntry {
   synced_at?: Date
 }
 
+interface PendingOutboundSyncResult {
+  entries: OutboundSyncEntry[]
+  total_pending: number
+}
+
 export interface SyncRouterDeps {
   deleteHealthConnectRecords: (user: string, externalIds: string[]) => Promise<number>
   processDailyAggregate: (user: string, aggregate: DailyAggregate) => Promise<void>
@@ -120,7 +125,7 @@ export interface SyncRouterDeps {
   ) => Promise<ActivityWatchSyncResult>
   getActivityWatchSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   // Outbound sync (Health Connect write-back)
-  getPendingOutboundSync: (user: string, limit?: number) => Promise<OutboundSyncEntry[]>
+  getPendingOutboundSync: (user: string, limit?: number) => Promise<PendingOutboundSyncResult>
   ackOutboundSync: (user: string, id: string, hcRecordId?: string) => Promise<boolean>
 }
 
@@ -491,13 +496,13 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     const user = req.user!
 
     try {
-      const entries = await deps.getPendingOutboundSync(user)
+      const { entries, total_pending } = await deps.getPendingOutboundSync(user)
       const data = entries.map((e) => ({
         ...e,
         created_at: e.created_at.toISOString(),
         synced_at: e.synced_at?.toISOString(),
       }))
-      res.json({ data, success: true })
+      res.json({ data, success: true, total_pending })
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
       res.status(500).json({ error: message, success: false })

--- a/packages/api-spec/src/schemas/outbound-sync.ts
+++ b/packages/api-spec/src/schemas/outbound-sync.ts
@@ -69,6 +69,9 @@ export const outboundSyncResponseSchema = baseResponseSchema
     data: z.array(outboundSyncEntrySchema).optional().meta({
       description: 'Pending outbound sync entries',
     }),
+    total_pending: z.number().int().optional().meta({
+      description: 'Total number of pending entries in the queue (for pagination)',
+    }),
   })
   .meta({ id: 'OutboundSyncResponse' })
 


### PR DESCRIPTION
## Summary

- **Add `total_pending` to outbound sync API response** so the Android app knows when there are more entries to fetch beyond the current page (default 100 entries)
- **Android app now loops page-by-page** until the outbound sync queue is fully drained (capped at 50 pages per sync pass to prevent runaway loops)
- **Fix calorie sync queueing**: Remove the broken 24h wall-clock cutoff in `enqueueCalorieSync` that could permanently prevent exercise calories from being synced to Health Connect. The cutoff compared data point timestamps against `Date.now()`, which meant that if calorie computation ran slightly late or the data was already stored from a previous computation, the outbound sync entries were silently dropped. Now, all incrementally-computed calorie points are queued. Only full historical recomputes (`computeAndStoreCaloriesAll`) skip queueing to avoid flooding the queue.
- **New integration tests** for pagination behavior (`total_pending` with `limit`, count after auto-expiry)

## Context

The outbound sync queue could accumulate hundreds of entries (e.g., per-minute calorie records for a full day), but the Android app only fetched one page of 100 and stopped. This meant the queue could never be fully drained during a single sync cycle. Combined with the 24h cutoff bug, exercise calorie data could fail to reach Health Connect entirely.