### PR TITLE
Clickable food items with sensitivity mapping and Today button

### DIFF
--- a/apps/web/src/components/DateNav.css
+++ b/apps/web/src/components/DateNav.css
@@ -26,6 +26,13 @@
   cursor: not-allowed;
 }
 
+.nav-today {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  color: #673ab8;
+  border-color: #c4b5fd;
+}
+
 .nav-date-label {
   font-size: 0.9rem;
   font-weight: 500;

--- a/apps/web/src/components/DateNav.tsx
+++ b/apps/web/src/components/DateNav.tsx
@@ -113,6 +113,16 @@ export function DateNav({
       >
         {'>>'}
       </button>
+      {!isToday && (
+        <button
+          type="button"
+          class="nav-btn nav-today"
+          onClick={() => onChange(todayStr())}
+          title="Jump to today"
+        >
+          Today
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { endOfDay, format, formatISO, startOfDay } from 'date-fns'
 import { useLocation } from 'preact-iso'
-import { useCallback, useState } from 'preact/hooks'
+import { useCallback, useRef, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { DateNav } from '../../components/DateNav'
@@ -15,6 +15,7 @@ import {
   setMealLogCompletedApi,
   unsetMealLogCompletedApi,
   updateMealApi,
+  updateUserSettings,
 } from '../../state/api'
 import { auth } from '../../state/auth'
 import './style.css'
@@ -39,7 +40,57 @@ const formatMealType = (type?: string): string =>
 const findMealsForSlot = (meals: Meal[], slotName: string): Meal[] =>
   meals.filter((m) => m.meal_type === slotName.toLowerCase())
 
-function MealDetails({ meal }: { meal: Meal }) {
+/** A clickable food item chip with popover for sensitivity mapping. */
+function FoodItemChip({
+  name,
+  mappedSensitivities,
+  sensitivityAreas,
+  onToggle,
+}: {
+  name: string
+  mappedSensitivities: string[]
+  sensitivityAreas: string[]
+  onToggle: (foodItem: string, area: string, checked: boolean) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLSpanElement>(null)
+
+  const hasMappings = mappedSensitivities.length > 0
+
+  return (
+    <span ref={ref} class={`food-item-chip ${hasMappings ? 'mapped' : ''}`} onClick={() => setOpen(!open)}>
+      {name}
+      {hasMappings && <span class="mapping-dot" />}
+      {open && sensitivityAreas.length > 0 && (
+        <div class="food-map-popover" onClick={(e) => e.stopPropagation()}>
+          <div class="popover-title">Sensitivities for "{name}"</div>
+          {sensitivityAreas.map((area) => (
+            <label key={area} class="popover-option">
+              <input
+                type="checkbox"
+                checked={mappedSensitivities.includes(area)}
+                onChange={(e) => onToggle(name, area, (e.target as HTMLInputElement).checked)}
+              />
+              {area}
+            </label>
+          ))}
+        </div>
+      )}
+    </span>
+  )
+}
+
+function MealDetails({
+  meal,
+  foodSensitivityMap,
+  sensitivityAreas,
+  onToggleFoodMapping,
+}: {
+  meal: Meal
+  foodSensitivityMap: Record<string, string[]>
+  sensitivityAreas: string[]
+  onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
+}) {
   const hasFoodItems = meal.food_items && meal.food_items.length > 0
   const hasSensitivities = meal.sensitivities && meal.sensitivities.length > 0
   const hasCalories = meal.calories !== undefined
@@ -52,9 +103,13 @@ function MealDetails({ meal }: { meal: Meal }) {
       {hasFoodItems && (
         <div class="food-items">
           {meal.food_items!.map((item, i) => (
-            <span key={i} class="food-item-chip">
-              {item.name}
-            </span>
+            <FoodItemChip
+              key={i}
+              name={item.name}
+              mappedSensitivities={foodSensitivityMap[item.name] ?? []}
+              sensitivityAreas={sensitivityAreas}
+              onToggle={onToggleFoodMapping}
+            />
           ))}
         </div>
       )}
@@ -78,7 +133,9 @@ interface MealSlotRowProps {
   slot: MealSlot
   meals: Meal[]
   sensitivityAreas: string[]
+  foodSensitivityMap: Record<string, string[]>
   onToggleSensitivity: (slot: MealSlot, area: string, existingMeal?: Meal) => void
+  onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
   onChangeHour: (meal: Meal, hour: number) => void
   onDelete: (id: string) => void
   isDeletePending: boolean
@@ -89,7 +146,9 @@ function MealSlotRow({
   slot,
   meals: slotMeals,
   sensitivityAreas,
+  foodSensitivityMap,
   onToggleSensitivity,
+  onToggleFoodMapping,
   onChangeHour,
   onDelete,
   isDeletePending,
@@ -154,7 +213,13 @@ function MealSlotRow({
       )}
 
       {slotMeals.map((meal) => (
-        <MealDetails key={meal.id} meal={meal} />
+        <MealDetails
+          key={meal.id}
+          meal={meal}
+          foodSensitivityMap={foodSensitivityMap}
+          sensitivityAreas={sensitivityAreas}
+          onToggleFoodMapping={onToggleFoodMapping}
+        />
       ))}
     </div>
   )
@@ -164,10 +229,16 @@ function OtherMeals({
   meals,
   onDelete,
   isDeletePending,
+  foodSensitivityMap,
+  sensitivityAreas,
+  onToggleFoodMapping,
 }: {
   meals: Meal[]
   onDelete: (id: string) => void
   isDeletePending: boolean
+  foodSensitivityMap: Record<string, string[]>
+  sensitivityAreas: string[]
+  onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
 }) {
   if (meals.length === 0) return null
   return (
@@ -187,7 +258,12 @@ function OtherMeals({
               buttonClass="btn-danger-small"
             />
           </div>
-          <MealDetails meal={meal} />
+          <MealDetails
+            meal={meal}
+            foodSensitivityMap={foodSensitivityMap}
+            sensitivityAreas={sensitivityAreas}
+            onToggleFoodMapping={onToggleFoodMapping}
+          />
         </div>
       ))}
     </div>
@@ -354,6 +430,25 @@ function MealsContent({ dayKey }: { dayKey: string }) {
   } = useMealMutations(mealsQueryKey, meals)
 
   const otherMeals = getOtherMeals(meals ?? [], mealSlots)
+  const foodSensitivityMap: Record<string, string[]> = settings?.food_sensitivity_map ?? {}
+  const queryClient = useQueryClient()
+
+  const foodMapMutation = useMutation({
+    mutationFn: (newMap: Record<string, string[]>) => updateUserSettings({ food_sensitivity_map: newMap }),
+    onSuccess: (result) => queryClient.setQueryData(['userSettings'], result),
+  })
+
+  const handleToggleFoodMapping = (foodItem: string, area: string, checked: boolean) => {
+    const current = foodSensitivityMap[foodItem] ?? []
+    const next = checked ? [...current, area] : current.filter((s) => s !== area)
+    const newMap = { ...foodSensitivityMap, [foodItem]: next.length > 0 ? next : undefined }
+    // Clean up entries with empty arrays
+    const cleaned = Object.fromEntries(Object.entries(newMap).filter(([, v]) => v && v.length > 0)) as Record<
+      string,
+      string[]
+    >
+    foodMapMutation.mutate(cleaned)
+  }
 
   if (!isLoggedIn) return <p>Please log in to use meal tracking.</p>
   if (isLoading) return <p class="loading">Loading...</p>
@@ -375,7 +470,9 @@ function MealsContent({ dayKey }: { dayKey: string }) {
             slot={slot}
             meals={findMealsForSlot(meals ?? [], slot.name)}
             sensitivityAreas={sensitivityAreas}
+            foodSensitivityMap={foodSensitivityMap}
             onToggleSensitivity={handleToggleSensitivity}
+            onToggleFoodMapping={handleToggleFoodMapping}
             onChangeHour={handleChangeHour}
             onDelete={(id) => deleteMutation.mutate(id)}
             isDeletePending={deleteMutation.isPending}
@@ -388,6 +485,9 @@ function MealsContent({ dayKey }: { dayKey: string }) {
         meals={otherMeals}
         onDelete={(id) => deleteMutation.mutate(id)}
         isDeletePending={deleteMutation.isPending}
+        foodSensitivityMap={foodSensitivityMap}
+        sensitivityAreas={sensitivityAreas}
+        onToggleFoodMapping={handleToggleFoodMapping}
       />
 
       <div class="log-completion">

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -186,9 +186,67 @@
   display: inline-block;
   padding: 0.125rem 0.5rem;
   font-size: 0.75rem;
-  background: #f3f4f6;
-  color: #4b5563;
+  background: #e0f2fe;
+  color: #0369a1;
+  cursor: pointer;
+  position: relative;
   border-radius: 10px;
+}
+
+.food-item-chip:hover {
+  background: #bae6fd;
+}
+
+.food-item-chip.mapped {
+  background: #dbeafe;
+  border: 1px solid #93c5fd;
+}
+
+.mapping-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: #673ab8;
+  border-radius: 50%;
+  margin-left: 0.25rem;
+  vertical-align: middle;
+}
+
+/* Food sensitivity mapping popover */
+
+.food-map-popover {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  margin-top: 0.25rem;
+  padding: 0.5rem;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-width: 180px;
+}
+
+.popover-title {
+  font-size: 0.7rem;
+  color: #6b7280;
+  margin-bottom: 0.375rem;
+  white-space: nowrap;
+}
+
+.popover-option {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.2rem 0;
+  font-size: 0.8rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+.popover-option input[type='checkbox'] {
+  accent-color: #673ab8;
 }
 
 .meal-sensitivities {
@@ -347,7 +405,29 @@
   }
 
   .food-item-chip {
-    background: #374151;
+    background: #1e3a5f;
+    color: #7dd3fc;
+  }
+
+  .food-item-chip:hover {
+    background: #1e4d8c;
+  }
+
+  .food-item-chip.mapped {
+    background: #1e3a5f;
+    border-color: #3b82f6;
+  }
+
+  .food-map-popover {
+    background: #1f2937;
+    border-color: #4b5563;
+  }
+
+  .popover-title {
+    color: #9ca3af;
+  }
+
+  .popover-option {
     color: #d1d5db;
   }
 


### PR DESCRIPTION
## Summary

- **Clickable food item chips** — click any food item (e.g., "Butter", "Toasted rye bread") to open a popover with sensitivity area checkboxes. Checking "Gluten" for "Rye bread" saves to `food_sensitivity_map` in user settings.
- **Visual distinction** — food items are blue (#e0f2fe), sensitivities stay purple (#ede9f0). Mapped food items show a purple dot indicator.
- **"Today" button** on DateNav — appears when not viewing today, for quick jump back.
- Dark mode support for all new elements.

## Test plan

- [ ] Navigate to a date with Oura meals (e.g., 2025-03-25)
- [ ] Click a food item chip — popover opens with sensitivity checkboxes
- [ ] Check a sensitivity — saves immediately, dot indicator appears
- [ ] Navigate to another day with the same food item — mapping persists
- [ ] Click "Today" button to jump back
- [ ] Visual: food items are blue, sensitivities are purple

🤖 Generated with [Claude Code](https://claude.com/claude-code)