### PR TITLE
feat: add sub-day bucket sizes (15m, 1h) to Chart Explorer

### DIFF
--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import * as db from '../db/index.ts'
-import { getChartData } from './chart-data.ts'
+import { buildBucketExpr, getChartData } from './chart-data.ts'
 
 // Mock the db module
 vi.mock('../db', () => ({
@@ -184,6 +184,58 @@ describe('getChartData', () => {
     expect(result[0].value).toBe(2.75)
   })
 
+  test('uses date_trunc with hour for 1h bucket size', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { bucket_start: new Date('2026-01-01T10:00:00Z'), value: 2n },
+        { bucket_start: new Date('2026-01-01T11:00:00Z'), value: 3n },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1h',
+      end: '2026-01-01T23:59:59Z',
+      pattern: 'coffee',
+      source_type: 'tag',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].bucket_start).toBe('2026-01-01T10:00:00.000Z')
+    expect(result[0].value).toBe(2)
+
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[1]).toContain('date_trunc')
+    expect(call[2]![0]).toBe('hour')
+  })
+
+  test('uses date_bin with 15 minutes interval for 15m bucket size', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { bucket_start: new Date('2026-01-01T10:00:00Z'), value: 1n },
+        { bucket_start: new Date('2026-01-01T10:15:00Z'), value: 2n },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '15m',
+      end: '2026-01-01T23:59:59Z',
+      pattern: 'coffee',
+      source_type: 'tag',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0].bucket_start).toBe('2026-01-01T10:00:00.000Z')
+    expect(result[1].value).toBe(2)
+
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[1]).toContain('date_bin')
+    expect(call[2]![0]).toBe('15 minutes')
+  })
+
   test('returns empty array for metric without pattern', async () => {
     const result = await getChartData('testuser', {
       aggregation: 'mean',
@@ -195,5 +247,43 @@ describe('getChartData', () => {
 
     expect(result).toEqual([])
     expect(db.query).not.toHaveBeenCalled()
+  })
+})
+
+describe('buildBucketExpr', () => {
+  test('returns date_trunc for day bucket', () => {
+    const { expr, params } = buildBucketExpr('1d', 'time', 1)
+    expect(expr).toContain('date_trunc')
+    expect(params).toEqual(['day'])
+  })
+
+  test('returns date_trunc for week bucket', () => {
+    const { expr, params } = buildBucketExpr('1w', 'time', 1)
+    expect(expr).toContain('date_trunc')
+    expect(params).toEqual(['week'])
+  })
+
+  test('returns date_trunc for month bucket', () => {
+    const { expr, params } = buildBucketExpr('1M', 'time', 1)
+    expect(expr).toContain('date_trunc')
+    expect(params).toEqual(['month'])
+  })
+
+  test('returns date_trunc with hour for 1h bucket', () => {
+    const { expr, params } = buildBucketExpr('1h', 'time', 1)
+    expect(expr).toContain('date_trunc')
+    expect(params).toEqual(['hour'])
+  })
+
+  test('returns date_bin with 15 minutes for 15m bucket', () => {
+    const { expr, params } = buildBucketExpr('15m', 'start_time', 1)
+    expect(expr).toContain('date_bin')
+    expect(expr).toContain('start_time')
+    expect(params).toEqual(['15 minutes'])
+  })
+
+  test('uses correct placeholder index', () => {
+    const { expr } = buildBucketExpr('1d', 'time', 3)
+    expect(expr).toContain('$3')
   })
 })

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -9,16 +9,50 @@ import type { ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
 
 import { query } from '../db/index.ts'
 
-/** Map bucket_size parameter to PostgreSQL date_trunc interval name. */
+/** Map bucket_size parameter to PostgreSQL date_trunc interval name (day and above). */
 const bucketToTrunc: Record<string, string> = {
   '1M': 'month',
   '1d': 'day',
   '1w': 'week',
 }
 
+/**
+ * Build a SQL expression for bucketing a timestamp column.
+ *
+ * For sub-day buckets (15m, 1h) we use PG 14+ `date_bin` which requires an
+ * origin timestamp.  For day/week/month we keep the simpler `date_trunc`.
+ *
+ * Returns `{ expr, params }` where `expr` is the SQL fragment with positional
+ * placeholders starting at `$<startIdx>` and `params` are the corresponding
+ * bind values.
+ */
+export const buildBucketExpr = (
+  bucketSize: string,
+  column: string,
+  startIdx: number,
+): { expr: string; params: string[] } => {
+  if (bucketSize === '15m') {
+    return {
+      expr: `date_bin($${startIdx}::interval, ${column} AT TIME ZONE 'UTC', '2000-01-01'::timestamptz)`,
+      params: ['15 minutes'],
+    }
+  }
+  if (bucketSize === '1h') {
+    return {
+      expr: `date_trunc($${startIdx}, ${column} AT TIME ZONE 'UTC')`,
+      params: ['hour'],
+    }
+  }
+  const truncInterval = bucketToTrunc[bucketSize] ?? 'day'
+  return {
+    expr: `date_trunc($${startIdx}, ${column} AT TIME ZONE 'UTC')`,
+    params: [truncInterval],
+  }
+}
+
 export interface ChartDataInput {
   aggregation: 'count' | 'mean' | 'sum'
-  bucket_size: '1M' | '1d' | '1w'
+  bucket_size: '15m' | '1M' | '1d' | '1h' | '1w'
   end: string
   pattern?: string
   source_type: ChartDataSourceType
@@ -32,19 +66,20 @@ const queryTagsByDefinition = async (
   tagDefinitionId: string,
   start: string,
   end: string,
-  truncInterval: string,
+  bucketSize: string,
 ): Promise<ChartDataBucket[]> => {
+  const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const result = await query(
     user,
-    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+    `SELECT ${bucket.expr} AS bucket_start,
             count(*) AS value
        FROM tags
-      WHERE tag_definition_id = $2
+      WHERE tag_definition_id = $${bucket.params.length + 1}
         AND deleted_at IS NULL
-        AND start_time BETWEEN $3 AND $4
+        AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [truncInterval, tagDefinitionId, start, end],
+    [...bucket.params, tagDefinitionId, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -58,19 +93,20 @@ const queryTagsByPattern = async (
   pattern: string,
   start: string,
   end: string,
-  truncInterval: string,
+  bucketSize: string,
 ): Promise<ChartDataBucket[]> => {
+  const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const result = await query(
     user,
-    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+    `SELECT ${bucket.expr} AS bucket_start,
             count(*) AS value
        FROM tags
-      WHERE tag ~* $2
+      WHERE tag ~* $${bucket.params.length + 1}
         AND deleted_at IS NULL
-        AND start_time BETWEEN $3 AND $4
+        AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [truncInterval, pattern, start, end],
+    [...bucket.params, pattern, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -84,20 +120,21 @@ const queryMetricBuckets = async (
   metric: string,
   start: string,
   end: string,
-  truncInterval: string,
+  bucketSize: string,
   aggregation: 'count' | 'mean' | 'sum',
 ): Promise<ChartDataBucket[]> => {
   const aggFn = aggregation === 'mean' ? 'AVG(value)' : aggregation === 'sum' ? 'SUM(value)' : 'COUNT(*)'
+  const bucket = buildBucketExpr(bucketSize, 'time', 1)
   const result = await query(
     user,
-    `SELECT date_trunc($1, time AT TIME ZONE 'UTC') AS bucket_start,
+    `SELECT ${bucket.expr} AS bucket_start,
             ${aggFn} AS value
        FROM time_series
-      WHERE metric = $2
-        AND time BETWEEN $3 AND $4
+      WHERE metric = $${bucket.params.length + 1}
+        AND time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [truncInterval, metric, start, end],
+    [...bucket.params, metric, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -111,20 +148,21 @@ const queryProductivityCategoryBuckets = async (
   categoryPath: string,
   start: string,
   end: string,
-  truncInterval: string,
+  bucketSize: string,
 ): Promise<ChartDataBucket[]> => {
+  const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const result = await query(
     user,
-    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+    `SELECT ${bucket.expr} AS bucket_start,
             SUM(duration_sec) / 3600.0 AS value
        FROM productivity
       WHERE deleted_at IS NULL
         AND resolved_category IS NOT NULL
-        AND array_to_string(resolved_category, ' > ') LIKE $2 || '%'
-        AND start_time BETWEEN $3 AND $4
+        AND array_to_string(resolved_category, ' > ') LIKE $${bucket.params.length + 1} || '%'
+        AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [truncInterval, categoryPath, start, end],
+    [...bucket.params, categoryPath, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -138,20 +176,21 @@ const queryActivityTypeBuckets = async (
   pattern: string,
   start: string,
   end: string,
-  truncInterval: string,
+  bucketSize: string,
 ): Promise<ChartDataBucket[]> => {
+  const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const result = await query(
     user,
-    `SELECT date_trunc($1, start_time AT TIME ZONE 'UTC') AS bucket_start,
+    `SELECT ${bucket.expr} AS bucket_start,
             SUM(EXTRACT(EPOCH FROM (end_time - start_time))) / 3600.0 AS value
        FROM activities
       WHERE activity_type = 'exercise'
         AND deleted_at IS NULL
-        AND (data->>'exerciseTypeName' = $2 OR data->>'exerciseType' = $2)
-        AND start_time BETWEEN $3 AND $4
+        AND (data->>'exerciseTypeName' = $${bucket.params.length + 1} OR data->>'exerciseType' = $${bucket.params.length + 1})
+        AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [truncInterval, pattern, start, end],
+    [...bucket.params, pattern, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -164,26 +203,25 @@ const queryActivityTypeBuckets = async (
  */
 export const getChartData = async (user: string, input: ChartDataInput): Promise<ChartDataBucket[]> => {
   const { aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id } = input
-  const truncInterval = bucketToTrunc[bucket_size] ?? 'day'
 
   switch (source_type) {
     case 'tag':
       if (tag_definition_id) {
-        return queryTagsByDefinition(user, tag_definition_id, start, end, truncInterval)
+        return queryTagsByDefinition(user, tag_definition_id, start, end, bucket_size)
       }
       if (!pattern) return []
-      return queryTagsByPattern(user, pattern, start, end, truncInterval)
+      return queryTagsByPattern(user, pattern, start, end, bucket_size)
 
     case 'metric':
       if (!pattern) return []
-      return queryMetricBuckets(user, pattern, start, end, truncInterval, aggregation)
+      return queryMetricBuckets(user, pattern, start, end, bucket_size, aggregation)
 
     case 'productivity_category':
       if (!pattern) return []
-      return queryProductivityCategoryBuckets(user, pattern, start, end, truncInterval)
+      return queryProductivityCategoryBuckets(user, pattern, start, end, bucket_size)
 
     case 'activity_type':
       if (!pattern) return []
-      return queryActivityTypeBuckets(user, pattern, start, end, truncInterval)
+      return queryActivityTypeBuckets(user, pattern, start, end, bucket_size)
   }
 }

--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -27,6 +27,8 @@ interface ParsedBar {
 const buildBarDateFormat = (extent: [Date, Date]) => {
   const spanMs = extent[1].getTime() - extent[0].getTime()
   const spanDays = spanMs / (1000 * 60 * 60 * 24)
+  if (spanDays < 2) return d3.timeFormat('%H:%M')
+  if (spanDays < 7) return d3.timeFormat('%b %d %H:%M')
   if (spanDays > 365) return d3.timeFormat("%b '%y")
   if (spanDays > 60) return d3.timeFormat('%b %d')
   return d3.timeFormat('%b %d')

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -38,9 +38,11 @@ import './style.css'
 
 type SourceType = 'tag' | 'metric' | 'productivity_category' | 'activity_type'
 type ChartType = 'trend' | 'bar'
-type BucketSize = '1d' | '1w' | '1M'
+type BucketSize = '15m' | '1h' | '1d' | '1w' | '1M'
 
 const LOOKBACK_OPTIONS = [
+  { label: '1 day', value: 1 },
+  { label: '3 days', value: 3 },
   { label: '30 days', value: 30 },
   { label: '90 days', value: 90 },
   { label: '180 days', value: 180 },
@@ -55,6 +57,8 @@ const HALF_LIFE_OPTIONS = [
 ]
 
 const BUCKET_SIZE_OPTIONS: { label: string; value: BucketSize }[] = [
+  { label: '15 min', value: '15m' },
+  { label: 'Hourly', value: '1h' },
   { label: 'Daily', value: '1d' },
   { label: 'Weekly', value: '1w' },
   { label: 'Monthly', value: '1M' },

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1732,7 +1732,7 @@ export interface FetchChartDataParams {
   end: string
   pattern?: string
   tag_definition_id?: string
-  bucket_size?: '1d' | '1w' | '1M'
+  bucket_size?: '15m' | '1h' | '1d' | '1w' | '1M'
   aggregation?: 'count' | 'sum' | 'mean'
 }
 

--- a/packages/api-spec/src/schemas/chart-data.ts
+++ b/packages/api-spec/src/schemas/chart-data.ts
@@ -25,8 +25,8 @@ export type ChartDataSourceType = z.infer<typeof chartDataSourceTypeSchema>
 /**
  * Bucket size for chart data aggregation.
  */
-export const chartDataBucketSizeSchema = z.enum(['1d', '1w', '1M']).meta({
-  description: 'Bucket size for aggregation: daily, weekly, or monthly',
+export const chartDataBucketSizeSchema = z.enum(['15m', '1h', '1d', '1w', '1M']).meta({
+  description: 'Bucket size for aggregation: 15 minutes, hourly, daily, weekly, or monthly',
   example: '1d',
   id: 'ChartDataBucketSize',
 })
@@ -74,7 +74,7 @@ export type ChartDataQuery = z.infer<typeof chartDataQuerySchema>
 export const chartDataHttpQuerySchema = z
   .object({
     aggregation: z.enum(['count', 'sum', 'mean']).optional(),
-    bucket_size: z.enum(['1d', '1w', '1M']).optional(),
+    bucket_size: z.enum(['15m', '1h', '1d', '1w', '1M']).optional(),
     end: z.string().meta({ description: 'End of time range (ISO 8601 string)' }),
     pattern: z.string().optional().meta({ description: 'Pattern to match' }),
     source_type: chartDataSourceTypeSchema,

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -124,7 +124,7 @@ export const trendChartConfigSchema = z
 export const barChartConfigSchema = z
   .object({
     aggregation: z.enum(['count', 'sum', 'mean']).optional().meta({ description: 'Aggregation method' }),
-    bucket_size: z.enum(['1d', '1w', '1M']).meta({ description: 'Time bucket size' }),
+    bucket_size: z.enum(['15m', '1h', '1d', '1w', '1M']).meta({ description: 'Time bucket size' }),
     lookback_days: z.number().int().positive().meta({ description: 'Days of data to display' }),
     pattern: z.string().min(1).optional().meta({ description: 'Tag pattern (regex) or metric name' }),
     source_type: z


### PR DESCRIPTION
## Summary
- Add 15-minute and 1-hour bucket sizes to chart data aggregation (api-spec, backend, web)
- Add 1-day and 3-day lookback options to the Chart Explorer page
- Use PostgreSQL `date_bin()` for 15m buckets and `date_trunc('hour')` for 1h buckets
- Show HH:MM axis formatting for sub-day time spans in the BarChart component
- Add unit tests for new bucket sizes and `buildBucketExpr` helper

## Test plan
- [ ] Verify 15m and 1h bucket sizes work with tag, metric, productivity, and activity queries
- [ ] Test Chart Explorer UI with 1-day lookback + 15m/1h buckets
- [ ] Confirm BarChart shows time-based labels (HH:MM) for short spans
- [ ] Verify existing daily/weekly/monthly buckets still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)