### PR TITLE
feat: add tag and metric meta pages

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -26,10 +26,12 @@ import { Goals } from './pages/Goals/index.jsx'
 import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
 import { Login } from './pages/Login/index.jsx'
+import { MetricMeta } from './pages/MetricMeta/index.jsx'
 import { Places } from './pages/Places/index.jsx'
 import { Settings } from './pages/Settings/index.jsx'
 import { Signup } from './pages/Signup/index.jsx'
 import { Sleep } from './pages/Sleep/index.jsx'
+import { TagMeta } from './pages/TagMeta/index.jsx'
 import { Timeline } from './pages/Timeline/index.jsx'
 import { Trends } from './pages/Trends/index.jsx'
 import { queryClient } from './state/queryClient.js'
@@ -51,6 +53,8 @@ export function App() {
             <Route path="/data" component={Data} />
             <Route path="/add" component={AddData} />
             <Route path="/detail/:type/:id" component={EntityDetail} />
+            <Route path="/tag/:tagKey" component={TagMeta} />
+            <Route path="/metric/:metricName" component={MetricMeta} />
             <Route path="/sleep" component={Sleep} />
             <Route path="/correlations" component={Correlations} />
             <Route path="/trends" component={Trends} />

--- a/apps/web/src/pages/EntityDetail/MetricDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/MetricDetail.tsx
@@ -100,7 +100,11 @@ export const MetricDetail = ({
           <span class="entity-source">Source: {parsed.source}</span>
         </div>
 
-        <h2>{metricLabel}</h2>
+        <h2>
+          <a href={`/metric/${encodeURIComponent(parsed.metric)}`} class="entity-meta-link">
+            {metricLabel}
+          </a>
+        </h2>
 
         <div class="entity-fields">
           <div class="field-row">
@@ -143,7 +147,11 @@ export const MetricDetail = ({
         <span class="entity-source">Source: {parsed.source}</span>
       </div>
 
-      <h2>{metricLabel}</h2>
+      <h2>
+        <a href={`/metric/${encodeURIComponent(parsed.metric)}`} class="entity-meta-link">
+          {metricLabel}
+        </a>
+      </h2>
 
       <div class="entity-fields">
         <div class="field-row">

--- a/apps/web/src/pages/EntityDetail/TagDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/TagDetail.tsx
@@ -8,6 +8,7 @@ import { formatDateTime, formatDuration, formatTime } from './format-utils'
 export const TagDetail = ({ tag }: { tag: Tag }) => {
   const end = tag.end_time
   const isPoint = !end
+  const tagMetaKey = tag.tag_key ?? tag.tag
 
   return (
     <div class="entity-info">
@@ -16,7 +17,11 @@ export const TagDetail = ({ tag }: { tag: Tag }) => {
         {tag.source && <span class="entity-source">Source: {tag.source}</span>}
       </div>
 
-      <h2>{tag.tag}</h2>
+      <h2>
+        <a href={`/tag/${encodeURIComponent(tagMetaKey)}`} class="entity-meta-link">
+          {tag.tag}
+        </a>
+      </h2>
 
       <div class="entity-fields">
         <div class="field-row">

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -73,6 +73,17 @@
   font-size: 1.5rem;
 }
 
+.entity-meta-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.15s;
+}
+
+.entity-meta-link:hover {
+  border-bottom-color: #673ab8;
+}
+
 .entity-subtitle {
   margin: -0.75rem 0 1rem;
   font-size: 0.9rem;
@@ -686,6 +697,10 @@
 
   .entity-info h2 {
     color: #f3f4f6;
+  }
+
+  .entity-meta-link:hover {
+    border-bottom-color: #8b5cf6;
   }
 
   .entity-subtitle {

--- a/apps/web/src/pages/MetricMeta/index.tsx
+++ b/apps/web/src/pages/MetricMeta/index.tsx
@@ -1,0 +1,322 @@
+/**
+ * Metric meta page — overview of a metric type (e.g. "weight", "body_fat", or custom metrics).
+ * Shows description, unit, trend chart, recent values, and edit for custom metrics.
+ */
+import { metricUnits as builtinMetricUnits } from '@aurboda/api-spec'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
+
+import {
+  fetchCustomMetrics,
+  fetchMetricTimeSeries,
+  fetchTrend,
+  updateCustomMetric,
+  type CustomMetricDefinition,
+  type FetchTrendParams,
+} from '../../state/api'
+import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
+import './style.css'
+
+const LOOKBACK_OPTIONS = [
+  { label: '30 days', value: 30 },
+  { label: '90 days', value: 90 },
+  { label: '180 days', value: 180 },
+  { label: '1 year', value: 365 },
+  { label: '2 years', value: 730 },
+  { label: 'All time', value: 3650 },
+]
+
+/** Map metric name to human-readable display label. */
+const formatMetricLabel = (metric: string): string =>
+  metric.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+
+/** Format a value with appropriate precision. */
+const formatValue = (value: number): string => {
+  if (Number.isInteger(value)) return String(value)
+  return value.toFixed(2)
+}
+
+function RecentValues({ metric, unit }: { metric: string; unit: string }) {
+  const end = new Date()
+  const start = new Date(end.getTime() - 30 * 86400000)
+
+  const { data, isLoading } = useQuery({
+    queryFn: () => fetchMetricTimeSeries(metric, start, end),
+    queryKey: ['metric-recent', metric],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (isLoading) return <p class="loading">Loading...</p>
+  if (!data || data.length === 0) return <p class="metric-meta-empty">No data in the last 30 days</p>
+
+  // Show up to 10 most recent
+  const recent = data.slice(-10).reverse()
+
+  return (
+    <div class="metric-meta-recent-list">
+      {recent.map(([date, value]) => (
+        <div key={date.toISOString()} class="metric-meta-recent-item">
+          <span class="metric-meta-recent-time">
+            {date.toLocaleDateString()}{' '}
+            {date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+          </span>
+          <span class="metric-meta-recent-value">
+            {formatValue(value)}
+            {unit ? ` ${unit}` : ''}
+          </span>
+        </div>
+      ))}
+      {data.length > 10 && (
+        <p class="metric-meta-more">
+          +{data.length - 10} more in last 30 days ({data.length} total)
+        </p>
+      )}
+    </div>
+  )
+}
+
+function CustomMetricEditor({
+  metric,
+  onUpdated,
+}: {
+  metric: CustomMetricDefinition
+  onUpdated: () => void
+}) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [unit, setUnit] = useState(metric.unit)
+  const [description, setDescription] = useState(metric.description ?? '')
+  const [minValue, setMinValue] = useState(metric.min_value?.toString() ?? '')
+  const [maxValue, setMaxValue] = useState(metric.max_value?.toString() ?? '')
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      updateCustomMetric(metric.name, {
+        description: description || undefined,
+        max_value: maxValue ? parseFloat(maxValue) : null,
+        min_value: minValue ? parseFloat(minValue) : null,
+        unit,
+      }),
+    onSuccess: () => {
+      setIsEditing(false)
+      onUpdated()
+    },
+  })
+
+  if (!isEditing) {
+    return (
+      <div class="metric-meta-custom-info">
+        <div class="metric-meta-custom-fields">
+          {metric.description && (
+            <div class="metric-meta-field-row">
+              <span class="metric-meta-field-label">Description</span>
+              <span>{metric.description}</span>
+            </div>
+          )}
+          <div class="metric-meta-field-row">
+            <span class="metric-meta-field-label">Unit</span>
+            <span>{metric.unit}</span>
+          </div>
+          {(metric.min_value !== undefined || metric.max_value !== undefined) && (
+            <div class="metric-meta-field-row">
+              <span class="metric-meta-field-label">Range</span>
+              <span>
+                {metric.min_value ?? '—'} – {metric.max_value ?? '—'}
+              </span>
+            </div>
+          )}
+        </div>
+        <button type="button" class="btn-secondary" onClick={() => setIsEditing(true)}>
+          Edit
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div class="metric-meta-custom-edit">
+      <div class="metric-meta-edit-grid">
+        <label>
+          <span class="metric-meta-field-label">Unit</span>
+          <input
+            type="text"
+            value={unit}
+            onInput={(e) => setUnit((e.target as HTMLInputElement).value)}
+            placeholder="e.g. kg, mg, count"
+          />
+        </label>
+        <label>
+          <span class="metric-meta-field-label">Description</span>
+          <input
+            type="text"
+            value={description}
+            onInput={(e) => setDescription((e.target as HTMLInputElement).value)}
+            placeholder="Description (optional)"
+          />
+        </label>
+        <label>
+          <span class="metric-meta-field-label">Min Value</span>
+          <input
+            type="number"
+            step="any"
+            value={minValue}
+            onInput={(e) => setMinValue((e.target as HTMLInputElement).value)}
+            placeholder="Min (optional)"
+          />
+        </label>
+        <label>
+          <span class="metric-meta-field-label">Max Value</span>
+          <input
+            type="number"
+            step="any"
+            value={maxValue}
+            onInput={(e) => setMaxValue((e.target as HTMLInputElement).value)}
+            placeholder="Max (optional)"
+          />
+        </label>
+      </div>
+      <div class="metric-meta-edit-actions">
+        <button
+          type="button"
+          class="btn-primary"
+          onClick={() => updateMutation.mutate()}
+          disabled={updateMutation.isPending || !unit.trim()}
+        >
+          {updateMutation.isPending ? 'Saving...' : 'Save'}
+        </button>
+        <button type="button" class="btn-secondary" onClick={() => setIsEditing(false)}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function MetricMeta() {
+  const { params } = useRoute()
+  const metricName = decodeURIComponent(params.metricName as string)
+  const queryClient = useQueryClient()
+
+  const [lookback, setLookback] = useState(90)
+
+  // Check if it's a custom metric
+  const { data: customMetrics } = useQuery({
+    queryFn: fetchCustomMetrics,
+    queryKey: ['custom-metrics'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const customMetric = customMetrics?.find((m) => m.name === metricName)
+  const isBuiltIn = !customMetric && metricName in (builtinMetricUnits as Record<string, string>)
+  const unit = customMetric?.unit ?? (builtinMetricUnits as Record<string, string>)[metricName] ?? ''
+  const label = formatMetricLabel(metricName)
+
+  // Trend query
+  const trendParams: FetchTrendParams = {
+    aggregation: 'mean',
+    display_period: 'daily',
+    half_life_days: 15,
+    lookback_days: lookback,
+    pattern: metricName,
+    source_type: 'metric',
+  }
+
+  const trendQuery = useQuery({
+    queryFn: () => fetchTrend(trendParams),
+    queryKey: ['trend', trendParams],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const handleCustomUpdated = () => {
+    queryClient.invalidateQueries({ queryKey: ['custom-metrics'] })
+    queryClient.invalidateQueries({ queryKey: ['customMetrics'] })
+  }
+
+  return (
+    <div class="metric-meta-page">
+      <header class="metric-meta-header">
+        <h1>{label}</h1>
+        <div class="metric-meta-subtitle">
+          <code>{metricName}</code>
+          {unit && <span class="metric-meta-unit-badge">{unit}</span>}
+          {isBuiltIn && <span class="metric-meta-type-badge">Built-in</span>}
+          {customMetric && <span class="metric-meta-type-badge custom">Custom</span>}
+        </div>
+      </header>
+
+      {/* Custom metric settings */}
+      {customMetric && (
+        <section class="metric-meta-section">
+          <h2>Definition</h2>
+          <CustomMetricEditor metric={customMetric} onUpdated={handleCustomUpdated} />
+        </section>
+      )}
+
+      {/* Built-in metric info */}
+      {isBuiltIn && (
+        <section class="metric-meta-section">
+          <h2>Info</h2>
+          <div class="metric-meta-field-row">
+            <span class="metric-meta-field-label">Type</span>
+            <span>Built-in metric</span>
+          </div>
+          <div class="metric-meta-field-row">
+            <span class="metric-meta-field-label">Unit</span>
+            <span>{unit}</span>
+          </div>
+        </section>
+      )}
+
+      {/* Trend */}
+      <section class="metric-meta-section">
+        <div class="metric-meta-section-header">
+          <h2>Trend</h2>
+          <select
+            value={lookback}
+            onChange={(e) => setLookback(Number((e.target as HTMLSelectElement).value))}
+          >
+            {LOOKBACK_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {trendQuery.isLoading && <p class="loading">Loading trend...</p>}
+        {trendQuery.error && <p class="error">Failed to load trend data</p>}
+        {trendQuery.data && (
+          <>
+            <div class="metric-meta-trend-value">
+              <span class="metric-meta-trend-number">{trendQuery.data.current_value.toFixed(2)}</span>
+              <span class="metric-meta-trend-unit">{unit || trendQuery.data.display_unit}</span>
+            </div>
+            <MiniTrendChart data={trendQuery.data.history} color="#2563eb" />
+          </>
+        )}
+      </section>
+
+      {/* Recent values */}
+      <section class="metric-meta-section">
+        <h2>Recent Values</h2>
+        <RecentValues metric={metricName} unit={unit} />
+      </section>
+
+      {/* Quick links */}
+      <section class="metric-meta-section">
+        <h2>Related</h2>
+        <div class="metric-meta-links">
+          <a href="/trends" class="metric-meta-link">
+            All Trends
+          </a>
+          <a href="/correlations" class="metric-meta-link">
+            Correlations
+          </a>
+          <a href="/data-sources/aurboda" class="metric-meta-link">
+            Custom Metrics Settings
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/pages/MetricMeta/style.css
+++ b/apps/web/src/pages/MetricMeta/style.css
@@ -1,0 +1,424 @@
+.metric-meta-page {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* Header */
+.metric-meta-header {
+  margin-bottom: 2rem;
+}
+
+.metric-meta-header h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: #1f2937;
+}
+
+.metric-meta-subtitle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.metric-meta-subtitle code {
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+  background: #f3f4f6;
+  border-radius: 4px;
+  color: #6b7280;
+}
+
+.metric-meta-unit-badge {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.6rem;
+  background: #eff6ff;
+  color: #2563eb;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.metric-meta-type-badge {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  background: #f3f4f6;
+  color: #6b7280;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.metric-meta-type-badge.custom {
+  background: #faf5ff;
+  color: #7c3aed;
+}
+
+/* Sections */
+.metric-meta-section {
+  margin-bottom: 2rem;
+  padding: 1.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.metric-meta-section h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 1rem;
+}
+
+.metric-meta-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.metric-meta-section-header h2 {
+  margin: 0;
+}
+
+.metric-meta-section-header select {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #374151;
+  background: #fff;
+}
+
+/* Field rows */
+.metric-meta-field-row {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.metric-meta-field-row:last-child {
+  margin-bottom: 0;
+}
+
+.metric-meta-field-label {
+  min-width: 100px;
+  color: #6b7280;
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+/* Custom metric editor */
+.metric-meta-custom-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.metric-meta-custom-fields {
+  flex: 1;
+}
+
+.metric-meta-custom-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.metric-meta-edit-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.metric-meta-edit-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.metric-meta-edit-grid input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: #1f2937;
+  background: #fff;
+}
+
+.metric-meta-edit-grid input:focus {
+  outline: none;
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.metric-meta-edit-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+/* Trend value */
+.metric-meta-trend-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.metric-meta-trend-number {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.metric-meta-trend-unit {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+/* Recent values */
+.metric-meta-recent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.metric-meta-recent-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #f3f4f6;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.metric-meta-recent-item:hover {
+  background: #f9fafb;
+}
+
+.metric-meta-recent-time {
+  color: #6b7280;
+}
+
+.metric-meta-recent-value {
+  font-weight: 600;
+  color: #374151;
+}
+
+.metric-meta-empty {
+  color: #9ca3af;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 1rem;
+}
+
+.metric-meta-more {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  text-align: center;
+  margin: 0.5rem 0 0;
+}
+
+/* Quick links */
+.metric-meta-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.metric-meta-link {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.85rem;
+  color: #374151;
+  transition: all 0.15s;
+}
+
+.metric-meta-link:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+/* Buttons */
+.metric-meta-page .btn-primary {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.metric-meta-page .btn-primary:hover:not(:disabled) {
+  background: #5e35b1;
+}
+
+.metric-meta-page .btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.metric-meta-page .btn-secondary {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid #d1d5db;
+  color: #374151;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.metric-meta-page .btn-secondary:hover {
+  background: #f3f4f6;
+}
+
+.metric-meta-page .loading,
+.metric-meta-page .error {
+  text-align: center;
+  padding: 1rem;
+  color: #6b7280;
+}
+
+.metric-meta-page .error {
+  color: #dc2626;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .metric-meta-header h1 {
+    color: #f9fafb;
+  }
+
+  .metric-meta-subtitle code {
+    background: #374151;
+    color: #9ca3af;
+  }
+
+  .metric-meta-unit-badge {
+    background: #1e3a5f;
+    color: #60a5fa;
+  }
+
+  .metric-meta-type-badge {
+    background: #374151;
+    color: #9ca3af;
+  }
+
+  .metric-meta-type-badge.custom {
+    background: #2e1065;
+    color: #c4b5fd;
+  }
+
+  .metric-meta-section {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .metric-meta-section h2 {
+    color: #e5e7eb;
+  }
+
+  .metric-meta-section-header select {
+    background: #111827;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .metric-meta-field-label {
+    color: #9ca3af;
+  }
+
+  .metric-meta-edit-grid input {
+    background: #111827;
+    border-color: #4b5563;
+    color: #f9fafb;
+  }
+
+  .metric-meta-edit-grid input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+  }
+
+  .metric-meta-trend-number {
+    color: #f9fafb;
+  }
+
+  .metric-meta-trend-unit {
+    color: #9ca3af;
+  }
+
+  .metric-meta-recent-item {
+    border-color: #374151;
+  }
+
+  .metric-meta-recent-item:hover {
+    background: #111827;
+  }
+
+  .metric-meta-recent-time {
+    color: #9ca3af;
+  }
+
+  .metric-meta-recent-value {
+    color: #e5e7eb;
+  }
+
+  .metric-meta-link {
+    border-color: #374151;
+    color: #d1d5db;
+  }
+
+  .metric-meta-link:hover {
+    background: #374151;
+    border-color: #4b5563;
+  }
+
+  .metric-meta-page .btn-secondary {
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .metric-meta-page .btn-secondary:hover {
+    background: #374151;
+  }
+}
+
+/* Responsive */
+@media (max-width: 639px) {
+  .metric-meta-page {
+    padding: 1rem;
+  }
+
+  .metric-meta-header h1 {
+    font-size: 1.35rem;
+  }
+
+  .metric-meta-edit-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-meta-field-row {
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .metric-meta-field-label {
+    min-width: auto;
+  }
+
+  .metric-meta-links {
+    flex-direction: column;
+  }
+
+  .metric-meta-link {
+    text-align: center;
+  }
+}

--- a/apps/web/src/pages/TagMeta/MiniTrendChart.tsx
+++ b/apps/web/src/pages/TagMeta/MiniTrendChart.tsx
@@ -1,0 +1,181 @@
+/**
+ * Compact D3 trend chart reusable in meta pages.
+ * Renders an area+line chart with tooltip crosshair.
+ */
+import * as d3 from 'd3'
+import { useEffect, useRef } from 'preact/hooks'
+
+export function MiniTrendChart({ data, color }: { data: { date: string; value: number }[]; color: string }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!svgRef.current || !containerRef.current || data.length < 2) return
+
+    const container = containerRef.current
+    const width = container.clientWidth
+    const height = 180
+
+    const svg = d3.select(svgRef.current)
+    svg.selectAll('*').remove()
+    svg.attr('width', width).attr('height', height)
+
+    const margin = { bottom: 30, left: 45, right: 15, top: 15 }
+    const innerWidth = width - margin.left - margin.right
+    const innerHeight = height - margin.top - margin.bottom
+
+    const parsedData = data.map((d) => ({
+      date: new Date(d.date),
+      value: d.value,
+    }))
+
+    const x = d3
+      .scaleTime()
+      .domain(d3.extent(parsedData, (d) => d.date) as [Date, Date])
+      .range([0, innerWidth])
+
+    const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
+    const yRange = yExtent[1] - yExtent[0]
+    const yPadding = yRange * 0.1 || 1
+    const y = d3
+      .scaleLinear()
+      .domain([Math.max(0, yExtent[0] - yPadding), yExtent[1] + yPadding])
+      .nice()
+      .range([innerHeight, 0])
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    // Grid
+    g.append('g')
+      .attr('class', 'grid')
+      .call(
+        d3
+          .axisLeft(y)
+          .tickSize(-innerWidth)
+          .tickFormat(() => ''),
+      )
+      .selectAll('line')
+      .attr('stroke', '#e5e7eb')
+      .attr('stroke-dasharray', '3,3')
+
+    // Area
+    const area = d3
+      .area<{ date: Date; value: number }>()
+      .x((d) => x(d.date))
+      .y0(innerHeight)
+      .y1((d) => y(d.value))
+      .curve(d3.curveMonotoneX)
+
+    g.append('path').datum(parsedData).attr('fill', color).attr('fill-opacity', 0.15).attr('d', area)
+
+    // Line
+    const line = d3
+      .line<{ date: Date; value: number }>()
+      .x((d) => x(d.date))
+      .y((d) => y(d.value))
+      .curve(d3.curveMonotoneX)
+
+    g.append('path')
+      .datum(parsedData)
+      .attr('fill', 'none')
+      .attr('stroke', color)
+      .attr('stroke-width', 2)
+      .attr('d', line)
+
+    // Axes
+    const dateExtent = d3.extent(parsedData, (d) => d.date) as [Date, Date]
+    const spanYears = dateExtent[1].getFullYear() - dateExtent[0].getFullYear()
+    const dateFormat = spanYears >= 1 ? d3.timeFormat("%b '%y") : d3.timeFormat('%b %d')
+
+    g.append('g')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(
+        d3
+          .axisBottom(x)
+          .ticks(5)
+          .tickFormat((d) => dateFormat(d as Date)),
+      )
+      .selectAll('text')
+      .attr('font-size', '11px')
+
+    g.append('g').call(d3.axisLeft(y).ticks(4)).selectAll('text').attr('font-size', '11px')
+
+    // Tooltip crosshair
+    const crosshair = g
+      .append('line')
+      .attr('y1', 0)
+      .attr('y2', innerHeight)
+      .attr('stroke', 'currentColor')
+      .attr('stroke-opacity', 0.4)
+      .attr('stroke-dasharray', '4 3')
+      .attr('pointer-events', 'none')
+      .style('display', 'none')
+
+    const highlightDot = g
+      .append('circle')
+      .attr('r', 4)
+      .attr('fill', color)
+      .attr('stroke', '#fff')
+      .attr('stroke-width', 2)
+      .attr('pointer-events', 'none')
+      .style('display', 'none')
+
+    const bisector = d3.bisector<{ date: Date; value: number }, Date>((d) => d.date).left
+    const tooltip = tooltipRef.current
+
+    g.append('rect')
+      .attr('width', innerWidth)
+      .attr('height', innerHeight)
+      .attr('fill', 'transparent')
+      .attr('pointer-events', 'all')
+      .on('mousemove', (event: MouseEvent) => {
+        const [mx] = d3.pointer(event)
+        const dateAtMouse = x.invert(mx)
+        const idx = bisector(parsedData, dateAtMouse, 1)
+        const d0 = parsedData[idx - 1]
+        const d1 = parsedData[idx]
+        if (!d0) return
+        const nearest =
+          d1 && dateAtMouse.getTime() - d0.date.getTime() > d1.date.getTime() - dateAtMouse.getTime()
+            ? d1
+            : d0
+        const cx = x(nearest.date)
+        const cy = y(nearest.value)
+
+        crosshair.attr('x1', cx).attr('x2', cx).style('display', null)
+        highlightDot.attr('cx', cx).attr('cy', cy).style('display', null)
+
+        if (tooltip) {
+          const dateLabel =
+            spanYears >= 1 ? d3.timeFormat("%b %d, '%y")(nearest.date) : d3.timeFormat('%b %d')(nearest.date)
+          tooltip.textContent = `${dateLabel}: ${nearest.value.toFixed(1)}`
+          tooltip.style.display = 'block'
+
+          const containerRect = container.getBoundingClientRect()
+          const tooltipX = mx + margin.left
+          const tooltipWidth = tooltip.offsetWidth
+          const left =
+            tooltipX + tooltipWidth + 12 > containerRect.width ? tooltipX - tooltipWidth - 12 : tooltipX + 12
+          tooltip.style.left = `${left}px`
+          tooltip.style.top = `${margin.top + 8}px`
+        }
+      })
+      .on('mouseleave', () => {
+        crosshair.style('display', 'none')
+        highlightDot.style('display', 'none')
+        if (tooltip) tooltip.style.display = 'none'
+      })
+  }, [data, color])
+
+  if (data.length < 2) {
+    return <div class="mini-trend-placeholder">Insufficient data for chart</div>
+  }
+
+  return (
+    <div ref={containerRef} class="mini-trend-container">
+      <svg ref={svgRef} />
+      <div class="mini-trend-tooltip" ref={tooltipRef} />
+    </div>
+  )
+}

--- a/apps/web/src/pages/TagMeta/TagIconPreview.tsx
+++ b/apps/web/src/pages/TagMeta/TagIconPreview.tsx
@@ -1,0 +1,17 @@
+/**
+ * Icon preview for tags — renders emoji or image URL.
+ */
+import { isEmoji, isUrl } from '../../utils/emojiLookup'
+
+export const TagIconPreview = ({ icon }: { icon: string }) => {
+  if (!icon) return null
+  if (isEmoji(icon)) return <span class="tag-meta-icon-preview">{icon}</span>
+  if (isUrl(icon)) {
+    return (
+      <span class="tag-meta-icon-preview">
+        <img src={icon} alt="icon" width="24" height="24" />
+      </span>
+    )
+  }
+  return null
+}

--- a/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
+++ b/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tag settings section — edit display name, icon, and save.
+ */
+import type { ProgrammaticTag } from '@aurboda/api-spec'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useState } from 'preact/hooks'
+
+import { setTagMapping } from '../../state/api'
+import { suggestEmoji } from '../../utils/emojiLookup'
+import { TagIconPreview } from './TagIconPreview'
+
+interface TagSettingsSectionProps {
+  tagInfo: ProgrammaticTag | undefined
+  effectiveTagKey: string
+  currentName: string
+  currentIcon: string
+}
+
+// eslint-disable-next-line complexity -- settings form with icon/name editing
+export function TagSettingsSection({
+  tagInfo,
+  effectiveTagKey,
+  currentName,
+  currentIcon,
+}: TagSettingsSectionProps) {
+  const queryClient = useQueryClient()
+  const [displayName, setDisplayName] = useState<string | undefined>(undefined)
+  const [iconValue, setIconValue] = useState<string | undefined>(undefined)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  const saveMutation = useMutation({
+    mutationFn: ({ name, icon }: { name: string; icon?: string }) =>
+      setTagMapping(effectiveTagKey, name, icon),
+    onError: () => setSaveStatus('error'),
+    onSuccess: () => {
+      setSaveStatus('saved')
+      queryClient.invalidateQueries({ queryKey: ['programmaticTags'] })
+      queryClient.invalidateQueries({ queryKey: ['tag-mappings'] })
+      queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+      setDisplayName(undefined)
+      setIconValue(undefined)
+    },
+  })
+
+  // Clear saved indicator
+  useEffect(() => {
+    if (saveStatus !== 'saved') return
+    const timer = setTimeout(() => setSaveStatus('idle'), 3000)
+    return () => clearTimeout(timer)
+  }, [saveStatus])
+
+  const suggested = suggestEmoji(currentName)
+  const shownIcon = iconValue ?? currentIcon
+  const shownName = displayName ?? currentName
+
+  const handleSave = () => {
+    const name = (displayName ?? currentName).trim()
+    if (!name) return
+    setSaveStatus('saving')
+    const iconChanged = iconValue !== undefined && iconValue !== currentIcon
+    saveMutation.mutate({ icon: iconChanged ? iconValue : undefined, name })
+  }
+
+  const hasChanges =
+    (displayName !== undefined && displayName !== currentName) ||
+    (iconValue !== undefined && iconValue !== currentIcon)
+
+  return (
+    <section class="tag-meta-section">
+      <h2>Settings</h2>
+      <div class="tag-meta-settings-grid">
+        <label>
+          <span class="tag-meta-field-label">Display Name</span>
+          <input
+            type="text"
+            value={shownName}
+            onInput={(e) => setDisplayName((e.target as HTMLInputElement).value)}
+            placeholder="Display name..."
+            disabled={tagInfo ? !tagInfo.is_programmatic : false}
+            readOnly={tagInfo ? !tagInfo.is_programmatic : false}
+          />
+          {tagInfo && !tagInfo.is_programmatic && (
+            <span class="tag-meta-field-hint">Non-programmatic tags use their name directly</span>
+          )}
+        </label>
+        <label>
+          <span class="tag-meta-field-label">Icon</span>
+          <div class="tag-meta-icon-row">
+            <input
+              type="text"
+              value={shownIcon}
+              onInput={(e) => setIconValue((e.target as HTMLInputElement).value)}
+              placeholder="Emoji or image URL..."
+            />
+            <TagIconPreview icon={shownIcon} />
+            {suggested && !shownIcon && (
+              <button
+                type="button"
+                class="tag-meta-emoji-suggest"
+                onClick={() => setIconValue(suggested)}
+                title={`Suggested: ${suggested}`}
+              >
+                {suggested}?
+              </button>
+            )}
+          </div>
+        </label>
+        {tagInfo?.is_programmatic && effectiveTagKey !== currentName && (
+          <div class="tag-meta-key-display">
+            <span class="tag-meta-field-label">Tag Key</span>
+            <code>{effectiveTagKey}</code>
+          </div>
+        )}
+      </div>
+      {hasChanges && (
+        <div class="tag-meta-save-row">
+          <button type="button" class="btn-primary" onClick={handleSave} disabled={saveMutation.isPending}>
+            {saveMutation.isPending ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            type="button"
+            class="btn-secondary"
+            onClick={() => {
+              setDisplayName(undefined)
+              setIconValue(undefined)
+            }}
+          >
+            Cancel
+          </button>
+          {saveStatus === 'saved' && <span class="tag-meta-status-saved">Saved</span>}
+          {saveStatus === 'error' && <span class="tag-meta-status-error">Failed to save</span>}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/pages/TagMeta/index.tsx
+++ b/apps/web/src/pages/TagMeta/index.tsx
@@ -1,0 +1,159 @@
+/**
+ * Tag meta page — overview of a tag type (e.g. "Coffee").
+ * Shows icon, display name, trend chart, occurrence count, and inline settings.
+ */
+import type { ProgrammaticTag } from '@aurboda/api-spec'
+
+import { useQuery } from '@tanstack/react-query'
+import { useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
+
+import { fetchProgrammaticTags, fetchTagMappings, fetchTrend, type FetchTrendParams } from '../../state/api'
+import { MiniTrendChart } from './MiniTrendChart'
+import { TagIconPreview } from './TagIconPreview'
+import { TagSettingsSection } from './TagSettingsSection'
+import './style.css'
+
+const LOOKBACK_OPTIONS = [
+  { label: '30 days', value: 30 },
+  { label: '90 days', value: 90 },
+  { label: '180 days', value: 180 },
+  { label: '1 year', value: 365 },
+  { label: '2 years', value: 730 },
+  { label: 'All time', value: 3650 },
+]
+
+function TagTrendSection({ tagKey, lookback }: { tagKey: string; lookback: number }) {
+  const trendParams: FetchTrendParams = {
+    display_period: 'monthly',
+    half_life_days: 15,
+    lookback_days: lookback,
+    pattern: tagKey,
+    source_type: 'tag',
+  }
+
+  const trendQuery = useQuery({
+    queryFn: () => fetchTrend(trendParams),
+    queryKey: ['trend', trendParams],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (trendQuery.isLoading) return <p class="loading">Loading trend...</p>
+  if (trendQuery.error) return <p class="error">Failed to load trend data</p>
+  if (!trendQuery.data) return null
+
+  return (
+    <>
+      <div class="tag-meta-trend-value">
+        <span class="tag-meta-trend-number">{trendQuery.data.current_value.toFixed(1)}</span>
+        <span class="tag-meta-trend-unit">{trendQuery.data.display_unit}</span>
+      </div>
+      <MiniTrendChart data={trendQuery.data.history} color="#8b5cf6" />
+    </>
+  )
+}
+
+function TagHeader({
+  tagInfo,
+  shownIcon,
+  shownName,
+}: {
+  tagInfo: ProgrammaticTag | undefined
+  shownIcon: string
+  shownName: string
+}) {
+  return (
+    <header class="tag-meta-header">
+      <div class="tag-meta-title-row">
+        {shownIcon ? <TagIconPreview icon={shownIcon} /> : <span class="tag-meta-icon-placeholder">?</span>}
+        <h1>{shownName}</h1>
+      </div>
+      {tagInfo && (
+        <div class="tag-meta-stats">
+          <span class="tag-meta-stat">
+            <strong>{tagInfo.count}</strong> occurrence{tagInfo.count !== 1 ? 's' : ''}
+          </span>
+          <span class="tag-meta-stat">Last: {new Date(tagInfo.latest_time).toLocaleDateString()}</span>
+        </div>
+      )}
+    </header>
+  )
+}
+
+export function TagMeta() {
+  const { params } = useRoute()
+  const tagKey = decodeURIComponent(params.tagKey as string)
+
+  const [lookback, setLookback] = useState(90)
+
+  // Fetch tag metadata
+  const { data: tags } = useQuery({
+    queryFn: fetchProgrammaticTags,
+    queryKey: ['programmaticTags'],
+  })
+
+  const { data: mappingsData } = useQuery({
+    queryFn: fetchTagMappings,
+    queryKey: ['tag-mappings'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const tagInfo = tags?.find((t) => t.tag_key === tagKey || t.current_name === tagKey)
+  const mappings = mappingsData?.mappings ?? {}
+  const icons = mappingsData?.icons ?? {}
+
+  // Resolve the effective tag key and display name
+  const effectiveTagKey = tagInfo?.tag_key ?? tagKey
+  const currentName = tagInfo?.current_name ?? mappings[tagKey] ?? tagKey
+  const currentIcon = icons[currentName] ?? icons[effectiveTagKey] ?? ''
+
+  return (
+    <div class="tag-meta-page">
+      <TagHeader tagInfo={tagInfo} shownIcon={currentIcon} shownName={currentName} />
+
+      <TagSettingsSection
+        tagInfo={tagInfo}
+        effectiveTagKey={effectiveTagKey}
+        currentName={currentName}
+        currentIcon={currentIcon}
+      />
+
+      {/* Trend section */}
+      <section class="tag-meta-section">
+        <div class="tag-meta-section-header">
+          <h2>Trend</h2>
+          <select
+            value={lookback}
+            onChange={(e) => setLookback(Number((e.target as HTMLSelectElement).value))}
+          >
+            {LOOKBACK_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <TagTrendSection tagKey={effectiveTagKey} lookback={lookback} />
+      </section>
+
+      {/* Quick links */}
+      <section class="tag-meta-section">
+        <h2>Related</h2>
+        <div class="tag-meta-links">
+          <a href="/trends" class="tag-meta-link">
+            All Trends
+          </a>
+          <a href="/correlations" class="tag-meta-link">
+            Correlations
+          </a>
+          <a href="/timeline" class="tag-meta-link">
+            Timeline
+          </a>
+          <a href="/data-sources/aurboda" class="tag-meta-link">
+            All Tag Mappings
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/pages/TagMeta/style.css
+++ b/apps/web/src/pages/TagMeta/style.css
@@ -1,0 +1,452 @@
+.tag-meta-page {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* Header */
+.tag-meta-header {
+  margin-bottom: 2rem;
+}
+
+.tag-meta-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.tag-meta-title-row h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0;
+  color: #1f2937;
+}
+
+.tag-meta-icon-preview {
+  font-size: 2rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.tag-meta-icon-preview img {
+  border-radius: 4px;
+}
+
+.tag-meta-icon-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #f3f4f6;
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  color: #9ca3af;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.tag-meta-stats {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.tag-meta-stat strong {
+  color: #374151;
+}
+
+/* Sections */
+.tag-meta-section {
+  margin-bottom: 2rem;
+  padding: 1.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.tag-meta-section h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 1rem;
+}
+
+.tag-meta-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.tag-meta-section-header h2 {
+  margin: 0;
+}
+
+.tag-meta-section-header select {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #374151;
+  background: #fff;
+}
+
+/* Settings */
+.tag-meta-settings-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tag-meta-settings-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.tag-meta-field-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.tag-meta-field-hint {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.tag-meta-settings-grid input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: #1f2937;
+  background: #fff;
+}
+
+.tag-meta-settings-grid input:focus {
+  outline: none;
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.tag-meta-settings-grid input:read-only {
+  background: #f9fafb;
+  color: #6b7280;
+}
+
+.tag-meta-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tag-meta-icon-row input {
+  flex: 1;
+}
+
+.tag-meta-emoji-suggest {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #faf5ff;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.15s;
+}
+
+.tag-meta-emoji-suggest:hover {
+  background: #ede9fe;
+}
+
+.tag-meta-key-display {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.tag-meta-key-display code {
+  font-size: 0.8rem;
+  padding: 0.375rem 0.5rem;
+  background: #f3f4f6;
+  border-radius: 4px;
+  color: #6b7280;
+  word-break: break-all;
+}
+
+.tag-meta-save-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.tag-meta-status-saved {
+  font-size: 0.85rem;
+  color: #16a34a;
+  font-weight: 500;
+}
+
+.tag-meta-status-error {
+  font-size: 0.85rem;
+  color: #dc2626;
+  font-weight: 500;
+}
+
+/* Trend */
+.tag-meta-trend-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.tag-meta-trend-number {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.tag-meta-trend-unit {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+/* Mini trend chart */
+.mini-trend-container {
+  position: relative;
+  width: 100%;
+  height: 180px;
+}
+
+.mini-trend-container svg {
+  display: block;
+}
+
+.mini-trend-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.85);
+  color: white;
+  padding: 0.375rem 0.625rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  z-index: 10;
+  display: none;
+}
+
+.mini-trend-placeholder {
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+/* Quick links */
+.tag-meta-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-meta-link {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.85rem;
+  color: #374151;
+  transition: all 0.15s;
+}
+
+.tag-meta-link:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+/* Buttons reused from detail page */
+.tag-meta-page .btn-primary {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.tag-meta-page .btn-primary:hover:not(:disabled) {
+  background: #5e35b1;
+}
+
+.tag-meta-page .btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tag-meta-page .btn-secondary {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid #d1d5db;
+  color: #374151;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.tag-meta-page .btn-secondary:hover {
+  background: #f3f4f6;
+}
+
+.tag-meta-page .loading,
+.tag-meta-page .error {
+  text-align: center;
+  padding: 1rem;
+  color: #6b7280;
+}
+
+.tag-meta-page .error {
+  color: #dc2626;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .tag-meta-title-row h1 {
+    color: #f9fafb;
+  }
+
+  .tag-meta-stats {
+    color: #9ca3af;
+  }
+
+  .tag-meta-stat strong {
+    color: #e5e7eb;
+  }
+
+  .tag-meta-icon-placeholder {
+    background: #374151;
+    border-color: #4b5563;
+    color: #6b7280;
+  }
+
+  .tag-meta-section {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .tag-meta-section h2 {
+    color: #e5e7eb;
+  }
+
+  .tag-meta-section-header select {
+    background: #111827;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .tag-meta-field-label {
+    color: #9ca3af;
+  }
+
+  .tag-meta-settings-grid input {
+    background: #111827;
+    border-color: #4b5563;
+    color: #f9fafb;
+  }
+
+  .tag-meta-settings-grid input:read-only {
+    background: #1f2937;
+    color: #9ca3af;
+  }
+
+  .tag-meta-settings-grid input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.2);
+  }
+
+  .tag-meta-emoji-suggest {
+    background: #2e1065;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .tag-meta-emoji-suggest:hover {
+    background: #3b0764;
+  }
+
+  .tag-meta-key-display code {
+    background: #374151;
+    color: #9ca3af;
+  }
+
+  .tag-meta-trend-number {
+    color: #f9fafb;
+  }
+
+  .tag-meta-trend-unit {
+    color: #9ca3af;
+  }
+
+  .mini-trend-placeholder {
+    background: #111827;
+    color: #6b7280;
+  }
+
+  .mini-trend-tooltip {
+    background: rgba(17, 24, 39, 0.95);
+  }
+
+  .tag-meta-link {
+    border-color: #374151;
+    color: #d1d5db;
+  }
+
+  .tag-meta-link:hover {
+    background: #374151;
+    border-color: #4b5563;
+  }
+
+  .tag-meta-page .btn-secondary {
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .tag-meta-page .btn-secondary:hover {
+    background: #374151;
+  }
+}
+
+/* Responsive */
+@media (max-width: 639px) {
+  .tag-meta-page {
+    padding: 1rem;
+  }
+
+  .tag-meta-title-row h1 {
+    font-size: 1.35rem;
+  }
+
+  .tag-meta-stats {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .tag-meta-links {
+    flex-direction: column;
+  }
+
+  .tag-meta-link {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `/tag/:tagKey` page as a hub for investigating and configuring individual tags — shows icon/alias settings (inline editable), occurrence count, EMA trend chart with configurable lookback, and links to related pages
- Add `/metric/:metricName` page as a hub for investigating and configuring individual metrics — shows unit/description for built-in and custom metrics, inline editing for custom metric definitions, EMA trend chart, recent values list, and links to related pages
- Link tag/metric headings on detail pages (`/detail/tag/:id` and `/detail/metric/:id`) to their respective meta pages, so navigating from a specific event to the tag/metric overview is a single click

### New files
- `apps/web/src/pages/TagMeta/` — TagMeta page with extracted TagSettingsSection, TagIconPreview, and reusable MiniTrendChart
- `apps/web/src/pages/MetricMeta/` — MetricMeta page with inline custom metric editor and recent values list

### Modified files
- `apps/web/src/index.tsx` — added routes
- `apps/web/src/pages/EntityDetail/TagDetail.tsx` — heading links to `/tag/:tagKey`
- `apps/web/src/pages/EntityDetail/MetricDetail.tsx` — heading links to `/metric/:metricName`
- `apps/web/src/pages/EntityDetail/style.css` — `.entity-meta-link` styling