### PR TITLE
refactor: extract shared UI components (SaveStatus, SettingsSection, SaveCancel, ConfirmButton)

### DIFF
--- a/apps/web/src/components/ConfirmButton.css
+++ b/apps/web/src/components/ConfirmButton.css
@@ -1,0 +1,16 @@
+.confirm-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.confirm-inline > span {
+  color: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+  .confirm-inline > span {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/components/ConfirmButton.tsx
+++ b/apps/web/src/components/ConfirmButton.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'preact/hooks'
+
+import './ConfirmButton.css'
+
+interface ConfirmButtonProps {
+  label: string
+  confirmMessage?: string
+  confirmLabel?: string
+  onConfirm: () => void
+  isPending?: boolean
+  pendingLabel?: string
+  buttonClass?: string
+  disabled?: boolean
+}
+
+export function ConfirmButton({
+  label,
+  confirmMessage = 'Are you sure?',
+  confirmLabel,
+  onConfirm,
+  isPending = false,
+  pendingLabel,
+  buttonClass = 'btn-danger',
+  disabled = false,
+}: ConfirmButtonProps) {
+  const [confirming, setConfirming] = useState(false)
+
+  if (!confirming) {
+    return (
+      <button type="button" class={buttonClass} disabled={disabled} onClick={() => setConfirming(true)}>
+        {label}
+      </button>
+    )
+  }
+
+  const resolvedConfirmLabel = confirmLabel ?? label
+  const resolvedPendingLabel = pendingLabel ?? `${label}...`
+
+  return (
+    <div class="confirm-inline">
+      <span>{confirmMessage}</span>
+      <button type="button" class="btn-danger" onClick={onConfirm} disabled={isPending}>
+        {isPending ? resolvedPendingLabel : resolvedConfirmLabel}
+      </button>
+      <button type="button" class="btn-secondary" onClick={() => setConfirming(false)}>
+        Cancel
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/CustomMetricsSettings.tsx
+++ b/apps/web/src/components/CustomMetricsSettings.tsx
@@ -8,6 +8,7 @@ import {
   updateCustomMetric,
   type CustomMetricDefinition,
 } from '../state/api'
+import { SettingsSection } from './SettingsSection'
 
 const CustomMetricRow = ({
   metric,
@@ -167,13 +168,10 @@ export function CustomMetricsSettings() {
   })
 
   return (
-    <section class="settings-section">
-      <h2>Custom Metrics</h2>
-      <p class="section-description">
-        Define custom metrics to track any numeric data. Custom metrics appear in the metric picker and can be
-        used in trends and dashboards.
-      </p>
-
+    <SettingsSection
+      title="Custom Metrics"
+      description="Define custom metrics to track any numeric data. Custom metrics appear in the metric picker and can be used in trends and dashboards."
+    >
       {(metrics ?? []).length > 0 && (
         <div class="custom-metrics-list">
           {(metrics ?? []).map((m) => (
@@ -237,6 +235,6 @@ export function CustomMetricsSettings() {
           {addMutation.isPending ? 'Adding...' : 'Add Metric'}
         </button>
       </div>
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/CustomMetricsSettings.tsx
+++ b/apps/web/src/components/CustomMetricsSettings.tsx
@@ -8,6 +8,7 @@ import {
   updateCustomMetric,
   type CustomMetricDefinition,
 } from '../state/api'
+import { ConfirmButton } from './ConfirmButton'
 import { SettingsSection } from './SettingsSection'
 
 const CustomMetricRow = ({
@@ -117,14 +118,14 @@ const CustomMetricRow = ({
         <button type="button" class="note-action-btn" onClick={() => setIsEditing(true)}>
           Edit
         </button>
-        <button
-          type="button"
-          class="note-action-btn danger"
-          onClick={() => deleteMutation.mutate()}
-          disabled={deleteMutation.isPending}
-        >
-          {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-        </button>
+        <ConfirmButton
+          label="Delete"
+          confirmMessage={`Delete metric "${metric.name}"?`}
+          onConfirm={() => deleteMutation.mutate()}
+          isPending={deleteMutation.isPending}
+          pendingLabel="Deleting..."
+          buttonClass="note-action-btn danger"
+        />
       </div>
     </div>
   )

--- a/apps/web/src/components/GoalsSettings.css
+++ b/apps/web/src/components/GoalsSettings.css
@@ -1,14 +1,3 @@
-.goals-section .section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.goals-section .section-header h2 {
-  margin: 0;
-}
-
 .add-goal-button {
   background: #673ab8;
   color: white;

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -4,6 +4,7 @@ import { useState } from 'preact/hooks'
 
 import { type Goal, updateUserSettings } from '../state/api'
 import { metricLabels } from '../utils/metricLabels'
+import { SettingsSection } from './SettingsSection'
 import './GoalsSettings.css'
 
 interface GoalsSettingsProps {
@@ -304,19 +305,18 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
   }
 
   return (
-    <section class="settings-section goals-section">
-      <div class="section-header">
-        <h2>Goals</h2>
+    <SettingsSection
+      title="Goals"
+      class="goals-section"
+      description="Set targets for metrics over a rolling time window. Goals are saved automatically when valid. Drag goals to reorder them for the widget."
+      headerExtra={
         <button type="button" class="add-goal-button" onClick={handleAddGoal}>
           + Add Goal
         </button>
-      </div>
-
-      <p class="section-description">
-        Set targets for metrics over a rolling time window. Goals are saved automatically when valid. Drag
-        goals to reorder them for the widget.
-      </p>
-
+      }
+      isEmpty={localGoals.length === 0}
+      emptyMessage={'No goals set. Click "+ Add Goal" to create one.'}
+    >
       {saveStatus.status === 'saving' && <p class="save-status saving">Saving...</p>}
       {saveStatus.status === 'saved' && saveStatus.time && (
         <p class="save-status saved">Saved {formatSavedTime(saveStatus.time)}</p>
@@ -327,116 +327,110 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
         </p>
       )}
 
-      {localGoals.length === 0 ? (
-        <p class="no-goals">No goals set. Click "+ Add Goal" to create one.</p>
-      ) : (
-        <div class="goals-list">
-          {localGoals.map((goal) => {
-            const validationError = validateGoal({
-              ...goal,
-              window: goal.window || '7d',
-            } as Goal)
-            const isInvalid = validationError !== null
+      <div class="goals-list">
+        {localGoals.map((goal) => {
+          const validationError = validateGoal({
+            ...goal,
+            window: goal.window || '7d',
+          } as Goal)
+          const isInvalid = validationError !== null
 
-            return (
-              <div
-                class={`goal-row ${isInvalid ? 'invalid' : ''} ${goal.isNew ? 'new' : ''} ${draggedId === goal.id ? 'dragging' : ''} ${dragOverId === goal.id ? 'drag-over' : ''}`}
-                key={goal.id}
-                draggable={!goal.isNew}
-                onDragStart={(e) => handleDragStart(e, goal.id)}
-                onDragOver={(e) => handleDragOver(e, goal.id)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, goal.id)}
-                onDragEnd={handleDragEnd}
-              >
-                <div class="drag-handle" title="Drag to reorder">
-                  ⋮⋮
-                </div>
-
-                <div class="goal-field metric-field">
-                  <label>Metric</label>
-                  <select
-                    value={goal.metric}
-                    onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
-                  >
-                    {validMetrics.map((metric) => (
-                      <option key={metric} value={metric}>
-                        {metricLabels[metric] ?? metric}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <div
-                  class={`goal-field min-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
-                >
-                  <label>Min</label>
-                  <div class="input-with-unit">
-                    <input
-                      type="number"
-                      value={toDisplayValue(goal.metric, goal.min)}
-                      onInput={(e) => handleFieldChange(goal.id, 'min', (e.target as HTMLInputElement).value)}
-                      onBlur={() => handleFieldBlur(goal.id)}
-                      placeholder="-"
-                    />
-                    <span class="unit">{getDisplayUnit(goal.metric)}</span>
-                  </div>
-                </div>
-
-                <div
-                  class={`goal-field max-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
-                >
-                  <label>Max</label>
-                  <div class="input-with-unit">
-                    <input
-                      type="number"
-                      value={toDisplayValue(goal.metric, goal.max)}
-                      onInput={(e) => handleFieldChange(goal.id, 'max', (e.target as HTMLInputElement).value)}
-                      onBlur={() => handleFieldBlur(goal.id)}
-                      placeholder="-"
-                    />
-                    <span class="unit">{getDisplayUnit(goal.metric)}</span>
-                  </div>
-                </div>
-
-                <div class="goal-field window-field">
-                  <label>
-                    Window{' '}
-                    <button
-                      type="button"
-                      class="info-button"
-                      onClick={() => setShowDurationHelp(!showDurationHelp)}
-                      aria-label="Duration format help"
-                    >
-                      i
-                    </button>
-                  </label>
-                  <input
-                    type="text"
-                    value={goal.window}
-                    onInput={(e) =>
-                      handleFieldChange(goal.id, 'window', (e.target as HTMLInputElement).value)
-                    }
-                    onBlur={() => handleFieldBlur(goal.id)}
-                    placeholder="7d"
-                  />
-                </div>
-
-                <button
-                  type="button"
-                  class="delete-goal-button"
-                  onClick={() => handleDeleteGoal(goal.id)}
-                  aria-label="Delete goal"
-                >
-                  ×
-                </button>
-
-                {isInvalid && <div class="validation-error">{validationError}</div>}
+          return (
+            <div
+              class={`goal-row ${isInvalid ? 'invalid' : ''} ${goal.isNew ? 'new' : ''} ${draggedId === goal.id ? 'dragging' : ''} ${dragOverId === goal.id ? 'drag-over' : ''}`}
+              key={goal.id}
+              draggable={!goal.isNew}
+              onDragStart={(e) => handleDragStart(e, goal.id)}
+              onDragOver={(e) => handleDragOver(e, goal.id)}
+              onDragLeave={handleDragLeave}
+              onDrop={(e) => handleDrop(e, goal.id)}
+              onDragEnd={handleDragEnd}
+            >
+              <div class="drag-handle" title="Drag to reorder">
+                ⋮⋮
               </div>
-            )
-          })}
-        </div>
-      )}
+
+              <div class="goal-field metric-field">
+                <label>Metric</label>
+                <select
+                  value={goal.metric}
+                  onChange={(e) => handleMetricChange(goal.id, (e.target as HTMLSelectElement).value)}
+                >
+                  {validMetrics.map((metric) => (
+                    <option key={metric} value={metric}>
+                      {metricLabels[metric] ?? metric}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div
+                class={`goal-field min-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
+              >
+                <label>Min</label>
+                <div class="input-with-unit">
+                  <input
+                    type="number"
+                    value={toDisplayValue(goal.metric, goal.min)}
+                    onInput={(e) => handleFieldChange(goal.id, 'min', (e.target as HTMLInputElement).value)}
+                    onBlur={() => handleFieldBlur(goal.id)}
+                    placeholder="-"
+                  />
+                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                </div>
+              </div>
+
+              <div
+                class={`goal-field max-field ${goal.min === undefined && goal.max === undefined ? 'field-error' : ''}`}
+              >
+                <label>Max</label>
+                <div class="input-with-unit">
+                  <input
+                    type="number"
+                    value={toDisplayValue(goal.metric, goal.max)}
+                    onInput={(e) => handleFieldChange(goal.id, 'max', (e.target as HTMLInputElement).value)}
+                    onBlur={() => handleFieldBlur(goal.id)}
+                    placeholder="-"
+                  />
+                  <span class="unit">{getDisplayUnit(goal.metric)}</span>
+                </div>
+              </div>
+
+              <div class="goal-field window-field">
+                <label>
+                  Window{' '}
+                  <button
+                    type="button"
+                    class="info-button"
+                    onClick={() => setShowDurationHelp(!showDurationHelp)}
+                    aria-label="Duration format help"
+                  >
+                    i
+                  </button>
+                </label>
+                <input
+                  type="text"
+                  value={goal.window}
+                  onInput={(e) => handleFieldChange(goal.id, 'window', (e.target as HTMLInputElement).value)}
+                  onBlur={() => handleFieldBlur(goal.id)}
+                  placeholder="7d"
+                />
+              </div>
+
+              <button
+                type="button"
+                class="delete-goal-button"
+                onClick={() => handleDeleteGoal(goal.id)}
+                aria-label="Delete goal"
+              >
+                ×
+              </button>
+
+              {isInvalid && <div class="validation-error">{validationError}</div>}
+            </div>
+          )
+        })}
+      </div>
 
       {showDurationHelp && (
         <div class="duration-help">
@@ -451,6 +445,6 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
           <p>Examples: 7d (7 days), 2w (2 weeks), 1M (1 month)</p>
         </div>
       )}
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/GoalsSettings.tsx
+++ b/apps/web/src/components/GoalsSettings.tsx
@@ -4,6 +4,7 @@ import { useState } from 'preact/hooks'
 
 import { type Goal, updateUserSettings } from '../state/api'
 import { metricLabels } from '../utils/metricLabels'
+import { type SaveStatus, SaveStatusIndicator } from './SaveStatusIndicator'
 import { SettingsSection } from './SettingsSection'
 import './GoalsSettings.css'
 
@@ -82,9 +83,7 @@ interface LocalGoal extends Omit<Goal, 'min' | 'max' | 'window'> {
 
 export function GoalsSettings({ goals }: GoalsSettingsProps) {
   const queryClient = useQueryClient()
-  const [saveStatus, setSaveStatus] = useState<{ status: 'idle' | 'saving' | 'saved'; time?: Date }>({
-    status: 'idle',
-  })
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
   const [showDurationHelp, setShowDurationHelp] = useState(false)
   const [draggedId, setDraggedId] = useState<string | null>(null)
   const [dragOverId, setDragOverId] = useState<string | null>(null)
@@ -294,16 +293,6 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
     setDragOverId(null)
   }
 
-  const formatSavedTime = (time: Date): string => {
-    const now = new Date()
-    const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
-    if (diffSec < 5) return 'just now'
-    if (diffSec < 60) return `${diffSec} seconds ago`
-    const diffMin = Math.floor(diffSec / 60)
-    if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
-    return time.toLocaleTimeString()
-  }
-
   return (
     <SettingsSection
       title="Goals"
@@ -317,10 +306,7 @@ export function GoalsSettings({ goals }: GoalsSettingsProps) {
       isEmpty={localGoals.length === 0}
       emptyMessage={'No goals set. Click "+ Add Goal" to create one.'}
     >
-      {saveStatus.status === 'saving' && <p class="save-status saving">Saving...</p>}
-      {saveStatus.status === 'saved' && saveStatus.time && (
-        <p class="save-status saved">Saved {formatSavedTime(saveStatus.time)}</p>
-      )}
+      <SaveStatusIndicator state={saveStatus} />
       {mutation.isError && (
         <p class="save-status error">
           Error: {mutation.error instanceof Error ? mutation.error.message : 'Failed to save'}

--- a/apps/web/src/components/LastFmTagRulesSettings/AddRuleForm.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/AddRuleForm.tsx
@@ -3,14 +3,14 @@
  */
 import { useState } from 'preact/hooks'
 
+import type { SaveStatus } from '../SaveStatusIndicator'
+
 import {
   createLastFmTagRule,
   type AddLastFmTagRuleBody,
   type LastFmMatchMode,
   type LastFmMatchType,
 } from '../../state/api'
-
-type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
 
 const getErrorMessage = (err: unknown): string => (err instanceof Error ? err.message : 'Failed to save')
 

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -12,6 +12,7 @@ import {
   type UpdateLastFmTagRuleBody,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { ConfirmButton } from '../ConfirmButton'
 import { SaveCancelRow } from '../SaveCancelRow'
 import { type SaveStatus, SaveStatusIndicator } from '../SaveStatusIndicator'
 import { SettingsSection } from '../SettingsSection'
@@ -312,15 +313,10 @@ function EditableRuleRow({
 }) {
   const [isEditing, setIsEditing] = useState(false)
 
-  const handleDelete = async () => {
-    if (!confirm(`Delete rule "${rule.rule_name}"?`)) return
-    try {
-      await deleteLastFmTagRule(rule.id)
-      onDeleted()
-    } catch {
-      // Error will be visible via the parent's status
-    }
-  }
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteLastFmTagRule(rule.id),
+    onSuccess: onDeleted,
+  })
 
   if (isEditing) {
     return (
@@ -355,9 +351,14 @@ function EditableRuleRow({
         <button type="button" class="edit-rule-button" onClick={() => setIsEditing(true)}>
           Edit
         </button>
-        <button type="button" class="remove-rule-button" onClick={handleDelete}>
-          Delete
-        </button>
+        <ConfirmButton
+          label="Delete"
+          confirmMessage={`Delete rule "${rule.rule_name}"?`}
+          onConfirm={() => deleteMutation.mutate()}
+          isPending={deleteMutation.isPending}
+          pendingLabel="Deleting..."
+          buttonClass="remove-rule-button"
+        />
       </div>
     </div>
   )

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -12,23 +12,12 @@ import {
   type UpdateLastFmTagRuleBody,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { type SaveStatus, SaveStatusIndicator } from '../SaveStatusIndicator'
 import { SettingsSection } from '../SettingsSection'
 import { AddRuleForm } from './AddRuleForm'
 import './style.css'
 
-type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
-
 const getErrorMessage = (err: unknown): string => (err instanceof Error ? err.message : 'Failed to save')
-
-function SaveIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
-  if (saveStatus.status === 'idle') return null
-  const messages: Record<string, string> = {
-    error: saveStatus.error ?? 'Error',
-    saved: 'Rule saved',
-    saving: 'Saving...',
-  }
-  return <span class={`save-indicator ${saveStatus.status}`}>{messages[saveStatus.status]}</span>
-}
 
 const needsTrack = (matchType: LastFmMatchType): boolean =>
   matchType === 'track' || matchType === 'track_artist'
@@ -413,7 +402,7 @@ export function LastFmTagRulesSettings() {
       title="Last.fm Auto-Tagging Rules"
       class="lastfm-rules-section"
       description="Create rules to automatically tag your listening sessions. When a scrobble matches a rule, a tag will be created at the scrobble time."
-      headerExtra={<SaveIndicator saveStatus={saveStatus} />}
+      headerExtra={<SaveStatusIndicator state={saveStatus} />}
       isLoading={isLoading}
       loadingMessage="Loading rules..."
     >

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -12,6 +12,7 @@ import {
   type UpdateLastFmTagRuleBody,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { SettingsSection } from '../SettingsSection'
 import { AddRuleForm } from './AddRuleForm'
 import './style.css'
 
@@ -408,38 +409,30 @@ export function LastFmTagRulesSettings() {
   const rulesList = rules ?? []
 
   return (
-    <section class="settings-section lastfm-rules-section">
-      <div class="section-header-row">
-        <h2>Last.fm Auto-Tagging Rules</h2>
-        <SaveIndicator saveStatus={saveStatus} />
-      </div>
-      <p class="section-description">
-        Create rules to automatically tag your listening sessions. When a scrobble matches a rule, a tag will
-        be created at the scrobble time.
-      </p>
-
-      {isLoading ? (
-        <p class="loading">Loading rules...</p>
-      ) : (
-        <>
-          {/* Existing rules */}
-          {rulesList.length > 0 && (
-            <div class="rules-list">
-              {rulesList.map((rule) => (
-                <EditableRuleRow
-                  key={rule.id}
-                  rule={rule}
-                  onDeleted={invalidateRules}
-                  onUpdated={invalidateRules}
-                />
-              ))}
-            </div>
-          )}
-
-          {/* Add new rule form */}
-          <AddRuleForm onRuleAdded={invalidateRules} setSaveStatus={setSaveStatus} />
-        </>
+    <SettingsSection
+      title="Last.fm Auto-Tagging Rules"
+      class="lastfm-rules-section"
+      description="Create rules to automatically tag your listening sessions. When a scrobble matches a rule, a tag will be created at the scrobble time."
+      headerExtra={<SaveIndicator saveStatus={saveStatus} />}
+      isLoading={isLoading}
+      loadingMessage="Loading rules..."
+    >
+      {/* Existing rules */}
+      {rulesList.length > 0 && (
+        <div class="rules-list">
+          {rulesList.map((rule) => (
+            <EditableRuleRow
+              key={rule.id}
+              rule={rule}
+              onDeleted={invalidateRules}
+              onUpdated={invalidateRules}
+            />
+          ))}
+        </div>
       )}
-    </section>
+
+      {/* Add new rule form */}
+      <AddRuleForm onRuleAdded={invalidateRules} setSaveStatus={setSaveStatus} />
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/LastFmTagRulesSettings/index.tsx
+++ b/apps/web/src/components/LastFmTagRulesSettings/index.tsx
@@ -12,6 +12,7 @@ import {
   type UpdateLastFmTagRuleBody,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { SaveCancelRow } from '../SaveCancelRow'
 import { type SaveStatus, SaveStatusIndicator } from '../SaveStatusIndicator'
 import { SettingsSection } from '../SettingsSection'
 import { AddRuleForm } from './AddRuleForm'
@@ -290,19 +291,11 @@ function RuleEditForm({
         </div>
       </div>
 
-      <div class="rule-edit-actions">
-        <button
-          type="button"
-          class="connect-button"
-          onClick={() => updateMutation.mutate()}
-          disabled={!canSave || updateMutation.isPending}
-        >
-          {updateMutation.isPending ? 'Saving...' : 'Save'}
-        </button>
-        <button type="button" class="cancel-button" onClick={onCancel}>
-          Cancel
-        </button>
-      </div>
+      <SaveCancelRow
+        onSave={() => updateMutation.mutate()}
+        onCancel={onCancel}
+        isPending={!canSave || updateMutation.isPending}
+      />
       {updateMutation.isError && <p class="rule-edit-error">{getErrorMessage(updateMutation.error)}</p>}
     </div>
   )

--- a/apps/web/src/components/LastFmTagRulesSettings/style.css
+++ b/apps/web/src/components/LastFmTagRulesSettings/style.css
@@ -1,8 +1,3 @@
-.lastfm-rules-section .loading {
-  color: #666;
-  font-style: italic;
-}
-
 .rules-list {
   display: flex;
   flex-direction: column;
@@ -244,10 +239,6 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .lastfm-rules-section .loading {
-    color: #aaa;
-  }
-
   .rule-item {
     border-color: #444;
   }

--- a/apps/web/src/components/SaveCancelRow.css
+++ b/apps/web/src/components/SaveCancelRow.css
@@ -1,0 +1,6 @@
+.save-cancel-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.75rem;
+}

--- a/apps/web/src/components/SaveCancelRow.tsx
+++ b/apps/web/src/components/SaveCancelRow.tsx
@@ -1,0 +1,41 @@
+import type { ComponentChildren } from 'preact'
+
+import type { SaveStatus } from './SaveStatusIndicator'
+
+import { SaveStatusIndicator } from './SaveStatusIndicator'
+import './SaveCancelRow.css'
+
+interface SaveCancelRowProps {
+  onSave: () => void
+  onCancel: () => void
+  isPending?: boolean
+  saveLabel?: string
+  savingLabel?: string
+  saveStatus?: SaveStatus
+  saveStatusVariant?: 'compact' | 'text'
+  children?: ComponentChildren
+}
+
+export function SaveCancelRow({
+  onSave,
+  onCancel,
+  isPending,
+  saveLabel = 'Save',
+  savingLabel = 'Saving...',
+  saveStatus,
+  saveStatusVariant,
+  children,
+}: SaveCancelRowProps) {
+  return (
+    <div class="save-cancel-row">
+      <button class="btn-primary" disabled={isPending} onClick={onSave}>
+        {isPending ? savingLabel : saveLabel}
+      </button>
+      <button class="btn-secondary" onClick={onCancel}>
+        Cancel
+      </button>
+      {saveStatus && <SaveStatusIndicator state={saveStatus} variant={saveStatusVariant} />}
+      {children}
+    </div>
+  )
+}

--- a/apps/web/src/components/SaveStatusIndicator.css
+++ b/apps/web/src/components/SaveStatusIndicator.css
@@ -1,0 +1,81 @@
+/* Compact variant — inline spinner/checkmark/error icon */
+.save-status-indicator.compact {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.save-status-indicator .status-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #e0e0e0;
+  border-top-color: #8b5cf6;
+  border-radius: 50%;
+  animation: save-status-spin 0.6s linear infinite;
+}
+
+.save-status-indicator .status-checkmark {
+  color: #22c55e;
+  font-size: 1.1rem;
+  font-weight: bold;
+}
+
+.save-status-indicator .status-error-icon {
+  color: #dc2626;
+  font-size: 1.1rem;
+  font-weight: bold;
+}
+
+/* Text variant — readable messages */
+.save-status-indicator.text {
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.save-status-indicator.text.saving {
+  color: #888;
+}
+
+.save-status-indicator.text.saved {
+  color: #4caf50;
+}
+
+.save-status-indicator.text.error {
+  color: #f44336;
+}
+
+@keyframes save-status-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .save-status-indicator .status-spinner {
+    border-color: #555;
+    border-top-color: #a78bfa;
+  }
+
+  .save-status-indicator .status-checkmark {
+    color: #4ade80;
+  }
+
+  .save-status-indicator .status-error-icon {
+    color: #ef4444;
+  }
+
+  .save-status-indicator.text.saving {
+    color: #aaa;
+  }
+
+  .save-status-indicator.text.saved {
+    color: #4ade80;
+  }
+
+  .save-status-indicator.text.error {
+    color: #ef4444;
+  }
+}

--- a/apps/web/src/components/SaveStatusIndicator.tsx
+++ b/apps/web/src/components/SaveStatusIndicator.tsx
@@ -1,0 +1,92 @@
+/**
+ * Shared save status indicator — shows saving/saved/error state.
+ * Two variants: 'compact' (spinner/checkmark/!) and 'text' (readable messages).
+ */
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+
+import './SaveStatusIndicator.css'
+
+export type SaveStatus =
+  | { status: 'idle' }
+  | { status: 'saving' }
+  | { status: 'saved'; time?: Date }
+  | { status: 'error'; error?: string }
+
+interface SaveStatusIndicatorProps {
+  state: SaveStatus
+  variant?: 'compact' | 'text'
+}
+
+const formatSavedTime = (time: Date): string => {
+  const now = new Date()
+  const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
+  if (diffSec < 5) return 'just now'
+  if (diffSec < 60) return `${diffSec} seconds ago`
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
+  return time.toLocaleTimeString()
+}
+
+export function SaveStatusIndicator({ state, variant = 'text' }: SaveStatusIndicatorProps) {
+  if (state.status === 'idle') return null
+
+  if (variant === 'compact') {
+    return (
+      <span class="save-status-indicator compact">
+        {state.status === 'saving' && <span class="status-spinner" title="Saving..." />}
+        {state.status === 'saved' && (
+          <span class="status-checkmark" title="Saved">
+            &#10003;
+          </span>
+        )}
+        {state.status === 'error' && (
+          <span
+            class="status-error-icon"
+            title={state.status === 'error' ? (state.error ?? 'Failed to save') : ''}
+          >
+            !
+          </span>
+        )}
+      </span>
+    )
+  }
+
+  return (
+    <span class={`save-status-indicator text ${state.status}`}>
+      {state.status === 'saving' && 'Saving...'}
+      {state.status === 'saved' && `Saved ${state.time ? formatSavedTime(state.time) : ''}`}
+      {state.status === 'error' && (state.error ?? 'Error saving')}
+    </span>
+  )
+}
+
+/**
+ * Hook that manages SaveStatus state with optional auto-clear.
+ * Replaces the copy-pasted useEffect timer pattern.
+ */
+export function useSaveStatus(autoClearMs?: number): [SaveStatus, (s: SaveStatus) => void] {
+  const [status, setStatusRaw] = useState<SaveStatus>({ status: 'idle' })
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const setStatus = useCallback(
+    (s: SaveStatus) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = undefined
+      }
+      setStatusRaw(s)
+      if (s.status === 'saved' && autoClearMs) {
+        timerRef.current = setTimeout(() => setStatusRaw({ status: 'idle' }), autoClearMs)
+      }
+    },
+    [autoClearMs],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return [status, setStatus]
+}

--- a/apps/web/src/components/SettingsSection.css
+++ b/apps/web/src/components/SettingsSection.css
@@ -1,0 +1,57 @@
+.settings-section {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.settings-section .section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.settings-section .section-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.settings-section .section-description {
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+.settings-section .loading {
+  color: #888;
+  font-style: italic;
+}
+
+.settings-section .no-data {
+  color: #888;
+  font-style: italic;
+  padding: 1rem;
+  text-align: center;
+  background: #f8f8f8;
+  border-radius: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .settings-section {
+    border-bottom-color: #444;
+  }
+
+  .settings-section .section-description {
+    color: #aaa;
+  }
+
+  .settings-section .loading {
+    color: #aaa;
+  }
+
+  .settings-section .no-data {
+    color: #aaa;
+    background: #2a2a2a;
+  }
+}

--- a/apps/web/src/components/SettingsSection.tsx
+++ b/apps/web/src/components/SettingsSection.tsx
@@ -1,0 +1,34 @@
+import type { ComponentChildren } from 'preact'
+
+import './SettingsSection.css'
+
+interface SettingsSectionProps {
+  title: string
+  description?: string
+  class?: string
+  headerExtra?: ComponentChildren
+  isLoading?: boolean
+  loadingMessage?: string
+  isEmpty?: boolean
+  emptyMessage?: string
+  children?: ComponentChildren
+}
+
+export function SettingsSection(props: SettingsSectionProps) {
+  return (
+    <section class={`settings-section ${props.class ?? ''}`}>
+      <div class="section-header">
+        <h2>{props.title}</h2>
+        {props.headerExtra}
+      </div>
+      {props.description && <p class="section-description">{props.description}</p>}
+      {props.isLoading ? (
+        <p class="loading">{props.loadingMessage ?? 'Loading...'}</p>
+      ) : props.isEmpty ? (
+        <p class="no-data">{props.emptyMessage}</p>
+      ) : (
+        props.children
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/components/TagMappingsSettings.css
+++ b/apps/web/src/components/TagMappingsSettings.css
@@ -1,14 +1,3 @@
-.tag-mappings-section .section-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
-}
-
-.tag-mappings-section .section-header h2 {
-  margin: 0;
-}
-
 .unmapped-badge {
   background: #f0ad4e;
   color: #fff;
@@ -16,25 +5,6 @@
   border-radius: 12px;
   font-size: 0.85rem;
   font-weight: 500;
-}
-
-.tag-mappings-section .section-description {
-  color: #666;
-  margin-bottom: 1rem;
-}
-
-.tag-mappings-section .no-tags {
-  color: #888;
-  font-style: italic;
-  padding: 1rem;
-  text-align: center;
-  background: #f8f8f8;
-  border-radius: 4px;
-}
-
-.tag-mappings-section .loading {
-  color: #888;
-  font-style: italic;
 }
 
 .tag-mappings-list {

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { fetchProgrammaticTags, fetchTagMappings, setTagMapping } from '../state/api'
 import { suggestEmoji } from '../utils/emojiLookup'
 import { IconInput } from './IconInput'
+import { SaveStatusIndicator, useSaveStatus } from './SaveStatusIndicator'
 import { SettingsSection } from './SettingsSection'
 import './TagMappingsSettings.css'
 
@@ -20,24 +21,6 @@ const formatTagKey = (tagKey: string): string => {
   }
   return tagKey
 }
-
-type RowStatus = 'idle' | 'saving' | 'saved' | 'error'
-
-const RowStatusIndicator = ({ status }: { status: RowStatus }) => (
-  <span class="row-status">
-    {status === 'saving' && <span class="status-saving" title="Saving..." />}
-    {status === 'saved' && (
-      <span class="status-saved" title="Saved">
-        &#10003;
-      </span>
-    )}
-    {status === 'error' && (
-      <span class="status-error" title="Failed to save">
-        !
-      </span>
-    )}
-  </span>
-)
 
 /** Determine what changed vs server state and return the name to save, or null if no save needed. */
 function getBlurSavePayload(
@@ -70,17 +53,10 @@ function TagMappingRow({
 }) {
   const [localValue, setLocalValue] = useState<string | undefined>(undefined)
   const [localIcon, setLocalIcon] = useState<string | undefined>(undefined)
-  const [status, setStatus] = useState<RowStatus>('idle')
+  const [status, setStatus] = useSaveStatus(3000)
   const [suggestedEmoji, setSuggestedEmoji] = useState<string | undefined>(undefined)
 
   const isProgrammatic = tag.is_programmatic
-
-  // Clear saved indicator after 3 seconds
-  useEffect(() => {
-    if (status !== 'saved') return
-    const timer = setTimeout(() => setStatus('idle'), 3000)
-    return () => clearTimeout(timer)
-  }, [status])
 
   const displayValue = localValue ?? tag.current_name ?? ''
   const displayIcon = localIcon ?? currentIcon ?? ''
@@ -105,14 +81,14 @@ function TagMappingRow({
       return
     }
 
-    setStatus('saving')
+    setStatus({ status: 'saving' })
     try {
       await onSave(tag.tag_key, payload.name, payload.iconChanged ? localIcon : undefined)
       setLocalValue(undefined)
       setLocalIcon(undefined)
-      setStatus('saved')
+      setStatus({ status: 'saved' })
     } catch {
-      setStatus('error')
+      setStatus({ status: 'error' })
     }
   }
 
@@ -123,15 +99,15 @@ function TagMappingRow({
     if (!name) return
 
     setSuggestedEmoji(undefined)
-    setStatus('saving')
+    setStatus({ status: 'saving' })
     try {
       await onSave(tag.tag_key, name, suggestedEmoji)
       setLocalValue(undefined)
       setLocalIcon(undefined)
-      setStatus('saved')
+      setStatus({ status: 'saved' })
     } catch {
       setLocalIcon(suggestedEmoji)
-      setStatus('error')
+      setStatus({ status: 'error' })
     }
   }
 
@@ -160,10 +136,10 @@ function TagMappingRow({
           onBlur={() => void handleBlur()}
           placeholder={isProgrammatic ? 'Enter display name...' : undefined}
           class={isUnmapped ? 'unmapped' : ''}
-          disabled={status === 'saving' || !isProgrammatic}
+          disabled={status.status === 'saving' || !isProgrammatic}
           readOnly={!isProgrammatic}
         />
-        <RowStatusIndicator status={status} />
+        <SaveStatusIndicator state={status} variant="compact" />
       </div>
 
       <div class="tag-icon-field">
@@ -177,7 +153,7 @@ function TagMappingRow({
           size={16}
           suggestedEmoji={suggestedEmoji}
           onAcceptSuggestion={() => void handleAcceptSuggestion()}
-          disabled={status === 'saving'}
+          disabled={status.status === 'saving'}
         />
       </div>
 

--- a/apps/web/src/components/TagMappingsSettings.tsx
+++ b/apps/web/src/components/TagMappingsSettings.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'preact/hooks'
 import { fetchProgrammaticTags, fetchTagMappings, setTagMapping } from '../state/api'
 import { suggestEmoji } from '../utils/emojiLookup'
 import { IconInput } from './IconInput'
+import { SettingsSection } from './SettingsSection'
 import './TagMappingsSettings.css'
 
 // Helper to check if a string is a UUID
@@ -217,44 +218,30 @@ export function TagMappingsSettings() {
     await mutation.mutateAsync({ icon, name, tagKey })
   }
 
-  if (isLoading) {
-    return (
-      <section class="settings-section tag-mappings-section">
-        <h2>Tag Mappings</h2>
-        <p class="loading">Loading tags...</p>
-      </section>
-    )
-  }
-
   const unmappedCount = tags?.filter((t) => t.is_programmatic && !t.current_name).length ?? 0
   const icons = mappingsData?.icons ?? {}
 
   return (
-    <section class="settings-section tag-mappings-section">
-      <div class="section-header">
-        <h2>Tag Mappings</h2>
-        {unmappedCount > 0 && <span class="unmapped-badge">{unmappedCount} unnamed</span>}
+    <SettingsSection
+      title="Tag Mappings"
+      class="tag-mappings-section"
+      description="Set display names for programmatic tags and icons for any tag. Icons can be emoji characters or image URLs. Changes save automatically when you leave the field."
+      headerExtra={unmappedCount > 0 && <span class="unmapped-badge">{unmappedCount} unnamed</span>}
+      isLoading={isLoading}
+      loadingMessage="Loading tags..."
+      isEmpty={!tags || tags.length === 0}
+      emptyMessage="No tags found. Tags will appear here after syncing data."
+    >
+      <div class="tag-mappings-list">
+        {(tags ?? []).map((tag) => (
+          <TagMappingRow
+            key={tag.tag_key}
+            tag={tag}
+            currentIcon={icons[tag.current_name ?? ''] ?? icons[tag.tag_key]}
+            onSave={handleSave}
+          />
+        ))}
       </div>
-
-      <p class="section-description">
-        Set display names for programmatic tags and icons for any tag. Icons can be emoji characters or image
-        URLs. Changes save automatically when you leave the field.
-      </p>
-
-      {!tags || tags.length === 0 ? (
-        <p class="no-tags">No tags found. Tags will appear here after syncing data.</p>
-      ) : (
-        <div class="tag-mappings-list">
-          {tags.map((tag) => (
-            <TagMappingRow
-              key={tag.tag_key}
-              tag={tag}
-              currentIcon={icons[tag.current_name ?? ''] ?? icons[tag.tag_key]}
-              onSave={handleSave}
-            />
-          ))}
-        </div>
-      )}
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/TimelineIconsSettings.css
+++ b/apps/web/src/components/TimelineIconsSettings.css
@@ -1,9 +1,3 @@
-.timeline-icons-section .section-description {
-  color: #666;
-  margin-bottom: 1rem;
-  line-height: 1.5;
-}
-
 .icon-group {
   margin-bottom: 1.5rem;
 }
@@ -123,10 +117,6 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .timeline-icons-section .section-description {
-    color: #aaa;
-  }
-
   .icon-group h3 {
     color: #bbb;
   }

--- a/apps/web/src/components/TimelineIconsSettings.tsx
+++ b/apps/web/src/components/TimelineIconsSettings.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 import { fetchUserSettings, updateUserSettings } from '../state/api'
 import { DEFAULT_ITEM_ICONS } from '../utils/emojiLookup'
 import { IconInput } from './IconInput'
+import { SettingsSection } from './SettingsSection'
 import './TimelineIconsSettings.css'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
@@ -202,25 +203,15 @@ export function TimelineIconsSettings() {
     [settings, queryClient],
   )
 
-  if (isLoading) {
-    return (
-      <section class="settings-section timeline-icons-section">
-        <h2>Timeline Icons</h2>
-        <p class="loading">Loading...</p>
-      </section>
-    )
-  }
-
   return (
-    <section class="settings-section timeline-icons-section">
-      <h2>Timeline Icons</h2>
-      <p class="section-description">
-        Customize the icons shown on the timeline for activities and exercise types. Icons can be emoji
-        characters, image URLs, or uploaded images. Default emojis are shown as placeholders.
-      </p>
-
+    <SettingsSection
+      title="Timeline Icons"
+      class="timeline-icons-section"
+      description="Customize the icons shown on the timeline for activities and exercise types. Icons can be emoji characters, image URLs, or uploaded images. Default emojis are shown as placeholders."
+      isLoading={isLoading}
+    >
       <IconGroup title="Activities" items={ACTIVITY_ITEMS} userIcons={userIcons} onSave={handleSave} />
       <IconGroup title="Exercise Types" items={EXERCISE_ITEMS} userIcons={userIcons} onSave={handleSave} />
-    </section>
+    </SettingsSection>
   )
 }

--- a/apps/web/src/components/TimelineIconsSettings.tsx
+++ b/apps/web/src/components/TimelineIconsSettings.tsx
@@ -3,15 +3,14 @@
  * Allows configuring emojis for activity types, exercise types, and tags.
  */
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
+import { useCallback, useMemo, useState } from 'preact/hooks'
 
 import { fetchUserSettings, updateUserSettings } from '../state/api'
 import { DEFAULT_ITEM_ICONS } from '../utils/emojiLookup'
 import { IconInput } from './IconInput'
+import { SaveStatusIndicator, useSaveStatus } from './SaveStatusIndicator'
 import { SettingsSection } from './SettingsSection'
 import './TimelineIconsSettings.css'
-
-type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 
 interface IconRowProps {
   iconKey: string
@@ -23,13 +22,7 @@ interface IconRowProps {
 
 function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowProps) {
   const [localValue, setLocalValue] = useState<string | undefined>(undefined)
-  const [status, setStatus] = useState<SaveStatus>('idle')
-
-  useEffect(() => {
-    if (status !== 'saved') return
-    const timer = setTimeout(() => setStatus('idle'), 3000)
-    return () => clearTimeout(timer)
-  }, [status])
+  const [status, setStatus] = useSaveStatus(3000)
 
   const displayValue = localValue ?? currentIcon ?? ''
   const isDefault = currentIcon === undefined
@@ -45,26 +38,26 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
       return
     }
 
-    setStatus('saving')
+    setStatus({ status: 'saving' })
     try {
       await onSave(iconKey, trimmed)
       setLocalValue(undefined)
-      setStatus('saved')
+      setStatus({ status: 'saved' })
     } catch {
-      setStatus('error')
+      setStatus({ status: 'error' })
     }
   }
 
   const handleIconChange = async (value: string) => {
     // If it's an uploaded icon path, save immediately
     if (value.startsWith('/api/icons/')) {
-      setStatus('saving')
+      setStatus({ status: 'saving' })
       try {
         await onSave(iconKey, value)
         setLocalValue(undefined)
-        setStatus('saved')
+        setStatus({ status: 'saved' })
       } catch {
-        setStatus('error')
+        setStatus({ status: 'error' })
       }
     } else {
       setLocalValue(value)
@@ -73,13 +66,13 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
 
   const handleReset = async () => {
     if (isDefault) return
-    setStatus('saving')
+    setStatus({ status: 'saving' })
     try {
       await onSave(iconKey, '')
       setLocalValue(undefined)
-      setStatus('saved')
+      setStatus({ status: 'saved' })
     } catch {
-      setStatus('error')
+      setStatus({ status: 'error' })
     }
   }
 
@@ -95,7 +88,7 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
           inputClass="icon-input"
           previewClass="icon-preview"
           size={16}
-          disabled={status === 'saving'}
+          disabled={status.status === 'saving'}
         />
         {!isDefault && (
           <button
@@ -107,9 +100,7 @@ function IconRow({ iconKey, label, currentIcon, defaultIcon, onSave }: IconRowPr
             x
           </button>
         )}
-        {status === 'saving' && <span class="icon-status-saving" />}
-        {status === 'saved' && <span class="icon-status-saved">&#10003;</span>}
-        {status === 'error' && <span class="icon-status-error">!</span>}
+        <SaveStatusIndicator state={status} variant="compact" />
       </div>
     </div>
   )

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -4,11 +4,10 @@ import { useCallback, useState } from 'preact/hooks'
 
 import type { InvitationResult, SignupMode } from '../../state/api'
 
+import { type SaveStatus, SaveStatusIndicator } from '../../components/SaveStatusIndicator'
 import { fetchAdminSettings, generateInvitation, updateAdminSettings } from '../../state/api'
 import { auth } from '../../state/auth'
 import './style.css'
-
-type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
 
 const signupModeDescriptions: Record<SignupMode, string> = {
   closed: 'No new users can sign up. Only existing accounts can log in.',
@@ -17,16 +16,6 @@ const signupModeDescriptions: Record<SignupMode, string> = {
 }
 
 const getErrorMessage = (err: unknown): string => (err instanceof Error ? err.message : 'Failed to save')
-
-const formatSavedTime = (time: Date): string => {
-  const now = new Date()
-  const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
-  if (diffSec < 5) return 'just now'
-  if (diffSec < 60) return `${diffSec} seconds ago`
-  const diffMin = Math.floor(diffSec / 60)
-  if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
-  return time.toLocaleTimeString()
-}
 
 const formatExpiryTime = (expiresAt: Date): string => {
   const now = new Date()
@@ -40,17 +29,6 @@ const formatExpiryTime = (expiresAt: Date): string => {
   const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
   if (hours > 0) return `${hours}h ${minutes}m`
   return `${minutes} minute${minutes > 1 ? 's' : ''}`
-}
-
-function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
-  if (saveStatus.status === 'idle') return null
-  return (
-    <span class={`save-indicator ${saveStatus.status}`}>
-      {saveStatus.status === 'saving' && 'Saving...'}
-      {saveStatus.status === 'saved' && saveStatus.time && `Saved ${formatSavedTime(saveStatus.time)}`}
-      {saveStatus.status === 'error' && (saveStatus.error ?? 'Error saving')}
-    </span>
-  )
 }
 
 function IntegrationsSection() {
@@ -108,7 +86,7 @@ function IntegrationsSection() {
       <div class="form-field">
         <div class="section-header-row">
           <label for="lastfm-api-key">Last.fm API Key</label>
-          <SaveStatusIndicator saveStatus={lastfmSaveStatus} />
+          <SaveStatusIndicator state={lastfmSaveStatus} />
         </div>
         {settings?.lastfm_api_key_set ? <p class="connected-status">Configured</p> : null}
         <div class="api-key-input-row">
@@ -139,7 +117,7 @@ function IntegrationsSection() {
         <div class="form-field">
           <div class="section-header-row">
             <label for="oura-webhook-toggle">Oura Webhook Push</label>
-            <SaveStatusIndicator saveStatus={ouraWebhookSaveStatus} />
+            <SaveStatusIndicator state={ouraWebhookSaveStatus} />
           </div>
           <label class="toggle-row">
             <input
@@ -277,7 +255,7 @@ export function AdminSettings() {
       <section class="settings-section">
         <div class="section-header-row">
           <h2>Server Settings</h2>
-          <SaveStatusIndicator saveStatus={saveStatus} />
+          <SaveStatusIndicator state={saveStatus} />
         </div>
 
         <div class="form-field">

--- a/apps/web/src/pages/DataSources/CalendarsSource.tsx
+++ b/apps/web/src/pages/DataSources/CalendarsSource.tsx
@@ -101,7 +101,7 @@ export function CalendarsSource() {
           <section class="settings-section">
             <div class="section-header-row">
               <h2>Calendars</h2>
-              <SaveStatusIndicator saveStatus={saveStatus} />
+              <SaveStatusIndicator state={saveStatus} />
             </div>
 
             {(userSettings?.calendars ?? []).length > 0 && (

--- a/apps/web/src/pages/DataSources/LastFmSource.tsx
+++ b/apps/web/src/pages/DataSources/LastFmSource.tsx
@@ -92,7 +92,7 @@ export function LastFmSource() {
           <section class="settings-section">
             <div class="section-header-row">
               <h2>Username</h2>
-              <SaveStatusIndicator saveStatus={saveStatus} />
+              <SaveStatusIndicator state={saveStatus} />
             </div>
             {userSettings?.lastfm_configured === false ? (
               <p class="field-description warning">

--- a/apps/web/src/pages/DataSources/RescueTimeSource.tsx
+++ b/apps/web/src/pages/DataSources/RescueTimeSource.tsx
@@ -115,7 +115,7 @@ export function RescueTimeSource() {
           <section class="settings-section">
             <div class="section-header-row">
               <h2>API Key</h2>
-              <SaveStatusIndicator saveStatus={saveStatus} />
+              <SaveStatusIndicator state={saveStatus} />
             </div>
             {isConfigured && <p class="connected-status">Configured</p>}
             <div class="form-field">

--- a/apps/web/src/pages/DataSources/shared.tsx
+++ b/apps/web/src/pages/DataSources/shared.tsx
@@ -1,19 +1,7 @@
 /**
  * Shared components for data source pages — save status indicators, status banners, etc.
  */
-
-export type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; error?: string }
-
-export function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
-  if (saveStatus.status === 'idle') return null
-  return (
-    <>
-      {saveStatus.status === 'saving' && <span class="save-indicator saving">Saving...</span>}
-      {saveStatus.status === 'saved' && <span class="save-indicator saved">Saved</span>}
-      {saveStatus.status === 'error' && <span class="save-indicator error">{saveStatus.error}</span>}
-    </>
-  )
-}
+export { type SaveStatus, SaveStatusIndicator } from '../../components/SaveStatusIndicator'
 
 export function StatusBanner({ connected, label }: { connected: boolean; label: string }) {
   return (

--- a/apps/web/src/pages/EntityDetail/NotesSection.tsx
+++ b/apps/web/src/pages/EntityDetail/NotesSection.tsx
@@ -6,6 +6,7 @@ import { useCallback, useState } from 'preact/hooks'
 import type { EntityType } from './EntityActions'
 
 import { MarkdownEditor } from '../../components/MarkdownEditor/index.jsx'
+import { SaveCancelRow } from '../../components/SaveCancelRow'
 import { addNote, deleteNote, fetchNotes, type NoteData, updateNote } from '../../state/api'
 
 export const NotesSection = ({
@@ -75,15 +76,6 @@ export const NotesSection = ({
     setEditContent(note.content)
   }, [])
 
-  const handleUpdate = useCallback(
-    (e: Event) => {
-      e.preventDefault()
-      if (!editingId || !editContent.trim()) return
-      updateMutation.mutate({ content: editContent, id: editingId })
-    },
-    [editingId, editContent, updateMutation],
-  )
-
   const notes = notesQuery.data ?? []
 
   return (
@@ -97,17 +89,17 @@ export const NotesSection = ({
           {notes.map((note) => (
             <div key={note.id} class="note-item">
               {editingId === note.id ? (
-                <form onSubmit={handleUpdate} class="note-edit-form">
+                <div class="note-edit-form">
                   <MarkdownEditor value={editContent} onChange={setEditContent} rows={3} />
-                  <div class="note-edit-actions">
-                    <button type="submit" class="btn-primary" disabled={updateMutation.isPending}>
-                      Save
-                    </button>
-                    <button type="button" class="btn-secondary" onClick={() => setEditingId(null)}>
-                      Cancel
-                    </button>
-                  </div>
-                </form>
+                  <SaveCancelRow
+                    onSave={() => {
+                      if (!editingId || !editContent.trim()) return
+                      updateMutation.mutate({ content: editContent, id: editingId })
+                    }}
+                    onCancel={() => setEditingId(null)}
+                    isPending={updateMutation.isPending}
+                  />
+                </div>
               ) : (
                 <>
                   <div

--- a/apps/web/src/pages/ExerciseMeta/index.tsx
+++ b/apps/web/src/pages/ExerciseMeta/index.tsx
@@ -8,7 +8,8 @@ import { useState } from 'preact/hooks'
 
 import { IconInput } from '../../components/IconInput'
 import { IconPreview } from '../../components/IconPreview'
-import { SaveStatusIndicator, useSaveStatus } from '../../components/SaveStatusIndicator'
+import { SaveCancelRow } from '../../components/SaveCancelRow'
+import { useSaveStatus } from '../../components/SaveStatusIndicator'
 import { fetchTagMappings, fetchTrend, type FetchTrendParams, updateUserSettings } from '../../state/api'
 import { resolveItemIcon } from '../../utils/emojiLookup'
 import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
@@ -93,23 +94,16 @@ function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: str
         </label>
       </div>
       {hasChanges && (
-        <div class="tag-meta-save-row">
-          <button
-            type="button"
-            class="btn-primary"
-            onClick={() => {
-              setSaveStatus({ status: 'saving' })
-              saveMutation.mutate(iconValue ?? '')
-            }}
-            disabled={saveMutation.isPending}
-          >
-            {saveMutation.isPending ? 'Saving...' : 'Save'}
-          </button>
-          <button type="button" class="btn-secondary" onClick={() => setIconValue(undefined)}>
-            Cancel
-          </button>
-          <SaveStatusIndicator state={saveStatus} variant="compact" />
-        </div>
+        <SaveCancelRow
+          onSave={() => {
+            setSaveStatus({ status: 'saving' })
+            saveMutation.mutate(iconValue ?? '')
+          }}
+          onCancel={() => setIconValue(undefined)}
+          isPending={saveMutation.isPending}
+          saveStatus={saveStatus}
+          saveStatusVariant="compact"
+        />
       )}
     </section>
   )

--- a/apps/web/src/pages/ExerciseMeta/index.tsx
+++ b/apps/web/src/pages/ExerciseMeta/index.tsx
@@ -4,10 +4,11 @@
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
-import { useEffect, useState } from 'preact/hooks'
+import { useState } from 'preact/hooks'
 
 import { IconInput } from '../../components/IconInput'
 import { IconPreview } from '../../components/IconPreview'
+import { SaveStatusIndicator, useSaveStatus } from '../../components/SaveStatusIndicator'
 import { fetchTagMappings, fetchTrend, type FetchTrendParams, updateUserSettings } from '../../state/api'
 import { resolveItemIcon } from '../../utils/emojiLookup'
 import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
@@ -59,7 +60,7 @@ function ExerciseTrendSection({ exerciseType, lookback }: { exerciseType: string
 function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: string; currentIcon: string }) {
   const queryClient = useQueryClient()
   const [iconValue, setIconValue] = useState<string | undefined>(undefined)
-  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [saveStatus, setSaveStatus] = useSaveStatus(3000)
 
   const displayName = formatExerciseTypeName(exerciseType)
   const iconKey = `exercise:${displayName}`
@@ -68,20 +69,14 @@ function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: str
     mutationFn: async (icon: string) => {
       await updateUserSettings({ item_icons: { [iconKey]: icon } })
     },
-    onError: () => setSaveStatus('error'),
+    onError: () => setSaveStatus({ status: 'error' }),
     onSuccess: () => {
-      setSaveStatus('saved')
+      setSaveStatus({ status: 'saved' })
       queryClient.invalidateQueries({ queryKey: ['tag-mappings'] })
       queryClient.invalidateQueries({ queryKey: ['userSettings'] })
       setIconValue(undefined)
     },
   })
-
-  useEffect(() => {
-    if (saveStatus !== 'saved') return
-    const timer = setTimeout(() => setSaveStatus('idle'), 3000)
-    return () => clearTimeout(timer)
-  }, [saveStatus])
 
   const shownIcon = iconValue ?? currentIcon
   const hasChanges = iconValue !== undefined && iconValue !== currentIcon
@@ -103,7 +98,7 @@ function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: str
             type="button"
             class="btn-primary"
             onClick={() => {
-              setSaveStatus('saving')
+              setSaveStatus({ status: 'saving' })
               saveMutation.mutate(iconValue ?? '')
             }}
             disabled={saveMutation.isPending}
@@ -113,8 +108,7 @@ function ExerciseIconSettings({ exerciseType, currentIcon }: { exerciseType: str
           <button type="button" class="btn-secondary" onClick={() => setIconValue(undefined)}>
             Cancel
           </button>
-          {saveStatus === 'saved' && <span class="tag-meta-status-saved">Saved</span>}
-          {saveStatus === 'error' && <span class="tag-meta-status-error">Failed to save</span>}
+          <SaveStatusIndicator state={saveStatus} variant="compact" />
         </div>
       )}
     </section>

--- a/apps/web/src/pages/Reports/ReportDetail.tsx
+++ b/apps/web/src/pages/Reports/ReportDetail.tsx
@@ -3,8 +3,9 @@ import type { Confidence, ReportEntry, ReportFlag } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
-import { useMemo, useState } from 'preact/hooks'
+import { useMemo } from 'preact/hooks'
 
+import { ConfirmButton } from '../../components/ConfirmButton'
 import { ReferenceRangeBar } from '../../components/ReferenceRangeBar'
 import { SparklineChart } from '../../components/SparklineChart'
 import { deleteReport, fetchReport, fetchReports, type Report } from '../../state/api'
@@ -205,8 +206,6 @@ export function ReportDetail() {
   const { route } = useLocation()
   const queryClient = useQueryClient()
   const id = params.id as string
-  const [confirmDelete, setConfirmDelete] = useState(false)
-
   const {
     data: report,
     isLoading,
@@ -307,26 +306,14 @@ export function ReportDetail() {
       <NotesSection entityType="report" entityId={id} />
 
       <section class="report-detail-actions">
-        {!confirmDelete ? (
-          <button type="button" class="btn-danger" onClick={() => setConfirmDelete(true)}>
-            Delete Report
-          </button>
-        ) : (
-          <div class="report-delete-confirm">
-            <span>Delete this report and its metric data?</span>
-            <button
-              type="button"
-              class="btn-danger"
-              onClick={() => deleteMutation.mutate()}
-              disabled={deleteMutation.isPending}
-            >
-              {deleteMutation.isPending ? 'Deleting...' : 'Confirm Delete'}
-            </button>
-            <button type="button" class="btn-secondary" onClick={() => setConfirmDelete(false)}>
-              Cancel
-            </button>
-          </div>
-        )}
+        <ConfirmButton
+          label="Delete Report"
+          confirmMessage="Delete this report and its metric data?"
+          confirmLabel="Confirm Delete"
+          onConfirm={() => deleteMutation.mutate()}
+          isPending={deleteMutation.isPending}
+          pendingLabel="Deleting..."
+        />
       </section>
     </div>
   )

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'preact/hooks'
 
 import type { BiologicalSex, HrZoneThresholds, UpdateSettingsInput } from '../../state/api'
 
+import { SettingsSection } from '../../components/SettingsSection'
 import { TimelineIconsSettings } from '../../components/TimelineIconsSettings'
 import { fetchUserSettings, updateUserSettings } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -161,11 +162,10 @@ export function Settings() {
     <div class="settings-page">
       <h1>Settings</h1>
 
-      <section class="settings-section">
-        <div class="section-header-row">
-          <h2>Personal Information</h2>
-          <SaveStatusIndicator saveStatus={personalInfoStatus} />
-        </div>
+      <SettingsSection
+        title="Personal Information"
+        headerExtra={<SaveStatusIndicator saveStatus={personalInfoStatus} />}
+      >
         <div class="form-field">
           <label for="birth-date">Birth Date</label>
           <input
@@ -192,18 +192,13 @@ export function Settings() {
             computation.
           </p>
         </div>
-      </section>
+      </SettingsSection>
 
-      <section class="settings-section">
-        <div class="section-header-row">
-          <h2>HR Zone Thresholds</h2>
-          <SaveStatusIndicator saveStatus={hrZonesStatus} />
-        </div>
-        <p class="section-description">
-          Customize the heart rate thresholds for each zone. These values represent the starting BPM for each
-          zone. Changes save automatically.
-        </p>
-
+      <SettingsSection
+        title="HR Zone Thresholds"
+        description="Customize the heart rate thresholds for each zone. These values represent the starting BPM for each zone. Changes save automatically."
+        headerExtra={<SaveStatusIndicator saveStatus={hrZonesStatus} />}
+      >
         <div class="hr-zones-form">
           {([1, 2, 3, 4, 5] as const).map((zone) => (
             <div class="zone-input" key={zone}>
@@ -230,7 +225,7 @@ export function Settings() {
         {hrZones === null && (
           <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
         )}
-      </section>
+      </SettingsSection>
 
       <TimelineIconsSettings />
 

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'preact/hooks'
 
 import type { BiologicalSex, HrZoneThresholds, UpdateSettingsInput } from '../../state/api'
 
+import { type SaveStatus, SaveStatusIndicator } from '../../components/SaveStatusIndicator'
 import { SettingsSection } from '../../components/SettingsSection'
 import { TimelineIconsSettings } from '../../components/TimelineIconsSettings'
 import { fetchUserSettings, updateUserSettings } from '../../state/api'
@@ -10,29 +11,6 @@ import { auth } from '../../state/auth'
 import { defaultHrZoneThresholds } from '../../utils/hrZones'
 import { parseZoneValue, updateZoneThreshold, validateHrZoneThresholds } from '../../utils/settings'
 import './style.css'
-
-type SaveStatus = { status: 'idle' | 'saving' | 'saved' | 'error'; time?: Date; error?: string }
-
-const formatSavedTime = (time: Date): string => {
-  const now = new Date()
-  const diffSec = Math.floor((now.getTime() - time.getTime()) / 1000)
-  if (diffSec < 5) return 'just now'
-  if (diffSec < 60) return `${diffSec} seconds ago`
-  const diffMin = Math.floor(diffSec / 60)
-  if (diffMin < 60) return `${diffMin} minute${diffMin > 1 ? 's' : ''} ago`
-  return time.toLocaleTimeString()
-}
-
-function SaveStatusIndicator({ saveStatus }: { saveStatus: SaveStatus }) {
-  if (saveStatus.status === 'idle') return null
-  return (
-    <span class={`save-indicator ${saveStatus.status}`}>
-      {saveStatus.status === 'saving' && 'Saving...'}
-      {saveStatus.status === 'saved' && saveStatus.time && `Saved ${formatSavedTime(saveStatus.time)}`}
-      {saveStatus.status === 'error' && (saveStatus.error ?? 'Error saving')}
-    </span>
-  )
-}
 
 export function Settings() {
   const isLoggedIn = auth.value.token
@@ -164,7 +142,7 @@ export function Settings() {
 
       <SettingsSection
         title="Personal Information"
-        headerExtra={<SaveStatusIndicator saveStatus={personalInfoStatus} />}
+        headerExtra={<SaveStatusIndicator state={personalInfoStatus} />}
       >
         <div class="form-field">
           <label for="birth-date">Birth Date</label>
@@ -197,7 +175,7 @@ export function Settings() {
       <SettingsSection
         title="HR Zone Thresholds"
         description="Customize the heart rate thresholds for each zone. These values represent the starting BPM for each zone. Changes save automatically."
-        headerExtra={<SaveStatusIndicator saveStatus={hrZonesStatus} />}
+        headerExtra={<SaveStatusIndicator state={hrZonesStatus} />}
       >
         <div class="hr-zones-form">
           {([1, 2, 3, 4, 5] as const).map((zone) => (

--- a/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
+++ b/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
@@ -7,7 +7,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { IconInput } from '../../components/IconInput'
-import { SaveStatusIndicator, useSaveStatus } from '../../components/SaveStatusIndicator'
+import { SaveCancelRow } from '../../components/SaveCancelRow'
+import { useSaveStatus } from '../../components/SaveStatusIndicator'
 import { setTagMapping } from '../../state/api'
 import { suggestEmoji } from '../../utils/emojiLookup'
 
@@ -97,22 +98,16 @@ export function TagSettingsSection({
         )}
       </div>
       {hasChanges && (
-        <div class="tag-meta-save-row">
-          <button type="button" class="btn-primary" onClick={handleSave} disabled={saveMutation.isPending}>
-            {saveMutation.isPending ? 'Saving...' : 'Save'}
-          </button>
-          <button
-            type="button"
-            class="btn-secondary"
-            onClick={() => {
-              setDisplayName(undefined)
-              setIconValue(undefined)
-            }}
-          >
-            Cancel
-          </button>
-          <SaveStatusIndicator state={saveStatus} variant="compact" />
-        </div>
+        <SaveCancelRow
+          onSave={handleSave}
+          onCancel={() => {
+            setDisplayName(undefined)
+            setIconValue(undefined)
+          }}
+          isPending={saveMutation.isPending}
+          saveStatus={saveStatus}
+          saveStatusVariant="compact"
+        />
       )}
     </section>
   )

--- a/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
+++ b/apps/web/src/pages/TagMeta/TagSettingsSection.tsx
@@ -4,9 +4,10 @@
 import type { ProgrammaticTag } from '@aurboda/api-spec'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useEffect, useState } from 'preact/hooks'
+import { useState } from 'preact/hooks'
 
 import { IconInput } from '../../components/IconInput'
+import { SaveStatusIndicator, useSaveStatus } from '../../components/SaveStatusIndicator'
 import { setTagMapping } from '../../state/api'
 import { suggestEmoji } from '../../utils/emojiLookup'
 
@@ -27,14 +28,14 @@ export function TagSettingsSection({
   const queryClient = useQueryClient()
   const [displayName, setDisplayName] = useState<string | undefined>(undefined)
   const [iconValue, setIconValue] = useState<string | undefined>(undefined)
-  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [saveStatus, setSaveStatus] = useSaveStatus(3000)
 
   const saveMutation = useMutation({
     mutationFn: ({ name, icon }: { name: string; icon?: string }) =>
       setTagMapping(effectiveTagKey, name, icon),
-    onError: () => setSaveStatus('error'),
+    onError: () => setSaveStatus({ status: 'error' }),
     onSuccess: () => {
-      setSaveStatus('saved')
+      setSaveStatus({ status: 'saved' })
       queryClient.invalidateQueries({ queryKey: ['programmaticTags'] })
       queryClient.invalidateQueries({ queryKey: ['tag-mappings'] })
       queryClient.invalidateQueries({ queryKey: ['userSettings'] })
@@ -43,13 +44,6 @@ export function TagSettingsSection({
     },
   })
 
-  // Clear saved indicator
-  useEffect(() => {
-    if (saveStatus !== 'saved') return
-    const timer = setTimeout(() => setSaveStatus('idle'), 3000)
-    return () => clearTimeout(timer)
-  }, [saveStatus])
-
   const suggested = suggestEmoji(currentName)
   const shownIcon = iconValue ?? currentIcon
   const shownName = displayName ?? currentName
@@ -57,7 +51,7 @@ export function TagSettingsSection({
   const handleSave = () => {
     const name = (displayName ?? currentName).trim()
     if (!name) return
-    setSaveStatus('saving')
+    setSaveStatus({ status: 'saving' })
     const iconChanged = iconValue !== undefined && iconValue !== currentIcon
     saveMutation.mutate({ icon: iconChanged ? iconValue : undefined, name })
   }
@@ -117,8 +111,7 @@ export function TagSettingsSection({
           >
             Cancel
           </button>
-          {saveStatus === 'saved' && <span class="tag-meta-status-saved">Saved</span>}
-          {saveStatus === 'error' && <span class="tag-meta-status-error">Failed to save</span>}
+          <SaveStatusIndicator state={saveStatus} variant="compact" />
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- **SaveStatusIndicator + useSaveStatus hook** — replaces 12 duplicated save status implementations with compact (spinner/checkmark/!) and text ("Saved 5s ago") variants
- **SettingsSection** — reusable section wrapper with title, description, loading/empty guards, and headerExtra slot
- **SaveCancelRow** — standardized save/cancel button pair with optional inline status
- **ConfirmButton** — two-state inline confirmation UI replacing `window.confirm()` and inline confirm/cancel patterns

## Test plan
- [ ] Settings page: personal info, HR zones, timeline icons sections render correctly
- [ ] Tag meta page: save/cancel buttons, status indicators work
- [ ] Exercise meta page: icon save/cancel works
- [ ] Last.fm tag rules: edit/save/delete with confirmation works
- [ ] Custom metrics: delete confirmation works
- [ ] Report detail: delete confirmation works
- [ ] Tag mappings: inline save status works

🤖 Generated with [Claude Code](https://claude.com/claude-code)