### PR TITLE
feat: report comparison + source filter on metric page

### DIFF
--- a/apps/web/src/components/SparklineChart.tsx
+++ b/apps/web/src/components/SparklineChart.tsx
@@ -1,0 +1,79 @@
+/**
+ * Reusable sparkline chart using D3.
+ * Renders a small area + line chart with a dot on the latest point.
+ */
+import * as d3 from 'd3'
+import { useEffect, useRef } from 'preact/hooks'
+
+export function SparklineChart({
+  data,
+  color,
+  width = 120,
+  height = 40,
+}: {
+  data: [Date, number][]
+  color: string
+  width?: number
+  height?: number
+}) {
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  useEffect(() => {
+    if (!svgRef.current || data.length < 2) return
+
+    const svg = d3.select(svgRef.current)
+    svg.selectAll('*').remove()
+
+    const margin = { bottom: 4, left: 4, right: 4, top: 4 }
+    const innerWidth = width - margin.left - margin.right
+    const innerHeight = height - margin.top - margin.bottom
+
+    const x = d3
+      .scaleTime()
+      .domain(d3.extent(data, (d) => d[0]) as [Date, Date])
+      .range([0, innerWidth])
+
+    const yExtent = d3.extent(data, (d) => d[1]) as [number, number]
+    const yPadding = (yExtent[1] - yExtent[0]) * 0.1 || 5
+    const y = d3
+      .scaleLinear()
+      .domain([yExtent[0] - yPadding, yExtent[1] + yPadding])
+      .range([innerHeight, 0])
+
+    const line = d3
+      .line<[Date, number]>()
+      .x((d) => x(d[0]))
+      .y((d) => y(d[1]))
+      .curve(d3.curveMonotoneX)
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    // Area fill
+    const area = d3
+      .area<[Date, number]>()
+      .x((d) => x(d[0]))
+      .y0(innerHeight)
+      .y1((d) => y(d[1]))
+      .curve(d3.curveMonotoneX)
+
+    g.append('path').datum(data).attr('fill', color).attr('fill-opacity', 0.15).attr('d', area)
+
+    // Line
+    g.append('path')
+      .datum(data)
+      .attr('fill', 'none')
+      .attr('stroke', color)
+      .attr('stroke-width', 1.5)
+      .attr('d', line)
+
+    // Latest point dot
+    const latest = data[data.length - 1]
+    g.append('circle').attr('cx', x(latest[0])).attr('cy', y(latest[1])).attr('r', 3).attr('fill', color)
+  }, [data, color, width, height])
+
+  if (data.length < 2) {
+    return null
+  }
+
+  return <svg ref={svgRef} width={width} height={height} />
+}

--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -5,9 +5,7 @@
 import type { SparklineCardConfig } from '@aurboda/api-spec'
 
 import { useQuery } from '@tanstack/react-query'
-import * as d3 from 'd3'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
-import { useEffect, useRef } from 'preact/hooks'
 
 import {
   fetchHrv,
@@ -20,80 +18,7 @@ import {
   fetchSteps,
   type PeriodMetricStats,
 } from '../../state/api'
-
-// Sparkline chart component using D3
-function SparklineChart({
-  data,
-  color,
-  width = 120,
-  height = 40,
-}: {
-  data: [Date, number][]
-  color: string
-  width?: number
-  height?: number
-}) {
-  const svgRef = useRef<SVGSVGElement>(null)
-
-  useEffect(() => {
-    if (!svgRef.current || data.length < 2) return
-
-    const svg = d3.select(svgRef.current)
-    svg.selectAll('*').remove()
-
-    const margin = { bottom: 4, left: 4, right: 4, top: 4 }
-    const innerWidth = width - margin.left - margin.right
-    const innerHeight = height - margin.top - margin.bottom
-
-    const x = d3
-      .scaleTime()
-      .domain(d3.extent(data, (d) => d[0]) as [Date, Date])
-      .range([0, innerWidth])
-
-    const yExtent = d3.extent(data, (d) => d[1]) as [number, number]
-    const yPadding = (yExtent[1] - yExtent[0]) * 0.1 || 5
-    const y = d3
-      .scaleLinear()
-      .domain([yExtent[0] - yPadding, yExtent[1] + yPadding])
-      .range([innerHeight, 0])
-
-    const line = d3
-      .line<[Date, number]>()
-      .x((d) => x(d[0]))
-      .y((d) => y(d[1]))
-      .curve(d3.curveMonotoneX)
-
-    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-
-    // Area fill
-    const area = d3
-      .area<[Date, number]>()
-      .x((d) => x(d[0]))
-      .y0(innerHeight)
-      .y1((d) => y(d[1]))
-      .curve(d3.curveMonotoneX)
-
-    g.append('path').datum(data).attr('fill', color).attr('fill-opacity', 0.15).attr('d', area)
-
-    // Line
-    g.append('path')
-      .datum(data)
-      .attr('fill', 'none')
-      .attr('stroke', color)
-      .attr('stroke-width', 1.5)
-      .attr('d', line)
-
-    // Latest point dot
-    const latest = data[data.length - 1]
-    g.append('circle').attr('cx', x(latest[0])).attr('cy', y(latest[1])).attr('r', 3).attr('fill', color)
-  }, [data, color, width, height])
-
-  if (data.length < 2) {
-    return <div class="sparkline-placeholder">Insufficient data</div>
-  }
-
-  return <svg ref={svgRef} width={width} height={height} />
-}
+import { SparklineChart } from '../SparklineChart'
 
 // Trend indicator component
 function TrendIndicator({ value, inverse = false }: { value: number | null; inverse?: boolean }) {

--- a/apps/web/src/pages/MetricMeta/index.tsx
+++ b/apps/web/src/pages/MetricMeta/index.tsx
@@ -10,10 +10,12 @@ import { useState } from 'preact/hooks'
 import {
   fetchCustomMetrics,
   fetchMetricTimeSeries,
+  fetchMetricTimeSeriesWithSource,
   fetchTrend,
   updateCustomMetric,
   type CustomMetricDefinition,
   type FetchTrendParams,
+  type MetricDataPointWithSource,
 } from '../../state/api'
 import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
 import './style.css'
@@ -35,6 +37,77 @@ const formatMetricLabel = (metric: string): string =>
 const formatValue = (value: number): string => {
   if (Number.isInteger(value)) return String(value)
   return value.toFixed(2)
+}
+
+/** Format a data source name for display. */
+const formatSourceLabel = (source: string): string =>
+  source.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
+
+function SourceFilteredChart({ metric, unit, lookback }: { metric: string; unit: string; lookback: number }) {
+  const [selectedSource, setSelectedSource] = useState<string | null>(null)
+
+  const end = new Date()
+  const start = new Date(end.getTime() - lookback * 86400000)
+
+  const { data, isLoading } = useQuery({
+    queryFn: () => fetchMetricTimeSeriesWithSource(metric, start, end),
+    queryKey: ['metric-with-source', metric, lookback],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (isLoading) return <p class="loading">Loading...</p>
+  if (!data || data.length === 0) return <p class="metric-meta-empty">No data available</p>
+
+  // Extract unique sources
+  const sources = [...new Set(data.map((d) => d.source))].sort()
+
+  // Only show this section if there are multiple sources
+  if (sources.length < 2) return null
+
+  // Filter data by selected source
+  const filtered: MetricDataPointWithSource[] = selectedSource
+    ? data.filter((d) => d.source === selectedSource)
+    : data
+
+  // Convert to chart data format
+  const chartData: { date: string; value: number }[] = filtered.map((d) => ({
+    date: d.time.toISOString().split('T')[0],
+    value: d.value,
+  }))
+
+  return (
+    <section class="metric-meta-section">
+      <h2>By Source</h2>
+      <div class="source-filter-chips">
+        <button
+          type="button"
+          class={`source-chip ${selectedSource === null ? 'active' : ''}`}
+          onClick={() => setSelectedSource(null)}
+        >
+          All ({data.length})
+        </button>
+        {sources.map((source) => {
+          const count = data.filter((d) => d.source === source).length
+          return (
+            <button
+              type="button"
+              key={source}
+              class={`source-chip ${selectedSource === source ? 'active' : ''}`}
+              onClick={() => setSelectedSource(selectedSource === source ? null : source)}
+            >
+              {formatSourceLabel(source)} ({count})
+            </button>
+          )
+        })}
+      </div>
+      {chartData.length >= 2 && <MiniTrendChart data={chartData} color="#2563eb" />}
+      {chartData.length < 2 && chartData.length > 0 && (
+        <p class="metric-meta-empty">
+          {formatValue(chartData[0].value)} {unit} ({chartData[0].date})
+        </p>
+      )}
+    </section>
+  )
 }
 
 function RecentValues({ metric, unit }: { metric: string; unit: string }) {
@@ -295,6 +368,9 @@ export function MetricMeta() {
           </>
         )}
       </section>
+
+      {/* Source-filtered chart (only shown when multiple sources exist) */}
+      <SourceFilteredChart metric={metricName} unit={unit} lookback={lookback} />
 
       {/* Recent values */}
       <section class="metric-meta-section">

--- a/apps/web/src/pages/MetricMeta/style.css
+++ b/apps/web/src/pages/MetricMeta/style.css
@@ -223,6 +223,37 @@
   margin: 0.5rem 0 0;
 }
 
+/* Source filter chips */
+.source-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-bottom: 1rem;
+}
+
+.source-chip {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: transparent;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.source-chip:hover {
+  background: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.source-chip.active {
+  background: #673ab8;
+  border-color: #673ab8;
+  color: white;
+}
+
 /* Quick links */
 .metric-meta-links {
   display: flex;
@@ -388,6 +419,22 @@
 
   .metric-meta-page .btn-secondary:hover {
     background: #374151;
+  }
+
+  .source-chip {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .source-chip:hover {
+    background: #374151;
+    border-color: #6b7280;
+  }
+
+  .source-chip.active {
+    background: #7c3aed;
+    border-color: #7c3aed;
+    color: white;
   }
 }
 

--- a/apps/web/src/pages/Reports/ReportDetail.css
+++ b/apps/web/src/pages/Reports/ReportDetail.css
@@ -1,5 +1,5 @@
 .report-detail-page {
-  max-width: 900px;
+  max-width: 960px;
   width: 100%;
   margin: 0 auto;
   padding: 2rem;
@@ -72,7 +72,7 @@
 
 .report-entries-table-header {
   display: grid;
-  grid-template-columns: 1.5fr 1fr 1.2fr 1.5fr;
+  grid-template-columns: 1.5fr 1.2fr 1.2fr 1.5fr;
   padding: 0.75rem 1rem;
   background: #f9fafb;
   font-size: 0.8rem;
@@ -82,13 +82,22 @@
   letter-spacing: 0.03em;
 }
 
+.report-entries-table-header.with-comparison {
+  grid-template-columns: 1.5fr 1.2fr 80px 1.2fr 1.5fr;
+}
+
 .report-entry-row {
   display: grid;
-  grid-template-columns: 1.5fr 1fr 1.2fr 1.5fr;
+  grid-template-columns: 1.5fr 1.2fr 1.2fr 1.5fr;
   padding: 0.75rem 1rem;
   border-top: 1px solid #f3f4f6;
   align-items: center;
   font-size: 0.9rem;
+}
+
+/* When sparkline column is present (has comparison data) */
+.report-entries-table-header.with-comparison ~ .report-entry-row {
+  grid-template-columns: 1.5fr 1.2fr 80px 1.2fr 1.5fr;
 }
 
 .report-entry-row:hover {
@@ -106,6 +115,9 @@
 }
 
 .report-entry-value {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
   font-weight: 600;
   color: #1f2937;
 }
@@ -114,6 +126,31 @@
   font-weight: 400;
   color: #6b7280;
   font-size: 0.85rem;
+}
+
+/* Delta indicator */
+.report-entry-delta {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.report-entry-delta.delta-up {
+  color: #059669;
+}
+
+.report-entry-delta.delta-down {
+  color: #dc2626;
+}
+
+.report-entry-delta.delta-neutral {
+  color: #6b7280;
+}
+
+/* Sparkline column */
+.report-entry-sparkline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .report-entry-badges {
@@ -142,7 +179,7 @@
 .report-entry-card-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .report-entry-card-metric {
@@ -152,10 +189,22 @@
   font-size: 0.95rem;
 }
 
+.report-entry-card-value-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.125rem;
+}
+
 .report-entry-card-value {
   font-weight: 600;
   font-size: 0.95rem;
   color: #1f2937;
+}
+
+.report-entry-card-sparkline {
+  display: flex;
+  justify-content: center;
 }
 
 .report-entry-card-badges {
@@ -330,6 +379,18 @@
   }
 
   .report-entry-unit {
+    color: #9ca3af;
+  }
+
+  .report-entry-delta.delta-up {
+    color: #34d399;
+  }
+
+  .report-entry-delta.delta-down {
+    color: #f87171;
+  }
+
+  .report-entry-delta.delta-neutral {
     color: #9ca3af;
   }
 

--- a/apps/web/src/pages/Reports/ReportDetail.tsx
+++ b/apps/web/src/pages/Reports/ReportDetail.tsx
@@ -3,10 +3,11 @@ import type { Confidence, ReportEntry, ReportFlag } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
-import { useState } from 'preact/hooks'
+import { useMemo, useState } from 'preact/hooks'
 
 import { ReferenceRangeBar } from '../../components/ReferenceRangeBar'
-import { deleteReport, fetchReport } from '../../state/api'
+import { SparklineChart } from '../../components/SparklineChart'
+import { deleteReport, fetchReport, fetchReports, type Report } from '../../state/api'
 import { NotesSection } from '../EntityDetail/NotesSection'
 import './ReportDetail.css'
 
@@ -16,6 +17,12 @@ const formatType = (type: string): string =>
 const formatValue = (value: number): string => {
   if (Number.isInteger(value)) return String(value)
   return value.toFixed(2)
+}
+
+const formatDelta = (delta: number): string => {
+  const prefix = delta > 0 ? '+' : ''
+  if (Number.isInteger(delta)) return `${prefix}${delta}`
+  return `${prefix}${delta.toFixed(2)}`
 }
 
 const FLAG_DISPLAY: Record<ReportFlag, { label: string; className: string }> = {
@@ -36,7 +43,78 @@ function formatMetricLabel(metric: string): string {
   return metric.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
 }
 
-function EntryRow({ entry }: { entry: ReportEntry }) {
+interface ComparisonData {
+  delta: number
+  previous_value: number
+}
+
+/** Build comparison data and sparkline histories from all reports of the same type. */
+function useReportComparison(report: Report | undefined, allReports: Report[] | undefined) {
+  return useMemo(() => {
+    if (!report || !allReports || allReports.length < 2) {
+      return {
+        comparisons: new Map<string, ComparisonData>(),
+        sparklines: new Map<string, [Date, number][]>(),
+      }
+    }
+
+    // Sort by date ascending
+    const sorted = [...allReports].sort((a, b) => a.date.getTime() - b.date.getTime())
+
+    // Find the previous report (the one before the current)
+    const currentIdx = sorted.findIndex((r) => r.id === report.id)
+    const previous = currentIdx > 0 ? sorted[currentIdx - 1] : undefined
+
+    // Build comparison map: metric -> { delta, previous_value }
+    const comparisons = new Map<string, ComparisonData>()
+    if (previous) {
+      const prevEntries = new Map(previous.entries.map((e) => [e.metric, e]))
+      for (const entry of report.entries) {
+        const prev = prevEntries.get(entry.metric)
+        if (prev && prev.value != null && entry.value != null) {
+          comparisons.set(entry.metric, {
+            delta: entry.value - prev.value,
+            previous_value: prev.value,
+          })
+        }
+      }
+    }
+
+    // Build sparkline data: metric -> [Date, number][] from all reports
+    const sparklines = new Map<string, [Date, number][]>()
+    for (const r of sorted) {
+      for (const entry of r.entries) {
+        if (entry.value == null) continue
+        const existing = sparklines.get(entry.metric) ?? []
+        existing.push([r.date, entry.value])
+        sparklines.set(entry.metric, existing)
+      }
+    }
+
+    return { comparisons, sparklines }
+  }, [report, allReports])
+}
+
+function DeltaIndicator({ delta, unit }: { delta: number; unit: string }) {
+  const arrow = delta > 0 ? '\u2191' : delta < 0 ? '\u2193' : ''
+  const className = delta > 0 ? 'delta-up' : delta < 0 ? 'delta-down' : 'delta-neutral'
+
+  return (
+    <span class={`report-entry-delta ${className}`} title={`Change: ${formatDelta(delta)} ${unit}`}>
+      {formatDelta(delta)} {arrow}
+    </span>
+  )
+}
+
+function EntryRow({
+  entry,
+  comparison,
+  sparklineData,
+}: {
+  entry: ReportEntry
+  comparison?: ComparisonData
+  sparklineData?: [Date, number][]
+}) {
   const flagInfo = entry.flag ? FLAG_DISPLAY[entry.flag] : undefined
   const confidenceInfo = entry.confidence ? CONFIDENCE_DISPLAY[entry.confidence] : undefined
 
@@ -46,7 +124,15 @@ function EntryRow({ entry }: { entry: ReportEntry }) {
         <a href={`/metric/${encodeURIComponent(entry.metric)}`}>{formatMetricLabel(entry.metric)}</a>
       </div>
       <div class="report-entry-value">
-        {formatValue(entry.value)} <span class="report-entry-unit">{entry.unit}</span>
+        <span>
+          {formatValue(entry.value)} <span class="report-entry-unit">{entry.unit}</span>
+        </span>
+        {comparison && <DeltaIndicator delta={comparison.delta} unit={entry.unit} />}
+      </div>
+      <div class="report-entry-sparkline">
+        {sparklineData && sparklineData.length >= 2 && (
+          <SparklineChart data={sparklineData} color="#673ab8" width={80} height={24} />
+        )}
       </div>
       <div class="report-entry-range">
         <ReferenceRangeBar
@@ -67,7 +153,15 @@ function EntryRow({ entry }: { entry: ReportEntry }) {
   )
 }
 
-function EntryCard({ entry }: { entry: ReportEntry }) {
+function EntryCard({
+  entry,
+  comparison,
+  sparklineData,
+}: {
+  entry: ReportEntry
+  comparison?: ComparisonData
+  sparklineData?: [Date, number][]
+}) {
   const flagInfo = entry.flag ? FLAG_DISPLAY[entry.flag] : undefined
   const confidenceInfo = entry.confidence ? CONFIDENCE_DISPLAY[entry.confidence] : undefined
 
@@ -77,10 +171,18 @@ function EntryCard({ entry }: { entry: ReportEntry }) {
         <a href={`/metric/${encodeURIComponent(entry.metric)}`} class="report-entry-card-metric">
           {formatMetricLabel(entry.metric)}
         </a>
-        <span class="report-entry-card-value">
-          {formatValue(entry.value)} {entry.unit}
-        </span>
+        <div class="report-entry-card-value-group">
+          <span class="report-entry-card-value">
+            {formatValue(entry.value)} {entry.unit}
+          </span>
+          {comparison && <DeltaIndicator delta={comparison.delta} unit={entry.unit} />}
+        </div>
       </div>
+      {sparklineData && sparklineData.length >= 2 && (
+        <div class="report-entry-card-sparkline">
+          <SparklineChart data={sparklineData} color="#673ab8" width={120} height={28} />
+        </div>
+      )}
       <ReferenceRangeBar
         value={entry.value}
         reference_low={entry.reference_low}
@@ -115,6 +217,16 @@ export function ReportDetail() {
     staleTime: 5 * 60 * 1000,
   })
 
+  // Fetch all reports of the same type for comparison
+  const { data: allReports } = useQuery({
+    enabled: !!report,
+    queryFn: () => fetchReports({ report_type: report!.report_type }),
+    queryKey: ['reports', report?.report_type],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const { comparisons, sparklines } = useReportComparison(report, allReports)
+
   const deleteMutation = useMutation({
     mutationFn: () => deleteReport(id),
     onSuccess: () => {
@@ -138,6 +250,8 @@ export function ReportDetail() {
     )
   }
 
+  const hasPrevious = comparisons.size > 0
+
   return (
     <div class="report-detail-page">
       <div class="report-detail-nav">
@@ -160,21 +274,32 @@ export function ReportDetail() {
 
         {/* Desktop table view */}
         <div class="report-entries-table">
-          <div class="report-entries-table-header">
+          <div class={`report-entries-table-header ${hasPrevious ? 'with-comparison' : ''}`}>
             <span>Metric</span>
             <span>Value</span>
+            {hasPrevious && <span>Trend</span>}
             <span>Range</span>
             <span>Status</span>
           </div>
           {report.entries.map((entry) => (
-            <EntryRow key={entry.id ?? entry.metric} entry={entry} />
+            <EntryRow
+              key={entry.id ?? entry.metric}
+              entry={entry}
+              comparison={comparisons.get(entry.metric)}
+              sparklineData={sparklines.get(entry.metric)}
+            />
           ))}
         </div>
 
         {/* Mobile card view */}
         <div class="report-entries-cards">
           {report.entries.map((entry) => (
-            <EntryCard key={entry.id ?? entry.metric} entry={entry} />
+            <EntryCard
+              key={entry.id ?? entry.metric}
+              entry={entry}
+              comparison={comparisons.get(entry.metric)}
+              sparklineData={sparklines.get(entry.metric)}
+            />
           ))}
         </div>
       </section>


### PR DESCRIPTION
## Summary

- **Report comparison view**: Report detail now shows delta values (e.g. `+1.2 ↑`) and mini sparklines per metric, computed from all reports of the same type. When viewing the May 2025 InBody scan, you see how each metric changed from the Dec 2024 scan.
- **Source filter on metric page**: The metric meta page (`/metric/body_fat`) gains a "By Source" section with clickable filter chips when multiple data sources exist. Click "Lab Report" to see only InBody data without Withings noise.
- **Shared SparklineChart**: Extracted from `SparklineCardWidget` into `components/SparklineChart.tsx` for reuse.

All client-side — no backend changes needed.

## Test plan

- [ ] Open a report detail page → verify delta values and sparklines appear for metrics that exist in the previous report
- [ ] Open `/metric/body_fat` → verify "By Source" section shows chips for each source, clicking filters the chart
- [ ] Verify mobile card view still works for report detail
- [ ] Dark mode: check delta colors, source chips, sparkline visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)