### PR TITLE
feat: add MFA support for Garmin Connect login

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@aurboda/api-spec": "workspace:*",
-    "@flow-js/garmin-connect": "^1.6.7",
+    "@flow-js/garmin-connect": "github:fiddur/garmin-connect#feat/mfa-support",
     "@js-temporal/polyfill": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "axios": "^1.11.0",

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -426,6 +426,24 @@ const main = async () => {
     }
   })
 
+  httpd.post('/auth/garmin/mfa', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { mfa_code } = req.body ?? {}
+
+    if (!mfa_code) {
+      res.status(400).json({ error: 'MFA code is required', success: false })
+      return
+    }
+
+    try {
+      await garmin.verifyMfa(user, mfa_code)
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'MFA verification failed'
+      res.status(401).json({ error: message, success: false })
+    }
+  })
+
   httpd.post('/auth/garmin/disconnect', authMiddleware, async (req, res) => {
     const user = req.user!
     try {

--- a/apps/backend/src/garmin.test.ts
+++ b/apps/backend/src/garmin.test.ts
@@ -2,340 +2,347 @@
  * Garmin Connect API client tests.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock the GarminConnect class from the library
 const mockGarminConnect = vi.hoisted(() => ({
-  exportToken: vi.fn().mockReturnValue({ oauth1: "token1", oauth2: "token2" }),
+  exportToken: vi.fn().mockReturnValue({ oauth1: 'token1', oauth2: 'token2' }),
   get: vi.fn().mockResolvedValue({}),
   getActivities: vi.fn().mockResolvedValue([]),
   getHeartRate: vi.fn().mockResolvedValue({}),
   getSleepData: vi.fn().mockResolvedValue({}),
-  getUserProfile: vi.fn().mockResolvedValue({ displayName: "user123" }),
+  getUserProfile: vi.fn().mockResolvedValue({ displayName: 'user123' }),
   getUserSettings: vi.fn().mockResolvedValue({ userData: {} }),
   loadToken: vi.fn(),
-  login: vi.fn().mockResolvedValue(undefined),
-}));
+  login: vi.fn().mockResolvedValue({ type: 'success' }),
+  verifyMfa: vi.fn().mockResolvedValue(undefined),
+}))
 
-vi.mock("@flow-js/garmin-connect", () => {
-  const MockGarminConnect = vi.fn();
-  Object.assign(MockGarminConnect.prototype, mockGarminConnect);
+vi.mock('@flow-js/garmin-connect', () => {
+  const MockGarminConnect = vi.fn()
+  Object.assign(MockGarminConnect.prototype, mockGarminConnect)
   return {
     default: { GarminConnect: MockGarminConnect },
     GarminConnect: MockGarminConnect,
-  };
-});
+  }
+})
 
-import garminConnectPkg from "@flow-js/garmin-connect";
-const { GarminConnect } = garminConnectPkg;
+import garminConnectPkg from '@flow-js/garmin-connect'
+const { GarminConnect } = garminConnectPkg
 
-import { garminClient, type GarminClientDeps } from "./garmin.ts";
+import { garminClient, type GarminClientDeps } from './garmin.ts'
 
-const testUser = "test-user";
-const storedTokens = { oauth1: "stored-token1", oauth2: "stored-token2" };
+const testUser = 'test-user'
+const storedTokens = { oauth1: 'stored-token1', oauth2: 'stored-token2' }
 
 const createMockDeps = (): GarminClientDeps => ({
   getOAuthToken: vi.fn().mockResolvedValue({
     access_token: JSON.stringify(storedTokens),
-    provider: "garmin",
+    provider: 'garmin',
   }),
   upsertOAuthToken: vi.fn().mockResolvedValue(undefined),
-});
+})
 
-describe("garminClient", () => {
-  let deps: GarminClientDeps;
+describe('garminClient', () => {
+  let deps: GarminClientDeps
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    deps = createMockDeps();
-  });
+    vi.clearAllMocks()
+    deps = createMockDeps()
+  })
 
-  describe("login", () => {
-    it("creates GarminConnect with credentials and logs in", async () => {
-      const client = garminClient(deps);
-      const result = await client.login(testUser, "user@example.com", "secret");
+  describe('login', () => {
+    it('creates GarminConnect with credentials and logs in', async () => {
+      const client = garminClient(deps)
+      const result = await client.login(testUser, 'user@example.com', 'secret')
 
       expect(GarminConnect).toHaveBeenCalledWith({
-        password: "secret",
-        username: "user@example.com",
-      });
-      expect(mockGarminConnect.login).toHaveBeenCalled();
+        password: 'secret',
+        username: 'user@example.com',
+      })
+      expect(mockGarminConnect.login).toHaveBeenCalled()
       expect(result).toEqual({
         success: true,
-        tokens: { oauth1: "token1", oauth2: "token2" },
-      });
-    });
+        tokens: { oauth1: 'token1', oauth2: 'token2' },
+      })
+    })
 
-    it("stores tokens after successful login", async () => {
-      const client = garminClient(deps);
-      await client.login(testUser, "user@example.com", "secret");
-
-      expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
-        provider: "garmin",
-      });
-    });
-  });
-
-  describe("disconnect", () => {
-    it("clears stored tokens", async () => {
-      const client = garminClient(deps);
-      await client.disconnect(testUser);
+    it('stores tokens after successful login', async () => {
+      const client = garminClient(deps)
+      await client.login(testUser, 'user@example.com', 'secret')
 
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: "",
-        provider: "garmin",
-      });
-    });
-  });
+        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
+        provider: 'garmin',
+      })
+    })
 
-  describe("restoreSession (via data methods)", () => {
-    it("throws when no token is stored", async () => {
-      vi.mocked(deps.getOAuthToken).mockResolvedValue(null);
+    it('returns mfa_required when Garmin requires MFA', async () => {
+      mockGarminConnect.login.mockResolvedValueOnce({
+        type: 'mfa_required',
+        loginParams: { clientId: 'test' },
+      })
 
-      const client = garminClient(deps);
+      const client = garminClient(deps)
+      const result = await client.login(testUser, 'user@example.com', 'secret')
+
+      expect(result).toEqual({ mfa_required: true })
+      expect(deps.upsertOAuthToken).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('verifyMfa', () => {
+    it('completes login after MFA verification', async () => {
+      mockGarminConnect.login.mockResolvedValueOnce({
+        type: 'mfa_required',
+        loginParams: { clientId: 'test' },
+      })
+
+      const client = garminClient(deps)
+      await client.login(testUser, 'user@example.com', 'secret')
+
+      const result = await client.verifyMfa(testUser, '123456')
+
+      expect(mockGarminConnect.verifyMfa).toHaveBeenCalledWith('123456')
+      expect(result).toEqual({
+        success: true,
+        tokens: { oauth1: 'token1', oauth2: 'token2' },
+      })
+      expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
+        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
+        provider: 'garmin',
+      })
+    })
+
+    it('throws when no pending MFA session exists', async () => {
+      const client = garminClient(deps)
+      await expect(client.verifyMfa(testUser, '123456')).rejects.toThrow('No pending MFA session')
+    })
+  })
+
+  describe('disconnect', () => {
+    it('clears stored tokens', async () => {
+      const client = garminClient(deps)
+      await client.disconnect(testUser)
+
+      expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
+        access_token: '',
+        provider: 'garmin',
+      })
+    })
+  })
+
+  describe('restoreSession (via data methods)', () => {
+    it('throws when no token is stored', async () => {
+      vi.mocked(deps.getOAuthToken).mockResolvedValue(null)
+
+      const client = garminClient(deps)
       await expect(client.getHeartRate(testUser, new Date())).rejects.toThrow(
-        "User has no Garmin session. Please connect Garmin first.",
-      );
-    });
+        'User has no Garmin session. Please connect Garmin first.',
+      )
+    })
 
-    it("loads stored tokens into GarminConnect", async () => {
-      const client = garminClient(deps);
-      await client.getHeartRate(testUser, new Date("2024-06-15"));
+    it('loads stored tokens into GarminConnect', async () => {
+      const client = garminClient(deps)
+      await client.getHeartRate(testUser, new Date('2024-06-15'))
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
-        "stored-token1",
-        "stored-token2",
-      );
-    });
-  });
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
+    })
+  })
 
-  describe("getDailySummary", () => {
-    it("restores session, fetches summary via get, and saves session", async () => {
-      const summaryData = { calendarDate: "2024-06-15", totalSteps: 10000 };
-      mockGarminConnect.get.mockResolvedValueOnce(summaryData);
+  describe('getDailySummary', () => {
+    it('restores session, fetches summary via get, and saves session', async () => {
+      const summaryData = { calendarDate: '2024-06-15', totalSteps: 10000 }
+      mockGarminConnect.get.mockResolvedValueOnce(summaryData)
 
-      const client = garminClient(deps);
-      const result = await client.getDailySummary(
-        testUser,
-        new Date("2024-06-15"),
-      );
+      const client = garminClient(deps)
+      const result = await client.getDailySummary(testUser, new Date('2024-06-15'))
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
-        "stored-token1",
-        "stored-token2",
-      );
-      expect(mockGarminConnect.getUserProfile).toHaveBeenCalled();
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
+      expect(mockGarminConnect.getUserProfile).toHaveBeenCalled()
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/usersummary-service/usersummary/daily/user123?calendarDate=2024-06-15",
-      );
-      expect(result).toEqual(summaryData);
+        '/usersummary-service/usersummary/daily/user123?calendarDate=2024-06-15',
+      )
+      expect(result).toEqual(summaryData)
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
-        provider: "garmin",
-      });
-    });
-  });
+        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
+        provider: 'garmin',
+      })
+    })
+  })
 
-  describe("getHeartRate", () => {
-    it("restores session, calls getHeartRate, and saves session", async () => {
-      const hrData = { heartRateValues: [[1000, 72]] };
-      mockGarminConnect.getHeartRate.mockResolvedValueOnce(hrData);
+  describe('getHeartRate', () => {
+    it('restores session, calls getHeartRate, and saves session', async () => {
+      const hrData = { heartRateValues: [[1000, 72]] }
+      mockGarminConnect.getHeartRate.mockResolvedValueOnce(hrData)
 
-      const client = garminClient(deps);
-      const date = new Date("2024-06-15");
-      const result = await client.getHeartRate(testUser, date);
+      const client = garminClient(deps)
+      const date = new Date('2024-06-15')
+      const result = await client.getHeartRate(testUser, date)
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
-        "stored-token1",
-        "stored-token2",
-      );
-      expect(mockGarminConnect.getHeartRate).toHaveBeenCalledWith(date);
-      expect(result).toEqual(hrData);
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
+      expect(mockGarminConnect.getHeartRate).toHaveBeenCalledWith(date)
+      expect(result).toEqual(hrData)
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
-        provider: "garmin",
-      });
-    });
-  });
+        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
+        provider: 'garmin',
+      })
+    })
+  })
 
-  describe("getStress", () => {
-    it("restores session, fetches stress via get, and saves session", async () => {
-      const stressData = { calendarDate: "2024-06-15", overallStressLevel: 42 };
-      mockGarminConnect.get.mockResolvedValueOnce(stressData);
+  describe('getStress', () => {
+    it('restores session, fetches stress via get, and saves session', async () => {
+      const stressData = { calendarDate: '2024-06-15', overallStressLevel: 42 }
+      mockGarminConnect.get.mockResolvedValueOnce(stressData)
 
-      const client = garminClient(deps);
-      const result = await client.getStress(testUser, new Date("2024-06-15"));
+      const client = garminClient(deps)
+      const result = await client.getStress(testUser, new Date('2024-06-15'))
 
-      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, "garmin");
-      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith(
-        "stored-token1",
-        "stored-token2",
-      );
-      expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/wellness-service/wellness/dailyStress/2024-06-15",
-      );
-      expect(result).toEqual(stressData);
+      expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
+      expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
+      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/dailyStress/2024-06-15')
+      expect(result).toEqual(stressData)
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
-        access_token: JSON.stringify({ oauth1: "token1", oauth2: "token2" }),
-        provider: "garmin",
-      });
-    });
-  });
+        access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
+        provider: 'garmin',
+      })
+    })
+  })
 
-  describe("getHrv", () => {
-    it("restores session, fetches HRV via get, and saves session", async () => {
+  describe('getHrv', () => {
+    it('restores session, fetches HRV via get, and saves session', async () => {
       const hrvData = {
-        calendarDate: "2024-06-15",
+        calendarDate: '2024-06-15',
         lastNightAvg: 42,
         weeklyAvg: 45,
-      };
-      mockGarminConnect.get.mockResolvedValueOnce(hrvData);
+      }
+      mockGarminConnect.get.mockResolvedValueOnce(hrvData)
 
-      const client = garminClient(deps);
-      const result = await client.getHrv(testUser, new Date("2024-06-15"));
+      const client = garminClient(deps)
+      const result = await client.getHrv(testUser, new Date('2024-06-15'))
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/hrv-service/hrv/2024-06-15",
-      );
-      expect(result).toEqual(hrvData);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+      expect(mockGarminConnect.get).toHaveBeenCalledWith('/hrv-service/hrv/2024-06-15')
+      expect(result).toEqual(hrvData)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getSleep", () => {
-    it("restores session, calls getSleepData, and saves session", async () => {
-      const sleepData = { dailySleepDTO: { calendarDate: "2024-06-15" } };
-      mockGarminConnect.getSleepData.mockResolvedValueOnce(sleepData);
+  describe('getSleep', () => {
+    it('restores session, calls getSleepData, and saves session', async () => {
+      const sleepData = { dailySleepDTO: { calendarDate: '2024-06-15' } }
+      mockGarminConnect.getSleepData.mockResolvedValueOnce(sleepData)
 
-      const client = garminClient(deps);
-      const date = new Date("2024-06-15");
-      const result = await client.getSleep(testUser, date);
+      const client = garminClient(deps)
+      const date = new Date('2024-06-15')
+      const result = await client.getSleep(testUser, date)
 
-      expect(mockGarminConnect.getSleepData).toHaveBeenCalledWith(date);
-      expect(result).toEqual(sleepData);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+      expect(mockGarminConnect.getSleepData).toHaveBeenCalledWith(date)
+      expect(result).toEqual(sleepData)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getBodyBattery", () => {
-    it("restores session, fetches body battery with date range, and saves session", async () => {
-      const bbData = [{ charged: 80, date: "2024-06-15", drained: 60 }];
-      mockGarminConnect.get.mockResolvedValueOnce(bbData);
+  describe('getBodyBattery', () => {
+    it('restores session, fetches body battery with date range, and saves session', async () => {
+      const bbData = [{ charged: 80, date: '2024-06-15', drained: 60 }]
+      mockGarminConnect.get.mockResolvedValueOnce(bbData)
 
-      const client = garminClient(deps);
-      const result = await client.getBodyBattery(
-        testUser,
-        new Date("2024-06-14"),
-        new Date("2024-06-15"),
-      );
+      const client = garminClient(deps)
+      const result = await client.getBodyBattery(testUser, new Date('2024-06-14'), new Date('2024-06-15'))
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/wellness-service/wellness/bodyBattery/reports/daily?startDate=2024-06-14&endDate=2024-06-15",
-      );
-      expect(result).toEqual(bbData);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+        '/wellness-service/wellness/bodyBattery/reports/daily?startDate=2024-06-14&endDate=2024-06-15',
+      )
+      expect(result).toEqual(bbData)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getActivities", () => {
-    it("restores session, calls getActivities with start and limit, and saves session", async () => {
-      const activities = [{ activityId: 1 }, { activityId: 2 }];
-      mockGarminConnect.getActivities.mockResolvedValueOnce(activities);
+  describe('getActivities', () => {
+    it('restores session, calls getActivities with start and limit, and saves session', async () => {
+      const activities = [{ activityId: 1 }, { activityId: 2 }]
+      mockGarminConnect.getActivities.mockResolvedValueOnce(activities)
 
-      const client = garminClient(deps);
-      const result = await client.getActivities(testUser, 0, 10);
+      const client = garminClient(deps)
+      const result = await client.getActivities(testUser, 0, 10)
 
-      expect(mockGarminConnect.getActivities).toHaveBeenCalledWith(0, 10);
-      expect(result).toEqual(activities);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+      expect(mockGarminConnect.getActivities).toHaveBeenCalledWith(0, 10)
+      expect(result).toEqual(activities)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getSpo2", () => {
-    it("restores session, fetches SpO2 via get, and saves session", async () => {
-      const spo2Data = { averageSpO2: 97, calendarDate: "2024-06-15" };
-      mockGarminConnect.get.mockResolvedValueOnce(spo2Data);
+  describe('getSpo2', () => {
+    it('restores session, fetches SpO2 via get, and saves session', async () => {
+      const spo2Data = { averageSpO2: 97, calendarDate: '2024-06-15' }
+      mockGarminConnect.get.mockResolvedValueOnce(spo2Data)
 
-      const client = garminClient(deps);
-      const result = await client.getSpo2(testUser, new Date("2024-06-15"));
+      const client = garminClient(deps)
+      const result = await client.getSpo2(testUser, new Date('2024-06-15'))
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/wellness-service/wellness/daily/spo2/2024-06-15",
-      );
-      expect(result).toEqual(spo2Data);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/daily/spo2/2024-06-15')
+      expect(result).toEqual(spo2Data)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getRespiration", () => {
-    it("restores session, fetches respiration via get, and saves session", async () => {
+  describe('getRespiration', () => {
+    it('restores session, fetches respiration via get, and saves session', async () => {
       const respData = {
         avgWakingRespirationValue: 16,
-        calendarDate: "2024-06-15",
-      };
-      mockGarminConnect.get.mockResolvedValueOnce(respData);
+        calendarDate: '2024-06-15',
+      }
+      mockGarminConnect.get.mockResolvedValueOnce(respData)
 
-      const client = garminClient(deps);
-      const result = await client.getRespiration(
-        testUser,
-        new Date("2024-06-15"),
-      );
+      const client = garminClient(deps)
+      const result = await client.getRespiration(testUser, new Date('2024-06-15'))
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/wellness-service/wellness/daily/respiration/2024-06-15",
-      );
-      expect(result).toEqual(respData);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+        '/wellness-service/wellness/daily/respiration/2024-06-15',
+      )
+      expect(result).toEqual(respData)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getTrainingReadiness", () => {
-    it("restores session, fetches training readiness via get, and saves session", async () => {
+  describe('getTrainingReadiness', () => {
+    it('restores session, fetches training readiness via get, and saves session', async () => {
       const trData = {
-        calendarDate: "2024-06-15",
-        level: "HIGH",
+        calendarDate: '2024-06-15',
+        level: 'HIGH',
         overallScore: 75,
-      };
-      mockGarminConnect.get.mockResolvedValueOnce(trData);
+      }
+      mockGarminConnect.get.mockResolvedValueOnce(trData)
 
-      const client = garminClient(deps);
-      const result = await client.getTrainingReadiness(
-        testUser,
-        new Date("2024-06-15"),
-      );
+      const client = garminClient(deps)
+      const result = await client.getTrainingReadiness(testUser, new Date('2024-06-15'))
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/metrics-service/metrics/trainingreadiness/2024-06-15",
-      );
-      expect(result).toEqual(trData);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
+        '/metrics-service/metrics/trainingreadiness/2024-06-15',
+      )
+      expect(result).toEqual(trData)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
 
-  describe("getIntensityMinutes", () => {
-    it("restores session, fetches intensity minutes via get, and saves session", async () => {
+  describe('getIntensityMinutes', () => {
+    it('restores session, fetches intensity minutes via get, and saves session', async () => {
       const imData = {
-        calendarDate: "2024-06-15",
+        calendarDate: '2024-06-15',
         moderateIntensityMinutes: 30,
         vigorousIntensityMinutes: 15,
-      };
-      mockGarminConnect.get.mockResolvedValueOnce(imData);
+      }
+      mockGarminConnect.get.mockResolvedValueOnce(imData)
 
-      const client = garminClient(deps);
-      const result = await client.getIntensityMinutes(
-        testUser,
-        new Date("2024-06-15"),
-      );
+      const client = garminClient(deps)
+      const result = await client.getIntensityMinutes(testUser, new Date('2024-06-15'))
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        "/wellness-service/wellness/daily/im/2024-06-15",
-      );
-      expect(result).toEqual(imData);
-      expect(deps.upsertOAuthToken).toHaveBeenCalled();
-    });
-  });
-});
+      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/daily/im/2024-06-15')
+      expect(result).toEqual(imData)
+      expect(deps.upsertOAuthToken).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -137,7 +137,7 @@ export interface GarminDailySummary {
 // Login result types
 // ============================================================================
 
-export interface GarminLoginResult {
+export interface GarminLoginSuccess {
   success: true
   tokens: IGarminTokens
 }
@@ -146,7 +146,7 @@ export interface GarminMfaRequired {
   mfa_required: true
 }
 
-export type LoginResult = GarminLoginResult | GarminMfaRequired
+export type LoginResult = GarminLoginSuccess | GarminMfaRequired
 
 // ============================================================================
 // Client factory
@@ -158,6 +158,16 @@ export interface GarminClientDeps {
 }
 
 const defaultDeps: GarminClientDeps = { getOAuthToken, upsertOAuthToken }
+
+/**
+ * Pending MFA sessions, keyed by user.
+ * Holds a live GarminConnect instance between login() and verifyMfa().
+ * Entries are cleaned up on completion, timeout, or disconnect.
+ */
+const pendingMfaSessions = new Map<string, { gc: InstanceType<typeof GarminConnect>; createdAt: number }>()
+
+/** Max time (ms) a pending MFA session is kept before being discarded. */
+const MFA_SESSION_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
 /**
  * Creates a Garmin Connect API client.
@@ -294,12 +304,59 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
     /**
      * Login with Garmin credentials. Returns tokens on success or indicates MFA required.
      * Credentials are used only for this call and never stored.
+     *
+     * When MFA is required, the GarminConnect instance is kept alive in
+     * `pendingMfaSessions` so that `verifyMfa()` can complete the flow.
      */
-
     async login(user: string, email: string, password: string): Promise<LoginResult> {
+      // Clean up any stale pending session for this user
+      pendingMfaSessions.delete(user)
+
       const gc = new GarminConnect({ password, username: email })
-      await gc.login()
-      // If we reach here, login succeeded (no MFA or MFA was not enabled)
+      const result = await gc.login()
+
+      if (result.type === 'success') {
+        const tokens = gc.exportToken()
+        await saveSession(user, gc)
+        return { success: true, tokens }
+      }
+
+      // MFA required — park the instance for verifyMfa()
+      pendingMfaSessions.set(user, { gc, createdAt: Date.now() })
+
+      // Schedule cleanup so we don't leak memory if verifyMfa() is never called
+      setTimeout(() => {
+        const entry = pendingMfaSessions.get(user)
+        if (entry && entry.createdAt <= Date.now() - MFA_SESSION_TTL_MS) {
+          pendingMfaSessions.delete(user)
+        }
+      }, MFA_SESSION_TTL_MS + 1000)
+
+      return { mfa_required: true }
+    },
+
+    /**
+     * Complete MFA verification after login() returned { mfa_required: true }.
+     *
+     * @param user     Aurboda user id
+     * @param mfaCode  The code from the user's email/SMS
+     */
+    async verifyMfa(user: string, mfaCode: string): Promise<GarminLoginSuccess> {
+      const entry = pendingMfaSessions.get(user)
+      if (!entry) {
+        throw new Error('No pending MFA session. Please start login again.')
+      }
+
+      if (Date.now() - entry.createdAt > MFA_SESSION_TTL_MS) {
+        pendingMfaSessions.delete(user)
+        throw new Error('MFA session expired. Please start login again.')
+      }
+
+      const { gc } = entry
+
+      await gc.verifyMfa(mfaCode)
+      pendingMfaSessions.delete(user)
+
       const tokens = gc.exportToken()
       await saveSession(user, gc)
       return { success: true, tokens }

--- a/apps/web/src/pages/DataSources/GarminSource.tsx
+++ b/apps/web/src/pages/DataSources/GarminSource.tsx
@@ -1,7 +1,13 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
 
-import { connectGarmin, disconnectGarmin, fetchUserSettings, syncGarmin } from '../../state/api'
+import {
+  connectGarmin,
+  disconnectGarmin,
+  fetchUserSettings,
+  syncGarmin,
+  verifyGarminMfa,
+} from '../../state/api'
 import { auth } from '../../state/auth'
 import { DataTypesList, LoginRequired, StatusBanner } from './shared'
 import './style.css'
@@ -20,6 +26,138 @@ const DATA_TYPES = [
   'Intensity minutes',
 ]
 
+type LoginStatus = 'idle' | 'loading' | 'mfa' | 'mfa_loading' | 'error'
+
+function GarminMfaForm({ onCancel, onSuccess }: { onCancel: () => void; onSuccess: () => void }) {
+  const [mfaCode, setMfaCode] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading'>('idle')
+  const [error, setError] = useState('')
+
+  const handleSubmit = useCallback(
+    async (e: Event) => {
+      e.preventDefault()
+      if (!mfaCode) return
+
+      setStatus('loading')
+      setError('')
+      try {
+        const result = await verifyGarminMfa(mfaCode)
+        if (result.success) {
+          onSuccess()
+        } else {
+          setStatus('idle')
+          setError(result.error ?? 'Verification failed')
+        }
+      } catch (err) {
+        setStatus('idle')
+        setError(err instanceof Error ? err.message : 'Verification failed')
+      }
+    },
+    [mfaCode, onSuccess],
+  )
+
+  return (
+    <form class="garmin-login-form" onSubmit={handleSubmit}>
+      <p class="field-description">
+        Garmin has sent a verification code to your email. Enter it below to complete login.
+      </p>
+      <div class="form-field">
+        <label for="garmin-mfa-code">Verification Code</label>
+        <input
+          id="garmin-mfa-code"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          autoComplete="one-time-code"
+          value={mfaCode}
+          onInput={(e) => setMfaCode((e.target as HTMLInputElement).value)}
+          placeholder="Enter code from email"
+          required
+          disabled={status === 'loading'}
+        />
+      </div>
+      <button type="submit" class="connect-button" disabled={status === 'loading' || !mfaCode}>
+        {status === 'loading' ? 'Verifying...' : 'Verify Code'}
+      </button>
+      <button type="button" class="connect-button disconnect-button" onClick={onCancel}>
+        Cancel
+      </button>
+      {error && <p class="garmin-login-error">{error}</p>}
+    </form>
+  )
+}
+
+function GarminLoginForm({ onMfaRequired, onSuccess }: { onMfaRequired: () => void; onSuccess: () => void }) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = useCallback(
+    async (e: Event) => {
+      e.preventDefault()
+      if (!email || !password) return
+
+      setLoading(true)
+      setError('')
+      try {
+        const result = await connectGarmin(email, password)
+        if (result.success) {
+          setEmail('')
+          setPassword('')
+          onSuccess()
+        } else if (result.mfa_required) {
+          onMfaRequired()
+        } else {
+          setError(result.error ?? 'Login failed')
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Login failed')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [email, password, onSuccess, onMfaRequired],
+  )
+
+  return (
+    <form class="garmin-login-form" onSubmit={handleSubmit}>
+      <div class="form-field">
+        <label for="garmin-email">Garmin Connect Email</label>
+        <input
+          id="garmin-email"
+          type="email"
+          value={email}
+          onInput={(e) => setEmail((e.target as HTMLInputElement).value)}
+          placeholder="your-email@example.com"
+          required
+          disabled={loading}
+        />
+      </div>
+      <div class="form-field">
+        <label for="garmin-password">Password</label>
+        <input
+          id="garmin-password"
+          type="password"
+          value={password}
+          onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
+          placeholder="Your Garmin password"
+          required
+          disabled={loading}
+        />
+      </div>
+      <button type="submit" class="connect-button" disabled={loading || !email || !password}>
+        {loading ? 'Connecting...' : 'Connect Garmin'}
+      </button>
+      <p class="field-description">
+        Your credentials are used only to authenticate with Garmin and are never stored on the server. Only
+        session tokens are saved.
+      </p>
+      {error && <p class="garmin-login-error">{error}</p>}
+    </form>
+  )
+}
+
 export function GarminSource() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()
@@ -32,11 +170,7 @@ export function GarminSource() {
 
   const isConnected = userSettings?.garmin_connected ?? false
 
-  // Login form state
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [loginStatus, setLoginStatus] = useState<'idle' | 'loading' | 'error'>('idle')
-  const [loginError, setLoginError] = useState('')
+  const [loginStatus, setLoginStatus] = useState<LoginStatus>('idle')
 
   // Disconnect state
   const [disconnecting, setDisconnecting] = useState(false)
@@ -45,34 +179,10 @@ export function GarminSource() {
   const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
   const [syncMessage, setSyncMessage] = useState('')
 
-  const handleLogin = useCallback(
-    async (e: Event) => {
-      e.preventDefault()
-      if (!email || !password) return
-
-      setLoginStatus('loading')
-      setLoginError('')
-      try {
-        const result = await connectGarmin(email, password)
-        if (result.success) {
-          setEmail('')
-          setPassword('')
-          setLoginStatus('idle')
-          await queryClient.invalidateQueries({ queryKey: ['userSettings'] })
-        } else if (result.mfa_required) {
-          setLoginStatus('error')
-          setLoginError('Garmin requires multi-factor authentication, which is not yet supported.')
-        } else {
-          setLoginStatus('error')
-          setLoginError(result.error ?? 'Login failed')
-        }
-      } catch (err) {
-        setLoginStatus('error')
-        setLoginError(err instanceof Error ? err.message : 'Login failed')
-      }
-    },
-    [email, password, queryClient],
-  )
+  const handleLoginSuccess = useCallback(async () => {
+    setLoginStatus('idle')
+    await queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+  }, [queryClient])
 
   const handleDisconnect = useCallback(async () => {
     setDisconnecting(true)
@@ -167,45 +277,10 @@ export function GarminSource() {
                   </div>
                   {syncMessage && <p class={`garmin-sync-message ${syncStatus}`}>{syncMessage}</p>}
                 </div>
+              ) : loginStatus === 'mfa' ? (
+                <GarminMfaForm onCancel={() => setLoginStatus('idle')} onSuccess={handleLoginSuccess} />
               ) : (
-                <form class="garmin-login-form" onSubmit={handleLogin}>
-                  <div class="form-field">
-                    <label for="garmin-email">Garmin Connect Email</label>
-                    <input
-                      id="garmin-email"
-                      type="email"
-                      value={email}
-                      onInput={(e) => setEmail((e.target as HTMLInputElement).value)}
-                      placeholder="your-email@example.com"
-                      required
-                      disabled={loginStatus === 'loading'}
-                    />
-                  </div>
-                  <div class="form-field">
-                    <label for="garmin-password">Password</label>
-                    <input
-                      id="garmin-password"
-                      type="password"
-                      value={password}
-                      onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
-                      placeholder="Your Garmin password"
-                      required
-                      disabled={loginStatus === 'loading'}
-                    />
-                  </div>
-                  <button
-                    type="submit"
-                    class="connect-button"
-                    disabled={loginStatus === 'loading' || !email || !password}
-                  >
-                    {loginStatus === 'loading' ? 'Connecting...' : 'Connect Garmin'}
-                  </button>
-                  <p class="field-description">
-                    Your credentials are used only to authenticate with Garmin and are never stored on the
-                    server. Only session tokens are saved.
-                  </p>
-                  {loginError && <p class="garmin-login-error">{loginError}</p>}
-                </form>
+                <GarminLoginForm onMfaRequired={() => setLoginStatus('mfa')} onSuccess={handleLoginSuccess} />
               )}
             </section>
           </>

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -510,6 +510,16 @@ export const connectGarmin = async (
   return response.data
 }
 
+export const verifyGarminMfa = async (mfaCode: string): Promise<{ success: boolean; error?: string }> => {
+  const { token } = auth.value
+  const response = await axios.post(
+    `${API_URL}/auth/garmin/mfa`,
+    { mfa_code: mfaCode },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data
+}
+
 export const disconnectGarmin = async (): Promise<{ success: boolean }> => {
   const { token } = auth.value
   const response = await axios.post(

--- a/docs/garmin.md
+++ b/docs/garmin.md
@@ -1,6 +1,6 @@
 # Garmin Connect
 
-[Garmin Connect](https://connect.garmin.com/) provides fitness and health data from Garmin wearable devices (watches, fitness trackers). Aurboda syncs data by scraping the Garmin Connect web API using the `@flow-js/garmin-connect` library, since Garmin's official API requires a partner license.
+[Garmin Connect](https://connect.garmin.com/) provides fitness and health data from Garmin wearable devices (watches, fitness trackers). Aurboda syncs data by scraping the Garmin Connect web API using a [fork of `@flow-js/garmin-connect`](https://github.com/fiddur/garmin-connect) with MFA support, since Garmin's official API requires a partner license.
 
 ## Data Synced
 
@@ -29,11 +29,10 @@ No server-side admin configuration is needed. Unlike Oura (which requires OAuth 
 1. Go to **Settings > Data Sources > Garmin Connect**
 2. Enter your Garmin Connect **email** and **password**
 3. Click **Connect**
-4. If successful, Settings will show "Connected"
+4. If your account has MFA (multi-factor authentication) enabled, Garmin will send a verification code to your email. Enter the code in the form that appears and click **Verify Code**.
+5. If successful, Settings will show "Connected"
 
 **Important:** Your Garmin credentials are used only for the initial authentication and are **never stored** on the server. Only the resulting OAuth session tokens are persisted, which allow continued access without re-entering credentials.
-
-If Garmin requires MFA (multi-factor authentication), you'll be prompted accordingly.
 
 ## Sync
 
@@ -70,5 +69,5 @@ This removes the stored session tokens. You'll need to re-enter your credentials
 
 - **No webhook/push support:** Garmin's official webhook API requires a partner license. Sync is pull-based only.
 - **Session expiry:** Garmin Connect sessions may expire, requiring the user to re-authenticate by entering credentials again.
-- **MFA:** If Garmin MFA is enabled, the current implementation may not fully support the MFA flow.
+- **MFA timeout:** The MFA verification code must be entered within 5 minutes of submitting credentials. If the session expires, start the login flow again.
 - **Rate limiting:** Garmin's unofficial API has undocumented rate limits. The day-by-day iteration with delays helps, but full resyncs of 90+ days may encounter limits.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/api-spec
       '@flow-js/garmin-connect':
-        specifier: ^1.6.7
-        version: 1.6.7
+        specifier: github:fiddur/garmin-connect#feat/mfa-support
+        version: https://codeload.github.com/fiddur/garmin-connect/tar.gz/1e05e47d57a751855082425fb98441b7313bb068
       '@js-temporal/polyfill':
         specifier: ^0.5.1
         version: 0.5.1
@@ -499,8 +499,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@flow-js/garmin-connect@1.6.7':
-    resolution: {integrity: sha512-r7D3YSJNPcgDFGSW6haLdNUS9SDLxHb6ccQynxhqPWL7tOpaOf3Wec9BheP0hdSEh5DLwDnyh/A+j3+4p36Hqg==}
+  '@flow-js/garmin-connect@https://codeload.github.com/fiddur/garmin-connect/tar.gz/1e05e47d57a751855082425fb98441b7313bb068':
+    resolution: {tarball: https://codeload.github.com/fiddur/garmin-connect/tar.gz/1e05e47d57a751855082425fb98441b7313bb068}
+    version: 1.6.7
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -3740,7 +3741,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@flow-js/garmin-connect@1.6.7':
+  '@flow-js/garmin-connect@https://codeload.github.com/fiddur/garmin-connect/tar.gz/1e05e47d57a751855082425fb98441b7313bb068':
     dependencies:
       app-root-path: 3.1.0
       axios: 1.13.3


### PR DESCRIPTION
## Summary

- Switch to a [fork of @flow-js/garmin-connect](https://github.com/fiddur/garmin-connect/tree/feat/mfa-support) that adds MFA support by replacing the HTML form-based SSO scraping with Garmin's mobile JSON API (matching [garth](https://github.com/matin/garth)'s approach)
- Implement a two-step login flow: login returns `mfa_required` when Garmin requires MFA, then a separate endpoint accepts the verification code
- Frontend shows an MFA code input form when login triggers MFA, with Cancel to go back

## Changes

### Fork (`@flow-js/garmin-connect`)
- `HttpClient.ts`: Replace embed/widget HTML scraping with `/mobile/api/login` and `/mobile/api/mfa/verifyCode` JSON endpoints
- `GarminConnect.ts`: Expose `verifyMfa()` method, `login()` returns `LoginResult` type
- `UrlClass.ts`: Add mobile SSO URL getters

### Backend
- `garmin.ts`: Two-step MFA flow with in-memory pending sessions (5min TTL with auto-cleanup)
- `api.ts`: New `POST /auth/garmin/mfa` endpoint accepting `{ mfa_code }`
- `garmin.test.ts`: Updated mocks + new MFA tests (all 113 garmin tests pass)

### Frontend
- `GarminSource.tsx`: Extracted `GarminMfaForm` and `GarminLoginForm` sub-components; shows MFA code input when login triggers MFA
- `api.ts`: New `verifyGarminMfa()` function

### Docs
- `garmin.md`: Updated to document MFA flow and link to the fork

## How to test
Sara's Garmin account has MFA enabled — have her try connecting via the Garmin data source page.