### PR TITLE
feat: add audit log for user-specific events

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -50,6 +50,7 @@ import { createOwnTracksRouter } from './owntracks.ts'
 import { syncRescueTimeData } from './rescuetime-sync.ts'
 import { createActivitiesRouter } from './routes/activities-router.ts'
 import { createAdminRouter } from './routes/admin-router.ts'
+import { createAuditLogRouter } from './routes/audit-log-router.ts'
 import { createChartDataRouter } from './routes/chart-data-router.ts'
 import { createCorrelationsRouter } from './routes/correlations-router.ts'
 import { createDashboardRouter } from './routes/dashboard-router.ts'
@@ -66,6 +67,7 @@ import { createSettingsRouter } from './routes/settings-router.ts'
 import { createTagsRouter } from './routes/tags-router.ts'
 import { createTrainingLoadRouter } from './routes/training-load-router.ts'
 import { createTrendsRouter } from './routes/trends-router.ts'
+import { pruneAuditLog } from './services/audit-log.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
 import { getCentralDb, initializeCentralDb } from './services/central-db.ts'
 import { createDetectionTrigger, type DetectionTrigger } from './services/detection-trigger.ts'
@@ -302,6 +304,12 @@ const main = async () => {
 
     const token = auth.createToken(user)
     const isAdmin = await centralDb.isAdmin(user)
+
+    // Prune old audit log entries in the background
+    centralDb
+      .getAuditLogRetentionDays()
+      .then((days) => pruneAuditLog(user, days))
+      .catch(() => {})
 
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ is_admin: isAdmin, refresh: token, token }))
@@ -551,6 +559,7 @@ const main = async () => {
   httpd.use(createActivitiesRouter(authMiddleware, syncProvider))
   httpd.use('/locations', createLocationsRouter(authMiddleware))
   httpd.use(createSettingsRouter(authMiddleware))
+  httpd.use(createAuditLogRouter(authMiddleware))
   httpd.use('/dashboard', createDashboardRouter(authMiddleware))
   httpd.use('/correlations', createCorrelationsRouter(authMiddleware, syncProvider))
   httpd.use('/training-load', createTrainingLoadRouter(authMiddleware))

--- a/apps/backend/src/db/audit-log.ts
+++ b/apps/backend/src/db/audit-log.ts
@@ -1,0 +1,98 @@
+/**
+ * Audit log database operations.
+ *
+ * Stores user-specific log entries (sync events, settings changes, errors, etc.)
+ * with automatic cleanup based on configurable retention period.
+ */
+
+import type { AuditLogCategory, AuditLogLevel } from '@aurboda/api-spec'
+
+import { query } from './connection.ts'
+
+export interface AuditLogRow {
+  id: string
+  timestamp: Date
+  level: AuditLogLevel
+  category: AuditLogCategory
+  message: string
+  details: Record<string, unknown> | null
+}
+
+export interface AuditLogQueryParams {
+  level?: AuditLogLevel
+  category?: AuditLogCategory
+  since?: Date
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Insert a new audit log entry.
+ */
+export const insertAuditLog = async (
+  user: string,
+  level: AuditLogLevel,
+  category: AuditLogCategory,
+  message: string,
+  details?: Record<string, unknown>,
+): Promise<void> => {
+  await query(user, `INSERT INTO audit_log (level, category, message, details) VALUES ($1, $2, $3, $4)`, [
+    level,
+    category,
+    message,
+    details ? JSON.stringify(details) : null,
+  ])
+}
+
+/**
+ * Query audit log entries with optional filters.
+ */
+export const queryAuditLog = async (
+  user: string,
+  params: AuditLogQueryParams = {},
+): Promise<{ rows: AuditLogRow[]; total: number }> => {
+  const conditions: string[] = []
+  const values: unknown[] = []
+  let paramIndex = 1
+
+  if (params.level) {
+    conditions.push(`level = $${paramIndex++}`)
+    values.push(params.level)
+  }
+  if (params.category) {
+    conditions.push(`category = $${paramIndex++}`)
+    values.push(params.category)
+  }
+  if (params.since) {
+    conditions.push(`timestamp >= $${paramIndex++}`)
+    values.push(params.since)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  const limit = params.limit ?? 200
+  const offset = params.offset ?? 0
+
+  const countResult = await query(user, `SELECT COUNT(*)::int AS total FROM audit_log ${where}`, values)
+  const total = countResult.rows[0]?.total ?? 0
+
+  const dataResult = await query<AuditLogRow>(
+    user,
+    `SELECT id, timestamp, level, category, message, details
+     FROM audit_log ${where}
+     ORDER BY timestamp DESC
+     LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+    [...values, limit, offset],
+  )
+
+  return { rows: dataResult.rows, total }
+}
+
+/**
+ * Delete audit log entries older than the given number of days.
+ */
+export const cleanupAuditLog = async (user: string, retentionDays: number): Promise<number> => {
+  const result = await query(user, `DELETE FROM audit_log WHERE timestamp < NOW() - INTERVAL '1 day' * $1`, [
+    retentionDays,
+  ])
+  return result.rowCount ?? 0
+}

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -291,6 +291,15 @@ export {
   touchMcpSession,
 } from './mcp-sessions.ts'
 
+// Audit log
+export {
+  cleanupAuditLog,
+  insertAuditLog,
+  queryAuditLog,
+  type AuditLogQueryParams,
+  type AuditLogRow,
+} from './audit-log.ts'
+
 // Row mappers (re-export for consumers that need them directly)
 export {
   mapActivityRow,

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -39,8 +39,10 @@ export const createAdminRouter = (
       const adminCount = await centralDb.getAdminCount()
       const lastFmApiKey = await centralDb.getLastFmApiKey()
       const ouraWebhookEnabled = await centralDb.getOuraWebhookEnabled()
+      const auditLogRetentionDays = await centralDb.getAuditLogRetentionDays()
       res.json({
         admin_count: adminCount,
+        audit_log_retention_days: auditLogRetentionDays,
         lastfm_api_key_set: !!lastFmApiKey,
         oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
         oura_webhook_enabled: ouraWebhookEnabled,
@@ -57,9 +59,12 @@ export const createAdminRouter = (
     adminMiddleware,
     validateBody(updateAdminSettingsBodySchema),
     async (req, res) => {
-      const { lastfm_api_key, oura_webhook_enabled, signup_mode } = req.body
+      const { audit_log_retention_days, lastfm_api_key, oura_webhook_enabled, signup_mode } = req.body
       if (signup_mode) {
         await centralDb.setSignupMode(signup_mode)
+      }
+      if (audit_log_retention_days !== undefined) {
+        await centralDb.setAuditLogRetentionDays(audit_log_retention_days)
       }
       if (lastfm_api_key !== undefined) {
         await centralDb.setLastFmApiKey(lastfm_api_key)
@@ -78,8 +83,10 @@ export const createAdminRouter = (
       const adminCount = await centralDb.getAdminCount()
       const lastFmApiKey = await centralDb.getLastFmApiKey()
       const ouraWebhookEnabledValue = await centralDb.getOuraWebhookEnabled()
+      const currentRetentionDays = await centralDb.getAuditLogRetentionDays()
       res.json({
         admin_count: adminCount,
+        audit_log_retention_days: currentRetentionDays,
         lastfm_api_key_set: !!lastFmApiKey,
         oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
         oura_webhook_enabled: ouraWebhookEnabledValue,

--- a/apps/backend/src/routes/audit-log-router.ts
+++ b/apps/backend/src/routes/audit-log-router.ts
@@ -3,7 +3,7 @@
  *
  * Handles: /user/audit-log
  */
-import { type AuditLogQuery, type AuditLogResponse, auditLogQuerySchema } from '@aurboda/api-spec'
+import { auditLogQuerySchema } from '@aurboda/api-spec'
 import { type RequestHandler, Router } from 'express'
 
 import { getAuditLog } from '../services/audit-log.ts'
@@ -12,39 +12,35 @@ export const createAuditLogRouter = (authMiddleware: RequestHandler): Router => 
   const router = Router()
 
   // GET /user/audit-log - Get audit log entries
-  router.get<Record<string, never>, AuditLogResponse, unknown, AuditLogQuery>(
-    '/user/audit-log',
-    authMiddleware,
-    async (req, res) => {
-      const parsed = auditLogQuerySchema.safeParse(req.query)
-      if (!parsed.success) {
-        res.status(400).json({ data: [], error: 'Invalid query parameters', success: false, total: 0 })
-        return
-      }
+  router.get('/user/audit-log', authMiddleware, async (req, res) => {
+    const parsed = auditLogQuerySchema.safeParse(req.query)
+    if (!parsed.success) {
+      res.status(400).json({ data: [], error: 'Invalid query parameters', success: false, total: 0 })
+      return
+    }
 
-      const { category, level, limit, offset, since } = parsed.data
-      const result = await getAuditLog(req.user!, {
-        category,
-        level,
-        limit,
-        offset,
-        since: since ? new Date(since) : undefined,
-      })
+    const { category, level, limit, offset, since } = parsed.data
+    const result = await getAuditLog(req.user!, {
+      category,
+      level,
+      limit,
+      offset,
+      since: since ? new Date(since) : undefined,
+    })
 
-      res.json({
-        data: result.rows.map((row) => ({
-          id: row.id,
-          timestamp: row.timestamp.toISOString(),
-          level: row.level,
-          category: row.category,
-          message: row.message,
-          details: row.details ?? undefined,
-        })),
-        success: true,
-        total: result.total,
-      })
-    },
-  )
+    res.json({
+      data: result.rows.map((row) => ({
+        category: row.category,
+        details: row.details ?? undefined,
+        id: row.id,
+        level: row.level,
+        message: row.message,
+        timestamp: row.timestamp.toISOString(),
+      })),
+      success: true,
+      total: result.total,
+    })
+  })
 
   return router
 }

--- a/apps/backend/src/routes/audit-log-router.ts
+++ b/apps/backend/src/routes/audit-log-router.ts
@@ -1,0 +1,50 @@
+/**
+ * Audit log route group.
+ *
+ * Handles: /user/audit-log
+ */
+import { type AuditLogQuery, type AuditLogResponse, auditLogQuerySchema } from '@aurboda/api-spec'
+import { type RequestHandler, Router } from 'express'
+
+import { getAuditLog } from '../services/audit-log.ts'
+
+export const createAuditLogRouter = (authMiddleware: RequestHandler): Router => {
+  const router = Router()
+
+  // GET /user/audit-log - Get audit log entries
+  router.get<Record<string, never>, AuditLogResponse, unknown, AuditLogQuery>(
+    '/user/audit-log',
+    authMiddleware,
+    async (req, res) => {
+      const parsed = auditLogQuerySchema.safeParse(req.query)
+      if (!parsed.success) {
+        res.status(400).json({ data: [], error: 'Invalid query parameters', success: false, total: 0 })
+        return
+      }
+
+      const { category, level, limit, offset, since } = parsed.data
+      const result = await getAuditLog(req.user!, {
+        category,
+        level,
+        limit,
+        offset,
+        since: since ? new Date(since) : undefined,
+      })
+
+      res.json({
+        data: result.rows.map((row) => ({
+          id: row.id,
+          timestamp: row.timestamp.toISOString(),
+          level: row.level,
+          category: row.category,
+          message: row.message,
+          details: row.details ?? undefined,
+        })),
+        success: true,
+        total: result.total,
+      })
+    },
+  )
+
+  return router
+}

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -682,6 +682,24 @@ export const createTableStatements: Record<string, string> = {
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `,
+
+  // Audit log for user-specific events (sync, auth, settings changes, etc.)
+  audit_log: `
+    CREATE TABLE IF NOT EXISTS audit_log (
+      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      timestamp       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      level           VARCHAR(10) NOT NULL DEFAULT 'info',
+      category        VARCHAR(20) NOT NULL,
+      message         TEXT NOT NULL,
+      details         JSONB
+    )
+  `,
+
+  audit_log_indexes: `
+    CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log (timestamp DESC);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_category ON audit_log (category);
+    CREATE INDEX IF NOT EXISTS idx_audit_log_level ON audit_log (level)
+  `,
 }
 
 /**
@@ -733,6 +751,8 @@ export const tableCreationOrder = [
   'goals',
   'goals_indexes',
   'user_settings',
+  'audit_log',
+  'audit_log_indexes',
   'notes',
   'notes_indexes',
   'mcp_sessions',

--- a/apps/backend/src/services/audit-log.ts
+++ b/apps/backend/src/services/audit-log.ts
@@ -1,0 +1,63 @@
+/**
+ * Audit log service.
+ *
+ * Provides a logger for user-specific events that writes to the audit_log table.
+ * System-level events (startup, shutdown) stay in console.log.
+ */
+
+import type { AuditLogCategory, AuditLogLevel } from '@aurboda/api-spec'
+
+import { cleanupAuditLog, insertAuditLog, queryAuditLog, type AuditLogQueryParams } from '../db/index.ts'
+
+/**
+ * Write an audit log entry for a user.
+ * Failures are caught and logged to stderr to avoid breaking the caller.
+ */
+export const auditLog = async (
+  user: string,
+  level: AuditLogLevel,
+  category: AuditLogCategory,
+  message: string,
+  details?: Record<string, unknown>,
+): Promise<void> => {
+  try {
+    await insertAuditLog(user, level, category, message, details)
+  } catch (err) {
+    // Fall back to stderr so we don't lose the info entirely
+    console.error(`⚠️ Failed to write audit log for ${user}:`, err)
+  }
+}
+
+/**
+ * Convenience loggers for common levels.
+ */
+export const auditInfo = (
+  user: string,
+  category: AuditLogCategory,
+  message: string,
+  details?: Record<string, unknown>,
+) => auditLog(user, 'info', category, message, details)
+
+export const auditWarn = (
+  user: string,
+  category: AuditLogCategory,
+  message: string,
+  details?: Record<string, unknown>,
+) => auditLog(user, 'warn', category, message, details)
+
+export const auditError = (
+  user: string,
+  category: AuditLogCategory,
+  message: string,
+  details?: Record<string, unknown>,
+) => auditLog(user, 'error', category, message, details)
+
+/**
+ * Query audit log entries for a user.
+ */
+export const getAuditLog = (user: string, params: AuditLogQueryParams = {}) => queryAuditLog(user, params)
+
+/**
+ * Remove old audit log entries for a user based on retention period.
+ */
+export const pruneAuditLog = (user: string, retentionDays: number) => cleanupAuditLog(user, retentionDays)

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -15,6 +15,7 @@ import pg from 'pg'
 export type SignupMode = 'open' | 'invite_only' | 'closed'
 
 export interface ServerSettings {
+  audit_log_retention_days: number
   lastfm_api_key: string
   oura_webhook_enabled: boolean
   oura_webhook_verification_token: string
@@ -76,6 +77,8 @@ export interface CentralDb {
   initializeCentralDb: () => Promise<void>
   getServerSetting: <K extends keyof ServerSettings>(key: K) => Promise<ServerSettings[K] | null>
   setServerSetting: <K extends keyof ServerSettings>(key: K, value: ServerSettings[K]) => Promise<void>
+  getAuditLogRetentionDays: () => Promise<number>
+  setAuditLogRetentionDays: (days: number) => Promise<void>
   getLastFmApiKey: () => Promise<string | null>
   setLastFmApiKey: (key: string | null) => Promise<void>
   getSignupMode: () => Promise<SignupMode>
@@ -289,6 +292,15 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       return result.rows.map((row) => row.username)
     },
 
+    getAuditLogRetentionDays: async (): Promise<number> => {
+      const client = await getClient()
+      const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [
+        'audit_log_retention_days',
+      ])
+      if (result.rows.length === 0) return 3
+      return result.rows[0].value as number
+    },
+
     getLastFmApiKey: async (): Promise<string | null> => {
       const client = await getClient()
       const result = await client.query('SELECT value FROM server_settings WHERE key = $1', [
@@ -366,6 +378,16 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       const client = await getClient()
       const result = await client.query('DELETE FROM admins WHERE username = $1', [username])
       return (result.rowCount ?? 0) > 0
+    },
+
+    setAuditLogRetentionDays: async (days: number): Promise<void> => {
+      const client = await getClient()
+      await client.query(
+        `INSERT INTO server_settings (key, value, updated_at)
+         VALUES ('audit_log_retention_days', $1, NOW())
+         ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+        [JSON.stringify(days)],
+      )
     },
 
     setLastFmApiKey: async (key: string | null): Promise<void> => {

--- a/apps/backend/src/services/detection-trigger.test.ts
+++ b/apps/backend/src/services/detection-trigger.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
+// Mock audit log to avoid DB connections in unit tests
+vi.mock('./audit-log.ts', () => ({
+  auditError: vi.fn(),
+  auditInfo: vi.fn(),
+  auditWarn: vi.fn(),
+}))
+
 import { createDetectionTrigger, type DetectionTriggerDeps } from './detection-trigger.ts'
 
 describe('createDetectionTrigger', () => {
@@ -165,25 +172,24 @@ describe('createDetectionTrigger', () => {
   })
 
   test('handles detection errors gracefully', async () => {
+    const { auditError } = await import('./audit-log.ts')
     const deps = createMockDeps()
     vi.mocked(deps.runDetectionForUser).mockRejectedValue(new Error('Detection failed'))
     const trigger = createDetectionTrigger(deps)
 
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
     trigger.triggerDetectionForUser('testuser')
     await vi.advanceTimersByTimeAsync(5000)
 
-    // Should have logged the error
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Detection failed for user testuser'),
-      expect.any(Error),
+    // Should have logged the error via audit log
+    expect(auditError).toHaveBeenCalledWith(
+      'testuser',
+      'data',
+      'Location detection failed',
+      expect.objectContaining({ error: expect.stringContaining('Detection failed') }),
     )
 
-    // Should still clean up pending detection
+    // Should still clean up pending detection despite the error
     expect(trigger.hasPendingDetection('testuser')).toBe(false)
-
-    consoleSpy.mockRestore()
   })
 
   test('cleans up pending detection after completion', async () => {

--- a/apps/backend/src/services/detection-trigger.ts
+++ b/apps/backend/src/services/detection-trigger.ts
@@ -8,6 +8,8 @@
 import type { DetectedLocation } from '../db/index.ts'
 import type { GeocodeQueue } from './geocode-queue.ts'
 
+import { auditError, auditInfo } from './audit-log.ts'
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -57,14 +59,16 @@ export const createDetectionTrigger = (deps: DetectionTriggerDeps): DetectionTri
    * Called after debounce period expires.
    */
   const executeDetectionForUser = async (user: string): Promise<void> => {
-    console.log(`Running detection for user ${user}`)
+    auditInfo(user, 'data', 'Running location detection')
 
     try {
       const result = await deps.runDetectionForUser(user)
 
-      console.log(
-        `Detection complete for ${user}: ${result.created} created, ${result.updated} updated, ${result.needsGeocode.length} need geocoding`,
-      )
+      auditInfo(user, 'data', 'Location detection complete', {
+        created: result.created,
+        updated: result.updated,
+        needs_geocode: result.needsGeocode.length,
+      })
 
       // Queue geocoding jobs if the queue is available
       if (deps.geocodeQueue && result.needsGeocode.length > 0) {
@@ -81,7 +85,7 @@ export const createDetectionTrigger = (deps: DetectionTriggerDeps): DetectionTri
         }
       }
     } catch (error) {
-      console.error(`Detection failed for user ${user}:`, error)
+      auditError(user, 'data', 'Location detection failed', { error: String(error) })
     }
   }
 

--- a/apps/backend/src/services/sync-provider.ts
+++ b/apps/backend/src/services/sync-provider.ts
@@ -25,6 +25,7 @@ import {
   needsSync as rescueTimeNeedsSync,
   syncRescueTimeData,
 } from '../rescuetime-sync.ts'
+import { auditError, auditInfo, auditWarn } from './audit-log.ts'
 import { getSettings } from './settings.ts'
 
 /** Default sync threshold - sync if last sync was more than 30 minutes ago */
@@ -64,10 +65,10 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
           return
         }
 
-        console.log('Auto-syncing calendars...')
+        auditInfo(user, 'sync', 'Auto-syncing calendars')
         await syncAllCalendars(user, settings.calendars)
       } catch (error) {
-        console.error('Failed to auto-sync calendars:', error)
+        auditError(user, 'sync', 'Failed to auto-sync calendars', { error: String(error) })
       }
     },
 
@@ -78,7 +79,9 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
         const syncState = await getSyncState(user, 'garmin', dataType)
 
         if (isGarminRateLimited(syncState)) {
-          console.log(`Garmin ${dataType} sync skipped - rate limited until ${syncState?.retry_after}`)
+          auditWarn(user, 'sync', `Garmin ${dataType} sync skipped - rate limited`, {
+            retry_after: syncState?.retry_after?.toISOString(),
+          })
           return
         }
 
@@ -87,10 +90,10 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
           return
         }
 
-        console.log(`Auto-syncing Garmin ${dataType}...`)
+        auditInfo(user, 'sync', `Auto-syncing Garmin ${dataType}`)
         await syncGarminDataType(user, config.garmin, dataType as GarminDataType)
       } catch (error) {
-        console.error(`Failed to auto-sync Garmin ${dataType}:`, error)
+        auditError(user, 'sync', `Failed to auto-sync Garmin ${dataType}`, { error: String(error) })
       }
     },
 
@@ -110,10 +113,10 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
           return
         }
 
-        console.log('Auto-syncing Last.fm scrobbles...')
+        auditInfo(user, 'sync', 'Auto-syncing Last.fm scrobbles')
         await syncLastFmData(user, apiKey, settings.lastfm_username)
       } catch (error) {
-        console.error('Failed to auto-sync Last.fm:', error)
+        auditError(user, 'sync', 'Failed to auto-sync Last.fm', { error: String(error) })
       }
     },
 
@@ -126,7 +129,9 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
 
         // Skip if rate limited
         if (isOuraRateLimited(syncState)) {
-          console.log(`Oura ${dataType} sync skipped - rate limited until ${syncState?.retry_after}`)
+          auditWarn(user, 'sync', `Oura ${dataType} sync skipped - rate limited`, {
+            retry_after: syncState?.retry_after?.toISOString(),
+          })
           return
         }
 
@@ -136,11 +141,11 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
           return // Recently synced, no need to sync again
         }
 
-        console.log(`Auto-syncing Oura ${dataType}...`)
+        auditInfo(user, 'sync', `Auto-syncing Oura ${dataType}`)
         const accessToken = await config.oura.getAccessToken(user)
         await syncOuraDataType(user, config.oura, ouraDataType, accessToken)
       } catch (error) {
-        console.error(`Failed to auto-sync Oura ${dataType}:`, error)
+        auditError(user, 'sync', `Failed to auto-sync Oura ${dataType}`, { error: String(error) })
       }
     },
 
@@ -154,10 +159,10 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
         if (isRescueTimeRateLimited(syncState)) return
         if (!rescueTimeNeedsSync(syncState, threshold)) return
 
-        console.log('Auto-syncing RescueTime productivity...')
+        auditInfo(user, 'sync', 'Auto-syncing RescueTime productivity')
         await syncRescueTimeData(user, settings.rescue_time_key)
       } catch (error) {
-        console.error('Failed to auto-sync RescueTime:', error)
+        auditError(user, 'sync', 'Failed to auto-sync RescueTime', { error: String(error) })
       }
     },
   }

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -9,6 +9,7 @@ import { Sidebar } from './components/Sidebar.jsx'
 import { NotFound } from './pages/_404.jsx'
 import { AddData } from './pages/AddData/index.jsx'
 import { AdminSettings } from './pages/AdminSettings/index.jsx'
+import { AuditLog } from './pages/AuditLog/index.jsx'
 import { Chart } from './pages/Chart/index.jsx'
 import { Correlations } from './pages/Correlations/index.jsx'
 import { Data } from './pages/Data/index.jsx'
@@ -96,6 +97,7 @@ export function App() {
               <Route path="/screentime-categories/:id" component={CategoryDetail} />
               <Route path="/screentime-categories" component={ScreentimeCategories} />
               <Route path="/settings" component={Settings} />
+              <Route path="/audit-log" component={AuditLog} />
               <Route path="/admin" component={AdminSettings} />
               <Route path="/help" component={DataSources} />
               <Route default component={NotFound} />

--- a/apps/web/src/pages/AuditLog/index.tsx
+++ b/apps/web/src/pages/AuditLog/index.tsx
@@ -1,0 +1,130 @@
+import type { AuditLogEntry } from '@aurboda/api-spec'
+
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+
+import { fetchAuditLog } from '../../state/api'
+import { auth } from '../../state/auth'
+import './style.css'
+
+const LEVEL_ICONS: Record<string, string> = {
+  error: '❌',
+  info: 'ℹ️',
+  warn: '⚠️',
+}
+
+const PAGE_SIZE = 50
+
+export function AuditLog() {
+  const isLoggedIn = auth.value.token
+  const [levelFilter, setLevelFilter] = useState<string>('')
+  const [categoryFilter, setCategoryFilter] = useState<string>('')
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [page, setPage] = useState(0)
+
+  const { data, isLoading } = useQuery({
+    enabled: !!isLoggedIn,
+    queryFn: () =>
+      fetchAuditLog({
+        category: categoryFilter || undefined,
+        level: levelFilter || undefined,
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+      }),
+    queryKey: ['auditLog', levelFilter, categoryFilter, page],
+    refetchInterval: 30000,
+  })
+
+  const entries = data?.data ?? []
+  const total = data?.total ?? 0
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const toggleExpand = (id: string) => {
+    setExpandedId(expandedId === id ? null : id)
+  }
+
+  const formatTime = (iso: string) => {
+    const d = new Date(iso)
+    return d.toLocaleString(undefined, {
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      month: 'short',
+      second: '2-digit',
+    })
+  }
+
+  return (
+    <div class="audit-log-page">
+      <h1>Audit Log</h1>
+
+      <div class="audit-log-filters">
+        <select
+          value={levelFilter}
+          onChange={(e) => {
+            setLevelFilter((e.target as HTMLSelectElement).value)
+            setPage(0)
+          }}
+        >
+          <option value="">All levels</option>
+          <option value="info">Info</option>
+          <option value="warn">Warning</option>
+          <option value="error">Error</option>
+        </select>
+        <select
+          value={categoryFilter}
+          onChange={(e) => {
+            setCategoryFilter((e.target as HTMLSelectElement).value)
+            setPage(0)
+          }}
+        >
+          <option value="">All categories</option>
+          <option value="sync">Sync</option>
+          <option value="auth">Auth</option>
+          <option value="settings">Settings</option>
+          <option value="data">Data</option>
+          <option value="system">System</option>
+        </select>
+        <span class="audit-log-count">{total} entries</span>
+      </div>
+
+      {isLoading && <p class="loading">Loading...</p>}
+
+      {!isLoading && entries.length === 0 && <p class="empty">No log entries found.</p>}
+
+      <div class="audit-log-list">
+        {entries.map((entry: AuditLogEntry) => (
+          <div
+            key={entry.id}
+            class={`audit-log-entry level-${entry.level}${expandedId === entry.id ? ' expanded' : ''}`}
+            onClick={() => toggleExpand(entry.id)}
+          >
+            <div class="audit-log-row">
+              <span class="audit-log-icon">{LEVEL_ICONS[entry.level] ?? ''}</span>
+              <span class="audit-log-time">{formatTime(entry.timestamp)}</span>
+              <span class="audit-log-category">{entry.category}</span>
+              <span class="audit-log-message">{entry.message}</span>
+            </div>
+            {expandedId === entry.id && entry.details && (
+              <pre class="audit-log-details">{JSON.stringify(entry.details, null, 2)}</pre>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div class="audit-log-pagination">
+          <button disabled={page === 0} onClick={() => setPage(page - 1)}>
+            Previous
+          </button>
+          <span>
+            Page {page + 1} of {totalPages}
+          </span>
+          <button disabled={page >= totalPages - 1} onClick={() => setPage(page + 1)}>
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/AuditLog/style.css
+++ b/apps/web/src/pages/AuditLog/style.css
@@ -1,0 +1,198 @@
+.audit-log-page {
+  width: 100%;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.audit-log-page h1 {
+  font-size: 1.75rem;
+  margin-bottom: 1rem;
+}
+
+.audit-log-filters {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.audit-log-filters select {
+  padding: 0.4rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.audit-log-count {
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.audit-log-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.audit-log-entry {
+  padding: 0.5rem 0.75rem;
+  border-left: 3px solid transparent;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.audit-log-entry:hover {
+  background: #f5f5f5;
+}
+
+.audit-log-entry.level-info {
+  border-left-color: #2196f3;
+}
+
+.audit-log-entry.level-warn {
+  border-left-color: #ff9800;
+}
+
+.audit-log-entry.level-error {
+  border-left-color: #f44336;
+}
+
+.audit-log-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.audit-log-icon {
+  flex-shrink: 0;
+  width: 1.25em;
+  text-align: center;
+}
+
+.audit-log-time {
+  color: #888;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.audit-log-category {
+  color: #673ab8;
+  font-weight: 500;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+  text-transform: uppercase;
+}
+
+.audit-log-message {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-log-entry.expanded .audit-log-message {
+  white-space: normal;
+}
+
+.audit-log-details {
+  margin: 0.5rem 0 0 2rem;
+  padding: 0.5rem;
+  background: #f8f8f8;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.audit-log-pagination {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+}
+
+.audit-log-pagination button {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.875rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.audit-log-pagination button:hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+.audit-log-pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.audit-log-page .loading,
+.audit-log-page .empty {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+  .audit-log-entry:hover {
+    background: #2a2a2a;
+  }
+
+  .audit-log-filters select {
+    background: #333;
+    border-color: #555;
+    color: #fff;
+  }
+
+  .audit-log-time {
+    color: #aaa;
+  }
+
+  .audit-log-category {
+    color: #b388ff;
+  }
+
+  .audit-log-count {
+    color: #aaa;
+  }
+
+  .audit-log-details {
+    background: #1a1a1a;
+    color: #ddd;
+  }
+
+  .audit-log-pagination button {
+    border-color: #555;
+    color: #fff;
+  }
+
+  .audit-log-pagination button:hover:not(:disabled) {
+    background: #333;
+  }
+}
+
+@media (max-width: 639px) {
+  .audit-log-page {
+    padding: 1rem;
+  }
+
+  .audit-log-row {
+    flex-wrap: wrap;
+  }
+
+  .audit-log-message {
+    width: 100%;
+    white-space: normal;
+  }
+}

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -217,6 +217,13 @@ export function Settings() {
           <a href="/data-sources">Data Sources</a>.
         </p>
       </section>
+
+      <section class="settings-section">
+        <h2>Audit Log</h2>
+        <p class="section-description">
+          View recent system events, sync operations, and errors. <a href="/audit-log">View audit log</a>
+        </p>
+      </section>
     </div>
   )
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -3,6 +3,7 @@ import type {
   ActivitiesQuery,
   ActivitiesResponse,
   ActivityCorrelation,
+  AuditLogResponse,
   ActivityImpactData,
   ActivityImpactQuery,
   ActivityImpactResponse,
@@ -1753,4 +1754,25 @@ export const fetchChartData = async (params: FetchChartDataParams): Promise<Char
   })
 
   return response.data.data?.buckets ?? []
+}
+
+// ============================================================================
+// Audit Log
+// ============================================================================
+
+export interface FetchAuditLogParams {
+  level?: string
+  category?: string
+  since?: string
+  limit?: number
+  offset?: number
+}
+
+export const fetchAuditLog = async (params: FetchAuditLogParams = {}): Promise<AuditLogResponse> => {
+  const { token } = auth.value
+  const response = await axios.get<AuditLogResponse>(`${API_URL}/user/audit-log`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+  return response.data
 }

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -111,6 +111,10 @@ export type LoginResponse = z.infer<typeof loginResponseSchema>
 export const adminSettingsResponseSchema = baseResponseSchema
   .extend({
     admin_count: z.number().int().meta({ description: 'Number of admin users' }),
+    audit_log_retention_days: z
+      .number()
+      .int()
+      .meta({ description: 'Number of days to keep audit log entries (default: 3)' }),
     lastfm_api_key_set: z.boolean().meta({ description: 'Whether a Last.fm API key is configured' }),
     oura_webhook_available: z.boolean().meta({
       description: 'Whether Oura webhook push can be enabled (requires HTTPS and Oura credentials)',
@@ -127,6 +131,13 @@ export type AdminSettingsResponse = z.infer<typeof adminSettingsResponseSchema>
  */
 export const updateAdminSettingsBodySchema = z
   .object({
+    audit_log_retention_days: z
+      .number()
+      .int()
+      .positive()
+      .max(365)
+      .optional()
+      .meta({ description: 'Number of days to keep audit log entries (1-365, default: 3)' }),
     lastfm_api_key: z
       .string()
       .nullable()

--- a/packages/api-spec/src/schemas/audit-log.ts
+++ b/packages/api-spec/src/schemas/audit-log.ts
@@ -1,0 +1,77 @@
+/**
+ * Audit log schemas for user-specific event logging.
+ */
+
+import { z } from 'zod'
+
+import { baseResponseSchema, iso8601DateTimeSchema } from './common.ts'
+
+// ============================================================================
+// Log levels and categories
+// ============================================================================
+
+export const auditLogLevelSchema = z.enum(['info', 'warn', 'error']).meta({
+  description: 'Severity level of the audit log entry',
+  id: 'AuditLogLevel',
+})
+
+export type AuditLogLevel = z.infer<typeof auditLogLevelSchema>
+
+export const auditLogCategorySchema = z.enum(['sync', 'auth', 'settings', 'data', 'system']).meta({
+  description: 'Category of the audit log entry',
+  id: 'AuditLogCategory',
+})
+
+export type AuditLogCategory = z.infer<typeof auditLogCategorySchema>
+
+// ============================================================================
+// Audit log entry
+// ============================================================================
+
+export const auditLogEntrySchema = z
+  .object({
+    id: z.string().uuid().meta({ description: 'Log entry ID' }),
+    timestamp: iso8601DateTimeSchema.meta({ description: 'When the event occurred' }),
+    level: auditLogLevelSchema,
+    category: auditLogCategorySchema,
+    message: z.string().meta({ description: 'Human-readable log message' }),
+    details: z.record(z.string(), z.unknown()).optional().meta({ description: 'Additional structured data' }),
+  })
+  .meta({ id: 'AuditLogEntry' })
+
+export type AuditLogEntry = z.infer<typeof auditLogEntrySchema>
+
+// ============================================================================
+// Query parameters
+// ============================================================================
+
+export const auditLogQuerySchema = z
+  .object({
+    level: auditLogLevelSchema.optional().meta({ description: 'Filter by log level' }),
+    category: auditLogCategorySchema.optional().meta({ description: 'Filter by category' }),
+    since: iso8601DateTimeSchema.optional().meta({ description: 'Only entries after this time' }),
+    limit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(1000)
+      .optional()
+      .meta({ description: 'Max entries to return (default 200)' }),
+    offset: z.coerce.number().int().min(0).optional().meta({ description: 'Number of entries to skip' }),
+  })
+  .meta({ id: 'AuditLogQuery' })
+
+export type AuditLogQuery = z.infer<typeof auditLogQuerySchema>
+
+// ============================================================================
+// Response
+// ============================================================================
+
+export const auditLogResponseSchema = baseResponseSchema
+  .extend({
+    data: z.array(auditLogEntrySchema).meta({ description: 'Log entries' }),
+    total: z.number().int().meta({ description: 'Total matching entries' }),
+  })
+  .meta({ id: 'AuditLogResponse' })
+
+export type AuditLogResponse = z.infer<typeof auditLogResponseSchema>

--- a/packages/api-spec/src/schemas/index.ts
+++ b/packages/api-spec/src/schemas/index.ts
@@ -4,6 +4,7 @@
 
 export * from './activities.ts'
 export * from './admin.ts'
+export * from './audit-log.ts'
 export * from './chart-data.ts'
 export * from './common.ts'
 export * from './correlations.ts'


### PR DESCRIPTION
## Summary

- Adds a per-user `audit_log` database table replacing chatty user-specific `console.log` calls
- System-level logs (startup, shutdown, DB creation) remain in stdout
- Admin-configurable retention period (`audit_log_retention_days`, default 3 days) in admin settings
- New REST endpoint `GET /user/audit-log` with filtering by level, category, since, and pagination
- New frontend page at `/audit-log` linked from user settings — entries are one-line with click-to-expand details
- Replaced sync-provider and detection-trigger console.logs with structured audit log writes
- Audit log writes are fire-and-forget (fall back to stderr on failure, never break the caller)

## Test plan

- [ ] Verify audit_log table is created on login/migration
- [ ] Trigger syncs and verify log entries appear in `/audit-log` page
- [ ] Test filtering by level and category
- [ ] Test pagination with many entries
- [ ] Verify admin can configure retention days in admin settings
- [ ] Verify old entries are cleaned up on login
- [ ] Verify click-to-expand shows details JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)