### PR TITLE
Meal UX improvements: create+open, food item detail, section reorder

### DIFF
--- a/apps/web/src/components/FoodItemAutocomplete.tsx
+++ b/apps/web/src/components/FoodItemAutocomplete.tsx
@@ -98,7 +98,9 @@ export function FoodItemAutocomplete({
               onClick={() => handleSelect(item)}
             >
               <span class="ac-name">{item.name}</span>
-              {item.calories !== undefined && <span class="ac-cal">{item.calories} kcal</span>}
+              <span class="ac-cal">
+                {item.calories !== undefined ? `${item.calories} kcal` : '(no data)'}
+              </span>
             </li>
           ))}
         </ul>

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -23,6 +23,7 @@ import { OwnTracksSource } from './pages/DataSources/OwnTracksSource.jsx'
 import { RescueTimeSource } from './pages/DataSources/RescueTimeSource.jsx'
 import { EntityDetail } from './pages/EntityDetail/index.jsx'
 import { ExerciseMeta } from './pages/ExerciseMeta/index.jsx'
+import { FoodItemDetail } from './pages/FoodItems/FoodItemDetail.jsx'
 import { FoodItems } from './pages/FoodItems/index.jsx'
 import { Goals } from './pages/Goals/index.jsx'
 import { Home } from './pages/Home/index.jsx'
@@ -65,6 +66,7 @@ export function App() {
             <Route path="/timeline" component={Timeline} />
             <Route path="/data" component={Data} />
             <Route path="/add" component={AddData} />
+            <Route path="/food-items/:id" component={FoodItemDetail} />
             <Route path="/food-items" component={FoodItems} />
             <Route path="/meals/:id" component={MealDetail} />
             <Route path="/meals" component={Meals} />

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -1,0 +1,106 @@
+.food-item-detail-page {
+  max-width: 700px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.food-item-detail-page h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0.5rem 0 1rem;
+  color: #1f2937;
+}
+
+.back-link {
+  color: #673ab8;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.fi-meta {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.nutrient-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.nutrient-section h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 0.5rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.nutrient-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.25rem 1rem;
+}
+
+.nutrient-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0;
+  font-size: 0.8rem;
+}
+
+.nutrient-label {
+  color: #6b7280;
+}
+
+.nutrient-value {
+  color: #374151;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-color-scheme: dark) {
+  .food-item-detail-page h1 {
+    color: #e5e7eb;
+  }
+
+  .back-link {
+    color: #c4b5fd;
+  }
+
+  .fi-meta {
+    color: #9ca3af;
+  }
+
+  .nutrient-section h3 {
+    color: #d1d5db;
+    border-color: #374151;
+  }
+
+  .nutrient-label {
+    color: #9ca3af;
+  }
+
+  .nutrient-value {
+    color: #d1d5db;
+  }
+}
+
+@media (max-width: 639px) {
+  .food-item-detail-page {
+    padding: 1rem;
+  }
+
+  .nutrient-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -2,7 +2,7 @@ import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
 
-import { type FoodItemEntity } from '../../state/api'
+import type { FoodItemEntity } from '../../state/api'
 import { auth } from '../../state/auth'
 import './FoodItemDetail.css'
 

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,0 +1,109 @@
+import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
+import { useQuery } from '@tanstack/react-query'
+import { useRoute } from 'preact-iso'
+
+import { type FoodItemEntity } from '../../state/api'
+import { auth } from '../../state/auth'
+import './FoodItemDetail.css'
+
+const API_URL = import.meta.env.VITE_API_URL || '/api'
+
+const fetchFoodItem = async (id: string): Promise<FoodItemEntity> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error('Food item not found')
+  const json = await res.json()
+  return json.data
+}
+
+const CATEGORIES: Array<{ key: NutrientFieldDef['category']; label: string }> = [
+  { key: 'macro', label: 'Macros' },
+  { key: 'extended_macro', label: 'Extended Macros' },
+  { key: 'fat_breakdown', label: 'Fat Breakdown' },
+  { key: 'vitamin', label: 'Vitamins' },
+  { key: 'mineral', label: 'Minerals' },
+  { key: 'amino_acid', label: 'Amino Acids' },
+  { key: 'other', label: 'Other' },
+]
+
+function NutrientSection({
+  item,
+  category,
+  label,
+}: {
+  item: FoodItemEntity
+  category: string
+  label: string
+}) {
+  const fields = NUTRIENT_FIELDS.filter((f) => f.category === category)
+  const populated = fields.filter((f) => item[f.name] !== undefined && item[f.name] !== null)
+  if (populated.length === 0) return null
+
+  return (
+    <div class="nutrient-section">
+      <h3>{label}</h3>
+      <div class="nutrient-grid">
+        {populated.map((f) => (
+          <div key={f.name} class="nutrient-row">
+            <span class="nutrient-label">{f.label}</span>
+            <span class="nutrient-value">
+              {typeof item[f.name] === 'number' ? (item[f.name] as number).toFixed(2) : item[f.name]} {f.unit}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function FoodItemDetail() {
+  const { params } = useRoute()
+  const id = params.id
+
+  const { data: item, isLoading } = useQuery({
+    queryFn: () => fetchFoodItem(id),
+    queryKey: ['foodItem', id],
+  })
+
+  if (isLoading) {
+    return (
+      <div class="food-item-detail-page">
+        <p class="loading">Loading...</p>
+      </div>
+    )
+  }
+  if (!item) {
+    return (
+      <div class="food-item-detail-page">
+        <p>Food item not found.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="food-item-detail-page">
+      <a href="/food-items" class="back-link">
+        &larr; Food Items
+      </a>
+
+      <h1>{item.name}</h1>
+
+      <div class="fi-meta">
+        {item.source && <span class="fi-source">Source: {item.source}</span>}
+        {item.default_quantity && (
+          <span class="fi-default">
+            Default: {item.default_quantity} {item.default_unit ?? 'serving'}
+          </span>
+        )}
+      </div>
+
+      <div class="nutrient-sections">
+        {CATEGORIES.map(({ key, label }) => (
+          <NutrientSection key={key} item={item} category={key} label={label} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -242,6 +242,11 @@
   font-size: 0.75rem;
   background: #e0f2fe;
   color: #0369a1;
+  text-decoration: none;
+}
+
+a.detail-food-link:hover {
+  background: #bae6fd;
   border-radius: 10px;
 }
 

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -147,7 +147,7 @@ function FoodItemRow({
             onChange(index, {
               ...item,
               name: fi.name,
-              quantity: fi.default_quantity ?? item.quantity,
+              quantity: fi.default_quantity ?? 1,
               unit: fi.default_unit ?? item.unit,
               calories: fi.calories ?? item.calories,
               protein: fi.protein ?? item.protein,
@@ -478,23 +478,6 @@ export function MealDetail() {
           )}
         </div>
 
-        {/* Macros */}
-        <div class="detail-row">
-          <label>Macros</label>
-          {isEditing ? (
-            <MacrosEditor
-              calories={editCal}
-              protein={editProt}
-              carbs={editCarbs}
-              fat={editFat}
-              fiber={editFiber}
-              onChange={(field, val) => setEditing({ ...editing, [field]: val })}
-            />
-          ) : (
-            <span class="detail-value">{macroDisplay || '—'}</span>
-          )}
-        </div>
-
         {/* Flags */}
         <div class="detail-row">
           <label>Flags</label>
@@ -527,15 +510,43 @@ export function MealDetail() {
             />
           ) : meal.food_items && meal.food_items.length > 0 ? (
             <div class="detail-food-items">
-              {meal.food_items.map((item, i) => (
-                <span key={i} class="detail-food-chip">
-                  {item.name}
-                  {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
-                </span>
-              ))}
+              {meal.food_items.map((item, i) =>
+                item.food_item_id ? (
+                  <a
+                    key={i}
+                    href={`/food-items/${item.food_item_id}`}
+                    class="detail-food-chip detail-food-link"
+                  >
+                    {item.name}
+                    {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
+                  </a>
+                ) : (
+                  <span key={i} class="detail-food-chip">
+                    {item.name}
+                    {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
+                  </span>
+                ),
+              )}
             </div>
           ) : (
             <span class="detail-value">—</span>
+          )}
+        </div>
+
+        {/* Macros */}
+        <div class="detail-row">
+          <label>Macros</label>
+          {isEditing ? (
+            <MacrosEditor
+              calories={editCal}
+              protein={editProt}
+              carbs={editCarbs}
+              fat={editFat}
+              fiber={editFiber}
+              onChange={(field, val) => setEditing({ ...editing, [field]: val })}
+            />
+          ) : (
+            <span class="detail-value">{macroDisplay || '—'}</span>
           )}
         </div>
 

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -173,6 +173,7 @@ interface MealSlotRowProps {
   onToggleSensitivity: (slot: MealSlot, area: string, existingMeal?: Meal) => void
   onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
   onChangeTime: (meal: Meal, hour: number, minute?: number) => void
+  onCreateAndOpen: (slot: MealSlot) => void
   onDelete: (id: string) => void
   isDeletePending: boolean
   isSaving: boolean
@@ -186,6 +187,7 @@ function MealSlotRow({
   onToggleSensitivity,
   onToggleFoodMapping,
   onChangeTime,
+  onCreateAndOpen,
   onDelete,
   isDeletePending,
   isSaving,
@@ -225,10 +227,19 @@ function MealSlotRow({
 
         {isSaving && <span class="saving-indicator" />}
 
-        {primaryMeal && (
+        {primaryMeal ? (
           <a href={`/meals/${primaryMeal.id}`} class="meal-edit-link" title="Edit meal details">
             ...
           </a>
+        ) : (
+          <button
+            type="button"
+            class="meal-edit-link"
+            title="Create meal and edit details"
+            onClick={() => onCreateAndOpen(slot)}
+          >
+            +
+          </button>
         )}
 
         {primaryMeal && (
@@ -453,6 +464,7 @@ function useMealMutations(mealsQueryKey: string[], meals: Meal[] | undefined) {
 // eslint-disable-next-line complexity -- React component with many hooks and conditional renders
 function MealsContent({ dayKey }: { dayKey: string }) {
   const isLoggedIn = auth.value.token
+  const { route } = useLocation()
 
   const { data: settings } = useQuery({
     enabled: !!isLoggedIn,
@@ -487,6 +499,20 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     deleteMutation,
     toggleCompletedMutation,
   } = useMealMutations(mealsQueryKey, meals)
+
+  const handleCreateAndOpen = async (slot: MealSlot) => {
+    const id = crypto.randomUUID()
+    const mealTime = new Date(dayKey)
+    mealTime.setHours(slot.default_hour, 0, 0, 0)
+    await addMealApi({
+      id,
+      meal_type: slot.name.toLowerCase(),
+      source: 'manual',
+      time: mealTime.toISOString(),
+    })
+    queryClient.invalidateQueries({ queryKey: ['meals'] })
+    route(`/meals/${id}`)
+  }
 
   const otherMeals = getOtherMeals(meals ?? [], mealSlots)
   const foodSensitivityMap: Record<string, string[]> = settings?.food_sensitivity_map ?? {}
@@ -535,6 +561,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
             onToggleSensitivity={handleToggleSensitivity}
             onToggleFoodMapping={handleToggleFoodMapping}
             onChangeTime={handleChangeTime}
+            onCreateAndOpen={handleCreateAndOpen}
             onDelete={(id) => deleteMutation.mutate(id)}
             isDeletePending={deleteMutation.isPending}
             isSaving={savingSlots.has(slot.name.toLowerCase())}


### PR DESCRIPTION
## Summary

Several UX improvements based on user feedback:

- **"+" button on empty slots** — create a meal and open its detail page directly, without needing to add a flag first
- **Food item detail page** (`/food-items/:id`) — shows all nutrients grouped by category (macros, vitamins, minerals, amino acids, etc.)
- **Clickable food item chips** — on meal detail, food items with `food_item_id` link to their detail page
- **Section reorder** — meal detail now shows Flags + Food Items above Macros (food items are the source of truth for nutrition)
- **Quantity defaults to 1** when selecting from autocomplete (instead of undefined)
- **"(no data)" indicator** in autocomplete for food items without calories (e.g., Oura items with names only)

## Test plan

- [ ] Empty slot shows "+" button → creates meal, navigates to detail page
- [ ] Autocomplete: select item → qty defaults to 1, macros pre-fill (for Cronometer items)
- [ ] Autocomplete: Oura items show "(no data)" instead of blank
- [ ] Save meal with food items → chips are clickable links to `/food-items/:id`
- [ ] Food item detail page shows all nutrients grouped by category
- [ ] Meal detail order: Type, Time, Name, Flags, Food Items, Macros, Notes, Source

🤖 Generated with [Claude Code](https://claude.com/claude-code)