### PR TITLE
feat: add Garmin metrics to chart metric picker

### DIFF
--- a/apps/web/src/utils/metricLabels.ts
+++ b/apps/web/src/utils/metricLabels.ts
@@ -31,6 +31,13 @@ export const metricLabels: Record<string, string> = {
   vo2_max: 'VO2 Max',
   weight: 'Weight',
   zone2_weekly: 'Zone 2 (Weekly)',
+  // Garmin metrics
+  stress_level: 'Stress Level',
+  body_battery: 'Body Battery',
+  training_readiness: 'Training Readiness',
+  intensity_minutes: 'Intensity Minutes',
+  respiratory_rate: 'Respiratory Rate',
+  cardiovascular_age: 'Cardiovascular Age',
 }
 
 /**

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -22,6 +22,7 @@ export const builtinDashboardMetrics = [
   // Period summary metrics
   'sleep_score',
   'readiness_score',
+  'resilience_score',
   'steps',
   'zone2_weekly',
   'weight',
@@ -29,9 +30,23 @@ export const builtinDashboardMetrics = [
   // Contextual HRV metrics
   'hrv_sleep',
   // Raw metrics
+  'heart_rate',
   'hrv_rmssd',
   'resting_heart_rate',
   'hr_zone_2_sec',
+  'spo2',
+  'vo2_max',
+  'calories_active',
+  'calories_total',
+  'distance',
+  'floors_climbed',
+  'cardiovascular_age',
+  // Garmin metrics
+  'stress_level',
+  'body_battery',
+  'training_readiness',
+  'intensity_minutes',
+  'respiratory_rate',
 ] as const
 
 export type BuiltinDashboardMetric = (typeof builtinDashboardMetrics)[number]


### PR DESCRIPTION
## Summary
- Add Garmin-specific metrics (stress level, body battery, training readiness, intensity minutes, respiratory rate) to the builtin dashboard metrics list
- Add display labels for the new metrics
- Also adds heart_rate, spo2, vo2_max, calories, distance, floors, cardiovascular_age, resilience_score which were in metricLabels but missing from the picker

## Test plan
- [ ] Open Chart page, select Metric source type, search for "stress" — should show Stress Level
- [ ] Search for "battery" — should show Body Battery

🤖 Generated with [Claude Code](https://claude.com/claude-code)