### PR TITLE
feat: Add to Dashboard button on chart page

### DIFF
--- a/apps/web/src/components/DashboardEditor/index.tsx
+++ b/apps/web/src/components/DashboardEditor/index.tsx
@@ -77,6 +77,18 @@ const widgetTemplates: WidgetTemplate[] = [
   {
     allowedSections: ['charts'],
     defaultConfig: () => ({
+      bucket_size: '1d',
+      lookback_days: 30,
+      pattern: 'coffee',
+      source_type: 'tag',
+    }),
+    description: 'Bucketed bar chart for tags, metrics, or categories',
+    label: 'Bar Chart',
+    type: 'bar_chart',
+  },
+  {
+    allowedSections: ['charts'],
+    defaultConfig: () => ({
       activity: 'exercise',
       activity_type: 'activity_type',
       period_days: 90,

--- a/apps/web/src/components/widgets/BarChartWidget.tsx
+++ b/apps/web/src/components/widgets/BarChartWidget.tsx
@@ -1,0 +1,87 @@
+/**
+ * BarChartWidget - Displays bucketed bar chart visualization on the dashboard.
+ */
+
+import type { BarChartConfig } from '@aurboda/api-spec'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchChartData } from '../../state/api'
+import { BarChart } from '../charts/BarChart'
+
+interface BarChartWidgetProps {
+  config: BarChartConfig
+}
+
+/** Compute start/end ISO strings from lookback_days. */
+function lookbackToRange(lookbackDays: number): { start: string; end: string } {
+  const end = new Date()
+  const start = new Date()
+  start.setDate(start.getDate() - lookbackDays)
+  return { end: end.toISOString(), start: start.toISOString() }
+}
+
+export function BarChartWidget({ config }: BarChartWidgetProps) {
+  const {
+    source_type,
+    pattern,
+    tag_definition_id,
+    title,
+    bucket_size,
+    lookback_days,
+    aggregation = 'count',
+  } = config
+
+  const { start, end } = lookbackToRange(lookback_days)
+
+  const chartQuery = useQuery({
+    enabled: Boolean(pattern ?? tag_definition_id),
+    queryFn: () =>
+      fetchChartData({
+        aggregation,
+        bucket_size,
+        end,
+        pattern: pattern ?? undefined,
+        source_type,
+        start,
+        ...(tag_definition_id ? { tag_definition_id } : {}),
+      }),
+    queryKey: [
+      'chart-data',
+      source_type,
+      pattern,
+      tag_definition_id,
+      bucket_size,
+      lookback_days,
+      aggregation,
+    ],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const displayTitle = title ?? `${pattern ?? 'chart'} (${bucket_size})`
+
+  if (chartQuery.isLoading) {
+    return (
+      <div class="bar-chart-widget">
+        <h4>{displayTitle}</h4>
+        <div class="chart-loading">Loading chart data...</div>
+      </div>
+    )
+  }
+
+  if (chartQuery.isError || !chartQuery.data) {
+    return (
+      <div class="bar-chart-widget">
+        <h4>{displayTitle}</h4>
+        <div class="chart-error">Unable to load chart data</div>
+      </div>
+    )
+  }
+
+  return (
+    <div class="bar-chart-widget">
+      <h4>{displayTitle}</h4>
+      <BarChart data={chartQuery.data} color="#8b5cf6" height={200} />
+    </div>
+  )
+}

--- a/apps/web/src/components/widgets/WidgetRenderer.tsx
+++ b/apps/web/src/components/widgets/WidgetRenderer.tsx
@@ -5,6 +5,7 @@
 import type { DashboardWidget } from '@aurboda/api-spec'
 
 import { ActivitySummaryWidget } from './ActivitySummaryWidget'
+import { BarChartWidget } from './BarChartWidget'
 import { CorrelationWidget } from './CorrelationWidget'
 import { MetricCardWidget } from './MetricCardWidget'
 import { QuickLinkWidget } from './QuickLinkWidget'
@@ -26,6 +27,8 @@ export function WidgetRenderer({ widget, isEditing, onRemove }: WidgetRendererPr
         return <SparklineCardWidget config={widget.config} />
       case 'trend_chart':
         return <TrendChartWidget config={widget.config} />
+      case 'bar_chart':
+        return <BarChartWidget config={widget.config} />
       case 'correlation':
         return <CorrelationWidget config={widget.config} />
       case 'activity_summary':

--- a/apps/web/src/components/widgets/index.ts
+++ b/apps/web/src/components/widgets/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { ActivitySummaryWidget } from './ActivitySummaryWidget'
+export { BarChartWidget } from './BarChartWidget'
 export { CorrelationWidget } from './CorrelationWidget'
 export { MetricCardWidget } from './MetricCardWidget'
 export { QuickLinkWidget } from './QuickLinkWidget'

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -6,9 +6,15 @@
  *   /chart?source_type=metric&pattern=weight&lookback_days=180&aggregation=mean
  *   /chart?source_type=tag&pattern=coffee&chart_type=bar&bucket_size=1d&lookback_days=30
  */
-import type { TagDefinition } from '@aurboda/api-spec'
+import type {
+  DashboardConfig,
+  DashboardSection,
+  DashboardWidget,
+  SectionType,
+  TagDefinition,
+} from '@aurboda/api-spec'
 
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation } from 'preact-iso'
 import { useCallback, useMemo, useState } from 'preact/hooks'
 
@@ -19,10 +25,12 @@ import { TagPicker } from '../../components/TagPicker'
 import {
   fetchChartData,
   type FetchChartDataParams,
+  fetchDashboard,
   fetchScreentimeCategories,
   fetchTagDefinitions,
   fetchTrend,
   type FetchTrendParams,
+  saveDashboard,
   type TrendDisplayPeriod,
 } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -433,10 +441,190 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
   )
 }
 
+/** Generate unique ID for widgets and sections. */
+const generateId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
+/** Build a dashboard widget config from the current chart state. */
+function buildWidgetFromState(state: ChartState, title: string): DashboardWidget {
+  if (state.chart_type === 'bar') {
+    return {
+      config: {
+        aggregation: state.aggregation,
+        bucket_size: state.bucket_size,
+        lookback_days: state.lookback_days,
+        ...(state.pattern ? { pattern: state.pattern } : {}),
+        source_type: state.source_type,
+        ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
+        ...(title ? { title } : {}),
+      },
+      id: generateId('widget'),
+      type: 'bar_chart',
+    } as DashboardWidget
+  }
+
+  return {
+    config: {
+      aggregation: state.aggregation,
+      display_period: state.display_period,
+      half_life_days: state.half_life_days,
+      lookback_days: state.lookback_days,
+      pattern: state.pattern,
+      source_type: state.source_type === 'tag' || state.source_type === 'metric' ? state.source_type : 'tag',
+      ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
+      ...(title ? { title } : {}),
+    },
+    id: generateId('widget'),
+    type: 'trend_chart',
+  } as DashboardWidget
+}
+
+/** Modal for adding the current chart to a dashboard section. */
+function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: () => void }) {
+  const queryClient = useQueryClient()
+  const [title, setTitle] = useState('')
+  const [selectedSectionId, setSelectedSectionId] = useState('')
+  const [newSectionTitle, setNewSectionTitle] = useState('')
+  const [saved, setSaved] = useState(false)
+
+  const dashboardQuery = useQuery({
+    queryFn: fetchDashboard,
+    queryKey: ['dashboard'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: saveDashboard,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['dashboard'], data)
+      setSaved(true)
+    },
+  })
+
+  const dashboard: DashboardConfig | undefined = dashboardQuery.data
+  const chartsSections = dashboard?.sections.filter((s) => s.type === 'charts') ?? []
+
+  const handleSave = () => {
+    if (!dashboard) return
+
+    const widget = buildWidgetFromState(state, title)
+
+    let newDashboard: DashboardConfig
+    if (selectedSectionId === '__new__') {
+      const sectionTitle = newSectionTitle.trim() || 'Charts'
+      const newSection: DashboardSection = {
+        id: generateId('section'),
+        title: sectionTitle,
+        type: 'charts' as SectionType,
+        widgets: [widget],
+      }
+      newDashboard = { ...dashboard, sections: [...dashboard.sections, newSection] }
+    } else {
+      newDashboard = {
+        ...dashboard,
+        sections: dashboard.sections.map((section) =>
+          section.id === selectedSectionId ? { ...section, widgets: [...section.widgets, widget] } : section,
+        ),
+      }
+    }
+
+    saveMutation.mutate(newDashboard)
+  }
+
+  const canSave =
+    !saveMutation.isPending &&
+    (selectedSectionId === '__new__' ? newSectionTitle.trim().length > 0 : selectedSectionId.length > 0)
+
+  return (
+    <div class="dashboard-editor-overlay" onClick={onClose}>
+      <div class="dashboard-editor-modal" onClick={(e) => e.stopPropagation()}>
+        <div class="modal-header">
+          <h3>Add to Dashboard</h3>
+          <button class="close-btn" onClick={onClose}>
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="modal-content">
+          {saved ? (
+            <div class="add-to-dash-success">Widget added to dashboard!</div>
+          ) : (
+            <div class="config-form">
+              <div class="form-group">
+                <label>Title (optional)</label>
+                <input
+                  type="text"
+                  value={title}
+                  onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+                  placeholder={state.pattern || 'Chart title'}
+                />
+              </div>
+
+              <div class="form-group">
+                <label>Dashboard Section</label>
+                <select
+                  value={selectedSectionId}
+                  onChange={(e) => setSelectedSectionId((e.target as HTMLSelectElement).value)}
+                >
+                  <option value="">Select a section...</option>
+                  {chartsSections.map((section) => (
+                    <option key={section.id} value={section.id}>
+                      {section.title}
+                    </option>
+                  ))}
+                  <option value="__new__">+ Create new section</option>
+                </select>
+              </div>
+
+              {selectedSectionId === '__new__' && (
+                <div class="form-group">
+                  <label>New Section Title</label>
+                  <input
+                    type="text"
+                    value={newSectionTitle}
+                    onInput={(e) => setNewSectionTitle((e.target as HTMLInputElement).value)}
+                    placeholder="e.g., My Charts"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div class="modal-footer">
+          {saved ? (
+            <button class="btn-primary" onClick={onClose}>
+              Done
+            </button>
+          ) : (
+            <>
+              <button class="btn-secondary" onClick={onClose}>
+                Cancel
+              </button>
+              <button class="btn-primary" onClick={handleSave} disabled={!canSave}>
+                {saveMutation.isPending ? 'Saving...' : 'Add Widget'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function Chart() {
   const isLoggedIn = auth.value.token
   const { query } = useLocation()
   const [state, setState] = useState(() => parseQuery(query))
+  const [showAddToDashboard, setShowAddToDashboard] = useState(false)
 
   const handleUpdate = useCallback(
     (patch: Partial<ChartState>) => {
@@ -494,6 +682,28 @@ export function Chart() {
             ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
           }}
         />
+      )}
+
+      {(state.pattern || state.tag_definition_id) && (
+        <div class="add-to-dashboard-row">
+          <button class="btn-add-to-dashboard" onClick={() => setShowAddToDashboard(true)}>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            Add to Dashboard
+          </button>
+        </div>
+      )}
+
+      {showAddToDashboard && (
+        <AddToDashboardModal state={state} onClose={() => setShowAddToDashboard(false)} />
       )}
     </div>
   )

--- a/apps/web/src/pages/Chart/style.css
+++ b/apps/web/src/pages/Chart/style.css
@@ -172,6 +172,40 @@
   background: #7c3aed;
 }
 
+/* Add to Dashboard button */
+.add-to-dashboard-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.btn-add-to-dashboard {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  background: #673ab8;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-add-to-dashboard:hover {
+  background: #5b32a3;
+}
+
+.add-to-dash-success {
+  text-align: center;
+  padding: 1.5rem;
+  color: #059669;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
   .chart-page h1 {
@@ -230,6 +264,10 @@
 
   .chart-login-prompt h2 {
     color: #e5e7eb;
+  }
+
+  .add-to-dash-success {
+    color: #34d399;
   }
 }
 

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -94,9 +94,37 @@ export const trendChartConfigSchema = z
     lookback_days: z.number().int().positive().optional().meta({ description: 'Days of data to analyze' }),
     pattern: z.string().min(1).meta({ description: 'Tag pattern (regex) or metric name' }),
     source_type: z.enum(['tag', 'metric']).meta({ description: 'Data source type' }),
+    tag_definition_id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'Tag definition ID (alternative to pattern)' }),
     title: z.string().optional().meta({ description: 'Chart title' }),
   })
   .meta({ id: 'TrendChartConfig' })
+
+/**
+ * Bar chart widget - displays bucketed bar chart visualization.
+ */
+export const barChartConfigSchema = z
+  .object({
+    aggregation: z.enum(['count', 'sum', 'mean']).optional().meta({ description: 'Aggregation method' }),
+    bucket_size: z.enum(['1d', '1w', '1M']).meta({ description: 'Time bucket size' }),
+    lookback_days: z.number().int().positive().meta({ description: 'Days of data to display' }),
+    pattern: z.string().min(1).optional().meta({ description: 'Tag pattern (regex) or metric name' }),
+    source_type: z
+      .enum(['tag', 'metric', 'productivity_category', 'activity_type'])
+      .meta({ description: 'Data source type' }),
+    tag_definition_id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'Tag definition ID (alternative to pattern)' }),
+    title: z.string().optional().meta({ description: 'Chart title' }),
+  })
+  .meta({ id: 'BarChartConfig' })
+
+export type BarChartConfig = z.infer<typeof barChartConfigSchema>
 
 export type TrendChartConfig = z.infer<typeof trendChartConfigSchema>
 
@@ -171,6 +199,7 @@ export const widgetTypeSchema = z.enum([
   'metric_card',
   'sparkline_card',
   'trend_chart',
+  'bar_chart',
   'correlation',
   'activity_summary',
   'quick_link',
@@ -196,6 +225,11 @@ export const dashboardWidgetSchema = z.discriminatedUnion('type', [
     config: trendChartConfigSchema,
     id: z.string().min(1).meta({ description: 'Unique widget ID' }),
     type: z.literal('trend_chart'),
+  }),
+  z.object({
+    config: barChartConfigSchema,
+    id: z.string().min(1).meta({ description: 'Unique widget ID' }),
+    type: z.literal('bar_chart'),
   }),
   z.object({
     config: correlationConfigSchema,


### PR DESCRIPTION
## Summary
- Adds `bar_chart` widget type to the dashboard schema (`barChartConfigSchema`) with `source_type`, `pattern`, `tag_definition_id`, `bucket_size`, `lookback_days`, `title`, and `aggregation`
- Adds optional `tag_definition_id` to the existing `trendChartConfigSchema`
- Creates `BarChartWidget` component for rendering bar charts on the dashboard
- Adds "Add to Dashboard" button on the Chart Explorer page that opens a modal to select a dashboard section (or create a new one) and saves the current chart config as a widget
- Updates `WidgetRenderer` and `DashboardEditor` to support the new `bar_chart` widget type

## Test plan
- [ ] Open Chart Explorer, configure a trend chart, click "Add to Dashboard", select a section, confirm — verify widget appears on dashboard
- [ ] Same flow with a bar chart
- [ ] Create a new section from the modal
- [ ] Verify bar_chart widget renders correctly on the dashboard
- [ ] Verify the button only appears when a source is selected (pattern or tag_definition_id)
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)