### PR TITLE
fix: timeline UI fixes for music toggle, exercise icons, and detail links

### DIFF
--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -115,7 +115,11 @@ const ExerciseStats = ({
       <div class="entity-fields">
         <div class="field-row">
           <span class="field-label">Exercise Type</span>
-          <span class="field-value">{formatExerciseTypeName(exerciseType)}</span>
+          <span class="field-value">
+            <a href={`/exercise/${encodeURIComponent(exerciseType)}`} class="entity-meta-link">
+              {formatExerciseTypeName(exerciseType)}
+            </a>
+          </span>
         </div>
       </div>
     )}
@@ -172,9 +176,13 @@ export const ExerciseDetail = ({
     <>
       <div class="entity-info">
         <div class="entity-meta">
-          <span class="entity-type-badge">
-            {exerciseType ? formatExerciseTypeName(exerciseType) : activity.activity_type}
-          </span>
+          {exerciseType ? (
+            <a href={`/exercise/${encodeURIComponent(exerciseType)}`} class="entity-type-badge">
+              {formatExerciseTypeName(exerciseType)}
+            </a>
+          ) : (
+            <span class="entity-type-badge">{activity.activity_type}</span>
+          )}
           {activity.source && <span class="entity-source">Source: {activity.source}</span>}
         </div>
 
@@ -187,7 +195,6 @@ export const ExerciseDetail = ({
           draft={draft}
           onDraftChange={onDraftChange}
           icon={icon}
-          titleHref={exerciseType ? `/exercise/${encodeURIComponent(exerciseType)}` : undefined}
         />
 
         {isEditing && (

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -61,6 +61,11 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  text-decoration: none;
+}
+
+a.entity-type-badge:hover {
+  background: #7c4dcd;
 }
 
 .entity-source {

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -2173,7 +2173,7 @@ export const Timeline = () => {
         {!legendCollapsed && (
           <div class="timeline-legend" ref={legendRef}>
             {/* ── Music (top-level) ── */}
-            {showMusicColumn && (
+            {hasLastFm && (
               <>
                 <button
                   key="music"

--- a/apps/web/src/utils/emojiLookup.ts
+++ b/apps/web/src/utils/emojiLookup.ts
@@ -48,7 +48,14 @@ export const resolveItemIcon = (key: string, userIcons: Record<string, string>):
     // Empty string means user explicitly cleared the icon
     return userIcons[key] || undefined
   }
-  return DEFAULT_ITEM_ICONS[key]
+  if (DEFAULT_ITEM_ICONS[key]) return DEFAULT_ITEM_ICONS[key]
+
+  // Case-insensitive fallback for defaults (exercise type names may differ in casing)
+  const lower = key.toLowerCase()
+  for (const [k, v] of Object.entries(DEFAULT_ITEM_ICONS)) {
+    if (k.toLowerCase() === lower) return v
+  }
+  return undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Music toggle fix**: Show the music legend checkbox when user has last.fm configured, even when music is hidden via `hide=music` URL parameter. Previously the checkbox disappeared because data fetching was disabled when hidden, making `showMusicColumn` false and the checkbox unreachable.
- **Exercise icon fix**: Add case-insensitive fallback in `resolveItemIcon` — default icon keys use title case (`exercise:Strength Training`) but the timeline's `formatExerciseType` produces lowercase (`exercise:strength training`).
- **Detail page links**: Make the exercise type badge ("STRENGTH TRAINING") and the "Exercise Type" field value clickable links to `/exercise/{type}`, instead of linking the activity title (e.g. "Gravl") which is instance-specific.

## Test plan
- [ ] Load timeline with `#hide=music` — music checkbox should still appear (strikethrough/dimmed), clicking it should unhide music
- [ ] Check that strength training and treadmill running activities show their icons in the timeline
- [ ] Click an exercise activity, verify the title is plain text and the badge + exercise type field link to the exercise type page

🤖 Generated with [Claude Code](https://claude.com/claude-code)