### PR TITLE
fix: use full URLs for Garmin Connect API calls

### DIFF
--- a/apps/backend/src/garmin.test.ts
+++ b/apps/backend/src/garmin.test.ts
@@ -163,7 +163,7 @@ describe('garminClient', () => {
       expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
       expect(mockGarminConnect.getUserProfile).toHaveBeenCalled()
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/usersummary-service/usersummary/daily/user123?calendarDate=2024-06-15',
+        'https://connectapi.garmin.com/usersummary-service/usersummary/daily/user123?calendarDate=2024-06-15',
       )
       expect(result).toEqual(summaryData)
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
@@ -203,7 +203,9 @@ describe('garminClient', () => {
 
       expect(deps.getOAuthToken).toHaveBeenCalledWith(testUser, 'garmin')
       expect(mockGarminConnect.loadToken).toHaveBeenCalledWith('stored-token1', 'stored-token2')
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/dailyStress/2024-06-15')
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        'https://connectapi.garmin.com/wellness-service/wellness/dailyStress/2024-06-15',
+      )
       expect(result).toEqual(stressData)
       expect(deps.upsertOAuthToken).toHaveBeenCalledWith(testUser, {
         access_token: JSON.stringify({ oauth1: 'token1', oauth2: 'token2' }),
@@ -224,7 +226,9 @@ describe('garminClient', () => {
       const client = garminClient(deps)
       const result = await client.getHrv(testUser, new Date('2024-06-15'))
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/hrv-service/hrv/2024-06-15')
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        'https://connectapi.garmin.com/hrv-service/hrv/2024-06-15',
+      )
       expect(result).toEqual(hrvData)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
     })
@@ -254,7 +258,7 @@ describe('garminClient', () => {
       const result = await client.getBodyBattery(testUser, new Date('2024-06-14'), new Date('2024-06-15'))
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/wellness-service/wellness/bodyBattery/reports/daily?startDate=2024-06-14&endDate=2024-06-15',
+        'https://connectapi.garmin.com/wellness-service/wellness/bodyBattery/reports/daily?startDate=2024-06-14&endDate=2024-06-15',
       )
       expect(result).toEqual(bbData)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
@@ -283,7 +287,9 @@ describe('garminClient', () => {
       const client = garminClient(deps)
       const result = await client.getSpo2(testUser, new Date('2024-06-15'))
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/daily/spo2/2024-06-15')
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        'https://connectapi.garmin.com/wellness-service/wellness/daily/spo2/2024-06-15',
+      )
       expect(result).toEqual(spo2Data)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
     })
@@ -301,7 +307,7 @@ describe('garminClient', () => {
       const result = await client.getRespiration(testUser, new Date('2024-06-15'))
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/wellness-service/wellness/daily/respiration/2024-06-15',
+        'https://connectapi.garmin.com/wellness-service/wellness/daily/respiration/2024-06-15',
       )
       expect(result).toEqual(respData)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
@@ -321,7 +327,7 @@ describe('garminClient', () => {
       const result = await client.getTrainingReadiness(testUser, new Date('2024-06-15'))
 
       expect(mockGarminConnect.get).toHaveBeenCalledWith(
-        '/metrics-service/metrics/trainingreadiness/2024-06-15',
+        'https://connectapi.garmin.com/metrics-service/metrics/trainingreadiness/2024-06-15',
       )
       expect(result).toEqual(trData)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
@@ -340,7 +346,9 @@ describe('garminClient', () => {
       const client = garminClient(deps)
       const result = await client.getIntensityMinutes(testUser, new Date('2024-06-15'))
 
-      expect(mockGarminConnect.get).toHaveBeenCalledWith('/wellness-service/wellness/daily/im/2024-06-15')
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        'https://connectapi.garmin.com/wellness-service/wellness/daily/im/2024-06-15',
+      )
       expect(result).toEqual(imData)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
     })

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -173,6 +173,9 @@ const MFA_SESSION_TTL_MS = 5 * 60 * 1000 // 5 minutes
  * Creates a Garmin Connect API client.
  * Does NOT require any server-side credentials (unlike Oura which needs client/secret).
  */
+/** Base URL for Garmin Connect API — gc.get() needs full URLs, not relative paths. */
+const GC_API = 'https://connectapi.garmin.com'
+
 export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
   /**
    * Restore a GarminConnect instance from stored tokens for a user.
@@ -222,7 +225,7 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
     async getBodyBattery(user: string, startDate: Date, endDate: Date): Promise<GarminBodyBatteryData[]> {
       const gc = await restoreSession(user)
       const result = await gc.get<GarminBodyBatteryData[]>(
-        `/wellness-service/wellness/bodyBattery/reports/daily?startDate=${fmt(startDate)}&endDate=${fmt(endDate)}`,
+        `${GC_API}/wellness-service/wellness/bodyBattery/reports/daily?startDate=${fmt(startDate)}&endDate=${fmt(endDate)}`,
       )
       await saveSession(user, gc)
       return result
@@ -235,8 +238,9 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
     async getDailySummary(user: string, date: Date): Promise<GarminDailySummary> {
       const gc = await restoreSession(user)
       const profile = await gc.getUserProfile()
+      if (!profile?.displayName) throw new Error('Could not retrieve Garmin user profile')
       const result = await gc.get<GarminDailySummary>(
-        `/usersummary-service/usersummary/daily/${profile.displayName}?calendarDate=${fmt(date)}`,
+        `${GC_API}/usersummary-service/usersummary/daily/${profile.displayName}?calendarDate=${fmt(date)}`,
       )
       await saveSession(user, gc) // persist any refreshed tokens
       return result
@@ -251,14 +255,16 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
 
     async getHrv(user: string, date: Date): Promise<GarminHrvData> {
       const gc = await restoreSession(user)
-      const result = await gc.get<GarminHrvData>(`/hrv-service/hrv/${fmt(date)}`)
+      const result = await gc.get<GarminHrvData>(`${GC_API}/hrv-service/hrv/${fmt(date)}`)
       await saveSession(user, gc)
       return result
     },
 
     async getIntensityMinutes(user: string, date: Date): Promise<GarminIntensityMinutes> {
       const gc = await restoreSession(user)
-      const result = await gc.get<GarminIntensityMinutes>(`/wellness-service/wellness/daily/im/${fmt(date)}`)
+      const result = await gc.get<GarminIntensityMinutes>(
+        `${GC_API}/wellness-service/wellness/daily/im/${fmt(date)}`,
+      )
       await saveSession(user, gc)
       return result
     },
@@ -266,7 +272,7 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
     async getRespiration(user: string, date: Date): Promise<GarminRespirationData> {
       const gc = await restoreSession(user)
       const result = await gc.get<GarminRespirationData>(
-        `/wellness-service/wellness/daily/respiration/${fmt(date)}`,
+        `${GC_API}/wellness-service/wellness/daily/respiration/${fmt(date)}`,
       )
       await saveSession(user, gc)
       return result
@@ -281,14 +287,18 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
 
     async getSpo2(user: string, date: Date): Promise<GarminSpo2Data> {
       const gc = await restoreSession(user)
-      const result = await gc.get<GarminSpo2Data>(`/wellness-service/wellness/daily/spo2/${fmt(date)}`)
+      const result = await gc.get<GarminSpo2Data>(
+        `${GC_API}/wellness-service/wellness/daily/spo2/${fmt(date)}`,
+      )
       await saveSession(user, gc)
       return result
     },
 
     async getStress(user: string, date: Date): Promise<GarminStressData> {
       const gc = await restoreSession(user)
-      const result = await gc.get<GarminStressData>(`/wellness-service/wellness/dailyStress/${fmt(date)}`)
+      const result = await gc.get<GarminStressData>(
+        `${GC_API}/wellness-service/wellness/dailyStress/${fmt(date)}`,
+      )
       await saveSession(user, gc)
       return result
     },
@@ -296,7 +306,7 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
     async getTrainingReadiness(user: string, date: Date): Promise<GarminTrainingReadiness> {
       const gc = await restoreSession(user)
       const result = await gc.get<GarminTrainingReadiness>(
-        `/metrics-service/metrics/trainingreadiness/${fmt(date)}`,
+        `${GC_API}/metrics-service/metrics/trainingreadiness/${fmt(date)}`,
       )
       await saveSession(user, gc)
       return result


### PR DESCRIPTION
## Summary
- Prepend `https://connectapi.garmin.com` to all custom `gc.get()` calls — the library's axios instance has no baseURL configured, so relative paths caused "Invalid URL" errors
- Guard against undefined `getUserProfile()` response with a clear error message

## Test plan
- [ ] Trigger Garmin sync — verify no more "Invalid URL" or "displayName" errors
- [ ] Verify stress, HRV, body battery, and other data types sync successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)