### PR TITLE
feat: horizontal timeline screentime stacked bars with side-by-side layout

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -137,6 +137,8 @@ export {
   getAllProductivityForCategorization,
   getDistinctApps,
   getProductivity,
+  type ProductivityBucketRow,
+  getProductivityBucketed,
   getProductivityById,
   insertProductivity,
   restoreProductivityRecord,

--- a/apps/backend/src/db/productivity.integration.test.ts
+++ b/apps/backend/src/db/productivity.integration.test.ts
@@ -555,6 +555,30 @@ describe('Productivity Integration Tests', () => {
       expect(rows).toHaveLength(0)
     })
 
+    test('handles uncategorized records (null resolved_category)', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'plasmashell',
+          duration_sec: 600,
+          end_time: new Date('2024-01-15T10:10:00Z'),
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+      ])
+
+      const rows = await getProductivityBucketed(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-16T00:00:00Z'),
+        '1 hours',
+        'UTC',
+      )
+
+      expect(rows).toHaveLength(1)
+      expect(rows[0].resolved_category).toBeNull()
+      expect(rows[0].total_sec).toBe(600)
+    })
+
     test('excludes soft-deleted records', async () => {
       const user = getTestUser()
       await insertProductivity(user, [

--- a/apps/backend/src/db/productivity.integration.test.ts
+++ b/apps/backend/src/db/productivity.integration.test.ts
@@ -12,6 +12,7 @@ import {
   getAllProductivityForCategorization,
   getDistinctApps,
   getProductivity,
+  getProductivityBucketed,
   insertProductivity,
   restoreProductivityRecord,
 } from '../db/index.ts'
@@ -486,6 +487,100 @@ describe('Productivity Integration Tests', () => {
       const user = getTestUser()
       const apps = await getDistinctApps(user)
       expect(apps).toHaveLength(0)
+    })
+  })
+
+  // ==========================================================================
+  // getProductivityBucketed
+  // ==========================================================================
+
+  describe('getProductivityBucketed', () => {
+    test('buckets records by hour with category breakdown', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          duration_sec: 1800,
+          end_time: new Date('2024-01-15T10:30:00Z'),
+          resolved_category: ['Work', 'Programming'],
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+        makeRecord({
+          activity: 'slack',
+          duration_sec: 600,
+          end_time: new Date('2024-01-15T10:40:00Z'),
+          resolved_category: ['Work', 'Communication'],
+          start_time: new Date('2024-01-15T10:30:00Z'),
+        }),
+        makeRecord({
+          activity: 'netflix',
+          duration_sec: 3600,
+          end_time: new Date('2024-01-15T12:00:00Z'),
+          resolved_category: ['Media', 'TV'],
+          start_time: new Date('2024-01-15T11:00:00Z'),
+        }),
+      ])
+
+      const rows = await getProductivityBucketed(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-16T00:00:00Z'),
+        '1 hours',
+        'UTC',
+      )
+
+      // Should have rows for 10:00 bucket (2 categories) and 11:00 bucket (1 category)
+      expect(rows.length).toBeGreaterThanOrEqual(3)
+
+      const hour10 = rows.filter((r) => r.bucket_start.getUTCHours() === 10)
+      expect(hour10).toHaveLength(2)
+      const totalSec10 = hour10.reduce((s, r) => s + r.total_sec, 0)
+      expect(totalSec10).toBe(2400) // 1800 + 600
+
+      const hour11 = rows.filter((r) => r.bucket_start.getUTCHours() === 11)
+      expect(hour11).toHaveLength(1)
+      expect(hour11[0].total_sec).toBe(3600)
+      expect(hour11[0].resolved_category).toEqual(['Media', 'TV'])
+    })
+
+    test('returns empty array when no records', async () => {
+      const user = getTestUser()
+      const rows = await getProductivityBucketed(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-16T00:00:00Z'),
+        '1 hours',
+        'UTC',
+      )
+      expect(rows).toHaveLength(0)
+    })
+
+    test('excludes soft-deleted records', async () => {
+      const user = getTestUser()
+      await insertProductivity(user, [
+        makeRecord({
+          activity: 'vscode',
+          duration_sec: 300,
+          end_time: new Date('2024-01-15T10:05:00Z'),
+          start_time: new Date('2024-01-15T10:00:00Z'),
+        }),
+      ])
+
+      const records = await getProductivity(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      await deleteProductivityRecord(user, records[0].id!)
+
+      const rows = await getProductivityBucketed(
+        user,
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-16T00:00:00Z'),
+        '1 hours',
+        'UTC',
+      )
+      expect(rows).toHaveLength(0)
     })
   })
 

--- a/apps/backend/src/db/productivity.ts
+++ b/apps/backend/src/db/productivity.ts
@@ -215,6 +215,51 @@ export const getDistinctApps = async (
 }
 
 /**
+ * A single row from the bucketed productivity query.
+ */
+export interface ProductivityBucketRow {
+  bucket_start: Date
+  resolved_category: string[] | null
+  total_sec: number
+  record_count: number
+}
+
+/**
+ * Get productivity records bucketed by time interval, grouped by resolved_category.
+ * Used for the horizontal timeline stacked bar chart.
+ *
+ * Uses date_bin with timezone support for DST-correct bucket alignment.
+ */
+export const getProductivityBucketed = async (
+  user: string,
+  start: Date,
+  end: Date,
+  interval: string,
+  tz: string = 'UTC',
+): Promise<ProductivityBucketRow[]> => {
+  const result = await query(
+    user,
+    `SELECT
+       date_bin($3::interval, start_time AT TIME ZONE $4, ($1 AT TIME ZONE $4)::timestamp) AT TIME ZONE $4 AS bucket_start,
+       resolved_category,
+       SUM(duration_sec)::int AS total_sec,
+       COUNT(*)::int AS record_count
+     FROM productivity
+     WHERE start_time >= $1 AND start_time < $2 AND deleted_at IS NULL
+     GROUP BY bucket_start, resolved_category
+     ORDER BY bucket_start`,
+    [start, end, interval, tz],
+  )
+
+  return result.rows.map((row) => ({
+    bucket_start: new Date(row.bucket_start as string),
+    record_count: row.record_count as number,
+    resolved_category: row.resolved_category || null,
+    total_sec: row.total_sec as number,
+  }))
+}
+
+/**
  * Get all non-deleted productivity records (for recategorization).
  * Returns only id, activity, and title to minimize memory usage.
  */

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -202,6 +202,54 @@ Use cases:
     },
   )
 
+  // Tool: query_productivity_bucketed
+  server.tool(
+    'query_productivity_bucketed',
+    'Query screentime/productivity data bucketed by time interval, grouped by category. Returns stacked duration per category per bucket. Useful for visualizing time spent on different activities over time.',
+    {
+      bucket: bucketSizeSchema,
+      end: timeRangeQuerySchema.shape.end,
+      start: timeRangeQuerySchema.shape.start,
+      tz: z
+        .string()
+        .optional()
+        .describe('IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). Defaults to UTC.'),
+    },
+    async ({ bucket, end, start, tz }) => {
+      const { interval, ms: bucketMs } = (await import('../services/queries.ts')).parseBucketSize(bucket)
+      const rows = await (
+        await import('../db/index.ts')
+      ).getProductivityBucketed(user, new Date(start), new Date(end), interval, tz ?? 'UTC')
+
+      const bucketMap = new Map<
+        string,
+        { start: Date; categories: Array<{ path: string[]; total_sec: number }>; total_sec: number }
+      >()
+
+      for (const row of rows) {
+        const key = row.bucket_start.toISOString()
+        let b = bucketMap.get(key)
+        if (!b) {
+          b = { categories: [], start: row.bucket_start, total_sec: 0 }
+          bucketMap.set(key, b)
+        }
+        b.total_sec += row.total_sec
+        b.categories.push({ path: row.resolved_category ?? [], total_sec: row.total_sec })
+      }
+
+      const buckets = [...bucketMap.values()]
+        .sort((a, b) => a.start.getTime() - b.start.getTime())
+        .map((b) => ({
+          categories: b.categories.sort((a, c) => c.total_sec - a.total_sec),
+          end: new Date(b.start.getTime() + bucketMs).toISOString(),
+          start: b.start.toISOString(),
+          total_sec: b.total_sec,
+        }))
+
+      return jsonResponse({ bucket, buckets, end, start, success: true })
+    },
+  )
+
   // Tool: query_locations
   server.tool(
     'query_locations',

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -217,35 +217,12 @@ Use cases:
     },
     async ({ bucket, end, start, tz }) => {
       const { interval, ms: bucketMs } = (await import('../services/queries.ts')).parseBucketSize(bucket)
+      const { assembleScreentimeBuckets } = await import('../services/queries.ts')
       const rows = await (
         await import('../db/index.ts')
       ).getProductivityBucketed(user, new Date(start), new Date(end), interval, tz ?? 'UTC')
 
-      const bucketMap = new Map<
-        string,
-        { start: Date; categories: Array<{ path: string[]; total_sec: number }>; total_sec: number }
-      >()
-
-      for (const row of rows) {
-        const key = row.bucket_start.toISOString()
-        let b = bucketMap.get(key)
-        if (!b) {
-          b = { categories: [], start: row.bucket_start, total_sec: 0 }
-          bucketMap.set(key, b)
-        }
-        b.total_sec += row.total_sec
-        b.categories.push({ path: row.resolved_category ?? [], total_sec: row.total_sec })
-      }
-
-      const buckets = [...bucketMap.values()]
-        .sort((a, b) => a.start.getTime() - b.start.getTime())
-        .map((b) => ({
-          categories: b.categories.sort((a, c) => c.total_sec - a.total_sec),
-          end: new Date(b.start.getTime() + bucketMs).toISOString(),
-          start: b.start.toISOString(),
-          total_sec: b.total_sec,
-        }))
-
+      const buckets = assembleScreentimeBuckets(rows, bucketMs)
       return jsonResponse({ bucket, buckets, end, start, success: true })
     },
   )

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -16,6 +16,9 @@ import {
   type ProductivityQuery,
   productivityQuerySchema,
   type ProductivityResponse,
+  type ScreentimeBucketedQuery,
+  screentimeBucketedQuerySchema,
+  type ScreentimeBucketedResponse,
   type UpdateActivityBody,
   updateActivityBodySchema,
   type UpdateActivityResponse,
@@ -26,6 +29,7 @@ import {
   getActivityById,
   getDistinctApps,
   getOverlappingActivities,
+  getProductivityBucketed,
   getProductivityById,
 } from '../db/index.ts'
 import {
@@ -36,7 +40,12 @@ import {
   restoreProductivity,
   updateActivity,
 } from '../services/mutations.ts'
-import { queryActivities, queryProductivity, type SyncProvider } from '../services/queries.ts'
+import {
+  parseBucketSize,
+  queryActivities,
+  queryProductivity,
+  type SyncProvider,
+} from '../services/queries.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createActivitiesRouter = (
@@ -292,6 +301,57 @@ export const createActivitiesRouter = (
 
     res.json({ success: true })
   })
+
+  // GET /productivity/bucketed - Get screentime bucketed by time and category
+  router.get<Record<string, never>, ScreentimeBucketedResponse, unknown, ScreentimeBucketedQuery>(
+    '/productivity/bucketed',
+    authMiddleware,
+    validateQuery(screentimeBucketedQuerySchema),
+    async (req, res) => {
+      const user = req.user!
+      const { start, end, bucket, tz } = req.query
+      const { interval, ms: bucketMs } = parseBucketSize(bucket)
+
+      const rows = await getProductivityBucketed(user, new Date(start), new Date(end), interval, tz ?? 'UTC')
+
+      // Group rows into buckets
+      const bucketMap = new Map<
+        string,
+        { start: Date; categories: Array<{ path: string[]; total_sec: number }>; total_sec: number }
+      >()
+
+      for (const row of rows) {
+        const key = row.bucket_start.toISOString()
+        let entry = bucketMap.get(key)
+        if (!entry) {
+          entry = { categories: [], start: row.bucket_start, total_sec: 0 }
+          bucketMap.set(key, entry)
+        }
+        entry.total_sec += row.total_sec
+        entry.categories.push({
+          path: row.resolved_category ?? [],
+          total_sec: row.total_sec,
+        })
+      }
+
+      const buckets = [...bucketMap.values()]
+        .sort((a, b) => a.start.getTime() - b.start.getTime())
+        .map((b) => ({
+          categories: b.categories.sort((a, c) => c.total_sec - a.total_sec),
+          end: new Date(b.start.getTime() + bucketMs).toISOString(),
+          start: b.start.toISOString(),
+          total_sec: b.total_sec,
+        }))
+
+      res.json({
+        bucket: req.query.bucket,
+        buckets,
+        end,
+        start,
+        success: true,
+      })
+    },
+  )
 
   // GET /productivity/apps - Get distinct app names with their categories
   router.get('/productivity/apps', authMiddleware, async (req, res) => {

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -41,6 +41,7 @@ import {
   updateActivity,
 } from '../services/mutations.ts'
 import {
+  assembleScreentimeBuckets,
   parseBucketSize,
   queryActivities,
   queryProductivity,
@@ -313,35 +314,7 @@ export const createActivitiesRouter = (
       const { interval, ms: bucketMs } = parseBucketSize(bucket)
 
       const rows = await getProductivityBucketed(user, new Date(start), new Date(end), interval, tz ?? 'UTC')
-
-      // Group rows into buckets
-      const bucketMap = new Map<
-        string,
-        { start: Date; categories: Array<{ path: string[]; total_sec: number }>; total_sec: number }
-      >()
-
-      for (const row of rows) {
-        const key = row.bucket_start.toISOString()
-        let entry = bucketMap.get(key)
-        if (!entry) {
-          entry = { categories: [], start: row.bucket_start, total_sec: 0 }
-          bucketMap.set(key, entry)
-        }
-        entry.total_sec += row.total_sec
-        entry.categories.push({
-          path: row.resolved_category ?? [],
-          total_sec: row.total_sec,
-        })
-      }
-
-      const buckets = [...bucketMap.values()]
-        .sort((a, b) => a.start.getTime() - b.start.getTime())
-        .map((b) => ({
-          categories: b.categories.sort((a, c) => c.total_sec - a.total_sec),
-          end: new Date(b.start.getTime() + bucketMs).toISOString(),
-          start: b.start.toISOString(),
-          total_sec: b.total_sec,
-        }))
+      const buckets = assembleScreentimeBuckets(rows, bucketMs)
 
       res.json({
         bucket: req.query.bucket,

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -5,6 +5,7 @@ import type { MetricType } from '../schema.ts'
 import * as db from '../db/index.ts'
 import * as locationsService from './locations.ts'
 import {
+  assembleScreentimeBuckets,
   findSleepLocation,
   getDailySummary,
   getPeriodSummary,
@@ -2100,25 +2101,52 @@ describe('queryTags with comments', () => {
 
     expect(result[0].comments).toEqual([])
   })
+})
 
-  test('includes external_id in response', async () => {
-    vi.mocked(db.getTags).mockResolvedValue([
+describe('assembleScreentimeBuckets', () => {
+  test('groups rows by bucket and aggregates totals', () => {
+    const rows = [
       {
-        external_id: 'ext-abc-123',
-        id: 'tag-1',
-        source: 'aurboda',
-        start_time: new Date('2024-01-15T08:00:00Z'),
-        tag: 'coffee',
+        bucket_start: new Date('2024-01-15T10:00:00Z'),
+        resolved_category: ['Work', 'Programming'],
+        total_sec: 1800,
       },
-      { id: 'tag-2', source: 'manual', start_time: new Date('2024-01-15T09:00:00Z'), tag: 'tea' },
-    ])
-    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
+      {
+        bucket_start: new Date('2024-01-15T10:00:00Z'),
+        resolved_category: ['Work', 'Communication'],
+        total_sec: 600,
+      },
+      { bucket_start: new Date('2024-01-15T11:00:00Z'), resolved_category: ['Media', 'TV'], total_sec: 3600 },
+    ]
+    const buckets = assembleScreentimeBuckets(rows, 3600000)
 
-    const result = await queryTags('testuser', new Date('2024-01-15'), new Date('2024-01-16'))
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0].total_sec).toBe(2400) // 1800 + 600
+    expect(buckets[0].categories).toHaveLength(2)
+    // Sorted by duration desc
+    expect(buckets[0].categories[0].total_sec).toBe(1800)
+    expect(buckets[1].total_sec).toBe(3600)
+  })
 
-    expect(result).toHaveLength(2)
-    expect(result[0].external_id).toBe('ext-abc-123')
-    expect(result[1].external_id).toBeUndefined()
+  test('handles null resolved_category as empty path', () => {
+    const rows = [{ bucket_start: new Date('2024-01-15T10:00:00Z'), resolved_category: null, total_sec: 300 }]
+    const buckets = assembleScreentimeBuckets(rows, 3600000)
+
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0].categories[0].path).toEqual([])
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(assembleScreentimeBuckets([], 3600000)).toEqual([])
+  })
+
+  test('sorts buckets chronologically', () => {
+    const rows = [
+      { bucket_start: new Date('2024-01-15T12:00:00Z'), resolved_category: null, total_sec: 100 },
+      { bucket_start: new Date('2024-01-15T10:00:00Z'), resolved_category: null, total_sec: 200 },
+    ]
+    const buckets = assembleScreentimeBuckets(rows, 3600000)
+    expect(new Date(buckets[0].start).getTime()).toBeLessThan(new Date(buckets[1].start).getTime())
   })
 })
 

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -1320,6 +1320,51 @@ export async function queryProductivity(
 }
 
 /**
+ * Assemble raw bucketed productivity rows into screentime buckets with category breakdown.
+ */
+export const assembleScreentimeBuckets = (
+  rows: Array<{
+    bucket_start: Date
+    resolved_category: string[] | null
+    total_sec: number
+  }>,
+  bucketMs: number,
+): Array<{
+  start: string
+  end: string
+  total_sec: number
+  categories: Array<{ path: string[]; total_sec: number }>
+}> => {
+  const bucketMap = new Map<
+    string,
+    { start: Date; categories: Array<{ path: string[]; total_sec: number }>; total_sec: number }
+  >()
+
+  for (const row of rows) {
+    const key = row.bucket_start.toISOString()
+    let entry = bucketMap.get(key)
+    if (!entry) {
+      entry = { categories: [], start: row.bucket_start, total_sec: 0 }
+      bucketMap.set(key, entry)
+    }
+    entry.total_sec += row.total_sec
+    entry.categories.push({
+      path: row.resolved_category ?? [],
+      total_sec: row.total_sec,
+    })
+  }
+
+  return [...bucketMap.values()]
+    .sort((a, b) => a.start.getTime() - b.start.getTime())
+    .map((b) => ({
+      categories: b.categories.sort((a, c) => c.total_sec - a.total_sec),
+      end: new Date(b.start.getTime() + bucketMs).toISOString(),
+      start: b.start.toISOString(),
+      total_sec: b.total_sec,
+    }))
+}
+
+/**
  * Query locations/places for a time range.
  */
 export async function queryLocations(user: string, start: Date, end: Date): Promise<PlaceSummary[]> {

--- a/apps/web/src/pages/Timeline/barLayout.test.ts
+++ b/apps/web/src/pages/Timeline/barLayout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest'
+
+import { computeBarLayout, slotPixels } from './barLayout'
+
+describe('computeBarLayout', () => {
+  test('single visible slot gets full width', () => {
+    const layout = computeBarLayout([{ id: 'a', visible: true }])
+    expect(layout.totalSlots).toBe(1)
+    expect(layout.slotWidth).toBe(1)
+    expect(layout.getOffset('a')).toBe(0)
+  })
+
+  test('two visible slots split evenly', () => {
+    const layout = computeBarLayout([
+      { id: 'a', visible: true },
+      { id: 'b', visible: true },
+    ])
+    expect(layout.totalSlots).toBe(2)
+    expect(layout.slotWidth).toBe(0.5)
+    expect(layout.getOffset('a')).toBe(0)
+    expect(layout.getOffset('b')).toBe(0.5)
+  })
+
+  test('hidden slots are excluded from layout', () => {
+    const layout = computeBarLayout([
+      { id: 'a', visible: true },
+      { id: 'b', visible: false },
+      { id: 'c', visible: true },
+    ])
+    expect(layout.totalSlots).toBe(2)
+    expect(layout.slotWidth).toBe(0.5)
+    expect(layout.getOffset('a')).toBe(0)
+    expect(layout.getOffset('c')).toBe(0.5)
+    // Hidden slot returns 0 as fallback
+    expect(layout.getOffset('b')).toBe(0)
+  })
+
+  test('no visible slots defaults to 1', () => {
+    const layout = computeBarLayout([{ id: 'a', visible: false }])
+    expect(layout.totalSlots).toBe(1)
+    expect(layout.slotWidth).toBe(1)
+  })
+
+  test('five visible slots (realistic config)', () => {
+    const layout = computeBarLayout([
+      { id: 'fatigue', visible: true },
+      { id: 'impulse', visible: true },
+      { id: 'screentime', visible: true },
+      { id: 'steps', visible: true },
+      { id: 'calories', visible: true },
+    ])
+    expect(layout.totalSlots).toBe(5)
+    expect(layout.slotWidth).toBeCloseTo(0.2)
+    expect(layout.getOffset('fatigue')).toBeCloseTo(0)
+    expect(layout.getOffset('impulse')).toBeCloseTo(0.2)
+    expect(layout.getOffset('screentime')).toBeCloseTo(0.4)
+    expect(layout.getOffset('steps')).toBeCloseTo(0.6)
+    expect(layout.getOffset('calories')).toBeCloseTo(0.8)
+  })
+})
+
+describe('slotPixels', () => {
+  test('computes pixel position for a slot', () => {
+    const { x, width } = slotPixels(100, 60, 0.5, 0.25, 0.5)
+    expect(x).toBe(130) // 100 + 60 * 0.5
+    expect(width).toBe(14.5) // 60 * 0.25 - 0.5
+  })
+
+  test('minimum width is 1', () => {
+    const { width } = slotPixels(0, 2, 0, 0.25, 0.5)
+    expect(width).toBe(1) // max(1, 2 * 0.25 - 0.5) = max(1, 0) = 1
+  })
+})

--- a/apps/web/src/pages/Timeline/barLayout.ts
+++ b/apps/web/src/pages/Timeline/barLayout.ts
@@ -1,0 +1,67 @@
+/**
+ * Bar layout system for the horizontal timeline.
+ *
+ * Computes side-by-side positions for bar-shaped data (steps, calories,
+ * training load impulse bars, screentime). Each bar type gets an equal
+ * fraction of the bucket width.
+ *
+ * Line/area charts (HR, HRV, CTL/ATL curves, TSB) are unaffected —
+ * they span the full track width as overlays.
+ */
+
+export interface BarSlot {
+  /** Unique identifier for this bar slot. */
+  id: string
+  /** Whether this slot is currently visible (for counting active slots). */
+  visible: boolean
+}
+
+export interface BarLayoutResult {
+  /** Total number of visible bar slots. */
+  totalSlots: number
+  /** Get the fractional x-offset (0..1) for a given slot id within a bucket. */
+  getOffset: (slotId: string) => number
+  /** Fractional width (0..1) of each bar slot within a bucket. */
+  slotWidth: number
+}
+
+/**
+ * Compute bar layout from the list of active bar slots.
+ * Each visible slot gets an equal share of the bucket width.
+ *
+ * Returns a layout object that maps slot IDs to their fractional x-offset.
+ */
+export const computeBarLayout = (slots: BarSlot[]): BarLayoutResult => {
+  const visibleSlots = slots.filter((s) => s.visible)
+  const totalSlots = Math.max(visibleSlots.length, 1)
+  const slotWidth = 1 / totalSlots
+
+  const offsetMap = new Map<string, number>()
+  let idx = 0
+  for (const slot of slots) {
+    if (slot.visible) {
+      offsetMap.set(slot.id, idx * slotWidth)
+      idx++
+    }
+  }
+
+  return {
+    getOffset: (slotId: string) => offsetMap.get(slotId) ?? 0,
+    slotWidth,
+    totalSlots,
+  }
+}
+
+/**
+ * Convert a fractional offset+width into pixel values for a specific bucket.
+ */
+export const slotPixels = (
+  bucketX: number,
+  bucketWidth: number,
+  offset: number,
+  slotWidth: number,
+  gap: number = 0.5,
+): { x: number; width: number } => ({
+  width: Math.max(1, bucketWidth * slotWidth - gap),
+  x: bucketX + bucketWidth * offset,
+})

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -5,12 +5,16 @@
  * - Steps and calories as bar charts behind the lines
  * - Crosshair tooltip on mouseover showing all metric values at that time
  */
-import type { RecoveryZones, TrainingLoadPoint, WorkoutTrimp } from '@aurboda/api-spec'
+import type { RecoveryZones, ScreentimeCategory, TrainingLoadPoint, WorkoutTrimp } from '@aurboda/api-spec'
 
 import * as d3 from 'd3'
 import { format } from 'date-fns'
 
+import type { ScreentimeBucketParsed } from '../../state/api'
+
 import { type MetricBucketParsed, aggregateBuckets } from '../../utils/chart'
+import { type BarLayoutResult, slotPixels } from './barLayout'
+import { buildScreentimeTooltipHtml, findScreentimeBucket } from './drawScreentimeTrack'
 import {
   ACTIVITY_IMPULSE_COLOR,
   ATL_COLOR,
@@ -68,6 +72,15 @@ export interface MetricsTrackConfig {
   trainingLoadWorkouts?: WorkoutTrimp[]
   /** Optional: recovery zone thresholds for combined tooltip. */
   trainingLoadZones?: RecoveryZones
+  /** Bar layout for side-by-side rendering. */
+  barLayout?: BarLayoutResult
+  /** Slot IDs for steps and calories in the bar layout. */
+  stepsSlotId?: string
+  caloriesSlotId?: string
+  /** Screentime bucketed data for combined tooltip. */
+  screentimeBuckets?: ScreentimeBucketParsed[]
+  /** Screentime categories for tooltip rendering. */
+  screentimeCategories?: ScreentimeCategory[]
 }
 
 // ── Bucket aggregation by zoom ────────────────────────────────────────────────
@@ -166,7 +179,7 @@ const drawBandChart = (
     .attr('pointer-events', 'none')
 }
 
-/** Draw bar charts for steps or calories. */
+/** Draw bar charts for steps or calories, with optional slot positioning. */
 const drawBarChart = (
   group: SvgGroup,
   buckets: MetricBucketParsed[],
@@ -176,14 +189,28 @@ const drawBarChart = (
   trackBottom: number,
   color: string,
   opacity: number,
+  barLayout?: BarLayoutResult,
+  slotId?: string,
 ): void => {
   for (const bucket of buckets) {
     const stats = bucket.metrics[metricName]
     if (!stats) continue
 
-    const x = xScale(bucket.start)
-    const xEnd = xScale(bucket.end)
-    const barWidth = Math.max(1, xEnd - x - 0.5)
+    const bucketX = xScale(bucket.start)
+    const bucketEnd = xScale(bucket.end)
+    const bucketWidth = Math.abs(bucketEnd - bucketX)
+
+    let x: number
+    let barWidth: number
+    if (barLayout && slotId) {
+      const slot = slotPixels(bucketX, bucketWidth, barLayout.getOffset(slotId), barLayout.slotWidth)
+      x = slot.x
+      barWidth = slot.width
+    } else {
+      x = bucketX
+      barWidth = Math.max(1, bucketWidth - 0.5)
+    }
+
     const barTop = yScale(stats.avg)
     const barHeight = trackBottom - barTop
 
@@ -440,6 +467,8 @@ const drawCrosshairOverlay = (
   trainingLoadPoints?: TrainingLoadPoint[],
   trainingLoadWorkouts?: WorkoutTrimp[],
   trainingLoadZones?: RecoveryZones,
+  screentimeBuckets?: ScreentimeBucketParsed[],
+  screentimeCategories?: ScreentimeCategory[],
 ): void => {
   outerG.selectAll('.metrics-crosshair').remove()
 
@@ -518,6 +547,17 @@ const drawCrosshairOverlay = (
         )
       }
 
+      // Append screentime section if available
+      if (screentimeBuckets && screentimeCategories) {
+        const stBucket = findScreentimeBucket(screentimeBuckets, hoverTime)
+        if (stBucket) {
+          const stHtml = buildScreentimeTooltipHtml(stBucket, screentimeCategories)
+          if (stHtml) {
+            html = (html ?? '') + stHtml
+          }
+        }
+      }
+
       if (!html) {
         hairline.style('display', 'none')
         hideTooltip()
@@ -572,10 +612,32 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
 
   // Draw bars first (behind lines)
   if (showSteps) {
-    drawBarChart(chartGroup, buckets, 'steps', xScale, ySteps, trackBottom, STEPS_COLOR, 0.25)
+    drawBarChart(
+      chartGroup,
+      buckets,
+      'steps',
+      xScale,
+      ySteps,
+      trackBottom,
+      STEPS_COLOR,
+      0.25,
+      config.barLayout,
+      config.stepsSlotId,
+    )
   }
   if (showCalories) {
-    drawBarChart(chartGroup, buckets, 'calories_active', xScale, yCal, trackBottom, CALORIES_COLOR, 0.2)
+    drawBarChart(
+      chartGroup,
+      buckets,
+      'calories_active',
+      xScale,
+      yCal,
+      trackBottom,
+      CALORIES_COLOR,
+      0.2,
+      config.barLayout,
+      config.caloriesSlotId,
+    )
   }
 
   // Draw band charts
@@ -588,7 +650,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     if (hrvBand.length > 1) drawBandChart(chartGroup, hrvBand, xScale, yHrv, HRV_COLOR)
   }
 
-  // Crosshair tooltip overlay (includes training load data in combined tooltip)
+  // Crosshair tooltip overlay (includes training load + screentime data in combined tooltip)
   drawCrosshairOverlay(
     outerG,
     xScale,
@@ -605,5 +667,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     config.trainingLoadPoints,
     config.trainingLoadWorkouts,
     config.trainingLoadZones,
+    config.screentimeBuckets,
+    config.screentimeCategories,
   )
 }

--- a/apps/web/src/pages/Timeline/drawScreentimeTrack.ts
+++ b/apps/web/src/pages/Timeline/drawScreentimeTrack.ts
@@ -1,0 +1,206 @@
+/**
+ * Draw the screentime stacked bar chart in the horizontal timeline metrics track.
+ *
+ * Each bucket is a single stacked bar showing time by top-level category,
+ * with category colors applied to segments.
+ */
+import type { ScreentimeCategory } from '@aurboda/api-spec'
+
+import * as d3 from 'd3'
+import { format } from 'date-fns'
+
+import type { ScreentimeBucketParsed } from '../../state/api'
+
+import { type BarLayoutResult, slotPixels } from './barLayout'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SvgGroup = d3.Selection<SVGGElement, unknown, any, any>
+
+export const SCREENTIME_COLOR = '#6366f1' // indigo default
+
+/** Default colors for uncategorized screentime. */
+const UNCATEGORIZED_COLOR = '#6b7280' // gray
+
+/** Get the color for a top-level category from the category list. */
+const getCategoryColor = (topLevel: string, categories: ScreentimeCategory[]): string => {
+  // Walk from exact match to parent
+  for (const cat of categories) {
+    if (cat.name[0] === topLevel && cat.color) return cat.color
+  }
+  return SCREENTIME_COLOR
+}
+
+/** Aggregate bucket categories to top-level for the stacked bar. */
+interface TopLevelCategory {
+  name: string
+  total_sec: number
+  color: string
+  /** Full paths for tooltip hierarchy. */
+  children: Array<{ path: string[]; total_sec: number }>
+}
+
+const aggregateToTopLevel = (
+  bucket: ScreentimeBucketParsed,
+  categories: ScreentimeCategory[],
+): TopLevelCategory[] => {
+  const map = new Map<string, TopLevelCategory>()
+  let uncategorizedSec = 0
+
+  for (const cat of bucket.categories) {
+    if (cat.path.length === 0) {
+      uncategorizedSec += cat.total_sec
+      continue
+    }
+    const topLevel = cat.path[0]
+    let entry = map.get(topLevel)
+    if (!entry) {
+      entry = {
+        children: [],
+        color: getCategoryColor(topLevel, categories),
+        name: topLevel,
+        total_sec: 0,
+      }
+      map.set(topLevel, entry)
+    }
+    entry.total_sec += cat.total_sec
+    entry.children.push({ path: cat.path, total_sec: cat.total_sec })
+  }
+
+  if (uncategorizedSec > 0) {
+    map.set('', {
+      children: [{ path: [], total_sec: uncategorizedSec }],
+      color: UNCATEGORIZED_COLOR,
+      name: 'Uncategorized',
+      total_sec: uncategorizedSec,
+    })
+  }
+
+  // Sort by duration descending (biggest at bottom of stack)
+  return [...map.values()].sort((a, b) => b.total_sec - a.total_sec)
+}
+
+/** Format seconds as compact duration (e.g. "2h 15m", "45m"). */
+const formatSec = (sec: number): string => {
+  const h = Math.floor(sec / 3600)
+  const m = Math.round((sec % 3600) / 60)
+  if (h > 0 && m > 0) return `${h}h ${m}m`
+  if (h > 0) return `${h}h`
+  return `${m}m`
+}
+
+// ── Drawing ──────────────────────────────────────────────────────────────────
+
+export interface DrawScreentimeConfig {
+  chartGroup: SvgGroup
+  buckets: ScreentimeBucketParsed[]
+  categories: ScreentimeCategory[]
+  xScale: d3.ScaleTime<number, number>
+  trackY: number
+  trackHeight: number
+  barLayout: BarLayoutResult
+  slotId: string
+}
+
+export const drawScreentimeBars = (config: DrawScreentimeConfig): void => {
+  const { chartGroup, buckets, categories, xScale, trackY, trackHeight, barLayout, slotId } = config
+  if (buckets.length === 0) return
+
+  const trackBottom = trackY + trackHeight
+
+  // Compute max total_sec across all buckets for Y-scale
+  let maxSec = 1
+  for (const b of buckets) {
+    if (b.total_sec > maxSec) maxSec = b.total_sec
+  }
+
+  // Y-scale: 0 at bottom to maxSec at top (with 10% headroom)
+  const yScale = d3
+    .scaleLinear()
+    .domain([0, maxSec * 1.1])
+    .range([trackBottom, trackY])
+
+  const slotOffset = barLayout.getOffset(slotId)
+
+  for (const bucket of buckets) {
+    if (bucket.total_sec <= 0) continue
+
+    const bucketX = xScale(bucket.start)
+    const bucketEnd = xScale(bucket.end)
+    const bucketWidth = Math.abs(bucketEnd - bucketX)
+
+    const { x: barX, width: barWidth } = slotPixels(bucketX, bucketWidth, slotOffset, barLayout.slotWidth)
+    if (barWidth < 1) continue
+
+    const topLevels = aggregateToTopLevel(bucket, categories)
+
+    // Draw stacked segments bottom-up
+    let stackY = trackBottom
+    for (const cat of topLevels) {
+      const segHeight = trackBottom - yScale(cat.total_sec)
+      if (segHeight <= 0) continue
+
+      chartGroup
+        .append('rect')
+        .attr('x', barX)
+        .attr('y', stackY - segHeight)
+        .attr('width', barWidth)
+        .attr('height', segHeight)
+        .attr('fill', cat.color)
+        .attr('opacity', 0.7)
+        .attr('pointer-events', 'none')
+
+      stackY -= segHeight
+    }
+  }
+}
+
+// ── Tooltip ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build the screentime tooltip HTML section for a given bucket.
+ * Shows hierarchical breakdown by category.
+ */
+export const buildScreentimeTooltipHtml = (
+  bucket: ScreentimeBucketParsed,
+  categories: ScreentimeCategory[],
+): string | null => {
+  if (bucket.total_sec <= 0) return null
+
+  const topLevels = aggregateToTopLevel(bucket, categories)
+
+  let html = '<div class="tooltip-separator"></div>'
+  html += '<div class="tooltip-title">Screen Time</div>'
+  html += `<div class="tooltip-time">${format(bucket.start, 'HH:mm')} – ${format(bucket.end, 'HH:mm')}</div>`
+  html += `<div class="tooltip-detail"><strong>Total</strong> <span>${formatSec(bucket.total_sec)}</span></div>`
+
+  for (const cat of topLevels) {
+    html += `<div class="tooltip-detail" style="padding-left:8px">`
+    html += `<span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:${cat.color};margin-right:4px"></span>`
+    html += `<strong>${cat.name}</strong> <span>${formatSec(cat.total_sec)}</span></div>`
+
+    // Show sub-categories if there are multiple children
+    const children = cat.children.filter((c) => c.path.length > 1).sort((a, b) => b.total_sec - a.total_sec)
+
+    for (const child of children) {
+      const label = child.path.slice(1).join(' > ')
+      html += `<div class="tooltip-detail" style="padding-left:24px;font-size:11px;color:#9ca3af">`
+      html += `${label} <span>${formatSec(child.total_sec)}</span></div>`
+    }
+  }
+
+  return html
+}
+
+/**
+ * Find the screentime bucket that contains the given date.
+ */
+export const findScreentimeBucket = (
+  buckets: ScreentimeBucketParsed[],
+  date: Date,
+): ScreentimeBucketParsed | undefined => {
+  const t = date.getTime()
+  for (const b of buckets) {
+    if (t >= b.start.getTime() && t < b.end.getTime()) return b
+  }
+  return undefined
+}

--- a/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
+++ b/apps/web/src/pages/Timeline/drawTrainingLoadTrack.ts
@@ -14,6 +14,8 @@ import type { RecoveryZones, TrainingLoadPoint, WorkoutTrimp } from '@aurboda/ap
 import * as d3 from 'd3'
 import { format } from 'date-fns'
 
+import type { BarLayoutResult } from './barLayout'
+
 // ── Colors ────────────────────────────────────────────────────────────────────
 
 export const CTL_COLOR = '#3b82f6' // blue (fitness)
@@ -56,6 +58,11 @@ export interface TrainingLoadTrackConfig {
   trackY: number
   /** Height of the track in pixels. */
   trackHeight: number
+  /** Bar layout for side-by-side rendering. */
+  barLayout?: BarLayoutResult
+  /** Slot IDs for the training load bars in the layout. */
+  fatigueSlotId?: string
+  impulseSlotId?: string
 }
 
 // ── Y-scale computation ───────────────────────────────────────────────────────
@@ -290,11 +297,15 @@ const drawFatigueBars = (
   yScale: d3.ScaleLinear<number, number>,
   trackBottom: number,
   barDurationMs: number = MS_PER_HOUR,
+  barLayout?: BarLayoutResult,
+  slotId?: string,
 ): void => {
   // Compute bar width from x-scale and bucket duration
   const sampleTime = points[0] ? parseTime(points[0].time) : new Date()
   const nextTime = new Date(sampleTime.getTime() + barDurationMs)
-  const barWidth = Math.max(1, Math.abs(xScale(nextTime) - xScale(sampleTime)) - 1)
+  const fullBarWidth = Math.max(1, Math.abs(xScale(nextTime) - xScale(sampleTime)) - 1)
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- barLayout could be missing
+  const barWidth = barLayout && slotId ? fullBarWidth * barLayout.slotWidth : fullBarWidth
 
   // Find max ATL for color scaling
   let maxAtl = 1
@@ -312,7 +323,9 @@ const drawFatigueBars = (
   for (const p of points) {
     if (p.atl <= 0) continue
 
-    const x = xScale(parseTime(p.time))
+    const baseX = xScale(parseTime(p.time))
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- barLayout could be missing
+    const x = barLayout && slotId ? baseX + fullBarWidth * barLayout.getOffset(slotId) : baseX
     const barTop = yScale(p.atl)
     const barHeight = trackBottom - barTop
     if (barHeight <= 0) continue
@@ -337,17 +350,23 @@ const drawImpulseBars = (
   yScale: d3.ScaleLinear<number, number>,
   trackBottom: number,
   barDurationMs: number = MS_PER_HOUR,
+  barLayout?: BarLayoutResult,
+  slotId?: string,
 ): void => {
   // Compute bar width from x-scale and bucket duration
   const sampleTime = points[0] ? parseTime(points[0].time) : new Date()
   const nextTime = new Date(sampleTime.getTime() + barDurationMs)
-  const barWidth = Math.max(1, Math.abs(xScale(nextTime) - xScale(sampleTime)) - 1)
+  const fullBarWidth = Math.max(1, Math.abs(xScale(nextTime) - xScale(sampleTime)) - 1)
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- barLayout could be missing
+  const barWidth = barLayout && slotId ? fullBarWidth * barLayout.slotWidth : fullBarWidth
 
   for (const p of points) {
     const total = p.training_impulse + p.activity_impulse
     if (total <= 0) continue
 
-    const x = xScale(parseTime(p.time))
+    const baseX = xScale(parseTime(p.time))
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- barLayout could be missing
+    const x = barLayout && slotId ? baseX + fullBarWidth * barLayout.getOffset(slotId) : baseX
 
     // Activity impulse bar (bottom of stack)
     if (p.activity_impulse > 0) {
@@ -581,10 +600,28 @@ export const drawTrainingLoadTrack = (config: TrainingLoadTrackConfig): void => 
   }
 
   // Draw ATL fatigue bars (behind everything else)
-  drawFatigueBars(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom, barDurationMs)
+  drawFatigueBars(
+    chartGroup,
+    displayPoints,
+    xScale,
+    yScales.yLoad,
+    trackBottom,
+    barDurationMs,
+    config.barLayout,
+    config.fatigueSlotId,
+  )
 
   // Draw impulse bars (training + activity) on top of fatigue bars
-  drawImpulseBars(chartGroup, displayPoints, xScale, yScales.yImpulse, trackBottom, barDurationMs)
+  drawImpulseBars(
+    chartGroup,
+    displayPoints,
+    xScale,
+    yScales.yImpulse,
+    trackBottom,
+    barDurationMs,
+    config.barLayout,
+    config.impulseSlotId,
+  )
 
   // Draw CTL/ATL curves (anchored at bucket midpoints)
   drawLoadCurves(chartGroup, displayPoints, xScale, yScales.yLoad, trackBottom, bootstrapping, barDurationMs)

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -20,6 +20,7 @@ import {
   fetchPlaces,
   fetchProductivity,
   fetchScreentimeCategories,
+  fetchScreentimeBucketed,
   fetchScrobbles,
   fetchTagMappings,
   fetchTags,
@@ -30,6 +31,7 @@ import { parseBucketedResponse } from '../../utils/chart'
 import { isEmoji, isUrl } from '../../utils/emojiLookup'
 import { packLanes } from '../../utils/lanePacking'
 import { buildActivityColumnItems, EXCLUDED_TAG_PREFIXES, EXCLUDED_TAG_SOURCES } from './activityMerge'
+import { computeBarLayout, type BarSlot } from './barLayout'
 import { categorizeMusic } from './categorizeMusic'
 import { drawActivitySparklines, parseBucketedData } from './drawActivitySparklines'
 import {
@@ -47,6 +49,7 @@ import {
   mergeScrobblesIntoSessions,
   MUSIC_STAFF_HEIGHT,
 } from './drawMusicStaff'
+import { drawScreentimeBars, SCREENTIME_COLOR } from './drawScreentimeTrack'
 import { CTL_COLOR, drawTrainingLoadTrack } from './drawTrainingLoadTrack'
 import { findOverlappingScrobbles } from './findOverlappingScrobbles'
 import { mergeProductivitySpans } from './productivityMerge'
@@ -86,6 +89,7 @@ type LegendCategory =
   | 'steps' // horizontal only
   | 'calories' // horizontal only
   | 'training_load' // horizontal only
+  | 'screen_time_h' // horizontal only — screentime stacked bar
 
 // Legacy category names for URL hash backward compatibility
 const LEGACY_CATEGORY_MAP: Record<string, LegendCategory> = {
@@ -370,6 +374,7 @@ const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = 
       item.color !== METRIC_COLOR) ||
     // Duration tags promoted to Activity column (have entity_type 'tag' but no activity_type)
     (item.column === 'Activity' && item.entity_type === 'tag' && !item.activity_type),
+  screen_time_h: () => false, // horizontal screentime bar controlled at draw level
   training_load: () => false,
 }
 
@@ -922,6 +927,15 @@ export const Timeline = () => {
     queryFn: () =>
       fetchTrainingLoad(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), trainingLoadBucketSize),
     queryKey: ['timeline-training-load', fromDate.value, toDate.value, trainingLoadBucketSize],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Screentime bucketed data (for horizontal stacked bar chart)
+  const screentimeBucketedQuery = useQuery({
+    enabled: !hiddenCategories.has('screen_time_h') && !hiddenCategories.has('metrics'),
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchScreentimeBucketed(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), bucketSize),
+    queryKey: ['timeline-screentime-bucketed', fromDate.value, toDate.value, bucketSize],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -1733,7 +1747,21 @@ export const Timeline = () => {
       const showSteps = !hiddenCategories.has('steps') && showMetricsTrack
       const showCalories = !hiddenCategories.has('calories') && showMetricsTrack
       const showTL = !hiddenCategories.has('training_load') && showMetricsTrack
-      if (showMetricsTrack && (metricsYScales || (showTL && trainingLoadData))) {
+      const showScreentimeH = !hiddenCategories.has('screen_time_h') && showMetricsTrack
+      const screentimeBuckets = screentimeBucketedQuery.data ?? []
+      const screentimeHasData = screentimeBuckets.length > 0
+
+      // Compute the bar layout for side-by-side bars
+      const barSlots: BarSlot[] = [
+        { id: 'fatigue', visible: showTL && !!trainingLoadData },
+        { id: 'impulse', visible: showTL && !!trainingLoadData },
+        { id: 'screentime', visible: showScreentimeH && screentimeHasData },
+        { id: 'steps', visible: showSteps },
+        { id: 'calories', visible: showCalories },
+      ]
+      const barLayout = computeBarLayout(barSlots)
+
+      if (showMetricsTrack && (metricsYScales || (showTL && trainingLoadData) || screentimeHasData)) {
         drawMetricsTrack({
           buckets: metricBuckets,
           chartGroup,
@@ -1765,6 +1793,15 @@ export const Timeline = () => {
             ? { yScales: metricsYScales }
             : { yScales: computeYScales([], trackMetrics, trackMetrics + metricsTrackHeight) }),
           xScale: currentXScale,
+          barLayout,
+          caloriesSlotId: 'calories',
+          stepsSlotId: 'steps',
+          ...(showScreentimeH && screentimeHasData
+            ? {
+                screentimeBuckets,
+                screentimeCategories: screentimeCategoriesQuery.data ?? [],
+              }
+            : {}),
           ...(showTL && trainingLoadData
             ? {
                 trainingLoadPoints: trainingLoadData.points,
@@ -1778,14 +1815,31 @@ export const Timeline = () => {
       // ── Training load track (CTL/ATL/TSB overlaid on metrics area) ──
       if (showMetricsTrack && showTL && trainingLoadData) {
         drawTrainingLoadTrack({
+          barLayout,
           bootstrapping: trainingLoadData.bootstrapping,
           chartGroup,
+          fatigueSlotId: 'fatigue',
+          impulseSlotId: 'impulse',
           points: trainingLoadData.points,
           trackHeight: metricsTrackHeight,
           trackY: trackMetrics,
           workouts: trainingLoadData.workouts,
           xScale: currentXScale,
           zones: trainingLoadData.zones ?? undefined,
+        })
+      }
+
+      // ── Screentime stacked bar chart ──
+      if (showMetricsTrack && showScreentimeH && screentimeHasData) {
+        drawScreentimeBars({
+          barLayout,
+          buckets: screentimeBuckets,
+          categories: screentimeCategoriesQuery.data ?? [],
+          chartGroup,
+          slotId: 'screentime',
+          trackHeight: metricsTrackHeight,
+          trackY: trackMetrics,
+          xScale: currentXScale,
         })
       }
 
@@ -2203,6 +2257,11 @@ export const Timeline = () => {
                       { cat: 'steps' as LegendCategory, color: STEPS_COLOR, label: 'Steps' },
                       { cat: 'calories' as LegendCategory, color: CALORIES_COLOR, label: 'Calories' },
                       { cat: 'training_load' as LegendCategory, color: CTL_COLOR, label: 'Training Load' },
+                      {
+                        cat: 'screen_time_h' as LegendCategory,
+                        color: SCREENTIME_COLOR,
+                        label: 'Screen Time',
+                      },
                     ]
                   : []),
               ].map(({ cat, color, label }) => (

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -315,6 +315,52 @@ export const fetchDistinctApps = async (): Promise<DistinctApp[]> => {
   return response.data.data ?? []
 }
 
+// Fetch screentime bucketed by time and category
+export interface ScreentimeBucketCategory {
+  path: string[]
+  total_sec: number
+}
+
+export interface ScreentimeBucketParsed {
+  start: Date
+  end: Date
+  total_sec: number
+  categories: ScreentimeBucketCategory[]
+}
+
+export const fetchScreentimeBucketed = async (
+  start: Date,
+  end: Date,
+  bucket: string,
+  tz?: string,
+): Promise<ScreentimeBucketParsed[]> => {
+  const { token } = auth.value
+  const params: Record<string, string> = {
+    bucket,
+    end: end.toISOString(),
+    start: start.toISOString(),
+  }
+  if (tz) params.tz = tz
+  const response = await axios.get<{
+    buckets?: Array<{
+      start: string
+      end: string
+      total_sec: number
+      categories: ScreentimeBucketCategory[]
+    }>
+    success: boolean
+  }>(`${API_URL}/productivity/bucketed`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+  return (response.data.buckets ?? []).map((b) => ({
+    categories: b.categories,
+    end: new Date(b.end),
+    start: new Date(b.start),
+    total_sec: b.total_sec,
+  }))
+}
+
 // Fetch location/place data for the specified date range
 export const fetchPlaces = async (start: Date, end: Date): Promise<Place[]> => {
   const { token } = auth.value

--- a/packages/api-spec/src/schemas/productivity.ts
+++ b/packages/api-spec/src/schemas/productivity.ts
@@ -5,11 +5,13 @@
 import { z } from 'zod'
 
 import {
+  baseResponseSchema,
   createDataArrayResponseSchema,
   dataSourceSchema,
   iso8601DateTimeSchema,
   timeRangeQuerySchema,
 } from './common.ts'
+import { bucketSizeSchema } from './metrics.ts'
 import { commentSchema } from './notes.ts'
 
 /**
@@ -59,3 +61,58 @@ export const productivityResponseSchema = createDataArrayResponseSchema(producti
 })
 
 export type ProductivityResponse = z.infer<typeof productivityResponseSchema>
+
+/**
+ * Category duration within a screentime bucket.
+ */
+export const screentimeBucketCategorySchema = z
+  .object({
+    path: z.array(z.string()).meta({ description: 'Category path, e.g. ["Work", "Programming"]' }),
+    total_sec: z.number().int().meta({ description: 'Total duration in seconds for this category' }),
+  })
+  .meta({ id: 'ScreentimeBucketCategory' })
+
+/**
+ * A single time bucket with aggregated screentime by category.
+ */
+export const screentimeBucketSchema = z
+  .object({
+    categories: z.array(screentimeBucketCategorySchema).meta({
+      description: 'Duration per resolved category within this bucket',
+    }),
+    end: iso8601DateTimeSchema.meta({ description: 'Bucket end time' }),
+    start: iso8601DateTimeSchema.meta({ description: 'Bucket start time' }),
+    total_sec: z.number().int().meta({ description: 'Total screentime duration in seconds' }),
+  })
+  .meta({ id: 'ScreentimeBucket' })
+
+export type ScreentimeBucket = z.infer<typeof screentimeBucketSchema>
+
+/**
+ * Query bucketed screentime request.
+ */
+export const screentimeBucketedQuerySchema = timeRangeQuerySchema
+  .extend({
+    bucket: bucketSizeSchema,
+    tz: z.string().optional().meta({
+      description: 'IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). Defaults to UTC.',
+      example: 'Europe/Stockholm',
+    }),
+  })
+  .meta({ id: 'ScreentimeBucketedQuery' })
+
+export type ScreentimeBucketedQuery = z.infer<typeof screentimeBucketedQuerySchema>
+
+/**
+ * Bucketed screentime response.
+ */
+export const screentimeBucketedResponseSchema = baseResponseSchema
+  .extend({
+    bucket: bucketSizeSchema.optional(),
+    buckets: z.array(screentimeBucketSchema).optional(),
+    end: iso8601DateTimeSchema.optional(),
+    start: iso8601DateTimeSchema.optional(),
+  })
+  .meta({ id: 'ScreentimeBucketedResponse' })
+
+export type ScreentimeBucketedResponse = z.infer<typeof screentimeBucketedResponseSchema>


### PR DESCRIPTION
## Summary

Adds a stacked bar chart for screentime in the horizontal timeline's metrics track, plus a new side-by-side bar layout system so all bar types (training load, screentime, steps, calories) share the time axis without overlapping.

### New: Screentime stacked bars

Each time bucket shows a single stacked bar with segments colored by top-level screentime category (using the category colors from screentime categories settings).

**Tooltip** shows a hierarchical breakdown:
```
Screen Time
Total              8h 53m
  TV               1h 35m
  Work             6h 15m
    Software Dev   4h 10m
    Communication     13m
```

Toggleable via the "Screen Time" legend item in the Metrics group (horizontal mode only).

### New: Side-by-side bar layout

Previously, steps, calories, and training load bars all **overlapped** in the same pixel region, differentiated only by opacity. Now they sit **side by side**, each taking 1/N of the bucket width.

Example with 5 active bar types: fatigue | impulse | screentime | steps | calories — each gets 1/5 of the bucket width.

**`barLayout.ts`** provides:
- `computeBarLayout(slots)` — assigns fractional offsets to visible slots
- `slotPixels()` — converts fractional layout to pixel coordinates

Line/area charts (HR, HRV, CTL/ATL curves, TSB line) still span the full track width as overlays.

### Backend

- **`GET /productivity/bucketed`** — new endpoint returning screentime duration grouped by time bucket + `resolved_category`, using `date_bin` for timezone-aware bucketing
- **`query_productivity_bucketed`** MCP tool
- **`ScreentimeBucket`** schema + query/response types in `@aurboda/api-spec`
- Integration tests for `getProductivityBucketed`

### Changes to existing draw modules

| Module                 | Change                                                          |
|------------------------|-----------------------------------------------------------------|
| `drawMetricsTrack`     | Steps/calories bars accept `barLayout` slot params; crosshair tooltip includes screentime section |
| `drawTrainingLoadTrack`| Fatigue/impulse bars accept `barLayout` slot params; curves/zones unchanged |
| `index.tsx`            | Screentime bucketed query, bar layout computation, legend toggle, draw orchestration |

### Tests

- 3 integration tests for `getProductivityBucketed` (bucketing, empty, soft-deleted exclusion)
- 7 unit tests for bar layout (`computeBarLayout`, `slotPixels`)