### PR TITLE
feat: move goal editing inline on the goals page

### DIFF
--- a/apps/web/src/pages/DataSources/AurbodaSource.tsx
+++ b/apps/web/src/pages/DataSources/AurbodaSource.tsx
@@ -1,13 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { CustomMetricsSettings } from '../../components/CustomMetricsSettings'
-import { GoalsSettings } from '../../components/GoalsSettings'
 import { TagMappingsSettings } from '../../components/TagMappingsSettings'
 import { fetchMetricTimeSeries, fetchUserSettings } from '../../state/api'
 import { auth } from '../../state/auth'
 import './style.css'
 
-const DATA_TYPES = ['Tags', 'Custom metrics', 'Manual data entry', 'Goals', 'Notes', 'Calories (computed)']
+const DATA_TYPES = ['Tags', 'Custom metrics', 'Manual data entry', 'Notes', 'Calories (computed)']
 
 function CalorieEstimationStatus({
   hasBirthDate,
@@ -126,8 +125,6 @@ export function AurbodaSource() {
       <TagMappingsSettings />
 
       <CustomMetricsSettings />
-
-      <GoalsSettings goals={userSettings?.goals ?? []} />
     </div>
   )
 }

--- a/apps/web/src/pages/Goals/index.tsx
+++ b/apps/web/src/pages/Goals/index.tsx
@@ -1,6 +1,7 @@
 import { metricUnits } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
+import { GoalsSettings } from '../../components/GoalsSettings'
 import { fetchGoalsProgress, fetchUserSettings, type GoalProgress } from '../../state/api'
 import { auth } from '../../state/auth'
 import { metricLabels } from '../../utils/metricLabels'
@@ -152,9 +153,7 @@ export function Goals() {
     return (
       <div class="goals-page">
         <h1>Goals</h1>
-        <p class="no-goals">
-          No goals set. Visit <a href="/settings">Settings</a> to create goals.
-        </p>
+        <GoalsSettings goals={goals} />
       </div>
     )
   }
@@ -194,9 +193,10 @@ export function Goals() {
           <>Rolling {goals[0]?.window ?? '7d'} window from today.</>
         ) : (
           <>Rolling windows from today.</>
-        )}{' '}
-        <a href="/settings">Edit goals</a>
+        )}
       </p>
+
+      <GoalsSettings goals={goals} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Moved the `GoalsSettings` component from the Data Sources page to the Goals page (`/goals`)
- Goals can now be edited directly where they are viewed — no navigation to settings needed
- Removed the broken "Edit goals" link that pointed to `/settings`

## Test plan
- [ ] Visit `/goals` — progress bars shown with editing form below
- [ ] Add/edit/delete/reorder goals on the goals page
- [ ] Visit Data Sources — goals section no longer appears
- [ ] Verify auto-save on blur still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)