### PR TITLE
feat: add lab reports web UI

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -21,6 +21,7 @@ const NAV_LINKS = [
   { href: '/hr-zones', label: 'HR Zones' },
   { href: '/timeline', label: 'Timeline' },
   { href: '/data', label: 'Data' },
+  { href: '/reports', label: 'Reports' },
   { href: '/add', label: '+ Add' },
   { href: '/trends', label: 'Trends' },
   { href: '/places', label: 'Places' },

--- a/apps/web/src/components/ReferenceRangeBar.css
+++ b/apps/web/src/components/ReferenceRangeBar.css
@@ -1,0 +1,79 @@
+.ref-range-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 120px;
+  max-width: 200px;
+}
+
+.ref-range-track {
+  position: relative;
+  height: 10px;
+  border-radius: 5px;
+  background: #f3f4f6;
+  overflow: visible;
+}
+
+.ref-range-zone {
+  position: absolute;
+  top: 0;
+  height: 100%;
+}
+
+.ref-range-low {
+  background: #fef3c7;
+  border-radius: 5px 0 0 5px;
+}
+
+.ref-range-normal {
+  background: #d1fae5;
+}
+
+.ref-range-high {
+  background: #fef3c7;
+  border-radius: 0 5px 5px 0;
+}
+
+.ref-range-marker {
+  position: absolute;
+  top: -2px;
+  width: 4px;
+  height: 14px;
+  border-radius: 2px;
+  transform: translateX(-2px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.ref-range-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.65rem;
+  color: #9ca3af;
+}
+
+.ref-range-label-spacer {
+  flex: 1;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .ref-range-track {
+    background: #374151;
+  }
+
+  .ref-range-low {
+    background: #78350f;
+  }
+
+  .ref-range-normal {
+    background: #064e3b;
+  }
+
+  .ref-range-high {
+    background: #78350f;
+  }
+
+  .ref-range-labels {
+    color: #6b7280;
+  }
+}

--- a/apps/web/src/components/ReferenceRangeBar.tsx
+++ b/apps/web/src/components/ReferenceRangeBar.tsx
@@ -1,0 +1,69 @@
+import type { ReportFlag } from '@aurboda/api-spec'
+
+import './ReferenceRangeBar.css'
+
+interface ReferenceRangeBarProps {
+  value: number
+  reference_low?: number
+  reference_high?: number
+  flag?: ReportFlag
+}
+
+const FLAG_COLORS: Record<string, string> = {
+  critical_high: '#dc2626',
+  critical_low: '#dc2626',
+  high: '#f59e0b',
+  low: '#f59e0b',
+  normal: '#22c55e',
+}
+
+/**
+ * Horizontal bar visualizing where a value falls relative to its reference range.
+ * Shows low/normal/high zones with a marker for the actual value.
+ */
+export function ReferenceRangeBar({ value, reference_low, reference_high, flag }: ReferenceRangeBarProps) {
+  if (reference_low === undefined && reference_high === undefined) {
+    return null
+  }
+
+  // Calculate display range: extend 30% beyond reference bounds
+  const low = reference_low ?? (reference_high! - Math.abs(reference_high!) * 0.5)
+  const high = reference_high ?? (reference_low! + Math.abs(reference_low!) * 0.5)
+  const span = high - low
+  const padding = span * 0.3
+  const displayMin = low - padding
+  const displayMax = high + padding
+  const displaySpan = displayMax - displayMin
+
+  // Position calculations as percentages
+  const lowPct = ((low - displayMin) / displaySpan) * 100
+  const highPct = ((high - displayMin) / displaySpan) * 100
+  const valuePct = Math.max(0, Math.min(100, ((value - displayMin) / displaySpan) * 100))
+
+  const markerColor = flag ? (FLAG_COLORS[flag] ?? '#6b7280') : '#6b7280'
+
+  return (
+    <div class="ref-range-bar" title={`Value: ${value}, Range: ${reference_low ?? '—'}–${reference_high ?? '—'}`}>
+      <div class="ref-range-track">
+        {/* Warning zones */}
+        <div class="ref-range-zone ref-range-low" style={{ left: 0, width: `${lowPct}%` }} />
+        <div
+          class="ref-range-zone ref-range-high"
+          style={{ left: `${highPct}%`, width: `${100 - highPct}%` }}
+        />
+        {/* Normal zone */}
+        <div
+          class="ref-range-zone ref-range-normal"
+          style={{ left: `${lowPct}%`, width: `${highPct - lowPct}%` }}
+        />
+        {/* Value marker */}
+        <div class="ref-range-marker" style={{ backgroundColor: markerColor, left: `${valuePct}%` }} />
+      </div>
+      <div class="ref-range-labels">
+        {reference_low !== undefined && <span class="ref-range-label-low">{reference_low}</span>}
+        <span class="ref-range-label-spacer" />
+        {reference_high !== undefined && <span class="ref-range-label-high">{reference_high}</span>}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -22,6 +22,9 @@ import { OuraSource } from './pages/DataSources/OuraSource.jsx'
 import { OwnTracksSource } from './pages/DataSources/OwnTracksSource.jsx'
 import { RescueTimeSource } from './pages/DataSources/RescueTimeSource.jsx'
 import { EntityDetail } from './pages/EntityDetail/index.jsx'
+import { AddReport } from './pages/Reports/AddReport.jsx'
+import { ReportDetail } from './pages/Reports/ReportDetail.jsx'
+import { Reports } from './pages/Reports/index.jsx'
 import { ExerciseMeta } from './pages/ExerciseMeta/index.jsx'
 import { Goals } from './pages/Goals/index.jsx'
 import { Home } from './pages/Home/index.jsx'
@@ -55,6 +58,9 @@ export function App() {
             <Route path="/timeline" component={Timeline} />
             <Route path="/data" component={Data} />
             <Route path="/add" component={AddData} />
+            <Route path="/reports/add" component={AddReport} />
+            <Route path="/reports/:id" component={ReportDetail} />
+            <Route path="/reports" component={Reports} />
             <Route path="/detail/:type/:id" component={EntityDetail} />
             <Route path="/tag/:tagKey" component={TagMeta} />
             <Route path="/exercise/:type" component={ExerciseMeta} />

--- a/apps/web/src/pages/Reports/AddReport.css
+++ b/apps/web/src/pages/Reports/AddReport.css
@@ -1,0 +1,130 @@
+.report-entries-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-entries-editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.report-entries-editor-header label {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.btn-add-entry {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8rem;
+  background: transparent;
+  border: 1px dashed #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #6b7280;
+}
+
+.btn-add-entry:hover {
+  border-color: #673ab8;
+  color: #673ab8;
+}
+
+.report-entry-form {
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-entry-form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.report-entry-form-number {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #9ca3af;
+}
+
+.report-entry-remove {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+}
+
+.report-entry-remove:hover {
+  color: #dc2626;
+}
+
+.btn-secondary-link {
+  padding: 0.5rem 1.5rem;
+  font-size: 0.9rem;
+  background: transparent;
+  border: 1px solid #d1d5db;
+  color: #374151;
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+}
+
+.btn-secondary-link:hover {
+  background: #f3f4f6;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .report-entries-editor-header label {
+    color: #d1d5db;
+  }
+
+  .btn-add-entry {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .btn-add-entry:hover {
+    border-color: #a78bfa;
+    color: #a78bfa;
+  }
+
+  .report-entry-form {
+    background: #111827;
+    border-color: #374151;
+  }
+
+  .report-entry-form-number {
+    color: #6b7280;
+  }
+
+  .report-entry-remove:hover {
+    color: #f87171;
+  }
+
+  .btn-secondary-link {
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .btn-secondary-link:hover {
+    background: #374151;
+  }
+}
+
+@media (max-width: 639px) {
+  .report-entry-form .form-row {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}

--- a/apps/web/src/pages/Reports/AddReport.tsx
+++ b/apps/web/src/pages/Reports/AddReport.tsx
@@ -1,0 +1,306 @@
+import type { Confidence } from '@aurboda/api-spec'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { useLocation } from 'preact-iso'
+import { useCallback, useState } from 'preact/hooks'
+
+import { MetricPicker } from '../../components/MetricPicker'
+import { createReport, fetchReports } from '../../state/api'
+import '../AddData/style.css'
+import './AddReport.css'
+
+interface EntryDraft {
+  key: number
+  metric: string
+  value: string
+  unit: string
+  method: string
+  confidence: Confidence
+  reference_low: string
+  reference_high: string
+}
+
+let entryKeyCounter = 0
+const newEntry = (): EntryDraft => ({
+  confidence: 'measured',
+  key: entryKeyCounter++,
+  method: '',
+  metric: '',
+  reference_high: '',
+  reference_low: '',
+  unit: '',
+  value: '',
+})
+
+const nowLocal = () => format(new Date(), "yyyy-MM-dd'T'HH:mm")
+
+const formatType = (type: string): string =>
+  type.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+
+export function AddReport() {
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
+
+  const [reportType, setReportType] = useState('')
+  const [date, setDate] = useState(nowLocal())
+  const [location, setLocation] = useState('')
+  const [notes, setNotes] = useState('')
+  const [entries, setEntries] = useState<EntryDraft[]>([newEntry()])
+  const [error, setError] = useState('')
+  const [showTypeSuggestions, setShowTypeSuggestions] = useState(false)
+
+  // Fetch existing report types for autocomplete
+  const { data: existingReports } = useQuery({
+    queryFn: () => fetchReports(),
+    queryKey: ['reports', ''],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const existingTypes = [...new Set((existingReports ?? []).map((r) => r.report_type))].sort()
+  const filteredTypes = existingTypes.filter(
+    (t) => reportType && t.toLowerCase().includes(reportType.toLowerCase()) && t !== reportType,
+  )
+
+  const updateEntry = useCallback((key: number, field: keyof EntryDraft, value: string) => {
+    setEntries((prev) => prev.map((e) => (e.key === key ? { ...e, [field]: value } : e)))
+  }, [])
+
+  const removeEntry = useCallback((key: number) => {
+    setEntries((prev) => {
+      if (prev.length <= 1) return prev
+      return prev.filter((e) => e.key !== key)
+    })
+  }, [])
+
+  const addEntry = useCallback(() => {
+    setEntries((prev) => [...prev, newEntry()])
+  }, [])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const validEntries = entries.filter((e) => e.metric && e.value && e.unit)
+      if (validEntries.length === 0) throw new Error('At least one complete entry is required')
+
+      return createReport({
+        date: new Date(date).toISOString(),
+        entries: validEntries.map((e) => ({
+          confidence: e.confidence,
+          metric: e.metric,
+          ...(e.method ? { method: e.method } : {}),
+          ...(e.reference_high ? { reference_high: parseFloat(e.reference_high) } : {}),
+          ...(e.reference_low ? { reference_low: parseFloat(e.reference_low) } : {}),
+          unit: e.unit,
+          value: parseFloat(e.value),
+        })),
+        ...(location ? { location } : {}),
+        ...(notes ? { notes } : {}),
+        report_type: reportType,
+      })
+    },
+    onError: (err: Error) => setError(err.message),
+    onSuccess: (report) => {
+      queryClient.invalidateQueries({ queryKey: ['reports'] })
+      route(`/reports/${report.id}`)
+    },
+  })
+
+  const hasValidEntries = entries.some((e) => e.metric && e.value && e.unit)
+
+  return (
+    <div class="add-data-page">
+      <div class="add-data-header">
+        <h1>Add Lab Report</h1>
+      </div>
+
+      <div class="add-form">
+        {error && <div class="add-error">{error}</div>}
+
+        <div class="form-field" style={{ position: 'relative' }}>
+          <label>Report Type</label>
+          <input
+            type="text"
+            value={reportType}
+            onInput={(e) => {
+              setReportType((e.target as HTMLInputElement).value)
+              setShowTypeSuggestions(true)
+            }}
+            onFocus={() => setShowTypeSuggestions(true)}
+            onBlur={() => setTimeout(() => setShowTypeSuggestions(false), 200)}
+            placeholder="e.g. blood_panel, inbody, hair_mineral_analysis"
+          />
+          {showTypeSuggestions && filteredTypes.length > 0 && (
+            <ul
+              class="tag-picker-dropdown"
+              style={{ left: 0, position: 'absolute', right: 0, top: '100%', zIndex: 10 }}
+            >
+              {filteredTypes.map((t) => (
+                <li
+                  key={t}
+                  class="tag-picker-option"
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    setReportType(t)
+                    setShowTypeSuggestions(false)
+                  }}
+                >
+                  <span class="tag-option-display">{formatType(t)}</span>
+                  <span class="metric-option-key">{t}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div class="form-row">
+          <div class="form-field">
+            <label>Date</label>
+            <input
+              type="datetime-local"
+              value={date}
+              onInput={(e) => setDate((e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <div class="form-field">
+            <label>Location</label>
+            <input
+              type="text"
+              value={location}
+              onInput={(e) => setLocation((e.target as HTMLInputElement).value)}
+              placeholder="e.g. Lab name, clinic"
+            />
+          </div>
+        </div>
+
+        <div class="form-field">
+          <label>Notes</label>
+          <textarea
+            value={notes}
+            onInput={(e) => setNotes((e.target as HTMLTextAreaElement).value)}
+            placeholder="e.g. Fasted 12h, exercised before scan"
+            rows={2}
+          />
+        </div>
+
+        <div class="report-entries-editor">
+          <div class="report-entries-editor-header">
+            <label>Entries</label>
+            <button type="button" class="btn-add-entry" onClick={addEntry}>
+              + Add Entry
+            </button>
+          </div>
+
+          {entries.map((entry, index) => (
+            <div key={entry.key} class="report-entry-form">
+              <div class="report-entry-form-header">
+                <span class="report-entry-form-number">#{index + 1}</span>
+                {entries.length > 1 && (
+                  <button
+                    type="button"
+                    class="report-entry-remove"
+                    onClick={() => removeEntry(entry.key)}
+                    title="Remove entry"
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+
+              <div class="form-row">
+                <div class="form-field" style={{ flex: 2 }}>
+                  <label>Metric</label>
+                  <MetricPicker
+                    value={entry.metric}
+                    onChange={(v) => updateEntry(entry.key, 'metric', v)}
+                    placeholder="Search metrics..."
+                  />
+                </div>
+                <div class="form-field">
+                  <label>Value</label>
+                  <input
+                    type="number"
+                    step="any"
+                    value={entry.value}
+                    onInput={(e) => updateEntry(entry.key, 'value', (e.target as HTMLInputElement).value)}
+                    placeholder="0.0"
+                  />
+                </div>
+                <div class="form-field">
+                  <label>Unit</label>
+                  <input
+                    type="text"
+                    value={entry.unit}
+                    onInput={(e) => updateEntry(entry.key, 'unit', (e.target as HTMLInputElement).value)}
+                    placeholder="kg, %, ng/mL"
+                  />
+                </div>
+              </div>
+
+              <div class="form-row">
+                <div class="form-field">
+                  <label>Method</label>
+                  <input
+                    type="text"
+                    value={entry.method}
+                    onInput={(e) => updateEntry(entry.key, 'method', (e.target as HTMLInputElement).value)}
+                    placeholder="e.g. bia, dexa, blood_draw"
+                  />
+                </div>
+                <div class="form-field">
+                  <label>Confidence</label>
+                  <select
+                    value={entry.confidence}
+                    onChange={(e) =>
+                      updateEntry(entry.key, 'confidence', (e.target as HTMLSelectElement).value)
+                    }
+                  >
+                    <option value="measured">Measured</option>
+                    <option value="estimated">Estimated</option>
+                    <option value="derived">Derived</option>
+                  </select>
+                </div>
+                <div class="form-field">
+                  <label>Ref Low</label>
+                  <input
+                    type="number"
+                    step="any"
+                    value={entry.reference_low}
+                    onInput={(e) =>
+                      updateEntry(entry.key, 'reference_low', (e.target as HTMLInputElement).value)
+                    }
+                    placeholder="—"
+                  />
+                </div>
+                <div class="form-field">
+                  <label>Ref High</label>
+                  <input
+                    type="number"
+                    step="any"
+                    value={entry.reference_high}
+                    onInput={(e) =>
+                      updateEntry(entry.key, 'reference_high', (e.target as HTMLInputElement).value)
+                    }
+                    placeholder="—"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div class="add-form-actions">
+          <button
+            class="btn-primary"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || !reportType.trim() || !date || !hasValidEntries}
+            type="button"
+          >
+            {mutation.isPending ? 'Saving...' : 'Save Report'}
+          </button>
+          <a href="/reports" class="btn-secondary-link">
+            Cancel
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Reports/ReportDetail.css
+++ b/apps/web/src/pages/Reports/ReportDetail.css
@@ -1,0 +1,425 @@
+.report-detail-page {
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.report-detail-nav {
+  margin-bottom: 1rem;
+}
+
+.report-detail-nav a {
+  font-size: 0.85rem;
+  color: #673ab8;
+  text-decoration: none;
+}
+
+.report-detail-nav a:hover {
+  text-decoration: underline;
+}
+
+/* Header */
+.report-detail-header {
+  margin-bottom: 2rem;
+}
+
+.report-detail-header h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: #1f2937;
+}
+
+.report-detail-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #6b7280;
+  flex-wrap: wrap;
+}
+
+.report-detail-location::before {
+  content: '\1F4CD ';
+}
+
+.report-detail-notes {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+  font-style: italic;
+}
+
+/* Entries section */
+.report-entries-section {
+  margin-bottom: 2rem;
+}
+
+.report-entries-section h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 1rem;
+}
+
+/* Table view (desktop) */
+.report-entries-table {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.report-entries-table-header {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1.2fr 1.5fr;
+  padding: 0.75rem 1rem;
+  background: #f9fafb;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.report-entry-row {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1.2fr 1.5fr;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid #f3f4f6;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.report-entry-row:hover {
+  background: #f9fafb;
+}
+
+.report-entry-metric a {
+  color: #673ab8;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.report-entry-metric a:hover {
+  text-decoration: underline;
+}
+
+.report-entry-value {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.report-entry-unit {
+  font-weight: 400;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.report-entry-badges {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+/* Card view (mobile) */
+.report-entries-cards {
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-entry-card {
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.report-entry-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.report-entry-card-metric {
+  color: #673ab8;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.report-entry-card-value {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.report-entry-card-badges {
+  display: flex;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+/* Badges */
+.report-flag-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.report-flag-badge.flag-normal {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.report-flag-badge.flag-warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.report-flag-badge.flag-critical {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.report-confidence-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.report-confidence-badge.confidence-measured {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.report-confidence-badge.confidence-estimated {
+  background: #f3f4f6;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+}
+
+.report-confidence-badge.confidence-derived {
+  background: transparent;
+  color: #9ca3af;
+  border: 1px dashed #d1d5db;
+}
+
+.report-method-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.7rem;
+  color: #9ca3af;
+  background: #f9fafb;
+  border-radius: 4px;
+}
+
+/* Actions */
+.report-detail-actions {
+  padding-top: 1.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.btn-danger {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  background: #dc2626;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.btn-danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid #d1d5db;
+  color: #374151;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  background: #f3f4f6;
+}
+
+.report-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #991b1b;
+}
+
+.loading,
+.error {
+  text-align: center;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+.error {
+  color: #dc2626;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .report-detail-nav a {
+    color: #a78bfa;
+  }
+
+  .report-detail-header h1 {
+    color: #f9fafb;
+  }
+
+  .report-detail-meta {
+    color: #9ca3af;
+  }
+
+  .report-detail-notes {
+    color: #9ca3af;
+  }
+
+  .report-entries-section h2 {
+    color: #e5e7eb;
+  }
+
+  .report-entries-table {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .report-entries-table-header {
+    background: #111827;
+    color: #9ca3af;
+  }
+
+  .report-entry-row {
+    border-color: #374151;
+  }
+
+  .report-entry-row:hover {
+    background: #111827;
+  }
+
+  .report-entry-metric a {
+    color: #a78bfa;
+  }
+
+  .report-entry-value {
+    color: #f9fafb;
+  }
+
+  .report-entry-unit {
+    color: #9ca3af;
+  }
+
+  .report-entry-card {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .report-entry-card-metric {
+    color: #a78bfa;
+  }
+
+  .report-entry-card-value {
+    color: #f9fafb;
+  }
+
+  .report-flag-badge.flag-normal {
+    background: #064e3b;
+    color: #6ee7b7;
+  }
+
+  .report-flag-badge.flag-warning {
+    background: #78350f;
+    color: #fde68a;
+  }
+
+  .report-flag-badge.flag-critical {
+    background: #7f1d1d;
+    color: #fca5a5;
+  }
+
+  .report-confidence-badge.confidence-measured {
+    background: #1e3a5f;
+    color: #60a5fa;
+  }
+
+  .report-confidence-badge.confidence-estimated {
+    background: #374151;
+    color: #9ca3af;
+    border-color: #4b5563;
+  }
+
+  .report-confidence-badge.confidence-derived {
+    color: #6b7280;
+    border-color: #4b5563;
+  }
+
+  .report-method-badge {
+    background: #374151;
+    color: #6b7280;
+  }
+
+  .report-detail-actions {
+    border-color: #374151;
+  }
+
+  .btn-secondary {
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .btn-secondary:hover {
+    background: #374151;
+  }
+
+  .report-delete-confirm {
+    color: #fca5a5;
+  }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .report-detail-page {
+    padding: 1rem;
+  }
+
+  .report-detail-header h1 {
+    font-size: 1.35rem;
+  }
+
+  .report-entries-table {
+    display: none;
+  }
+
+  .report-entries-cards {
+    display: flex;
+  }
+
+  .report-delete-confirm {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/apps/web/src/pages/Reports/ReportDetail.tsx
+++ b/apps/web/src/pages/Reports/ReportDetail.tsx
@@ -1,0 +1,196 @@
+import type { Confidence, ReportEntry, ReportFlag } from '@aurboda/api-spec'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { useLocation, useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
+
+import { ReferenceRangeBar } from '../../components/ReferenceRangeBar'
+import { deleteReport, fetchReport } from '../../state/api'
+import './ReportDetail.css'
+
+const formatType = (type: string): string =>
+  type.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+
+const formatValue = (value: number): string => {
+  if (Number.isInteger(value)) return String(value)
+  return value.toFixed(2)
+}
+
+const FLAG_DISPLAY: Record<ReportFlag, { label: string; className: string }> = {
+  critical_high: { className: 'flag-critical', label: 'Critical High' },
+  critical_low: { className: 'flag-critical', label: 'Critical Low' },
+  high: { className: 'flag-warning', label: 'High' },
+  low: { className: 'flag-warning', label: 'Low' },
+  normal: { className: 'flag-normal', label: 'Normal' },
+}
+
+const CONFIDENCE_DISPLAY: Record<Confidence, { label: string; className: string }> = {
+  derived: { className: 'confidence-derived', label: 'Derived' },
+  estimated: { className: 'confidence-estimated', label: 'Estimated' },
+  measured: { className: 'confidence-measured', label: 'Measured' },
+}
+
+function formatMetricLabel(metric: string): string {
+  return metric.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function EntryRow({ entry }: { entry: ReportEntry }) {
+  const flagInfo = entry.flag ? FLAG_DISPLAY[entry.flag] : undefined
+  const confidenceInfo = entry.confidence ? CONFIDENCE_DISPLAY[entry.confidence] : undefined
+
+  return (
+    <div class="report-entry-row">
+      <div class="report-entry-metric">
+        <a href={`/metric/${encodeURIComponent(entry.metric)}`}>{formatMetricLabel(entry.metric)}</a>
+      </div>
+      <div class="report-entry-value">
+        {formatValue(entry.value)} <span class="report-entry-unit">{entry.unit}</span>
+      </div>
+      <div class="report-entry-range">
+        <ReferenceRangeBar
+          value={entry.value}
+          reference_low={entry.reference_low}
+          reference_high={entry.reference_high}
+          flag={entry.flag}
+        />
+      </div>
+      <div class="report-entry-badges">
+        {flagInfo && <span class={`report-flag-badge ${flagInfo.className}`}>{flagInfo.label}</span>}
+        {confidenceInfo && (
+          <span class={`report-confidence-badge ${confidenceInfo.className}`}>{confidenceInfo.label}</span>
+        )}
+        {entry.method && <span class="report-method-badge">{entry.method}</span>}
+      </div>
+    </div>
+  )
+}
+
+function EntryCard({ entry }: { entry: ReportEntry }) {
+  const flagInfo = entry.flag ? FLAG_DISPLAY[entry.flag] : undefined
+  const confidenceInfo = entry.confidence ? CONFIDENCE_DISPLAY[entry.confidence] : undefined
+
+  return (
+    <div class="report-entry-card">
+      <div class="report-entry-card-header">
+        <a href={`/metric/${encodeURIComponent(entry.metric)}`} class="report-entry-card-metric">
+          {formatMetricLabel(entry.metric)}
+        </a>
+        <span class="report-entry-card-value">
+          {formatValue(entry.value)} {entry.unit}
+        </span>
+      </div>
+      <ReferenceRangeBar
+        value={entry.value}
+        reference_low={entry.reference_low}
+        reference_high={entry.reference_high}
+        flag={entry.flag}
+      />
+      <div class="report-entry-card-badges">
+        {flagInfo && <span class={`report-flag-badge ${flagInfo.className}`}>{flagInfo.label}</span>}
+        {confidenceInfo && (
+          <span class={`report-confidence-badge ${confidenceInfo.className}`}>{confidenceInfo.label}</span>
+        )}
+        {entry.method && <span class="report-method-badge">{entry.method}</span>}
+      </div>
+    </div>
+  )
+}
+
+export function ReportDetail() {
+  const { params } = useRoute()
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
+  const id = params.id as string
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const { data: report, isLoading, error } = useQuery({
+    queryFn: () => fetchReport(id),
+    queryKey: ['report', id],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteReport(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reports'] })
+      route('/reports')
+    },
+  })
+
+  if (isLoading) return <div class="report-detail-page"><p class="loading">Loading report...</p></div>
+  if (error || !report) {
+    return <div class="report-detail-page"><p class="error">Report not found</p></div>
+  }
+
+  return (
+    <div class="report-detail-page">
+      <div class="report-detail-nav">
+        <a href="/reports">&larr; All Reports</a>
+      </div>
+
+      <header class="report-detail-header">
+        <h1>{formatType(report.report_type)}</h1>
+        <div class="report-detail-meta">
+          <span class="report-detail-date">{format(report.date, 'yyyy-MM-dd HH:mm')}</span>
+          {report.location && <span class="report-detail-location">{report.location}</span>}
+        </div>
+        {report.notes && <p class="report-detail-notes">{report.notes}</p>}
+      </header>
+
+      <section class="report-entries-section">
+        <h2>{report.entries.length} {report.entries.length === 1 ? 'Entry' : 'Entries'}</h2>
+
+        {/* Desktop table view */}
+        <div class="report-entries-table">
+          <div class="report-entries-table-header">
+            <span>Metric</span>
+            <span>Value</span>
+            <span>Range</span>
+            <span>Status</span>
+          </div>
+          {report.entries.map((entry) => (
+            <EntryRow key={entry.id ?? entry.metric} entry={entry} />
+          ))}
+        </div>
+
+        {/* Mobile card view */}
+        <div class="report-entries-cards">
+          {report.entries.map((entry) => (
+            <EntryCard key={entry.id ?? entry.metric} entry={entry} />
+          ))}
+        </div>
+      </section>
+
+      <section class="report-detail-actions">
+        {!confirmDelete ? (
+          <button
+            type="button"
+            class="btn-danger"
+            onClick={() => setConfirmDelete(true)}
+          >
+            Delete Report
+          </button>
+        ) : (
+          <div class="report-delete-confirm">
+            <span>Delete this report and its metric data?</span>
+            <button
+              type="button"
+              class="btn-danger"
+              onClick={() => deleteMutation.mutate()}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
+            </button>
+            <button
+              type="button"
+              class="btn-secondary"
+              onClick={() => setConfirmDelete(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Reports/index.tsx
+++ b/apps/web/src/pages/Reports/index.tsx
@@ -1,0 +1,116 @@
+import type { ReportFlag } from '@aurboda/api-spec'
+import { useQuery } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { useState } from 'preact/hooks'
+
+import { fetchReports, type Report } from '../../state/api'
+import './style.css'
+
+const formatType = (type: string): string =>
+  type.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+
+const FLAG_LABELS: Record<ReportFlag, string> = {
+  critical_high: 'Critical High',
+  critical_low: 'Critical Low',
+  high: 'High',
+  low: 'Low',
+  normal: 'Normal',
+}
+
+function flagSummary(report: Report): string {
+  const nonNormal = report.entries.filter((e) => e.flag && e.flag !== 'normal')
+  if (nonNormal.length === 0) return ''
+
+  const counts = new Map<ReportFlag, number>()
+  for (const entry of nonNormal) {
+    counts.set(entry.flag!, (counts.get(entry.flag!) ?? 0) + 1)
+  }
+
+  return [...counts.entries()].map(([flag, count]) => `${count} ${FLAG_LABELS[flag]}`).join(', ')
+}
+
+function flagBadgeClass(report: Report): string {
+  const flags = report.entries.map((e) => e.flag).filter(Boolean) as ReportFlag[]
+  if (flags.some((f) => f === 'critical_low' || f === 'critical_high')) return 'report-flag-critical'
+  if (flags.some((f) => f === 'low' || f === 'high')) return 'report-flag-warning'
+  return ''
+}
+
+export function Reports() {
+  const [filterType, setFilterType] = useState('')
+
+  const { data: reports, isLoading } = useQuery({
+    queryFn: () => fetchReports(filterType ? { report_type: filterType } : undefined),
+    queryKey: ['reports', filterType],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Get unique report types for filter dropdown
+  const { data: allReports } = useQuery({
+    queryFn: () => fetchReports(),
+    queryKey: ['reports', ''],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const reportTypes = [...new Set((allReports ?? []).map((r) => r.report_type))].sort()
+
+  // Sort newest first
+  const sorted = [...(reports ?? [])].sort((a, b) => b.date.getTime() - a.date.getTime())
+
+  return (
+    <div class="reports-page">
+      <div class="reports-header">
+        <h1>Lab Reports</h1>
+        <a href="/reports/add" class="btn-primary">
+          + Add Report
+        </a>
+      </div>
+
+      {reportTypes.length > 0 && (
+        <div class="reports-filter">
+          <select value={filterType} onChange={(e) => setFilterType((e.target as HTMLSelectElement).value)}>
+            <option value="">All types</option>
+            {reportTypes.map((type) => (
+              <option key={type} value={type}>
+                {formatType(type)}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {isLoading && <p class="loading">Loading reports...</p>}
+
+      {!isLoading && sorted.length === 0 && (
+        <div class="reports-empty">
+          <p>No lab reports yet.</p>
+          <p>
+            <a href="/reports/add">Add your first report</a>
+          </p>
+        </div>
+      )}
+
+      <div class="reports-list">
+        {sorted.map((report) => {
+          const summary = flagSummary(report)
+          const badgeClass = flagBadgeClass(report)
+          return (
+            <a key={report.id} href={`/reports/${report.id}`} class="report-card">
+              <div class="report-card-header">
+                <span class="report-card-type">{formatType(report.report_type)}</span>
+                <span class="report-card-date">{format(report.date, 'yyyy-MM-dd')}</span>
+              </div>
+              <div class="report-card-meta">
+                {report.location && <span class="report-card-location">{report.location}</span>}
+                <span class="report-card-entries">
+                  {report.entries.length} {report.entries.length === 1 ? 'entry' : 'entries'}
+                </span>
+              </div>
+              {summary && <div class={`report-card-flags ${badgeClass}`}>{summary}</div>}
+            </a>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Reports/style.css
+++ b/apps/web/src/pages/Reports/style.css
@@ -1,0 +1,190 @@
+.reports-page {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.reports-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.reports-header h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0;
+  color: #1f2937;
+}
+
+.reports-header .btn-primary {
+  padding: 0.5rem 1.25rem;
+  font-size: 0.9rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.reports-header .btn-primary:hover {
+  background: #5e35b1;
+}
+
+.reports-filter {
+  margin-bottom: 1rem;
+}
+
+.reports-filter select {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #374151;
+  background: #fff;
+}
+
+.reports-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #9ca3af;
+}
+
+.reports-empty a {
+  color: #673ab8;
+}
+
+.reports-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-card {
+  display: block;
+  padding: 1rem 1.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.report-card:hover {
+  border-color: #d1d5db;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.report-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.375rem;
+}
+
+.report-card-type {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #1f2937;
+}
+
+.report-card-date {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.report-card-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.report-card-location::before {
+  content: '\1F4CD ';
+}
+
+.report-card-flags {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.report-card-flags.report-flag-warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.report-card-flags.report-flag-critical {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+  color: #6b7280;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .reports-header h1 {
+    color: #f9fafb;
+  }
+
+  .reports-filter select {
+    background: #111827;
+    border-color: #4b5563;
+    color: #e5e7eb;
+  }
+
+  .report-card {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .report-card:hover {
+    border-color: #4b5563;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .report-card-type {
+    color: #f9fafb;
+  }
+
+  .report-card-date {
+    color: #9ca3af;
+  }
+
+  .report-card-meta {
+    color: #9ca3af;
+  }
+
+  .report-card-flags.report-flag-warning {
+    background: #78350f;
+    color: #fde68a;
+  }
+
+  .report-card-flags.report-flag-critical {
+    background: #7f1d1d;
+    color: #fca5a5;
+  }
+}
+
+@media (max-width: 639px) {
+  .reports-page {
+    padding: 1rem;
+  }
+
+  .reports-header h1 {
+    font-size: 1.35rem;
+  }
+}

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -10,6 +10,7 @@ import type {
   AddActivityBody,
   AddActivityResponse,
   AddCustomMetricBody,
+  AddReportBody,
   AddLastFmTagRuleBody,
   AddLastFmTagRuleResponse,
   AddMetricBody,
@@ -64,6 +65,9 @@ import type {
   QueryMetricsBucketedResponse,
   QueryMetricsQuery,
   QueryMetricsResponse,
+  Report as ApiReport,
+  ReportResponse,
+  ReportsResponse,
   ScreentimeCategory,
   ScreentimeCategoryListResponse,
   ScreentimeCategoryResponse,
@@ -147,6 +151,13 @@ export interface Tag extends Omit<ApiTag, 'start_time' | 'end_time'> {
 export interface Scrobble extends Omit<ApiScrobble, 'recorded_at'> {
   recorded_at: Date
 }
+
+export interface Report extends Omit<ApiReport, 'date' | 'created_at'> {
+  date: Date
+  created_at?: Date
+}
+
+export type { AddReportBody, Confidence, ReportEntry, ReportFlag } from '@aurboda/api-spec'
 
 // Defined locally to avoid Zod type resolution issues with api-spec's z.infer<z.ZodEnum>
 export type BiologicalSex = 'male' | 'female'
@@ -1437,4 +1448,50 @@ export const fetchTrainingLoad = async (
     },
   })
   return response.data.data!
+}
+
+// ==========================================================================
+// Reports API
+// ==========================================================================
+
+const mapReport = (r: ApiReport): Report => ({
+  ...r,
+  created_at: r.created_at ? new Date(r.created_at) : undefined,
+  date: new Date(r.date),
+})
+
+export const fetchReports = async (params?: {
+  report_type?: string
+  start?: string
+  end?: string
+}): Promise<Report[]> => {
+  const { token } = auth.value
+  const response = await axios.get<ReportsResponse>(`${API_URL}/reports`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+  return (response.data.data ?? []).map(mapReport)
+}
+
+export const fetchReport = async (id: string): Promise<Report> => {
+  const { token } = auth.value
+  const response = await axios.get<ReportResponse>(`${API_URL}/reports/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return mapReport(response.data.data!)
+}
+
+export const createReport = async (body: AddReportBody): Promise<Report> => {
+  const { token } = auth.value
+  const response = await axios.post<ReportResponse>(`${API_URL}/reports`, body, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return mapReport(response.data.data!)
+}
+
+export const deleteReport = async (id: string): Promise<void> => {
+  const { token } = auth.value
+  await axios.delete(`${API_URL}/reports/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
 }


### PR DESCRIPTION
## Summary

Closes #380

- **Reports list page** (`/reports`) — chronological list with type filter, flag summaries, and "Add Report" button
- **Report detail page** (`/reports/:id`) — entries table with reference range bar visualization, color-coded flag badges, confidence badges (Measured/Estimated/Derived), method labels, and metric links to `/metric/:name`
- **Add Report form** (`/reports/add`) — report type with autocomplete, date/location/notes fields, dynamic entry list with MetricPicker, value/unit/method/confidence/reference range inputs
- **Reference range bar component** — reusable horizontal bar showing where a value falls relative to its reference range (green normal zone, amber warning, red critical)
- **Navigation** — "Reports" link added to header nav
- **API client** — `fetchReports`, `fetchReport`, `createReport`, `deleteReport` functions

The UI is generic across report types (blood panels, InBody scans, hair mineral analyses, etc.) and uses confidence badges to differentiate measurement reliability (e.g., InBody BIA muscle mass vs Withings scale estimate).

## Test plan

- [ ] Navigate to `/reports` — shows empty state with "Add Report" link
- [ ] Click "Add Report" — fill in report type, date, entries with reference ranges
- [ ] Submit → redirects to detail page with entries, range bars, flags, badges
- [ ] Verify metric links navigate to `/metric/:name`
- [ ] Delete report → redirects to list
- [ ] Filter by report type in the list view
- [ ] Test responsive layout (mobile: entries become cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)