### PR TITLE
feat: bar chart support with bucketed data endpoint

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -50,6 +50,7 @@ import { createOwnTracksRouter } from './owntracks.ts'
 import { syncRescueTimeData } from './rescuetime-sync.ts'
 import { createActivitiesRouter } from './routes/activities-router.ts'
 import { createAdminRouter } from './routes/admin-router.ts'
+import { createChartDataRouter } from './routes/chart-data-router.ts'
 import { createCorrelationsRouter } from './routes/correlations-router.ts'
 import { createDashboardRouter } from './routes/dashboard-router.ts'
 import { createFoodItemsRouter } from './routes/food-items-router.ts'
@@ -554,6 +555,7 @@ const main = async () => {
   httpd.use('/correlations', createCorrelationsRouter(authMiddleware, syncProvider))
   httpd.use('/training-load', createTrainingLoadRouter(authMiddleware))
   httpd.use('/trends', createTrendsRouter(authMiddleware))
+  httpd.use('/chart-data', createChartDataRouter(authMiddleware))
   httpd.use('/screentime-categories', createScreentimeCategoriesRouter(authMiddleware))
   httpd.use(
     '/admin',

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -18,6 +18,7 @@ import type { CentralDb } from './services/central-db.ts'
 import type { SyncProvider } from './services/queries.ts'
 
 import { registerActivityTools } from './mcp/activity-tools.ts'
+import { registerChartTools } from './mcp/chart-tools.ts'
 import { registerCorrelationTools } from './mcp/correlation-tools.ts'
 import { registerFoodItemTools } from './mcp/food-item-tools.ts'
 import { registerLastFmTools } from './mcp/lastfm-tools.ts'
@@ -61,6 +62,7 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
   registerCorrelationTools(server, user, deps.sync)
   registerTrainingLoadTools(server, user)
   registerTrendTools(server, user)
+  registerChartTools(server, user)
   registerNoteTools(server, user)
   registerMealTools(server, user)
   registerFoodItemTools(server, user)

--- a/apps/backend/src/mcp/chart-tools.ts
+++ b/apps/backend/src/mcp/chart-tools.ts
@@ -1,0 +1,41 @@
+/**
+ * MCP chart data tools — bucketed aggregation for bar charts.
+ */
+import { chartDataQuerySchema } from '@aurboda/api-spec'
+
+import { getChartData } from '../services/chart-data.ts'
+import { jsonResponse, type McpServer } from './helpers.ts'
+
+export const registerChartTools = (server: McpServer, user: string) => {
+  server.tool(
+    'query_chart_data',
+    `Query bucketed chart data for tags, metrics, productivity categories, or activity types.
+Returns time-bucketed aggregated values suitable for bar charts.
+
+Bucket sizes: 1d (daily), 1w (weekly), 1M (monthly)
+Aggregation: count (number of occurrences), sum (total value), mean (average value)
+
+Examples:
+- Daily coffee counts this month: source_type="tag", pattern="coffee", bucket_size="1d", aggregation="count"
+- Weekly average weight: source_type="metric", pattern="weight", bucket_size="1w", aggregation="mean"
+- Monthly programming hours: source_type="productivity_category", pattern="Work > Programming", bucket_size="1M"`,
+    { ...chartDataQuerySchema.shape },
+    async ({ aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id }) => {
+      try {
+        const buckets = await getChartData(user, {
+          aggregation,
+          bucket_size,
+          end,
+          pattern,
+          source_type,
+          start,
+          tag_definition_id,
+        })
+        return jsonResponse({ data: { buckets }, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        return jsonResponse({ error: message, success: false })
+      }
+    },
+  )
+}

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -1,0 +1,49 @@
+/**
+ * Chart data route group.
+ *
+ * Handles: /chart-data
+ */
+import { type ChartDataHttpQuery, chartDataHttpQuerySchema, type ChartDataResponse } from '@aurboda/api-spec'
+import { type RequestHandler, Router } from 'express'
+
+import { getChartData } from '../services/chart-data.ts'
+import { validateQuery } from '../validation.ts'
+
+export const createChartDataRouter = (authMiddleware: RequestHandler): Router => {
+  const router = Router()
+
+  // GET /chart-data — bucketed aggregation for bar charts
+  router.get<Record<string, never>, ChartDataResponse, unknown, ChartDataHttpQuery>(
+    '/',
+    authMiddleware,
+    validateQuery(chartDataHttpQuerySchema),
+    async (req, res) => {
+      const { aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id } = req.query
+      const user = req.user!
+
+      if (!pattern && !tag_definition_id) {
+        return res
+          .status(400)
+          .json({ error: 'Either pattern or tag_definition_id is required', success: false })
+      }
+
+      try {
+        const buckets = await getChartData(user, {
+          aggregation: aggregation ?? 'count',
+          bucket_size: bucket_size ?? '1d',
+          end,
+          pattern,
+          source_type,
+          start,
+          tag_definition_id,
+        })
+        res.json({ data: { buckets }, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.status(400).json({ error: message, success: false })
+      }
+    },
+  )
+
+  return router
+}

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import * as db from '../db/index.ts'
+import { getChartData } from './chart-data.ts'
+
+// Mock the db module
+vi.mock('../db', () => ({
+  query: vi.fn(),
+}))
+
+describe('getChartData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns bucketed tag counts by tag_definition_id', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), value: 3n },
+        { bucket_start: new Date('2026-01-02T00:00:00Z'), value: 5n },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      source_type: 'tag',
+      start: '2026-01-01T00:00:00Z',
+      tag_definition_id: '550e8400-e29b-41d4-a716-446655440000',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].bucket_start).toBe('2026-01-01T00:00:00.000Z')
+    expect(result[0].value).toBe(3)
+    expect(result[1].value).toBe(5)
+
+    // Verify the SQL uses date_trunc with 'day'
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[2]![0]).toBe('day')
+  })
+
+  test('returns bucketed tag counts by pattern', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [{ bucket_start: new Date('2026-01-06T00:00:00Z'), value: 7n }],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1w',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'coffee',
+      source_type: 'tag',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].value).toBe(7)
+
+    // Verify the SQL uses date_trunc with 'week'
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[2]![0]).toBe('week')
+  })
+
+  test('returns empty array for tags without pattern or tag_definition_id', async () => {
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      source_type: 'tag',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toEqual([])
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  test('returns bucketed metric data with mean aggregation', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), value: 72.5 },
+        { bucket_start: new Date('2026-02-01T00:00:00Z'), value: 71.8 },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'mean',
+      bucket_size: '1M',
+      end: '2026-02-28T23:59:59Z',
+      pattern: 'weight',
+      source_type: 'metric',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].value).toBe(72.5)
+
+    // Verify the SQL uses date_trunc with 'month'
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[2]![0]).toBe('month')
+    // Verify AVG aggregation is used for 'mean'
+    expect(call[1]).toContain('AVG(value)')
+  })
+
+  test('returns bucketed metric data with sum aggregation', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [{ bucket_start: new Date('2026-01-01T00:00:00Z'), value: 8500 }],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'sum',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'steps',
+      source_type: 'metric',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].value).toBe(8500)
+
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[1]).toContain('SUM(value)')
+  })
+
+  test('returns bucketed metric data with count aggregation', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [{ bucket_start: new Date('2026-01-01T00:00:00Z'), value: 24n }],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'heart_rate',
+      source_type: 'metric',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].value).toBe(24)
+
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[1]).toContain('COUNT(*)')
+  })
+
+  test('returns bucketed productivity category hours', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), value: 3.5 },
+        { bucket_start: new Date('2026-01-02T00:00:00Z'), value: 4.2 },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'Work > Programming',
+      source_type: 'productivity_category',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].value).toBe(3.5)
+    expect(result[1].value).toBe(4.2)
+  })
+
+  test('returns bucketed activity type hours', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [{ bucket_start: new Date('2026-01-06T00:00:00Z'), value: 2.75 }],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1w',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'running',
+      source_type: 'activity_type',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].value).toBe(2.75)
+  })
+
+  test('returns empty array for metric without pattern', async () => {
+    const result = await getChartData('testuser', {
+      aggregation: 'mean',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      source_type: 'metric',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toEqual([])
+    expect(db.query).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -1,0 +1,189 @@
+/**
+ * Chart data service — bucketed aggregation of tags, metrics,
+ * productivity categories, and activity types.
+ *
+ * Returns time-bucketed data for bar chart visualizations.
+ */
+
+import type { ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
+
+import { query } from '../db/index.ts'
+
+/** Map bucket_size parameter to PostgreSQL date_trunc interval name. */
+const bucketToTrunc: Record<string, string> = {
+  '1M': 'month',
+  '1d': 'day',
+  '1w': 'week',
+}
+
+export interface ChartDataInput {
+  aggregation: 'count' | 'mean' | 'sum'
+  bucket_size: '1M' | '1d' | '1w'
+  end: string
+  pattern?: string
+  source_type: ChartDataSourceType
+  start: string
+  tag_definition_id?: string
+}
+
+/** Query bucketed tag counts by tag_definition_id. */
+const queryTagsByDefinition = async (
+  user: string,
+  tagDefinitionId: string,
+  start: string,
+  end: string,
+  truncInterval: string,
+): Promise<ChartDataBucket[]> => {
+  const result = await query(
+    user,
+    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+            count(*) AS value
+       FROM tags
+      WHERE tag_definition_id = $2
+        AND deleted_at IS NULL
+        AND start_time BETWEEN $3 AND $4
+      GROUP BY 1
+      ORDER BY 1`,
+    [truncInterval, tagDefinitionId, start, end],
+  )
+  return result.rows.map((row) => ({
+    bucket_start: row.bucket_start.toISOString(),
+    value: Number(row.value),
+  }))
+}
+
+/** Query bucketed tag counts by regex pattern. */
+const queryTagsByPattern = async (
+  user: string,
+  pattern: string,
+  start: string,
+  end: string,
+  truncInterval: string,
+): Promise<ChartDataBucket[]> => {
+  const result = await query(
+    user,
+    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+            count(*) AS value
+       FROM tags
+      WHERE tag ~* $2
+        AND deleted_at IS NULL
+        AND start_time BETWEEN $3 AND $4
+      GROUP BY 1
+      ORDER BY 1`,
+    [truncInterval, pattern, start, end],
+  )
+  return result.rows.map((row) => ({
+    bucket_start: row.bucket_start.toISOString(),
+    value: Number(row.value),
+  }))
+}
+
+/** Query bucketed metric data with the specified aggregation. */
+const queryMetricBuckets = async (
+  user: string,
+  metric: string,
+  start: string,
+  end: string,
+  truncInterval: string,
+  aggregation: 'count' | 'mean' | 'sum',
+): Promise<ChartDataBucket[]> => {
+  const aggFn = aggregation === 'mean' ? 'AVG(value)' : aggregation === 'sum' ? 'SUM(value)' : 'COUNT(*)'
+  const result = await query(
+    user,
+    `SELECT date_trunc($1, time AT TIME ZONE 'UTC') AS bucket_start,
+            ${aggFn} AS value
+       FROM time_series
+      WHERE metric = $2
+        AND time BETWEEN $3 AND $4
+      GROUP BY 1
+      ORDER BY 1`,
+    [truncInterval, metric, start, end],
+  )
+  return result.rows.map((row) => ({
+    bucket_start: row.bucket_start.toISOString(),
+    value: Number(row.value),
+  }))
+}
+
+/** Query bucketed productivity category hours. */
+const queryProductivityCategoryBuckets = async (
+  user: string,
+  categoryPath: string,
+  start: string,
+  end: string,
+  truncInterval: string,
+): Promise<ChartDataBucket[]> => {
+  const result = await query(
+    user,
+    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+            SUM(duration_sec) / 3600.0 AS value
+       FROM productivity
+      WHERE deleted_at IS NULL
+        AND resolved_category IS NOT NULL
+        AND array_to_string(resolved_category, ' > ') LIKE $2 || '%'
+        AND start_time BETWEEN $3 AND $4
+      GROUP BY 1
+      ORDER BY 1`,
+    [truncInterval, categoryPath, start, end],
+  )
+  return result.rows.map((row) => ({
+    bucket_start: row.bucket_start.toISOString(),
+    value: Number(row.value),
+  }))
+}
+
+/** Query bucketed activity type hours. */
+const queryActivityTypeBuckets = async (
+  user: string,
+  pattern: string,
+  start: string,
+  end: string,
+  truncInterval: string,
+): Promise<ChartDataBucket[]> => {
+  const result = await query(
+    user,
+    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+            SUM(EXTRACT(EPOCH FROM (end_time - start_time))) / 3600.0 AS value
+       FROM activities
+      WHERE activity_type = 'exercise'
+        AND deleted_at IS NULL
+        AND (data->>'exerciseTypeName' = $2 OR data->>'exerciseType' = $2)
+        AND start_time BETWEEN $3 AND $4
+      GROUP BY 1
+      ORDER BY 1`,
+    [truncInterval, pattern, start, end],
+  )
+  return result.rows.map((row) => ({
+    bucket_start: row.bucket_start.toISOString(),
+    value: Number(row.value),
+  }))
+}
+
+/**
+ * Get bucketed chart data for the given source type and parameters.
+ */
+export const getChartData = async (user: string, input: ChartDataInput): Promise<ChartDataBucket[]> => {
+  const { aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id } = input
+  const truncInterval = bucketToTrunc[bucket_size] ?? 'day'
+
+  switch (source_type) {
+    case 'tag':
+      if (tag_definition_id) {
+        return queryTagsByDefinition(user, tag_definition_id, start, end, truncInterval)
+      }
+      if (!pattern) return []
+      return queryTagsByPattern(user, pattern, start, end, truncInterval)
+
+    case 'metric':
+      if (!pattern) return []
+      return queryMetricBuckets(user, pattern, start, end, truncInterval, aggregation)
+
+    case 'productivity_category':
+      if (!pattern) return []
+      return queryProductivityCategoryBuckets(user, pattern, start, end, truncInterval)
+
+    case 'activity_type':
+      if (!pattern) return []
+      return queryActivityTypeBuckets(user, pattern, start, end, truncInterval)
+  }
+}

--- a/apps/web/src/components/charts/BarChart.css
+++ b/apps/web/src/components/charts/BarChart.css
@@ -1,0 +1,42 @@
+.bar-chart-container {
+  position: relative;
+  width: 100%;
+}
+
+.bar-chart-container svg {
+  display: block;
+}
+
+.bar-chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.85);
+  color: white;
+  padding: 0.375rem 0.625rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  z-index: 10;
+  display: none;
+}
+
+.bar-chart-placeholder {
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .bar-chart-tooltip {
+    background: rgba(17, 24, 39, 0.95);
+  }
+
+  .bar-chart-placeholder {
+    background: #111827;
+    color: #6b7280;
+  }
+}

--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -1,0 +1,188 @@
+/**
+ * D3 bar chart component for bucketed chart data.
+ *
+ * Renders vertical bars with responsive width, tooltip on hover,
+ * and smart date formatting based on data density.
+ */
+import * as d3 from 'd3'
+import { useEffect, useRef } from 'preact/hooks'
+
+import './BarChart.css'
+
+export interface BarChartProps {
+  /** Bucketed data points. */
+  data: { bucket_start: string; value: number }[]
+  /** Bar fill colour (default '#8b5cf6'). */
+  color?: string
+  /** Chart height in pixels (default 300). */
+  height?: number
+}
+
+interface ParsedBar {
+  date: Date
+  value: number
+}
+
+/** Pick a d3 time format based on total time span. */
+const buildBarDateFormat = (extent: [Date, Date]) => {
+  const spanMs = extent[1].getTime() - extent[0].getTime()
+  const spanDays = spanMs / (1000 * 60 * 60 * 24)
+  if (spanDays > 365) return d3.timeFormat("%b '%y")
+  if (spanDays > 60) return d3.timeFormat('%b %d')
+  return d3.timeFormat('%b %d')
+}
+
+/** Render axes. */
+function renderAxes(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  x: d3.ScaleBand<string>,
+  y: d3.ScaleLinear<number, number>,
+  bars: ParsedBar[],
+  innerWidth: number,
+  innerHeight: number,
+  dateFormat: (date: Date) => string,
+) {
+  // Show at most ~10 tick labels to avoid overlap
+  const maxTicks = Math.min(bars.length, 10)
+  const tickInterval = Math.max(1, Math.ceil(bars.length / maxTicks))
+  const tickValues = bars.filter((_, i) => i % tickInterval === 0).map((d) => d.date.toISOString())
+
+  g.append('g')
+    .attr('transform', `translate(0,${innerHeight})`)
+    .call(
+      d3
+        .axisBottom(x)
+        .tickValues(tickValues)
+        .tickFormat((d) => dateFormat(new Date(d))),
+    )
+    .selectAll('text')
+    .attr('font-size', '11px')
+    .attr('text-anchor', 'end')
+    .attr('transform', 'rotate(-35)')
+
+  g.append('g').call(d3.axisLeft(y).ticks(5)).selectAll('text').attr('font-size', '11px')
+}
+
+/** Render grid lines behind bars. */
+function renderGrid(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  y: d3.ScaleLinear<number, number>,
+  innerWidth: number,
+) {
+  g.append('g')
+    .attr('class', 'grid')
+    .call(
+      d3
+        .axisLeft(y)
+        .tickSize(-innerWidth)
+        .tickFormat(() => ''),
+    )
+    .selectAll('line')
+    .attr('stroke', '#e5e7eb')
+    .attr('stroke-dasharray', '3,3')
+}
+
+/** Render bars with tooltip interaction. */
+function renderBars(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  bars: ParsedBar[],
+  x: d3.ScaleBand<string>,
+  y: d3.ScaleLinear<number, number>,
+  innerHeight: number,
+  color: string,
+  tooltip: HTMLDivElement,
+  container: HTMLDivElement,
+  margin: { left: number; top: number },
+  dateFormat: (date: Date) => string,
+) {
+  g.selectAll('.bar')
+    .data(bars)
+    .join('rect')
+    .attr('class', 'bar')
+    .attr('x', (d) => x(d.date.toISOString()) ?? 0)
+    .attr('y', (d) => y(d.value))
+    .attr('width', x.bandwidth())
+    .attr('height', (d) => innerHeight - y(d.value))
+    .attr('fill', color)
+    .attr('rx', 2)
+    .on('mouseenter', (event: MouseEvent, d) => {
+      d3.select(event.target as SVGRectElement).attr('fill-opacity', 0.8)
+      tooltip.textContent = `${dateFormat(d.date)}: ${d.value.toFixed(1)}`
+      tooltip.style.display = 'block'
+    })
+    .on('mousemove', (event: MouseEvent) => {
+      const containerRect = container.getBoundingClientRect()
+      const [mx] = d3.pointer(event, container)
+      const tooltipWidth = tooltip.offsetWidth
+      const left = mx + tooltipWidth + 12 > containerRect.width ? mx - tooltipWidth - 12 : mx + 12
+      tooltip.style.left = `${left}px`
+      tooltip.style.top = `${margin.top + 8}px`
+    })
+    .on('mouseleave', (event: MouseEvent) => {
+      d3.select(event.target as SVGRectElement).attr('fill-opacity', 1)
+      tooltip.style.display = 'none'
+    })
+}
+
+export function BarChart({ data, color = '#8b5cf6', height = 300 }: BarChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!svgRef.current || !containerRef.current || data.length === 0) return
+
+    const container = containerRef.current
+    const chartWidth = container.clientWidth
+    const chartHeight = height
+
+    const svg = d3.select(svgRef.current)
+    svg.selectAll('*').remove()
+    svg.attr('width', chartWidth).attr('height', chartHeight)
+
+    const margin = { bottom: 50, left: 50, right: 20, top: 20 }
+    const innerWidth = chartWidth - margin.left - margin.right
+    const innerHeight = chartHeight - margin.top - margin.bottom
+
+    const bars: ParsedBar[] = data.map((d) => ({
+      date: new Date(d.bucket_start),
+      value: d.value,
+    }))
+
+    const x = d3
+      .scaleBand<string>()
+      .domain(bars.map((d) => d.date.toISOString()))
+      .range([0, innerWidth])
+      .padding(0.2)
+
+    const yMax = d3.max(bars, (d) => d.value) ?? 1
+    const y = d3
+      .scaleLinear()
+      .domain([0, yMax * 1.1])
+      .nice()
+      .range([innerHeight, 0])
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
+    const dateFormat = buildBarDateFormat(dateExtent)
+
+    renderGrid(g, y, innerWidth)
+    renderAxes(g, x, y, bars, innerWidth, innerHeight, dateFormat)
+
+    if (tooltipRef.current) {
+      renderBars(g, bars, x, y, innerHeight, color, tooltipRef.current, container, margin, dateFormat)
+    }
+  }, [data, color, height])
+
+  if (data.length === 0) {
+    return <div class="bar-chart-placeholder">No data for the selected range</div>
+  }
+
+  return (
+    <div ref={containerRef} class="bar-chart-container">
+      <svg ref={svgRef} />
+      <div class="bar-chart-tooltip" ref={tooltipRef} />
+    </div>
+  )
+}

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -1,9 +1,10 @@
 /**
- * Chart exploration page — configurable trend chart with URL-driven state.
+ * Chart exploration page — configurable trend + bar chart with URL-driven state.
  *
  * Reads/writes config via query params so charts are shareable/bookmarkable:
  *   /chart?source_type=tag&tag_definition_id=<uuid>&lookback_days=90&display_period=monthly&half_life_days=15
  *   /chart?source_type=metric&pattern=weight&lookback_days=180&aggregation=mean
+ *   /chart?source_type=tag&pattern=coffee&chart_type=bar&bucket_size=1d&lookback_days=30
  */
 import type { TagDefinition } from '@aurboda/api-spec'
 
@@ -11,10 +12,13 @@ import { useQuery } from '@tanstack/react-query'
 import { useLocation } from 'preact-iso'
 import { useCallback, useMemo, useState } from 'preact/hooks'
 
+import { BarChart } from '../../components/charts/BarChart'
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { MetricPicker } from '../../components/MetricPicker'
 import { TagPicker } from '../../components/TagPicker'
 import {
+  fetchChartData,
+  type FetchChartDataParams,
   fetchScreentimeCategories,
   fetchTagDefinitions,
   fetchTrend,
@@ -25,6 +29,8 @@ import { auth } from '../../state/auth'
 import './style.css'
 
 type SourceType = 'tag' | 'metric' | 'productivity_category' | 'activity_type'
+type ChartType = 'trend' | 'bar'
+type BucketSize = '1d' | '1w' | '1M'
 
 const LOOKBACK_OPTIONS = [
   { label: '30 days', value: 30 },
@@ -40,10 +46,30 @@ const HALF_LIFE_OPTIONS = [
   { label: '30 days (Stable)', value: 30 },
 ]
 
+const BUCKET_SIZE_OPTIONS: { label: string; value: BucketSize }[] = [
+  { label: 'Daily', value: '1d' },
+  { label: 'Weekly', value: '1w' },
+  { label: 'Monthly', value: '1M' },
+]
+
+interface ChartState {
+  aggregation: 'count' | 'mean' | 'sum'
+  bucket_size: BucketSize
+  chart_type: ChartType
+  display_period: TrendDisplayPeriod
+  half_life_days: number
+  lookback_days: number
+  pattern: string
+  source_type: SourceType
+  tag_definition_id: string
+}
+
 /** Parse URL query params into chart config state. */
-function parseQuery(query: Record<string, string>) {
+function parseQuery(query: Record<string, string>): ChartState {
   return {
     aggregation: (query.aggregation ?? 'count') as 'count' | 'mean' | 'sum',
+    bucket_size: (query.bucket_size ?? '1d') as BucketSize,
+    chart_type: (query.chart_type ?? 'trend') as ChartType,
     display_period: (query.display_period ?? 'monthly') as TrendDisplayPeriod,
     half_life_days: Number(query.half_life_days) || 15,
     lookback_days: Number(query.lookback_days) || 90,
@@ -54,18 +80,31 @@ function parseQuery(query: Record<string, string>) {
 }
 
 /** Sync current state to URL query params. */
-function syncUrl(state: ReturnType<typeof parseQuery>) {
+function syncUrl(state: ChartState) {
   const params = new URLSearchParams()
   params.set('source_type', state.source_type)
   if (state.pattern) params.set('pattern', state.pattern)
   if (state.tag_definition_id) params.set('tag_definition_id', state.tag_definition_id)
   params.set('lookback_days', String(state.lookback_days))
-  params.set('display_period', state.display_period)
-  params.set('half_life_days', String(state.half_life_days))
+  params.set('chart_type', state.chart_type)
+  if (state.chart_type === 'trend') {
+    params.set('display_period', state.display_period)
+    params.set('half_life_days', String(state.half_life_days))
+  } else {
+    params.set('bucket_size', state.bucket_size)
+  }
   if (state.source_type === 'metric' && state.aggregation !== 'count') {
     params.set('aggregation', state.aggregation)
   }
   history.replaceState(null, '', `${window.location.pathname}?${params}`)
+}
+
+/** Compute start/end ISO strings from lookback_days. */
+function lookbackToRange(lookbackDays: number): { start: string; end: string } {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(start.getDate() - lookbackDays)
+  return { end: end.toISOString(), start: start.toISOString() }
 }
 
 /** Simple category picker for screentime categories. */
@@ -88,7 +127,7 @@ function CategoryPicker({ value, onChange }: { value: string; onChange: (v: stri
   )
 }
 
-/** Tag definition picker — searchable dropdown of all definitions. */
+/** Tag definition picker -- searchable dropdown of all definitions. */
 function TagDefinitionPicker({
   definitions,
   selectedId,
@@ -140,12 +179,13 @@ function TagDefinitionPicker({
   )
 }
 
-function ChartControls({
+/** Source picker shared between both chart modes. */
+function SourcePicker({
   state,
   onUpdate,
 }: {
-  state: ReturnType<typeof parseQuery>
-  onUpdate: (patch: Partial<ReturnType<typeof parseQuery>>) => void
+  state: ChartState
+  onUpdate: (patch: Partial<ChartState>) => void
 }) {
   const { data: tagDefinitions = [] } = useQuery({
     queryFn: fetchTagDefinitions,
@@ -154,69 +194,101 @@ function ChartControls({
   })
 
   return (
+    <div class="chart-controls-row">
+      <label>
+        Source Type
+        <select
+          value={state.source_type}
+          onChange={(e) => {
+            const source_type = (e.target as HTMLSelectElement).value as SourceType
+            onUpdate({ source_type, pattern: '', tag_definition_id: '' })
+          }}
+        >
+          <option value="tag">Tag</option>
+          <option value="metric">Metric</option>
+          <option value="productivity_category">Screentime Category</option>
+          <option value="activity_type">Activity Type</option>
+        </select>
+      </label>
+
+      <label class="source-picker">
+        {state.source_type === 'tag' && tagDefinitions.length > 0 ? (
+          <>
+            Tag Definition
+            <TagDefinitionPicker
+              definitions={tagDefinitions}
+              selectedId={state.tag_definition_id}
+              onChange={(id, pattern) => onUpdate({ tag_definition_id: id, pattern })}
+            />
+          </>
+        ) : state.source_type === 'tag' ? (
+          <>
+            Tags
+            <TagPicker
+              selectedTags={state.pattern ? state.pattern.split('|').filter(Boolean) : []}
+              onChange={(tags) => onUpdate({ pattern: tags.join('|') })}
+            />
+          </>
+        ) : state.source_type === 'productivity_category' ? (
+          <>
+            Category
+            <CategoryPicker value={state.pattern} onChange={(pattern) => onUpdate({ pattern })} />
+          </>
+        ) : state.source_type === 'activity_type' ? (
+          <>
+            Activity Type
+            <input
+              type="text"
+              value={state.pattern}
+              onInput={(e) => onUpdate({ pattern: (e.target as HTMLInputElement).value })}
+              placeholder="e.g. running, cycling..."
+            />
+          </>
+        ) : (
+          <>
+            Metric
+            <MetricPicker
+              value={state.pattern}
+              onChange={(pattern) => onUpdate({ pattern })}
+              placeholder="Search metrics..."
+            />
+          </>
+        )}
+      </label>
+    </div>
+  )
+}
+
+function ChartControls({
+  state,
+  onUpdate,
+}: {
+  state: ChartState
+  onUpdate: (patch: Partial<ChartState>) => void
+}) {
+  return (
     <div class="chart-controls">
       <div class="chart-controls-row">
         <label>
-          Source Type
-          <select
-            value={state.source_type}
-            onChange={(e) => {
-              const source_type = (e.target as HTMLSelectElement).value as SourceType
-              onUpdate({ source_type, pattern: '', tag_definition_id: '' })
-            }}
-          >
-            <option value="tag">Tag</option>
-            <option value="metric">Metric</option>
-            <option value="productivity_category">Screentime Category</option>
-            <option value="activity_type">Activity Type</option>
-          </select>
-        </label>
-
-        <label class="source-picker">
-          {state.source_type === 'tag' && tagDefinitions.length > 0 ? (
-            <>
-              Tag Definition
-              <TagDefinitionPicker
-                definitions={tagDefinitions}
-                selectedId={state.tag_definition_id}
-                onChange={(id, pattern) => onUpdate({ tag_definition_id: id, pattern })}
-              />
-            </>
-          ) : state.source_type === 'tag' ? (
-            <>
-              Tags
-              <TagPicker
-                selectedTags={state.pattern ? state.pattern.split('|').filter(Boolean) : []}
-                onChange={(tags) => onUpdate({ pattern: tags.join('|') })}
-              />
-            </>
-          ) : state.source_type === 'productivity_category' ? (
-            <>
-              Category
-              <CategoryPicker value={state.pattern} onChange={(pattern) => onUpdate({ pattern })} />
-            </>
-          ) : state.source_type === 'activity_type' ? (
-            <>
-              Activity Type
-              <input
-                type="text"
-                value={state.pattern}
-                onInput={(e) => onUpdate({ pattern: (e.target as HTMLInputElement).value })}
-                placeholder="e.g. running, cycling..."
-              />
-            </>
-          ) : (
-            <>
-              Metric
-              <MetricPicker
-                value={state.pattern}
-                onChange={(pattern) => onUpdate({ pattern })}
-                placeholder="Search metrics..."
-              />
-            </>
-          )}
+          Chart Type
+          <div class="chart-type-toggle">
+            <button
+              class={`chart-type-btn ${state.chart_type === 'trend' ? 'active' : ''}`}
+              onClick={() => onUpdate({ chart_type: 'trend' })}
+            >
+              Trend (EMA)
+            </button>
+            <button
+              class={`chart-type-btn ${state.chart_type === 'bar' ? 'active' : ''}`}
+              onClick={() => onUpdate({ chart_type: 'bar' })}
+            >
+              Bar
+            </button>
+          </div>
         </label>
       </div>
+
+      <SourcePicker state={state} onUpdate={onUpdate} />
 
       <div class="chart-controls-row">
         <label>
@@ -233,33 +305,51 @@ function ChartControls({
           </select>
         </label>
 
-        <label>
-          Display Period
-          <select
-            value={state.display_period}
-            onChange={(e) =>
-              onUpdate({ display_period: (e.target as HTMLSelectElement).value as TrendDisplayPeriod })
-            }
-          >
-            <option value="daily">Per day</option>
-            <option value="weekly">Per week</option>
-            <option value="monthly">Per month</option>
-          </select>
-        </label>
+        {state.chart_type === 'trend' ? (
+          <>
+            <label>
+              Display Period
+              <select
+                value={state.display_period}
+                onChange={(e) =>
+                  onUpdate({ display_period: (e.target as HTMLSelectElement).value as TrendDisplayPeriod })
+                }
+              >
+                <option value="daily">Per day</option>
+                <option value="weekly">Per week</option>
+                <option value="monthly">Per month</option>
+              </select>
+            </label>
 
-        <label>
-          Half-life
-          <select
-            value={state.half_life_days}
-            onChange={(e) => onUpdate({ half_life_days: Number((e.target as HTMLSelectElement).value) })}
-          >
-            {HALF_LIFE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
+            <label>
+              Half-life
+              <select
+                value={state.half_life_days}
+                onChange={(e) => onUpdate({ half_life_days: Number((e.target as HTMLSelectElement).value) })}
+              >
+                {HALF_LIFE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </>
+        ) : (
+          <label>
+            Bucket Size
+            <select
+              value={state.bucket_size}
+              onChange={(e) => onUpdate({ bucket_size: (e.target as HTMLSelectElement).value as BucketSize })}
+            >
+              {BUCKET_SIZE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
 
         {state.source_type === 'metric' && (
           <label>
@@ -281,7 +371,7 @@ function ChartControls({
   )
 }
 
-function ChartDisplay({ params }: { params: FetchTrendParams }) {
+function TrendDisplay({ params }: { params: FetchTrendParams }) {
   const trendQuery = useQuery({
     enabled: Boolean(params.pattern),
     queryFn: () => fetchTrend(params),
@@ -314,13 +404,42 @@ function ChartDisplay({ params }: { params: FetchTrendParams }) {
   )
 }
 
+function BarDisplay({ params }: { params: FetchChartDataParams }) {
+  const barQuery = useQuery({
+    enabled: Boolean(params.pattern || params.tag_definition_id),
+    queryFn: () => fetchChartData(params),
+    queryKey: ['chart-data', params],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (!params.pattern && !params.tag_definition_id) {
+    return <div class="chart-empty">Select a source to view chart data.</div>
+  }
+
+  if (barQuery.isLoading) {
+    return <div class="chart-loading">Loading chart data...</div>
+  }
+
+  if (barQuery.isError) {
+    return <div class="chart-error">Failed to load chart data.</div>
+  }
+
+  const buckets = barQuery.data ?? []
+
+  return (
+    <div class="chart-display">
+      <BarChart data={buckets} color="#8b5cf6" height={350} />
+    </div>
+  )
+}
+
 export function Chart() {
   const isLoggedIn = auth.value.token
   const { query } = useLocation()
   const [state, setState] = useState(() => parseQuery(query))
 
   const handleUpdate = useCallback(
-    (patch: Partial<ReturnType<typeof parseQuery>>) => {
+    (patch: Partial<ChartState>) => {
       const next = { ...state, ...patch }
       setState(next)
       syncUrl(next)
@@ -339,26 +458,43 @@ export function Chart() {
     )
   }
 
-  const fetchParams: FetchTrendParams = {
-    aggregation: state.source_type === 'metric' ? state.aggregation : 'count',
-    display_period: state.display_period,
-    half_life_days: state.half_life_days,
-    lookback_days: state.lookback_days,
-    pattern: state.pattern,
-    source_type: state.source_type,
-    ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
-  }
+  const { start, end } = lookbackToRange(state.lookback_days)
 
   return (
     <div class="chart-page">
       <h1>Chart Explorer</h1>
       <p class="chart-page-description">
-        Explore time-weighted averages (EMA) for tags, metrics, screentime categories, and activity types.
-        Adjust the controls to change what data is displayed.
+        Explore time-weighted averages (EMA) or raw bucketed data for tags, metrics, screentime categories,
+        and activity types. Toggle between Trend and Bar chart modes.
       </p>
 
       <ChartControls state={state} onUpdate={handleUpdate} />
-      <ChartDisplay params={fetchParams} />
+
+      {state.chart_type === 'trend' ? (
+        <TrendDisplay
+          params={{
+            aggregation: state.source_type === 'metric' ? state.aggregation : 'count',
+            display_period: state.display_period,
+            half_life_days: state.half_life_days,
+            lookback_days: state.lookback_days,
+            pattern: state.pattern,
+            source_type: state.source_type,
+            ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
+          }}
+        />
+      ) : (
+        <BarDisplay
+          params={{
+            aggregation: state.source_type === 'metric' ? state.aggregation : 'count',
+            bucket_size: state.bucket_size,
+            end,
+            pattern: state.pattern || undefined,
+            source_type: state.source_type,
+            start,
+            ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/Chart/style.css
+++ b/apps/web/src/pages/Chart/style.css
@@ -69,6 +69,40 @@
   box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
 }
 
+/* Chart type toggle */
+.chart-type-toggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.chart-type-btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #fff;
+  color: #374151;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.chart-type-btn:not(:last-child) {
+  border-right: 1px solid #d1d5db;
+}
+
+.chart-type-btn.active {
+  background: #8b5cf6;
+  color: #fff;
+}
+
+.chart-type-btn:hover:not(.active) {
+  background: #f3f4f6;
+}
+
 /* Chart area */
 .chart-display {
   background: #fff;
@@ -162,6 +196,23 @@
     background: #111827;
     border-color: #4b5563;
     color: #f9fafb;
+  }
+
+  .chart-type-toggle {
+    border-color: #4b5563;
+  }
+
+  .chart-type-btn {
+    background: #111827;
+    color: #e5e7eb;
+  }
+
+  .chart-type-btn:not(:last-child) {
+    border-right-color: #4b5563;
+  }
+
+  .chart-type-btn:hover:not(.active) {
+    background: #1f2937;
   }
 
   .chart-display {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -28,6 +28,9 @@ import type {
   Tag as ApiTag,
   BaselineData,
   BaselineResponse,
+  ChartDataBucket,
+  ChartDataResponse,
+  ChartDataSourceType,
   CreateScreentimeCategoryBody,
   CustomMetricDefinition,
   CustomMetricsListResponse,
@@ -1698,4 +1701,38 @@ export const searchFoodItemsApi = async (q: string, limit = 10): Promise<FoodIte
     params: { q, limit },
   })
   return response.data.data ?? []
+}
+
+// ==========================================================================
+// Chart Data API (bucketed aggregation for bar charts)
+// ==========================================================================
+
+export interface FetchChartDataParams {
+  source_type: ChartDataSourceType
+  start: string
+  end: string
+  pattern?: string
+  tag_definition_id?: string
+  bucket_size?: '1d' | '1w' | '1M'
+  aggregation?: 'count' | 'sum' | 'mean'
+}
+
+export const fetchChartData = async (params: FetchChartDataParams): Promise<ChartDataBucket[]> => {
+  const { token } = auth.value
+  const query: Record<string, string> = {
+    source_type: params.source_type,
+    start: params.start,
+    end: params.end,
+  }
+  if (params.pattern) query.pattern = params.pattern
+  if (params.tag_definition_id) query.tag_definition_id = params.tag_definition_id
+  if (params.bucket_size) query.bucket_size = params.bucket_size
+  if (params.aggregation) query.aggregation = params.aggregation
+
+  const response = await axios.get<ChartDataResponse>(`${API_URL}/chart-data`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: query,
+  })
+
+  return response.data.data?.buckets ?? []
 }

--- a/packages/api-spec/src/schemas/chart-data.ts
+++ b/packages/api-spec/src/schemas/chart-data.ts
@@ -1,0 +1,117 @@
+/**
+ * Chart data schemas for bucketed aggregation of tags, metrics,
+ * productivity categories, and activity types.
+ *
+ * Supports daily, weekly, and monthly bucketing with count/sum/mean aggregation.
+ */
+
+import { z } from 'zod'
+
+import { baseResponseSchema } from './common.ts'
+
+/**
+ * Source type for chart data queries.
+ */
+export const chartDataSourceTypeSchema = z
+  .enum(['tag', 'metric', 'productivity_category', 'activity_type'])
+  .meta({
+    description: 'Type of data source for chart data query',
+    example: 'tag',
+    id: 'ChartDataSourceType',
+  })
+
+export type ChartDataSourceType = z.infer<typeof chartDataSourceTypeSchema>
+
+/**
+ * Bucket size for chart data aggregation.
+ */
+export const chartDataBucketSizeSchema = z.enum(['1d', '1w', '1M']).meta({
+  description: 'Bucket size for aggregation: daily, weekly, or monthly',
+  example: '1d',
+  id: 'ChartDataBucketSize',
+})
+
+export type ChartDataBucketSize = z.infer<typeof chartDataBucketSizeSchema>
+
+/**
+ * Aggregation method for chart data.
+ */
+export const chartDataAggregationSchema = z.enum(['count', 'sum', 'mean']).meta({
+  description: 'Aggregation method: count, sum, or mean',
+  example: 'count',
+  id: 'ChartDataAggregation',
+})
+
+export type ChartDataAggregation = z.infer<typeof chartDataAggregationSchema>
+
+/**
+ * Query schema for chart data endpoint (typed, for service layer).
+ */
+export const chartDataQuerySchema = z
+  .object({
+    aggregation: chartDataAggregationSchema.default('count').meta({ description: 'Aggregation method' }),
+    bucket_size: chartDataBucketSizeSchema.default('1d').meta({ description: 'Bucket size for aggregation' }),
+    end: z.iso.datetime().meta({ description: 'End of time range (ISO 8601)' }),
+    pattern: z
+      .string()
+      .optional()
+      .meta({ description: 'Pattern to match (regex for tags, metric name for metrics, category path)' }),
+    source_type: chartDataSourceTypeSchema.meta({ description: 'Type of data source' }),
+    start: z.iso.datetime().meta({ description: 'Start of time range (ISO 8601)' }),
+    tag_definition_id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'Tag definition ID (alternative to pattern for tags)' }),
+  })
+  .meta({ id: 'ChartDataQuery', description: 'Query parameters for bucketed chart data' })
+
+export type ChartDataQuery = z.infer<typeof chartDataQuerySchema>
+
+/**
+ * HTTP query schema for Express query params (all strings).
+ */
+export const chartDataHttpQuerySchema = z
+  .object({
+    aggregation: z.enum(['count', 'sum', 'mean']).optional(),
+    bucket_size: z.enum(['1d', '1w', '1M']).optional(),
+    end: z.string().meta({ description: 'End of time range (ISO 8601 string)' }),
+    pattern: z.string().optional().meta({ description: 'Pattern to match' }),
+    source_type: chartDataSourceTypeSchema,
+    start: z.string().meta({ description: 'Start of time range (ISO 8601 string)' }),
+    tag_definition_id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'Tag definition ID (alternative to pattern for tags)' }),
+  })
+  .meta({ id: 'ChartDataHttpQuery', description: 'HTTP query parameters for chart data endpoint' })
+
+export type ChartDataHttpQuery = z.infer<typeof chartDataHttpQuerySchema>
+
+/**
+ * A single bucket in the chart data response.
+ */
+export const chartDataBucketSchema = z
+  .object({
+    bucket_start: z.string().meta({ description: 'Start of the bucket (ISO 8601 datetime)' }),
+    value: z.number().meta({ description: 'Aggregated value for this bucket' }),
+  })
+  .meta({ id: 'ChartDataBucket', description: 'A single data bucket with start time and aggregated value' })
+
+export type ChartDataBucket = z.infer<typeof chartDataBucketSchema>
+
+/**
+ * Response schema for chart data endpoint.
+ */
+export const chartDataResponseSchema = baseResponseSchema
+  .extend({
+    data: z
+      .object({
+        buckets: z.array(chartDataBucketSchema),
+      })
+      .optional(),
+  })
+  .meta({ id: 'ChartDataResponse', description: 'Response containing bucketed chart data' })
+
+export type ChartDataResponse = z.infer<typeof chartDataResponseSchema>

--- a/packages/api-spec/src/schemas/index.ts
+++ b/packages/api-spec/src/schemas/index.ts
@@ -4,6 +4,7 @@
 
 export * from './activities.ts'
 export * from './admin.ts'
+export * from './chart-data.ts'
 export * from './common.ts'
 export * from './correlations.ts'
 export * from './food-items.ts'


### PR DESCRIPTION
## Summary
- New `/chart-data` REST endpoint and `query_chart_data` MCP tool for time-bucketed aggregation (daily/weekly/monthly) of tags, metrics, productivity categories, and activity types
- New `BarChart` D3 component with responsive bars, tooltips, and smart date formatting
- Chart Explorer page now has a Trend (EMA) / Bar toggle, with bucket size selector for bar mode
- Zod schemas in `@aurboda/api-spec` for chart data query/response types
- Unit tests for the chart-data service (9 tests, all passing)

## Test plan
- [ ] Verify `GET /api/chart-data?source_type=tag&pattern=coffee&start=...&end=...&bucket_size=1d` returns bucketed counts
- [ ] Verify bar chart renders correctly on the Chart Explorer page
- [ ] Toggle between Trend and Bar modes, confirm controls update appropriately
- [ ] Test with different source types (tag, metric, productivity_category, activity_type)
- [ ] Test bucket sizes (daily, weekly, monthly)
- [ ] Verify MCP tool `query_chart_data` works via MCP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)