### PR TITLE
Fix log_completed timezone, meals docs, Cronometer in data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ No public signup, but self-hosting is straightforward via Docker. It was initiat
 - [**Screentime Categories**](docs/features/screentime-categories.md) -- Hierarchical app categorization with productivity scoring
 - [**Training Load**](docs/features/training-load.md) -- Banister model fitness/fatigue tracking (CTL/ATL/TSB)
 - [**Places**](docs/features/places.md) -- GPS location history, auto-detected locations, visit tracking with PostGIS
+- [**Meals & Nutrition**](docs/features/meals.md) -- Quick sensitivity logging, Cronometer/Oura import, per-item micronutrients
 - [**Lab Reports**](docs/features/lab-reports.md) -- Structured lab results with metric write-through and reference ranges
 - [**Active Calorie Computation**](docs/features/calories.md) -- HR-based calculation with gap-fill from Health Connect
 - **MCP Integration** -- Full AI assistant access via [Model Context Protocol](docs/mcp-server.md) (50+ tools)

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -19,10 +19,12 @@ const checkLogCompleted = async (user: string, start?: string): Promise<boolean 
 }
 
 const handleQueryMeals: RequestHandler = async (req, res) => {
-  const { meal_type, start, end } = req.query as Record<string, string | undefined>
+  const { meal_type, start, end, date } = req.query as Record<string, string | undefined>
   const user = req.user!
   const result = await queryMeals(user, { end, meal_type, start })
-  const log_completed = await checkLogCompleted(user, start)
+  // Use explicit `date` param (local date from frontend) for log_completed check,
+  // not `start` which is UTC and may be a different calendar date due to timezone offset
+  const log_completed = await checkLogCompleted(user, date)
   res.json({ data: result.data, log_completed, success: true })
 }
 

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -233,9 +233,18 @@ function GuestHome({ canSignup }: { canSignup: boolean }) {
             </tr>
             <tr>
               <td>
+                <a href="https://cronometer.com/" target="_blank" rel="noopener noreferrer">
+                  <strong>Cronometer</strong>
+                </a>
+              </td>
+              <td>Meals with full per-item macros and ~50 micronutrients</td>
+              <td>CSV import script</td>
+            </tr>
+            <tr>
+              <td>
                 <strong>Manual Entry</strong>
               </td>
-              <td>Any metric, tag, activity, or note</td>
+              <td>Any metric, tag, activity, meal, or note</td>
               <td>Web UI, REST API, or MCP</td>
             </tr>
           </tbody>
@@ -276,6 +285,10 @@ function GuestHome({ canSignup }: { canSignup: boolean }) {
           <li>
             <strong>Places</strong> — GPS location history, auto-detected locations, visit tracking with
             PostGIS
+          </li>
+          <li>
+            <strong>Meals & Nutrition</strong> — Quick sensitivity logging, Cronometer/Oura import, per-item
+            micronutrients
           </li>
           <li>
             <strong>Lab Reports</strong> — Structured lab results with metric write-through and reference

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -422,7 +422,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
 
   const { data: mealsResult, isLoading } = useQuery({
     enabled: !!isLoggedIn,
-    queryFn: () => fetchMeals({ start: dayStart.toISOString(), end: dayEnd.toISOString() }),
+    queryFn: () => fetchMeals({ start: dayStart.toISOString(), end: dayEnd.toISOString(), date: dayKey }),
     queryKey: mealsQueryKey,
     staleTime: 30_000,
   })

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -14,6 +14,7 @@ Aurboda aggregates health, productivity, and location data from multiple sources
 | [Last.fm](./lastfm.md)                | Music scrobbles, auto-generated tags                                        | Pull (API)                              | API key (admin setting)      | Last.fm username                                         |
 | [Calendars](./calendars.md)           | Calendar events (stored as tags)                                            | Pull (ICS fetch)                        | None                         | ICS URL(s)                                               |
 | [OwnTracks](./owntracks.md)           | GPS location, geofences                                                     | Push (HTTP)                             | None                         | OwnTracks app config                                     |
+| Cronometer                            | Meals with full per-item macros and ~50 micronutrients                      | CSV import script                       | None                         | Export CSV from Cronometer                               |
 
 ## Sync Behavior
 

--- a/docs/features/meals.md
+++ b/docs/features/meals.md
@@ -1,0 +1,101 @@
+# Meals & Nutrition
+
+Track food intake with sensitivity/allergen logging, imported nutrition data from Cronometer and Oura, and per-item micronutrient tracking.
+
+## Quick Logging (Web UI)
+
+The `/meals` page provides a day-by-day view with configurable meal slots (Breakfast, Lunch, Snack, Dinner). Each slot has:
+
+- **Time preset buttons** -- quickly set the meal time to your default hour +/- 1
+- **Sensitivity checkboxes** -- check which sensitivity areas apply (e.g., gluten, dairy, red meat)
+- **Food item chips** -- click any food item to map it to sensitivity areas (saved globally)
+- **"Logging complete" checkbox** -- mark a day as fully logged for data reliability
+
+### Configuration (Settings page)
+
+- **Sensitivity Areas** -- define the areas you want to track (e.g., "gluten", "dairy", "red_meat", "legumes")
+- **Meal Slots** -- define slot names and default hours (e.g., Breakfast at 7, Lunch at 12)
+- **Food-to-Sensitivity Map** -- automatically built as you click food items and assign sensitivities
+
+### Meal Detail Page
+
+Click a meal name or the "..." button on a slot row to open `/meals/:id`, where you can edit:
+
+- Name/description
+- Exact time (datetime picker)
+- Notes
+
+## Data Model
+
+Each meal has:
+
+- `id` (UUID, client-generated for idempotent PUT)
+- `time`, `meal_type`, `name`, `source`
+- Macros: `calories`, `protein`, `carbs`, `fat`, `fiber`
+- `food_items[]` -- individual food items, each with name, quantity, unit, macros, and micronutrients
+- `micros` -- meal-level micronutrients (aggregated from food items)
+- `sensitivities[]` -- tagged sensitivity areas
+- `notes`
+
+### Micronutrient Format
+
+Micronutrients use structured `{ value, unit }` objects for explicit unit tracking:
+
+```json
+{
+  "b1_thiamine": { "value": 0.57, "unit": "mg" },
+  "vitamin_c": { "value": 14.86, "unit": "mg" },
+  "iron": { "value": 3.1, "unit": "mg" },
+  "vitamin_d": { "value": 80.0, "unit": "iu" }
+}
+```
+
+Legacy data (from Oura) uses plain numbers: `{ "iron": 3.2 }`.
+
+## Data Sources
+
+### Manual (Web UI)
+
+Quick-log via sensitivity checkboxes. Creates meals with `source: "manual"`.
+
+### Oura
+
+Meals synced from the Oura app. Includes meal name, food items (names only, no nutrition data), and meal type. See [Oura docs](../oura.md).
+
+### Cronometer
+
+Import from CSV export using the import script:
+
+```bash
+cd apps/backend && npx tsx ../../scripts/cronometer/import.ts <servings.csv> [dailysummary.csv]
+```
+
+Imports:
+
+- Food items with full per-item macros and ~50 micronutrients (all with explicit units)
+- Meal-level aggregated totals
+- Daily `log_completed` flags from the daily summary
+- Default meal times from meal type (Breakfast=7, Lunch=12, Dinner=18, Snacks=15)
+
+The script uses `PUT /meals` (idempotent) so re-running is safe.
+
+Auth is read from `~/.config/aurboda/config`.
+
+## API
+
+- `PUT /meals` -- upsert a meal (client-generated UUID, idempotent)
+- `POST /meals` -- create a meal (server-generated UUID, backwards-compatible)
+- `GET /meals?start=&end=&date=` -- query meals with optional log_completed
+- `GET /meals/:id` -- get a single meal
+- `PATCH /meals/:id` -- update meal fields
+- `DELETE /meals/:id` -- delete a meal
+- `PUT /meals/log-completed/:date` -- mark day as logging-complete
+- `DELETE /meals/log-completed/:date` -- unmark
+
+## MCP Tools
+
+- `add_meal` -- create/upsert a meal
+- `query_meals` -- query by date range and meal type
+- `get_meal` -- get by ID
+- `update_meal` -- update fields
+- `delete_meal` -- delete by ID

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -204,6 +204,7 @@ export type UpdateMealBody = z.infer<typeof updateMealBodySchema>
  */
 export const mealsQuerySchema = z
   .object({
+    date: z.string().optional().meta({ description: 'Local date (YYYY-MM-DD) for log_completed check' }),
     end: iso8601DateTimeSchema.optional().meta({ description: 'End date/time filter' }),
     meal_type: z.string().optional().meta({ description: 'Filter by meal type' }),
     start: iso8601DateTimeSchema.optional().meta({ description: 'Start date/time filter' }),

--- a/scripts/cronometer/import.ts
+++ b/scripts/cronometer/import.ts
@@ -8,10 +8,10 @@
  * Uses PUT /meals (idempotent upsert) so re-running is safe.
  */
 
-import { readFileSync } from 'fs'
 import { randomUUID } from 'crypto'
-import { resolve } from 'path'
+import { readFileSync } from 'fs'
 import { homedir } from 'os'
+import { resolve } from 'path'
 
 // ── Config ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Fix: log_completed timezone bug** — the backend was extracting the date from the UTC `start` param (`2026-03-24T23:00:00Z` → `2026-03-24`), but the user's local date was `2026-03-25` (CET). Now the frontend passes the local date as an explicit `date` query param.
- **Docs**: New `docs/features/meals.md` with full feature documentation
- **README**: Added Meals & Nutrition to features list
- **Home page**: Added Meals to features list and Cronometer to data sources table
- **Data sources**: Added Cronometer to the overview table
- **Import script**: `scripts/cronometer/import.ts` (was committed to develop accidentally, now properly in this branch too)

## Test plan

- [ ] Toggle "Logging complete" checkbox — stays checked after page reload
- [ ] Works in CET timezone (where UTC date differs from local date)
- [ ] Meals listed in README, Home page, and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)