### PR TITLE
feat: link dashboard chart widgets to chart page and fix width

### DIFF
--- a/apps/web/src/components/charts/TrendLineChart.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.tsx
@@ -284,11 +284,7 @@ export function TrendLineChart({ data, color, height = 200, width, compact = fal
   }
 
   return (
-    <div
-      ref={containerRef}
-      class="trend-line-chart-container"
-      style={width ? { width: `${width}px` } : undefined}
-    >
+    <div ref={containerRef} class="trend-line-chart-container">
       <svg ref={svgRef} />
       {!compact && <div class="trend-line-chart-tooltip" ref={tooltipRef} />}
     </div>

--- a/apps/web/src/components/widgets/BarChartWidget.tsx
+++ b/apps/web/src/components/widgets/BarChartWidget.tsx
@@ -7,6 +7,7 @@ import type { BarChartConfig } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
 import { fetchChartData } from '../../state/api'
+import { buildChartUrl } from '../../utils/chart-url'
 import { BarChart } from '../charts/BarChart'
 
 interface BarChartWidgetProps {
@@ -59,10 +60,19 @@ export function BarChartWidget({ config }: BarChartWidgetProps) {
   })
 
   const displayTitle = title ?? `${pattern ?? 'chart'} (${bucket_size})`
+  const chartUrl = buildChartUrl({
+    aggregation,
+    bucket_size,
+    chart_type: 'bar',
+    lookback_days,
+    pattern: pattern ?? undefined,
+    source_type,
+    tag_definition_id,
+  })
 
   if (chartQuery.isLoading) {
     return (
-      <div class="bar-chart-widget">
+      <div class="chart-widget">
         <h4>{displayTitle}</h4>
         <div class="chart-loading">Loading chart data...</div>
       </div>
@@ -71,7 +81,7 @@ export function BarChartWidget({ config }: BarChartWidgetProps) {
 
   if (chartQuery.isError || !chartQuery.data) {
     return (
-      <div class="bar-chart-widget">
+      <div class="chart-widget">
         <h4>{displayTitle}</h4>
         <div class="chart-error">Unable to load chart data</div>
       </div>
@@ -79,9 +89,9 @@ export function BarChartWidget({ config }: BarChartWidgetProps) {
   }
 
   return (
-    <div class="bar-chart-widget">
+    <a href={chartUrl} class="chart-widget chart-widget-link">
       <h4>{displayTitle}</h4>
       <BarChart data={chartQuery.data} color="#8b5cf6" height={200} />
-    </div>
+    </a>
   )
 }

--- a/apps/web/src/components/widgets/TrendChartWidget.tsx
+++ b/apps/web/src/components/widgets/TrendChartWidget.tsx
@@ -7,6 +7,7 @@ import type { TrendChartConfig } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
 import { fetchTrend } from '../../state/api'
+import { buildChartUrl } from '../../utils/chart-url'
 import { TrendLineChart } from '../charts/TrendLineChart'
 
 interface TrendChartWidgetProps {
@@ -39,10 +40,20 @@ export function TrendChartWidget({ config }: TrendChartWidgetProps) {
   })
 
   const displayTitle = title ?? `${pattern} trend`
+  const chartUrl = buildChartUrl({
+    aggregation,
+    chart_type: 'trend',
+    display_period,
+    half_life_days,
+    lookback_days,
+    pattern,
+    source_type,
+    tag_definition_id: config.tag_definition_id,
+  })
 
   if (trendQuery.isLoading) {
     return (
-      <div class="trend-chart-widget">
+      <div class="chart-widget">
         <h4>{displayTitle}</h4>
         <div class="chart-loading">Loading trend data...</div>
       </div>
@@ -51,7 +62,7 @@ export function TrendChartWidget({ config }: TrendChartWidgetProps) {
 
   if (trendQuery.isError || !trendQuery.data) {
     return (
-      <div class="trend-chart-widget">
+      <div class="chart-widget">
         <h4>{displayTitle}</h4>
         <div class="chart-error">Unable to load trend data</div>
       </div>
@@ -59,12 +70,12 @@ export function TrendChartWidget({ config }: TrendChartWidgetProps) {
   }
 
   return (
-    <div class="trend-chart-widget">
+    <a href={chartUrl} class="chart-widget chart-widget-link">
       <h4>{displayTitle}</h4>
-      <div class="trend-chart-widget-value">
+      <div class="chart-widget-value">
         {trendQuery.data.current_value.toFixed(1)} / {display_period}
       </div>
-      <TrendLineChart data={trendQuery.data.history} color="#673ab8" width={300} height={150} compact />
-    </div>
+      <TrendLineChart data={trendQuery.data.history} color="#673ab8" height={150} compact />
+    </a>
   )
 }

--- a/apps/web/src/pages/Dashboard/style.css
+++ b/apps/web/src/pages/Dashboard/style.css
@@ -615,8 +615,8 @@
   gap: 1rem;
 }
 
-/* Trend chart widget styles */
-.dashboard .trend-chart-widget,
+/* Chart widget styles (trend, bar, correlation) */
+.dashboard .chart-widget,
 .dashboard .correlation-widget {
   background: #f9fafb;
   border-radius: 12px;
@@ -624,11 +624,28 @@
   border: 1px solid #e5e7eb;
 }
 
-.dashboard .trend-chart-widget h4,
+.dashboard .chart-widget-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.2s;
+}
+
+.dashboard .chart-widget-link:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.dashboard .chart-widget h4,
 .dashboard .correlation-widget h4 {
   margin: 0 0 0.75rem 0;
   font-size: 1rem;
   color: #374151;
+}
+
+.dashboard .chart-widget-value {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-bottom: 0.5rem;
 }
 
 .dashboard .chart-loading,
@@ -774,15 +791,19 @@
     color: #9ca3af;
   }
 
-  .dashboard .trend-chart-widget,
+  .dashboard .chart-widget,
   .dashboard .correlation-widget {
     background: #1f2937;
     border-color: #374151;
   }
 
-  .dashboard .trend-chart-widget h4,
+  .dashboard .chart-widget h4,
   .dashboard .correlation-widget h4 {
     color: #d1d5db;
+  }
+
+  .dashboard .chart-widget-value {
+    color: #9ca3af;
   }
 
   .dashboard .add-section-placeholder {

--- a/apps/web/src/utils/chart-url.ts
+++ b/apps/web/src/utils/chart-url.ts
@@ -1,0 +1,32 @@
+/** Build a /chart URL from widget config parameters. */
+export function buildChartUrl(params: {
+  aggregation?: string
+  bucket_size?: string
+  chart_type: 'trend' | 'bar'
+  display_period?: string
+  half_life_days?: number
+  lookback_days?: number
+  pattern?: string
+  source_type: string
+  tag_definition_id?: string
+}): string {
+  const qs = new URLSearchParams()
+  qs.set('source_type', params.source_type)
+  if (params.pattern) qs.set('pattern', params.pattern)
+  if (params.tag_definition_id) qs.set('tag_definition_id', params.tag_definition_id)
+  if (params.lookback_days) qs.set('lookback_days', String(params.lookback_days))
+  qs.set('chart_type', params.chart_type)
+
+  if (params.chart_type === 'trend') {
+    if (params.display_period) qs.set('display_period', params.display_period)
+    if (params.half_life_days) qs.set('half_life_days', String(params.half_life_days))
+  } else {
+    if (params.bucket_size) qs.set('bucket_size', params.bucket_size)
+  }
+
+  if (params.aggregation && params.aggregation !== 'count') {
+    qs.set('aggregation', params.aggregation)
+  }
+
+  return `/chart?${qs}`
+}


### PR DESCRIPTION
## Summary
- Chart widgets (trend + bar) on the dashboard now link to the `/chart` page with matching query params, so clicking opens the full chart explorer
- Unified CSS class names from `trend-chart-widget`/`bar-chart-widget` to shared `chart-widget` class
- Removed hardcoded `width={300}` from TrendLineChart in dashboard widgets so charts fill the available widget width
- Added `chart-url.ts` utility for building chart page URLs from widget config

## Test plan
- [ ] Verify trend chart widgets on dashboard are clickable and navigate to correct chart page
- [ ] Verify bar chart widgets on dashboard are clickable and navigate to correct chart page  
- [ ] Verify chart widgets now use full available width in their container
- [ ] Verify dark mode styling still works for chart widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)