### PR TITLE
fix: align calorie bars with screentime and fix tooltip bucket size

### DIFF
--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -12,7 +12,7 @@ import { format } from 'date-fns'
 
 import type { ScreentimeBucketParsed } from '../../state/api'
 
-import { type MetricBucketParsed, aggregateBuckets } from '../../utils/chart'
+import { type MetricBucketParsed, aggregateBuckets, aggregateBucketsAligned } from '../../utils/chart'
 import { type BarLayoutResult, slotPixels } from './barLayout'
 import { buildScreentimeTooltipHtml, findScreentimeBucket } from './drawScreentimeTrack'
 import {
@@ -105,14 +105,13 @@ const getAggregationFactor = (pixelsPerHour: number, buckets: MetricBucketParsed
 }
 
 /**
- * Compute the aggregation factor to bring metric buckets to the target bar bucket size.
- * E.g., if buckets are 5m and target is 1h (3600000ms), factor = 12.
+ * Check if bar buckets need time-aligned aggregation.
+ * Returns true if the native bucket size is smaller than the target bar bucket size.
  */
-const computeBarAggregationFactor = (buckets: MetricBucketParsed[], barBucketMs?: number): number => {
-  if (!barBucketMs || buckets.length < 2) return 1
+const needsBarAggregation = (buckets: MetricBucketParsed[], barBucketMs?: number): boolean => {
+  if (!barBucketMs || buckets.length < 2) return false
   const bucketMs = buckets[1]!.start.getTime() - buckets[0]!.start.getTime()
-  if (bucketMs >= barBucketMs) return 1
-  return Math.round(barBucketMs / bucketMs)
+  return bucketMs < barBucketMs
 }
 
 // ── Gap detection ─────────────────────────────────────────────────────────────
@@ -427,6 +426,7 @@ export const computeYScales = (
   buckets: MetricBucketParsed[],
   trackY: number,
   trackBottom: number,
+  barBuckets?: MetricBucketParsed[],
 ): MetricsYScales => {
   // HR: fixed domain
   const yHr = d3.scaleLinear().domain([40, 200]).range([trackBottom, trackY])
@@ -449,15 +449,16 @@ export const computeYScales = (
     .nice()
     .range([trackBottom, trackY])
 
-  // Steps: dynamic domain
-  const stepsMax = getMetricMax(buckets, 'steps', 1000)
+  // Steps: dynamic domain (use bar-aggregated data for correct scale)
+  const barData = barBuckets ?? buckets
+  const stepsMax = getMetricMax(barData, 'steps', 1000)
   const ySteps = d3
     .scaleLinear()
     .domain([0, stepsMax * 1.1])
     .range([trackBottom, trackY])
 
-  // Calories: dynamic domain
-  const calMax = getMetricMax(buckets, 'calories_active', 100)
+  // Calories: dynamic domain (use bar-aggregated data for correct scale)
+  const calMax = getMetricMax(barData, 'calories_active', 100)
   const yCal = d3
     .scaleLinear()
     .domain([0, calMax * 1.1])
@@ -466,12 +467,50 @@ export const computeYScales = (
   return { yCal, yHr, yHrv, ySteps }
 }
 
+// ── Crosshair helpers ─────────────────────────────────────────────────────────
+
+/** Binary search for the bucket containing the given timestamp. */
+const findBucketAt = (bs: MetricBucketParsed[], timeMs: number): MetricBucketParsed | null => {
+  let lo = 0
+  let hi = bs.length - 1
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1
+    const b = bs[mid]!
+    if (timeMs < b.start.getTime()) hi = mid - 1
+    else if (timeMs >= b.end.getTime()) lo = mid + 1
+    else return b
+  }
+  return null
+}
+
+/**
+ * Build a tooltip bucket by merging bar-aligned data (for calories/steps time range)
+ * with fine-grained line data (for precise HR/HRV values).
+ */
+const buildTooltipBucket = (
+  barBucket: MetricBucketParsed | null,
+  lineBucket: MetricBucketParsed | null,
+): MetricBucketParsed | null => {
+  const base = barBucket ?? lineBucket
+  if (!base) return null
+  if (!barBucket || !lineBucket || barBucket === lineBucket) return base
+  return {
+    ...barBucket,
+    metrics: {
+      ...barBucket.metrics,
+      ...(lineBucket.metrics.heart_rate && { heart_rate: lineBucket.metrics.heart_rate }),
+      ...(lineBucket.metrics.hrv_rmssd && { hrv_rmssd: lineBucket.metrics.hrv_rmssd }),
+    },
+  }
+}
+
 // ── Crosshair overlay ─────────────────────────────────────────────────────────
 
 const drawCrosshairOverlay = (
   outerG: SvgGroup,
   xScale: d3.ScaleTime<number, number>,
   buckets: MetricBucketParsed[],
+  barBuckets: MetricBucketParsed[],
   trackY: number,
   trackHeight: number,
   chartWidth: number,
@@ -516,32 +555,18 @@ const drawCrosshairOverlay = (
       const hoverTime = xScale.invert(mx!)
       const hoverMs = hoverTime.getTime()
 
-      // Binary search for the bucket containing hoverTime (start <= hoverTime < end)
-      let nearest: MetricBucketParsed | null = null
-      if (buckets.length > 0) {
-        let lo = 0
-        let hi = buckets.length - 1
-        while (lo <= hi) {
-          const mid = (lo + hi) >>> 1
-          const b = buckets[mid]!
-          if (hoverMs < b.start.getTime()) {
-            hi = mid - 1
-          } else if (hoverMs >= b.end.getTime()) {
-            lo = mid + 1
-          } else {
-            nearest = b
-            break
-          }
-        }
-      }
+      // Find the bar-aligned bucket (for time header + calories/steps) and fine bucket (for HR/HRV)
+      const barBucket = barBuckets.length > 0 ? findBucketAt(barBuckets, hoverMs) : null
+      const lineBucket = buckets.length > 0 ? findBucketAt(buckets, hoverMs) : null
+      const tooltipBucket = buildTooltipBucket(barBucket, lineBucket)
 
       // Build tooltip: use metric bucket if available, otherwise training-load-only
       let html: string | null = null
-      if (nearest) {
-        const bucketDuration = nearest.end.getTime() - nearest.start.getTime()
+      if (tooltipBucket) {
+        const bucketDuration = tooltipBucket.end.getTime() - tooltipBucket.start.getTime()
         const tolerance = Math.max(2 * 3600_000, bucketDuration)
         html = buildMetricsTooltipHtml(
-          nearest,
+          tooltipBucket,
           showHR,
           showHRV,
           showSteps,
@@ -685,9 +710,10 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
   const lineFactor = getAggregationFactor(pixelsPerHour, rawBuckets)
   const buckets = aggregateBuckets(rawBuckets, lineFactor)
 
-  // Aggregate for bar charts (steps/calories) — coarser, matching barBucketMs
-  const barFactor = computeBarAggregationFactor(rawBuckets, config.barBucketMs)
-  const barBuckets = barFactor !== lineFactor ? aggregateBuckets(rawBuckets, barFactor) : buckets
+  // Aggregate for bar charts (steps/calories) — time-aligned to match screentime/training load
+  const barBuckets = needsBarAggregation(rawBuckets, config.barBucketMs)
+    ? aggregateBucketsAligned(rawBuckets, config.barBucketMs!)
+    : buckets
 
   const trackBottom = trackY + trackHeight
 
@@ -713,6 +739,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     outerG,
     xScale,
     buckets,
+    barBuckets,
     trackY,
     trackHeight,
     chartWidth,

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -27,7 +27,7 @@ import {
   fetchTrainingLoad,
   fetchUserSettings,
 } from '../../state/api'
-import { parseBucketedResponse } from '../../utils/chart'
+import { aggregateBucketsAligned, parseBucketedResponse } from '../../utils/chart'
 import { isEmoji, isUrl } from '../../utils/emojiLookup'
 import { packLanes } from '../../utils/lanePacking'
 import { buildActivityColumnItems, EXCLUDED_TAG_PREFIXES, EXCLUDED_TAG_SOURCES } from './activityMerge'
@@ -1418,8 +1418,18 @@ export const Timeline = () => {
 
     // Compute Y-scales once (stable per render, only depends on data, not zoom)
     const metricsTrackBottom = trackMetrics + metricsTrackHeight
+    // Pre-compute bar-aggregated buckets for Y-scale computation (so calorie/steps scales
+    // match the actual bar values, not the finer line-chart bucket peaks)
+    const barBucketMs = barBucketSize === '1w' ? 7 * 86400000 : barBucketSize === '1d' ? 86400000 : 3600000
+    const barAggBuckets =
+      metricBuckets.length >= 2 &&
+      metricBuckets[1]!.start.getTime() - metricBuckets[0]!.start.getTime() < barBucketMs
+        ? aggregateBucketsAligned(metricBuckets, barBucketMs)
+        : metricBuckets
     const metricsYScales =
-      metricBuckets.length > 0 ? computeYScales(metricBuckets, trackMetrics, metricsTrackBottom) : null
+      metricBuckets.length > 0
+        ? computeYScales(metricBuckets, trackMetrics, metricsTrackBottom, barAggBuckets)
+        : null
 
     // Combine activity items and all non-hidden tags (point and duration) into the activity lane
     const visibleActivityItems = activityItems.filter((i) => !isItemHidden(i))
@@ -1802,7 +1812,7 @@ export const Timeline = () => {
             ? { yScales: metricsYScales }
             : { yScales: computeYScales([], trackMetrics, trackMetrics + metricsTrackHeight) }),
           xScale: currentXScale,
-          barBucketMs: barBucketSize === '1w' ? 7 * 86400000 : barBucketSize === '1d' ? 86400000 : 3600000,
+          barBucketMs,
           barLayout,
           caloriesSlotId: 'calories',
           stepsSlotId: 'steps',

--- a/apps/web/src/utils/chart.ts
+++ b/apps/web/src/utils/chart.ts
@@ -114,3 +114,95 @@ export const aggregateBuckets = (buckets: MetricBucketParsed[], factor: number):
 
   return result
 }
+
+/**
+ * Aggregate buckets into time-aligned windows (e.g., align to hour boundaries).
+ * Unlike `aggregateBuckets` which groups by consecutive index, this groups buckets
+ * by which target window they fall into, ensuring alignment with other data sources
+ * (screentime, training load) that use clean time boundaries.
+ *
+ * @param buckets - Pre-sorted array of metric buckets
+ * @param windowMs - Target window size in ms (e.g. 3600000 for 1 hour)
+ * @returns Aggregated buckets aligned to window boundaries
+ */
+export const aggregateBucketsAligned = (
+  buckets: MetricBucketParsed[],
+  windowMs: number,
+): MetricBucketParsed[] => {
+  if (buckets.length === 0) return []
+
+  const result: MetricBucketParsed[] = []
+  let currentWindowStart = Math.floor(buckets[0]!.start.getTime() / windowMs) * windowMs
+  let chunk: MetricBucketParsed[] = []
+
+  for (const bucket of buckets) {
+    const bucketWindowStart = Math.floor(bucket.start.getTime() / windowMs) * windowMs
+
+    if (bucketWindowStart !== currentWindowStart) {
+      // Flush the previous window
+      if (chunk.length > 0) {
+        result.push(
+          mergeBucketChunk(chunk, new Date(currentWindowStart), new Date(currentWindowStart + windowMs)),
+        )
+      }
+      currentWindowStart = bucketWindowStart
+      chunk = []
+    }
+    chunk.push(bucket)
+  }
+
+  // Flush the last window
+  if (chunk.length > 0) {
+    result.push(
+      mergeBucketChunk(chunk, new Date(currentWindowStart), new Date(currentWindowStart + windowMs)),
+    )
+  }
+
+  return result
+}
+
+/** Merge a chunk of buckets into a single bucket with given start/end boundaries. */
+const mergeBucketChunk = (chunk: MetricBucketParsed[], start: Date, end: Date): MetricBucketParsed => {
+  const merged: MetricBucketParsed = { end, metrics: {}, start }
+
+  const metricNames = new Set<string>()
+  for (const b of chunk) {
+    for (const name of Object.keys(b.metrics)) {
+      metricNames.add(name)
+    }
+  }
+
+  for (const name of metricNames) {
+    let totalWeightedAvg = 0
+    let totalCount = 0
+    let totalSum = 0
+    let hasSum = false
+    let globalMin = Infinity
+    let globalMax = -Infinity
+
+    for (const b of chunk) {
+      const stats = b.metrics[name]
+      if (!stats) continue
+      totalWeightedAvg += stats.avg * stats.count
+      totalCount += stats.count
+      if (stats.sum !== undefined) {
+        totalSum += stats.sum
+        hasSum = true
+      }
+      if (stats.min < globalMin) globalMin = stats.min
+      if (stats.max > globalMax) globalMax = stats.max
+    }
+
+    if (totalCount > 0) {
+      merged.metrics[name] = {
+        avg: totalWeightedAvg / totalCount,
+        count: totalCount,
+        max: globalMax,
+        min: globalMin,
+        ...(hasSum && { sum: totalSum }),
+      }
+    }
+  }
+
+  return merged
+}


### PR DESCRIPTION
## Summary

- Calorie bars now align properly with screentime bars (no more overlap)
- Tooltip shows the 1h bar bucket value instead of a 5-minute slice
- Bar Y-scale uses bar-aggregated data for correct proportions

## Problem

1. **Overlap**: Calorie bars were re-aggregated from 5-min to 1h using consecutive-index grouping, which didn't align to hour boundaries if the first bucket started at e.g. 05:02. Screentime bars from the backend start at clean hour boundaries, causing visual misalignment.

2. **Tooltip**: The crosshair tooltip used the fine-grained 5-min line chart bucket for all metrics, showing a narrow time range and a single 5-min calorie value instead of the 1h bar value.

3. **Y-scale**: Calorie/steps Y-scale was computed from 5-min peak values while bars showed 1h averages, making bars appear too short.

## Changes

- **`utils/chart.ts`**: New `aggregateBucketsAligned()` function that groups buckets by time-aligned windows (floor to hour/day/week boundary) instead of consecutive index
- **`drawMetricsTrack.ts`**: Uses aligned aggregation for bar charts; tooltip merges bar bucket (for time range + calories/steps) with fine bucket (for HR/HRV); extracted `findBucketAt` and `buildTooltipBucket` helpers to reduce complexity
- **`index.tsx`**: Pre-computes bar-aggregated buckets for Y-scale computation; uses the same `barBucketMs` variable throughout