### PR TITLE
fix: accept any metric name in query endpoints

### DIFF
--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -259,20 +259,6 @@ describe('MCP Server', () => {
       expect(response.parsed.result.content[0].text).toMatch(/Invalid (date|ISO datetime)/i)
     })
 
-    test('returns error for invalid metrics', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
-      const response = await callTool(app, token, 'query_period_summary', {
-        end: '2024-01-31T23:59:59Z',
-        metrics: ['invalid_metric', 'hrv_rmssd'],
-        start: '2024-01-01T00:00:00Z',
-      })
-
-      expect(response.parsed.result.content[0].text).toContain('Invalid metrics')
-      expect(response.parsed.result.content[0].text).toContain('invalid_metric')
-    })
-
     test('calculates change from previous period', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -6,7 +6,6 @@ import {
   activityTypeSchema,
   bucketSizeSchema,
   dateOnlySchema,
-  isValidMetricOrCustom,
   type MetricType,
   timeRangeQuerySchema,
   validMetrics,
@@ -43,11 +42,6 @@ export const registerQueryTools = (server: McpServer, user: string, sync?: SyncP
     },
     async ({ end, metric, start }) => {
       const customMetrics = await getCustomMetrics(user)
-      if (!isValidMetricOrCustom(metric, customMetrics)) {
-        const customNames = customMetrics.map((m) => m.name)
-        const allMetrics = [...validMetrics, ...customNames]
-        return errorResponse(`Invalid metric "${metric}". Valid metrics are: ${allMetrics.join(', ')}`)
-      }
 
       const result = await queryMetrics(user, metric, new Date(start), new Date(end), customMetrics)
       return jsonResponse(result)
@@ -88,18 +82,6 @@ Use cases:
     },
     async ({ bucket, end, exclude, metrics, start, tz }) => {
       const customMetrics = await getCustomMetrics(user)
-
-      // Validate specified metrics if provided
-      if (metrics) {
-        const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
-        if (invalidMetrics.length > 0) {
-          const customNames = customMetrics.map((m) => m.name)
-          const allMetrics = [...validMetrics, ...customNames]
-          return errorResponse(
-            `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${allMetrics.join(', ')}`,
-          )
-        }
-      }
 
       const result = await queryMetricsBucketed(
         user,
@@ -145,16 +127,6 @@ Use cases:
       metrics: z.array(z.string()).describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
     },
     async ({ end, metrics, start }) => {
-      const customMetrics = await getCustomMetrics(user)
-      const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
-      if (invalidMetrics.length > 0) {
-        const customNames = customMetrics.map((m) => m.name)
-        const allMetrics = [...validMetrics, ...customNames]
-        return errorResponse(
-          `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${allMetrics.join(', ')}`,
-        )
-      }
-
       const summary = await getPeriodSummary(user, metrics as string[], new Date(start), new Date(end))
       return jsonResponse(summary)
     },

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -36,8 +36,9 @@ import {
 } from '@aurboda/api-spec'
 import { type RequestHandler, Router } from 'express'
 
+import type { MetricType } from '../schema.ts'
+
 import { getUserSettings } from '../db/index.ts'
-import { isValidMetricOrCustom, type MetricType, validMetrics } from '../schema.ts'
 import { computeAndStoreCalories, computeAndStoreCaloriesAll } from '../services/calorie-computation.ts'
 import {
   addCustomMetric,
@@ -77,17 +78,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
       // Parse optional metrics and exclude lists
       const metrics = metricsParam ? metricsParam.split(',') : undefined
       const exclude = excludeParam ? excludeParam.split(',') : undefined
-
-      // Validate specified metrics if provided
-      if (metrics) {
-        const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
-        if (invalidMetrics.length > 0) {
-          return res.status(400).json({
-            error: `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${validMetrics.join(', ')}`,
-            success: false,
-          })
-        }
-      }
 
       const result = await queryMetricsBucketed(
         user,
@@ -268,13 +258,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
       const settings = await getUserSettings(user)
       const customMetrics = settings?.custom_metrics ?? []
 
-      if (!isValidMetricOrCustom(metric, customMetrics)) {
-        return res.status(400).json({
-          error: `Invalid metric "${metric}". Valid metrics are: ${validMetrics.join(', ')}`,
-          success: false,
-        })
-      }
-
       const result = await queryMetrics(user, metric, new Date(start), new Date(end), customMetrics)
       res.json({ ...result, success: true })
     },
@@ -319,17 +302,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
       const { start, end, metrics: metricsParam } = req.query
       const user = req.user!
 
-      const settings = await getUserSettings(user)
-      const customMetrics = settings?.custom_metrics ?? []
-
       const metrics = metricsParam.split(',')
-      const invalidMetrics = metrics.filter((m) => !isValidMetricOrCustom(m, customMetrics))
-      if (invalidMetrics.length > 0) {
-        return res.status(400).json({
-          error: `Invalid metrics: ${invalidMetrics.join(', ')}. Valid metrics are: ${validMetrics.join(', ')}`,
-          success: false,
-        })
-      }
 
       const summary = await getPeriodSummary(user, metrics, new Date(start), new Date(end))
       res.json({ ...summary, success: true })

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -33,7 +33,6 @@ import {
   getMetricUnit,
   isContextualHrvMetric,
   isHrZoneMetric,
-  isValidMetricOrCustom,
   type MetricType,
   metricUnits,
 } from '../schema.ts'
@@ -469,9 +468,7 @@ export async function queryMetricsBucketed(
   } else {
     // Discover all metrics with data in the range
     const available = await getDistinctMetrics(user, start, end)
-    resolvedMetrics = available.filter(
-      (m) => !excludeSet.has(m) && isValidMetricOrCustom(m, options.customMetrics),
-    ) as MetricType[]
+    resolvedMetrics = available.filter((m) => !excludeSet.has(m)) as MetricType[]
   }
 
   if (resolvedMetrics.length === 0) {

--- a/apps/backend/src/services/trends.test.ts
+++ b/apps/backend/src/services/trends.test.ts
@@ -90,15 +90,6 @@ describe('getTrend', () => {
     expect(result.current_value).toBe(71.5)
   })
 
-  test('throws error for invalid metric', async () => {
-    await expect(
-      getTrend('testuser', {
-        pattern: 'invalid_metric_name',
-        source_type: 'metric',
-      }),
-    ).rejects.toThrow('Invalid metric: invalid_metric_name')
-  })
-
   test('accepts custom metrics when provided', async () => {
     vi.mocked(db.query).mockResolvedValue({
       rows: [
@@ -117,16 +108,6 @@ describe('getTrend', () => {
     expect(result.source_type).toBe('metric')
     expect(result.pattern).toBe('fissure_pain')
     expect(result.current_value).toBe(2.1)
-  })
-
-  test('throws error for invalid custom metric name', async () => {
-    await expect(
-      getTrend('testuser', {
-        custom_metrics: [{ name: 'fissure_pain', unit: 'score' }],
-        pattern: 'totally_unknown',
-        source_type: 'metric',
-      }),
-    ).rejects.toThrow('Invalid metric: totally_unknown')
   })
 
   test('handles empty data', async () => {

--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -10,7 +10,6 @@ import {
   type CustomMetricDefinition,
   displayPeriodMultipliers,
   exerciseTypes,
-  isValidMetricOrCustom,
   type MetricType,
   type TrendDisplayPeriod,
   type TrendHistoryPoint,
@@ -342,7 +341,6 @@ const getExerciseTypeValueStr = (name: string): string => {
 export const getTrend = async (user: string, input: GetTrendInput): Promise<TrendResult> => {
   const {
     aggregation = 'count',
-    custom_metrics: customMetrics = [],
     display_period: displayPeriod = 'monthly',
     half_life_days: halfLifeDays = 15,
     lookback_days: lookbackDays = 90,
@@ -418,10 +416,6 @@ export const getTrend = async (user: string, input: GetTrendInput): Promise<Tren
     }
   } else {
     // Metric source
-    if (!isValidMetricOrCustom(pattern, customMetrics)) {
-      throw new Error(`Invalid metric: ${pattern}`)
-    }
-
     const metricAggregation = aggregation === 'count' ? 'mean' : aggregation
 
     const { currentValue, history } = await calculateMetricTrend(


### PR DESCRIPTION
## Summary
- Removed strict metric name validation from all read/query endpoints (REST API and MCP tools)
- Query endpoints now accept any metric name, returning empty data if no matching records exist
- This fixes the issue where metrics from lab reports (e.g. `body_fat_mass`) couldn't be viewed on the metric detail page
- Write endpoints (addMetric, bulkAddMetrics) retain validation to prevent typos

## Test plan
- [x] Existing trends tests pass
- [x] Existing queries tests pass
- [ ] Verify `/metric/body_fat_mass` loads data on aurboda.net after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)