### PR TITLE
feat: add BLE auto-reconnect for known sensor devices

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
     <!-- Activity recognition for phone step counter (Android 10+) -->
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
 
+    <!-- Auto-reconnect BLE devices after boot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 
     <!-- Alphabetically Sorted Health Permissions -->
@@ -140,6 +143,16 @@
             android:name=".ble.SensorService"
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
+
+        <!-- Auto-reconnect BLE devices on boot and Bluetooth state change -->
+        <receiver
+            android:name=".ble.BleAutoConnectReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.bluetooth.adapter.action.STATE_CHANGED" />
+            </intent-filter>
+        </receiver>
 
         <!-- FileProvider for APK installation -->
         <provider

--- a/apps/android/app/src/main/java/net/aurboda/ble/BleAutoConnectReceiver.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleAutoConnectReceiver.kt
@@ -1,0 +1,56 @@
+package net.aurboda.ble
+
+import android.app.ForegroundServiceStartNotAllowedException
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+
+private const val TAG = "BleAutoConnectReceiver"
+
+/**
+ * Receives BOOT_COMPLETED and BLUETOOTH_STATE_CHANGED broadcasts to
+ * automatically reconnect to saved BLE devices.
+ */
+class BleAutoConnectReceiver : BroadcastReceiver() {
+  override fun onReceive(
+    context: Context,
+    intent: Intent,
+  ) {
+    when (intent.action) {
+      Intent.ACTION_BOOT_COMPLETED -> {
+        Log.d(TAG, "Boot completed, checking for saved devices")
+        triggerAutoReconnect(context)
+      }
+      BluetoothAdapter.ACTION_STATE_CHANGED -> {
+        val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+        if (state == BluetoothAdapter.STATE_ON) {
+          Log.d(TAG, "Bluetooth turned on, checking for saved devices")
+          triggerAutoReconnect(context)
+        }
+      }
+    }
+  }
+
+  private fun triggerAutoReconnect(context: Context) {
+    val savedDevices = AutoReconnectPrefs.getSavedDevices(context)
+    if (savedDevices.isNotEmpty()) {
+      Log.d(TAG, "Found ${savedDevices.size} saved device(s), starting auto-reconnect")
+      try {
+        SensorService.autoReconnect(context)
+      } catch (e: Exception) {
+        // On Android 12+ starting foreground services from background is restricted.
+        // BOOT_COMPLETED has a short exemption window, but Bluetooth state changes do not.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && e is ForegroundServiceStartNotAllowedException) {
+          Log.w(TAG, "Cannot start foreground service from background (Android 12+ restriction)", e)
+        } else {
+          Log.e(TAG, "Failed to start auto-reconnect service", e)
+        }
+      }
+    } else {
+      Log.d(TAG, "No saved devices, skipping auto-reconnect")
+    }
+  }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleConnectionManager.kt
@@ -355,8 +355,18 @@ class BleConnectionManager(
     }
   }
 
+  /**
+   * Connect to a BLE device.
+   * @param deviceAddress MAC address of the device
+   * @param autoConnect When true, uses the Android BLE autoConnect mode which passively waits
+   *   for the device to become available. Best for reconnecting to known devices in the background.
+   *   When false, attempts an immediate direct connection (faster when device is nearby and advertising).
+   */
   @SuppressLint("MissingPermission")
-  fun connect(deviceAddress: String) {
+  fun connect(
+    deviceAddress: String,
+    autoConnect: Boolean = false,
+  ) {
     if (_connectionState.value is BleConnectionState.Connected ||
       _connectionState.value is BleConnectionState.Connecting
     ) {
@@ -376,8 +386,8 @@ class BleConnectionManager(
       val device = adapter.getRemoteDevice(deviceAddress)
       connectedDevice = device
       _connectionState.value = BleConnectionState.Connecting
-      Log.d(TAG, "Connecting to device: $deviceAddress")
-      bluetoothGatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+      Log.d(TAG, "Connecting to device: $deviceAddress (autoConnect=$autoConnect)")
+      bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback, BluetoothDevice.TRANSPORT_LE)
     } catch (e: IllegalArgumentException) {
       Log.e(TAG, "Invalid device address: $deviceAddress", e)
       _connectionState.value = BleConnectionState.Error("Invalid device address")

--- a/apps/android/app/src/main/java/net/aurboda/ble/BleSensorData.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/BleSensorData.kt
@@ -1,43 +1,121 @@
 package net.aurboda.ble
 
+import android.content.Context
+import android.util.Log
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.time.Instant
 
+@Serializable
 enum class SensorType {
-    HEART_RATE,
-    RUNNING_SPEED_CADENCE
+  HEART_RATE,
+  RUNNING_SPEED_CADENCE,
 }
 
 data class HeartRateSample(
-    val timestamp: Instant,
-    val bpm: Int,
-    val rrIntervals: List<Int>? = null  // in ms
+  val timestamp: Instant,
+  val bpm: Int,
+  val rrIntervals: List<Int>? = null, // in ms
 )
 
 data class CadenceSample(
-    val timestamp: Instant,
-    val cadence: Int,  // steps per minute
-    val speed: Float?,  // m/s
-    val strideLengthCm: Int? = null,
-    val totalDistanceMeters: Float? = null,
-    val isRunning: Boolean = false
+  val timestamp: Instant,
+  val cadence: Int, // steps per minute
+  val speed: Float?, // m/s
+  val strideLengthCm: Int? = null,
+  val totalDistanceMeters: Float? = null,
+  val isRunning: Boolean = false,
 )
 
 data class DiscoveredDevice(
-    val address: String,
-    val name: String?,
-    val rssi: Int,
-    val sensorType: SensorType
+  val address: String,
+  val name: String?,
+  val rssi: Int,
+  val sensorType: SensorType,
 )
 
 data class ConnectedDevice(
-    val address: String,
-    val name: String?,
-    val type: SensorType
+  val address: String,
+  val name: String?,
+  val type: SensorType,
 )
 
 sealed class BleConnectionState {
-    data object Disconnected : BleConnectionState()
-    data object Connecting : BleConnectionState()
-    data object Connected : BleConnectionState()
-    data class Error(val message: String) : BleConnectionState()
+  data object Disconnected : BleConnectionState()
+
+  data object Connecting : BleConnectionState()
+
+  data object Connected : BleConnectionState()
+
+  data class Error(
+    val message: String,
+  ) : BleConnectionState()
+}
+
+/**
+ * Serializable representation of a device saved for auto-reconnect.
+ */
+@Serializable
+data class SavedDevice(
+  val address: String,
+  val name: String?,
+  val type: SensorType,
+)
+
+private const val PREFS_NAME = "ble_auto_reconnect"
+private const val KEY_SAVED_DEVICES = "saved_devices"
+private const val AUTO_RECONNECT_TAG = "AutoReconnectPrefs"
+
+/**
+ * Manages persisted auto-reconnect device list in SharedPreferences.
+ */
+object AutoReconnectPrefs {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  fun getSavedDevices(context: Context): List<SavedDevice> {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val raw = prefs.getString(KEY_SAVED_DEVICES, null) ?: return emptyList()
+    return try {
+      json.decodeFromString<List<SavedDevice>>(raw)
+    } catch (e: Exception) {
+      Log.e(AUTO_RECONNECT_TAG, "Failed to parse saved devices", e)
+      emptyList()
+    }
+  }
+
+  fun addDevice(
+    context: Context,
+    device: SavedDevice,
+  ) {
+    val current = getSavedDevices(context).toMutableList()
+    // Replace if already present (address match), otherwise add
+    current.removeAll { it.address == device.address }
+    current.add(device)
+    save(context, current)
+    Log.d(AUTO_RECONNECT_TAG, "Added auto-reconnect device: ${device.name} (${device.address})")
+  }
+
+  fun removeDevice(
+    context: Context,
+    address: String,
+  ) {
+    val current = getSavedDevices(context).toMutableList()
+    current.removeAll { it.address == address }
+    save(context, current)
+    Log.d(AUTO_RECONNECT_TAG, "Removed auto-reconnect device: $address")
+  }
+
+  fun isAutoReconnectEnabled(
+    context: Context,
+    address: String,
+  ): Boolean = getSavedDevices(context).any { it.address == address }
+
+  private fun save(
+    context: Context,
+    devices: List<SavedDevice>,
+  ) {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    prefs.edit().putString(KEY_SAVED_DEVICES, json.encodeToString(devices)).apply()
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ble/SensorService.kt
@@ -56,6 +56,9 @@ private const val RR_BUFFER_MIN_SIZE = 30 // Minimum intervals for HRV calculati
 private const val RR_BUFFER_MAX_SIZE = 300 // Maximum intervals (~5 minutes at 60bpm)
 private const val CHART_HISTORY_DURATION_MS = 5 * 60 * 1000L // 5 minutes of chart history
 private const val ONE_MINUTE_MS = 60_000L
+private const val RECONNECT_BASE_DELAY_MS = 2_000L
+private const val RECONNECT_MAX_DELAY_MS = 60_000L
+private const val RECONNECT_MAX_ATTEMPTS = 20
 
 /**
  * Data point for chart display with timestamp.
@@ -209,6 +212,10 @@ class SensorService : Service() {
   private var syncJob: Job? = null
   private var phoneStepJob: Job? = null
 
+  // Auto-reconnect tracking
+  private val reconnectJobs = mutableMapOf<String, Job>()
+  private val reconnectAttempts = mutableMapOf<String, Int>()
+
   // Phone step counter
   private var phoneStepCounter: PhoneStepCounter? = null
 
@@ -264,12 +271,22 @@ class SensorService : Service() {
       ACTION_DISCONNECT -> {
         val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
         if (deviceAddress != null) {
+          // Cancel any pending reconnect for this device
+          cancelReconnect(deviceAddress)
           disconnectDevice(deviceAddress)
         } else {
+          // Cancel all reconnects
+          reconnectJobs.values.forEach { it.cancel() }
+          reconnectJobs.clear()
+          reconnectAttempts.clear()
           disconnectAll()
         }
       }
       ACTION_STOP -> {
+        // Cancel all reconnects before stopping
+        reconnectJobs.values.forEach { it.cancel() }
+        reconnectJobs.clear()
+        reconnectAttempts.clear()
         stopSensorService()
       }
       ACTION_START_PHONE_STEPS -> {
@@ -278,8 +295,22 @@ class SensorService : Service() {
       ACTION_STOP_PHONE_STEPS -> {
         stopPhoneStepCounter()
       }
+      ACTION_AUTO_RECONNECT -> {
+        reconnectSavedDevices()
+      }
+      ACTION_TOGGLE_AUTO_RECONNECT -> {
+        val deviceAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
+        val enabled = intent.getBooleanExtra(EXTRA_AUTO_RECONNECT_ENABLED, false)
+        if (deviceAddress != null) {
+          handleAutoReconnectToggle(deviceAddress, enabled)
+        }
+      }
+      null -> {
+        // Service restarted by system (START_STICKY) -- must satisfy foreground contract
+        reconnectSavedDevices()
+      }
     }
-    return START_NOT_STICKY
+    return START_STICKY
   }
 
   override fun onBind(intent: Intent?): IBinder? = null
@@ -353,6 +384,7 @@ class SensorService : Service() {
           phoneStepsText != null -> append(phoneStepsText)
           state.hasConnectedDevices -> append("${state.connectedDevices.size} sensor(s) connected")
           state.isConnecting -> append("Connecting...")
+          reconnectJobs.isNotEmpty() -> append("Reconnecting to ${reconnectJobs.size} device(s)...")
           else -> append("Ready")
         }
       }
@@ -375,7 +407,32 @@ class SensorService : Service() {
     notificationManager.notify(NOTIFICATION_ID, notification)
   }
 
-  private fun connectToDevice(deviceAddress: String) {
+  private fun reconnectSavedDevices() {
+    val savedDevices = AutoReconnectPrefs.getSavedDevices(this)
+    if (savedDevices.isNotEmpty()) {
+      Log.d(TAG, "Auto-reconnecting to ${savedDevices.size} saved device(s)")
+      if (!_serviceState.value.isRunning) {
+        startForegroundWithNotification()
+      }
+      savedDevices.forEach { saved ->
+        connectToDevice(saved.address, autoConnect = true)
+      }
+    } else {
+      Log.d(TAG, "No saved devices to auto-reconnect")
+      if (!_serviceState.value.hasConnectedDevices && !_serviceState.value.isConnecting) {
+        // Must satisfy foreground contract before stopping
+        if (!_serviceState.value.isRunning) {
+          startForegroundWithNotification()
+        }
+        stopSensorService()
+      }
+    }
+  }
+
+  private fun connectToDevice(
+    deviceAddress: String,
+    autoConnect: Boolean = false,
+  ) {
     // Don't connect if already connected or connecting to this device
     if (connectionManagers.containsKey(deviceAddress)) {
       Log.w(TAG, "Already connected to device: $deviceAddress")
@@ -386,7 +443,7 @@ class SensorService : Service() {
       return
     }
 
-    Log.d(TAG, "Connecting to device: $deviceAddress")
+    Log.d(TAG, "Connecting to device: $deviceAddress (autoConnect=$autoConnect)")
     updateState { it.copy(connectingDevices = it.connectingDevices + deviceAddress) }
 
     val manager = BleConnectionManager(this)
@@ -400,6 +457,8 @@ class SensorService : Service() {
 
           when (state) {
             is BleConnectionState.Connected -> {
+              // Reset reconnect counter on successful connection
+              reconnectAttempts.remove(deviceAddress)
               updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
               startDataCollection(manager, deviceAddress)
               startSyncLoop()
@@ -410,6 +469,7 @@ class SensorService : Service() {
             is BleConnectionState.Error -> {
               Log.e(TAG, "Connection error for $deviceAddress: ${state.message}")
               updateState { it.copy(connectingDevices = it.connectingDevices - deviceAddress) }
+              // Reconnect will be handled by handleDeviceDisconnected when Disconnected follows
             }
             else -> {}
           }
@@ -494,7 +554,7 @@ class SensorService : Service() {
     connectionManagers[deviceAddress] = manager
     deviceJobs[deviceAddress] = jobs
 
-    manager.connect(deviceAddress)
+    manager.connect(deviceAddress, autoConnect = autoConnect)
   }
 
   private fun updateDeviceState(
@@ -550,11 +610,99 @@ class SensorService : Service() {
     }
     updateNotification()
 
-    // Stop service if no devices connected
-    if (connectionManagers.isEmpty() && _serviceState.value.connectingDevices.isEmpty()) {
-      Log.d(TAG, "No devices connected, stopping service")
+    // Check if we should auto-reconnect
+    val shouldAutoReconnect = AutoReconnectPrefs.isAutoReconnectEnabled(this, deviceAddress)
+    if (shouldAutoReconnect) {
+      Log.d(TAG, "Auto-reconnect enabled for $deviceAddress, scheduling reconnect")
+      scheduleReconnect(deviceAddress)
+      return
+    }
+
+    // Stop service if no devices connected, no reconnects pending, and no phone step counter
+    if (connectionManagers.isEmpty() &&
+      _serviceState.value.connectingDevices.isEmpty() &&
+      reconnectJobs.isEmpty() &&
+      !_serviceState.value.phoneStepCounterActive
+    ) {
+      Log.d(TAG, "No devices connected and no reconnects pending, stopping service")
       stopSensorService()
     }
+  }
+
+  private fun scheduleReconnect(deviceAddress: String) {
+    // Cancel any existing reconnect job for this device
+    reconnectJobs[deviceAddress]?.cancel()
+
+    val attempt = (reconnectAttempts[deviceAddress] ?: 0) + 1
+    reconnectAttempts[deviceAddress] = attempt
+
+    if (attempt > RECONNECT_MAX_ATTEMPTS) {
+      Log.w(TAG, "Max reconnect attempts ($RECONNECT_MAX_ATTEMPTS) reached for $deviceAddress")
+      reconnectAttempts.remove(deviceAddress)
+      reconnectJobs.remove(deviceAddress)
+      // Stop service if nothing else is active
+      if (connectionManagers.isEmpty() &&
+        _serviceState.value.connectingDevices.isEmpty() &&
+        reconnectJobs.isEmpty() &&
+        !_serviceState.value.phoneStepCounterActive
+      ) {
+        stopSensorService()
+      }
+      return
+    }
+
+    // Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s, ...
+    val delayMs =
+      (RECONNECT_BASE_DELAY_MS * (1L shl (attempt - 1).coerceAtMost(5)))
+        .coerceAtMost(RECONNECT_MAX_DELAY_MS)
+
+    Log.d(TAG, "Scheduling reconnect #$attempt for $deviceAddress in ${delayMs}ms")
+
+    reconnectJobs[deviceAddress] =
+      serviceScope.launch {
+        delay(delayMs)
+        // Only reconnect if still in the saved list and BLE is enabled
+        if (AutoReconnectPrefs.isAutoReconnectEnabled(this@SensorService, deviceAddress) &&
+          isBleEnabled(this@SensorService)
+        ) {
+          reconnectJobs.remove(deviceAddress)
+          Log.d(TAG, "Attempting reconnect #$attempt for $deviceAddress")
+          connectToDevice(deviceAddress, autoConnect = true)
+        } else {
+          reconnectJobs.remove(deviceAddress)
+          Log.d(TAG, "Skipping reconnect for $deviceAddress (removed from auto-reconnect or BLE disabled)")
+          reconnectAttempts.remove(deviceAddress)
+        }
+      }
+  }
+
+  private fun cancelReconnect(deviceAddress: String) {
+    reconnectJobs[deviceAddress]?.cancel()
+    reconnectJobs.remove(deviceAddress)
+    reconnectAttempts.remove(deviceAddress)
+  }
+
+  private fun handleAutoReconnectToggle(
+    deviceAddress: String,
+    enabled: Boolean,
+  ) {
+    val deviceState = _serviceState.value.connectedDevices[deviceAddress]
+    if (enabled && deviceState != null) {
+      val saved =
+        SavedDevice(
+          address = deviceAddress,
+          name = deviceState.device.name,
+          type = deviceState.device.type,
+        )
+      AutoReconnectPrefs.addDevice(this, saved)
+      Log.d(TAG, "Auto-reconnect enabled for ${saved.name} ($deviceAddress)")
+    } else {
+      AutoReconnectPrefs.removeDevice(this, deviceAddress)
+      cancelReconnect(deviceAddress)
+      Log.d(TAG, "Auto-reconnect disabled for $deviceAddress")
+    }
+    // Notify UI by emitting updated state (force re-read of prefs)
+    updateState { it.copy() }
   }
 
   private fun startDataCollection(
@@ -1211,7 +1359,10 @@ class SensorService : Service() {
     }
 
     // Stop service if nothing else is running
-    if (!_serviceState.value.hasConnectedDevices && !_serviceState.value.isConnecting) {
+    if (!_serviceState.value.hasConnectedDevices &&
+      !_serviceState.value.isConnecting &&
+      reconnectJobs.isEmpty()
+    ) {
       stopSensorService()
     } else {
       updateNotification()
@@ -1229,6 +1380,11 @@ class SensorService : Service() {
   private fun cleanup() {
     syncJob?.cancel()
     phoneStepJob?.cancel()
+
+    // Cancel all reconnect jobs
+    reconnectJobs.values.forEach { it.cancel() }
+    reconnectJobs.clear()
+    reconnectAttempts.clear()
 
     // Stop phone step counter
     phoneStepCounter?.stopMonitoring()
@@ -1266,7 +1422,10 @@ class SensorService : Service() {
     const val ACTION_STOP = "net.aurboda.action.STOP_SENSOR_SERVICE"
     const val ACTION_START_PHONE_STEPS = "net.aurboda.action.START_PHONE_STEPS"
     const val ACTION_STOP_PHONE_STEPS = "net.aurboda.action.STOP_PHONE_STEPS"
+    const val ACTION_AUTO_RECONNECT = "net.aurboda.action.AUTO_RECONNECT"
+    const val ACTION_TOGGLE_AUTO_RECONNECT = "net.aurboda.action.TOGGLE_AUTO_RECONNECT"
     const val EXTRA_DEVICE_ADDRESS = "device_address"
+    const val EXTRA_AUTO_RECONNECT_ENABLED = "auto_reconnect_enabled"
 
     private val _serviceState = MutableStateFlow(SensorServiceState())
     val serviceState: StateFlow<SensorServiceState> = _serviceState.asStateFlow()
@@ -1323,6 +1482,28 @@ class SensorService : Service() {
       val intent =
         Intent(context, SensorService::class.java).apply {
           action = ACTION_STOP
+        }
+      context.startService(intent)
+    }
+
+    fun autoReconnect(context: Context) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_AUTO_RECONNECT
+        }
+      context.startForegroundService(intent)
+    }
+
+    fun toggleAutoReconnect(
+      context: Context,
+      deviceAddress: String,
+      enabled: Boolean,
+    ) {
+      val intent =
+        Intent(context, SensorService::class.java).apply {
+          action = ACTION_TOGGLE_AUTO_RECONNECT
+          putExtra(EXTRA_DEVICE_ADDRESS, deviceAddress)
+          putExtra(EXTRA_AUTO_RECONNECT_ENABLED, enabled)
         }
       context.startService(intent)
     }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
@@ -46,7 +45,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -74,811 +72,868 @@ import java.time.Duration
 import java.time.Instant
 
 @Composable
-fun LiveScreen(
-    modifier: Modifier = Modifier
-) {
-    val context = LocalContext.current
-    var hasPermissions by remember { mutableStateOf(hasBlePermissions(context)) }
-    var bleEnabled by remember { mutableStateOf(isBleEnabled(context)) }
-    val bleSupported = remember { isBleSupported(context) }
+fun LiveScreen(modifier: Modifier = Modifier) {
+  val context = LocalContext.current
+  var hasPermissions by remember { mutableStateOf(hasBlePermissions(context)) }
+  var bleEnabled by remember { mutableStateOf(isBleEnabled(context)) }
+  val bleSupported = remember { isBleSupported(context) }
 
-    // Activity recognition permission for phone step counter (Android 10+)
-    var hasActivityRecognitionPermission by remember {
-        mutableStateOf(
-            androidx.core.content.ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.ACTIVITY_RECOGNITION
-            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
-        )
-    }
-    val activityRecognitionPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission()
+  // Activity recognition permission for phone step counter (Android 10+)
+  var hasActivityRecognitionPermission by remember {
+    mutableStateOf(
+      androidx.core.content.ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.ACTIVITY_RECOGNITION,
+      ) == android.content.pm.PackageManager.PERMISSION_GRANTED,
+    )
+  }
+  val activityRecognitionPermissionLauncher =
+    rememberLauncherForActivityResult(
+      contract = ActivityResultContracts.RequestPermission(),
     ) { granted ->
-        hasActivityRecognitionPermission = granted
-        if (granted) {
-            SensorService.startPhoneStepCounter(context)
-        }
+      hasActivityRecognitionPermission = granted
+      if (granted) {
+        SensorService.startPhoneStepCounter(context)
+      }
     }
 
-    // Health Connect client and write permission state
-    val healthConnectClient = remember { HealthConnectClient.getOrCreate(context) }
-    var hasHrWritePermission by remember { mutableStateOf<Boolean?>(null) }
-    var hasStepsWritePermission by remember { mutableStateOf<Boolean?>(null) }
-    var pendingDeviceToConnect by remember { mutableStateOf<DiscoveredDevice?>(null) }
+  // Health Connect client and write permission state
+  val healthConnectClient = remember { HealthConnectClient.getOrCreate(context) }
+  var hasHrWritePermission by remember { mutableStateOf<Boolean?>(null) }
+  var hasStepsWritePermission by remember { mutableStateOf<Boolean?>(null) }
+  var pendingDeviceToConnect by remember { mutableStateOf<DiscoveredDevice?>(null) }
 
-    val hrWritePermission = remember {
-        HealthPermission.getWritePermission(HeartRateRecord::class)
+  val hrWritePermission =
+    remember {
+      HealthPermission.getWritePermission(HeartRateRecord::class)
     }
-    val stepsWritePermission = remember {
-        HealthPermission.getWritePermission(StepsRecord::class)
+  val stepsWritePermission =
+    remember {
+      HealthPermission.getWritePermission(StepsRecord::class)
     }
 
-    // Health Connect permission launcher
-    val healthConnectPermissionLauncher = rememberLauncherForActivityResult(
-        contract = PermissionController.createRequestPermissionResultContract()
+  // Health Connect permission launcher
+  val healthConnectPermissionLauncher =
+    rememberLauncherForActivityResult(
+      contract = PermissionController.createRequestPermissionResultContract(),
     ) { granted: Set<String> ->
-        // Only update permission state if we actually asked for that permission
-        // (don't set to false if we didn't ask for it)
-        if (granted.contains(hrWritePermission)) {
-            hasHrWritePermission = true
-        }
-        if (granted.contains(stepsWritePermission)) {
-            hasStepsWritePermission = true
-        }
-        Log.d("LiveScreen", "Health Connect permission granted: $granted")
+      // Only update permission state if we actually asked for that permission
+      // (don't set to false if we didn't ask for it)
+      if (granted.contains(hrWritePermission)) {
+        hasHrWritePermission = true
+      }
+      if (granted.contains(stepsWritePermission)) {
+        hasStepsWritePermission = true
+      }
+      Log.d("LiveScreen", "Health Connect permission granted: $granted")
 
-        // Connect to device regardless of permission result - data still syncs to backend,
-        // and SensorService gracefully handles missing Health Connect write permission
-        pendingDeviceToConnect?.let { device ->
-            SensorService.connect(context, device.address)
-            pendingDeviceToConnect = null
-        }
+      // Connect to device regardless of permission result - data still syncs to backend,
+      // and SensorService gracefully handles missing Health Connect write permission
+      pendingDeviceToConnect?.let { device ->
+        SensorService.connect(context, device.address)
+        pendingDeviceToConnect = null
+      }
     }
 
-    // Check Health Connect permission on launch
-    // Only set to true if granted; leave as null if not granted (so we ask on first connect)
-    LaunchedEffect(Unit) {
-        val granted = healthConnectClient.permissionController.getGrantedPermissions()
-        val hrGranted = granted.contains(hrWritePermission)
-        val stepsGranted = granted.contains(stepsWritePermission)
-        if (hrGranted) hasHrWritePermission = true
-        if (stepsGranted) hasStepsWritePermission = true
-        Log.d("LiveScreen", "Initial Health Connect permissions: hr=$hrGranted, steps=$stepsGranted")
+  // Check Health Connect permission on launch
+  // Only set to true if granted; leave as null if not granted (so we ask on first connect)
+  LaunchedEffect(Unit) {
+    val granted = healthConnectClient.permissionController.getGrantedPermissions()
+    val hrGranted = granted.contains(hrWritePermission)
+    val stepsGranted = granted.contains(stepsWritePermission)
+    if (hrGranted) hasHrWritePermission = true
+    if (stepsGranted) hasStepsWritePermission = true
+    Log.d("LiveScreen", "Initial Health Connect permissions: hr=$hrGranted, steps=$stepsGranted")
+  }
+
+  // Observe service state
+  val serviceState by SensorService.serviceState.collectAsState()
+  val connectedDevices = serviceState.connectedDevices
+  val connectingDevices = serviceState.connectingDevices
+
+  var isScanning by remember { mutableStateOf(false) }
+  var scanError by remember { mutableStateOf<String?>(null) }
+  val discoveredDevices = remember { mutableStateListOf<DiscoveredDevice>() }
+
+  // Filter out already connected devices from discovered list
+  val availableDevices =
+    discoveredDevices.filter { device ->
+      !connectedDevices.containsKey(device.address) && !connectingDevices.contains(device.address)
     }
 
-    // Observe service state
-    val serviceState by SensorService.serviceState.collectAsState()
-    val connectedDevices = serviceState.connectedDevices
-    val connectingDevices = serviceState.connectingDevices
-
-    var isScanning by remember { mutableStateOf(false) }
-    var scanError by remember { mutableStateOf<String?>(null) }
-    val discoveredDevices = remember { mutableStateListOf<DiscoveredDevice>() }
-
-    // Filter out already connected devices from discovered list
-    val availableDevices = discoveredDevices.filter { device ->
-        !connectedDevices.containsKey(device.address) && !connectingDevices.contains(device.address)
-    }
-
-    // Permission launcher
-    val permissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
+  // Permission launcher
+  val permissionLauncher =
+    rememberLauncherForActivityResult(
+      contract = ActivityResultContracts.RequestMultiplePermissions(),
     ) { permissions ->
-        hasPermissions = permissions.values.all { it }
+      hasPermissions = permissions.values.all { it }
     }
 
-    // Scan for devices
-    LaunchedEffect(isScanning) {
-        if (isScanning && hasPermissions && bleEnabled) {
-            scanError = null
-            discoveredDevices.clear()
-            scanForSensors(context).collect { state ->
-                when (state) {
-                    is BleScanState.Scanning -> { /* Already handled by isScanning flag */ }
-                    is BleScanState.DeviceFound -> {
-                        if (discoveredDevices.none { it.address == state.device.address }) {
-                            discoveredDevices.add(state.device)
-                        }
-                    }
-                    is BleScanState.Error -> {
-                        scanError = state.message
-                        isScanning = false
-                    }
-                    is BleScanState.ScanComplete -> {
-                        isScanning = false
-                    }
-                    is BleScanState.Idle -> { /* Initial state */ }
-                }
+  // Scan for devices
+  LaunchedEffect(isScanning) {
+    if (isScanning && hasPermissions && bleEnabled) {
+      scanError = null
+      discoveredDevices.clear()
+      scanForSensors(context).collect { state ->
+        when (state) {
+          is BleScanState.Scanning -> { /* Already handled by isScanning flag */ }
+          is BleScanState.DeviceFound -> {
+            if (discoveredDevices.none { it.address == state.device.address }) {
+              discoveredDevices.add(state.device)
             }
+          }
+          is BleScanState.Error -> {
+            scanError = state.message
+            isScanning = false
+          }
+          is BleScanState.ScanComplete -> {
+            isScanning = false
+          }
+          is BleScanState.Idle -> { /* Initial state */ }
         }
+      }
+    }
+  }
+
+  Column(
+    modifier =
+      modifier
+        .fillMaxSize()
+        .padding(16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = "Live Sensors",
+      style = MaterialTheme.typography.headlineMedium,
+      modifier = Modifier.padding(bottom = 16.dp),
+    )
+
+    if (!bleSupported) {
+      Text(
+        text = "Bluetooth Low Energy is not supported on this device",
+        color = MaterialTheme.colorScheme.error,
+        textAlign = TextAlign.Center,
+      )
+      return@Column
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    if (!hasPermissions) {
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
         Text(
-            text = "Live Sensors",
-            style = MaterialTheme.typography.headlineMedium,
-            modifier = Modifier.padding(bottom = 16.dp)
+          text = "Bluetooth permissions are required to connect to heart rate monitors and step sensors.",
+          textAlign = TextAlign.Center,
         )
-
-        if (!bleSupported) {
-            Text(
-                text = "Bluetooth Low Energy is not supported on this device",
-                color = MaterialTheme.colorScheme.error,
-                textAlign = TextAlign.Center
+        Button(
+          onClick = {
+            permissionLauncher.launch(
+              arrayOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+              ),
             )
-            return@Column
+          },
+        ) {
+          Text("Grant Permissions")
         }
-
-        if (!hasPermissions) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    text = "Bluetooth permissions are required to connect to heart rate monitors and step sensors.",
-                    textAlign = TextAlign.Center
-                )
-                Button(
-                    onClick = {
-                        permissionLauncher.launch(
-                            arrayOf(
-                                Manifest.permission.BLUETOOTH_SCAN,
-                                Manifest.permission.BLUETOOTH_CONNECT,
-                                Manifest.permission.ACCESS_FINE_LOCATION
-                            )
-                        )
-                    }
-                ) {
-                    Text("Grant Permissions")
-                }
-            }
-            return@Column
-        }
-
-        if (!bleEnabled) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    text = "Bluetooth is disabled. Please enable it to connect to sensors.",
-                    textAlign = TextAlign.Center
-                )
-                Button(
-                    onClick = {
-                        context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
-                    }
-                ) {
-                    Text("Open Bluetooth Settings")
-                }
-                Button(
-                    onClick = { bleEnabled = isBleEnabled(context) }
-                ) {
-                    Text("Refresh")
-                }
-            }
-            return@Column
-        }
-
-        // Connected Devices Section
-        if (connectedDevices.isNotEmpty()) {
-            connectedDevices.forEach { (address, deviceState) ->
-                val healthConnectEnabled = when (deviceState.device.type) {
-                    SensorType.HEART_RATE -> hasHrWritePermission == true
-                    SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission == true
-                }
-                val requiredPermissions = when (deviceState.device.type) {
-                    SensorType.HEART_RATE -> setOf(hrWritePermission)
-                    SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
-                }
-                ConnectedDeviceCard(
-                    deviceState = deviceState,
-                    serviceRunning = serviceState.isRunning,
-                    pendingSamples = serviceState.pendingSamples + serviceState.pendingCadenceSamples,
-                    healthConnectEnabled = healthConnectEnabled,
-                    currentHrv = serviceState.currentHrv,
-                    hrvReliable = serviceState.hrvReliable,
-                    rrIntervalCount = serviceState.rrIntervalCount,
-                    hrChartData = serviceState.hrChartHistory,
-                    hrvChartData = serviceState.hrvChartHistory,
-                    onEnableHealthConnect = {
-                        healthConnectPermissionLauncher.launch(requiredPermissions)
-                    },
-                    onDisconnect = { SensorService.disconnect(context, address) }
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-        }
-
-        // Connecting indicator
-        if (connectingDevices.isNotEmpty()) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer
-                )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text("Connecting to ${connectingDevices.size} device(s)...")
-                }
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-        }
-
-        // Stop All button when multiple devices connected
-        if (connectedDevices.size > 1) {
-            OutlinedButton(
-                onClick = { SensorService.stop(context) },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Stop All Sensors")
-            }
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-
-        // Phone Step Counter Section
-        PhoneStepCounterCard(
-            isActive = serviceState.phoneStepCounterActive,
-            stepCount = serviceState.phoneStepsSinceStart,
-            lastUpdateTime = serviceState.phoneStepLastUpdateTime,
-            onStart = {
-                if (hasActivityRecognitionPermission) {
-                    SensorService.startPhoneStepCounter(context)
-                } else {
-                    activityRecognitionPermissionLauncher.launch(Manifest.permission.ACTIVITY_RECOGNITION)
-                }
-            },
-            onStop = { SensorService.stopPhoneStepCounter(context) }
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Scanner Section - always visible to allow adding more devices
-        ScannerSection(
-            isScanning = isScanning,
-            discoveredDevices = availableDevices,
-            scanError = scanError,
-            onStartScan = {
-                isScanning = true
-            },
-            onStopScan = {
-                isScanning = false
-            },
-            onConnectDevice = { device ->
-                // Stop scanning once a device is being connected
-                isScanning = false
-
-                // Check Health Connect write permission based on device type
-                val hasPermission = when (device.sensorType) {
-                    SensorType.HEART_RATE -> hasHrWritePermission
-                    SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission
-                }
-                val requiredPermissions = when (device.sensorType) {
-                    SensorType.HEART_RATE -> setOf(hrWritePermission)
-                    SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
-                }
-
-                when (hasPermission) {
-                    true -> {
-                        // Permission already granted, connect directly
-                        SensorService.connect(context, device.address)
-                    }
-                    false -> {
-                        // Permission was denied previously, connect anyway
-                        // (data still syncs to backend, just not to Health Connect)
-                        SensorService.connect(context, device.address)
-                    }
-                    null -> {
-                        // Haven't asked yet, request permission first
-                        pendingDeviceToConnect = device
-                        healthConnectPermissionLauncher.launch(requiredPermissions)
-                    }
-                }
-            }
-        )
+      }
+      return@Column
     }
+
+    if (!bleEnabled) {
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Text(
+          text = "Bluetooth is disabled. Please enable it to connect to sensors.",
+          textAlign = TextAlign.Center,
+        )
+        Button(
+          onClick = {
+            context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
+          },
+        ) {
+          Text("Open Bluetooth Settings")
+        }
+        Button(
+          onClick = { bleEnabled = isBleEnabled(context) },
+        ) {
+          Text("Refresh")
+        }
+      }
+      return@Column
+    }
+
+    // Connected Devices Section
+    if (connectedDevices.isNotEmpty()) {
+      connectedDevices.forEach { (address, deviceState) ->
+        val healthConnectEnabled =
+          when (deviceState.device.type) {
+            SensorType.HEART_RATE -> hasHrWritePermission == true
+            SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission == true
+          }
+        val requiredPermissions =
+          when (deviceState.device.type) {
+            SensorType.HEART_RATE -> setOf(hrWritePermission)
+            SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
+          }
+        val autoReconnectEnabled = AutoReconnectPrefs.isAutoReconnectEnabled(context, address)
+        ConnectedDeviceCard(
+          deviceState = deviceState,
+          serviceRunning = serviceState.isRunning,
+          pendingSamples = serviceState.pendingSamples + serviceState.pendingCadenceSamples,
+          healthConnectEnabled = healthConnectEnabled,
+          autoReconnectEnabled = autoReconnectEnabled,
+          currentHrv = serviceState.currentHrv,
+          hrvReliable = serviceState.hrvReliable,
+          rrIntervalCount = serviceState.rrIntervalCount,
+          hrChartData = serviceState.hrChartHistory,
+          hrvChartData = serviceState.hrvChartHistory,
+          onEnableHealthConnect = {
+            healthConnectPermissionLauncher.launch(requiredPermissions)
+          },
+          onToggleAutoReconnect = { enabled ->
+            SensorService.toggleAutoReconnect(context, address, enabled)
+          },
+          onDisconnect = { SensorService.disconnect(context, address) },
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+      }
+    }
+
+    // Connecting indicator
+    if (connectingDevices.isNotEmpty()) {
+      Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+          CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+          ),
+      ) {
+        Row(
+          modifier =
+            Modifier
+              .fillMaxWidth()
+              .padding(16.dp),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.Center,
+        ) {
+          CircularProgressIndicator(modifier = Modifier.size(24.dp))
+          Spacer(modifier = Modifier.width(12.dp))
+          Text("Connecting to ${connectingDevices.size} device(s)...")
+        }
+      }
+      Spacer(modifier = Modifier.height(12.dp))
+    }
+
+    // Stop All button when multiple devices connected
+    if (connectedDevices.size > 1) {
+      OutlinedButton(
+        onClick = { SensorService.stop(context) },
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Text("Stop All Sensors")
+      }
+      Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    // Phone Step Counter Section
+    PhoneStepCounterCard(
+      isActive = serviceState.phoneStepCounterActive,
+      stepCount = serviceState.phoneStepsSinceStart,
+      lastUpdateTime = serviceState.phoneStepLastUpdateTime,
+      onStart = {
+        if (hasActivityRecognitionPermission) {
+          SensorService.startPhoneStepCounter(context)
+        } else {
+          activityRecognitionPermissionLauncher.launch(Manifest.permission.ACTIVITY_RECOGNITION)
+        }
+      },
+      onStop = { SensorService.stopPhoneStepCounter(context) },
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Scanner Section - always visible to allow adding more devices
+    ScannerSection(
+      isScanning = isScanning,
+      discoveredDevices = availableDevices,
+      scanError = scanError,
+      onStartScan = {
+        isScanning = true
+      },
+      onStopScan = {
+        isScanning = false
+      },
+      onConnectDevice = { device ->
+        // Stop scanning once a device is being connected
+        isScanning = false
+
+        // Check Health Connect write permission based on device type
+        val hasPermission =
+          when (device.sensorType) {
+            SensorType.HEART_RATE -> hasHrWritePermission
+            SensorType.RUNNING_SPEED_CADENCE -> hasStepsWritePermission
+          }
+        val requiredPermissions =
+          when (device.sensorType) {
+            SensorType.HEART_RATE -> setOf(hrWritePermission)
+            SensorType.RUNNING_SPEED_CADENCE -> setOf(stepsWritePermission)
+          }
+
+        when (hasPermission) {
+          true -> {
+            // Permission already granted, connect directly
+            SensorService.connect(context, device.address)
+          }
+          false -> {
+            // Permission was denied previously, connect anyway
+            // (data still syncs to backend, just not to Health Connect)
+            SensorService.connect(context, device.address)
+          }
+          null -> {
+            // Haven't asked yet, request permission first
+            pendingDeviceToConnect = device
+            healthConnectPermissionLauncher.launch(requiredPermissions)
+          }
+        }
+      },
+    )
+  }
 }
 
 @Composable
 private fun ConnectedDeviceCard(
-    deviceState: DeviceState,
-    serviceRunning: Boolean,
-    pendingSamples: Int,
-    healthConnectEnabled: Boolean,
-    currentHrv: Double?,
-    hrvReliable: Boolean,
-    rrIntervalCount: Int,
-    hrChartData: List<ChartDataPoint>,
-    hrvChartData: List<ChartDataPoint>,
-    onEnableHealthConnect: () -> Unit,
-    onDisconnect: () -> Unit
+  deviceState: DeviceState,
+  serviceRunning: Boolean,
+  pendingSamples: Int,
+  healthConnectEnabled: Boolean,
+  autoReconnectEnabled: Boolean,
+  currentHrv: Double?,
+  hrvReliable: Boolean,
+  rrIntervalCount: Int,
+  hrChartData: List<ChartDataPoint>,
+  hrvChartData: List<ChartDataPoint>,
+  onEnableHealthConnect: () -> Unit,
+  onToggleAutoReconnect: (Boolean) -> Unit,
+  onDisconnect: () -> Unit,
 ) {
-    val device = deviceState.device
-    val heartRate = deviceState.currentHeartRate
-    val cadence = deviceState.currentCadence
-    val stepsSinceStart = deviceState.stepsSinceStart
-    val batteryLevel = deviceState.batteryLevel
+  val device = deviceState.device
+  val heartRate = deviceState.currentHeartRate
+  val cadence = deviceState.currentCadence
+  val stepsSinceStart = deviceState.stepsSinceStart
+  val batteryLevel = deviceState.batteryLevel
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+    colors =
+      CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+      ),
+  ) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+      // Chart background layer - only show for HR devices with data
+      if (device.type == SensorType.HEART_RATE && (hrChartData.isNotEmpty() || hrvChartData.isNotEmpty())) {
+        LiveDataChart(
+          hrData = hrChartData,
+          hrvData = hrvChartData,
+          modifier =
+            Modifier
+              .matchParentSize()
+              .padding(start = 8.dp, end = 8.dp, top = 32.dp, bottom = 48.dp),
         )
-    ) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-            // Chart background layer - only show for HR devices with data
-            if (device.type == SensorType.HEART_RATE && (hrChartData.isNotEmpty() || hrvChartData.isNotEmpty())) {
-                LiveDataChart(
-                    hrData = hrChartData,
-                    hrvData = hrvChartData,
-                    modifier = Modifier
-                        .matchParentSize()
-                        .padding(start = 8.dp, end = 8.dp, top = 32.dp, bottom = 48.dp)
-                )
-            }
+      }
 
-            // Foreground content
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Icon(
-                        imageVector = when (device.type) {
-                            SensorType.HEART_RATE -> Icons.Default.Favorite
-                            SensorType.RUNNING_SPEED_CADENCE -> Icons.Default.PlayArrow
-                        },
-                        contentDescription = null,
-                        tint = when (device.type) {
-                            SensorType.HEART_RATE -> MaterialTheme.colorScheme.error
-                            SensorType.RUNNING_SPEED_CADENCE -> MaterialTheme.colorScheme.primary
-                        }
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = device.name ?: "Unknown Device",
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    // Battery indicator
-                    if (batteryLevel != null) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        BatteryIndicator(level = batteryLevel)
-                    }
-                }
+      // Foreground content
+      Column(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.Center,
+        ) {
+          Icon(
+            imageVector =
+              when (device.type) {
+                SensorType.HEART_RATE -> Icons.Default.Favorite
+                SensorType.RUNNING_SPEED_CADENCE -> Icons.Default.PlayArrow
+              },
+            contentDescription = null,
+            tint =
+              when (device.type) {
+                SensorType.HEART_RATE -> MaterialTheme.colorScheme.error
+                SensorType.RUNNING_SPEED_CADENCE -> MaterialTheme.colorScheme.primary
+              },
+          )
+          Spacer(modifier = Modifier.width(8.dp))
+          Text(
+            text = device.name ?: "Unknown Device",
+            style = MaterialTheme.typography.titleMedium,
+          )
+          // Battery indicator
+          if (batteryLevel != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            BatteryIndicator(level = batteryLevel)
+          }
+        }
 
-                // Connection health indicator (RSSI + data freshness)
-                ConnectionHealthIndicator(
-                    rssi = deviceState.rssi,
-                    lastDataReceivedTime = deviceState.lastDataReceivedTime
-                )
+        // Connection health indicator (RSSI + data freshness)
+        ConnectionHealthIndicator(
+          rssi = deviceState.rssi,
+          lastDataReceivedTime = deviceState.lastDataReceivedTime,
+        )
 
-                Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(12.dp))
 
-            when (device.type) {
-                SensorType.HEART_RATE -> {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = heartRate?.toString() ?: "--",
-                                fontSize = 48.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                            Text(
-                                text = "BPM",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(24.dp))
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = currentHrv?.let { String.format("%.0f", it) } ?: "--",
-                                fontSize = 32.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = if (hrvReliable)
-                                    MaterialTheme.colorScheme.onPrimaryContainer
-                                else
-                                    MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.5f)
-                            )
-                            Text(
-                                text = if (rrIntervalCount < 30) "HRV ($rrIntervalCount/30)" else "HRV",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                            )
-                        }
-                    }
-                }
-                SensorType.RUNNING_SPEED_CADENCE -> {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = cadence?.toString() ?: "--",
-                                fontSize = 48.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                            Text(
-                                text = "SPM",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(24.dp))
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = stepsSinceStart.toString(),
-                                fontSize = 32.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                            Text(
-                                text = "steps",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Service status
-            if (serviceRunning) {
-                Spacer(modifier = Modifier.height(8.dp))
-                val statusText = buildString {
-                    append(if (pendingSamples > 0) "Syncing ($pendingSamples pending)" else "Syncing")
-                    if (!healthConnectEnabled) {
-                        append(" • HC off")
-                    }
-                }
-                Text(
-                    text = statusText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (healthConnectEnabled)
-                        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
-                    else
-                        MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
-                )
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
+        when (device.type) {
+          SensorType.HEART_RATE -> {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.Center,
             ) {
-                OutlinedButton(onClick = onDisconnect) {
-                    Text("Disconnect")
-                }
-                if (!healthConnectEnabled) {
-                    Button(onClick = onEnableHealthConnect) {
-                        Text("Enable HC")
-                    }
-                }
+              Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                  text = heartRate?.toString() ?: "--",
+                  fontSize = 48.sp,
+                  fontWeight = FontWeight.Bold,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Text(
+                  text = "BPM",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                )
+              }
+              Spacer(modifier = Modifier.width(24.dp))
+              Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                  text = currentHrv?.let { String.format("%.0f", it) } ?: "--",
+                  fontSize = 32.sp,
+                  fontWeight = FontWeight.Bold,
+                  color =
+                    if (hrvReliable) {
+                      MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                      MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.5f)
+                    },
+                )
+                Text(
+                  text = if (rrIntervalCount < 30) "HRV ($rrIntervalCount/30)" else "HRV",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                )
+              }
             }
-        }  // Column
-        }  // Box
-    }
+          }
+          SensorType.RUNNING_SPEED_CADENCE -> {
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.Center,
+            ) {
+              Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                  text = cadence?.toString() ?: "--",
+                  fontSize = 48.sp,
+                  fontWeight = FontWeight.Bold,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Text(
+                  text = "SPM",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                )
+              }
+              Spacer(modifier = Modifier.width(24.dp))
+              Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                  text = stepsSinceStart.toString(),
+                  fontSize = 32.sp,
+                  fontWeight = FontWeight.Bold,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Text(
+                  text = "steps",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                )
+              }
+            }
+          }
+        }
+
+        // Service status
+        if (serviceRunning) {
+          Spacer(modifier = Modifier.height(8.dp))
+          val statusText =
+            buildString {
+              append(if (pendingSamples > 0) "Syncing ($pendingSamples pending)" else "Syncing")
+              if (!healthConnectEnabled) {
+                append(" • HC off")
+              }
+            }
+          Text(
+            text = statusText,
+            style = MaterialTheme.typography.bodySmall,
+            color =
+              if (healthConnectEnabled) {
+                MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+              } else {
+                MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+              },
+          )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Auto-reconnect toggle
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.Center,
+          modifier = Modifier.padding(vertical = 4.dp),
+        ) {
+          Text(
+            text = "Auto-reconnect",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
+          )
+          Spacer(modifier = Modifier.width(8.dp))
+          Switch(
+            checked = autoReconnectEnabled,
+            onCheckedChange = onToggleAutoReconnect,
+          )
+        }
+
+        Row(
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          OutlinedButton(onClick = onDisconnect) {
+            Text("Disconnect")
+          }
+          if (!healthConnectEnabled) {
+            Button(onClick = onEnableHealthConnect) {
+              Text("Enable HC")
+            }
+          }
+        }
+      } // Column
+    } // Box
+  }
 }
 
 @Composable
 private fun PhoneStepCounterCard(
-    isActive: Boolean,
-    stepCount: Int,
-    lastUpdateTime: Instant?,
-    onStart: () -> Unit,
-    onStop: () -> Unit
+  isActive: Boolean,
+  stepCount: Int,
+  lastUpdateTime: Instant?,
+  onStart: () -> Unit,
+  onStop: () -> Unit,
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = if (isActive)
-                MaterialTheme.colorScheme.tertiaryContainer
-            else
-                MaterialTheme.colorScheme.surfaceVariant
-        )
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+    colors =
+      CardDefaults.cardColors(
+        containerColor =
+          if (isActive) {
+            MaterialTheme.colorScheme.tertiaryContainer
+          } else {
+            MaterialTheme.colorScheme.surfaceVariant
+          },
+      ),
+  ) {
+    Column(
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .padding(16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.PlayArrow,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "Phone Step Counter",
-                    style = MaterialTheme.typography.titleMedium
-                )
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+      ) {
+        Icon(
+          imageVector = Icons.Default.PlayArrow,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+          text = "Phone Step Counter",
+          style = MaterialTheme.typography.titleMedium,
+        )
+      }
+
+      if (isActive) {
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+          text = stepCount.toString(),
+          fontSize = 48.sp,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+        Text(
+          text = "steps",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+        )
+
+        // Data freshness indicator
+        if (lastUpdateTime != null) {
+          Spacer(modifier = Modifier.height(4.dp))
+          val now = remember { mutableStateOf(Instant.now()) }
+          LaunchedEffect(Unit) {
+            while (true) {
+              now.value = Instant.now()
+              kotlinx.coroutines.delay(1000)
             }
-
-            if (isActive) {
-                Spacer(modifier = Modifier.height(12.dp))
-
-                Text(
-                    text = stepCount.toString(),
-                    fontSize = 48.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer
-                )
-                Text(
-                    text = "steps",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
-                )
-
-                // Data freshness indicator
-                if (lastUpdateTime != null) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    val now = remember { mutableStateOf(Instant.now()) }
-                    LaunchedEffect(Unit) {
-                        while (true) {
-                            now.value = Instant.now()
-                            kotlinx.coroutines.delay(1000)
-                        }
-                    }
-                    val staleness = Duration.between(lastUpdateTime, now.value).toMillis() / 1000.0
-                    val stalenessText = when {
-                        staleness < 1 -> "updating now"
-                        staleness < 60 -> "${staleness.toInt()}s ago"
-                        else -> "${(staleness / 60).toInt()}m ago"
-                    }
-                    Text(
-                        text = "Last update: $stalenessText",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f)
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-                OutlinedButton(onClick = onStop) {
-                    Text("Stop Counting")
-                }
-            } else {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Use your phone's built-in step sensor",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = onStart) {
-                    Text("Start Counting")
-                }
+          }
+          val staleness = Duration.between(lastUpdateTime, now.value).toMillis() / 1000.0
+          val stalenessText =
+            when {
+              staleness < 1 -> "updating now"
+              staleness < 60 -> "${staleness.toInt()}s ago"
+              else -> "${(staleness / 60).toInt()}m ago"
             }
+          Text(
+            text = "Last update: $stalenessText",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.6f),
+          )
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(onClick = onStop) {
+          Text("Stop Counting")
+        }
+      } else {
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+          text = "Use your phone's built-in step sensor",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onStart) {
+          Text("Start Counting")
+        }
+      }
     }
+  }
 }
 
 @Composable
 private fun ScannerSection(
-    isScanning: Boolean,
-    discoveredDevices: List<DiscoveredDevice>,
-    scanError: String?,
-    onStartScan: () -> Unit,
-    onStopScan: () -> Unit,
-    onConnectDevice: (DiscoveredDevice) -> Unit
+  isScanning: Boolean,
+  discoveredDevices: List<DiscoveredDevice>,
+  scanError: String?,
+  onStartScan: () -> Unit,
+  onStopScan: () -> Unit,
+  onConnectDevice: (DiscoveredDevice) -> Unit,
 ) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        // Scan button
-        if (isScanning) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                Spacer(modifier = Modifier.width(12.dp))
-                Text("Scanning for devices...")
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            OutlinedButton(onClick = onStopScan) {
-                Text("Stop Scan")
-            }
-        } else {
-            Button(onClick = onStartScan) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = null
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Scan for Devices")
-            }
-        }
-
-        if (scanError != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = scanError,
-                color = MaterialTheme.colorScheme.error
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Discovered devices list
-        if (discoveredDevices.isNotEmpty()) {
-            Text(
-                text = "Discovered Devices",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
-
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(discoveredDevices) { device ->
-                    DiscoveredDeviceItem(
-                        device = device,
-                        onConnect = { onConnectDevice(device) }
-                    )
-                }
-            }
-        } else if (!isScanning && discoveredDevices.isEmpty()) {
-            Text(
-                text = "Tap 'Scan for Devices' to find nearby Bluetooth sensors.",
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Card(
-                    modifier = Modifier.weight(1f),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant
-                    )
-                ) {
-                    Column(
-                        modifier = Modifier.padding(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Favorite,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = "Heart Rate Monitor",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Bold,
-                            textAlign = TextAlign.Center
-                        )
-                        Text(
-                            text = "Tracks heart rate and HRV in real time",
-                            style = MaterialTheme.typography.bodySmall,
-                            textAlign = TextAlign.Center,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-                Card(
-                    modifier = Modifier.weight(1f),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant
-                    )
-                ) {
-                    Column(
-                        modifier = Modifier.padding(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.PlayArrow,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = "Step Sensor",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Bold,
-                            textAlign = TextAlign.Center
-                        )
-                        Text(
-                            text = "Tracks cadence and steps from a footpod",
-                            style = MaterialTheme.typography.bodySmall,
-                            textAlign = TextAlign.Center,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-            }
-        }
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    // Scan button
+    if (isScanning) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+      ) {
+        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+        Spacer(modifier = Modifier.width(12.dp))
+        Text("Scanning for devices...")
+      }
+      Spacer(modifier = Modifier.height(8.dp))
+      OutlinedButton(onClick = onStopScan) {
+        Text("Stop Scan")
+      }
+    } else {
+      Button(onClick = onStartScan) {
+        Icon(
+          imageVector = Icons.Default.Search,
+          contentDescription = null,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text("Scan for Devices")
+      }
     }
+
+    if (scanError != null) {
+      Spacer(modifier = Modifier.height(8.dp))
+      Text(
+        text = scanError,
+        color = MaterialTheme.colorScheme.error,
+      )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Discovered devices list
+    if (discoveredDevices.isNotEmpty()) {
+      Text(
+        text = "Discovered Devices",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(bottom = 8.dp),
+      )
+
+      LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        items(discoveredDevices) { device ->
+          DiscoveredDeviceItem(
+            device = device,
+            onConnect = { onConnectDevice(device) },
+          )
+        }
+      }
+    } else if (!isScanning && discoveredDevices.isEmpty()) {
+      Text(
+        text = "Tap 'Scan for Devices' to find nearby Bluetooth sensors.",
+        textAlign = TextAlign.Center,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(modifier = Modifier.height(12.dp))
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Card(
+          modifier = Modifier.weight(1f),
+          colors =
+            CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        ) {
+          Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            Icon(
+              imageVector = Icons.Default.Favorite,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+              text = "Heart Rate Monitor",
+              style = MaterialTheme.typography.labelMedium,
+              fontWeight = FontWeight.Bold,
+              textAlign = TextAlign.Center,
+            )
+            Text(
+              text = "Tracks heart rate and HRV in real time",
+              style = MaterialTheme.typography.bodySmall,
+              textAlign = TextAlign.Center,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+        Card(
+          modifier = Modifier.weight(1f),
+          colors =
+            CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        ) {
+          Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            Icon(
+              imageVector = Icons.Default.PlayArrow,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+              text = "Step Sensor",
+              style = MaterialTheme.typography.labelMedium,
+              fontWeight = FontWeight.Bold,
+              textAlign = TextAlign.Center,
+            )
+            Text(
+              text = "Tracks cadence and steps from a footpod",
+              style = MaterialTheme.typography.bodySmall,
+              textAlign = TextAlign.Center,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+      }
+    }
+  }
 }
 
 @Composable
 private fun DiscoveredDeviceItem(
-    device: DiscoveredDevice,
-    onConnect: () -> Unit
+  device: DiscoveredDevice,
+  onConnect: () -> Unit,
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth()
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    Row(
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .padding(12.dp),
+      verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = when (device.sensorType) {
-                    SensorType.HEART_RATE -> Icons.Default.Favorite
-                    SensorType.RUNNING_SPEED_CADENCE -> Icons.Default.PlayArrow
-                },
-                contentDescription = null,
-                tint = when (device.sensorType) {
-                    SensorType.HEART_RATE -> MaterialTheme.colorScheme.error
-                    SensorType.RUNNING_SPEED_CADENCE -> MaterialTheme.colorScheme.primary
-                }
-            )
+      Icon(
+        imageVector =
+          when (device.sensorType) {
+            SensorType.HEART_RATE -> Icons.Default.Favorite
+            SensorType.RUNNING_SPEED_CADENCE -> Icons.Default.PlayArrow
+          },
+        contentDescription = null,
+        tint =
+          when (device.sensorType) {
+            SensorType.HEART_RATE -> MaterialTheme.colorScheme.error
+            SensorType.RUNNING_SPEED_CADENCE -> MaterialTheme.colorScheme.primary
+          },
+      )
 
-            Spacer(modifier = Modifier.width(12.dp))
+      Spacer(modifier = Modifier.width(12.dp))
 
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = device.name ?: "Unknown Device",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
-                )
-                Text(
-                    text = when (device.sensorType) {
-                        SensorType.HEART_RATE -> "Heart Rate Monitor"
-                        SensorType.RUNNING_SPEED_CADENCE -> "Step Sensor"
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = "Signal: ${device.rssi} dBm",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = device.name ?: "Unknown Device",
+          style = MaterialTheme.typography.bodyLarge,
+          fontWeight = FontWeight.Medium,
+        )
+        Text(
+          text =
+            when (device.sensorType) {
+              SensorType.HEART_RATE -> "Heart Rate Monitor"
+              SensorType.RUNNING_SPEED_CADENCE -> "Step Sensor"
+            },
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+          text = "Signal: ${device.rssi} dBm",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
 
-            Button(onClick = onConnect) {
-                Text("Connect")
-            }
-        }
+      Button(onClick = onConnect) {
+        Text("Connect")
+      }
     }
+  }
 }
 
-private const val CHART_DURATION_MS = 5 * 60 * 1000L  // 5 minutes
+private const val CHART_DURATION_MS = 5 * 60 * 1000L // 5 minutes
 
 /**
  * Draws a line chart with HR (red) and HRV (green) data as a background.
@@ -886,219 +941,230 @@ private const val CHART_DURATION_MS = 5 * 60 * 1000L  // 5 minutes
  */
 @Composable
 private fun LiveDataChart(
-    hrData: List<ChartDataPoint>,
-    hrvData: List<ChartDataPoint>,
-    modifier: Modifier = Modifier
+  hrData: List<ChartDataPoint>,
+  hrvData: List<ChartDataPoint>,
+  modifier: Modifier = Modifier,
 ) {
-    val hrColor = Color(0xFFE57373)  // Light red
-    val hrvColor = Color(0xFF81C784)  // Light green
+  val hrColor = Color(0xFFE57373) // Light red
+  val hrvColor = Color(0xFF81C784) // Light green
 
-    Canvas(modifier = modifier) {
-        val width = size.width
-        val height = size.height
-        val now = System.currentTimeMillis()
-        val startTime = now - CHART_DURATION_MS
+  Canvas(modifier = modifier) {
+    val width = size.width
+    val height = size.height
+    val now = System.currentTimeMillis()
+    val startTime = now - CHART_DURATION_MS
 
-        // Helper function to draw a line for a dataset
-        fun drawDataLine(
-            data: List<ChartDataPoint>,
-            color: Color,
-            minValue: Float,
-            maxValue: Float
-        ) {
-            if (data.size < 2) return
+    // Helper function to draw a line for a dataset
+    fun drawDataLine(
+      data: List<ChartDataPoint>,
+      color: Color,
+      minValue: Float,
+      maxValue: Float,
+    ) {
+      if (data.size < 2) return
 
-            val valueRange = maxValue - minValue
-            if (valueRange <= 0) return
+      val valueRange = maxValue - minValue
+      if (valueRange <= 0) return
 
-            val path = Path()
-            var started = false
+      val path = Path()
+      var started = false
 
-            data.forEachIndexed { index, point ->
-                val x = ((point.timestamp - startTime).toFloat() / CHART_DURATION_MS) * width
-                val normalizedY = (point.value - minValue) / valueRange
-                val y = height - (normalizedY * height)  // Use full height, scale to exact min/max
+      data.forEachIndexed { index, point ->
+        val x = ((point.timestamp - startTime).toFloat() / CHART_DURATION_MS) * width
+        val normalizedY = (point.value - minValue) / valueRange
+        val y = height - (normalizedY * height) // Use full height, scale to exact min/max
 
-                if (!started) {
-                    path.moveTo(x, y)
-                    started = true
-                } else {
-                    path.lineTo(x, y)
-                }
-            }
-
-            drawPath(
-                path = path,
-                color = color,
-                style = Stroke(width = 2f)
-            )
+        if (!started) {
+          path.moveTo(x, y)
+          started = true
+        } else {
+          path.lineTo(x, y)
         }
+      }
 
-        // Calculate ranges for HR data - use exact min/max from data
-        if (hrData.isNotEmpty()) {
-            val hrValues = hrData.map { it.value }
-            val hrMin = hrValues.minOrNull() ?: 60f
-            val hrMax = hrValues.maxOrNull() ?: 100f
-            drawDataLine(hrData, hrColor, hrMin, hrMax)
-        }
-
-        // Calculate ranges for HRV data - use exact min/max from data
-        if (hrvData.isNotEmpty()) {
-            val hrvValues = hrvData.map { it.value }
-            val hrvMin = hrvValues.minOrNull() ?: 20f
-            val hrvMax = hrvValues.maxOrNull() ?: 80f
-            drawDataLine(hrvData, hrvColor, hrvMin, hrvMax)
-        }
+      drawPath(
+        path = path,
+        color = color,
+        style = Stroke(width = 2f),
+      )
     }
+
+    // Calculate ranges for HR data - use exact min/max from data
+    if (hrData.isNotEmpty()) {
+      val hrValues = hrData.map { it.value }
+      val hrMin = hrValues.minOrNull() ?: 60f
+      val hrMax = hrValues.maxOrNull() ?: 100f
+      drawDataLine(hrData, hrColor, hrMin, hrMax)
+    }
+
+    // Calculate ranges for HRV data - use exact min/max from data
+    if (hrvData.isNotEmpty()) {
+      val hrvValues = hrvData.map { it.value }
+      val hrvMin = hrvValues.minOrNull() ?: 20f
+      val hrvMax = hrvValues.maxOrNull() ?: 80f
+      drawDataLine(hrvData, hrvColor, hrvMin, hrvMax)
+    }
+  }
 }
 
 @Composable
 private fun BatteryIndicator(level: Int) {
-    val color = when {
-        level <= 20 -> MaterialTheme.colorScheme.error
-        level <= 50 -> MaterialTheme.colorScheme.tertiary
-        else -> MaterialTheme.colorScheme.primary
+  val color =
+    when {
+      level <= 20 -> MaterialTheme.colorScheme.error
+      level <= 50 -> MaterialTheme.colorScheme.tertiary
+      else -> MaterialTheme.colorScheme.primary
     }
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(horizontal = 4.dp)
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.padding(horizontal = 4.dp),
+  ) {
+    // Battery body
+    Box(
+      modifier =
+        Modifier
+          .size(width = 20.dp, height = 10.dp)
+          .border(1.dp, color, shape = MaterialTheme.shapes.extraSmall)
+          .padding(1.dp),
     ) {
-        // Battery body
-        Box(
-            modifier = Modifier
-                .size(width = 20.dp, height = 10.dp)
-                .border(1.dp, color, shape = MaterialTheme.shapes.extraSmall)
-                .padding(1.dp)
-        ) {
-            // Battery fill level
-            Box(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth(level / 100f)
-                    .background(color, shape = MaterialTheme.shapes.extraSmall)
-            )
-        }
-        // Battery tip
-        Box(
-            modifier = Modifier
-                .size(width = 2.dp, height = 5.dp)
-                .background(color, shape = MaterialTheme.shapes.extraSmall)
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(
-            text = "$level%",
-            style = MaterialTheme.typography.bodySmall,
-            color = color
-        )
+      // Battery fill level
+      Box(
+        modifier =
+          Modifier
+            .fillMaxHeight()
+            .fillMaxWidth(level / 100f)
+            .background(color, shape = MaterialTheme.shapes.extraSmall),
+      )
     }
+    // Battery tip
+    Box(
+      modifier =
+        Modifier
+          .size(width = 2.dp, height = 5.dp)
+          .background(color, shape = MaterialTheme.shapes.extraSmall),
+    )
+    Spacer(modifier = Modifier.width(4.dp))
+    Text(
+      text = "$level%",
+      style = MaterialTheme.typography.bodySmall,
+      color = color,
+    )
+  }
 }
 
 @Composable
 private fun ConnectionHealthIndicator(
-    rssi: Int?,
-    lastDataReceivedTime: Instant?
+  rssi: Int?,
+  lastDataReceivedTime: Instant?,
 ) {
-    val now = remember { mutableStateOf(Instant.now()) }
+  val now = remember { mutableStateOf(Instant.now()) }
 
-    // Update "now" every second to keep staleness indicator current
-    LaunchedEffect(Unit) {
-        while (true) {
-            now.value = Instant.now()
-            kotlinx.coroutines.delay(1000)
-        }
+  // Update "now" every second to keep staleness indicator current
+  LaunchedEffect(Unit) {
+    while (true) {
+      now.value = Instant.now()
+      kotlinx.coroutines.delay(1000)
+    }
+  }
+
+  val staleness =
+    lastDataReceivedTime?.let {
+      Duration.between(it, now.value).toMillis() / 1000.0
     }
 
-    val staleness = lastDataReceivedTime?.let {
-        Duration.between(it, now.value).toMillis() / 1000.0
+  // RSSI signal strength interpretation:
+  // > -50 dBm: Excellent
+  // -50 to -70 dBm: Good
+  // -70 to -80 dBm: Fair
+  // < -80 dBm: Weak
+  val signalStrength =
+    rssi?.let {
+      when {
+        it > -50 -> "excellent"
+        it > -70 -> "good"
+        it > -80 -> "fair"
+        else -> "weak"
+      }
     }
 
-    // RSSI signal strength interpretation:
-    // > -50 dBm: Excellent
-    // -50 to -70 dBm: Good
-    // -70 to -80 dBm: Fair
-    // < -80 dBm: Weak
-    val signalStrength = rssi?.let {
-        when {
-            it > -50 -> "excellent"
-            it > -70 -> "good"
-            it > -80 -> "fair"
-            else -> "weak"
-        }
+  val signalColor =
+    when (signalStrength) {
+      "excellent" -> Color(0xFF4CAF50) // Green
+      "good" -> Color(0xFF8BC34A) // Light green
+      "fair" -> Color(0xFFFF9800) // Orange
+      "weak" -> Color(0xFFF44336) // Red
+      else -> Color.Gray
     }
 
-    val signalColor = when (signalStrength) {
-        "excellent" -> Color(0xFF4CAF50) // Green
-        "good" -> Color(0xFF8BC34A) // Light green
-        "fair" -> Color(0xFFFF9800) // Orange
-        "weak" -> Color(0xFFF44336) // Red
-        else -> Color.Gray
-    }
-
-    // Staleness color: green if fresh, yellow if getting stale, red if very stale
-    val stalenessColor = staleness?.let {
-        when {
-            it < 3 -> Color(0xFF4CAF50) // Green - fresh
-            it < 10 -> Color(0xFFFF9800) // Orange - getting stale
-            else -> Color(0xFFF44336) // Red - stale
-        }
+  // Staleness color: green if fresh, yellow if getting stale, red if very stale
+  val stalenessColor =
+    staleness?.let {
+      when {
+        it < 3 -> Color(0xFF4CAF50) // Green - fresh
+        it < 10 -> Color(0xFFFF9800) // Orange - getting stale
+        else -> Color(0xFFF44336) // Red - stale
+      }
     } ?: Color.Gray
 
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.Center,
+    modifier = Modifier.padding(vertical = 4.dp),
+  ) {
+    // Signal strength indicator (4 bars)
     Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center,
-        modifier = Modifier.padding(vertical = 4.dp)
+      horizontalArrangement = Arrangement.spacedBy(1.dp),
+      verticalAlignment = Alignment.Bottom,
+      modifier = Modifier.height(14.dp),
     ) {
-        // Signal strength indicator (4 bars)
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(1.dp),
-            verticalAlignment = Alignment.Bottom,
-            modifier = Modifier.height(14.dp)
-        ) {
-            val bars = when (signalStrength) {
-                "excellent" -> 4
-                "good" -> 3
-                "fair" -> 2
-                "weak" -> 1
-                else -> 0
-            }
-            for (i in 1..4) {
-                Box(
-                    modifier = Modifier
-                        .width(3.dp)
-                        .height((4 + i * 2).dp)
-                        .background(
-                            if (i <= bars) signalColor else signalColor.copy(alpha = 0.3f),
-                            shape = MaterialTheme.shapes.extraSmall
-                        )
-                )
-            }
+      val bars =
+        when (signalStrength) {
+          "excellent" -> 4
+          "good" -> 3
+          "fair" -> 2
+          "weak" -> 1
+          else -> 0
         }
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        // RSSI value
-        Text(
-            text = rssi?.let { "${it}dBm" } ?: "--",
-            style = MaterialTheme.typography.labelSmall,
-            color = signalColor
+      for (i in 1..4) {
+        Box(
+          modifier =
+            Modifier
+              .width(3.dp)
+              .height((4 + i * 2).dp)
+              .background(
+                if (i <= bars) signalColor else signalColor.copy(alpha = 0.3f),
+                shape = MaterialTheme.shapes.extraSmall,
+              ),
         )
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        // Data freshness indicator
-        val stalenessText = staleness?.let {
-            when {
-                it < 1 -> "now"
-                it < 60 -> "${it.toInt()}s ago"
-                else -> "${(it / 60).toInt()}m ago"
-            }
-        } ?: "no data"
-
-        Text(
-            text = stalenessText,
-            style = MaterialTheme.typography.labelSmall,
-            color = stalenessColor
-        )
+      }
     }
+
+    Spacer(modifier = Modifier.width(4.dp))
+
+    // RSSI value
+    Text(
+      text = rssi?.let { "${it}dBm" } ?: "--",
+      style = MaterialTheme.typography.labelSmall,
+      color = signalColor,
+    )
+
+    Spacer(modifier = Modifier.width(8.dp))
+
+    // Data freshness indicator
+    val stalenessText =
+      staleness?.let {
+        when {
+          it < 1 -> "now"
+          it < 60 -> "${it.toInt()}s ago"
+          else -> "${(it / 60).toInt()}m ago"
+        }
+      } ?: "no data"
+
+    Text(
+      text = stalenessText,
+      style = MaterialTheme.typography.labelSmall,
+      color = stalenessColor,
+    )
+  }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/LiveScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,6 +59,7 @@ import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.StepsRecord
+import net.aurboda.ble.AutoReconnectPrefs
 import net.aurboda.ble.BleScanState
 import net.aurboda.ble.ChartDataPoint
 import net.aurboda.ble.DeviceState


### PR DESCRIPTION
## Summary

- **Auto-reconnect toggle**: When a BLE device is connected, a toggle switch appears in the connected device card to enable/disable auto-reconnect for that device
- **Persistent storage**: Saved device addresses/names/types are persisted in SharedPreferences, surviving app restarts
- **Background reconnection**: Uses `autoConnect=true` in BLE GATT for passive, low-power reconnection when a known device comes in range
- **Exponential backoff**: Reconnect attempts use 2s→4s→8s→16s→32s→60s backoff with max 20 attempts
- **Boot & Bluetooth receiver**: `BleAutoConnectReceiver` listens for `BOOT_COMPLETED` and `BLUETOOTH_STATE_CHANGED` to trigger reconnection to saved devices
- **Service resilience**: Changed from `START_NOT_STICKY` to `START_STICKY` so Android restarts the service if killed, with null-intent handling to reconnect saved devices

## Files Changed

| File | Change |
|------|--------|
| `BleSensorData.kt` | Added `SavedDevice` data class and `AutoReconnectPrefs` SharedPreferences manager |
| `BleConnectionManager.kt` | Added `autoConnect` parameter to `connect()` for passive background reconnection |
| `SensorService.kt` | Reconnect scheduling with backoff, `START_STICKY`, new actions for auto-reconnect and toggle |
| `BleAutoConnectReceiver.kt` | **New** — BroadcastReceiver for boot and BT state changes |
| `LiveScreen.kt` | Auto-reconnect toggle Switch in connected device card |
| `AndroidManifest.xml` | Added `RECEIVE_BOOT_COMPLETED` permission and receiver declaration |