### PR TITLE
feat: clickable grouped screentime + data page time filtering + AFK filtering

### DIFF
--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -213,17 +213,23 @@ const buildItems = (
   return items.sort((a, b) => a.start.getTime() - b.start.getTime())
 }
 
-const parseUrlState = (query: Record<string, string>): { date: string; hidden: Set<ItemType> } => {
+const parseUrlState = (
+  query: Record<string, string>,
+): { date: string; from: string | undefined; hidden: Set<ItemType>; to: string | undefined } => {
   const date = query.date ?? formatISO(new Date(), { representation: 'date' })
   const hideStr = query.hide ?? ''
   const hidden = new Set<ItemType>(hideStr ? (hideStr.split(',') as ItemType[]) : [])
-  return { date, hidden }
+  const from = query.from || undefined
+  const to = query.to || undefined
+  return { date, from, hidden, to }
 }
 
-const syncUrl = (dateStr: string, hidden: Set<ItemType>) => {
+const syncUrl = (dateStr: string, hidden: Set<ItemType>, from?: string, to?: string) => {
   const params = new URLSearchParams()
   params.set('date', dateStr)
   if (hidden.size > 0) params.set('hide', [...hidden].join(','))
+  if (from) params.set('from', from)
+  if (to) params.set('to', to)
   history.replaceState(null, '', `${window.location.pathname}?${params}`)
 }
 
@@ -234,19 +240,20 @@ export const Data = () => {
 
   const [dateStr, setDateStr] = useState(initial.date)
   const [hiddenTypes, setHiddenTypes] = useState<Set<ItemType>>(initial.hidden)
+  const [timeFrom, setTimeFrom] = useState<string | undefined>(initial.from)
+  const [timeTo, setTimeTo] = useState<string | undefined>(initial.to)
 
+  const hasTimeFilter = Boolean(timeFrom || timeTo)
   const activeTypes = new Set(ALL_TYPES.filter((t) => !hiddenTypes.has(t)))
 
   // Sync URL on state changes
   useEffect(() => {
-    syncUrl(dateStr, hiddenTypes)
-  }, [dateStr, hiddenTypes])
+    syncUrl(dateStr, hiddenTypes, timeFrom, timeTo)
+  }, [dateStr, hiddenTypes, timeFrom, timeTo])
 
-  // Compute day boundaries in the browser's timezone for the specific date.
-  // Using ISO string with explicit time avoids DST issues where date-fns startOfDay/endOfDay
-  // would use the current timezone offset instead of the offset on the viewed date.
-  const start = new Date(`${dateStr}T00:00:00`)
-  const end = new Date(`${dateStr}T23:59:59.999`)
+  // Compute query boundaries — use time filter if present, otherwise full day.
+  const start = timeFrom ? new Date(timeFrom) : new Date(`${dateStr}T00:00:00`)
+  const end = timeTo ? new Date(timeTo) : new Date(`${dateStr}T23:59:59.999`)
 
   // Cancel in-flight queries when date changes
   const queryClient = useQueryClient()
@@ -260,56 +267,63 @@ export const Data = () => {
       queryClient.cancelQueries({ queryKey: ['data-reports'] })
       queryClient.cancelQueries({ queryKey: ['data-productivity'] })
       setDateStr(newDate)
+      setTimeFrom(undefined)
+      setTimeTo(undefined)
     },
     [queryClient],
   )
 
+  const clearTimeFilter = useCallback(() => {
+    setTimeFrom(undefined)
+    setTimeTo(undefined)
+  }, [])
+
   const activitiesQuery = useQuery({
     enabled: activeTypes.has('activity'),
     queryFn: () => fetchActivities(start, end, ['sleep', 'exercise', 'meditation', 'nap', 'rest']),
-    queryKey: ['data-activities', dateStr],
+    queryKey: ['data-activities', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
   const tagsQuery = useQuery({
     enabled: activeTypes.has('tag'),
     queryFn: () => fetchTags(start, end),
-    queryKey: ['data-tags', dateStr],
+    queryKey: ['data-tags', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
   const placesQuery = useQuery({
     enabled: activeTypes.has('location'),
     queryFn: () => fetchPlaces(start, end),
-    queryKey: ['data-places', dateStr],
+    queryKey: ['data-places', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
   const scrobblesQuery = useQuery({
     enabled: activeTypes.has('music'),
     queryFn: () => fetchScrobbles(start, end),
-    queryKey: ['data-scrobbles', dateStr],
+    queryKey: ['data-scrobbles', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
   const mealsQuery = useQuery({
     enabled: activeTypes.has('meal'),
     queryFn: () => fetchMeals({ start: start.toISOString(), end: end.toISOString() }),
-    queryKey: ['data-meals', dateStr],
+    queryKey: ['data-meals', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
   const reportsQuery = useQuery({
     enabled: activeTypes.has('report'),
     queryFn: () => fetchReports({ start: start.toISOString(), end: end.toISOString() }),
-    queryKey: ['data-reports', dateStr],
+    queryKey: ['data-reports', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
   const productivityQuery = useQuery({
     enabled: activeTypes.has('screentime'),
     queryFn: () => fetchProductivity(start, end),
-    queryKey: ['data-productivity', dateStr],
+    queryKey: ['data-productivity', dateStr, timeFrom, timeTo],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -353,6 +367,16 @@ export const Data = () => {
     <div class="data-page">
       <div class="data-sidebar">
         <DateNav value={dateStr} onChange={handleDateChange} dateFormat="EEE MMM d, yyyy" />
+        {hasTimeFilter && (
+          <div class="data-time-filter">
+            <span>
+              {format(start, 'HH:mm')} – {format(end, 'HH:mm')}
+            </span>
+            <button type="button" onClick={clearTimeFilter} title="Clear time filter">
+              &times;
+            </button>
+          </div>
+        )}
         <div class="data-type-filters">
           {ALL_TYPES.map((t) => (
             <button
@@ -378,7 +402,9 @@ export const Data = () => {
 
         {!isLoading && !isFetching && !isError && (
           <div class="data-list">
-            {allItems.length === 0 && <p class="data-status">No data for this day</p>}
+            {allItems.length === 0 && (
+              <p class="data-status">No data for this {hasTimeFilter ? 'time range' : 'day'}</p>
+            )}
             {allItems.map((item, i) => {
               const El = item.href ? 'a' : 'div'
               return (

--- a/apps/web/src/pages/Data/style.css
+++ b/apps/web/src/pages/Data/style.css
@@ -26,6 +26,35 @@
   align-self: flex-start;
 }
 
+/* Time filter chip */
+.data-time-filter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.3rem 0.625rem;
+  background: #ede9fe;
+  border: 1px solid #c4b5fd;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  color: #5b21b6;
+}
+
+.data-time-filter button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  color: #7c3aed;
+  padding: 0 0.15rem;
+  border-radius: 50%;
+}
+
+.data-time-filter button:hover {
+  background: #ddd6fe;
+}
+
 /* Type filter buttons (stacked vertically in sidebar) */
 .data-type-filters {
   display: flex;
@@ -198,5 +227,19 @@
 
   .data-item-detail {
     color: #9ca3af;
+  }
+
+  .data-time-filter {
+    background: #2e1065;
+    border-color: #6d28d9;
+    color: #c4b5fd;
+  }
+
+  .data-time-filter button {
+    color: #a78bfa;
+  }
+
+  .data-time-filter button:hover {
+    background: #4c1d95;
   }
 }

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -2420,10 +2420,31 @@ const mergeSmallItems = (
       const mergedStart = items.reduce((min, i) => (i.start < min ? i.start : min), items[0]!.start)
       const mergedEnd = items.reduce((max, i) => (i.end > max ? i.end : max), items[0]!.end)
       const first = items[0]!
+      // Build a Data page link showing only the relevant type for this time range
+      const columnToDataType: Partial<Record<Column, string>> = {
+        Activity: 'activity',
+        Exercise: 'activity',
+        Location: 'location',
+        Music: 'music',
+        'Screen Time': 'screentime',
+        'Sleep / Rest': 'activity',
+        'Tags / Events': 'tag',
+      }
+      const dataType = columnToDataType[first.column]
+      const allDataTypes = ['activity', 'tag', 'location', 'music', 'meal', 'report', 'screentime']
+      const hideTypes = dataType ? allDataTypes.filter((t) => t !== dataType) : []
+      const dataParams = new URLSearchParams({
+        date: formatISO(mergedStart, { representation: 'date' }),
+        from: mergedStart.toISOString(),
+        to: mergedEnd.toISOString(),
+      })
+      if (hideTypes.length > 0) dataParams.set('hide', hideTypes.join(','))
+
       const merged: ChartItem = {
         color: first.color,
         column: first.column,
         end: mergedEnd,
+        href: `/data?${dataParams}`,
         isPoint: false,
         label: `${items.length} items`,
         start: mergedStart,

--- a/docs/activitywatch.md
+++ b/docs/activitywatch.md
@@ -34,6 +34,12 @@ Each record contains:
 
 Window titles are available in the raw ActivityWatch data but are not currently stored (to avoid sensitive information leaking into the database). Category and productivity scores are not assigned yet — see the [categorization follow-up](https://github.com/fiddur/aurboda/issues/218).
 
+### AFK Filtering
+
+The push agent automatically filters out screentime events that fall entirely within an AFK (away from keyboard) period, as reported by `aw-watcher-afk`. This prevents idle time (e.g. overnight screen-on) from inflating screentime totals.
+
+Events that only partially overlap with an AFK period are kept (conservative approach). If `aw-watcher-afk` is not running, no filtering is applied.
+
 ## Admin Setup
 
 No server-side configuration is needed. Each user sets up their own push agent with their own API token.
@@ -92,13 +98,23 @@ else
 fi
 END_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Find the aw-watcher-window bucket for this host
-BUCKET_ID=$(curl -sf "${AW_URL}/api/0/buckets/" \
-  | python3 -c "
+# Find the aw-watcher-window and aw-watcher-afk buckets for this host
+BUCKETS_JSON=$(curl -sf "${AW_URL}/api/0/buckets/" || true)
+
+BUCKET_ID=$(echo "$BUCKETS_JSON" | python3 -c "
 import sys, json
 buckets = json.load(sys.stdin)
 for bid, b in buckets.items():
     if b.get('type') == 'currentwindow':
+        print(bid)
+        break
+" || true)
+
+AFK_BUCKET_ID=$(echo "$BUCKETS_JSON" | python3 -c "
+import sys, json
+buckets = json.load(sys.stdin)
+for bid, b in buckets.items():
+    if b.get('type') == 'afkstatus':
         print(bid)
         break
 " || true)
@@ -108,9 +124,16 @@ if [[ -z "$BUCKET_ID" ]]; then
   exit 0
 fi
 
-# Fetch events
+# Fetch window events
 EVENTS=$(curl -sf \
   "${AW_URL}/api/0/buckets/${BUCKET_ID}/events?start=${START_TIME}&end=${END_TIME}&limit=10000")
+
+# Fetch AFK events (used to filter out idle screentime)
+AFK_EVENTS="[]"
+if [[ -n "$AFK_BUCKET_ID" ]]; then
+  AFK_EVENTS=$(curl -sf \
+    "${AW_URL}/api/0/buckets/${AFK_BUCKET_ID}/events?start=${START_TIME}&end=${END_TIME}&limit=10000" || echo "[]")
+fi
 
 EVENT_COUNT=$(echo "$EVENTS" | python3 -c "import sys, json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
 
@@ -120,16 +143,47 @@ if [[ "$EVENT_COUNT" -eq 0 ]]; then
   exit 0
 fi
 
-echo "Pushing ${EVENT_COUNT} events (${START_TIME} → ${END_TIME}) as device '${DEVICE_NAME}'"
+echo "Found ${EVENT_COUNT} events (${START_TIME} → ${END_TIME}) for device '${DEVICE_NAME}'"
 
-# Transform and push
-PAYLOAD=$(echo "$EVENTS" | python3 -c "
+# Transform, filter AFK, and push
+PAYLOAD=$(python3 -c "
 import sys, json
-events = json.load(sys.stdin)
+from datetime import datetime, timedelta, timezone
+
+events = json.loads(sys.argv[1])
+afk_events = json.loads(sys.argv[2])
+device_name = sys.argv[3]
+
+def parse_ts(ts):
+    # Handle both 'Z' suffix and '+00:00' offset
+    ts = ts.replace('Z', '+00:00')
+    return datetime.fromisoformat(ts)
+
+# Build list of AFK periods
+afk_periods = []
+for ae in afk_events:
+    if ae.get('data', {}).get('status') == 'afk':
+        start = parse_ts(ae['timestamp'])
+        end = start + timedelta(seconds=ae['duration'])
+        afk_periods.append((start, end))
+
+def is_during_afk(evt_start, evt_end):
+    \"\"\"Check if the event falls entirely within an AFK period.\"\"\"
+    for afk_start, afk_end in afk_periods:
+        if evt_start >= afk_start and evt_end <= afk_end:
+            return True
+    return False
+
 transformed = []
+filtered_count = 0
 for e in events:
     app = e.get('data', {}).get('app', '')
     if not app:
+        continue
+    evt_start = parse_ts(e['timestamp'])
+    evt_end = evt_start + timedelta(seconds=e['duration'])
+    if afk_periods and is_during_afk(evt_start, evt_end):
+        filtered_count += 1
         continue
     transformed.append({
         'timestamp': e['timestamp'],
@@ -137,8 +191,22 @@ for e in events:
         'app': app,
         'title': e.get('data', {}).get('title', ''),
     })
-print(json.dumps({'device_name': '$(echo $DEVICE_NAME)', 'events': transformed}))
-")
+
+if filtered_count > 0:
+    print(f'Filtered {filtered_count} AFK events', file=sys.stderr)
+
+print(json.dumps({'device_name': device_name, 'events': transformed}))
+" "$EVENTS" "$AFK_EVENTS" "$DEVICE_NAME")
+
+PUSH_COUNT=$(echo "$PAYLOAD" | python3 -c "import sys, json; print(len(json.load(sys.stdin).get('events', [])))" 2>/dev/null || echo 0)
+
+if [[ "$PUSH_COUNT" -eq 0 ]]; then
+  echo "All events were AFK — nothing to push"
+  echo "$END_TIME" > "$STATE_FILE"
+  exit 0
+fi
+
+echo "Pushing ${PUSH_COUNT} events (${EVENT_COUNT} total, $((EVENT_COUNT - PUSH_COUNT)) filtered as AFK)"
 
 HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
   -X POST "${AURBODA_URL}/sync/activitywatch" \


### PR DESCRIPTION
## Summary

- **Clickable grouped screentime**: Grouped items in the vertical timeline (e.g. "26 screen time") now link to the Data page filtered to show those records in the group's time range
- **Data page time filtering**: Added `from`/`to` URL query params for sub-day filtering. Shows a purple filter chip with the active time range and an X to clear it. Navigating to a different day clears the filter.
- **AFK filtering in push agent**: Updated the ActivityWatch push agent script to also read the `aw-watcher-afk` bucket and exclude events that fall entirely within AFK periods, preventing idle overnight screentime from being synced

## Test plan

- [ ] Navigate to vertical timeline, zoom out until screentime items merge into groups
- [ ] Click a grouped item — should navigate to `/data?date=...&from=...&to=...&hide=...` showing only screentime for that time range
- [ ] Verify the time filter chip appears with correct times and the X button clears it
- [ ] Verify navigating to a different day clears the time filter
- [ ] Verify "No data for this time range" message when filter yields no results
- [ ] Update local `aw-to-aurboda.sh` script and test that AFK events are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)