### PR TITLE
feat: timezone-aware MCP timestamps

### DIFF
--- a/apps/backend/src/mcp.integration.test.ts
+++ b/apps/backend/src/mcp.integration.test.ts
@@ -65,6 +65,7 @@ describe('MCP Database Integration Tests (Stateless)', () => {
           arguments: {
             end: '2024-01-31T23:59:59Z',
             start: '2024-01-01T00:00:00Z',
+            tz: 'UTC',
           },
           name: 'query_tags',
         },
@@ -95,6 +96,7 @@ describe('MCP Database Integration Tests (Stateless)', () => {
           arguments: {
             end: '2024-01-31T23:59:59Z',
             start: '2024-01-01T00:00:00Z',
+            tz: 'UTC',
           },
           name: 'query_tags',
         },
@@ -111,6 +113,7 @@ describe('MCP Database Integration Tests (Stateless)', () => {
           arguments: {
             end: '2024-02-28T23:59:59Z',
             start: '2024-02-01T00:00:00Z',
+            tz: 'UTC',
           },
           name: 'query_tags',
         },
@@ -136,6 +139,7 @@ describe('MCP Database Integration Tests (Stateless)', () => {
           arguments: {
             end: '2024-01-31T23:59:59Z',
             start: '2024-01-01T00:00:00Z',
+            tz: 'UTC',
           },
           name: 'query_tags',
         },
@@ -151,6 +155,7 @@ describe('MCP Database Integration Tests (Stateless)', () => {
           arguments: {
             end: '2024-01-31T23:59:59Z',
             start: '2024-01-01T00:00:00Z',
+            tz: 'UTC',
           },
           name: 'query_tags',
         },

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -223,6 +223,7 @@ describe('MCP Server', () => {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -253,6 +254,7 @@ describe('MCP Server', () => {
         end: 'not-a-date',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       // Schema validation catches invalid dates before our handler runs
@@ -287,6 +289,7 @@ describe('MCP Server', () => {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -322,6 +325,7 @@ describe('MCP Server', () => {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -357,6 +361,7 @@ describe('MCP Server', () => {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -392,6 +397,7 @@ describe('MCP Server', () => {
         end: '2024-01-31T23:59:59Z',
         metrics: ['hrv_rmssd'],
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -444,6 +450,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'query_tags', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -468,6 +475,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'query_tags', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -512,7 +520,7 @@ describe('MCP Server', () => {
         tag_mappings: { [uuid]: 'Food' },
       })
 
-      const response = await callTool(app, token, 'get_programmatic_tags', {})
+      const response = await callTool(app, token, 'get_programmatic_tags', { tz: 'UTC' })
 
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
@@ -521,7 +529,7 @@ describe('MCP Server', () => {
         count: 5,
         current_name: 'Food',
         is_programmatic: true,
-        latest_time: '2024-01-15T12:00:00.000Z',
+        latest_time: '2024-01-15T12:00:00+00:00',
         tag_key: uuid,
       })
     })
@@ -541,7 +549,7 @@ describe('MCP Server', () => {
       ])
       vi.mocked(db.getUserSettings).mockResolvedValue(null)
 
-      const response = await callTool(app, token, 'get_programmatic_tags', {})
+      const response = await callTool(app, token, 'get_programmatic_tags', { tz: 'UTC' })
 
       expect(response.status).toBe(200)
       expect(response.toolResult.success).toBe(true)
@@ -551,14 +559,14 @@ describe('MCP Server', () => {
         count: 3,
         current_name: 'VocalExercise',
         is_programmatic: false,
-        latest_time: '2024-01-15T14:00:00.000Z',
+        latest_time: '2024-01-15T14:00:00+00:00',
         tag_key: 'VocalExercise',
       })
       expect(response.toolResult.data[1]).toEqual({
         count: 10,
         current_name: 'coffee',
         is_programmatic: false,
-        latest_time: '2024-01-15T16:00:00.000Z',
+        latest_time: '2024-01-15T16:00:00+00:00',
         tag_key: 'coffee',
       })
     })
@@ -574,7 +582,7 @@ describe('MCP Server', () => {
       ])
       vi.mocked(db.getUserSettings).mockResolvedValue(null)
 
-      const response = await callTool(app, token, 'get_programmatic_tags', {})
+      const response = await callTool(app, token, 'get_programmatic_tags', { tz: 'UTC' })
 
       expect(response.toolResult.data).toHaveLength(2)
       // Programmatic tag without mapping has null current_name
@@ -639,6 +647,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'query_activities', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -669,6 +678,7 @@ describe('MCP Server', () => {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
         types: ['exercise'],
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -735,6 +745,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'query_productivity', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -803,6 +814,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'query_locations', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -823,6 +835,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'query_locations', {
         end: '2024-01-31T23:59:59Z',
         start: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -958,6 +971,7 @@ describe('MCP Server', () => {
         exercise_type: 'weightlifting',
         start_time: '2024-03-15T10:30:00Z',
         title: 'Upper body',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -994,6 +1008,7 @@ describe('MCP Server', () => {
         end_time: '2024-03-15T07:30:00Z',
         start_time: '2024-03-15T07:00:00Z',
         title: 'Morning meditation',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -1024,6 +1039,7 @@ describe('MCP Server', () => {
               end_time: '2024-03-15T11:45:00Z',
               exercise_type: 'invalid_exercise_type',
               start_time: '2024-03-15T10:30:00Z',
+              tz: 'UTC',
             },
             name: 'add_activity',
           },
@@ -1055,6 +1071,7 @@ describe('MCP Server', () => {
               activity_type: 'exercise',
               end_time: '2024-03-15T09:00:00Z',
               start_time: '2024-03-15T10:30:00Z',
+              tz: 'UTC',
             },
             name: 'add_activity',
           },
@@ -1109,6 +1126,7 @@ describe('MCP Server', () => {
         exercise_type: 'weightlifting',
         id: testActivityId,
         title: 'Workout',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -1141,6 +1159,7 @@ describe('MCP Server', () => {
       const response = await callTool(app, token, 'update_activity', {
         id: testActivityId,
         notes: 'Great session',
+        tz: 'UTC',
       })
 
       expect(response.status).toBe(200)
@@ -1168,6 +1187,7 @@ describe('MCP Server', () => {
             arguments: {
               exercise_type: 'not_a_real_exercise',
               id: testActivityId,
+              tz: 'UTC',
             },
             name: 'update_activity',
           },
@@ -1195,6 +1215,7 @@ describe('MCP Server', () => {
         end_time: '2024-03-15T12:00:00Z',
         id: testActivityId,
         start_time: '2024-03-15T09:00:00Z',
+        tz: 'UTC',
       })
 
       expect(mutations.updateActivity).toHaveBeenCalledWith('testuser', testActivityId, {
@@ -1226,6 +1247,7 @@ describe('MCP Server', () => {
             arguments: {
               id: testActivityId,
               title: 'New title',
+              tz: 'UTC',
             },
             name: 'update_activity',
           },

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -7,12 +7,13 @@ import {
   exerciseTypeNames,
   getExerciseTypeValue,
   isValidExerciseType,
+  tzSchema,
   updateActivityBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import { addActivity, deleteActivity, restoreActivity, updateActivity } from '../services/mutations.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerActivityTools = (server: McpServer, user: string) => {
   // Tool: add_activity
@@ -28,8 +29,9 @@ export const registerActivityTools = (server: McpServer, user: string) => {
         .describe(
           `Exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
         ),
+      tz: tzSchema,
     },
-    async ({ activity_type, end_time, exercise_type, notes, start_time, title }) => {
+    async ({ activity_type, end_time, exercise_type, notes, start_time, title, tz }) => {
       const startDate = new Date(start_time)
       const endDate = new Date(end_time)
 
@@ -59,7 +61,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
         return errorResponse(result.error ?? 'Failed to add activity')
       }
 
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -99,8 +101,9 @@ export const registerActivityTools = (server: McpServer, user: string) => {
         .describe(
           `New exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
         ),
+      tz: tzSchema,
     },
-    async ({ id, start_time, end_time, title, notes, exercise_type }) => {
+    async ({ id, start_time, end_time, title, notes, exercise_type, tz }) => {
       let data: Record<string, unknown> | undefined
       if (exercise_type !== undefined) {
         if (!isValidExerciseType(exercise_type)) {
@@ -126,7 +129,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
         return errorResponse(result.error ?? 'Failed to update activity')
       }
 
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 }

--- a/apps/backend/src/mcp/correlation-tools.ts
+++ b/apps/backend/src/mcp/correlation-tools.ts
@@ -7,6 +7,7 @@ import {
   eventProbabilityInputSchema,
   genericCorrelationBodySchema,
   hrvCorrelationInputSchema,
+  tzSchema,
 } from '@aurboda/api-spec'
 
 import {
@@ -18,7 +19,7 @@ import {
   type OutcomeConfig,
   type TriggerCondition,
 } from '../services/correlations.ts'
-import { jsonResponse, type McpServer, type SyncProvider } from './helpers.ts'
+import { type McpServer, type SyncProvider, tzJsonResponse } from './helpers.ts'
 
 export const registerCorrelationTools = (server: McpServer, user: string, sync?: SyncProvider) => {
   // Tool: get_baseline
@@ -29,11 +30,12 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
       reference_date: dateOnlySchema
         .optional()
         .describe('Reference date for baseline calculation in YYYY-MM-DD format. Defaults to today.'),
+      tz: tzSchema,
     },
-    async ({ reference_date }) => {
+    async ({ reference_date, tz }) => {
       const referenceDate = reference_date ? new Date(reference_date) : undefined
       const baseline = await getBaseline(user, referenceDate)
-      return jsonResponse({ data: baseline, success: true })
+      return tzJsonResponse({ data: baseline, success: true }, tz)
     },
   )
 
@@ -41,11 +43,11 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   server.tool(
     'get_hrv_activities_correlation',
     'Get HRV correlations with various activities. Returns Pearson correlation coefficients between HRV and productivity, locations, activities, and tags.',
-    { ...hrvCorrelationInputSchema.shape },
-    async ({ period_days }) => {
+    { ...hrvCorrelationInputSchema.shape, tz: tzSchema },
+    async ({ period_days, tz }) => {
       const periodDays = period_days ?? 30
       const correlations = await getHrvActivitiesCorrelation(user, periodDays, sync)
-      return jsonResponse({ data: correlations, success: true })
+      return tzJsonResponse({ data: correlations, success: true }, tz)
     },
   )
 
@@ -53,13 +55,13 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   server.tool(
     'get_activity_impact',
     'Get the impact of a specific activity/tag on HRV and heart rate. Compares metric values before, during, and after the activity using time windows.',
-    { ...activityImpactInputSchema.shape },
-    async ({ activity, activity_type, period_days, window_minutes }) => {
+    { ...activityImpactInputSchema.shape, tz: tzSchema },
+    async ({ activity, activity_type, period_days, window_minutes, tz }) => {
       const periodDays = period_days ?? 90
       const windowMinutes = window_minutes ?? 30
 
       const impact = await getActivityImpact(user, activity, activity_type, windowMinutes, periodDays, sync)
-      return jsonResponse({ data: impact, success: true })
+      return tzJsonResponse({ data: impact, success: true }, tz)
     },
   )
 
@@ -67,8 +69,8 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   server.tool(
     'get_event_probability',
     'Get the probability correlation between two events. Analyzes whether one event (trigger) increases or decreases the probability of another event (outcome) occurring within specified time windows. Uses chi-squared test for statistical significance.',
-    { ...eventProbabilityInputSchema.shape },
-    async ({ lag_windows, outcome_pattern, period_days, trigger_type, trigger_value }) => {
+    { ...eventProbabilityInputSchema.shape, tz: tzSchema },
+    async ({ lag_windows, outcome_pattern, period_days, trigger_type, trigger_value, tz }) => {
       const probability = await getEventProbability(
         user,
         { type: trigger_type, value: trigger_value },
@@ -77,7 +79,7 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
         period_days ?? 365,
         sync,
       )
-      return jsonResponse({ data: probability, success: true })
+      return tzJsonResponse({ data: probability, success: true }, tz)
     },
   )
 
@@ -91,8 +93,8 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
 Examples:
 - "Does meditation correlate with more productive time?" -> trigger: tag "meditation", outcome: productivity
 - "When I exercise 3x and tag FatCoffee 5x in a week, does my weight change?" -> compound triggers, metric outcome`,
-    { ...genericCorrelationBodySchema.shape },
-    async ({ lag_windows, outcome, period_days, triggers }) => {
+    { ...genericCorrelationBodySchema.shape, tz: tzSchema },
+    async ({ lag_windows, outcome, period_days, triggers, tz }) => {
       const result = await getGenericCorrelation(
         user,
         triggers as TriggerCondition[],
@@ -101,7 +103,7 @@ Examples:
         period_days ?? 90,
         sync,
       )
-      return jsonResponse({ data: result, success: true })
+      return tzJsonResponse({ data: result, success: true }, tz)
     },
   )
 }

--- a/apps/backend/src/mcp/helpers.ts
+++ b/apps/backend/src/mcp/helpers.ts
@@ -5,12 +5,24 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
  */
 import { validMetrics } from '@aurboda/api-spec'
 
+import { convertTimestamps } from './tz-utils.ts'
+
 /** Metric name description using validMetrics from api-spec. */
 export const metricDescription = `Metric name. Valid metrics: ${validMetrics.join(', ')}`
 
 /** Helper to create JSON text response. */
 export const jsonResponse = (data: unknown) => ({
   content: [{ text: JSON.stringify(data, null, 2), type: 'text' as const }],
+})
+
+/** Helper to create JSON text response with timezone-converted timestamps. */
+export const tzJsonResponse = (data: unknown, tz: string) => ({
+  content: [
+    {
+      text: JSON.stringify({ ...(convertTimestamps(data, tz) as object), tz }, null, 2),
+      type: 'text' as const,
+    },
+  ],
 })
 
 /** Helper to create error response. */

--- a/apps/backend/src/mcp/lastfm-tools.ts
+++ b/apps/backend/src/mcp/lastfm-tools.ts
@@ -4,6 +4,7 @@
 import {
   addLastFmTagRuleBodySchema,
   scrobblesQuerySchema,
+  tzSchema,
   updateLastFmTagRuleBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -18,23 +19,24 @@ import {
   type LastFmMatchType,
 } from '../db/index.ts'
 import { applyRuleRetroactively, cleanupRuleTags, retagAllScrobbles } from '../lastfm-sync.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
+import { formatInTz } from './tz-utils.ts'
 
 export const registerLastFmTools = (server: McpServer, user: string) => {
   // Tool: query_scrobbles
   server.tool(
     'query_scrobbles',
     'Query Last.fm scrobbles for a time range. Returns tracks played with artist, album, and timestamp.',
-    { ...scrobblesQuerySchema.shape },
-    async ({ start, end }) => {
+    { ...scrobblesQuerySchema.shape, tz: tzSchema },
+    async ({ start, end, tz }) => {
       const scrobbles = await getScrobbles(user, new Date(start), new Date(end))
       const serialized = scrobbles.map((s) => ({
         album: s.album,
         artist: s.artist,
-        recorded_at: s.recorded_at.toISOString(),
+        recorded_at: formatInTz(s.recorded_at, tz),
         track: s.track,
       }))
-      return jsonResponse({ data: serialized, success: true })
+      return tzJsonResponse({ data: serialized, success: true }, tz)
     },
   )
 
@@ -42,14 +44,14 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
   server.tool(
     'get_lastfm_tag_rules',
     'Get all Last.fm auto-tagging rules. These rules create tags when scrobbles match specified criteria.',
-    {},
-    async () => {
+    { tz: tzSchema },
+    async ({ tz }) => {
       const rules = await getLastFmTagRules(user)
       const serialized = rules.map((r) => ({
         ...r,
-        created_at: r.created_at.toISOString(),
+        created_at: formatInTz(r.created_at, tz),
       }))
-      return jsonResponse({ data: serialized, success: true })
+      return tzJsonResponse({ data: serialized, success: true }, tz)
     },
   )
 
@@ -57,7 +59,7 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
   server.tool(
     'add_lastfm_tag_rule',
     'Add a Last.fm auto-tagging rule. Creates tags when scrobbles match the specified criteria. The rule is applied retroactively to all existing scrobbles.',
-    { ...addLastFmTagRuleBodySchema.shape },
+    { ...addLastFmTagRuleBodySchema.shape, tz: tzSchema },
     async ({
       artist_name,
       artist_names,
@@ -67,6 +69,7 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
       rule_name,
       tag_name,
       track_name,
+      tz,
     }) => {
       if ((match_type === 'track' || match_type === 'track_artist') && !track_name) {
         return errorResponse(`track_name is required for match_type "${match_type}"`)
@@ -91,14 +94,17 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
         // Apply the new rule retroactively to all existing scrobbles
         const tagsApplied = await applyRuleRetroactively(user, rule)
 
-        return jsonResponse({
-          data: {
-            ...rule,
-            created_at: rule.created_at.toISOString(),
-            tags_applied: tagsApplied,
+        return tzJsonResponse(
+          {
+            data: {
+              ...rule,
+              created_at: formatInTz(rule.created_at, tz),
+              tags_applied: tagsApplied,
+            },
+            success: true,
           },
-          success: true,
-        })
+          tz,
+        )
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         if (message.includes('unique_rule')) {
@@ -116,6 +122,7 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
     {
       id: z.string().uuid().describe('The ID of the rule to update'),
       ...updateLastFmTagRuleBodySchema.shape,
+      tz: tzSchema,
     },
     async ({
       id,
@@ -127,6 +134,7 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
       rule_name,
       tag_name,
       track_name,
+      tz,
     }) => {
       try {
         // Clean up old auto-tags before updating
@@ -149,14 +157,17 @@ export const registerLastFmTools = (server: McpServer, user: string) => {
 
         const tagsApplied = await applyRuleRetroactively(user, updated)
 
-        return jsonResponse({
-          data: {
-            ...updated,
-            created_at: updated.created_at.toISOString(),
-            tags_applied: tagsApplied,
+        return tzJsonResponse(
+          {
+            data: {
+              ...updated,
+              created_at: formatInTz(updated.created_at, tz),
+              tags_applied: tagsApplied,
+            },
+            success: true,
           },
-          success: true,
-        })
+          tz,
+        )
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         if (message.includes('unique_rule')) {

--- a/apps/backend/src/mcp/location-tools.ts
+++ b/apps/backend/src/mcp/location-tools.ts
@@ -5,6 +5,7 @@ import {
   addNamedLocationBodySchema,
   promoteDetectedLocationBodySchema,
   timeRangeQuerySchema,
+  tzSchema,
   updateNamedLocationBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -17,7 +18,7 @@ import {
   insertNamedLocation,
   updateNamedLocation,
 } from '../services/locations.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerLocationTools = (server: McpServer, user: string) => {
   // Tool: get_named_locations
@@ -38,15 +39,16 @@ export const registerLocationTools = (server: McpServer, user: string) => {
     {
       ...timeRangeQuerySchema.shape,
       min_duration: z.number().optional().describe('Minimum stay duration in minutes. Defaults to 60.'),
+      tz: tzSchema,
     },
-    async ({ end, min_duration, start }) => {
+    async ({ end, min_duration, start, tz }) => {
       const detected = await getDetectedLocations(user, {
         end: new Date(end),
         minDurationMinutes: min_duration,
         start: new Date(start),
       })
 
-      return jsonResponse({ data: detected, success: true })
+      return tzJsonResponse({ data: detected, success: true }, tz)
     },
   )
 

--- a/apps/backend/src/mcp/meal-tools.ts
+++ b/apps/backend/src/mcp/meal-tools.ts
@@ -3,21 +3,21 @@
  *
  * Provides tools for adding, querying, and deleting meal/nutrition records.
  */
-import { addMealBodySchema, mealsQuerySchema, updateMealBodySchema } from '@aurboda/api-spec'
+import { addMealBodySchema, mealsQuerySchema, tzSchema, updateMealBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import { addMeal, deleteMealById, getMeal, queryMeals, updateMealById } from '../services/meals.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerMealTools = (server: McpServer, user: string) => {
   // Tool: add_meal
   server.tool(
     'add_meal',
     'Add a meal record with optional nutrition details. Supports food items, macros (calories, protein, carbs, fat, fiber), and micronutrients.',
-    { ...addMealBodySchema.shape },
-    async (params) => {
+    { ...addMealBodySchema.shape, tz: tzSchema },
+    async ({ tz, ...params }) => {
       const result = await addMeal(user, { ...params })
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -25,14 +25,14 @@ export const registerMealTools = (server: McpServer, user: string) => {
   server.tool(
     'query_meals',
     'Query meals for a date range, optionally filtered by meal type.',
-    { ...mealsQuerySchema.shape },
-    async (params) => {
+    { ...mealsQuerySchema.shape, tz: tzSchema },
+    async ({ tz, ...params }) => {
       const result = await queryMeals(user, {
         end: params.end,
         meal_type: params.meal_type,
         start: params.start,
       })
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -54,13 +54,13 @@ export const registerMealTools = (server: McpServer, user: string) => {
   server.tool(
     'update_meal',
     'Update an existing meal record. Only provided fields are changed.',
-    { id: z.string().uuid().describe('The meal ID to update'), ...updateMealBodySchema.shape },
-    async ({ id, ...params }) => {
+    { id: z.string().uuid().describe('The meal ID to update'), ...updateMealBodySchema.shape, tz: tzSchema },
+    async ({ id, tz, ...params }) => {
       const result = await updateMealById(user, id, params)
       if (!result.success) {
         return errorResponse(result.error ?? 'Meal not found')
       }
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -68,13 +68,13 @@ export const registerMealTools = (server: McpServer, user: string) => {
   server.tool(
     'get_meal',
     'Get a single meal by its ID, including food items and nutrition data.',
-    { id: z.string().uuid().describe('The meal ID') },
-    async ({ id }) => {
+    { id: z.string().uuid().describe('The meal ID'), tz: tzSchema },
+    async ({ id, tz }) => {
       const result = await getMeal(user, id)
       if (!result.success) {
         return errorResponse(result.error ?? 'Meal not found')
       }
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 }

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -7,6 +7,7 @@ import {
   bulkMetricItemSchema,
   customMetricDefinitionSchema,
   recalculateCaloriesBodySchema,
+  tzSchema,
   updateCustomMetricBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -28,6 +29,7 @@ import {
   type McpServer,
   metricDescription,
   parseOptionalDate,
+  tzJsonResponse,
 } from './helpers.ts'
 
 export const registerMetricTools = (server: McpServer, user: string) => {
@@ -35,8 +37,8 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   server.tool(
     'add_metric',
     'Add a manual health metric measurement. Use this to log data not captured automatically.',
-    { ...addMetricBodySchema.shape },
-    async ({ metric, time, value }) => {
+    { ...addMetricBodySchema.shape, tz: tzSchema },
+    async ({ metric, time, value, tz }) => {
       const measurementTime = time ? parseOptionalDate(time) : new Date()
       if (!measurementTime) {
         return errorResponse('Invalid time format. Use ISO 8601 format.')
@@ -46,7 +48,7 @@ export const registerMetricTools = (server: McpServer, user: string) => {
       if (!result.success) {
         return errorResponse(result.error ?? 'Failed to add metric')
       }
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -62,8 +64,9 @@ export const registerMetricTools = (server: McpServer, user: string) => {
         .max(50)
         .optional()
         .describe('Default data source for all items (defaults to "aurboda")'),
+      tz: tzSchema,
     },
-    async ({ data, source }) => {
+    async ({ data, source, tz }) => {
       const items = data.map((item) => ({
         metric: item.metric,
         source: item.source,
@@ -77,7 +80,7 @@ export const registerMetricTools = (server: McpServer, user: string) => {
       }
 
       const result = await bulkAddMetrics(user, items, source)
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -192,8 +195,13 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   server.tool(
     'recalculate_calories',
     'Recalculate calories burned from HR data for a time range. Requires sex and birth_date in settings. Uses weight from Health Connect and VO2 max (measured or age/sex fallback). Omit start/end to recompute all historical data. Full recomputes run asynchronously and return immediately.',
-    { ...recalculateCaloriesBodySchema.shape, end: z.string().optional(), start: z.string().optional() },
-    async ({ start, end }) => {
+    {
+      ...recalculateCaloriesBodySchema.shape,
+      end: z.string().optional(),
+      start: z.string().optional(),
+      tz: tzSchema,
+    },
+    async ({ start, end, tz }) => {
       if (!start || !end) {
         // Full recompute runs async — fire and forget, return immediately
         computeAndStoreCaloriesAll(user).then(
@@ -203,10 +211,13 @@ export const registerMetricTools = (server: McpServer, user: string) => {
             ),
           (error) => console.error(`🔥 Async calorie recompute failed for ${user}:`, error),
         )
-        return jsonResponse({ started: true, message: 'Full calorie recomputation started in background' })
+        return tzJsonResponse(
+          { started: true, message: 'Full calorie recomputation started in background' },
+          tz,
+        )
       }
       const result = await computeAndStoreCalories(user, new Date(start), new Date(end), { force: true })
-      return jsonResponse({ ...result, success: true })
+      return tzJsonResponse({ ...result, success: true }, tz)
     },
   )
 }

--- a/apps/backend/src/mcp/note-tools.ts
+++ b/apps/backend/src/mcp/note-tools.ts
@@ -1,11 +1,11 @@
 /**
  * MCP note management tools.
  */
-import { addNoteBodySchema, notesQuerySchema, updateNoteBodySchema } from '@aurboda/api-spec'
+import { addNoteBodySchema, notesQuerySchema, tzSchema, updateNoteBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import { addNote, deleteNoteById, getNotesForEntity, updateNoteContent } from '../services/mutations.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerNoteTools = (server: McpServer, user: string) => {
   // Tool: add_note
@@ -23,10 +23,10 @@ export const registerNoteTools = (server: McpServer, user: string) => {
   server.tool(
     'get_notes',
     'Get all notes for an entity (activity, tag, productivity record, or metric data point). For metrics, use entity_type "metric" with entity_id as a composite key: "<iso_time>|<metric>|<source>".',
-    { ...notesQuerySchema.shape },
-    async ({ entity_type, entity_id }) => {
+    { ...notesQuerySchema.shape, tz: tzSchema },
+    async ({ entity_type, entity_id, tz }) => {
       const notes = await getNotesForEntity(user, entity_type, entity_id)
-      return jsonResponse({ data: notes, success: true })
+      return tzJsonResponse({ data: notes, success: true }, tz)
     },
   )
 

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -8,6 +8,7 @@ import {
   dateOnlySchema,
   type MetricType,
   timeRangeQuerySchema,
+  tzSchema,
   validMetrics,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -25,10 +26,10 @@ import {
 } from '../services/queries.ts'
 import {
   errorResponse,
-  jsonResponse,
   type McpServer,
   metricDescription,
   type SyncProvider,
+  tzJsonResponse,
 } from './helpers.ts'
 
 export const registerQueryTools = (server: McpServer, user: string, sync?: SyncProvider) => {
@@ -39,12 +40,13 @@ export const registerQueryTools = (server: McpServer, user: string, sync?: SyncP
     {
       ...timeRangeQuerySchema.shape,
       metric: z.string().describe(metricDescription),
+      tz: tzSchema,
     },
-    async ({ end, metric, start }) => {
+    async ({ end, metric, start, tz }) => {
       const customMetrics = await getCustomMetrics(user)
 
       const result = await queryMetrics(user, metric, new Date(start), new Date(end), customMetrics)
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -75,10 +77,7 @@ Use cases:
         .array(z.string())
         .optional()
         .describe(`Metrics to include (omit for all). Valid built-in metrics: ${validMetrics.join(', ')}`),
-      tz: z
-        .string()
-        .optional()
-        .describe('IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). Defaults to UTC.'),
+      tz: tzSchema,
     },
     async ({ bucket, end, exclude, metrics, start, tz }) => {
       const customMetrics = await getCustomMetrics(user)
@@ -91,7 +90,7 @@ Use cases:
         bucket,
         { customMetrics, exclude, tz },
       )
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -101,8 +100,9 @@ Use cases:
     'Get a comprehensive summary of health data for a specific day including heart rate, steps, sleep, exercise, meals, tags, productivity, and visited places. Also includes Oura scores (sleep_score, readiness_score, resilience_score, cardiovascular_age) when available.\n\nExercise sessions include a human-readable `exercise_type` name (e.g., "yoga", "running", "weightlifting").\n\nMeals include macros (calories, protein, carbs, fat, fiber) and food item names.\n\nSleep sessions are disambiguated: `primary_sleep` is the session the user woke up from on this date (following Oura convention), `evening_sleep` is the session started this evening that continues to the next day. Each sleep session includes `sleep_date` (the date it belongs to, using wake-up convention) and `sleep_location` (best-guess location). The `oura_scores.sleep_score` evaluates the `primary_sleep` session.',
     {
       date: dateOnlySchema.describe('Date in YYYY-MM-DD format (e.g., 2024-01-15)'),
+      tz: tzSchema,
     },
-    async ({ date }) => {
+    async ({ date, tz }) => {
       const dateMatch = date.match(/^(\d{4})-(\d{2})-(\d{2})$/)
       if (!dateMatch) {
         return errorResponse('Invalid date format. Use YYYY-MM-DD format.')
@@ -113,8 +113,8 @@ Use cases:
         return errorResponse('Invalid date.')
       }
 
-      const summary = await getDailySummary(user, dateObj, sync)
-      return jsonResponse(summary)
+      const summary = await getDailySummary(user, dateObj, sync, tz)
+      return tzJsonResponse(summary, tz)
     },
   )
 
@@ -125,10 +125,11 @@ Use cases:
     {
       ...timeRangeQuerySchema.shape,
       metrics: z.array(z.string()).describe(`Metrics to include. Valid metrics: ${validMetrics.join(', ')}`),
+      tz: tzSchema,
     },
-    async ({ end, metrics, start }) => {
+    async ({ end, metrics, start, tz }) => {
       const summary = await getPeriodSummary(user, metrics as string[], new Date(start), new Date(end))
-      return jsonResponse(summary)
+      return tzJsonResponse(summary, tz)
     },
   )
 
@@ -136,10 +137,10 @@ Use cases:
   server.tool(
     'query_tags',
     'Query tags/labels for a time range. Returns all tags with start times, optional end times, and tag text.',
-    { ...timeRangeQuerySchema.shape },
-    async ({ end, start }) => {
+    { ...timeRangeQuerySchema.shape, tz: tzSchema },
+    async ({ end, start, tz }) => {
       const tags = await queryTags(user, new Date(start), new Date(end), sync)
-      return jsonResponse({ data: tags, success: true })
+      return tzJsonResponse({ data: tags, success: true }, tz)
     },
   )
 
@@ -155,11 +156,12 @@ Use cases:
         .describe(
           'Activity types to include. Defaults to all types (sleep, exercise, meditation, nap, rest).',
         ),
+      tz: tzSchema,
     },
-    async ({ end, start, types }) => {
+    async ({ end, start, types, tz }) => {
       const requestedTypes = types ?? [...activityTypes]
       const activities = await queryActivities(user, requestedTypes, new Date(start), new Date(end), sync)
-      return jsonResponse({ data: activities, success: true })
+      return tzJsonResponse({ data: activities, success: true }, tz)
     },
   )
 
@@ -167,10 +169,10 @@ Use cases:
   server.tool(
     'query_productivity',
     'Query productivity data (from RescueTime) for a time range. Returns application/website usage with productivity scores.',
-    { ...timeRangeQuerySchema.shape },
-    async ({ end, start }) => {
+    { ...timeRangeQuerySchema.shape, tz: tzSchema },
+    async ({ end, start, tz }) => {
       const productivity = await queryProductivity(user, new Date(start), new Date(end), sync)
-      return jsonResponse({ data: productivity, success: true })
+      return tzJsonResponse({ data: productivity, success: true }, tz)
     },
   )
 
@@ -182,20 +184,17 @@ Use cases:
       bucket: bucketSizeSchema,
       end: timeRangeQuerySchema.shape.end,
       start: timeRangeQuerySchema.shape.start,
-      tz: z
-        .string()
-        .optional()
-        .describe('IANA timezone for bucket alignment (e.g. "Europe/Stockholm"). Defaults to UTC.'),
+      tz: tzSchema,
     },
     async ({ bucket, end, start, tz }) => {
       const { interval, ms: bucketMs } = (await import('../services/queries.ts')).parseBucketSize(bucket)
       const { assembleScreentimeBuckets } = await import('../services/queries.ts')
       const rows = await (
         await import('../db/index.ts')
-      ).getProductivityBucketed(user, new Date(start), new Date(end), interval, tz ?? 'UTC')
+      ).getProductivityBucketed(user, new Date(start), new Date(end), interval, tz)
 
       const buckets = assembleScreentimeBuckets(rows, bucketMs)
-      return jsonResponse({ bucket, buckets, end, start, success: true })
+      return tzJsonResponse({ bucket, buckets, end, start, success: true }, tz)
     },
   )
 
@@ -203,10 +202,10 @@ Use cases:
   server.tool(
     'query_locations',
     'Query location/place visits for a time range. Returns places visited with names, coordinates, duration, and source (named, detected, or owntracks).',
-    { ...timeRangeQuerySchema.shape },
-    async ({ end, start }) => {
+    { ...timeRangeQuerySchema.shape, tz: tzSchema },
+    async ({ end, start, tz }) => {
       const places = await queryLocations(user, new Date(start), new Date(end))
-      return jsonResponse({ data: places, success: true })
+      return tzJsonResponse({ data: places, success: true }, tz)
     },
   )
 }

--- a/apps/backend/src/mcp/report-tools.ts
+++ b/apps/backend/src/mcp/report-tools.ts
@@ -3,7 +3,7 @@
  *
  * Provides tools for creating, querying, and deleting structured lab reports.
  */
-import { addReportBodySchema, reportsQuerySchema, updateReportBodySchema } from '@aurboda/api-spec'
+import { addReportBodySchema, reportsQuerySchema, tzSchema, updateReportBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import {
@@ -14,15 +14,15 @@ import {
   queryReports,
   updateReport,
 } from '../services/reports.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerReportTools = (server: McpServer, user: string) => {
   // Tool: add_report
   server.tool(
     'add_report',
     'Create a structured lab report with grouped measurements (e.g., InBody scan, blood panel, hair mineral analysis). Each entry is also written to the metric time series for trend tracking. Flags are auto-derived from reference ranges if not set.',
-    { ...addReportBodySchema.shape },
-    async (params) => {
+    { ...addReportBodySchema.shape, tz: tzSchema },
+    async ({ tz, ...params }) => {
       const result = await addReport(user, {
         date: params.date,
         entries: params.entries,
@@ -30,7 +30,7 @@ export const registerReportTools = (server: McpServer, user: string) => {
         notes: params.notes,
         report_type: params.report_type,
       })
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -38,13 +38,13 @@ export const registerReportTools = (server: McpServer, user: string) => {
   server.tool(
     'get_report',
     'Fetch a single lab report by its ID, including all entries with their metadata.',
-    { id: z.string().uuid().describe('The report ID') },
-    async ({ id }) => {
+    { id: z.string().uuid().describe('The report ID'), tz: tzSchema },
+    async ({ id, tz }) => {
       const result = await getReport(user, id)
       if (!result.success) {
         return errorResponse(result.error ?? 'Report not found')
       }
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -52,14 +52,14 @@ export const registerReportTools = (server: McpServer, user: string) => {
   server.tool(
     'query_reports',
     'List lab reports, optionally filtered by type (e.g., "inbody", "blood_panel") and/or date range.',
-    { ...reportsQuerySchema.shape },
-    async (params) => {
+    { ...reportsQuerySchema.shape, tz: tzSchema },
+    async ({ tz, ...params }) => {
       const result = await queryReports(user, {
         end: params.end,
         report_type: params.report_type,
         start: params.start,
       })
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -67,13 +67,17 @@ export const registerReportTools = (server: McpServer, user: string) => {
   server.tool(
     'update_report',
     'Update a lab report. Can modify metadata (report_type, date, location, notes) and/or replace all entries. When entries are provided, they fully replace existing entries. Flags are auto-derived from reference ranges if not set.',
-    { id: z.string().uuid().describe('The report ID to update'), ...updateReportBodySchema.shape },
-    async ({ id, ...params }) => {
+    {
+      id: z.string().uuid().describe('The report ID to update'),
+      ...updateReportBodySchema.shape,
+      tz: tzSchema,
+    },
+    async ({ id, tz, ...params }) => {
       const result = await updateReport(user, id, params)
       if (!result.success) {
         return errorResponse(result.error ?? 'Report not found')
       }
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -95,10 +99,10 @@ export const registerReportTools = (server: McpServer, user: string) => {
   server.tool(
     'get_latest_metric',
     'Get the most recent value for any metric regardless of age. Useful for lab data that may be months old (e.g., "what was last body_fat?", "latest ferritin?").',
-    { metric: z.string().min(1).max(50).describe('Metric name (built-in or custom)') },
-    async ({ metric }) => {
+    { metric: z.string().min(1).max(50).describe('Metric name (built-in or custom)'), tz: tzSchema },
+    async ({ metric, tz }) => {
       const result = await getLatestMetric(user, metric)
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 }

--- a/apps/backend/src/mcp/settings-tools.ts
+++ b/apps/backend/src/mcp/settings-tools.ts
@@ -1,7 +1,7 @@
 /**
  * MCP user settings and tag mapping tools.
  */
-import { setTagMappingBodySchema, updateSettingsInputSchema } from '@aurboda/api-spec'
+import { setTagMappingBodySchema, tzSchema, updateSettingsInputSchema } from '@aurboda/api-spec'
 
 import { getProgrammaticTags, getUniqueTags, getUserSettings } from '../db/index.ts'
 import { getGoalsProgress } from '../services/goals.ts'
@@ -11,13 +11,14 @@ import {
   setTagMapping,
   validateAndUpdateSettings,
 } from '../services/settings.ts'
-import { jsonResponse, type McpServer } from './helpers.ts'
+import { jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
+import { formatInTz } from './tz-utils.ts'
 
 export const registerSettingsTools = (server: McpServer, user: string) => {
   // Tool: get_user_settings
   server.tool(
     'get_user_settings',
-    'Get user settings including birth date and effective HR zones. HR zones are used to calculate time spent in different heart rate zones during exercise.',
+    "Get user settings including birth date, effective HR zones, and timezone (tz). The tz field returns the auto-detected timezone from the user's device — use it as the tz parameter for all other tools that require it.",
     {},
     async () => {
       const result = await getSettingsResponse(user)
@@ -51,8 +52,8 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
   server.tool(
     'get_programmatic_tags',
     'Get all tags available for mapping. Includes programmatic tags (UUIDs, tag_* prefixes) that need human-readable display names, plus all other tags so icons can be set on any tag. Tags with is_programmatic=true and no current_name are unmapped.',
-    {},
-    async () => {
+    { tz: tzSchema },
+    async ({ tz }) => {
       const tags = await getProgrammaticTags(user)
       const settings = await getUserSettings(user)
       const mappings = settings?.tag_mappings ?? {}
@@ -61,11 +62,11 @@ export const registerSettingsTools = (server: McpServer, user: string) => {
         count: tag.count,
         current_name: tag.isProgrammatic ? (mappings[tag.tagKey] ?? null) : tag.tagKey,
         is_programmatic: tag.isProgrammatic,
-        latest_time: tag.latestTime.toISOString(),
+        latest_time: formatInTz(tag.latestTime, tz),
         tag_key: tag.tagKey,
       }))
 
-      return jsonResponse({ data, success: true })
+      return tzJsonResponse({ data, success: true }, tz)
     },
   )
 

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -9,6 +9,7 @@ import {
   syncOuraBodySchema,
   syncProviderSchema,
   syncRescueTimeBodySchema,
+  tzSchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
@@ -30,7 +31,8 @@ import { syncAllOuraData } from '../oura-sync.ts'
 import { syncRescueTimeData } from '../rescuetime-sync.ts'
 import { getCentralDb } from '../services/central-db.ts'
 import { getSettings } from '../services/settings.ts'
-import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
+import { formatInTz } from './tz-utils.ts'
 
 type OuraClient = ReturnType<typeof ouraClient>
 
@@ -211,8 +213,9 @@ export const registerSyncTools = (
     'Get the current sync status for Oura, Garmin, RescueTime, Calendar, Last.fm, and ActivityWatch data sources. Shows last sync time, status, and any errors.',
     {
       provider: syncProviderSchema.optional().describe('Which provider to check. Defaults to "all".'),
+      tz: tzSchema,
     },
-    async ({ provider = 'all' }) => {
+    async ({ provider = 'all', tz }) => {
       try {
         const states: Record<string, unknown[]> = {}
         const providers = provider === 'all' ? syncProviders : syncProviders.filter((p) => p === provider)
@@ -221,7 +224,7 @@ export const registerSyncTools = (
           states[p] = await getAllSyncStates(user, p)
         }
 
-        return jsonResponse({ states, success: true })
+        return tzJsonResponse({ states, success: true }, tz)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         return jsonResponse({ error: message, success: false })
@@ -235,20 +238,24 @@ export const registerSyncTools = (
     'Get pending outbound sync entries that need to be written to Health Connect. Returns changes (inserts, updates, deletes) queued for the Android app to apply.',
     {
       limit: z.number().int().min(1).max(500).optional().describe('Max entries to return (default 100)'),
+      tz: tzSchema,
     },
-    async ({ limit }) => {
+    async ({ limit, tz }) => {
       try {
         const { entries, total_pending } = await getPendingOutboundSync(user, limit)
-        return jsonResponse({
-          count: entries.length,
-          data: entries.map((e) => ({
-            ...e,
-            created_at: e.created_at.toISOString(),
-            synced_at: e.synced_at?.toISOString(),
-          })),
-          success: true,
-          total_pending,
-        })
+        return tzJsonResponse(
+          {
+            count: entries.length,
+            data: entries.map((e) => ({
+              ...e,
+              created_at: formatInTz(e.created_at, tz),
+              synced_at: e.synced_at ? formatInTz(e.synced_at, tz) : undefined,
+            })),
+            success: true,
+            total_pending,
+          },
+          tz,
+        )
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         return jsonResponse({ error: message, success: false })
@@ -305,19 +312,23 @@ export const registerSyncTools = (
     'Get outbound sync history including completed and failed entries. Shows fail_count and fail_reason for debugging sync issues.',
     {
       limit: z.number().int().min(1).max(500).optional().describe('Max entries to return (default 50)'),
+      tz: tzSchema,
     },
-    async ({ limit }) => {
+    async ({ limit, tz }) => {
       try {
         const entries = await getOutboundSyncHistory(user, limit)
-        return jsonResponse({
-          count: entries.length,
-          data: entries.map((e) => ({
-            ...e,
-            created_at: e.created_at.toISOString(),
-            synced_at: e.synced_at?.toISOString(),
-          })),
-          success: true,
-        })
+        return tzJsonResponse(
+          {
+            count: entries.length,
+            data: entries.map((e) => ({
+              ...e,
+              created_at: formatInTz(e.created_at, tz),
+              synced_at: e.synced_at ? formatInTz(e.synced_at, tz) : undefined,
+            })),
+            success: true,
+          },
+          tz,
+        )
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         return jsonResponse({ error: message, success: false })

--- a/apps/backend/src/mcp/tag-tools.ts
+++ b/apps/backend/src/mcp/tag-tools.ts
@@ -1,19 +1,19 @@
 /**
  * MCP tag management tools.
  */
-import { addTagBodySchema, deleteTagParamsSchema, updateTagBodySchema } from '@aurboda/api-spec'
+import { addTagBodySchema, deleteTagParamsSchema, tzSchema, updateTagBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import { addTag, deleteTag, restoreTag, updateTag } from '../services/mutations.ts'
-import { errorResponse, jsonResponse, type McpServer, parseOptionalDate } from './helpers.ts'
+import { errorResponse, jsonResponse, type McpServer, parseOptionalDate, tzJsonResponse } from './helpers.ts'
 
 export const registerTagTools = (server: McpServer, user: string) => {
   // Tool: add_tag
   server.tool(
     'add_tag',
     'Add a manual tag/label to mark an activity or event. Tags can have a start time and optional end time.',
-    { ...addTagBodySchema.shape },
-    async ({ end_time, merge_span, start_time, tag }) => {
+    { ...addTagBodySchema.shape, tz: tzSchema },
+    async ({ end_time, merge_span, start_time, tag, tz }) => {
       const startDate = new Date(start_time)
 
       let endDate: Date | undefined
@@ -31,7 +31,7 @@ export const registerTagTools = (server: McpServer, user: string) => {
         start_time: startDate,
         tag,
       })
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 
@@ -39,13 +39,17 @@ export const registerTagTools = (server: McpServer, user: string) => {
   server.tool(
     'update_tag',
     "Update a tag's start and/or end time.",
-    { id: z.string().uuid().describe('The ID of the tag to update'), ...updateTagBodySchema.shape },
-    async ({ id, start_time, end_time }) => {
+    {
+      id: z.string().uuid().describe('The ID of the tag to update'),
+      ...updateTagBodySchema.shape,
+      tz: tzSchema,
+    },
+    async ({ id, start_time, end_time, tz }) => {
       const result = await updateTag(user, id, {
         end_time: end_time === null ? null : end_time ? new Date(end_time) : undefined,
         start_time: start_time ? new Date(start_time) : undefined,
       })
-      return jsonResponse(result)
+      return tzJsonResponse(result, tz)
     },
   )
 

--- a/apps/backend/src/mcp/training-load-tools.ts
+++ b/apps/backend/src/mcp/training-load-tools.ts
@@ -1,10 +1,10 @@
 /**
  * MCP training load tools.
  */
-import { getTrainingLoadInputSchema } from '@aurboda/api-spec'
+import { getTrainingLoadInputSchema, tzSchema } from '@aurboda/api-spec'
 
 import { computeTrainingLoad, createTrainingLoadDeps } from '../services/training-load.ts'
-import { jsonResponse, type McpServer } from './helpers.ts'
+import { jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerTrainingLoadTools = (server: McpServer, user: string) => {
   const deps = createTrainingLoadDeps()
@@ -32,11 +32,11 @@ Parameters can be configured in user settings (training_load).
 
 Example: "Show my training load for the last 3 months"
 → start: 3 months ago, end: today`,
-    { ...getTrainingLoadInputSchema.shape },
+    { ...getTrainingLoadInputSchema.shape, tz: tzSchema },
     async ({ start, end, bucket_size, tz }) => {
       try {
         const result = await computeTrainingLoad(deps, user, new Date(start), new Date(end), bucket_size, tz)
-        return jsonResponse({ data: result, success: true })
+        return tzJsonResponse({ data: result, success: true }, tz)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         return jsonResponse({ error: message, success: false })

--- a/apps/backend/src/mcp/tz-utils.test.ts
+++ b/apps/backend/src/mcp/tz-utils.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'vitest'
+
+import { convertTimestamps, dateOnlyToRange, formatInTz } from './tz-utils.ts'
+
+describe('formatInTz', () => {
+  test('converts UTC to CET (winter)', () => {
+    const date = new Date('2024-01-15T14:30:00Z')
+    const result = formatInTz(date, 'Europe/Stockholm')
+    expect(result).toBe('2024-01-15T15:30:00+01:00')
+  })
+
+  test('converts UTC to CEST (summer)', () => {
+    const date = new Date('2024-07-15T14:30:00Z')
+    const result = formatInTz(date, 'Europe/Stockholm')
+    expect(result).toBe('2024-07-15T16:30:00+02:00')
+  })
+
+  test('handles UTC timezone', () => {
+    const date = new Date('2024-01-15T14:30:00Z')
+    const result = formatInTz(date, 'UTC')
+    expect(result).toBe('2024-01-15T14:30:00+00:00')
+  })
+
+  test('handles midnight boundary crossing', () => {
+    // 23:30 UTC = 00:30 next day in CET
+    const date = new Date('2024-01-15T23:30:00Z')
+    const result = formatInTz(date, 'Europe/Stockholm')
+    expect(result).toBe('2024-01-16T00:30:00+01:00')
+  })
+
+  test('handles DST transition day (spring forward)', () => {
+    // 2024-03-31 is CET→CEST transition for Europe/Stockholm
+    // At 02:00 CET, clocks jump to 03:00 CEST
+    const beforeTransition = new Date('2024-03-31T00:30:00Z') // 01:30 CET
+    expect(formatInTz(beforeTransition, 'Europe/Stockholm')).toBe('2024-03-31T01:30:00+01:00')
+
+    const afterTransition = new Date('2024-03-31T01:30:00Z') // 03:30 CEST
+    expect(formatInTz(afterTransition, 'Europe/Stockholm')).toBe('2024-03-31T03:30:00+02:00')
+  })
+})
+
+describe('dateOnlyToRange', () => {
+  test('returns full day in CET (winter)', () => {
+    const { start, end } = dateOnlyToRange('2024-01-15', 'Europe/Stockholm')
+    // CET is UTC+1, so day starts at 23:00 UTC previous day
+    expect(start.toISOString()).toBe('2024-01-14T23:00:00.000Z')
+    expect(end.toISOString()).toBe('2024-01-15T22:59:59.999Z')
+  })
+
+  test('returns full day in CEST (summer)', () => {
+    const { start, end } = dateOnlyToRange('2024-07-15', 'Europe/Stockholm')
+    // CEST is UTC+2, so day starts at 22:00 UTC previous day
+    expect(start.toISOString()).toBe('2024-07-14T22:00:00.000Z')
+    expect(end.toISOString()).toBe('2024-07-15T21:59:59.999Z')
+  })
+
+  test('returns full day in UTC', () => {
+    const { start, end } = dateOnlyToRange('2024-01-15', 'UTC')
+    expect(start.toISOString()).toBe('2024-01-15T00:00:00.000Z')
+    expect(end.toISOString()).toBe('2024-01-15T23:59:59.999Z')
+  })
+
+  test('handles DST transition day (spring forward = 23h day)', () => {
+    // 2024-03-31: CET→CEST transition, day is only 23 hours
+    const { start, end } = dateOnlyToRange('2024-03-31', 'Europe/Stockholm')
+    expect(start.toISOString()).toBe('2024-03-30T23:00:00.000Z') // midnight CET = 23:00 UTC
+    expect(end.toISOString()).toBe('2024-03-31T21:59:59.999Z') // midnight CEST = 22:00 UTC, minus 1ms
+  })
+})
+
+describe('convertTimestamps', () => {
+  test('converts ISO datetime strings', () => {
+    const data = { start_time: '2024-01-15T14:30:00.000Z', tag: 'coffee' }
+    const result = convertTimestamps(data, 'Europe/Stockholm')
+    expect(result).toEqual({ start_time: '2024-01-15T15:30:00+01:00', tag: 'coffee' })
+  })
+
+  test('converts Date objects', () => {
+    const data = { time: new Date('2024-01-15T14:30:00Z') }
+    const result = convertTimestamps(data, 'Europe/Stockholm')
+    expect(result).toEqual({ time: '2024-01-15T15:30:00+01:00' })
+  })
+
+  test('skips date-only fields', () => {
+    const data = {
+      birth_date: '1990-01-15',
+      date: '2024-01-15',
+      sleep_date: '2024-01-15',
+      start_time: '2024-01-15T14:30:00Z',
+    }
+    const result = convertTimestamps(data, 'Europe/Stockholm')
+    expect(result).toEqual({
+      birth_date: '1990-01-15',
+      date: '2024-01-15',
+      sleep_date: '2024-01-15',
+      start_time: '2024-01-15T15:30:00+01:00',
+    })
+  })
+
+  test('handles nested objects', () => {
+    const data = {
+      data: [{ end_time: '2024-01-15T16:00:00Z', start_time: '2024-01-15T14:30:00Z' }],
+      success: true,
+    }
+    const result = convertTimestamps(data, 'Europe/Stockholm')
+    expect(result).toEqual({
+      data: [{ end_time: '2024-01-15T17:00:00+01:00', start_time: '2024-01-15T15:30:00+01:00' }],
+      success: true,
+    })
+  })
+
+  test('handles null and undefined', () => {
+    expect(convertTimestamps(null, 'Europe/Stockholm')).toBeNull()
+    expect(convertTimestamps(undefined, 'Europe/Stockholm')).toBeUndefined()
+  })
+
+  test('passes through non-datetime strings', () => {
+    const data = { name: 'coffee', type: 'exercise' }
+    expect(convertTimestamps(data, 'Europe/Stockholm')).toEqual(data)
+  })
+
+  test('handles arrays of timestamps', () => {
+    const data = ['2024-01-15T14:30:00Z', '2024-01-15T15:00:00Z']
+    const result = convertTimestamps(data, 'Europe/Stockholm')
+    expect(result).toEqual(['2024-01-15T15:30:00+01:00', '2024-01-15T16:00:00+01:00'])
+  })
+})

--- a/apps/backend/src/mcp/tz-utils.ts
+++ b/apps/backend/src/mcp/tz-utils.ts
@@ -1,0 +1,61 @@
+/**
+ * Timezone utilities for MCP timestamp handling.
+ *
+ * Uses Temporal API for DST-correct timezone conversion.
+ */
+import { Temporal } from '@js-temporal/polyfill'
+
+/**
+ * Format a UTC Date as an ISO 8601 string with the correct offset for the given timezone.
+ * E.g. formatInTz(new Date('2024-01-15T14:30:00Z'), 'Europe/Stockholm') => '2024-01-15T15:30:00+01:00'
+ */
+export const formatInTz = (date: Date, tz: string): string => {
+  const instant = Temporal.Instant.fromEpochMilliseconds(date.getTime())
+  const zoned = instant.toZonedDateTimeISO(tz)
+  return zoned.toString({ timeZoneName: 'never' })
+}
+
+/**
+ * Convert a date-only string (YYYY-MM-DD) to a UTC Date range for the full day in the given timezone.
+ * E.g. dateOnlyToRange('2024-01-15', 'Europe/Stockholm') =>
+ *   { start: Date('2024-01-14T23:00:00Z'), end: Date('2024-01-15T22:59:59.999Z') }
+ */
+export const dateOnlyToRange = (dateStr: string, tz: string): { start: Date; end: Date } => {
+  const localDate = Temporal.PlainDate.from(dateStr)
+  const startOfDay = localDate.toZonedDateTime(tz)
+  const startOfNextDay = localDate.add({ days: 1 }).toZonedDateTime(tz)
+  return {
+    end: new Date(startOfNextDay.epochMilliseconds - 1),
+    start: new Date(startOfDay.epochMilliseconds),
+  }
+}
+
+/** Fields that contain date-only values (YYYY-MM-DD) and should not be timezone-converted. */
+const dateOnlyFields = new Set(['date', 'birth_date', 'sleep_date', 'start_date', 'reference_date'])
+
+/**
+ * Deep-transform ISO datetime strings in a JSON-serializable value to the user's timezone.
+ * Converts strings matching ISO 8601 datetime format (with time component) to offset-aware format.
+ * Skips date-only fields and non-datetime strings.
+ */
+export const convertTimestamps = (data: unknown, tz: string): unknown => {
+  if (data === null || data === undefined) return data
+  if (data instanceof Date) return formatInTz(data, tz)
+  if (typeof data === 'string') {
+    // Match ISO 8601 datetime strings (must have time component with T separator)
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(data)) {
+      const d = new Date(data)
+      if (!isNaN(d.getTime())) return formatInTz(d, tz)
+    }
+    return data
+  }
+  if (Array.isArray(data)) return data.map((item) => convertTimestamps(item, tz))
+  if (typeof data === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      result[key] = dateOnlyFields.has(key) ? value : convertTimestamps(value, tz)
+    }
+    return result
+  }
+  return data
+}

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -678,6 +678,7 @@ export async function getDailySummary(
   user: string,
   date: Date,
   sync?: SyncProvider,
+  tz?: string,
 ): Promise<DailySummaryResult> {
   // Fire-and-forget: trigger background sync so data is fresh for the next request,
   // but return current data immediately to avoid blocking on slow external APIs
@@ -691,10 +692,20 @@ export async function getDailySummary(
     ])
   }
 
-  const start = new Date(date)
-  start.setHours(0, 0, 0, 0)
-  const end = new Date(date)
-  end.setHours(23, 59, 59, 999)
+  let start: Date
+  let end: Date
+  if (tz) {
+    const { dateOnlyToRange } = await import('../mcp/tz-utils.ts')
+    const dateStr = date.toISOString().slice(0, 10)
+    const range = dateOnlyToRange(dateStr, tz)
+    start = range.start
+    end = range.end
+  } else {
+    start = new Date(date)
+    start.setHours(0, 0, 0, 0)
+    end = new Date(date)
+    end.setHours(23, 59, 59, 999)
+  }
 
   // Run queries in parallel
   const [

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -216,6 +216,7 @@ const withDefaults = (settings: UserSettings) => ({
   tag_icons: settings.item_icons ?? {},
   tag_mappings: settings.tag_mappings ?? {},
   training_load: settings.training_load ?? null,
+  tz: settings.device_timezone ?? null,
 })
 
 export const getSettingsResponse = async (user: string): Promise<SettingsResponse> => {
@@ -262,6 +263,7 @@ const EMPTY_SETTINGS_DEFAULTS = {
   tag_icons: {},
   tag_mappings: {},
   training_load: null,
+  tz: null,
 }
 
 const buildErrorSettingsResponse = async (errorMessage: string): Promise<SettingsResponse> => ({

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -164,6 +164,16 @@ export const iso8601DateTimeSchema = z.iso.datetime().meta({
 })
 
 /**
+ * IANA timezone string schema (e.g. "Europe/Stockholm").
+ */
+export const tzSchema = z.string().meta({
+  description:
+    'IANA timezone (e.g. "Europe/Stockholm"). Required for correct timestamp formatting and date interpretation.',
+  example: 'Europe/Stockholm',
+  id: 'Timezone',
+})
+
+/**
  * Date-only string schema (YYYY-MM-DD).
  */
 export const dateOnlySchema = z.iso.date().meta({

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -270,6 +270,9 @@ export const userSettingsResponseSchema = baseResponseSchema
     training_load: trainingLoadSettingsSchema
       .nullable()
       .meta({ description: 'Training load (Banister model) parameters (null = defaults)' }),
+    tz: z.string().nullable().meta({
+      description: 'User timezone (IANA format, e.g. Europe/Stockholm). Auto-detected from device.',
+    }),
   })
   .meta({ id: 'UserSettingsResponse' })
 


### PR DESCRIPTION
## Summary

- All MCP tools that handle timestamps now **require a `tz` parameter** (IANA timezone string like `Europe/Stockholm`), forcing the AI agent to always be timezone-aware
- Output timestamps include timezone offset (e.g. `2024-01-15T15:30:00+01:00`) instead of `Z`, and responses include a `tz` field
- Agent discovers timezone via `get_user_settings` which exposes `device_timezone` (auto-detected from Android app) as `tz`
- `getDailySummary` now uses timezone-aware day boundaries when `tz` is provided (fixes midnight UTC vs midnight local time)

### New utilities (`apps/backend/src/mcp/tz-utils.ts`)
- `formatInTz(date, tz)` — UTC Date → ISO string with correct offset
- `dateOnlyToRange(dateStr, tz)` — date-only string → full day UTC range in user's timezone
- `convertTimestamps(data, tz)` — deep-transforms all ISO datetime strings in a response object
- `tzJsonResponse(data, tz)` — wraps `convertTimestamps` + adds `tz` to response envelope

### Tools updated (14 modules)
query-tools, tag-tools, activity-tools, metric-tools, meal-tools, sync-tools, lastfm-tools, location-tools, correlation-tools, training-load-tools, note-tools, report-tools, settings-tools

### Tools unchanged (no timestamps)
food-item-tools, screentime-category-tools (plus non-temporal operations in other modules)

## Test plan
- [x] tz-utils unit tests (16 tests) including DST transitions
- [x] MCP unit tests (32 tests) updated for required tz parameter
- [x] TypeScript check passes
- [x] pnpm fix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)