### PR TITLE
Add Places and Lab Reports feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Detailed documentation for specific features and data processing pipelines:
 - [Sleep Analysis](docs/features/sleep.md) -- Sleep quality tracking, hypnogram, Oura scores, sleep location
 - [Screentime Categories](docs/features/screentime-categories.md) -- Hierarchical app categorization with productivity scoring
 - [Training Load](docs/features/training-load.md) -- Banister model fitness/fatigue tracking (CTL/ATL/TSB)
+- [Places & Location Tracking](docs/features/places.md) -- Auto-detected locations, geocoding, visit tracking
+- [Lab Reports](docs/features/lab-reports.md) -- Structured lab results with metric write-through
 - [Active Calorie Computation](docs/features/calories.md) -- HR-based calculation, gap-fill, source filtering
 
 ---

--- a/docs/features/lab-reports.md
+++ b/docs/features/lab-reports.md
@@ -1,0 +1,89 @@
+# Lab Reports
+
+Lab Reports let you store structured measurements from body composition scans, blood work, hair mineral analyses, and other lab tests. Each measurement is automatically written through to Aurboda's metric time series, so lab values appear alongside your regular health data in trends, period summaries, and AI queries.
+
+This feature is currently **API and MCP only** -- there is no web UI for viewing or entering lab reports. (See issue #380 for planned web UI.)
+
+## What a Report Contains
+
+Each report has:
+
+- A **report type** -- a free-form label like "inbody", "blood_panel", "hair_mineral_analysis", "dexa", "lipid_panel", or any string you choose.
+- A **date** -- when the lab visit or scan occurred.
+- An optional **location** -- where the test was done (e.g., "Genki gym", "Trace Elements Lab").
+- Optional **notes** -- context like "Fasted 12h" or "No exercise before scan".
+- One or more **entries** -- individual measurements.
+
+### Report Entries
+
+Each entry in a report stores:
+
+| Field | Description | Example |
+|---|---|---|
+| **Metric** | What was measured (free-form name) | `body_fat`, `ferritin`, `calcium` |
+| **Value** | The numeric result | `18.5`, `45.0`, `97.2` |
+| **Unit** | Measurement unit | `%`, `ng/mL`, `mg%` |
+| **Method** | How it was measured (optional) | `bia_segmental`, `blood_draw`, `hair_analysis` |
+| **Confidence** | Measurement reliability (optional) | `measured`, `estimated`, `derived` |
+| **Reference low/high** | Normal range (optional) | `30.0` - `400.0` for ferritin |
+| **Flag** | Out-of-range indicator (optional, auto-derived) | `normal`, `low`, `high`, `critical_low`, `critical_high` |
+
+### Automatic Flag Derivation
+
+If you provide reference ranges but no flag, the system determines it automatically:
+
+- **Normal**: Value within the reference range.
+- **Low** / **High**: Value outside the range.
+- **Critical low** / **Critical high**: Value more than 50% beyond the range boundary.
+
+You can also set flags explicitly to override the auto-derivation.
+
+## Write-Through to Time Series
+
+This is the key architectural feature. When you create a report, every entry is also written to Aurboda's `time_series` with source `lab_report`. This means:
+
+- A body fat measurement from an InBody scan shows up in the same weight/body fat trend charts as data from your scale or Health Connect.
+- A ferritin value from blood work is queryable alongside all your other metrics.
+- The `get_latest_metric` tool can find your most recent lab value even if the blood panel is months old.
+
+When a report is deleted, the corresponding time-series entries are cleanly removed without affecting data from other sources.
+
+## Common Report Types
+
+| Type | Typical Metrics | Typical Method |
+|---|---|---|
+| **InBody scan** | weight, body_fat, bmi, skeletal_muscle_mass, ecw_ratio | bia_segmental |
+| **Blood panel** | ferritin, iron, b12, vitamin_d, testosterone, cortisol | blood_draw |
+| **Hair mineral analysis** | calcium, magnesium, sodium, potassium, zinc, copper | hair_analysis |
+| **DEXA scan** | body_fat, bone_density, lean_body_mass | dexa |
+| **Lipid panel** | total_cholesterol, ldl, hdl, triglycerides | blood_draw |
+
+Report types are completely free-form -- use any label that makes sense for your tests.
+
+## API and MCP Access
+
+### MCP Tools
+
+| Tool | Description |
+|---|---|
+| `add_report` | Create a report with entries. All entries are written through to metrics. |
+| `get_report` | Fetch a single report with all entries. |
+| `query_reports` | List reports, optionally filtered by type and date range. |
+| `delete_report` | Delete a report and its write-through metric data. |
+| `get_latest_metric` | Get the most recent value for any metric (useful for "what was my last ferritin?"). |
+
+### REST API
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/reports` | Create a report with entries |
+| `GET` | `/reports` | Query reports (filter by type, date range) |
+| `GET` | `/reports/:id` | Get a single report |
+| `DELETE` | `/reports/:id` | Delete a report and metric data |
+
+## Known Limitations
+
+- **No web UI** -- reports can only be created and viewed via the API or MCP tools. An AI assistant (via MCP) is currently the most practical way to enter lab data.
+- **Reports are immutable** -- there is no update/patch endpoint. To correct an error, delete and recreate the report.
+- **Metric names are free-form** -- there is no validation that a metric name in a report entry matches the system's known metrics. Custom metric names work fine but won't have labels or units configured unless you also create a custom metric definition.
+- **No reference range tracking over time** -- reference ranges are stored per-entry but there's no visualization of how your values trend relative to their ranges.

--- a/docs/features/places.md
+++ b/docs/features/places.md
@@ -1,0 +1,93 @@
+# Places & Location Tracking
+
+Aurboda tracks where you spend your time. The Places page shows your daily movements on an interactive map with a chronological list of place visits. The system automatically detects locations you visit frequently, geocodes them to street addresses, and lets you name them.
+
+## The Places Page
+
+The page at `/places` has a split layout: a visit list on the left and an interactive map on the right (stacked vertically on mobile).
+
+### Date Navigation
+
+A date picker with previous/next-day buttons lets you browse one day at a time. The default is today.
+
+### Visit List
+
+Place visits are shown chronologically, each displaying:
+
+- **Time range** (e.g., "09:15 - 12:30")
+- **Place name** (e.g., "Office", "Home", or an auto-geocoded address)
+- **Duration** in minutes
+- **Source indicator** as a colored left border
+
+Between consecutive visits, **transit** entries appear as dashed connectors showing the gap time.
+
+### Source Types
+
+| Source | Color | Description |
+|---|---|---|
+| **Named** | Green | Locations you've named (e.g., "Home", "Gym") |
+| **Detected** | Orange | Automatically detected frequent locations with geocoded addresses |
+| **OwnTracks** | Blue | Identified by OwnTracks geofence regions |
+| **Unknown** | Gray | Unidentified locations, shown as "Somewhere" |
+
+### Map
+
+An interactive OpenStreetMap map. Clicking a place in the visit list places a marker on the map and centers on that location.
+
+### Naming Locations
+
+Clicking an unnamed place (detected or unknown) opens a naming dialog. Enter a name like "Home" or "Office", and the location is promoted to a named location. Named locations are then recognized automatically in all future visits.
+
+For detected locations, the auto-geocoded address is pre-filled as a suggestion.
+
+## How Location Detection Works
+
+The detection pipeline runs automatically in the background:
+
+1. **GPS data arrives** from OwnTracks as continuous location updates.
+2. **Stay detection**: Points within a 200-meter radius where you remained for 60+ minutes are grouped into a "stay."
+3. **Clustering**: Multiple stays at similar locations are merged, tracking visit count, total time, and a suggested radius.
+4. **Geocoding**: New detected locations are reverse-geocoded via OpenStreetMap's Nominatim service to get a street address. Geocoding is rate-limited (1 request per 1.1 seconds) and retried on failure.
+5. **Visit resolution**: When querying a day's visits, each GPS period is matched against named locations (highest priority), detected locations, OwnTracks regions, and finally marked as unknown.
+
+Short unknown visits under 5 minutes (typically GPS jitter) are merged into adjacent visits to reduce noise.
+
+## Integration with Other Features
+
+### Timeline
+
+The Timeline shows a location track with colored blocks for each place visit. Clicking a location block on the Timeline links to the Places page for that date and location.
+
+### Sleep Location
+
+The daily summary includes a **sleep location** for each sleep session -- the place where you spent the most time during sleep, determined by finding the visit with the longest overlap.
+
+### Correlations
+
+The Correlations page includes a "Locations" table showing how your HRV and heart rate correlate with different places you visit.
+
+## URL Deep-Linking
+
+The Places page supports URL parameters for deep-linking:
+
+```
+/places?date=2026-03-19&name=Office
+```
+
+This opens the Places page for a specific date and auto-selects the named place.
+
+## What Data It Needs
+
+Location tracking requires **OwnTracks** configured in HTTP mode, sending continuous GPS updates to Aurboda. See [docs/owntracks.md](../owntracks.md) for setup.
+
+The more frequently OwnTracks sends updates, the more accurate stay detection and visit tracking become. A 5-15 minute reporting interval works well for most users.
+
+**PostGIS** is required on the database (included in the Docker setup) for geographic distance calculations.
+
+## Known Limitations
+
+- Location tracking depends entirely on **OwnTracks GPS data**. There is no integration with Google Maps Timeline, Apple Location Services, or other providers.
+- Detection requires **60+ minutes** at a location within 200 meters. Brief visits (e.g., a 30-minute coffee shop stop) are not auto-detected as frequent locations but still appear as visits.
+- Geocoding uses OpenStreetMap's Nominatim, which is rate-limited and may not have addresses for all locations (especially rural or newly developed areas).
+- The map defaults to Stockholm coordinates when no location data exists for the selected day.
+- There is no **weekly or monthly location summary** -- the page shows one day at a time.


### PR DESCRIPTION
## Summary

Two user-focused feature docs:

- **Places & Location Tracking** (`docs/features/places.md`) -- Daily visit tracking on an interactive map, auto-detection pipeline (stay detection, clustering, geocoding), location naming, source types, deep-linking, integration with Timeline/Sleep/Correlations
- **Lab Reports** (`docs/features/lab-reports.md`) -- Structured lab results (API/MCP only), write-through to metric time series, flag auto-derivation, common report types, API and MCP tools

Both linked from the README's Feature Documentation section.