### PR TITLE
Fix nutrient sidebar hidden on wide screens

### DIFF
--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -11,6 +11,10 @@
   gap: 1.5rem;
 }
 
+.nutrient-groups.collapsed-mobile {
+  display: none;
+}
+
 @media (min-width: 900px) {
   .detail-layout {
     flex-direction: row;
@@ -132,9 +136,6 @@
   background: #fafafa;
 }
 
-.nutrient-groups.collapsed-mobile {
-  display: none;
-}
 
 .nutrient-toggle {
   background: none;


### PR DESCRIPTION
The `.nutrient-groups.collapsed-mobile { display: none }` global rule was placed after the media query override, overriding it due to CSS cascade order. Moved it before the media query so the wide-screen `display: flex` override takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)