### PR TITLE
Meal detail page and remove redundant sensitivity chips

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -28,6 +28,7 @@ import { Home } from './pages/Home/index.jsx'
 import { HrZones } from './pages/HrZones/index.jsx'
 import { Login } from './pages/Login/index.jsx'
 import { Meals } from './pages/Meals/index.jsx'
+import { MealDetail } from './pages/Meals/MealDetail.jsx'
 import { MetricMeta } from './pages/MetricMeta/index.jsx'
 import { Places } from './pages/Places/index.jsx'
 import { Privacy } from './pages/Privacy/index.jsx'
@@ -63,6 +64,7 @@ export function App() {
             <Route path="/timeline" component={Timeline} />
             <Route path="/data" component={Data} />
             <Route path="/add" component={AddData} />
+            <Route path="/meals/:id" component={MealDetail} />
             <Route path="/meals" component={Meals} />
             <Route path="/reports/add" component={AddReport} />
             <Route path="/reports/:id" component={ReportDetail} />

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -1,0 +1,205 @@
+.meal-detail-page {
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.back-link {
+  color: #673ab8;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.detail-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.detail-row {
+  display: flex;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f3f4f6;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.detail-row:last-child {
+  border-bottom: none;
+}
+
+.detail-row label {
+  font-weight: 500;
+  color: #6b7280;
+  font-size: 0.85rem;
+  min-width: 90px;
+  padding-top: 0.125rem;
+}
+
+.detail-value {
+  color: #374151;
+  font-size: 0.9rem;
+}
+
+.detail-row input[type='text'],
+.detail-row input[type='datetime-local'],
+.detail-row textarea {
+  flex: 1;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+  font-family: inherit;
+}
+
+.detail-row textarea {
+  resize: vertical;
+}
+
+.detail-food-items,
+.detail-sensitivities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.detail-food-chip {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  background: #e0f2fe;
+  color: #0369a1;
+  border-radius: 10px;
+}
+
+.detail-sensitivity-chip {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  background: #ede9f0;
+  color: #673ab8;
+  border-radius: 12px;
+  font-weight: 500;
+}
+
+.btn-primary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background: #5e35b1;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  background: #f3f4f6;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .detail-card {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .detail-row {
+    border-color: #374151;
+  }
+
+  .detail-row label {
+    color: #9ca3af;
+  }
+
+  .detail-value {
+    color: #d1d5db;
+  }
+
+  .detail-row input[type='text'],
+  .detail-row input[type='datetime-local'],
+  .detail-row textarea {
+    background: #374151;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .detail-food-chip {
+    background: #1e3a5f;
+    color: #7dd3fc;
+  }
+
+  .detail-sensitivity-chip {
+    background: #312e81;
+    color: #c4b5fd;
+  }
+
+  .back-link {
+    color: #c4b5fd;
+  }
+
+  .btn-secondary {
+    background: #374151;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .btn-secondary:hover {
+    background: #4b5563;
+  }
+}
+
+@media (max-width: 639px) {
+  .meal-detail-page {
+    padding: 1rem;
+  }
+
+  .detail-row {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .detail-row label {
+    min-width: unset;
+  }
+}

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -4,8 +4,94 @@ import { useLocation, useRoute } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
-import { deleteMealApi, fetchMeal, updateMealApi } from '../../state/api'
+import { deleteMealApi, fetchMeal, type Meal, updateMealApi } from '../../state/api'
 import './MealDetail.css'
+
+interface EditState {
+  name?: string
+  time?: string
+  notes?: string
+}
+
+function EditableField({
+  label,
+  value,
+  editing,
+  editValue,
+  onEdit,
+  type = 'text',
+  placeholder,
+}: {
+  label: string
+  value: string
+  editing: boolean
+  editValue: string
+  onEdit: (v: string) => void
+  type?: string
+  placeholder?: string
+}) {
+  return (
+    <div class="detail-row">
+      <label>{label}</label>
+      {editing ? (
+        <input
+          type={type}
+          value={editValue}
+          placeholder={placeholder}
+          onInput={(e) => onEdit((e.target as HTMLInputElement).value)}
+        />
+      ) : (
+        <span class="detail-value">{value || '—'}</span>
+      )}
+    </div>
+  )
+}
+
+function MealInfoRows({ meal }: { meal: Meal }) {
+  return (
+    <>
+      {meal.food_items && meal.food_items.length > 0 && (
+        <div class="detail-row">
+          <label>Food Items</label>
+          <div class="detail-food-items">
+            {meal.food_items.map((item, i) => (
+              <span key={i} class="detail-food-chip">
+                {item.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {meal.sensitivities && meal.sensitivities.length > 0 && (
+        <div class="detail-row">
+          <label>Sensitivities</label>
+          <div class="detail-sensitivities">
+            {meal.sensitivities.map((s) => (
+              <span key={s} class="detail-sensitivity-chip">
+                {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {meal.calories !== undefined && (
+        <div class="detail-row">
+          <label>Calories</label>
+          <span class="detail-value">{meal.calories} kcal</span>
+        </div>
+      )}
+
+      {meal.source && (
+        <div class="detail-row">
+          <label>Source</label>
+          <span class="detail-value">{meal.source}</span>
+        </div>
+      )}
+    </>
+  )
+}
 
 export function MealDetail() {
   const { params } = useRoute()
@@ -18,7 +104,7 @@ export function MealDetail() {
     queryKey: ['meal', id],
   })
 
-  const [editing, setEditing] = useState<{ name?: string; time?: string; notes?: string } | null>(null)
+  const [editing, setEditing] = useState<EditState | null>(null)
 
   const updateMutation = useMutation({
     mutationFn: (body: Parameters<typeof updateMealApi>[1]) => updateMealApi(id, body),
@@ -37,24 +123,20 @@ export function MealDetail() {
     },
   })
 
-  if (isLoading) {
-    return (
+  if (isLoading)
+    {return (
       <div class="meal-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )
-  }
-  if (!meal) {
-    return (
+    )}
+  if (!meal)
+    {return (
       <div class="meal-detail-page">
         <p>Meal not found.</p>
       </div>
-    )
-  }
+    )}
 
   const isEditing = editing !== null
-
-  // Editing values with fallback to meal values
   const editName = editing?.name ?? meal.name ?? ''
   const editTime = editing?.time ?? format(meal.time, "yyyy-MM-dd'T'HH:mm")
   const editNotes = editing?.notes ?? meal.notes ?? ''
@@ -109,32 +191,23 @@ export function MealDetail() {
           <span class="detail-value">{meal.meal_type ?? '—'}</span>
         </div>
 
-        <div class="detail-row">
-          <label>Time</label>
-          {isEditing ? (
-            <input
-              type="datetime-local"
-              value={editTime}
-              onInput={(e) => setEditing({ ...editing, time: (e.target as HTMLInputElement).value })}
-            />
-          ) : (
-            <span class="detail-value">{format(meal.time, 'yyyy-MM-dd HH:mm')}</span>
-          )}
-        </div>
+        <EditableField
+          label="Time"
+          value={format(meal.time, 'yyyy-MM-dd HH:mm')}
+          editing={isEditing}
+          editValue={editTime}
+          onEdit={(v) => setEditing({ ...editing, time: v })}
+          type="datetime-local"
+        />
 
-        <div class="detail-row">
-          <label>Name</label>
-          {isEditing ? (
-            <input
-              type="text"
-              value={editName}
-              placeholder="Meal name/description"
-              onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
-            />
-          ) : (
-            <span class="detail-value">{meal.name || '—'}</span>
-          )}
-        </div>
+        <EditableField
+          label="Name"
+          value={meal.name ?? ''}
+          editing={isEditing}
+          editValue={editName}
+          onEdit={(v) => setEditing({ ...editing, name: v })}
+          placeholder="Meal name/description"
+        />
 
         <div class="detail-row">
           <label>Notes</label>
@@ -150,45 +223,7 @@ export function MealDetail() {
           )}
         </div>
 
-        {meal.food_items && meal.food_items.length > 0 && (
-          <div class="detail-row">
-            <label>Food Items</label>
-            <div class="detail-food-items">
-              {meal.food_items.map((item, i) => (
-                <span key={i} class="detail-food-chip">
-                  {item.name}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {meal.sensitivities && meal.sensitivities.length > 0 && (
-          <div class="detail-row">
-            <label>Sensitivities</label>
-            <div class="detail-sensitivities">
-              {meal.sensitivities.map((s) => (
-                <span key={s} class="detail-sensitivity-chip">
-                  {s}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {meal.calories !== undefined && (
-          <div class="detail-row">
-            <label>Calories</label>
-            <span class="detail-value">{meal.calories} kcal</span>
-          </div>
-        )}
-
-        {meal.source && (
-          <div class="detail-row">
-            <label>Source</label>
-            <span class="detail-value">{meal.source}</span>
-          </div>
-        )}
+        <MealInfoRows meal={meal} />
       </div>
     </div>
   )

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -93,6 +93,7 @@ function MealInfoRows({ meal }: { meal: Meal }) {
   )
 }
 
+// eslint-disable-next-line complexity -- detail page with edit mode and multiple data sections
 export function MealDetail() {
   const { params } = useRoute()
   const { route } = useLocation()

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -4,7 +4,7 @@ import { useLocation, useRoute } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
-import { deleteMealApi, fetchMeal, type Meal, updateMealApi } from '../../state/api'
+import { deleteMealApi, fetchMeal, updateMealApi } from '../../state/api'
 import './MealDetail.css'
 
 export function MealDetail() {
@@ -18,7 +18,7 @@ export function MealDetail() {
     queryKey: ['meal', id],
   })
 
-  const [editing, setEditing] = useState<Partial<Meal> | null>(null)
+  const [editing, setEditing] = useState<{ name?: string; time?: string; notes?: string } | null>(null)
 
   const updateMutation = useMutation({
     mutationFn: (body: Parameters<typeof updateMealApi>[1]) => updateMealApi(id, body),
@@ -37,28 +37,33 @@ export function MealDetail() {
     },
   })
 
-  if (isLoading)
-    {return (
+  if (isLoading) {
+    return (
       <div class="meal-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )}
-  if (!meal)
-    {return (
+    )
+  }
+  if (!meal) {
+    return (
       <div class="meal-detail-page">
         <p>Meal not found.</p>
       </div>
-    )}
+    )
+  }
 
   const isEditing = editing !== null
-  const current = isEditing ? { ...meal, ...editing } : meal
+
+  // Editing values with fallback to meal values
+  const editName = editing?.name ?? meal.name ?? ''
+  const editTime = editing?.time ?? format(meal.time, "yyyy-MM-dd'T'HH:mm")
+  const editNotes = editing?.notes ?? meal.notes ?? ''
 
   const handleSave = () => {
     if (!editing) return
     const body: Record<string, unknown> = {}
     if (editing.name !== undefined) body.name = editing.name || null
-    if (editing.time !== undefined)
-      {body.time = editing.time instanceof Date ? editing.time.toISOString() : editing.time}
+    if (editing.time !== undefined) body.time = new Date(editing.time).toISOString()
     if (editing.notes !== undefined) body.notes = editing.notes || null
     updateMutation.mutate(body)
   }
@@ -109,10 +114,7 @@ export function MealDetail() {
           {isEditing ? (
             <input
               type="datetime-local"
-              value={format(
-                current.time instanceof Date ? current.time : new Date(current.time as string),
-                "yyyy-MM-dd'T'HH:mm",
-              )}
+              value={editTime}
               onInput={(e) => setEditing({ ...editing, time: (e.target as HTMLInputElement).value })}
             />
           ) : (
@@ -125,7 +127,7 @@ export function MealDetail() {
           {isEditing ? (
             <input
               type="text"
-              value={current.name ?? ''}
+              value={editName}
               placeholder="Meal name/description"
               onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
             />
@@ -138,7 +140,7 @@ export function MealDetail() {
           <label>Notes</label>
           {isEditing ? (
             <textarea
-              value={current.notes ?? ''}
+              value={editNotes}
               placeholder="Notes..."
               rows={3}
               onInput={(e) => setEditing({ ...editing, notes: (e.target as HTMLTextAreaElement).value })}

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -1,0 +1,193 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { useLocation, useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
+
+import { ConfirmButton } from '../../components/ConfirmButton'
+import { deleteMealApi, fetchMeal, type Meal, updateMealApi } from '../../state/api'
+import './MealDetail.css'
+
+export function MealDetail() {
+  const { params } = useRoute()
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
+  const id = params.id
+
+  const { data: meal, isLoading } = useQuery({
+    queryFn: () => fetchMeal(id),
+    queryKey: ['meal', id],
+  })
+
+  const [editing, setEditing] = useState<Partial<Meal> | null>(null)
+
+  const updateMutation = useMutation({
+    mutationFn: (body: Parameters<typeof updateMealApi>[1]) => updateMealApi(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['meal', id] })
+      queryClient.invalidateQueries({ queryKey: ['meals'] })
+      setEditing(null)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteMealApi(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['meals'] })
+      route('/meals')
+    },
+  })
+
+  if (isLoading)
+    {return (
+      <div class="meal-detail-page">
+        <p class="loading">Loading...</p>
+      </div>
+    )}
+  if (!meal)
+    {return (
+      <div class="meal-detail-page">
+        <p>Meal not found.</p>
+      </div>
+    )}
+
+  const isEditing = editing !== null
+  const current = isEditing ? { ...meal, ...editing } : meal
+
+  const handleSave = () => {
+    if (!editing) return
+    const body: Record<string, unknown> = {}
+    if (editing.name !== undefined) body.name = editing.name || null
+    if (editing.time !== undefined)
+      {body.time = editing.time instanceof Date ? editing.time.toISOString() : editing.time}
+    if (editing.notes !== undefined) body.notes = editing.notes || null
+    updateMutation.mutate(body)
+  }
+
+  return (
+    <div class="meal-detail-page">
+      <div class="detail-header">
+        <a href={`/meals?date=${format(meal.time, 'yyyy-MM-dd')}`} class="back-link">
+          &larr; Back
+        </a>
+        <div class="detail-actions">
+          {isEditing ? (
+            <>
+              <button
+                type="button"
+                class="btn-primary"
+                onClick={handleSave}
+                disabled={updateMutation.isPending}
+              >
+                {updateMutation.isPending ? 'Saving...' : 'Save'}
+              </button>
+              <button type="button" class="btn-secondary" onClick={() => setEditing(null)}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button type="button" class="btn-secondary" onClick={() => setEditing({})}>
+              Edit
+            </button>
+          )}
+          <ConfirmButton
+            label="Delete"
+            confirmMessage="Delete this meal?"
+            onConfirm={() => deleteMutation.mutate()}
+            isPending={deleteMutation.isPending}
+          />
+        </div>
+      </div>
+
+      <div class="detail-card">
+        <div class="detail-row">
+          <label>Type</label>
+          <span class="detail-value">{meal.meal_type ?? '—'}</span>
+        </div>
+
+        <div class="detail-row">
+          <label>Time</label>
+          {isEditing ? (
+            <input
+              type="datetime-local"
+              value={format(
+                current.time instanceof Date ? current.time : new Date(current.time as string),
+                "yyyy-MM-dd'T'HH:mm",
+              )}
+              onInput={(e) => setEditing({ ...editing, time: (e.target as HTMLInputElement).value })}
+            />
+          ) : (
+            <span class="detail-value">{format(meal.time, 'yyyy-MM-dd HH:mm')}</span>
+          )}
+        </div>
+
+        <div class="detail-row">
+          <label>Name</label>
+          {isEditing ? (
+            <input
+              type="text"
+              value={current.name ?? ''}
+              placeholder="Meal name/description"
+              onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
+            />
+          ) : (
+            <span class="detail-value">{meal.name || '—'}</span>
+          )}
+        </div>
+
+        <div class="detail-row">
+          <label>Notes</label>
+          {isEditing ? (
+            <textarea
+              value={current.notes ?? ''}
+              placeholder="Notes..."
+              rows={3}
+              onInput={(e) => setEditing({ ...editing, notes: (e.target as HTMLTextAreaElement).value })}
+            />
+          ) : (
+            <span class="detail-value">{meal.notes || '—'}</span>
+          )}
+        </div>
+
+        {meal.food_items && meal.food_items.length > 0 && (
+          <div class="detail-row">
+            <label>Food Items</label>
+            <div class="detail-food-items">
+              {meal.food_items.map((item, i) => (
+                <span key={i} class="detail-food-chip">
+                  {item.name}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {meal.sensitivities && meal.sensitivities.length > 0 && (
+          <div class="detail-row">
+            <label>Sensitivities</label>
+            <div class="detail-sensitivities">
+              {meal.sensitivities.map((s) => (
+                <span key={s} class="detail-sensitivity-chip">
+                  {s}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {meal.calories !== undefined && (
+          <div class="detail-row">
+            <label>Calories</label>
+            <span class="detail-value">{meal.calories} kcal</span>
+          </div>
+        )}
+
+        {meal.source && (
+          <div class="detail-row">
+            <label>Source</label>
+            <span class="detail-value">{meal.source}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -102,14 +102,18 @@ function MealDetails({
   onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
 }) {
   const hasFoodItems = meal.food_items && meal.food_items.length > 0
-  const hasSensitivities = meal.sensitivities && meal.sensitivities.length > 0
   const hasCalories = meal.calories !== undefined
+  const hasContent = meal.name || hasFoodItems || meal.notes || hasCalories
 
-  if (!meal.name && !hasFoodItems && !hasSensitivities && !meal.notes && !hasCalories) return null
+  if (!hasContent) return null
 
   return (
     <div class="meal-details">
-      {meal.name && <div class="meal-name">{meal.name}</div>}
+      {meal.name && (
+        <a href={`/meals/${meal.id}`} class="meal-name">
+          {meal.name}
+        </a>
+      )}
       {hasFoodItems && (
         <div class="food-items">
           {meal.food_items!.map((item, i) => (
@@ -120,15 +124,6 @@ function MealDetails({
               sensitivityAreas={sensitivityAreas}
               onToggle={onToggleFoodMapping}
             />
-          ))}
-        </div>
-      )}
-      {hasSensitivities && (
-        <div class="meal-sensitivities">
-          {meal.sensitivities!.map((s) => (
-            <span key={s} class="sensitivity-chip">
-              {s}
-            </span>
           ))}
         </div>
       )}
@@ -194,6 +189,12 @@ function MealSlotRow({
         </div>
 
         {isSaving && <span class="saving-indicator" />}
+
+        {primaryMeal && (
+          <a href={`/meals/${primaryMeal.id}`} class="meal-edit-link" title="Edit meal details">
+            ...
+          </a>
+        )}
 
         {primaryMeal && (
           <ConfirmButton

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -173,6 +173,25 @@
   color: #374151;
   font-weight: 500;
   margin-bottom: 0.375rem;
+  text-decoration: none;
+  display: block;
+}
+
+a.meal-name:hover {
+  color: #673ab8;
+}
+
+.meal-edit-link {
+  font-size: 0.8rem;
+  color: #6b7280;
+  text-decoration: none;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+}
+
+.meal-edit-link:hover {
+  background: #f3f4f6;
+  color: #673ab8;
 }
 
 .food-items {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1556,6 +1556,14 @@ export const fetchMeals = async (params?: MealsQuery): Promise<MealsResult> => {
   }
 }
 
+export const fetchMeal = async (id: string): Promise<Meal> => {
+  const { token } = auth.value
+  const response = await axios.get<MealResponse>(`${API_URL}/meals/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return mapMeal(response.data.data!)
+}
+
 export const addMealApi = async (body: AddMealBody): Promise<Meal> => {
   const { token } = auth.value
   const payload = { ...body, id: body.id ?? crypto.randomUUID() }


### PR DESCRIPTION
## Summary

- **Meal detail page** (`/meals/:id`) — view and edit name, exact time (datetime-local picker), notes. Shows food items, sensitivities, calories, source. Delete navigates back to day view.
- **Removed sensitivity chips** from meal cards on the day view — the sensitivity checkboxes on each slot row already show this clearly
- **Clickable meal names** link to the detail page. "..." button on slot rows opens detail.
- Food items stay blue, sensitivities stay purple on the detail page

## Test plan

- [ ] Click a meal name or "..." button — opens /meals/:id detail page
- [ ] Click Edit — name, time, notes become editable
- [ ] Save changes — navigates back, changes persist
- [ ] Delete from detail page — navigates to /meals
- [ ] Back link goes to the correct date's meal view
- [ ] Sensitivity chips no longer appear on day view (only checkboxes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)