### PR TITLE
chore: modernize node imports in cronometer script

### DIFF
--- a/scripts/cronometer/import.ts
+++ b/scripts/cronometer/import.ts
@@ -8,10 +8,10 @@
  * Uses PUT /meals (idempotent upsert) so re-running is safe.
  */
 
-import { randomUUID } from 'crypto'
-import { readFileSync } from 'fs'
-import { homedir } from 'os'
-import { resolve } from 'path'
+import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
 
 // ── Config ───────────────────────────────────────────────────────────────────
 
@@ -91,8 +91,8 @@ const parseNutrientColumn = (header: string): { key: string; unit: string } | nu
 
   // Normalize name to snake_case key
   const key = name
-    .replace(/[()]/g, '')
-    .replace(/[\s-]+/g, '_')
+    .replaceAll(/[()]/g, '')
+    .replaceAll(/[\s-]+/g, '_')
     .toLowerCase()
 
   return { key, unit: unit.toLowerCase() }


### PR DESCRIPTION
## Summary

- Use `node:` prefix for Node.js built-in imports (`node:crypto`, `node:fs`, `node:os`, `node:path`)
- Use `replaceAll` instead of `replace` for global regex replacements

🤖 Generated with [Claude Code](https://claude.com/claude-code)