### PR TITLE
feat: OAuth 2.1 for MCP server (Claude.ai custom connectors)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -56,6 +56,7 @@ import { createLocationsRouter } from './routes/locations-router.ts'
 import { createMealsRouter } from './routes/meals-router.ts'
 import { createMetricsRouter } from './routes/metrics-router.ts'
 import { createNotesRouter } from './routes/notes-router.ts'
+import { createOAuthRouter } from './routes/oauth-router.ts'
 import { createReportsRouter } from './routes/reports-router.ts'
 import { createScreentimeCategoriesRouter } from './routes/screentime-categories-router.ts'
 import { createSettingsRouter } from './routes/settings-router.ts'
@@ -119,9 +120,12 @@ const main = async () => {
   // CORS must come first for preflight requests
   httpd.use(cors({ origin: true }))
 
+  // Mount OAuth endpoints BEFORE body-parser (uses its own parsers)
+  httpd.use(createOAuthRouter({ centralDb, loginToUserDb, webHost }))
+
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
   // Stateless mode — no session tracking needed (tools only, no subscriptions)
-  httpd.use('/mcp', createMcpRouter(auth, { garmin, oura, sync: syncProvider }))
+  httpd.use('/mcp', createMcpRouter(auth, { centralDb, garmin, oura, sync: syncProvider }))
 
   httpd.use(json({ limit: '10mb' }))
 

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -14,6 +14,7 @@ import { type Request, type Response, Router } from 'express'
 import type { Auth } from './auth.ts'
 import type { GarminClient } from './garmin.ts'
 import type { ouraClient } from './oura.ts'
+import type { CentralDb } from './services/central-db.ts'
 import type { SyncProvider } from './services/queries.ts'
 
 import { registerActivityTools } from './mcp/activity-tools.ts'
@@ -31,10 +32,12 @@ import { registerSyncTools } from './mcp/sync-tools.ts'
 import { registerTagTools } from './mcp/tag-tools.ts'
 import { registerTrainingLoadTools } from './mcp/training-load-tools.ts'
 import { registerTrendTools } from './mcp/trend-tools.ts'
+import { isOAuthAccessToken, validateAccessToken } from './services/oauth.ts'
 
 type OuraClientType = ReturnType<typeof ouraClient>
 
 interface McpDeps {
+  centralDb?: CentralDb
   garmin?: GarminClient
   oura?: OuraClientType
   sync?: SyncProvider
@@ -75,13 +78,20 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
 export function createMcpRouter(auth: Auth, deps: McpDeps = {}): Router {
   const router = Router()
 
-  const getAuthenticatedUser = (req: Request): string | null => {
+  const getAuthenticatedUser = async (req: Request): Promise<string | null> => {
     const authHeader = req.headers.authorization
     if (typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
       return null
     }
+    const token = authHeader.slice('Bearer '.length)
+
+    // Try OAuth access token first (prefixed with aur_at_)
+    if (isOAuthAccessToken(token) && deps.centralDb) {
+      return validateAccessToken({ centralDb: deps.centralDb }, token)
+    }
+
+    // Fall back to existing AES-256-GCM token
     try {
-      const token = authHeader.slice('Bearer '.length)
       return auth.getUsernameFromToken(token)
     } catch {
       return null
@@ -90,7 +100,7 @@ export function createMcpRouter(auth: Auth, deps: McpDeps = {}): Router {
 
   // POST /mcp - Handle JSON-RPC requests (stateless: fresh server per request)
   router.post('/', async (req: Request, res: Response) => {
-    const user = getAuthenticatedUser(req)
+    const user = await getAuthenticatedUser(req)
     if (!user) {
       res.status(401).json({ error: 'Unauthorized' })
       return

--- a/apps/backend/src/routes/oauth-router.ts
+++ b/apps/backend/src/routes/oauth-router.ts
@@ -1,0 +1,248 @@
+/**
+ * OAuth 2.1 router for MCP authentication.
+ *
+ * Provides endpoints required by the MCP spec for OAuth 2.1 authorization
+ * server discovery, authorization, token exchange, and dynamic client
+ * registration. Endpoints are mounted at the domain root level.
+ */
+import express, { Router, type Request, type Response } from 'express'
+
+import type { CentralDb } from '../services/central-db.ts'
+
+import {
+  createAuthorizationCode,
+  exchangeAuthorizationCode,
+  refreshAccessToken,
+  registerClient,
+} from '../services/oauth.ts'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface OAuthRouterDeps {
+  centralDb: CentralDb
+  loginToUserDb: (username: string, password: string) => Promise<unknown>
+  webHost: string
+}
+
+// ============================================================================
+// Login form HTML
+// ============================================================================
+
+const loginFormHtml = (params: {
+  client_id: string
+  redirect_uri: string
+  state: string
+  code_challenge: string
+  code_challenge_method: string
+  error?: string
+}) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aurboda — Sign In</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    .card { background: #1e293b; border-radius: 12px; padding: 2rem; width: 100%; max-width: 400px; box-shadow: 0 4px 24px rgba(0,0,0,0.3); }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    p.sub { color: #94a3b8; margin-bottom: 1.5rem; font-size: 0.9rem; }
+    label { display: block; margin-bottom: 0.25rem; font-size: 0.875rem; color: #94a3b8; }
+    input[type="text"], input[type="password"] { width: 100%; padding: 0.6rem 0.75rem; border: 1px solid #334155; border-radius: 6px; background: #0f172a; color: #e2e8f0; font-size: 1rem; margin-bottom: 1rem; }
+    input:focus { outline: none; border-color: #6366f1; }
+    button { width: 100%; padding: 0.7rem; border: none; border-radius: 6px; background: #6366f1; color: white; font-size: 1rem; cursor: pointer; font-weight: 500; }
+    button:hover { background: #4f46e5; }
+    .error { background: #7f1d1d; color: #fca5a5; padding: 0.6rem 0.75rem; border-radius: 6px; margin-bottom: 1rem; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Aurboda</h1>
+    <p class="sub">Sign in to authorize access to your health data.</p>
+    ${params.error ? `<div class="error">${params.error}</div>` : ''}
+    <form method="POST" action="/authorize">
+      <input type="hidden" name="client_id" value="${escapeHtml(params.client_id)}">
+      <input type="hidden" name="redirect_uri" value="${escapeHtml(params.redirect_uri)}">
+      <input type="hidden" name="state" value="${escapeHtml(params.state)}">
+      <input type="hidden" name="code_challenge" value="${escapeHtml(params.code_challenge)}">
+      <input type="hidden" name="code_challenge_method" value="${escapeHtml(params.code_challenge_method)}">
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username" required autocomplete="username">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required autocomplete="current-password">
+      <button type="submit">Sign In</button>
+    </form>
+  </div>
+</body>
+</html>`
+
+const escapeHtml = (str: string): string =>
+  str.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+
+// ============================================================================
+// Router factory
+// ============================================================================
+
+export const createOAuthRouter = (deps: OAuthRouterDeps): Router => {
+  const { centralDb, loginToUserDb, webHost } = deps
+  const router = Router()
+  const oauthDeps = { centralDb }
+
+  // OAuth metadata discovery
+  router.get('/.well-known/oauth-authorization-server', (_req: Request, res: Response) => {
+    const issuer = webHost
+    res.json({
+      issuer,
+      authorization_endpoint: `${issuer}/authorize`,
+      token_endpoint: `${issuer}/token`,
+      registration_endpoint: `${issuer}/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['none'],
+    })
+  })
+
+  // Authorization endpoint — GET serves login form
+  router.get('/authorize', (req: Request, res: Response) => {
+    const { client_id, redirect_uri, state, code_challenge, code_challenge_method } = req.query as Record<
+      string,
+      string
+    >
+
+    if (!client_id || !redirect_uri || !code_challenge || !code_challenge_method) {
+      res.status(400).send('Missing required OAuth parameters')
+      return
+    }
+
+    res.type('html').send(
+      loginFormHtml({
+        client_id,
+        redirect_uri,
+        state: state ?? '',
+        code_challenge,
+        code_challenge_method,
+      }),
+    )
+  })
+
+  // Authorization endpoint — POST handles login + redirect
+  router.post('/authorize', express.urlencoded({ extended: false }), async (req: Request, res: Response) => {
+    const { client_id, redirect_uri, state, code_challenge, code_challenge_method, username, password } =
+      req.body
+
+    if (!client_id || !redirect_uri || !code_challenge || !code_challenge_method || !username || !password) {
+      res.status(400).send('Missing required parameters')
+      return
+    }
+
+    // Authenticate user
+    try {
+      await loginToUserDb(username, password)
+    } catch {
+      res.type('html').send(
+        loginFormHtml({
+          client_id,
+          redirect_uri,
+          state: state ?? '',
+          code_challenge,
+          code_challenge_method,
+          error: 'Invalid username or password',
+        }),
+      )
+      return
+    }
+
+    // Generate authorization code
+    try {
+      const code = await createAuthorizationCode(oauthDeps, {
+        client_id,
+        username,
+        redirect_uri,
+        code_challenge,
+        code_challenge_method,
+      })
+
+      const redirectUrl = new URL(redirect_uri)
+      redirectUrl.searchParams.set('code', code)
+      if (state) {
+        redirectUrl.searchParams.set('state', state)
+      }
+
+      res.redirect(302, redirectUrl.toString())
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Authorization failed'
+      res.status(400).json({ error: message })
+    }
+  })
+
+  // Token endpoint
+  router.post('/token', express.urlencoded({ extended: false }), async (req: Request, res: Response) => {
+    const { grant_type } = req.body
+
+    try {
+      if (grant_type === 'authorization_code') {
+        const { code, client_id, redirect_uri, code_verifier } = req.body
+        if (!code || !client_id || !redirect_uri || !code_verifier) {
+          res.status(400).json({ error: 'invalid_request', error_description: 'Missing required parameters' })
+          return
+        }
+
+        const result = await exchangeAuthorizationCode(oauthDeps, {
+          code,
+          client_id,
+          redirect_uri,
+          code_verifier,
+        })
+
+        res.json(result)
+      } else if (grant_type === 'refresh_token') {
+        const { refresh_token, client_id } = req.body
+        if (!refresh_token || !client_id) {
+          res.status(400).json({ error: 'invalid_request', error_description: 'Missing required parameters' })
+          return
+        }
+
+        const result = await refreshAccessToken(oauthDeps, { refresh_token, client_id })
+        res.json(result)
+      } else {
+        res.status(400).json({ error: 'unsupported_grant_type' })
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Token exchange failed'
+      res.status(400).json({ error: 'invalid_grant', error_description: message })
+    }
+  })
+
+  // Dynamic client registration (RFC 7591)
+  router.post('/register', express.json(), async (req: Request, res: Response) => {
+    const { client_name, redirect_uris, token_endpoint_auth_method } = req.body
+
+    if (!client_name || !redirect_uris || !Array.isArray(redirect_uris) || redirect_uris.length === 0) {
+      res
+        .status(400)
+        .json({
+          error: 'invalid_client_metadata',
+          error_description: 'client_name and redirect_uris are required',
+        })
+      return
+    }
+
+    try {
+      const result = await registerClient(oauthDeps, {
+        client_name,
+        redirect_uris,
+        token_endpoint_auth_method,
+      })
+
+      res.status(201).json(result)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Registration failed'
+      res.status(400).json({ error: 'invalid_client_metadata', error_description: message })
+    }
+  })
+
+  return router
+}

--- a/apps/backend/src/services/central-db.test.ts
+++ b/apps/backend/src/services/central-db.test.ts
@@ -438,4 +438,190 @@ describe('central-db', () => {
       expect(result).toBe(5)
     })
   })
+
+  describe('createOAuthClient', () => {
+    test('inserts OAuth client', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      await centralDb.createOAuthClient({
+        client_id: 'aur_test123',
+        client_name: 'Test Client',
+        redirect_uris: ['https://example.com/cb'],
+        token_endpoint_auth_method: 'none',
+      })
+
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO oauth_clients'), [
+        'aur_test123',
+        'Test Client',
+        '["https://example.com/cb"]',
+        'none',
+      ])
+    })
+  })
+
+  describe('getOAuthClient', () => {
+    test('returns client when found', async () => {
+      const row = {
+        client_id: 'aur_test',
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/cb'],
+        token_endpoint_auth_method: 'none',
+        created_at: new Date(),
+      }
+      mockClient.query.mockResolvedValue({ rows: [row] })
+
+      const result = await centralDb.getOAuthClient('aur_test')
+
+      expect(result).toEqual(row)
+    })
+
+    test('returns null when not found', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getOAuthClient('unknown')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('saveAuthorizationCode', () => {
+    test('inserts authorization code', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+      const expiresAt = new Date()
+
+      await centralDb.saveAuthorizationCode({
+        code: 'test-code',
+        client_id: 'aur_test',
+        username: 'testuser',
+        redirect_uri: 'https://example.com/cb',
+        code_challenge: 'challenge',
+        code_challenge_method: 'S256',
+        expires_at: expiresAt,
+      })
+
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO oauth_authorization_codes'),
+        ['test-code', 'aur_test', 'testuser', 'https://example.com/cb', 'challenge', 'S256', expiresAt],
+      )
+    })
+  })
+
+  describe('consumeAuthorizationCode', () => {
+    test('returns and marks code as used atomically', async () => {
+      const row = {
+        code: 'test-code',
+        client_id: 'aur_test',
+        username: 'testuser',
+        redirect_uri: 'https://example.com/cb',
+        code_challenge: 'challenge',
+        code_challenge_method: 'S256',
+        expires_at: new Date(),
+        used: true,
+      }
+      mockClient.query.mockResolvedValue({ rows: [row] })
+
+      const result = await centralDb.consumeAuthorizationCode('test-code')
+
+      expect(result).toEqual(row)
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE oauth_authorization_codes'),
+        ['test-code'],
+      )
+    })
+
+    test('returns null for already-used or expired code', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.consumeAuthorizationCode('used-code')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('saveOAuthToken', () => {
+    test('inserts OAuth token', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+      const now = new Date()
+
+      await centralDb.saveOAuthToken({
+        token: 'aur_at_test',
+        token_type: 'access',
+        client_id: 'aur_test',
+        username: 'testuser',
+        expires_at: now,
+        revoked: false,
+        parent_token: null,
+        created_at: now,
+      })
+
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO oauth_tokens'), [
+        'aur_at_test',
+        'access',
+        'aur_test',
+        'testuser',
+        now,
+        false,
+        null,
+      ])
+    })
+  })
+
+  describe('getOAuthToken', () => {
+    test('returns valid token', async () => {
+      const row = {
+        token: 'aur_at_test',
+        token_type: 'access',
+        client_id: 'aur_test',
+        username: 'testuser',
+        expires_at: new Date(Date.now() + 3600_000),
+        revoked: false,
+        parent_token: null,
+        created_at: new Date(),
+      }
+      mockClient.query.mockResolvedValue({ rows: [row] })
+
+      const result = await centralDb.getOAuthToken('aur_at_test')
+
+      expect(result).toEqual(row)
+    })
+
+    test('returns null for revoked/expired token', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] })
+
+      const result = await centralDb.getOAuthToken('revoked')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('revokeOAuthToken', () => {
+    test('returns true when token revoked', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 1 })
+
+      const result = await centralDb.revokeOAuthToken('aur_at_test')
+
+      expect(result).toBe(true)
+    })
+
+    test('returns false when token not found', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 0 })
+
+      const result = await centralDb.revokeOAuthToken('unknown')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('cleanupExpiredOAuth', () => {
+    test('deletes expired codes and tokens', async () => {
+      mockClient.query.mockResolvedValue({ rowCount: 0 })
+
+      await centralDb.cleanupExpiredOAuth()
+
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM oauth_authorization_codes'),
+      )
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM oauth_tokens'))
+    })
+  })
 })

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -38,6 +38,36 @@ export interface OuraWebhookSubscription {
   updated_at: Date
 }
 
+export interface OAuthClient {
+  client_id: string
+  client_name: string
+  redirect_uris: string[]
+  token_endpoint_auth_method: string
+  created_at: Date
+}
+
+export interface OAuthAuthorizationCode {
+  code: string
+  client_id: string
+  username: string
+  redirect_uri: string
+  code_challenge: string
+  code_challenge_method: string
+  expires_at: Date
+  used: boolean
+}
+
+export interface OAuthToken {
+  token: string
+  token_type: 'access' | 'refresh'
+  client_id: string
+  username: string
+  expires_at: Date
+  revoked: boolean
+  parent_token: string | null
+  created_at: Date
+}
+
 export interface CentralDbDeps {
   getClient: () => Promise<pg.Client>
 }
@@ -66,6 +96,14 @@ export interface CentralDb {
   getOuraWebhookSubscriptions: () => Promise<OuraWebhookSubscription[]>
   deleteOuraWebhookSubscription: (ouraSubscriptionId: string) => Promise<boolean>
   deleteAllOuraWebhookSubscriptions: () => Promise<number>
+  createOAuthClient: (client: Omit<OAuthClient, 'created_at'>) => Promise<void>
+  getOAuthClient: (clientId: string) => Promise<OAuthClient | null>
+  saveAuthorizationCode: (code: Omit<OAuthAuthorizationCode, 'used'>) => Promise<void>
+  consumeAuthorizationCode: (code: string) => Promise<OAuthAuthorizationCode | null>
+  saveOAuthToken: (token: OAuthToken) => Promise<void>
+  getOAuthToken: (token: string) => Promise<OAuthToken | null>
+  revokeOAuthToken: (token: string) => Promise<boolean>
+  cleanupExpiredOAuth: () => Promise<void>
 }
 
 // ============================================================================
@@ -159,6 +197,42 @@ const CREATE_OURA_WEBHOOK_SUBSCRIPTIONS_TABLE = `
     expiration_time TIMESTAMPTZ,
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`
+
+const CREATE_OAUTH_CLIENTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS oauth_clients (
+    client_id VARCHAR(255) PRIMARY KEY,
+    client_name VARCHAR(255) NOT NULL,
+    redirect_uris JSONB NOT NULL DEFAULT '[]',
+    token_endpoint_auth_method VARCHAR(50) NOT NULL DEFAULT 'none',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`
+
+const CREATE_OAUTH_AUTHORIZATION_CODES_TABLE = `
+  CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+    code VARCHAR(255) PRIMARY KEY,
+    client_id VARCHAR(255) NOT NULL REFERENCES oauth_clients(client_id),
+    username VARCHAR(255) NOT NULL,
+    redirect_uri TEXT NOT NULL,
+    code_challenge VARCHAR(255) NOT NULL,
+    code_challenge_method VARCHAR(10) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used BOOLEAN NOT NULL DEFAULT FALSE
+  )
+`
+
+const CREATE_OAUTH_TOKENS_TABLE = `
+  CREATE TABLE IF NOT EXISTS oauth_tokens (
+    token VARCHAR(255) PRIMARY KEY,
+    token_type VARCHAR(10) NOT NULL CHECK (token_type IN ('access', 'refresh')),
+    client_id VARCHAR(255) NOT NULL REFERENCES oauth_clients(client_id),
+    username VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked BOOLEAN NOT NULL DEFAULT FALSE,
+    parent_token VARCHAR(255),
+    created_at TIMESTAMPTZ DEFAULT NOW()
   )
 `
 
@@ -270,6 +344,9 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       await client.query(CREATE_ADMINS_TABLE)
       await client.query(CREATE_OURA_USER_MAPPINGS_TABLE)
       await client.query(CREATE_OURA_WEBHOOK_SUBSCRIPTIONS_TABLE)
+      await client.query(CREATE_OAUTH_CLIENTS_TABLE)
+      await client.query(CREATE_OAUTH_AUTHORIZATION_CODES_TABLE)
+      await client.query(CREATE_OAUTH_TOKENS_TABLE)
 
       // Set default signup_mode if not exists
       await client.query(
@@ -359,6 +436,101 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
            data_type = $2, event_type = $3, callback_url = $4, expiration_time = $5, updated_at = NOW()`,
         [sub.oura_subscription_id, sub.data_type, sub.event_type, sub.callback_url, sub.expiration_time],
       )
+    },
+
+    createOAuthClient: async (client_data: Omit<OAuthClient, 'created_at'>): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO oauth_clients (client_id, client_name, redirect_uris, token_endpoint_auth_method)
+         VALUES ($1, $2, $3, $4)`,
+        [
+          client_data.client_id,
+          client_data.client_name,
+          JSON.stringify(client_data.redirect_uris),
+          client_data.token_endpoint_auth_method,
+        ],
+      )
+    },
+
+    getOAuthClient: async (clientId: string): Promise<OAuthClient | null> => {
+      const client = await getClient()
+      const result = await client.query(
+        'SELECT client_id, client_name, redirect_uris, token_endpoint_auth_method, created_at FROM oauth_clients WHERE client_id = $1',
+        [clientId],
+      )
+      if (result.rows.length === 0) return null
+      return result.rows[0]
+    },
+
+    saveAuthorizationCode: async (code: Omit<OAuthAuthorizationCode, 'used'>): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO oauth_authorization_codes (code, client_id, username, redirect_uri, code_challenge, code_challenge_method, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          code.code,
+          code.client_id,
+          code.username,
+          code.redirect_uri,
+          code.code_challenge,
+          code.code_challenge_method,
+          code.expires_at,
+        ],
+      )
+    },
+
+    consumeAuthorizationCode: async (code: string): Promise<OAuthAuthorizationCode | null> => {
+      const client = await getClient()
+      const result = await client.query(
+        `UPDATE oauth_authorization_codes
+         SET used = TRUE
+         WHERE code = $1 AND used = FALSE AND expires_at > NOW()
+         RETURNING code, client_id, username, redirect_uri, code_challenge, code_challenge_method, expires_at, used`,
+        [code],
+      )
+      if (result.rows.length === 0) return null
+      return result.rows[0]
+    },
+
+    saveOAuthToken: async (token: OAuthToken): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO oauth_tokens (token, token_type, client_id, username, expires_at, revoked, parent_token)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          token.token,
+          token.token_type,
+          token.client_id,
+          token.username,
+          token.expires_at,
+          token.revoked,
+          token.parent_token,
+        ],
+      )
+    },
+
+    getOAuthToken: async (token: string): Promise<OAuthToken | null> => {
+      const client = await getClient()
+      const result = await client.query(
+        `SELECT token, token_type, client_id, username, expires_at, revoked, parent_token, created_at
+         FROM oauth_tokens
+         WHERE token = $1 AND revoked = FALSE AND expires_at > NOW()`,
+        [token],
+      )
+      if (result.rows.length === 0) return null
+      return result.rows[0]
+    },
+
+    revokeOAuthToken: async (token: string): Promise<boolean> => {
+      const client = await getClient()
+      const result = await client.query('UPDATE oauth_tokens SET revoked = TRUE WHERE token = $1', [token])
+      return (result.rowCount ?? 0) > 0
+    },
+
+    cleanupExpiredOAuth: async (): Promise<void> => {
+      const client = await getClient()
+      await client.query('DELETE FROM oauth_authorization_codes WHERE expires_at < NOW()')
+      await client.query('DELETE FROM oauth_tokens WHERE expires_at < NOW()')
     },
   }
 }

--- a/apps/backend/src/services/oauth.test.ts
+++ b/apps/backend/src/services/oauth.test.ts
@@ -1,0 +1,353 @@
+import { createHash } from 'node:crypto'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { CentralDb, OAuthAuthorizationCode, OAuthClient, OAuthToken } from './central-db.ts'
+
+import {
+  createAuthorizationCode,
+  exchangeAuthorizationCode,
+  isOAuthAccessToken,
+  refreshAccessToken,
+  registerClient,
+  validateAccessToken,
+} from './oauth.ts'
+
+const createMockCentralDb = () =>
+  ({
+    createOAuthClient: vi.fn(),
+    getOAuthClient: vi.fn(),
+    saveAuthorizationCode: vi.fn(),
+    consumeAuthorizationCode: vi.fn(),
+    saveOAuthToken: vi.fn(),
+    getOAuthToken: vi.fn(),
+    revokeOAuthToken: vi.fn(),
+    cleanupExpiredOAuth: vi.fn(),
+  }) as unknown as CentralDb & {
+    createOAuthClient: ReturnType<typeof vi.fn>
+    getOAuthClient: ReturnType<typeof vi.fn>
+    saveAuthorizationCode: ReturnType<typeof vi.fn>
+    consumeAuthorizationCode: ReturnType<typeof vi.fn>
+    saveOAuthToken: ReturnType<typeof vi.fn>
+    getOAuthToken: ReturnType<typeof vi.fn>
+    revokeOAuthToken: ReturnType<typeof vi.fn>
+    cleanupExpiredOAuth: ReturnType<typeof vi.fn>
+  }
+
+const makePkce = () => {
+  const verifier = 'test-code-verifier-that-is-long-enough'
+  const challenge = createHash('sha256').update(verifier).digest('base64url')
+  return { verifier, challenge }
+}
+
+describe('oauth service', () => {
+  let mockDb: ReturnType<typeof createMockCentralDb>
+  let deps: { centralDb: CentralDb }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDb = createMockCentralDb()
+    deps = { centralDb: mockDb }
+  })
+
+  describe('registerClient', () => {
+    test('creates client with generated client_id', async () => {
+      const result = await registerClient(deps, {
+        client_name: 'Test Client',
+        redirect_uris: ['https://example.com/callback'],
+      })
+
+      expect(result.client_id).toMatch(/^aur_/)
+      expect(result.client_name).toBe('Test Client')
+      expect(result.redirect_uris).toEqual(['https://example.com/callback'])
+      expect(result.token_endpoint_auth_method).toBe('none')
+      expect(mockDb.createOAuthClient).toHaveBeenCalledWith(
+        expect.objectContaining({ client_name: 'Test Client' }),
+      )
+    })
+  })
+
+  describe('createAuthorizationCode', () => {
+    test('generates code for valid client and redirect_uri', async () => {
+      const client: OAuthClient = {
+        client_id: 'aur_test',
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/cb'],
+        token_endpoint_auth_method: 'none',
+        created_at: new Date(),
+      }
+      mockDb.getOAuthClient.mockResolvedValue(client)
+
+      const pkce = makePkce()
+      const code = await createAuthorizationCode(deps, {
+        client_id: 'aur_test',
+        username: 'testuser',
+        redirect_uri: 'https://example.com/cb',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+      })
+
+      expect(typeof code).toBe('string')
+      expect(code.length).toBeGreaterThan(20)
+      expect(mockDb.saveAuthorizationCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_id: 'aur_test',
+          username: 'testuser',
+          code_challenge: pkce.challenge,
+        }),
+      )
+    })
+
+    test('rejects unknown client_id', async () => {
+      mockDb.getOAuthClient.mockResolvedValue(null)
+
+      await expect(
+        createAuthorizationCode(deps, {
+          client_id: 'unknown',
+          username: 'testuser',
+          redirect_uri: 'https://example.com/cb',
+          code_challenge: 'abc',
+          code_challenge_method: 'S256',
+        }),
+      ).rejects.toThrow('Unknown client_id')
+    })
+
+    test('rejects invalid redirect_uri', async () => {
+      mockDb.getOAuthClient.mockResolvedValue({
+        client_id: 'aur_test',
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/cb'],
+        token_endpoint_auth_method: 'none',
+        created_at: new Date(),
+      })
+
+      await expect(
+        createAuthorizationCode(deps, {
+          client_id: 'aur_test',
+          username: 'testuser',
+          redirect_uri: 'https://evil.com/cb',
+          code_challenge: 'abc',
+          code_challenge_method: 'S256',
+        }),
+      ).rejects.toThrow('Invalid redirect_uri')
+    })
+
+    test('rejects non-S256 code_challenge_method', async () => {
+      mockDb.getOAuthClient.mockResolvedValue({
+        client_id: 'aur_test',
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/cb'],
+        token_endpoint_auth_method: 'none',
+        created_at: new Date(),
+      })
+
+      await expect(
+        createAuthorizationCode(deps, {
+          client_id: 'aur_test',
+          username: 'testuser',
+          redirect_uri: 'https://example.com/cb',
+          code_challenge: 'abc',
+          code_challenge_method: 'plain',
+        }),
+      ).rejects.toThrow('Only S256')
+    })
+  })
+
+  describe('exchangeAuthorizationCode', () => {
+    test('exchanges valid code for tokens', async () => {
+      const pkce = makePkce()
+      const authCode: OAuthAuthorizationCode = {
+        code: 'test-code',
+        client_id: 'aur_test',
+        username: 'testuser',
+        redirect_uri: 'https://example.com/cb',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        expires_at: new Date(Date.now() + 600_000),
+        used: true,
+      }
+      mockDb.consumeAuthorizationCode.mockResolvedValue(authCode)
+
+      const result = await exchangeAuthorizationCode(deps, {
+        code: 'test-code',
+        client_id: 'aur_test',
+        redirect_uri: 'https://example.com/cb',
+        code_verifier: pkce.verifier,
+      })
+
+      expect(result.access_token).toMatch(/^aur_at_/)
+      expect(result.refresh_token).toMatch(/^aur_rt_/)
+      expect(result.token_type).toBe('bearer')
+      expect(result.expires_in).toBe(3600)
+      expect(mockDb.saveOAuthToken).toHaveBeenCalledTimes(2)
+    })
+
+    test('rejects invalid code', async () => {
+      mockDb.consumeAuthorizationCode.mockResolvedValue(null)
+
+      await expect(
+        exchangeAuthorizationCode(deps, {
+          code: 'invalid',
+          client_id: 'aur_test',
+          redirect_uri: 'https://example.com/cb',
+          code_verifier: 'anything',
+        }),
+      ).rejects.toThrow('Invalid or expired authorization code')
+    })
+
+    test('rejects client_id mismatch', async () => {
+      const pkce = makePkce()
+      mockDb.consumeAuthorizationCode.mockResolvedValue({
+        code: 'test-code',
+        client_id: 'aur_other',
+        username: 'testuser',
+        redirect_uri: 'https://example.com/cb',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        expires_at: new Date(Date.now() + 600_000),
+        used: true,
+      })
+
+      await expect(
+        exchangeAuthorizationCode(deps, {
+          code: 'test-code',
+          client_id: 'aur_test',
+          redirect_uri: 'https://example.com/cb',
+          code_verifier: pkce.verifier,
+        }),
+      ).rejects.toThrow('client_id mismatch')
+    })
+
+    test('rejects bad PKCE verifier', async () => {
+      const pkce = makePkce()
+      mockDb.consumeAuthorizationCode.mockResolvedValue({
+        code: 'test-code',
+        client_id: 'aur_test',
+        username: 'testuser',
+        redirect_uri: 'https://example.com/cb',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        expires_at: new Date(Date.now() + 600_000),
+        used: true,
+      })
+
+      await expect(
+        exchangeAuthorizationCode(deps, {
+          code: 'test-code',
+          client_id: 'aur_test',
+          redirect_uri: 'https://example.com/cb',
+          code_verifier: 'wrong-verifier',
+        }),
+      ).rejects.toThrow('PKCE verification failed')
+    })
+  })
+
+  describe('refreshAccessToken', () => {
+    test('rotates tokens on valid refresh', async () => {
+      const oldRefresh: OAuthToken = {
+        token: 'aur_rt_old',
+        token_type: 'refresh',
+        client_id: 'aur_test',
+        username: 'testuser',
+        expires_at: new Date(Date.now() + 86400_000),
+        revoked: false,
+        parent_token: 'aur_at_old',
+        created_at: new Date(),
+      }
+      mockDb.getOAuthToken.mockResolvedValue(oldRefresh)
+
+      const result = await refreshAccessToken(deps, {
+        refresh_token: 'aur_rt_old',
+        client_id: 'aur_test',
+      })
+
+      expect(result.access_token).toMatch(/^aur_at_/)
+      expect(result.refresh_token).toMatch(/^aur_rt_/)
+      expect(mockDb.revokeOAuthToken).toHaveBeenCalledWith('aur_rt_old')
+      expect(mockDb.revokeOAuthToken).toHaveBeenCalledWith('aur_at_old')
+      expect(mockDb.saveOAuthToken).toHaveBeenCalledTimes(2)
+    })
+
+    test('rejects invalid refresh token', async () => {
+      mockDb.getOAuthToken.mockResolvedValue(null)
+
+      await expect(
+        refreshAccessToken(deps, { refresh_token: 'invalid', client_id: 'aur_test' }),
+      ).rejects.toThrow('Invalid or expired refresh token')
+    })
+
+    test('rejects client_id mismatch', async () => {
+      mockDb.getOAuthToken.mockResolvedValue({
+        token: 'aur_rt_old',
+        token_type: 'refresh',
+        client_id: 'aur_other',
+        username: 'testuser',
+        expires_at: new Date(Date.now() + 86400_000),
+        revoked: false,
+        parent_token: null,
+        created_at: new Date(),
+      })
+
+      await expect(
+        refreshAccessToken(deps, { refresh_token: 'aur_rt_old', client_id: 'aur_test' }),
+      ).rejects.toThrow('client_id mismatch')
+    })
+  })
+
+  describe('validateAccessToken', () => {
+    test('returns username for valid access token', async () => {
+      mockDb.getOAuthToken.mockResolvedValue({
+        token: 'aur_at_test',
+        token_type: 'access',
+        client_id: 'aur_test',
+        username: 'testuser',
+        expires_at: new Date(Date.now() + 3600_000),
+        revoked: false,
+        parent_token: null,
+        created_at: new Date(),
+      })
+
+      const result = await validateAccessToken(deps, 'aur_at_test')
+
+      expect(result).toBe('testuser')
+    })
+
+    test('returns null for invalid token', async () => {
+      mockDb.getOAuthToken.mockResolvedValue(null)
+
+      const result = await validateAccessToken(deps, 'invalid')
+
+      expect(result).toBeNull()
+    })
+
+    test('returns null for refresh token', async () => {
+      mockDb.getOAuthToken.mockResolvedValue({
+        token: 'aur_rt_test',
+        token_type: 'refresh',
+        client_id: 'aur_test',
+        username: 'testuser',
+        expires_at: new Date(Date.now() + 86400_000),
+        revoked: false,
+        parent_token: null,
+        created_at: new Date(),
+      })
+
+      const result = await validateAccessToken(deps, 'aur_rt_test')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('isOAuthAccessToken', () => {
+    test('returns true for aur_at_ prefix', () => {
+      expect(isOAuthAccessToken('aur_at_something')).toBe(true)
+    })
+
+    test('returns false for AES token', () => {
+      expect(isOAuthAccessToken('abc123-def456-ghi789')).toBe(false)
+    })
+
+    test('returns false for refresh token', () => {
+      expect(isOAuthAccessToken('aur_rt_something')).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/services/oauth.ts
+++ b/apps/backend/src/services/oauth.ts
@@ -1,0 +1,260 @@
+/**
+ * OAuth 2.1 service for MCP authentication.
+ *
+ * Implements authorization code flow with PKCE (S256) for Claude.ai
+ * custom connectors and other OAuth 2.1 clients.
+ */
+import { createHash, randomBytes } from 'node:crypto'
+
+import type { CentralDb } from './central-db.ts'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface OAuthDeps {
+  centralDb: CentralDb
+}
+
+export interface RegisterClientInput {
+  client_name: string
+  redirect_uris: string[]
+  token_endpoint_auth_method?: string
+}
+
+export interface RegisterClientResult {
+  client_id: string
+  client_name: string
+  redirect_uris: string[]
+  token_endpoint_auth_method: string
+}
+
+export interface CreateAuthCodeParams {
+  client_id: string
+  username: string
+  redirect_uri: string
+  code_challenge: string
+  code_challenge_method: string
+}
+
+export interface ExchangeCodeParams {
+  code: string
+  client_id: string
+  redirect_uri: string
+  code_verifier: string
+}
+
+export interface TokenResult {
+  access_token: string
+  token_type: 'bearer'
+  expires_in: number
+  refresh_token: string
+}
+
+export interface RefreshTokenParams {
+  refresh_token: string
+  client_id: string
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ACCESS_TOKEN_LIFETIME_SECONDS = 3600 // 1 hour
+const REFRESH_TOKEN_LIFETIME_SECONDS = 30 * 24 * 3600 // 30 days
+const AUTH_CODE_LIFETIME_SECONDS = 600 // 10 minutes
+
+const ACCESS_TOKEN_PREFIX = 'aur_at_'
+const REFRESH_TOKEN_PREFIX = 'aur_rt_'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const generateToken = (prefix: string): string => prefix + randomBytes(32).toString('base64url')
+
+const generateClientId = (): string => 'aur_' + randomBytes(16).toString('base64url')
+
+const generateAuthCode = (): string => randomBytes(32).toString('base64url')
+
+const verifyPkceS256 = (codeVerifier: string, codeChallenge: string): boolean => {
+  const computed = createHash('sha256').update(codeVerifier).digest('base64url')
+  return computed === codeChallenge
+}
+
+// ============================================================================
+// Service functions
+// ============================================================================
+
+export const registerClient = async (
+  deps: OAuthDeps,
+  input: RegisterClientInput,
+): Promise<RegisterClientResult> => {
+  const clientId = generateClientId()
+  const authMethod = input.token_endpoint_auth_method ?? 'none'
+
+  await deps.centralDb.createOAuthClient({
+    client_id: clientId,
+    client_name: input.client_name,
+    redirect_uris: input.redirect_uris,
+    token_endpoint_auth_method: authMethod,
+  })
+
+  return {
+    client_id: clientId,
+    client_name: input.client_name,
+    redirect_uris: input.redirect_uris,
+    token_endpoint_auth_method: authMethod,
+  }
+}
+
+export const createAuthorizationCode = async (
+  deps: OAuthDeps,
+  params: CreateAuthCodeParams,
+): Promise<string> => {
+  const client = await deps.centralDb.getOAuthClient(params.client_id)
+  if (!client) {
+    throw new Error('Unknown client_id')
+  }
+
+  if (!client.redirect_uris.includes(params.redirect_uri)) {
+    throw new Error('Invalid redirect_uri')
+  }
+
+  if (params.code_challenge_method !== 'S256') {
+    throw new Error('Only S256 code_challenge_method is supported')
+  }
+
+  const code = generateAuthCode()
+  const expiresAt = new Date(Date.now() + AUTH_CODE_LIFETIME_SECONDS * 1000)
+
+  await deps.centralDb.saveAuthorizationCode({
+    code,
+    client_id: params.client_id,
+    username: params.username,
+    redirect_uri: params.redirect_uri,
+    code_challenge: params.code_challenge,
+    code_challenge_method: params.code_challenge_method,
+    expires_at: expiresAt,
+  })
+
+  return code
+}
+
+export const exchangeAuthorizationCode = async (
+  deps: OAuthDeps,
+  params: ExchangeCodeParams,
+): Promise<TokenResult> => {
+  const authCode = await deps.centralDb.consumeAuthorizationCode(params.code)
+  if (!authCode) {
+    throw new Error('Invalid or expired authorization code')
+  }
+
+  if (authCode.client_id !== params.client_id) {
+    throw new Error('client_id mismatch')
+  }
+
+  if (authCode.redirect_uri !== params.redirect_uri) {
+    throw new Error('redirect_uri mismatch')
+  }
+
+  if (!verifyPkceS256(params.code_verifier, authCode.code_challenge)) {
+    throw new Error('PKCE verification failed')
+  }
+
+  const accessToken = generateToken(ACCESS_TOKEN_PREFIX)
+  const refreshToken = generateToken(REFRESH_TOKEN_PREFIX)
+  const now = Date.now()
+
+  await deps.centralDb.saveOAuthToken({
+    token: accessToken,
+    token_type: 'access',
+    client_id: authCode.client_id,
+    username: authCode.username,
+    expires_at: new Date(now + ACCESS_TOKEN_LIFETIME_SECONDS * 1000),
+    revoked: false,
+    parent_token: null,
+    created_at: new Date(now),
+  })
+
+  await deps.centralDb.saveOAuthToken({
+    token: refreshToken,
+    token_type: 'refresh',
+    client_id: authCode.client_id,
+    username: authCode.username,
+    expires_at: new Date(now + REFRESH_TOKEN_LIFETIME_SECONDS * 1000),
+    revoked: false,
+    parent_token: accessToken,
+    created_at: new Date(now),
+  })
+
+  return {
+    access_token: accessToken,
+    token_type: 'bearer',
+    expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
+    refresh_token: refreshToken,
+  }
+}
+
+export const refreshAccessToken = async (
+  deps: OAuthDeps,
+  params: RefreshTokenParams,
+): Promise<TokenResult> => {
+  const oldRefresh = await deps.centralDb.getOAuthToken(params.refresh_token)
+  if (!oldRefresh || oldRefresh.token_type !== 'refresh') {
+    throw new Error('Invalid or expired refresh token')
+  }
+
+  if (oldRefresh.client_id !== params.client_id) {
+    throw new Error('client_id mismatch')
+  }
+
+  // Revoke old tokens (rotation)
+  await deps.centralDb.revokeOAuthToken(params.refresh_token)
+  if (oldRefresh.parent_token) {
+    await deps.centralDb.revokeOAuthToken(oldRefresh.parent_token)
+  }
+
+  const accessToken = generateToken(ACCESS_TOKEN_PREFIX)
+  const refreshToken = generateToken(REFRESH_TOKEN_PREFIX)
+  const now = Date.now()
+
+  await deps.centralDb.saveOAuthToken({
+    token: accessToken,
+    token_type: 'access',
+    client_id: oldRefresh.client_id,
+    username: oldRefresh.username,
+    expires_at: new Date(now + ACCESS_TOKEN_LIFETIME_SECONDS * 1000),
+    revoked: false,
+    parent_token: null,
+    created_at: new Date(now),
+  })
+
+  await deps.centralDb.saveOAuthToken({
+    token: refreshToken,
+    token_type: 'refresh',
+    client_id: oldRefresh.client_id,
+    username: oldRefresh.username,
+    expires_at: new Date(now + REFRESH_TOKEN_LIFETIME_SECONDS * 1000),
+    revoked: false,
+    parent_token: accessToken,
+    created_at: new Date(now),
+  })
+
+  return {
+    access_token: accessToken,
+    token_type: 'bearer',
+    expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
+    refresh_token: refreshToken,
+  }
+}
+
+export const validateAccessToken = async (deps: OAuthDeps, token: string): Promise<string | null> => {
+  const oauthToken = await deps.centralDb.getOAuthToken(token)
+  if (!oauthToken || oauthToken.token_type !== 'access') {
+    return null
+  }
+  return oauthToken.username
+}
+
+export const isOAuthAccessToken = (token: string): boolean => token.startsWith(ACCESS_TOKEN_PREFIX)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -23,12 +23,42 @@ The MCP server is available at `/mcp` and uses the Streamable HTTP transport:
 
 ## Authentication
 
-The MCP server uses the same Bearer token authentication as the REST API:
+The MCP server supports two authentication methods:
 
-1. Obtain a token via `POST /api/v2/login`
+### OAuth 2.1 (for Claude.ai Custom Connectors)
+
+The server implements OAuth 2.1 with PKCE (S256) for clients that support it, such as Claude.ai custom connectors.
+
+**Discovery:** `GET /.well-known/oauth-authorization-server` returns the authorization server metadata.
+
+**OAuth endpoints:**
+
+| Endpoint        | Method | Description                                |
+| --------------- | ------ | ------------------------------------------ |
+| `/register`     | POST   | Dynamic client registration (RFC 7591)     |
+| `/authorize`    | GET    | Serves login form with OAuth params        |
+| `/authorize`    | POST   | Handles login + redirects with auth code   |
+| `/token`        | POST   | Exchanges auth code or refresh token       |
+
+**Supported grants:** `authorization_code` (with PKCE S256), `refresh_token`
+
+**Token lifetimes:** Access tokens expire after 1 hour, refresh tokens after 30 days.
+
+**Connecting Claude.ai:**
+
+1. In Claude.ai, add a custom connector with the MCP URL: `https://aurboda.net/mcp`
+2. Claude.ai will auto-discover the OAuth endpoints via `/.well-known/oauth-authorization-server`
+3. On first use, you will be redirected to sign in with your Aurboda credentials
+4. Claude.ai handles token refresh automatically
+
+### Bearer Token (for Claude Desktop / API clients)
+
+For direct API access, use the existing AES-256-GCM Bearer token:
+
+1. Obtain a token via `POST /api/login`
 2. Include the token in the `Authorization` header: `Authorization: Bearer <token>`
 
-Each MCP session is scoped to the authenticated user.
+Both authentication methods are supported simultaneously. Each MCP session is scoped to the authenticated user.
 
 ## Tools
 
@@ -200,16 +230,6 @@ The following metrics are available for querying and manual entry:
 | `readiness_score`          | score       | Readiness score (0-100)        |
 | `resilience_score`         | score       | Resilience score (0-100)       |
 | `productivity_score`       | score       | Productivity score (0-100)     |
-
-## Session Management
-
-The MCP server maintains per-user sessions:
-
-- Sessions are created on the first request with a valid token
-- The session ID is returned in the `Mcp-Session-Id` response header
-- Include the session ID in subsequent requests via the `Mcp-Session-Id` header
-- Sessions are isolated per user - a user cannot access another user's session
-- Use `DELETE /mcp` to explicitly end a session
 
 ## Connecting with Claude Desktop
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,43 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # OAuth 2.1 endpoints for MCP authentication
+    location = /.well-known/oauth-authorization-server {
+        proxy_pass http://127.0.0.1:3000/.well-known/oauth-authorization-server;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /authorize {
+        proxy_pass http://127.0.0.1:3000/authorize;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /token {
+        proxy_pass http://127.0.0.1:3000/token;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /register {
+        proxy_pass http://127.0.0.1:3000/register;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # MCP endpoint - cleaner URL for AI assistants
     location /mcp {
         proxy_pass http://127.0.0.1:3000/mcp;


### PR DESCRIPTION
## Summary

- Add OAuth 2.1 authorization server with PKCE (S256) support for MCP authentication
- Implement dynamic client registration (RFC 7591), authorization code flow, and token refresh with rotation
- Add 3 new central DB tables (`oauth_clients`, `oauth_authorization_codes`, `oauth_tokens`) with full CRUD methods
- Create OAuth service module with dependency injection and OAuth router with discovery endpoint
- Update MCP router for dual-mode auth: OAuth access tokens (`aur_at_` prefix) alongside existing AES-256-GCM tokens
- Add nginx location blocks for OAuth endpoints at domain root level
- Update MCP server docs with OAuth setup for Claude.ai custom connectors

## Test plan

- [x] `pnpm check` passes (types + linting)
- [x] All 1133 unit tests pass (53 test files)
- [x] OAuth service unit tests cover: client registration, PKCE verification, code exchange, token refresh/rotation, validation
- [x] Central DB tests cover all new OAuth CRUD methods
- [ ] Manual test: `curl` full OAuth flow once deployed (register -> authorize -> token -> /mcp)
- [ ] Verify existing AES Bearer tokens still work on /mcp (backwards compatibility)
- [ ] Test with Claude.ai custom connector

🤖 Generated with [Claude Code](https://claude.com/claude-code)