### PR TITLE
feat: screentime categories Phase 3 — trend charts and timeline icons

### DIFF
--- a/apps/backend/src/services/trends.test.ts
+++ b/apps/backend/src/services/trends.test.ts
@@ -130,6 +130,28 @@ describe('getTrend', () => {
     expect(result.history[1].date).toBe('2026-02-02')
   })
 
+  test('returns trend data for productivity_category', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { day: new Date('2026-01-15'), ema_value: 2.3 },
+        { day: new Date('2026-02-02'), ema_value: 3.1 },
+      ],
+    } as never)
+
+    const result = await getTrend('testuser', {
+      display_period: 'daily',
+      pattern: 'Work > Programming',
+      source_type: 'productivity_category',
+    })
+
+    expect(result.source_type).toBe('productivity_category')
+    expect(result.pattern).toBe('Work > Programming')
+    expect(result.aggregation).toBe('sum')
+    expect(result.display_unit).toBe('hours per day')
+    expect(result.current_value).toBe(3.1)
+    expect(result.history).toHaveLength(2)
+  })
+
   test('uses sum aggregation for metrics when specified', async () => {
     vi.mocked(db.query).mockResolvedValue({
       rows: [{ day: new Date('2026-02-02'), ema_value: 150.0 }],

--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -180,7 +180,82 @@ const calculateMetricTrend = async (
 }
 
 /**
- * Get the trend for a tag pattern or metric.
+ * Calculate the EMA-weighted trend for time spent in a productivity category.
+ *
+ * Aggregates daily total duration (in hours) of productivity records whose
+ * resolved_category path starts with the given category path, then applies EMA.
+ * Pattern is the category path joined by ' > ', e.g. "Work > Programming".
+ */
+const calculateProductivityCategoryTrend = async (
+  user: string,
+  categoryPath: string,
+  halfLifeDays: number,
+  lookbackDays: number,
+  displayPeriod: TrendDisplayPeriod,
+): Promise<{ currentValue: number; history: TrendHistoryPoint[] }> => {
+  const multiplier = displayPeriodMultipliers[displayPeriod]
+
+  // Convert "Work > Programming" to a PostgreSQL array prefix match.
+  // We use array_to_string to convert resolved_category to a string that starts with the path.
+  const result = await query(
+    user,
+    `
+    WITH date_range AS (
+      SELECT generate_series(
+        CURRENT_DATE - INTERVAL '1 day' * $2::integer,
+        CURRENT_DATE,
+        '1 day'
+      )::date AS day
+    ),
+    daily_values AS (
+      SELECT
+        d.day,
+        t.daily_hours
+      FROM date_range d
+      LEFT JOIN (
+        SELECT
+          date_trunc('day', start_time AT TIME ZONE 'UTC')::date as day,
+          SUM(duration_sec) / 3600.0 as daily_hours
+        FROM productivity
+        WHERE deleted_at IS NULL
+          AND resolved_category IS NOT NULL
+          AND array_to_string(resolved_category, ' > ') LIKE $1 || '%'
+          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+        GROUP BY 1
+      ) t ON d.day = t.day
+    ),
+    ema_calc AS (
+      SELECT
+        dv.day,
+        $4::float * SUM(COALESCE(dv2.daily_hours, 0) * EXP(-$3::float * (dv.day - dv2.day)::float / $5::float)) /
+        NULLIF(SUM(EXP(-$3::float * (dv.day - dv2.day)::float / $5::float)), 0) as ema_value
+      FROM daily_values dv
+      CROSS JOIN LATERAL (
+        SELECT day, daily_hours
+        FROM daily_values
+        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * LEAST($2::integer, 90)
+      ) dv2
+      GROUP BY dv.day
+    )
+    SELECT day, COALESCE(ema_value, 0) as ema_value
+    FROM ema_calc
+    ORDER BY day
+    `,
+    [categoryPath, lookbackDays, LN2, multiplier, halfLifeDays],
+  )
+
+  const history: TrendHistoryPoint[] = result.rows.map((row) => ({
+    date: row.day.toISOString().split('T')[0],
+    value: Number(row.ema_value),
+  }))
+
+  const currentValue = history.length > 0 ? history[history.length - 1].value : 0
+
+  return { currentValue, history }
+}
+
+/**
+ * Get the trend for a tag pattern, metric, or productivity category.
  */
 export const getTrend = async (user: string, input: GetTrendInput): Promise<TrendResult> => {
   const {
@@ -212,6 +287,26 @@ export const getTrend = async (user: string, input: GetTrendInput): Promise<Tren
       current_value: currentValue,
       display_period: displayPeriod,
       display_unit: displayUnits[displayPeriod],
+      half_life_days: halfLifeDays,
+      history,
+      lookback_days: lookbackDays,
+      pattern,
+      source_type: sourceType,
+    }
+  } else if (sourceType === 'productivity_category') {
+    const { currentValue, history } = await calculateProductivityCategoryTrend(
+      user,
+      pattern,
+      halfLifeDays,
+      lookbackDays,
+      displayPeriod,
+    )
+
+    return {
+      aggregation: 'sum',
+      current_value: currentValue,
+      display_period: displayPeriod,
+      display_unit: `hours ${displayUnits[displayPeriod]}`,
       half_life_days: halfLifeDays,
       history,
       lookback_days: lookbackDays,

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -11,9 +11,11 @@ import { useCallback, useState } from 'preact/hooks'
 
 import {
   type DistinctApp,
+  type FetchTrendParams,
   fetchDistinctApps,
   fetchScreentimeCategories,
   fetchScreentimeCategoryById,
+  fetchTrend,
   fetchUserSettings,
   recategorizeScreentime,
   updateScreentimeCategory,
@@ -21,6 +23,7 @@ import {
 } from '../../state/api'
 import { auth } from '../../state/auth'
 import { isEmoji, isUrl, suggestEmoji } from '../../utils/emojiLookup'
+import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
 import './style.css'
 
 // ============================================================================
@@ -385,6 +388,57 @@ function UncategorizedAppList({
 }
 
 // ============================================================================
+// Trend section
+// ============================================================================
+
+function CategoryTrendSection({ categoryPath, color }: { categoryPath: string; color: string }) {
+  const [lookback, setLookback] = useState(90)
+
+  const trendParams: FetchTrendParams = {
+    display_period: 'daily',
+    half_life_days: 15,
+    lookback_days: lookback,
+    pattern: categoryPath,
+    source_type: 'productivity_category',
+  }
+
+  const trendQuery = useQuery({
+    queryFn: () => fetchTrend(trendParams),
+    queryKey: ['trend', trendParams],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  return (
+    <div class="category-section">
+      <div class="category-trend-header">
+        <h3>Time trend</h3>
+        <select
+          class="category-trend-lookback"
+          value={lookback}
+          onChange={(e) => setLookback(Number((e.target as HTMLSelectElement).value))}
+        >
+          <option value="30">30 days</option>
+          <option value="90">90 days</option>
+          <option value="180">6 months</option>
+          <option value="365">1 year</option>
+        </select>
+      </div>
+      {trendQuery.isLoading && <p class="loading">Loading trend...</p>}
+      {trendQuery.error && <p class="sc-empty">No trend data available</p>}
+      {trendQuery.data && (
+        <>
+          <div class="category-trend-value">
+            <span class="category-trend-number">{trendQuery.data.current_value.toFixed(1)}</span>
+            <span class="category-trend-unit">{trendQuery.data.display_unit}</span>
+          </div>
+          <MiniTrendChart data={trendQuery.data.history} color={color} />
+        </>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
 // Category info fields
 // ============================================================================
 
@@ -572,6 +626,7 @@ export function CategoryDetail() {
         totalTime={totalTime}
         onIconSaved={invalidateIcons}
       />
+      <CategoryTrendSection categoryPath={category.name.join(' > ')} color={category.color ?? '#673ab8'} />
       <ChildCategoriesList children={children} distinctApps={distinctApps} icons={icons} />
       <MatchedAppList apps={matchedApps} category={category} onAppRemoved={invalidateAll} />
       <UncategorizedAppList

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -144,6 +144,46 @@
   gap: 0.5rem;
 }
 
+/* Trend section */
+.category-trend-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.category-trend-header h3 {
+  margin: 0;
+}
+
+.category-trend-lookback {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.category-trend-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.category-trend-number {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.category-trend-unit {
+  font-size: 0.85rem;
+  color: #9ca3af;
+}
+
 .count-badge {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -496,9 +496,24 @@ const getResolvedColor = (p: ProductivityRecord, categories: ScreentimeCategory[
   return getProductivityColor(p.productivity)
 }
 
+const resolveCategoryIcon = (
+  resolvedCategory: string[] | undefined,
+  itemIcons: Record<string, string>,
+): string | undefined => {
+  if (!resolvedCategory || resolvedCategory.length === 0) return undefined
+  // Walk from deepest to shallowest category, looking for an icon
+  for (let depth = resolvedCategory.length; depth > 0; depth--) {
+    const path = resolvedCategory.slice(0, depth).join(' > ')
+    const icon = itemIcons[`category:${path}`]
+    if (icon) return icon
+  }
+  return undefined
+}
+
 const categorizeProductivity = (
   productivity: ProductivityRecord[],
   categories: ScreentimeCategory[],
+  itemIcons: Record<string, string>,
 ): ChartItem[] =>
   productivity.map((p) => {
     const categoryLabel = p.resolved_category?.join(' > ') || p.category || ''
@@ -508,6 +523,7 @@ const categorizeProductivity = (
       end: p.end_time,
       entity_id: p.id,
       entity_type: 'productivity' as const,
+      icon: resolveCategoryIcon(p.resolved_category, itemIcons),
       isPoint: false,
       label: p.activity,
       start: p.start_time,
@@ -940,7 +956,7 @@ export const Timeline = () => {
       ...activityItems,
       ...categorizeLocations(places, uniquePlaceNames),
       ...categorizeTags(nonActivityTags, itemIcons),
-      ...categorizeProductivity(productivity, screentimeCategoriesQuery.data ?? []),
+      ...categorizeProductivity(productivity, screentimeCategoriesQuery.data ?? [], itemIcons),
       ...occasionalMetricItems,
       ...musicItems,
     ],

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -4,7 +4,13 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 
 import { MetricPicker } from '../../components/MetricPicker'
 import { TagPicker } from '../../components/TagPicker'
-import { fetchTrend, type FetchTrendParams, type TrendDisplayPeriod, type TrendResult } from '../../state/api'
+import {
+  fetchScreentimeCategories,
+  fetchTrend,
+  type FetchTrendParams,
+  type TrendDisplayPeriod,
+  type TrendResult,
+} from '../../state/api'
 import { auth } from '../../state/auth'
 import {
   addSavedTrend,
@@ -236,6 +242,26 @@ const LOOKBACK_OPTIONS = [
   { label: 'All time', value: 3650 }, // 10 years as "all time"
 ]
 
+// Simple category picker using a select of all screentime categories
+function CategoryPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const { data: categories = [] } = useQuery({
+    queryFn: fetchScreentimeCategories,
+    queryKey: ['screentime-categories'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  return (
+    <select value={value} onChange={(e) => onChange((e.target as HTMLSelectElement).value)}>
+      <option value="">Select a category...</option>
+      {categories.map((cat) => (
+        <option key={cat.id} value={cat.name.join(' > ')}>
+          {cat.name.join(' > ')}
+        </option>
+      ))}
+    </select>
+  )
+}
+
 // Form for configuring a trend
 // eslint-disable-next-line complexity -- TODO: refactor
 function TrendConfigForm({
@@ -252,7 +278,9 @@ function TrendConfigForm({
   submitLabel?: string
 }) {
   const [name, setName] = useState(initialValues?.name ?? '')
-  const [sourceType, setSourceType] = useState<'tag' | 'metric'>(initialValues?.params.source_type ?? 'tag')
+  const [sourceType, setSourceType] = useState<'tag' | 'metric' | 'productivity_category'>(
+    initialValues?.params.source_type ?? 'tag',
+  )
   const [pattern, setPattern] = useState(initialValues?.params.pattern ?? '')
   const [halfLifeDays, setHalfLifeDays] = useState(initialValues?.params.half_life_days ?? 15)
   const [lookbackDays, setLookbackDays] = useState(initialValues?.params.lookback_days ?? 90)
@@ -297,10 +325,15 @@ function TrendConfigForm({
           Source Type
           <select
             value={sourceType}
-            onChange={(e) => setSourceType((e.target as HTMLSelectElement).value as 'tag' | 'metric')}
+            onChange={(e) =>
+              setSourceType(
+                (e.target as HTMLSelectElement).value as 'tag' | 'metric' | 'productivity_category',
+              )
+            }
           >
             <option value="tag">Tag</option>
             <option value="metric">Metric</option>
+            <option value="productivity_category">Screentime Category</option>
           </select>
         </label>
         {sourceType === 'tag' ? (
@@ -310,6 +343,11 @@ function TrendConfigForm({
               selectedTags={pattern ? pattern.split('|').filter(Boolean) : []}
               onChange={(tags) => setPattern(tags.join('|'))}
             />
+          </label>
+        ) : sourceType === 'productivity_category' ? (
+          <label class="pattern-input">
+            Category
+            <CategoryPicker value={pattern} onChange={setPattern} />
           </label>
         ) : (
           <label class="pattern-input">

--- a/packages/api-spec/src/schemas/trends.ts
+++ b/packages/api-spec/src/schemas/trends.ts
@@ -12,7 +12,7 @@ import { baseResponseSchema } from './common.ts'
 /**
  * Source type for trend calculation.
  */
-export const trendSourceTypeSchema = z.enum(['tag', 'metric']).meta({
+export const trendSourceTypeSchema = z.enum(['tag', 'metric', 'productivity_category']).meta({
   description: 'Type of data source for trend calculation',
   example: 'tag',
   id: 'TrendSourceType',


### PR DESCRIPTION
## Summary

Phase 3 of the screentime categories usability improvements. Builds on #361 (navigation) and #362 (bottom-up categorization, icons).

### Trend charts for categories

- **Backend**: New `productivity_category` source type in the trend API
  - Queries the `productivity` table, aggregating daily total hours for records whose `resolved_category` path starts with the given pattern
  - EMA smoothing same as tags/metrics, with `sum` aggregation for hours
  - Display unit is "hours per day/week/month"
  - Pattern is the category path, e.g., "Work > Programming" (matches that prefix and all children)

- **Category detail page**: Inline trend chart showing time spent in the category over time
  - Uses `MiniTrendChart` (reused from TagMeta)
  - Selectable lookback period: 30 days, 90 days, 6 months, 1 year
  - Shows current trend value with unit

- **Trends page**: Added "Screentime Category" as a source type option
  - `CategoryPicker` dropdown lists all screentime categories
  - Full trend configuration (half-life, lookback, display period) works as with tags/metrics

### Timeline category icons

- Productivity items on the timeline now display category icons
  - `categorizeProductivity` resolves icons from `item_icons` using `category:` prefix keys
  - Walks the `resolved_category` path from deepest to shallowest (same pattern as color resolution)
  - Existing SVG rendering code already handles `item.icon` for emojis and image URLs — no rendering changes needed

### Tests

- Unit test for `productivity_category` trend calculation via `getTrend`