### PR TITLE
fix: handle Health Connect rate limiting in outbound sync

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -210,6 +210,9 @@ sealed class WriteResult {
   data class TransientFailure(
     val reason: String,
   ) : WriteResult()
+
+  /** Health Connect API quota exceeded — stop all writes immediately. */
+  data object RateLimited : WriteResult()
 }
 
 /**
@@ -237,8 +240,17 @@ suspend fun writeToHealthConnect(
       }
     }
   } catch (e: Exception) {
-    Log.e(TAG, "🚫 Failed to write ${entry.hc_record_type} to Health Connect: ${e.message}", e)
-    WriteResult.TransientFailure("exception: ${e.message}")
+    val msg = e.message ?: ""
+    val causeMsg = e.cause?.message ?: ""
+    if (msg.contains("quota exceeded", ignoreCase = true) ||
+      causeMsg.contains("quota exceeded", ignoreCase = true)
+    ) {
+      Log.w(TAG, "⚠️ Health Connect API quota exceeded, stopping outbound sync")
+      WriteResult.RateLimited
+    } else {
+      Log.e(TAG, "🚫 Failed to write ${entry.hc_record_type} to Health Connect: ${e.message}", e)
+      WriteResult.TransientFailure("exception: ${e.message}")
+    }
   }
 
 /**
@@ -566,6 +578,7 @@ suspend fun processOutboundSync(
   val allSkipReasons = mutableListOf<String>()
   val allFailReasons = mutableListOf<String>()
   var pagesProcessed = 0
+  var rateLimited = false
 
   for (page in 1..MAX_OUTBOUND_SYNC_PAGES) {
     val fetchResult = fetchOutboundSyncEntries(apiUrl, authToken, httpClient)
@@ -608,6 +621,14 @@ suspend fun processOutboundSync(
           Log.e(TAG, "🚫 Transient failure for entry ${entry.id} (${entry.hc_record_type}/${entry.operation}): ${result.reason}")
           failItems.add(OutboundSyncFailItemApi(id = entry.id, reason = result.reason))
         }
+        is WriteResult.RateLimited -> {
+          rateLimited = true
+          val reason = "${entry.hc_record_type}: API quota exceeded"
+          allFailReasons.add(reason)
+          Log.w(TAG, "⚠️ Rate limited on entry ${entry.id} (${entry.hc_record_type}), stopping outbound sync")
+          failItems.add(OutboundSyncFailItemApi(id = entry.id, reason = "API call quota exceeded"))
+          break // Stop processing entries in this page
+        }
       }
     }
 
@@ -629,6 +650,12 @@ suspend fun processOutboundSync(
     // Best-effort report transient failures so backend can track them
     if (failItems.isNotEmpty()) {
       reportOutboundSyncFailures(failItems, apiUrl, authToken, httpClient)
+    }
+
+    // Stop fetching more pages if rate limited — remaining entries will retry next sync cycle
+    if (rateLimited) {
+      Log.w(TAG, "⚠️ Health Connect API quota exceeded, deferring remaining entries to next sync cycle")
+      break
     }
 
     // If we processed fewer entries than the total pending, there are more pages

--- a/apps/backend/src/db/outbound-sync.integration.test.ts
+++ b/apps/backend/src/db/outbound-sync.integration.test.ts
@@ -105,29 +105,40 @@ describe('Outbound Sync Queue Integration Tests', () => {
   })
 
   describe('getPendingOutboundSync', () => {
-    test('returns entries ordered newest-first', async () => {
+    test('returns entries ordered by priority then newest-first', async () => {
       const user = getTestUser()
 
       await enqueueOutboundSync(user, {
-        entity_id: 'first',
-        entity_type: 'activity',
-        hc_record_type: 'ExerciseSessionRecord',
-        operation: 'insert',
-        payload: {},
-      })
-
-      await enqueueOutboundSync(user, {
-        entity_id: 'second',
+        entity_id: 'ts-first',
         entity_type: 'time_series',
         hc_record_type: 'WeightRecord',
         operation: 'insert',
         payload: {},
       })
 
+      await enqueueOutboundSync(user, {
+        entity_id: 'ts-second',
+        entity_type: 'time_series',
+        hc_record_type: 'HeightRecord',
+        operation: 'insert',
+        payload: {},
+      })
+
+      await enqueueOutboundSync(user, {
+        entity_id: 'activity-first',
+        entity_type: 'activity',
+        hc_record_type: 'ExerciseSessionRecord',
+        operation: 'insert',
+        payload: {},
+      })
+
       const { entries: pending } = await getPendingOutboundSync(user)
-      expect(pending).toHaveLength(2)
-      expect(pending[0].entity_id).toBe('second')
-      expect(pending[1].entity_id).toBe('first')
+      expect(pending).toHaveLength(3)
+      // Activities are prioritized over time_series
+      expect(pending[0].entity_id).toBe('activity-first')
+      // Within same entity_type, newest-first
+      expect(pending[1].entity_id).toBe('ts-second')
+      expect(pending[2].entity_id).toBe('ts-first')
     })
 
     test('respects limit and returns total_pending', async () => {

--- a/apps/backend/src/db/outbound-sync.ts
+++ b/apps/backend/src/db/outbound-sync.ts
@@ -110,7 +110,9 @@ export const getPendingOutboundSync = async (
             hc_record_id, status, fail_count, fail_reason, created_at, synced_at
      FROM outbound_sync_queue
      WHERE status = 'pending'
-     ORDER BY created_at DESC
+     ORDER BY
+       CASE WHEN entity_type = 'activity' THEN 0 ELSE 1 END,
+       created_at DESC
      LIMIT $1`,
     [limit],
   )


### PR DESCRIPTION
## Summary
- Detect Health Connect API "quota exceeded" errors and stop processing immediately instead of cascading failures on every remaining entry in the page
- Add `WriteResult.RateLimited` variant that short-circuits the outbound sync loop, deferring remaining entries to the next sync cycle (15 min)
- Prioritize activity records (exercises, sleep) over time-series data in the backend outbound sync queue ordering, so exercises aren't starved by per-minute calorie/HR data when quotas are tight

## Test plan
- [ ] Deploy and trigger a sync with many pending records — verify rate limit stops processing instead of 8+ cascading failures
- [ ] Verify exercises sync before calorie data when both are pending
- [ ] Verify remaining entries stay pending and sync on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)