### PR TITLE
perf: optimize backend query performance

### DIFF
--- a/apps/backend/src/services/correlations.ts
+++ b/apps/backend/src/services/correlations.ts
@@ -359,9 +359,31 @@ const chiSquaredTest = (
 
 /**
  * Get HRV/HR data points that fall within a time range.
+ * Uses binary search since data is sorted by time (from SQL ORDER BY).
  */
 const getDataInRange = (data: [Date, number][], start: Date, end: Date): number[] => {
-  return data.filter(([time]) => time >= start && time <= end).map(([, value]) => value)
+  const startMs = start.getTime()
+  const endMs = end.getTime()
+
+  // Binary search for first index where time >= start
+  let lo = 0
+  let hi = data.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (data[mid][0].getTime() < startMs) lo = mid + 1
+    else hi = mid
+  }
+  const startIdx = lo
+
+  // Binary search for first index where time > end
+  hi = data.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (data[mid][0].getTime() <= endMs) lo = mid + 1
+    else hi = mid
+  }
+
+  return data.slice(startIdx, lo).map(([, v]) => v)
 }
 
 /**

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -104,8 +104,10 @@ describe('getDailySummary', () => {
   test('aggregates all data sources for a day', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([
-        // Daily heart rate data
+        // Daily heart rate data (exercise session HR is filtered from this in memory)
         [new Date('2024-01-15T10:00:00Z'), 72],
+        [new Date('2024-01-15T10:15:00Z'), 80],
+        [new Date('2024-01-15T10:30:00Z'), 75],
         [new Date('2024-01-15T11:00:00Z'), 80],
         [new Date('2024-01-15T12:00:00Z'), 65],
       ])
@@ -113,12 +115,6 @@ describe('getDailySummary', () => {
         // Daily steps data
         [new Date('2024-01-15T08:00:00Z'), 5000],
         [new Date('2024-01-15T12:00:00Z'), 3000],
-      ])
-      .mockResolvedValueOnce([
-        // Exercise session HR data (for HR zone calculation)
-        [new Date('2024-01-15T10:00:00Z'), 72],
-        [new Date('2024-01-15T10:15:00Z'), 80],
-        [new Date('2024-01-15T10:30:00Z'), 75],
       ])
 
     // Sleep sessions now use getSleepSessions with date overlap logic
@@ -185,8 +181,8 @@ describe('getDailySummary', () => {
 
     // Heart rate stats
     expect(result.heart_rate).toEqual({
-      avg: 72,
-      count: 3,
+      avg: 74, // (72+80+75+80+65)/5 = 74.4, rounded to 74
+      count: 5,
       max: 80,
       min: 65,
     })
@@ -370,16 +366,15 @@ describe('getDailySummary', () => {
   })
 
   test('computes hr_zone_secs for exercise sessions with HR data', async () => {
-    // First call: daily heart rate, second call: daily steps, third call: exercise session HR
+    // First call: daily heart rate (includes exercise session data), second call: daily steps
     vi.mocked(db.getTimeSeries)
-      .mockResolvedValueOnce([]) // daily heart_rate
-      .mockResolvedValueOnce([]) // daily steps
       .mockResolvedValueOnce([
         // exercise session HR data - in zone 1 (90-107 with default zones)
         [new Date('2024-01-15T10:00:00Z'), 95],
         [new Date('2024-01-15T10:00:02Z'), 100],
         [new Date('2024-01-15T10:00:04Z'), 98],
-      ])
+      ]) // daily heart_rate (filtered in memory for exercise sessions)
+      .mockResolvedValueOnce([]) // daily steps
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
     vi.mocked(db.getActivities).mockResolvedValue([
@@ -407,9 +402,8 @@ describe('getDailySummary', () => {
 
   test('does not include hr_zone_secs when exercise has no HR data', async () => {
     vi.mocked(db.getTimeSeries)
-      .mockResolvedValueOnce([]) // daily heart_rate
+      .mockResolvedValueOnce([]) // daily heart_rate (no HR data during exercise)
       .mockResolvedValueOnce([]) // daily steps
-      .mockResolvedValueOnce([]) // exercise session HR data - empty
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
     vi.mocked(db.getActivities).mockResolvedValue([
@@ -440,13 +434,12 @@ describe('getDailySummary', () => {
     })
 
     vi.mocked(db.getTimeSeries)
-      .mockResolvedValueOnce([]) // daily heart_rate
-      .mockResolvedValueOnce([]) // daily steps
       .mockResolvedValueOnce([
         // HR at 85 - would be zone 0 with defaults (90), but zone 1 with custom (80)
         [new Date('2024-01-15T10:00:00Z'), 85],
         [new Date('2024-01-15T10:00:02Z'), 85],
-      ])
+      ]) // daily heart_rate (filtered in memory for exercise sessions)
+      .mockResolvedValueOnce([]) // daily steps
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
     vi.mocked(db.getActivities).mockResolvedValue([

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -719,6 +719,7 @@ export async function getDailySummary(
     ouraMetrics,
     dayNotes,
     dayMeals,
+    stepsAggregate,
   ] = await Promise.all([
     getTimeSeries(user, 'heart_rate', start, end),
     getTimeSeries(user, 'steps', start, end),
@@ -735,6 +736,7 @@ export async function getDailySummary(
     ),
     getNotesForTimeRange(user, start, end),
     getMeals(user, { start, end }),
+    getDailyAggregateValue(user, 'steps', date),
   ])
 
   // Calculate heart rate stats
@@ -750,7 +752,6 @@ export async function getDailySummary(
       : null
 
   // Get steps - prefer aggregate (deduplicated) over summing raw records
-  const stepsAggregate = await getDailyAggregateValue(user, 'steps', date)
   const totalSteps =
     stepsAggregate !== null ? stepsAggregate : stepsData.reduce((sum, [, value]) => sum + value, 0)
 
@@ -795,36 +796,34 @@ export async function getDailySummary(
   // Get user's HR zones for exercise session HR zone calculation
   const { zones: hrZones } = await getEffectiveHrZones(user)
 
-  // Compute HR zones for exercise sessions
-  const exerciseSessionsWithHrZones: SessionSummary[] = await Promise.all(
-    exerciseSessions.map(async (s) => {
-      // Resolve human-readable exercise type name from numeric Health Connect ID
-      const dataObj = s.data as Record<string, unknown> | undefined
-      const exerciseTypeCode = dataObj?.exerciseType
-      const exerciseType =
-        typeof exerciseTypeCode === 'number' ? getExerciseTypeName(exerciseTypeCode) : undefined
+  // Compute HR zones for exercise sessions (filter already-fetched HR data in memory)
+  const exerciseSessionsWithHrZones: SessionSummary[] = exerciseSessions.map((s) => {
+    // Resolve human-readable exercise type name from numeric Health Connect ID
+    const dataObj = s.data as Record<string, unknown> | undefined
+    const exerciseTypeCode = dataObj?.exerciseType
+    const exerciseType =
+      typeof exerciseTypeCode === 'number' ? getExerciseTypeName(exerciseTypeCode) : undefined
 
-      const sessionSummary: SessionSummary = {
-        duration: s.end_time
-          ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60)
-          : undefined,
-        end_time: s.end_time?.toISOString(),
-        exercise_type: exerciseType,
-        start_time: s.start_time.toISOString(),
-        title: s.title,
+    const sessionSummary: SessionSummary = {
+      duration: s.end_time
+        ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60)
+        : undefined,
+      end_time: s.end_time?.toISOString(),
+      exercise_type: exerciseType,
+      start_time: s.start_time.toISOString(),
+      title: s.title,
+    }
+
+    // Only compute HR zones for sessions with end time
+    if (s.end_time) {
+      const sessionHrData = heartRateData.filter(([time]) => time >= s.start_time && time <= s.end_time!)
+      if (sessionHrData.length > 0) {
+        sessionSummary.hr_zone_secs = computeHrZoneSecs(sessionHrData, hrZones)
       }
+    }
 
-      // Only compute HR zones for sessions with end time
-      if (s.end_time) {
-        const sessionHrData = await getTimeSeries(user, 'heart_rate', s.start_time, s.end_time)
-        if (sessionHrData.length > 0) {
-          sessionSummary.hr_zone_secs = computeHrZoneSecs(sessionHrData, hrZones)
-        }
-      }
-
-      return sessionSummary
-    }),
-  )
+    return sessionSummary
+  })
 
   // Fetch tag comments
   const tagIds = tags.map((t) => t.id).filter((id): id is string => id !== undefined)
@@ -1035,10 +1034,14 @@ export async function getPeriodSummary(
   // Calculate days in period for completeness calculation
   const daysInPeriod = Math.ceil(periodMs / (1000 * 60 * 60 * 24))
 
+  // Pre-index lookups for O(1) access instead of O(n) find/filter per metric
+  const prevStatsMap = new Map(previousStats.map((s) => [s.metric, s]))
+  const dailyByMetric = Map.groupBy(dailyAggregates, (d) => d.metric)
+
   // Build response with trends and completeness for regular metrics
   const metricsWithTrends: PeriodMetricStats[] = currentStats.map((stat) => {
-    const prevStat = previousStats.find((p) => p.metric === stat.metric)
-    const dailyData = dailyAggregates.filter((d) => d.metric === stat.metric)
+    const prevStat = prevStatsMap.get(stat.metric)
+    const dailyData = dailyByMetric.get(stat.metric) ?? []
 
     // Calculate trend using linear regression on daily averages
     let trend: number | null = null


### PR DESCRIPTION
## Summary
- **Fix N+1 in getDailySummary**: Exercise session HR zone calculation was re-querying the DB per session. Now filters the already-fetched daily HR data in memory.
- **Parallelize steps aggregate**: Moved `getDailyAggregateValue` into the initial `Promise.all` batch, eliminating a sequential roundtrip.
- **Binary search in correlations**: Replaced O(n*m) linear `.filter()` in `getDataInRange` with binary search, since data is sorted by time.
- **Map lookups in period summary**: Pre-index `previousStats` and `dailyAggregates` for O(1) access instead of O(n) `.find()`/`.filter()`.

## Test plan
- [x] All 1508 backend unit tests pass
- [x] Type checks and linting pass
- [ ] Manual test: load Dashboard daily summary on a day with multiple exercise sessions
- [ ] Manual test: load Correlations page with 30+ day period
- [ ] Manual test: load Timeline page and verify loading feels snappier

🤖 Generated with [Claude Code](https://claude.com/claude-code)