### PR TITLE
Aggregate all 65 nutrients from food items into meal response

### DIFF
--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -5,6 +5,8 @@
  * Food items are stored relationally via the food_items + meal_food_items junction table.
  */
 
+import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+
 import {
   deleteMeal as dbDeleteMeal,
   findOrCreateFoodItem,
@@ -81,6 +83,7 @@ interface MealResponse {
   food_items?: MealFoodItem[]
   micros?: Micros
   notes?: string
+  nutrients?: Record<string, number>
   sensitivities?: string[]
   created_at: string
 }
@@ -101,7 +104,7 @@ interface MealsResult {
 // Helpers
 // ============================================================================
 
-const formatMeal = (meal: Meal): MealResponse => ({
+const formatMeal = (meal: Meal & { nutrients?: Record<string, number> }): MealResponse => ({
   calories: meal.calories,
   carbs: meal.carbs,
   created_at: meal.created_at.toISOString(),
@@ -113,6 +116,7 @@ const formatMeal = (meal: Meal): MealResponse => ({
   micros: meal.micros,
   name: meal.name,
   notes: meal.notes,
+  nutrients: meal.nutrients,
   protein: meal.protein,
   sensitivities: meal.sensitivities,
   source: meal.source,
@@ -133,15 +137,37 @@ const linksToFoodItems = (links: MealFoodItemLink[]): MealFoodItem[] =>
     fiber: link.fiber as number | undefined,
   }))
 
-/** Attach food items from junction table to meals, replacing JSONB food_items. */
-const attachFoodItems = async (user: string, meals: Meal[]): Promise<Meal[]> => {
+/** Aggregate all nutrient columns from junction links into a flat record. */
+const aggregateNutrients = (links: MealFoodItemLink[]): Record<string, number> => {
+  const totals: Record<string, number> = {}
+  for (const link of links) {
+    for (const field of NUTRIENT_FIELD_NAMES) {
+      const val = link[field]
+      if (typeof val === 'number' && val > 0) {
+        totals[field] = (totals[field] ?? 0) + val
+      }
+    }
+  }
+  // Round to 2 decimal places
+  for (const key of Object.keys(totals)) {
+    totals[key] = Math.round(totals[key] * 100) / 100
+  }
+  return totals
+}
+
+/** Attach food items and aggregated nutrients from junction table to meals. */
+const attachFoodItems = async (
+  user: string,
+  meals: Meal[],
+): Promise<Array<Meal & { nutrients?: Record<string, number> }>> => {
   const mealIds = meals.map((m) => m.id)
   const junctionMap = await getMealFoodItemsBatch(user, mealIds)
 
   return meals.map((meal) => {
     const links = junctionMap.get(meal.id)
     if (links && links.length > 0) {
-      return { ...meal, food_items: linksToFoodItems(links) }
+      const nutrients = aggregateNutrients(links)
+      return { ...meal, food_items: linksToFoodItems(links), nutrients }
     }
     // Fall back to JSONB food_items if no junction rows exist (legacy data)
     return meal

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -89,6 +89,57 @@
   flex: 1;
 }
 
+/* Nutrient breakdown */
+
+.nutrient-breakdown {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.nutrient-toggle {
+  background: none;
+  border: none;
+  color: #673ab8;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0;
+  font-weight: 500;
+}
+
+.nutrient-toggle:hover {
+  text-decoration: underline;
+}
+
+.nutrient-groups {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.nutrient-group h4 {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  margin: 0 0 0.25rem;
+  padding-bottom: 0.125rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.nutrient-line {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  padding: 0.125rem 0;
+  color: #374151;
+}
+
+.nutrient-line span:last-child {
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
 .type-editor select,
 .type-editor input {
   padding: 0.375rem 0.5rem;
@@ -296,6 +347,23 @@ a.detail-food-link:hover {
 
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
+  .nutrient-breakdown {
+    border-color: #374151;
+  }
+
+  .nutrient-toggle {
+    color: #c4b5fd;
+  }
+
+  .nutrient-group h4 {
+    color: #9ca3af;
+    border-color: #374151;
+  }
+
+  .nutrient-line {
+    color: #d1d5db;
+  }
+
   .detail-card {
     background: #1f2937;
     border-color: #374151;

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -1,3 +1,4 @@
+import { NUTRIENT_FIELDS } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
@@ -255,6 +256,53 @@ function FoodItemsEditor({
 }
 
 // ── Read-only info rows ──────────────────────────────────────────────────────
+
+// ── Nutrient breakdown ───────────────────────────────────────────────────────
+
+const NUTRIENT_CATEGORIES = [
+  { key: 'macro', label: 'Macros' },
+  { key: 'extended_macro', label: 'Extended' },
+  { key: 'fat_breakdown', label: 'Fats' },
+  { key: 'vitamin', label: 'Vitamins' },
+  { key: 'mineral', label: 'Minerals' },
+  { key: 'amino_acid', label: 'Amino Acids' },
+  { key: 'other', label: 'Other' },
+] as const
+
+function NutrientBreakdown({ nutrients }: { nutrients: Record<string, number> }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div class="nutrient-breakdown">
+      <button type="button" class="nutrient-toggle" onClick={() => setExpanded(!expanded)}>
+        {expanded ? '▾' : '▸'} Full nutrients ({Object.keys(nutrients).length} values)
+      </button>
+      {expanded && (
+        <div class="nutrient-groups">
+          {NUTRIENT_CATEGORIES.map(({ key, label }) => {
+            const fields = NUTRIENT_FIELDS.filter(
+              (f) => f.category === key && nutrients[f.name] !== undefined,
+            )
+            if (fields.length === 0) return null
+            return (
+              <div key={key} class="nutrient-group">
+                <h4>{label}</h4>
+                {fields.map((f) => (
+                  <div key={f.name} class="nutrient-line">
+                    <span>{f.label}</span>
+                    <span>
+                      {nutrients[f.name].toFixed(1)} {f.unit}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
 
 // ── Edit state ───────────────────────────────────────────────────────────────
 
@@ -549,6 +597,11 @@ export function MealDetail() {
             <span class="detail-value">{macroDisplay || '—'}</span>
           )}
         </div>
+
+        {/* Full Nutrients (from junction aggregation) */}
+        {!isEditing && meal.nutrients && Object.keys(meal.nutrients).length > 0 && (
+          <NutrientBreakdown nutrients={meal.nutrients} />
+        )}
 
         {/* Notes */}
         <div class="detail-row">

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -162,6 +162,7 @@ export interface Scrobble extends Omit<ApiScrobble, 'recorded_at'> {
 export interface Meal extends Omit<ApiMeal, 'time' | 'created_at'> {
   time: Date
   created_at?: Date
+  nutrients?: Record<string, number>
 }
 
 export interface Report extends Omit<ApiReport, 'date' | 'created_at'> {


### PR DESCRIPTION
## Summary

**Backend**: When reading meals with junction-linked food items, all 65 nutrient columns are now aggregated (summed) from the `meal_food_items` rows and returned as a `nutrients` field on the meal response.

**Frontend**: Meal detail page shows an expandable "Full nutrients" section (collapsed by default) with values grouped by category:
- Macros, Extended Macros, Fat Breakdown, Vitamins, Minerals, Amino Acids, Other
- Only nutrients with values are shown
- Values rounded to 1 decimal place with units

This means meals with Cronometer-imported food items (which have full nutrition data in the canonical library) will show complete nutrient breakdowns.

## Test plan

- [ ] View a meal with Cronometer food items → "Full nutrients" expandable section appears
- [ ] Click to expand → grouped nutrient values displayed
- [ ] Meals without junction food items → no nutrients section (legacy JSONB)
- [ ] Unit tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)