### PR TITLE
fix: filter null body battery values before DB insert

### DIFF
--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -352,7 +352,7 @@ const processBodyBattery = async (
     // Insert time-series points from the body battery values array
     if (day.bodyBatteryValuesArray?.length) {
       for (const [ts, value] of day.bodyBatteryValuesArray) {
-        if (ts && value >= 0) {
+        if (ts && value != null && value >= 0) {
           points.push({ metric: 'body_battery', source: 'garmin', time: new Date(ts), unit: 'score', value })
         }
       }


### PR DESCRIPTION
## Summary
- Filter out null values from Garmin's `bodyBatteryValuesArray` before inserting into time_series
- `null >= 0` evaluates to `true` in JS, so null values bypassed the existing check

## Test plan
- [ ] Trigger Garmin sync — verify no more "null value in column value" errors for bodyBattery

🤖 Generated with [Claude Code](https://claude.com/claude-code)