### PR TITLE
feat: search filter and sort-by-recent for uncategorized apps list

### DIFF
--- a/apps/backend/src/db/productivity.integration.test.ts
+++ b/apps/backend/src/db/productivity.integration.test.ts
@@ -397,18 +397,20 @@ describe('Productivity Integration Tests', () => {
       const apps = await getDistinctApps(user)
       expect(apps).toHaveLength(2)
 
-      // Sorted by total duration desc, so vscode (900s) first
-      expect(apps[0].activity).toBe('vscode')
-      expect(apps[0].title).toBe('main.ts — myproject')
-      expect(apps[0].resolved_category).toEqual(['Work', 'Programming'])
-      expect(apps[0].total_duration_sec).toBe(900)
-      expect(apps[0].record_count).toBe(2)
+      // Sorted by last_seen desc, so firefox (10:15) first, vscode (10:05) second
+      expect(apps[0].activity).toBe('firefox')
+      expect(apps[0].title).toBeUndefined()
+      expect(apps[0].resolved_category).toBeUndefined()
+      expect(apps[0].total_duration_sec).toBe(120)
+      expect(apps[0].record_count).toBe(1)
+      expect(apps[0].last_seen).toBeDefined()
 
-      expect(apps[1].activity).toBe('firefox')
-      expect(apps[1].title).toBeUndefined()
-      expect(apps[1].resolved_category).toBeUndefined()
-      expect(apps[1].total_duration_sec).toBe(120)
-      expect(apps[1].record_count).toBe(1)
+      expect(apps[1].activity).toBe('vscode')
+      expect(apps[1].title).toBe('main.ts — myproject')
+      expect(apps[1].resolved_category).toEqual(['Work', 'Programming'])
+      expect(apps[1].total_duration_sec).toBe(900)
+      expect(apps[1].record_count).toBe(2)
+      expect(apps[1].last_seen).toBeDefined()
     })
 
     test('groups separately by title (e.g. browser with different window titles)', async () => {

--- a/apps/backend/src/db/productivity.ts
+++ b/apps/backend/src/db/productivity.ts
@@ -192,21 +192,24 @@ export const getDistinctApps = async (
     resolved_category?: string[]
     total_duration_sec: number
     record_count: number
+    last_seen: Date
   }>
 > => {
   const result = await query(
     user,
     `SELECT activity, title, resolved_category,
             SUM(duration_sec)::int AS total_duration_sec,
-            COUNT(*)::int AS record_count
+            COUNT(*)::int AS record_count,
+            MAX(start_time) AS last_seen
      FROM productivity
      WHERE deleted_at IS NULL
      GROUP BY activity, title, resolved_category
-     ORDER BY SUM(duration_sec) DESC`,
+     ORDER BY MAX(start_time) DESC`,
   )
 
   return result.rows.map((row) => ({
     activity: row.activity,
+    last_seen: new Date(row.last_seen as string),
     record_count: row.record_count,
     resolved_category: row.resolved_category || undefined,
     title: row.title || undefined,

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -538,19 +538,20 @@ function MatchedAppList({
 }
 
 // Simplified uncategorized list (the AddConfirmDialog is imported from the previous version)
+const MAX_UNCATEGORIZED_SHOWN = 30
+
 function UncategorizedAppList({
   apps,
   category,
-  total,
   onAppAdded,
 }: {
   apps: DistinctApp[]
   category: ScreentimeCategory
-  total: number
   onAppAdded: () => void
 }) {
   const queryClient = useQueryClient()
   const [confirmingApp, setConfirmingApp] = useState<DistinctApp | null>(null)
+  const [search, setSearch] = useState('')
 
   const addMutation = useMutation({
     mutationFn: async (term: string) => {
@@ -568,18 +569,42 @@ function UncategorizedAppList({
     },
   })
 
-  if (total === 0) return null
+  if (apps.length === 0) return null
 
-  const headerTitle =
-    total > apps.length ? `Uncategorized apps (showing ${apps.length} of ${total})` : 'Uncategorized apps'
+  // Filter by search term (case-insensitive match on activity + title)
+  const lowerSearch = search.toLowerCase()
+  const filtered = search
+    ? apps.filter(
+        (app) =>
+          app.activity.toLowerCase().includes(lowerSearch) ||
+          (app.title && app.title.toLowerCase().includes(lowerSearch)),
+      )
+    : apps
+
+  const shown = filtered.slice(0, MAX_UNCATEGORIZED_SHOWN)
+  const hiddenCount = filtered.length - shown.length
 
   return (
     <div class="category-section">
       <h3>
-        {headerTitle} <span class="count-badge">{total}</span>
+        Uncategorized apps <span class="count-badge">{apps.length}</span>
       </h3>
+      <div class="uncategorized-search">
+        <input
+          type="text"
+          value={search}
+          onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
+          placeholder="Search apps..."
+          class="auto-save-input"
+        />
+        {search && filtered.length !== apps.length && (
+          <span class="uncategorized-filter-count">
+            {filtered.length} match{filtered.length !== 1 ? 'es' : ''}
+          </span>
+        )}
+      </div>
       <div class="app-list">
-        {apps.map((app) => (
+        {shown.map((app) => (
           <div key={`${app.activity}\x00${app.title ?? ''}`} class="app-row">
             <div class="app-name-col">
               <span class="app-name">{app.activity}</span>
@@ -601,6 +626,9 @@ function UncategorizedAppList({
           </div>
         ))}
       </div>
+      {hiddenCount > 0 && (
+        <p class="uncategorized-more">{hiddenCount} more — refine your search to see them</p>
+      )}
       {confirmingApp && (
         <AddConfirmDialog
           app={confirmingApp}
@@ -1103,12 +1131,7 @@ function ExistingCategoryPage({
       <CategoryTrendSection categoryPath={category.name.join(' > ')} color={category.color ?? '#673ab8'} />
       <ChildCategoriesList children={children} distinctApps={distinctApps} icons={icons} />
       <MatchedAppList apps={matchedApps} category={category} onAppRemoved={onFieldSaved} />
-      <UncategorizedAppList
-        apps={uncategorized.slice(0, 30)}
-        category={category}
-        total={uncategorized.length}
-        onAppAdded={onFieldSaved}
-      />
+      <UncategorizedAppList apps={uncategorized} category={category} onAppAdded={onFieldSaved} />
 
       <div class="category-footer">
         <a href="/screentime-categories" class="manage-link">

--- a/apps/web/src/pages/ScreentimeCategories/style.css
+++ b/apps/web/src/pages/ScreentimeCategories/style.css
@@ -282,6 +282,27 @@
   color: #6b7280;
 }
 
+/* Uncategorized apps search */
+.uncategorized-search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.uncategorized-filter-count {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  white-space: nowrap;
+}
+
+.uncategorized-more {
+  font-size: 0.8rem;
+  color: #9ca3af;
+  font-style: italic;
+  margin-top: 0.5rem;
+}
+
 /* Children list */
 .children-list {
   display: flex;

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -304,6 +304,7 @@ export interface DistinctApp {
   resolved_category?: string[]
   total_duration_sec: number
   record_count: number
+  last_seen?: string
 }
 
 export const fetchDistinctApps = async (): Promise<DistinctApp[]> => {


### PR DESCRIPTION
## Summary

Two improvements to the uncategorized apps list on the category detail page:

### 1. Search filter
With 1400+ uncategorized apps, showing only the first 30 was unhelpful. Now there's a search input that filters by activity name and window title (case-insensitive). Shows at most 30 matching results with a "N more — refine your search" hint.

### 2. Sort by recently used
Previously sorted by total duration (heaviest users first). Now sorted by `last_seen` (MAX start_time) so recently active apps appear first — more useful for categorizing what you just used.

### Changes
- **Backend**: `getDistinctApps` adds `MAX(start_time) AS last_seen` and `ORDER BY MAX(start_time) DESC`
- **Frontend**: Search input, client-side filtering, removed pre-slicing (all apps passed to component, filtered + capped at 30 in render)