### PR TITLE
feat: support hrv_sleep sparkline in dashboard

### DIFF
--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -1001,6 +1001,162 @@ describe('getPeriodSummary', () => {
     expect(zone1).toBeDefined()
     expect(zone1!.avg).toBeGreaterThan(0)
   })
+
+  test('computes contextual HRV stats from classified HRV data', async () => {
+    // No regular metrics
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+
+    // HRV data during sleep hours
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T01:00:00Z'), 40],
+      [new Date('2024-01-15T02:00:00Z'), 45],
+      [new Date('2024-01-15T03:00:00Z'), 50],
+      [new Date('2024-01-15T04:00:00Z'), 55],
+    ])
+
+    // Sleep session covering the HRV data
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+
+    // No exercise
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['hrv_sleep'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metrics).toHaveLength(1)
+    const hrvSleep = result.metrics[0]
+    expect(hrvSleep.metric).toBe('hrv_sleep')
+    expect(hrvSleep.avg).toBe(47.5)
+    expect(hrvSleep.min).toBe(40)
+    expect(hrvSleep.max).toBe(55)
+    expect(hrvSleep.count).toBe(4)
+    expect(hrvSleep.unit).toBe('ms')
+  })
+
+  test('computes contextual HRV with previous period comparison', async () => {
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+
+    // Current period: HRV during sleep = avg 50
+    // Previous period: HRV during sleep = avg 40
+    // -> +25% change
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([
+        // Current period hrv_rmssd
+        [new Date('2024-01-15T02:00:00Z'), 45],
+        [new Date('2024-01-15T03:00:00Z'), 55],
+      ])
+      .mockResolvedValueOnce([
+        // Previous period hrv_rmssd
+        [new Date('2024-01-14T02:00:00Z'), 35],
+        [new Date('2024-01-14T03:00:00Z'), 45],
+      ])
+
+    // Sleep sessions for both periods
+    vi.mocked(db.getSleepSessions)
+      .mockResolvedValueOnce([
+        {
+          activity_type: 'sleep',
+          end_time: new Date('2024-01-15T07:00:00Z'),
+          source: 'oura',
+          start_time: new Date('2024-01-15T00:00:00Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          activity_type: 'sleep',
+          end_time: new Date('2024-01-14T07:00:00Z'),
+          source: 'oura',
+          start_time: new Date('2024-01-14T00:00:00Z'),
+        },
+      ])
+
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['hrv_sleep'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metrics).toHaveLength(1)
+    expect(result.metrics[0].change_from_previous_period_percent).toBe(25)
+  })
+
+  test('returns zero stats for contextual HRV with no matching data', async () => {
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['hrv_sleep'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metrics).toHaveLength(1)
+    expect(result.metrics[0].metric).toBe('hrv_sleep')
+    expect(result.metrics[0].count).toBe(0)
+    expect(result.metrics[0].avg).toBe(0)
+  })
+
+  test('mixes regular metrics with contextual HRV metrics', async () => {
+    // Regular metric stats for heart_rate
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([
+      { avg: 72, count: 100, max: 150, metric: 'heart_rate', min: 55, stddev: 15, unit: 'bpm' },
+    ])
+    vi.mocked(db.getDailyAggregates).mockResolvedValue([])
+
+    // HRV data during sleep
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2024-01-15T02:00:00Z'), 42],
+      [new Date('2024-01-15T03:00:00Z'), 48],
+    ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-01-15T07:00:00Z'),
+        source: 'oura',
+        start_time: new Date('2024-01-15T00:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getActivities).mockResolvedValue([])
+
+    const result = await getPeriodSummary(
+      'testuser',
+      ['heart_rate', 'hrv_sleep'],
+      new Date('2024-01-15'),
+      new Date('2024-01-15T23:59:59Z'),
+    )
+
+    expect(result.metrics).toHaveLength(2)
+
+    const heartRate = result.metrics.find((m) => m.metric === 'heart_rate')
+    const hrvSleep = result.metrics.find((m) => m.metric === 'hrv_sleep')
+
+    expect(heartRate).toBeDefined()
+    expect(heartRate!.avg).toBe(72)
+    expect(hrvSleep).toBeDefined()
+    expect(hrvSleep!.avg).toBe(45)
+    expect(hrvSleep!.count).toBe(2)
+  })
 })
 
 describe('queryMetricsBucketed', () => {

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -904,9 +904,14 @@ export async function getPeriodSummary(
   start: Date,
   end: Date,
 ): Promise<PeriodSummaryResult> {
-  // Separate HR zone metrics from regular metrics
-  const regularMetrics = metrics.filter((m) => !isHrZoneMetric(m as MetricType))
+  // Separate special metric types from regular metrics
+  const regularMetrics = metrics.filter(
+    (m) => !isHrZoneMetric(m as MetricType) && !isContextualHrvMetric(m as MetricType),
+  )
   const hrZoneMetricsRequested = metrics.filter((m) => isHrZoneMetric(m as MetricType)) as MetricType[]
+  const contextualHrvMetricsRequested = metrics.filter((m) =>
+    isContextualHrvMetric(m as MetricType),
+  ) as MetricType[]
 
   // Calculate period length for previous period comparison
   const periodMs = end.getTime() - start.getTime()
@@ -914,11 +919,12 @@ export async function getPeriodSummary(
   const prevEnd = new Date(start.getTime() - 1)
 
   // Fetch current and previous period stats in parallel (for regular metrics)
-  const [currentStats, previousStats, dailyAggregates, hrZoneStats] = await Promise.all([
+  const [currentStats, previousStats, dailyAggregates, hrZoneStats, contextualHrvStats] = await Promise.all([
     getTimeSeriesStats(user, regularMetrics, start, end),
     getTimeSeriesStats(user, regularMetrics, prevStart, prevEnd),
     getDailyAggregates(user, regularMetrics, start, end),
     computeHrZoneStats(user, hrZoneMetricsRequested, start, end),
+    computeContextualHrvStats(user, contextualHrvMetricsRequested, start, end, prevStart, prevEnd),
   ])
 
   // Calculate days in period for completeness calculation
@@ -1002,8 +1008,8 @@ export async function getPeriodSummary(
     })
   }
 
-  // Add HR zone stats
-  metricsWithTrends.push(...hrZoneStats)
+  // Add HR zone stats and contextual HRV stats
+  metricsWithTrends.push(...hrZoneStats, ...contextualHrvStats)
 
   return {
     end: end.toISOString(),
@@ -1012,6 +1018,113 @@ export async function getPeriodSummary(
     start: start.toISOString(),
   }
 }
+
+/**
+ * Compute period summary stats for contextual HRV metrics (hrv_sleep, hrv_activity, hrv_awake).
+ * These are computed by filtering hrv_rmssd data by overlapping sleep/activity windows.
+ */
+async function computeContextualHrvStats(
+  user: string,
+  metrics: MetricType[],
+  start: Date,
+  end: Date,
+  prevStart: Date,
+  prevEnd: Date,
+): Promise<PeriodMetricStats[]> {
+  if (metrics.length === 0) return []
+
+  // Fetch current and previous period data in parallel
+  const [currentData, previousData] = await Promise.all([
+    getClassifiedHrvData(user, start, end),
+    getClassifiedHrvData(user, prevStart, prevEnd),
+  ])
+
+  return metrics.map((metric) => {
+    const context = contextualHrvMetricToContext[metric]
+    if (!context) {
+      return emptyPeriodMetricStats(metric)
+    }
+
+    const values = currentData[context]
+    const prevValues = previousData[context]
+
+    if (values.length === 0) {
+      return emptyPeriodMetricStats(metric)
+    }
+
+    const nums = values.map(([, v]) => v)
+    const avg = nums.reduce((a, b) => a + b, 0) / nums.length
+    const min = Math.min(...nums)
+    const max = Math.max(...nums)
+    const variance = nums.reduce((sum, v) => sum + (v - avg) ** 2, 0) / nums.length
+    const stddev = Math.sqrt(variance)
+
+    // Previous period comparison
+    let changeFromPrevious: number | null = null
+    if (prevValues.length > 0) {
+      const prevNums = prevValues.map(([, v]) => v)
+      const prevAvg = prevNums.reduce((a, b) => a + b, 0) / prevNums.length
+      if (prevAvg !== 0) {
+        changeFromPrevious = ((avg - prevAvg) / prevAvg) * 100
+      }
+    }
+
+    // Outliers
+    const outlierThreshold = stddev * 2
+    const outliers: { type: 'high' | 'low'; value: number }[] = []
+    if (stddev > 0) {
+      if (max > avg + outlierThreshold) outliers.push({ type: 'high', value: max })
+      if (min < avg - outlierThreshold) outliers.push({ type: 'low', value: min })
+    }
+
+    return {
+      avg: Math.round(avg * 100) / 100,
+      change_from_previous_period_percent:
+        changeFromPrevious !== null ? Math.round(changeFromPrevious * 10) / 10 : null,
+      completeness_percent: values.length > 0 ? 100 : 0,
+      count: values.length,
+      max: Math.round(max * 100) / 100,
+      metric,
+      min: Math.round(min * 100) / 100,
+      outliers: outliers.length > 0 ? outliers : undefined,
+      stddev: Math.round(stddev * 100) / 100,
+      trend_per_day: null,
+      unit: metricUnits[metric] ?? 'ms',
+    }
+  })
+}
+
+/**
+ * Get HRV data classified by context (sleep/activity/awake) for a time range.
+ */
+async function getClassifiedHrvData(
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<Record<HrvContext, [Date, number][]>> {
+  const [hrvData, { sleepWindows, activityWindows }] = await Promise.all([
+    getTimeSeries(user, 'hrv_rmssd', start, end),
+    getHrvContextWindows(user, start, end),
+  ])
+
+  if (hrvData.length === 0) return { activity: [], awake: [], sleep: [] }
+
+  return classifyHrvByContext(hrvData, sleepWindows, activityWindows)
+}
+
+const emptyPeriodMetricStats = (metric: string): PeriodMetricStats => ({
+  avg: 0,
+  change_from_previous_period_percent: null,
+  completeness_percent: 0,
+  count: 0,
+  max: 0,
+  metric,
+  min: 0,
+  outliers: undefined,
+  stddev: 0,
+  trend_per_day: null,
+  unit: metricUnits[metric as MetricType] ?? 'ms',
+})
 
 /**
  * Query tags for a time range.

--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef } from 'preact/hooks'
 
 import {
   fetchHrv,
+  fetchHrvSleep,
   fetchMetricTimeSeries,
   fetchPeriodSummary,
   fetchReadinessScores,
@@ -116,6 +117,7 @@ interface SparklineCardWidgetProps {
 // Map metric names to display titles
 const metricTitles: Record<string, string> = {
   hrv_rmssd: 'HRV',
+  hrv_sleep: 'HRV (Sleep)',
   readiness_score: 'Readiness Score',
   resting_heart_rate: 'Resting HR',
   sleep_score: 'Sleep Score',
@@ -125,6 +127,7 @@ const metricTitles: Record<string, string> = {
 // Map metric names to API fetch functions
 const metricFetchers: Record<string, (start: Date, end: Date) => Promise<[Date, number][]>> = {
   hrv_rmssd: fetchHrv,
+  hrv_sleep: fetchHrvSleep,
   readiness_score: fetchReadinessScores,
   resting_heart_rate: fetchRestingHeartRate,
   sleep_score: fetchSleepScores,
@@ -134,6 +137,7 @@ const metricFetchers: Record<string, (start: Date, end: Date) => Promise<[Date, 
 // Map widget metric to API metric name for period summary
 const metricToApiMetric: Record<string, string> = {
   hrv_rmssd: 'hrv_rmssd',
+  hrv_sleep: 'hrv_sleep',
   readiness_score: 'readiness_score',
   resting_heart_rate: 'resting_heart_rate',
   sleep_score: 'sleep_score',

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -235,6 +235,21 @@ export const fetchHrv = async (start: Date, end: Date): Promise<[Date, number][]
   return (response.data.data ?? []).map(({ time, value }) => [new Date(time), value])
 }
 
+// Fetch HRV sleep (contextual: only during sleep) for the specified date range
+export const fetchHrvSleep = async (start: Date, end: Date): Promise<[Date, number][]> => {
+  const { token } = auth.value
+  const params: QueryMetricsQuery = {
+    end: end.toISOString(),
+    start: start.toISOString(),
+  }
+  const response = await axios.get<QueryMetricsResponse>(`${API_URL}/metrics/hrv_sleep`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+
+  return (response.data.data ?? []).map(({ time, value }) => [new Date(time), value])
+}
+
 // Fetch activities (sleep, exercise, meditation) for the specified date range
 export const fetchActivities = async (
   start: Date,

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -26,6 +26,8 @@ export const builtinDashboardMetrics = [
   'zone2_weekly',
   'weight',
   'body_fat',
+  // Contextual HRV metrics
+  'hrv_sleep',
   // Raw metrics
   'hrv_rmssd',
   'resting_heart_rate',


### PR DESCRIPTION
## Summary

Closes #224

- Add contextual HRV (hrv_sleep, hrv_activity, hrv_awake) support to `getPeriodSummary()` — previously these metrics were silently ignored since they don't exist in the `time_series` table
- Add `fetchHrvSleep` API function and wire it into `SparklineCardWidget` fetcher maps
- Add `hrv_sleep` to `builtinDashboardMetrics` in api-spec

## Test plan

- [x] Unit tests for contextual HRV stats computation (4 new tests)
- [x] All 82 existing queries tests still pass
- [ ] Verify hrv_sleep sparkline renders on dashboard with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)