### PR TITLE
Auto-sum meal macros from food items on save

### DIFF
--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -273,7 +273,7 @@ interface EditState {
 }
 
 /** Build the PATCH body from edit state, auto-summing macros from food items. */
-const buildSaveBody = (editing: EditState, meal: { food_items?: unknown[] }): Record<string, unknown> => {
+const buildSaveBody = (editing: EditState): Record<string, unknown> => {
   const body: Record<string, unknown> = {}
   if (editing.name !== undefined) body.name = editing.name || null
   if (editing.time !== undefined) body.time = new Date(editing.time).toISOString()
@@ -389,7 +389,7 @@ export function MealDetail() {
 
   const handleSave = () => {
     if (!editing) return
-    const body = buildSaveBody(editing, meal)
+    const body = buildSaveBody(editing)
     updateMutation.mutate(body)
   }
 

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -361,13 +361,30 @@ export function MealDetail() {
     if (editing.time !== undefined) body.time = new Date(editing.time).toISOString()
     if (editing.notes !== undefined) body.notes = editing.notes || null
     if (editing.meal_type !== undefined) body.meal_type = editing.meal_type
-    if (editing.calories !== undefined) body.calories = editing.calories
-    if (editing.protein !== undefined) body.protein = editing.protein
-    if (editing.carbs !== undefined) body.carbs = editing.carbs
-    if (editing.fat !== undefined) body.fat = editing.fat
-    if (editing.fiber !== undefined) body.fiber = editing.fiber
-    if (editing.food_items !== undefined) body.food_items = editing.food_items.filter((fi) => fi.name.trim())
     if (editing.sensitivities !== undefined) body.sensitivities = editing.sensitivities
+
+    // If food items were edited, auto-sum macros from them
+    const items = editing.food_items?.filter((fi) => fi.name.trim())
+    if (items !== undefined) {
+      body.food_items = items
+      const sum = (field: keyof FoodItemEdit) => {
+        const total = items.reduce((s, fi) => s + ((fi[field] as number) ?? 0), 0)
+        return total > 0 ? Math.round(total * 100) / 100 : null
+      }
+      body.calories = sum('calories')
+      body.protein = sum('protein')
+      body.carbs = sum('carbs')
+      body.fat = sum('fat')
+      body.fiber = sum('fiber')
+    } else {
+      // Manual macro edits (no food item changes)
+      if (editing.calories !== undefined) body.calories = editing.calories
+      if (editing.protein !== undefined) body.protein = editing.protein
+      if (editing.carbs !== undefined) body.carbs = editing.carbs
+      if (editing.fat !== undefined) body.fat = editing.fat
+      if (editing.fiber !== undefined) body.fiber = editing.fiber
+    }
+
     updateMutation.mutate(body)
   }
 

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -272,6 +272,39 @@ interface EditState {
   sensitivities?: string[]
 }
 
+/** Build the PATCH body from edit state, auto-summing macros from food items. */
+const buildSaveBody = (editing: EditState, meal: { food_items?: unknown[] }): Record<string, unknown> => {
+  const body: Record<string, unknown> = {}
+  if (editing.name !== undefined) body.name = editing.name || null
+  if (editing.time !== undefined) body.time = new Date(editing.time).toISOString()
+  if (editing.notes !== undefined) body.notes = editing.notes || null
+  if (editing.meal_type !== undefined) body.meal_type = editing.meal_type
+  if (editing.sensitivities !== undefined) body.sensitivities = editing.sensitivities
+
+  const items = editing.food_items?.filter((fi) => fi.name.trim())
+  if (items !== undefined) {
+    body.food_items = items
+    // Auto-sum macros from food items
+    const sumField = (field: keyof FoodItemEdit) => {
+      const total = items.reduce((s, fi) => s + ((fi[field] as number) ?? 0), 0)
+      return total > 0 ? Math.round(total * 100) / 100 : null
+    }
+    body.calories = sumField('calories')
+    body.protein = sumField('protein')
+    body.carbs = sumField('carbs')
+    body.fat = sumField('fat')
+    body.fiber = sumField('fiber')
+  } else {
+    if (editing.calories !== undefined) body.calories = editing.calories
+    if (editing.protein !== undefined) body.protein = editing.protein
+    if (editing.carbs !== undefined) body.carbs = editing.carbs
+    if (editing.fat !== undefined) body.fat = editing.fat
+    if (editing.fiber !== undefined) body.fiber = editing.fiber
+  }
+
+  return body
+}
+
 // ── Main component ───────────────────────────────────────────────────────────
 
 // eslint-disable-next-line complexity -- detail page with edit mode and multiple data sections
@@ -356,35 +389,7 @@ export function MealDetail() {
 
   const handleSave = () => {
     if (!editing) return
-    const body: Record<string, unknown> = {}
-    if (editing.name !== undefined) body.name = editing.name || null
-    if (editing.time !== undefined) body.time = new Date(editing.time).toISOString()
-    if (editing.notes !== undefined) body.notes = editing.notes || null
-    if (editing.meal_type !== undefined) body.meal_type = editing.meal_type
-    if (editing.sensitivities !== undefined) body.sensitivities = editing.sensitivities
-
-    // If food items were edited, auto-sum macros from them
-    const items = editing.food_items?.filter((fi) => fi.name.trim())
-    if (items !== undefined) {
-      body.food_items = items
-      const sum = (field: keyof FoodItemEdit) => {
-        const total = items.reduce((s, fi) => s + ((fi[field] as number) ?? 0), 0)
-        return total > 0 ? Math.round(total * 100) / 100 : null
-      }
-      body.calories = sum('calories')
-      body.protein = sum('protein')
-      body.carbs = sum('carbs')
-      body.fat = sum('fat')
-      body.fiber = sum('fiber')
-    } else {
-      // Manual macro edits (no food item changes)
-      if (editing.calories !== undefined) body.calories = editing.calories
-      if (editing.protein !== undefined) body.protein = editing.protein
-      if (editing.carbs !== undefined) body.carbs = editing.carbs
-      if (editing.fat !== undefined) body.fat = editing.fat
-      if (editing.fiber !== undefined) body.fiber = editing.fiber
-    }
-
+    const body = buildSaveBody(editing, meal)
     updateMutation.mutate(body)
   }
 


### PR DESCRIPTION
When food items are edited and saved, the meal's top-level macros (calories, protein, carbs, fat, fiber) are auto-calculated as the sum of all food item values. So adding "Fat coffee" (367 kcal, 40g fat) as a food item immediately updates the meal totals.

Manual macro edits still work when food items aren't being changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)