### PR TITLE
fix: screentime categories list correctness and title context

### DIFF
--- a/apps/backend/src/db/productivity.integration.test.ts
+++ b/apps/backend/src/db/productivity.integration.test.ts
@@ -366,7 +366,7 @@ describe('Productivity Integration Tests', () => {
   // ==========================================================================
 
   describe('getDistinctApps', () => {
-    test('returns distinct apps with categories and stats', async () => {
+    test('returns distinct apps with categories, titles, and stats', async () => {
       const user = getTestUser()
       await insertProductivity(user, [
         makeRecord({
@@ -375,6 +375,7 @@ describe('Productivity Integration Tests', () => {
           end_time: new Date('2024-01-15T10:05:00Z'),
           resolved_category: ['Work', 'Programming'],
           start_time: new Date('2024-01-15T10:00:00Z'),
+          title: 'main.ts — myproject',
         }),
         makeRecord({
           activity: 'vscode',
@@ -382,6 +383,7 @@ describe('Productivity Integration Tests', () => {
           end_time: new Date('2024-01-15T10:15:00Z'),
           resolved_category: ['Work', 'Programming'],
           start_time: new Date('2024-01-15T10:05:00Z'),
+          title: 'main.ts — myproject',
         }),
         makeRecord({
           activity: 'firefox',
@@ -396,14 +398,47 @@ describe('Productivity Integration Tests', () => {
 
       // Sorted by total duration desc, so vscode (900s) first
       expect(apps[0].activity).toBe('vscode')
+      expect(apps[0].title).toBe('main.ts — myproject')
       expect(apps[0].resolved_category).toEqual(['Work', 'Programming'])
       expect(apps[0].total_duration_sec).toBe(900)
       expect(apps[0].record_count).toBe(2)
 
       expect(apps[1].activity).toBe('firefox')
+      expect(apps[1].title).toBeUndefined()
       expect(apps[1].resolved_category).toBeUndefined()
       expect(apps[1].total_duration_sec).toBe(120)
       expect(apps[1].record_count).toBe(1)
+    })
+
+    test('groups separately by title (e.g. browser with different window titles)', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'firefox',
+          duration_sec: 300,
+          end_time: new Date('2024-01-15T10:05:00Z'),
+          resolved_category: ['Media', 'TV'],
+          start_time: new Date('2024-01-15T10:00:00Z'),
+          title: 'Netflix - Mozilla Firefox',
+        }),
+        makeRecord({
+          activity: 'firefox',
+          duration_sec: 200,
+          end_time: new Date('2024-01-15T10:08:20Z'),
+          resolved_category: ['Work'],
+          start_time: new Date('2024-01-15T10:05:00Z'),
+          title: 'GitHub - Mozilla Firefox',
+        }),
+      ])
+
+      const apps = await getDistinctApps(user)
+      // Same app with different titles and categories = two entries
+      expect(apps).toHaveLength(2)
+      const activities = apps.map((a) => a.activity)
+      expect(activities).toEqual(['firefox', 'firefox'])
+      const titles = apps.map((a) => a.title)
+      expect(titles).toContain('Netflix - Mozilla Firefox')
+      expect(titles).toContain('GitHub - Mozilla Firefox')
     })
 
     test('groups separately by resolved_category', async () => {
@@ -415,6 +450,7 @@ describe('Productivity Integration Tests', () => {
           end_time: new Date('2024-01-15T10:05:00Z'),
           resolved_category: ['Work'],
           start_time: new Date('2024-01-15T10:00:00Z'),
+          title: 'GitHub',
         }),
         makeRecord({
           activity: 'firefox',
@@ -422,11 +458,12 @@ describe('Productivity Integration Tests', () => {
           end_time: new Date('2024-01-15T10:08:20Z'),
           resolved_category: ['Media', 'Social Media'],
           start_time: new Date('2024-01-15T10:05:00Z'),
+          title: 'Twitter',
         }),
       ])
 
       const apps = await getDistinctApps(user)
-      // Same app with different categories = two entries
+      // Same app with different titles/categories = two entries
       expect(apps).toHaveLength(2)
     })
 

--- a/apps/backend/src/db/productivity.ts
+++ b/apps/backend/src/db/productivity.ts
@@ -174,20 +174,34 @@ export const batchUpdateResolvedCategory = async (
 }
 
 /**
- * Get distinct app names with their resolved categories.
- * Returns unique (activity, resolved_category) pairs, useful for category management UI.
+ * Get distinct app/title combinations with their resolved categories and usage stats.
+ *
+ * Groups by (activity, title, resolved_category) so that e.g. "firefox" opened to
+ * a Netflix page appears separately from "firefox" opened to GitHub — making it
+ * clear why a browser app shows up under a particular category.
+ *
+ * Useful for category management UI: shows what's matched and what isn't, with
+ * enough context to understand why.
  */
 export const getDistinctApps = async (
   user: string,
 ): Promise<
-  Array<{ activity: string; resolved_category?: string[]; total_duration_sec: number; record_count: number }>
+  Array<{
+    activity: string
+    title?: string
+    resolved_category?: string[]
+    total_duration_sec: number
+    record_count: number
+  }>
 > => {
   const result = await query(
     user,
-    `SELECT activity, resolved_category, SUM(duration_sec)::int AS total_duration_sec, COUNT(*)::int AS record_count
+    `SELECT activity, title, resolved_category,
+            SUM(duration_sec)::int AS total_duration_sec,
+            COUNT(*)::int AS record_count
      FROM productivity
      WHERE deleted_at IS NULL
-     GROUP BY activity, resolved_category
+     GROUP BY activity, title, resolved_category
      ORDER BY SUM(duration_sec) DESC`,
   )
 
@@ -195,6 +209,7 @@ export const getDistinctApps = async (
     activity: row.activity,
     record_count: row.record_count,
     resolved_category: row.resolved_category || undefined,
+    title: row.title || undefined,
     total_duration_sec: row.total_duration_sec,
   }))
 }

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -247,8 +247,8 @@ function MatchedAppList({
         rule_regex: newRegex,
         rule_type: newRegex ? 'regex' : 'none',
       })
-      // Recategorize in background
-      void recategorizeScreentime()
+      // Wait for recategorization so the lists reflect the change immediately
+      await recategorizeScreentime()
     },
     onSuccess: () => {
       setRemovingApp(null)
@@ -275,8 +275,11 @@ function MatchedAppList({
       </h3>
       <div class="app-list">
         {apps.map((app) => (
-          <div key={app.activity} class="app-row">
-            <span class="app-name">{app.activity}</span>
+          <div key={`${app.activity}\x00${app.title ?? ''}`} class="app-row">
+            <div class="app-name-col">
+              <span class="app-name">{app.activity}</span>
+              {app.title && <span class="app-title">{app.title}</span>}
+            </div>
             <div class="app-row-right">
               <span class="app-stats">
                 {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
@@ -324,8 +327,8 @@ function UncategorizedAppList({
         rule_regex: newRegex,
         rule_type: 'regex',
       })
-      // Recategorize in background
-      void recategorizeScreentime()
+      // Wait for recategorization so lists reflect the change immediately
+      await recategorizeScreentime()
     },
     onSuccess: () => {
       setAddingApp(null)
@@ -336,7 +339,7 @@ function UncategorizedAppList({
     onError: () => setAddingApp(null),
   })
 
-  const title =
+  const headerTitle =
     total > apps.length ? `Uncategorized apps (showing ${apps.length} of ${total})` : 'Uncategorized apps'
 
   if (total === 0) {
@@ -351,12 +354,15 @@ function UncategorizedAppList({
   return (
     <div class="category-section">
       <h3>
-        {title} <span class="count-badge">{total}</span>
+        {headerTitle} <span class="count-badge">{total}</span>
       </h3>
       <div class="app-list">
         {apps.map((app) => (
-          <div key={app.activity} class="app-row">
-            <span class="app-name">{app.activity}</span>
+          <div key={`${app.activity}\x00${app.title ?? ''}`} class="app-row">
+            <div class="app-name-col">
+              <span class="app-name">{app.activity}</span>
+              {app.title && <span class="app-title">{app.title}</span>}
+            </div>
             <div class="app-row-right">
               <span class="app-stats">
                 {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -219,9 +219,25 @@
   border-bottom: none;
 }
 
+.app-name-col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 0.1rem;
+}
+
 .app-name {
   font-weight: 500;
   color: #374151;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-title {
+  font-size: 0.75rem;
+  color: #9ca3af;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -331,6 +347,10 @@
 
   .app-name {
     color: #d1d5db;
+  }
+
+  .app-title {
+    color: #6b7280;
   }
 
   .child-category-card {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -297,9 +297,10 @@ export const fetchProductivityById = async (id: string): Promise<ProductivityRec
   }
 }
 
-// Fetch distinct app names with their categories and usage stats
+// Fetch distinct app/title combinations with their categories and usage stats
 export interface DistinctApp {
   activity: string
+  title?: string
   resolved_category?: string[]
   total_duration_sec: number
   record_count: number


### PR DESCRIPTION
## Summary

Three bugs found from testing in production:

### 1. Lists don't update immediately after Add/Remove

**Root cause**: `void recategorizeScreentime()` fired asynchronously, then `onSuccess` immediately invalidated and re-fetched `productivity-apps` — but recategorization hadn't finished yet, so the old data came back.

**Fix**: Changed `void recategorizeScreentime()` to `await recategorizeScreentime()` in both `addMutation` and `removeMutation`, so the query invalidation only fires after all records have been re-categorized.

### 2. Misleading matched apps (e.g. "firefox" under TV/Netflix category)

**Root cause**: The regex `netflix` matched Firefox window titles like "Netflix - Mozilla Firefox". The DB query grouped by `(activity, resolved_category)` only, so all Firefox records that had Netflix open appeared as a single "firefox" entry under the TV category — with no hint of why.

**Fix**: Changed `getDistinctApps` to group by `(activity, title, resolved_category)`, giving title-level granularity. Now each app+title combo is a separate row.

### 3. No title context shown in the app lists

**Fix**: Both "Matched apps" and "Uncategorized apps" lists now show the window title below the app name when present, e.g.:
```
firefox
Netflix - Mozilla Firefox        2h 15m · 45 records  [Remove]
```

This makes it immediately clear why a browser app is matched, and helps decide how to categorize uncategorized ones.

### Tests

Updated `getDistinctApps` integration tests to cover:
- Title included in returned data
- Title-level grouping for same app with different window titles