### PR TITLE
fix: add logging to Garmin MFA verify flow

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -453,6 +453,7 @@ const main = async () => {
       await garmin.verifyMfa(user, mfa_code)
       res.json({ success: true })
     } catch (error) {
+      console.error(`🔑 Garmin MFA endpoint error for user=${user}:`, error)
       const message = error instanceof Error ? error.message : 'MFA verification failed'
       res.status(401).json({ error: message, success: false })
     }

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -352,23 +352,29 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
      * @param mfaCode  The code from the user's email/SMS
      */
     async verifyMfa(user: string, mfaCode: string): Promise<GarminLoginSuccess> {
+      console.log(`🔑 Garmin MFA verify for user=${user}`)
       const entry = pendingMfaSessions.get(user)
       if (!entry) {
+        console.error(`🔑 Garmin MFA: no pending session for user=${user}`)
         throw new Error('No pending MFA session. Please start login again.')
       }
 
       if (Date.now() - entry.createdAt > MFA_SESSION_TTL_MS) {
         pendingMfaSessions.delete(user)
+        console.error(`🔑 Garmin MFA: session expired for user=${user}`)
         throw new Error('MFA session expired. Please start login again.')
       }
 
       const { gc } = entry
 
+      console.log(`🔑 Garmin MFA: calling verifyMfa on GarminConnect...`)
       await gc.verifyMfa(mfaCode)
+      console.log(`🔑 Garmin MFA: verification succeeded for user=${user}`)
       pendingMfaSessions.delete(user)
 
       const tokens = gc.exportToken()
       await saveSession(user, gc)
+      console.log(`🔑 Garmin MFA: tokens saved for user=${user}`)
       return { success: true, tokens }
     },
   }


### PR DESCRIPTION
## Summary
- Added step-by-step logging to the MFA verify path
- Logs: session lookup, expiry check, verifyMfa call, success, token save
- Also logs errors in the API endpoint

## Test plan
- [ ] Deploy and retry — logs will show exactly what happens during MFA verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)