### PR TITLE
fix: correct timezone boundaries for Data page queries

### DIFF
--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { addDays, endOfDay, format, formatISO, startOfDay, subDays } from 'date-fns'
+import { format, formatISO } from 'date-fns'
 import { useLocation } from 'preact-iso'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 
@@ -242,9 +242,11 @@ export const Data = () => {
     syncUrl(dateStr, hiddenTypes)
   }, [dateStr, hiddenTypes])
 
-  const date = new Date(dateStr)
-  const start = subDays(startOfDay(date), 0.5)
-  const end = addDays(endOfDay(date), 0.5)
+  // Compute day boundaries in the browser's timezone for the specific date.
+  // Using ISO string with explicit time avoids DST issues where date-fns startOfDay/endOfDay
+  // would use the current timezone offset instead of the offset on the viewed date.
+  const start = new Date(`${dateStr}T00:00:00`)
+  const end = new Date(`${dateStr}T23:59:59.999`)
 
   // Cancel in-flight queries when date changes
   const queryClient = useQueryClient()


### PR DESCRIPTION
## Summary
- Replace the 0.5-day buffer (`subDays(startOfDay, 0.5)` / `addDays(endOfDay, 0.5)`) with exact midnight-to-midnight boundaries
- Use `new Date('YYYY-MM-DDT00:00:00')` which correctly uses the timezone offset that was in effect on the viewed date, not the browser's current offset
- Previously, viewing Jan 8 (CET, UTC+1) while browser is in CEST (UTC+2) would compute boundaries using CEST offset, causing data from Jan 7 late evening to bleed through

## Test plan
- [ ] View data for a January date — should not show tags from the previous day
- [ ] Verify data boundaries are correct for dates in both CET and CEST periods

🤖 Generated with [Claude Code](https://claude.com/claude-code)