### PR TITLE
feat: sync status and Sync Now button on data source pages

### DIFF
--- a/apps/web/src/pages/DataSources/GarminSource.tsx
+++ b/apps/web/src/pages/DataSources/GarminSource.tsx
@@ -4,12 +4,13 @@ import { useCallback, useState } from 'preact/hooks'
 import {
   connectGarmin,
   disconnectGarmin,
+  fetchGarminSyncStatus,
   fetchUserSettings,
   syncGarmin,
   verifyGarminMfa,
 } from '../../state/api'
 import { auth } from '../../state/auth'
-import { DataTypesList, LoginRequired, StatusBanner } from './shared'
+import { DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
 
 const DATA_TYPES = [
@@ -170,6 +171,12 @@ export function GarminSource() {
 
   const isConnected = userSettings?.garmin_connected ?? false
 
+  const { data: syncStatusData, isLoading: syncStatusLoading } = useQuery({
+    enabled: !!isLoggedIn && isConnected,
+    queryFn: fetchGarminSyncStatus,
+    queryKey: ['garminSyncStatus'],
+  })
+
   const [loginStatus, setLoginStatus] = useState<LoginStatus>('idle')
 
   // Disconnect state
@@ -194,6 +201,11 @@ export function GarminSource() {
     } finally {
       setDisconnecting(false)
     }
+  }, [queryClient])
+
+  const handleSyncNow = useCallback(async () => {
+    await syncGarmin(false)
+    await queryClient.invalidateQueries({ queryKey: ['garminSyncStatus'] })
   }, [queryClient])
 
   const handleFullResync = useCallback(async () => {
@@ -239,6 +251,14 @@ export function GarminSource() {
               connected={isConnected}
               label={isConnected ? 'Garmin Connect is connected' : 'Garmin Connect not connected'}
             />
+
+            {isConnected && (
+              <SyncStatusBar
+                states={syncStatusData?.states}
+                isLoading={syncStatusLoading}
+                onSyncNow={handleSyncNow}
+              />
+            )}
 
             <div class="links-row">
               <a

--- a/apps/web/src/pages/DataSources/OuraSource.tsx
+++ b/apps/web/src/pages/DataSources/OuraSource.tsx
@@ -1,10 +1,13 @@
+import type { ProviderSyncStatus, UserSettingsResponse } from '@aurboda/api-spec'
+
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
 
 import { TagMappingsSettings } from '../../components/TagMappingsSettings'
 import { API_URL } from '../../config'
-import { fetchUserSettings, syncOura } from '../../state/api'
+import { fetchOuraSyncStatus, fetchUserSettings, syncOura } from '../../state/api'
 import { auth } from '../../state/auth'
+import { DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
 
 const DATA_TYPES = [
@@ -18,15 +21,17 @@ const DATA_TYPES = [
   'Oura tags (mood, symptoms, etc.)',
 ]
 
-export function OuraSource() {
-  const isLoggedIn = auth.value.token
+function OuraConnection({
+  userSettings,
+  syncStates,
+  syncStatusLoading,
+}: {
+  userSettings: UserSettingsResponse
+  syncStates: ProviderSyncStatus[] | undefined
+  syncStatusLoading: boolean
+}) {
   const queryClient = useQueryClient()
-
-  const { data: userSettings, isLoading } = useQuery({
-    enabled: !!isLoggedIn,
-    queryFn: fetchUserSettings,
-    queryKey: ['userSettings'],
-  })
+  const isOuraConnected = userSettings.oura_connected ?? false
 
   const [ouraSyncStatus, setOuraSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
   const [ouraSyncMessage, setOuraSyncMessage] = useState<string>('')
@@ -34,6 +39,11 @@ export function OuraSource() {
   const handleConnectOura = () => {
     window.location.href = `${API_URL}/auth/connectOura`
   }
+
+  const handleSyncNow = useCallback(async () => {
+    await syncOura(false)
+    await queryClient.invalidateQueries({ queryKey: ['ouraSyncStatus'] })
+  }, [queryClient])
 
   const handleOuraFullResync = useCallback(async () => {
     setOuraSyncStatus('syncing')
@@ -50,15 +60,77 @@ export function OuraSource() {
     }
   }, [queryClient])
 
-  if (!isLoggedIn) {
-    return (
-      <div class="data-sources-page">
-        <p>Please log in to view data source settings.</p>
-      </div>
-    )
-  }
+  return (
+    <>
+      <StatusBanner
+        connected={isOuraConnected}
+        label={isOuraConnected ? 'Oura Ring is connected' : 'Oura Ring not connected'}
+      />
+
+      {isOuraConnected && (
+        <SyncStatusBar states={syncStates} isLoading={syncStatusLoading} onSyncNow={handleSyncNow} />
+      )}
+
+      <section class="settings-section">
+        <h2>Connection</h2>
+
+        {isOuraConnected ? (
+          <div class="oura-connected-row">
+            <p class="connected-status">Connected</p>
+            <button
+              type="button"
+              class="connect-button oura-resync-button"
+              disabled={ouraSyncStatus === 'syncing'}
+              onClick={handleOuraFullResync}
+            >
+              {ouraSyncStatus === 'syncing' ? 'Syncing...' : 'Full Re-sync'}
+            </button>
+            {ouraSyncMessage && <span class={`oura-sync-message ${ouraSyncStatus}`}>{ouraSyncMessage}</span>}
+          </div>
+        ) : userSettings.oura_configured === false ? (
+          <>
+            <button type="button" class="connect-button" disabled>
+              Connect Oura
+            </button>
+            <p class="field-description warning">
+              Oura OAuth is not configured on the server. Ask your administrator to set up OURA_CLIENT and
+              OURA_SECRET environment variables.
+            </p>
+          </>
+        ) : (
+          <>
+            <button type="button" class="connect-button" onClick={handleConnectOura}>
+              Connect Oura
+            </button>
+            <p class="field-description">
+              Click to authorize Aurboda to access your Oura data. You will be redirected to Oura to grant
+              permission.
+            </p>
+          </>
+        )}
+      </section>
+    </>
+  )
+}
+
+export function OuraSource() {
+  const isLoggedIn = auth.value.token
+
+  const { data: userSettings, isLoading } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+  })
 
   const isOuraConnected = userSettings?.oura_connected ?? false
+
+  const { data: syncStatusData, isLoading: syncStatusLoading } = useQuery({
+    enabled: !!isLoggedIn && isOuraConnected,
+    queryFn: fetchOuraSyncStatus,
+    queryKey: ['ouraSyncStatus'],
+  })
+
+  if (!isLoggedIn) return <LoginRequired />
 
   return (
     <div class="data-sources-page">
@@ -76,16 +148,7 @@ export function OuraSource() {
           via the Oura Cloud API and receives real-time updates via webhooks.
         </p>
 
-        <div class="data-types-section">
-          <h2>Data provided</h2>
-          <div class="data-types-list">
-            {DATA_TYPES.map((dt) => (
-              <span key={dt} class="data-type-badge">
-                {dt}
-              </span>
-            ))}
-          </div>
-        </div>
+        <DataTypesList types={DATA_TYPES} />
 
         <div class="links-row">
           <a
@@ -100,55 +163,13 @@ export function OuraSource() {
 
         {isLoading ? (
           <div class="loading">Loading...</div>
-        ) : (
-          <>
-            <div class={`status-banner ${isOuraConnected ? 'connected' : 'not-connected'}`}>
-              <span class={`status-dot ${isOuraConnected ? 'connected' : 'not-connected'}`} />
-              {isOuraConnected ? 'Oura Ring is connected' : 'Oura Ring not connected'}
-            </div>
-
-            <section class="settings-section">
-              <h2>Connection</h2>
-
-              {isOuraConnected ? (
-                <div class="oura-connected-row">
-                  <p class="connected-status">Connected</p>
-                  <button
-                    type="button"
-                    class="connect-button oura-resync-button"
-                    disabled={ouraSyncStatus === 'syncing'}
-                    onClick={handleOuraFullResync}
-                  >
-                    {ouraSyncStatus === 'syncing' ? 'Syncing...' : 'Full Re-sync'}
-                  </button>
-                  {ouraSyncMessage && (
-                    <span class={`oura-sync-message ${ouraSyncStatus}`}>{ouraSyncMessage}</span>
-                  )}
-                </div>
-              ) : userSettings?.oura_configured === false ? (
-                <>
-                  <button type="button" class="connect-button" disabled>
-                    Connect Oura
-                  </button>
-                  <p class="field-description warning">
-                    Oura OAuth is not configured on the server. Ask your administrator to set up OURA_CLIENT
-                    and OURA_SECRET environment variables.
-                  </p>
-                </>
-              ) : (
-                <>
-                  <button type="button" class="connect-button" onClick={handleConnectOura}>
-                    Connect Oura
-                  </button>
-                  <p class="field-description">
-                    Click to authorize Aurboda to access your Oura data. You will be redirected to Oura to
-                    grant permission.
-                  </p>
-                </>
-              )}
-            </section>
-          </>
-        )}
+        ) : userSettings ? (
+          <OuraConnection
+            userSettings={userSettings}
+            syncStates={syncStatusData?.states}
+            syncStatusLoading={syncStatusLoading}
+          />
+        ) : null}
       </div>
 
       <TagMappingsSettings />

--- a/apps/web/src/pages/DataSources/shared.tsx
+++ b/apps/web/src/pages/DataSources/shared.tsx
@@ -1,6 +1,10 @@
 /**
  * Shared components for data source pages — save status indicators, status banners, etc.
  */
+import type { ProviderSyncStatus } from '@aurboda/api-spec'
+
+import { useCallback, useState } from 'preact/hooks'
+
 export { type SaveStatus, SaveStatusIndicator } from '../../components/SaveStatusIndicator'
 
 export function StatusBanner({ connected, label }: { connected: boolean; label: string }) {
@@ -31,6 +35,74 @@ export function LoginRequired() {
   return (
     <div class="data-sources-page">
       <p>Please log in to view data source settings.</p>
+    </div>
+  )
+}
+
+const formatSyncTime = (iso: string): string => {
+  const date = new Date(iso)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60_000)
+
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin} min ago`
+
+  const diffHours = Math.floor(diffMin / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/** Shows the most recent sync time across all data types, with a "Sync Now" button. */
+export function SyncStatusBar({
+  states,
+  isLoading,
+  onSyncNow,
+}: {
+  states: ProviderSyncStatus[] | undefined
+  isLoading: boolean
+  onSyncNow: () => Promise<void>
+}) {
+  const [syncing, setSyncing] = useState(false)
+  const [syncResult, setSyncResult] = useState<{ status: 'done' | 'error'; message: string } | null>(null)
+
+  const handleSync = useCallback(async () => {
+    setSyncing(true)
+    setSyncResult(null)
+    try {
+      await onSyncNow()
+      setSyncResult({ status: 'done', message: 'Sync complete' })
+    } catch (err) {
+      setSyncResult({ status: 'error', message: err instanceof Error ? err.message : 'Sync failed' })
+    } finally {
+      setSyncing(false)
+    }
+  }, [onSyncNow])
+
+  if (isLoading) return null
+
+  const lastSync = states
+    ?.filter((s) => s.last_sync_time)
+    .sort((a, b) => new Date(b.last_sync_time!).getTime() - new Date(a.last_sync_time!).getTime())[0]
+
+  const hasError = states?.some((s) => s.status === 'error')
+
+  return (
+    <div class="sync-status-bar">
+      <span class="sync-status-time">
+        {lastSync?.last_sync_time ? `Last synced ${formatSyncTime(lastSync.last_sync_time)}` : 'Never synced'}
+        {hasError && <span class="sync-status-error"> (some data types have errors)</span>}
+      </span>
+      <button type="button" class="sync-now-button" disabled={syncing} onClick={handleSync}>
+        {syncing ? 'Syncing...' : 'Sync Now'}
+      </button>
+      {syncResult && <span class={`sync-result ${syncResult.status}`}>{syncResult.message}</span>}
     </div>
   )
 }

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -432,6 +432,52 @@
   color: #f44336;
 }
 
+/* Sync status bar */
+.data-sources-page .sync-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.data-sources-page .sync-status-time {
+  color: #6b7280;
+}
+
+.data-sources-page .sync-status-error {
+  color: #f44336;
+}
+
+.data-sources-page .sync-now-button {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.data-sources-page .sync-now-button:hover:not(:disabled) {
+  background: #5e35b1;
+}
+
+.data-sources-page .sync-now-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.data-sources-page .sync-result.done {
+  color: #4caf50;
+}
+
+.data-sources-page .sync-result.error {
+  color: #f44336;
+}
+
 /* Garmin specific */
 .data-sources-page .garmin-connected-actions .connected-status {
   margin-bottom: 0.75rem;
@@ -721,6 +767,18 @@
     background: #2a2a2a;
     border-color: #555;
     color: #ddd;
+  }
+
+  .data-sources-page .sync-status-time {
+    color: #9ca3af;
+  }
+
+  .data-sources-page .sync-now-button {
+    background: #7c3aed;
+  }
+
+  .data-sources-page .sync-now-button:hover:not(:disabled) {
+    background: #6d28d9;
   }
 }
 

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -38,6 +38,7 @@ import type {
   DashboardResponse,
   ExerciseTypeName,
   GarminSyncResponse,
+  GarminSyncStatusResponse,
   Goal,
   GoalProgress,
   GoalsProgressResponse,
@@ -56,6 +57,7 @@ import type {
   NamedLocation,
   NamedLocationsResponse,
   OuraSyncResponse,
+  OuraSyncStatusResponse,
   PeriodMetricStats,
   PeriodSummaryQuery,
   PeriodSummaryResponse,
@@ -603,6 +605,14 @@ export const syncOura = async (fullResync?: boolean): Promise<OuraSyncResponse> 
   return response.data
 }
 
+export const fetchOuraSyncStatus = async (): Promise<OuraSyncStatusResponse> => {
+  const { token } = auth.value
+  const response = await axios.get<OuraSyncStatusResponse>(`${API_URL}/sync/oura/status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return response.data
+}
+
 // Garmin Connect auth + sync
 export const connectGarmin = async (
   email: string,
@@ -644,6 +654,14 @@ export const syncGarmin = async (fullResync?: boolean): Promise<GarminSyncRespon
     { full_resync: fullResync },
     { headers: { Authorization: `Bearer ${token}` } },
   )
+  return response.data
+}
+
+export const fetchGarminSyncStatus = async (): Promise<GarminSyncStatusResponse> => {
+  const { token } = auth.value
+  const response = await axios.get<GarminSyncStatusResponse>(`${API_URL}/sync/garmin/status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
   return response.data
 }
 


### PR DESCRIPTION
## Summary
- Add "Last synced X ago" display and "Sync Now" button to both Garmin Connect and Oura Ring data source pages
- Sync Now triggers an incremental sync (not full resync), fetching only recent data
- Extract `SyncStatusBar` as a shared component for reuse across data sources
- Refactor `OuraSource` to reduce cyclomatic complexity (extracted `OuraConnection` component)

## Test plan
- [ ] Navigate to /data-sources/garmin — verify last sync time and Sync Now button appear when connected
- [ ] Navigate to /data-sources/oura — verify same
- [ ] Click Sync Now — verify it triggers sync and shows "Sync complete" on success
- [ ] Verify dark mode styling looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)