### PR TITLE
feat: add icon upload with auto-resize

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,6 +17,7 @@
     "@flow-js/garmin-connect": "github:fiddur/garmin-connect#feat/mfa-support",
     "@js-temporal/polyfill": "^0.5.1",
     "@modelcontextprotocol/sdk": "^1.25.2",
+    "@types/multer": "^2.1.0",
     "axios": "^1.11.0",
     "cors": "^2.8.5",
     "d3": "^7.9.0",
@@ -24,10 +25,12 @@
     "env-schema": "^6.0.0",
     "express": "^5.1.0",
     "jsdom": "^26.1.0",
+    "multer": "^2.1.1",
     "node-ical": "^0.25.1",
     "pg": "^8.13.1",
     "pg-boss": "^12.5.4",
     "pg-format": "^1.0.4",
+    "sharp": "^0.34.5",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -52,6 +52,7 @@ import { createActivitiesRouter } from './routes/activities-router.ts'
 import { createAdminRouter } from './routes/admin-router.ts'
 import { createCorrelationsRouter } from './routes/correlations-router.ts'
 import { createDashboardRouter } from './routes/dashboard-router.ts'
+import { createIconsRouter } from './routes/icons-router.ts'
 import { createLocationsRouter } from './routes/locations-router.ts'
 import { createMealsRouter } from './routes/meals-router.ts'
 import { createMetricsRouter } from './routes/metrics-router.ts'
@@ -540,6 +541,7 @@ const main = async () => {
 
   httpd.use(createMetricsRouter(authMiddleware, syncProvider))
   httpd.use('/tags', createTagsRouter(authMiddleware, syncProvider))
+  httpd.use('/icons', createIconsRouter(authMiddleware))
   httpd.use('/notes', createNotesRouter(authMiddleware))
   httpd.use('/meals', createMealsRouter(authMiddleware))
   httpd.use('/reports', createReportsRouter(authMiddleware))

--- a/apps/backend/src/db/icons.integration.test.ts
+++ b/apps/backend/src/db/icons.integration.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { deleteIcon, getIcon, insertIcon } from './icons.ts'
+
+const CONTAINER_TIMEOUT = 60_000
+
+describe('Icons Integration Tests', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  describe('insertIcon', () => {
+    test('inserts an icon and returns a UUID', async () => {
+      const user = getTestUser()
+      const data = Buffer.from('fake-png-data')
+
+      const id = await insertIcon(user, 'image/png', data)
+
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    })
+  })
+
+  describe('getIcon', () => {
+    test('retrieves an inserted icon', async () => {
+      const user = getTestUser()
+      const data = Buffer.from('fake-svg-data')
+
+      const id = await insertIcon(user, 'image/svg+xml', data)
+      const icon = await getIcon(user, id)
+
+      expect(icon).toBeDefined()
+      expect(icon!.content_type).toBe('image/svg+xml')
+      expect(icon!.data).toEqual(data)
+    })
+
+    test('returns undefined for non-existent icon', async () => {
+      const user = getTestUser()
+      const icon = await getIcon(user, '00000000-0000-0000-0000-000000000000')
+      expect(icon).toBeUndefined()
+    })
+  })
+
+  describe('deleteIcon', () => {
+    test('deletes an existing icon', async () => {
+      const user = getTestUser()
+      const id = await insertIcon(user, 'image/png', Buffer.from('data'))
+
+      const deleted = await deleteIcon(user, id)
+      expect(deleted).toBe(true)
+
+      const icon = await getIcon(user, id)
+      expect(icon).toBeUndefined()
+    })
+
+    test('returns false for non-existent icon', async () => {
+      const user = getTestUser()
+      const deleted = await deleteIcon(user, '00000000-0000-0000-0000-000000000000')
+      expect(deleted).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/db/icons.ts
+++ b/apps/backend/src/db/icons.ts
@@ -1,0 +1,27 @@
+/**
+ * Uploaded icons CRUD operations.
+ */
+import { query } from './connection.ts'
+
+export const insertIcon = async (user: string, contentType: string, data: Buffer): Promise<string> => {
+  const result = await query(
+    user,
+    `INSERT INTO uploaded_icons (content_type, data) VALUES ($1, $2) RETURNING id`,
+    [contentType, data],
+  )
+  return result.rows[0].id as string
+}
+
+export const getIcon = async (
+  user: string,
+  id: string,
+): Promise<{ content_type: string; data: Buffer } | undefined> => {
+  const result = await query(user, `SELECT content_type, data FROM uploaded_icons WHERE id = $1`, [id])
+  if (result.rows.length === 0) return undefined
+  return { content_type: result.rows[0].content_type as string, data: result.rows[0].data as Buffer }
+}
+
+export const deleteIcon = async (user: string, id: string): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM uploaded_icons WHERE id = $1`, [id])
+  return (result.rowCount ?? 0) > 0
+}

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -220,6 +220,9 @@ export {
   type PendingOutboundSyncResult,
 } from './outbound-sync.ts'
 
+// Uploaded icons
+export { deleteIcon, getIcon, insertIcon } from './icons.ts'
+
 // Settings
 export { getUserSettings, upsertUserSettings } from './settings.ts'
 

--- a/apps/backend/src/routes/icons-router.ts
+++ b/apps/backend/src/routes/icons-router.ts
@@ -1,0 +1,91 @@
+/**
+ * Icons route group.
+ *
+ * Handles: /icons/*
+ *
+ * POST /icons — upload an icon (authenticated)
+ * GET /icons/:user/:id — serve an icon (public, cached 1 year)
+ * DELETE /icons/:id — delete an icon (authenticated)
+ */
+import { type RequestHandler, Router } from 'express'
+import multer from 'multer'
+
+import { getIcon } from '../db/icons.ts'
+import { isAllowedContentType, processAndStoreIcon, removeIcon } from '../services/icons.ts'
+
+const upload = multer({
+  limits: { fileSize: 10 * 1024 * 1024 },
+  storage: multer.memoryStorage(),
+})
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
+  const router = Router()
+
+  // GET /icons/:user/:id — serve icon (no auth, for <img src>)
+  router.get<{ user: string; id: string }>('/:user/:id', async (req, res) => {
+    const { user, id } = req.params
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: 'Invalid icon ID', success: false })
+      return
+    }
+
+    const icon = await getIcon(user, id)
+    if (!icon) {
+      res.status(404).json({ error: 'Icon not found', success: false })
+      return
+    }
+
+    res.set('Content-Type', icon.content_type)
+    res.set('Cache-Control', 'public, max-age=31536000, immutable')
+    res.send(icon.data)
+  })
+
+  // POST /icons — upload an icon
+  router.post('/', authMiddleware, upload.single('icon'), async (req, res) => {
+    const user = req.user!
+    const file = req.file
+    if (!file) {
+      res.status(400).json({ error: 'No file uploaded', success: false })
+      return
+    }
+
+    if (!isAllowedContentType(file.mimetype)) {
+      res.status(400).json({
+        error: `Unsupported file type: ${file.mimetype}. Allowed: PNG, JPEG, WebP, GIF, SVG`,
+        success: false,
+      })
+      return
+    }
+
+    try {
+      const id = await processAndStoreIcon(user, file.buffer, file.mimetype)
+      const url = `/api/icons/${user}/${id}`
+      res.status(201).json({ id, success: true, url })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to process icon'
+      res.status(400).json({ error: message, success: false })
+    }
+  })
+
+  // DELETE /icons/:id — delete an icon
+  router.delete<{ id: string }>('/:id', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { id } = req.params
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: 'Invalid icon ID', success: false })
+      return
+    }
+
+    const deleted = await removeIcon(user, id)
+    if (!deleted) {
+      res.status(404).json({ error: 'Icon not found', success: false })
+      return
+    }
+
+    res.json({ success: true })
+  })
+
+  return router
+}

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -437,6 +437,16 @@ export const createTableStatements: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_time_series_metric_source_time ON time_series (metric, source, time DESC)
   `,
 
+  // Uploaded icon images (stored as binary blobs)
+  uploaded_icons: `
+    CREATE TABLE IF NOT EXISTS uploaded_icons (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      content_type    VARCHAR(50) NOT NULL,
+      data            BYTEA NOT NULL,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
+
   // User settings (HR zones, birth date, etc.)
   user_settings: `
     CREATE TABLE IF NOT EXISTS user_settings (
@@ -484,6 +494,7 @@ export const tableCreationOrder = [
   'report_entries_indexes',
   'oauth_tokens',
   'sync_state',
+  'uploaded_icons',
   'user_settings',
   'notes',
   'notes_indexes',

--- a/apps/backend/src/services/icons.test.ts
+++ b/apps/backend/src/services/icons.test.ts
@@ -1,0 +1,118 @@
+import sharp from 'sharp'
+import { describe, expect, test } from 'vitest'
+
+import { isAllowedContentType, processIcon } from './icons.ts'
+
+const MAX_BYTES = 256 * 1024
+
+describe('isAllowedContentType', () => {
+  test('accepts valid image types', () => {
+    expect(isAllowedContentType('image/png')).toBe(true)
+    expect(isAllowedContentType('image/jpeg')).toBe(true)
+    expect(isAllowedContentType('image/webp')).toBe(true)
+    expect(isAllowedContentType('image/gif')).toBe(true)
+    expect(isAllowedContentType('image/svg+xml')).toBe(true)
+  })
+
+  test('rejects invalid types', () => {
+    expect(isAllowedContentType('text/html')).toBe(false)
+    expect(isAllowedContentType('application/pdf')).toBe(false)
+    expect(isAllowedContentType('image/bmp')).toBe(false)
+  })
+})
+
+describe('processIcon', () => {
+  test('rejects unsupported content type', async () => {
+    await expect(processIcon(Buffer.from('data'), 'text/plain')).rejects.toThrow('Unsupported content type')
+  })
+
+  test('passes through SVG under size limit', async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>')
+    const result = await processIcon(svg, 'image/svg+xml')
+    expect(result.content_type).toBe('image/svg+xml')
+    expect(result.data).toEqual(svg)
+  })
+
+  test('rejects SVG over size limit', async () => {
+    const svg = Buffer.alloc(MAX_BYTES + 1, 'x')
+    await expect(processIcon(svg, 'image/svg+xml')).rejects.toThrow('SVG exceeds')
+  })
+
+  test('passes through small PNG without modification', async () => {
+    // Create a tiny 2x2 PNG — well under 256KB
+    const smallPng = await sharp({
+      create: { width: 2, height: 2, channels: 4, background: { r: 255, g: 0, b: 0, alpha: 1 } },
+    })
+      .png()
+      .toBuffer()
+
+    expect(smallPng.length).toBeLessThan(MAX_BYTES)
+    const result = await processIcon(smallPng, 'image/png')
+    expect(result.content_type).toBe('image/png')
+    expect(result.data).toEqual(smallPng)
+  })
+
+  test('resizes large PNG to fit within limit', async () => {
+    // Create a 1000x1000 PNG with random-ish data to exceed 256KB
+    const largePng = await sharp({
+      create: { width: 1000, height: 1000, channels: 4, background: { r: 128, g: 64, b: 192, alpha: 1 } },
+    })
+      .png({ compressionLevel: 0 })
+      .toBuffer()
+
+    // If this doesn't exceed the limit naturally, add noise
+    const inputSize = largePng.length
+    if (inputSize <= MAX_BYTES) {
+      // The solid color compresses well, so test with noisy data
+      const noisyPng = await sharp(
+        Buffer.from(Array.from({ length: 1000 * 1000 * 4 }, () => Math.floor(Math.random() * 256))),
+        { raw: { width: 1000, height: 1000, channels: 4 } },
+      )
+        .png({ compressionLevel: 0 })
+        .toBuffer()
+
+      expect(noisyPng.length).toBeGreaterThan(MAX_BYTES)
+      const result = await processIcon(noisyPng, 'image/png')
+      expect(result.data.length).toBeLessThanOrEqual(MAX_BYTES)
+      expect(result.content_type).toBe('image/png')
+
+      // Verify resized dimensions
+      const metadata = await sharp(result.data).metadata()
+      expect(metadata.width).toBeLessThanOrEqual(256)
+      expect(metadata.height).toBeLessThanOrEqual(256)
+    } else {
+      const result = await processIcon(largePng, 'image/png')
+      expect(result.data.length).toBeLessThanOrEqual(MAX_BYTES)
+    }
+  })
+
+  test('resizes large JPEG', async () => {
+    // Create a large JPEG from noisy data
+    const noisyJpeg = await sharp(
+      Buffer.from(Array.from({ length: 1000 * 1000 * 3 }, () => Math.floor(Math.random() * 256))),
+      { raw: { width: 1000, height: 1000, channels: 3 } },
+    )
+      .jpeg({ quality: 100 })
+      .toBuffer()
+
+    if (noisyJpeg.length > MAX_BYTES) {
+      const result = await processIcon(noisyJpeg, 'image/jpeg')
+      expect(result.data.length).toBeLessThanOrEqual(MAX_BYTES)
+      expect(result.content_type).toBe('image/jpeg')
+    }
+  })
+
+  test('handles GIF passthrough', async () => {
+    // Create a small single-frame GIF
+    const gif = await sharp({
+      create: { width: 10, height: 10, channels: 4, background: { r: 255, g: 0, b: 0, alpha: 1 } },
+    })
+      .gif()
+      .toBuffer()
+
+    expect(gif.length).toBeLessThan(MAX_BYTES)
+    const result = await processIcon(gif, 'image/gif')
+    expect(result.content_type).toBe('image/gif')
+    expect(result.data).toEqual(gif)
+  })
+})

--- a/apps/backend/src/services/icons.ts
+++ b/apps/backend/src/services/icons.ts
@@ -1,0 +1,88 @@
+/**
+ * Icon upload processing — resize and compress images to fit within 256KB.
+ */
+import sharp from 'sharp'
+
+import { deleteIcon, insertIcon } from '../db/icons.ts'
+
+const MAX_ICON_BYTES = 256 * 1024
+const MAX_ICON_PIXELS = 256
+
+const ALLOWED_CONTENT_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/svg+xml'])
+
+export const isAllowedContentType = (contentType: string): boolean => ALLOWED_CONTENT_TYPES.has(contentType)
+
+/**
+ * Process an uploaded image buffer:
+ * - SVG: stored as-is if within size limit
+ * - Raster: stored as-is if within size limit, otherwise resized to 256×256 and compressed
+ * - Animated GIF/PNG: animation frames are preserved during resize
+ *
+ * Returns { data, contentType } of the processed image.
+ * Throws if the image cannot be compressed to fit within 256KB.
+ */
+export const processIcon = async (
+  buffer: Buffer,
+  contentType: string,
+): Promise<{ data: Buffer; content_type: string }> => {
+  if (!isAllowedContentType(contentType)) {
+    throw new Error(`Unsupported content type: ${contentType}`)
+  }
+
+  // SVG: store as-is, just check size
+  if (contentType === 'image/svg+xml') {
+    if (buffer.length > MAX_ICON_BYTES) {
+      throw new Error(`SVG exceeds ${MAX_ICON_BYTES} bytes (${buffer.length} bytes)`)
+    }
+    return { data: buffer, content_type: contentType }
+  }
+
+  // Raster: if already small enough, store as-is
+  if (buffer.length <= MAX_ICON_BYTES) {
+    return { data: buffer, content_type: contentType }
+  }
+
+  // Need to resize and compress
+  const isAnimated = contentType === 'image/gif' || contentType === 'image/png'
+  let pipeline = sharp(buffer, { animated: isAnimated }).resize(MAX_ICON_PIXELS, MAX_ICON_PIXELS, {
+    fit: 'inside',
+    withoutEnlargement: true,
+  })
+
+  // Compress based on format
+  if (contentType === 'image/png') {
+    pipeline = pipeline.png({ compressionLevel: 9 })
+  } else if (contentType === 'image/jpeg') {
+    pipeline = pipeline.jpeg({ quality: 80 })
+  } else if (contentType === 'image/webp') {
+    pipeline = pipeline.webp({ quality: 80 })
+  } else if (contentType === 'image/gif') {
+    pipeline = pipeline.gif()
+  }
+
+  const processed = await pipeline.toBuffer()
+
+  if (processed.length > MAX_ICON_BYTES) {
+    throw new Error(`Image still exceeds ${MAX_ICON_BYTES} bytes after resize (${processed.length} bytes)`)
+  }
+
+  return { data: processed, content_type: contentType }
+}
+
+/**
+ * Process and store an uploaded icon image.
+ * Returns the icon UUID.
+ */
+export const processAndStoreIcon = async (
+  user: string,
+  buffer: Buffer,
+  contentType: string,
+): Promise<string> => {
+  const processed = await processIcon(buffer, contentType)
+  return insertIcon(user, processed.content_type, processed.data)
+}
+
+/**
+ * Delete an uploaded icon.
+ */
+export const removeIcon = async (user: string, id: string): Promise<boolean> => deleteIcon(user, id)

--- a/apps/web/src/components/IconInput.css
+++ b/apps/web/src/components/IconInput.css
@@ -1,0 +1,37 @@
+.icon-upload-btn {
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 4px;
+  background: var(--bg-secondary, #f5f5f5);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.icon-upload-btn:hover:not(:disabled) {
+  background: var(--bg-hover, #e8e8e8);
+}
+
+.icon-upload-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.icon-suggestion-btn {
+  padding: 2px 6px;
+  font-size: 0.85rem;
+  border: 1px dashed var(--border-color, #ccc);
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.icon-suggestion-btn:hover {
+  opacity: 1;
+}
+
+.icon-upload-error {
+  color: var(--color-error, #e53e3e);
+  font-size: 0.75rem;
+}

--- a/apps/web/src/components/IconInput.tsx
+++ b/apps/web/src/components/IconInput.tsx
@@ -1,0 +1,121 @@
+/**
+ * Shared icon input — text field for emoji/URL, upload button, preview, and optional emoji suggestion.
+ * Used by tag settings, exercise meta, timeline icon settings, screentime category detail,
+ * and tag mappings settings.
+ */
+import { useRef, useState } from 'preact/hooks'
+
+import { uploadIcon } from '../state/api'
+import { isEmoji, isIconPath, isUrl } from '../utils/emojiLookup'
+import './IconInput.css'
+
+interface IconInputProps {
+  /** Current icon value (emoji, URL, or icon path) */
+  value: string
+  /** Called when the icon value changes (from typing or upload) */
+  onChange: (value: string) => void
+  /** Called on blur (for auto-save patterns) */
+  onBlur?: () => void
+  /** Placeholder text */
+  placeholder?: string
+  /** Icon preview size in pixels */
+  size?: number
+  /** Suggested emoji to offer */
+  suggestedEmoji?: string
+  /** Called when a suggested emoji is accepted (some consumers auto-save on accept) */
+  onAcceptSuggestion?: (emoji: string) => void
+  /** CSS class for the text input */
+  inputClass?: string
+  /** CSS class for the preview span */
+  previewClass?: string
+  /** Disabled state */
+  disabled?: boolean
+}
+
+export function IconInput({
+  value,
+  onChange,
+  onBlur,
+  placeholder = 'Emoji or image URL...',
+  size = 24,
+  suggestedEmoji,
+  onAcceptSuggestion,
+  inputClass,
+  previewClass,
+  disabled,
+}: IconInputProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | undefined>(undefined)
+
+  const handleFileUpload = async (file: File) => {
+    setUploadError(undefined)
+    setUploading(true)
+    try {
+      const { url } = await uploadIcon(file)
+      onChange(url)
+    } catch (error) {
+      setUploadError(error instanceof Error ? error.message : 'Upload failed')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const isImage = value && (isUrl(value) || isIconPath(value))
+
+  return (
+    <>
+      <input
+        type="text"
+        value={value}
+        onInput={(e) => onChange((e.target as HTMLInputElement).value)}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        class={inputClass}
+        disabled={disabled || uploading}
+      />
+      {value && (
+        <span class={previewClass ?? 'icon-preview'}>
+          {isEmoji(value) ? (
+            value
+          ) : isImage ? (
+            <img src={value} alt="icon" width={size} height={size} />
+          ) : null}
+        </span>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = (e.target as HTMLInputElement).files?.[0]
+          if (file) void handleFileUpload(file)
+        }}
+      />
+      <button
+        type="button"
+        class="icon-upload-btn"
+        onClick={() => fileInputRef.current?.click()}
+        title="Upload icon image"
+        disabled={disabled || uploading}
+      >
+        {uploading ? '...' : 'Upload'}
+      </button>
+      {suggestedEmoji && !value && (
+        <button
+          type="button"
+          class="icon-suggestion-btn"
+          onClick={() => {
+            onChange(suggestedEmoji)
+            onAcceptSuggestion?.(suggestedEmoji)
+          }}
+          title={`Suggested: ${suggestedEmoji}`}
+        >
+          {suggestedEmoji}?
+        </button>
+      )}
+      {uploadError && <span class="icon-upload-error">{uploadError}</span>}
+    </>
+  )
+}

--- a/apps/web/src/components/IconPreview.tsx
+++ b/apps/web/src/components/IconPreview.tsx
@@ -2,12 +2,12 @@
  * Shared icon preview — renders emoji text or image URL.
  * Replaces duplicated IconPreview/TagIconPreview components across pages.
  */
-import { isEmoji, isUrl } from '../utils/emojiLookup'
+import { isEmoji, isIconPath, isUrl } from '../utils/emojiLookup'
 
 export const IconPreview = ({ icon, size = 24 }: { icon: string; size?: number }) => {
   if (!icon) return null
   if (isEmoji(icon)) return <span class="icon-preview icon-preview-emoji">{icon}</span>
-  if (isUrl(icon)) {
+  if (isUrl(icon) || isIconPath(icon)) {
     return (
       <span class="icon-preview">
         <img src={icon} alt="icon" width={size} height={size} />

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'preact/hooks'
 
 import { fetchProgrammaticTags, fetchTagMappings, setTagMapping } from '../state/api'
-import { isEmoji, isUrl, suggestEmoji } from '../utils/emojiLookup'
+import { isEmoji, isIconPath, isUrl, suggestEmoji } from '../utils/emojiLookup'
 import './TagMappingsSettings.css'
 
 // Helper to check if a string is a UUID
@@ -40,7 +40,7 @@ const RowStatusIndicator = ({ status }: { status: RowStatus }) => (
 const IconPreview = ({ icon }: { icon: string }) => {
   if (!icon) return null
   if (isEmoji(icon)) return <span class="tag-icon-preview">{icon}</span>
-  if (isUrl(icon)) {
+  if (isUrl(icon) || isIconPath(icon)) {
     return (
       <span class="tag-icon-preview">
         <img src={icon} alt="icon" width="16" height="16" />

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -4,7 +4,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'preact/hooks'
 
 import { fetchProgrammaticTags, fetchTagMappings, setTagMapping } from '../state/api'
-import { isEmoji, isIconPath, isUrl, suggestEmoji } from '../utils/emojiLookup'
+import { suggestEmoji } from '../utils/emojiLookup'
+import { IconInput } from './IconInput'
 import './TagMappingsSettings.css'
 
 // Helper to check if a string is a UUID
@@ -36,19 +37,6 @@ const RowStatusIndicator = ({ status }: { status: RowStatus }) => (
     )}
   </span>
 )
-
-const IconPreview = ({ icon }: { icon: string }) => {
-  if (!icon) return null
-  if (isEmoji(icon)) return <span class="tag-icon-preview">{icon}</span>
-  if (isUrl(icon) || isIconPath(icon)) {
-    return (
-      <span class="tag-icon-preview">
-        <img src={icon} alt="icon" width="16" height="16" />
-      </span>
-    )
-  }
-  return null
-}
 
 /** Determine what changed vs server state and return the name to save, or null if no save needed. */
 function getBlurSavePayload(
@@ -178,27 +166,18 @@ function TagMappingRow({
       </div>
 
       <div class="tag-icon-field">
-        <input
-          type="text"
+        <IconInput
           value={displayIcon}
-          onInput={(e) => setLocalIcon((e.target as HTMLInputElement).value)}
+          onChange={setLocalIcon}
           onBlur={() => void handleBlur()}
           placeholder="Icon"
-          title="Emoji character or image URL"
-          class="tag-icon-input"
+          inputClass="tag-icon-input"
+          previewClass="tag-icon-preview"
+          size={16}
+          suggestedEmoji={suggestedEmoji}
+          onAcceptSuggestion={() => void handleAcceptSuggestion()}
           disabled={status === 'saving'}
         />
-        <IconPreview icon={displayIcon} />
-        {suggestedEmoji && !displayIcon && (
-          <button
-            type="button"
-            class="tag-icon-suggestion"
-            onClick={handleAcceptSuggestion}
-            title={`Suggested: ${suggestedEmoji}`}
-          >
-            {suggestedEmoji}?
-          </button>
-        )}
       </div>
 
       {isProgrammatic && (

--- a/apps/web/src/components/TimelineIconsSettings.tsx
+++ b/apps/web/src/components/TimelineIconsSettings.tsx
@@ -3,10 +3,11 @@
  * Allows configuring emojis for activity types, exercise types, and tags.
  */
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 
-import { fetchUserSettings, updateUserSettings, uploadIcon } from '../state/api'
-import { DEFAULT_ITEM_ICONS, isEmoji, isIconPath, isUrl } from '../utils/emojiLookup'
+import { fetchUserSettings, updateUserSettings } from '../state/api'
+import { DEFAULT_ITEM_ICONS } from '../utils/emojiLookup'
+import { IconInput } from './IconInput'
 import './TimelineIconsSettings.css'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
@@ -19,23 +20,9 @@ interface IconRowProps {
   onSave: (key: string, icon: string) => Promise<void>
 }
 
-const IconPreview = ({ icon }: { icon: string }) => {
-  if (!icon) return null
-  if (isEmoji(icon)) return <span class="icon-preview">{icon}</span>
-  if (isUrl(icon) || isIconPath(icon)) {
-    return (
-      <span class="icon-preview">
-        <img src={icon} alt="icon" width="16" height="16" />
-      </span>
-    )
-  }
-  return null
-}
-
 function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowProps) {
   const [localValue, setLocalValue] = useState<string | undefined>(undefined)
   const [status, setStatus] = useState<SaveStatus>('idle')
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (status !== 'saved') return
@@ -67,15 +54,19 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
     }
   }
 
-  const handleFileUpload = async (file: File) => {
-    setStatus('saving')
-    try {
-      const { url } = await uploadIcon(file)
-      await onSave(iconKey, url)
-      setLocalValue(undefined)
-      setStatus('saved')
-    } catch {
-      setStatus('error')
+  const handleIconChange = async (value: string) => {
+    // If it's an uploaded icon path, save immediately
+    if (value.startsWith('/api/icons/')) {
+      setStatus('saving')
+      try {
+        await onSave(iconKey, value)
+        setLocalValue(undefined)
+        setStatus('saved')
+      } catch {
+        setStatus('error')
+      }
+    } else {
+      setLocalValue(value)
     }
   }
 
@@ -83,10 +74,6 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
     if (isDefault) return
     setStatus('saving')
     try {
-      // Save empty string to clear the user override; the DB migration
-      // stores '' which resolveItemIcon interprets as "no icon" — but for
-      // a reset we actually want to *remove* the key so the default kicks in.
-      // The parent handler already handles this by deleting the key.
       await onSave(iconKey, '')
       setLocalValue(undefined)
       setStatus('saved')
@@ -99,36 +86,16 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
     <div class="icon-row">
       <span class="icon-row-label">{label}</span>
       <div class="icon-row-field">
-        <input
-          type="text"
-          value={displayValue}
-          onInput={(e) => setLocalValue((e.target as HTMLInputElement).value)}
+        <IconInput
+          value={effectiveIcon}
+          onChange={(v) => void handleIconChange(v)}
           onBlur={() => void handleBlur()}
           placeholder={defaultIcon || 'none'}
-          title="Emoji character or image URL"
-          class="icon-input"
+          inputClass="icon-input"
+          previewClass="icon-preview"
+          size={16}
           disabled={status === 'saving'}
         />
-        <IconPreview icon={effectiveIcon} />
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
-          style={{ display: 'none' }}
-          onChange={(e) => {
-            const file = (e.target as HTMLInputElement).files?.[0]
-            if (file) void handleFileUpload(file)
-          }}
-        />
-        <button
-          type="button"
-          class="icon-upload-btn"
-          onClick={() => fileInputRef.current?.click()}
-          title="Upload icon image"
-          disabled={status === 'saving'}
-        >
-          Upload
-        </button>
         {!isDefault && (
           <button
             type="button"
@@ -249,7 +216,7 @@ export function TimelineIconsSettings() {
       <h2>Timeline Icons</h2>
       <p class="section-description">
         Customize the icons shown on the timeline for activities and exercise types. Icons can be emoji
-        characters or image URLs. Default emojis are shown as placeholders.
+        characters, image URLs, or uploaded images. Default emojis are shown as placeholders.
       </p>
 
       <IconGroup title="Activities" items={ACTIVITY_ITEMS} userIcons={userIcons} onSave={handleSave} />

--- a/apps/web/src/components/TimelineIconsSettings.tsx
+++ b/apps/web/src/components/TimelineIconsSettings.tsx
@@ -3,10 +3,10 @@
  * Allows configuring emojis for activity types, exercise types, and tags.
  */
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
-import { fetchUserSettings, updateUserSettings } from '../state/api'
-import { DEFAULT_ITEM_ICONS, isEmoji, isUrl } from '../utils/emojiLookup'
+import { fetchUserSettings, updateUserSettings, uploadIcon } from '../state/api'
+import { DEFAULT_ITEM_ICONS, isEmoji, isIconPath, isUrl } from '../utils/emojiLookup'
 import './TimelineIconsSettings.css'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
@@ -22,7 +22,7 @@ interface IconRowProps {
 const IconPreview = ({ icon }: { icon: string }) => {
   if (!icon) return null
   if (isEmoji(icon)) return <span class="icon-preview">{icon}</span>
-  if (isUrl(icon)) {
+  if (isUrl(icon) || isIconPath(icon)) {
     return (
       <span class="icon-preview">
         <img src={icon} alt="icon" width="16" height="16" />
@@ -35,6 +35,7 @@ const IconPreview = ({ icon }: { icon: string }) => {
 function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowProps) {
   const [localValue, setLocalValue] = useState<string | undefined>(undefined)
   const [status, setStatus] = useState<SaveStatus>('idle')
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (status !== 'saved') return
@@ -59,6 +60,18 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
     setStatus('saving')
     try {
       await onSave(iconKey, trimmed)
+      setLocalValue(undefined)
+      setStatus('saved')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  const handleFileUpload = async (file: File) => {
+    setStatus('saving')
+    try {
+      const { url } = await uploadIcon(file)
+      await onSave(iconKey, url)
       setLocalValue(undefined)
       setStatus('saved')
     } catch {
@@ -97,6 +110,25 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
           disabled={status === 'saving'}
         />
         <IconPreview icon={effectiveIcon} />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const file = (e.target as HTMLInputElement).files?.[0]
+            if (file) void handleFileUpload(file)
+          }}
+        />
+        <button
+          type="button"
+          class="icon-upload-btn"
+          onClick={() => fileInputRef.current?.click()}
+          title="Upload icon image"
+          disabled={status === 'saving'}
+        >
+          Upload
+        </button>
         {!isDefault && (
           <button
             type="button"

--- a/apps/web/src/pages/ExerciseMeta/index.tsx
+++ b/apps/web/src/pages/ExerciseMeta/index.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
 import { useEffect, useState } from 'preact/hooks'
 
+import { IconInput } from '../../components/IconInput'
 import { IconPreview } from '../../components/IconPreview'
 import { fetchTagMappings, fetchTrend, type FetchTrendParams, updateUserSettings } from '../../state/api'
 import { resolveItemIcon } from '../../utils/emojiLookup'
@@ -92,13 +93,7 @@ function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: str
         <label>
           <span class="tag-meta-field-label">Icon</span>
           <div class="tag-meta-icon-row">
-            <input
-              type="text"
-              value={shownIcon}
-              onInput={(e) => setIconValue((e.target as HTMLInputElement).value)}
-              placeholder="Emoji or image URL..."
-            />
-            <IconPreview icon={shownIcon} />
+            <IconInput value={shownIcon} onChange={setIconValue} previewClass="tag-meta-icon-preview" />
           </div>
         </label>
       </div>

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -11,6 +11,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 
+import { IconInput } from '../../components/IconInput'
 import {
   type DistinctApp,
   type FetchTrendParams,
@@ -26,7 +27,7 @@ import {
   upsertScreentimeCategory,
 } from '../../state/api'
 import { auth } from '../../state/auth'
-import { isEmoji, isIconPath, isUrl, suggestEmoji } from '../../utils/emojiLookup'
+import { isEmoji, suggestEmoji } from '../../utils/emojiLookup'
 import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
 import './style.css'
 
@@ -205,23 +206,6 @@ function AutoSaveColor({
   )
 }
 
-// ============================================================================
-// Icon editor (reused from previous implementation)
-// ============================================================================
-
-function IconPreview({ icon }: { icon: string }) {
-  if (!icon) return null
-  if (isEmoji(icon)) return <span class="category-icon-preview">{icon}</span>
-  if (isUrl(icon) || isIconPath(icon)) {
-    return (
-      <span class="category-icon-preview">
-        <img src={icon} alt="icon" width="24" height="24" />
-      </span>
-    )
-  }
-  return null
-}
-
 function CategoryIconEditor({
   categoryName,
   currentIcon,
@@ -262,28 +246,15 @@ function CategoryIconEditor({
       <span class="field-label">Icon</span>
       <span class="field-value">
         <div class="category-icon-edit-row">
-          <input
-            type="text"
+          <IconInput
             value={shownIcon}
-            onInput={(e) => setIconValue((e.target as HTMLInputElement).value)}
+            onChange={setIconValue}
             onBlur={handleBlur}
-            placeholder="Emoji or image URL..."
-            class="category-icon-input"
+            inputClass="category-icon-input"
+            previewClass="category-icon-preview"
+            suggestedEmoji={suggested}
+            onAcceptSuggestion={(emoji) => saveMutation.mutate(emoji)}
           />
-          <IconPreview icon={shownIcon} />
-          {suggested && !shownIcon && (
-            <button
-              type="button"
-              class="category-icon-suggestion"
-              onClick={() => {
-                setIconValue(suggested)
-                saveMutation.mutate(suggested)
-              }}
-              title={`Suggested: ${suggested}`}
-            >
-              {suggested}?
-            </button>
-          )}
         </div>
       </span>
     </div>

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -26,7 +26,7 @@ import {
   upsertScreentimeCategory,
 } from '../../state/api'
 import { auth } from '../../state/auth'
-import { isEmoji, isUrl, suggestEmoji } from '../../utils/emojiLookup'
+import { isEmoji, isIconPath, isUrl, suggestEmoji } from '../../utils/emojiLookup'
 import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
 import './style.css'
 
@@ -212,7 +212,7 @@ function AutoSaveColor({
 function IconPreview({ icon }: { icon: string }) {
   if (!icon) return null
   if (isEmoji(icon)) return <span class="category-icon-preview">{icon}</span>
-  if (isUrl(icon)) {
+  if (isUrl(icon) || isIconPath(icon)) {
     return (
       <span class="category-icon-preview">
         <img src={icon} alt="icon" width="24" height="24" />

--- a/apps/web/src/pages/TagMeta/TagIconPreview.tsx
+++ b/apps/web/src/pages/TagMeta/TagIconPreview.tsx
@@ -1,12 +1,12 @@
 /**
  * Icon preview for tags — renders emoji or image URL.
  */
-import { isEmoji, isUrl } from '../../utils/emojiLookup'
+import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 
 export const TagIconPreview = ({ icon }: { icon: string }) => {
   if (!icon) return null
   if (isEmoji(icon)) return <span class="tag-meta-icon-preview">{icon}</span>
-  if (isUrl(icon)) {
+  if (isUrl(icon) || isIconPath(icon)) {
     return (
       <span class="tag-meta-icon-preview">
         <img src={icon} alt="icon" width="24" height="24" />

--- a/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
+++ b/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
@@ -4,9 +4,9 @@
 import type { ProgrammaticTag } from '@aurboda/api-spec'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 
-import { setTagMapping } from '../../state/api'
+import { setTagMapping, uploadIcon } from '../../state/api'
 import { suggestEmoji } from '../../utils/emojiLookup'
 import { TagIconPreview } from './TagIconPreview'
 
@@ -28,6 +28,8 @@ export function TagSettingsSection({
   const [displayName, setDisplayName] = useState<string | undefined>(undefined)
   const [iconValue, setIconValue] = useState<string | undefined>(undefined)
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [uploadError, setUploadError] = useState<string | undefined>(undefined)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const saveMutation = useMutation({
     mutationFn: ({ name, icon }: { name: string; icon?: string }) =>
@@ -62,6 +64,16 @@ export function TagSettingsSection({
     saveMutation.mutate({ icon: iconChanged ? iconValue : undefined, name })
   }
 
+  const handleFileUpload = async (file: File) => {
+    setUploadError(undefined)
+    try {
+      const { url } = await uploadIcon(file)
+      setIconValue(url)
+    } catch (error) {
+      setUploadError(error instanceof Error ? error.message : 'Upload failed')
+    }
+  }
+
   const hasChanges =
     (displayName !== undefined && displayName !== currentName) ||
     (iconValue !== undefined && iconValue !== currentIcon)
@@ -94,6 +106,24 @@ export function TagSettingsSection({
               placeholder="Emoji or image URL..."
             />
             <TagIconPreview icon={shownIcon} />
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const file = (e.target as HTMLInputElement).files?.[0]
+                if (file) void handleFileUpload(file)
+              }}
+            />
+            <button
+              type="button"
+              class="tag-meta-emoji-suggest"
+              onClick={() => fileInputRef.current?.click()}
+              title="Upload icon image"
+            >
+              Upload
+            </button>
             {suggested && !shownIcon && (
               <button
                 type="button"
@@ -104,6 +134,7 @@ export function TagSettingsSection({
                 {suggested}?
               </button>
             )}
+            {uploadError && <span class="tag-meta-status-error">{uploadError}</span>}
           </div>
         </label>
         {tagInfo?.is_programmatic && effectiveTagKey !== currentName && (

--- a/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
+++ b/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
@@ -4,11 +4,11 @@
 import type { ProgrammaticTag } from '@aurboda/api-spec'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
-import { setTagMapping, uploadIcon } from '../../state/api'
+import { IconInput } from '../../components/IconInput'
+import { setTagMapping } from '../../state/api'
 import { suggestEmoji } from '../../utils/emojiLookup'
-import { TagIconPreview } from './TagIconPreview'
 
 interface TagSettingsSectionProps {
   tagInfo: ProgrammaticTag | undefined
@@ -28,8 +28,6 @@ export function TagSettingsSection({
   const [displayName, setDisplayName] = useState<string | undefined>(undefined)
   const [iconValue, setIconValue] = useState<string | undefined>(undefined)
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-  const [uploadError, setUploadError] = useState<string | undefined>(undefined)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const saveMutation = useMutation({
     mutationFn: ({ name, icon }: { name: string; icon?: string }) =>
@@ -64,16 +62,6 @@ export function TagSettingsSection({
     saveMutation.mutate({ icon: iconChanged ? iconValue : undefined, name })
   }
 
-  const handleFileUpload = async (file: File) => {
-    setUploadError(undefined)
-    try {
-      const { url } = await uploadIcon(file)
-      setIconValue(url)
-    } catch (error) {
-      setUploadError(error instanceof Error ? error.message : 'Upload failed')
-    }
-  }
-
   const hasChanges =
     (displayName !== undefined && displayName !== currentName) ||
     (iconValue !== undefined && iconValue !== currentIcon)
@@ -99,42 +87,12 @@ export function TagSettingsSection({
         <label>
           <span class="tag-meta-field-label">Icon</span>
           <div class="tag-meta-icon-row">
-            <input
-              type="text"
+            <IconInput
               value={shownIcon}
-              onInput={(e) => setIconValue((e.target as HTMLInputElement).value)}
-              placeholder="Emoji or image URL..."
+              onChange={setIconValue}
+              suggestedEmoji={suggested}
+              previewClass="tag-meta-icon-preview"
             />
-            <TagIconPreview icon={shownIcon} />
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
-              style={{ display: 'none' }}
-              onChange={(e) => {
-                const file = (e.target as HTMLInputElement).files?.[0]
-                if (file) void handleFileUpload(file)
-              }}
-            />
-            <button
-              type="button"
-              class="tag-meta-emoji-suggest"
-              onClick={() => fileInputRef.current?.click()}
-              title="Upload icon image"
-            >
-              Upload
-            </button>
-            {suggested && !shownIcon && (
-              <button
-                type="button"
-                class="tag-meta-emoji-suggest"
-                onClick={() => setIconValue(suggested)}
-                title={`Suggested: ${suggested}`}
-              >
-                {suggested}?
-              </button>
-            )}
-            {uploadError && <span class="tag-meta-status-error">{uploadError}</span>}
           </div>
         </label>
         {tagInfo?.is_programmatic && effectiveTagKey !== currentName && (

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -29,7 +29,7 @@ import {
   fetchUserSettings,
 } from '../../state/api'
 import { aggregateBucketsAligned, parseBucketedResponse } from '../../utils/chart'
-import { isEmoji, isUrl } from '../../utils/emojiLookup'
+import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import { packLanes } from '../../utils/lanePacking'
 import { buildActivityColumnItems, EXCLUDED_TAG_PREFIXES, EXCLUDED_TAG_SOURCES } from './activityMerge'
 import { computeBarLayout, type BarSlot } from './barLayout'
@@ -1602,7 +1602,7 @@ export const Timeline = () => {
               .text(icon)
               .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
               .on('mouseleave', hideTooltip)
-          } else if (icon && isUrl(icon)) {
+          } else if (icon && (isUrl(icon) || isIconPath(icon))) {
             parent
               .append('image')
               .attr('href', icon)
@@ -1669,7 +1669,7 @@ export const Timeline = () => {
             .attr('font-size', `${ICON_SIZE}px`)
             .attr('pointer-events', 'none')
             .text(item.icon)
-        } else if (item.icon && isUrl(item.icon)) {
+        } else if (item.icon && (isUrl(item.icon) || isIconPath(item.icon))) {
           parent
             .append('image')
             .attr('href', item.icon)
@@ -2539,7 +2539,7 @@ const drawPointMarker = (
     return
   }
 
-  if (item.icon && isUrl(item.icon)) {
+  if (item.icon && (isUrl(item.icon) || isIconPath(item.icon))) {
     const imgSize = 18
     parent
       .append('image')
@@ -2603,7 +2603,7 @@ const drawBlockOverlay = (
     return
   }
 
-  if (item.icon && isUrl(item.icon)) {
+  if (item.icon && (isUrl(item.icon) || isIconPath(item.icon))) {
     const imgSize = 18
     parent
       .append('image')

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -559,6 +559,19 @@ export const updateUserSettings = async (params: UpdateSettingsInput): Promise<U
   return response.data
 }
 
+// Upload an icon image, returns { id, url }
+export const uploadIcon = async (file: File): Promise<{ id: string; url: string }> => {
+  const { token } = auth.value
+  const formData = new FormData()
+  formData.append('icon', file)
+  const response = await axios.post<{ id: string; success: boolean; url: string }>(
+    `${API_URL}/icons`,
+    formData,
+    { headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' } },
+  )
+  return { id: response.data.id, url: response.data.url }
+}
+
 // Trigger Oura sync
 export const syncOura = async (fullResync?: boolean): Promise<OuraSyncResponse> => {
   const { token } = auth.value

--- a/apps/web/src/utils/emojiLookup.ts
+++ b/apps/web/src/utils/emojiLookup.ts
@@ -232,3 +232,8 @@ export const isUrl = (str: string): boolean => {
     return false
   }
 }
+
+/**
+ * Check if a string is a path to an uploaded icon.
+ */
+export const isIconPath = (str: string): boolean => str.startsWith('/api/icons/')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
         version: 1.25.3(hono@4.11.6)(zod@4.3.6)
+      '@types/multer':
+        specifier: ^2.1.0
+        version: 2.1.0
       axios:
         specifier: ^1.11.0
         version: 1.13.3
@@ -59,6 +62,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      multer:
+        specifier: ^2.1.1
+        version: 2.1.1
       node-ical:
         specifier: ^0.25.1
         version: 0.25.1
@@ -71,6 +77,9 @@ importers:
       pg-format:
         specifier: ^1.0.4
         version: 1.0.4
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -342,6 +351,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -689,6 +701,143 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -1420,6 +1569,9 @@ packages:
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
+  '@types/multer@2.1.0':
+    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -1591,6 +1743,9 @@ packages:
     resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
     engines: {node: '>= 6.0.0'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
@@ -1731,6 +1886,9 @@ packages:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -1740,6 +1898,10 @@ packages:
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
     engines: {node: '>=10.0.0'}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
 
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
@@ -1845,6 +2007,10 @@ packages:
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   concurrently@9.2.1:
     resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
@@ -2103,6 +2269,10 @@ packages:
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -2663,6 +2833,10 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -2744,6 +2918,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+    engines: {node: '>= 10.16.0'}
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
@@ -3162,6 +3340,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3254,6 +3436,10 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -3416,9 +3602,16 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3852,6 +4045,11 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -4062,6 +4260,102 @@ snapshots:
   '@hono/node-server@1.19.9(hono@4.11.6)':
     dependencies:
       hono: 4.11.6
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/external-editor@1.0.3(@types/node@22.19.7)':
     dependencies:
@@ -4705,6 +4999,10 @@ snapshots:
 
   '@types/methods@1.1.4': {}
 
+  '@types/multer@2.1.0':
+    dependencies:
+      '@types/express': 5.0.6
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -4887,6 +5185,8 @@ snapshots:
 
   app-root-path@3.1.0: {}
 
+  append-field@1.0.0: {}
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.5.0
@@ -5051,6 +5351,8 @@ snapshots:
 
   buffer-crc32@1.0.0: {}
 
+  buffer-from@1.1.2: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -5063,6 +5365,10 @@ snapshots:
 
   buildcheck@0.0.7:
     optional: true
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   byline@5.0.0: {}
 
@@ -5161,6 +5467,13 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   concurrently@9.2.1:
     dependencies:
@@ -5428,6 +5741,8 @@ snapshots:
   depd@2.0.0: {}
 
   destr@2.0.5: {}
+
+  detect-libc@2.1.2: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -6070,6 +6385,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
@@ -6131,6 +6448,13 @@ snapshots:
       ufo: 1.6.3
 
   ms@2.1.3: {}
+
+  multer@2.1.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
 
   mute-stream@0.0.8: {}
 
@@ -6629,6 +6953,37 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -6720,6 +7075,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
+
+  streamsearch@1.1.0: {}
 
   streamx@2.23.0:
     dependencies:
@@ -6939,11 +7296,18 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary
- Upload icon images (PNG, JPEG, WebP, GIF, SVG) stored as bytea in PostgreSQL
- Auto-resize/compress images over 256KB to 256×256 using Sharp
- GET endpoint serves icons with 1-year cache headers; new UUID on replacement for cache busting
- Upload buttons added to tag settings and timeline icon settings UI
- `isIconPath()` helper ensures `/api/icons/` paths render as images across all icon preview components

## API
- `POST /api/icons` — upload (multipart, authenticated), returns `{ id, url }`
- `GET /api/icons/:user/:id` — serve (public, no auth needed for `<img src>`)
- `DELETE /api/icons/:id` — delete (authenticated)

## Test plan
- [x] Unit tests for icon processing service (9 tests)
- [x] Integration tests for DB CRUD operations (5 tests)
- [ ] Manual: upload a >256KB image, verify resize and 256KB limit
- [ ] Manual: set uploaded icon on a tag, verify display in timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)