### PR TITLE
feat: tag editing UI and fix addTag wrong ID

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -126,6 +126,7 @@ export {
   insertTag,
   isProgrammaticTag,
   restoreTag,
+  updateTag,
   updateTagEndTime,
   updateTagNameByKey,
 } from './tags.ts'

--- a/apps/backend/src/db/tags.ts
+++ b/apps/backend/src/db/tags.ts
@@ -124,6 +124,39 @@ export const findMergeableTag = async (
 }
 
 /**
+ * Update a tag's start_time and/or end_time by database ID.
+ */
+export const updateTag = async (
+  user: string,
+  id: string,
+  updates: { start_time?: Date; end_time?: Date | null },
+): Promise<boolean> => {
+  const setClauses: string[] = []
+  const params: unknown[] = []
+  let paramIndex = 1
+
+  if (updates.start_time !== undefined) {
+    setClauses.push(`start_time = $${paramIndex++}`)
+    params.push(updates.start_time)
+  }
+  if (updates.end_time !== undefined) {
+    setClauses.push(`end_time = $${paramIndex++}`)
+    params.push(updates.end_time)
+  }
+
+  if (setClauses.length === 0) return true
+
+  params.push(id)
+  const result = await query(
+    user,
+    `UPDATE tags SET ${setClauses.join(', ')} WHERE id = $${paramIndex} AND deleted_at IS NULL`,
+    params,
+  )
+
+  return (result.rowCount ?? 0) > 0
+}
+
+/**
  * Update the end_time of an existing tag.
  */
 export const updateTagEndTime = async (user: string, externalId: string, endTime: Date): Promise<boolean> => {

--- a/apps/backend/src/mcp/tag-tools.ts
+++ b/apps/backend/src/mcp/tag-tools.ts
@@ -1,10 +1,10 @@
 /**
  * MCP tag management tools.
  */
-import { addTagBodySchema, deleteTagParamsSchema } from '@aurboda/api-spec'
+import { addTagBodySchema, deleteTagParamsSchema, updateTagBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 
-import { addTag, deleteTag, restoreTag } from '../services/mutations.ts'
+import { addTag, deleteTag, restoreTag, updateTag } from '../services/mutations.ts'
 import { errorResponse, jsonResponse, type McpServer, parseOptionalDate } from './helpers.ts'
 
 export const registerTagTools = (server: McpServer, user: string) => {
@@ -30,6 +30,20 @@ export const registerTagTools = (server: McpServer, user: string) => {
         mergeSpan: merge_span,
         start_time: startDate,
         tag,
+      })
+      return jsonResponse(result)
+    },
+  )
+
+  // Tool: update_tag
+  server.tool(
+    'update_tag',
+    "Update a tag's start and/or end time.",
+    { id: z.string().uuid().describe('The ID of the tag to update'), ...updateTagBodySchema.shape },
+    async ({ id, start_time, end_time }) => {
+      const result = await updateTag(user, id, {
+        end_time: end_time === null ? null : end_time ? new Date(end_time) : undefined,
+        start_time: start_time ? new Date(start_time) : undefined,
       })
       return jsonResponse(result)
     },

--- a/apps/backend/src/routes/oauth-router.ts
+++ b/apps/backend/src/routes/oauth-router.ts
@@ -221,12 +221,10 @@ export const createOAuthRouter = (deps: OAuthRouterDeps): Router => {
     const { client_name, redirect_uris, token_endpoint_auth_method } = req.body
 
     if (!client_name || !redirect_uris || !Array.isArray(redirect_uris) || redirect_uris.length === 0) {
-      res
-        .status(400)
-        .json({
-          error: 'invalid_client_metadata',
-          error_description: 'client_name and redirect_uris are required',
-        })
+      res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'client_name and redirect_uris are required',
+      })
       return
     }
 

--- a/apps/backend/src/routes/tags-router.ts
+++ b/apps/backend/src/routes/tags-router.ts
@@ -17,11 +17,13 @@ import {
   tagsQuerySchema,
   type TagsResponse,
   type UniqueTagsResponse,
+  type UpdateTagBody,
+  updateTagBodySchema,
 } from '@aurboda/api-spec'
 import { type RequestHandler, Router } from 'express'
 
 import { getProgrammaticTags, getTagById, getUniqueTags, getUserSettings } from '../db/index.ts'
-import { addTag, deleteTag, deleteTagById, restoreTag } from '../services/mutations.ts'
+import { addTag, deleteTag, deleteTagById, restoreTag, updateTag } from '../services/mutations.ts'
 import { queryTags, type SyncProvider } from '../services/queries.ts'
 import { getTagMappings, setTagMapping } from '../services/settings.ts'
 import { validateBody, validateQuery } from '../validation.ts'
@@ -102,6 +104,29 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
       success: true,
     })
   })
+
+  // PATCH /tags/id/:id - Update a tag's times
+  router.patch<{ id: string }, unknown, UpdateTagBody>(
+    '/id/:id',
+    authMiddleware,
+    validateBody(updateTagBodySchema),
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
+      const { start_time, end_time } = req.body
+
+      const result = await updateTag(user, id, {
+        end_time: end_time === null ? null : end_time ? new Date(end_time) : undefined,
+        start_time: start_time ? new Date(start_time) : undefined,
+      })
+
+      if (!result.success) {
+        return res.status(result.error === 'Tag not found' ? 404 : 400).json(result)
+      }
+
+      res.json({ success: true })
+    },
+  )
 
   // DELETE /tags/id/:id - Soft-delete a tag by UUID (not external_id)
   router.delete<{ id: string }>('/id/:id', authMiddleware, async (req, res) => {

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -16,6 +16,7 @@ import {
   getCustomMetrics,
   updateActivity,
   updateCustomMetric,
+  updateTag,
 } from './mutations.ts'
 
 // Mock the db module
@@ -27,11 +28,13 @@ vi.mock('../db', () => ({
   enqueueOutboundSync: vi.fn().mockResolvedValue(undefined),
   findMergeableTag: vi.fn(),
   getActivityById: vi.fn(),
+  getTagById: vi.fn(),
   getUserSettings: vi.fn(),
   insertActivity: vi.fn(),
   insertTag: vi.fn(),
   insertTimeSeries: vi.fn(),
   updateActivity: vi.fn(),
+  updateTag: vi.fn(),
   updateTagEndTime: vi.fn(),
   upsertUserSettings: vi.fn(),
 }))
@@ -150,7 +153,7 @@ describe('addTag', () => {
     expect(result.success).toBe(true)
     expect(result.merged).toBe(true)
     expect(result.extendedBySeconds).toBe(60) // From 09:59:00 to 10:00:00
-    expect(result.id).toBe('existing-tag-id')
+    expect(result.id).toBe('db-id')
     expect(result.start_time).toBe('2024-01-15T09:00:00.000Z') // Original start
     expect(result.end_time).toBe('2024-01-15T10:00:00.000Z') // New end
 
@@ -1396,6 +1399,79 @@ describe('parseMetricEntityId', () => {
       metric: 'weight',
       source: 'aurboda',
       time,
+    })
+  })
+})
+
+describe('updateTag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns error when tag not found', async () => {
+    vi.mocked(db.getTagById).mockResolvedValue(null)
+
+    const result = await updateTag('testuser', 'nonexistent-id', {
+      start_time: new Date('2024-01-15T10:00:00Z'),
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Tag not found')
+  })
+
+  test('updates start_time', async () => {
+    vi.mocked(db.getTagById).mockResolvedValue({
+      id: 'tag-id',
+      source: 'aurboda',
+      start_time: new Date('2024-01-15T09:00:00Z'),
+      end_time: new Date('2024-01-15T10:00:00Z'),
+      tag: 'test',
+    })
+    vi.mocked(db.updateTag).mockResolvedValue(true)
+
+    const result = await updateTag('testuser', 'tag-id', {
+      start_time: new Date('2024-01-15T08:00:00Z'),
+    })
+
+    expect(result.success).toBe(true)
+    expect(db.updateTag).toHaveBeenCalledWith('testuser', 'tag-id', {
+      start_time: new Date('2024-01-15T08:00:00Z'),
+    })
+  })
+
+  test('rejects end_time before start_time', async () => {
+    vi.mocked(db.getTagById).mockResolvedValue({
+      id: 'tag-id',
+      source: 'aurboda',
+      start_time: new Date('2024-01-15T10:00:00Z'),
+      tag: 'test',
+    })
+
+    const result = await updateTag('testuser', 'tag-id', {
+      end_time: new Date('2024-01-15T09:00:00Z'),
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('end_time must be after start_time')
+  })
+
+  test('clears end_time with null', async () => {
+    vi.mocked(db.getTagById).mockResolvedValue({
+      id: 'tag-id',
+      source: 'aurboda',
+      start_time: new Date('2024-01-15T09:00:00Z'),
+      end_time: new Date('2024-01-15T10:00:00Z'),
+      tag: 'test',
+    })
+    vi.mocked(db.updateTag).mockResolvedValue(true)
+
+    const result = await updateTag('testuser', 'tag-id', {
+      end_time: null,
+    })
+
+    expect(result.success).toBe(true)
+    expect(db.updateTag).toHaveBeenCalledWith('testuser', 'tag-id', {
+      end_time: null,
     })
   })
 })

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -19,9 +19,11 @@ import {
   findHcRecordId,
   findMergeableTag,
   getUserSettings,
+  getTagById,
   insertTag,
   insertTimeSeries,
   type TimeSeriesPoint,
+  updateTag as dbUpdateTag,
   updateTagEndTime,
 } from '../db/index.ts'
 import {
@@ -177,7 +179,7 @@ export async function addTag(user: string, input: AddTagInput): Promise<AddTagRe
       return {
         end_time: newEndTime.toISOString(),
         extendedBySeconds,
-        id: existingTag.external_id,
+        id: existingTag.id!,
         merged: true,
         start_time: existingTag.start_time.toISOString(),
         success: true,
@@ -189,7 +191,7 @@ export async function addTag(user: string, input: AddTagInput): Promise<AddTagRe
   // Create a new tag
   const externalId = randomUUID()
 
-  await insertTag(user, {
+  const dbId = await insertTag(user, {
     end_time: input.end_time,
     external_id: externalId,
     source: 'aurboda',
@@ -199,12 +201,43 @@ export async function addTag(user: string, input: AddTagInput): Promise<AddTagRe
 
   return {
     end_time: input.end_time?.toISOString(),
-    id: externalId,
+    id: dbId,
     start_time: input.start_time.toISOString(),
     success: true,
     tag: input.tag,
     ...(input.mergeSpan !== undefined ? { merged: false } : {}),
   }
+}
+
+export interface UpdateTagInput {
+  start_time?: Date
+  end_time?: Date | null
+}
+
+export interface UpdateTagResult {
+  success: boolean
+  error?: string
+}
+
+export async function updateTag(user: string, id: string, input: UpdateTagInput): Promise<UpdateTagResult> {
+  const existing = await getTagById(user, id)
+  if (!existing) {
+    return { error: 'Tag not found', success: false }
+  }
+
+  const finalStartTime = input.start_time ?? existing.start_time
+  const finalEndTime = input.end_time === null ? undefined : (input.end_time ?? existing.end_time)
+
+  if (finalEndTime && finalEndTime <= finalStartTime) {
+    return { error: 'end_time must be after start_time', success: false }
+  }
+
+  const updates: { start_time?: Date; end_time?: Date | null } = {}
+  if (input.start_time !== undefined) updates.start_time = input.start_time
+  if (input.end_time !== undefined) updates.end_time = input.end_time
+
+  await dbUpdateTag(user, id, updates)
+  return { success: true }
 }
 
 /** Validate custom metric value range; returns error string if invalid, null if ok. */

--- a/apps/web/src/pages/EntityDetail/TagDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/TagDetail.tsx
@@ -1,13 +1,30 @@
 import type { Tag } from '../../state/api'
 
 /**
- * Tag detail view.
+ * Tag detail view with optional edit mode for start/end times.
  */
 import { IconPreview } from '../../components/IconPreview'
 import { resolveItemIcon, suggestEmoji } from '../../utils/emojiLookup'
-import { formatDateTime, formatDuration, formatTime } from './format-utils'
+import { formatDateTime, formatDateTimeLocal, formatDuration, formatTime } from './format-utils'
 
-export const TagDetail = ({ tag, itemIcons }: { tag: Tag; itemIcons: Record<string, string> }) => {
+export interface TagDraft {
+  start_time: string // yyyy-MM-ddTHH:mm for datetime-local
+  end_time: string
+}
+
+export const TagDetail = ({
+  tag,
+  itemIcons,
+  isEditing = false,
+  draft,
+  onDraftChange,
+}: {
+  tag: Tag
+  itemIcons: Record<string, string>
+  isEditing?: boolean
+  draft?: TagDraft
+  onDraftChange?: (d: TagDraft) => void
+}) => {
   const end = tag.end_time
   const isPoint = !end
   const tagMetaKey = tag.tag_key ?? tag.tag
@@ -15,6 +32,83 @@ export const TagDetail = ({ tag, itemIcons }: { tag: Tag; itemIcons: Record<stri
     resolveItemIcon(tag.tag, itemIcons) ??
     (tag.tag_key ? resolveItemIcon(tag.tag_key, itemIcons) : undefined) ??
     suggestEmoji(tag.tag)
+
+  if (isEditing && draft && onDraftChange) {
+    const draftStart = new Date(draft.start_time)
+    const draftEnd = draft.end_time ? new Date(draft.end_time) : undefined
+    const hasDraftEnd = Boolean(draft.end_time)
+    const draftDuration =
+      hasDraftEnd && !isNaN(draftStart.getTime()) && !isNaN(draftEnd!.getTime())
+        ? formatDuration(draftStart, draftEnd!)
+        : undefined
+
+    return (
+      <div class="entity-info">
+        <div class="entity-meta">
+          <span class="entity-type-badge">tag</span>
+          {tag.source && <span class="entity-source">Source: {tag.source}</span>}
+        </div>
+
+        <h2 class="entity-title-with-icon">
+          {icon && <IconPreview icon={icon} size={28} />}
+          {tag.tag}
+        </h2>
+
+        <div class="entity-fields">
+          <div class="field-row">
+            <span class="field-label">Start</span>
+            <span class="field-value">
+              <input
+                type="datetime-local"
+                class="edit-datetime-input"
+                value={draft.start_time}
+                onInput={(e) => onDraftChange({ ...draft, start_time: (e.target as HTMLInputElement).value })}
+              />
+            </span>
+          </div>
+          <div class="field-row">
+            <span class="field-label">End</span>
+            <span class="field-value">
+              {hasDraftEnd ? (
+                <input
+                  type="datetime-local"
+                  class="edit-datetime-input"
+                  value={draft.end_time}
+                  onInput={(e) => onDraftChange({ ...draft, end_time: (e.target as HTMLInputElement).value })}
+                />
+              ) : (
+                <button
+                  class="btn-secondary"
+                  type="button"
+                  onClick={() =>
+                    onDraftChange({ ...draft, end_time: formatDateTimeLocal(new Date()) })
+                  }
+                >
+                  Set end time
+                </button>
+              )}
+              {hasDraftEnd && (
+                <button
+                  class="btn-secondary"
+                  type="button"
+                  style={{ marginLeft: '0.5rem' }}
+                  onClick={() => onDraftChange({ ...draft, end_time: '' })}
+                >
+                  Clear
+                </button>
+              )}
+            </span>
+          </div>
+          {draftDuration && (
+            <div class="field-row">
+              <span class="field-label">Duration</span>
+              <span class="field-value">{draftDuration}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div class="entity-info">

--- a/apps/web/src/pages/EntityDetail/TagDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/TagDetail.tsx
@@ -12,6 +12,96 @@ export interface TagDraft {
   end_time: string
 }
 
+const resolveTagIcon = (tag: Tag, itemIcons: Record<string, string>) =>
+  resolveItemIcon(tag.tag, itemIcons) ??
+  (tag.tag_key ? resolveItemIcon(tag.tag_key, itemIcons) : undefined) ??
+  suggestEmoji(tag.tag)
+
+const TagEditView = ({
+  tag,
+  icon,
+  draft,
+  onDraftChange,
+}: {
+  tag: Tag
+  icon?: string
+  draft: TagDraft
+  onDraftChange: (d: TagDraft) => void
+}) => {
+  const draftStart = new Date(draft.start_time)
+  const draftEnd = draft.end_time ? new Date(draft.end_time) : undefined
+  const hasDraftEnd = Boolean(draft.end_time)
+  const draftDuration =
+    hasDraftEnd && !isNaN(draftStart.getTime()) && !isNaN(draftEnd!.getTime())
+      ? formatDuration(draftStart, draftEnd!)
+      : undefined
+
+  return (
+    <div class="entity-info">
+      <div class="entity-meta">
+        <span class="entity-type-badge">tag</span>
+        {tag.source && <span class="entity-source">Source: {tag.source}</span>}
+      </div>
+
+      <h2 class="entity-title-with-icon">
+        {icon && <IconPreview icon={icon} size={28} />}
+        {tag.tag}
+      </h2>
+
+      <div class="entity-fields">
+        <div class="field-row">
+          <span class="field-label">Start</span>
+          <span class="field-value">
+            <input
+              type="datetime-local"
+              class="edit-datetime-input"
+              value={draft.start_time}
+              onInput={(e) => onDraftChange({ ...draft, start_time: (e.target as HTMLInputElement).value })}
+            />
+          </span>
+        </div>
+        <div class="field-row">
+          <span class="field-label">End</span>
+          <span class="field-value">
+            {hasDraftEnd ? (
+              <input
+                type="datetime-local"
+                class="edit-datetime-input"
+                value={draft.end_time}
+                onInput={(e) => onDraftChange({ ...draft, end_time: (e.target as HTMLInputElement).value })}
+              />
+            ) : (
+              <button
+                class="btn-secondary"
+                type="button"
+                onClick={() => onDraftChange({ ...draft, end_time: formatDateTimeLocal(new Date()) })}
+              >
+                Set end time
+              </button>
+            )}
+            {hasDraftEnd && (
+              <button
+                class="btn-secondary"
+                type="button"
+                style={{ marginLeft: '0.5rem' }}
+                onClick={() => onDraftChange({ ...draft, end_time: '' })}
+              >
+                Clear
+              </button>
+            )}
+          </span>
+        </div>
+        {draftDuration && (
+          <div class="field-row">
+            <span class="field-label">Duration</span>
+            <span class="field-value">{draftDuration}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export const TagDetail = ({
   tag,
   itemIcons,
@@ -28,86 +118,10 @@ export const TagDetail = ({
   const end = tag.end_time
   const isPoint = !end
   const tagMetaKey = tag.tag_key ?? tag.tag
-  const icon =
-    resolveItemIcon(tag.tag, itemIcons) ??
-    (tag.tag_key ? resolveItemIcon(tag.tag_key, itemIcons) : undefined) ??
-    suggestEmoji(tag.tag)
+  const icon = resolveTagIcon(tag, itemIcons)
 
   if (isEditing && draft && onDraftChange) {
-    const draftStart = new Date(draft.start_time)
-    const draftEnd = draft.end_time ? new Date(draft.end_time) : undefined
-    const hasDraftEnd = Boolean(draft.end_time)
-    const draftDuration =
-      hasDraftEnd && !isNaN(draftStart.getTime()) && !isNaN(draftEnd!.getTime())
-        ? formatDuration(draftStart, draftEnd!)
-        : undefined
-
-    return (
-      <div class="entity-info">
-        <div class="entity-meta">
-          <span class="entity-type-badge">tag</span>
-          {tag.source && <span class="entity-source">Source: {tag.source}</span>}
-        </div>
-
-        <h2 class="entity-title-with-icon">
-          {icon && <IconPreview icon={icon} size={28} />}
-          {tag.tag}
-        </h2>
-
-        <div class="entity-fields">
-          <div class="field-row">
-            <span class="field-label">Start</span>
-            <span class="field-value">
-              <input
-                type="datetime-local"
-                class="edit-datetime-input"
-                value={draft.start_time}
-                onInput={(e) => onDraftChange({ ...draft, start_time: (e.target as HTMLInputElement).value })}
-              />
-            </span>
-          </div>
-          <div class="field-row">
-            <span class="field-label">End</span>
-            <span class="field-value">
-              {hasDraftEnd ? (
-                <input
-                  type="datetime-local"
-                  class="edit-datetime-input"
-                  value={draft.end_time}
-                  onInput={(e) => onDraftChange({ ...draft, end_time: (e.target as HTMLInputElement).value })}
-                />
-              ) : (
-                <button
-                  class="btn-secondary"
-                  type="button"
-                  onClick={() =>
-                    onDraftChange({ ...draft, end_time: formatDateTimeLocal(new Date()) })
-                  }
-                >
-                  Set end time
-                </button>
-              )}
-              {hasDraftEnd && (
-                <button
-                  class="btn-secondary"
-                  type="button"
-                  style={{ marginLeft: '0.5rem' }}
-                  onClick={() => onDraftChange({ ...draft, end_time: '' })}
-                >
-                  Clear
-                </button>
-              )}
-            </span>
-          </div>
-          {draftDuration && (
-            <div class="field-row">
-              <span class="field-label">Duration</span>
-              <span class="field-value">{draftDuration}</span>
-            </div>
-          )}
-        </div>
-      </div>
-    )
+    return <TagEditView tag={tag} icon={icon} draft={draft} onDraftChange={onDraftChange} />
   }
 
   return (

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -20,6 +20,7 @@ import {
   fetchTagById,
   fetchTagMappings,
   updateActivity,
+  updateTag,
 } from '../../state/api'
 import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
@@ -32,7 +33,7 @@ import { MusicPlaylist } from './MusicPlaylist'
 import { NotesSection } from './NotesSection'
 import { ProductivityDetail } from './ProductivityDetail'
 import { SleepDetail } from './SleepDetail'
-import { TagDetail } from './TagDetail'
+import { type TagDraft, TagDetail } from './TagDetail'
 import './style.css'
 
 const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
@@ -329,6 +330,41 @@ const TagContent = ({ entityId }: { entityId: string }) => {
     [queryClient, entityId],
   )
 
+  const [isEditing, setIsEditing] = useState(false)
+  const emptyDraft: TagDraft = { end_time: '', start_time: '' }
+  const [draft, setDraft] = useState<TagDraft>(emptyDraft)
+
+  const startEditing = useCallback(() => {
+    if (!tag) return
+    setDraft({
+      end_time: tag.end_time ? formatDateTimeLocal(tag.end_time) : '',
+      start_time: formatDateTimeLocal(tag.start_time),
+    })
+    setIsEditing(true)
+  }, [tag])
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      if (!tag) return Promise.resolve()
+      const body: { start_time?: string; end_time?: string | null } = {}
+      const origStart = formatDateTimeLocal(tag.start_time)
+      const origEnd = tag.end_time ? formatDateTimeLocal(tag.end_time) : ''
+
+      if (draft.start_time !== origStart) {
+        body.start_time = new Date(draft.start_time).toISOString()
+      }
+      if (draft.end_time !== origEnd) {
+        body.end_time = draft.end_time ? new Date(draft.end_time).toISOString() : null
+      }
+      if (Object.keys(body).length === 0) return Promise.resolve()
+      return updateTag(entityId, body)
+    },
+    onSuccess: () => {
+      setIsEditing(false)
+      invalidate()
+    },
+  })
+
   if (isLoading) return <p class="loading">Loading...</p>
   if (isError || !tag) return <p class="error">Failed to load tag</p>
 
@@ -339,15 +375,24 @@ const TagContent = ({ entityId }: { entityId: string }) => {
         entityId={entityId}
         isDeleted={Boolean(tag.deleted_at)}
         onMutationSuccess={invalidate}
-        canEdit={false}
+        canEdit={true}
         isMerged={false}
-        isEditing={false}
-        onStartEditing={() => {}}
-        onCancelEditing={() => {}}
-        onSave={() => {}}
-        isSaving={false}
+        isEditing={isEditing}
+        onStartEditing={startEditing}
+        onCancelEditing={() => {
+          setIsEditing(false)
+          setDraft(emptyDraft)
+        }}
+        onSave={() => saveMutation.mutate()}
+        isSaving={saveMutation.isPending}
       />
-      <TagDetail tag={tag} itemIcons={itemIcons} />
+      <TagDetail
+        tag={tag}
+        itemIcons={itemIcons}
+        isEditing={isEditing}
+        draft={draft}
+        onDraftChange={setDraft}
+      />
       <NotesSection entityType="tag" entityId={entityId} />
     </>
   )

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1158,6 +1158,13 @@ export const fetchTagById = async (id: string): Promise<Tag> => {
   }
 }
 
+export const updateTag = async (id: string, body: { start_time?: string; end_time?: string | null }): Promise<void> => {
+  const { token } = auth.value
+  await axios.patch(`${API_URL}/tags/id/${id}`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
 // ============================================================================
 // Notes
 // ============================================================================

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1158,7 +1158,10 @@ export const fetchTagById = async (id: string): Promise<Tag> => {
   }
 }
 
-export const updateTag = async (id: string, body: { start_time?: string; end_time?: string | null }): Promise<void> => {
+export const updateTag = async (
+  id: string,
+  body: { start_time?: string; end_time?: string | null },
+): Promise<void> => {
   const { token } = auth.value
   await axios.patch(`${API_URL}/tags/id/${id}`, body, {
     headers: { Authorization: `Bearer ${token}` },

--- a/packages/api-spec/src/schemas/tags.ts
+++ b/packages/api-spec/src/schemas/tags.ts
@@ -98,6 +98,20 @@ export const addTagResponseSchema = baseResponseSchema
 export type AddTagResponse = z.infer<typeof addTagResponseSchema>
 
 /**
+ * Update tag request body.
+ */
+export const updateTagBodySchema = z
+  .object({
+    end_time: iso8601DateTimeSchema.nullable().optional().meta({
+      description: 'End time (null to clear, omit to keep unchanged)',
+    }),
+    start_time: iso8601DateTimeSchema.optional().meta({ description: 'Start time' }),
+  })
+  .meta({ id: 'UpdateTagBody', description: 'Body for updating a tag' })
+
+export type UpdateTagBody = z.infer<typeof updateTagBodySchema>
+
+/**
  * Delete tag params.
  */
 export const deleteTagParamsSchema = z


### PR DESCRIPTION
## Summary
- **Bug fix**: `addTag` was returning `external_id` as `id` in the response, causing 404 errors when navigating to the tag detail page after creating a tag (the detail page looks up by database `id`)
- **Feature**: Added pencil icon edit UI on the tag detail page to modify start time and set/clear end time, matching the existing edit pattern used for activities/exercises
- **API**: Added `PATCH /tags/id/:id` endpoint and `update_tag` MCP tool for updating tag times

## Test plan
- [ ] Create a new tag via Add Data — verify it navigates to the correct detail page without errors
- [ ] On a tag detail page, click the pencil icon to enter edit mode
- [ ] Modify start time and save — verify it persists
- [ ] Set an end time on a point-in-time tag and save
- [ ] Clear end time on a span tag using the Clear button
- [ ] Verify unit tests pass (4 new tests for updateTag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)