### PR TITLE
Full meal detail editor and meals on timeline

### DIFF
--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -77,6 +77,121 @@
   resize: vertical;
 }
 
+.detail-row-block {
+  flex-direction: column;
+}
+
+/* Type editor */
+
+.type-editor {
+  display: flex;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.type-editor select,
+.type-editor input {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+}
+
+/* Macros grid */
+
+.macros-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.macro-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.macro-input span {
+  font-size: 0.7rem;
+  color: #6b7280;
+}
+
+.macro-input input {
+  width: 70px;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+}
+
+/* Flags editor */
+
+.flags-editor {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.flag-check {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+  cursor: pointer;
+}
+
+.flag-check input[type='checkbox'] {
+  accent-color: #673ab8;
+}
+
+/* Food items editor */
+
+.food-items-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  width: 100%;
+}
+
+.food-item-edit-row {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+.food-name-input {
+  flex: 2;
+  min-width: 0;
+}
+
+.food-num-input {
+  width: 60px;
+}
+
+.food-unit-input {
+  width: 70px;
+}
+
+.food-item-edit-row input {
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+}
+
+.btn-add-item {
+  align-self: flex-start;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.5rem;
+}
+
 .detail-food-items,
 .detail-sensitivities {
   display: flex;
@@ -158,10 +273,24 @@
 
   .detail-row input[type='text'],
   .detail-row input[type='datetime-local'],
-  .detail-row textarea {
+  .detail-row input[type='number'],
+  .detail-row textarea,
+  .detail-row select,
+  .type-editor select,
+  .type-editor input,
+  .macro-input input,
+  .food-item-edit-row input {
     background: #374151;
     border-color: #4b5563;
     color: #d1d5db;
+  }
+
+  .macro-input span {
+    color: #9ca3af;
+  }
+
+  .flag-check {
+    color: #9ca3af;
   }
 
   .detail-food-chip {

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -4,94 +4,217 @@ import { useLocation, useRoute } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
-import { deleteMealApi, fetchMeal, type Meal, updateMealApi } from '../../state/api'
+import { deleteMealApi, fetchMeal, fetchUserSettings, updateMealApi } from '../../state/api'
 import './MealDetail.css'
 
-interface EditState {
-  name?: string
-  time?: string
-  notes?: string
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+interface FoodItemEdit {
+  name: string
+  quantity?: number
+  unit?: string
+  calories?: number
+  protein?: number
+  carbs?: number
+  fat?: number
+  fiber?: number
 }
 
-function EditableField({
-  label,
-  value,
-  editing,
-  editValue,
-  onEdit,
-  type = 'text',
-  placeholder,
-}: {
-  label: string
-  value: string
-  editing: boolean
-  editValue: string
-  onEdit: (v: string) => void
-  type?: string
-  placeholder?: string
-}) {
+const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack', 'drink']
+
+function MealTypeEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const isCustom = !MEAL_TYPES.includes(value)
   return (
-    <div class="detail-row">
-      <label>{label}</label>
-      {editing ? (
+    <div class="type-editor">
+      <select
+        value={isCustom ? '__custom' : value}
+        onChange={(e) => {
+          const v = (e.target as HTMLSelectElement).value
+          if (v !== '__custom') onChange(v)
+        }}
+      >
+        {MEAL_TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </option>
+        ))}
+        <option value="__custom">Other...</option>
+      </select>
+      {isCustom && (
         <input
-          type={type}
-          value={editValue}
-          placeholder={placeholder}
-          onInput={(e) => onEdit((e.target as HTMLInputElement).value)}
+          type="text"
+          value={value}
+          placeholder="Custom type"
+          onInput={(e) => onChange((e.target as HTMLInputElement).value)}
         />
-      ) : (
-        <span class="detail-value">{value || '—'}</span>
       )}
     </div>
   )
 }
 
-function MealInfoRows({ meal }: { meal: Meal }) {
+function MacrosEditor({
+  calories,
+  protein,
+  carbs,
+  fat,
+  fiber,
+  onChange,
+}: {
+  calories?: number | null
+  protein?: number | null
+  carbs?: number | null
+  fat?: number | null
+  fiber?: number | null
+  onChange: (field: string, value: number | null) => void
+}) {
+  const parseNum = (v: string) => (v === '' ? null : parseFloat(v))
   return (
-    <>
-      {meal.food_items && meal.food_items.length > 0 && (
-        <div class="detail-row">
-          <label>Food Items</label>
-          <div class="detail-food-items">
-            {meal.food_items.map((item, i) => (
-              <span key={i} class="detail-food-chip">
-                {item.name}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {meal.sensitivities && meal.sensitivities.length > 0 && (
-        <div class="detail-row">
-          <label>Flags</label>
-          <div class="detail-sensitivities">
-            {meal.sensitivities.map((s) => (
-              <span key={s} class="detail-sensitivity-chip">
-                {s}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {meal.calories !== undefined && (
-        <div class="detail-row">
-          <label>Calories</label>
-          <span class="detail-value">{meal.calories} kcal</span>
-        </div>
-      )}
-
-      {meal.source && (
-        <div class="detail-row">
-          <label>Source</label>
-          <span class="detail-value">{meal.source}</span>
-        </div>
-      )}
-    </>
+    <div class="macros-grid">
+      {(['calories', 'protein', 'carbs', 'fat', 'fiber'] as const).map((field) => {
+        const val = { calories, protein, carbs, fat, fiber }[field]
+        return (
+          <label key={field} class="macro-input">
+            <span>{field === 'calories' ? 'kcal' : `${field} (g)`}</span>
+            <input
+              type="number"
+              step="0.1"
+              value={val ?? ''}
+              onInput={(e) => onChange(field, parseNum((e.target as HTMLInputElement).value))}
+            />
+          </label>
+        )
+      })}
+    </div>
   )
 }
+
+function MealFlagsEditor({
+  selected,
+  areas,
+  onChange,
+}: {
+  selected: string[]
+  areas: string[]
+  onChange: (flags: string[]) => void
+}) {
+  if (areas.length === 0) return null
+  return (
+    <div class="flags-editor">
+      {areas.map((area) => (
+        <label key={area} class="flag-check">
+          <input
+            type="checkbox"
+            checked={selected.includes(area)}
+            onChange={() => {
+              const next = selected.includes(area) ? selected.filter((s) => s !== area) : [...selected, area]
+              onChange(next)
+            }}
+          />
+          {area}
+        </label>
+      ))}
+    </div>
+  )
+}
+
+function FoodItemRow({
+  item,
+  index,
+  onChange,
+  onRemove,
+}: {
+  item: FoodItemEdit
+  index: number
+  onChange: (index: number, item: FoodItemEdit) => void
+  onRemove: (index: number) => void
+}) {
+  const update = (field: string, value: unknown) => onChange(index, { ...item, [field]: value })
+  const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
+  return (
+    <div class="food-item-edit-row">
+      <input
+        type="text"
+        value={item.name}
+        placeholder="Food name"
+        class="food-name-input"
+        onInput={(e) => update('name', (e.target as HTMLInputElement).value)}
+      />
+      <input
+        type="number"
+        step="0.1"
+        value={item.quantity ?? ''}
+        placeholder="Qty"
+        class="food-num-input"
+        onInput={(e) => update('quantity', parseNum((e.target as HTMLInputElement).value))}
+      />
+      <input
+        type="text"
+        value={item.unit ?? ''}
+        placeholder="Unit"
+        class="food-unit-input"
+        onInput={(e) => update('unit', (e.target as HTMLInputElement).value)}
+      />
+      <input
+        type="number"
+        step="0.1"
+        value={item.calories ?? ''}
+        placeholder="kcal"
+        class="food-num-input"
+        onInput={(e) => update('calories', parseNum((e.target as HTMLInputElement).value))}
+      />
+      <button type="button" class="btn-danger-small" onClick={() => onRemove(index)}>
+        &times;
+      </button>
+    </div>
+  )
+}
+
+function FoodItemsEditor({
+  items,
+  onChange,
+}: {
+  items: FoodItemEdit[]
+  onChange: (items: FoodItemEdit[]) => void
+}) {
+  const handleChange = (index: number, item: FoodItemEdit) => {
+    const next = [...items]
+    next[index] = item
+    onChange(next)
+  }
+  const handleRemove = (index: number) => onChange(items.filter((_, i) => i !== index))
+  const handleAdd = () => onChange([...items, { name: '' }])
+
+  return (
+    <div class="food-items-editor">
+      {items.map((item, i) => (
+        <FoodItemRow key={i} item={item} index={i} onChange={handleChange} onRemove={handleRemove} />
+      ))}
+      <button type="button" class="btn-secondary btn-add-item" onClick={handleAdd}>
+        + Add food item
+      </button>
+    </div>
+  )
+}
+
+// ── Read-only info rows ──────────────────────────────────────────────────────
+
+// ── Edit state ───────────────────────────────────────────────────────────────
+
+interface EditState {
+  name?: string
+  time?: string
+  notes?: string
+  meal_type?: string
+  calories?: number | null
+  protein?: number | null
+  carbs?: number | null
+  fat?: number | null
+  fiber?: number | null
+  food_items?: FoodItemEdit[]
+  sensitivities?: string[]
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
 
 // eslint-disable-next-line complexity -- detail page with edit mode and multiple data sections
 export function MealDetail() {
@@ -103,6 +226,11 @@ export function MealDetail() {
   const { data: meal, isLoading } = useQuery({
     queryFn: () => fetchMeal(id),
     queryKey: ['meal', id],
+  })
+
+  const { data: settings } = useQuery({
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
   })
 
   const [editing, setEditing] = useState<EditState | null>(null)
@@ -124,25 +252,47 @@ export function MealDetail() {
     },
   })
 
-  if (isLoading) {
-    return (
+  if (isLoading)
+    {return (
       <div class="meal-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )
-  }
-  if (!meal) {
-    return (
+    )}
+  if (!meal)
+    {return (
       <div class="meal-detail-page">
         <p>Meal not found.</p>
       </div>
-    )
-  }
+    )}
 
   const isEditing = editing !== null
+  const flagAreas: string[] = settings?.sensitivity_areas ?? []
+
+  // Edit values with fallback to meal
   const editName = editing?.name ?? meal.name ?? ''
   const editTime = editing?.time ?? format(meal.time, "yyyy-MM-dd'T'HH:mm")
   const editNotes = editing?.notes ?? meal.notes ?? ''
+  const editType = editing?.meal_type ?? meal.meal_type ?? 'lunch'
+  const editCal = editing?.calories !== undefined ? editing.calories : meal.calories
+  const editProt = editing?.protein !== undefined ? editing.protein : meal.protein
+  const editCarbs = editing?.carbs !== undefined ? editing.carbs : meal.carbs
+  const editFat = editing?.fat !== undefined ? editing.fat : meal.fat
+  const editFiber = editing?.fiber !== undefined ? editing.fiber : meal.fiber
+  const editItems =
+    editing?.food_items ??
+    (meal.food_items ?? []).map((fi) => ({
+      name: fi.name,
+      quantity: fi.quantity,
+      unit: fi.unit,
+      calories: fi.calories,
+      protein: fi.protein,
+      carbs: fi.carbs,
+      fat: fi.fat,
+      fiber: fi.fiber,
+    }))
+  const editFlags = editing?.sensitivities ?? meal.sensitivities ?? []
+
+  const startEditing = () => setEditing({})
 
   const handleSave = () => {
     if (!editing) return
@@ -150,8 +300,26 @@ export function MealDetail() {
     if (editing.name !== undefined) body.name = editing.name || null
     if (editing.time !== undefined) body.time = new Date(editing.time).toISOString()
     if (editing.notes !== undefined) body.notes = editing.notes || null
+    if (editing.meal_type !== undefined) body.meal_type = editing.meal_type
+    if (editing.calories !== undefined) body.calories = editing.calories
+    if (editing.protein !== undefined) body.protein = editing.protein
+    if (editing.carbs !== undefined) body.carbs = editing.carbs
+    if (editing.fat !== undefined) body.fat = editing.fat
+    if (editing.fiber !== undefined) body.fiber = editing.fiber
+    if (editing.food_items !== undefined) body.food_items = editing.food_items.filter((fi) => fi.name.trim())
+    if (editing.sensitivities !== undefined) body.sensitivities = editing.sensitivities
     updateMutation.mutate(body)
   }
+
+  const macroDisplay = [
+    meal.calories !== undefined && `${meal.calories} kcal`,
+    meal.protein !== undefined && `${meal.protein}g protein`,
+    meal.carbs !== undefined && `${meal.carbs}g carbs`,
+    meal.fat !== undefined && `${meal.fat}g fat`,
+    meal.fiber !== undefined && `${meal.fiber}g fiber`,
+  ]
+    .filter(Boolean)
+    .join(' · ')
 
   return (
     <div class="meal-detail-page">
@@ -175,7 +343,7 @@ export function MealDetail() {
               </button>
             </>
           ) : (
-            <button type="button" class="btn-secondary" onClick={() => setEditing({})}>
+            <button type="button" class="btn-secondary" onClick={startEditing}>
               Edit
             </button>
           )}
@@ -189,29 +357,107 @@ export function MealDetail() {
       </div>
 
       <div class="detail-card">
+        {/* Type */}
         <div class="detail-row">
           <label>Type</label>
-          <span class="detail-value">{meal.meal_type ?? '—'}</span>
+          {isEditing ? (
+            <MealTypeEditor value={editType} onChange={(v) => setEditing({ ...editing, meal_type: v })} />
+          ) : (
+            <span class="detail-value">{meal.meal_type ?? '—'}</span>
+          )}
         </div>
 
-        <EditableField
-          label="Time"
-          value={format(meal.time, 'yyyy-MM-dd HH:mm')}
-          editing={isEditing}
-          editValue={editTime}
-          onEdit={(v) => setEditing({ ...editing, time: v })}
-          type="datetime-local"
-        />
+        {/* Time */}
+        <div class="detail-row">
+          <label>Time</label>
+          {isEditing ? (
+            <input
+              type="datetime-local"
+              value={editTime}
+              onInput={(e) => setEditing({ ...editing, time: (e.target as HTMLInputElement).value })}
+            />
+          ) : (
+            <span class="detail-value">{format(meal.time, 'yyyy-MM-dd HH:mm')}</span>
+          )}
+        </div>
 
-        <EditableField
-          label="Name"
-          value={meal.name ?? ''}
-          editing={isEditing}
-          editValue={editName}
-          onEdit={(v) => setEditing({ ...editing, name: v })}
-          placeholder="Meal name/description"
-        />
+        {/* Name */}
+        <div class="detail-row">
+          <label>Name</label>
+          {isEditing ? (
+            <input
+              type="text"
+              value={editName}
+              placeholder="Meal name"
+              onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
+            />
+          ) : (
+            <span class="detail-value">{meal.name || '—'}</span>
+          )}
+        </div>
 
+        {/* Macros */}
+        <div class="detail-row">
+          <label>Macros</label>
+          {isEditing ? (
+            <MacrosEditor
+              calories={editCal}
+              protein={editProt}
+              carbs={editCarbs}
+              fat={editFat}
+              fiber={editFiber}
+              onChange={(field, val) => setEditing({ ...editing, [field]: val })}
+            />
+          ) : (
+            <span class="detail-value">{macroDisplay || '—'}</span>
+          )}
+        </div>
+
+        {/* Flags */}
+        <div class="detail-row">
+          <label>Flags</label>
+          {isEditing ? (
+            <MealFlagsEditor
+              selected={editFlags}
+              areas={flagAreas}
+              onChange={(flags) => setEditing({ ...editing, sensitivities: flags })}
+            />
+          ) : meal.sensitivities && meal.sensitivities.length > 0 ? (
+            <div class="detail-sensitivities">
+              {meal.sensitivities.map((s) => (
+                <span key={s} class="detail-sensitivity-chip">
+                  {s}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span class="detail-value">—</span>
+          )}
+        </div>
+
+        {/* Food Items */}
+        <div class="detail-row detail-row-block">
+          <label>Food Items</label>
+          {isEditing ? (
+            <FoodItemsEditor
+              items={editItems}
+              onChange={(items) => setEditing({ ...editing, food_items: items })}
+            />
+          ) : meal.food_items && meal.food_items.length > 0 ? (
+            <div class="detail-food-items">
+              {meal.food_items.map((item, i) => (
+                <span key={i} class="detail-food-chip">
+                  {item.name}
+                  {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span class="detail-value">—</span>
+          )}
+        </div>
+
+        {/* Notes */}
         <div class="detail-row">
           <label>Notes</label>
           {isEditing ? (
@@ -226,7 +472,12 @@ export function MealDetail() {
           )}
         </div>
 
-        <MealInfoRows meal={meal} />
+        {!isEditing && (
+          <div class="detail-row">
+            <label>Source</label>
+            <span class="detail-value">{meal.source ?? '—'}</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -11,12 +11,13 @@ import * as d3 from 'd3'
 import { addDays, differenceInCalendarDays, endOfDay, format, formatISO, startOfDay, subDays } from 'date-fns'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
-import type { Activity, Place, ProductivityRecord, Tag } from '../../state/api'
+import type { Activity, Meal, Place, ProductivityRecord, Tag } from '../../state/api'
 import type { ChartItem, Column, Orientation } from './types'
 
 import {
   fetchActivities,
   fetchBucketedMetrics,
+  fetchMeals,
   fetchCustomMetrics,
   fetchPlaces,
   fetchProductivity,
@@ -29,7 +30,7 @@ import {
   fetchUserSettings,
 } from '../../state/api'
 import { aggregateBucketsAligned, parseBucketedResponse } from '../../utils/chart'
-import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
+import { isEmoji, isIconPath, isUrl, resolveItemIcon } from '../../utils/emojiLookup'
 import { packLanes } from '../../utils/lanePacking'
 import { buildActivityColumnItems, EXCLUDED_TAG_PREFIXES, EXCLUDED_TAG_SOURCES } from './activityMerge'
 import { computeBarLayout, type BarSlot } from './barLayout'
@@ -83,6 +84,7 @@ type LegendCategory =
   | 'exercise'
   | 'tags'
   | 'calendar'
+  | 'meal'
   | 'screentime' // vertical only
   // Metrics sub-toggles
   | 'hr'
@@ -339,6 +341,7 @@ const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = 
   hr: () => false,
   hrv: () => false,
   location: (item) => item.column === 'Location',
+  meal: (item) => item.entity_type === 'meal',
   meditation: (item) => item.column === 'Activity' && item.activity_type === 'meditation',
   metrics: () => false, // metrics track controlled via sub-toggles at draw level
   music: (item) => item.column === 'Music',
@@ -403,6 +406,34 @@ const categorizeTags = (tags: Tag[], itemIcons: Record<string, string>): ChartIt
         },
       }
     })
+
+const categorizeMeals = (meals: Meal[], itemIcons: Record<string, string>): ChartItem[] =>
+  meals.map((m) => {
+    const icon =
+      resolveItemIcon(`meal:${m.meal_type ?? 'default'}`, itemIcons) ??
+      resolveItemIcon('meal:default', itemIcons) ??
+      '🍽️'
+    const end = new Date(m.time.getTime() + 15 * 60000)
+    const typeLabel = m.meal_type ? m.meal_type.charAt(0).toUpperCase() + m.meal_type.slice(1) : 'Meal'
+    const details = [m.name, m.calories ? `${m.calories} kcal` : undefined].filter(Boolean) as string[]
+    return {
+      color: '#f59e0b',
+      column: 'Tags / Events' as Column,
+      end,
+      entity_id: m.id,
+      entity_type: 'meal' as const,
+      href: `/meals/${m.id}`,
+      icon,
+      isPoint: true,
+      label: m.name ?? typeLabel,
+      start: m.time,
+      tooltip: {
+        details: details.length > 0 ? details : [typeLabel],
+        time: formatTime(m.time),
+        title: `${icon} ${typeLabel}`,
+      },
+    }
+  })
 
 const formatMetricLabel = (metric: string): string =>
   metric.replaceAll('_', ' ').replaceAll(/\b\w/g, (c) => c.toUpperCase())
@@ -705,6 +736,14 @@ export const Timeline = () => {
     staleTime: 5 * 60 * 1000,
   })
 
+  const mealsQuery = useQuery({
+    enabled: !hiddenCategories.has('meal'),
+    placeholderData: keepPreviousData,
+    queryFn: () => fetchMeals({ start: fetchStart.toISOString(), end: fetchEnd.toISOString() }),
+    queryKey: ['timeline-meals', fromDate.value, toDate.value],
+    staleTime: 5 * 60 * 1000,
+  })
+
   const productivityQuery = useQuery({
     enabled: !hiddenCategories.has('activity') && !hiddenCategories.has('screentime'),
     placeholderData: keepPreviousData,
@@ -974,6 +1013,11 @@ export const Timeline = () => {
     [showMusicColumn],
   )
 
+  const mealItems = useMemo(
+    () => categorizeMeals(mealsQuery.data?.meals ?? [], itemIcons),
+    [mealsQuery.data, itemIcons],
+  )
+
   const allChartItems = useMemo(
     () => [
       ...activityItems,
@@ -982,6 +1026,7 @@ export const Timeline = () => {
       ...categorizeProductivity(productivity, screentimeCategoriesQuery.data ?? [], itemIcons),
       ...occasionalMetricItems,
       ...musicItems,
+      ...mealItems,
     ],
     [
       activityItems,
@@ -993,6 +1038,7 @@ export const Timeline = () => {
       screentimeCategoriesQuery.data,
       occasionalMetricItems,
       musicItems,
+      mealItems,
     ],
   )
 
@@ -1024,6 +1070,7 @@ export const Timeline = () => {
     activitiesQuery.isFetching ||
     placesQuery.isFetching ||
     tagsQuery.isFetching ||
+    mealsQuery.isFetching ||
     productivityQuery.isFetching ||
     scrobblesQuery.isFetching ||
     bucketedMetricsQuery.isFetching

--- a/apps/web/src/pages/Timeline/types.ts
+++ b/apps/web/src/pages/Timeline/types.ts
@@ -24,7 +24,7 @@ export interface ChartItem {
   tooltip: TooltipContent
   isPoint: boolean
   entity_id?: string
-  entity_type?: 'activity' | 'tag' | 'productivity' | 'metric'
+  entity_type?: 'activity' | 'tag' | 'productivity' | 'metric' | 'meal'
   href?: string
   /** Activity type for sparkline overlay targeting */
   activity_type?: 'sleep' | 'nap' | 'meditation' | 'exercise' | 'rest'

--- a/apps/web/src/utils/emojiLookup.ts
+++ b/apps/web/src/utils/emojiLookup.ts
@@ -36,6 +36,14 @@ export const DEFAULT_ITEM_ICONS: Record<string, string> = {
   'exercise:Walking': '🚶',
   'exercise:Weightlifting': '🏋️',
   'exercise:Workout': '🏋️',
+
+  // Meal types
+  'meal:breakfast': '🍳',
+  'meal:lunch': '🍽️',
+  'meal:dinner': '🍽️',
+  'meal:snack': '🍿',
+  'meal:drink': '☕',
+  'meal:default': '🍽️',
   'exercise:Yoga': '🧘',
 }
 


### PR DESCRIPTION
## Summary

### Meal Detail Editor (Phase 2)
The `/meals/:id` detail page is now a full meal editor. All fields are editable:
- **Meal type** — dropdown (breakfast/lunch/dinner/snack/drink) + custom free text
- **Macros** — compact grid for calories, protein, carbs, fat, fiber
- **Meal flags** — checkboxes from user's configured flag areas
- **Food items** — add/remove/edit rows with name, quantity, unit, calories
- **Name, time, notes** — already editable from before

No backend changes needed — `updateMealBodySchema` and `updateMeal` DB already support all fields.

### Timeline Integration (Phase 3)
Meals now appear on the timeline:
- Point items in the "Tags / Events" column with amber color
- Default meal emojis: 🍳 breakfast, 🍽️ lunch/dinner, 🍿 snack, ☕ drink
- Customizable via `item_icons` with `meal:{type}` prefix
- Tooltip shows name, type, calories
- Click navigates to `/meals/:id`
- `'meal'` legend toggle to show/hide

## Test plan

- [ ] Open /meals/:id — click Edit
- [ ] Change meal type via dropdown, change macros, toggle flags, add/remove food items
- [ ] Save — changes persist
- [ ] Timeline shows meal emojis at correct times
- [ ] Click meal on timeline → opens detail page
- [ ] Toggle meals off in timeline legend — meal items disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)