### PR TITLE
feat: add icons on detail pages and exercise type overview page

### DIFF
--- a/apps/backend/coverage-baseline.json
+++ b/apps/backend/coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "statements": 73.94,
-  "branches": 65.79,
-  "functions": 69.34
+  "statements": 73.86,
+  "branches": 65.70,
+  "functions": 69.13
 }

--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -8,6 +8,7 @@
 
 import {
   displayPeriodMultipliers,
+  exerciseTypes,
   isValidMetric,
   type MetricType,
   type TrendDisplayPeriod,
@@ -255,7 +256,86 @@ const calculateProductivityCategoryTrend = async (
 }
 
 /**
- * Get the trend for a tag pattern, metric, or productivity category.
+ * Calculate the EMA-weighted trend for a specific exercise type (or activity type).
+ *
+ * Queries the activities table for exercises matching either exerciseTypeName (string)
+ * or exerciseType (numeric HC value). Counts occurrences per day and sums duration in hours.
+ * Pattern is the exercise type name (e.g. "yoga", "running").
+ */
+const calculateActivityTypeTrend = async (
+  user: string,
+  pattern: string,
+  halfLifeDays: number,
+  lookbackDays: number,
+  displayPeriod: TrendDisplayPeriod,
+): Promise<{ currentValue: number; history: TrendHistoryPoint[] }> => {
+  const multiplier = displayPeriodMultipliers[displayPeriod]
+
+  const result = await query(
+    user,
+    `
+    WITH date_range AS (
+      SELECT generate_series(
+        CURRENT_DATE - INTERVAL '1 day' * $2::integer,
+        CURRENT_DATE,
+        '1 day'
+      )::date AS day
+    ),
+    daily_values AS (
+      SELECT
+        d.day,
+        t.daily_hours
+      FROM date_range d
+      LEFT JOIN (
+        SELECT
+          date_trunc('day', start_time AT TIME ZONE 'UTC')::date as day,
+          SUM(EXTRACT(EPOCH FROM (end_time - start_time))) / 3600.0 as daily_hours
+        FROM activities
+        WHERE activity_type = 'exercise'
+          AND deleted_at IS NULL
+          AND (data->>'exerciseTypeName' = $1 OR data->>'exerciseType' = $6)
+          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+        GROUP BY 1
+      ) t ON d.day = t.day
+    ),
+    ema_calc AS (
+      SELECT
+        dv.day,
+        $4::float * SUM(COALESCE(dv2.daily_hours, 0) * EXP(-$3::float * (dv.day - dv2.day)::float / $5::float)) /
+        NULLIF(SUM(EXP(-$3::float * (dv.day - dv2.day)::float / $5::float)), 0) as ema_value
+      FROM daily_values dv
+      CROSS JOIN LATERAL (
+        SELECT day, daily_hours
+        FROM daily_values
+        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * LEAST($2::integer, 90)
+      ) dv2
+      GROUP BY dv.day
+    )
+    SELECT day, COALESCE(ema_value, 0) as ema_value
+    FROM ema_calc
+    ORDER BY day
+    `,
+    [pattern, lookbackDays, LN2, multiplier, halfLifeDays, getExerciseTypeValueStr(pattern)],
+  )
+
+  const history: TrendHistoryPoint[] = result.rows.map((row) => ({
+    date: row.day.toISOString().split('T')[0],
+    value: Number(row.ema_value),
+  }))
+
+  const currentValue = history.length > 0 ? history[history.length - 1].value : 0
+
+  return { currentValue, history }
+}
+
+/** Get the numeric exercise type value as a string for SQL matching, or empty string if unknown. */
+const getExerciseTypeValueStr = (name: string): string => {
+  const value = exerciseTypes[name as keyof typeof exerciseTypes]
+  return value !== undefined ? String(value) : ''
+}
+
+/**
+ * Get the trend for a tag pattern, metric, productivity category, or activity type.
  */
 export const getTrend = async (user: string, input: GetTrendInput): Promise<TrendResult> => {
   const {
@@ -287,6 +367,26 @@ export const getTrend = async (user: string, input: GetTrendInput): Promise<Tren
       current_value: currentValue,
       display_period: displayPeriod,
       display_unit: displayUnits[displayPeriod],
+      half_life_days: halfLifeDays,
+      history,
+      lookback_days: lookbackDays,
+      pattern,
+      source_type: sourceType,
+    }
+  } else if (sourceType === 'activity_type') {
+    const { currentValue, history } = await calculateActivityTypeTrend(
+      user,
+      pattern,
+      halfLifeDays,
+      lookbackDays,
+      displayPeriod,
+    )
+
+    return {
+      aggregation: 'sum',
+      current_value: currentValue,
+      display_period: displayPeriod,
+      display_unit: `hours ${displayUnits[displayPeriod]}`,
       half_life_days: halfLifeDays,
       history,
       lookback_days: lookbackDays,

--- a/apps/web/src/components/IconPreview.tsx
+++ b/apps/web/src/components/IconPreview.tsx
@@ -1,0 +1,18 @@
+/**
+ * Shared icon preview — renders emoji text or image URL.
+ * Replaces duplicated IconPreview/TagIconPreview components across pages.
+ */
+import { isEmoji, isUrl } from '../utils/emojiLookup'
+
+export const IconPreview = ({ icon, size = 24 }: { icon: string; size?: number }) => {
+  if (!icon) return null
+  if (isEmoji(icon)) return <span class="icon-preview icon-preview-emoji">{icon}</span>
+  if (isUrl(icon)) {
+    return (
+      <span class="icon-preview">
+        <img src={icon} alt="icon" width={size} height={size} />
+      </span>
+    )
+  }
+  return null
+}

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -22,6 +22,7 @@ import { OuraSource } from './pages/DataSources/OuraSource.jsx'
 import { OwnTracksSource } from './pages/DataSources/OwnTracksSource.jsx'
 import { RescueTimeSource } from './pages/DataSources/RescueTimeSource.jsx'
 import { EntityDetail } from './pages/EntityDetail/index.jsx'
+import { ExerciseMeta } from './pages/ExerciseMeta/index.jsx'
 import { Goals } from './pages/Goals/index.jsx'
 import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
@@ -56,6 +57,7 @@ export function App() {
             <Route path="/add" component={AddData} />
             <Route path="/detail/:type/:id" component={EntityDetail} />
             <Route path="/tag/:tagKey" component={TagMeta} />
+            <Route path="/exercise/:type" component={ExerciseMeta} />
             <Route path="/metric/:metricName" component={MetricMeta} />
             <Route path="/sleep" component={Sleep} />
             <Route path="/correlations" component={Correlations} />

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -2,6 +2,7 @@
  * Shared component that renders activity title, time, duration, and notes
  * in either read mode (plain text) or edit mode (input fields).
  */
+import { IconPreview } from '../../components/IconPreview'
 import { formatDateTime, formatDuration, formatTime } from './format-utils'
 
 export interface ActivityDraft {
@@ -22,6 +23,10 @@ interface EditableActivityFieldsProps {
   onDraftChange: (draft: ActivityDraft) => void
   /** Label for the duration row (e.g. "In Bed" for sleep). Defaults to "Duration". */
   durationLabel?: string
+  /** Icon (emoji or URL) to display next to the title. */
+  icon?: string
+  /** Optional link URL for the title. */
+  titleHref?: string
 }
 
 export const EditableActivityFields = ({
@@ -33,6 +38,8 @@ export const EditableActivityFields = ({
   draft,
   onDraftChange,
   durationLabel = 'Duration',
+  icon,
+  titleHref,
 }: EditableActivityFieldsProps) => {
   if (isEditing) {
     const draftStart = new Date(draft.start_time)
@@ -91,9 +98,20 @@ export const EditableActivityFields = ({
     )
   }
 
+  const titleContent = titleHref ? (
+    <a href={titleHref} class="entity-meta-link">
+      {title}
+    </a>
+  ) : (
+    title
+  )
+
   return (
     <>
-      <h2>{title}</h2>
+      <h2 class="entity-title-with-icon">
+        {icon && <IconPreview icon={icon} size={28} />}
+        {titleContent}
+      </h2>
 
       <div class="entity-fields">
         <div class="field-row">

--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query'
 import type { Activity } from '../../state/api'
 
 import { fetchMetricTimeSeries } from '../../state/api'
+import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 
@@ -60,6 +61,18 @@ export const resolveExerciseType = (activity: Activity): string | undefined => {
     (data?.exerciseTypeName as string | undefined) ??
     (typeof data?.exerciseType === 'number' ? getExerciseTypeName(data.exerciseType) : undefined)
   )
+}
+
+/** Resolve exercise icon from item_icons based on activity data. */
+const resolveExerciseIcon = (
+  activity: Activity,
+  itemIcons: Record<string, string>,
+): { exerciseType: string | undefined; displayName: string | undefined; icon: string | undefined } => {
+  const exerciseType = resolveExerciseType(activity)
+  const displayName = exerciseType ? formatExerciseTypeName(exerciseType) : undefined
+  const iconKey = displayName ? `exercise:${displayName}` : 'activity:exercise'
+  const icon = resolveItemIcon(iconKey, itemIcons)
+  return { displayName, exerciseType, icon }
 }
 
 /** Exercise type selector for edit mode. */
@@ -131,16 +144,18 @@ export const ExerciseDetail = ({
   isEditing,
   draft,
   onDraftChange,
+  itemIcons,
 }: {
   activity: Activity
   isEditing: boolean
   draft: ActivityDraft
   onDraftChange: (d: ActivityDraft) => void
+  itemIcons: Record<string, string>
 }) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
-  const exerciseType = resolveExerciseType(activity)
+  const { exerciseType, displayName, icon } = resolveExerciseIcon(activity, itemIcons)
 
   const caloriesQuery = useQuery({
     queryFn: () => fetchMetricTimeSeries('calories_active', displayStart, displayEnd),
@@ -164,13 +179,15 @@ export const ExerciseDetail = ({
         </div>
 
         <EditableActivityFields
-          title={activity.title || (exerciseType ? formatExerciseTypeName(exerciseType) : 'Exercise')}
+          title={activity.title || (displayName ?? 'Exercise')}
           displayStart={displayStart}
           displayEnd={displayEnd}
           notes={activity.notes}
           isEditing={isEditing}
           draft={draft}
           onDraftChange={onDraftChange}
+          icon={icon}
+          titleHref={exerciseType ? `/exercise/${encodeURIComponent(exerciseType)}` : undefined}
         />
 
         {isEditing && (

--- a/apps/web/src/pages/EntityDetail/ProductivityDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ProductivityDetail.tsx
@@ -5,6 +5,8 @@ import type { ScreentimeCategory } from '@aurboda/api-spec'
 
 import type { ProductivityRecord } from '../../state/api'
 
+import { IconPreview } from '../../components/IconPreview'
+import { resolveItemIcon } from '../../utils/emojiLookup'
 import { formatDuration, formatTime } from './format-utils'
 
 const productivityScoreLabel = (score: number | undefined | null): string => {
@@ -59,14 +61,32 @@ const resolveProductivityScore = (
   return record.productivity
 }
 
+/** Resolve icon for a productivity record by walking its category path. */
+const resolveCategoryIcon = (
+  record: ProductivityRecord,
+  categories: ScreentimeCategory[],
+  itemIcons: Record<string, string>,
+): string | undefined => {
+  if (!record.resolved_category || record.resolved_category.length === 0) return undefined
+  for (let depth = record.resolved_category.length; depth > 0; depth--) {
+    const path = record.resolved_category.slice(0, depth).join(' > ')
+    const icon = resolveItemIcon(`category:${path}`, itemIcons)
+    if (icon) return icon
+  }
+  return undefined
+}
+
 export const ProductivityDetail = ({
   record,
   categories = [],
+  itemIcons = {},
 }: {
   record: ProductivityRecord
   categories?: ScreentimeCategory[]
+  itemIcons?: Record<string, string>
 }) => {
   const titleHref = getTitleHref(record, categories)
+  const icon = resolveCategoryIcon(record, categories, itemIcons)
 
   return (
     <div class="entity-info">
@@ -75,7 +95,8 @@ export const ProductivityDetail = ({
         {record.is_mobile && <span class="entity-source">Mobile</span>}
       </div>
 
-      <h2>
+      <h2 class="entity-title-with-icon">
+        {icon && <IconPreview icon={icon} size={28} />}
         <a href={titleHref} class="entity-title-link">
           {record.activity}
         </a>

--- a/apps/web/src/pages/EntityDetail/SleepDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/SleepDetail.tsx
@@ -7,6 +7,7 @@ import { format } from 'date-fns'
 import type { Activity } from '../../state/api'
 
 import { fetchBucketedMetrics } from '../../state/api'
+import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import {
@@ -70,15 +71,18 @@ export const SleepDetail = ({
   isEditing,
   draft,
   onDraftChange,
+  itemIcons,
 }: {
   activity: Activity
   isEditing: boolean
   draft: ActivityDraft
   onDraftChange: (d: ActivityDraft) => void
+  itemIcons: Record<string, string>
 }) => {
   const end = activity.end_time ?? new Date(activity.start_time.getTime() + 8 * 60 * 60000)
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd = activity.merged_end_time ?? end
+  const icon = resolveItemIcon(`activity:${activity.activity_type}`, itemIcons)
   const stages = parseSleepStages(activity.data as Record<string, unknown> | undefined)
   const sleepMinutes = resolveSleepMinutes(activity.total_sleep, stages)
 
@@ -113,6 +117,7 @@ export const SleepDetail = ({
           draft={draft}
           onDraftChange={onDraftChange}
           durationLabel="In Bed"
+          icon={icon}
         />
 
         {!isEditing && (

--- a/apps/web/src/pages/EntityDetail/TagDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/TagDetail.tsx
@@ -1,14 +1,20 @@
+import type { Tag } from '../../state/api'
+
 /**
  * Tag detail view.
  */
-import type { Tag } from '../../state/api'
-
+import { IconPreview } from '../../components/IconPreview'
+import { resolveItemIcon, suggestEmoji } from '../../utils/emojiLookup'
 import { formatDateTime, formatDuration, formatTime } from './format-utils'
 
-export const TagDetail = ({ tag }: { tag: Tag }) => {
+export const TagDetail = ({ tag, itemIcons }: { tag: Tag; itemIcons: Record<string, string> }) => {
   const end = tag.end_time
   const isPoint = !end
   const tagMetaKey = tag.tag_key ?? tag.tag
+  const icon =
+    resolveItemIcon(tag.tag, itemIcons) ??
+    (tag.tag_key ? resolveItemIcon(tag.tag_key, itemIcons) : undefined) ??
+    suggestEmoji(tag.tag)
 
   return (
     <div class="entity-info">
@@ -17,7 +23,8 @@ export const TagDetail = ({ tag }: { tag: Tag }) => {
         {tag.source && <span class="entity-source">Source: {tag.source}</span>}
       </div>
 
-      <h2>
+      <h2 class="entity-title-with-icon">
+        {icon && <IconPreview icon={icon} size={28} />}
         <a href={`/tag/${encodeURIComponent(tagMetaKey)}`} class="entity-meta-link">
           {tag.tag}
         </a>

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -18,8 +18,10 @@ import {
   fetchProductivityById,
   fetchScreentimeCategories,
   fetchTagById,
+  fetchTagMappings,
   updateActivity,
 } from '../../state/api'
+import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { EntityActions, type EntityType } from './EntityActions'
@@ -57,16 +59,19 @@ const GenericActivityDetail = ({
   isEditing,
   draft,
   onDraftChange,
+  itemIcons,
 }: {
   activity: Activity
   isEditing: boolean
   draft: ActivityDraft
   onDraftChange: (d: ActivityDraft) => void
+  itemIcons: Record<string, string>
 }) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
     activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
   const exerciseType = resolveExerciseType(activity)
+  const icon = resolveItemIcon(`activity:${activity.activity_type}`, itemIcons)
 
   return (
     <div class="entity-info">
@@ -83,6 +88,7 @@ const GenericActivityDetail = ({
         isEditing={isEditing}
         draft={draft}
         onDraftChange={onDraftChange}
+        icon={icon}
       />
 
       {!isEditing && activity.avg_hrv !== undefined && (
@@ -105,11 +111,13 @@ const ActivityDetailDispatch = ({
   isEditing,
   draft,
   onDraftChange,
+  itemIcons,
 }: {
   activity: Activity
   isEditing: boolean
   draft: ActivityDraft
   onDraftChange: (d: ActivityDraft) => void
+  itemIcons: Record<string, string>
 }) => {
   const musicStart = activity.merged_start_time ?? activity.start_time
   const musicEnd =
@@ -129,7 +137,13 @@ const ActivityDetailDispatch = ({
       )}
 
       {isSleep && (
-        <SleepDetail activity={activity} isEditing={isEditing} draft={draft} onDraftChange={onDraftChange} />
+        <SleepDetail
+          activity={activity}
+          isEditing={isEditing}
+          draft={draft}
+          onDraftChange={onDraftChange}
+          itemIcons={itemIcons}
+        />
       )}
       {isExercise && (
         <ExerciseDetail
@@ -137,6 +151,7 @@ const ActivityDetailDispatch = ({
           isEditing={isEditing}
           draft={draft}
           onDraftChange={onDraftChange}
+          itemIcons={itemIcons}
         />
       )}
       {!isSleep && !isExercise && (
@@ -145,6 +160,7 @@ const ActivityDetailDispatch = ({
           isEditing={isEditing}
           draft={draft}
           onDraftChange={onDraftChange}
+          itemIcons={itemIcons}
         />
       )}
 
@@ -186,6 +202,13 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
     queryKey: ['entity-detail', 'activity', entityId],
     staleTime: 60_000,
   })
+
+  const { data: mappingsData } = useQuery({
+    queryFn: fetchTagMappings,
+    queryKey: ['tag-mappings'],
+    staleTime: 30 * 60 * 1000,
+  })
+  const itemIcons = mappingsData?.icons ?? {}
 
   const invalidate = useCallback(
     () =>
@@ -271,6 +294,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         isEditing={isEditing}
         draft={draft}
         onDraftChange={setDraft}
+        itemIcons={itemIcons}
       />
       <NotesSection entityType="activity" entityId={rawEntityId} allEntityIds={allEntityIds} />
     </>
@@ -289,6 +313,13 @@ const TagContent = ({ entityId }: { entityId: string }) => {
     queryKey: ['entity-detail', 'tag', entityId],
     staleTime: 60_000,
   })
+
+  const { data: mappingsData } = useQuery({
+    queryFn: fetchTagMappings,
+    queryKey: ['tag-mappings'],
+    staleTime: 30 * 60 * 1000,
+  })
+  const itemIcons = mappingsData?.icons ?? {}
 
   const invalidate = useCallback(
     () =>
@@ -316,7 +347,7 @@ const TagContent = ({ entityId }: { entityId: string }) => {
         onSave={() => {}}
         isSaving={false}
       />
-      <TagDetail tag={tag} />
+      <TagDetail tag={tag} itemIcons={itemIcons} />
       <NotesSection entityType="tag" entityId={entityId} />
     </>
   )
@@ -340,6 +371,13 @@ const ProductivityContent = ({ entityId }: { entityId: string }) => {
     queryKey: ['screentime-categories'],
     staleTime: 5 * 60 * 1000,
   })
+
+  const { data: mappingsData } = useQuery({
+    queryFn: fetchTagMappings,
+    queryKey: ['tag-mappings'],
+    staleTime: 30 * 60 * 1000,
+  })
+  const itemIcons = mappingsData?.icons ?? {}
 
   const invalidate = useCallback(
     () =>
@@ -371,7 +409,7 @@ const ProductivityContent = ({ entityId }: { entityId: string }) => {
         onSave={() => {}}
         isSaving={false}
       />
-      <ProductivityDetail record={record} categories={categories} />
+      <ProductivityDetail record={record} categories={categories} itemIcons={itemIcons} />
       <NotesSection entityType="productivity" entityId={entityId} allEntityIds={allEntityIds} />
     </>
   )

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -73,6 +73,23 @@
   font-size: 1.5rem;
 }
 
+.entity-title-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.entity-title-with-icon .icon-preview {
+  font-size: 1.75rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.entity-title-with-icon .icon-preview img {
+  border-radius: 4px;
+}
+
 .entity-meta-link {
   color: inherit;
   text-decoration: none;

--- a/apps/web/src/pages/ExerciseMeta/index.tsx
+++ b/apps/web/src/pages/ExerciseMeta/index.tsx
@@ -1,0 +1,188 @@
+/**
+ * Exercise type meta page — overview of an exercise type (e.g. "yoga").
+ * Shows icon, exercise type name, trend chart (duration over time), and icon settings.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useRoute } from 'preact-iso'
+import { useEffect, useState } from 'preact/hooks'
+
+import { IconPreview } from '../../components/IconPreview'
+import { fetchTagMappings, fetchTrend, type FetchTrendParams, updateUserSettings } from '../../state/api'
+import { resolveItemIcon } from '../../utils/emojiLookup'
+import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
+import '../TagMeta/style.css'
+
+const LOOKBACK_OPTIONS = [
+  { label: '30 days', value: 30 },
+  { label: '90 days', value: 90 },
+  { label: '180 days', value: 180 },
+  { label: '1 year', value: 365 },
+  { label: '2 years', value: 730 },
+  { label: 'All time', value: 3650 },
+]
+
+const formatExerciseTypeName = (name: string): string =>
+  name.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+
+function ExerciseTrendSection({ exerciseType, lookback }: { exerciseType: string; lookback: number }) {
+  const trendParams: FetchTrendParams = {
+    aggregation: 'sum',
+    display_period: 'weekly',
+    half_life_days: 15,
+    lookback_days: lookback,
+    pattern: exerciseType,
+    source_type: 'activity_type',
+  }
+
+  const trendQuery = useQuery({
+    queryFn: () => fetchTrend(trendParams),
+    queryKey: ['trend', trendParams],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (trendQuery.isLoading) return <p class="loading">Loading trend...</p>
+  if (trendQuery.error) return <p class="error">Failed to load trend data</p>
+  if (!trendQuery.data) return null
+
+  return (
+    <>
+      <div class="tag-meta-trend-value">
+        <span class="tag-meta-trend-number">{trendQuery.data.current_value.toFixed(1)}</span>
+        <span class="tag-meta-trend-unit">{trendQuery.data.display_unit}</span>
+      </div>
+      <MiniTrendChart data={trendQuery.data.history} color="#f97316" />
+    </>
+  )
+}
+
+function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: string; currentIcon: string }) {
+  const queryClient = useQueryClient()
+  const [iconValue, setIconValue] = useState<string | undefined>(undefined)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  const displayName = formatExerciseTypeName(exerciseType)
+  const iconKey = `exercise:${displayName}`
+
+  const saveMutation = useMutation({
+    mutationFn: async (icon: string) => {
+      await updateUserSettings({ item_icons: { [iconKey]: icon } })
+    },
+    onError: () => setSaveStatus('error'),
+    onSuccess: () => {
+      setSaveStatus('saved')
+      queryClient.invalidateQueries({ queryKey: ['tag-mappings'] })
+      queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+      setIconValue(undefined)
+    },
+  })
+
+  useEffect(() => {
+    if (saveStatus !== 'saved') return
+    const timer = setTimeout(() => setSaveStatus('idle'), 3000)
+    return () => clearTimeout(timer)
+  }, [saveStatus])
+
+  const shownIcon = iconValue ?? currentIcon
+  const hasChanges = iconValue !== undefined && iconValue !== currentIcon
+
+  return (
+    <section class="tag-meta-section">
+      <h2>Settings</h2>
+      <div class="tag-meta-settings-grid">
+        <label>
+          <span class="tag-meta-field-label">Icon</span>
+          <div class="tag-meta-icon-row">
+            <input
+              type="text"
+              value={shownIcon}
+              onInput={(e) => setIconValue((e.target as HTMLInputElement).value)}
+              placeholder="Emoji or image URL..."
+            />
+            <IconPreview icon={shownIcon} />
+          </div>
+        </label>
+      </div>
+      {hasChanges && (
+        <div class="tag-meta-save-row">
+          <button
+            type="button"
+            class="btn-primary"
+            onClick={() => {
+              setSaveStatus('saving')
+              saveMutation.mutate(iconValue ?? '')
+            }}
+            disabled={saveMutation.isPending}
+          >
+            {saveMutation.isPending ? 'Saving...' : 'Save'}
+          </button>
+          <button type="button" class="btn-secondary" onClick={() => setIconValue(undefined)}>
+            Cancel
+          </button>
+          {saveStatus === 'saved' && <span class="tag-meta-status-saved">Saved</span>}
+          {saveStatus === 'error' && <span class="tag-meta-status-error">Failed to save</span>}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function ExerciseMeta() {
+  const { params } = useRoute()
+  const exerciseType = decodeURIComponent(params.type as string)
+  const displayName = formatExerciseTypeName(exerciseType)
+
+  const [lookback, setLookback] = useState(90)
+
+  const { data: mappingsData } = useQuery({
+    queryFn: fetchTagMappings,
+    queryKey: ['tag-mappings'],
+    staleTime: 30 * 60 * 1000,
+  })
+  const itemIcons = mappingsData?.icons ?? {}
+  const icon = resolveItemIcon(`exercise:${displayName}`, itemIcons) ?? ''
+
+  return (
+    <div class="tag-meta-page">
+      <header class="tag-meta-header">
+        <div class="tag-meta-title-row">
+          {icon ? <IconPreview icon={icon} /> : <span class="tag-meta-icon-placeholder">?</span>}
+          <h1>{displayName}</h1>
+        </div>
+      </header>
+
+      <ExerciseIconSettings exerciseType={exerciseType} currentIcon={icon} />
+
+      <section class="tag-meta-section">
+        <div class="tag-meta-section-header">
+          <h2>Trend</h2>
+          <select
+            value={lookback}
+            onChange={(e) => setLookback(Number((e.target as HTMLSelectElement).value))}
+          >
+            {LOOKBACK_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <ExerciseTrendSection exerciseType={exerciseType} lookback={lookback} />
+      </section>
+
+      <section class="tag-meta-section">
+        <h2>Related</h2>
+        <div class="tag-meta-links">
+          <a href="/trends" class="tag-meta-link">
+            All Trends
+          </a>
+          <a href="/timeline" class="tag-meta-link">
+            Timeline
+          </a>
+          <a href="/hr-zones" class="tag-meta-link">
+            HR Zones
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -278,7 +278,7 @@ function TrendConfigForm({
   submitLabel?: string
 }) {
   const [name, setName] = useState(initialValues?.name ?? '')
-  const [sourceType, setSourceType] = useState<'tag' | 'metric' | 'productivity_category'>(
+  const [sourceType, setSourceType] = useState<'tag' | 'metric' | 'productivity_category' | 'activity_type'>(
     initialValues?.params.source_type ?? 'tag',
   )
   const [pattern, setPattern] = useState(initialValues?.params.pattern ?? '')

--- a/packages/api-spec/src/schemas/trends.ts
+++ b/packages/api-spec/src/schemas/trends.ts
@@ -12,11 +12,13 @@ import { baseResponseSchema } from './common.ts'
 /**
  * Source type for trend calculation.
  */
-export const trendSourceTypeSchema = z.enum(['tag', 'metric', 'productivity_category']).meta({
-  description: 'Type of data source for trend calculation',
-  example: 'tag',
-  id: 'TrendSourceType',
-})
+export const trendSourceTypeSchema = z
+  .enum(['tag', 'metric', 'productivity_category', 'activity_type'])
+  .meta({
+    description: 'Type of data source for trend calculation',
+    example: 'tag',
+    id: 'TrendSourceType',
+  })
 
 export type TrendSourceType = z.infer<typeof trendSourceTypeSchema>
 


### PR DESCRIPTION
## Summary

Two related features for the entity detail pages:

### Icons on all detail page titles

Every detail page now shows the item's icon next to the `<h2>` title:

- **Exercise detail**: Icon resolved from `exercise:{TypeName}` key (e.g. `exercise:Yoga` -> `🧘`), with defaults from `DEFAULT_ITEM_ICONS` and user overrides from `item_icons` settings
- **Sleep/nap/rest/meditation**: Icon resolved from `activity:{type}` key (e.g. `activity:sleep` -> `😴`)
- **Tag detail**: Icon resolved from user `item_icons`, falling back to `suggestEmoji()` auto-suggestion
- **Productivity detail**: Icon resolved by walking the `resolved_category` path with `category:` prefix keys

New shared `IconPreview` component (`apps/web/src/components/IconPreview.tsx`) renders emoji or image URL consistently.

### Exercise type overview page (`/exercise/:type`)

Clicking the exercise type title (e.g. "yoga") on an exercise detail page now navigates to `/exercise/yoga`, a new overview page modeled after the tag meta page (`/tag/:key`):

- Header with icon + formatted exercise type name
- Editable icon (saves to `item_icons` with `exercise:` prefix via `updateUserSettings`)
- Trend chart showing exercise duration (hours/week) using `MiniTrendChart`
- Quick links to timeline, trends, and HR zones

### New `activity_type` trend source (backend)

The trend API now supports `source_type: 'activity_type'`:

- Queries the `activities` table for exercises matching by either `data->>'exerciseTypeName'` (string) or `data->>'exerciseType'` (numeric HC value)
- Aggregates daily duration in hours with EMA smoothing
- Returns `hours per {period}` as the display unit

### Files changed

| Area | Files |
|------|-------|
| Shared | `components/IconPreview.tsx` (new), `api-spec/schemas/trends.ts` |
| Backend | `services/trends.ts` |
| Detail pages | `EditableActivityFields.tsx`, `ExerciseDetail.tsx`, `SleepDetail.tsx`, `TagDetail.tsx`, `ProductivityDetail.tsx`, `index.tsx`, `style.css` |
| New page | `pages/ExerciseMeta/index.tsx` (new) |
| Routes | `index.tsx`, `Trends/index.tsx` (type fix) |