### PR TITLE
feat: add 'exclude from screen time' flag for screentime categories

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -205,6 +205,13 @@ export const migrateSchema = async (user: string) => {
     )
   }
 
+  if (existingTableNames.has('screentime_categories')) {
+    await query(
+      db,
+      `ALTER TABLE screentime_categories ADD COLUMN IF NOT EXISTS exclude_from_screentime BOOLEAN DEFAULT FALSE`,
+    )
+  }
+
   // Migrate notes entity_id from UUID to TEXT (supports composite keys for metrics)
   if (existingTableNames.has('notes')) {
     await query(db, `ALTER TABLE notes ALTER COLUMN entity_id TYPE TEXT`)

--- a/apps/backend/src/db/screentime-categories.ts
+++ b/apps/backend/src/db/screentime-categories.ts
@@ -8,6 +8,7 @@ import { query } from './connection.ts'
 const mapRow = (row: Record<string, unknown>): ScreentimeCategory => ({
   color: (row.color as string) || undefined,
   created_at: new Date(row.created_at as string),
+  exclude_from_screentime: (row.exclude_from_screentime as boolean) || undefined,
   id: row.id as string,
   ignore_case: row.ignore_case as boolean,
   name: row.name as string[],
@@ -21,7 +22,7 @@ const mapRow = (row: Record<string, unknown>): ScreentimeCategory => ({
 export const getScreentimeCategories = async (user: string): Promise<ScreentimeCategory[]> => {
   const result = await query(
     user,
-    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, sort_order, created_at, updated_at
+    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at
      FROM screentime_categories
      ORDER BY sort_order, name`,
   )
@@ -35,7 +36,7 @@ export const getScreentimeCategoryById = async (
 ): Promise<ScreentimeCategory | null> => {
   const result = await query(
     user,
-    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, sort_order, created_at, updated_at
+    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at
      FROM screentime_categories
      WHERE id = $1`,
     [id],
@@ -50,9 +51,9 @@ export const insertScreentimeCategory = async (
 ): Promise<ScreentimeCategory> => {
   const result = await query(
     user,
-    `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, sort_order)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, sort_order, created_at, updated_at`,
+    `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at`,
     [
       input.name,
       input.rule_type,
@@ -60,6 +61,7 @@ export const insertScreentimeCategory = async (
       input.ignore_case ?? true,
       input.color || null,
       input.score ?? null,
+      input.exclude_from_screentime ?? false,
       input.sort_order ?? 0,
     ],
   )
@@ -99,6 +101,10 @@ export const updateScreentimeCategory = async (
   if (input.score !== undefined) {
     fields.push(`score = $${paramIndex++}`)
     values.push(input.score)
+  }
+  if (input.exclude_from_screentime !== undefined) {
+    fields.push(`exclude_from_screentime = $${paramIndex++}`)
+    values.push(input.exclude_from_screentime)
   }
   if (input.sort_order !== undefined) {
     fields.push(`sort_order = $${paramIndex++}`)
@@ -165,9 +171,9 @@ export const bulkInsertScreentimeCategories = async (
 
   for (let i = 0; i < categories.length; i++) {
     const c = categories[i]
-    const offset = i * 7
+    const offset = i * 8
     valueClauses.push(
-      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7})`,
+      `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8})`,
     )
     params.push(
       c.name,
@@ -176,15 +182,16 @@ export const bulkInsertScreentimeCategories = async (
       c.ignore_case ?? true,
       c.color || null,
       c.score ?? null,
+      c.exclude_from_screentime ?? false,
       c.sort_order ?? i,
     )
   }
 
   const result = await query(
     user,
-    `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, sort_order)
+    `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
      VALUES ${valueClauses.join(', ')}
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, sort_order, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at`,
     params,
   )
 

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -224,6 +224,7 @@ export interface ScreentimeCategory {
   ignore_case: boolean
   color?: string
   score?: number
+  exclude_from_screentime?: boolean
   sort_order: number
   created_at: Date
   updated_at: Date
@@ -236,6 +237,7 @@ export interface ScreentimeCategoryInput {
   ignore_case?: boolean
   color?: string
   score?: number
+  exclude_from_screentime?: boolean
   sort_order?: number
 }
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -370,6 +370,7 @@ export const createTableStatements: Record<string, string> = {
       ignore_case     BOOLEAN DEFAULT TRUE,
       color           VARCHAR(20),
       score           SMALLINT,
+      exclude_from_screentime BOOLEAN DEFAULT FALSE,
       sort_order      INTEGER DEFAULT 0,
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/apps/web/src/components/ScreentimeCategoriesSettings/index.tsx
+++ b/apps/web/src/components/ScreentimeCategoriesSettings/index.tsx
@@ -102,12 +102,14 @@ function CategoryRow({
   const [editColor, setEditColor] = useState(cat.color ?? '')
   const [editScore, setEditScore] = useState<string>(cat.score !== undefined ? String(cat.score) : '')
   const [editIgnoreCase, setEditIgnoreCase] = useState(cat.ignore_case)
+  const [editExclude, setEditExclude] = useState(cat.exclude_from_screentime ?? false)
 
   const updateMutation = useMutation({
     mutationFn: () => {
       const newName = [...cat.name.slice(0, -1), editName.trim()]
       return updateScreentimeCategory(cat.id, {
         color: editColor || undefined,
+        exclude_from_screentime: editExclude,
         ignore_case: editIgnoreCase,
         name: newName,
         rule_regex: editRegex || undefined,
@@ -126,7 +128,6 @@ function CategoryRow({
     onSuccess: onDeleted,
   })
 
-  const displayName = cat.name[cat.name.length - 1]
   const indent = node.depth * 24
 
   if (isEditing) {
@@ -192,6 +193,14 @@ function CategoryRow({
               />
               Ignore case
             </label>
+            <label class="sc-case-label">
+              <input
+                type="checkbox"
+                checked={editExclude}
+                onChange={(e) => setEditExclude((e.target as HTMLInputElement).checked)}
+              />
+              Exclude from screen time
+            </label>
           </div>
         </div>
         <div class="sc-actions">
@@ -213,6 +222,40 @@ function CategoryRow({
   }
 
   return (
+    <CategoryRowView
+      cat={cat}
+      indent={indent}
+      onEdit={() => setIsEditing(true)}
+      onDelete={() => {
+        if (node.children.length > 0) {
+          if (!confirm(`Delete "${cat.name.join(' > ')}" and all its ${node.children.length} children?`)) {
+            return
+          }
+        }
+        deleteMutation.mutate()
+      }}
+      isDeleting={deleteMutation.isPending}
+    />
+  )
+}
+
+/** Display mode for a category row (extracted to reduce CategoryRow complexity). */
+function CategoryRowView({
+  cat,
+  indent,
+  onEdit,
+  onDelete,
+  isDeleting,
+}: {
+  cat: ScreentimeCategory
+  indent: number
+  onEdit: () => void
+  onDelete: () => void
+  isDeleting: boolean
+}) {
+  const displayName = cat.name[cat.name.length - 1]
+
+  return (
     <div class="sc-row" style={{ paddingLeft: `${indent + 8}px` }}>
       <div class="sc-info">
         {cat.color && <span class="sc-color-dot" style={{ background: cat.color }} />}
@@ -220,28 +263,15 @@ function CategoryRow({
           {displayName}
         </a>
         {cat.rule_regex && <code class="sc-regex">{cat.rule_regex}</code>}
+        {cat.exclude_from_screentime && <span class="sc-excluded-badge">excluded</span>}
         {cat.score !== undefined && <span class="sc-score">{productivityScoreLabel(cat.score)}</span>}
       </div>
       <div class="sc-actions">
-        <button type="button" class="note-action-btn" onClick={() => setIsEditing(true)}>
+        <button type="button" class="note-action-btn" onClick={onEdit}>
           Edit
         </button>
-        <button
-          type="button"
-          class="note-action-btn danger"
-          onClick={() => {
-            if (node.children.length > 0) {
-              if (
-                !confirm(`Delete "${cat.name.join(' > ')}" and all its ${node.children.length} children?`)
-              ) {
-                return
-              }
-            }
-            deleteMutation.mutate()
-          }}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? '...' : 'Delete'}
+        <button type="button" class="note-action-btn danger" onClick={onDelete} disabled={isDeleting}>
+          {isDeleting ? '...' : 'Delete'}
         </button>
       </div>
     </div>

--- a/apps/web/src/components/ScreentimeCategoriesSettings/style.css
+++ b/apps/web/src/components/ScreentimeCategoriesSettings/style.css
@@ -251,6 +251,15 @@
     background: #1e1e1e;
   }
 
+  .sc-excluded-badge {
+    font-size: 0.7rem;
+    color: #9ca3af;
+    background: #f3f4f6;
+    padding: 0.1rem 0.375rem;
+    border-radius: 3px;
+    font-style: italic;
+  }
+
   .sc-regex {
     background: #374151;
     color: #9ca3af;

--- a/apps/web/src/pages/Timeline/drawScreentimeTrack.ts
+++ b/apps/web/src/pages/Timeline/drawScreentimeTrack.ts
@@ -39,8 +39,21 @@ interface TopLevelCategory {
   children: Array<{ path: string[]; total_sec: number }>
 }
 
+/** Check if a category path matches an excluded category (or has an excluded ancestor). */
+export const isExcludedCategory = (path: string[], categories: ScreentimeCategory[]): boolean => {
+  for (let depth = path.length; depth > 0; depth--) {
+    const subpath = path.slice(0, depth)
+    const cat = categories.find(
+      (c) => c.name.length === subpath.length && c.name.every((s, i) => s === subpath[i]),
+    )
+    if (cat?.exclude_from_screentime) return true
+  }
+  return false
+}
+
 /**
  * Aggregate bucket categories to top-level for the stacked bar.
+ * Categories with exclude_from_screentime are skipped.
  * When capSec is provided and the total exceeds it (multi-device overlap),
  * all durations are scaled down proportionally so the total equals capSec.
  */
@@ -53,6 +66,8 @@ const aggregateToTopLevel = (
   let uncategorizedSec = 0
 
   for (const cat of bucket.categories) {
+    // Skip excluded categories
+    if (cat.path.length > 0 && isExcludedCategory(cat.path, categories)) continue
     if (cat.path.length === 0) {
       uncategorizedSec += cat.total_sec
       continue
@@ -188,17 +203,17 @@ export const buildScreentimeTooltipHtml = (
   if (bucket.total_sec <= 0) return null
 
   const bucketDurationSec = (bucket.end.getTime() - bucket.start.getTime()) / 1000
-  const rawTotal = bucket.total_sec
-  const isCapped = rawTotal > bucketDurationSec
-  const cappedTotal = isCapped ? bucketDurationSec : rawTotal
   const topLevels = aggregateToTopLevel(bucket, categories, bucketDurationSec)
+  const effectiveTotal = topLevels.reduce((s, c) => s + c.total_sec, 0)
+
+  if (effectiveTotal <= 0) return null
 
   let html = '<div class="tooltip-separator"></div>'
   html += '<div class="tooltip-title">Screen Time</div>'
   html += `<div class="tooltip-time">${format(bucket.start, 'HH:mm')} – ${format(bucket.end, 'HH:mm')}</div>`
-  html += `<div class="tooltip-detail"><strong>Total</strong> <span>${formatSec(cappedTotal)}</span>`
-  if (isCapped) {
-    html += ` <span style="font-size:11px;color:#9ca3af">(multi-device: ${formatSec(rawTotal)})</span>`
+  html += `<div class="tooltip-detail"><strong>Total</strong> <span>${formatSec(effectiveTotal)}</span>`
+  if (bucket.total_sec > effectiveTotal + 60) {
+    html += ` <span style="font-size:11px;color:#9ca3af">(excl. ${formatSec(bucket.total_sec - effectiveTotal)})</span>`
   }
   html += '</div>'
 

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -49,7 +49,7 @@ import {
   mergeScrobblesIntoSessions,
   MUSIC_STAFF_HEIGHT,
 } from './drawMusicStaff'
-import { drawScreentimeBars, SCREENTIME_COLOR } from './drawScreentimeTrack'
+import { drawScreentimeBars, isExcludedCategory, SCREENTIME_COLOR } from './drawScreentimeTrack'
 import { CTL_COLOR, drawTrainingLoadTrack } from './drawTrainingLoadTrack'
 import { findOverlappingScrobbles } from './findOverlappingScrobbles'
 import { mergeProductivitySpans } from './productivityMerge'
@@ -521,7 +521,14 @@ const categorizeProductivity = (
   categories: ScreentimeCategory[],
   itemIcons: Record<string, string>,
 ): ChartItem[] => {
-  const spans = mergeProductivitySpans(productivity)
+  // Filter out records matching excluded categories (e.g. plasmashell/idle)
+  const filtered = productivity.filter(
+    (p) =>
+      !p.resolved_category ||
+      p.resolved_category.length === 0 ||
+      !isExcludedCategory(p.resolved_category, categories),
+  )
+  const spans = mergeProductivitySpans(filtered)
 
   return spans.map((span) => {
     const isCategorized = span.groupKey !== ''

--- a/packages/api-spec/src/schemas/screentime-categories.ts
+++ b/packages/api-spec/src/schemas/screentime-categories.ts
@@ -30,6 +30,10 @@ export const screentimeCategorySchema = z
       .optional()
       .meta({ description: 'Hex color (e.g. "#22c55e"). Inherited from parent if not set.' }),
     created_at: z.string().optional().meta({ description: 'Creation timestamp' }),
+    exclude_from_screentime: z.boolean().optional().meta({
+      description:
+        'When true, records matching this category are excluded from screen time summaries and timelines. Useful for idle/background apps like plasmashell.',
+    }),
     id: z.string().uuid().meta({ description: 'Category ID' }),
     ignore_case: z.boolean().meta({ description: 'Whether regex matching is case-insensitive' }),
     name: z
@@ -60,6 +64,10 @@ export type ScreentimeCategory = z.infer<typeof screentimeCategorySchema>
 export const createScreentimeCategoryBodySchema = z
   .object({
     color: z.string().optional().meta({ description: 'Hex color (e.g. "#22c55e")' }),
+    exclude_from_screentime: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Exclude from screen time summaries and timelines' }),
     ignore_case: z
       .boolean()
       .optional()
@@ -86,6 +94,10 @@ export type CreateScreentimeCategoryBody = z.infer<typeof createScreentimeCatego
 export const updateScreentimeCategoryBodySchema = z
   .object({
     color: z.string().optional().meta({ description: 'Hex color' }),
+    exclude_from_screentime: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Exclude from screen time summaries and timelines' }),
     ignore_case: z.boolean().optional().meta({ description: 'Case-insensitive regex matching' }),
     name: z.array(z.string()).min(1).optional().meta({ description: 'Hierarchical category path' }),
     rule_regex: z.string().optional().meta({ description: 'Regex pattern' }),


### PR DESCRIPTION
## Summary

Adds a way to mark a screentime category as \"NOT screen time\". When ActivityWatch reports background/idle apps like plasmashell, they can be assigned to an \"Excluded\" category that doesn't count in summaries and timelines.

### New: exclude_from_screentime flag

A boolean on screentime categories. When true:

- **Horizontal timeline**: Category is skipped in the stacked bar aggregation; tooltip shows \"(excl. Xm)\" when time was excluded
- **Vertical timeline**: Records matching excluded categories are dropped before merging into spans
- **Category list**: Shows an \"excluded\" badge next to the category name

### How to use

1. Create a category like \"Excluded\" or \"Idle\"
2. Edit it and check \"Exclude from screen time\"
3. Add matchers for idle apps (plasmashell, screenlock, etc.)
4. Those apps will be categorized (for reference) but won't inflate screen time totals

### Changes

| Area | File | Change |
|------|------|--------|
| Schema | `screentime-categories.ts` | Add `exclude_from_screentime` to category, create, update schemas |
| DB | `schema.ts`, `connection.ts` | New column + migration |
| DB | `types.ts`, `screentime-categories.ts` | CRUD handles new field |
| Frontend | `ScreentimeCategoriesSettings` | Checkbox in edit form, badge in display mode |
| Timeline | `drawScreentimeTrack.ts` | `isExcludedCategory()` + filtering in `aggregateToTopLevel` |
| Timeline | `index.tsx` | Filter excluded records in `categorizeProductivity` |