### PR TITLE
feat: meal edit mode on create + fix stale data across detail pages

### DIFF
--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -9,7 +9,7 @@
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
-import { useCallback, useState } from 'preact/hooks'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 
 import type { Activity, ExerciseTypeName, SourceRecord } from '../../state/api'
 
@@ -219,6 +219,13 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
     [queryClient, entityId],
   )
 
+  // Invalidate timeline queries when leaving so parent views show fresh data
+  useEffect(
+    () => () =>
+      void queryClient.invalidateQueries({ predicate: (q) => String(q.queryKey[0]).startsWith('timeline-') }),
+    [queryClient],
+  )
+
   const [isEditing, setIsEditing] = useState(false)
   const emptyDraft: ActivityDraft = {
     end_time: '',
@@ -328,6 +335,13 @@ const TagContent = ({ entityId }: { entityId: string }) => {
         queryKey: ['entity-detail', 'tag', entityId],
       }),
     [queryClient, entityId],
+  )
+
+  // Invalidate timeline queries when leaving so parent views show fresh data
+  useEffect(
+    () => () =>
+      void queryClient.invalidateQueries({ predicate: (q) => String(q.queryKey[0]).startsWith('timeline-') }),
+    [queryClient],
   )
 
   const [isEditing, setIsEditing] = useState(false)

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,7 +1,7 @@
 import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation, useRoute } from 'preact-iso'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 import type { FoodItemEntity } from '../../state/api'
 
@@ -120,6 +120,9 @@ export function FoodItemDetail() {
   })
 
   const [editing, setEditing] = useState<Record<string, unknown> | null>(null)
+
+  // Invalidate parent list when leaving so it shows fresh data
+  useEffect(() => () => void queryClient.invalidateQueries({ queryKey: ['foodItems'] }), [queryClient])
 
   const updateMutation = useMutation({
     mutationFn: (body: Record<string, unknown>) => updateFoodItemApi(id, body),

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -2,7 +2,7 @@ import { NUTRIENT_FIELDS } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { FoodItemAutocomplete } from '../../components/FoodItemAutocomplete'
@@ -355,7 +355,7 @@ const buildSaveBody = (editing: EditState): Record<string, unknown> => {
 // eslint-disable-next-line complexity -- detail page with edit mode and multiple data sections
 export function MealDetail() {
   const { params } = useRoute()
-  const { route } = useLocation()
+  const { route, query } = useLocation()
   const queryClient = useQueryClient()
   const id = params.id
 
@@ -369,7 +369,11 @@ export function MealDetail() {
     queryKey: ['userSettings'],
   })
 
-  const [editing, setEditing] = useState<EditState | null>(null)
+  const startInEditMode = new URLSearchParams(query).has('edit')
+  const [editing, setEditing] = useState<EditState | null>(startInEditMode ? {} : null)
+
+  // Invalidate the meals list when leaving this page so the day overview refreshes
+  useEffect(() => () => void queryClient.invalidateQueries({ queryKey: ['meals'] }), [queryClient])
 
   const updateMutation = useMutation({
     mutationFn: (body: Parameters<typeof updateMealApi>[1]) => updateMealApi(id, body),

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -570,7 +570,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
       time: mealTime.toISOString(),
     })
     queryClient.invalidateQueries({ queryKey: ['meals'] })
-    route(`/meals/${id}`)
+    route(`/meals/${id}?edit=1`)
   }
 
   const otherMeals = getOtherMeals(meals ?? [], mealSlots)

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -9,7 +9,7 @@ import type { ScreentimeCategory } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
-import { useCallback, useState } from 'preact/hooks'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 
 import { IconInput } from '../../components/IconInput'
 import {
@@ -1016,6 +1016,9 @@ export function CategoryDetail() {
     queryClient.invalidateQueries({ queryKey: ['screentime-categories'] })
     queryClient.invalidateQueries({ queryKey: ['productivity-apps'] })
   }, [queryClient, categoryId])
+
+  // Invalidate parent list when leaving so it shows fresh data
+  useEffect(() => () => void invalidateAll(), [invalidateAll])
 
   const invalidateIcons = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ['userSettings'] })


### PR DESCRIPTION
## Summary
- When clicking "+" to create a new meal on the day overview, the meal detail page now opens directly in edit mode (via `?edit=1` query param), saving an extra click.
- Added unmount cleanup effects across detail pages (MealDetail, EntityDetail for activities/tags, CategoryDetail, FoodItemDetail) to invalidate parent list/timeline queries when navigating back, ensuring fresh data is always displayed.

## Test plan
- [ ] Create a new meal via "+" on day overview → verify it opens in edit mode
- [ ] Add food items, save, navigate back → verify the meal appears immediately on the day overview
- [ ] Edit an activity on the timeline detail page, go back → verify timeline reflects changes
- [ ] Edit a screentime category, go back to list → verify list reflects changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)