### PR TITLE
Derive meal sensitivities from food-to-sensitivity mapping

### DIFF
--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -160,7 +160,10 @@ function MealSlotRow({
   isSaving,
 }: MealSlotRowProps) {
   const primaryMeal = slotMeals[0]
-  const sensitivities = primaryMeal?.sensitivities ?? []
+  const explicit = primaryMeal?.sensitivities ?? []
+  const derived = derivedSensitivities(primaryMeal, foodSensitivityMap)
+  // Union of explicit + derived — checkbox shows checked if either
+  const effectiveSensitivities = new Set([...explicit, ...derived])
   const mealHour = primaryMeal ? primaryMeal.time.getHours() : slot.default_hour
   const hours = [slot.default_hour - 1, slot.default_hour, slot.default_hour + 1].filter(
     (h) => h >= 0 && h <= 23,
@@ -210,16 +213,20 @@ function MealSlotRow({
 
       {sensitivityAreas.length > 0 && (
         <div class="sensitivity-checks">
-          {sensitivityAreas.map((area) => (
-            <label key={area} class="sensitivity-label">
-              <input
-                type="checkbox"
-                checked={sensitivities.includes(area)}
-                onChange={() => onToggleSensitivity(slot, area, primaryMeal)}
-              />
-              {area}
-            </label>
-          ))}
+          {sensitivityAreas.map((area) => {
+            const isDerived = derived.has(area)
+            const isExplicit = explicit.includes(area)
+            return (
+              <label key={area} class={`sensitivity-label ${isDerived && !isExplicit ? 'derived' : ''}`}>
+                <input
+                  type="checkbox"
+                  checked={effectiveSensitivities.has(area)}
+                  onChange={() => onToggleSensitivity(slot, area, primaryMeal)}
+                />
+                {area}
+              </label>
+            )
+          })}
         </div>
       )}
 
@@ -282,6 +289,15 @@ function OtherMeals({
 }
 
 const todayISO = () => formatISO(new Date(), { representation: 'date' })
+
+/** Compute sensitivities derived from food items via the food-to-sensitivity mapping. */
+const derivedSensitivities = (meal: Meal | undefined, foodMap: Record<string, string[]>): Set<string> => {
+  const derived = new Set<string>()
+  for (const item of meal?.food_items ?? []) {
+    for (const area of foodMap[item.name] ?? []) derived.add(area)
+  }
+  return derived
+}
 
 const getOtherMeals = (meals: Meal[], slots: MealSlot[]): Meal[] => {
   const slotTypes = new Set(slots.map((s) => s.name.toLowerCase()))

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -162,6 +162,11 @@
   accent-color: #673ab8;
 }
 
+.sensitivity-label.derived {
+  font-style: italic;
+  opacity: 0.8;
+}
+
 .meal-details {
   margin-top: 0.5rem;
   padding-top: 0.5rem;


### PR DESCRIPTION
## Summary

Sensitivity checkboxes now show the **union** of explicit sensitivities and those derived from the food-item mapping. If "Picanha" is mapped to "Red Meat" in settings, any meal containing Picanha will show "Red Meat" checked automatically.

- Derived-only sensitivities shown in *italic* to distinguish from explicit
- Retroactive: updating a food mapping affects all historical meals instantly (computed at display time, not stored)
- Toggling a checkbox still writes/removes from the explicit sensitivities

## Test plan

- [ ] Map "Picanha" to "Red Meat" via food item popover
- [ ] Navigate to a day with Picanha — "Red Meat" checkbox is checked (italic)
- [ ] Explicitly check "Red Meat" — no longer italic (now both explicit + derived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)