### PR TITLE
feat: left sidebar nav, full-width pages, stable meals layout

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,32 +1,8 @@
 import { useLocation } from 'preact-iso'
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 
 import { auth, logout } from '../state/auth'
-
-const DATA_SOURCE_LINKS = [
-  { label: 'Overview', path: '/data-sources' },
-  { label: 'Aurboda (Web / API)', path: '/data-sources/aurboda' },
-  { label: 'Aurboda Android', path: '/data-sources/android-app' },
-  { label: 'Oura Ring', path: '/data-sources/oura' },
-  { label: 'ActivityWatch (Desktop)', path: '/data-sources/activitywatch-desktop' },
-  { label: 'ActivityWatch (Android)', path: '/data-sources/activitywatch-android' },
-  { label: 'RescueTime', path: '/data-sources/rescue-time' },
-  { label: 'Last.fm', path: '/data-sources/lastfm' },
-  { label: 'OwnTracks', path: '/data-sources/owntracks' },
-  { label: 'Calendars', path: '/data-sources/calendars' },
-]
-
-const NAV_LINKS = [
-  { href: '/goals', label: 'Goals' },
-  { href: '/hr-zones', label: 'HR Zones' },
-  { href: '/timeline', label: 'Timeline' },
-  { href: '/data', label: 'Data' },
-  { href: '/meals', label: 'Meals' },
-  { href: '/reports', label: 'Reports' },
-  { href: '/add', label: '+ Add' },
-  { href: '/trends', label: 'Trends' },
-  { href: '/places', label: 'Places' },
-]
+import { DATA_SOURCE_LINKS, NAV_LINKS } from './nav-links'
 
 // eslint-disable-next-line complexity -- navigation component with many branches
 export function Header() {
@@ -34,10 +10,8 @@ export function Header() {
   const isLoggedIn = auth.value.token
   const isAdmin = auth.value.is_admin
 
-  const [dropdownOpen, setDropdownOpen] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [dsExpandedInDrawer, setDsExpandedInDrawer] = useState(false)
-  const dropdownRef = useRef<HTMLDivElement>(null)
 
   const isDataSourcesActive = url.startsWith('/data-sources')
 
@@ -46,28 +20,8 @@ export function Header() {
     logout()
   }
 
-  const toggleDropdown = useCallback(
-    (e: Event) => {
-      e.preventDefault()
-      setDropdownOpen(!dropdownOpen)
-    },
-    [dropdownOpen],
-  )
-
   const toggleDrawer = useCallback(() => setDrawerOpen((v) => !v), [])
   const closeDrawer = useCallback(() => setDrawerOpen(false), [])
-
-  // Close desktop dropdown when clicking outside
-  useEffect(() => {
-    if (!dropdownOpen) return
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false)
-      }
-    }
-    document.addEventListener('click', handleClickOutside)
-    return () => document.removeEventListener('click', handleClickOutside)
-  }, [dropdownOpen])
 
   // Close drawer on Escape
   useEffect(() => {
@@ -79,64 +33,13 @@ export function Header() {
     return () => document.removeEventListener('keydown', handleKey)
   }, [drawerOpen])
 
-  // Close dropdown and drawer on navigation
+  // Close drawer on navigation
   useEffect(() => {
-    setDropdownOpen(false)
     setDrawerOpen(false)
   }, [url])
 
   return (
     <header>
-      {/* ── Desktop nav ─────────────────────────────────────── */}
-      <nav class="nav-desktop">
-        <a href="/" class={url === '/' ? 'active' : undefined}>
-          Home
-        </a>
-        {isLoggedIn ? (
-          <>
-            {NAV_LINKS.map((link) => (
-              <a key={link.href} href={link.href} class={url === link.href ? 'active' : undefined}>
-                {link.label}
-              </a>
-            ))}
-            <div class={`nav-dropdown${isDataSourcesActive ? ' active' : ''}`} ref={dropdownRef}>
-              <a
-                href="/data-sources"
-                class={isDataSourcesActive ? 'active dropdown-toggle' : 'dropdown-toggle'}
-                onClick={toggleDropdown}
-              >
-                Data Sources <span class="dropdown-arrow">{dropdownOpen ? '\u25B4' : '\u25BE'}</span>
-              </a>
-              {dropdownOpen && (
-                <div class="dropdown-menu">
-                  {DATA_SOURCE_LINKS.map((link) => (
-                    <a key={link.path} href={link.path} class={url === link.path ? 'active' : ''}>
-                      {link.label}
-                    </a>
-                  ))}
-                </div>
-              )}
-            </div>
-            {isAdmin && (
-              <a href="/admin" class={url === '/admin' ? 'active' : undefined}>
-                Admin
-              </a>
-            )}
-            <span class="spacer" />
-            <a href="/settings" class={url === '/settings' ? 'active user-link' : 'user-link'}>
-              {auth.value.user}
-            </a>
-            <a href="#" onClick={handleLogout} class="logout-link">
-              Logout
-            </a>
-          </>
-        ) : (
-          <a href="/login" class={url === '/login' ? 'active' : undefined}>
-            Login
-          </a>
-        )}
-      </nav>
-
       {/* ── Mobile nav bar (hamburger) ───────────────────────── */}
       <nav class="nav-mobile">
         <a href="/" class={`nav-mobile-home${url === '/' ? ' active' : ''}`}>
@@ -170,7 +73,7 @@ export function Header() {
             <a href="/" class={url === '/' ? 'active' : undefined} onClick={closeDrawer}>
               Home
             </a>
-            {NAV_LINKS.map((link) => (
+            {NAV_LINKS.filter((l) => l.href !== '/').map((link) => (
               <a
                 key={link.href}
                 href={link.href}

--- a/apps/web/src/components/Sidebar.css
+++ b/apps/web/src/components/Sidebar.css
@@ -1,0 +1,184 @@
+/* ── Sidebar (desktop only) ────────────────────────────────── */
+
+.sidebar {
+  width: 240px;
+  background: #673ab8;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow-y: auto;
+  flex-shrink: 0;
+  transition: width 0.2s ease;
+}
+
+.sidebar.collapsed {
+  width: 56px;
+}
+
+/* ── Header with brand + toggle ───────────────────────────── */
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem;
+  gap: 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  min-height: 48px;
+}
+
+.sidebar-brand {
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.1rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.sidebar-toggle {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  padding: 0.25rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-radius: 4px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.sidebar-toggle:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* ── Navigation links ─────────────────────────────────────── */
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0;
+  flex: 1;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  transition: background 0.15s;
+  overflow: hidden;
+}
+
+.sidebar-link:hover {
+  background: rgba(0, 0, 0, 0.2);
+  color: #fff;
+}
+
+.sidebar-link.active {
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+}
+
+.sidebar-icon {
+  font-size: 1.1rem;
+  width: 1.5rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.sidebar-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Hide labels when collapsed */
+.sidebar.collapsed .sidebar-label,
+.sidebar.collapsed .sidebar-brand,
+.sidebar.collapsed .sidebar-section-arrow {
+  display: none;
+}
+
+.sidebar.collapsed .sidebar-header {
+  justify-content: center;
+}
+
+.sidebar.collapsed .sidebar-toggle {
+  margin-left: 0;
+}
+
+.sidebar.collapsed .sidebar-link {
+  justify-content: center;
+  padding: 0.5rem;
+}
+
+.sidebar.collapsed .sidebar-sub-links {
+  display: none;
+}
+
+/* ── Data Sources expandable section ──────────────────────── */
+
+.sidebar-section-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  transition: background 0.15s;
+}
+
+.sidebar-section-btn:hover {
+  background: rgba(0, 0, 0, 0.2);
+  color: #fff;
+}
+
+.sidebar-section-btn.active {
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+}
+
+.sidebar-section-arrow {
+  margin-left: auto;
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.sidebar-sub-links {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-sub-links .sidebar-link {
+  padding-left: 2.5rem;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+/* ── Footer section (user, settings, logout) ──────────────── */
+
+.sidebar-footer {
+  margin-top: auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 0.5rem 0;
+}
+
+/* ── Hide on narrow screens ───────────────────────────────── */
+
+@media (max-width: 60em) {
+  .sidebar {
+    display: none;
+  }
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,0 +1,137 @@
+import { useLocation } from 'preact-iso'
+import { useState } from 'preact/hooks'
+
+import { auth, logout } from '../state/auth'
+import { DATA_SOURCE_LINKS, NAV_LINKS } from './nav-links'
+import './Sidebar.css'
+
+const COLLAPSED_KEY = 'sidebar-collapsed'
+
+// eslint-disable-next-line complexity -- navigation component with many conditional branches
+export function Sidebar() {
+  const { url } = useLocation()
+  const isLoggedIn = auth.value.token
+  const isAdmin = auth.value.is_admin
+
+  const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSED_KEY) === '1')
+  const [dsExpanded, setDsExpanded] = useState(() => url.startsWith('/data-sources'))
+
+  const toggleCollapsed = () => {
+    const next = !collapsed
+    setCollapsed(next)
+    localStorage.setItem(COLLAPSED_KEY, next ? '1' : '0')
+    // Notify charts/maps that layout changed
+    setTimeout(() => window.dispatchEvent(new Event('resize')), 220)
+  }
+
+  const handleLogout = (e: Event) => {
+    e.preventDefault()
+    logout()
+  }
+
+  const isDataSourcesActive = url.startsWith('/data-sources')
+
+  return (
+    <aside class={`sidebar${collapsed ? ' collapsed' : ''}`}>
+      <div class="sidebar-header">
+        <span class="sidebar-brand">Aurboda</span>
+        <button
+          class="sidebar-toggle"
+          onClick={toggleCollapsed}
+          title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          type="button"
+        >
+          {collapsed ? '▶' : '◀'}
+        </button>
+      </div>
+
+      <nav class="sidebar-nav">
+        {isLoggedIn ? (
+          <>
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                class={`sidebar-link${url === link.href ? ' active' : ''}`}
+                title={collapsed ? link.label : undefined}
+              >
+                <span class="sidebar-icon">{link.icon}</span>
+                <span class="sidebar-label">{link.label}</span>
+              </a>
+            ))}
+
+            {/* Data Sources expandable */}
+            <button
+              class={`sidebar-section-btn${isDataSourcesActive ? ' active' : ''}`}
+              onClick={() => setDsExpanded((v) => !v)}
+              title={collapsed ? 'Data Sources' : undefined}
+              type="button"
+            >
+              <span class="sidebar-icon">📡</span>
+              <span class="sidebar-label">Data Sources</span>
+              <span class="sidebar-section-arrow">{dsExpanded ? '▴' : '▾'}</span>
+            </button>
+            {dsExpanded && (
+              <div class="sidebar-sub-links">
+                {DATA_SOURCE_LINKS.map((link) => (
+                  <a
+                    key={link.path}
+                    href={link.path}
+                    class={`sidebar-link${url === link.path ? ' active' : ''}`}
+                  >
+                    <span class="sidebar-label">{link.label}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+
+            {isAdmin && (
+              <a
+                href="/admin"
+                class={`sidebar-link${url === '/admin' ? ' active' : ''}`}
+                title={collapsed ? 'Admin' : undefined}
+              >
+                <span class="sidebar-icon">⚙️</span>
+                <span class="sidebar-label">Admin</span>
+              </a>
+            )}
+          </>
+        ) : (
+          <a
+            href="/login"
+            class={`sidebar-link${url === '/login' ? ' active' : ''}`}
+            title={collapsed ? 'Login' : undefined}
+          >
+            <span class="sidebar-icon">🔑</span>
+            <span class="sidebar-label">Login</span>
+          </a>
+        )}
+      </nav>
+
+      {isLoggedIn && (
+        <div class="sidebar-footer">
+          <a
+            href="/settings"
+            class={`sidebar-link${url === '/settings' ? ' active' : ''}`}
+            title={collapsed ? 'Settings' : undefined}
+          >
+            <span class="sidebar-icon">⚙</span>
+            <span class="sidebar-label">Settings</span>
+          </a>
+          <a
+            href="/settings"
+            class={`sidebar-link${url === '/settings' ? ' active' : ''}`}
+            title={collapsed ? auth.value.user : undefined}
+          >
+            <span class="sidebar-icon">👤</span>
+            <span class="sidebar-label">{auth.value.user}</span>
+          </a>
+          <a href="#" class="sidebar-link" onClick={handleLogout}>
+            <span class="sidebar-icon">🚪</span>
+            <span class="sidebar-label">Logout</span>
+          </a>
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -1,0 +1,25 @@
+export const NAV_LINKS = [
+  { href: '/', label: 'Home', icon: '🏠' },
+  { href: '/goals', label: 'Goals', icon: '🎯' },
+  { href: '/hr-zones', label: 'HR Zones', icon: '💓' },
+  { href: '/timeline', label: 'Timeline', icon: '📅' },
+  { href: '/data', label: 'Data', icon: '📊' },
+  { href: '/meals', label: 'Meals', icon: '🍽' },
+  { href: '/reports', label: 'Reports', icon: '📝' },
+  { href: '/add', label: '+ Add', icon: '➕' },
+  { href: '/trends', label: 'Trends', icon: '📈' },
+  { href: '/places', label: 'Places', icon: '📍' },
+]
+
+export const DATA_SOURCE_LINKS = [
+  { label: 'Overview', path: '/data-sources', icon: '📡' },
+  { label: 'Aurboda (Web / API)', path: '/data-sources/aurboda' },
+  { label: 'Aurboda Android', path: '/data-sources/android-app' },
+  { label: 'Oura Ring', path: '/data-sources/oura' },
+  { label: 'ActivityWatch (Desktop)', path: '/data-sources/activitywatch-desktop' },
+  { label: 'ActivityWatch (Android)', path: '/data-sources/activitywatch-android' },
+  { label: 'RescueTime', path: '/data-sources/rescue-time' },
+  { label: 'Last.fm', path: '/data-sources/lastfm' },
+  { label: 'OwnTracks', path: '/data-sources/owntracks' },
+  { label: 'Calendars', path: '/data-sources/calendars' },
+]

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -5,6 +5,7 @@ import { LocationProvider, Route, Router } from 'preact-iso'
 
 import { Footer } from './components/Footer.jsx'
 import { Header } from './components/Header.jsx'
+import { Sidebar } from './components/Sidebar.jsx'
 import { NotFound } from './pages/_404.jsx'
 import { AddData } from './pages/AddData/index.jsx'
 import { AdminSettings } from './pages/AdminSettings/index.jsx'
@@ -54,53 +55,56 @@ export function App() {
     <QueryClientProvider client={queryClient}>
       <LocationProvider>
         <Header />
-        <main>
-          <Router>
-            <Route path="/" component={Home} />
-            <Route path="/login" component={Login} />
-            <Route path="/signup" component={Signup} />
-            <Route path="/privacy" component={Privacy} />
-            <Route path="/terms" component={Terms} />
-            <Route path="/goals" component={Goals} />
-            <Route path="/hr-zones" component={HrZones} />
-            <Route path="/timeline" component={Timeline} />
-            <Route path="/data" component={Data} />
-            <Route path="/add" component={AddData} />
-            <Route path="/food-items/:id" component={FoodItemDetail} />
-            <Route path="/food-items" component={FoodItems} />
-            <Route path="/meals/:id" component={MealDetail} />
-            <Route path="/meals" component={Meals} />
-            <Route path="/reports/add" component={AddReport} />
-            <Route path="/reports/:id" component={ReportDetail} />
-            <Route path="/reports" component={Reports} />
-            <Route path="/detail/:type/:id" component={EntityDetail} />
-            <Route path="/tag/:tagKey" component={TagMeta} />
-            <Route path="/exercise/:type" component={ExerciseMeta} />
-            <Route path="/metric/:metricName" component={MetricMeta} />
-            <Route path="/sleep" component={Sleep} />
-            <Route path="/correlations" component={Correlations} />
-            <Route path="/trends" component={Trends} />
-            <Route path="/places" component={Places} />
-            <Route path="/data-sources" component={DataSources} />
-            <Route path="/data-sources/aurboda" component={AurbodaSource} />
-            <Route path="/data-sources/android-app" component={AndroidAppSource} />
-            <Route path="/data-sources/oura" component={OuraSource} />
-            <Route path="/data-sources/garmin" component={GarminSource} />
-            <Route path="/data-sources/activitywatch-desktop" component={ActivityWatchDesktopSource} />
-            <Route path="/data-sources/activitywatch-android" component={ActivityWatchAndroidSource} />
-            <Route path="/data-sources/rescue-time" component={RescueTimeSource} />
-            <Route path="/data-sources/lastfm" component={LastFmSource} />
-            <Route path="/data-sources/owntracks" component={OwnTracksSource} />
-            <Route path="/data-sources/calendars" component={CalendarsSource} />
-            <Route path="/screentime-categories/:id" component={CategoryDetail} />
-            <Route path="/screentime-categories" component={ScreentimeCategories} />
-            <Route path="/settings" component={Settings} />
-            <Route path="/admin" component={AdminSettings} />
-            <Route path="/help" component={DataSources} />
-            <Route default component={NotFound} />
-          </Router>
-        </main>
-        <Footer />
+        <Sidebar />
+        <div class="app-content">
+          <main>
+            <Router>
+              <Route path="/" component={Home} />
+              <Route path="/login" component={Login} />
+              <Route path="/signup" component={Signup} />
+              <Route path="/privacy" component={Privacy} />
+              <Route path="/terms" component={Terms} />
+              <Route path="/goals" component={Goals} />
+              <Route path="/hr-zones" component={HrZones} />
+              <Route path="/timeline" component={Timeline} />
+              <Route path="/data" component={Data} />
+              <Route path="/add" component={AddData} />
+              <Route path="/food-items/:id" component={FoodItemDetail} />
+              <Route path="/food-items" component={FoodItems} />
+              <Route path="/meals/:id" component={MealDetail} />
+              <Route path="/meals" component={Meals} />
+              <Route path="/reports/add" component={AddReport} />
+              <Route path="/reports/:id" component={ReportDetail} />
+              <Route path="/reports" component={Reports} />
+              <Route path="/detail/:type/:id" component={EntityDetail} />
+              <Route path="/tag/:tagKey" component={TagMeta} />
+              <Route path="/exercise/:type" component={ExerciseMeta} />
+              <Route path="/metric/:metricName" component={MetricMeta} />
+              <Route path="/sleep" component={Sleep} />
+              <Route path="/correlations" component={Correlations} />
+              <Route path="/trends" component={Trends} />
+              <Route path="/places" component={Places} />
+              <Route path="/data-sources" component={DataSources} />
+              <Route path="/data-sources/aurboda" component={AurbodaSource} />
+              <Route path="/data-sources/android-app" component={AndroidAppSource} />
+              <Route path="/data-sources/oura" component={OuraSource} />
+              <Route path="/data-sources/garmin" component={GarminSource} />
+              <Route path="/data-sources/activitywatch-desktop" component={ActivityWatchDesktopSource} />
+              <Route path="/data-sources/activitywatch-android" component={ActivityWatchAndroidSource} />
+              <Route path="/data-sources/rescue-time" component={RescueTimeSource} />
+              <Route path="/data-sources/lastfm" component={LastFmSource} />
+              <Route path="/data-sources/owntracks" component={OwnTracksSource} />
+              <Route path="/data-sources/calendars" component={CalendarsSource} />
+              <Route path="/screentime-categories/:id" component={CategoryDetail} />
+              <Route path="/screentime-categories" component={ScreentimeCategories} />
+              <Route path="/settings" component={Settings} />
+              <Route path="/admin" component={AdminSettings} />
+              <Route path="/help" component={DataSources} />
+              <Route default component={NotFound} />
+            </Router>
+          </main>
+          <Footer />
+        </div>
         <ReactQueryDevtools initialIsOpen={false} />
       </LocationProvider>
     </QueryClientProvider>

--- a/apps/web/src/pages/AddData/style.css
+++ b/apps/web/src/pages/AddData/style.css
@@ -1,7 +1,7 @@
 .add-data-page {
-  max-width: 600px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .add-data-header {

--- a/apps/web/src/pages/AdminSettings/style.css
+++ b/apps/web/src/pages/AdminSettings/style.css
@@ -1,7 +1,7 @@
 .admin-settings-page {
-  max-width: 600px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .admin-settings-page h1 {

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -1,7 +1,7 @@
 .correlations-page {
-  max-width: 1000px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .correlations-page .correlations-header {

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -4,8 +4,6 @@
 
 .data-sources-page {
   width: 100%;
-  max-width: 900px;
-  margin: 0 auto;
   padding: 2rem;
   box-sizing: border-box;
 }

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -1,8 +1,7 @@
 .entity-detail-page {
-  max-width: 1200px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 /* Deleted banner */

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -1,8 +1,7 @@
 .food-item-detail-page {
-  max-width: 1100px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .fi-detail-header {

--- a/apps/web/src/pages/FoodItems/style.css
+++ b/apps/web/src/pages/FoodItems/style.css
@@ -1,8 +1,7 @@
 .food-items-page {
-  max-width: 900px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .food-items-page h1 {

--- a/apps/web/src/pages/Goals/style.css
+++ b/apps/web/src/pages/Goals/style.css
@@ -1,7 +1,7 @@
 .goals-page {
-  max-width: 600px;
-  margin: 0 auto;
+  width: 100%;
   padding: 1rem;
+  box-sizing: border-box;
 }
 
 .goals-page h1 {

--- a/apps/web/src/pages/Help/style.css
+++ b/apps/web/src/pages/Help/style.css
@@ -1,8 +1,7 @@
 .help-page {
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
   box-sizing: border-box;
 }
 

--- a/apps/web/src/pages/Home/style.css
+++ b/apps/web/src/pages/Home/style.css
@@ -1,7 +1,7 @@
 .home {
-  max-width: 800px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
   text-align: left;
 }
 

--- a/apps/web/src/pages/HrZones/style.css
+++ b/apps/web/src/pages/HrZones/style.css
@@ -1,7 +1,7 @@
 .hr-zones-page {
-  max-width: 600px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .hr-zones-page h1 {

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -1,8 +1,7 @@
 .meal-detail-page {
-  max-width: 1100px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .detail-layout {
@@ -22,13 +21,14 @@
   }
 
   .detail-card {
-    flex: 1;
+    flex: 2;
     min-width: 0;
   }
 
   .nutrient-breakdown {
-    width: 320px;
-    flex-shrink: 0;
+    flex: 1;
+    min-width: 200px;
+    max-width: 400px;
     position: sticky;
     top: 1rem;
     max-height: calc(100vh - 2rem);
@@ -136,6 +136,10 @@
   background: #fafafa;
 }
 
+.nutrient-placeholder {
+  border-style: dashed;
+  background: transparent;
+}
 
 .nutrient-toggle {
   background: none;

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -620,9 +620,12 @@ export function MealDetail() {
         </div>
 
         {/* Nutrient sidebar — shown beside the card on wide screens */}
-        {!isEditing && meal.nutrients && Object.keys(meal.nutrients).length > 0 && (
-          <NutrientBreakdown nutrients={meal.nutrients} />
-        )}
+        {!isEditing &&
+          (meal.nutrients && Object.keys(meal.nutrients).length > 0 ? (
+            <NutrientBreakdown nutrients={meal.nutrients} />
+          ) : (
+            <div class="nutrient-breakdown nutrient-placeholder" />
+          ))}
       </div>
     </div>
   )

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -311,28 +311,36 @@ const aggregateDayNutrients = (meals: Meal[]): Record<string, number> => {
 
 function DayNutrientSummary({ meals }: { meals: Meal[] }) {
   const nutrients = aggregateDayNutrients(meals)
-  if (Object.keys(nutrients).length === 0) return null
+  const hasNutrients = Object.keys(nutrients).length > 0
 
   return (
-    <div class="day-nutrient-summary">
-      <h3>Day Totals</h3>
-      {NUTRIENT_CATEGORIES.map(({ key, label }) => {
-        const fields = NUTRIENT_FIELDS.filter((f) => f.category === key && nutrients[f.name] !== undefined)
-        if (fields.length === 0) return null
-        return (
-          <div key={key} class="day-nutrient-group">
-            <h4>{label}</h4>
-            {fields.map((f) => (
-              <div key={f.name} class="day-nutrient-line">
-                <span>{f.label}</span>
-                <span>
-                  {nutrients[f.name].toFixed(1)} {f.unit}
-                </span>
+    <div class={`day-nutrient-summary${hasNutrients ? '' : ' empty'}`}>
+      {!hasNutrients ? (
+        <p class="no-nutrients">No nutrient data for this day.</p>
+      ) : (
+        <>
+          <h3>Day Totals</h3>
+          {NUTRIENT_CATEGORIES.map(({ key, label }) => {
+            const fields = NUTRIENT_FIELDS.filter(
+              (f) => f.category === key && nutrients[f.name] !== undefined,
+            )
+            if (fields.length === 0) return null
+            return (
+              <div key={key} class="day-nutrient-group">
+                <h4>{label}</h4>
+                {fields.map((f) => (
+                  <div key={f.name} class="day-nutrient-line">
+                    <span>{f.label}</span>
+                    <span>
+                      {nutrients[f.name].toFixed(1)} {f.unit}
+                    </span>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        )
-      })}
+            )
+          })}
+        </>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -1,8 +1,7 @@
 .meals-page {
-  max-width: 1100px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 /* Day layout: side-by-side on wide screens */
@@ -14,7 +13,7 @@
 }
 
 .day-main {
-  flex: 1;
+  flex: 2;
   min-width: 0;
 }
 
@@ -25,8 +24,9 @@
   }
 
   .day-nutrient-summary {
-    width: 280px;
-    flex-shrink: 0;
+    flex: 1;
+    min-width: 200px;
+    max-width: 360px;
     position: sticky;
     top: 1rem;
     max-height: calc(100vh - 2rem);
@@ -41,6 +41,18 @@
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background: #fafafa;
+}
+
+.day-nutrient-summary.empty {
+  border-style: dashed;
+  background: transparent;
+}
+
+.no-nutrients {
+  color: #9ca3af;
+  font-size: 0.85rem;
+  margin: 0;
+  text-align: center;
 }
 
 .day-nutrient-summary h3 {

--- a/apps/web/src/pages/MetricMeta/style.css
+++ b/apps/web/src/pages/MetricMeta/style.css
@@ -1,8 +1,7 @@
 .metric-meta-page {
-  max-width: 800px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 /* Header */

--- a/apps/web/src/pages/Reports/ReportDetail.css
+++ b/apps/web/src/pages/Reports/ReportDetail.css
@@ -1,8 +1,7 @@
 .report-detail-page {
-  max-width: 960px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .report-detail-nav {

--- a/apps/web/src/pages/Reports/style.css
+++ b/apps/web/src/pages/Reports/style.css
@@ -1,8 +1,7 @@
 .reports-page {
-  max-width: 800px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .reports-header {

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -1,7 +1,7 @@
 .settings-page {
-  max-width: 600px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .settings-page h1 {

--- a/apps/web/src/pages/Sleep/style.css
+++ b/apps/web/src/pages/Sleep/style.css
@@ -1,7 +1,7 @@
 .sleep-page {
-  max-width: 900px;
-  margin: 0 auto;
+  width: 100%;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 .sleep-page .sleep-header {

--- a/apps/web/src/pages/TagMeta/style.css
+++ b/apps/web/src/pages/TagMeta/style.css
@@ -1,8 +1,7 @@
 .tag-meta-page {
-  max-width: 800px;
   width: 100%;
-  margin: 0 auto;
   padding: 2rem;
+  box-sizing: border-box;
 }
 
 /* Header */

--- a/apps/web/src/pages/Trends/style.css
+++ b/apps/web/src/pages/Trends/style.css
@@ -6,7 +6,6 @@
 
 .page-header {
   margin-bottom: 2rem;
-  max-width: 800px;
 }
 
 .page-header h1 {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -17,95 +17,50 @@ body {
   margin: 0;
 }
 
+/* ── App shell: sidebar + content on wide, column on narrow ── */
+
 #app {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   min-height: 100vh;
   height: 100vh;
 }
 
-/* ── Header ────────────────────────────────────────────────── */
+.app-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  height: 100vh;
+}
+
+@media (max-width: 60em) {
+  #app {
+    flex-direction: column;
+  }
+
+  .app-content {
+    height: auto;
+    flex: 1;
+  }
+}
+
+/* ── Header (mobile only) ─────────────────────────────────── */
 
 header {
   background-color: #673ab8;
-}
-
-/* Desktop nav — shown by default, hidden on narrow screens */
-.nav-desktop {
-  display: flex;
-  align-items: center;
-}
-
-.nav-desktop .spacer {
-  flex: 1;
-}
-
-.nav-desktop a {
-  color: #fff;
-  padding: 0.75rem;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.nav-desktop a.active {
-  background-color: #0005;
-}
-
-.nav-desktop a:hover {
-  background-color: #0008;
-}
-
-/* Nav dropdown for Data Sources — desktop */
-.nav-dropdown {
-  position: relative;
-  display: flex;
-  align-items: stretch;
-}
-
-.nav-dropdown .dropdown-toggle {
-  cursor: pointer;
-  user-select: none;
-  display: flex;
-  align-items: center;
-}
-
-.dropdown-arrow {
-  font-size: 0.7em;
-  margin-left: 0.125rem;
-}
-
-.dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 100;
-  background: #673ab8;
-  border-radius: 0 0 6px 6px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-  min-width: 220px;
-  display: flex;
-  flex-direction: column;
-}
-
-.dropdown-menu a {
-  padding: 0.5rem 1rem;
-  color: #fff;
-  text-decoration: none;
-  white-space: nowrap;
-  font-size: 0.9rem;
-}
-
-.dropdown-menu a:hover {
-  background-color: #0008;
-}
-
-.dropdown-menu a.active {
-  background-color: #0005;
-}
-
-/* Mobile nav bar — hidden by default, shown on narrow screens */
-.nav-mobile {
   display: none;
+}
+
+@media (max-width: 60em) {
+  header {
+    display: block;
+  }
+}
+
+/* Mobile nav bar */
+.nav-mobile {
+  display: flex;
   align-items: center;
   padding: 0 0.5rem;
 }
@@ -138,7 +93,8 @@ header {
   background-color: #0008;
 }
 
-/* Drawer backdrop */
+/* ── Drawer (mobile overlay) ──────────────────────────────── */
+
 .drawer-backdrop {
   position: fixed;
   inset: 0;
@@ -146,7 +102,6 @@ header {
   z-index: 200;
 }
 
-/* Left drawer */
 .nav-drawer {
   position: fixed;
   top: 0;
@@ -233,6 +188,11 @@ header {
   background-color: #0005;
 }
 
+.dropdown-arrow {
+  font-size: 0.7em;
+  margin-left: 0.125rem;
+}
+
 .drawer-sub-link {
   padding-left: 2rem !important;
   font-size: 0.9rem !important;
@@ -242,22 +202,6 @@ header {
 .drawer-spacer {
   flex: 1;
   min-height: 1rem;
-}
-
-/* ── Responsive: which nav to show ───────────────────────── */
-
-/*
- * Switch to hamburger when the desktop nav would be too cramped.
- * ~60em covers the approximate character width of all nav items.
- */
-@media (max-width: 60em) {
-  .nav-desktop {
-    display: none;
-  }
-
-  .nav-mobile {
-    display: flex;
-  }
 }
 
 /* ── Main content ─────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Replace horizontal top nav with persistent left sidebar on wide screens (240px expanded, 56px icon-only collapsed, state saved in localStorage)
- Mobile hamburger + drawer navigation unchanged
- Remove `max-width` + centering from ~20 page containers so content uses full width
- Fix meals list and detail page layout jumpiness by always rendering the nutrient column (dashed placeholder when empty, flex 2/3 + 1/3 proportions)

## Test plan
- [ ] Sidebar: expand/collapse toggle, localStorage persistence across reload
- [ ] Sidebar: all nav links work, Data Sources expandable section
- [ ] Mobile (<60em): sidebar hidden, hamburger + drawer works as before
- [ ] Wide screens: pages use full width, no centering gaps
- [ ] Meals list: navigate between days with/without nutrients — no layout jump
- [ ] MealDetail: same stability check
- [ ] Dark mode on all pages
- [ ] Timeline fills viewport height correctly
- [ ] Dashboard grid still responsive
- [ ] Places map fills remaining space
- [ ] D3 charts resize after sidebar collapse/expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)