### PR TITLE
fix: align all bar bucket sizes to 1h for sub-day views

### DIFF
--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -81,6 +81,12 @@ export interface MetricsTrackConfig {
   screentimeBuckets?: ScreentimeBucketParsed[]
   /** Screentime categories for tooltip rendering. */
   screentimeCategories?: ScreentimeCategory[]
+  /**
+   * Target bar bucket size in ms. When set, steps/calories bars are re-aggregated
+   * to this bucket size so they align with training load and screentime bars.
+   * Defaults to native bucket size (no forced aggregation).
+   */
+  barBucketMs?: number
 }
 
 // ── Bucket aggregation by zoom ────────────────────────────────────────────────
@@ -96,6 +102,17 @@ const getAggregationFactor = (pixelsPerHour: number, buckets: MetricBucketParsed
   if (pixelsPerHour > 100) return 1 // 5m buckets as-is
   if (pixelsPerHour > 20) return 3 // merge to ~15m
   return 6 // merge to ~30m
+}
+
+/**
+ * Compute the aggregation factor to bring metric buckets to the target bar bucket size.
+ * E.g., if buckets are 5m and target is 1h (3600000ms), factor = 12.
+ */
+const computeBarAggregationFactor = (buckets: MetricBucketParsed[], barBucketMs?: number): number => {
+  if (!barBucketMs || buckets.length < 2) return 1
+  const bucketMs = buckets[1]!.start.getTime() - buckets[0]!.start.getTime()
+  if (bucketMs >= barBucketMs) return 1
+  return Math.round(barBucketMs / bucketMs)
 }
 
 // ── Gap detection ─────────────────────────────────────────────────────────────
@@ -574,6 +591,65 @@ const drawCrosshairOverlay = (
 
 // ── Main draw function ────────────────────────────────────────────────────────
 
+/** Draw bar charts (steps/calories) and band charts (HR/HRV). */
+const drawBarAndBandCharts = (
+  chartGroup: SvgGroup,
+  barBuckets: MetricBucketParsed[],
+  lineBuckets: MetricBucketParsed[],
+  xScale: d3.ScaleTime<number, number>,
+  yScales: MetricsYScales,
+  trackBottom: number,
+  showSteps: boolean,
+  showCalories: boolean,
+  showHR: boolean,
+  showHRV: boolean,
+  barLayout?: BarLayoutResult,
+  stepsSlotId?: string,
+  caloriesSlotId?: string,
+): void => {
+  const { yCal, yHr, yHrv, ySteps } = yScales
+
+  // Draw bars first (behind lines), using coarser bar buckets
+  if (showSteps) {
+    drawBarChart(
+      chartGroup,
+      barBuckets,
+      'steps',
+      xScale,
+      ySteps,
+      trackBottom,
+      STEPS_COLOR,
+      0.25,
+      barLayout,
+      stepsSlotId,
+    )
+  }
+  if (showCalories) {
+    drawBarChart(
+      chartGroup,
+      barBuckets,
+      'calories_active',
+      xScale,
+      yCal,
+      trackBottom,
+      CALORIES_COLOR,
+      0.2,
+      barLayout,
+      caloriesSlotId,
+    )
+  }
+
+  // Draw band charts (using finer line buckets)
+  if (showHR) {
+    const hrBand = extractBandData(lineBuckets, 'heart_rate')
+    if (hrBand.length > 1) drawBandChart(chartGroup, hrBand, xScale, yHr, HR_COLOR)
+  }
+  if (showHRV) {
+    const hrvBand = extractBandData(lineBuckets, 'hrv_rmssd')
+    if (hrvBand.length > 1) drawBandChart(chartGroup, hrvBand, xScale, yHrv, HRV_COLOR)
+  }
+}
+
 /**
  * Draw the metrics track: bars for steps/calories, then band charts for HR/HRV,
  * and an interactive crosshair overlay for tooltips.
@@ -601,54 +677,36 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
 
   const hasMetrics = showHR || showHRV || showSteps || showCalories
   const hasTrainingLoad = config.trainingLoadPoints && config.trainingLoadPoints.length > 0
-  if (rawBuckets.length === 0 && !hasTrainingLoad) return
-  if (!hasMetrics && !hasTrainingLoad) return
+  const hasScreentime = config.screentimeBuckets && config.screentimeBuckets.length > 0
+  if (rawBuckets.length === 0 && !hasTrainingLoad && !hasScreentime) return
+  if (!hasMetrics && !hasTrainingLoad && !hasScreentime) return
 
-  const factor = getAggregationFactor(pixelsPerHour, rawBuckets)
-  const buckets = aggregateBuckets(rawBuckets, factor)
+  // Aggregate for line charts (HR/HRV) — finer granularity
+  const lineFactor = getAggregationFactor(pixelsPerHour, rawBuckets)
+  const buckets = aggregateBuckets(rawBuckets, lineFactor)
+
+  // Aggregate for bar charts (steps/calories) — coarser, matching barBucketMs
+  const barFactor = computeBarAggregationFactor(rawBuckets, config.barBucketMs)
+  const barBuckets = barFactor !== lineFactor ? aggregateBuckets(rawBuckets, barFactor) : buckets
+
   const trackBottom = trackY + trackHeight
 
-  const { yCal, yHr, yHrv, ySteps } = yScales
-
-  // Draw bars first (behind lines)
-  if (showSteps) {
-    drawBarChart(
-      chartGroup,
-      buckets,
-      'steps',
-      xScale,
-      ySteps,
-      trackBottom,
-      STEPS_COLOR,
-      0.25,
-      config.barLayout,
-      config.stepsSlotId,
-    )
-  }
-  if (showCalories) {
-    drawBarChart(
-      chartGroup,
-      buckets,
-      'calories_active',
-      xScale,
-      yCal,
-      trackBottom,
-      CALORIES_COLOR,
-      0.2,
-      config.barLayout,
-      config.caloriesSlotId,
-    )
-  }
-
-  // Draw band charts
-  if (showHR) {
-    const hrBand = extractBandData(buckets, 'heart_rate')
-    if (hrBand.length > 1) drawBandChart(chartGroup, hrBand, xScale, yHr, HR_COLOR)
-  }
-  if (showHRV) {
-    const hrvBand = extractBandData(buckets, 'hrv_rmssd')
-    if (hrvBand.length > 1) drawBandChart(chartGroup, hrvBand, xScale, yHrv, HRV_COLOR)
-  }
+  // Draw bars and band charts (extracted to reduce complexity)
+  drawBarAndBandCharts(
+    chartGroup,
+    barBuckets,
+    buckets,
+    xScale,
+    yScales,
+    trackBottom,
+    showSteps,
+    showCalories,
+    showHR,
+    showHRV,
+    config.barLayout,
+    config.stepsSlotId,
+    config.caloriesSlotId,
+  )
 
   // Crosshair tooltip overlay (includes training load + screentime data in combined tooltip)
   drawCrosshairOverlay(

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -911,12 +911,14 @@ export const Timeline = () => {
 
   // ── Legend / filtering ─────────────────────────────────────────────────────
 
-  // Training load uses the same unified bucket size as general metrics.
-  // The training load backend accepts '1h', '1d', '1w' — map the unified size accordingly.
-  const trainingLoadBucketSize = useMemo((): '1h' | '1d' | '1w' => {
+  // Unified bar bucket size — all bar-shaped data (training load, steps, calories, screentime)
+  // uses the same bucket size so they align visually side by side.
+  // Training load backend only supports '1h', '1d', '1w', which constrains the minimum.
+  // Line charts (HR/HRV) still use the finer `bucketSize` for smooth rendering.
+  const barBucketSize = useMemo((): '1h' | '1d' | '1w' => {
     if (bucketSize === '1w') return '1w'
     if (bucketSize === '1d') return '1d'
-    // For sub-day metric buckets (5m, 15m, 1h), use hourly training load
+    // For sub-day views, all bars use hourly buckets
     return '1h'
   }, [bucketSize])
 
@@ -924,18 +926,18 @@ export const Timeline = () => {
   const trainingLoadQuery = useQuery({
     enabled: !hiddenCategories.has('training_load'),
     placeholderData: keepPreviousData,
-    queryFn: () =>
-      fetchTrainingLoad(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), trainingLoadBucketSize),
-    queryKey: ['timeline-training-load', fromDate.value, toDate.value, trainingLoadBucketSize],
+    queryFn: () => fetchTrainingLoad(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), barBucketSize),
+    queryKey: ['timeline-training-load', fromDate.value, toDate.value, barBucketSize],
     staleTime: 5 * 60 * 1000,
   })
 
   // Screentime bucketed data (for horizontal stacked bar chart)
+  // Uses the same barBucketSize so it aligns with steps/calories/training load
   const screentimeBucketedQuery = useQuery({
     enabled: !hiddenCategories.has('screen_time_h') && !hiddenCategories.has('metrics'),
     placeholderData: keepPreviousData,
-    queryFn: () => fetchScreentimeBucketed(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), bucketSize),
-    queryKey: ['timeline-screentime-bucketed', fromDate.value, toDate.value, bucketSize],
+    queryFn: () => fetchScreentimeBucketed(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), barBucketSize),
+    queryKey: ['timeline-screentime-bucketed', fromDate.value, toDate.value, barBucketSize],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -1793,6 +1795,7 @@ export const Timeline = () => {
             ? { yScales: metricsYScales }
             : { yScales: computeYScales([], trackMetrics, trackMetrics + metricsTrackHeight) }),
           xScale: currentXScale,
+          barBucketMs: barBucketSize === '1w' ? 7 * 86400000 : barBucketSize === '1d' ? 86400000 : 3600000,
           barLayout,
           caloriesSlotId: 'calories',
           stepsSlotId: 'steps',


### PR DESCRIPTION
## Summary

Fixes bars being different widths in the horizontal timeline. Steps, calories, and screentime bars were drawn at 5m bucket size while training load used 1h — resulting in confusingly thin bars next to wide ones.

### Before
- Steps/calories/screentime: 5m buckets (tiny narrow bars)
- Training load: 1h buckets (wide bars)

### After
All bars use the same bucket size:
- Sub-day views: **1h** (matches training load)
- 30+ day views: 1d
- 365+ day views: 1w

Line charts (HR/HRV) still use finer buckets for smooth rendering.

### How it works
- `barBucketSize` replaces `trainingLoadBucketSize` — used for training load AND screentime queries
- Steps/calories data is fetched at fine granularity (for HR/HRV lines) but re-aggregated to `barBucketMs` at draw time via new `computeBarAggregationFactor`
- All 5 bar types (fatigue, impulse, screentime, steps, calories) now have equal-width bars side by side