### PR TITLE
feat: screentime categories UI — standalone page, category detail, and navigation

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -135,6 +135,7 @@ export {
   batchUpdateResolvedCategory,
   deleteProductivityRecord,
   getAllProductivityForCategorization,
+  getDistinctApps,
   getProductivity,
   getProductivityById,
   insertProductivity,

--- a/apps/backend/src/db/productivity.integration.test.ts
+++ b/apps/backend/src/db/productivity.integration.test.ts
@@ -10,6 +10,7 @@ import {
   batchUpdateResolvedCategory,
   deleteProductivityRecord,
   getAllProductivityForCategorization,
+  getDistinctApps,
   getProductivity,
   insertProductivity,
   restoreProductivityRecord,
@@ -357,6 +358,97 @@ describe('Productivity Integration Tests', () => {
 
       const forCategorization = await getAllProductivityForCategorization(user)
       expect(forCategorization).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // getDistinctApps
+  // ==========================================================================
+
+  describe('getDistinctApps', () => {
+    test('returns distinct apps with categories and stats', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          duration_sec: 300,
+          end_time: new Date('2024-01-15T10:05:00Z'),
+          resolved_category: ['Work', 'Programming'],
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+        makeRecord({
+          activity: 'vscode',
+          duration_sec: 600,
+          end_time: new Date('2024-01-15T10:15:00Z'),
+          resolved_category: ['Work', 'Programming'],
+          start_time: new Date('2024-01-15T10:05:00Z'),
+        }),
+        makeRecord({
+          activity: 'firefox',
+          duration_sec: 120,
+          end_time: new Date('2024-01-15T10:17:00Z'),
+          start_time: new Date('2024-01-15T10:15:00Z'),
+        }),
+      ])
+
+      const apps = await getDistinctApps(user)
+      expect(apps).toHaveLength(2)
+
+      // Sorted by total duration desc, so vscode (900s) first
+      expect(apps[0].activity).toBe('vscode')
+      expect(apps[0].resolved_category).toEqual(['Work', 'Programming'])
+      expect(apps[0].total_duration_sec).toBe(900)
+      expect(apps[0].record_count).toBe(2)
+
+      expect(apps[1].activity).toBe('firefox')
+      expect(apps[1].resolved_category).toBeUndefined()
+      expect(apps[1].total_duration_sec).toBe(120)
+      expect(apps[1].record_count).toBe(1)
+    })
+
+    test('groups separately by resolved_category', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'firefox',
+          duration_sec: 300,
+          end_time: new Date('2024-01-15T10:05:00Z'),
+          resolved_category: ['Work'],
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+        makeRecord({
+          activity: 'firefox',
+          duration_sec: 200,
+          end_time: new Date('2024-01-15T10:08:20Z'),
+          resolved_category: ['Media', 'Social Media'],
+          start_time: new Date('2024-01-15T10:05:00Z'),
+        }),
+      ])
+
+      const apps = await getDistinctApps(user)
+      // Same app with different categories = two entries
+      expect(apps).toHaveLength(2)
+    })
+
+    test('excludes soft-deleted records', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [makeRecord({ activity: 'vscode', duration_sec: 300 })])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      await deleteProductivityRecord(user, records[0].id!)
+
+      const apps = await getDistinctApps(user)
+      expect(apps).toHaveLength(0)
+    })
+
+    test('returns empty array when no records exist', async () => {
+      const user = getTestUser()
+      const apps = await getDistinctApps(user)
+      expect(apps).toHaveLength(0)
     })
   })
 

--- a/apps/backend/src/db/productivity.ts
+++ b/apps/backend/src/db/productivity.ts
@@ -174,6 +174,32 @@ export const batchUpdateResolvedCategory = async (
 }
 
 /**
+ * Get distinct app names with their resolved categories.
+ * Returns unique (activity, resolved_category) pairs, useful for category management UI.
+ */
+export const getDistinctApps = async (
+  user: string,
+): Promise<
+  Array<{ activity: string; resolved_category?: string[]; total_duration_sec: number; record_count: number }>
+> => {
+  const result = await query(
+    user,
+    `SELECT activity, resolved_category, SUM(duration_sec)::int AS total_duration_sec, COUNT(*)::int AS record_count
+     FROM productivity
+     WHERE deleted_at IS NULL
+     GROUP BY activity, resolved_category
+     ORDER BY SUM(duration_sec) DESC`,
+  )
+
+  return result.rows.map((row) => ({
+    activity: row.activity,
+    record_count: row.record_count,
+    resolved_category: row.resolved_category || undefined,
+    total_duration_sec: row.total_duration_sec,
+  }))
+}
+
+/**
  * Get all non-deleted productivity records (for recategorization).
  * Returns only id, activity, and title to minimize memory usage.
  */

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -22,7 +22,12 @@ import {
 } from '@aurboda/api-spec'
 import { type RequestHandler, Router } from 'express'
 
-import { getActivityById, getOverlappingActivities } from '../db/index.ts'
+import {
+  getActivityById,
+  getDistinctApps,
+  getOverlappingActivities,
+  getProductivityById,
+} from '../db/index.ts'
 import {
   addActivity,
   deleteActivity,
@@ -286,6 +291,39 @@ export const createActivitiesRouter = (
     }
 
     res.json({ success: true })
+  })
+
+  // GET /productivity/apps - Get distinct app names with their categories
+  router.get('/productivity/apps', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const apps = await getDistinctApps(user)
+    res.json({ data: apps, success: true })
+  })
+
+  // GET /productivity/:id - Get a single productivity record by ID
+  router.get<{ id: string }>('/productivity/:id', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const record = await getProductivityById(user, req.params.id)
+    if (!record) {
+      return res.status(404).json({ error: 'Productivity record not found', success: false })
+    }
+    res.json({
+      data: {
+        activity: record.activity,
+        category: record.category,
+        device_name: record.device_name,
+        duration_sec: record.duration_sec,
+        end_time: record.end_time.toISOString(),
+        id: record.id,
+        is_mobile: record.is_mobile,
+        productivity: record.productivity,
+        resolved_category: record.resolved_category,
+        source: record.source,
+        start_time: record.start_time.toISOString(),
+        title: record.title,
+      },
+      success: true,
+    })
   })
 
   // DELETE /productivity/:id - Soft-delete a productivity record

--- a/apps/web/src/components/ScreentimeCategoriesSettings/index.tsx
+++ b/apps/web/src/components/ScreentimeCategoriesSettings/index.tsx
@@ -216,7 +216,9 @@ function CategoryRow({
     <div class="sc-row" style={{ paddingLeft: `${indent + 8}px` }}>
       <div class="sc-info">
         {cat.color && <span class="sc-color-dot" style={{ background: cat.color }} />}
-        <span class="sc-name">{displayName}</span>
+        <a href={`/screentime-categories/${cat.id}`} class="sc-name sc-name-link">
+          {displayName}
+        </a>
         {cat.rule_regex && <code class="sc-regex">{cat.rule_regex}</code>}
         {cat.score !== undefined && <span class="sc-score">{productivityScoreLabel(cat.score)}</span>}
       </div>

--- a/apps/web/src/components/ScreentimeCategoriesSettings/style.css
+++ b/apps/web/src/components/ScreentimeCategoriesSettings/style.css
@@ -50,6 +50,15 @@
   font-size: 0.9rem;
 }
 
+.sc-name-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sc-name-link:hover {
+  color: #673ab8;
+}
+
 .sc-regex {
   font-size: 0.8rem;
   color: #6b7280;

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -28,6 +28,8 @@ import { HrZones } from './pages/HrZones/index.jsx'
 import { Login } from './pages/Login/index.jsx'
 import { MetricMeta } from './pages/MetricMeta/index.jsx'
 import { Places } from './pages/Places/index.jsx'
+import { CategoryDetail } from './pages/ScreentimeCategories/CategoryDetail.jsx'
+import { ScreentimeCategories } from './pages/ScreentimeCategories/index.jsx'
 import { Settings } from './pages/Settings/index.jsx'
 import { Signup } from './pages/Signup/index.jsx'
 import { Sleep } from './pages/Sleep/index.jsx'
@@ -70,6 +72,8 @@ export function App() {
             <Route path="/data-sources/lastfm" component={LastFmSource} />
             <Route path="/data-sources/owntracks" component={OwnTracksSource} />
             <Route path="/data-sources/calendars" component={CalendarsSource} />
+            <Route path="/screentime-categories/:id" component={CategoryDetail} />
+            <Route path="/screentime-categories" component={ScreentimeCategories} />
             <Route path="/settings" component={Settings} />
             <Route path="/admin" component={AdminSettings} />
             <Route path="/help" component={DataSources} />

--- a/apps/web/src/pages/DataSources/ActivityWatchAndroidSource.tsx
+++ b/apps/web/src/pages/DataSources/ActivityWatchAndroidSource.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 
-import { ScreentimeCategoriesSettings } from '../../components/ScreentimeCategoriesSettings'
 import { fetchProductivity } from '../../state/api'
 import { auth } from '../../state/auth'
 import './style.css'
@@ -104,7 +103,11 @@ export function ActivityWatchAndroidSource() {
         )}
       </div>
 
-      <ScreentimeCategoriesSettings />
+      <section class="settings-section">
+        <a href="/screentime-categories" class="manage-link">
+          Manage screentime categories
+        </a>
+      </section>
     </div>
   )
 }

--- a/apps/web/src/pages/DataSources/ActivityWatchDesktopSource.tsx
+++ b/apps/web/src/pages/DataSources/ActivityWatchDesktopSource.tsx
@@ -160,6 +160,12 @@ export function ActivityWatchDesktopSource() {
           </div>
         </section>
       </div>
+
+      <section class="settings-section">
+        <a href="/screentime-categories" class="manage-link">
+          Manage screentime categories
+        </a>
+      </section>
     </div>
   )
 }

--- a/apps/web/src/pages/DataSources/RescueTimeSource.tsx
+++ b/apps/web/src/pages/DataSources/RescueTimeSource.tsx
@@ -2,7 +2,6 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 import { useCallback, useState } from 'preact/hooks'
 
-import { ScreentimeCategoriesSettings } from '../../components/ScreentimeCategoriesSettings'
 import {
   fetchProductivity,
   fetchUserSettings,
@@ -139,7 +138,11 @@ export function RescueTimeSource() {
         )}
       </div>
 
-      <ScreentimeCategoriesSettings />
+      <section class="settings-section">
+        <a href="/screentime-categories" class="manage-link">
+          Manage screentime categories
+        </a>
+      </section>
     </div>
   )
 }

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -745,3 +745,14 @@
     font-size: 1.5rem;
   }
 }
+
+/* Manage link (used to link to shared settings pages) */
+.manage-link {
+  color: #673ab8;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.manage-link:hover {
+  text-decoration: underline;
+}

--- a/apps/web/src/pages/EntityDetail/ProductivityDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ProductivityDetail.tsx
@@ -1,6 +1,8 @@
 /**
  * Productivity record detail view.
  */
+import type { ScreentimeCategory } from '@aurboda/api-spec'
+
 import type { ProductivityRecord } from '../../state/api'
 
 import { formatDuration, formatTime } from './format-utils'
@@ -22,49 +24,100 @@ const productivityScoreLabel = (score: number | undefined | null): string => {
   }
 }
 
-export const ProductivityDetail = ({ record }: { record: ProductivityRecord }) => (
-  <div class="entity-info">
-    <div class="entity-meta">
-      <span class="entity-type-badge">screen time</span>
-      {record.is_mobile && <span class="entity-source">Mobile</span>}
-    </div>
+/** Find the category whose name path matches the given path. */
+const findCategoryByPath = (
+  categories: ScreentimeCategory[],
+  path: string[],
+): ScreentimeCategory | undefined =>
+  categories.find((c) => c.name.length === path.length && c.name.every((seg, i) => seg === path[i]))
 
-    <h2>{record.activity}</h2>
-    {record.title && <p class="entity-subtitle">{record.title}</p>}
+/** Get the link target for the app title. */
+const getTitleHref = (record: ProductivityRecord, categories: ScreentimeCategory[]): string => {
+  if (record.resolved_category && record.resolved_category.length > 0) {
+    const cat = findCategoryByPath(categories, record.resolved_category)
+    if (cat) return `/screentime-categories/${cat.id}`
+  }
+  return '/screentime-categories'
+}
 
-    <div class="entity-fields">
-      <div class="field-row">
-        <span class="field-label">Time</span>
-        <span class="field-value">
-          {formatTime(record.start_time)} – {formatTime(record.end_time)}
-        </span>
+export const ProductivityDetail = ({
+  record,
+  categories = [],
+}: {
+  record: ProductivityRecord
+  categories?: ScreentimeCategory[]
+}) => {
+  const titleHref = getTitleHref(record, categories)
+
+  return (
+    <div class="entity-info">
+      <div class="entity-meta">
+        <span class="entity-type-badge">screen time</span>
+        {record.is_mobile && <span class="entity-source">Mobile</span>}
       </div>
-      <div class="field-row">
-        <span class="field-label">Duration</span>
-        <span class="field-value">{formatDuration(record.start_time, record.end_time)}</span>
+
+      <h2>
+        <a href={titleHref} class="entity-title-link">
+          {record.activity}
+        </a>
+      </h2>
+      {record.title && <p class="entity-subtitle">{record.title}</p>}
+
+      <div class="entity-fields">
+        <div class="field-row">
+          <span class="field-label">Time</span>
+          <span class="field-value">
+            {formatTime(record.start_time)} – {formatTime(record.end_time)}
+          </span>
+        </div>
+        <div class="field-row">
+          <span class="field-label">Duration</span>
+          <span class="field-value">{formatDuration(record.start_time, record.end_time)}</span>
+        </div>
+        {record.resolved_category && record.resolved_category.length > 0 && (
+          <div class="field-row">
+            <span class="field-label">Category</span>
+            <span class="field-value">
+              {record.resolved_category.map((segment, i) => {
+                const path = record.resolved_category!.slice(0, i + 1)
+                const cat = findCategoryByPath(categories, path)
+                return (
+                  <span key={i}>
+                    {i > 0 && ' > '}
+                    {cat ? (
+                      <a href={`/screentime-categories/${cat.id}`} class="category-link">
+                        {segment}
+                      </a>
+                    ) : (
+                      segment
+                    )}
+                  </span>
+                )
+              })}
+            </span>
+          </div>
+        )}
+        {record.category && !(record.resolved_category && record.resolved_category.length > 0) && (
+          <div class="field-row">
+            <span class="field-label">Category</span>
+            <span class="field-value">
+              <a href="/screentime-categories" class="category-link">
+                {record.category}
+              </a>
+            </span>
+          </div>
+        )}
+        <div class="field-row">
+          <span class="field-label">Productivity</span>
+          <span class="field-value">{productivityScoreLabel(record.productivity)}</span>
+        </div>
+        {record.source_ids && record.source_ids.length > 1 && (
+          <div class="field-row">
+            <span class="field-label">Merged spans</span>
+            <span class="field-value">{record.source_ids.length}</span>
+          </div>
+        )}
       </div>
-      {record.resolved_category && record.resolved_category.length > 0 && (
-        <div class="field-row">
-          <span class="field-label">Category</span>
-          <span class="field-value">{record.resolved_category.join(' > ')}</span>
-        </div>
-      )}
-      {record.category && !(record.resolved_category && record.resolved_category.length > 0) && (
-        <div class="field-row">
-          <span class="field-label">Category</span>
-          <span class="field-value">{record.category}</span>
-        </div>
-      )}
-      <div class="field-row">
-        <span class="field-label">Productivity</span>
-        <span class="field-value">{productivityScoreLabel(record.productivity)}</span>
-      </div>
-      {record.source_ids && record.source_ids.length > 1 && (
-        <div class="field-row">
-          <span class="field-label">Merged spans</span>
-          <span class="field-value">{record.source_ids.length}</span>
-        </div>
-      )}
     </div>
-  </div>
-)
+  )
+}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -11,9 +11,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 
-import type { Activity, ExerciseTypeName, ProductivityRecord, SourceRecord } from '../../state/api'
+import type { Activity, ExerciseTypeName, SourceRecord } from '../../state/api'
 
-import { fetchActivityById, fetchProductivity, fetchTagById, updateActivity } from '../../state/api'
+import {
+  fetchActivityById,
+  fetchProductivityById,
+  fetchScreentimeCategories,
+  fetchTagById,
+  updateActivity,
+} from '../../state/api'
 import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { EntityActions, type EntityType } from './EntityActions'
@@ -328,14 +334,15 @@ const ProductivityContent = ({ entityId }: { entityId: string }) => {
     isLoading,
     isError,
   } = useQuery({
-    queryFn: async (): Promise<ProductivityRecord | null> => {
-      const dayEnd = new Date()
-      dayEnd.setHours(23, 59, 59, 999)
-      const records = await fetchProductivity(new Date(Date.now() - 7 * 86400000), dayEnd)
-      return records.find((r) => r.id === entityId || r.source_ids?.includes(entityId)) ?? null
-    },
+    queryFn: () => fetchProductivityById(entityId),
     queryKey: ['entity-detail', 'productivity', entityId],
     staleTime: 60_000,
+  })
+
+  const { data: categories = [] } = useQuery({
+    queryFn: fetchScreentimeCategories,
+    queryKey: ['screentime-categories'],
+    staleTime: 5 * 60 * 1000,
   })
 
   const invalidate = useCallback(
@@ -368,7 +375,7 @@ const ProductivityContent = ({ entityId }: { entityId: string }) => {
         onSave={() => {}}
         isSaving={false}
       />
-      <ProductivityDetail record={record} />
+      <ProductivityDetail record={record} categories={categories} />
       <NotesSection entityType="productivity" entityId={entityId} allEntityIds={allEntityIds} />
     </>
   )

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -84,6 +84,24 @@
   border-bottom-color: #673ab8;
 }
 
+.entity-title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.entity-title-link:hover {
+  color: #673ab8;
+}
+
+.category-link {
+  color: #673ab8;
+  text-decoration: none;
+}
+
+.category-link:hover {
+  text-decoration: underline;
+}
+
 .entity-subtitle {
   margin: -0.75rem 0 1rem;
   font-size: 0.9rem;

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -1,0 +1,270 @@
+/**
+ * Category detail/info page.
+ * Shows category details, matched apps, child categories, and links back to management.
+ */
+import type { ScreentimeCategory } from '@aurboda/api-spec'
+
+import { useQuery } from '@tanstack/react-query'
+import { useRoute } from 'preact-iso'
+
+import {
+  type DistinctApp,
+  fetchDistinctApps,
+  fetchScreentimeCategories,
+  fetchScreentimeCategoryById,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+import './style.css'
+
+const productivityScoreLabel = (score: number | undefined): string => {
+  if (score === undefined) return 'Inherited from parent'
+  const labels: Record<number, string> = {
+    [-2]: 'Very Distracting',
+    [-1]: 'Distracting',
+    0: 'Neutral',
+    1: 'Productive',
+    2: 'Very Productive',
+  }
+  return labels[score] ?? `${score}`
+}
+
+const formatDuration = (totalSec: number): string => {
+  const hours = Math.floor(totalSec / 3600)
+  const minutes = Math.floor((totalSec % 3600) / 60)
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+/** Find child categories of the given category. */
+const getChildren = (categories: ScreentimeCategory[], parent: ScreentimeCategory): ScreentimeCategory[] =>
+  categories.filter(
+    (c) =>
+      c.name.length === parent.name.length + 1 &&
+      c.name.slice(0, parent.name.length).join(' > ') === parent.name.join(' > '),
+  )
+
+/** Check if a resolved_category path matches or is a child of this category. */
+const matchesCategory = (resolved: string[] | undefined, categoryName: string[]): boolean => {
+  if (!resolved || resolved.length < categoryName.length) return false
+  return categoryName.every((seg, i) => resolved[i] === seg)
+}
+
+/** Get apps that match this specific category (not child categories). */
+const getMatchedApps = (apps: DistinctApp[], categoryName: string[]): DistinctApp[] =>
+  apps.filter(
+    (app) =>
+      app.resolved_category &&
+      app.resolved_category.length === categoryName.length &&
+      matchesCategory(app.resolved_category, categoryName),
+  )
+
+/** Get apps that match this category or any of its children. */
+const getAllMatchedApps = (apps: DistinctApp[], categoryName: string[]): DistinctApp[] =>
+  apps.filter((app) => matchesCategory(app.resolved_category, categoryName))
+
+/** Get uncategorized apps (no resolved_category). */
+const getUncategorizedApps = (apps: DistinctApp[]): DistinctApp[] =>
+  apps.filter((app) => !app.resolved_category)
+
+function CategoryBreadcrumb({
+  categories,
+  category,
+}: {
+  categories: ScreentimeCategory[]
+  category: ScreentimeCategory
+}) {
+  const segments = category.name
+
+  return (
+    <nav class="category-breadcrumb">
+      <a href="/screentime-categories">Categories</a>
+      {segments.map((segment, i) => {
+        const path = segments.slice(0, i + 1)
+        const parentCat = categories.find((c) => c.name.join(' > ') === path.join(' > '))
+        const isLast = i === segments.length - 1
+
+        return (
+          <span key={i}>
+            <span class="breadcrumb-separator">&gt;</span>
+            {isLast ? (
+              <span class="breadcrumb-current">{segment}</span>
+            ) : parentCat ? (
+              <a href={`/screentime-categories/${parentCat.id}`}>{segment}</a>
+            ) : (
+              <span>{segment}</span>
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}
+
+function AppList({ apps, title, emptyText }: { apps: DistinctApp[]; title: string; emptyText: string }) {
+  if (apps.length === 0) {
+    return (
+      <div class="category-section">
+        <h3>{title}</h3>
+        <p class="sc-empty">{emptyText}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="category-section">
+      <h3>
+        {title} <span class="count-badge">{apps.length}</span>
+      </h3>
+      <div class="app-list">
+        {apps.map((app) => (
+          <div key={app.activity} class="app-row">
+            <span class="app-name">{app.activity}</span>
+            <span class="app-stats">
+              {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function CategoryDetail() {
+  const { params } = useRoute()
+  const categoryId = params.id
+  const isLoggedIn = auth.value.token
+
+  const { data: category, isLoading: categoryLoading } = useQuery({
+    enabled: !!isLoggedIn && !!categoryId,
+    queryFn: () => fetchScreentimeCategoryById(categoryId),
+    queryKey: ['screentime-category', categoryId],
+  })
+
+  const { data: allCategories = [] } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchScreentimeCategories,
+    queryKey: ['screentime-categories'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { data: distinctApps = [] } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchDistinctApps,
+    queryKey: ['productivity-apps'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (!isLoggedIn) {
+    return (
+      <div class="data-sources-page">
+        <p>Please log in to view category details.</p>
+      </div>
+    )
+  }
+
+  if (categoryLoading) {
+    return (
+      <div class="data-sources-page">
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+
+  if (!category) {
+    return (
+      <div class="data-sources-page">
+        <p class="error">Category not found.</p>
+        <a href="/screentime-categories">Back to categories</a>
+      </div>
+    )
+  }
+
+  const children = getChildren(allCategories, category)
+  const matchedApps = getMatchedApps(distinctApps, category.name)
+  const allMatched = getAllMatchedApps(distinctApps, category.name)
+  const uncategorized = getUncategorizedApps(distinctApps)
+  const totalTime = allMatched.reduce((sum, a) => sum + a.total_duration_sec, 0)
+
+  return (
+    <div class="data-sources-page">
+      <CategoryBreadcrumb categories={allCategories} category={category} />
+
+      <div class="category-header">
+        {category.color && <span class="category-color-swatch" style={{ background: category.color }} />}
+        <h1>{category.name.join(' > ')}</h1>
+      </div>
+
+      {/* Category details */}
+      <div class="category-details">
+        <div class="entity-fields">
+          {category.rule_regex && (
+            <div class="field-row">
+              <span class="field-label">Matching rule</span>
+              <span class="field-value">
+                <code>{category.rule_regex}</code>
+              </span>
+            </div>
+          )}
+          {!category.rule_regex && category.rule_type === 'none' && (
+            <div class="field-row">
+              <span class="field-label">Matching rule</span>
+              <span class="field-value muted">Grouping only (no direct matching)</span>
+            </div>
+          )}
+          <div class="field-row">
+            <span class="field-label">Productivity</span>
+            <span class="field-value">{productivityScoreLabel(category.score)}</span>
+          </div>
+          <div class="field-row">
+            <span class="field-label">Case insensitive</span>
+            <span class="field-value">{category.ignore_case ? 'Yes' : 'No'}</span>
+          </div>
+          <div class="field-row">
+            <span class="field-label">Total tracked time</span>
+            <span class="field-value">{formatDuration(totalTime)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Child categories */}
+      {children.length > 0 && (
+        <div class="category-section">
+          <h3>
+            Sub-categories <span class="count-badge">{children.length}</span>
+          </h3>
+          <div class="children-list">
+            {children.map((child) => {
+              const childTime = getAllMatchedApps(distinctApps, child.name).reduce(
+                (sum, a) => sum + a.total_duration_sec,
+                0,
+              )
+              return (
+                <a key={child.id} href={`/screentime-categories/${child.id}`} class="child-category-card">
+                  {child.color && <span class="sc-color-dot" style={{ background: child.color }} />}
+                  <span class="child-name">{child.name[child.name.length - 1]}</span>
+                  {childTime > 0 && <span class="child-stats">{formatDuration(childTime)}</span>}
+                </a>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Matched apps */}
+      <AppList apps={matchedApps} title="Matched apps" emptyText="No apps match this category directly." />
+
+      {/* Uncategorized apps (helpful for assigning) */}
+      <AppList
+        apps={uncategorized.slice(0, 20)}
+        title={`Uncategorized apps${uncategorized.length > 20 ? ` (showing 20 of ${uncategorized.length})` : ''}`}
+        emptyText="All apps are categorized!"
+      />
+
+      <div class="category-footer">
+        <a href="/screentime-categories" class="manage-link">
+          Manage all categories
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/ScreentimeCategories/index.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * Standalone screentime categories page.
+ * Extracted from data source settings so categories are a first-class navigable concept.
+ */
+import { ScreentimeCategoriesSettings } from '../../components/ScreentimeCategoriesSettings'
+import { auth } from '../../state/auth'
+
+export function ScreentimeCategories() {
+  const isLoggedIn = auth.value.token
+  if (!isLoggedIn) {
+    return (
+      <div class="data-sources-page">
+        <p>Please log in to manage screentime categories.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="data-sources-page">
+      <div class="page-header">
+        <h1>Screentime Categories</h1>
+        <p class="page-subtitle">
+          Organize your screen time data by assigning apps and websites to categories. Categories are shared
+          across all screen time sources (RescueTime, ActivityWatch Desktop, ActivityWatch Android).
+        </p>
+      </div>
+
+      <ScreentimeCategoriesSettings />
+    </div>
+  )
+}

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -1,0 +1,184 @@
+/* ============================================================================
+ * Category Detail page styles
+ * ============================================================================ */
+
+/* Breadcrumb navigation */
+.category-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.category-breadcrumb a {
+  color: #673ab8;
+  text-decoration: none;
+}
+
+.category-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-separator {
+  color: #9ca3af;
+  margin: 0 0.25rem;
+}
+
+.breadcrumb-current {
+  color: #374151;
+  font-weight: 500;
+}
+
+/* Category header */
+.category-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.category-header h1 {
+  margin: 0;
+}
+
+.category-color-swatch {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+/* Category details */
+.category-details {
+  margin-bottom: 2rem;
+}
+
+.category-details code {
+  background: #f3f4f6;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.category-details .muted {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+/* Sections */
+.category-section {
+  margin-bottom: 2rem;
+}
+
+.category-section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 0.75rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+  background: #f3f4f6;
+  border-radius: 99px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+/* Children list */
+.children-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.child-category-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  text-decoration: none;
+  color: #374151;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+
+.child-category-card:hover {
+  border-color: #673ab8;
+  box-shadow: 0 1px 3px rgba(103, 58, 184, 0.12);
+}
+
+.child-name {
+  font-weight: 500;
+}
+
+.child-stats {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+/* App list */
+.app-list {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.app-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.app-row:last-child {
+  border-bottom: none;
+}
+
+.app-name {
+  font-weight: 500;
+  color: #374151;
+}
+
+.app-stats {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  white-space: nowrap;
+}
+
+/* Footer */
+.category-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.manage-link {
+  color: #673ab8;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.manage-link:hover {
+  text-decoration: underline;
+}

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -278,6 +278,42 @@ export const fetchProductivity = async (start: Date, end: Date): Promise<Product
   }))
 }
 
+// Fetch a single productivity record by ID
+export const fetchProductivityById = async (id: string): Promise<ProductivityRecord | null> => {
+  const { token } = auth.value
+  try {
+    const response = await axios.get<{ data: ApiProductivityRecord; success: boolean }>(
+      `${API_URL}/productivity/${id}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    const record = response.data.data
+    return {
+      ...record,
+      end_time: new Date(record.end_time),
+      start_time: new Date(record.start_time),
+    }
+  } catch {
+    return null
+  }
+}
+
+// Fetch distinct app names with their categories and usage stats
+export interface DistinctApp {
+  activity: string
+  resolved_category?: string[]
+  total_duration_sec: number
+  record_count: number
+}
+
+export const fetchDistinctApps = async (): Promise<DistinctApp[]> => {
+  const { token } = auth.value
+  const response = await axios.get<{ data: DistinctApp[]; success: boolean }>(
+    `${API_URL}/productivity/apps`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data ?? []
+}
+
 // Fetch location/place data for the specified date range
 export const fetchPlaces = async (start: Date, end: Date): Promise<Place[]> => {
   const { token } = auth.value
@@ -1197,6 +1233,18 @@ export const fetchScreentimeCategories = async (): Promise<ScreentimeCategory[]>
     headers: { Authorization: `Bearer ${token}` },
   })
   return response.data.data ?? []
+}
+
+export const fetchScreentimeCategoryById = async (id: string): Promise<ScreentimeCategory | null> => {
+  const { token } = auth.value
+  try {
+    const response = await axios.get<ScreentimeCategoryResponse>(`${API_URL}/screentime-categories/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    return response.data.data ?? null
+  } catch {
+    return null
+  }
 }
 
 export const createScreentimeCategory = async (


### PR DESCRIPTION
## Summary

- **Standalone screentime categories page** at `/screentime-categories` — extracted from data source settings so categories are a first-class navigable concept
- **Category detail page** at `/screentime-categories/:id` — shows category info (rule, score, color), matched apps with usage stats, sub-categories, and uncategorized apps
- **Clickable navigation** from productivity detail pages — app title links to its category info page (or categories page if uncategorized), category breadcrumb segments are individually clickable
- **Backend improvements** — `GET /productivity/:id` for direct single-record fetch (replaces 7-day client-side filter hack), `GET /productivity/apps` for distinct apps with category/usage stats

## Changes

### Backend
- `GET /productivity/:id` — new endpoint using existing `getProductivityById` DB function
- `GET /productivity/apps` — new endpoint with `getDistinctApps` DB function (aggregates by activity + resolved_category)
- Integration tests for `getDistinctApps`

### Frontend
- New `/screentime-categories` page wrapping `ScreentimeCategoriesSettings`
- New `/screentime-categories/:id` category detail page with breadcrumb nav, matched apps, sub-categories
- `ProductivityDetail` — title links to category info, category path has clickable breadcrumb segments  
- `ProductivityContent` — uses `fetchProductivityById` instead of 7-day range fetch + client filter
- Category row names in `ScreentimeCategoriesSettings` now link to their detail pages
- Data source pages (RescueTime, AW Android, AW Desktop) replaced embedded settings with link to `/screentime-categories`

## Phase 1 of Screentime Categories Usability

This is Phase 1 focused on navigation and discovery. Future phases will add:
- Phase 2: Bottom-up categorization UX (add/remove apps from category detail page, auto-generate regex)
- Phase 3: Trend charts for time-in-category, icon support for categories