### PR TITLE
feat: add metric extraction for SpeedRecord and PowerRecord

### DIFF
--- a/apps/backend/src/db/health-connect.ts
+++ b/apps/backend/src/db/health-connect.ts
@@ -192,13 +192,21 @@ function extractTimeSeriesPoints(
   metric: MetricType,
   data: Record<string, unknown>,
 ): TimeSeriesPoint[] {
-  // Records with samples (HeartRateRecord, etc.)
+  // Records with samples (HeartRateRecord, SpeedRecord, PowerRecord, etc.)
   if (data.samples && Array.isArray(data.samples)) {
-    return (data.samples as { time: string; beatsPerMinute?: number }[]).map((sample) => ({
+    const sampleValueField: Record<string, string> = {
+      HeartRateRecord: 'beatsPerMinute',
+      SpeedRecord: 'speedInMetersPerSecond',
+      PowerRecord: 'powerInWatts',
+    }
+    const field = sampleValueField[recordType]
+    if (!field) return []
+
+    return (data.samples as { time: string; [key: string]: unknown }[]).map((sample) => ({
       metric,
       source: 'health_connect' as DataSource,
       time: new Date(sample.time),
-      value: sample.beatsPerMinute || 0,
+      value: (sample[field] as number) || 0,
     }))
   }
 

--- a/apps/backend/src/migrate.ts
+++ b/apps/backend/src/migrate.ts
@@ -121,13 +121,21 @@ function extractTimeSeriesPoints(
   metric: MetricType,
   data: Record<string, unknown>,
 ): TimeSeriesPoint[] {
-  // Records with samples (HeartRateRecord, etc.)
+  // Records with samples (HeartRateRecord, SpeedRecord, PowerRecord, etc.)
   if (data.samples && Array.isArray(data.samples)) {
-    return (data.samples as { time: string; beatsPerMinute?: number }[]).map((sample) => ({
+    const sampleValueField: Record<string, string> = {
+      HeartRateRecord: 'beatsPerMinute',
+      SpeedRecord: 'speedInMetersPerSecond',
+      PowerRecord: 'powerInWatts',
+    }
+    const field = sampleValueField[recordType]
+    if (!field) return []
+
+    return (data.samples as { time: string; [key: string]: unknown }[]).map((sample) => ({
       metric,
       source: 'health_connect' as DataSource,
       time: new Date(sample.time),
-      value: sample.beatsPerMinute || 0,
+      value: (sample[field] as number) || 0,
     }))
   }
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -519,6 +519,8 @@ export const healthConnectMetricMapping: Record<string, MetricType | null> = {
   TotalCaloriesBurnedRecord: 'calories_total',
   Vo2MaxRecord: 'vo2_max',
   WeightRecord: 'weight',
+  SpeedRecord: 'speed',
+  PowerRecord: 'power',
 }
 
 /**

--- a/docs/health-connect.md
+++ b/docs/health-connect.md
@@ -25,6 +25,8 @@
 | RespiratoryRateRecord           | `respiratory_rate`                                    |
 | Vo2MaxRecord                    | `vo2_max`                                             |
 | BasalMetabolicRateRecord        | `calories_basal`                                      |
+| SpeedRecord                     | `speed` (m/s, from exercise samples)                  |
+| PowerRecord                     | `power` (watts, from exercise samples)                |
 
 ### Cumulative Metrics (daily aggregates)
 

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -60,6 +60,8 @@ export const validMetrics = [
   'body_battery',
   'training_readiness',
   'intensity_minutes',
+  'speed',
+  'power',
 ] as const
 
 export const metricTypeSchema = z.enum(validMetrics).meta({
@@ -224,6 +226,8 @@ export const metricUnits: Record<MetricType, string> = {
   intensity_minutes: 'min',
   vo2_max: 'mL/kg/min',
   weight: 'kg',
+  speed: 'm/s',
+  power: 'W',
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #315 (SpeedRecord and PowerRecord parts)

- Added `speed` (m/s) and `power` (W) as metric types in `api-spec`
- Added `SpeedRecord` and `PowerRecord` to `healthConnectMetricMapping`
- Updated `extractTimeSeriesPoints` to extract values from sample arrays (both in `health-connect.ts` and `migrate.ts`)
- Updated health-connect docs

The Android app already sends these record types with sample data — this change makes the backend extract time_series points from them instead of only storing raw records.

Note: ElevationGainedRecord (item 4 in #315) is left for a separate PR as it needs Android-side work too.

## Test plan

- [ ] Verify existing unit tests pass (1444 tests passing)
- [ ] Deploy and trigger a sync from Android with speed/power data
- [ ] Check that `speed` and `power` metrics appear in time_series

🤖 Generated with [Claude Code](https://claude.com/claude-code)