### PR TITLE
fix: exclude uncategorized screentime covered by categorized spans

### DIFF
--- a/apps/web/src/pages/Timeline/productivityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/productivityMerge.test.ts
@@ -144,7 +144,7 @@ describe('mergeProductivitySpans', () => {
     expect(spans[0].records).toHaveLength(2)
   })
 
-  test('handles mixed categorized and uncategorized interleaved records', () => {
+  test('excludes uncategorized records fully covered by categorized spans', () => {
     const records = [
       makeRecord({
         activity: 'vscode',
@@ -152,6 +152,7 @@ describe('mergeProductivitySpans', () => {
         resolved_category: ['Work'],
         start_time: t(10, 0),
       }),
+      // plasmashell 10:10-10:15 is fully inside Work 10:00-11:00
       makeRecord({ activity: 'plasmashell', end_time: t(10, 15), start_time: t(10, 10) }),
       makeRecord({
         activity: 'vscode',
@@ -162,15 +163,31 @@ describe('mergeProductivitySpans', () => {
     ]
     const spans = mergeProductivitySpans(records)
 
-    // Work records merge together, plasmashell is separate
+    // plasmashell is excluded because it's fully covered by the Work span
+    expect(spans).toHaveLength(1)
+    expect(spans[0].groupKey).toBe('Work')
+    expect(spans[0].records).toHaveLength(2)
+    expect(spans[0].start).toEqual(t(10, 0))
+    expect(spans[0].end).toEqual(t(11, 0))
+  })
+
+  test('keeps uncategorized records not covered by any categorized span', () => {
+    const records = [
+      makeRecord({
+        activity: 'vscode',
+        end_time: t(10, 30),
+        resolved_category: ['Work'],
+        start_time: t(10, 0),
+      }),
+      // plasmashell 11:00-11:15 is outside the Work span
+      makeRecord({ activity: 'plasmashell', end_time: t(11, 15), start_time: t(11, 0) }),
+    ]
+    const spans = mergeProductivitySpans(records)
+
     expect(spans).toHaveLength(2)
     const workSpan = spans.find((s) => s.groupKey === 'Work')!
-    expect(workSpan.records).toHaveLength(2)
-    expect(workSpan.start).toEqual(t(10, 0))
-    expect(workSpan.end).toEqual(t(11, 0))
-
+    expect(workSpan).toBeDefined()
     const uncatSpan = spans.find((s) => s.groupKey === '')!
-    expect(uncatSpan.records).toHaveLength(1)
     expect(uncatSpan.records[0].activity).toBe('plasmashell')
   })
 

--- a/apps/web/src/pages/Timeline/productivityMerge.ts
+++ b/apps/web/src/pages/Timeline/productivityMerge.ts
@@ -28,6 +28,9 @@ export interface MergedProductivitySpan {
 /**
  * Merge adjacent/overlapping productivity records that share the same category.
  * Adjacent records within MERGE_GAP_MS are merged into a single span.
+ *
+ * Uncategorized records that overlap with categorized spans are excluded to avoid
+ * giant background blobs covering the entire day on the timeline.
  */
 export const mergeProductivitySpans = (productivity: ProductivityRecord[]): MergedProductivitySpan[] => {
   if (productivity.length === 0) return []
@@ -35,33 +38,62 @@ export const mergeProductivitySpans = (productivity: ProductivityRecord[]): Merg
   // Sort by start time
   const sorted = [...productivity].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
 
-  const spans: MergedProductivitySpan[] = []
-  // Track open spans per group key
-  const openSpans = new Map<string, MergedProductivitySpan>()
+  // Phase 1: Build categorized spans first
+  const categorizedSpans: MergedProductivitySpan[] = []
+  const categorizedOpenSpans = new Map<string, MergedProductivitySpan>()
+  const uncategorizedRecords: ProductivityRecord[] = []
 
   for (const record of sorted) {
     const key = productivityGroupKey(record)
-    const open = openSpans.get(key)
+    if (key === '') {
+      uncategorizedRecords.push(record)
+      continue
+    }
 
+    const open = categorizedOpenSpans.get(key)
     if (open && record.start_time.getTime() <= open.end.getTime() + MERGE_GAP_MS) {
-      // Extend the existing span
       if (record.end_time > open.end) open.end = record.end_time
       open.records.push(record)
     } else {
-      // Close the previous span for this group (if any) and start a new one
-      if (open) spans.push(open)
-      const newSpan: MergedProductivitySpan = {
+      if (open) categorizedSpans.push(open)
+      categorizedOpenSpans.set(key, {
         end: record.end_time,
         groupKey: key,
         records: [record],
         start: record.start_time,
-      }
-      openSpans.set(key, newSpan)
+      })
     }
   }
+  for (const span of categorizedOpenSpans.values()) categorizedSpans.push(span)
 
-  // Close all remaining open spans
-  for (const span of openSpans.values()) spans.push(span)
+  // Phase 2: Filter uncategorized records — exclude those fully covered by a categorized span
+  const isFullyCovered = (record: ProductivityRecord): boolean => {
+    const rs = record.start_time.getTime()
+    const re = record.end_time.getTime()
+    return categorizedSpans.some((span) => span.start.getTime() <= rs && span.end.getTime() >= re)
+  }
 
-  return spans.sort((a, b) => a.start.getTime() - b.start.getTime())
+  const visibleUncategorized = uncategorizedRecords.filter((r) => !isFullyCovered(r))
+
+  // Phase 3: Merge the remaining uncategorized records
+  const uncategorizedSpans: MergedProductivitySpan[] = []
+  let openUncat: MergedProductivitySpan | null = null
+
+  for (const record of visibleUncategorized) {
+    if (openUncat && record.start_time.getTime() <= openUncat.end.getTime() + MERGE_GAP_MS) {
+      if (record.end_time > openUncat.end) openUncat.end = record.end_time
+      openUncat.records.push(record)
+    } else {
+      if (openUncat) uncategorizedSpans.push(openUncat)
+      openUncat = {
+        end: record.end_time,
+        groupKey: '',
+        records: [record],
+        start: record.start_time,
+      }
+    }
+  }
+  if (openUncat) uncategorizedSpans.push(openUncat)
+
+  return [...categorizedSpans, ...uncategorizedSpans].sort((a, b) => a.start.getTime() - b.start.getTime())
 }


### PR DESCRIPTION
## Summary

Fixes the vertical timeline Screen Time column where giant grey uncategorized blobs overlapped with and obscured categorized spans (Software Dev, Communication, TV).

### Problem

Uncategorized records like `plasmashell` run continuously in the background. The merge logic combined them into huge spans covering the entire workday. These overlapped temporally with categorized spans, causing `packLanes` to stack them in parallel lanes — the result was a mess of narrow strips drawn on top of each other, with categorized items barely visible.

### Fix

The merge now runs in three phases:
1. **Build categorized spans first** — merge adjacent same-category records
2. **Filter uncategorized records** — drop any that are fully contained within a categorized span (e.g., `plasmashell` 10:10-10:15 inside `Work` 10:00-11:00)
3. **Merge remaining uncategorized** — only records in time gaps between categorized spans survive

### Result

Categorized spans (Software Dev, Communication, TV) stand out clearly. Uncategorized records only appear in gaps where nothing is categorized. No more giant grey blobs hiding the useful data.

### Tests

Updated existing test + added new test for the coverage exclusion behavior. 11 tests passing.