### PR TITLE
fix: Garmin sync credentials, granular stress data, and error reporting

### DIFF
--- a/apps/backend/src/garmin-process.test.ts
+++ b/apps/backend/src/garmin-process.test.ts
@@ -432,7 +432,7 @@ describe('processGarminData', () => {
 
   describe('stress', () => {
     test('inserts raw record with correct fields', async () => {
-      const data = { calendarDate: '2025-01-15', overallStressLevel: 38 }
+      const data = { calendarDate: '2025-01-15', overallStressLevel: 38, stressValuesArray: null }
 
       await processGarminData(user, 'stress', data, mockDeps)
 
@@ -445,8 +445,30 @@ describe('processGarminData', () => {
       })
     })
 
-    test('inserts stress_level time series point', async () => {
-      const data = { calendarDate: '2025-01-15', overallStressLevel: 38 }
+    test('inserts granular stress time series from stressValuesArray', async () => {
+      const data = {
+        calendarDate: '2025-01-15',
+        overallStressLevel: 38,
+        stressValuesArray: [
+          [1736935200000, 25],
+          [1736935500000, 42],
+          [1736935800000, -1],
+          [1736936100000, 0],
+          [1736936400000, 55],
+        ] as [number, number][],
+      }
+
+      await processGarminData(user, 'stress', data, mockDeps)
+
+      expect(mockDeps.insertTimeSeries).toHaveBeenCalledWith(user, [
+        { metric: 'stress_level', source: 'garmin', time: new Date(1736935200000), unit: 'score', value: 25 },
+        { metric: 'stress_level', source: 'garmin', time: new Date(1736935500000), unit: 'score', value: 42 },
+        { metric: 'stress_level', source: 'garmin', time: new Date(1736936400000), unit: 'score', value: 55 },
+      ])
+    })
+
+    test('falls back to overallStressLevel when stressValuesArray is null', async () => {
+      const data = { calendarDate: '2025-01-15', overallStressLevel: 38, stressValuesArray: null }
 
       await processGarminData(user, 'stress', data, mockDeps)
 
@@ -455,8 +477,24 @@ describe('processGarminData', () => {
       ])
     })
 
-    test('skips time series when overallStressLevel is 0', async () => {
-      const data = { calendarDate: '2025-01-15', overallStressLevel: 0 }
+    test('skips time series when no valid data', async () => {
+      const data = { calendarDate: '2025-01-15', overallStressLevel: 0, stressValuesArray: null }
+
+      await processGarminData(user, 'stress', data, mockDeps)
+
+      expect(mockDeps.insertTimeSeries).not.toHaveBeenCalled()
+    })
+
+    test('filters out negative and zero stress values', async () => {
+      const data = {
+        calendarDate: '2025-01-15',
+        overallStressLevel: 0,
+        stressValuesArray: [
+          [1736935200000, -1],
+          [1736935500000, -2],
+          [1736935800000, 0],
+        ] as [number, number][],
+      }
 
       await processGarminData(user, 'stress', data, mockDeps)
 
@@ -473,7 +511,7 @@ describe('processGarminData', () => {
         await processGarminData(
           user,
           'stress',
-          { calendarDate: '2025-01-15', overallStressLevel: 38 },
+          { calendarDate: '2025-01-15', overallStressLevel: 38, stressValuesArray: null },
           mockDeps,
         ),
       ).toBe(1)

--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -304,8 +304,19 @@ const processStress = async (
   const time = dateAt(data.calendarDate)
   await deps.insertRawRecord(user, makeRaw('garmin_stress', `garmin-stress-${data.calendarDate}`, time, data))
 
-  const points: TimeSeriesPoint[] = []
-  if (data.overallStressLevel > 0) {
+  // Prefer granular time-series data from stressValuesArray
+  const points: TimeSeriesPoint[] = (data.stressValuesArray ?? [])
+    .filter(([ts, value]) => ts && value > 0)
+    .map(([ts, value]) => ({
+      metric: 'stress_level' as const,
+      source: 'garmin' as const,
+      time: new Date(ts),
+      unit: 'score',
+      value,
+    }))
+
+  // Fall back to daily average if no granular data
+  if (points.length === 0 && data.overallStressLevel > 0) {
     points.push({
       metric: 'stress_level',
       source: 'garmin',

--- a/apps/backend/src/garmin-sync.ts
+++ b/apps/backend/src/garmin-sync.ts
@@ -35,6 +35,7 @@ export interface SyncResult {
   records_processed: number
   status: 'success' | 'skipped' | 'error' | 'rate_limited'
   error?: string
+  errors_by_day?: number
   retry_after?: Date
 }
 
@@ -65,6 +66,31 @@ export const isRateLimited = (syncState: SyncState | null): boolean => {
 // Single data type sync
 // ============================================================================
 
+/** Iterate day-by-day over a date range, fetching and processing each day. */
+const syncDateRange = async (
+  user: string,
+  garmin: GarminClient,
+  dataType: GarminDataType,
+  startDate: Date,
+  endDate: Date,
+): Promise<{ totalRecords: number; dayErrors: number }> => {
+  let totalRecords = 0
+  let dayErrors = 0
+
+  const currentDate = new Date(startDate)
+  while (currentDate <= endDate) {
+    const result = await fetchAndProcess(user, garmin, dataType, currentDate)
+    totalRecords += result.records
+    if (result.error) dayErrors++
+
+    currentDate.setTime(addDays(currentDate, 1).getTime())
+
+    if (currentDate <= endDate) await delay(REQUEST_DELAY_MS)
+  }
+
+  return { totalRecords, dayErrors }
+}
+
 export const syncGarminDataType = async (
   user: string,
   garmin: GarminClient,
@@ -90,46 +116,31 @@ export const syncGarminDataType = async (
   })
 
   try {
-    // Determine date range
     const now = new Date()
-    let startDate: Date
+    const startDate =
+      options?.fullResync || !syncState?.last_sync_time
+        ? (options?.startDate ?? subDays(now, DEFAULT_SYNC_HISTORY_DAYS))
+        : subDays(syncState.last_sync_time, INCREMENTAL_SYNC_OVERLAP_DAYS)
 
-    if (options?.fullResync || !syncState?.last_sync_time) {
-      // First sync or full resync
-      startDate = options?.startDate ?? subDays(now, DEFAULT_SYNC_HISTORY_DAYS)
-    } else {
-      // Incremental sync with overlap
-      startDate = subDays(syncState.last_sync_time, INCREMENTAL_SYNC_OVERLAP_DAYS)
-    }
+    const { totalRecords, dayErrors } = await syncDateRange(user, garmin, dataType, startDate, now)
 
-    let totalRecords = 0
-
-    // Iterate day by day (most Garmin endpoints are per-day)
-    const currentDate = new Date(startDate)
-    while (currentDate <= now) {
-      const records = await fetchAndProcess(user, garmin, dataType, currentDate)
-      totalRecords += records
-
-      // Move to next day
-      currentDate.setTime(addDays(currentDate, 1).getTime())
-
-      // Rate limit ourselves
-      if (currentDate <= now) {
-        await delay(REQUEST_DELAY_MS)
-      }
-    }
-
-    // Mark as idle on success
+    // Mark as idle on success (with warning if some days had errors)
+    const errorMessage = dayErrors > 0 ? `${dayErrors} day(s) had fetch errors` : undefined
     await upsertSyncState(user, {
       data_type: dataType,
-      error_message: undefined,
+      error_message: errorMessage,
       last_sync_time: now,
       provider: 'garmin',
       retry_after: undefined,
       status: 'idle',
     })
 
-    return { data_type: dataType, records_processed: totalRecords, status: 'success' }
+    return {
+      data_type: dataType,
+      errors_by_day: dayErrors > 0 ? dayErrors : undefined,
+      records_processed: totalRecords,
+      status: 'success',
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
 
@@ -197,15 +208,16 @@ const fetchAndProcess = async (
   garmin: GarminClient,
   dataType: GarminDataType,
   date: Date,
-): Promise<number> => {
+): Promise<{ records: number; error?: string }> => {
   try {
     const data = await fetchDataType(garmin, user, dataType, date)
-    if (data == null) return 0
-    return await processGarminData(user, dataType, data)
+    if (data == null) return { records: 0 }
+    return { records: await processGarminData(user, dataType, data) }
   } catch (error) {
     // If a single day fails, log and continue (don't abort the whole sync)
-    console.error(`Garmin sync error for ${dataType} on ${date.toISOString().slice(0, 10)}:`, error)
-    return 0
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Garmin sync error for ${dataType} on ${date.toISOString().slice(0, 10)}:`, message)
+    return { error: message, records: 0 }
   }
 }
 

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -183,7 +183,7 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
     if (!stored) throw new Error('User has no Garmin session. Please connect Garmin first.')
 
     const tokens: IGarminTokens = JSON.parse(stored.access_token)
-    const gc = new GarminConnect()
+    const gc = new GarminConnect({ username: '', password: '' })
     gc.loadToken(tokens.oauth1, tokens.oauth2)
     return gc
   }

--- a/apps/web/src/pages/DataSources/GarminSource.tsx
+++ b/apps/web/src/pages/DataSources/GarminSource.tsx
@@ -10,21 +10,21 @@ import {
   verifyGarminMfa,
 } from '../../state/api'
 import { auth } from '../../state/auth'
-import { DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
+import { type DataTypeItem, DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
 
-const DATA_TYPES = [
-  'Daily summary (steps, distance, calories, floors)',
-  'Heart rate (resting + samples)',
-  'HRV (last night average)',
-  'Sleep (duration, stages, score)',
-  'Stress level',
-  'Body Battery',
-  'Activities (exercise with HR, VO2 max)',
-  'SpO2 (blood oxygen)',
-  'Respiration rate',
-  'Training readiness',
-  'Intensity minutes',
+const DATA_TYPES: DataTypeItem[] = [
+  { label: 'Daily summary (steps, distance, calories, floors)', href: '/metric/steps' },
+  { label: 'Heart rate (resting + samples)', href: '/metric/heart_rate' },
+  { label: 'HRV (last night average)', href: '/metric/hrv_rmssd' },
+  { label: 'Sleep (duration, stages, score)', href: '/sleep' },
+  { label: 'Stress level', href: '/metric/stress_level' },
+  { label: 'Body Battery', href: '/metric/body_battery' },
+  { label: 'Activities (exercise with HR, VO2 max)' },
+  { label: 'SpO2 (blood oxygen)', href: '/metric/spo2' },
+  { label: 'Respiration rate', href: '/metric/respiratory_rate' },
+  { label: 'Training readiness', href: '/metric/training_readiness' },
+  { label: 'Intensity minutes', href: '/metric/intensity_minutes' },
 ]
 
 type LoginStatus = 'idle' | 'loading' | 'mfa' | 'mfa_loading' | 'error'

--- a/apps/web/src/pages/DataSources/OuraSource.tsx
+++ b/apps/web/src/pages/DataSources/OuraSource.tsx
@@ -7,18 +7,18 @@ import { TagMappingsSettings } from '../../components/TagMappingsSettings'
 import { API_URL } from '../../config'
 import { fetchOuraSyncStatus, fetchUserSettings, syncOura } from '../../state/api'
 import { auth } from '../../state/auth'
-import { DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
+import { type DataTypeItem, DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
 
-const DATA_TYPES = [
-  'Sleep (duration, stages, scores)',
-  'Readiness score',
-  'Resilience',
-  'HRV (resting)',
-  'Cardiovascular age',
-  'Resting heart rate',
-  'Meditation / breathing sessions',
-  'Oura tags (mood, symptoms, etc.)',
+const DATA_TYPES: DataTypeItem[] = [
+  { label: 'Sleep (duration, stages, scores)', href: '/sleep' },
+  { label: 'Readiness score', href: '/metric/readiness_score' },
+  { label: 'Resilience', href: '/metric/resilience_score' },
+  { label: 'HRV (resting)', href: '/metric/hrv_rmssd' },
+  { label: 'Cardiovascular age', href: '/metric/cardiovascular_age' },
+  { label: 'Resting heart rate', href: '/metric/resting_heart_rate' },
+  { label: 'Meditation / breathing sessions' },
+  { label: 'Oura tags (mood, symptoms, etc.)' },
 ]
 
 function OuraConnection({

--- a/apps/web/src/pages/DataSources/shared.tsx
+++ b/apps/web/src/pages/DataSources/shared.tsx
@@ -16,16 +16,28 @@ export function StatusBanner({ connected, label }: { connected: boolean; label: 
   )
 }
 
-export function DataTypesList({ types }: { types: string[] }) {
+export interface DataTypeItem {
+  label: string
+  href?: string
+}
+
+export function DataTypesList({ types }: { types: (string | DataTypeItem)[] }) {
   return (
     <div class="data-types-section">
       <h2>Data provided</h2>
       <div class="data-types-list">
-        {types.map((dt) => (
-          <span key={dt} class="data-type-badge">
-            {dt}
-          </span>
-        ))}
+        {types.map((dt) => {
+          const item = typeof dt === 'string' ? { label: dt } : dt
+          return item.href ? (
+            <a key={item.label} class="data-type-badge data-type-link" href={item.href}>
+              {item.label}
+            </a>
+          ) : (
+            <span key={item.label} class="data-type-badge">
+              {item.label}
+            </span>
+          )
+        })}
       </div>
     </div>
   )
@@ -100,6 +112,7 @@ export function SyncStatusBar({
         {hasError && <span class="sync-status-error"> (some data types have errors)</span>}
       </span>
       <button type="button" class="sync-now-button" disabled={syncing} onClick={handleSync}>
+        {syncing && <span class="sync-spinner" />}
         {syncing ? 'Syncing...' : 'Sync Now'}
       </button>
       {syncResult && <span class={`sync-result ${syncResult.status}`}>{syncResult.message}</span>}

--- a/apps/web/src/pages/DataSources/shared.tsx
+++ b/apps/web/src/pages/DataSources/shared.tsx
@@ -104,12 +104,16 @@ export function SyncStatusBar({
     .sort((a, b) => new Date(b.last_sync_time!).getTime() - new Date(a.last_sync_time!).getTime())[0]
 
   const hasError = states?.some((s) => s.status === 'error')
+  const warnings = states?.filter((s) => s.error_message && s.status !== 'error') ?? []
 
   return (
     <div class="sync-status-bar">
       <span class="sync-status-time">
         {lastSync?.last_sync_time ? `Last synced ${formatSyncTime(lastSync.last_sync_time)}` : 'Never synced'}
         {hasError && <span class="sync-status-error"> (some data types have errors)</span>}
+        {!hasError && warnings.length > 0 && (
+          <span class="sync-status-warning"> ({warnings.length} data type(s) had partial failures)</span>
+        )}
       </span>
       <button type="button" class="sync-now-button" disabled={syncing} onClick={handleSync}>
         {syncing && <span class="sync-spinner" />}

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -167,6 +167,20 @@
   color: #374151;
 }
 
+.data-source-detail a.data-type-link {
+  text-decoration: none;
+  color: #673ab8;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+
+.data-source-detail a.data-type-link:hover {
+  background: #f3f0ff;
+  border-color: #673ab8;
+}
+
 .data-source-detail .doc-link {
   display: inline-flex;
   align-items: center;
@@ -470,6 +484,24 @@
   cursor: not-allowed;
 }
 
+.data-sources-page .sync-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: sync-spin 0.6s linear infinite;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+}
+
+@keyframes sync-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .data-sources-page .sync-result.done {
   color: #4caf50;
 }
@@ -678,6 +710,15 @@
     background: #374151;
     border-color: #4b5563;
     color: #d1d5db;
+  }
+
+  .data-source-detail a.data-type-link {
+    color: #a78bfa;
+  }
+
+  .data-source-detail a.data-type-link:hover {
+    background: #2d2053;
+    border-color: #8b5cf6;
   }
 
   .data-source-detail .doc-link {

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -465,6 +465,10 @@
   color: #f44336;
 }
 
+.data-sources-page .sync-status-warning {
+  color: #f57c00;
+}
+
 .data-sources-page .sync-now-button {
   padding: 0.3rem 0.75rem;
   font-size: 0.8rem;

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -345,6 +345,11 @@ export const garminSyncResultSchema = z
   .object({
     data_type: garminDataTypeSchema,
     error: z.string().optional().meta({ description: 'Error message if status is error' }),
+    errors_by_day: z
+      .number()
+      .int()
+      .optional()
+      .meta({ description: 'Number of days that had fetch errors (data still synced for other days)' }),
     records_processed: z.number().int().meta({ description: 'Number of records processed' }),
     retry_after: iso8601DateTimeSchema.optional().meta({ description: 'Time when retry is allowed' }),
     status: syncResultStatusSchema,


### PR DESCRIPTION
## Summary
- Fix "Missing credentials" error in Garmin session restore by passing dummy credentials to GarminConnect constructor (tokens loaded via loadToken)
- Store granular stress time-series from `stressValuesArray` instead of just the daily `overallStressLevel` average
- Track and surface per-day fetch errors in sync state and UI (orange warning for partial failures)
- Add clickable data type badges linking to metric pages on Garmin/Oura source pages
- Add spinner animation to Sync Now button

## Test plan
- [ ] Trigger Garmin sync — verify no "Missing credentials" error in logs
- [ ] Check stress_level metric after sync — should have granular time-series data
- [ ] Verify partial day failures show as warnings in the data source UI
- [ ] Verify clickable badges link to correct metric pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)