### PR TITLE
fix: resolve custom exercise icons case-insensitively in timeline

### DIFF
--- a/apps/web/src/utils/emojiLookup.test.ts
+++ b/apps/web/src/utils/emojiLookup.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveItemIcon } from './emojiLookup'
+
+describe('resolveItemIcon', () => {
+  it('returns exact match from user icons', () => {
+    expect(resolveItemIcon('exercise:Yoga', { 'exercise:Yoga': '🧘‍♀️' })).toBe('🧘‍♀️')
+  })
+
+  it('returns case-insensitive match from user icons', () => {
+    // ExerciseMeta saves title-cased keys; timeline looks up lowercase
+    expect(resolveItemIcon('exercise:running treadmill', { 'exercise:Running Treadmill': '🏃‍♂️' })).toBe('🏃‍♂️')
+  })
+
+  it('returns case-insensitive match for single-word exercise types', () => {
+    expect(resolveItemIcon('exercise:yoga', { 'exercise:Yoga': '🧘‍♀️' })).toBe('🧘‍♀️')
+  })
+
+  it('returns undefined for empty string user icon (explicit clear)', () => {
+    expect(resolveItemIcon('exercise:Yoga', { 'exercise:Yoga': '' })).toBeUndefined()
+  })
+
+  it('returns undefined for case-insensitive empty string user icon', () => {
+    expect(resolveItemIcon('exercise:yoga', { 'exercise:Yoga': '' })).toBeUndefined()
+  })
+
+  it('falls back to defaults when no user icon set', () => {
+    expect(resolveItemIcon('exercise:Running', {})).toBe('🏃')
+  })
+
+  it('falls back to defaults case-insensitively', () => {
+    expect(resolveItemIcon('exercise:running', {})).toBe('🏃')
+  })
+
+  it('returns undefined when no match found', () => {
+    expect(resolveItemIcon('exercise:Unknown Sport', {})).toBeUndefined()
+  })
+
+  it('prefers user icon over default', () => {
+    expect(resolveItemIcon('exercise:Running', { 'exercise:Running': '🦵' })).toBe('🦵')
+  })
+})

--- a/apps/web/src/utils/emojiLookup.ts
+++ b/apps/web/src/utils/emojiLookup.ts
@@ -48,10 +48,16 @@ export const resolveItemIcon = (key: string, userIcons: Record<string, string>):
     // Empty string means user explicitly cleared the icon
     return userIcons[key] || undefined
   }
+
+  // Case-insensitive fallback for user icons (keys may differ in casing between pages)
+  const lower = key.toLowerCase()
+  for (const [k, v] of Object.entries(userIcons)) {
+    if (k.toLowerCase() === lower) return v || undefined
+  }
+
   if (DEFAULT_ITEM_ICONS[key]) return DEFAULT_ITEM_ICONS[key]
 
   // Case-insensitive fallback for defaults (exercise type names may differ in casing)
-  const lower = key.toLowerCase()
   for (const [k, v] of Object.entries(DEFAULT_ITEM_ICONS)) {
     if (k.toLowerCase() === lower) return v
   }


### PR DESCRIPTION
## Summary
- Custom exercise icons set on `/exercise/running_treadmill` etc. weren't appearing on the timeline
- Root cause: ExerciseMeta saves icon keys title-cased (`exercise:Running Treadmill`) but the timeline looks them up lowercase (`exercise:running treadmill`)
- `resolveItemIcon` now does case-insensitive matching for user icons, not just defaults

## Test plan
- [x] Unit tests for `resolveItemIcon` covering case-insensitive user icon lookup
- [ ] Verify running_treadmill and yoga show custom icons on timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)