### PR TITLE
Responsive side-by-side layout for meal nutrients

### DIFF
--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -1,5 +1,5 @@
 .food-item-detail-page {
-  max-width: 700px;
+  max-width: 1100px;
   width: 100%;
   margin: 0 auto;
   padding: 2rem;

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -5,11 +5,117 @@
   padding: 2rem;
 }
 
+.fi-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.fi-detail-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .food-item-detail-page h1 {
   font-size: 1.5rem;
   font-weight: 600;
-  margin: 0.5rem 0 1rem;
+  margin: 0 0 1rem;
   color: #1f2937;
+}
+
+.fi-name-input {
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.fi-default-edit {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.fi-default-edit input {
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+}
+
+.fi-default-edit input[type='number'] {
+  width: 60px;
+}
+
+.fi-default-edit input[type='text'] {
+  width: 100px;
+}
+
+.nutrient-edit {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.nutrient-edit input {
+  width: 70px;
+  padding: 0.125rem 0.25rem;
+  font-size: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  color: #374151;
+  background: #fff;
+  text-align: right;
+}
+
+.nutrient-unit {
+  font-size: 0.65rem;
+  color: #9ca3af;
+  min-width: 20px;
+}
+
+.btn-primary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background: #5e35b1;
+}
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  background: #f3f4f6;
 }
 
 .back-link {
@@ -69,6 +175,25 @@
 }
 
 @media (prefers-color-scheme: dark) {
+  .food-item-detail-page h1,
+  .fi-name-input {
+    color: #e5e7eb;
+  }
+
+  .fi-name-input,
+  .fi-default-edit input,
+  .nutrient-edit input {
+    background: #374151;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
+  .btn-secondary {
+    background: #374151;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+
   .food-item-detail-page h1 {
     color: #e5e7eb;
   }

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,8 +1,11 @@
 import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
-import { useQuery } from '@tanstack/react-query'
-import { useRoute } from 'preact-iso'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocation, useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
 
 import type { FoodItemEntity } from '../../state/api'
+
+import { ConfirmButton } from '../../components/ConfirmButton'
 import { auth } from '../../state/auth'
 import './FoodItemDetail.css'
 
@@ -16,6 +19,27 @@ const fetchFoodItem = async (id: string): Promise<FoodItemEntity> => {
   if (!res.ok) throw new Error('Food item not found')
   const json = await res.json()
   return json.data
+}
+
+const updateFoodItemApi = async (id: string, body: Record<string, unknown>): Promise<FoodItemEntity> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}`, {
+    body: JSON.stringify(body),
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    method: 'PATCH',
+  })
+  if (!res.ok) throw new Error('Update failed')
+  const json = await res.json()
+  return json.data
+}
+
+const deleteFoodItemApi = async (id: string): Promise<void> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    method: 'DELETE',
+  })
+  if (!res.ok) throw new Error('Delete failed')
 }
 
 const CATEGORIES: Array<{ key: NutrientFieldDef['category']; label: string }> = [
@@ -32,34 +56,62 @@ function NutrientSection({
   item,
   category,
   label,
+  editing,
+  onEdit,
 }: {
   item: FoodItemEntity
   category: string
   label: string
+  editing: Record<string, unknown> | null
+  onEdit?: (field: string, value: number | undefined) => void
 }) {
   const fields = NUTRIENT_FIELDS.filter((f) => f.category === category)
-  const populated = fields.filter((f) => item[f.name] !== undefined && item[f.name] !== null)
+  const isEditing = editing !== null
+  const populated = isEditing
+    ? fields
+    : fields.filter((f) => item[f.name] !== undefined && item[f.name] !== null)
   if (populated.length === 0) return null
 
   return (
     <div class="nutrient-section">
       <h3>{label}</h3>
       <div class="nutrient-grid">
-        {populated.map((f) => (
-          <div key={f.name} class="nutrient-row">
-            <span class="nutrient-label">{f.label}</span>
-            <span class="nutrient-value">
-              {typeof item[f.name] === 'number' ? (item[f.name] as number).toFixed(2) : item[f.name]} {f.unit}
-            </span>
-          </div>
-        ))}
+        {populated.map((f) => {
+          const val = editing?.[f.name] !== undefined ? editing[f.name] : item[f.name]
+          return (
+            <div key={f.name} class="nutrient-row">
+              <span class="nutrient-label">{f.label}</span>
+              {isEditing ? (
+                <span class="nutrient-edit">
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={val ?? ''}
+                    onInput={(e) => {
+                      const v = (e.target as HTMLInputElement).value
+                      onEdit?.(f.name, v === '' ? undefined : parseFloat(v))
+                    }}
+                  />
+                  <span class="nutrient-unit">{f.unit}</span>
+                </span>
+              ) : (
+                <span class="nutrient-value">
+                  {typeof val === 'number' ? val.toFixed(2) : val} {f.unit}
+                </span>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )
 }
 
+// eslint-disable-next-line complexity -- detail page with edit mode
 export function FoodItemDetail() {
   const { params } = useRoute()
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
   const id = params.id
 
   const { data: item, isLoading } = useQuery({
@@ -67,41 +119,135 @@ export function FoodItemDetail() {
     queryKey: ['foodItem', id],
   })
 
-  if (isLoading) {
-    return (
+  const [editing, setEditing] = useState<Record<string, unknown> | null>(null)
+
+  const updateMutation = useMutation({
+    mutationFn: (body: Record<string, unknown>) => updateFoodItemApi(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['foodItem', id] })
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      setEditing(null)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteFoodItemApi(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      route('/food-items')
+    },
+  })
+
+  if (isLoading)
+    {return (
       <div class="food-item-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )
-  }
-  if (!item) {
-    return (
+    )}
+  if (!item)
+    {return (
       <div class="food-item-detail-page">
         <p>Food item not found.</p>
       </div>
-    )
+    )}
+
+  const isEditing = editing !== null
+  const editName = (editing?.name as string) ?? item.name
+  const editQty = (editing?.default_quantity as number) ?? item.default_quantity
+  const editUnit = (editing?.default_unit as string) ?? item.default_unit
+
+  const handleSave = () => {
+    if (!editing) return
+    updateMutation.mutate(editing)
   }
 
   return (
     <div class="food-item-detail-page">
-      <a href="/food-items" class="back-link">
-        &larr; Food Items
-      </a>
+      <div class="fi-detail-header">
+        <a href="/food-items" class="back-link">
+          &larr; Food Items
+        </a>
+        <div class="fi-detail-actions">
+          {isEditing ? (
+            <>
+              <button
+                type="button"
+                class="btn-primary"
+                onClick={handleSave}
+                disabled={updateMutation.isPending}
+              >
+                {updateMutation.isPending ? 'Saving...' : 'Save'}
+              </button>
+              <button type="button" class="btn-secondary" onClick={() => setEditing(null)}>
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button type="button" class="btn-secondary" onClick={() => setEditing({})}>
+              Edit
+            </button>
+          )}
+          <ConfirmButton
+            label="Delete"
+            confirmMessage={`Delete ${item.name}?`}
+            onConfirm={() => deleteMutation.mutate()}
+            isPending={deleteMutation.isPending}
+          />
+        </div>
+      </div>
 
-      <h1>{item.name}</h1>
+      {isEditing ? (
+        <input
+          type="text"
+          class="fi-name-input"
+          value={editName}
+          onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
+        />
+      ) : (
+        <h1>{item.name}</h1>
+      )}
 
       <div class="fi-meta">
         {item.source && <span class="fi-source">Source: {item.source}</span>}
-        {item.default_quantity && (
+        {isEditing ? (
+          <span class="fi-default-edit">
+            Default:
+            <input
+              type="number"
+              step="0.1"
+              value={editQty ?? ''}
+              placeholder="Qty"
+              onInput={(e) =>
+                setEditing({
+                  ...editing,
+                  default_quantity: parseFloat((e.target as HTMLInputElement).value) || undefined,
+                })
+              }
+            />
+            <input
+              type="text"
+              value={editUnit ?? ''}
+              placeholder="Unit"
+              onInput={(e) => setEditing({ ...editing, default_unit: (e.target as HTMLInputElement).value })}
+            />
+          </span>
+        ) : item.default_quantity ? (
           <span class="fi-default">
             Default: {item.default_quantity} {item.default_unit ?? 'serving'}
           </span>
-        )}
+        ) : null}
       </div>
 
       <div class="nutrient-sections">
         {CATEGORIES.map(({ key, label }) => (
-          <NutrientSection key={key} item={item} category={key} label={label} />
+          <NutrientSection
+            key={key}
+            item={item}
+            category={key}
+            label={label}
+            editing={editing}
+            onEdit={(field, value) => setEditing({ ...editing, [field]: value })}
+          />
         ))}
       </div>
     </div>

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -86,7 +86,7 @@ function NutrientSection({
                   <input
                     type="number"
                     step="0.01"
-                    value={val ?? ''}
+                    value={typeof val === 'number' ? val : ''}
                     onInput={(e) => {
                       const v = (e.target as HTMLInputElement).value
                       onEdit?.(f.name, v === '' ? undefined : parseFloat(v))
@@ -138,18 +138,20 @@ export function FoodItemDetail() {
     },
   })
 
-  if (isLoading)
-    {return (
+  if (isLoading) {
+    return (
       <div class="food-item-detail-page">
         <p class="loading">Loading...</p>
       </div>
-    )}
-  if (!item)
-    {return (
+    )
+  }
+  if (!item) {
+    return (
       <div class="food-item-detail-page">
         <p>Food item not found.</p>
       </div>
-    )}
+    )
+  }
 
   const isEditing = editing !== null
   const editName = (editing?.name as string) ?? item.name

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -1,8 +1,43 @@
 .meal-detail-page {
-  max-width: 600px;
+  max-width: 1100px;
   width: 100%;
   margin: 0 auto;
   padding: 2rem;
+}
+
+.detail-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .detail-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .detail-card {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .nutrient-breakdown {
+    width: 320px;
+    flex-shrink: 0;
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
+  }
+
+  .nutrient-toggle {
+    display: none;
+  }
+
+  .nutrient-groups.collapsed-mobile {
+    display: flex;
+  }
 }
 
 .detail-header {
@@ -92,7 +127,13 @@
 
 .nutrient-breakdown {
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.nutrient-groups.collapsed-mobile {
+  display: none;
 }
 
 .nutrient-toggle {
@@ -111,8 +152,8 @@
 
 .nutrient-groups {
   margin-top: 0.75rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
@@ -348,6 +389,7 @@ a.detail-food-link:hover {
 @media (prefers-color-scheme: dark) {
   .nutrient-breakdown {
     border-color: #374151;
+    background: #1f2937;
   }
 
   .nutrient-toggle {

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -32,7 +32,6 @@
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background: #fff;
-  overflow: hidden;
 }
 
 .detail-row {

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -270,36 +270,33 @@ const NUTRIENT_CATEGORIES = [
 ] as const
 
 function NutrientBreakdown({ nutrients }: { nutrients: Record<string, number> }) {
-  const [expanded, setExpanded] = useState(false)
+  const [collapsed, setCollapsed] = useState(true)
 
   return (
     <div class="nutrient-breakdown">
-      <button type="button" class="nutrient-toggle" onClick={() => setExpanded(!expanded)}>
-        {expanded ? '▾' : '▸'} Full nutrients ({Object.keys(nutrients).length} values)
+      {/* Toggle only visible on narrow screens (hidden via CSS on wide) */}
+      <button type="button" class="nutrient-toggle" onClick={() => setCollapsed(!collapsed)}>
+        {collapsed ? '▸' : '▾'} Nutrients ({Object.keys(nutrients).length})
       </button>
-      {expanded && (
-        <div class="nutrient-groups">
-          {NUTRIENT_CATEGORIES.map(({ key, label }) => {
-            const fields = NUTRIENT_FIELDS.filter(
-              (f) => f.category === key && nutrients[f.name] !== undefined,
-            )
-            if (fields.length === 0) return null
-            return (
-              <div key={key} class="nutrient-group">
-                <h4>{label}</h4>
-                {fields.map((f) => (
-                  <div key={f.name} class="nutrient-line">
-                    <span>{f.label}</span>
-                    <span>
-                      {nutrients[f.name].toFixed(1)} {f.unit}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )
-          })}
-        </div>
-      )}
+      <div class={`nutrient-groups ${collapsed ? 'collapsed-mobile' : ''}`}>
+        {NUTRIENT_CATEGORIES.map(({ key, label }) => {
+          const fields = NUTRIENT_FIELDS.filter((f) => f.category === key && nutrients[f.name] !== undefined)
+          if (fields.length === 0) return null
+          return (
+            <div key={key} class="nutrient-group">
+              <h4>{label}</h4>
+              {fields.map((f) => (
+                <div key={f.name} class="nutrient-line">
+                  <span>{f.label}</span>
+                  <span>
+                    {nutrients[f.name].toFixed(1)} {f.unit}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -486,143 +483,145 @@ export function MealDetail() {
         </div>
       </div>
 
-      <div class="detail-card">
-        {/* Type */}
-        <div class="detail-row">
-          <label>Type</label>
-          {isEditing ? (
-            <MealTypeEditor value={editType} onChange={(v) => setEditing({ ...editing, meal_type: v })} />
-          ) : (
-            <span class="detail-value">{meal.meal_type ?? '—'}</span>
-          )}
-        </div>
+      <div class="detail-layout">
+        <div class="detail-card">
+          {/* Type */}
+          <div class="detail-row">
+            <label>Type</label>
+            {isEditing ? (
+              <MealTypeEditor value={editType} onChange={(v) => setEditing({ ...editing, meal_type: v })} />
+            ) : (
+              <span class="detail-value">{meal.meal_type ?? '—'}</span>
+            )}
+          </div>
 
-        {/* Time */}
-        <div class="detail-row">
-          <label>Time</label>
-          {isEditing ? (
-            <input
-              type="datetime-local"
-              value={editTime}
-              onInput={(e) => setEditing({ ...editing, time: (e.target as HTMLInputElement).value })}
-            />
-          ) : (
-            <span class="detail-value">{format(meal.time, 'yyyy-MM-dd HH:mm')}</span>
-          )}
-        </div>
+          {/* Time */}
+          <div class="detail-row">
+            <label>Time</label>
+            {isEditing ? (
+              <input
+                type="datetime-local"
+                value={editTime}
+                onInput={(e) => setEditing({ ...editing, time: (e.target as HTMLInputElement).value })}
+              />
+            ) : (
+              <span class="detail-value">{format(meal.time, 'yyyy-MM-dd HH:mm')}</span>
+            )}
+          </div>
 
-        {/* Name */}
-        <div class="detail-row">
-          <label>Name</label>
-          {isEditing ? (
-            <input
-              type="text"
-              value={editName}
-              placeholder="Meal name"
-              onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
-            />
-          ) : (
-            <span class="detail-value">{meal.name || '—'}</span>
-          )}
-        </div>
+          {/* Name */}
+          <div class="detail-row">
+            <label>Name</label>
+            {isEditing ? (
+              <input
+                type="text"
+                value={editName}
+                placeholder="Meal name"
+                onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
+              />
+            ) : (
+              <span class="detail-value">{meal.name || '—'}</span>
+            )}
+          </div>
 
-        {/* Flags */}
-        <div class="detail-row">
-          <label>Flags</label>
-          {isEditing ? (
-            <MealFlagsEditor
-              selected={editFlags}
-              areas={flagAreas}
-              onChange={(flags) => setEditing({ ...editing, sensitivities: flags })}
-            />
-          ) : meal.sensitivities && meal.sensitivities.length > 0 ? (
-            <div class="detail-sensitivities">
-              {meal.sensitivities.map((s) => (
-                <span key={s} class="detail-sensitivity-chip">
-                  {s}
-                </span>
-              ))}
-            </div>
-          ) : (
-            <span class="detail-value">—</span>
-          )}
-        </div>
-
-        {/* Food Items */}
-        <div class="detail-row detail-row-block">
-          <label>Food Items</label>
-          {isEditing ? (
-            <FoodItemsEditor
-              items={editItems}
-              onChange={(items) => setEditing({ ...editing, food_items: items })}
-            />
-          ) : meal.food_items && meal.food_items.length > 0 ? (
-            <div class="detail-food-items">
-              {meal.food_items.map((item, i) =>
-                item.food_item_id ? (
-                  <a
-                    key={i}
-                    href={`/food-items/${item.food_item_id}`}
-                    class="detail-food-chip detail-food-link"
-                  >
-                    {item.name}
-                    {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
-                  </a>
-                ) : (
-                  <span key={i} class="detail-food-chip">
-                    {item.name}
-                    {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
+          {/* Flags */}
+          <div class="detail-row">
+            <label>Flags</label>
+            {isEditing ? (
+              <MealFlagsEditor
+                selected={editFlags}
+                areas={flagAreas}
+                onChange={(flags) => setEditing({ ...editing, sensitivities: flags })}
+              />
+            ) : meal.sensitivities && meal.sensitivities.length > 0 ? (
+              <div class="detail-sensitivities">
+                {meal.sensitivities.map((s) => (
+                  <span key={s} class="detail-sensitivity-chip">
+                    {s}
                   </span>
-                ),
-              )}
+                ))}
+              </div>
+            ) : (
+              <span class="detail-value">—</span>
+            )}
+          </div>
+
+          {/* Food Items */}
+          <div class="detail-row detail-row-block">
+            <label>Food Items</label>
+            {isEditing ? (
+              <FoodItemsEditor
+                items={editItems}
+                onChange={(items) => setEditing({ ...editing, food_items: items })}
+              />
+            ) : meal.food_items && meal.food_items.length > 0 ? (
+              <div class="detail-food-items">
+                {meal.food_items.map((item, i) =>
+                  item.food_item_id ? (
+                    <a
+                      key={i}
+                      href={`/food-items/${item.food_item_id}`}
+                      class="detail-food-chip detail-food-link"
+                    >
+                      {item.name}
+                      {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
+                    </a>
+                  ) : (
+                    <span key={i} class="detail-food-chip">
+                      {item.name}
+                      {item.quantity ? ` (${item.quantity}${item.unit ? ' ' + item.unit : ''})` : ''}
+                    </span>
+                  ),
+                )}
+              </div>
+            ) : (
+              <span class="detail-value">—</span>
+            )}
+          </div>
+
+          {/* Macros */}
+          <div class="detail-row">
+            <label>Macros</label>
+            {isEditing ? (
+              <MacrosEditor
+                calories={editCal}
+                protein={editProt}
+                carbs={editCarbs}
+                fat={editFat}
+                fiber={editFiber}
+                onChange={(field, val) => setEditing({ ...editing, [field]: val })}
+              />
+            ) : (
+              <span class="detail-value">{macroDisplay || '—'}</span>
+            )}
+          </div>
+
+          {/* Notes */}
+          <div class="detail-row">
+            <label>Notes</label>
+            {isEditing ? (
+              <textarea
+                value={editNotes}
+                placeholder="Notes..."
+                rows={3}
+                onInput={(e) => setEditing({ ...editing, notes: (e.target as HTMLTextAreaElement).value })}
+              />
+            ) : (
+              <span class="detail-value">{meal.notes || '—'}</span>
+            )}
+          </div>
+
+          {!isEditing && (
+            <div class="detail-row">
+              <label>Source</label>
+              <span class="detail-value">{meal.source ?? '—'}</span>
             </div>
-          ) : (
-            <span class="detail-value">—</span>
           )}
         </div>
 
-        {/* Macros */}
-        <div class="detail-row">
-          <label>Macros</label>
-          {isEditing ? (
-            <MacrosEditor
-              calories={editCal}
-              protein={editProt}
-              carbs={editCarbs}
-              fat={editFat}
-              fiber={editFiber}
-              onChange={(field, val) => setEditing({ ...editing, [field]: val })}
-            />
-          ) : (
-            <span class="detail-value">{macroDisplay || '—'}</span>
-          )}
-        </div>
-
-        {/* Full Nutrients (from junction aggregation) */}
+        {/* Nutrient sidebar — shown beside the card on wide screens */}
         {!isEditing && meal.nutrients && Object.keys(meal.nutrients).length > 0 && (
           <NutrientBreakdown nutrients={meal.nutrients} />
-        )}
-
-        {/* Notes */}
-        <div class="detail-row">
-          <label>Notes</label>
-          {isEditing ? (
-            <textarea
-              value={editNotes}
-              placeholder="Notes..."
-              rows={3}
-              onInput={(e) => setEditing({ ...editing, notes: (e.target as HTMLTextAreaElement).value })}
-            />
-          ) : (
-            <span class="detail-value">{meal.notes || '—'}</span>
-          )}
-        </div>
-
-        {!isEditing && (
-          <div class="detail-row">
-            <label>Source</label>
-            <span class="detail-value">{meal.source ?? '—'}</span>
-          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -1,5 +1,5 @@
 .meals-page {
-  max-width: 800px;
+  max-width: 1100px;
   width: 100%;
   margin: 0 auto;
   padding: 2rem;


### PR DESCRIPTION
On wide screens (>900px), the meal detail page shows nutrients in a sidebar panel beside the main card. On narrow screens, it collapses below with a toggle.

- Meal detail page: `detail-layout` flex container, card + nutrient sidebar
- Widen max-width from 600/800px to 1100px
- Nutrient panel: sticky, scrollable, always visible on wide screens
- Mobile: collapsible toggle preserved
- Food item detail page also widened

🤖 Generated with [Claude Code](https://claude.com/claude-code)