### PR TITLE
feat: separate gap-fill calorie source and timezone-aware daily aggregates

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ Replace `:latest` with `:develop` in docker-compose.yml to use development build
 
 ---
 
+## Feature Documentation
+
+Detailed documentation for specific features and data processing pipelines:
+
+- [Active Calorie Computation](docs/features/calories.md) -- HR-based calculation, gap-fill, source filtering
+
+---
+
 ## Architecture
 
 ```

--- a/apps/android/app/src/main/java/net/aurboda/DailyAggregateSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DailyAggregateSync.kt
@@ -103,6 +103,7 @@ suspend fun fetchDailyAggregates(
               metric = metricType,
               value = value,
               dataOrigins = dataOrigins,
+              timezone = zoneId.id, // IANA timezone for correct day boundary alignment
             ),
           )
           Log.d(TAG, "Aggregate for $metricType on $date: $value from ${dataOrigins.size} sources")

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -33,6 +33,7 @@ import {
   resetSyncState,
   schemaInitialized,
   updateDetectedLocation,
+  upsertUserSettings,
 } from './db/index.ts'
 import { syncAllGarminData } from './garmin-sync.ts'
 import { garminClient } from './garmin.ts'
@@ -393,6 +394,8 @@ const main = async () => {
         syncRescueTime: transformRescueTimeSyncResult,
         triggerCalorieComputation: (user: string, start: Date, end: Date) =>
           triggerCalorieComputation(user, start, end),
+        upsertUserSettings: (user: string, settings: Record<string, unknown>) =>
+          upsertUserSettings(user, settings),
       },
       authMiddleware,
     ),

--- a/apps/backend/src/db/cumulative-query.ts
+++ b/apps/backend/src/db/cumulative-query.ts
@@ -10,7 +10,7 @@ import type { QueryResultRow } from 'pg'
  * when aurboda computes per-minute values, the health_connect_aggregate
  * daily totals must be excluded to avoid nonsense averages.
  */
-import { aurbodaOnlyMetrics, cumulativeMetrics, type MetricType } from '@aurboda/api-spec'
+import { aurbodaOnlyMetrics, aurbodaOnlySources, cumulativeMetrics, type MetricType } from '@aurboda/api-spec'
 
 /**
  * Split a list of metric names into three groups:
@@ -54,8 +54,8 @@ interface SplitQueryOptions<T> {
  * for the additional params (e.g. $2 for start, $3 for end). The cumulative SQL can
  * reference additional placeholders for cumulativeExtraParams.
  *
- * Aurboda-only metrics reuse the cumulative SQL template but with ['aurboda'] as the
- * source filter instead of the standard cumulativeSources.
+ * Aurboda-only metrics reuse the cumulative SQL template but with aurbodaOnlySources
+ * (HR-computed + gap-fill) as the source filter instead of the standard cumulativeSources.
  */
 export const querySplitByCumulative = async <T>(options: SplitQueryOptions<T>): Promise<T[]> => {
   const { aurbodaOnly, cumulative, nonCumulative } = splitMetricsByCumulative(options.metrics)
@@ -72,11 +72,12 @@ export const querySplitByCumulative = async <T>(options: SplitQueryOptions<T>): 
   }
 
   if (aurbodaOnly.length > 0) {
-    // Use the same cumulative SQL template but with 'aurboda' as the only source
+    // Use the same cumulative SQL template but with aurbodaOnlySources (HR-computed + gap-fill)
     const extraParams = options.cumulativeExtraParams ?? []
-    // Replace the cumulativeSources param with just ['aurboda']
+    // Replace the cumulativeSources param with aurbodaOnlySources
     // The cumulativeExtraParams[0] is the sources array, so we override it
-    const aurbodaExtraParams = extraParams.length > 0 ? [['aurboda'], ...extraParams.slice(1)] : [['aurboda']]
+    const aurbodaExtraParams =
+      extraParams.length > 0 ? [aurbodaOnlySources, ...extraParams.slice(1)] : [aurbodaOnlySources]
     const result = await options.queryFn(options.sqlCumulative, [
       aurbodaOnly,
       ...options.params,

--- a/apps/backend/src/db/health-connect.test.ts
+++ b/apps/backend/src/db/health-connect.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+
+import { localMidnightToUtc } from './health-connect.ts'
+
+describe('localMidnightToUtc', () => {
+  test('falls back to UTC midnight when no timezone is provided', () => {
+    const result = localMidnightToUtc('2026-03-18')
+    expect(result.toISOString()).toBe('2026-03-18T00:00:00.000Z')
+  })
+
+  test('converts CET (UTC+1) midnight to correct UTC time', () => {
+    // March 18 in Stockholm (CET, UTC+1) starts at 23:00 UTC on March 17
+    const result = localMidnightToUtc('2026-03-18', 'Europe/Stockholm')
+    expect(result.toISOString()).toBe('2026-03-17T23:00:00.000Z')
+  })
+
+  test('handles CEST (UTC+2) correctly during summer time', () => {
+    // July 15 in Stockholm (CEST, UTC+2) starts at 22:00 UTC on July 14
+    const result = localMidnightToUtc('2026-07-15', 'Europe/Stockholm')
+    expect(result.toISOString()).toBe('2026-07-14T22:00:00.000Z')
+  })
+
+  test('handles positive UTC offset (Asia/Tokyo, UTC+9)', () => {
+    // March 18 in Tokyo (UTC+9) starts at 15:00 UTC on March 17
+    const result = localMidnightToUtc('2026-03-18', 'Asia/Tokyo')
+    expect(result.toISOString()).toBe('2026-03-17T15:00:00.000Z')
+  })
+
+  test('handles negative UTC offset (America/New_York, UTC-5 EST)', () => {
+    // January 15 in New York (EST, UTC-5) starts at 05:00 UTC on January 15
+    const result = localMidnightToUtc('2026-01-15', 'America/New_York')
+    expect(result.toISOString()).toBe('2026-01-15T05:00:00.000Z')
+  })
+
+  test('handles UTC timezone', () => {
+    const result = localMidnightToUtc('2026-03-18', 'UTC')
+    expect(result.toISOString()).toBe('2026-03-18T00:00:00.000Z')
+  })
+
+  test('falls back to UTC midnight for invalid timezone', () => {
+    const result = localMidnightToUtc('2026-03-18', 'Invalid/Timezone')
+    expect(result.toISOString()).toBe('2026-03-18T00:00:00.000Z')
+  })
+
+  test('handles New Zealand (UTC+12/+13)', () => {
+    // March 18 in Auckland (NZDT, UTC+13 during DST) starts at 11:00 UTC on March 17
+    const result = localMidnightToUtc('2026-03-18', 'Pacific/Auckland')
+    expect(result.toISOString()).toBe('2026-03-17T11:00:00.000Z')
+  })
+})

--- a/apps/backend/src/db/health-connect.ts
+++ b/apps/backend/src/db/health-connect.ts
@@ -410,10 +410,81 @@ export const deleteHealthConnectRecords = async (user: string, externalIds: stri
 // ============================================================================
 
 /**
+ * Convert a date string (YYYY-MM-DD) to midnight in the given IANA timezone, returned as UTC.
+ * E.g., "2026-03-18" + "Europe/Stockholm" (CET, UTC+1) → 2026-03-17T23:00:00Z
+ *
+ * Falls back to UTC midnight if timezone is invalid or missing.
+ */
+export const localMidnightToUtc = (dateStr: string, timezone?: string): Date => {
+  if (!timezone) {
+    const time = new Date(dateStr)
+    time.setUTCHours(0, 0, 0, 0)
+    return time
+  }
+
+  try {
+    // Parse the date components to avoid Date constructor timezone ambiguity
+    const [y, m, d] = dateStr.split('-').map(Number)
+
+    // Use Intl.DateTimeFormat to find the UTC offset for this date in this timezone.
+    // Create a UTC date at midnight, then find what UTC time corresponds to local midnight.
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+
+    // Binary-search approach: start from UTC midnight of the target date,
+    // then adjust based on the timezone offset.
+    // A simpler approach: construct a date string with timezone and parse it.
+    const utcGuess = new Date(Date.UTC(y, m - 1, d, 0, 0, 0))
+
+    // Get what local time this UTC time corresponds to
+    const parts = formatter.formatToParts(utcGuess)
+    const localHour = Number(parts.find((p) => p.type === 'hour')?.value ?? 0)
+    const localDay = Number(parts.find((p) => p.type === 'day')?.value ?? d)
+    const localMonth = Number(parts.find((p) => p.type === 'month')?.value ?? m)
+
+    // Calculate offset: if UTC midnight shows as local 01:00 on same day, offset is +1h
+    // So local midnight is 1 hour before UTC midnight → UTC 23:00 previous day
+    let offsetMs: number
+    if (localDay === d && localMonth === m) {
+      // Same day: offset in hours is localHour
+      offsetMs = localHour * 60 * 60 * 1000
+    } else if (localDay > d || localMonth > m) {
+      // Crossed to next day: offset is positive and large (e.g., UTC+12)
+      offsetMs = localHour * 60 * 60 * 1000 + 24 * 60 * 60 * 1000
+    } else {
+      // Crossed to previous day: offset is negative (e.g., UTC-12)
+      offsetMs = (localHour - 24) * 60 * 60 * 1000
+    }
+
+    // Local midnight = UTC midnight - offset
+    return new Date(utcGuess.getTime() - offsetMs)
+  } catch {
+    // Invalid timezone: fall back to UTC midnight
+    const time = new Date(dateStr)
+    time.setUTCHours(0, 0, 0, 0)
+    return time
+  }
+}
+
+/**
  * Process a daily aggregate from Health Connect.
  * Stores deduplicated daily totals for cumulative metrics.
+ *
+ * When timezone is provided, the aggregate is stored at local midnight
+ * converted to UTC, ensuring correct day alignment for gap-fill.
  */
-export const processDailyAggregate = async (user: string, aggregate: DailyAggregate) => {
+export const processDailyAggregate = async (
+  user: string,
+  aggregate: DailyAggregate & { timezone?: string },
+): Promise<string | undefined> => {
   if (!isValidMetric(aggregate.metric)) {
     console.warn(`Invalid metric in daily aggregate: ${aggregate.metric}`)
     return
@@ -425,9 +496,8 @@ export const processDailyAggregate = async (user: string, aggregate: DailyAggreg
     return
   }
 
-  // Parse the date and set to midnight UTC
-  const time = new Date(aggregate.date)
-  time.setUTCHours(0, 0, 0, 0)
+  // Convert date to local midnight in the device's timezone (or UTC midnight if no timezone)
+  const time = localMidnightToUtc(aggregate.date, aggregate.timezone)
 
   await query(
     user,
@@ -436,6 +506,8 @@ export const processDailyAggregate = async (user: string, aggregate: DailyAggreg
      ON CONFLICT (time, metric, source) DO UPDATE SET value = EXCLUDED.value`,
     [time, metric, aggregate.value, metricUnits[metric]],
   )
+
+  return aggregate.timezone
 }
 
 /**

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -7,6 +7,7 @@ import type { BucketedMetricData, DailyMetricAggregate, MetricStats, TimeSeriesP
 
 import {
   aurbodaOnlyMetrics,
+  aurbodaOnlySources,
   cumulativeMetrics,
   cumulativeSources,
   type MetricType,
@@ -18,7 +19,7 @@ import { parseMetricType } from './row-mappers.ts'
 
 /** Get the source filter for a single metric: aurboda-only, cumulative sources, or all sources (null). */
 const getSourceFilter = (metric: string): string[] | null => {
-  if (aurbodaOnlyMetrics.includes(metric as MetricType)) return ['aurboda']
+  if (aurbodaOnlyMetrics.includes(metric as MetricType)) return aurbodaOnlySources
   if (cumulativeMetrics.includes(metric as MetricType)) return cumulativeSources
   return null
 }
@@ -305,7 +306,7 @@ export const getMetricTimeRange = async (
 export const deleteTimeSeriesPoint = async (user: string, metric: string, time: Date): Promise<boolean> => {
   const result = await query(
     user,
-    `DELETE FROM time_series WHERE metric = $1 AND time = $2 AND source IN ('manual', 'aurboda')`,
+    `DELETE FROM time_series WHERE metric = $1 AND time = $2 AND source IN ('manual', 'aurboda', 'aurboda_gap_fill')`,
     [metric, time],
   )
   return (result.rowCount ?? 0) > 0
@@ -314,7 +315,7 @@ export const deleteTimeSeriesPoint = async (user: string, metric: string, time: 
 export const deleteTimeSeriesMetric = async (user: string, metric: string): Promise<number> => {
   const result = await query(
     user,
-    `DELETE FROM time_series WHERE metric = $1 AND source IN ('manual', 'aurboda')`,
+    `DELETE FROM time_series WHERE metric = $1 AND source IN ('manual', 'aurboda', 'aurboda_gap_fill')`,
     [metric],
   )
   return result.rowCount ?? 0

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -393,6 +393,7 @@ export interface UserSettings {
   calendars?: CalendarConfig[] // Calendar ICS URL configurations
   custom_metrics?: CustomMetricDefinition[] // User-defined custom metric types
   dashboard?: DashboardConfig // Custom dashboard configuration
+  device_timezone?: string // IANA timezone from the Android device (e.g. "Europe/Stockholm")
   goals?: Goal[] // User-defined goals for tracking metrics
   hr_zone_start?: { 1: number; 2: number; 3: number; 4: number; 5: number }
   lastfm_username?: string // Last.fm username for scrobble sync

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -8,6 +8,7 @@
 // Re-export common types from shared api-spec package
 export {
   aurbodaOnlyMetrics,
+  aurbodaOnlySources,
   contextualHrvMetrics,
   cumulativeMetrics,
   cumulativeSources,

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -10,6 +10,7 @@ import type { BiologicalSex } from '@aurboda/api-spec'
 
 import type { TimeSeriesPoint } from '../db/types.ts'
 
+import { localMidnightToUtc } from '../db/health-connect.ts'
 import { enqueueOutboundSync, getUserSettings, upsertUserSettings } from '../db/index.ts'
 import {
   deleteTimeSeriesBySource,
@@ -181,6 +182,7 @@ export const computeAndStoreCalories = async (
   // 6. Delete existing aurboda calories if force-recomputing
   if (options?.force) {
     await deleteTimeSeriesBySource(user, 'calories_active', 'aurboda', start, end)
+    await deleteTimeSeriesBySource(user, 'calories_active', 'aurboda_gap_fill', start, end)
   }
 
   // 7. Check if aurboda calories already exist for this range to avoid recomputing
@@ -213,7 +215,14 @@ export const computeAndStoreCalories = async (
     }
   }
 
-  // 10. Store as time_series
+  // 10. Delete stale gap-fill points for minutes that now have HR-computed values
+  if (newPoints.length > 0) {
+    const rangeStart = newPoints[0].time
+    const rangeEnd = new Date(newPoints[newPoints.length - 1].time.getTime() + 60_000)
+    await deleteTimeSeriesBySource(user, 'calories_active', 'aurboda_gap_fill', rangeStart, rangeEnd)
+  }
+
+  // 11. Store as time_series
   const timeSeriesPoints: TimeSeriesPoint[] = newPoints.map((p) => ({
     metric: 'calories_active',
     source: 'aurboda' as const,
@@ -223,12 +232,12 @@ export const computeAndStoreCalories = async (
   }))
   await insertTimeSeries(user, timeSeriesPoints)
 
-  // 11. Queue outbound sync (best-effort, skipped during full historical recomputes)
+  // 12. Queue outbound sync (best-effort, skipped during full historical recomputes)
   if (!options?.skipSync) {
     await enqueueCalorieSync(user, newPoints)
   }
 
-  // 12. Invalidate training load impulse buckets so they recompute from new calorie data
+  // 13. Invalidate training load impulse buckets so they recompute from new calorie data
   await invalidateTrainingLoadImpulses(user, start)
 
   return {
@@ -253,10 +262,11 @@ export interface GapFillDayResult {
  *
  * This function:
  * 1. Reads the HC aggregate for the day
- * 2. Reads existing aurboda calorie points for the day
- * 3. Computes the residual (HC total - aurboda sum)
- * 4. Distributes it evenly across minutes without HR coverage
- * 5. Stores gap-fill points with source 'aurboda'
+ * 2. Deletes existing gap-fill points for the day (idempotent re-run)
+ * 3. Reads existing HR-computed aurboda calorie points for the day
+ * 4. Computes the residual (HC total - aurboda sum)
+ * 5. Distributes it evenly across minutes without HR coverage
+ * 6. Stores gap-fill points with source 'aurboda_gap_fill'
  */
 export const gapFillCaloriesForDay = async (user: string, dayStartUtc: Date): Promise<GapFillDayResult> => {
   const dayEndUtc = new Date(dayStartUtc.getTime() + 24 * 60 * 60 * 1000 - 1)
@@ -273,7 +283,10 @@ export const gapFillCaloriesForDay = async (user: string, dayStartUtc: Date): Pr
 
   const hcAggregateKcal = hcData.reduce((sum, [, value]) => sum + value, 0)
 
-  // 2. Get existing aurboda calorie points for this day
+  // 2. Delete existing gap-fill points for this day (makes re-runs idempotent)
+  await deleteTimeSeriesBySource(user, 'calories_active', 'aurboda_gap_fill', dayStartUtc, dayEndUtc)
+
+  // 3. Get existing HR-computed aurboda calorie points for this day
   const existingData = await getTimeSeriesBySource(user, 'calories_active', 'aurboda', dayStartUtc, dayEndUtc)
   const aurbodaPoints: CalorieDataPoint[] = existingData.map(([time, value]) => ({
     end_time: new Date(time.getTime() + 60_000),
@@ -281,7 +294,7 @@ export const gapFillCaloriesForDay = async (user: string, dayStartUtc: Date): Pr
     time,
   }))
 
-  // 3. Compute gap-fill points
+  // 4. Compute gap-fill points
   const result = computeGapFillPoints({
     aurboda_points: aurbodaPoints,
     day_start: dayStartUtc,
@@ -290,17 +303,17 @@ export const gapFillCaloriesForDay = async (user: string, dayStartUtc: Date): Pr
 
   if (result.points.length === 0) return { gap_minutes: 0, points_stored: 0, residual_kcal: 0 }
 
-  // 4. Store gap-fill points as aurboda source
+  // 5. Store gap-fill points with separate source for identification
   const timeSeriesPoints: TimeSeriesPoint[] = result.points.map((p) => ({
     metric: 'calories_active',
-    source: 'aurboda' as const,
+    source: 'aurboda_gap_fill' as const,
     time: p.time,
     unit: 'kcal',
     value: p.kcal,
   }))
   await insertTimeSeries(user, timeSeriesPoints)
 
-  // 5. Invalidate training load impulse buckets for this day
+  // 6. Invalidate training load impulse buckets for this day
   await invalidateTrainingLoadImpulses(user, dayStartUtc)
 
   return {
@@ -311,8 +324,38 @@ export const gapFillCaloriesForDay = async (user: string, dayStartUtc: Date): Pr
 }
 
 /**
+ * Get the user's device timezone from settings, or undefined if not set.
+ */
+const getDeviceTimezone = async (user: string): Promise<string | undefined> => {
+  const settings = await getUserSettings(user)
+  return (settings?.device_timezone as string) ?? undefined
+}
+
+/**
+ * Get the local-timezone day start (as UTC) for a given UTC timestamp.
+ * If no timezone is available, falls back to UTC day boundaries.
+ */
+const getLocalDayStart = (utcTime: Date, timezone?: string): Date => {
+  if (!timezone) {
+    const dayMs = 24 * 60 * 60 * 1000
+    return new Date(Math.floor(utcTime.getTime() / dayMs) * dayMs)
+  }
+
+  // Use localMidnightToUtc with the date string in the target timezone
+  const formatter = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+  const localDateStr = formatter.format(utcTime) // "YYYY-MM-DD" format
+  return localMidnightToUtc(localDateStr, timezone)
+}
+
+/**
  * Gap-fill calories for all calendar days within a time range.
- * Iterates day by day (UTC) and runs gap-fill for each.
+ * Uses the device timezone (from user settings) for day boundary alignment,
+ * matching how the Android app computes daily aggregates.
  */
 export const gapFillCaloriesForRange = async (
   user: string,
@@ -324,10 +367,12 @@ export const gapFillCaloriesForRange = async (
   total_points_stored: number
   total_residual_kcal: number
 }> => {
-  // Align to UTC day boundaries
+  const timezone = await getDeviceTimezone(user)
+
+  // Get the local-timezone day boundaries
   const dayMs = 24 * 60 * 60 * 1000
-  const firstDay = new Date(Math.floor(start.getTime() / dayMs) * dayMs)
-  const lastDay = new Date(Math.floor(end.getTime() / dayMs) * dayMs)
+  const firstDay = getLocalDayStart(start, timezone)
+  const lastDay = getLocalDayStart(end, timezone)
 
   let daysProcessed = 0
   let totalGapMinutes = 0

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -34,6 +34,7 @@ describe('sync router', () => {
     syncOura: vi.fn().mockResolvedValue({ success: true }),
     syncRescueTime: vi.fn().mockResolvedValue({ success: true }),
     triggerCalorieComputation: vi.fn().mockResolvedValue(undefined),
+    upsertUserSettings: vi.fn().mockResolvedValue(undefined),
   }
 
   // Simple auth middleware that sets req.user for tests

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -74,7 +74,8 @@ interface PendingOutboundSyncResult {
 
 export interface SyncRouterDeps {
   deleteHealthConnectRecords: (user: string, externalIds: string[]) => Promise<number>
-  processDailyAggregate: (user: string, aggregate: DailyAggregate) => Promise<void>
+  processDailyAggregate: (user: string, aggregate: DailyAggregate) => Promise<string | undefined>
+  upsertUserSettings: (user: string, settings: Record<string, unknown>) => Promise<unknown>
   processHealthConnectBatch: (
     user: string,
     recordType: string,
@@ -158,8 +159,15 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
           `dates ${dates[0]}..${dates[dates.length - 1]}`,
       )
 
+      let deviceTimezone: string | undefined
       for (const aggregate of data) {
-        await deps.processDailyAggregate(user, aggregate)
+        const tz = await deps.processDailyAggregate(user, aggregate)
+        if (tz) deviceTimezone = tz
+      }
+
+      // Store the device timezone in user settings for gap-fill day boundary alignment
+      if (deviceTimezone) {
+        await deps.upsertUserSettings(user, { device_timezone: deviceTimezone })
       }
 
       res.json({ success: true })

--- a/docs/PLAN-calorie-source-separation.md
+++ b/docs/PLAN-calorie-source-separation.md
@@ -1,0 +1,59 @@
+# Plan: Calorie Source Separation & Timezone-Aware Gap-Fill
+
+## Problem
+
+Gap-fill and HR-based calorie computation both use `source: 'aurboda'`. When gap-fill runs
+before HR data arrives (common with out-of-order syncs), it permanently occupies minute slots,
+and subsequent HR-based computation skips them ("all minutes already computed"). This causes
+exercise periods with 170+ bpm heart rate to show only the tiny gap-fill baseline value.
+
+Additionally, the Android app aggregates daily calories using local timezone day boundaries,
+but the backend stores and gap-fills using UTC day boundaries — a timezone mismatch.
+
+## Solution
+
+### Part A: Documentation
+
+- **A1.** Create `docs/features/calories.md` documenting calorie computation, data sources,
+  HR-based calculation, gap-fill, and source filtering.
+- **A2.** Add "Feature Documentation" section to `README.md` linking to `docs/features/`.
+
+### Part B: Source Separation (`aurboda_gap_fill`)
+
+- **B1.** `packages/api-spec/src/schemas/common.ts`: Add `'aurboda_gap_fill'` to
+  `dataSourceSchema`. Add `aurbodaOnlySources` constant.
+- **B2.** `apps/backend/src/db/time-series.ts`: `getSourceFilter` returns `aurbodaOnlySources`.
+  Add `'aurboda_gap_fill'` to delete `IN` clauses.
+- **B3.** `apps/backend/src/db/cumulative-query.ts`: Use `aurbodaOnlySources` instead of
+  hardcoded `['aurboda']`.
+- **B4.** `apps/backend/src/services/calorie-computation.ts` gap-fill: Write with source
+  `'aurboda_gap_fill'`. Delete existing gap-fill before recomputing (idempotent).
+- **B5.** HR computation: Delete stale `aurboda_gap_fill` points before inserting HR-computed
+  points.
+- **B6.** Force-recompute: Also delete `'aurboda_gap_fill'` alongside `'aurboda'`.
+- **B7.** Build and regenerate api-spec.
+
+### Part C: Timezone-Aware Daily Aggregates
+
+- **C1.** `packages/api-spec/src/schemas/sync.ts`: Add optional `timezone` field to
+  `dailyAggregateSchema`.
+- **C2.** `apps/android/.../DailyAggregateSync.kt`: Send `timezone = ZoneId.systemDefault().id`.
+- **C3.** `apps/backend/src/db/health-connect.ts` `processDailyAggregate`: When timezone
+  provided, store at local midnight converted to UTC. Store timezone in user settings.
+- **C4.** Gap-fill: Use timezone from user settings for day boundaries.
+
+### Part E: Tests
+
+- Update calorie computation tests for new source.
+- Test timezone handling in processDailyAggregate.
+- `pnpm fix && pnpm check`.
+
+### Post-deploy
+
+- Run `recalculate_calories` via MCP.
+- Add goal: `{ metric: 'calories_active', min: 4200, window: '7d' }`.
+
+### Deferred / Known Limitations
+
+- **Goals may undercount calories_active** if HR sum exceeds HC aggregate (rare in practice).
+- **Per-source calorie trust** — future setting for devices like Withings Scanwatch 2.

--- a/docs/features/calories.md
+++ b/docs/features/calories.md
@@ -1,0 +1,128 @@
+# Active Calorie Computation
+
+Active calories represent energy expenditure above resting metabolic rate. Aurboda computes per-minute active calories from heart rate data using a published formula, and supplements gaps in HR coverage with data from Health Connect's daily aggregate.
+
+## Data Sources
+
+| Source                   | DB `source` value          | Granularity     | Used in queries?      | Description                                                                                                 |
+| ------------------------ | -------------------------- | --------------- | --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| HR-based computation     | `aurboda`                  | Per-minute      | Yes                   | Computed from heart rate data using the Omnicalculator HR-to-calories formula                               |
+| Gap-fill                 | `aurboda_gap_fill`         | Per-minute      | Yes                   | Residual from HC aggregate distributed across minutes without HR coverage                                   |
+| Health Connect records   | `health_connect`           | Arbitrary spans | No (filtered out)     | Raw `ActiveCaloriesBurnedRecord` from phone apps; stored but excluded from queries to avoid double-counting |
+| Health Connect aggregate | `health_connect_aggregate` | Daily           | No (used by gap-fill) | Deduplicated daily total from the phone's Health Connect layer                                              |
+| Garmin daily summary     | `garmin`                   | Daily           | No (filtered out)     | Single daily value from Garmin; stored but excluded from queries                                            |
+
+### Source Filtering
+
+Queries for `calories_active` only return data from `aurboda` and `aurboda_gap_fill` sources. This is controlled by the `aurbodaOnlyMetrics` / `aurbodaOnlySources` constants in `packages/api-spec/src/schemas/common.ts`. The filtering prevents double-counting since raw Health Connect records, Garmin data, and the HC aggregate would overlap with aurboda's computed values.
+
+## HR-Based Computation
+
+### Formula
+
+Uses the [Omnicalculator HR-to-calories formula](https://www.omnicalculator.com/sports/calories-burned-by-heart-rate):
+
+- **Men:** `CB = T * (0.634*H + 0.404*V + 0.394*W + 0.271*A - 95.7735) / 4.184`
+- **Women:** `CB = T * (0.45*H + 0.380*V + 0.103*W + 0.274*A - 59.3954) / 4.184`
+
+Where: H = heart rate (bpm), V = VO2 max (mL/kg/min), W = weight (kg), A = age (years), T = 1 minute.
+
+### Required Inputs
+
+Gathered from user settings and recent time-series data:
+
+| Input      | Source                                              | Lookback       |
+| ---------- | --------------------------------------------------- | -------------- |
+| Sex        | User settings (`sex`)                               | N/A (required) |
+| Birth date | User settings (`birth_date`)                        | N/A (required) |
+| Weight     | `weight` metric                                     | 90 days        |
+| VO2 max    | `vo2_max` metric, or population fallback by sex/age | 730 days       |
+| Resting HR | `resting_heart_rate` metric, defaults to 60 bpm     | 90 days        |
+
+If sex, birth date, or weight are missing, computation is skipped entirely.
+
+### Baseline Subtraction
+
+The formula computes **total** caloric burn including BMR. To isolate active-only calories:
+
+1. A baseline HR is computed as `resting_hr * 1.2` (the `BASELINE_HR_MULTIPLIER`)
+2. The formula is evaluated at this baseline HR to get `baselineKcal` per minute
+3. For each minute: `active_kcal = max(0, total_formula_output - baselineKcal)`
+
+This naturally produces 0 active calories when HR is at or below the baseline (sleep, rest). The 1.2x multiplier was empirically validated: during actual sleep stages, HR stays at or below `resting_hr * 1.2`.
+
+### Hold-Last-Value Interpolation
+
+For sparse HR data (e.g., Oura's 5-minute intervals), the last HR reading is held forward for up to `MAX_HOLD_MINUTES = 5` minutes. Beyond that gap, minutes are skipped entirely (no stale data).
+
+### Computation Triggers
+
+Calorie computation is triggered automatically when HR data is ingested:
+
+- **Health Connect sync** (`POST /sync/health-connect/HeartRateRecord`) -- triggered in `sync-router.ts`
+- **Oura sync** (sleep and session data types contain HR samples) -- triggered in `oura-sync.ts`
+- **Manual recompute** (`recalculate_calories` MCP tool or API) -- force-recomputes from all HR data
+
+### Incremental vs Force Computation
+
+- **Incremental** (default): Checks for existing `aurboda` calorie points in the time range and skips already-computed minutes. Only computes new minutes from fresh HR data.
+- **Force** (`recalculate_calories`): Deletes all existing `aurboda` and `aurboda_gap_fill` calorie points, then recomputes from scratch. Processes in daily chunks to avoid memory issues.
+
+## Gap-Fill
+
+### Motivation
+
+HR-based computation only covers minutes where heart rate data exists. Some periods may have no HR coverage (wrist off, no HR monitor worn, phone-only activity tracking). The Health Connect daily aggregate captures activity from all phone apps (step-based calorie estimates, etc.) and provides a deduplicated daily total.
+
+Gap-fill distributes the "residual" -- calories captured by the phone but not by HR computation -- across minutes without HR coverage.
+
+### Algorithm
+
+For each calendar day:
+
+1. Read the HC daily aggregate for `calories_active` (source `health_connect_aggregate`)
+2. Read existing HR-computed calorie points (source `aurboda`) for the day
+3. Compute: `residual = hc_aggregate - sum(aurboda_points)`
+4. If `residual > 0`: distribute it evenly across gap minutes (minutes with no `aurboda` point)
+5. Store gap-fill points with source `aurboda_gap_fill`
+
+If the HR-based sum already exceeds the HC aggregate, no gap-fill is produced. This means the daily total naturally reflects `max(hc_aggregate, hr_based_sum)`.
+
+### Day Boundaries and Timezone
+
+The Android app aggregates daily calories using the device's local timezone. The backend stores the aggregate with the timezone from the payload, converting the local date to the correct UTC timestamp.
+
+Gap-fill uses the timezone from user settings (updated from the latest aggregate) to determine day boundaries, ensuring alignment between the aggregate's coverage window and the gap-fill distribution.
+
+### Idempotent Re-runs
+
+Gap-fill deletes existing `aurboda_gap_fill` points for the day before recomputing. This makes re-runs safe and prevents stale gap-fill from accumulating.
+
+### HR Computation Cleans Up Gap-Fill
+
+When new HR data arrives and calories are computed for previously gap-filled minutes, the stale gap-fill points for those minutes are deleted before the HR-computed values are inserted. This ensures HR-derived values always take precedence over gap-fill estimates.
+
+## Outbound Sync
+
+Only HR-computed calories (source `aurboda`) are synced back to Health Connect as `ActiveCaloriesBurnedRecord`. Gap-fill points are NOT synced back since they originate from the phone's aggregate data and writing them back would cause double-counting.
+
+## Daily Totals and Goals
+
+Goals for `calories_active` use `getDailyAggregateValue()` which reads from `cumulativeSources` (`health_connect_aggregate` or `aurboda`). This typically returns the HC aggregate value.
+
+The timeline's 1-day bucket view sums all `aurboda` + `aurboda_gap_fill` per-minute points, which after gap-fill should equal `max(hc_aggregate, hr_based_sum)`.
+
+## Known Limitations
+
+- **Goals vs timeline inconsistency**: Goals may show the HC aggregate value while the timeline shows the (potentially higher) HR-based sum. In practice, the HC aggregate is rarely lower than the HR computation since it includes contributions from all phone apps.
+- **Per-source calorie trust**: Currently, aurboda always recalculates from HR data regardless of whether the originating device (e.g., Withings Scanwatch 2) already computed accurate per-minute calories. A future setting could allow trusting a specific source's calorie values directly.
+
+## Key Files
+
+| File                                               | Purpose                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------ |
+| `apps/backend/src/services/calories.ts`            | Core formulas, gap-fill algorithm, constants                 |
+| `apps/backend/src/services/calorie-computation.ts` | Orchestration: gather inputs, compute, store, sync, gap-fill |
+| `apps/backend/src/db/time-series.ts`               | DB read/write, source filtering                              |
+| `apps/backend/src/db/cumulative-query.ts`          | Split queries by cumulative/aurbodaOnly/nonCumulative        |
+| `packages/api-spec/src/schemas/common.ts`          | Metric types, source constants, aurbodaOnlyMetrics           |

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -131,6 +131,7 @@ export const dataSourceSchema = z
   .enum([
     'activitywatch',
     'aurboda',
+    'aurboda_gap_fill',
     'health_connect',
     'health_connect_aggregate',
     'lab_report',
@@ -329,7 +330,7 @@ export const cumulativeMetrics: MetricType[] = [
 export const cumulativeSources: DataSource[] = ['health_connect_aggregate', 'aurboda']
 
 /**
- * Metrics where 'aurboda' per-minute data should be used exclusively
+ * Metrics where aurboda-computed per-minute data should be used exclusively
  * instead of mixing with 'health_connect_aggregate' daily totals.
  *
  * When aurboda computes per-minute values (e.g., calories from HR data),
@@ -337,6 +338,13 @@ export const cumulativeSources: DataSource[] = ['health_connect_aggregate', 'aur
  * nonsense if AVG'd with per-minute values in the same bucket.
  */
 export const aurbodaOnlyMetrics: MetricType[] = ['calories_active']
+
+/**
+ * Sources used for aurboda-only metrics: HR-computed values and gap-fill estimates.
+ * Gap-fill uses a separate source so HR computation can detect and replace gap-filled
+ * minutes when real HR data arrives later.
+ */
+export const aurbodaOnlySources: DataSource[] = ['aurboda', 'aurboda_gap_fill']
 
 /**
  * Place visit source schema.

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -148,11 +148,24 @@ export const dailyAggregateSchema = z
     data_origins: z.array(z.string()).meta({ description: 'Contributing app package names' }),
     date: dateOnlySchema,
     metric: z.enum(cumulativeMetrics).meta({ description: 'Cumulative metric type' }),
+    timezone: z
+      .string()
+      .meta({
+        description: 'IANA timezone of the device when the aggregate was computed (e.g. "Europe/Stockholm")',
+        example: 'Europe/Stockholm',
+      })
+      .optional(),
     value: z.number().meta({ description: 'Aggregated value for the day' }),
   })
   .meta({ id: 'DailyAggregate' })
 
-export type DailyAggregate = z.infer<typeof dailyAggregateSchema>
+export interface DailyAggregate {
+  data_origins: string[]
+  date: string
+  metric: (typeof cumulativeMetrics)[number]
+  timezone?: string
+  value: number
+}
 
 /**
  * Daily aggregates request body schema.


### PR DESCRIPTION
## Summary

- **Fix**: Gap-fill calorie points now use a separate `aurboda_gap_fill` source, preventing them from blocking HR-based calorie computation when HR data arrives late
- **Fix**: Daily aggregates now carry device timezone, enabling correct day boundary alignment for gap-fill (previously misaligned for non-UTC timezones)
- **Docs**: New `docs/features/calories.md` documenting the full calorie computation pipeline

## Problem

When gap-fill ran before HR data arrived (common with out-of-order syncs), it permanently occupied minute slots with source `aurboda`. Subsequent HR-based computation saw these as "already computed" and skipped them — causing exercise periods with 170+ bpm heart rate to show only the tiny gap-fill baseline value (~0.01 kcal/min).

Additionally, the Android app aggregated daily calories using local timezone boundaries but the backend stored them at UTC midnight, creating a 1+ hour misalignment.

## Changes

### Source Separation (Part B)
- Add `aurboda_gap_fill` to `DataSource` enum and new `aurbodaOnlySources` constant
- Gap-fill writes with `source: 'aurboda_gap_fill'` instead of `'aurboda'`
- HR computation deletes stale gap-fill points before inserting HR-computed values
- Gap-fill deletes existing gap-fill before recomputing (idempotent re-runs)
- Force-recompute deletes both `aurboda` and `aurboda_gap_fill` sources
- Source filter updated to include both sources in queries

### Timezone-Aware Daily Aggregates (Part C)
- Add optional `timezone` field to `dailyAggregateSchema` (backward compatible)
- Android app sends `ZoneId.systemDefault().id` with each aggregate
- Backend converts date to local midnight in device timezone before storing
- Gap-fill uses device timezone from user settings for day boundary alignment
- `localMidnightToUtc()` utility with unit tests for timezone conversion

### Documentation (Part A)
- New `docs/features/calories.md` covering data sources, HR formula, gap-fill algorithm, source filtering
- "Feature Documentation" section added to README.md

## Post-deploy

- Run `recalculate_calories` via MCP to recompute all data with the new source separation
- Add 7d active calorie goal via MCP/API