### PR TITLE
Wire junction table into meal service

### DIFF
--- a/apps/backend/src/db/food-items.integration.test.ts
+++ b/apps/backend/src/db/food-items.integration.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import {
+  deleteFoodItem,
+  findOrCreateFoodItem,
+  getFoodItemById,
+  getFoodItemByName,
+  searchFoodItems,
+  updateFoodItem,
+  upsertFoodItem,
+} from './food-items.ts'
+import { getMealFoodItems, setMealFoodItems } from './meal-food-items.ts'
+import { insertMeal } from './meals.ts'
+
+const CONTAINER_TIMEOUT = 60_000
+
+describe('Food Items Integration Tests', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  describe('upsertFoodItem', () => {
+    test('creates a food item with macros', async () => {
+      const user = getTestUser()
+
+      const item = await upsertFoodItem(user, {
+        name: 'Rye Bread',
+        source: 'cronometer',
+        default_quantity: 2,
+        default_unit: 'large slice',
+        calories: 222.74,
+        protein: 7.31,
+        carbs: 41.54,
+        fat: 2.84,
+        fiber: 3.84,
+      })
+
+      expect(item.id).toBeDefined()
+      expect(item.name).toBe('Rye Bread')
+      expect(item.name_lower).toBe('rye bread')
+      expect(item.source).toBe('cronometer')
+      expect(item.calories).toBe(222.74)
+      expect(item.protein).toBe(7.31)
+    })
+
+    test('deduplicates by name (case-insensitive)', async () => {
+      const user = getTestUser()
+
+      const first = await upsertFoodItem(user, { name: 'Rye Bread', calories: 200 })
+      const second = await upsertFoodItem(user, { name: 'rye bread', calories: 250 })
+
+      expect(first.id).toBe(second.id)
+      expect(second.calories).toBe(250) // Updated
+    })
+  })
+
+  describe('searchFoodItems', () => {
+    test('finds items by prefix', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: 'Rye Bread' })
+      await upsertFoodItem(user, { name: 'Rice' })
+      await upsertFoodItem(user, { name: 'Banana' })
+
+      const results = await searchFoodItems(user, 'r', 10)
+      expect(results).toHaveLength(2)
+      expect(results.map((r) => r.name).sort()).toEqual(['Rice', 'Rye Bread'])
+    })
+
+    test('is case-insensitive', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: 'Fat Coffee' })
+
+      const results = await searchFoodItems(user, 'fat', 10)
+      expect(results).toHaveLength(1)
+      expect(results[0].name).toBe('Fat Coffee')
+    })
+  })
+
+  describe('getFoodItemByName', () => {
+    test('finds by exact name (case-insensitive)', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: 'Banana', calories: 105 })
+
+      const found = await getFoodItemByName(user, 'BANANA')
+      expect(found).not.toBeNull()
+      expect(found!.calories).toBe(105)
+    })
+
+    test('returns null for missing name', async () => {
+      const user = getTestUser()
+      const found = await getFoodItemByName(user, 'Nonexistent')
+      expect(found).toBeNull()
+    })
+  })
+
+  describe('findOrCreateFoodItem', () => {
+    test('creates if not found', async () => {
+      const user = getTestUser()
+
+      const item = await findOrCreateFoodItem(user, 'New Food', { calories: 100 })
+      expect(item.name).toBe('New Food')
+      expect(item.calories).toBe(100)
+    })
+
+    test('returns existing if found', async () => {
+      const user = getTestUser()
+
+      const first = await upsertFoodItem(user, { name: 'Existing', calories: 200 })
+      const second = await findOrCreateFoodItem(user, 'existing', { calories: 300 })
+
+      expect(second.id).toBe(first.id)
+      expect(second.calories).toBe(200) // Not overwritten
+    })
+  })
+
+  describe('updateFoodItem', () => {
+    test('updates specific fields', async () => {
+      const user = getTestUser()
+
+      const item = await upsertFoodItem(user, { name: 'Bread', calories: 200, protein: 7 })
+      const updated = await updateFoodItem(user, item.id, { calories: 250 })
+
+      expect(updated!.calories).toBe(250)
+      expect(updated!.protein).toBe(7) // Unchanged
+    })
+  })
+
+  describe('deleteFoodItem', () => {
+    test('deletes a food item', async () => {
+      const user = getTestUser()
+
+      const item = await upsertFoodItem(user, { name: 'ToDelete' })
+      const deleted = await deleteFoodItem(user, item.id)
+      expect(deleted).toBe(true)
+
+      const found = await getFoodItemById(user, item.id)
+      expect(found).toBeNull()
+    })
+  })
+
+  describe('meal_food_items junction', () => {
+    test('links food items to meals', async () => {
+      const user = getTestUser()
+
+      const food1 = await upsertFoodItem(user, { name: 'Bread', calories: 200 })
+      const food2 = await upsertFoodItem(user, { name: 'Butter', calories: 100, fat: 11 })
+      const meal = await insertMeal(user, { time: new Date('2025-06-15T08:00:00Z') })
+
+      await setMealFoodItems(user, meal.id, [
+        { food_item_id: food1.id, quantity: 2, unit: 'slice', sort_order: 0, calories: 400 },
+        { food_item_id: food2.id, quantity: 1, unit: 'tbsp', sort_order: 1, calories: 100, fat: 11 },
+      ])
+
+      const links = await getMealFoodItems(user, meal.id)
+      expect(links).toHaveLength(2)
+      expect(links[0].food_item_name).toBe('Bread')
+      expect(links[0].calories).toBe(400)
+      expect(links[1].food_item_name).toBe('Butter')
+      expect(links[1].fat).toBe(11)
+    })
+
+    test('replaces junction rows on re-set', async () => {
+      const user = getTestUser()
+
+      const food = await upsertFoodItem(user, { name: 'Rice' })
+      const meal = await insertMeal(user, { time: new Date('2025-06-15T12:00:00Z') })
+
+      await setMealFoodItems(user, meal.id, [
+        { food_item_id: food.id, quantity: 1, unit: 'cup', sort_order: 0 },
+      ])
+
+      const food2 = await upsertFoodItem(user, { name: 'Chicken' })
+      await setMealFoodItems(user, meal.id, [
+        { food_item_id: food2.id, quantity: 150, unit: 'g', sort_order: 0 },
+      ])
+
+      const links = await getMealFoodItems(user, meal.id)
+      expect(links).toHaveLength(1)
+      expect(links[0].food_item_name).toBe('Chicken')
+    })
+
+    test('cascade deletes junction rows when meal is deleted', async () => {
+      const user = getTestUser()
+
+      const food = await upsertFoodItem(user, { name: 'Egg' })
+      const meal = await insertMeal(user, { time: new Date('2025-06-15T07:00:00Z') })
+
+      await setMealFoodItems(user, meal.id, [{ food_item_id: food.id, quantity: 2, sort_order: 0 }])
+
+      const { deleteMeal } = await import('./meals.ts')
+      await deleteMeal(user, meal.id)
+
+      const links = await getMealFoodItems(user, meal.id)
+      expect(links).toHaveLength(0)
+    })
+  })
+})

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -316,6 +316,7 @@ export type NutrientValue = number | { value: number; unit: string }
 export type Micros = Record<string, NutrientValue>
 
 export interface MealFoodItem {
+  food_item_id?: string
   name: string
   quantity?: number
   unit?: string

--- a/apps/backend/src/services/meals.test.ts
+++ b/apps/backend/src/services/meals.test.ts
@@ -6,10 +6,14 @@ import { addMeal, deleteMealById, getMeal, queryMeals, updateMealById } from './
 // Mock the db module
 vi.mock('../db', () => ({
   deleteMeal: vi.fn(),
+  findOrCreateFoodItem: vi.fn().mockResolvedValue({ id: 'fi-1', name: 'test' }),
   getMealById: vi.fn(),
+  getMealFoodItems: vi.fn().mockResolvedValue([]),
+  getMealFoodItemsBatch: vi.fn().mockResolvedValue(new Map()),
   getMeals: vi.fn(),
-  upsertMeal: vi.fn(),
+  setMealFoodItems: vi.fn().mockResolvedValue(undefined),
   updateMeal: vi.fn(),
+  upsertMeal: vi.fn(),
 }))
 
 const mockUpsertMeal = vi.mocked(db.upsertMeal)

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -2,16 +2,24 @@
  * Meals service — CRUD operations for meal/nutrition records.
  *
  * Handles adding, querying, and deleting meals with optional nutrition data.
+ * Food items are stored relationally via the food_items + meal_food_items junction table.
  */
+
+import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 
 import {
   deleteMeal as dbDeleteMeal,
+  findOrCreateFoodItem,
   getMealById as dbGetMealById,
+  getMealFoodItems,
+  getMealFoodItemsBatch,
   getMeals as dbGetMeals,
-  upsertMeal as dbUpsertMeal,
+  setMealFoodItems,
   updateMeal as dbUpdateMeal,
+  upsertMeal as dbUpsertMeal,
   type Meal,
   type MealFoodItem,
+  type MealFoodItemLink,
   type Micros,
 } from '../db/index.ts'
 
@@ -93,7 +101,7 @@ interface MealsResult {
 }
 
 // ============================================================================
-// Formatters
+// Helpers
 // ============================================================================
 
 const formatMeal = (meal: Meal): MealResponse => ({
@@ -113,6 +121,78 @@ const formatMeal = (meal: Meal): MealResponse => ({
   source: meal.source,
   time: meal.time.toISOString(),
 })
+
+/** Convert junction links to the MealFoodItem format for API responses. */
+const linksToFoodItems = (links: MealFoodItemLink[]): MealFoodItem[] =>
+  links.map((link) => {
+    const item: MealFoodItem = {
+      food_item_id: link.food_item_id,
+      name: link.food_item_name ?? '',
+      quantity: link.quantity as number | undefined,
+      unit: link.unit as string | undefined,
+    }
+    // Copy macro fields
+    for (const field of ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const) {
+      const val = link[field]
+      if (typeof val === 'number') (item as Record<string, unknown>)[field] = val
+    }
+    return item
+  })
+
+/** Attach food items from junction table to meals, replacing JSONB food_items. */
+const attachFoodItems = async (user: string, meals: Meal[]): Promise<Meal[]> => {
+  const mealIds = meals.map((m) => m.id)
+  const junctionMap = await getMealFoodItemsBatch(user, mealIds)
+
+  return meals.map((meal) => {
+    const links = junctionMap.get(meal.id)
+    if (links && links.length > 0) {
+      return { ...meal, food_items: linksToFoodItems(links) }
+    }
+    // Fall back to JSONB food_items if no junction rows exist (legacy data)
+    return meal
+  })
+}
+
+/** Write food items to the junction table for a meal. */
+const syncFoodItemsToJunction = async (
+  user: string,
+  mealId: string,
+  foodItems: FoodItemInput[],
+  source = 'manual',
+): Promise<void> => {
+  const junctionItems = []
+  for (let i = 0; i < foodItems.length; i++) {
+    const fi = foodItems[i]
+    // Find or create canonical food item with the macro defaults
+    const canonical = await findOrCreateFoodItem(user, fi.name, {
+      source,
+      default_quantity: fi.quantity,
+      default_unit: fi.unit,
+      calories: fi.calories,
+      protein: fi.protein,
+      carbs: fi.carbs,
+      fat: fi.fat,
+      fiber: fi.fiber,
+    })
+
+    const junctionItem: Record<string, unknown> = {
+      food_item_id: canonical.id,
+      quantity: fi.quantity,
+      unit: fi.unit,
+      sort_order: i,
+      // Copy macros as snapshot
+      calories: fi.calories,
+      protein: fi.protein,
+      carbs: fi.carbs,
+      fat: fi.fat,
+      fiber: fi.fiber,
+    }
+    junctionItems.push(junctionItem)
+  }
+
+  await setMealFoodItems(user, mealId, junctionItems as Parameters<typeof setMealFoodItems>[2])
+}
 
 // ============================================================================
 // Service Functions
@@ -141,6 +221,11 @@ export async function addMeal(user: string, input: AddMealInput): Promise<MealRe
     time: mealTime,
   })
 
+  // Write junction table rows for food items
+  if (input.food_items && input.food_items.length > 0) {
+    await syncFoodItemsToJunction(user, meal.id, input.food_items, input.source)
+  }
+
   return { data: formatMeal(meal), success: true }
 }
 
@@ -159,6 +244,15 @@ export async function updateMealById(user: string, id: string, input: UpdateMeal
     return { error: 'Meal not found', success: false }
   }
 
+  // Update junction table if food items changed
+  if (input.food_items !== undefined) {
+    if (input.food_items === null || input.food_items.length === 0) {
+      await setMealFoodItems(user, id, [])
+    } else {
+      await syncFoodItemsToJunction(user, id, input.food_items, meal.source)
+    }
+  }
+
   return { data: formatMeal(meal), success: true }
 }
 
@@ -170,7 +264,10 @@ export async function getMeal(user: string, id: string): Promise<MealResult> {
   if (!meal) {
     return { error: 'Meal not found', success: false }
   }
-  return { data: formatMeal(meal), success: true }
+
+  // Populate food items from junction table
+  const [enriched] = await attachFoodItems(user, [meal])
+  return { data: formatMeal(enriched), success: true }
 }
 
 /**
@@ -186,7 +283,9 @@ export async function queryMeals(
     start: filters.start ? new Date(filters.start) : undefined,
   })
 
-  return { data: meals.map(formatMeal), success: true }
+  // Populate food items from junction table
+  const enriched = await attachFoodItems(user, meals)
+  return { data: enriched.map(formatMeal), success: true }
 }
 
 /**

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -124,20 +124,17 @@ const formatMeal = (meal: Meal): MealResponse => ({
 
 /** Convert junction links to the MealFoodItem format for API responses. */
 const linksToFoodItems = (links: MealFoodItemLink[]): MealFoodItem[] =>
-  links.map((link) => {
-    const item: MealFoodItem = {
-      food_item_id: link.food_item_id,
-      name: link.food_item_name ?? '',
-      quantity: link.quantity as number | undefined,
-      unit: link.unit as string | undefined,
-    }
-    // Copy macro fields
-    for (const field of ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const) {
-      const val = link[field]
-      if (typeof val === 'number') (item as Record<string, unknown>)[field] = val
-    }
-    return item
-  })
+  links.map((link) => ({
+    food_item_id: link.food_item_id,
+    name: link.food_item_name ?? '',
+    quantity: link.quantity as number | undefined,
+    unit: link.unit as string | undefined,
+    calories: link.calories as number | undefined,
+    protein: link.protein as number | undefined,
+    carbs: link.carbs as number | undefined,
+    fat: link.fat as number | undefined,
+    fiber: link.fiber as number | undefined,
+  }))
 
 /** Attach food items from junction table to meals, replacing JSONB food_items. */
 const attachFoodItems = async (user: string, meals: Meal[]): Promise<Meal[]> => {

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -5,13 +5,10 @@
  * Food items are stored relationally via the food_items + meal_food_items junction table.
  */
 
-import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
-
 import {
   deleteMeal as dbDeleteMeal,
   findOrCreateFoodItem,
   getMealById as dbGetMealById,
-  getMealFoodItems,
   getMealFoodItemsBatch,
   getMeals as dbGetMeals,
   setMealFoodItems,

--- a/apps/backend/src/test/db-test-helper.ts
+++ b/apps/backend/src/test/db-test-helper.ts
@@ -74,6 +74,8 @@ export const cleanTestDb = async (): Promise<void> => {
 
   // Truncate tables in reverse order to handle foreign keys
   const tables = [
+    'meal_food_items',
+    'food_items',
     'report_entries',
     'reports',
     'meals',


### PR DESCRIPTION
## Summary

Meals now use the relational junction table for food items:

- **Write path**: `addMeal`/`updateMealById` find-or-create canonical food items and write junction rows (alongside JSONB for backwards compat during transition)
- **Read path**: `getMeal`/`queryMeals` populate `food_items` from junction table with `food_item_id`, falling back to JSONB for legacy data without junction rows
- **`food_item_id`** included in food item responses for linking to canonical entries

## Test plan

- [ ] Add a food item to a meal via autocomplete → junction rows created
- [ ] Query meal → food_items includes food_item_id
- [ ] Old Oura meals (no junction rows) still show JSONB food_items
- [ ] Unit tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)