### PR TITLE
feat: screentime categories Phase 2 — bottom-up categorization and icon support

### DIFF
--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -1,20 +1,31 @@
 /**
  * Category detail/info page.
- * Shows category details, matched apps, child categories, and links back to management.
+ * Shows category details, icon editing, matched apps (with remove),
+ * child categories, and uncategorized apps (with add-to-category).
  */
 import type { ScreentimeCategory } from '@aurboda/api-spec'
 
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
+import { useCallback, useState } from 'preact/hooks'
 
 import {
   type DistinctApp,
   fetchDistinctApps,
   fetchScreentimeCategories,
   fetchScreentimeCategoryById,
+  fetchUserSettings,
+  recategorizeScreentime,
+  updateScreentimeCategory,
+  updateUserSettings,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { isEmoji, isUrl, suggestEmoji } from '../../utils/emojiLookup'
 import './style.css'
+
+// ============================================================================
+// Helpers
+// ============================================================================
 
 const productivityScoreLabel = (score: number | undefined): string => {
   if (score === undefined) return 'Inherited from parent'
@@ -34,6 +45,27 @@ const formatDuration = (totalSec: number): string => {
   if (hours > 0) return `${hours}h ${minutes}m`
   return `${minutes}m`
 }
+
+/** Build the item_icons key for a category. */
+const categoryIconKey = (name: string[]): string => `category:${name.join(' > ')}`
+
+/**
+ * Parse a pipe-separated regex into individual terms.
+ * E.g. "GitHub|Stack Overflow|vscode" -> ["GitHub", "Stack Overflow", "vscode"]
+ */
+const parseRegexTerms = (regex: string): string[] =>
+  regex
+    .split('|')
+    .map((t) => t.trim())
+    .filter(Boolean)
+
+/**
+ * Build a pipe-separated regex from terms.
+ * Escapes regex special chars in each term so they match literally.
+ */
+const escapeRegexChars = (s: string): string => s.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const buildRegex = (terms: string[]): string => terms.map(escapeRegexChars).join('|')
 
 /** Find child categories of the given category. */
 const getChildren = (categories: ScreentimeCategory[], parent: ScreentimeCategory): ScreentimeCategory[] =>
@@ -65,6 +97,10 @@ const getAllMatchedApps = (apps: DistinctApp[], categoryName: string[]): Distinc
 /** Get uncategorized apps (no resolved_category). */
 const getUncategorizedApps = (apps: DistinctApp[]): DistinctApp[] =>
   apps.filter((app) => !app.resolved_category)
+
+// ============================================================================
+// Sub-components
+// ============================================================================
 
 function CategoryBreadcrumb({
   categories,
@@ -100,12 +136,134 @@ function CategoryBreadcrumb({
   )
 }
 
-function AppList({ apps, title, emptyText }: { apps: DistinctApp[]; title: string; emptyText: string }) {
+function IconPreview({ icon }: { icon: string }) {
+  if (!icon) return null
+  if (isEmoji(icon)) return <span class="category-icon-preview">{icon}</span>
+  if (isUrl(icon)) {
+    return (
+      <span class="category-icon-preview">
+        <img src={icon} alt="icon" width="24" height="24" />
+      </span>
+    )
+  }
+  return null
+}
+
+function CategoryIconEditor({
+  categoryName,
+  currentIcon,
+  onSaved,
+}: {
+  categoryName: string[]
+  currentIcon: string
+  onSaved: () => void
+}) {
+  const [iconValue, setIconValue] = useState<string | undefined>(undefined)
+  const shownIcon = iconValue ?? currentIcon
+
+  // Suggest emoji based on the leaf category name
+  const leafName = categoryName[categoryName.length - 1] ?? ''
+  const suggested = !shownIcon ? suggestEmoji(leafName) : undefined
+
+  const saveMutation = useMutation({
+    mutationFn: async (icon: string) => {
+      // Read current settings, merge our icon, save back
+      const settings = await fetchUserSettings()
+      const currentIcons = settings.item_icons ?? {}
+      const key = categoryIconKey(categoryName)
+      const newIcons = { ...currentIcons }
+      if (icon) {
+        newIcons[key] = icon
+      } else {
+        delete newIcons[key]
+      }
+      await updateUserSettings({ item_icons: newIcons })
+    },
+    onSuccess: () => {
+      onSaved()
+    },
+  })
+
+  const handleBlur = () => {
+    if (iconValue === undefined) return
+    if (iconValue === currentIcon) return
+    saveMutation.mutate(iconValue)
+  }
+
+  return (
+    <div class="field-row">
+      <span class="field-label">Icon</span>
+      <span class="field-value">
+        <div class="category-icon-edit-row">
+          <input
+            type="text"
+            value={shownIcon}
+            onInput={(e) => setIconValue((e.target as HTMLInputElement).value)}
+            onBlur={handleBlur}
+            placeholder="Emoji or image URL..."
+            class="category-icon-input"
+          />
+          <IconPreview icon={shownIcon} />
+          {suggested && !shownIcon && (
+            <button
+              type="button"
+              class="category-icon-suggestion"
+              onClick={() => {
+                setIconValue(suggested)
+                saveMutation.mutate(suggested)
+              }}
+              title={`Suggested: ${suggested}`}
+            >
+              {suggested}?
+            </button>
+          )}
+          {saveMutation.isPending && <span class="category-save-status">Saving...</span>}
+        </div>
+      </span>
+    </div>
+  )
+}
+
+function MatchedAppList({
+  apps,
+  category,
+  onAppRemoved,
+}: {
+  apps: DistinctApp[]
+  category: ScreentimeCategory
+  onAppRemoved: () => void
+}) {
+  const queryClient = useQueryClient()
+  const [removingApp, setRemovingApp] = useState<string | null>(null)
+
+  const removeMutation = useMutation({
+    mutationFn: async (appName: string) => {
+      setRemovingApp(appName)
+      const currentTerms = parseRegexTerms(category.rule_regex ?? '')
+      // Remove terms that match this app name (case-insensitive comparison)
+      const newTerms = currentTerms.filter((t) => t.toLowerCase() !== appName.toLowerCase())
+      const newRegex = newTerms.length > 0 ? buildRegex(newTerms) : undefined
+      await updateScreentimeCategory(category.id, {
+        rule_regex: newRegex,
+        rule_type: newRegex ? 'regex' : 'none',
+      })
+      // Recategorize in background
+      void recategorizeScreentime()
+    },
+    onSuccess: () => {
+      setRemovingApp(null)
+      onAppRemoved()
+      queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
+      queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
+    },
+    onError: () => setRemovingApp(null),
+  })
+
   if (apps.length === 0) {
     return (
       <div class="category-section">
-        <h3>{title}</h3>
-        <p class="sc-empty">{emptyText}</p>
+        <h3>Matched apps</h3>
+        <p class="sc-empty">No apps match this category directly.</p>
       </div>
     )
   }
@@ -113,15 +271,28 @@ function AppList({ apps, title, emptyText }: { apps: DistinctApp[]; title: strin
   return (
     <div class="category-section">
       <h3>
-        {title} <span class="count-badge">{apps.length}</span>
+        Matched apps <span class="count-badge">{apps.length}</span>
       </h3>
       <div class="app-list">
         {apps.map((app) => (
           <div key={app.activity} class="app-row">
             <span class="app-name">{app.activity}</span>
-            <span class="app-stats">
-              {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
-            </span>
+            <div class="app-row-right">
+              <span class="app-stats">
+                {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
+              </span>
+              {category.rule_regex && (
+                <button
+                  type="button"
+                  class="app-action-btn danger"
+                  onClick={() => removeMutation.mutate(app.activity)}
+                  disabled={removingApp === app.activity}
+                  title={`Remove "${app.activity}" from this category`}
+                >
+                  {removingApp === app.activity ? '...' : 'Remove'}
+                </button>
+              )}
+            </div>
           </div>
         ))}
       </div>
@@ -129,10 +300,183 @@ function AppList({ apps, title, emptyText }: { apps: DistinctApp[]; title: strin
   )
 }
 
+function UncategorizedAppList({
+  apps,
+  category,
+  total,
+  onAppAdded,
+}: {
+  apps: DistinctApp[]
+  category: ScreentimeCategory
+  total: number
+  onAppAdded: () => void
+}) {
+  const queryClient = useQueryClient()
+  const [addingApp, setAddingApp] = useState<string | null>(null)
+
+  const addMutation = useMutation({
+    mutationFn: async (appName: string) => {
+      setAddingApp(appName)
+      const currentTerms = parseRegexTerms(category.rule_regex ?? '')
+      const newTerms = [...currentTerms, appName]
+      const newRegex = buildRegex(newTerms)
+      await updateScreentimeCategory(category.id, {
+        rule_regex: newRegex,
+        rule_type: 'regex',
+      })
+      // Recategorize in background
+      void recategorizeScreentime()
+    },
+    onSuccess: () => {
+      setAddingApp(null)
+      onAppAdded()
+      queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
+      queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
+    },
+    onError: () => setAddingApp(null),
+  })
+
+  const title =
+    total > apps.length ? `Uncategorized apps (showing ${apps.length} of ${total})` : 'Uncategorized apps'
+
+  if (total === 0) {
+    return (
+      <div class="category-section">
+        <h3>Uncategorized apps</h3>
+        <p class="sc-empty">All apps are categorized!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="category-section">
+      <h3>
+        {title} <span class="count-badge">{total}</span>
+      </h3>
+      <div class="app-list">
+        {apps.map((app) => (
+          <div key={app.activity} class="app-row">
+            <span class="app-name">{app.activity}</span>
+            <div class="app-row-right">
+              <span class="app-stats">
+                {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
+              </span>
+              <button
+                type="button"
+                class="app-action-btn add"
+                onClick={() => addMutation.mutate(app.activity)}
+                disabled={addingApp === app.activity}
+                title={`Add "${app.activity}" to ${category.name.join(' > ')}`}
+              >
+                {addingApp === app.activity ? '...' : 'Add here'}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Category info fields
+// ============================================================================
+
+function CategoryFields({
+  category,
+  currentIcon,
+  totalTime,
+  onIconSaved,
+}: {
+  category: ScreentimeCategory
+  currentIcon: string
+  totalTime: number
+  onIconSaved: () => void
+}) {
+  return (
+    <div class="category-details">
+      <div class="entity-fields">
+        <CategoryIconEditor categoryName={category.name} currentIcon={currentIcon} onSaved={onIconSaved} />
+        {category.rule_regex && (
+          <div class="field-row">
+            <span class="field-label">Matching rule</span>
+            <span class="field-value">
+              <code>{category.rule_regex}</code>
+            </span>
+          </div>
+        )}
+        {!category.rule_regex && category.rule_type === 'none' && (
+          <div class="field-row">
+            <span class="field-label">Matching rule</span>
+            <span class="field-value muted">Grouping only (no direct matching)</span>
+          </div>
+        )}
+        <div class="field-row">
+          <span class="field-label">Productivity</span>
+          <span class="field-value">{productivityScoreLabel(category.score)}</span>
+        </div>
+        <div class="field-row">
+          <span class="field-label">Total tracked time</span>
+          <span class="field-value">{formatDuration(totalTime)}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Children list
+// ============================================================================
+
+function ChildCategoriesList({
+  children,
+  distinctApps,
+  icons,
+}: {
+  children: ScreentimeCategory[]
+  distinctApps: DistinctApp[]
+  icons: Record<string, string>
+}) {
+  if (children.length === 0) return null
+
+  return (
+    <div class="category-section">
+      <h3>
+        Sub-categories <span class="count-badge">{children.length}</span>
+      </h3>
+      <div class="children-list">
+        {children.map((child) => {
+          const childIcon = icons[categoryIconKey(child.name)] ?? ''
+          const childTime = getAllMatchedApps(distinctApps, child.name).reduce(
+            (sum, a) => sum + a.total_duration_sec,
+            0,
+          )
+          return (
+            <a key={child.id} href={`/screentime-categories/${child.id}`} class="child-category-card">
+              {childIcon && isEmoji(childIcon) ? (
+                <span class="child-icon">{childIcon}</span>
+              ) : (
+                child.color && <span class="sc-color-dot" style={{ background: child.color }} />
+              )}
+              <span class="child-name">{child.name[child.name.length - 1]}</span>
+              {childTime > 0 && <span class="child-stats">{formatDuration(childTime)}</span>}
+            </a>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
 export function CategoryDetail() {
   const { params } = useRoute()
   const categoryId = params.id
   const isLoggedIn = auth.value.token
+  const queryClient = useQueryClient()
 
   const { data: category, isLoading: categoryLoading } = useQuery({
     enabled: !!isLoggedIn && !!categoryId,
@@ -153,6 +497,23 @@ export function CategoryDetail() {
     queryKey: ['productivity-apps'],
     staleTime: 5 * 60 * 1000,
   })
+
+  const { data: userSettings } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const invalidateAll = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['screentime-category', categoryId] })
+    queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
+    queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
+  }, [queryClient, categoryId])
+
+  const invalidateIcons = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+  }, [queryClient])
 
   if (!isLoggedIn) {
     return (
@@ -184,80 +545,34 @@ export function CategoryDetail() {
   const allMatched = getAllMatchedApps(distinctApps, category.name)
   const uncategorized = getUncategorizedApps(distinctApps)
   const totalTime = allMatched.reduce((sum, a) => sum + a.total_duration_sec, 0)
+  const icons = userSettings?.item_icons ?? {}
+  const currentIcon = icons[categoryIconKey(category.name)] ?? ''
 
   return (
     <div class="data-sources-page">
       <CategoryBreadcrumb categories={allCategories} category={category} />
 
       <div class="category-header">
-        {category.color && <span class="category-color-swatch" style={{ background: category.color }} />}
-        <h1>{category.name.join(' > ')}</h1>
+        {currentIcon && isEmoji(currentIcon) && <span class="category-header-icon">{currentIcon}</span>}
+        {category.color && !currentIcon && (
+          <span class="category-color-swatch" style={{ background: category.color }} />
+        )}
+        <h1>{category.name[category.name.length - 1]}</h1>
       </div>
 
-      {/* Category details */}
-      <div class="category-details">
-        <div class="entity-fields">
-          {category.rule_regex && (
-            <div class="field-row">
-              <span class="field-label">Matching rule</span>
-              <span class="field-value">
-                <code>{category.rule_regex}</code>
-              </span>
-            </div>
-          )}
-          {!category.rule_regex && category.rule_type === 'none' && (
-            <div class="field-row">
-              <span class="field-label">Matching rule</span>
-              <span class="field-value muted">Grouping only (no direct matching)</span>
-            </div>
-          )}
-          <div class="field-row">
-            <span class="field-label">Productivity</span>
-            <span class="field-value">{productivityScoreLabel(category.score)}</span>
-          </div>
-          <div class="field-row">
-            <span class="field-label">Case insensitive</span>
-            <span class="field-value">{category.ignore_case ? 'Yes' : 'No'}</span>
-          </div>
-          <div class="field-row">
-            <span class="field-label">Total tracked time</span>
-            <span class="field-value">{formatDuration(totalTime)}</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Child categories */}
-      {children.length > 0 && (
-        <div class="category-section">
-          <h3>
-            Sub-categories <span class="count-badge">{children.length}</span>
-          </h3>
-          <div class="children-list">
-            {children.map((child) => {
-              const childTime = getAllMatchedApps(distinctApps, child.name).reduce(
-                (sum, a) => sum + a.total_duration_sec,
-                0,
-              )
-              return (
-                <a key={child.id} href={`/screentime-categories/${child.id}`} class="child-category-card">
-                  {child.color && <span class="sc-color-dot" style={{ background: child.color }} />}
-                  <span class="child-name">{child.name[child.name.length - 1]}</span>
-                  {childTime > 0 && <span class="child-stats">{formatDuration(childTime)}</span>}
-                </a>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* Matched apps */}
-      <AppList apps={matchedApps} title="Matched apps" emptyText="No apps match this category directly." />
-
-      {/* Uncategorized apps (helpful for assigning) */}
-      <AppList
-        apps={uncategorized.slice(0, 20)}
-        title={`Uncategorized apps${uncategorized.length > 20 ? ` (showing 20 of ${uncategorized.length})` : ''}`}
-        emptyText="All apps are categorized!"
+      <CategoryFields
+        category={category}
+        currentIcon={currentIcon}
+        totalTime={totalTime}
+        onIconSaved={invalidateIcons}
+      />
+      <ChildCategoriesList children={children} distinctApps={distinctApps} icons={icons} />
+      <MatchedAppList apps={matchedApps} category={category} onAppRemoved={invalidateAll} />
+      <UncategorizedAppList
+        apps={uncategorized.slice(0, 30)}
+        category={category}
+        total={uncategorized.length}
+        onAppAdded={invalidateAll}
       />
 
       <div class="category-footer">

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -44,6 +44,11 @@
   margin: 0;
 }
 
+.category-header-icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
 .category-color-swatch {
   display: inline-block;
   width: 20px;
@@ -68,6 +73,60 @@
 .category-details .muted {
   color: #9ca3af;
   font-style: italic;
+}
+
+/* Icon editing */
+.category-icon-edit-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.category-icon-input {
+  width: 160px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+}
+
+.category-icon-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.category-icon-preview {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.category-icon-preview img {
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.category-icon-suggestion {
+  background: none;
+  border: 1px dashed #d1d5db;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #6b7280;
+  transition: border-color 0.15s;
+}
+
+.category-icon-suggestion:hover {
+  border-color: #673ab8;
+  color: #673ab8;
+}
+
+.category-save-status {
+  font-size: 0.8rem;
+  color: #9ca3af;
 }
 
 /* Sections */
@@ -126,6 +185,11 @@
   box-shadow: 0 1px 3px rgba(103, 58, 184, 0.12);
 }
 
+.child-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
 .child-name {
   font-weight: 500;
 }
@@ -158,12 +222,60 @@
 .app-name {
   font-weight: 500;
   color: #374151;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-row-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
 }
 
 .app-stats {
   font-size: 0.8rem;
   color: #9ca3af;
   white-space: nowrap;
+}
+
+/* App action buttons */
+.app-action-btn {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.app-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.app-action-btn.add {
+  color: #673ab8;
+  border-color: #673ab8;
+}
+
+.app-action-btn.add:hover:not(:disabled) {
+  background: #673ab8;
+  color: white;
+}
+
+.app-action-btn.danger {
+  color: #9ca3af;
+  border-color: #e5e7eb;
+}
+
+.app-action-btn.danger:hover:not(:disabled) {
+  color: #ef4444;
+  border-color: #ef4444;
 }
 
 /* Footer */
@@ -181,4 +293,88 @@
 
 .manage-link:hover {
   text-decoration: underline;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .category-details code {
+    background: #374151;
+    color: #d1d5db;
+  }
+
+  .category-icon-input {
+    border-color: #4b5563;
+  }
+
+  .category-icon-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .category-icon-suggestion {
+    border-color: #4b5563;
+  }
+
+  .category-icon-suggestion:hover {
+    border-color: #8b5cf6;
+    color: #8b5cf6;
+  }
+
+  .app-list {
+    background: #1e1e1e;
+    border-color: #333;
+  }
+
+  .app-row {
+    border-bottom-color: #333;
+  }
+
+  .app-name {
+    color: #d1d5db;
+  }
+
+  .child-category-card {
+    background: #1e1e1e;
+    border-color: #333;
+  }
+
+  .child-category-card:hover {
+    border-color: #8b5cf6;
+  }
+
+  .app-action-btn {
+    border-color: #4b5563;
+  }
+
+  .app-action-btn.add {
+    color: #8b5cf6;
+    border-color: #8b5cf6;
+  }
+
+  .app-action-btn.add:hover:not(:disabled) {
+    background: #8b5cf6;
+  }
+
+  .app-action-btn.danger:hover:not(:disabled) {
+    color: #f87171;
+    border-color: #f87171;
+  }
+}
+
+/* Mobile */
+@media (max-width: 639px) {
+  .app-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .app-row-right {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .category-icon-edit-row {
+    flex-wrap: wrap;
+  }
 }

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -106,12 +106,13 @@ export const tagIconsSchema = z.record(z.string(), z.string()).meta({
  * - Tag names or tag_keys: "Coffee", "meditation" (no prefix, backwards-compatible with tag_icons)
  * - Activity types: "activity:sleep", "activity:nap", "activity:meditation"
  * - Exercise types: "exercise:Running", "exercise:Biking", etc.
+ * - Screentime categories: "category:Work", "category:Work > Programming"
  *
  * Values are emoji characters or image URLs. An empty string explicitly clears the default icon.
  */
 export const itemIconsSchema = z.record(z.string(), z.string()).meta({
   description:
-    'Unified icon mappings for all timeline items (tags, activities, exercise types). Keys use prefix convention: activity:sleep, exercise:Running, or plain tag names.',
+    'Unified icon mappings for all timeline items (tags, activities, exercise types, screentime categories). Keys use prefix convention: activity:sleep, exercise:Running, category:Work > Programming, or plain tag names.',
   id: 'ItemIcons',
 })
 


### PR DESCRIPTION
## Summary

Phase 2 of the screentime categories usability improvements. Builds on #361 (Phase 1: navigation and pages).

**Core idea**: Instead of requiring users to write regex patterns, they can now categorize apps with a single click from the category detail page.

## Changes

### Bottom-up categorization (no regex knowledge needed)
- **"Add here" button** on uncategorized apps — clicking it adds the app name to the category's regex rule automatically (escaping special chars)
- **"Remove" button** on matched apps — removes the app from the category rule
- Both actions trigger background recategorization so changes apply immediately
- The regex is auto-generated behind the scenes as a pipe-separated list of literal app names

### Icon support for categories
- **Icon editing** on the category detail page — type an emoji or paste an image URL
- **Auto-suggest**: suggests an emoji based on the category name (e.g., "Work" suggests briefcase)
- Icons stored in `item_icons` using `category:` prefix convention (e.g., `category:Work > Programming`)
- Icons displayed in the category header and on child category cards
- Updated `itemIconsSchema` to document the new prefix

### UX improvements
- Extracted `CategoryFields` and `ChildCategoriesList` components for cleaner code
- Removed "Case insensitive" field (implementation detail) from the details view
- Shows leaf category name in header instead of full path (breadcrumb already shows the path)
- Dark mode support for all new elements
- Mobile-responsive layout for app list rows

## What users can do now

1. See a productivity record (e.g., "Emacs") → click the title → land on its category page
2. If uncategorized, land on the categories management page → click a category → see uncategorized apps → click "Add here" next to "Emacs"
3. Done! Emacs is now categorized, regex is auto-generated, all records are recategorized
4. Set an icon for the category to make it visually distinct