### PR TITLE
Use idempotent PUT for meal creation

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -178,6 +178,7 @@ export {
   getMealLogCompleted,
   getMeals,
   insertMeal,
+  upsertMeal,
   setMealLogCompleted,
   unsetMealLogCompleted,
   updateMeal,

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -34,8 +34,7 @@ export interface InsertMealInput {
  * This makes the operation idempotent — retries with the same ID are safe.
  */
 export const upsertMeal = async (user: string, input: InsertMealInput): Promise<Meal> => {
-  const params = [
-    input.id ?? null,
+  const commonParams = [
     input.source ?? 'manual',
     input.meal_type ?? null,
     input.name ?? null,
@@ -51,21 +50,27 @@ export const upsertMeal = async (user: string, input: InsertMealInput): Promise<
     input.sensitivities ?? null,
   ]
 
-  const sql = input.id
-    ? `INSERT INTO meals (id, source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-       ON CONFLICT (id) DO UPDATE SET
-         source = EXCLUDED.source, meal_type = EXCLUDED.meal_type, name = EXCLUDED.name,
-         time = EXCLUDED.time, calories = EXCLUDED.calories, protein = EXCLUDED.protein,
-         carbs = EXCLUDED.carbs, fat = EXCLUDED.fat, fiber = EXCLUDED.fiber,
-         food_items = EXCLUDED.food_items, micros = EXCLUDED.micros,
-         notes = EXCLUDED.notes, sensitivities = EXCLUDED.sensitivities
-       RETURNING ${MEAL_COLUMNS}`
-    : `INSERT INTO meals (source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
-       VALUES ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-       RETURNING ${MEAL_COLUMNS}`
-
-  const result = await query(user, sql, params)
+  const result = input.id
+    ? await query(
+        user,
+        `INSERT INTO meals (id, source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+         ON CONFLICT (id) DO UPDATE SET
+           source = EXCLUDED.source, meal_type = EXCLUDED.meal_type, name = EXCLUDED.name,
+           time = EXCLUDED.time, calories = EXCLUDED.calories, protein = EXCLUDED.protein,
+           carbs = EXCLUDED.carbs, fat = EXCLUDED.fat, fiber = EXCLUDED.fiber,
+           food_items = EXCLUDED.food_items, micros = EXCLUDED.micros,
+           notes = EXCLUDED.notes, sensitivities = EXCLUDED.sensitivities
+         RETURNING ${MEAL_COLUMNS}`,
+        [input.id, ...commonParams],
+      )
+    : await query(
+        user,
+        `INSERT INTO meals (source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         RETURNING ${MEAL_COLUMNS}`,
+        commonParams,
+      )
   return mapMealRow(result.rows[0])
 }
 

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -12,6 +12,7 @@ const MEAL_COLUMNS =
   'id, source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities, created_at'
 
 export interface InsertMealInput {
+  id?: string
   source?: string
   meal_type?: string
   name?: string
@@ -28,33 +29,48 @@ export interface InsertMealInput {
 }
 
 /**
- * Insert a meal record.
+ * Upsert a meal record.
+ * If `id` is provided, inserts with that ID or updates on conflict.
+ * This makes the operation idempotent — retries with the same ID are safe.
  */
-export const insertMeal = async (user: string, input: InsertMealInput): Promise<Meal> => {
-  const result = await query(
-    user,
-    `INSERT INTO meals (source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-     RETURNING ${MEAL_COLUMNS}`,
-    [
-      input.source ?? 'manual',
-      input.meal_type ?? null,
-      input.name ?? null,
-      input.time,
-      input.calories ?? null,
-      input.protein ?? null,
-      input.carbs ?? null,
-      input.fat ?? null,
-      input.fiber ?? null,
-      input.food_items ? JSON.stringify(input.food_items) : null,
-      input.micros ? JSON.stringify(input.micros) : null,
-      input.notes ?? null,
-      input.sensitivities ?? null,
-    ],
-  )
+export const upsertMeal = async (user: string, input: InsertMealInput): Promise<Meal> => {
+  const params = [
+    input.id ?? null,
+    input.source ?? 'manual',
+    input.meal_type ?? null,
+    input.name ?? null,
+    input.time,
+    input.calories ?? null,
+    input.protein ?? null,
+    input.carbs ?? null,
+    input.fat ?? null,
+    input.fiber ?? null,
+    input.food_items ? JSON.stringify(input.food_items) : null,
+    input.micros ? JSON.stringify(input.micros) : null,
+    input.notes ?? null,
+    input.sensitivities ?? null,
+  ]
 
+  const sql = input.id
+    ? `INSERT INTO meals (id, source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+       ON CONFLICT (id) DO UPDATE SET
+         source = EXCLUDED.source, meal_type = EXCLUDED.meal_type, name = EXCLUDED.name,
+         time = EXCLUDED.time, calories = EXCLUDED.calories, protein = EXCLUDED.protein,
+         carbs = EXCLUDED.carbs, fat = EXCLUDED.fat, fiber = EXCLUDED.fiber,
+         food_items = EXCLUDED.food_items, micros = EXCLUDED.micros,
+         notes = EXCLUDED.notes, sensitivities = EXCLUDED.sensitivities
+       RETURNING ${MEAL_COLUMNS}`
+    : `INSERT INTO meals (source, meal_type, name, time, calories, protein, carbs, fat, fiber, food_items, micros, notes, sensitivities)
+       VALUES ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+       RETURNING ${MEAL_COLUMNS}`
+
+  const result = await query(user, sql, params)
   return mapMealRow(result.rows[0])
 }
+
+/** @deprecated Use upsertMeal instead. Kept for backwards compatibility. */
+export const insertMeal = upsertMeal
 
 /**
  * Get a single meal by ID.

--- a/apps/backend/src/mcp/meal-tools.ts
+++ b/apps/backend/src/mcp/meal-tools.ts
@@ -16,21 +16,7 @@ export const registerMealTools = (server: McpServer, user: string) => {
     'Add a meal record with optional nutrition details. Supports food items, macros (calories, protein, carbs, fat, fiber), and micronutrients.',
     { ...addMealBodySchema.shape },
     async (params) => {
-      const result = await addMeal(user, {
-        calories: params.calories,
-        carbs: params.carbs,
-        fat: params.fat,
-        fiber: params.fiber,
-        food_items: params.food_items,
-        meal_type: params.meal_type,
-        micros: params.micros,
-        name: params.name,
-        notes: params.notes,
-        protein: params.protein,
-        sensitivities: params.sensitivities,
-        source: params.source,
-        time: params.time,
-      })
+      const result = await addMeal(user, { ...params })
       return jsonResponse(result)
     },
   )

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -4,7 +4,6 @@
  * Handles: /meals/*
  */
 import {
-  type AddMealBody,
   addMealBodySchema,
   type DeleteMealResponse,
   type MealResponse,

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -80,37 +80,22 @@ export const createMealsRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ data: result.data, success: true })
   })
 
-  // POST /meals - Create a new meal
-  router.post<Record<string, never>, MealResponse, AddMealBody>(
-    '/',
-    authMiddleware,
-    validateBody(addMealBodySchema),
-    async (req, res) => {
-      const user = req.user!
+  // PUT /meals - Upsert a meal (idempotent — client provides ID)
+  // POST /meals - Create a meal (backwards-compatible, server generates ID)
+  const handleUpsertMeal: RequestHandler = async (req, res) => {
+    const user = req.user!
+    const result = await addMeal(user, { ...req.body })
 
-      const result = await addMeal(user, {
-        calories: req.body.calories,
-        carbs: req.body.carbs,
-        fat: req.body.fat,
-        fiber: req.body.fiber,
-        food_items: req.body.food_items,
-        meal_type: req.body.meal_type,
-        micros: req.body.micros,
-        name: req.body.name,
-        notes: req.body.notes,
-        protein: req.body.protein,
-        sensitivities: req.body.sensitivities,
-        source: req.body.source,
-        time: req.body.time,
-      })
+    if (!result.success) {
+      return res.status(400).json({ error: result.error, success: false })
+    }
 
-      if (!result.success) {
-        return res.status(400).json({ error: result.error, success: false })
-      }
+    res.json({ data: result.data, success: true })
+  }
 
-      res.json({ data: result.data, success: true })
-    },
-  )
+  const upsertMiddleware = [authMiddleware, validateBody(addMealBodySchema), handleUpsertMeal]
+  router.put('/', ...upsertMiddleware)
+  router.post('/', ...upsertMiddleware)
 
   // PATCH /meals/:id - Update a meal
   router.patch<{ id: string }, MealResponse, UpdateMealBody>(

--- a/apps/backend/src/services/meals.test.ts
+++ b/apps/backend/src/services/meals.test.ts
@@ -8,11 +8,11 @@ vi.mock('../db', () => ({
   deleteMeal: vi.fn(),
   getMealById: vi.fn(),
   getMeals: vi.fn(),
-  insertMeal: vi.fn(),
+  upsertMeal: vi.fn(),
   updateMeal: vi.fn(),
 }))
 
-const mockInsertMeal = vi.mocked(db.insertMeal)
+const mockUpsertMeal = vi.mocked(db.upsertMeal)
 const mockGetMealById = vi.mocked(db.getMealById)
 const mockGetMeals = vi.mocked(db.getMeals)
 const mockDeleteMeal = vi.mocked(db.deleteMeal)
@@ -44,7 +44,7 @@ describe('addMeal', () => {
       time: new Date('2025-06-15T08:00:00Z'),
     }
 
-    mockInsertMeal.mockResolvedValue(mockMeal)
+    mockUpsertMeal.mockResolvedValue(mockMeal)
 
     const result = await addMeal('testuser', {
       calories: 650,
@@ -73,7 +73,7 @@ describe('addMeal', () => {
   })
 
   test('creates a meal with sensitivities', async () => {
-    mockInsertMeal.mockResolvedValue({
+    mockUpsertMeal.mockResolvedValue({
       created_at: new Date('2025-06-15T10:00:00Z'),
       id: 'meal-3',
       meal_type: 'dinner',
@@ -90,14 +90,14 @@ describe('addMeal', () => {
 
     expect(result.success).toBe(true)
     expect(result.data!.sensitivities).toEqual(['gluten', 'dairy'])
-    expect(mockInsertMeal).toHaveBeenCalledWith(
+    expect(mockUpsertMeal).toHaveBeenCalledWith(
       'testuser',
       expect.objectContaining({ sensitivities: ['gluten', 'dairy'] }),
     )
   })
 
   test('creates a meal with minimal fields', async () => {
-    mockInsertMeal.mockResolvedValue({
+    mockUpsertMeal.mockResolvedValue({
       created_at: new Date('2025-06-15T10:00:00Z'),
       id: 'meal-2',
       source: 'manual',

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -8,7 +8,7 @@ import {
   deleteMeal as dbDeleteMeal,
   getMealById as dbGetMealById,
   getMeals as dbGetMeals,
-  insertMeal as dbInsertMeal,
+  upsertMeal as dbUpsertMeal,
   updateMeal as dbUpdateMeal,
   type Meal,
   type MealFoodItem,
@@ -30,6 +30,7 @@ interface FoodItemInput {
 }
 
 export interface AddMealInput {
+  id?: string
   time: string // ISO 8601
   meal_type?: string
   name?: string
@@ -122,7 +123,8 @@ const formatMeal = (meal: Meal): MealResponse => ({
 export async function addMeal(user: string, input: AddMealInput): Promise<MealResult> {
   const mealTime = new Date(input.time)
 
-  const meal = await dbInsertMeal(user, {
+  const meal = await dbUpsertMeal(user, {
+    id: input.id,
     calories: input.calories,
     carbs: input.carbs,
     fat: input.fat,

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { endOfDay, format, formatISO, startOfDay } from 'date-fns'
-import { useCallback, useRef, useState } from 'preact/hooks'
+import { useCallback, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { DateNav } from '../../components/DateNav'
@@ -198,9 +198,6 @@ export function Meals() {
   const queryClient = useQueryClient()
 
   const [dayKey, setDayKey] = useState(() => formatISO(new Date(), { representation: 'date' }))
-  // Track slots with in-flight creation to prevent duplicates
-  const pendingCreates = useRef(new Set<string>())
-  // Track which slots have active mutations for the spinner
   const [savingSlots, setSavingSlots] = useState(new Set<string>())
 
   const { data: settings } = useQuery({
@@ -252,18 +249,11 @@ export function Meals() {
 
   const invalidateMeals = () => queryClient.invalidateQueries({ queryKey: ['meals'] })
 
-  const addMutation = useMutation({
+  // PUT is idempotent — safe to retry, no duplicate risk
+  const upsertMutation = useMutation({
     mutationFn: addMealApi,
-    onSuccess: (newMeal) => {
-      pendingCreates.current.delete(newMeal.meal_type ?? '')
-      // Replace the optimistic placeholder with the real meal
-      optimisticUpdate((old) => old.map((m) => (m.id === `pending-${newMeal.meal_type}` ? newMeal : m)))
-      invalidateMeals()
-    },
-    onError: (_err, variables) => {
-      const slotName = variables.meal_type ?? ''
-      pendingCreates.current.delete(slotName)
-      markSlotSaving(slotName, false)
+    onSettled: (_data, _err, variables) => {
+      if (variables.meal_type) markSlotSaving(variables.meal_type, false)
       invalidateMeals()
     },
   })
@@ -272,7 +262,6 @@ export function Meals() {
     mutationFn: ({ id, ...body }: { id: string; sensitivities?: string[]; time?: string }) =>
       updateMealApi(id, body),
     onSettled: (_data, _err, variables) => {
-      // Find the meal's slot to clear saving indicator
       const meal = (meals ?? []).find((m) => m.id === variables.id)
       if (meal?.meal_type) markSlotSaving(meal.meal_type, false)
       invalidateMeals()
@@ -291,38 +280,21 @@ export function Meals() {
     markSlotSaving(slotName, true)
 
     if (existingMeal) {
-      // Update existing meal optimistically
       const current = existingMeal.sensitivities ?? []
       const next = current.includes(area) ? current.filter((s) => s !== area) : [...current, area]
       optimisticUpdate((old) =>
         old.map((m) => (m.id === existingMeal.id ? { ...m, sensitivities: next } : m)),
       )
       updateMutation.mutate({ id: existingMeal.id!, sensitivities: next })
-    } else if (pendingCreates.current.has(slotName)) {
-      // A create is already in flight for this slot — update the optimistic placeholder
-      optimisticUpdate((old) =>
-        old.map((m) => {
-          if (m.id !== `pending-${slotName}`) return m
-          const current = m.sensitivities ?? []
-          const next = current.includes(area) ? current.filter((s) => s !== area) : [...current, area]
-          return { ...m, sensitivities: next }
-        }),
-      )
-      // The real meal will arrive from addMutation.onSuccess and we'll reconcile
     } else {
-      // Create new meal — add optimistic placeholder and guard against duplicates
-      pendingCreates.current.add(slotName)
+      // Create new meal with client-generated UUID — PUT is idempotent
+      const id = crypto.randomUUID()
       const mealTime = new Date(selectedDate)
       mealTime.setHours(slot.default_hour, 0, 0, 0)
-      const placeholder: Meal = {
-        id: `pending-${slotName}`,
-        meal_type: slotName,
-        sensitivities: [area],
-        source: 'manual',
-        time: mealTime,
-      }
+      const placeholder: Meal = { id, meal_type: slotName, sensitivities: [area], source: 'manual', time: mealTime }
       optimisticUpdate((old) => [...old, placeholder])
-      addMutation.mutate({
+      upsertMutation.mutate({
+        id,
         meal_type: slotName,
         sensitivities: [area],
         source: 'manual',
@@ -399,7 +371,7 @@ export function Meals() {
             </label>
           </div>
 
-          {(addMutation.isError || updateMutation.isError) && (
+          {(upsertMutation.isError || updateMutation.isError) && (
             <p class="error-message">Something went wrong. Please try again.</p>
           )}
         </>

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1550,7 +1550,8 @@ export const fetchMeals = async (params?: MealsQuery): Promise<Meal[]> => {
 
 export const addMealApi = async (body: AddMealBody): Promise<Meal> => {
   const { token } = auth.value
-  const response = await axios.post<MealResponse>(`${API_URL}/meals`, body, {
+  const payload = { ...body, id: body.id ?? crypto.randomUUID() }
+  const response = await axios.put<MealResponse>(`${API_URL}/meals`, payload, {
     headers: { Authorization: `Bearer ${token}` },
   })
   return mapMeal(response.data.data!)

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -108,6 +108,11 @@ export type Meal = z.infer<typeof mealSchema>
  */
 export const addMealBodySchema = z
   .object({
+    id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'Client-generated meal ID (enables idempotent PUT)' }),
     calories: z.number().optional().meta({ description: 'Total energy in kcal' }),
     carbs: z.number().optional().meta({ description: 'Total carbohydrates in grams' }),
     fat: z.number().optional().meta({ description: 'Total fat in grams' }),


### PR DESCRIPTION
## Summary

- **PUT /meals** with client-generated UUID — inherently idempotent, retries/duplicates are safe at the protocol level
- DB `upsertMeal` does `INSERT ... ON CONFLICT (id) DO UPDATE`
- Frontend generates UUID via `crypto.randomUUID()` before sending — optimistic placeholder uses the real ID immediately
- Removes the `pendingCreates` workaround since PUT handles dedup natively
- POST /meals kept for backwards compatibility (MCP, other clients)

## Test plan

- [ ] Check a sensitivity on a new slot — creates one meal (no duplicates even on rapid clicks)
- [ ] Toggle sensitivities on existing meal — updates in place
- [ ] MCP add_meal still works (uses POST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)