### PR TITLE
Add Sleep, Screentime Categories, and Training Load feature docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ Detailed documentation for specific features and data processing pipelines:
 - [Correlation Analysis](docs/features/correlations.md) -- Statistical correlations, activity impact, event probability
 - [Trends (EMA)](docs/features/trends.md) -- Exponential Moving Average smoothing for tags, metrics, and screen time
 - [Goals](docs/features/goals.md) -- Rolling-window health targets with "losing tomorrow" calculations
+- [Sleep Analysis](docs/features/sleep.md) -- Sleep quality tracking, hypnogram, Oura scores, sleep location
+- [Screentime Categories](docs/features/screentime-categories.md) -- Hierarchical app categorization with productivity scoring
+- [Training Load](docs/features/training-load.md) -- Banister model fitness/fatigue tracking (CTL/ATL/TSB)
 - [Active Calorie Computation](docs/features/calories.md) -- HR-based calculation, gap-fill, source filtering
 
 ---

--- a/docs/features/screentime-categories.md
+++ b/docs/features/screentime-categories.md
@@ -1,0 +1,93 @@
+# Screentime Categories
+
+Screentime Categories let you organize your screen time data into a meaningful hierarchy. Instead of seeing a flat list of apps and websites, you define categories like "Work > Programming" or "Media > Social Media" and assign apps to them using regex patterns. Categories are shared across all screen time sources (RescueTime, ActivityWatch Desktop, ActivityWatch Android).
+
+## How Categories Work
+
+Each category has:
+
+- A **hierarchical name** (e.g., "Work > Programming > IDE"). The path determines the parent-child relationship.
+- A **regex pattern** that matches against app names and window titles. For example, `GitHub|Stack Overflow|vscode` matches any of those.
+- A **productivity score** from -2 (Very Distracting) to +2 (Very Productive). Children inherit their parent's score unless overridden.
+- A **color** for display on the Timeline and elsewhere. Also inherited from parent if not set.
+- An optional **exclude from screentime** flag that hides matched records from the Timeline and summaries (useful for system processes like window managers).
+
+When a screen time record comes in, it's tested against all category regex patterns. If multiple match, the **deepest** (most specific) category wins. A record matching both "Work" and "Work > Programming" is categorized as "Work > Programming".
+
+Categories with no regex pattern serve as grouping containers -- they organize subcategories but don't match anything directly.
+
+## Managing Categories
+
+The management page at `/screentime-categories` shows your category tree with indented hierarchy. Each category displays its name, regex pattern, color, and score. From here you can:
+
+### Create a category
+
+Choose a parent (or top level), give it a name, set a regex pattern, and optionally pick a color and score. Creating a category with a regex automatically recategorizes all existing screen time records.
+
+### Edit a category
+
+Change the name, regex, color, score, case sensitivity, or the "exclude from screentime" flag. Saving triggers automatic recategorization.
+
+### Delete a category
+
+Removes the category and all its children. Triggers recategorization.
+
+### Load defaults
+
+Pre-built categories compatible with ActivityWatch:
+- **Work** (green, Very Productive) -- with subcategories for Programming, Image, Video, Audio, 3D
+- **Media** (red, Distracting) -- with Games, Video, Social Media, Music
+- **Comms** (cyan, Neutral) -- with IM and Email
+
+Defaults are appended to existing categories, not replacing them.
+
+### Import from ActivityWatch
+
+If you run ActivityWatch locally, enter its URL (default `http://localhost:5600`) to import its category configuration. Categories are converted from ActivityWatch format and inserted. Optionally replace all existing categories.
+
+## Category Detail Page
+
+Clicking a category name opens its detail page showing:
+
+- **Time trend**: An EMA chart showing hours spent in this category over time, with adjustable lookback period.
+- **Sub-categories**: Cards for each child category with total time.
+- **Matched apps**: Apps currently assigned to this category, with a "Remove" button to unassign.
+- **Uncategorized apps**: Apps with no category, with an "Add here" button to quickly assign them. You can match by app name, a keyword from the window title, or a custom term.
+- **Icon**: An emoji or image you can assign to the category (shown on the Timeline).
+
+## Where Categories Appear
+
+### Timeline
+
+Screen time blocks on the Timeline are colored by their category color. Excluded categories are filtered out entirely. In horizontal mode, screen time appears as stacked bar charts bucketed by top-level category.
+
+### Correlations
+
+The Correlations page includes a "Productivity Categories" table showing how each category correlates with your HRV and heart rate, including Pearson correlation coefficients.
+
+### Trends
+
+You can create trend charts for any screentime category, tracking hours spent over time with EMA smoothing.
+
+### Detail view
+
+When clicking a screen time record, the detail page shows the resolved category path with links to each level.
+
+## What Data It Needs
+
+Screen time data from at least one source:
+
+| Source | What it provides |
+|---|---|
+| **RescueTime** | App and website usage with built-in productivity scores. Categories override RescueTime's own scoring. |
+| **ActivityWatch Desktop** | Window-level app usage from desktop. Pushed via agent script. |
+| **ActivityWatch Android** | App usage from Android phone. |
+
+Categories apply equally to data from all sources.
+
+## Known Limitations
+
+- Category matching is **regex-based**, which is powerful but can be tricky for complex patterns. Most users just need pipe-separated app names (e.g., `Slack|Discord|Teams`).
+- Recategorization runs in the background after rule changes. For large datasets, this may take a few seconds.
+- The "exclude from screentime" flag filters records from the Timeline and daily summaries, but the data is still stored and accessible via the API.
+- Multi-device overlap (e.g., desktop and phone active simultaneously) is handled by capping total time to the bucket duration, but within a single category the overlap isn't deduplicated.

--- a/docs/features/sleep.md
+++ b/docs/features/sleep.md
@@ -1,0 +1,90 @@
+# Sleep Analysis
+
+Aurboda provides dedicated sleep tracking and analysis. The Sleep page shows your sleep quality trends over configurable periods, while the sleep detail view gives you a full breakdown of individual sessions including a hypnogram, Oura scores, and HR/HRV overlays.
+
+## The Sleep Page
+
+The page at `/sleep` shows your sleep quality over a selectable period (7, 14, 30, 60, or 90 days).
+
+### Overview Stats
+
+Four cards at the top show key metrics with trend arrows comparing to the previous period:
+
+- **Sleep Score** -- Overall quality (from Oura), averaged over the period.
+- **Duration** -- Average hours of actual sleep per night (excluding awake time).
+- **Efficiency** -- Time asleep vs. time in bed (percentage).
+- **Latency** -- Time to fall asleep.
+
+### Sleep Score Trend
+
+A line chart showing your nightly sleep score over time with a dashed average line. The chart uses a blue gradient fill and shows individual data points.
+
+### Sleep Duration Bars
+
+A bar chart showing hours of sleep per night, color-coded:
+
+- **Green** (7-9 hours) -- optimal range, highlighted as a target zone band.
+- **Yellow** (6-7 or 9+ hours) -- caution range.
+- **Red** (under 6 hours) -- insufficient sleep.
+
+A dashed average line shows your overall average.
+
+### Sleep Components
+
+Five Oura sleep sub-scores (when available): Total Score, Deep Sleep, REM Sleep, Restfulness, and Timing. Each shows the period average with a trend percentage.
+
+## Sleep Detail View
+
+Clicking a sleep session (from the Timeline, Data Browser, or elsewhere) opens a detailed view showing:
+
+### Hypnogram
+
+A colored chart showing your progression through sleep stages over the night:
+
+- **Awake** (amber, top)
+- **REM** (purple)
+- **Light** (light blue)
+- **Deep** (indigo, bottom)
+
+Heart rate (red) and HRV (teal) lines can be overlaid on the hypnogram. Hovering shows exact values at any point in time.
+
+### Sleep Metrics
+
+When connected to Oura: Sleep Score, Efficiency, Restfulness, Deep Score, and REM Score displayed as metric cards.
+
+Time fields show "In Bed" (total time in bed), "Asleep" (actual sleep time excluding awake periods), and average HRV during the session.
+
+### Additional Context
+
+- **Music** playing during the session (via Last.fm).
+- **Sleep location** -- the place where you slept, determined by finding the location visit with the longest overlap during the sleep window.
+- **Source records** -- if the sleep was merged from multiple sources (e.g., Oura + Health Connect), shows each source with links.
+- **Notes** -- attach comments to any sleep session.
+
+## Primary vs. Evening Sleep
+
+The daily summary distinguishes two sleep slots:
+
+- **Primary sleep**: The session you woke up from on a given date. This is the session Oura's sleep score evaluates.
+- **Evening sleep**: The session that started in the evening and continues into the next day.
+
+Sleep dates use the **wake-up convention**: a session starting at 11pm on March 7 and ending at 7am on March 8 has a sleep date of March 8.
+
+## What Data It Needs
+
+| Feature | Data source |
+|---|---|
+| Sleep sessions | Oura, Garmin, or Health Connect |
+| Sleep stages (hypnogram) | Health Connect (via Oura/Garmin or watch) |
+| Sleep scores and components | Oura (primary source), Garmin (sleep score only) |
+| HR/HRV during sleep | Oura, Garmin, or Health Connect |
+| Sleep location | OwnTracks |
+
+The Sleep page works with any sleep source, but Oura provides the richest data (scores, sub-components, stages).
+
+## Known Limitations
+
+- Sleep components (deep, REM, restfulness, timing) are **Oura-specific**. They don't appear for Garmin-only or Health Connect-only users.
+- The Sleep page does not track **sleep debt** or **sleep need** -- it shows quality metrics but not how much sleep you need vs. how much you're getting. (See issue #302 for planned sleep debt tracking.)
+- Sleep duration uses the calculated "asleep" time when available (excluding awake periods). When stage data is missing, it falls back to total time in bed.
+- There is no sleep **timing consistency** analysis (e.g., tracking bedtime regularity over time), though the Oura "Timing" sub-score partially covers this.

--- a/docs/features/training-load.md
+++ b/docs/features/training-load.md
@@ -1,0 +1,104 @@
+# Training Load
+
+Training Load uses the Banister impulse-response model to track your fitness, fatigue, and form over time. It turns individual workouts into a continuous picture of your training state -- are you building fitness, accumulating too much fatigue, or in a balanced recovery zone?
+
+The training load track appears on the Timeline in horizontal mode. It's also available via the API and MCP tools for AI-driven analysis.
+
+## Key Concepts
+
+### CTL (Chronic Training Load) -- "Fitness"
+
+A long-term exponential moving average of your training stress (default time constant: 42 days). Represents your accumulated fitness. Higher CTL means you've been training consistently. The CTL curve takes weeks to build and weeks to decay.
+
+Shown as a **blue filled area** on the Timeline.
+
+### ATL (Acute Training Load) -- "Fatigue"
+
+A short-term exponential moving average of your training stress (default time constant: 7 days). Represents recent fatigue. High ATL means you've trained hard recently and may need recovery.
+
+Shown as **colored bars** behind the impulse bars: light blue when low, shifting through orange to red as fatigue increases.
+
+### TSB (Training Stress Balance) -- "Form"
+
+The difference: **TSB = CTL - ATL**. When positive (green), you're fresh -- fitness exceeds current fatigue. When negative (red), you're fatigued -- recent training stress exceeds your fitness base.
+
+Shown as a **line** that's green above zero and red below, with a dashed zero reference line.
+
+### TRIMP (Training Impulse)
+
+A per-workout load score computed from heart rate intensity and duration. Harder, longer workouts produce higher TRIMP. The formula accounts for the exponential nature of training stress -- time at high heart rates contributes disproportionately more than time at low heart rates.
+
+When heart rate data isn't available for a workout, TRIMP defaults to a simple duration-based estimate.
+
+### Activity Impulse
+
+Training stress from general daily movement (active calories). Converted from calories using a scale factor (default: 100 active calories = 10 impulse units). This captures non-workout activity like walking and housework.
+
+## Recovery Zones
+
+Once you have about 6 weeks of training data, recovery zones appear as colored horizontal bands on the Timeline. They classify your current fatigue relative to your historical fitness:
+
+| Zone | Meaning | Visual |
+|---|---|---|
+| **Undertrained** | Not training enough to maintain current fitness | Blue tint |
+| **Balanced** | Optimal training range | Green tint |
+| **Strained** | Elevated fatigue, risk of overreaching | Orange tint |
+| **Very Strained** | Very high fatigue, high overtraining risk | Red tint |
+
+Zone boundaries are based on your average CTL: balanced is 0.8x to 1.3x, strained is 1.3x to 1.7x, very strained is above 1.7x.
+
+## The Timeline Track
+
+In horizontal mode, the training load track shows within the Metrics lane:
+
+- **Stacked impulse bars**: Purple (TRIMP from workouts) and light blue (activity impulse from calories) per time bucket.
+- **Fatigue bars**: Background bars showing ATL, colored by intensity.
+- **CTL curve**: Blue filled area. Dashed during the bootstrapping period (first ~6 weeks).
+- **TSB line**: Green when fresh, red when fatigued.
+- **Recovery zone bands**: Colored backgrounds (after bootstrapping).
+
+Hovering shows a tooltip with fitness (CTL), fatigue (ATL), form (TSB with Fresh/Fatigued label), impulse values, recovery zone, and details of nearby workouts (title, duration, TRIMP, average HR).
+
+## Bootstrapping Period
+
+The first ~6 weeks of data are a bootstrapping period. During this time:
+
+- The CTL curve is shown as **dashed** with reduced opacity.
+- **Recovery zones are not displayed** (not enough data to be meaningful).
+- The `bootstrapping` flag is set in the API response.
+
+This is because the 42-day CTL time constant needs approximately 42 days of data before the fitness estimate stabilizes.
+
+## Configuration
+
+Training load settings can be adjusted in user settings:
+
+| Setting | Default | Description |
+|---|---|---|
+| **Max HR** | Auto-detected | Overrides the maximum heart rate used for TRIMP calculation. Falls back to: highest observed HR in the last year, then 220 - age, then 190 bpm. |
+| **Resting HR** | Auto-detected | Overrides resting HR. Falls back to: most recent resting HR metric, then 60 bpm. |
+| **Acute time constant** | 7 days | Controls how quickly the fatigue (ATL) EMA responds. Lower = more responsive. |
+| **Chronic time constant** | 42 days | Controls how quickly the fitness (CTL) EMA responds. Lower = more responsive. |
+| **Activity impulse scale** | 0.1 | Converts active calories to impulse units. |
+
+The TRIMP formula uses a sex-dependent weighting constant (k-factor): 1.92 for males, 1.67 for females. This is automatically selected based on your biological sex setting.
+
+## What Data It Needs
+
+| Input | Source | Used for |
+|---|---|---|
+| Exercise sessions | Oura, Garmin, Health Connect | TRIMP calculation (with HR data) |
+| Heart rate during exercise | Any HR source overlapping exercise sessions | Accurate TRIMP scoring |
+| Active calories | Health Connect aggregate, HR-computed | Activity impulse |
+| Resting heart rate | Oura, Garmin, Health Connect | TRIMP baseline |
+| Max heart rate | Observed from data, or manual setting | TRIMP scaling |
+| Biological sex | User settings | TRIMP k-factor selection |
+
+Training load works with just exercise sessions (using duration fallback), but is most accurate with heart rate data during workouts.
+
+## Known Limitations
+
+- There is **no dedicated Training Load page** -- it only appears as a track on the Timeline in horizontal mode. (See issue #381 for a planned dedicated page.)
+- Recovery zones require ~6 weeks of exercise data and a meaningful average CTL. Users who train infrequently may never see zones.
+- The TRIMP formula assumes a specific relationship between heart rate and metabolic load. Individual variations (e.g., cardiac drift, heat, altitude) are not accounted for.
+- Activity impulse from calories is a rough proxy for training stress. It doesn't distinguish between easy and hard non-workout activity.


### PR DESCRIPTION
## Summary

Three user-focused feature docs:

- **Sleep Analysis** (`docs/features/sleep.md`) -- Quality tracking, hypnogram, Oura scores, primary/evening sleep disambiguation, sleep location detection
- **Screentime Categories** (`docs/features/screentime-categories.md`) -- Hierarchical regex categorization, productivity scoring, ActivityWatch import, defaults, integration with Timeline/Correlations/Trends
- **Training Load** (`docs/features/training-load.md`) -- Banister model (CTL/ATL/TSB), TRIMP computation, recovery zones, bootstrapping period, Timeline visualization, configuration

All three linked from the README's Feature Documentation section.