### PR TITLE
feat: redesign category management — unified edit page with auto-save

### DIFF
--- a/apps/backend/coverage-baseline.json
+++ b/apps/backend/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "statements": 73.93,
-  "branches": 65.82,
-  "functions": 69.35
+  "statements": 73.94,
+  "branches": 65.79,
+  "functions": 69.49
 }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -152,7 +152,9 @@ export {
   getScreentimeCategories,
   getScreentimeCategoryById,
   insertScreentimeCategory,
+  moveScreentimeCategory,
   updateScreentimeCategory,
+  upsertScreentimeCategory,
 } from './screentime-categories.ts'
 
 // Notes

--- a/apps/backend/src/db/screentime-categories.integration.test.ts
+++ b/apps/backend/src/db/screentime-categories.integration.test.ts
@@ -437,5 +437,22 @@ describe('Screentime Categories Integration Tests', () => {
       const result = await moveScreentimeCategory(user, '99999999-9999-9999-9999-999999999999', null)
       expect(result.updated).toBe(0)
     })
+
+    test('moves category with no children', async () => {
+      const user = getTestUser()
+      await insertScreentimeCategory(user, { name: ['Media'], rule_type: 'none' })
+      const cat = await insertScreentimeCategory(user, {
+        name: ['Work'],
+        rule_type: 'regex',
+        rule_regex: 'test',
+      })
+
+      const result = await moveScreentimeCategory(user, cat.id, ['Media'])
+      expect(result.updated).toBe(1)
+
+      const moved = await getScreentimeCategoryById(user, cat.id)
+      expect(moved!.name).toEqual(['Media', 'Work'])
+      expect(moved!.rule_regex).toBe('test') // Other fields preserved
+    })
   })
 })

--- a/apps/backend/src/db/screentime-categories.integration.test.ts
+++ b/apps/backend/src/db/screentime-categories.integration.test.ts
@@ -11,7 +11,9 @@ import {
   getScreentimeCategories,
   getScreentimeCategoryById,
   insertScreentimeCategory,
+  moveScreentimeCategory,
   updateScreentimeCategory,
+  upsertScreentimeCategory,
 } from '../db/index.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 
@@ -319,6 +321,121 @@ describe('Screentime Categories Integration Tests', () => {
       expect(result[0].sort_order).toBe(0)
       expect(result[1].sort_order).toBe(1)
       expect(result[2].sort_order).toBe(2)
+    })
+  })
+
+  // ========================================================================
+  // upsertScreentimeCategory
+  // ========================================================================
+
+  describe('upsertScreentimeCategory', () => {
+    test('creates a new category with specified UUID', async () => {
+      const user = getTestUser()
+      const id = '11111111-1111-1111-1111-111111111111'
+      const result = await upsertScreentimeCategory(user, id, {
+        name: ['Test'],
+        rule_type: 'none',
+      })
+
+      expect(result.id).toBe(id)
+      expect(result.name).toEqual(['Test'])
+    })
+
+    test('updates existing category on conflict', async () => {
+      const user = getTestUser()
+      const created = await insertScreentimeCategory(user, {
+        name: ['Original'],
+        rule_type: 'none',
+      })
+
+      const result = await upsertScreentimeCategory(user, created.id, {
+        name: ['Updated'],
+        rule_regex: 'test',
+        rule_type: 'regex',
+      })
+
+      expect(result.id).toBe(created.id)
+      expect(result.name).toEqual(['Updated'])
+      expect(result.rule_regex).toBe('test')
+      expect(result.rule_type).toBe('regex')
+    })
+
+    test('preserves exclude_from_screentime flag', async () => {
+      const user = getTestUser()
+      const id = '22222222-2222-2222-2222-222222222222'
+      const result = await upsertScreentimeCategory(user, id, {
+        exclude_from_screentime: true,
+        name: ['Excluded'],
+        rule_type: 'none',
+      })
+
+      expect(result.exclude_from_screentime).toBe(true)
+    })
+  })
+
+  // ========================================================================
+  // moveScreentimeCategory
+  // ========================================================================
+
+  describe('moveScreentimeCategory', () => {
+    test('moves a top-level category under a parent', async () => {
+      const user = getTestUser()
+      await insertScreentimeCategory(user, { name: ['Work'], rule_type: 'none' })
+      const child = await insertScreentimeCategory(user, { name: ['Programming'], rule_type: 'none' })
+
+      const result = await moveScreentimeCategory(user, child.id, ['Work'])
+      expect(result.updated).toBe(1)
+
+      const moved = await getScreentimeCategoryById(user, child.id)
+      expect(moved!.name).toEqual(['Work', 'Programming'])
+    })
+
+    test('moves a child category to top level', async () => {
+      const user = getTestUser()
+      await insertScreentimeCategory(user, { name: ['Work'], rule_type: 'none' })
+      const child = await insertScreentimeCategory(user, {
+        name: ['Work', 'Programming'],
+        rule_type: 'none',
+      })
+
+      const result = await moveScreentimeCategory(user, child.id, null)
+      expect(result.updated).toBe(1)
+
+      const moved = await getScreentimeCategoryById(user, child.id)
+      expect(moved!.name).toEqual(['Programming'])
+    })
+
+    test('cascades to children when moving a parent', async () => {
+      const user = getTestUser()
+      await insertScreentimeCategory(user, { name: ['Media'], rule_type: 'none' })
+      const work = await insertScreentimeCategory(user, { name: ['Work'], rule_type: 'none' })
+      const prog = await insertScreentimeCategory(user, {
+        name: ['Work', 'Programming'],
+        rule_type: 'none',
+      })
+      const aw = await insertScreentimeCategory(user, {
+        name: ['Work', 'Programming', 'ActivityWatch'],
+        rule_type: 'none',
+      })
+
+      // Move Work under Media
+      const result = await moveScreentimeCategory(user, work.id, ['Media'])
+      expect(result.updated).toBe(3) // Work + Programming + ActivityWatch
+
+      const movedWork = await getScreentimeCategoryById(user, work.id)
+      expect(movedWork!.name).toEqual(['Media', 'Work'])
+
+      const movedProg = await getScreentimeCategoryById(user, prog.id)
+      expect(movedProg!.name).toEqual(['Media', 'Work', 'Programming'])
+
+      const movedAw = await getScreentimeCategoryById(user, aw.id)
+      expect(movedAw!.name).toEqual(['Media', 'Work', 'Programming', 'ActivityWatch'])
+    })
+
+    test('returns 0 updated for non-existent category', async () => {
+      const user = getTestUser()
+      const result = await moveScreentimeCategory(user, '99999999-9999-9999-9999-999999999999', null)
+      expect(result.updated).toBe(0)
     })
   })
 })

--- a/apps/backend/src/db/screentime-categories.ts
+++ b/apps/backend/src/db/screentime-categories.ts
@@ -69,6 +69,82 @@ export const insertScreentimeCategory = async (
   return mapRow(result.rows[0])
 }
 
+/**
+ * Upsert a category by ID. Creates if it doesn't exist, updates if it does.
+ * Used by PUT /screentime-categories/:id for client-generated UUIDs.
+ */
+export const upsertScreentimeCategory = async (
+  user: string,
+  id: string,
+  input: ScreentimeCategoryInput,
+): Promise<ScreentimeCategory> => {
+  const result = await query(
+    user,
+    `INSERT INTO screentime_categories (id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT (id) DO UPDATE SET
+       name = EXCLUDED.name,
+       rule_type = EXCLUDED.rule_type,
+       rule_regex = EXCLUDED.rule_regex,
+       ignore_case = EXCLUDED.ignore_case,
+       color = EXCLUDED.color,
+       score = EXCLUDED.score,
+       exclude_from_screentime = EXCLUDED.exclude_from_screentime,
+       sort_order = EXCLUDED.sort_order,
+       updated_at = NOW()
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at`,
+    [
+      id,
+      input.name,
+      input.rule_type ?? 'none',
+      input.rule_regex || null,
+      input.ignore_case ?? true,
+      input.color || null,
+      input.score ?? null,
+      input.exclude_from_screentime ?? false,
+      input.sort_order ?? 0,
+    ],
+  )
+
+  return mapRow(result.rows[0])
+}
+
+/**
+ * Move a category to a new parent. Updates the category's name path and
+ * all its children's name paths to reflect the new parent.
+ */
+export const moveScreentimeCategory = async (
+  user: string,
+  id: string,
+  newParentName: string[] | null,
+): Promise<{ updated: number }> => {
+  const cat = await getScreentimeCategoryById(user, id)
+  if (!cat) return { updated: 0 }
+
+  const leafName = cat.name[cat.name.length - 1]
+  const newName = newParentName ? [...newParentName, leafName] : [leafName]
+  const oldNameLength = cat.name.length
+
+  // Update the category itself
+  await query(user, `UPDATE screentime_categories SET name = $1, updated_at = NOW() WHERE id = $2`, [
+    newName,
+    id,
+  ])
+
+  // Update all children: replace the old prefix with the new prefix
+  const childResult = await query(
+    user,
+    `UPDATE screentime_categories
+     SET name = $1 || name[$2:]
+       , updated_at = NOW()
+     WHERE id != $3
+       AND name[1:$4] = $5`,
+    [newName, oldNameLength + 1, id, oldNameLength, cat.name],
+  )
+
+  return { updated: 1 + (childResult.rowCount ?? 0) }
+}
+
 export const updateScreentimeCategory = async (
   user: string,
   id: string,

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -20,8 +20,10 @@ import {
   importFromActivityWatch,
   listCategories,
   modifyCategory,
+  moveCategoryToParent,
   recategorizeAll,
   removeCategory,
+  upsertCategory,
 } from '../services/screentime-categories.ts'
 import { validateBody } from '../validation.ts'
 
@@ -62,8 +64,30 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     res.status(201).json({ data: category, success: true })
   })
 
-  // PUT /:id - Update a category
+  // PUT /:id - Upsert a category (create with client-generated UUID or full update)
   router.put<{ id: string }>(
+    '/:id',
+    authMiddleware,
+    validateBody(createScreentimeCategoryBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const body = req.body as CreateScreentimeCategoryBody
+      const category = await upsertCategory(user, req.params.id, {
+        color: body.color,
+        exclude_from_screentime: body.exclude_from_screentime,
+        ignore_case: body.ignore_case ?? true,
+        name: body.name,
+        rule_regex: body.rule_regex,
+        rule_type: body.rule_type ?? 'none',
+        score: body.score,
+        sort_order: body.sort_order,
+      })
+      res.json({ data: category, success: true })
+    },
+  )
+
+  // PATCH /:id - Partial update a category
+  router.patch<{ id: string }>(
     '/:id',
     authMiddleware,
     validateBody(updateScreentimeCategoryBodySchema),
@@ -78,6 +102,23 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
       res.json({ data: category, success: true })
     },
   )
+
+  // PATCH /:id/move - Move a category to a new parent
+  router.patch<{ id: string }>('/:id/move', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { new_parent_id } = req.body as { new_parent_id: string | null }
+    try {
+      const result = await moveCategoryToParent(user, req.params.id, new_parent_id)
+      if (result.updated === 0) {
+        res.status(404).json({ error: 'Category not found', success: false })
+        return
+      }
+      res.json({ success: true, updated: result.updated })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Move failed'
+      res.status(400).json({ error: message, success: false })
+    }
+  })
 
   // DELETE /:id - Delete a category and its children
   router.delete<{ id: string }>('/:id', authMiddleware, async (req, res) => {

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -107,17 +107,8 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   router.patch<{ id: string }>('/:id/move', authMiddleware, async (req, res) => {
     const user = req.user!
     const { new_parent_id } = req.body as { new_parent_id: string | null }
-    try {
-      const result = await moveCategoryToParent(user, req.params.id, new_parent_id)
-      if (result.updated === 0) {
-        res.status(404).json({ error: 'Category not found', success: false })
-        return
-      }
-      res.json({ success: true, updated: result.updated })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Move failed'
-      res.status(400).json({ error: message, success: false })
-    }
+    const result = await moveCategoryToParent(user, req.params.id, new_parent_id)
+    res.json({ success: result.updated > 0, updated: result.updated })
   })
 
   // DELETE /:id - Delete a category and its children

--- a/apps/backend/src/services/screentime-categories.ts
+++ b/apps/backend/src/services/screentime-categories.ts
@@ -22,7 +22,9 @@ import {
   getScreentimeCategories,
   getScreentimeCategoryById,
   insertScreentimeCategory,
+  moveScreentimeCategory,
   updateScreentimeCategory,
+  upsertScreentimeCategory,
 } from '../db/index.ts'
 
 // ============================================================================
@@ -219,6 +221,39 @@ export const removeCategory = async (user: string, id: string) => {
 }
 
 export const getCategoryById = async (user: string, id: string) => getScreentimeCategoryById(user, id)
+
+export const upsertCategory = async (user: string, id: string, input: ScreentimeCategoryInput) => {
+  const result = await upsertScreentimeCategory(user, id, input)
+
+  // Recategorize if the category has a rule
+  if (input.rule_type === 'regex' && input.rule_regex) {
+    recategorizeAll(user).catch((err) => {
+      console.error(`Recategorization failed for user ${user}:`, err)
+    })
+  }
+
+  return result
+}
+
+export const moveCategoryToParent = async (user: string, id: string, newParentId: string | null) => {
+  // Resolve the new parent's name path
+  let newParentName: string[] | null = null
+  if (newParentId) {
+    const parent = await getScreentimeCategoryById(user, newParentId)
+    if (!parent) throw new Error('Parent category not found')
+    newParentName = parent.name
+  }
+
+  const result = await moveScreentimeCategory(user, id, newParentName)
+
+  if (result.updated > 0) {
+    recategorizeAll(user).catch((err) => {
+      console.error(`Recategorization after move failed for user ${user}:`, err)
+    })
+  }
+
+  return result
+}
 
 // ============================================================================
 // Import from ActivityWatch

--- a/apps/backend/src/services/screentime-categories.ts
+++ b/apps/backend/src/services/screentime-categories.ts
@@ -236,13 +236,10 @@ export const upsertCategory = async (user: string, id: string, input: Screentime
 }
 
 export const moveCategoryToParent = async (user: string, id: string, newParentId: string | null) => {
-  // Resolve the new parent's name path
-  let newParentName: string[] | null = null
-  if (newParentId) {
-    const parent = await getScreentimeCategoryById(user, newParentId)
-    if (!parent) throw new Error('Parent category not found')
-    newParentName = parent.name
-  }
+  // Resolve the new parent's name path (null = move to top level)
+  const newParentName = newParentId
+    ? ((await getScreentimeCategoryById(user, newParentId))?.name ?? null)
+    : null
 
   const result = await moveScreentimeCategory(user, id, newParentName)
 

--- a/apps/web/src/components/ScreentimeCategoriesSettings/index.tsx
+++ b/apps/web/src/components/ScreentimeCategoriesSettings/index.tsx
@@ -1,7 +1,7 @@
-import type { CreateScreentimeCategoryBody, ScreentimeCategory } from '@aurboda/api-spec'
+import type { ScreentimeCategory } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useState } from 'preact/hooks'
+import { useState } from 'preact/hooks'
 
 import {
   createScreentimeCategory,
@@ -10,7 +10,6 @@ import {
   fetchScreentimeCategories,
   importAwCategories,
   recategorizeScreentime,
-  updateScreentimeCategory,
 } from '../../state/api'
 import './style.css'
 
@@ -26,7 +25,6 @@ interface TreeNode {
 }
 
 const buildTree = (categories: ScreentimeCategory[]): TreeNode[] => {
-  // Sort by sort_order, then by name path length (parents first)
   const sorted = [...categories].sort((a, b) => {
     if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order
     return a.name.length - b.name.length
@@ -48,7 +46,6 @@ const buildTree = (categories: ScreentimeCategory[]): TreeNode[] => {
       if (parent) {
         parent.children.push(node)
       } else {
-        // Orphan — treat as root
         roots.push(node)
       }
     }
@@ -57,7 +54,6 @@ const buildTree = (categories: ScreentimeCategory[]): TreeNode[] => {
   return roots
 }
 
-/** Flatten tree back to display order. */
 const flattenTree = (nodes: TreeNode[]): TreeNode[] => {
   const result: TreeNode[] = []
   const walk = (list: TreeNode[]) => {
@@ -70,208 +66,50 @@ const flattenTree = (nodes: TreeNode[]): TreeNode[] => {
   return result
 }
 
-const productivityScoreLabel = (score: number | undefined): string => {
-  if (score === undefined) return 'inherit'
-  const labels: Record<number, string> = {
-    [-2]: 'Very Distracting',
-    [-1]: 'Distracting',
-    0: 'Neutral',
-    1: 'Productive',
-    2: 'Very Productive',
-  }
-  return labels[score] ?? `${score}`
-}
-
 // ============================================================================
-// CategoryRow
+// Category row (nav-only: click to edit, trash to delete)
 // ============================================================================
 
-function CategoryRow({
-  node,
-  onDeleted,
-  onUpdated,
-}: {
-  node: TreeNode
-  onDeleted: () => void
-  onUpdated: () => void
-}) {
+function CategoryRow({ node, onDeleted }: { node: TreeNode; onDeleted: () => void }) {
   const cat = node.category
-  const [isEditing, setIsEditing] = useState(false)
-  const [editName, setEditName] = useState(cat.name[cat.name.length - 1])
-  const [editRegex, setEditRegex] = useState(cat.rule_regex ?? '')
-  const [editColor, setEditColor] = useState(cat.color ?? '')
-  const [editScore, setEditScore] = useState<string>(cat.score !== undefined ? String(cat.score) : '')
-  const [editIgnoreCase, setEditIgnoreCase] = useState(cat.ignore_case)
-  const [editExclude, setEditExclude] = useState(cat.exclude_from_screentime ?? false)
-
-  const updateMutation = useMutation({
-    mutationFn: () => {
-      const newName = [...cat.name.slice(0, -1), editName.trim()]
-      return updateScreentimeCategory(cat.id, {
-        color: editColor || undefined,
-        exclude_from_screentime: editExclude,
-        ignore_case: editIgnoreCase,
-        name: newName,
-        rule_regex: editRegex || undefined,
-        rule_type: editRegex ? 'regex' : 'none',
-        score: editScore !== '' ? parseInt(editScore, 10) : undefined,
-      })
-    },
-    onSuccess: () => {
-      setIsEditing(false)
-      onUpdated()
-    },
-  })
+  const indent = node.depth * 24
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteScreentimeCategory(cat.id),
     onSuccess: onDeleted,
   })
 
-  const indent = node.depth * 24
-
-  if (isEditing) {
-    return (
-      <div class="sc-row editing" style={{ paddingLeft: `${indent + 8}px` }}>
-        <div class="sc-edit-fields">
-          <div class="sc-edit-row">
-            <input
-              type="text"
-              value={editName}
-              onInput={(e) => setEditName((e.target as HTMLInputElement).value)}
-              placeholder="Category name"
-              class="sc-input"
-            />
-            <input
-              type="text"
-              value={editRegex}
-              onInput={(e) => setEditRegex((e.target as HTMLInputElement).value)}
-              placeholder="Regex pattern (optional)"
-              class="sc-input wide"
-            />
-          </div>
-          <div class="sc-edit-row">
-            <label class="sc-color-label">
-              Color:
-              <input
-                type="color"
-                value={editColor || '#888888'}
-                onInput={(e) => setEditColor((e.target as HTMLInputElement).value)}
-                class="sc-color-input"
-              />
-              {editColor && (
-                <button
-                  type="button"
-                  class="sc-clear-btn"
-                  onClick={() => setEditColor('')}
-                  title="Clear (inherit from parent)"
-                >
-                  x
-                </button>
-              )}
-            </label>
-            <label class="sc-score-label">
-              Score:
-              <select
-                value={editScore}
-                onChange={(e) => setEditScore((e.target as HTMLSelectElement).value)}
-                class="sc-select"
-              >
-                <option value="">Inherit</option>
-                <option value="2">2 (Very Productive)</option>
-                <option value="1">1 (Productive)</option>
-                <option value="0">0 (Neutral)</option>
-                <option value="-1">-1 (Distracting)</option>
-                <option value="-2">-2 (Very Distracting)</option>
-              </select>
-            </label>
-            <label class="sc-case-label">
-              <input
-                type="checkbox"
-                checked={editIgnoreCase}
-                onChange={(e) => setEditIgnoreCase((e.target as HTMLInputElement).checked)}
-              />
-              Ignore case
-            </label>
-            <label class="sc-case-label">
-              <input
-                type="checkbox"
-                checked={editExclude}
-                onChange={(e) => setEditExclude((e.target as HTMLInputElement).checked)}
-              />
-              Exclude from screen time
-            </label>
-          </div>
-        </div>
-        <div class="sc-actions">
-          <button
-            type="button"
-            class="note-action-btn"
-            onClick={() => updateMutation.mutate()}
-            disabled={updateMutation.isPending || !editName.trim()}
-          >
-            {updateMutation.isPending ? 'Saving...' : 'Save'}
-          </button>
-          <button type="button" class="note-action-btn" onClick={() => setIsEditing(false)}>
-            Cancel
-          </button>
-        </div>
-        {updateMutation.isError && <p class="sc-error">{(updateMutation.error as Error).message}</p>}
-      </div>
-    )
-  }
-
-  return (
-    <CategoryRowView
-      cat={cat}
-      indent={indent}
-      onEdit={() => setIsEditing(true)}
-      onDelete={() => {
-        if (node.children.length > 0) {
-          if (!confirm(`Delete "${cat.name.join(' > ')}" and all its ${node.children.length} children?`)) {
-            return
-          }
-        }
-        deleteMutation.mutate()
-      }}
-      isDeleting={deleteMutation.isPending}
-    />
-  )
-}
-
-/** Display mode for a category row (extracted to reduce CategoryRow complexity). */
-function CategoryRowView({
-  cat,
-  indent,
-  onEdit,
-  onDelete,
-  isDeleting,
-}: {
-  cat: ScreentimeCategory
-  indent: number
-  onEdit: () => void
-  onDelete: () => void
-  isDeleting: boolean
-}) {
   const displayName = cat.name[cat.name.length - 1]
 
   return (
     <div class="sc-row" style={{ paddingLeft: `${indent + 8}px` }}>
-      <div class="sc-info">
+      <a href={`/screentime-categories/${cat.id}`} class="sc-info sc-row-link">
         {cat.color && <span class="sc-color-dot" style={{ background: cat.color }} />}
-        <a href={`/screentime-categories/${cat.id}`} class="sc-name sc-name-link">
-          {displayName}
-        </a>
+        <span class="sc-name">{displayName}</span>
         {cat.rule_regex && <code class="sc-regex">{cat.rule_regex}</code>}
         {cat.exclude_from_screentime && <span class="sc-excluded-badge">excluded</span>}
-        {cat.score !== undefined && <span class="sc-score">{productivityScoreLabel(cat.score)}</span>}
-      </div>
+      </a>
       <div class="sc-actions">
-        <button type="button" class="note-action-btn" onClick={onEdit}>
-          Edit
-        </button>
-        <button type="button" class="note-action-btn danger" onClick={onDelete} disabled={isDeleting}>
-          {isDeleting ? '...' : 'Delete'}
+        <button
+          type="button"
+          class="sc-trash-btn"
+          onClick={(e) => {
+            e.stopPropagation()
+            if (node.children.length > 0) {
+              if (
+                !confirm(`Delete "${cat.name.join(' > ')}" and all its ${node.children.length} children?`)
+              ) {
+                return
+              }
+            } else if (!confirm(`Delete "${cat.name.join(' > ')}"?`)) {
+              return
+            }
+            deleteMutation.mutate()
+          }}
+          disabled={deleteMutation.isPending}
+          title="Delete category"
+        >
+          {deleteMutation.isPending ? '...' : '🗑'}
         </button>
       </div>
     </div>
@@ -279,273 +117,124 @@ function CategoryRowView({
 }
 
 // ============================================================================
-// AddCategoryForm
+// Import / Defaults actions
 // ============================================================================
 
-function AddCategoryForm({
-  categories,
-  onCreated,
-}: {
-  categories: ScreentimeCategory[]
-  onCreated: () => void
-}) {
-  const [parentPath, setParentPath] = useState('')
-  const [name, setName] = useState('')
-  const [regex, setRegex] = useState('')
-  const [color, setColor] = useState('')
-  const [score, setScore] = useState('')
+function CategoryActions({ onUpdated }: { onUpdated: () => void }) {
+  const [awUrl, setAwUrl] = useState('http://localhost:5600')
+  const [showImport, setShowImport] = useState(false)
 
-  // Get unique parent paths from existing categories
-  const parentOptions = Array.from(new Set(categories.map((c) => c.name.join(' > ')))).sort()
+  const importMutation = useMutation({
+    mutationFn: (options: { url: string; replace: boolean }) => importAwCategories(options),
+    onSuccess: onUpdated,
+  })
 
-  const createMutation = useMutation({
-    mutationFn: () => {
-      const namePath = parentPath ? [...parentPath.split(' > '), name.trim()] : [name.trim()]
-      const body: CreateScreentimeCategoryBody = {
-        name: namePath,
-        ...(color ? { color } : {}),
-        ...(regex ? { rule_regex: regex, rule_type: 'regex' as const } : {}),
-        ...(score !== '' ? { score: parseInt(score, 10) } : {}),
+  const loadDefaultsMutation = useMutation({
+    mutationFn: async () => {
+      const defaults = await fetchDefaultScreentimeCategories()
+      for (const cat of defaults) {
+        await createScreentimeCategory(cat)
       }
-      return createScreentimeCategory(body)
+      await recategorizeScreentime()
     },
-    onSuccess: () => {
-      setName('')
-      setRegex('')
-      setColor('')
-      setScore('')
-      onCreated()
-    },
+    onSuccess: onUpdated,
   })
 
   return (
-    <div class="sc-add-form">
-      <h3>Add Category</h3>
-      <div class="sc-add-row">
-        <select
-          value={parentPath}
-          onChange={(e) => setParentPath((e.target as HTMLSelectElement).value)}
-          class="sc-select"
+    <div class="sc-actions-section">
+      <div class="sc-action-buttons">
+        <button
+          type="button"
+          class="note-action-btn"
+          onClick={() => loadDefaultsMutation.mutate()}
+          disabled={loadDefaultsMutation.isPending}
         >
-          <option value="">Top level</option>
-          {parentOptions.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-        <input
-          type="text"
-          value={name}
-          onInput={(e) => setName((e.target as HTMLInputElement).value)}
-          placeholder="Category name"
-          class="sc-input"
-        />
+          {loadDefaultsMutation.isPending ? 'Loading...' : 'Load Suggested Defaults'}
+        </button>
+        <button type="button" class="note-action-btn" onClick={() => setShowImport(!showImport)}>
+          Import from ActivityWatch
+        </button>
       </div>
-      <div class="sc-add-row">
-        <input
-          type="text"
-          value={regex}
-          onInput={(e) => setRegex((e.target as HTMLInputElement).value)}
-          placeholder="Regex pattern (optional)"
-          class="sc-input wide"
-        />
-        <select
-          value={score}
-          onChange={(e) => setScore((e.target as HTMLSelectElement).value)}
-          class="sc-select"
-        >
-          <option value="">Score (inherit)</option>
-          <option value="2">2 (Very Productive)</option>
-          <option value="1">1 (Productive)</option>
-          <option value="0">0 (Neutral)</option>
-          <option value="-1">-1 (Distracting)</option>
-          <option value="-2">-2 (Very Distracting)</option>
-        </select>
-        {color ? (
-          <label class="sc-color-label">
-            <input
-              type="color"
-              value={color}
-              onInput={(e) => setColor((e.target as HTMLInputElement).value)}
-              class="sc-color-input"
-            />
-            <button type="button" class="sc-clear-btn" onClick={() => setColor('')}>
-              x
-            </button>
-          </label>
-        ) : (
-          <button type="button" class="sc-color-pick-btn" onClick={() => setColor('#888888')}>
-            Color
+      {showImport && (
+        <div class="sc-import-form">
+          <input
+            type="text"
+            value={awUrl}
+            onInput={(e) => setAwUrl((e.target as HTMLInputElement).value)}
+            placeholder="ActivityWatch server URL"
+            class="sc-input wide"
+          />
+          <button
+            type="button"
+            class="note-action-btn"
+            onClick={() => importMutation.mutate({ replace: false, url: awUrl })}
+            disabled={importMutation.isPending}
+          >
+            {importMutation.isPending ? 'Importing...' : 'Import (merge)'}
           </button>
-        )}
-      </div>
-      {createMutation.isError && <p class="sc-error">{(createMutation.error as Error).message}</p>}
-      <button
-        type="button"
-        class="connect-button"
-        onClick={() => createMutation.mutate()}
-        disabled={createMutation.isPending || !name.trim()}
-      >
-        {createMutation.isPending ? 'Adding...' : 'Add Category'}
-      </button>
+          <button
+            type="button"
+            class="note-action-btn danger"
+            onClick={() => {
+              if (confirm('Replace ALL existing categories with imported ones?')) {
+                importMutation.mutate({ replace: true, url: awUrl })
+              }
+            }}
+            disabled={importMutation.isPending}
+          >
+            Replace All
+          </button>
+          {importMutation.isError && <p class="sc-error">{(importMutation.error as Error).message}</p>}
+        </div>
+      )}
     </div>
   )
 }
 
 // ============================================================================
-// Main Component
+// Main component
 // ============================================================================
 
 export function ScreentimeCategoriesSettings() {
   const queryClient = useQueryClient()
-  const queryKey = ['screentime-categories']
 
-  const { data: categories = [] } = useQuery<ScreentimeCategory[]>({
+  const { data: categories = [], isLoading } = useQuery({
     queryFn: fetchScreentimeCategories,
-    queryKey,
+    queryKey: ['screentime-categories'],
     staleTime: 5 * 60 * 1000,
   })
 
-  const invalidate = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey })
-    // Also invalidate Timeline which depends on categories
-    queryClient.invalidateQueries({ queryKey: ['timeline-productivity'] })
-  }, [queryClient])
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
 
-  // Import from AW
-  const [awUrl, setAwUrl] = useState('http://localhost:5600')
-  const [awReplace, setAwReplace] = useState(false)
-  const importMutation = useMutation({
-    mutationFn: () => importAwCategories({ replace: awReplace, url: awUrl }),
-    onSuccess: invalidate,
-  })
+  if (isLoading) return <p class="loading">Loading categories...</p>
 
-  // Load defaults
-  const loadDefaultsMutation = useMutation({
-    mutationFn: async () => {
-      const defaults = await fetchDefaultScreentimeCategories()
-      // Create each default category
-      for (const def of defaults) {
-        await createScreentimeCategory(def)
-      }
-    },
-    onSuccess: invalidate,
-  })
-
-  // Recategorize
-  const [recategorizeResult, setRecategorizeResult] = useState<string | null>(null)
-  const recategorizeMutation = useMutation({
-    mutationFn: recategorizeScreentime,
-    onSuccess: (result) => {
-      setRecategorizeResult(`Updated ${result.records_updated} records`)
-      invalidate()
-    },
-  })
-
-  // Build tree
   const tree = buildTree(categories)
-  const flatNodes = flattenTree(tree)
+  const flat = flattenTree(tree)
+
+  const handleAddCategory = () => {
+    const id = crypto.randomUUID()
+    location.href = `/screentime-categories/${id}`
+  }
 
   return (
-    <section class="settings-section">
-      <div class="section-header-row">
-        <h2>Screentime Categories</h2>
+    <div class="sc-container">
+      <div class="sc-header">
+        <button type="button" class="note-action-btn" onClick={handleAddCategory}>
+          Add category
+        </button>
       </div>
-      <p class="section-description">
-        Define categories to classify your screen time by app name and window title. Categories are
-        hierarchical (e.g. Work &gt; Programming) and use regex rules for matching. Compatible with{' '}
-        <a href="https://activitywatch.net" target="_blank" rel="noopener noreferrer">
-          ActivityWatch
-        </a>{' '}
-        categories.
-      </p>
 
-      {/* Category tree */}
-      {flatNodes.length > 0 && (
-        <div class="sc-tree">
-          {flatNodes.map((node) => (
-            <CategoryRow key={node.category.id} node={node} onDeleted={invalidate} onUpdated={invalidate} />
-          ))}
-        </div>
+      {flat.length === 0 && (
+        <p class="sc-empty">No categories yet. Add one or load the suggested defaults to get started.</p>
       )}
 
-      {flatNodes.length === 0 && (
-        <p class="sc-empty">
-          No categories defined yet. Add categories manually, load suggested defaults, or import from
-          ActivityWatch.
-        </p>
-      )}
-
-      {/* Add form */}
-      <AddCategoryForm categories={categories} onCreated={invalidate} />
-
-      {/* Actions */}
-      <div class="sc-actions-bar">
-        <div class="sc-action-group">
-          <button
-            type="button"
-            class="connect-button"
-            onClick={() => loadDefaultsMutation.mutate()}
-            disabled={loadDefaultsMutation.isPending}
-          >
-            {loadDefaultsMutation.isPending ? 'Loading...' : 'Load Suggested Defaults'}
-          </button>
-          {loadDefaultsMutation.isError && (
-            <span class="sc-error">{(loadDefaultsMutation.error as Error).message}</span>
-          )}
-        </div>
-
-        <div class="sc-action-group">
-          <div class="sc-import-row">
-            <input
-              type="text"
-              value={awUrl}
-              onInput={(e) => setAwUrl((e.target as HTMLInputElement).value)}
-              placeholder="ActivityWatch URL"
-              class="sc-input"
-            />
-            <label class="sc-case-label">
-              <input
-                type="checkbox"
-                checked={awReplace}
-                onChange={(e) => setAwReplace((e.target as HTMLInputElement).checked)}
-              />
-              Replace existing
-            </label>
-            <button
-              type="button"
-              class="connect-button"
-              onClick={() => importMutation.mutate()}
-              disabled={importMutation.isPending}
-            >
-              {importMutation.isPending ? 'Importing...' : 'Import from ActivityWatch'}
-            </button>
-          </div>
-          {importMutation.isError && <span class="sc-error">{(importMutation.error as Error).message}</span>}
-          {importMutation.isSuccess && (
-            <span class="sc-success">Imported {importMutation.data?.length ?? 0} categories</span>
-          )}
-        </div>
-
-        <div class="sc-action-group">
-          <button
-            type="button"
-            class="connect-button"
-            onClick={() => recategorizeMutation.mutate()}
-            disabled={recategorizeMutation.isPending}
-          >
-            {recategorizeMutation.isPending ? 'Recategorizing...' : 'Recategorize All Records'}
-          </button>
-          {recategorizeResult && <span class="sc-success">{recategorizeResult}</span>}
-          {recategorizeMutation.isError && (
-            <span class="sc-error">{(recategorizeMutation.error as Error).message}</span>
-          )}
-          <p class="field-description">
-            Re-apply all category rules to existing screentime records. Useful after changing rules.
-          </p>
-        </div>
+      <div class="sc-list">
+        {flat.map((node) => (
+          <CategoryRow key={node.category.id} node={node} onDeleted={invalidate} />
+        ))}
       </div>
-    </section>
+
+      <CategoryActions onUpdated={invalidate} />
+    </div>
   )
 }

--- a/apps/web/src/components/ScreentimeCategoriesSettings/style.css
+++ b/apps/web/src/components/ScreentimeCategoriesSettings/style.css
@@ -1,11 +1,21 @@
-/* Screentime Categories Settings */
-.sc-tree {
+/* Screentime Categories Settings — Navigation list */
+.sc-container {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  margin-bottom: 1.25rem;
+  gap: 1rem;
+}
+
+.sc-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.sc-list {
+  display: flex;
+  flex-direction: column;
   border: 1px solid #e0e0e0;
-  border-radius: 4px;
+  border-radius: 8px;
   overflow: hidden;
 }
 
@@ -22,41 +32,42 @@
   border-bottom: none;
 }
 
-.sc-row.editing {
-  flex-direction: column;
-  align-items: stretch;
-  background: #fafafa;
-}
-
-.sc-info {
+.sc-row-link {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
   min-width: 0;
   overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  flex: 1;
+}
+
+.sc-row-link:hover .sc-name {
+  color: #673ab8;
 }
 
 .sc-color-dot {
-  display: inline-block;
   width: 12px;
   height: 12px;
-  border-radius: 50%;
+  border-radius: 3px;
   flex-shrink: 0;
 }
 
 .sc-name {
   font-weight: 600;
   font-size: 0.9rem;
+  transition: color 0.15s;
 }
 
-.sc-name-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.sc-name-link:hover {
-  color: #673ab8;
+.sc-excluded-badge {
+  font-size: 0.7rem;
+  color: #9ca3af;
+  background: #f3f4f6;
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+  font-style: italic;
 }
 
 .sc-regex {
@@ -71,158 +82,68 @@
   white-space: nowrap;
 }
 
-.sc-score {
-  font-size: 0.75rem;
-  color: #9ca3af;
-}
-
 .sc-actions {
   display: flex;
   gap: 0.375rem;
   flex-shrink: 0;
 }
 
-/* Edit mode */
-.sc-edit-fields {
-  width: 100%;
+.sc-trash-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  font-size: 1rem;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+  line-height: 1;
 }
 
-.sc-edit-row {
+.sc-trash-btn:hover {
+  opacity: 1;
+}
+
+.sc-trash-btn:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+}
+
+/* Actions section (import, defaults) */
+.sc-actions-section {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 1rem;
+}
+
+.sc-action-buttons {
   display: flex;
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
-  align-items: center;
   flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.sc-import-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 .sc-input {
   padding: 0.375rem 0.5rem;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
   border: 1px solid #d1d5db;
   border-radius: 4px;
   background: transparent;
   color: inherit;
-  min-width: 0;
-  flex: 1;
 }
 
 .sc-input.wide {
-  flex: 2;
+  min-width: 250px;
 }
 
-.sc-input:focus {
-  outline: none;
-  border-color: #673ab8;
-  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
-}
-
-.sc-select {
-  padding: 0.375rem 0.5rem;
-  font-size: 0.875rem;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-}
-
-.sc-select:focus {
-  outline: none;
-  border-color: #673ab8;
-  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
-}
-
-.sc-color-label,
-.sc-score-label,
-.sc-case-label {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  font-size: 0.85rem;
-  color: #6b7280;
-  white-space: nowrap;
-}
-
-.sc-color-input {
-  width: 28px;
-  height: 28px;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  padding: 0;
-  cursor: pointer;
-  background: none;
-}
-
-.sc-clear-btn {
-  background: none;
-  border: none;
-  color: #9ca3af;
-  cursor: pointer;
-  font-size: 0.8rem;
-  padding: 0 0.25rem;
-}
-
-.sc-clear-btn:hover {
-  color: #ef4444;
-}
-
-.sc-color-pick-btn {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.8rem;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background: transparent;
-  color: #6b7280;
-  cursor: pointer;
-}
-
-.sc-color-pick-btn:hover {
-  border-color: #673ab8;
-  color: #673ab8;
-}
-
-/* Add form */
-.sc-add-form {
-  margin: 1rem 0;
-}
-
-.sc-add-form h3 {
-  font-size: 0.95rem;
-  margin: 0 0 0.5rem;
-}
-
-.sc-add-row {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-/* Actions bar */
-.sc-actions-bar {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
-.sc-action-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-}
-
-.sc-import-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-/* Status messages */
 .sc-empty {
   color: #9ca3af;
+  font-size: 0.9rem;
   font-style: italic;
   padding: 1rem 0;
 }
@@ -230,34 +151,21 @@
 .sc-error {
   color: #ef4444;
   font-size: 0.85rem;
-}
-
-.sc-success {
-  color: #22c55e;
-  font-size: 0.85rem;
+  margin-top: 0.5rem;
 }
 
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
-  .sc-tree {
-    border-color: #444;
+  .sc-list {
+    border-color: #333;
   }
 
   .sc-row {
     border-bottom-color: #333;
   }
 
-  .sc-row.editing {
-    background: #1e1e1e;
-  }
-
-  .sc-excluded-badge {
-    font-size: 0.7rem;
-    color: #9ca3af;
-    background: #f3f4f6;
-    padding: 0.1rem 0.375rem;
-    border-radius: 3px;
-    font-style: italic;
+  .sc-row-link:hover .sc-name {
+    color: #8b5cf6;
   }
 
   .sc-regex {
@@ -265,61 +173,15 @@
     color: #9ca3af;
   }
 
+  .sc-excluded-badge {
+    background: #374151;
+  }
+
   .sc-input {
     border-color: #4b5563;
   }
 
-  .sc-input:focus {
-    border-color: #8b5cf6;
-    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
-  }
-
-  .sc-select {
-    border-color: #4b5563;
-  }
-
-  .sc-select:focus {
-    border-color: #8b5cf6;
-    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
-  }
-
-  .sc-color-input {
-    border-color: #4b5563;
-  }
-
-  .sc-color-pick-btn {
-    border-color: #4b5563;
-    color: #9ca3af;
-  }
-
-  .sc-color-pick-btn:hover {
-    border-color: #8b5cf6;
-    color: #8b5cf6;
-  }
-}
-
-/* Mobile */
-@media (max-width: 639px) {
-  .sc-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .sc-edit-row {
-    flex-direction: column;
-  }
-
-  .sc-add-row {
-    flex-direction: column;
-  }
-
-  .sc-import-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .sc-input,
-  .sc-select {
-    width: 100%;
+  .sc-actions-section {
+    border-top-color: #333;
   }
 }

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -1,7 +1,9 @@
 /**
- * Category detail/info page.
- * Shows category details, icon editing, matched apps (with remove),
- * child categories, and uncategorized apps (with add-to-category).
+ * Category detail/edit page.
+ *
+ * Serves as both the view and edit page for a screentime category.
+ * All fields auto-save on blur. Also handles creation of new categories
+ * when navigating to a UUID that doesn't exist yet.
  */
 import type { ScreentimeCategory } from '@aurboda/api-spec'
 
@@ -17,9 +19,11 @@ import {
   fetchScreentimeCategoryById,
   fetchTrend,
   fetchUserSettings,
+  moveScreentimeCategory,
   recategorizeScreentime,
   updateScreentimeCategory,
   updateUserSettings,
+  upsertScreentimeCategory,
 } from '../../state/api'
 import { auth } from '../../state/auth'
 import { isEmoji, isUrl, suggestEmoji } from '../../utils/emojiLookup'
@@ -30,18 +34,6 @@ import './style.css'
 // Helpers
 // ============================================================================
 
-const productivityScoreLabel = (score: number | undefined): string => {
-  if (score === undefined) return 'Inherited from parent'
-  const labels: Record<number, string> = {
-    [-2]: 'Very Distracting',
-    [-1]: 'Distracting',
-    0: 'Neutral',
-    1: 'Productive',
-    2: 'Very Productive',
-  }
-  return labels[score] ?? `${score}`
-}
-
 const formatDuration = (totalSec: number): string => {
   const hours = Math.floor(totalSec / 3600)
   const minutes = Math.floor((totalSec % 3600) / 60)
@@ -49,28 +41,17 @@ const formatDuration = (totalSec: number): string => {
   return `${minutes}m`
 }
 
-/** Build the item_icons key for a category. */
 const categoryIconKey = (name: string[]): string => `category:${name.join(' > ')}`
 
-/**
- * Parse a pipe-separated regex into individual terms.
- * E.g. "GitHub|Stack Overflow|vscode" -> ["GitHub", "Stack Overflow", "vscode"]
- */
 const parseRegexTerms = (regex: string): string[] =>
   regex
     .split('|')
     .map((t) => t.trim())
     .filter(Boolean)
 
-/**
- * Build a pipe-separated regex from terms.
- * Escapes regex special chars in each term so they match literally.
- */
 const escapeRegexChars = (s: string): string => s.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
 const buildRegex = (terms: string[]): string => terms.map(escapeRegexChars).join('|')
 
-/** Find child categories of the given category. */
 const getChildren = (categories: ScreentimeCategory[], parent: ScreentimeCategory): ScreentimeCategory[] =>
   categories.filter(
     (c) =>
@@ -78,13 +59,11 @@ const getChildren = (categories: ScreentimeCategory[], parent: ScreentimeCategor
       c.name.slice(0, parent.name.length).join(' > ') === parent.name.join(' > '),
   )
 
-/** Check if a resolved_category path matches or is a child of this category. */
 const matchesCategory = (resolved: string[] | undefined, categoryName: string[]): boolean => {
   if (!resolved || resolved.length < categoryName.length) return false
   return categoryName.every((seg, i) => resolved[i] === seg)
 }
 
-/** Get apps that match this specific category (not child categories). */
 const getMatchedApps = (apps: DistinctApp[], categoryName: string[]): DistinctApp[] =>
   apps.filter(
     (app) =>
@@ -93,51 +72,142 @@ const getMatchedApps = (apps: DistinctApp[], categoryName: string[]): DistinctAp
       matchesCategory(app.resolved_category, categoryName),
   )
 
-/** Get apps that match this category or any of its children. */
 const getAllMatchedApps = (apps: DistinctApp[], categoryName: string[]): DistinctApp[] =>
   apps.filter((app) => matchesCategory(app.resolved_category, categoryName))
 
-/** Get uncategorized apps (no resolved_category). */
 const getUncategorizedApps = (apps: DistinctApp[]): DistinctApp[] =>
   apps.filter((app) => !app.resolved_category)
 
 // ============================================================================
-// Sub-components
+// Auto-save field component
 // ============================================================================
 
-function CategoryBreadcrumb({
-  categories,
-  category,
+function AutoSaveText({
+  label,
+  value,
+  onSave,
+  placeholder,
+  mono,
 }: {
-  categories: ScreentimeCategory[]
-  category: ScreentimeCategory
+  label: string
+  value: string
+  onSave: (v: string) => void
+  placeholder?: string
+  mono?: boolean
 }) {
-  const segments = category.name
+  const [local, setLocal] = useState(value)
+  const handleBlur = () => {
+    if (local !== value) onSave(local)
+  }
 
   return (
-    <nav class="category-breadcrumb">
-      <a href="/screentime-categories">Categories</a>
-      {segments.map((segment, i) => {
-        const path = segments.slice(0, i + 1)
-        const parentCat = categories.find((c) => c.name.join(' > ') === path.join(' > '))
-        const isLast = i === segments.length - 1
-
-        return (
-          <span key={i}>
-            <span class="breadcrumb-separator">&gt;</span>
-            {isLast ? (
-              <span class="breadcrumb-current">{segment}</span>
-            ) : parentCat ? (
-              <a href={`/screentime-categories/${parentCat.id}`}>{segment}</a>
-            ) : (
-              <span>{segment}</span>
-            )}
-          </span>
-        )
-      })}
-    </nav>
+    <div class="field-row">
+      <span class="field-label">{label}</span>
+      <span class="field-value">
+        <input
+          type="text"
+          value={local}
+          onInput={(e) => setLocal((e.target as HTMLInputElement).value)}
+          onBlur={handleBlur}
+          placeholder={placeholder}
+          class={`auto-save-input${mono ? ' mono' : ''}`}
+        />
+      </span>
+    </div>
   )
 }
+
+function AutoSaveSelect({
+  label,
+  value,
+  onSave,
+  options,
+}: {
+  label: string
+  value: string
+  onSave: (v: string) => void
+  options: Array<{ value: string; label: string }>
+}) {
+  return (
+    <div class="field-row">
+      <span class="field-label">{label}</span>
+      <span class="field-value">
+        <select
+          value={value}
+          onChange={(e) => onSave((e.target as HTMLSelectElement).value)}
+          class="auto-save-select"
+        >
+          {options.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </span>
+    </div>
+  )
+}
+
+function AutoSaveCheckbox({
+  label,
+  checked,
+  onSave,
+}: {
+  label: string
+  checked: boolean
+  onSave: (v: boolean) => void
+}) {
+  return (
+    <div class="field-row">
+      <span class="field-label">{label}</span>
+      <span class="field-value">
+        <label class="auto-save-checkbox">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => onSave((e.target as HTMLInputElement).checked)}
+          />
+        </label>
+      </span>
+    </div>
+  )
+}
+
+function AutoSaveColor({
+  label,
+  value,
+  onSave,
+}: {
+  label: string
+  value: string
+  onSave: (v: string) => void
+}) {
+  return (
+    <div class="field-row">
+      <span class="field-label">{label}</span>
+      <span class="field-value">
+        <div class="auto-save-color-row">
+          <input
+            type="color"
+            value={value || '#888888'}
+            onInput={(e) => onSave((e.target as HTMLInputElement).value)}
+            class="auto-save-color-input"
+          />
+          {value && (
+            <button type="button" class="sc-clear-btn" onClick={() => onSave('')} title="Clear (inherit)">
+              x
+            </button>
+          )}
+          {!value && <span class="muted">Inherited from parent</span>}
+        </div>
+      </span>
+    </div>
+  )
+}
+
+// ============================================================================
+// Icon editor (reused from previous implementation)
+// ============================================================================
 
 function IconPreview({ icon }: { icon: string }) {
   if (!icon) return null
@@ -163,14 +233,11 @@ function CategoryIconEditor({
 }) {
   const [iconValue, setIconValue] = useState<string | undefined>(undefined)
   const shownIcon = iconValue ?? currentIcon
-
-  // Suggest emoji based on the leaf category name
   const leafName = categoryName[categoryName.length - 1] ?? ''
   const suggested = !shownIcon ? suggestEmoji(leafName) : undefined
 
   const saveMutation = useMutation({
     mutationFn: async (icon: string) => {
-      // Read current settings, merge our icon, save back
       const settings = await fetchUserSettings()
       const currentIcons = settings.item_icons ?? {}
       const key = categoryIconKey(categoryName)
@@ -182,14 +249,11 @@ function CategoryIconEditor({
       }
       await updateUserSettings({ item_icons: newIcons })
     },
-    onSuccess: () => {
-      onSaved()
-    },
+    onSuccess: onSaved,
   })
 
   const handleBlur = () => {
-    if (iconValue === undefined) return
-    if (iconValue === currentIcon) return
+    if (iconValue === undefined || iconValue === currentIcon) return
     saveMutation.mutate(iconValue)
   }
 
@@ -220,14 +284,163 @@ function CategoryIconEditor({
               {suggested}?
             </button>
           )}
-          {saveMutation.isPending && <span class="category-save-status">Saving...</span>}
         </div>
       </span>
     </div>
   )
 }
 
-/** Aggregate DistinctApp rows by app name, summing durations and counts. */
+// ============================================================================
+// Parent selector (for reparenting)
+// ============================================================================
+
+function ParentSelector({
+  category,
+  allCategories,
+  onMoved,
+}: {
+  category: ScreentimeCategory
+  allCategories: ScreentimeCategory[]
+  onMoved: () => void
+}) {
+  const queryClient = useQueryClient()
+  const currentParentPath = category.name.slice(0, -1)
+  const currentParentKey = currentParentPath.join(' > ') || '__top__'
+
+  // Exclude self and descendants
+  const isDescendant = (cat: ScreentimeCategory): boolean =>
+    cat.name.length >= category.name.length && category.name.every((s, i) => s === cat.name[i])
+
+  const availableParents = allCategories.filter((c) => !isDescendant(c))
+
+  const moveMutation = useMutation({
+    mutationFn: async (newParentId: string | null) => {
+      await moveScreentimeCategory(category.id, newParentId)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
+      queryClient.invalidateQueries({ queryKey: ['screentime-category', category.id] })
+      onMoved()
+    },
+  })
+
+  const handleChange = (value: string) => {
+    if (value === currentParentKey) return
+    const newParentId = value === '__top__' ? null : value
+    moveMutation.mutate(newParentId)
+  }
+
+  return (
+    <AutoSaveSelect
+      label="Parent"
+      value={currentParentKey}
+      onSave={handleChange}
+      options={[
+        { label: 'Top level', value: '__top__' },
+        ...availableParents.map((c) => ({
+          label: c.name.join(' > '),
+          value: c.id,
+        })),
+      ]}
+    />
+  )
+}
+
+// ============================================================================
+// Editable fields section
+// ============================================================================
+
+function EditableFields({
+  category,
+  allCategories,
+  currentIcon,
+  totalTime,
+  onFieldSaved,
+  onIconSaved,
+  onMoved,
+}: {
+  category: ScreentimeCategory
+  allCategories: ScreentimeCategory[]
+  currentIcon: string
+  totalTime: number
+  onFieldSaved: () => void
+  onIconSaved: () => void
+  onMoved: () => void
+}) {
+  const saveField = (field: string, value: unknown) => {
+    const body: Record<string, unknown> = { [field]: value }
+    // If changing regex, also update rule_type
+    if (field === 'rule_regex') {
+      body.rule_type = value ? 'regex' : 'none'
+    }
+    updateScreentimeCategory(category.id, body).then(onFieldSaved)
+  }
+
+  const saveName = (leafName: string) => {
+    if (!leafName.trim()) return
+    const newName = [...category.name.slice(0, -1), leafName.trim()]
+    updateScreentimeCategory(category.id, { name: newName }).then(onFieldSaved)
+  }
+
+  return (
+    <div class="category-details">
+      <div class="entity-fields">
+        <CategoryIconEditor categoryName={category.name} currentIcon={currentIcon} onSaved={onIconSaved} />
+        <AutoSaveText
+          label="Name"
+          value={category.name[category.name.length - 1]}
+          onSave={saveName}
+          placeholder="Category name"
+        />
+        <ParentSelector category={category} allCategories={allCategories} onMoved={onMoved} />
+        <AutoSaveText
+          label="Matching rule"
+          value={category.rule_regex ?? ''}
+          onSave={(v) => saveField('rule_regex', v || undefined)}
+          placeholder="Regex pattern (e.g. Slack|Discord)"
+          mono
+        />
+        <AutoSaveColor
+          label="Color"
+          value={category.color ?? ''}
+          onSave={(v) => saveField('color', v || undefined)}
+        />
+        <AutoSaveSelect
+          label="Productivity"
+          value={category.score !== undefined ? String(category.score) : ''}
+          onSave={(v) => saveField('score', v !== '' ? parseInt(v, 10) : undefined)}
+          options={[
+            { label: 'Inherit from parent', value: '' },
+            { label: 'Very Productive (2)', value: '2' },
+            { label: 'Productive (1)', value: '1' },
+            { label: 'Neutral (0)', value: '0' },
+            { label: 'Distracting (-1)', value: '-1' },
+            { label: 'Very Distracting (-2)', value: '-2' },
+          ]}
+        />
+        <AutoSaveCheckbox
+          label="Ignore case"
+          checked={category.ignore_case}
+          onSave={(v) => saveField('ignore_case', v)}
+        />
+        <AutoSaveCheckbox
+          label="Exclude from screen time"
+          checked={category.exclude_from_screentime ?? false}
+          onSave={(v) => saveField('exclude_from_screentime', v)}
+        />
+        <div class="field-row">
+          <span class="field-label">Total tracked time</span>
+          <span class="field-value">{formatDuration(totalTime)}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Matched / Uncategorized app lists (kept from previous implementation)
+// ============================================================================
+
 interface AggregatedApp {
   activity: string
   total_duration_sec: number
@@ -266,21 +479,18 @@ function MatchedAppList({
 }) {
   const queryClient = useQueryClient()
   const [removingApp, setRemovingApp] = useState<string | null>(null)
-
   const aggregated = aggregateByAppName(apps)
 
   const removeMutation = useMutation({
     mutationFn: async (appName: string) => {
       setRemovingApp(appName)
       const currentTerms = parseRegexTerms(category.rule_regex ?? '')
-      // Remove terms that match this app name (case-insensitive comparison)
       const newTerms = currentTerms.filter((t) => t.toLowerCase() !== appName.toLowerCase())
       const newRegex = newTerms.length > 0 ? buildRegex(newTerms) : undefined
       await updateScreentimeCategory(category.id, {
         rule_regex: newRegex,
         rule_type: newRegex ? 'regex' : 'none',
       })
-      // Wait for recategorization so the lists reflect the change immediately
       await recategorizeScreentime()
     },
     onSuccess: () => {
@@ -292,14 +502,7 @@ function MatchedAppList({
     onError: () => setRemovingApp(null),
   })
 
-  if (aggregated.length === 0) {
-    return (
-      <div class="category-section">
-        <h3>Matched apps</h3>
-        <p class="sc-empty">No apps match this category directly.</p>
-      </div>
-    )
-  }
+  if (aggregated.length === 0) return null
 
   return (
     <div class="category-section">
@@ -334,18 +537,93 @@ function MatchedAppList({
   )
 }
 
-/**
- * Extract a short keyword from a window title for use as a matching term.
- * E.g. "Threads - NaturalCycles - Slack — Mozilla Firefox" → "Slack"
- * Splits on common separators and picks the shortest meaningful segment.
- */
+// Simplified uncategorized list (the AddConfirmDialog is imported from the previous version)
+function UncategorizedAppList({
+  apps,
+  category,
+  total,
+  onAppAdded,
+}: {
+  apps: DistinctApp[]
+  category: ScreentimeCategory
+  total: number
+  onAppAdded: () => void
+}) {
+  const queryClient = useQueryClient()
+  const [confirmingApp, setConfirmingApp] = useState<DistinctApp | null>(null)
+
+  const addMutation = useMutation({
+    mutationFn: async (term: string) => {
+      const currentTerms = parseRegexTerms(category.rule_regex ?? '')
+      const newTerms = [...currentTerms, term]
+      const newRegex = buildRegex(newTerms)
+      await updateScreentimeCategory(category.id, { rule_regex: newRegex, rule_type: 'regex' })
+      await recategorizeScreentime()
+    },
+    onSuccess: () => {
+      setConfirmingApp(null)
+      onAppAdded()
+      queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
+      queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
+    },
+  })
+
+  if (total === 0) return null
+
+  const headerTitle =
+    total > apps.length ? `Uncategorized apps (showing ${apps.length} of ${total})` : 'Uncategorized apps'
+
+  return (
+    <div class="category-section">
+      <h3>
+        {headerTitle} <span class="count-badge">{total}</span>
+      </h3>
+      <div class="app-list">
+        {apps.map((app) => (
+          <div key={`${app.activity}\x00${app.title ?? ''}`} class="app-row">
+            <div class="app-name-col">
+              <span class="app-name">{app.activity}</span>
+              {app.title && <span class="app-title">{app.title}</span>}
+            </div>
+            <div class="app-row-right">
+              <span class="app-stats">
+                {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
+              </span>
+              <button
+                type="button"
+                class="app-action-btn add"
+                onClick={() => setConfirmingApp(app)}
+                title={`Add to ${category.name.join(' > ')}`}
+              >
+                Add here
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {confirmingApp && (
+        <AddConfirmDialog
+          app={confirmingApp}
+          category={category}
+          onConfirm={(term) => addMutation.mutate(term)}
+          onCancel={() => setConfirmingApp(null)}
+          isPending={addMutation.isPending}
+        />
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Add confirm dialog (kept from previous version)
+// ============================================================================
+
 const suggestTitleKeyword = (title: string): string | undefined => {
   const parts = title
     .split(/\s[—–\-|]\s|:\s/)
     .map((p) => p.trim())
     .filter((p) => p.length >= 2 && p.length <= 40)
   if (parts.length === 0) return undefined
-  // Prefer shorter segments (more likely to be an app/site name), but not the browser name
   const browserNames = [
     'mozilla firefox',
     'google chrome',
@@ -359,7 +637,6 @@ const suggestTitleKeyword = (title: string): string | undefined => {
   return filtered.reduce((a, b) => (a.length <= b.length ? a : b))
 }
 
-/** Confirmation dialog for adding an app/title to a category. */
 function AddConfirmDialog({
   app,
   category,
@@ -399,7 +676,6 @@ function AddConfirmDialog({
         <p class="add-confirm-desc">
           Choose what to match. The term will be added to the category's matching rule.
         </p>
-
         <div class="add-confirm-options">
           <label class="add-confirm-option">
             <input
@@ -415,7 +691,6 @@ function AddConfirmDialog({
               </div>
             </div>
           </label>
-
           {titleKeyword && (
             <label class="add-confirm-option">
               <input
@@ -432,7 +707,6 @@ function AddConfirmDialog({
               </div>
             </label>
           )}
-
           <label class="add-confirm-option">
             <input
               type="radio"
@@ -456,7 +730,6 @@ function AddConfirmDialog({
             </div>
           </label>
         </div>
-
         <div class="add-confirm-actions">
           <button
             type="button"
@@ -471,93 +744,6 @@ function AddConfirmDialog({
           </button>
         </div>
       </div>
-    </div>
-  )
-}
-
-function UncategorizedAppList({
-  apps,
-  category,
-  total,
-  onAppAdded,
-}: {
-  apps: DistinctApp[]
-  category: ScreentimeCategory
-  total: number
-  onAppAdded: () => void
-}) {
-  const queryClient = useQueryClient()
-  const [confirmingApp, setConfirmingApp] = useState<DistinctApp | null>(null)
-
-  const addMutation = useMutation({
-    mutationFn: async (term: string) => {
-      const currentTerms = parseRegexTerms(category.rule_regex ?? '')
-      const newTerms = [...currentTerms, term]
-      const newRegex = buildRegex(newTerms)
-      await updateScreentimeCategory(category.id, {
-        rule_regex: newRegex,
-        rule_type: 'regex',
-      })
-      // Wait for recategorization so lists reflect the change immediately
-      await recategorizeScreentime()
-    },
-    onSuccess: () => {
-      setConfirmingApp(null)
-      onAppAdded()
-      queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
-      queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
-    },
-  })
-
-  const headerTitle =
-    total > apps.length ? `Uncategorized apps (showing ${apps.length} of ${total})` : 'Uncategorized apps'
-
-  if (total === 0) {
-    return (
-      <div class="category-section">
-        <h3>Uncategorized apps</h3>
-        <p class="sc-empty">All apps are categorized!</p>
-      </div>
-    )
-  }
-
-  return (
-    <div class="category-section">
-      <h3>
-        {headerTitle} <span class="count-badge">{total}</span>
-      </h3>
-      <div class="app-list">
-        {apps.map((app) => (
-          <div key={`${app.activity}\x00${app.title ?? ''}`} class="app-row">
-            <div class="app-name-col">
-              <span class="app-name">{app.activity}</span>
-              {app.title && <span class="app-title">{app.title}</span>}
-            </div>
-            <div class="app-row-right">
-              <span class="app-stats">
-                {formatDuration(app.total_duration_sec)} &middot; {app.record_count} records
-              </span>
-              <button
-                type="button"
-                class="app-action-btn add"
-                onClick={() => setConfirmingApp(app)}
-                title={`Add to ${category.name.join(' > ')}`}
-              >
-                Add here
-              </button>
-            </div>
-          </div>
-        ))}
-      </div>
-      {confirmingApp && (
-        <AddConfirmDialog
-          app={confirmingApp}
-          category={category}
-          onConfirm={(term) => addMutation.mutate(term)}
-          onCancel={() => setConfirmingApp(null)}
-          isPending={addMutation.isPending}
-        />
-      )}
     </div>
   )
 }
@@ -614,52 +800,6 @@ function CategoryTrendSection({ categoryPath, color }: { categoryPath: string; c
 }
 
 // ============================================================================
-// Category info fields
-// ============================================================================
-
-function CategoryFields({
-  category,
-  currentIcon,
-  totalTime,
-  onIconSaved,
-}: {
-  category: ScreentimeCategory
-  currentIcon: string
-  totalTime: number
-  onIconSaved: () => void
-}) {
-  return (
-    <div class="category-details">
-      <div class="entity-fields">
-        <CategoryIconEditor categoryName={category.name} currentIcon={currentIcon} onSaved={onIconSaved} />
-        {category.rule_regex && (
-          <div class="field-row">
-            <span class="field-label">Matching rule</span>
-            <span class="field-value">
-              <code>{category.rule_regex}</code>
-            </span>
-          </div>
-        )}
-        {!category.rule_regex && category.rule_type === 'none' && (
-          <div class="field-row">
-            <span class="field-label">Matching rule</span>
-            <span class="field-value muted">Grouping only (no direct matching)</span>
-          </div>
-        )}
-        <div class="field-row">
-          <span class="field-label">Productivity</span>
-          <span class="field-value">{productivityScoreLabel(category.score)}</span>
-        </div>
-        <div class="field-row">
-          <span class="field-label">Total tracked time</span>
-          <span class="field-value">{formatDuration(totalTime)}</span>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ============================================================================
 // Children list
 // ============================================================================
 
@@ -704,6 +844,138 @@ function ChildCategoriesList({
 }
 
 // ============================================================================
+// Breadcrumb
+// ============================================================================
+
+function CategoryBreadcrumb({
+  categories,
+  category,
+}: {
+  categories: ScreentimeCategory[]
+  category: ScreentimeCategory
+}) {
+  const segments = category.name
+
+  return (
+    <nav class="category-breadcrumb">
+      <a href="/screentime-categories">Categories</a>
+      {segments.map((segment, i) => {
+        const path = segments.slice(0, i + 1)
+        const parentCat = categories.find((c) => c.name.join(' > ') === path.join(' > '))
+        const isLast = i === segments.length - 1
+
+        return (
+          <span key={i}>
+            <span class="breadcrumb-separator">&gt;</span>
+            {isLast ? (
+              <span class="breadcrumb-current">{segment}</span>
+            ) : parentCat ? (
+              <a href={`/screentime-categories/${parentCat.id}`}>{segment}</a>
+            ) : (
+              <span>{segment}</span>
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}
+
+// ============================================================================
+// New category creation mode
+// ============================================================================
+
+function NewCategoryPage({ categoryId }: { categoryId: string }) {
+  const queryClient = useQueryClient()
+  const [name, setName] = useState('')
+  const [created, setCreated] = useState(false)
+
+  // Parse parent from URL query string
+  const urlParams = new URLSearchParams(window.location.search)
+  const parentId = urlParams.get('parent')
+
+  const { data: allCategories = [] } = useQuery({
+    queryFn: fetchScreentimeCategories,
+    queryKey: ['screentime-categories'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const parent = parentId ? allCategories.find((c) => c.id === parentId) : undefined
+
+  const createMutation = useMutation({
+    mutationFn: async (leafName: string) => {
+      const parentPath = parent ? parent.name : []
+      await upsertScreentimeCategory(categoryId, {
+        name: [...parentPath, leafName],
+      })
+    },
+    onSuccess: () => {
+      setCreated(true)
+      queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
+      queryClient.invalidateQueries({ queryKey: ['screentime-category', categoryId] })
+    },
+  })
+
+  if (created) {
+    // Category was created — re-render will load the real detail page
+    return (
+      <div class="data-sources-page">
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="data-sources-page">
+      <nav class="category-breadcrumb">
+        <a href="/screentime-categories">Categories</a>
+        <span class="breadcrumb-separator">&gt;</span>
+        <span class="breadcrumb-current">New category</span>
+      </nav>
+
+      <h1>New Category</h1>
+
+      <div class="category-details">
+        <div class="entity-fields">
+          {parent && (
+            <div class="field-row">
+              <span class="field-label">Parent</span>
+              <span class="field-value">{parent.name.join(' > ')}</span>
+            </div>
+          )}
+          <div class="field-row">
+            <span class="field-label">Name</span>
+            <span class="field-value">
+              <input
+                type="text"
+                value={name}
+                onInput={(e) => setName((e.target as HTMLInputElement).value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && name.trim()) createMutation.mutate(name.trim())
+                }}
+                placeholder="Category name"
+                class="auto-save-input"
+                autoFocus
+              />
+            </span>
+          </div>
+        </div>
+        <div style={{ marginTop: '1rem' }}>
+          <button
+            type="button"
+            class="note-action-btn"
+            onClick={() => createMutation.mutate(name.trim())}
+            disabled={!name.trim() || createMutation.isPending}
+          >
+            {createMutation.isPending ? 'Creating...' : 'Create'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
 // Main component
 // ============================================================================
 
@@ -727,7 +999,7 @@ export function CategoryDetail() {
   })
 
   const { data: distinctApps = [] } = useQuery({
-    enabled: !!isLoggedIn,
+    enabled: !!isLoggedIn && !!category,
     queryFn: fetchDistinctApps,
     queryKey: ['productivity-apps'],
     staleTime: 5 * 60 * 1000,
@@ -766,15 +1038,39 @@ export function CategoryDetail() {
     )
   }
 
+  // If category not found, show creation mode (client-generated UUID)
   if (!category) {
-    return (
-      <div class="data-sources-page">
-        <p class="error">Category not found.</p>
-        <a href="/screentime-categories">Back to categories</a>
-      </div>
-    )
+    return <NewCategoryPage categoryId={categoryId} />
   }
 
+  return (
+    <ExistingCategoryPage
+      category={category}
+      allCategories={allCategories}
+      distinctApps={distinctApps}
+      userSettings={userSettings}
+      onFieldSaved={invalidateAll}
+      onIconSaved={invalidateIcons}
+    />
+  )
+}
+
+/** Render an existing category's detail/edit page. */
+function ExistingCategoryPage({
+  category,
+  allCategories,
+  distinctApps,
+  userSettings,
+  onFieldSaved,
+  onIconSaved,
+}: {
+  category: ScreentimeCategory
+  allCategories: ScreentimeCategory[]
+  distinctApps: DistinctApp[]
+  userSettings?: { item_icons?: Record<string, string> }
+  onFieldSaved: () => void
+  onIconSaved: () => void
+}) {
   const children = getChildren(allCategories, category)
   const matchedApps = getMatchedApps(distinctApps, category.name)
   const allMatched = getAllMatchedApps(distinctApps, category.name)
@@ -795,25 +1091,28 @@ export function CategoryDetail() {
         <h1>{category.name[category.name.length - 1]}</h1>
       </div>
 
-      <CategoryFields
+      <EditableFields
         category={category}
+        allCategories={allCategories}
         currentIcon={currentIcon}
         totalTime={totalTime}
-        onIconSaved={invalidateIcons}
+        onFieldSaved={onFieldSaved}
+        onIconSaved={onIconSaved}
+        onMoved={onFieldSaved}
       />
       <CategoryTrendSection categoryPath={category.name.join(' > ')} color={category.color ?? '#673ab8'} />
       <ChildCategoriesList children={children} distinctApps={distinctApps} icons={icons} />
-      <MatchedAppList apps={matchedApps} category={category} onAppRemoved={invalidateAll} />
+      <MatchedAppList apps={matchedApps} category={category} onAppRemoved={onFieldSaved} />
       <UncategorizedAppList
         apps={uncategorized.slice(0, 30)}
         category={category}
         total={uncategorized.length}
-        onAppAdded={invalidateAll}
+        onAppAdded={onFieldSaved}
       />
 
       <div class="category-footer">
         <a href="/screentime-categories" class="manage-link">
-          Manage all categories
+          Back to all categories
         </a>
       </div>
     </div>

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -129,6 +129,90 @@
   color: #9ca3af;
 }
 
+/* Auto-save field inputs */
+.auto-save-input {
+  width: 280px;
+  max-width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+}
+
+.auto-save-input.mono {
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+
+.auto-save-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.auto-save-select {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.auto-save-select:focus {
+  outline: none;
+  border-color: #673ab8;
+}
+
+.auto-save-checkbox {
+  cursor: pointer;
+}
+
+.auto-save-checkbox input {
+  accent-color: #673ab8;
+  width: 16px;
+  height: 16px;
+}
+
+.auto-save-color-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.auto-save-color-input {
+  width: 40px;
+  height: 28px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 1px;
+}
+
+.sc-clear-btn {
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 0.15rem 0.4rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.sc-clear-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.muted {
+  color: #9ca3af;
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
 /* Sections */
 .category-section {
   margin-bottom: 2rem;

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1314,9 +1314,24 @@ export const createScreentimeCategory = async (
   return response.data.data!
 }
 
+/** Partial update (PATCH) — used for auto-save on individual fields. */
 export const updateScreentimeCategory = async (
   id: string,
   body: UpdateScreentimeCategoryBody,
+): Promise<ScreentimeCategory> => {
+  const { token } = auth.value
+  const response = await axios.patch<ScreentimeCategoryResponse>(
+    `${API_URL}/screentime-categories/${id}`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data!
+}
+
+/** Full upsert (PUT) — used for creating with client-generated UUID. */
+export const upsertScreentimeCategory = async (
+  id: string,
+  body: CreateScreentimeCategoryBody,
 ): Promise<ScreentimeCategory> => {
   const { token } = auth.value
   const response = await axios.put<ScreentimeCategoryResponse>(
@@ -1325,6 +1340,16 @@ export const updateScreentimeCategory = async (
     { headers: { Authorization: `Bearer ${token}` } },
   )
   return response.data.data!
+}
+
+/** Move a category to a new parent (or top level if null). */
+export const moveScreentimeCategory = async (id: string, newParentId: string | null): Promise<void> => {
+  const { token } = auth.value
+  await axios.patch(
+    `${API_URL}/screentime-categories/${id}/move`,
+    { new_parent_id: newParentId },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
 }
 
 export const deleteScreentimeCategory = async (id: string): Promise<void> => {


### PR DESCRIPTION
## Summary

Major UX redesign of screentime category management. All editing is consolidated onto the category detail page with auto-save fields. The list page becomes a clean navigation hub.

### Before
- Category list had inline edit forms (cramped, settings split between list and detail pages)
- Some settings (icon, exclude_from_screentime) only on detail page, others (name, regex, color, score) only in list
- No way to move categories between parents

### After
- **List page**: Clean navigation — click row to edit, trash icon to delete, "Add" button for new categories
- **Detail page**: All fields editable with auto-save on blur — name, parent, regex, color, score, ignore_case, exclude_from_screentime, icon
- **Parent dropdown**: Move any category to a different parent or top level (cascades to children)
- **New categories**: "Add category" generates UUID client-side, navigates to detail page in creation mode

### Backend changes
| Endpoint | Verb | Description |
|----------|------|-------------|
| `/screentime-categories/:id` | **PUT** | Upsert (create with client UUID or full update) |
| `/screentime-categories/:id` | **PATCH** | Partial update (auto-save individual fields) |
| `/screentime-categories/:id/move` | **PATCH** | Reparent category (updates self + all children) |

### How it works

1. User clicks "Add category" → generates UUID → navigates to `/screentime-categories/<uuid>`
2. Detail page detects category doesn't exist → shows creation form
3. User types name, hits Enter or clicks Create → `PUT /screentime-categories/<uuid>` creates it
4. Page reloads as the full edit page with all fields
5. Any field change auto-saves on blur via `PATCH`
6. Parent dropdown change triggers `PATCH /:id/move` which cascades to children