### PR TITLE
fix: report entries NOT NULL constraint and value ordering (#425)

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -19,14 +19,16 @@ export const _setClientForUser = (user: string, client: Client) => {
 }
 
 /**
- * Check if an error is a PostgreSQL schema error (missing table or column).
- * Only these errors should trigger automatic migration retry.
+ * Check if an error is a PostgreSQL schema error that migration can fix.
+ * Includes missing tables/columns and NOT NULL violations (from columns
+ * that became nullable but the migration hasn't run yet).
  * @internal Exported for testing.
  */
 export const _isSchemaError = (error: unknown): boolean => {
   if (!(error instanceof Error)) return false
   const code = (error as Error & { code?: string }).code
-  return code === '42P01' || code === '42703' // undefined_table, undefined_column
+  // 42P01 = undefined_table, 42703 = undefined_column, 23502 = not_null_violation
+  return code === '42P01' || code === '42703' || code === '23502'
 }
 
 const migrationInProgress: Record<string, Promise<void> | undefined> = {}

--- a/apps/backend/src/services/reports.ts
+++ b/apps/backend/src/services/reports.ts
@@ -205,7 +205,14 @@ export async function addReport(user: string, input: AddReportInput): Promise<Re
     flag: e.flag ?? deriveFlag(e.value, e.reference_low, e.reference_high),
   }))
 
-  // Insert report + entry metadata (no value/unit — those go to time_series)
+  // Write values to time_series FIRST (single source of truth for metric values).
+  // Must happen before insertReport because the DB layer joins with time_series on read.
+  const timeSeriesPoints = toTimeSeriesPoints(entries, reportDate)
+  if (timeSeriesPoints.length > 0) {
+    await insertTimeSeries(user, timeSeriesPoints)
+  }
+
+  // Insert report + entry metadata (no value/unit — values come from time_series join)
   const report = await dbInsertReport(user, {
     entries: toDbEntries(entries),
     location: input.location,
@@ -213,12 +220,6 @@ export async function addReport(user: string, input: AddReportInput): Promise<Re
     report_date: reportDate,
     report_type: input.report_type,
   })
-
-  // Write values to time_series (single source of truth for metric values)
-  const timeSeriesPoints = toTimeSeriesPoints(entries, reportDate)
-  if (timeSeriesPoints.length > 0) {
-    await insertTimeSeries(user, timeSeriesPoints)
-  }
 
   return { data: formatReport(report), success: true }
 }
@@ -275,20 +276,8 @@ export async function updateReport(
     flag: e.flag ?? deriveFlag(e.value, e.reference_low, e.reference_high),
   }))
 
-  // 4. Build DB update input (entries without value/unit)
-  const dbInput: Parameters<typeof dbUpdateReport>[2] = {}
-  if (input.report_type !== undefined) dbInput.report_type = input.report_type
-  if (input.date !== undefined) dbInput.report_date = new Date(input.date)
-  if (input.location !== undefined) dbInput.location = input.location
-  if (input.notes !== undefined) dbInput.notes = input.notes
-  if (processedEntries !== undefined) dbInput.entries = toDbEntries(processedEntries)
-
-  const updated = await dbUpdateReport(user, id, dbInput)
-  if (!updated) {
-    return { error: 'Report not found', success: false }
-  }
-
-  // 5. Time_series maintenance: clean old, insert new
+  // 4. Time_series maintenance: clean old, insert new.
+  // Must happen BEFORE dbUpdateReport because it joins with time_series on read.
   await cleanupTimeSeries(user, oldEntryMetrics)
 
   const newDate = input.date ? new Date(input.date) : existing.report_date
@@ -303,6 +292,19 @@ export async function updateReport(
   const timeSeriesPoints = toTimeSeriesPoints(currentEntries as AddReportEntryInput[], newDate)
   if (timeSeriesPoints.length > 0) {
     await insertTimeSeries(user, timeSeriesPoints)
+  }
+
+  // 5. Build DB update input (entries without value/unit)
+  const dbInput: Parameters<typeof dbUpdateReport>[2] = {}
+  if (input.report_type !== undefined) dbInput.report_type = input.report_type
+  if (input.date !== undefined) dbInput.report_date = new Date(input.date)
+  if (input.location !== undefined) dbInput.location = input.location
+  if (input.notes !== undefined) dbInput.notes = input.notes
+  if (processedEntries !== undefined) dbInput.entries = toDbEntries(processedEntries)
+
+  const updated = await dbUpdateReport(user, id, dbInput)
+  if (!updated) {
+    return { error: 'Report not found', success: false }
   }
 
   // 6. Sync note times if date changed


### PR DESCRIPTION
## Summary

Fixes #425 — `update_report` (and `add_report`) failing with NOT NULL constraint on `report_entries.value`.

Two root causes:

- **Migration never ran**: The `DROP NOT NULL` migration for `report_entries.value/unit` was in `migrateSchema`, but `not_null_violation` (PG error 23502) wasn't in `_isSchemaError`. So the migration was never triggered for existing databases. Added 23502 to the schema error check so it auto-migrates on first failure.

- **Wrong ordering**: `addReport`/`updateReport` wrote time_series AFTER the DB insert/update, but the DB layer joins with time_series to get values. The returned report had null values. Reordered to write time_series BEFORE the DB operation.

## Test plan

- [x] Unit tests pass (15/15)
- [x] `pnpm fix` and `pnpm check` pass
- [ ] MCP: `update_report` with entries no longer fails
- [ ] MCP: `add_report` returns entries with correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)