### PR TITLE
fix: make calorie recalculation async for full recomputes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ No public signup, but self-hosting is straightforward via Docker. It was initiat
 
 ### Data Sources
 
-| Source | What it provides | Docs |
-|---|---|---|
-| [**Android Health Connect**](docs/health-connect.md) | Heart rate, HRV, sleep, exercise (80+ types), steps, weight, SpO2, VO2 max, calories, and more | Push from Android app |
-| **BLE Sensors** | Real-time heart rate, HRV (Polar H10, etc.) and steps (Zwift RunPod, etc.) | Live via Android app |
-| [**Oura Ring**](docs/oura.md) | Sleep stages/scores, readiness, resilience, cardiovascular age, HRV, heart rate, meditation, tags | Pull (API) + Push (webhooks) |
-| [**Garmin Connect**](docs/garmin.md) | Daily summary, HR, HRV, sleep, stress, body battery, activities, SpO2, respiration, training readiness | Pull (session-based) |
-| [**OwnTracks**](docs/owntracks.md) | GPS locations, geofences, place visits | Push (HTTP mode) |
-| [**RescueTime**](docs/rescuetime.md) | App/website usage, productivity scores, categories | Pull (API) |
-| [**ActivityWatch**](docs/activitywatch.md) | App/window usage per device (desktop and Android) | Push (agent script) |
-| [**Last.fm**](docs/lastfm.md) | Music scrobbles with auto-generated tags from configurable rules | Pull (API) |
-| [**Calendars (ICS)**](docs/calendars.md) | Calendar events imported as tags (Google Calendar, Outlook, iCloud, Nextcloud, etc.) | Pull (ICS fetch) |
-| **Manual Entry** | Any metric, tag, activity, or note | Web UI, REST API, or MCP |
+| Source                                               | What it provides                                                                                       | Docs                         |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| [**Android Health Connect**](docs/health-connect.md) | Heart rate, HRV, sleep, exercise (80+ types), steps, weight, SpO2, VO2 max, calories, and more         | Push from Android app        |
+| **BLE Sensors**                                      | Real-time heart rate, HRV (Polar H10, etc.) and steps (Zwift RunPod, etc.)                             | Live via Android app         |
+| [**Oura Ring**](docs/oura.md)                        | Sleep stages/scores, readiness, resilience, cardiovascular age, HRV, heart rate, meditation, tags      | Pull (API) + Push (webhooks) |
+| [**Garmin Connect**](docs/garmin.md)                 | Daily summary, HR, HRV, sleep, stress, body battery, activities, SpO2, respiration, training readiness | Pull (session-based)         |
+| [**OwnTracks**](docs/owntracks.md)                   | GPS locations, geofences, place visits                                                                 | Push (HTTP mode)             |
+| [**RescueTime**](docs/rescuetime.md)                 | App/website usage, productivity scores, categories                                                     | Pull (API)                   |
+| [**ActivityWatch**](docs/activitywatch.md)           | App/window usage per device (desktop and Android)                                                      | Push (agent script)          |
+| [**Last.fm**](docs/lastfm.md)                        | Music scrobbles with auto-generated tags from configurable rules                                       | Pull (API)                   |
+| [**Calendars (ICS)**](docs/calendars.md)             | Calendar events imported as tags (Google Calendar, Outlook, iCloud, Nextcloud, etc.)                   | Pull (ICS fetch)             |
+| **Manual Entry**                                     | Any metric, tag, activity, or note                                                                     | Web UI, REST API, or MCP     |
 
 See [docs/data-sources.md](docs/data-sources.md) for setup overview.
 

--- a/apps/backend/coverage-baseline.json
+++ b/apps/backend/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "statements": 73.94,
   "branches": 65.79,
-  "functions": 69.49
+  "functions": 69.34
 }

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -191,12 +191,19 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   // Tool: recalculate_calories
   server.tool(
     'recalculate_calories',
-    'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback). Omit start/end to recompute all historical data.',
+    'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback). Omit start/end to recompute all historical data. Full recomputes run asynchronously and return immediately.',
     { ...recalculateCaloriesBodySchema.shape, end: z.string().optional(), start: z.string().optional() },
     async ({ start, end }) => {
       if (!start || !end) {
-        const result = await computeAndStoreCaloriesAll(user)
-        return jsonResponse({ ...result, success: true })
+        // Full recompute runs async — fire and forget, return immediately
+        computeAndStoreCaloriesAll(user).then(
+          (result) =>
+            console.log(
+              `🔥 Async calorie recompute done for ${user}: ${result.points_stored} points across ${result.days_processed} days`,
+            ),
+          (error) => console.error(`🔥 Async calorie recompute failed for ${user}:`, error),
+        )
+        return jsonResponse({ started: true, message: 'Full calorie recomputation started in background' })
       }
       const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
       return jsonResponse({ ...result, success: true })

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -30,7 +30,6 @@ import {
   queryMetricsQuerySchema,
   type QueryMetricsResponse,
   type RecalculateCaloriesBody,
-  recalculateCaloriesBodySchema,
   type RecalculateCaloriesResponse,
   type UpdateCustomMetricBody,
   updateCustomMetricBodySchema,
@@ -39,7 +38,7 @@ import { type RequestHandler, Router } from 'express'
 
 import { getUserSettings } from '../db/index.ts'
 import { isValidMetricOrCustom, type MetricType, validMetrics } from '../schema.ts'
-import { computeAndStoreCalories } from '../services/calorie-computation.ts'
+import { computeAndStoreCalories, computeAndStoreCaloriesAll } from '../services/calorie-computation.ts'
 import {
   addCustomMetric,
   addMetric,
@@ -160,13 +159,30 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics/recalculate-calories - Recalculate calorie burn from HR data
-  router.post<Record<string, never>, RecalculateCaloriesResponse, RecalculateCaloriesBody>(
+  // With start/end: synchronous range recompute. Without: async full recompute.
+  router.post<Record<string, never>, RecalculateCaloriesResponse, Partial<RecalculateCaloriesBody>>(
     '/metrics/recalculate-calories',
     authMiddleware,
-    validateBody(recalculateCaloriesBodySchema),
     async (req, res) => {
       const { start, end } = req.body
       const user = req.user!
+
+      if (!start || !end) {
+        // Full recompute runs async — fire and forget
+        computeAndStoreCaloriesAll(user).then(
+          (result) =>
+            console.log(
+              `🔥 Async calorie recompute done for ${user}: ${result.points_stored} points across ${result.days_processed} days`,
+            ),
+          (error) => console.error(`🔥 Async calorie recompute failed for ${user}:`, error),
+        )
+        return res.json({
+          points_computed: 0,
+          points_stored: 0,
+          skipped_reason: 'full recomputation started in background',
+          success: true,
+        })
+      }
 
       const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
       res.json({ ...result, success: true })

--- a/docs/features/correlations.md
+++ b/docs/features/correlations.md
@@ -32,13 +32,13 @@ Each table covers a different category of data:
 
 Every row displays:
 
-| Column | What it means |
-|---|---|
-| **HRV** | Your average HRV during or around that activity (in ms) |
-| **Delta HRV** | Difference from your baseline. Positive (green) = better than usual |
-| **HR** | Your average heart rate during or around that activity (in bpm) |
-| **Delta HR** | Difference from baseline. Negative (green) = lower than usual, which is typically better |
-| **Samples** | Total minutes of HR/HRV data collected |
+| Column        | What it means                                                                            |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| **HRV**       | Your average HRV during or around that activity (in ms)                                  |
+| **Delta HRV** | Difference from your baseline. Positive (green) = better than usual                      |
+| **HR**        | Your average heart rate during or around that activity (in bpm)                          |
+| **Delta HR**  | Difference from baseline. Negative (green) = lower than usual, which is typically better |
+| **Samples**   | Total minutes of HR/HRV data collected                                                   |
 
 ### Activity Impact Detail
 
@@ -76,6 +76,7 @@ The most powerful analysis tool. It supports compound triggers (multiple conditi
 ### Compound Triggers
 
 You can combine multiple conditions with AND logic. Each trigger can specify:
+
 - **What to match**: An activity type, tag, productivity category, or app name (regex patterns).
 - **Minimum count**: How many times the trigger must occur within the window (default: 1).
 - **Window**: Rolling window in days to count occurrences (default: 1 day).
@@ -100,12 +101,12 @@ Configurable time windows (e.g., 24h, 48h, 7d) determine how far after the trigg
 
 Correlation analysis requires **HRV and heart rate data** as the baseline metric. This comes from Oura, Garmin, or Health Connect. The richer your data, the more meaningful the correlations:
 
-| For correlating with... | You need... |
-|---|---|
-| Activities | Exercise/sleep/meditation data from Oura, Garmin, or Health Connect |
-| Locations | Place visits from OwnTracks |
-| Productivity | Screen time data from RescueTime or ActivityWatch |
-| Tags | Any tags -- manual, Oura, calendar imports, Last.fm auto-tags |
+| For correlating with... | You need...                                                         |
+| ----------------------- | ------------------------------------------------------------------- |
+| Activities              | Exercise/sleep/meditation data from Oura, Garmin, or Health Connect |
+| Locations               | Place visits from OwnTracks                                         |
+| Productivity            | Screen time data from RescueTime or ActivityWatch                   |
+| Tags                    | Any tags -- manual, Oura, calendar imports, Last.fm auto-tags       |
 
 Minimum data requirements vary by category: activities need at least 1 occurrence, tags need at least 2, locations need 30+ minutes of overlap, and productivity categories need 10+ minutes.
 
@@ -120,12 +121,12 @@ Different categories sample HRV from different time windows:
 
 ## Statistical Methods
 
-| Method | Used for | Description |
-|---|---|---|
-| **Pearson correlation (r)** | Productivity categories | Measures linear correlation between productivity score and HRV. Range: -1 to 1. |
-| **Delta from baseline** | All categories | Simple difference between the activity's mean HRV/HR and your overall baseline. |
-| **Relative risk** | Event probability, generic correlation | Ratio of P(outcome given trigger) to P(outcome without trigger). |
-| **Chi-squared test** | Event probability, generic correlation | Tests whether the trigger-outcome association is statistically significant. |
+| Method                      | Used for                               | Description                                                                     |
+| --------------------------- | -------------------------------------- | ------------------------------------------------------------------------------- |
+| **Pearson correlation (r)** | Productivity categories                | Measures linear correlation between productivity score and HRV. Range: -1 to 1. |
+| **Delta from baseline**     | All categories                         | Simple difference between the activity's mean HRV/HR and your overall baseline. |
+| **Relative risk**           | Event probability, generic correlation | Ratio of P(outcome given trigger) to P(outcome without trigger).                |
+| **Chi-squared test**        | Event probability, generic correlation | Tests whether the trigger-outcome association is statistically significant.     |
 
 ## Known Limitations
 

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -66,11 +66,11 @@ A clickable navigation tile with a colored icon and label. Links to any page in 
 
 Widgets are organized into sections, each with a title and a layout type:
 
-| Section type | Layout | Best for |
-|---|---|---|
-| **Metrics** | Responsive card grid (auto-fills columns, minimum 200px wide) | Metric cards, sparklines, activity summaries |
-| **Charts** | Single column, full width | Trend charts, correlation charts |
-| **Links** | Responsive grid of smaller tiles (minimum 140px wide) | Quick-link navigation |
+| Section type | Layout                                                        | Best for                                     |
+| ------------ | ------------------------------------------------------------- | -------------------------------------------- |
+| **Metrics**  | Responsive card grid (auto-fills columns, minimum 200px wide) | Metric cards, sparklines, activity summaries |
+| **Charts**   | Single column, full width                                     | Trend charts, correlation charts             |
+| **Links**    | Responsive grid of smaller tiles (minimum 140px wide)         | Quick-link navigation                        |
 
 Sections are collapsible -- click the section header to toggle between expanded and collapsed. On wide screens, multiple sections can appear side by side.
 
@@ -97,16 +97,16 @@ When adding a Metric Card or Sparkline Card, the metric picker shows a searchabl
 
 The dashboard works with whatever data sources you have connected. Widgets gracefully handle missing data -- a metric card with no data simply shows no value. The more sources you connect, the more useful the dashboard becomes:
 
-| Widget content | Data sources |
-|---|---|
-| HRV and resting HR baselines | Oura, Garmin, or Health Connect |
-| Sleep score | Oura |
-| Readiness score | Oura |
-| Steps | Garmin or Health Connect |
-| Zone 2 minutes | Any source providing HR during exercise |
-| Activity summary | Any activity source |
-| Trend charts | Depends on what you're trending (tags, metrics) |
-| Correlation impact | HRV data + the activity/tag you're analyzing |
+| Widget content               | Data sources                                    |
+| ---------------------------- | ----------------------------------------------- |
+| HRV and resting HR baselines | Oura, Garmin, or Health Connect                 |
+| Sleep score                  | Oura                                            |
+| Readiness score              | Oura                                            |
+| Steps                        | Garmin or Health Connect                        |
+| Zone 2 minutes               | Any source providing HR during exercise         |
+| Activity summary             | Any activity source                             |
+| Trend charts                 | Depends on what you're trending (tags, metrics) |
+| Correlation impact           | HRV data + the activity/tag you're analyzing    |
 
 ## Known Limitations
 

--- a/docs/features/goals.md
+++ b/docs/features/goals.md
@@ -14,11 +14,11 @@ Progress is the sum of the metric over the rolling window. For a 7-day window, t
 
 ### Examples
 
-| Goal | Metric | Min | Max | Window | Meaning |
-|---|---|---|---|---|---|
-| Zone 2 cardio | HR Zone 2 | 150 min | -- | 7d | At least 150 minutes of aerobic cardio per week |
-| Zone 5 intensity | HR Zone 5 | 5 min | 10 min | 7d | 5-10 minutes of max-effort work per week |
-| Weekly steps | Steps | 70,000 | -- | 7d | At least 70,000 steps per week (~10k/day) |
+| Goal             | Metric    | Min     | Max    | Window | Meaning                                         |
+| ---------------- | --------- | ------- | ------ | ------ | ----------------------------------------------- |
+| Zone 2 cardio    | HR Zone 2 | 150 min | --     | 7d     | At least 150 minutes of aerobic cardio per week |
+| Zone 5 intensity | HR Zone 5 | 5 min   | 10 min | 7d     | 5-10 minutes of max-effort work per week        |
+| Weekly steps     | Steps     | 70,000  | --     | 7d     | At least 70,000 steps per week (~10k/day)       |
 
 ## Default Goals
 
@@ -60,11 +60,11 @@ Goals are configured under **Data Sources > Aurboda (Web/API)** in the web UI.
 
 For each goal you can set:
 
-| Field | Description |
-|---|---|
-| **Metric** | Dropdown of all available metrics (60+ options) |
-| **Min** | Minimum target. For time-based metrics (HR zones), enter in minutes (stored as seconds internally) |
-| **Max** | Maximum target. Same display conversion. At least one of min or max required. |
+| Field      | Description                                                                                                                       |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Metric** | Dropdown of all available metrics (60+ options)                                                                                   |
+| **Min**    | Minimum target. For time-based metrics (HR zones), enter in minutes (stored as seconds internally)                                |
+| **Max**    | Maximum target. Same display conversion. At least one of min or max required.                                                     |
 | **Window** | Rolling window duration. Default `7d`. Supports: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), `M` (months) |
 
 Goals can be **drag-reordered** -- the order determines how they appear on the Goals page and in the Android widget. Changes save automatically.
@@ -87,14 +87,14 @@ The Android home screen widget shows the same goal progress as the web page. Eac
 
 Goals work with any metric in the system. The metric must have data within the rolling window for progress to appear. Common metric sources:
 
-| Metric type | Typical source |
-|---|---|
+| Metric type     | Typical source                                                |
+| --------------- | ------------------------------------------------------------- |
 | HR Zone minutes | Computed from exercise HR data (Oura, Garmin, Health Connect) |
-| Steps | Garmin, Health Connect |
-| Distance | Health Connect |
-| Calories | Computed from HR data or Health Connect |
-| Sleep score | Oura |
-| Weight | Manual entry, Health Connect |
+| Steps           | Garmin, Health Connect                                        |
+| Distance        | Health Connect                                                |
+| Calories        | Computed from HR data or Health Connect                       |
+| Sleep score     | Oura                                                          |
+| Weight          | Manual entry, Health Connect                                  |
 
 ## Known Limitations
 

--- a/docs/features/hr-zones.md
+++ b/docs/features/hr-zones.md
@@ -4,14 +4,14 @@ Aurboda tracks time spent in six heart rate zones during exercise, with weekly t
 
 ## The Six Zones
 
-| Zone | Name      | Color       | Description                     |
-| ---- | --------- | ----------- | ------------------------------- |
-| 0    | Rest      | Gray        | Below Zone 1 threshold          |
-| 1    | Warm-up   | Light blue  | Light activity, ~50% of max HR  |
-| 2    | Aerobic   | Green       | Steady-state cardio, ~60% of max HR |
-| 3    | Tempo     | Amber       | Comfortably hard, ~70% of max HR |
-| 4    | Threshold | Orange      | Hard effort, ~80% of max HR    |
-| 5    | Max effort| Red         | All-out sprints, ~90% of max HR |
+| Zone | Name       | Color      | Description                         |
+| ---- | ---------- | ---------- | ----------------------------------- |
+| 0    | Rest       | Gray       | Below Zone 1 threshold              |
+| 1    | Warm-up    | Light blue | Light activity, ~50% of max HR      |
+| 2    | Aerobic    | Green      | Steady-state cardio, ~60% of max HR |
+| 3    | Tempo      | Amber      | Comfortably hard, ~70% of max HR    |
+| 4    | Threshold  | Orange     | Hard effort, ~80% of max HR         |
+| 5    | Max effort | Red        | All-out sprints, ~90% of max HR     |
 
 Zone boundaries are defined by BPM thresholds. Everything below the Zone 1 threshold counts as Zone 0 (rest); everything at or above the Zone 5 threshold counts as Zone 5 (max effort).
 
@@ -42,14 +42,14 @@ You can always see which mode is active in Settings. The "Reset to defaults" but
 
 The HR Zones page displays progress toward weekly targets based on the **Galpin/Huberman protocol** -- exercise science recommendations for cardiovascular health and longevity:
 
-| Zone | Weekly target | Rationale |
-| ---- | ------------- | --------- |
-| 0    | --            | Not targeted |
-| 1    | 60 min        | Warm-up and recovery |
+| Zone | Weekly target | Rationale                                               |
+| ---- | ------------- | ------------------------------------------------------- |
+| 0    | --            | Not targeted                                            |
+| 1    | 60 min        | Warm-up and recovery                                    |
 | 2    | **200 min**   | Aerobic base building -- the cornerstone recommendation |
-| 3    | 60 min        | Tempo and lactate threshold work |
-| 4    | 30 min        | High-intensity threshold training |
-| 5    | **10 min**    | Brief max-effort intervals (sprints, VO2 max work) |
+| 3    | 60 min        | Tempo and lactate threshold work                        |
+| 4    | 30 min        | High-intensity threshold training                       |
+| 5    | **10 min**    | Brief max-effort intervals (sprints, VO2 max work)      |
 
 The key takeaway is 150-200 minutes per week in Zone 2 (easy, conversational-pace cardio) and 5-10 minutes per week in Zone 5 (all-out effort). These targets are also available as default Goals (see [Goals](goals.md)).
 
@@ -96,12 +96,12 @@ The Android home screen widget shows goal progress including zone targets. It up
 
 HR zone tracking requires **heart rate data during exercise**. This can come from:
 
-| Source | HR granularity | Zone accuracy |
-| --- | --- | --- |
-| BLE chest strap (Polar H10, etc.) via Android app | ~1 second | Excellent |
-| Health Connect (smartwatch HR) | Varies (1-60 seconds) | Good |
-| Oura Ring | ~5 minutes | Approximate |
-| Garmin Connect | ~15 seconds | Good |
+| Source                                            | HR granularity        | Zone accuracy |
+| ------------------------------------------------- | --------------------- | ------------- |
+| BLE chest strap (Polar H10, etc.) via Android app | ~1 second             | Excellent     |
+| Health Connect (smartwatch HR)                    | Varies (1-60 seconds) | Good          |
+| Oura Ring                                         | ~5 minutes            | Approximate   |
+| Garmin Connect                                    | ~15 seconds           | Good          |
 
 You also need exercise sessions recorded (from any source) so the system knows which HR data corresponds to a workout versus resting.
 

--- a/docs/features/lab-reports.md
+++ b/docs/features/lab-reports.md
@@ -18,15 +18,15 @@ Each report has:
 
 Each entry in a report stores:
 
-| Field | Description | Example |
-|---|---|---|
-| **Metric** | What was measured (free-form name) | `body_fat`, `ferritin`, `calcium` |
-| **Value** | The numeric result | `18.5`, `45.0`, `97.2` |
-| **Unit** | Measurement unit | `%`, `ng/mL`, `mg%` |
-| **Method** | How it was measured (optional) | `bia_segmental`, `blood_draw`, `hair_analysis` |
-| **Confidence** | Measurement reliability (optional) | `measured`, `estimated`, `derived` |
-| **Reference low/high** | Normal range (optional) | `30.0` - `400.0` for ferritin |
-| **Flag** | Out-of-range indicator (optional, auto-derived) | `normal`, `low`, `high`, `critical_low`, `critical_high` |
+| Field                  | Description                                     | Example                                                  |
+| ---------------------- | ----------------------------------------------- | -------------------------------------------------------- |
+| **Metric**             | What was measured (free-form name)              | `body_fat`, `ferritin`, `calcium`                        |
+| **Value**              | The numeric result                              | `18.5`, `45.0`, `97.2`                                   |
+| **Unit**               | Measurement unit                                | `%`, `ng/mL`, `mg%`                                      |
+| **Method**             | How it was measured (optional)                  | `bia_segmental`, `blood_draw`, `hair_analysis`           |
+| **Confidence**         | Measurement reliability (optional)              | `measured`, `estimated`, `derived`                       |
+| **Reference low/high** | Normal range (optional)                         | `30.0` - `400.0` for ferritin                            |
+| **Flag**               | Out-of-range indicator (optional, auto-derived) | `normal`, `low`, `high`, `critical_low`, `critical_high` |
 
 ### Automatic Flag Derivation
 
@@ -50,13 +50,13 @@ When a report is deleted, the corresponding time-series entries are cleanly remo
 
 ## Common Report Types
 
-| Type | Typical Metrics | Typical Method |
-|---|---|---|
-| **InBody scan** | weight, body_fat, bmi, skeletal_muscle_mass, ecw_ratio | bia_segmental |
-| **Blood panel** | ferritin, iron, b12, vitamin_d, testosterone, cortisol | blood_draw |
-| **Hair mineral analysis** | calcium, magnesium, sodium, potassium, zinc, copper | hair_analysis |
-| **DEXA scan** | body_fat, bone_density, lean_body_mass | dexa |
-| **Lipid panel** | total_cholesterol, ldl, hdl, triglycerides | blood_draw |
+| Type                      | Typical Metrics                                        | Typical Method |
+| ------------------------- | ------------------------------------------------------ | -------------- |
+| **InBody scan**           | weight, body_fat, bmi, skeletal_muscle_mass, ecw_ratio | bia_segmental  |
+| **Blood panel**           | ferritin, iron, b12, vitamin_d, testosterone, cortisol | blood_draw     |
+| **Hair mineral analysis** | calcium, magnesium, sodium, potassium, zinc, copper    | hair_analysis  |
+| **DEXA scan**             | body_fat, bone_density, lean_body_mass                 | dexa           |
+| **Lipid panel**           | total_cholesterol, ldl, hdl, triglycerides             | blood_draw     |
 
 Report types are completely free-form -- use any label that makes sense for your tests.
 
@@ -64,22 +64,22 @@ Report types are completely free-form -- use any label that makes sense for your
 
 ### MCP Tools
 
-| Tool | Description |
-|---|---|
-| `add_report` | Create a report with entries. All entries are written through to metrics. |
-| `get_report` | Fetch a single report with all entries. |
-| `query_reports` | List reports, optionally filtered by type and date range. |
-| `delete_report` | Delete a report and its write-through metric data. |
+| Tool                | Description                                                                         |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `add_report`        | Create a report with entries. All entries are written through to metrics.           |
+| `get_report`        | Fetch a single report with all entries.                                             |
+| `query_reports`     | List reports, optionally filtered by type and date range.                           |
+| `delete_report`     | Delete a report and its write-through metric data.                                  |
 | `get_latest_metric` | Get the most recent value for any metric (useful for "what was my last ferritin?"). |
 
 ### REST API
 
-| Method | Path | Description |
-|---|---|---|
-| `POST` | `/reports` | Create a report with entries |
-| `GET` | `/reports` | Query reports (filter by type, date range) |
-| `GET` | `/reports/:id` | Get a single report |
-| `DELETE` | `/reports/:id` | Delete a report and metric data |
+| Method   | Path           | Description                                |
+| -------- | -------------- | ------------------------------------------ |
+| `POST`   | `/reports`     | Create a report with entries               |
+| `GET`    | `/reports`     | Query reports (filter by type, date range) |
+| `GET`    | `/reports/:id` | Get a single report                        |
+| `DELETE` | `/reports/:id` | Delete a report and metric data            |
 
 ## Known Limitations
 

--- a/docs/features/places.md
+++ b/docs/features/places.md
@@ -23,12 +23,12 @@ Between consecutive visits, **transit** entries appear as dashed connectors show
 
 ### Source Types
 
-| Source | Color | Description |
-|---|---|---|
-| **Named** | Green | Locations you've named (e.g., "Home", "Gym") |
-| **Detected** | Orange | Automatically detected frequent locations with geocoded addresses |
-| **OwnTracks** | Blue | Identified by OwnTracks geofence regions |
-| **Unknown** | Gray | Unidentified locations, shown as "Somewhere" |
+| Source        | Color  | Description                                                       |
+| ------------- | ------ | ----------------------------------------------------------------- |
+| **Named**     | Green  | Locations you've named (e.g., "Home", "Gym")                      |
+| **Detected**  | Orange | Automatically detected frequent locations with geocoded addresses |
+| **OwnTracks** | Blue   | Identified by OwnTracks geofence regions                          |
+| **Unknown**   | Gray   | Unidentified locations, shown as "Somewhere"                      |
 
 ### Map
 

--- a/docs/features/screentime-categories.md
+++ b/docs/features/screentime-categories.md
@@ -35,6 +35,7 @@ Removes the category and all its children. Triggers recategorization.
 ### Load defaults
 
 Pre-built categories compatible with ActivityWatch:
+
 - **Work** (green, Very Productive) -- with subcategories for Programming, Image, Video, Audio, 3D
 - **Media** (red, Distracting) -- with Games, Video, Social Media, Music
 - **Comms** (cyan, Neutral) -- with IM and Email
@@ -77,11 +78,11 @@ When clicking a screen time record, the detail page shows the resolved category 
 
 Screen time data from at least one source:
 
-| Source | What it provides |
-|---|---|
-| **RescueTime** | App and website usage with built-in productivity scores. Categories override RescueTime's own scoring. |
-| **ActivityWatch Desktop** | Window-level app usage from desktop. Pushed via agent script. |
-| **ActivityWatch Android** | App usage from Android phone. |
+| Source                    | What it provides                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **RescueTime**            | App and website usage with built-in productivity scores. Categories override RescueTime's own scoring. |
+| **ActivityWatch Desktop** | Window-level app usage from desktop. Pushed via agent script.                                          |
+| **ActivityWatch Android** | App usage from Android phone.                                                                          |
 
 Categories apply equally to data from all sources.
 

--- a/docs/features/sleep.md
+++ b/docs/features/sleep.md
@@ -72,13 +72,13 @@ Sleep dates use the **wake-up convention**: a session starting at 11pm on March 
 
 ## What Data It Needs
 
-| Feature | Data source |
-|---|---|
-| Sleep sessions | Oura, Garmin, or Health Connect |
-| Sleep stages (hypnogram) | Health Connect (via Oura/Garmin or watch) |
+| Feature                     | Data source                                      |
+| --------------------------- | ------------------------------------------------ |
+| Sleep sessions              | Oura, Garmin, or Health Connect                  |
+| Sleep stages (hypnogram)    | Health Connect (via Oura/Garmin or watch)        |
 | Sleep scores and components | Oura (primary source), Garmin (sleep score only) |
-| HR/HRV during sleep | Oura, Garmin, or Health Connect |
-| Sleep location | OwnTracks |
+| HR/HRV during sleep         | Oura, Garmin, or Health Connect                  |
+| Sleep location              | OwnTracks                                        |
 
 The Sleep page works with any sleep source, but Oura provides the richest data (scores, sub-components, stages).
 

--- a/docs/features/timeline.md
+++ b/docs/features/timeline.md
@@ -70,6 +70,7 @@ The music track only appears when you have Last.fm configured.
 ### Heart Rate and HRV
 
 In **horizontal mode**, these appear as ribbon charts in the Metrics lane:
+
 - **Heart rate** as a red band showing the average with a min-max area fill (range 40-200 bpm).
 - **HRV** as a green/teal band with a dynamic range.
 

--- a/docs/features/training-load.md
+++ b/docs/features/training-load.md
@@ -38,12 +38,12 @@ Training stress from general daily movement (active calories). Converted from ca
 
 Once you have about 6 weeks of training data, recovery zones appear as colored horizontal bands on the Timeline. They classify your current fatigue relative to your historical fitness:
 
-| Zone | Meaning | Visual |
-|---|---|---|
-| **Undertrained** | Not training enough to maintain current fitness | Blue tint |
-| **Balanced** | Optimal training range | Green tint |
-| **Strained** | Elevated fatigue, risk of overreaching | Orange tint |
-| **Very Strained** | Very high fatigue, high overtraining risk | Red tint |
+| Zone              | Meaning                                         | Visual      |
+| ----------------- | ----------------------------------------------- | ----------- |
+| **Undertrained**  | Not training enough to maintain current fitness | Blue tint   |
+| **Balanced**      | Optimal training range                          | Green tint  |
+| **Strained**      | Elevated fatigue, risk of overreaching          | Orange tint |
+| **Very Strained** | Very high fatigue, high overtraining risk       | Red tint    |
 
 Zone boundaries are based on your average CTL: balanced is 0.8x to 1.3x, strained is 1.3x to 1.7x, very strained is above 1.7x.
 
@@ -73,26 +73,26 @@ This is because the 42-day CTL time constant needs approximately 42 days of data
 
 Training load settings can be adjusted in user settings:
 
-| Setting | Default | Description |
-|---|---|---|
-| **Max HR** | Auto-detected | Overrides the maximum heart rate used for TRIMP calculation. Falls back to: highest observed HR in the last year, then 220 - age, then 190 bpm. |
-| **Resting HR** | Auto-detected | Overrides resting HR. Falls back to: most recent resting HR metric, then 60 bpm. |
-| **Acute time constant** | 7 days | Controls how quickly the fatigue (ATL) EMA responds. Lower = more responsive. |
-| **Chronic time constant** | 42 days | Controls how quickly the fitness (CTL) EMA responds. Lower = more responsive. |
-| **Activity impulse scale** | 0.1 | Converts active calories to impulse units. |
+| Setting                    | Default       | Description                                                                                                                                     |
+| -------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Max HR**                 | Auto-detected | Overrides the maximum heart rate used for TRIMP calculation. Falls back to: highest observed HR in the last year, then 220 - age, then 190 bpm. |
+| **Resting HR**             | Auto-detected | Overrides resting HR. Falls back to: most recent resting HR metric, then 60 bpm.                                                                |
+| **Acute time constant**    | 7 days        | Controls how quickly the fatigue (ATL) EMA responds. Lower = more responsive.                                                                   |
+| **Chronic time constant**  | 42 days       | Controls how quickly the fitness (CTL) EMA responds. Lower = more responsive.                                                                   |
+| **Activity impulse scale** | 0.1           | Converts active calories to impulse units.                                                                                                      |
 
 The TRIMP formula uses a sex-dependent weighting constant (k-factor): 1.92 for males, 1.67 for females. This is automatically selected based on your biological sex setting.
 
 ## What Data It Needs
 
-| Input | Source | Used for |
-|---|---|---|
-| Exercise sessions | Oura, Garmin, Health Connect | TRIMP calculation (with HR data) |
-| Heart rate during exercise | Any HR source overlapping exercise sessions | Accurate TRIMP scoring |
-| Active calories | Health Connect aggregate, HR-computed | Activity impulse |
-| Resting heart rate | Oura, Garmin, Health Connect | TRIMP baseline |
-| Max heart rate | Observed from data, or manual setting | TRIMP scaling |
-| Biological sex | User settings | TRIMP k-factor selection |
+| Input                      | Source                                      | Used for                         |
+| -------------------------- | ------------------------------------------- | -------------------------------- |
+| Exercise sessions          | Oura, Garmin, Health Connect                | TRIMP calculation (with HR data) |
+| Heart rate during exercise | Any HR source overlapping exercise sessions | Accurate TRIMP scoring           |
+| Active calories            | Health Connect aggregate, HR-computed       | Activity impulse                 |
+| Resting heart rate         | Oura, Garmin, Health Connect                | TRIMP baseline                   |
+| Max heart rate             | Observed from data, or manual setting       | TRIMP scaling                    |
+| Biological sex             | User settings                               | TRIMP k-factor selection         |
 
 Training load works with just exercise sessions (using duration fallback), but is most accurate with heart rate data during workouts.
 

--- a/docs/features/trends.md
+++ b/docs/features/trends.md
@@ -8,11 +8,11 @@ The Trends page lets you configure and save multiple trend cards. Trends also ap
 
 EMA is a weighted average where recent data counts more than old data. The **half-life** controls how quickly old data fades:
 
-| Half-life | Label | Behavior |
-|---|---|---|
-| **7 days** | Quick | Responds fast to changes. A week of new behavior dominates. Good for daily habits like coffee. |
-| **15 days** | Responsive | Balanced default. Smooths out noise but reflects changes within ~2 weeks. |
-| **30 days** | Stable | Very smooth line. Short-term spikes are flattened. Good for slow-moving things like weight. |
+| Half-life   | Label      | Behavior                                                                                       |
+| ----------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| **7 days**  | Quick      | Responds fast to changes. A week of new behavior dominates. Good for daily habits like coffee. |
+| **15 days** | Responsive | Balanced default. Smooths out noise but reflects changes within ~2 weeks.                      |
+| **30 days** | Stable     | Very smooth line. Short-term spikes are flattened. Good for slow-moving things like weight.    |
 
 After one half-life, old data has 50% weight. After two half-lives, 25%. After three, 12.5%. So a 15-day half-life means data from 45 days ago has essentially no influence.
 
@@ -41,15 +41,15 @@ The trend value is shown as "hours per day" (or per week/month).
 
 When adding or editing a trend, you can configure:
 
-| Option | Choices | What it does |
-|---|---|---|
-| **Name** | Free text | Display name for the trend card. Defaults to the pattern if blank. |
-| **Source type** | Tag, Metric, Screentime Category | What data to trend. |
-| **Pattern** | Tag picker (multi-select), Metric picker, or Category picker | What to match. Tags support regex with multiple selections joined by `\|`. |
-| **Half-life** | 7 (Quick), 15 (Responsive), 30 (Stable) | How quickly old data fades. See table above. |
-| **Lookback** | 30 days to 5 years, or All time | How far back the chart extends. |
-| **Display as** | Per day, Per week, Per month | Rate normalization. Same data, different scale. |
-| **Aggregation** | Average, Sum (metrics only) | Whether to average or total daily metric values. |
+| Option          | Choices                                                      | What it does                                                               |
+| --------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| **Name**        | Free text                                                    | Display name for the trend card. Defaults to the pattern if blank.         |
+| **Source type** | Tag, Metric, Screentime Category                             | What data to trend.                                                        |
+| **Pattern**     | Tag picker (multi-select), Metric picker, or Category picker | What to match. Tags support regex with multiple selections joined by `\|`. |
+| **Half-life**   | 7 (Quick), 15 (Responsive), 30 (Stable)                      | How quickly old data fades. See table above.                               |
+| **Lookback**    | 30 days to 5 years, or All time                              | How far back the chart extends.                                            |
+| **Display as**  | Per day, Per week, Per month                                 | Rate normalization. Same data, different scale.                            |
+| **Aggregation** | Average, Sum (metrics only)                                  | Whether to average or total daily metric values.                           |
 
 ## The Trends Page
 
@@ -64,11 +64,11 @@ The `/trends` page shows a grid of your saved trend cards. Each card displays:
 
 New users start with three presets:
 
-| Name | Type | Pattern | Half-life | Display |
-|---|---|---|---|---|
-| Painkillers | Tag | `pain_killer\|painkiller\|ibuprofen` | 15 days | Per month |
-| Coffee | Tag | `coffee` | 7 days | Per day |
-| Weight | Metric | `weight` | 14 days | Per day |
+| Name        | Type   | Pattern                              | Half-life | Display   |
+| ----------- | ------ | ------------------------------------ | --------- | --------- |
+| Painkillers | Tag    | `pain_killer\|painkiller\|ibuprofen` | 15 days   | Per month |
+| Coffee      | Tag    | `coffee`                             | 7 days    | Per day   |
+| Weight      | Metric | `weight`                             | 14 days   | Per day   |
 
 You can add, edit, or remove trends freely. The "Reset" button restores the defaults.
 
@@ -96,11 +96,11 @@ Trend charts can be added as widgets on the Dashboard. Configure the source type
 
 Trends work with whatever data you have:
 
-| Source type | Needs |
-|---|---|
-| Tags | Any tags -- manual, Oura, calendar imports, Last.fm auto-tags |
-| Metrics | Time series data from any source (Oura, Garmin, Health Connect, manual) |
-| Screentime | Productivity data from RescueTime or ActivityWatch |
+| Source type | Needs                                                                   |
+| ----------- | ----------------------------------------------------------------------- |
+| Tags        | Any tags -- manual, Oura, calendar imports, Last.fm auto-tags           |
+| Metrics     | Time series data from any source (Oura, Garmin, Health Connect, manual) |
+| Screentime  | Productivity data from RescueTime or ActivityWatch                      |
 
 The more historical data you have, the more useful long lookback periods become. A 30-day lookback with only 10 days of data will look sparse.
 


### PR DESCRIPTION
## Summary

- Full calorie recalculation (omit start/end) now runs asynchronously, returning immediately instead of timing out
- Range-specific recalculation (with start/end) remains synchronous

## Problem

The `recalculate_calories` MCP tool and REST endpoint timed out when doing a full historical recompute, since processing months/years of HR data exceeds both MCP and HTTP request timeouts.

## Changes

- **MCP tool** (`metric-tools.ts`): When `start`/`end` are omitted, fires off `computeAndStoreCaloriesAll` as a background promise and returns `{ started: true, message: "..." }` immediately
- **REST endpoint** (`metrics-router.ts`): Same async pattern when `start`/`end` are absent; returns `{ success: true, skipped_reason: "full recomputation started in background" }`. Validation middleware removed since body fields are now optional.