### PR TITLE
feat: support custom metrics in trend charts

### DIFF
--- a/apps/backend/src/mcp/trend-tools.ts
+++ b/apps/backend/src/mcp/trend-tools.ts
@@ -3,6 +3,7 @@
  */
 import { getTrendQuerySchema } from '@aurboda/api-spec'
 
+import { getUserSettings } from '../db/index.ts'
 import { getTrend } from '../services/trends.ts'
 import { jsonResponse, type McpServer } from './helpers.ts'
 
@@ -25,8 +26,12 @@ Common half-life values:
     { ...getTrendQuerySchema.shape },
     async ({ aggregation, display_period, half_life_days, lookback_days, pattern, source_type }) => {
       try {
+        const settings = await getUserSettings(user)
+        const customMetrics = settings?.custom_metrics ?? []
+
         const result = await getTrend(user, {
           aggregation,
+          custom_metrics: customMetrics,
           display_period,
           half_life_days,
           lookback_days,

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -6,6 +6,7 @@
 import { type TrendQuery, trendQuerySchema, type TrendResponse } from '@aurboda/api-spec'
 import { type RequestHandler, Router } from 'express'
 
+import { getUserSettings } from '../db/index.ts'
 import { getTrend } from '../services/trends.ts'
 import { validateQuery } from '../validation.ts'
 
@@ -25,8 +26,12 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
       const lookbackDays = lookback_days ? parseInt(lookback_days, 10) : undefined
 
       try {
+        const settings = await getUserSettings(user)
+        const customMetrics = settings?.custom_metrics ?? []
+
         const result = await getTrend(user, {
           aggregation,
+          custom_metrics: customMetrics,
           display_period,
           half_life_days: halfLifeDays,
           lookback_days: lookbackDays,

--- a/apps/backend/src/services/trends.test.ts
+++ b/apps/backend/src/services/trends.test.ts
@@ -99,6 +99,36 @@ describe('getTrend', () => {
     ).rejects.toThrow('Invalid metric: invalid_metric_name')
   })
 
+  test('accepts custom metrics when provided', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { day: new Date('2026-01-20'), ema_value: 3.5 },
+        { day: new Date('2026-02-02'), ema_value: 2.1 },
+      ],
+    } as never)
+
+    const result = await getTrend('testuser', {
+      aggregation: 'mean',
+      custom_metrics: [{ name: 'fissure_pain', type: 'number', unit: 'score' }],
+      pattern: 'fissure_pain',
+      source_type: 'metric',
+    })
+
+    expect(result.source_type).toBe('metric')
+    expect(result.pattern).toBe('fissure_pain')
+    expect(result.current_value).toBe(2.1)
+  })
+
+  test('throws error for invalid custom metric name', async () => {
+    await expect(
+      getTrend('testuser', {
+        custom_metrics: [{ name: 'fissure_pain', type: 'number', unit: 'score' }],
+        pattern: 'totally_unknown',
+        source_type: 'metric',
+      }),
+    ).rejects.toThrow('Invalid metric: totally_unknown')
+  })
+
   test('handles empty data', async () => {
     vi.mocked(db.query).mockResolvedValue({
       rows: [],

--- a/apps/backend/src/services/trends.test.ts
+++ b/apps/backend/src/services/trends.test.ts
@@ -109,7 +109,7 @@ describe('getTrend', () => {
 
     const result = await getTrend('testuser', {
       aggregation: 'mean',
-      custom_metrics: [{ name: 'fissure_pain', type: 'number', unit: 'score' }],
+      custom_metrics: [{ name: 'fissure_pain', unit: 'score' }],
       pattern: 'fissure_pain',
       source_type: 'metric',
     })
@@ -122,7 +122,7 @@ describe('getTrend', () => {
   test('throws error for invalid custom metric name', async () => {
     await expect(
       getTrend('testuser', {
-        custom_metrics: [{ name: 'fissure_pain', type: 'number', unit: 'score' }],
+        custom_metrics: [{ name: 'fissure_pain', unit: 'score' }],
         pattern: 'totally_unknown',
         source_type: 'metric',
       }),

--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -7,9 +7,10 @@
  */
 
 import {
+  type CustomMetricDefinition,
   displayPeriodMultipliers,
   exerciseTypes,
-  isValidMetric,
+  isValidMetricOrCustom,
   type MetricType,
   type TrendDisplayPeriod,
   type TrendHistoryPoint,
@@ -27,6 +28,7 @@ const LN2 = 0.693147
 
 export interface GetTrendInput {
   aggregation?: 'count' | 'mean' | 'sum'
+  custom_metrics?: CustomMetricDefinition[]
   display_period?: TrendDisplayPeriod
   half_life_days?: number
   lookback_days?: number
@@ -340,6 +342,7 @@ const getExerciseTypeValueStr = (name: string): string => {
 export const getTrend = async (user: string, input: GetTrendInput): Promise<TrendResult> => {
   const {
     aggregation = 'count',
+    custom_metrics: customMetrics = [],
     display_period: displayPeriod = 'monthly',
     half_life_days: halfLifeDays = 15,
     lookback_days: lookbackDays = 90,
@@ -415,7 +418,7 @@ export const getTrend = async (user: string, input: GetTrendInput): Promise<Tren
     }
   } else {
     // Metric source
-    if (!isValidMetric(pattern)) {
+    if (!isValidMetricOrCustom(pattern, customMetrics)) {
       throw new Error(`Invalid metric: ${pattern}`)
     }
 


### PR DESCRIPTION
## Summary

Closes #225

- Replace `isValidMetric()` with `isValidMetricOrCustom()` in `getTrend()` so custom metrics (e.g. `fissure_pain`) work in trend chart widgets
- Trends router and MCP tool now fetch user settings to pass custom metric definitions
- Added `custom_metrics` field to `GetTrendInput` interface

## Test plan

- [x] New test: custom metrics accepted when provided
- [x] New test: unknown metrics still rejected even with custom metrics list
- [x] All existing trend tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)