### PR TITLE
Fix migration script import path for workspace resolution

### DIFF
--- a/scripts/migration/normalize-food-items.ts
+++ b/scripts/migration/normalize-food-items.ts
@@ -10,7 +10,7 @@
  * Usage: cd apps/backend && npx tsx ../../scripts/migration/normalize-food-items.ts
  */
 
-import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+import { NUTRIENT_FIELD_NAMES } from '../../packages/api-spec/src/schemas/nutrients.ts'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { resolve } from 'node:path'


### PR DESCRIPTION
Use relative import for api-spec in migration script since tsx can't resolve pnpm workspace packages when run from apps/backend context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)