### PR TITLE
Update welcome page and add privacy/terms pages

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -3,7 +3,8 @@ export function Footer() {
     <footer class="site-footer">
       <p>
         <a href="https://github.com/fiddur/aurboda">Aurboda</a> ©Fredrik Liljegren 2026{' '}
-        <a href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL-3.0</a>
+        <a href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL-3.0</a> · <a href="/privacy">Privacy</a>{' '}
+        · <a href="/terms">Terms</a>
       </p>
     </footer>
   )

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -29,6 +29,7 @@ import { HrZones } from './pages/HrZones/index.jsx'
 import { Login } from './pages/Login/index.jsx'
 import { MetricMeta } from './pages/MetricMeta/index.jsx'
 import { Places } from './pages/Places/index.jsx'
+import { Privacy } from './pages/Privacy/index.jsx'
 import { AddReport } from './pages/Reports/AddReport.jsx'
 import { Reports } from './pages/Reports/index.jsx'
 import { ReportDetail } from './pages/Reports/ReportDetail.jsx'
@@ -38,6 +39,7 @@ import { Settings } from './pages/Settings/index.jsx'
 import { Signup } from './pages/Signup/index.jsx'
 import { Sleep } from './pages/Sleep/index.jsx'
 import { TagMeta } from './pages/TagMeta/index.jsx'
+import { Terms } from './pages/Terms/index.jsx'
 import { Timeline } from './pages/Timeline/index.jsx'
 import { Trends } from './pages/Trends/index.jsx'
 import { queryClient } from './state/queryClient.js'
@@ -53,6 +55,8 @@ export function App() {
             <Route path="/" component={Home} />
             <Route path="/login" component={Login} />
             <Route path="/signup" component={Signup} />
+            <Route path="/privacy" component={Privacy} />
+            <Route path="/terms" component={Terms} />
             <Route path="/goals" component={Goals} />
             <Route path="/hr-zones" component={HrZones} />
             <Route path="/timeline" component={Timeline} />

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -4,51 +4,122 @@ import { auth, ensureStatusLoaded, signupAllowed } from '../../state/auth'
 import { Dashboard } from '../Dashboard'
 import './style.css'
 
+function Screenshot({
+  src,
+  alt,
+  caption,
+  className,
+}: {
+  src: string
+  alt: string
+  caption: string
+  className?: string
+}) {
+  return (
+    <figure class={className}>
+      <a href={src} target="_blank" rel="noopener noreferrer">
+        <img src={src} alt={alt} />
+      </a>
+      <figcaption>{caption}</figcaption>
+    </figure>
+  )
+}
+
 function GuestHome({ canSignup }: { canSignup: boolean }) {
   return (
     <>
       <section class="intro">
         <p>
-          Your health data is scattered across apps and services. Aurboda brings it all together, letting you
-          visualize trends and discuss your health with AI assistants.
+          Your health, fitness, productivity, and location data is scattered across apps and services. Aurboda
+          aggregates it all into one self-hosted platform, provides rich visualizations, and exposes
+          everything to AI assistants via{' '}
+          <a href="https://modelcontextprotocol.io/" target="_blank" rel="noopener noreferrer">
+            MCP (Model Context Protocol)
+          </a>
+          .
         </p>
 
         <h3>What it does</h3>
         <ul>
           <li>
-            <strong>Aggregates</strong> health data from Android Health Connect, Oura, OwnTracks, and
-            RescueTime into one place.
+            <strong>Aggregates</strong> health data from Android Health Connect, Oura, Garmin, OwnTracks,
+            RescueTime, ActivityWatch, Last.fm, calendar feeds, and more.
           </li>
           <li>
-            <strong>Visualizes</strong> your heart rate zones, sleep patterns, location history, and exercise
-            data.
+            <strong>Visualizes</strong> timelines, heart rate zones, sleep patterns, trends, correlations,
+            location history, training load, and screen time.
           </li>
           <li>
-            <strong>AI-ready</strong> via MCP (Model Context Protocol) — optionally connect Claude or other AI
-            assistants to your self-hosted instance to ask questions about your health data.
+            <strong>AI-ready</strong> via MCP — connect Claude or other AI assistants to your self-hosted
+            instance to query your health data and find insights.
           </li>
         </ul>
 
         <div class="screenshots">
-          <figure>
-            <img src="/screenshots/app.jpg" alt="Aurboda Android app showing HR zone minutes" />
-            <figcaption>Android app: HR zone tracking</figcaption>
-          </figure>
-          <figure>
-            <img src="/screenshots/widget.jpg" alt="Aurboda home screen widget" />
-            <figcaption>Home screen widget</figcaption>
-          </figure>
-          <figure>
-            <img src="/screenshots/app-live.png" alt="Live BLE sensor data" />
-            <figcaption>Live BLE sensors: HR, HRV, and steps</figcaption>
-          </figure>
+          <Screenshot
+            src="/screenshots/timeline-detail.jpg"
+            alt="Timeline with strength training details, heart rate, and location"
+            caption="Timeline: activity details, HR, location"
+          />
+          <Screenshot
+            src="/screenshots/timeline-sleep.jpg"
+            alt="Timeline showing sleep details with Oura scores"
+            caption="Timeline: sleep details and scores"
+          />
+          <Screenshot
+            src="/screenshots/timeline-mobile.jpg"
+            alt="Timeline on mobile"
+            caption="Mobile timeline"
+            className="narrow"
+          />
         </div>
 
         <div class="screenshots">
-          <figure class="wide">
-            <img src="/screenshots/ai-chat.png" alt="AI analyzing health data" />
-            <figcaption>AI health insights via MCP</figcaption>
-          </figure>
+          <Screenshot
+            src="/screenshots/hr-zones.jpg"
+            alt="HR zone minutes breakdown"
+            caption="HR zone tracking"
+            className="narrow"
+          />
+          <Screenshot
+            src="/screenshots/trends.jpg"
+            alt="Trend cards showing metrics over time"
+            caption="Trends with EMA smoothing"
+          />
+        </div>
+
+        <div class="screenshots">
+          <Screenshot
+            src="/screenshots/places.jpg"
+            alt="Places view with location timeline and map"
+            caption="Places and location history"
+          />
+          <Screenshot
+            src="/screenshots/ai-chat.png"
+            alt="AI analyzing health data"
+            caption="AI health insights via MCP"
+          />
+        </div>
+
+        <div class="screenshots">
+          <Screenshot
+            src="/screenshots/app.jpg"
+            alt="Aurboda Android app showing HR zone minutes"
+            caption="Android app: HR zones"
+            className="narrow"
+          />
+          <Screenshot
+            src="/screenshots/app-live.png"
+            alt="Live BLE sensor data"
+            caption="Live BLE sensors"
+            className="narrow"
+          />
+          <Screenshot
+            src="/screenshots/widget.jpg"
+            alt="Aurboda home screen widget"
+            caption="Home screen widget"
+            className="narrow"
+          />
         </div>
 
         <p>
@@ -57,14 +128,14 @@ function GuestHome({ canSignup }: { canSignup: boolean }) {
           </a>
         </p>
         <p class="note">
-          Currently in early development.{' '}
+          No public signup — self-host your own instance or{' '}
           {canSignup ? (
             <>
-              <a href="/signup">Sign up</a> to get started, or self-host your own instance.
+              <a href="/signup">sign up</a> if you have an invite.
             </>
           ) : (
             <>
-              Signup is not available on this server. You can self-host or contact me through{' '}
+              contact me through{' '}
               <a href="https://www.reddit.com/user/fiddur/" target="_blank" rel="noopener noreferrer">
                 reddit
               </a>
@@ -76,54 +147,143 @@ function GuestHome({ canSignup }: { canSignup: boolean }) {
 
       <section class="features">
         <h2>Data Sources</h2>
-        <ul>
-          <li>
-            Android Health Connect from{' '}
-            <a href="https://github.com/fiddur/aurboda" target="_blank" rel="noopener noreferrer">
-              Aurboda App
-            </a>
-          </li>
-          <li>
-            Bluetooth heart rate monitors (e.g., Polar H10) — real-time HR and HRV via the app's Live screen
-          </li>
-          <li>
-            Bluetooth step sensors (e.g., Zwift RunPod) — real-time cadence and step counting via the app's
-            Live screen
-          </li>
-          <li>
-            <a href="https://owntracks.org/" target="_blank" rel="noopener noreferrer">
-              OwnTracks
-            </a>{' '}
-            (json http mode)
-          </li>
-          <li>
-            <a href="https://ouraring.com/" target="_blank" rel="noopener noreferrer">
-              Oura
-            </a>{' '}
-            API
-          </li>
-          <li>
-            <a href="https://www.rescuetime.com/" target="_blank" rel="noopener noreferrer">
-              RescueTime
-            </a>{' '}
-            API
-          </li>
-        </ul>
+        <table class="data-sources-table">
+          <thead>
+            <tr>
+              <th>Source</th>
+              <th>What it provides</th>
+              <th>How</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>Android Health Connect</strong>
+              </td>
+              <td>Heart rate, HRV, sleep, exercise (80+ types), steps, weight, SpO2, VO2 max, calories</td>
+              <td>Push from Android app</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>BLE Sensors</strong>
+              </td>
+              <td>Real-time heart rate, HRV (Polar H10, etc.) and steps (Zwift RunPod, etc.)</td>
+              <td>Live via Android app</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://ouraring.com/" target="_blank" rel="noopener noreferrer">
+                  <strong>Oura Ring</strong>
+                </a>
+              </td>
+              <td>Sleep stages/scores, readiness, resilience, cardiovascular age, HRV, heart rate, tags</td>
+              <td>Pull (API) + Push (webhooks)</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://connect.garmin.com/" target="_blank" rel="noopener noreferrer">
+                  <strong>Garmin Connect</strong>
+                </a>
+              </td>
+              <td>Daily summary, HR, HRV, sleep, stress, body battery, activities, SpO2, respiration</td>
+              <td>Pull (session-based)</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://owntracks.org/" target="_blank" rel="noopener noreferrer">
+                  <strong>OwnTracks</strong>
+                </a>
+              </td>
+              <td>GPS locations, geofences, place visits</td>
+              <td>Push (HTTP mode)</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://www.rescuetime.com/" target="_blank" rel="noopener noreferrer">
+                  <strong>RescueTime</strong>
+                </a>
+              </td>
+              <td>App/website usage, productivity scores, categories</td>
+              <td>Pull (API)</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://activitywatch.net/" target="_blank" rel="noopener noreferrer">
+                  <strong>ActivityWatch</strong>
+                </a>
+              </td>
+              <td>App/window usage per device (desktop and Android)</td>
+              <td>Push (agent script)</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://www.last.fm/" target="_blank" rel="noopener noreferrer">
+                  <strong>Last.fm</strong>
+                </a>
+              </td>
+              <td>Music scrobbles with auto-generated tags from configurable rules</td>
+              <td>Pull (API)</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Calendars (ICS)</strong>
+              </td>
+              <td>Calendar events imported as tags (Google Calendar, Outlook, iCloud, Nextcloud, etc.)</td>
+              <td>Pull (ICS fetch)</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>Manual Entry</strong>
+              </td>
+              <td>Any metric, tag, activity, or note</td>
+              <td>Web UI, REST API, or MCP</td>
+            </tr>
+          </tbody>
+        </table>
       </section>
 
       <section class="features">
-        <h2>Visualizations</h2>
-        <h3>Web &amp; Android</h3>
+        <h2>Features</h2>
         <ul>
           <li>
-            Minutes in HR zones for last 7 days (due to the Galpin/Huberman recommendation to be in zone 2
-            150-200 minutes per week and zone 5 5-10 minutes). Android also has a widget.
+            <strong>Timeline</strong> — Multi-track interactive day view: activities, tags, metrics, screen
+            time, music, and location
           </li>
-        </ul>
-        <h3>Web only</h3>
-        <ul>
-          <li>Timeline with Heartrate, tags, places etc...</li>
-          <li>Location timeline with option to name the locations.</li>
+          <li>
+            <strong>Dashboard</strong> — Customizable widget-based home page with metric cards, sparklines,
+            trends, and correlations
+          </li>
+          <li>
+            <strong>HR Zones</strong> — Weekly heart rate zone tracking with Huberman/Galpin protocol targets
+          </li>
+          <li>
+            <strong>Correlation Analysis</strong> — Pearson coefficients, chi-squared tests, relative risk,
+            activity impact timelines
+          </li>
+          <li>
+            <strong>Trends (EMA)</strong> — Exponential Moving Average smoothing for tags, metrics, and screen
+            time
+          </li>
+          <li>
+            <strong>Goals</strong> — Rolling-window health targets
+          </li>
+          <li>
+            <strong>Sleep Analysis</strong> — Sleep quality tracking, hypnogram, Oura scores
+          </li>
+          <li>
+            <strong>Training Load</strong> — Banister model fitness/fatigue tracking (CTL/ATL/TSB)
+          </li>
+          <li>
+            <strong>Places</strong> — GPS location history, auto-detected locations, visit tracking with
+            PostGIS
+          </li>
+          <li>
+            <strong>Lab Reports</strong> — Structured lab results with metric write-through and reference
+            ranges
+          </li>
+          <li>
+            <strong>MCP Integration</strong> — Full AI assistant access via Model Context Protocol (50+ tools)
+          </li>
         </ul>
       </section>
 
@@ -186,6 +346,12 @@ function GuestHome({ canSignup }: { canSignup: boolean }) {
         <p>
           This project embodies that spirit: gathering scattered health data from multiple sources into a
           unified foundation for understanding your wellbeing.
+        </p>
+      </section>
+
+      <section class="legal">
+        <p>
+          <a href="/privacy">Privacy Policy</a> · <a href="/terms">Terms of Service</a>
         </p>
       </section>
     </>

--- a/apps/web/src/pages/Home/style.css
+++ b/apps/web/src/pages/Home/style.css
@@ -63,17 +63,63 @@
   text-align: center;
 }
 
+.home .screenshots figure.narrow {
+  max-width: 180px;
+}
+
 .home .screenshots img {
   max-width: 280px;
   height: auto;
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.home .screenshots figure.narrow img {
+  max-width: 180px;
+}
+
+.home .screenshots img:hover {
+  transform: scale(1.03);
 }
 
 .home .screenshots figcaption {
   font-size: 0.875rem;
   color: #666;
   margin-top: 0.5rem;
+}
+
+.home .data-sources-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
+
+.home .data-sources-table th,
+.home .data-sources-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.home .data-sources-table th {
+  font-weight: 600;
+  border-bottom: 2px solid #673ab8;
+}
+
+.home .data-sources-table td:first-child {
+  white-space: nowrap;
+}
+
+.home .legal {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #666;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #ddd;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -83,6 +129,16 @@
 
   .home .screenshots img {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+
+  .home .data-sources-table th,
+  .home .data-sources-table td {
+    border-color: #444;
+  }
+
+  .home .legal {
+    color: #aaa;
+    border-color: #444;
   }
 }
 

--- a/apps/web/src/pages/Privacy/index.tsx
+++ b/apps/web/src/pages/Privacy/index.tsx
@@ -1,0 +1,83 @@
+import '../Home/style.css'
+
+export function Privacy() {
+  return (
+    <div class="home">
+      <h1>Privacy Policy</h1>
+      <p>
+        <em>Last updated: 2026-03-24</em>
+      </p>
+
+      <section>
+        <h2>Overview</h2>
+        <p>
+          Aurboda is a self-hosted health data aggregation platform. Your data stays on the server you or your
+          administrator control. We do not sell, share, or transfer your personal data to any third parties.
+        </p>
+      </section>
+
+      <section>
+        <h2>Data We Collect</h2>
+        <p>Aurboda stores the health and activity data you choose to connect:</p>
+        <ul>
+          <li>Health metrics (heart rate, HRV, sleep, exercise, steps, weight, SpO2, etc.)</li>
+          <li>Location data (GPS positions, place visits) if OwnTracks is connected</li>
+          <li>Screen time and app usage if RescueTime or ActivityWatch is connected</li>
+          <li>Music listening history if Last.fm is connected</li>
+          <li>Calendar events if calendar feeds are connected</li>
+          <li>Account credentials (username, hashed password) for authentication</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>How Data Is Used</h2>
+        <p>Your data is used solely to provide the Aurboda service to you:</p>
+        <ul>
+          <li>Displaying visualizations, trends, and correlations</li>
+          <li>Providing data to AI assistants via MCP when you choose to connect them</li>
+          <li>Generating statistical analyses (correlations, training load, goals)</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Data Sharing</h2>
+        <p>
+          <strong>We do not share your data with any third parties.</strong> Your data remains on the Aurboda
+          server instance. The only external communication is with the data source APIs you have explicitly
+          configured (Oura, Garmin, RescueTime, Last.fm, etc.) to fetch your own data.
+        </p>
+      </section>
+
+      <section>
+        <h2>Data Storage</h2>
+        <p>
+          All data is stored in a PostgreSQL database on the server running the Aurboda instance. Data
+          retention and backups are managed by whoever administers the server.
+        </p>
+      </section>
+
+      <section>
+        <h2>Your Rights</h2>
+        <p>
+          You can view, export, or delete your data at any time through the Aurboda interface, REST API, or
+          MCP tools. Contact your server administrator for account deletion.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          For questions about this policy, contact the project maintainer via{' '}
+          <a href="https://www.reddit.com/user/fiddur/" target="_blank" rel="noopener noreferrer">
+            reddit
+          </a>{' '}
+          or through{' '}
+          <a href="https://github.com/fiddur/aurboda" target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>
+          .
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Terms/index.tsx
+++ b/apps/web/src/pages/Terms/index.tsx
@@ -1,0 +1,91 @@
+import '../Home/style.css'
+
+export function Terms() {
+  return (
+    <div class="home">
+      <h1>Terms of Service</h1>
+      <p>
+        <em>Last updated: 2026-03-24</em>
+      </p>
+
+      <section>
+        <h2>Acceptance</h2>
+        <p>
+          By using Aurboda, you agree to these terms. Aurboda is provided as open-source software under the{' '}
+          <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">
+            GNU AGPL-3.0 license
+          </a>
+          .
+        </p>
+      </section>
+
+      <section>
+        <h2>Access</h2>
+        <p>
+          Aurboda does not offer public registration. Access to any hosted instance is by invitation only.
+          Self-hosting is available to anyone under the terms of the AGPL-3.0 license.
+        </p>
+      </section>
+
+      <section>
+        <h2>Your Data</h2>
+        <p>
+          You retain ownership of all data you store in Aurboda. The service aggregates data from sources you
+          explicitly connect and does not claim any rights to your data. See our{' '}
+          <a href="/privacy">Privacy Policy</a> for details on how data is handled.
+        </p>
+      </section>
+
+      <section>
+        <h2>Third-Party Services</h2>
+        <p>
+          Aurboda connects to third-party APIs (Oura, Garmin, RescueTime, Last.fm, etc.) on your behalf to
+          fetch your data. Your use of those services is governed by their respective terms and privacy
+          policies. Aurboda only reads data from these services — it does not write to or modify your data on
+          third-party platforms.
+        </p>
+      </section>
+
+      <section>
+        <h2>Disclaimer</h2>
+        <p>
+          Aurboda is provided "as is" without warranty of any kind. It is not a medical device and should not
+          be used for medical diagnosis or treatment decisions. The visualizations, correlations, and AI
+          insights are for informational purposes only.
+        </p>
+      </section>
+
+      <section>
+        <h2>Limitation of Liability</h2>
+        <p>
+          The maintainers and contributors of Aurboda are not liable for any damages arising from your use of
+          the software, including but not limited to data loss, service interruptions, or decisions made based
+          on information provided by the platform.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes</h2>
+        <p>
+          These terms may be updated from time to time. Continued use of the service constitutes acceptance of
+          the updated terms.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          For questions about these terms, contact the project maintainer via{' '}
+          <a href="https://www.reddit.com/user/fiddur/" target="_blank" rel="noopener noreferrer">
+            reddit
+          </a>{' '}
+          or through{' '}
+          <a href="https://github.com/fiddur/aurboda" target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>
+          .
+        </p>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Updated data sources list on welcome page to match README (added Garmin, ActivityWatch, Last.fm, Calendars, Manual Entry) — now uses a table layout
- Added a features section listing all current features
- Screenshots are now small thumbnails that open full-size when clicked
- Added Privacy Policy and Terms of Service pages at `/privacy` and `/terms` (needed for API client registrations, e.g. Oura)
- Added privacy/terms links to the site footer

## Test plan
- [ ] Visit aurboda.net as a logged-out user, verify updated welcome page
- [ ] Verify data sources table matches README
- [ ] Click screenshots to confirm they open full-size in new tab
- [ ] Navigate to /privacy and /terms, verify content
- [ ] Check footer links work on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)