### PR TITLE
feat: add stress_level to Timeline page

### DIFF
--- a/apps/web/src/pages/Timeline/drawActivitySparklines.ts
+++ b/apps/web/src/pages/Timeline/drawActivitySparklines.ts
@@ -12,15 +12,19 @@ interface ParsedBucket {
   start: Date
   hr?: number
   hrv?: number
+  stress?: number
 }
 
 const HR_COLOR = '#ef4444' // red
 const HRV_COLOR = '#14b8a6' // teal
+const STRESS_COLOR = '#f97316' // orange
 
 /** HR domain range for sparklines (bpm) */
 const HR_RANGE: [number, number] = [40, 200]
 /** HRV domain range for sparklines (ms) */
 const HRV_RANGE: [number, number] = [0, 150]
+/** Stress domain range for sparklines (Garmin 0–100) */
+const STRESS_RANGE: [number, number] = [0, 100]
 
 /** Minimum block height in pixels before we attempt to draw sparklines. */
 const MIN_SPARKLINE_HEIGHT = 40
@@ -34,6 +38,7 @@ export const parseBucketedData = (data: QueryMetricsBucketedResponse | undefined
     hr: b.metrics.heart_rate?.avg,
     hrv: b.metrics.hrv_rmssd?.avg,
     start: new Date(b.start),
+    stress: b.metrics.stress_level?.avg,
   }))
 }
 
@@ -49,9 +54,10 @@ export const drawActivitySparklines = (
   yScale: d3.ScaleTime<number, number>,
   showHR: boolean,
   showHRV: boolean,
+  showStress: boolean,
   getItemRect: (item: ChartItem) => { x: number; width: number } | undefined,
 ) => {
-  if (buckets.length === 0 || (!showHR && !showHRV)) return
+  if (buckets.length === 0 || (!showHR && !showHRV && !showStress)) return
 
   const activityItems = items.filter((item) => item.activity_type && !item.isPoint)
 
@@ -113,6 +119,21 @@ export const drawActivitySparklines = (
           rect.width,
           HRV_COLOR,
           HRV_RANGE,
+        )
+      }
+    }
+
+    if (showStress) {
+      const stressPoints = activityBuckets.filter((b) => b.stress !== undefined)
+      if (stressPoints.length >= 2) {
+        drawSparkline(
+          sparkGroup,
+          stressPoints.map((b) => ({ time: b.start, value: b.stress! })),
+          yScale,
+          rect.x,
+          rect.width,
+          STRESS_COLOR,
+          STRESS_RANGE,
         )
       }
     }

--- a/apps/web/src/pages/Timeline/drawActivitySparklines.ts
+++ b/apps/web/src/pages/Timeline/drawActivitySparklines.ts
@@ -93,47 +93,29 @@ export const drawActivitySparklines = (
       .attr('clip-path', `url(#${clipId})`)
       .attr('pointer-events', 'none')
 
-    if (showHR) {
-      const hrPoints = activityBuckets.filter((b) => b.hr !== undefined)
-      if (hrPoints.length >= 2) {
-        drawSparkline(
-          sparkGroup,
-          hrPoints.map((b) => ({ time: b.start, value: b.hr! })),
-          yScale,
-          rect.x,
-          rect.width,
-          HR_COLOR,
-          HR_RANGE,
-        )
-      }
-    }
+    const sparklineSeries: {
+      show: boolean
+      key: keyof ParsedBucket
+      color: string
+      range: [number, number]
+    }[] = [
+      { show: showHR, key: 'hr', color: HR_COLOR, range: HR_RANGE },
+      { show: showHRV, key: 'hrv', color: HRV_COLOR, range: HRV_RANGE },
+      { show: showStress, key: 'stress', color: STRESS_COLOR, range: STRESS_RANGE },
+    ]
 
-    if (showHRV) {
-      const hrvPoints = activityBuckets.filter((b) => b.hrv !== undefined)
-      if (hrvPoints.length >= 2) {
+    for (const { show, key, color, range } of sparklineSeries) {
+      if (!show) continue
+      const points = activityBuckets.filter((b) => b[key] !== undefined)
+      if (points.length >= 2) {
         drawSparkline(
           sparkGroup,
-          hrvPoints.map((b) => ({ time: b.start, value: b.hrv! })),
+          points.map((b) => ({ time: b.start, value: b[key] as number })),
           yScale,
           rect.x,
           rect.width,
-          HRV_COLOR,
-          HRV_RANGE,
-        )
-      }
-    }
-
-    if (showStress) {
-      const stressPoints = activityBuckets.filter((b) => b.stress !== undefined)
-      if (stressPoints.length >= 2) {
-        drawSparkline(
-          sparkGroup,
-          stressPoints.map((b) => ({ time: b.start, value: b.stress! })),
-          yScale,
-          rect.x,
-          rect.width,
-          STRESS_COLOR,
-          STRESS_RANGE,
+          color,
+          range,
         )
       }
     }

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -321,38 +321,61 @@ const buildMetricsTooltipHtml = (
   html += `<div class="tooltip-time">${timeRange}</div>`
   let hasContent = false
 
-  if (showHR) {
-    const hr = bucket.metrics.heart_rate
-    if (hr) {
-      html += `<div class="tooltip-detail" style="color:${HR_COLOR}">❤ HR: ${Math.round(hr.avg)} bpm (${Math.round(hr.min)}–${Math.round(hr.max)})</div>`
-      hasContent = true
-    }
-  }
-  if (showHRV) {
-    const hrv = bucket.metrics.hrv_rmssd
-    if (hrv) {
-      html += `<div class="tooltip-detail" style="color:${HRV_COLOR}">♥ HRV: ${Math.round(hrv.avg)} ms (${Math.round(hrv.min)}–${Math.round(hrv.max)})</div>`
-      hasContent = true
-    }
-  }
-  if (showStress) {
-    const stress = bucket.metrics.stress_level
-    if (stress) {
-      html += `<div class="tooltip-detail" style="color:${STRESS_COLOR}">😰 Stress: ${Math.round(stress.avg)} (${Math.round(stress.min)}–${Math.round(stress.max)})</div>`
-      hasContent = true
-    }
-  }
-  if (showSteps) {
-    const steps = bucket.metrics.steps
-    if (steps) {
-      html += `<div class="tooltip-detail" style="color:${STEPS_COLOR}">🚶 Steps: ${steps.avg.toFixed(1)}/min</div>`
-      hasContent = true
-    }
-  }
-  if (showCalories) {
-    const cal = bucket.metrics.calories_active
-    if (cal) {
-      html += `<div class="tooltip-detail" style="color:${CALORIES_COLOR}">🔥 Calories: ${cal.avg.toFixed(1)} kcal/min</div>`
+  const tooltipMetrics: {
+    show: boolean
+    key: string
+    icon: string
+    label: string
+    color: string
+    fmt: (m: { avg: number; min: number; max: number }) => string
+  }[] = [
+    {
+      show: showHR,
+      key: 'heart_rate',
+      icon: '❤',
+      label: 'HR',
+      color: HR_COLOR,
+      fmt: (m) => `${Math.round(m.avg)} bpm (${Math.round(m.min)}–${Math.round(m.max)})`,
+    },
+    {
+      show: showHRV,
+      key: 'hrv_rmssd',
+      icon: '♥',
+      label: 'HRV',
+      color: HRV_COLOR,
+      fmt: (m) => `${Math.round(m.avg)} ms (${Math.round(m.min)}–${Math.round(m.max)})`,
+    },
+    {
+      show: showStress,
+      key: 'stress_level',
+      icon: '😰',
+      label: 'Stress',
+      color: STRESS_COLOR,
+      fmt: (m) => `${Math.round(m.avg)} (${Math.round(m.min)}–${Math.round(m.max)})`,
+    },
+    {
+      show: showSteps,
+      key: 'steps',
+      icon: '🚶',
+      label: 'Steps',
+      color: STEPS_COLOR,
+      fmt: (m) => `${m.avg.toFixed(1)}/min`,
+    },
+    {
+      show: showCalories,
+      key: 'calories_active',
+      icon: '🔥',
+      label: 'Calories',
+      color: CALORIES_COLOR,
+      fmt: (m) => `${m.avg.toFixed(1)} kcal/min`,
+    },
+  ]
+
+  for (const { show, key, icon, label, color, fmt } of tooltipMetrics) {
+    if (!show) continue
+    const m = bucket.metrics[key]
+    if (m) {
+      html += `<div class="tooltip-detail" style="color:${color}">${icon} ${label}: ${fmt(m)}</div>`
       hasContent = true
     }
   }

--- a/apps/web/src/pages/Timeline/drawMetricsTrack.ts
+++ b/apps/web/src/pages/Timeline/drawMetricsTrack.ts
@@ -33,6 +33,7 @@ export const HR_COLOR = '#ef4444'
 export const HRV_COLOR = '#10b981'
 export const STEPS_COLOR = '#9ca3af'
 export const CALORIES_COLOR = '#f59e0b'
+export const STRESS_COLOR = '#f97316'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -61,6 +62,7 @@ export interface MetricsTrackConfig {
   /** Visibility toggles. */
   showHR: boolean
   showHRV: boolean
+  showStress: boolean
   showSteps: boolean
   showCalories: boolean
   /** Tooltip callback — receives HTML content and mouse event. */
@@ -300,6 +302,7 @@ const buildMetricsTooltipHtml = (
   bucket: MetricBucketParsed,
   showHR: boolean,
   showHRV: boolean,
+  showStress: boolean,
   showSteps: boolean,
   showCalories: boolean,
   trainingLoadPoints?: TrainingLoadPoint[],
@@ -329,6 +332,13 @@ const buildMetricsTooltipHtml = (
     const hrv = bucket.metrics.hrv_rmssd
     if (hrv) {
       html += `<div class="tooltip-detail" style="color:${HRV_COLOR}">♥ HRV: ${Math.round(hrv.avg)} ms (${Math.round(hrv.min)}–${Math.round(hrv.max)})</div>`
+      hasContent = true
+    }
+  }
+  if (showStress) {
+    const stress = bucket.metrics.stress_level
+    if (stress) {
+      html += `<div class="tooltip-detail" style="color:${STRESS_COLOR}">😰 Stress: ${Math.round(stress.avg)} (${Math.round(stress.min)}–${Math.round(stress.max)})</div>`
       hasContent = true
     }
   }
@@ -418,6 +428,7 @@ const getMetricMax = (buckets: MetricBucketParsed[], metricName: string, fallbac
 export interface MetricsYScales {
   yHr: d3.ScaleLinear<number, number>
   yHrv: d3.ScaleLinear<number, number>
+  yStress: d3.ScaleLinear<number, number>
   ySteps: d3.ScaleLinear<number, number>
   yCal: d3.ScaleLinear<number, number>
 }
@@ -430,6 +441,9 @@ export const computeYScales = (
 ): MetricsYScales => {
   // HR: fixed domain
   const yHr = d3.scaleLinear().domain([40, 200]).range([trackBottom, trackY])
+
+  // Stress: fixed domain 0–100
+  const yStress = d3.scaleLinear().domain([0, 100]).range([trackBottom, trackY])
 
   // HRV: dynamic domain based on data
   let hrvMin = Infinity
@@ -464,7 +478,7 @@ export const computeYScales = (
     .domain([0, calMax * 1.1])
     .range([trackBottom, trackY])
 
-  return { yCal, yHr, yHrv, ySteps }
+  return { yCal, yHr, yHrv, ySteps, yStress }
 }
 
 // ── Crosshair helpers ─────────────────────────────────────────────────────────
@@ -500,6 +514,7 @@ const buildTooltipBucket = (
       ...barBucket.metrics,
       ...(lineBucket.metrics.heart_rate && { heart_rate: lineBucket.metrics.heart_rate }),
       ...(lineBucket.metrics.hrv_rmssd && { hrv_rmssd: lineBucket.metrics.hrv_rmssd }),
+      ...(lineBucket.metrics.stress_level && { stress_level: lineBucket.metrics.stress_level }),
     },
   }
 }
@@ -516,6 +531,7 @@ const drawCrosshairOverlay = (
   chartWidth: number,
   showHR: boolean,
   showHRV: boolean,
+  showStress: boolean,
   showSteps: boolean,
   showCalories: boolean,
   showTooltipHtml: (event: MouseEvent, html: string) => void,
@@ -569,6 +585,7 @@ const drawCrosshairOverlay = (
           tooltipBucket,
           showHR,
           showHRV,
+          showStress,
           showSteps,
           showCalories,
           trainingLoadPoints,
@@ -628,11 +645,12 @@ const drawBarAndBandCharts = (
   showCalories: boolean,
   showHR: boolean,
   showHRV: boolean,
+  showStress: boolean,
   barLayout?: BarLayoutResult,
   stepsSlotId?: string,
   caloriesSlotId?: string,
 ): void => {
-  const { yCal, yHr, yHrv, ySteps } = yScales
+  const { yCal, yHr, yHrv, ySteps, yStress } = yScales
 
   // Draw bars first (behind lines), using coarser bar buckets
   if (showSteps) {
@@ -673,6 +691,10 @@ const drawBarAndBandCharts = (
     const hrvBand = extractBandData(lineBuckets, 'hrv_rmssd')
     if (hrvBand.length > 1) drawBandChart(chartGroup, hrvBand, xScale, yHrv, HRV_COLOR)
   }
+  if (showStress) {
+    const stressBand = extractBandData(lineBuckets, 'stress_level')
+    if (stressBand.length > 1) drawBandChart(chartGroup, stressBand, xScale, yStress, STRESS_COLOR)
+  }
 }
 
 /**
@@ -694,13 +716,14 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     yScales,
     showHR,
     showHRV,
+    showStress,
     showSteps,
     showCalories,
     showTooltipHtml,
     hideTooltip,
   } = config
 
-  const hasMetrics = showHR || showHRV || showSteps || showCalories
+  const hasMetrics = showHR || showHRV || showStress || showSteps || showCalories
   const hasTrainingLoad = config.trainingLoadPoints && config.trainingLoadPoints.length > 0
   const hasScreentime = config.screentimeBuckets && config.screentimeBuckets.length > 0
   if (rawBuckets.length === 0 && !hasTrainingLoad && !hasScreentime) return
@@ -729,6 +752,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     showCalories,
     showHR,
     showHRV,
+    showStress,
     config.barLayout,
     config.stepsSlotId,
     config.caloriesSlotId,
@@ -745,6 +769,7 @@ export const drawMetricsTrack = (config: MetricsTrackConfig): void => {
     chartWidth,
     showHR,
     showHRV,
+    showStress,
     showSteps,
     showCalories,
     showTooltipHtml,

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -342,6 +342,7 @@ const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = 
   exercise: (item) => item.column === 'Activity' && item.activity_type === 'exercise',
   hr: () => false,
   hrv: () => false,
+  stress: () => false,
   location: (item) => item.column === 'Location',
   meal: (item) => item.entity_type === 'meal',
   meditation: (item) => item.column === 'Activity' && item.activity_type === 'meditation',

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -43,6 +43,7 @@ import {
   HR_COLOR,
   HRV_COLOR,
   STEPS_COLOR,
+  STRESS_COLOR,
 } from './drawMetricsTrack'
 import {
   buildMusicTooltipHtml,
@@ -89,6 +90,7 @@ type LegendCategory =
   // Metrics sub-toggles
   | 'hr'
   | 'hrv'
+  | 'stress'
   | 'steps' // horizontal only
   | 'calories' // horizontal only
   | 'training_load' // horizontal only
@@ -1321,7 +1323,8 @@ export const Timeline = () => {
 
       const showSparkHR = !hiddenCategories.has('hr')
       const showSparkHRV = !hiddenCategories.has('hrv')
-      if (sparklineBuckets.length > 0 && (showSparkHR || showSparkHRV)) {
+      const showSparkStress = !hiddenCategories.has('stress')
+      if (sparklineBuckets.length > 0 && (showSparkHR || showSparkHRV || showSparkStress)) {
         const getItemRect = (item: ChartItem): { x: number; width: number } | undefined => {
           for (let ci = 0; ci < columnData.length; ci++) {
             const cd = columnData[ci]!
@@ -1345,6 +1348,7 @@ export const Timeline = () => {
           currentYScale,
           showSparkHR,
           showSparkHRV,
+          showSparkStress,
           getItemRect,
         )
       }
@@ -1793,6 +1797,7 @@ export const Timeline = () => {
       // ── Metrics track (HR/HRV band charts + steps/calories bars + combined tooltip) ──
       const showHR = !hiddenCategories.has('hr') && showMetricsTrack
       const showHRV = !hiddenCategories.has('hrv') && showMetricsTrack
+      const showStress = !hiddenCategories.has('stress') && showMetricsTrack
       const showSteps = !hiddenCategories.has('steps') && showMetricsTrack
       const showCalories = !hiddenCategories.has('calories') && showMetricsTrack
       const showTL = !hiddenCategories.has('training_load') && showMetricsTrack
@@ -1822,6 +1827,7 @@ export const Timeline = () => {
           showHR,
           showHRV,
           showSteps,
+          showStress,
           showTooltipHtml: (event: MouseEvent, html: string) => {
             if (!tooltipRef.current || !containerRef.current) return
             const tip = tooltipRef.current
@@ -2302,6 +2308,7 @@ export const Timeline = () => {
               {[
                 { cat: 'hr' as LegendCategory, color: HR_COLOR, label: 'HR' },
                 { cat: 'hrv' as LegendCategory, color: HRV_COLOR, label: 'HRV' },
+                { cat: 'stress' as LegendCategory, color: STRESS_COLOR, label: 'Stress' },
                 ...(orientation === 'horizontal'
                   ? [
                       { cat: 'steps' as LegendCategory, color: STEPS_COLOR, label: 'Steps' },


### PR DESCRIPTION
## Summary
- Add Garmin stress level (0–100) as a band chart in the horizontal metrics track, following the same pattern as HR and HRV
- Add stress sparkline overlay inside activity blocks in vertical (Day) view
- Add legend toggle, tooltip display, and crosshair integration for stress

## Test plan
- [ ] Open Timeline in horizontal mode and verify orange stress band chart appears alongside HR/HRV
- [ ] Hover over the metrics track and confirm stress values appear in the tooltip
- [ ] Toggle the Stress legend entry off and verify the band disappears
- [ ] Open Timeline in vertical (Day) mode and verify orange stress sparklines appear inside activity blocks
- [ ] Verify no regressions in HR, HRV, steps, and calories display

🤖 Generated with [Claude Code](https://claude.com/claude-code)