### PR TITLE
fix: add debug logging to Garmin login flow

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -430,6 +430,7 @@ const main = async () => {
         res.json({ success: true })
       }
     } catch (error) {
+      console.error(`🔑 Garmin login endpoint error for user=${user}:`, error)
       const message = error instanceof Error ? error.message : 'Login failed'
       res.status(401).json({ error: message, success: false })
     }

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -312,8 +312,18 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
       // Clean up any stale pending session for this user
       pendingMfaSessions.delete(user)
 
+      console.log(`🔑 Garmin login attempt for user=${user}, email=${email}`)
       const gc = new GarminConnect({ password, username: email })
-      const result = await gc.login()
+
+      let result
+      try {
+        result = await gc.login()
+      } catch (error) {
+        console.error(`🔑 Garmin login threw for user=${user}, email=${email}:`, error)
+        throw error
+      }
+
+      console.log(`🔑 Garmin login result for user=${user}: type=${result.type}`)
 
       if (result.type === 'success') {
         const tokens = gc.exportToken()


### PR DESCRIPTION
## Summary
- Adds `console.log`/`console.error` to the Garmin login flow in `garmin.ts` and the `/auth/garmin/login` endpoint in `api.ts`
- Logs login attempts (user + email), result type, and full error objects on failure
- Helps diagnose why some users (Sara) get 401 on Garmin login while others succeed

## Test plan
- [ ] Deploy and have Sara attempt Garmin login again
- [ ] Check server logs for the detailed error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)