### PR TITLE
fix: merge item_icons in updateSettings to prevent wiping existing icons

### DIFF
--- a/apps/backend/src/services/settings.test.ts
+++ b/apps/backend/src/services/settings.test.ts
@@ -326,6 +326,25 @@ describe('validateAndUpdateSettings', () => {
     expect(db.upsertUserSettings).toHaveBeenCalledWith('testuser', { item_icons: icons })
   })
 
+  test('merges partial item_icons with existing icons', async () => {
+    const existingIcons = { Coffee: '☕', 'exercise:Running': '🏃' }
+    vi.mocked(db.getUserSettings).mockResolvedValue({ item_icons: existingIcons })
+    vi.mocked(db.upsertUserSettings).mockResolvedValue({
+      item_icons: { ...existingIcons, 'exercise:Yoga': '🧘' },
+    })
+    vi.mocked(db.getOAuthToken).mockResolvedValue(null)
+
+    const result = await validateAndUpdateSettings('testuser', {
+      item_icons: { 'exercise:Yoga': '🧘' },
+    })
+
+    expect(result.success).toBe(true)
+    // Should merge new icon with existing ones, not replace
+    expect(db.upsertUserSettings).toHaveBeenCalledWith('testuser', {
+      item_icons: { Coffee: '☕', 'exercise:Running': '🏃', 'exercise:Yoga': '🧘' },
+    })
+  })
+
   test('clears item_icons when set to null', async () => {
     vi.mocked(db.getUserSettings).mockResolvedValue({ item_icons: { Coffee: '☕' } })
     vi.mocked(db.upsertUserSettings).mockResolvedValue({})

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -279,6 +279,13 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
     }
   }
 
+  // Shallow-merge dict fields so partial updates don't wipe existing entries.
+  // e.g. updating one exercise icon shouldn't delete all tag icons.
+  if (updates.item_icons) {
+    const current = await getSettings(user)
+    updates.item_icons = { ...current.item_icons, ...updates.item_icons }
+  }
+
   // Apply updates
   await updateSettingsInternal(user, updates)
 


### PR DESCRIPTION
## Summary
- `validateAndUpdateSettings` was replacing the entire `item_icons` dict when only a partial update was sent (e.g. saving one exercise icon from the ExerciseMeta page)
- This caused all previously saved tag icons to be wiped out
- Now shallow-merges incoming `item_icons` with existing ones before persisting, matching how `buildTagMappingUpdates` already works

## Test plan
- [x] Unit test: partial `item_icons` update merges with existing icons
- [ ] Set a tag icon, then set an exercise icon — verify the tag icon is still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)