### PR TITLE
refactor: extract shared SettingsSection component

### DIFF
--- a/apps/web/src/components/CustomMetricsSettings.tsx
+++ b/apps/web/src/components/CustomMetricsSettings.tsx
@@ -8,6 +8,7 @@ import {
   updateCustomMetric,
   type CustomMetricDefinition,
 } from '../state/api'
+import { SettingsSection } from './SettingsSection'
 
 const CustomMetricRow = ({
   metric,
@@ -167,13 +168,10 @@ export function CustomMetricsSettings() {
   })
 
   return (
-    <section class="settings-section">
-      <h2>Custom Metrics</h2>
-      <p class="section-description">
-        Define custom metrics to track any numeric data. Custom metrics appear in the metric picker and can be
-        used in trends and dashboards.
-      </p>
-
+    <SettingsSection
+      title="Custom Metrics"
+      description="Define custom metrics to track any numeric data. Custom metrics appear in the metric picker and can be used in trends and dashboards."
+    >
       {(metrics ?? []).length > 0 && (
         <div class="custom-metrics-list">
           {(metrics ?? []).map((m) => (
@@ -237,6 +235,6 @@ export function CustomMetricsSettings() {
           {addMutation.isPending ? 'Adding...' : 'Add Metric'}
         </button>
       </div>
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/GoalsSettings.css
+++ b/apps/web/src/components/GoalsSettings.css
@@ -1,14 +1,3 @@
-.goals-section .section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.goals-section .section-header h2 {
-  margin: 0;
-}
-
 .add-goal-button {
   background: #673ab8;
   color: white;

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -4,6 +4,7 @@ import { useState } from 'preact/hooks'
 
 import { type Goal, updateUserSettings } from '../state/api'
 import { metricLabels } from '../utils/metricLabels'
+import { SettingsSection } from './SettingsSection'
 import './GoalsSettings.css'
 
 interface GoalsSettingsProps {
@@ -304,19 +305,18 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
   }
 
   return (
-    <section class="settings-section goals-section">
-      <div class="section-header">
-        <h2>Goals</h2>
+    <SettingsSection
+      title="Goals"
+      class="goals-section"
+      description="Set targets for metrics over a rolling time window. Goals are saved automatically when valid. Drag goals to reorder them for the widget."
+      headerExtra={
         <button type="button" class="add-goal-button" onClick={handleAddGoal}>
           + Add Goal
         </button>
-      </div>
-
-      <p class="section-description">
-        Set targets for metrics over a rolling time window. Goals are saved automatically when valid. Drag
-        goals to reorder them for the widget.
-      </p>
-
+      }
+      isEmpty={localGoals.length === 0}
+      emptyMessage={'No goals set. Click "+ Add Goal" to create one.'}
+    >
       {saveStatus.status === 'saving' && <p class="save-status saving">Saving...</p>}
       {saveStatus.status === 'saved' && saveStatus.time && (
         <p class="save-status saved">Saved {formatSavedTime(saveStatus.time)}</p>
@@ -327,116 +327,110 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
         </p>
       )}
 
-      {localGoals.length === 0 ? (
-        <p class="no-goals">No goals set. Click "+ Add Goal" to create one.</p>
-      ) : (
-        <div class="goals-list">
-          {localGoals.map((goal) => {
-            const validationError = validateGoal({
-              ...goal,
-              window: goal.window || '7d',
-            } as Goal)
-            const isInvalid = validationError !== null
+      <div class="goals-list">
+        {localGoals.map((goal) => {
+          const validationError = validateGoal({
+            ...goal,
+            window: goal.window || '7d',
+          } as Goal)
+          const isInvalid = validationError !== null
 
-            return (
-              <div
-                class={`goal-row ${isInvalid ? 'invalid' : ''} ${goal.isNew ? 'new' : ''} ${draggedId === goal.id ? 'dragging' : ''} ${dragOverId === goal.id ? 'drag-over' : ''}`}
-                key={goal.id}
-                draggable={!goal.isNew}
-                onDragStart={(e) => handleDragStart(e, goal.id)}
-                onDragOver={(e) => handleDragOver(e, goal.id)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, goal.id)}
-                onDragEnd={handleDragEnd}
-              >
-                <div class="drag-handle" title="Drag to reorder">
-                  ⋮⋮
-                </div>
-
-                <div class="goal-field metric-field">
-                  <label>Metric</label>
-                  <select
-                    value={goal.metric}
-                    onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
-                  >
-                    {validMetrics.map((metric) => (
-                      <option key={metric} value={metric}>
-                        {metricLabels[metric] ?? metric}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <div
-                  class={`goal-field min-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
-                >
-                  <label>Min</label>
-                  <div class="input-with-unit">
-                    <input
-                      type="number"
-                      value={toDisplayValue(goal.metric, goal.min)}
-                      onInput={(e) => handleFieldChange(goal.id, 'min', (e.target as HTMLInputElement).value)}
-                      onBlur={() => handleFieldBlur(goal.id)}
-                      placeholder="-"
-                    />
-                    <span class="unit">{getDisplayUnit(goal.metric)}</span>
-                  </div>
-                </div>
-
-                <div
-                  class={`goal-field max-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
-                >
-                  <label>Max</label>
-                  <div class="input-with-unit">
-                    <input
-                      type="number"
-                      value={toDisplayValue(goal.metric, goal.max)}
-                      onInput={(e) => handleFieldChange(goal.id, 'max', (e.target as HTMLInputElement).value)}
-                      onBlur={() => handleFieldBlur(goal.id)}
-                      placeholder="-"
-                    />
-                    <span class="unit">{getDisplayUnit(goal.metric)}</span>
-                  </div>
-                </div>
-
-                <div class="goal-field window-field">
-                  <label>
-                    Window{' '}
-                    <button
-                      type="button"
-                      class="info-button"
-                      onClick={() => setShowDurationHelp(!showDurationHelp)}
-                      aria-label="Duration format help"
-                    >
-                      i
-                    </button>
-                  </label>
-                  <input
-                    type="text"
-                    value={goal.window}
-                    onInput={(e) =>
-                      handleFieldChange(goal.id, 'window', (e.target as HTMLInputElement).value)
-                    }
-                    onBlur={() => handleFieldBlur(goal.id)}
-                    placeholder="7d"
-                  />
-                </div>
-
-                <button
-                  type="button"
-                  class="delete-goal-button"
-                  onClick={() => handleDeleteGoal(goal.id)}
-                  aria-label="Delete goal"
-                >
-                  ×
-                </button>
-
-                {isInvalid && <div class="validation-error">{validationError}</div>}
+          return (
+            <div
+              class={`goal-row ${isInvalid ? 'invalid' : ''} ${goal.isNew ? 'new' : ''} ${draggedId === goal.id ? 'dragging' : ''} ${dragOverId === goal.id ? 'drag-over' : ''}`}
+              key={goal.id}
+              draggable={!goal.isNew}
+              onDragStart={(e) => handleDragStart(e, goal.id)}
+              onDragOver={(e) => handleDragOver(e, goal.id)}
+              onDragLeave={handleDragLeave}
+              onDrop={(e) => handleDrop(e, goal.id)}
+              onDragEnd={handleDragEnd}
+            >
+              <div class="drag-handle" title="Drag to reorder">
+                ⋮⋮
               </div>
-            )
-          })}
-        </div>
-      )}
+
+              <div class="goal-field metric-field">
+                <label>Metric</label>
+                <select
+                  value={goal.metric}
+                  onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
+                >
+                  {validMetrics.map((metric) => (
+                    <option key={metric} value={metric}>
+                      {metricLabels[metric] ?? metric}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div
+                class={`goal-field min-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
+              >
+                <label>Min</label>
+                <div class="input-with-unit">
+                  <input
+                    type="number"
+                    value={toDisplayValue(goal.metric, goal.min)}
+                    onInput={(e) => handleFieldChange(goal.id, 'min', (e.target as HTMLInputElement).value)}
+                    onBlur={() => handleFieldBlur(goal.id)}
+                    placeholder="-"
+                  />
+                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                </div>
+              </div>
+
+              <div
+                class={`goal-field max-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
+              >
+                <label>Max</label>
+                <div class="input-with-unit">
+                  <input
+                    type="number"
+                    value={toDisplayValue(goal.metric, goal.max)}
+                    onInput={(e) => handleFieldChange(goal.id, 'max', (e.target as HTMLInputElement).value)}
+                    onBlur={() => handleFieldBlur(goal.id)}
+                    placeholder="-"
+                  />
+                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                </div>
+              </div>
+
+              <div class="goal-field window-field">
+                <label>
+                  Window{' '}
+                  <button
+                    type="button"
+                    class="info-button"
+                    onClick={() => setShowDurationHelp(!showDurationHelp)}
+                    aria-label="Duration format help"
+                  >
+                    i
+                  </button>
+                </label>
+                <input
+                  type="text"
+                  value={goal.window}
+                  onInput={(e) => handleFieldChange(goal.id, 'window', (e.target as HTMLInputElement).value)}
+                  onBlur={() => handleFieldBlur(goal.id)}
+                  placeholder="7d"
+                />
+              </div>
+
+              <button
+                type="button"
+                class="delete-goal-button"
+                onClick={() => handleDeleteGoal(goal.id)}
+                aria-label="Delete goal"
+              >
+                ×
+              </button>
+
+              {isInvalid && <div class="validation-error">{validationError}</div>}
+            </div>
+          )
+        })}
+      </div>
 
       {showDurationHelp && (
         <div class="duration-help">
@@ -451,6 +445,6 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
           <p>Examples: 7d (7 days), 2w (2 weeks), 1M (1 month)</p>
         </div>
       )}
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -12,6 +12,7 @@ import {
   type UpdateLastFmTagRuleBody,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { SettingsSection } from '../SettingsSection'
 import { AddRuleForm } from './AddRuleForm'
 import './style.css'
 
@@ -408,38 +409,30 @@ export function LastFmTagRulesSettings() {
   const rulesList = rules ?? []
 
   return (
-    <section class="settings-section lastfm-rules-section">
-      <div class="section-header-row">
-        <h2>Last.fm Auto-Tagging Rules</h2>
-        <SaveIndicator saveStatus={saveStatus} />
-      </div>
-      <p class="section-description">
-        Create rules to automatically tag your listening sessions. When a scrobble matches a rule, a tag will
-        be created at the scrobble time.
-      </p>
-
-      {isLoading ? (
-        <p class="loading">Loading rules...</p>
-      ) : (
-        <>
-          {/* Existing rules */}
-          {rulesList.length > 0 && (
-            <div class="rules-list">
-              {rulesList.map((rule) => (
-                <EditableRuleRow
-                  key={rule.id}
-                  rule={rule}
-                  onDeleted={invalidateRules}
-                  onUpdated={invalidateRules}
-                />
-              ))}
-            </div>
-          )}
-
-          {/* Add new rule form */}
-          <AddRuleForm onRuleAdded={invalidateRules} setSaveStatus={setSaveStatus} />
-        </>
+    <SettingsSection
+      title="Last.fm Auto-Tagging Rules"
+      class="lastfm-rules-section"
+      description="Create rules to automatically tag your listening sessions. When a scrobble matches a rule, a tag will be created at the scrobble time."
+      headerExtra={<SaveIndicator saveStatus={saveStatus} />}
+      isLoading={isLoading}
+      loadingMessage="Loading rules..."
+    >
+      {/* Existing rules */}
+      {rulesList.length > 0 && (
+        <div class="rules-list">
+          {rulesList.map((rule) => (
+            <EditableRuleRow
+              key={rule.id}
+              rule={rule}
+              onDeleted={invalidateRules}
+              onUpdated={invalidateRules}
+            />
+          ))}
+        </div>
       )}
-    </section>
+
+      {/* Add new rule form */}
+      <AddRuleForm onRuleAdded={invalidateRules} setSaveStatus={setSaveStatus} />
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/LastFmTagRulesSettings/style.css
+++ b/apps/web/src/components/LastFmTagRulesSettings/style.css
@@ -1,8 +1,3 @@
-.lastfm-rules-section .loading {
-  color: #666;
-  font-style: italic;
-}
-
 .rules-list {
   display: flex;
   flex-direction: column;
@@ -244,10 +239,6 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .lastfm-rules-section .loading {
-    color: #aaa;
-  }
-
   .rule-item {
     border-color: #444;
   }

--- a/apps/web/src/components/SettingsSection.css
+++ b/apps/web/src/components/SettingsSection.css
@@ -1,0 +1,57 @@
+.settings-section {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-section .section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.settings-section .section-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.settings-section .section-description {
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+.settings-section .loading {
+  color: #888;
+  font-style: italic;
+}
+
+.settings-section .no-data {
+  color: #888;
+  font-style: italic;
+  padding: 1rem;
+  text-align: center;
+  background: #f8f8f8;
+  border-radius: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .settings-section {
+    border-bottom-color: #444;
+  }
+
+  .settings-section .section-description {
+    color: #aaa;
+  }
+
+  .settings-section .loading {
+    color: #aaa;
+  }
+
+  .settings-section .no-data {
+    color: #aaa;
+    background: #2a2a2a;
+  }
+}

--- a/apps/web/src/components/SettingsSection.tsx
+++ b/apps/web/src/components/SettingsSection.tsx
@@ -1,0 +1,34 @@
+import type { ComponentChildren } from 'preact'
+
+import './SettingsSection.css'
+
+interface SettingsSectionProps {
+  title: string
+  description?: string
+  class?: string
+  headerExtra?: ComponentChildren
+  isLoading?: boolean
+  loadingMessage?: string
+  isEmpty?: boolean
+  emptyMessage?: string
+  children?: ComponentChildren
+}
+
+export function SettingsSection(props: SettingsSectionProps) {
+  return (
+    <section class={`settings-section ${props.class ?? ''}`}>
+      <div class="section-header">
+        <h2>{props.title}</h2>
+        {props.headerExtra}
+      </div>
+      {props.description && <p class="section-description">{props.description}</p>}
+      {props.isLoading ? (
+        <p class="loading">{props.loadingMessage ?? 'Loading...'}</p>
+      ) : props.isEmpty ? (
+        <p class="no-data">{props.emptyMessage}</p>
+      ) : (
+        props.children
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/components/TagMappingsSettings.css
+++ b/apps/web/src/components/TagMappingsSettings.css
@@ -1,14 +1,3 @@
-.tag-mappings-section .section-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
-}
-
-.tag-mappings-section .section-header h2 {
-  margin: 0;
-}
-
 .unmapped-badge {
   background: #f0ad4e;
   color: #fff;
@@ -16,25 +5,6 @@
   border-radius: 12px;
   font-size: 0.85rem;
   font-weight: 500;
-}
-
-.tag-mappings-section .section-description {
-  color: #666;
-  margin-bottom: 1rem;
-}
-
-.tag-mappings-section .no-tags {
-  color: #888;
-  font-style: italic;
-  padding: 1rem;
-  text-align: center;
-  background: #f8f8f8;
-  border-radius: 4px;
-}
-
-.tag-mappings-section .loading {
-  color: #888;
-  font-style: italic;
 }
 
 .tag-mappings-list {

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { fetchProgrammaticTags, fetchTagMappings, setTagMapping } from '../state/api'
 import { suggestEmoji } from '../utils/emojiLookup'
 import { IconInput } from './IconInput'
+import { SettingsSection } from './SettingsSection'
 import './TagMappingsSettings.css'
 
 // Helper to check if a string is a UUID
@@ -217,44 +218,30 @@ export function TagMappingsSettings() {
     await mutation.mutateAsync({ icon, name, tagKey })
   }
 
-  if (isLoading) {
-    return (
-      <section class="settings-section tag-mappings-section">
-        <h2>Tag Mappings</h2>
-        <p class="loading">Loading tags...</p>
-      </section>
-    )
-  }
-
   const unmappedCount = tags?.filter((t) => t.is_programmatic && !t.current_name).length ?? 0
   const icons = mappingsData?.icons ?? {}
 
   return (
-    <section class="settings-section tag-mappings-section">
-      <div class="section-header">
-        <h2>Tag Mappings</h2>
-        {unmappedCount > 0 && <span class="unmapped-badge">{unmappedCount} unnamed</span>}
+    <SettingsSection
+      title="Tag Mappings"
+      class="tag-mappings-section"
+      description="Set display names for programmatic tags and icons for any tag. Icons can be emoji characters or image URLs. Changes save automatically when you leave the field."
+      headerExtra={unmappedCount > 0 && <span class="unmapped-badge">{unmappedCount} unnamed</span>}
+      isLoading={isLoading}
+      loadingMessage="Loading tags..."
+      isEmpty={!tags || tags.length === 0}
+      emptyMessage="No tags found. Tags will appear here after syncing data."
+    >
+      <div class="tag-mappings-list">
+        {(tags ?? []).map((tag) => (
+          <TagMappingRow
+            key={tag.tag_key}
+            tag={tag}
+            currentIcon={icons[tag.current_name ?? ''] ?? icons[tag.tag_key]}
+            onSave={handleSave}
+          />
+        ))}
       </div>
-
-      <p class="section-description">
-        Set display names for programmatic tags and icons for any tag. Icons can be emoji characters or image
-        URLs. Changes save automatically when you leave the field.
-      </p>
-
-      {!tags || tags.length === 0 ? (
-        <p class="no-tags">No tags found. Tags will appear here after syncing data.</p>
-      ) : (
-        <div class="tag-mappings-list">
-          {tags.map((tag) => (
-            <TagMappingRow
-              key={tag.tag_key}
-              tag={tag}
-              currentIcon={icons[tag.current_name ?? ''] ?? icons[tag.tag_key]}
-              onSave={handleSave}
-            />
-          ))}
-        </div>
-      )}
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/TimelineIconsSettings.css
+++ b/apps/web/src/components/TimelineIconsSettings.css
@@ -1,9 +1,3 @@
-.timeline-icons-section .section-description {
-  color: #666;
-  margin-bottom: 1rem;
-  line-height: 1.5;
-}
-
 .icon-group {
   margin-bottom: 1.5rem;
 }
@@ -123,10 +117,6 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .timeline-icons-section .section-description {
-    color: #aaa;
-  }
-
   .icon-group h3 {
     color: #bbb;
   }

--- a/apps/web/src/components/TimelineIconsSettings.tsx
+++ b/apps/web/src/components/TimelineIconsSettings.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { fetchUserSettings, updateUserSettings } from '../state/api'
 import { DEFAULT_ITEM_ICONS } from '../utils/emojiLookup'
 import { IconInput } from './IconInput'
+import { SettingsSection } from './SettingsSection'
 import './TimelineIconsSettings.css'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
@@ -202,25 +203,15 @@ export function TimelineIconsSettings() {
     [settings, queryClient],
   )
 
-  if (isLoading) {
-    return (
-      <section class="settings-section timeline-icons-section">
-        <h2>Timeline Icons</h2>
-        <p class="loading">Loading...</p>
-      </section>
-    )
-  }
-
   return (
-    <section class="settings-section timeline-icons-section">
-      <h2>Timeline Icons</h2>
-      <p class="section-description">
-        Customize the icons shown on the timeline for activities and exercise types. Icons can be emoji
-        characters, image URLs, or uploaded images. Default emojis are shown as placeholders.
-      </p>
-
+    <SettingsSection
+      title="Timeline Icons"
+      class="timeline-icons-section"
+      description="Customize the icons shown on the timeline for activities and exercise types. Icons can be emoji characters, image URLs, or uploaded images. Default emojis are shown as placeholders."
+      isLoading={isLoading}
+    >
       <IconGroup title="Activities" items={ACTIVITY_ITEMS} userIcons={userIcons} onSave={handleSave} />
       <IconGroup title="Exercise Types" items={EXERCISE_ITEMS} userIcons={userIcons} onSave={handleSave} />
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'preact/hooks'
 
 import type { BiologicalSex, HrZoneThresholds, UpdateSettingsInput } from '../../state/api'
 
+import { SettingsSection } from '../../components/SettingsSection'
 import { TimelineIconsSettings } from '../../components/TimelineIconsSettings'
 import { fetchUserSettings, updateUserSettings } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -161,11 +162,10 @@ export function Settings() {
     <div class="settings-page">
       <h1>Settings</h1>
 
-      <section class="settings-section">
-        <div class="section-header-row">
-          <h2>Personal Information</h2>
-          <SaveStatusIndicator saveStatus={personalInfoStatus} />
-        </div>
+      <SettingsSection
+        title="Personal Information"
+        headerExtra={<SaveStatusIndicator saveStatus={personalInfoStatus} />}
+      >
         <div class="form-field">
           <label for="birth-date">Birth Date</label>
           <input
@@ -192,18 +192,13 @@ export function Settings() {
             computation.
           </p>
         </div>
-      </section>
+      </SettingsSection>
 
-      <section class="settings-section">
-        <div class="section-header-row">
-          <h2>HR Zone Thresholds</h2>
-          <SaveStatusIndicator saveStatus={hrZonesStatus} />
-        </div>
-        <p class="section-description">
-          Customize the heart rate thresholds for each zone. These values represent the starting BPM for each
-          zone. Changes save automatically.
-        </p>
-
+      <SettingsSection
+        title="HR Zone Thresholds"
+        description="Customize the heart rate thresholds for each zone. These values represent the starting BPM for each zone. Changes save automatically."
+        headerExtra={<SaveStatusIndicator saveStatus={hrZonesStatus} />}
+      >
         <div class="hr-zones-form">
           {([1, 2, 3, 4, 5] as const).map((zone) => (
             <div class="zone-input" key={zone}>
@@ -230,7 +225,7 @@ export function Settings() {
         {hrZones === null && (
           <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
         )}
-      </section>
+      </SettingsSection>
 
       <TimelineIconsSettings />
 


### PR DESCRIPTION
## Summary
- Create a reusable `SettingsSection` component (`SettingsSection.tsx` + `SettingsSection.css`) that consolidates the repeated section/header/description/loading/empty pattern
- Migrate 6 consumers: TagMappingsSettings, TimelineIconsSettings, GoalsSettings, CustomMetricsSettings, LastFmTagRulesSettings, and Settings page sections
- Remove now-redundant CSS from consumer stylesheets (section-header, section-description, loading, no-data styles)

## Test plan
- [ ] Verify each settings section renders correctly with title, description, loading, and empty states
- [ ] Check dark mode styling for all migrated sections
- [ ] Verify headerExtra content (badges, buttons, save indicators) displays properly
- [ ] Test loading states show the correct loading messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)