### PR TITLE
feat: merge overlapping screentime records on the vertical timeline

### DIFF
--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -49,6 +49,7 @@ import {
 } from './drawMusicStaff'
 import { CTL_COLOR, drawTrainingLoadTrack } from './drawTrainingLoadTrack'
 import { findOverlappingScrobbles } from './findOverlappingScrobbles'
+import { mergeProductivitySpans } from './productivityMerge'
 import './style.css'
 
 // ── Signals (module-level, persist across SPA navigations) ────────────────────
@@ -514,31 +515,50 @@ const categorizeProductivity = (
   productivity: ProductivityRecord[],
   categories: ScreentimeCategory[],
   itemIcons: Record<string, string>,
-): ChartItem[] =>
-  productivity.map((p) => {
-    const categoryLabel = p.resolved_category?.join(' > ') || p.category || ''
+): ChartItem[] => {
+  const spans = mergeProductivitySpans(productivity)
+
+  return spans.map((span) => {
+    const isCategorized = span.groupKey !== ''
+    const representative = span.records[0]
+    const label = isCategorized
+      ? (span.groupKey.split(' > ').pop() ?? span.groupKey)
+      : span.records.length === 1
+        ? representative.activity
+        : `${span.records.length} screen time`
+
+    // Build tooltip details listing constituent apps
+    const uniqueApps = [...new Set(span.records.map((r) => r.activity))]
+    const tooltipApps =
+      uniqueApps.length <= 4
+        ? uniqueApps.join(', ')
+        : `${uniqueApps.slice(0, 3).join(', ')} +${uniqueApps.length - 3}`
+
     return {
-      color: getResolvedColor(p, categories),
+      color: getResolvedColor(representative, categories),
       column: 'Screen Time' as Column,
-      end: p.end_time,
-      entity_id: p.id,
+      end: span.end,
+      entity_id: span.records.length === 1 ? representative.id : undefined,
       entity_type: 'productivity' as const,
-      icon: resolveCategoryIcon(p.resolved_category, itemIcons),
+      icon: resolveCategoryIcon(representative.resolved_category, itemIcons),
       isPoint: false,
-      label: p.activity,
-      start: p.start_time,
+      label,
+      start: span.start,
       tooltip: {
         details: [
-          categoryLabel,
-          p.title ? `Title: ${p.title}` : '',
-          formatDuration(p.start_time, p.end_time),
-          p.productivity != null ? `Score: ${p.productivity}` : '',
+          isCategorized ? span.groupKey : '',
+          span.records.length > 1
+            ? `${span.records.length} records: ${tooltipApps}`
+            : representative.activity,
+          span.records.length === 1 && representative.title ? `Title: ${representative.title}` : '',
+          formatDuration(span.start, span.end),
         ].filter(Boolean),
-        time: `${formatTime(p.start_time)} – ${formatTime(p.end_time)}`,
-        title: p.activity,
+        time: `${formatTime(span.start)} – ${formatTime(span.end)}`,
+        title: label,
       },
     }
   })
+}
 
 // ── Tooltip HTML builder ──────────────────────────────────────────────────────
 

--- a/apps/web/src/pages/Timeline/productivityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/productivityMerge.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'vitest'
+
+import type { ProductivityRecord } from '../../state/api'
+
+import { mergeProductivitySpans } from './productivityMerge'
+
+const makeRecord = (
+  overrides: Partial<ProductivityRecord> & { start_time: Date; end_time: Date },
+): ProductivityRecord => ({
+  activity: 'test-app',
+  duration_sec: Math.round((overrides.end_time.getTime() - overrides.start_time.getTime()) / 1000),
+  ...overrides,
+})
+
+const t = (h: number, m: number) => new Date(2024, 0, 15, h, m)
+
+describe('mergeProductivitySpans', () => {
+  test('returns empty array for empty input', () => {
+    expect(mergeProductivitySpans([])).toEqual([])
+  })
+
+  test('single record becomes a single span', () => {
+    const records = [makeRecord({ activity: 'vscode', end_time: t(10, 30), start_time: t(10, 0) })]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(1)
+    expect(spans[0].records).toHaveLength(1)
+    expect(spans[0].groupKey).toBe('')
+  })
+
+  test('merges adjacent uncategorized records', () => {
+    const records = [
+      makeRecord({ activity: 'vscode', end_time: t(10, 10), start_time: t(10, 0) }),
+      makeRecord({ activity: 'firefox', end_time: t(10, 20), start_time: t(10, 10) }),
+      makeRecord({ activity: 'slack', end_time: t(10, 25), start_time: t(10, 20) }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(1)
+    expect(spans[0].records).toHaveLength(3)
+    expect(spans[0].start).toEqual(t(10, 0))
+    expect(spans[0].end).toEqual(t(10, 25))
+    expect(spans[0].groupKey).toBe('')
+  })
+
+  test('merges adjacent same-category records', () => {
+    const records = [
+      makeRecord({
+        activity: 'netflix',
+        end_time: t(13, 15),
+        resolved_category: ['Media', 'TV'],
+        start_time: t(13, 10),
+      }),
+      makeRecord({
+        activity: 'netflix',
+        end_time: t(13, 20),
+        resolved_category: ['Media', 'TV'],
+        start_time: t(13, 15),
+      }),
+      makeRecord({
+        activity: 'netflix',
+        end_time: t(13, 25),
+        resolved_category: ['Media', 'TV'],
+        start_time: t(13, 20),
+      }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(1)
+    expect(spans[0].records).toHaveLength(3)
+    expect(spans[0].groupKey).toBe('Media > TV')
+    expect(spans[0].start).toEqual(t(13, 10))
+    expect(spans[0].end).toEqual(t(13, 25))
+  })
+
+  test('keeps different categories as separate spans', () => {
+    const records = [
+      makeRecord({
+        activity: 'vscode',
+        end_time: t(10, 30),
+        resolved_category: ['Work', 'Programming'],
+        start_time: t(10, 0),
+      }),
+      makeRecord({
+        activity: 'netflix',
+        end_time: t(10, 30),
+        resolved_category: ['Media', 'TV'],
+        start_time: t(10, 0),
+      }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(2)
+    const keys = spans.map((s) => s.groupKey).sort()
+    expect(keys).toEqual(['Media > TV', 'Work > Programming'])
+  })
+
+  test('splits spans when gap exceeds threshold', () => {
+    const records = [
+      makeRecord({ activity: 'vscode', end_time: t(10, 10), start_time: t(10, 0) }),
+      // 5-minute gap (> 2 minutes)
+      makeRecord({ activity: 'vscode', end_time: t(10, 25), start_time: t(10, 15) }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(2)
+  })
+
+  test('merges records within the 2-minute gap threshold', () => {
+    const records = [
+      makeRecord({ activity: 'vscode', end_time: t(10, 10), start_time: t(10, 0) }),
+      // 1.5-minute gap (< 2 minutes)
+      makeRecord({
+        activity: 'vscode',
+        end_time: t(10, 22),
+        start_time: new Date(2024, 0, 15, 10, 11, 30),
+      }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(1)
+    expect(spans[0].records).toHaveLength(2)
+  })
+
+  test('merges overlapping records of the same category', () => {
+    const records = [
+      makeRecord({
+        activity: 'firefox',
+        end_time: t(11, 0),
+        resolved_category: ['Work'],
+        start_time: t(10, 0),
+      }),
+      makeRecord({
+        activity: 'vscode',
+        end_time: t(10, 45),
+        resolved_category: ['Work'],
+        start_time: t(10, 30),
+      }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans).toHaveLength(1)
+    expect(spans[0].end).toEqual(t(11, 0))
+    expect(spans[0].records).toHaveLength(2)
+  })
+
+  test('handles mixed categorized and uncategorized interleaved records', () => {
+    const records = [
+      makeRecord({
+        activity: 'vscode',
+        end_time: t(10, 30),
+        resolved_category: ['Work'],
+        start_time: t(10, 0),
+      }),
+      makeRecord({ activity: 'plasmashell', end_time: t(10, 15), start_time: t(10, 10) }),
+      makeRecord({
+        activity: 'vscode',
+        end_time: t(11, 0),
+        resolved_category: ['Work'],
+        start_time: t(10, 30),
+      }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    // Work records merge together, plasmashell is separate
+    expect(spans).toHaveLength(2)
+    const workSpan = spans.find((s) => s.groupKey === 'Work')!
+    expect(workSpan.records).toHaveLength(2)
+    expect(workSpan.start).toEqual(t(10, 0))
+    expect(workSpan.end).toEqual(t(11, 0))
+
+    const uncatSpan = spans.find((s) => s.groupKey === '')!
+    expect(uncatSpan.records).toHaveLength(1)
+    expect(uncatSpan.records[0].activity).toBe('plasmashell')
+  })
+
+  test('output is sorted by start time', () => {
+    const records = [
+      makeRecord({
+        activity: 'netflix',
+        end_time: t(13, 30),
+        resolved_category: ['TV'],
+        start_time: t(13, 0),
+      }),
+      makeRecord({ activity: 'vscode', end_time: t(10, 30), start_time: t(10, 0) }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
+    expect(spans[0].start.getTime()).toBeLessThan(spans[1].start.getTime())
+  })
+})

--- a/apps/web/src/pages/Timeline/productivityMerge.ts
+++ b/apps/web/src/pages/Timeline/productivityMerge.ts
@@ -1,0 +1,67 @@
+/**
+ * Merge adjacent/overlapping productivity records into continuous spans.
+ *
+ * Records sharing the same resolved_category (or both uncategorized) are merged
+ * when they overlap or are within a short gap. This prevents dozens of tiny
+ * window-level ActivityWatch records from creating a mess of lanes on the timeline.
+ */
+import type { ProductivityRecord } from '../../state/api'
+
+/**
+ * Group key for merging productivity records.
+ * Records with the same category path are merged together.
+ * Uncategorized records share a common empty-string key.
+ */
+export const productivityGroupKey = (p: ProductivityRecord): string =>
+  p.resolved_category && p.resolved_category.length > 0 ? p.resolved_category.join(' > ') : ''
+
+/** Gap threshold for merging adjacent same-category records (2 minutes). */
+export const MERGE_GAP_MS = 2 * 60 * 1000
+
+export interface MergedProductivitySpan {
+  start: Date
+  end: Date
+  groupKey: string
+  records: ProductivityRecord[]
+}
+
+/**
+ * Merge adjacent/overlapping productivity records that share the same category.
+ * Adjacent records within MERGE_GAP_MS are merged into a single span.
+ */
+export const mergeProductivitySpans = (productivity: ProductivityRecord[]): MergedProductivitySpan[] => {
+  if (productivity.length === 0) return []
+
+  // Sort by start time
+  const sorted = [...productivity].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+
+  const spans: MergedProductivitySpan[] = []
+  // Track open spans per group key
+  const openSpans = new Map<string, MergedProductivitySpan>()
+
+  for (const record of sorted) {
+    const key = productivityGroupKey(record)
+    const open = openSpans.get(key)
+
+    if (open && record.start_time.getTime() <= open.end.getTime() + MERGE_GAP_MS) {
+      // Extend the existing span
+      if (record.end_time > open.end) open.end = record.end_time
+      open.records.push(record)
+    } else {
+      // Close the previous span for this group (if any) and start a new one
+      if (open) spans.push(open)
+      const newSpan: MergedProductivitySpan = {
+        end: record.end_time,
+        groupKey: key,
+        records: [record],
+        start: record.start_time,
+      }
+      openSpans.set(key, newSpan)
+    }
+  }
+
+  // Close all remaining open spans
+  for (const span of openSpans.values()) spans.push(span)
+
+  return spans.sort((a, b) => a.start.getTime() - b.start.getTime())
+}


### PR DESCRIPTION
## Summary

Fixes the visual mess in the Screen Time column on the vertical timeline where dozens of tiny overlapping ActivityWatch records would stack in separate lanes, making it impossible to read.

### Problem

ActivityWatch generates a productivity record per window focus change. When you have Firefox, Emacs, plasmashell, etc. all running, you get overlapping records like:
- `firefox` 11:28-12:13
- `plasmashell` 11:56-11:56
- `emacs` 11:30-12:00

These all went to the Screen Time column as separate `ChartItem`s, causing `packLanes` to create many narrow lanes stacked on top of each other. Additionally, Netflix sessions split into 5-minute chunks (13:10-13:15, 13:15-13:20, etc.) weren't merged even though they share the same category.

### Solution

New `mergeProductivitySpans()` function (extracted to `productivityMerge.ts` for testability) that pre-processes productivity records before creating ChartItems:

1. **Groups records by category path** (or "uncategorized" for records without a resolved_category)
2. **Merges adjacent/overlapping records** in the same group into continuous spans (2-minute gap threshold)
3. **Produces clean labels**: 
   - Categorized spans show the leaf category name (e.g., "TV" instead of "netflix")  
   - Single uncategorized records show the app name
   - Merged uncategorized groups show "N screen time"
4. **Tooltips** list constituent apps and total duration

### Result

Before: Firefox (11:28-12:13) and plasmashell (11:56-11:56) → 2 lanes stacking on top of each other  
After: One "2 screen time" span (11:28-12:13) in a single lane

Before: Netflix × 3 at 13:10-13:15, 13:15-13:20, 13:20-13:25 → 3 separate blocks  
After: One "TV" span (13:10-13:25)

### Tests

10 unit tests covering: empty input, single records, adjacent merging, same-category merging, different categories staying separate, gap threshold, overlapping records, interleaved categorized/uncategorized, sort order.