### PR TITLE
Show all macros when editing food items in meal detail

### DIFF
--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -160,8 +160,45 @@
 
 .food-item-edit-row {
   display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fafafa;
+}
+
+.food-row-top {
+  display: flex;
   gap: 0.375rem;
   align-items: center;
+}
+
+.food-row-macros {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.food-row-macros label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.0625rem;
+}
+
+.food-row-macros span {
+  font-size: 0.65rem;
+  color: #6b7280;
+}
+
+.food-row-macros input {
+  width: 55px;
+  padding: 0.2rem 0.3rem;
+  font-size: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  color: #374151;
+  background: #fff;
 }
 
 .food-name-input {
@@ -279,10 +316,20 @@
   .type-editor select,
   .type-editor input,
   .macro-input input,
-  .food-item-edit-row input {
+  .food-item-edit-row input,
+  .food-row-macros input {
     background: #374151;
     border-color: #4b5563;
     color: #d1d5db;
+  }
+
+  .food-item-edit-row {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .food-row-macros span {
+    color: #9ca3af;
   }
 
   .macro-input span {

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -139,49 +139,90 @@ function FoodItemRow({
   const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
   return (
     <div class="food-item-edit-row">
-      <FoodItemAutocomplete
-        value={item.name}
-        onChange={(name) => update('name', name)}
-        onSelect={(fi: FoodItemEntity) => {
-          onChange(index, {
-            ...item,
-            name: fi.name,
-            quantity: fi.default_quantity ?? item.quantity,
-            unit: fi.default_unit ?? item.unit,
-            calories: fi.calories ?? item.calories,
-            protein: fi.protein ?? item.protein,
-            carbs: fi.carbs ?? item.carbs,
-            fat: fi.fat ?? item.fat,
-            fiber: fi.fiber ?? item.fiber,
-          })
-        }}
-      />
-      <input
-        type="number"
-        step="0.1"
-        value={item.quantity ?? ''}
-        placeholder="Qty"
-        class="food-num-input"
-        onInput={(e) => update('quantity', parseNum((e.target as HTMLInputElement).value))}
-      />
-      <input
-        type="text"
-        value={item.unit ?? ''}
-        placeholder="Unit"
-        class="food-unit-input"
-        onInput={(e) => update('unit', (e.target as HTMLInputElement).value)}
-      />
-      <input
-        type="number"
-        step="0.1"
-        value={item.calories ?? ''}
-        placeholder="kcal"
-        class="food-num-input"
-        onInput={(e) => update('calories', parseNum((e.target as HTMLInputElement).value))}
-      />
-      <button type="button" class="btn-danger-small" onClick={() => onRemove(index)}>
-        &times;
-      </button>
+      <div class="food-row-top">
+        <FoodItemAutocomplete
+          value={item.name}
+          onChange={(name) => update('name', name)}
+          onSelect={(fi: FoodItemEntity) => {
+            onChange(index, {
+              ...item,
+              name: fi.name,
+              quantity: fi.default_quantity ?? item.quantity,
+              unit: fi.default_unit ?? item.unit,
+              calories: fi.calories ?? item.calories,
+              protein: fi.protein ?? item.protein,
+              carbs: fi.carbs ?? item.carbs,
+              fat: fi.fat ?? item.fat,
+              fiber: fi.fiber ?? item.fiber,
+            })
+          }}
+        />
+        <input
+          type="number"
+          step="0.1"
+          value={item.quantity ?? ''}
+          placeholder="Qty"
+          class="food-num-input"
+          onInput={(e) => update('quantity', parseNum((e.target as HTMLInputElement).value))}
+        />
+        <input
+          type="text"
+          value={item.unit ?? ''}
+          placeholder="Unit"
+          class="food-unit-input"
+          onInput={(e) => update('unit', (e.target as HTMLInputElement).value)}
+        />
+        <button type="button" class="btn-danger-small" onClick={() => onRemove(index)}>
+          &times;
+        </button>
+      </div>
+      <div class="food-row-macros">
+        <label>
+          <span>kcal</span>
+          <input
+            type="number"
+            step="0.1"
+            value={item.calories ?? ''}
+            onInput={(e) => update('calories', parseNum((e.target as HTMLInputElement).value))}
+          />
+        </label>
+        <label>
+          <span>prot</span>
+          <input
+            type="number"
+            step="0.1"
+            value={item.protein ?? ''}
+            onInput={(e) => update('protein', parseNum((e.target as HTMLInputElement).value))}
+          />
+        </label>
+        <label>
+          <span>carbs</span>
+          <input
+            type="number"
+            step="0.1"
+            value={item.carbs ?? ''}
+            onInput={(e) => update('carbs', parseNum((e.target as HTMLInputElement).value))}
+          />
+        </label>
+        <label>
+          <span>fat</span>
+          <input
+            type="number"
+            step="0.1"
+            value={item.fat ?? ''}
+            onInput={(e) => update('fat', parseNum((e.target as HTMLInputElement).value))}
+          />
+        </label>
+        <label>
+          <span>fiber</span>
+          <input
+            type="number"
+            step="0.1"
+            value={item.fiber ?? ''}
+            onInput={(e) => update('fiber', parseNum((e.target as HTMLInputElement).value))}
+          />
+        </label>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Food item edit rows now display all macro inputs (kcal, protein, carbs, fat, fiber) in a compact second line. These are pre-filled when selecting from autocomplete and visible for manual editing.

Previously only the name, qty, unit, and kcal were shown — protein/carbs/fat/fiber were set internally but invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)