### PR TITLE
Fix nutrient scroll + food item detail edit mode

### DIFF
--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -5,11 +5,117 @@
   padding: 2rem;
 }
 
+.fi-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.fi-detail-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .food-item-detail-page h1 {
   font-size: 1.5rem;
   font-weight: 600;
-  margin: 0.5rem 0 1rem;
+  margin: 0 0 1rem;
   color: #1f2937;
+}
+
+.fi-name-input {
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.fi-default-edit {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.fi-default-edit input {
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+}
+
+.fi-default-edit input[type='number'] {
+  width: 60px;
+}
+
+.fi-default-edit input[type='text'] {
+  width: 100px;
+}
+
+.nutrient-edit {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.nutrient-edit input {
+  width: 70px;
+  padding: 0.125rem 0.25rem;
+  font-size: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  color: #374151;
+  background: #fff;
+  text-align: right;
+}
+
+.nutrient-unit {
+  font-size: 0.65rem;
+  color: #9ca3af;
+  min-width: 20px;
+}
+
+.btn-primary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background: #5e35b1;
+}
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  background: #f3f4f6;
 }
 
 .back-link {
@@ -69,6 +175,25 @@
 }
 
 @media (prefers-color-scheme: dark) {
+  .food-item-detail-page h1,
+  .fi-name-input {
+    color: #e5e7eb;
+  }
+
+  .fi-name-input,
+  .fi-default-edit input,
+  .nutrient-edit input {
+    background: #374151;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .btn-secondary {
+    background: #374151;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
   .food-item-detail-page h1 {
     color: #e5e7eb;
   }

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,8 +1,11 @@
 import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
-import { useQuery } from '@tanstack/react-query'
-import { useRoute } from 'preact-iso'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocation, useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
 
 import type { FoodItemEntity } from '../../state/api'
+
+import { ConfirmButton } from '../../components/ConfirmButton'
 import { auth } from '../../state/auth'
 import './FoodItemDetail.css'
 
@@ -16,6 +19,27 @@ const fetchFoodItem = async (id: string): Promise<FoodItemEntity> => {
   if (!res.ok) throw new Error('Food item not found')
   const json = await res.json()
   return json.data
+}
+
+const updateFoodItemApi = async (id: string, body: Record<string, unknown>): Promise<FoodItemEntity> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}`, {
+    body: JSON.stringify(body),
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    method: 'PATCH',
+  })
+  if (!res.ok) throw new Error('Update failed')
+  const json = await res.json()
+  return json.data
+}
+
+const deleteFoodItemApi = async (id: string): Promise<void> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    method: 'DELETE',
+  })
+  if (!res.ok) throw new Error('Delete failed')
 }
 
 const CATEGORIES: Array<{ key: NutrientFieldDef['category']; label: string }> = [
@@ -32,34 +56,62 @@ function NutrientSection({
   item,
   category,
   label,
+  editing,
+  onEdit,
 }: {
   item: FoodItemEntity
   category: string
   label: string
+  editing: Record<string, unknown> | null
+  onEdit?: (field: string, value: number | undefined) => void
 }) {
   const fields = NUTRIENT_FIELDS.filter((f) => f.category === category)
-  const populated = fields.filter((f) => item[f.name] !== undefined && item[f.name] !== null)
+  const isEditing = editing !== null
+  const populated = isEditing
+    ? fields
+    : fields.filter((f) => item[f.name] !== undefined && item[f.name] !== null)
   if (populated.length === 0) return null
 
   return (
     <div class="nutrient-section">
       <h3>{label}</h3>
       <div class="nutrient-grid">
-        {populated.map((f) => (
-          <div key={f.name} class="nutrient-row">
-            <span class="nutrient-label">{f.label}</span>
-            <span class="nutrient-value">
-              {typeof item[f.name] === 'number' ? (item[f.name] as number).toFixed(2) : item[f.name]} {f.unit}
-            </span>
-          </div>
-        ))}
+        {populated.map((f) => {
+          const val = editing?.[f.name] !== undefined ? editing[f.name] : item[f.name]
+          return (
+            <div key={f.name} class="nutrient-row">
+              <span class="nutrient-label">{f.label}</span>
+              {isEditing ? (
+                <span class="nutrient-edit">
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={val ?? ''}
+                    onInput={(e) => {
+                      const v = (e.target as HTMLInputElement).value
+                      onEdit?.(f.name, v === '' ? undefined : parseFloat(v))
+                    }}
+                  />
+                  <span class="nutrient-unit">{f.unit}</span>
+                </span>
+              ) : (
+                <span class="nutrient-value">
+                  {typeof val === 'number' ? val.toFixed(2) : val} {f.unit}
+                </span>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )
 }
 
+// eslint-disable-next-line complexity -- detail page with edit mode
 export function FoodItemDetail() {
   const { params } = useRoute()
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
   const id = params.id
 
   const { data: item, isLoading } = useQuery({
@@ -67,41 +119,135 @@ export function FoodItemDetail() {
     queryKey: ['foodItem', id],
   })
 
-  if (isLoading) {
-    return (
+  const [editing, setEditing] = useState<Record<string, unknown> | null>(null)
+
+  const updateMutation = useMutation({
+    mutationFn: (body: Record<string, unknown>) => updateFoodItemApi(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['foodItem', id] })
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      setEditing(null)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteFoodItemApi(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      route('/food-items')
+    },
+  })
+
+  if (isLoading)
+    {return (
       <div class="food-item-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )
-  }
-  if (!item) {
-    return (
+    )}
+  if (!item)
+    {return (
       <div class="food-item-detail-page">
         <p>Food item not found.</p>
       </div>
-    )
+    )}
+
+  const isEditing = editing !== null
+  const editName = (editing?.name as string) ?? item.name
+  const editQty = (editing?.default_quantity as number) ?? item.default_quantity
+  const editUnit = (editing?.default_unit as string) ?? item.default_unit
+
+  const handleSave = () => {
+    if (!editing) return
+    updateMutation.mutate(editing)
   }
 
   return (
     <div class="food-item-detail-page">
-      <a href="/food-items" class="back-link">
-        &larr; Food Items
-      </a>
+      <div class="fi-detail-header">
+        <a href="/food-items" class="back-link">
+          &larr; Food Items
+        </a>
+        <div class="fi-detail-actions">
+          {isEditing ? (
+            <>
+              <button
+                type="button"
+                class="btn-primary"
+                onClick={handleSave}
+                disabled={updateMutation.isPending}
+              >
+                {updateMutation.isPending ? 'Saving...' : 'Save'}
+              </button>
+              <button type="button" class="btn-secondary" onClick={() => setEditing(null)}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button type="button" class="btn-secondary" onClick={() => setEditing({})}>
+              Edit
+            </button>
+          )}
+          <ConfirmButton
+            label="Delete"
+            confirmMessage={`Delete ${item.name}?`}
+            onConfirm={() => deleteMutation.mutate()}
+            isPending={deleteMutation.isPending}
+          />
+        </div>
+      </div>
 
-      <h1>{item.name}</h1>
+      {isEditing ? (
+        <input
+          type="text"
+          class="fi-name-input"
+          value={editName}
+          onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
+        />
+      ) : (
+        <h1>{item.name}</h1>
+      )}
 
       <div class="fi-meta">
         {item.source && <span class="fi-source">Source: {item.source}</span>}
-        {item.default_quantity && (
+        {isEditing ? (
+          <span class="fi-default-edit">
+            Default:
+            <input
+              type="number"
+              step="0.1"
+              value={editQty ?? ''}
+              placeholder="Qty"
+              onInput={(e) =>
+                setEditing({
+                  ...editing,
+                  default_quantity: parseFloat((e.target as HTMLInputElement).value) || undefined,
+                })
+              }
+            />
+            <input
+              type="text"
+              value={editUnit ?? ''}
+              placeholder="Unit"
+              onInput={(e) => setEditing({ ...editing, default_unit: (e.target as HTMLInputElement).value })}
+            />
+          </span>
+        ) : item.default_quantity ? (
           <span class="fi-default">
             Default: {item.default_quantity} {item.default_unit ?? 'serving'}
           </span>
-        )}
+        ) : null}
       </div>
 
       <div class="nutrient-sections">
         {CATEGORIES.map(({ key, label }) => (
-          <NutrientSection key={key} item={item} category={key} label={label} />
+          <NutrientSection
+            key={key}
+            item={item}
+            category={key}
+            label={label}
+            editing={editing}
+            onEdit={(field, value) => setEditing({ ...editing, [field]: value })}
+          />
         ))}
       </div>
     </div>

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -86,7 +86,7 @@ function NutrientSection({
                   <input
                     type="number"
                     step="0.01"
-                    value={val ?? ''}
+                    value={typeof val === 'number' ? val : ''}
                     onInput={(e) => {
                       const v = (e.target as HTMLInputElement).value
                       onEdit?.(f.name, v === '' ? undefined : parseFloat(v))

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -32,7 +32,6 @@
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background: #fff;
-  overflow: hidden;
 }
 
 .detail-row {


### PR DESCRIPTION
- Fix: remove `overflow: hidden` from meal detail card so full nutrients section is visible
- Food item detail page (`/food-items/:id`) now has full edit mode: name, default qty/unit, all nutrients editable
- In edit mode, all nutrient fields shown (not just populated ones) so you can add values

🤖 Generated with [Claude Code](https://claude.com/claude-code)