### PR TITLE
fix: replace misused header elements with div on page content

### DIFF
--- a/apps/web/src/pages/ExerciseMeta/index.tsx
+++ b/apps/web/src/pages/ExerciseMeta/index.tsx
@@ -143,12 +143,12 @@ export function ExerciseMeta() {
 
   return (
     <div class="tag-meta-page">
-      <header class="tag-meta-header">
+      <div class="tag-meta-header">
         <div class="tag-meta-title-row">
           {icon ? <IconPreview icon={icon} /> : <span class="tag-meta-icon-placeholder">?</span>}
           <h1>{displayName}</h1>
         </div>
-      </header>
+      </div>
 
       <ExerciseIconSettings exerciseType={exerciseType} currentIcon={icon} />
 

--- a/apps/web/src/pages/MetricMeta/index.tsx
+++ b/apps/web/src/pages/MetricMeta/index.tsx
@@ -307,7 +307,7 @@ export function MetricMeta() {
 
   return (
     <div class="metric-meta-page">
-      <header class="metric-meta-header">
+      <div class="metric-meta-header">
         <h1>{label}</h1>
         <div class="metric-meta-subtitle">
           <code>{metricName}</code>
@@ -315,7 +315,7 @@ export function MetricMeta() {
           {isBuiltIn && <span class="metric-meta-type-badge">Built-in</span>}
           {customMetric && <span class="metric-meta-type-badge custom">Custom</span>}
         </div>
-      </header>
+      </div>
 
       {/* Custom metric settings */}
       {customMetric && (

--- a/apps/web/src/pages/Reports/ReportDetail.tsx
+++ b/apps/web/src/pages/Reports/ReportDetail.tsx
@@ -258,14 +258,14 @@ export function ReportDetail() {
         <a href="/reports">&larr; All Reports</a>
       </div>
 
-      <header class="report-detail-header">
+      <div class="report-detail-header">
         <h1>{formatType(report.report_type)}</h1>
         <div class="report-detail-meta">
           <span class="report-detail-date">{format(report.date, 'yyyy-MM-dd HH:mm')}</span>
           {report.location && <span class="report-detail-location">{report.location}</span>}
         </div>
         {report.notes && <p class="report-detail-notes">{report.notes}</p>}
-      </header>
+      </div>
 
       <section class="report-entries-section">
         <h2>

--- a/apps/web/src/pages/TagMeta/index.tsx
+++ b/apps/web/src/pages/TagMeta/index.tsx
@@ -63,7 +63,7 @@ function TagHeader({
   shownName: string
 }) {
   return (
-    <header class="tag-meta-header">
+    <div class="tag-meta-header">
       <div class="tag-meta-title-row">
         {shownIcon ? <TagIconPreview icon={shownIcon} /> : <span class="tag-meta-icon-placeholder">?</span>}
         <h1>{shownName}</h1>
@@ -76,7 +76,7 @@ function TagHeader({
           <span class="tag-meta-stat">Last: {new Date(tagInfo.latest_time).toLocaleDateString()}</span>
         </div>
       )}
-    </header>
+    </div>
   )
 }
 

--- a/apps/web/src/pages/Trends/index.tsx
+++ b/apps/web/src/pages/Trends/index.tsx
@@ -545,13 +545,13 @@ export function Trends() {
 
   return (
     <div class="trends-page">
-      <header class="page-header">
+      <div class="page-header">
         <h1>Trends</h1>
         <p class="page-description">
           Time-weighted averages using Exponential Moving Average (EMA). Recent data is weighted more heavily,
           with the half-life controlling how quickly older data loses influence.
         </p>
-      </header>
+      </div>
 
       <section class="saved-trends">
         <div class="section-header">


### PR DESCRIPTION
## Summary

Replaced `<header>` with `<div>` on 5 pages where it was incorrectly used for page content headers. The `<header>` element gets the nav bar's pink/purple background in dark mode, making page titles look like part of the navigation.

**Fixed pages:**
- Reports detail
- Metric meta
- Tag meta
- Exercise meta
- Trends

Only the top navigation bar (`components/Header.tsx`) should use `<header>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)