### PR TITLE
fix: add confirmation dialog for 'Add here' with match granularity options

### DIFF
--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -306,6 +306,147 @@ function MatchedAppList({
   )
 }
 
+/**
+ * Extract a short keyword from a window title for use as a matching term.
+ * E.g. "Threads - NaturalCycles - Slack — Mozilla Firefox" → "Slack"
+ * Splits on common separators and picks the shortest meaningful segment.
+ */
+const suggestTitleKeyword = (title: string): string | undefined => {
+  const parts = title
+    .split(/\s[—–\-|]\s|:\s/)
+    .map((p) => p.trim())
+    .filter((p) => p.length >= 2 && p.length <= 40)
+  if (parts.length === 0) return undefined
+  // Prefer shorter segments (more likely to be an app/site name), but not the browser name
+  const browserNames = [
+    'mozilla firefox',
+    'google chrome',
+    'chromium',
+    'gnu emacs',
+    'safari',
+    'microsoft edge',
+  ]
+  const filtered = parts.filter((p) => !browserNames.includes(p.toLowerCase()))
+  if (filtered.length === 0) return parts[0]
+  return filtered.reduce((a, b) => (a.length <= b.length ? a : b))
+}
+
+/** Confirmation dialog for adding an app/title to a category. */
+function AddConfirmDialog({
+  app,
+  category,
+  onConfirm,
+  onCancel,
+  isPending,
+}: {
+  app: DistinctApp
+  category: ScreentimeCategory
+  onConfirm: (term: string) => void
+  onCancel: () => void
+  isPending: boolean
+}) {
+  const titleKeyword = app.title ? suggestTitleKeyword(app.title) : undefined
+  const [customTerm, setCustomTerm] = useState('')
+  const [selectedOption, setSelectedOption] = useState<'app' | 'title' | 'custom'>(
+    titleKeyword ? 'title' : 'app',
+  )
+
+  const getSelectedTerm = (): string => {
+    switch (selectedOption) {
+      case 'app':
+        return app.activity
+      case 'title':
+        return titleKeyword ?? app.activity
+      case 'custom':
+        return customTerm.trim()
+    }
+  }
+
+  const selectedTerm = getSelectedTerm()
+
+  return (
+    <div class="add-confirm-backdrop" onClick={onCancel}>
+      <div class="add-confirm-dialog" onClick={(e) => e.stopPropagation()}>
+        <h4>Add to {category.name.join(' > ')}</h4>
+        <p class="add-confirm-desc">
+          Choose what to match. The term will be added to the category's matching rule.
+        </p>
+
+        <div class="add-confirm-options">
+          <label class="add-confirm-option">
+            <input
+              type="radio"
+              name="match-type"
+              checked={selectedOption === 'app'}
+              onChange={() => setSelectedOption('app')}
+            />
+            <div>
+              <strong>App name</strong> — matches all <em>{app.activity}</em> usage
+              <div class="add-confirm-preview">
+                <code>{escapeRegexChars(app.activity)}</code>
+              </div>
+            </div>
+          </label>
+
+          {titleKeyword && (
+            <label class="add-confirm-option">
+              <input
+                type="radio"
+                name="match-type"
+                checked={selectedOption === 'title'}
+                onChange={() => setSelectedOption('title')}
+              />
+              <div>
+                <strong>Title keyword</strong> — matches windows containing <em>{titleKeyword}</em>
+                <div class="add-confirm-preview">
+                  <code>{escapeRegexChars(titleKeyword)}</code>
+                </div>
+              </div>
+            </label>
+          )}
+
+          <label class="add-confirm-option">
+            <input
+              type="radio"
+              name="match-type"
+              checked={selectedOption === 'custom'}
+              onChange={() => setSelectedOption('custom')}
+            />
+            <div>
+              <strong>Custom term</strong>
+              {selectedOption === 'custom' && (
+                <div class="add-confirm-custom-input">
+                  <input
+                    type="text"
+                    value={customTerm}
+                    onInput={(e) => setCustomTerm((e.target as HTMLInputElement).value)}
+                    placeholder="Type a matching term..."
+                    autoFocus
+                  />
+                </div>
+              )}
+            </div>
+          </label>
+        </div>
+
+        <div class="add-confirm-actions">
+          <button
+            type="button"
+            class="app-action-btn add"
+            onClick={() => onConfirm(selectedTerm)}
+            disabled={isPending || !selectedTerm}
+          >
+            {isPending ? 'Adding...' : `Add "${selectedTerm}"`}
+          </button>
+          <button type="button" class="app-action-btn" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function UncategorizedAppList({
   apps,
   category,
@@ -318,13 +459,12 @@ function UncategorizedAppList({
   onAppAdded: () => void
 }) {
   const queryClient = useQueryClient()
-  const [addingApp, setAddingApp] = useState<string | null>(null)
+  const [confirmingApp, setConfirmingApp] = useState<DistinctApp | null>(null)
 
   const addMutation = useMutation({
-    mutationFn: async (appName: string) => {
-      setAddingApp(appName)
+    mutationFn: async (term: string) => {
       const currentTerms = parseRegexTerms(category.rule_regex ?? '')
-      const newTerms = [...currentTerms, appName]
+      const newTerms = [...currentTerms, term]
       const newRegex = buildRegex(newTerms)
       await updateScreentimeCategory(category.id, {
         rule_regex: newRegex,
@@ -334,12 +474,11 @@ function UncategorizedAppList({
       await recategorizeScreentime()
     },
     onSuccess: () => {
-      setAddingApp(null)
+      setConfirmingApp(null)
       onAppAdded()
       queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
       queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
     },
-    onError: () => setAddingApp(null),
   })
 
   const headerTitle =
@@ -373,16 +512,24 @@ function UncategorizedAppList({
               <button
                 type="button"
                 class="app-action-btn add"
-                onClick={() => addMutation.mutate(app.activity)}
-                disabled={addingApp === app.activity}
-                title={`Add "${app.activity}" to ${category.name.join(' > ')}`}
+                onClick={() => setConfirmingApp(app)}
+                title={`Add to ${category.name.join(' > ')}`}
               >
-                {addingApp === app.activity ? '...' : 'Add here'}
+                Add here
               </button>
             </div>
           </div>
         ))}
       </div>
+      {confirmingApp && (
+        <AddConfirmDialog
+          app={confirmingApp}
+          category={category}
+          onConfirm={(term) => addMutation.mutate(term)}
+          onCancel={() => setConfirmingApp(null)}
+          isPending={addMutation.isPending}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -351,6 +351,118 @@
   text-decoration: underline;
 }
 
+/* Add confirmation dialog */
+.add-confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.add-confirm-dialog {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 480px;
+  width: 90vw;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+}
+
+.add-confirm-dialog h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+}
+
+.add-confirm-desc {
+  margin: 0 0 1rem 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.add-confirm-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.add-confirm-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  transition: border-color 0.15s;
+}
+
+.add-confirm-option:has(input:checked) {
+  border-color: #673ab8;
+  background: #faf5ff;
+}
+
+.add-confirm-option input[type='radio'] {
+  margin-top: 0.25rem;
+  accent-color: #673ab8;
+}
+
+.add-confirm-option strong {
+  font-weight: 600;
+}
+
+.add-confirm-option em {
+  color: #673ab8;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.add-confirm-preview {
+  margin-top: 0.25rem;
+}
+
+.add-confirm-preview code {
+  background: #f3f4f6;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+  color: #374151;
+}
+
+.add-confirm-custom-input {
+  margin-top: 0.375rem;
+}
+
+.add-confirm-custom-input input {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+}
+
+.add-confirm-custom-input input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.add-confirm-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.add-confirm-actions .app-action-btn {
+  font-size: 0.85rem;
+  padding: 0.4rem 0.75rem;
+}
+
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
   .category-details code {
@@ -374,6 +486,38 @@
   .category-icon-suggestion:hover {
     border-color: #8b5cf6;
     color: #8b5cf6;
+  }
+
+  .add-confirm-dialog {
+    background: #1e1e1e;
+    color: #d1d5db;
+  }
+
+  .add-confirm-option {
+    border-color: #333;
+  }
+
+  .add-confirm-option:has(input:checked) {
+    border-color: #8b5cf6;
+    background: #1a1025;
+  }
+
+  .add-confirm-option em {
+    color: #8b5cf6;
+  }
+
+  .add-confirm-preview code {
+    background: #374151;
+    color: #d1d5db;
+  }
+
+  .add-confirm-custom-input input {
+    border-color: #4b5563;
+  }
+
+  .add-confirm-custom-input input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
   }
 
   .app-list {


### PR DESCRIPTION
## Summary

**Problem**: Clicking "Add here" on an uncategorized entry like \`firefox · Threads - NaturalCycles - Slack — Mozilla Firefox\` added \`firefox\` as a regex term, matching ALL Firefox usage. Way too broad — user intended to categorize Slack-related usage, not all browsing.

**Fix**: Replace the direct mutation with a confirmation dialog offering three match options:

### Match options

1. **App name** (broad) — matches all usage of that app
   - Example: `firefox` → matches every Firefox record
   
2. **Title keyword** (narrow) — auto-extracted from the window title, picks the shortest meaningful segment
   - Example: from "Threads - NaturalCycles - Slack — Mozilla Firefox" → suggests `Slack`
   - Filters out browser names (Mozilla Firefox, Google Chrome, etc.)
   
3. **Custom term** — user types whatever they want

### UX

- Each option shows the escaped regex preview so users know exactly what will be matched
- Radio buttons with visual highlight on the selected option
- The "Title keyword" option is pre-selected when a title is available (since it's the safer default)
- Confirm button shows the selected term: `Add "Slack"`
- Full dark mode support

### `suggestTitleKeyword` heuristic

Splits the window title on common separators (`—`, `–`, `-`, `|`, `:`) and picks the shortest segment that isn't a browser name. This works well for patterns like:
- "Threads - NaturalCycles - Slack — Mozilla Firefox" → **Slack**
- "GitHub - Pull request #367" → **GitHub**
- "pregnancyEndData.service.ts - GNU Emacs at spanda" → **GNU Emacs at spanda** (falls back since no short non-browser segment)