### PR TITLE
fix: resolve exercise type from numeric HC value, not just string name

### DIFF
--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -1,7 +1,7 @@
 /**
  * Exercise-specific detail view with HR chart and HR zone bar.
  */
-import { exerciseTypeNames } from '@aurboda/api-spec'
+import { exerciseTypeNames, getExerciseTypeName } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
 import type { Activity } from '../../state/api'
@@ -52,6 +52,38 @@ const HrZoneBar = ({ zones }: { zones: Record<number, number> }) => {
 }
 
 const formatExerciseTypeName = (name: string): string => name.replaceAll('_', ' ')
+
+/** Resolve exercise type name from activity data (supports both string name and numeric HC value). */
+export const resolveExerciseType = (activity: Activity): string | undefined => {
+  const data = activity.data as Record<string, unknown> | undefined
+  return (
+    (data?.exerciseTypeName as string | undefined) ??
+    (typeof data?.exerciseType === 'number' ? getExerciseTypeName(data.exerciseType) : undefined)
+  )
+}
+
+/** Exercise type selector for edit mode. */
+const ExerciseTypeSelect = ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+  <div class="entity-fields" style={{ marginTop: '0.5rem' }}>
+    <div class="field-row">
+      <span class="field-label">Exercise Type</span>
+      <span class="field-value">
+        <select
+          class="edit-datetime-input"
+          value={value}
+          onChange={(e) => onChange((e.target as HTMLSelectElement).value)}
+        >
+          <option value="">-- Select --</option>
+          {exerciseTypeNames.map((name) => (
+            <option key={name} value={name}>
+              {formatExerciseTypeName(name)}
+            </option>
+          ))}
+        </select>
+      </span>
+    </div>
+  </div>
+)
 
 /** Read-only display of exercise stats (type, calories, HRV, HR zones). */
 const ExerciseStats = ({
@@ -108,9 +140,7 @@ export const ExerciseDetail = ({
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
-  const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseTypeName as
-    | string
-    | undefined
+  const exerciseType = resolveExerciseType(activity)
 
   const caloriesQuery = useQuery({
     queryFn: () => fetchMetricTimeSeries('calories_active', displayStart, displayEnd),
@@ -144,27 +174,10 @@ export const ExerciseDetail = ({
         />
 
         {isEditing && (
-          <div class="entity-fields" style={{ marginTop: '0.5rem' }}>
-            <div class="field-row">
-              <span class="field-label">Exercise Type</span>
-              <span class="field-value">
-                <select
-                  class="edit-datetime-input"
-                  value={draft.exercise_type ?? exerciseType ?? ''}
-                  onChange={(e) =>
-                    onDraftChange({ ...draft, exercise_type: (e.target as HTMLSelectElement).value })
-                  }
-                >
-                  <option value="">-- Select --</option>
-                  {exerciseTypeNames.map((name) => (
-                    <option key={name} value={name}>
-                      {formatExerciseTypeName(name)}
-                    </option>
-                  ))}
-                </select>
-              </span>
-            </div>
-          </div>
+          <ExerciseTypeSelect
+            value={draft.exercise_type ?? exerciseType ?? ''}
+            onChange={(value) => onDraftChange({ ...draft, exercise_type: value })}
+          />
         )}
 
         {!isEditing && (

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -23,7 +23,7 @@ import {
 import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { EntityActions, type EntityType } from './EntityActions'
-import { ExerciseDetail } from './ExerciseDetail'
+import { ExerciseDetail, resolveExerciseType } from './ExerciseDetail'
 import { formatDateTimeLocal, formatTime } from './format-utils'
 import { MetricContent } from './MetricContent'
 import { MusicPlaylist } from './MusicPlaylist'
@@ -66,9 +66,7 @@ const GenericActivityDetail = ({
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
-  const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseTypeName as
-    | string
-    | undefined
+  const exerciseType = resolveExerciseType(activity)
 
   return (
     <div class="entity-info">
@@ -163,9 +161,7 @@ const makeDraft = (activity: Activity): ActivityDraft => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
-  const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseTypeName as
-    | string
-    | undefined
+  const exerciseType = resolveExerciseType(activity)
   return {
     end_time: formatDateTimeLocal(displayEnd),
     exercise_type: exerciseType,

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- large visualization component */
 import {
+  getExerciseTypeName as getExerciseTypeNameFromValue,
   metricUnits as builtinMetricUnits,
   type QueryMetricsBucketedResponse,
   type ScreentimeCategory,
@@ -269,38 +270,16 @@ const getTagColor = (tag: Tag): string => tagSourceColors[tag.source ?? 'default
 const getProductivityColor = (score: number | undefined): string =>
   productivityColors[score ?? 0] ?? productivityColors[0]!
 
-const exerciseTypeNames: Record<number, string> = {
-  0: 'Workout',
-  8: 'Biking',
-  10: 'Boot Camp',
-  13: 'Calisthenics',
-  16: 'Dancing',
-  25: 'Elliptical',
-  34: 'HIIT',
-  35: 'Hiking',
-  37: 'Ice Skating',
-  48: 'Pilates',
-  51: 'Rock Climbing',
-  53: 'Rowing',
-  56: 'Running',
-  57: 'Treadmill',
-  66: 'Soccer',
-  68: 'Stair Climbing',
-  70: 'Strength Training',
-  71: 'Stretching',
-  74: 'Swimming (Open Water)',
-  75: 'Swimming (Pool)',
-  79: 'Walking',
-  81: 'Weightlifting',
-  83: 'Yoga',
-}
+const formatExerciseType = (name: string): string => name.replaceAll('_', ' ')
 
 const getExerciseTypeName = (activity: Activity): string => {
-  const exerciseType = (activity.data as Record<string, unknown> | undefined)?.exerciseType as
-    | number
-    | undefined
-  if (exerciseType !== undefined && exerciseTypeNames[exerciseType]) {
-    return exerciseTypeNames[exerciseType]
+  const data = activity.data as Record<string, unknown> | undefined
+  const typeName = data?.exerciseTypeName as string | undefined
+  if (typeName) return formatExerciseType(typeName)
+  const typeValue = data?.exerciseType as number | undefined
+  if (typeValue !== undefined) {
+    const name = getExerciseTypeNameFromValue(typeValue)
+    if (name) return formatExerciseType(name)
   }
   return activity.title || 'Workout'
 }

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -120,6 +120,15 @@ export const exerciseTypeSchema = z
 
 export const isValidExerciseType = (name: string): name is ExerciseTypeName => name in exerciseTypes
 
+/** Reverse lookup: Health Connect exercise type integer → exercise type name. */
+const exerciseTypesByValue = Object.fromEntries(
+  Object.entries(exerciseTypes).map(([name, value]) => [value, name]),
+) as Record<number, ExerciseTypeName>
+
+/** Get the exercise type name from its Health Connect integer value, or undefined if unknown. */
+export const getExerciseTypeName = (value: number): ExerciseTypeName | undefined =>
+  exerciseTypesByValue[value]
+
 export const getExerciseTypeValue = (name: ExerciseTypeName): number => exerciseTypes[name]
 
 /**


### PR DESCRIPTION
## Summary

Follow-up fix for #391 — Exercise detail page still showed generic "exercise" for Health Connect synced activities.

**Root cause:** Health Connect synced exercises store `exerciseType` as a numeric integer (e.g. `83` for yoga) in the `data` JSONB. The detail page only looked for `exerciseTypeName` (a string), which is only set when creating/editing activities via the API. The timeline already handled this with a hardcoded partial map.

**Changes:**

- **`api-spec`**: Add `getExerciseTypeName(value: number)` reverse lookup (integer → name) from the existing `exerciseTypes` map
- **`ExerciseDetail.tsx`**: Add `resolveExerciseType()` helper that checks `exerciseTypeName` first, then falls back to numeric `exerciseType` via the reverse lookup. Extract `ExerciseTypeSelect` sub-component to satisfy complexity lint.
- **`index.tsx`**: Use `resolveExerciseType()` in `GenericActivityDetail` and `makeDraft` (fixes edit form pre-selection)
- **`Timeline/index.tsx`**: Replace hardcoded partial `exerciseTypeNames` map (only ~20 types) with the api-spec reverse lookup (all 83 types)