### PR TITLE
chore: remove stale README sections and bump CI actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       node: ${{ steps.filter.outputs.node }}
       android: ${{ steps.filter.outputs.android }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 <h1 align="center">Aurboda</h1>
 <h3 align="center">Self-Hosted Self-Quantification Aggregator</h3>
 
-<p align="center">
-  <a href="https://codecov.io/gh/fiddur/aurboda"><img src="https://codecov.io/gh/fiddur/aurboda/graph/badge.svg?flag=backend" alt="Backend Coverage" /></a>
-</p>
-
 Your health, fitness, productivity, and location data is scattered across apps and services. Aurboda aggregates it all into one self-hosted platform, provides rich visualizations, and exposes everything to AI assistants via [MCP (Model Context Protocol)](https://modelcontextprotocol.io/).
 
 No public signup, but self-hosting is straightforward via Docker. It was initiated as a personal (manually coded) hobby project but has grown with AI coding; take it or leave it.
@@ -173,39 +169,6 @@ To change default port, modify `"8080:80"` to `"YOUR_PORT:80"` in docker-compose
 ### Development Builds
 
 Replace `:latest` with `:develop` in docker-compose.yml to use development builds.
-
----
-
-## Architecture
-
-```
-                         +------------------+
-                         |   Android App    |
-                         | (Health Connect, |
-                         |  BLE sensors)    |
-                         +--------+---------+
-                                  |
-+------------------+     +--------v---------+     +------------------+
-|  OwnTracks       +---->|     Backend      |<----+    Web UI        |
-|  ActivityWatch   |     |  (REST API + MCP)|     |   (Preact)       |
-|  Oura (webhooks) |     +--------+---------+     +------------------+
-+------------------+         ^    |
-                             |    |
-+------------------+         |    v
-|  Oura (API)      +---------+ +------------------+
-|  RescueTime      |           |   PostgreSQL     |
-|  Last.fm         |           |   (PostGIS)      |
-|  Calendars (ICS) +---------+ +------------------+
-+------------------+
-```
-
-**Components:**
-
-- `apps/backend` -- Node.js/TypeScript API server with MCP support
-- `apps/web` -- Preact-based visualization dashboard
-- `apps/android` -- Kotlin/Jetpack Compose Health Connect client with BLE support
-- `packages/api-spec` -- Shared Zod schemas, OpenAPI spec, generated TypeScript types and Kotlin models
-- Database: PostgreSQL with PostGIS, per-user database isolation
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove stale codecov badge (coverage is no longer uploaded to codecov)
- Remove outdated ASCII architecture chart
- Bump `actions/checkout` v4 → v6 (Node.js 24 compatible)
- Bump `dorny/paths-filter` v3 → v4 (Node.js 24 compatible)

## Test plan
- [x] README renders correctly without removed sections
- [ ] CI passes with bumped action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)