### PR TITLE
Rename Sensitivities to Meal Flags and add dynamic time slots

### DIFF
--- a/apps/web/src/components/MealPreferencesSettings.tsx
+++ b/apps/web/src/components/MealPreferencesSettings.tsx
@@ -94,12 +94,10 @@ export function MealPreferencesSettings() {
       isLoading={isLoading}
       headerExtra={<SaveStatusIndicator state={saveStatus} />}
     >
-      {/* Sensitivity Areas */}
+      {/* Meal Flags */}
       <div class="meal-pref-subsection">
-        <h3>Sensitivity Areas</h3>
-        <p class="subsection-desc">
-          Food sensitivities you want to track (e.g., gluten, dairy, red meat, legumes).
-        </p>
+        <h3>Meal Flags</h3>
+        <p class="subsection-desc">Flags for categorizing meals (e.g., gluten, dairy, keto, cheat day).</p>
 
         <div class="area-list">
           {currentAreas.map((area) => (
@@ -120,7 +118,7 @@ export function MealPreferencesSettings() {
         <div class="add-row">
           <input
             type="text"
-            placeholder="Add sensitivity area..."
+            placeholder="Add meal flag..."
             value={newArea}
             onInput={(e) => setNewArea((e.target as HTMLInputElement).value)}
             onKeyDown={(e) => e.key === 'Enter' && addArea()}

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -65,7 +65,7 @@ function MealInfoRows({ meal }: { meal: Meal }) {
 
       {meal.sensitivities && meal.sensitivities.length > 0 && (
         <div class="detail-row">
-          <label>Sensitivities</label>
+          <label>Flags</label>
           <div class="detail-sensitivities">
             {meal.sensitivities.map((s) => (
               <span key={s} class="detail-sensitivity-chip">
@@ -124,18 +124,20 @@ export function MealDetail() {
     },
   })
 
-  if (isLoading)
-    {return (
+  if (isLoading) {
+    return (
       <div class="meal-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )}
-  if (!meal)
-    {return (
+    )
+  }
+  if (!meal) {
+    return (
       <div class="meal-detail-page">
         <p>Meal not found.</p>
       </div>
-    )}
+    )
+  }
 
   const isEditing = editing !== null
   const editName = editing?.name ?? meal.name ?? ''

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -32,7 +32,39 @@ const DEFAULT_MEAL_SLOTS: MealSlot[] = [
   { name: 'Dinner', default_hour: 18 },
 ]
 
-const formatHour = (hour: number): string => `${hour}:00`
+const formatTime = (hour: number, minute: number): string => `${hour}:${String(minute).padStart(2, '0')}`
+
+interface TimeOption {
+  hour: number
+  minute: number
+  label: string
+}
+
+/** Build time selector options: preset hours ± 1, plus the actual meal time if non-round. */
+const buildTimeOptions = (defaultHour: number, mealHour: number, mealMinute: number): TimeOption[] => {
+  const presets: TimeOption[] = [defaultHour - 1, defaultHour, defaultHour + 1]
+    .filter((h) => h >= 0 && h <= 23)
+    .map((h) => ({ hour: h, minute: 0, label: formatTime(h, 0) }))
+
+  // If meal has a non-round time that isn't already a preset, insert it sorted
+  if (mealMinute !== 0) {
+    const mealKey = mealHour * 60 + mealMinute
+    const alreadyPresent = presets.some((p) => p.hour === mealHour && p.minute === mealMinute)
+    if (!alreadyPresent) {
+      const mealOption: TimeOption = {
+        hour: mealHour,
+        minute: mealMinute,
+        label: formatTime(mealHour, mealMinute),
+      }
+      const idx = presets.findIndex((p) => p.hour * 60 + p.minute > mealKey)
+      if (idx === -1) presets.push(mealOption)
+      else presets.splice(idx, 0, mealOption)
+    }
+  }
+
+  return presets
+}
+
 
 const formatMealType = (type?: string): string =>
   type ? type.charAt(0).toUpperCase() + type.slice(1) : 'Meal'
@@ -73,7 +105,7 @@ function FoodItemChip({
       {hasMappings && <span class="mapping-dot" />}
       {open && sensitivityAreas.length > 0 && (
         <div class="food-map-popover" onClick={(e) => e.stopPropagation()}>
-          <div class="popover-title">Sensitivities for "{name}"</div>
+          <div class="popover-title">Flags for "{name}"</div>
           {sensitivityAreas.map((area) => (
             <label key={area} class="popover-option">
               <input
@@ -141,7 +173,7 @@ interface MealSlotRowProps {
   foodSensitivityMap: Record<string, string[]>
   onToggleSensitivity: (slot: MealSlot, area: string, existingMeal?: Meal) => void
   onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
-  onChangeHour: (meal: Meal, hour: number) => void
+  onChangeTime: (meal: Meal, hour: number, minute?: number) => void
   onDelete: (id: string) => void
   isDeletePending: boolean
   isSaving: boolean
@@ -154,7 +186,7 @@ function MealSlotRow({
   foodSensitivityMap,
   onToggleSensitivity,
   onToggleFoodMapping,
-  onChangeHour,
+  onChangeTime,
   onDelete,
   isDeletePending,
   isSaving,
@@ -164,10 +196,11 @@ function MealSlotRow({
   const derived = derivedSensitivities(primaryMeal, foodSensitivityMap)
   // Union of explicit + derived — checkbox shows checked if either
   const effectiveSensitivities = new Set([...explicit, ...derived])
-  const mealHour = primaryMeal ? primaryMeal.time.getHours() : slot.default_hour
-  const hours = [slot.default_hour - 1, slot.default_hour, slot.default_hour + 1].filter(
-    (h) => h >= 0 && h <= 23,
-  )
+  const mealH = primaryMeal ? primaryMeal.time.getHours() : slot.default_hour
+  const mealM = primaryMeal ? primaryMeal.time.getMinutes() : 0
+
+  // Build time options: preset hours + actual meal time if non-round
+  const timeOptions = buildTimeOptions(slot.default_hour, mealH, mealM)
 
   return (
     <div class={`meal-slot-row ${primaryMeal ? 'has-meal' : ''}`}>
@@ -175,18 +208,18 @@ function MealSlotRow({
         <span class="slot-name">{slot.name}</span>
 
         <div class="time-selector">
-          {hours.map((h) => (
+          {timeOptions.map((t) => (
             <button
-              key={h}
+              key={t.label}
               type="button"
-              class={`time-btn ${mealHour === h ? 'active' : ''}`}
+              class={`time-btn ${mealH === t.hour && mealM === t.minute ? 'active' : ''}`}
               onClick={() => {
-                if (primaryMeal) onChangeHour(primaryMeal, h)
+                if (primaryMeal) onChangeTime(primaryMeal, t.hour, t.minute)
               }}
-              disabled={!primaryMeal && h !== slot.default_hour}
-              title={!primaryMeal ? 'Log a meal first to change the time' : `Set time to ${formatHour(h)}`}
+              disabled={!primaryMeal && t.hour !== slot.default_hour}
+              title={!primaryMeal ? 'Log a meal first to change the time' : `Set time to ${t.label}`}
             >
-              {formatHour(h)}
+              {t.label}
             </button>
           ))}
         </div>
@@ -399,9 +432,9 @@ function useMealMutations(mealsQueryKey: string[], meals: Meal[] | undefined) {
     }
   }
 
-  const handleChangeHour = (meal: Meal, hour: number) => {
+  const handleChangeTime = (meal: Meal, hour: number, minute = 0) => {
     const newTime = new Date(meal.time)
-    newTime.setHours(hour, 0, 0, 0)
+    newTime.setHours(hour, minute, 0, 0)
     optimisticUpdate((old) => old.map((m) => (m.id === meal.id ? { ...m, time: newTime } : m)))
     if (meal.meal_type) markSlotSaving(meal.meal_type, true)
     updateMutation.mutate({ id: meal.id!, time: newTime.toISOString() })
@@ -410,7 +443,7 @@ function useMealMutations(mealsQueryKey: string[], meals: Meal[] | undefined) {
   return {
     savingSlots,
     handleToggleSensitivity,
-    handleChangeHour,
+    handleChangeTime,
     upsertMutation,
     updateMutation,
     deleteMutation,
@@ -449,7 +482,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
   const {
     savingSlots,
     handleToggleSensitivity,
-    handleChangeHour,
+    handleChangeTime,
     upsertMutation,
     updateMutation,
     deleteMutation,
@@ -488,7 +521,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     <>
       {sensitivityAreas.length === 0 && (
         <p class="config-hint">
-          Configure your sensitivity areas and meal slots in <a href="/settings">Settings</a>.
+          Configure your meal flags and meal slots in <a href="/settings">Settings</a>.
         </p>
       )}
 
@@ -502,7 +535,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
             foodSensitivityMap={foodSensitivityMap}
             onToggleSensitivity={handleToggleSensitivity}
             onToggleFoodMapping={handleToggleFoodMapping}
-            onChangeHour={handleChangeHour}
+            onChangeTime={handleChangeTime}
             onDelete={(id) => deleteMutation.mutate(id)}
             isDeletePending={deleteMutation.isPending}
             isSaving={savingSlots.has(slot.name.toLowerCase())}

--- a/docs/features/meals.md
+++ b/docs/features/meals.md
@@ -1,21 +1,21 @@
 # Meals & Nutrition
 
-Track food intake with sensitivity/allergen logging, imported nutrition data from Cronometer and Oura, and per-item micronutrient tracking.
+Track food intake with meal flag/allergen logging, imported nutrition data from Cronometer and Oura, and per-item micronutrient tracking.
 
 ## Quick Logging (Web UI)
 
 The `/meals` page provides a day-by-day view with configurable meal slots (Breakfast, Lunch, Snack, Dinner). Each slot has:
 
 - **Time preset buttons** -- quickly set the meal time to your default hour +/- 1
-- **Sensitivity checkboxes** -- check which sensitivity areas apply (e.g., gluten, dairy, red meat)
-- **Food item chips** -- click any food item to map it to sensitivity areas (saved globally)
+- **Meal Flag checkboxes** -- check which meal flags apply (e.g., gluten, dairy, red meat)
+- **Food item chips** -- click any food item to map it to meal flags (saved globally)
 - **"Logging complete" checkbox** -- mark a day as fully logged for data reliability
 
 ### Configuration (Settings page)
 
-- **Sensitivity Areas** -- define the areas you want to track (e.g., "gluten", "dairy", "red_meat", "legumes")
+- **Meal Flags** -- define the areas you want to track (e.g., "gluten", "dairy", "red_meat", "legumes")
 - **Meal Slots** -- define slot names and default hours (e.g., Breakfast at 7, Lunch at 12)
-- **Food-to-Sensitivity Map** -- automatically built as you click food items and assign sensitivities
+- **Food-to-Meal Flag Map** -- automatically built as you click food items and assign meal flags
 
 ### Meal Detail Page
 
@@ -34,7 +34,7 @@ Each meal has:
 - Macros: `calories`, `protein`, `carbs`, `fat`, `fiber`
 - `food_items[]` -- individual food items, each with name, quantity, unit, macros, and micronutrients
 - `micros` -- meal-level micronutrients (aggregated from food items)
-- `sensitivities[]` -- tagged sensitivity areas
+- `meal flags[]` -- tagged meal flags
 - `notes`
 
 ### Micronutrient Format
@@ -56,7 +56,7 @@ Legacy data (from Oura) uses plain numbers: `{ "iron": 3.2 }`.
 
 ### Manual (Web UI)
 
-Quick-log via sensitivity checkboxes. Creates meals with `source: "manual"`.
+Quick-log via meal flag checkboxes. Creates meals with `source: "manual"`.
 
 ### Oura
 


### PR DESCRIPTION
## Summary

**UI Rename:** "Sensitivity Areas" → "Meal Flags" throughout the UI (settings, day view, detail page, docs). API/DB field names unchanged for backwards compatibility.

**Dynamic time slots:** When a meal is logged at a non-round time (e.g., 6:45), that time appears as its own button alongside the preset hours: `[6:00] [6:45] [7:00] [8:00]`. Minutes are preserved when switching times.

## Test plan

- [ ] Settings page shows "Meal Flags" heading with updated description
- [ ] Food item popover shows "Flags for..." instead of "Sensitivities for..."
- [ ] Detail page shows "Flags" label
- [ ] Import a meal via MCP at 6:45 — day view shows [6:00] [6:45] [7:00] [8:00] buttons
- [ ] Clicking 7:00 changes meal to 7:00; clicking 6:45 changes back

🤖 Generated with [Claude Code](https://claude.com/claude-code)