### PR TITLE
fix: move all remaining user-specific logs to audit log

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -67,7 +67,7 @@ import { createSettingsRouter } from './routes/settings-router.ts'
 import { createTagsRouter } from './routes/tags-router.ts'
 import { createTrainingLoadRouter } from './routes/training-load-router.ts'
 import { createTrendsRouter } from './routes/trends-router.ts'
-import { auditInfo, pruneAuditLog } from './services/audit-log.ts'
+import { auditError, auditInfo, pruneAuditLog } from './services/audit-log.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
 import { getCentralDb, initializeCentralDb } from './services/central-db.ts'
 import { createDetectionTrigger, type DetectionTrigger } from './services/detection-trigger.ts'
@@ -313,8 +313,7 @@ const main = async () => {
           // Run migrations for existing databases
           await migrateSchema(user)
         }
-      } catch (err) {
-        console.log(err)
+      } catch {
         return next(unauthorized)
       }
     } else return next(unauthorized)
@@ -462,7 +461,7 @@ const main = async () => {
         res.json({ success: true })
       }
     } catch (error) {
-      console.error(`🔑 Garmin login endpoint error for user=${user}:`, error)
+      auditError(user, 'auth', 'Garmin login endpoint error', { error: String(error) })
       const message = error instanceof Error ? error.message : 'Login failed'
       res.status(401).json({ error: message, success: false })
     }
@@ -481,7 +480,7 @@ const main = async () => {
       await garmin.verifyMfa(user, mfa_code)
       res.json({ success: true })
     } catch (error) {
-      console.error(`🔑 Garmin MFA endpoint error for user=${user}:`, error)
+      auditError(user, 'auth', 'Garmin MFA endpoint error', { error: String(error) })
       const message = error instanceof Error ? error.message : 'MFA verification failed'
       res.status(401).json({ error: message, success: false })
     }

--- a/apps/backend/src/db/mcp-sessions.ts
+++ b/apps/backend/src/db/mcp-sessions.ts
@@ -10,7 +10,6 @@ import { mapMcpSessionRow } from './row-mappers.ts'
  * Save an MCP session to the database.
  */
 export const saveMcpSession = async (user: string, sessionId: string): Promise<McpSessionRecord> => {
-  console.log(`[MCP-DB] saveMcpSession: saving session ${sessionId} for user ${user}`)
   const result = await query(
     user,
     `INSERT INTO mcp_sessions (session_id, username, created_at, last_activity)
@@ -20,7 +19,6 @@ export const saveMcpSession = async (user: string, sessionId: string): Promise<M
     [sessionId, user],
   )
 
-  console.log(`[MCP-DB] saveMcpSession: saved session ${sessionId}, result:`, result.rows[0])
   return mapMcpSessionRow(result.rows[0])
 }
 
@@ -28,7 +26,6 @@ export const saveMcpSession = async (user: string, sessionId: string): Promise<M
  * Get an MCP session by ID.
  */
 export const getMcpSession = async (user: string, sessionId: string): Promise<McpSessionRecord | null> => {
-  console.log(`[MCP-DB] getMcpSession: looking for session ${sessionId}`)
   const result = await query(
     user,
     `SELECT session_id, username, created_at, last_activity
@@ -37,12 +34,7 @@ export const getMcpSession = async (user: string, sessionId: string): Promise<Mc
     [sessionId],
   )
 
-  if (result.rows.length === 0) {
-    console.log(`[MCP-DB] getMcpSession: session ${sessionId} not found`)
-    return null
-  }
-
-  console.log(`[MCP-DB] getMcpSession: found session ${sessionId}:`, result.rows[0])
+  if (result.rows.length === 0) return null
   return mapMcpSessionRow(result.rows[0])
 }
 

--- a/apps/backend/src/garmin-sync.ts
+++ b/apps/backend/src/garmin-sync.ts
@@ -12,6 +12,7 @@ import type { GarminClient } from './garmin.ts'
 
 import { getSyncState, upsertSyncState } from './db/index.ts'
 import { type GarminDataType, garminDataTypes, processGarminData } from './garmin-process.ts'
+import { auditError } from './services/audit-log.ts'
 
 // ============================================================================
 // Constants
@@ -216,7 +217,10 @@ const fetchAndProcess = async (
   } catch (error) {
     // If a single day fails, log and continue (don't abort the whole sync)
     const message = error instanceof Error ? error.message : String(error)
-    console.error(`Garmin sync error for ${dataType} on ${date.toISOString().slice(0, 10)}:`, message)
+    auditError(user, 'sync', `Garmin sync error for ${dataType}`, {
+      date: date.toISOString().slice(0, 10),
+      error: message,
+    })
     return { error: message, records: 0 }
   }
 }

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -14,6 +14,7 @@ import garminConnectPkg from '@flow-js/garmin-connect'
 const { GarminConnect } = garminConnectPkg
 
 import { getOAuthToken, upsertOAuthToken } from './db/index.ts'
+import { auditError, auditInfo } from './services/audit-log.ts'
 
 // ============================================================================
 // Types for Garmin API responses (from custom GET endpoints)
@@ -322,18 +323,18 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
       // Clean up any stale pending session for this user
       pendingMfaSessions.delete(user)
 
-      console.log(`🔑 Garmin login attempt for user=${user}, email=${email}`)
+      auditInfo(user, 'auth', 'Garmin login attempt', { email })
       const gc = new GarminConnect({ password, username: email })
 
       let result
       try {
         result = await gc.login()
       } catch (error) {
-        console.error(`🔑 Garmin login threw for user=${user}, email=${email}:`, error)
+        auditError(user, 'auth', 'Garmin login failed', { email, error: String(error) })
         throw error
       }
 
-      console.log(`🔑 Garmin login result for user=${user}: type=${result.type}`)
+      auditInfo(user, 'auth', `Garmin login result: ${result.type}`)
 
       if (result.type === 'success') {
         const tokens = gc.exportToken()
@@ -362,29 +363,27 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
      * @param mfaCode  The code from the user's email/SMS
      */
     async verifyMfa(user: string, mfaCode: string): Promise<GarminLoginSuccess> {
-      console.log(`🔑 Garmin MFA verify for user=${user}`)
+      auditInfo(user, 'auth', 'Garmin MFA verify')
       const entry = pendingMfaSessions.get(user)
       if (!entry) {
-        console.error(`🔑 Garmin MFA: no pending session for user=${user}`)
+        auditError(user, 'auth', 'Garmin MFA: no pending session')
         throw new Error('No pending MFA session. Please start login again.')
       }
 
       if (Date.now() - entry.createdAt > MFA_SESSION_TTL_MS) {
         pendingMfaSessions.delete(user)
-        console.error(`🔑 Garmin MFA: session expired for user=${user}`)
+        auditError(user, 'auth', 'Garmin MFA: session expired')
         throw new Error('MFA session expired. Please start login again.')
       }
 
       const { gc } = entry
 
-      console.log(`🔑 Garmin MFA: calling verifyMfa on GarminConnect...`)
       await gc.verifyMfa(mfaCode)
-      console.log(`🔑 Garmin MFA: verification succeeded for user=${user}`)
+      auditInfo(user, 'auth', 'Garmin MFA verification succeeded')
       pendingMfaSessions.delete(user)
 
       const tokens = gc.exportToken()
       await saveSession(user, gc)
-      console.log(`🔑 Garmin MFA: tokens saved for user=${user}`)
       return { success: true, tokens }
     },
   }

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -12,6 +12,7 @@ import {
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
+import { auditError, auditInfo } from '../services/audit-log.ts'
 import { computeAndStoreCalories, computeAndStoreCaloriesAll } from '../services/calorie-computation.ts'
 import {
   addCustomMetric,
@@ -206,10 +207,10 @@ export const registerMetricTools = (server: McpServer, user: string) => {
         // Full recompute runs async — fire and forget, return immediately
         computeAndStoreCaloriesAll(user).then(
           (result) =>
-            console.log(
-              `🔥 Async calorie recompute done for ${user}: ${result.points_stored} points across ${result.days_processed} days`,
-            ),
-          (error) => console.error(`🔥 Async calorie recompute failed for ${user}:`, error),
+            auditInfo(user, 'data', `Async calorie recompute done: ${result.points_stored} points`, {
+              days: result.days_processed,
+            }),
+          (error) => auditError(user, 'data', 'Async calorie recompute failed', { error: String(error) }),
         )
         return tzJsonResponse(
           { started: true, message: 'Full calorie recomputation started in background' },

--- a/apps/backend/src/oura-webhook-router.ts
+++ b/apps/backend/src/oura-webhook-router.ts
@@ -10,6 +10,7 @@ import { Router } from 'express'
 import type { OuraDataType } from './oura-sync.ts'
 
 import { ouraWebhookDataTypeMap, type OuraWebhookDataType } from './oura-webhook-api.ts'
+import { auditError, auditInfo } from './services/audit-log.ts'
 
 const DEBOUNCE_MS = 5000
 
@@ -38,7 +39,9 @@ export const createOuraWebhookRouter = (deps: OuraWebhookRouterDeps): OuraWebhoo
     const timeout = setTimeout(() => {
       pendingSyncs.delete(key)
       deps.syncOuraDataTypeForUser(username, dataType).catch((error) => {
-        console.error(`Webhook-triggered sync failed for ${username}/${dataType}:`, error)
+        auditError(username, 'sync', `Webhook-triggered Oura sync failed for ${dataType}`, {
+          error: String(error),
+        })
       })
     }, DEBOUNCE_MS)
 
@@ -73,7 +76,6 @@ export const createOuraWebhookRouter = (deps: OuraWebhookRouterDeps): OuraWebhoo
     // Map Oura data type to our internal type
     const ourDataType = ouraWebhookDataTypeMap[data_type as OuraWebhookDataType]
     if (!ourDataType) {
-      console.log(`Oura webhook: ignoring unknown data_type=${data_type} event_type=${event_type}`)
       res.json({ status: 'ok' })
       return
     }
@@ -81,12 +83,11 @@ export const createOuraWebhookRouter = (deps: OuraWebhookRouterDeps): OuraWebhoo
     // Look up local username from Oura user ID
     const username = await deps.getUsernameByOuraUserId(user_id)
     if (!username) {
-      console.log(`Oura webhook: ignoring unknown user_id=${user_id}`)
       res.json({ status: 'ok' })
       return
     }
 
-    console.log(`Oura webhook: ${event_type} ${data_type} for user ${username}, scheduling sync`)
+    auditInfo(username, 'sync', `Oura webhook: ${event_type} ${data_type}, scheduling sync`)
     scheduleDebouncedSync(username, ourDataType)
 
     res.json({ status: 'ok' })

--- a/apps/backend/src/oura.ts
+++ b/apps/backend/src/oura.ts
@@ -57,7 +57,6 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
       `https://api.ouraring.com/v2/usercollection/${type}?start_date=${formatISO(start, { representation: 'date' })}&end_date=${formatISO(addDays(end, 1), { representation: 'date' })}`,
       { headers: { Authorization: `Bearer ${token}` } },
     )
-    console.log(type, start, end, response.data)
     return response.data.data
   }
 
@@ -75,7 +74,6 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
 
   return {
     async authCb(req: Request, res: Response) {
-      console.log(req.query)
       const { code, scope, state, error } = req.query as Record<string, string | undefined>
 
       if (error) {
@@ -98,7 +96,6 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
       tokenUrl.searchParams.append('redirect_uri', redirectUri)
 
       const response = await axios.post(tokenUrl.toString())
-      console.log(response.data)
 
       const { access_token, refresh_token, expires_in } = response.data
 
@@ -115,7 +112,6 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
         const personalInfo = await getPersonalInfo(access_token)
         if (personalInfo?.id) {
           await options.onUserAuthenticated(personalInfo.id, user)
-          console.log(`Stored Oura user mapping: ${personalInfo.id} -> ${user}`)
         }
       }
 
@@ -139,7 +135,6 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
       tokenUrl.searchParams.append('client_secret', secret)
 
       const response = await axios.post(tokenUrl.toString())
-      console.log(response.data)
       const { access_token, refresh_token, expires_in } = response.data
 
       await upsertOAuthToken(user, {

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -38,6 +38,7 @@ import { type RequestHandler, Router } from 'express'
 
 import type { MetricType } from '../schema.ts'
 
+import { auditError, auditInfo } from '../services/audit-log.ts'
 import { computeAndStoreCalories, computeAndStoreCaloriesAll } from '../services/calorie-computation.ts'
 import {
   addCustomMetric,
@@ -159,10 +160,10 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
         // Full recompute runs async — fire and forget
         computeAndStoreCaloriesAll(user).then(
           (result) =>
-            console.log(
-              `🔥 Async calorie recompute done for ${user}: ${result.points_stored} points across ${result.days_processed} days`,
-            ),
-          (error) => console.error(`🔥 Async calorie recompute failed for ${user}:`, error),
+            auditInfo(user, 'data', `Async calorie recompute done: ${result.points_stored} points`, {
+              days: result.days_processed,
+            }),
+          (error) => auditError(user, 'data', 'Async calorie recompute failed', { error: String(error) }),
         )
         return res.json({
           points_computed: 0,

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -21,6 +21,7 @@ import {
   insertTimeSeries,
 } from '../db/time-series.ts'
 import { isHealthConnectSyncableMetric, metricToHealthConnectType } from '../schema.ts'
+import { auditError, auditInfo } from './audit-log.ts'
 import {
   type CalorieDataPoint,
   computeCaloriesPerMinute,
@@ -95,7 +96,7 @@ export const enqueueCalorieSync = async (
       })
     }
   } catch (err) {
-    console.error('Failed to enqueue calorie outbound sync:', err)
+    auditError(user, 'data', 'Failed to enqueue calorie outbound sync', { error: String(err) })
   }
 }
 
@@ -119,7 +120,7 @@ const invalidateTrainingLoadImpulses = async (user: string, fromTime: Date): Pro
       },
     })
   } catch (err) {
-    console.error('Failed to invalidate training load impulses:', err)
+    auditError(user, 'data', 'Failed to invalidate training load impulses', { error: String(err) })
   }
 }
 
@@ -444,12 +445,10 @@ export const computeAndStoreCaloriesAll = async (
   const gapFill = await gapFillCaloriesForRange(user, range.min, range.max)
   totalStored += gapFill.total_points_stored
 
-  console.log(
-    `🔥 Full recompute: ${totalStored} calorie points across ${daysProcessed} days for ${user}` +
-      (gapFill.total_points_stored > 0
-        ? ` (${gapFill.total_points_stored} gap-filled from HC aggregate)`
-        : ''),
-  )
+  auditInfo(user, 'data', `Full calorie recompute: ${totalStored} points across ${daysProcessed} days`, {
+    gap_filled: gapFill.total_points_stored,
+    vo2_max_source: vo2MaxSource,
+  })
 
   return {
     days_processed: daysProcessed,
@@ -468,20 +467,19 @@ export const triggerCalorieComputation = async (user: string, start: Date, end: 
   try {
     const result = await computeAndStoreCalories(user, start, end)
     if (result.points_stored > 0) {
-      console.log(
-        `🔥 Computed ${result.points_stored} calorie data points for ${user} ` +
-          `(VO2max: ${result.vo2_max_source})`,
-      )
+      auditInfo(user, 'data', `Computed ${result.points_stored} calorie points`, {
+        vo2_max_source: result.vo2_max_source,
+      })
     }
     // Gap-fill from HC aggregate for days in the range
     const gapFill = await gapFillCaloriesForRange(user, start, end)
     if (gapFill.total_points_stored > 0) {
-      console.log(
-        `🔥 Gap-filled ${gapFill.total_points_stored} calorie points for ${user} ` +
-          `(${gapFill.total_residual_kcal.toFixed(0)} kcal residual across ${gapFill.days_processed} days)`,
-      )
+      auditInfo(user, 'data', `Gap-filled ${gapFill.total_points_stored} calorie points`, {
+        days: gapFill.days_processed,
+        residual_kcal: Math.round(gapFill.total_residual_kcal),
+      })
     }
   } catch (err) {
-    console.error('Calorie computation failed (non-fatal):', err)
+    auditError(user, 'data', 'Calorie computation failed', { error: String(err) })
   }
 }

--- a/apps/backend/src/services/geocode-queue.ts
+++ b/apps/backend/src/services/geocode-queue.ts
@@ -10,6 +10,7 @@ import * as PgBossModule from 'pg-boss'
 
 import type { DetectedLocationUpdate } from '../db/index.ts'
 
+import { auditError, auditInfo, auditWarn } from './audit-log.ts'
 import { reverseGeocode } from './geocoding.ts'
 
 // ============================================================================
@@ -132,7 +133,7 @@ const createJobHandler = (deps: GeocodeQueueDeps) => {
     for (const job of jobs) {
       const { detectedLocationId, lat, lon, user } = job.data
 
-      console.log(`Processing geocode job for location ${detectedLocationId} at ${lat}, ${lon}`)
+      auditInfo(user, 'data', `Processing geocode job for location ${detectedLocationId}`, { lat, lon })
 
       const result = await reverseGeocode(lat, lon)
 
@@ -145,28 +146,28 @@ const createJobHandler = (deps: GeocodeQueueDeps) => {
           address: result.data.address,
           geocode_status: 'success',
         })
-        console.log(`Geocoded location ${detectedLocationId}: ${result.data.address}`)
+        auditInfo(user, 'data', `Geocoded location ${detectedLocationId}`, { address: result.data.address })
       } else {
         // Handle different error types
         const { error } = result
         if (error.type === 'network') {
           // Network error - retry by throwing
-          console.error(`Network error geocoding ${detectedLocationId}: ${error.message}`)
+          auditError(user, 'data', `Network error geocoding ${detectedLocationId}`, { error: error.message })
           throw new Error(`Network error: ${error.message}`)
         } else if (error.type === 'http') {
           // HTTP error - retry for server errors (5xx), fail for client errors
           if (error.status >= 500) {
-            console.error(`Server error geocoding ${detectedLocationId}: ${error.status}`)
+            auditError(user, 'data', `Server error geocoding ${detectedLocationId}`, { status: error.status })
             throw new Error(`HTTP ${error.status}: ${error.statusText}`)
           }
           // Client error (4xx) - don't retry
-          console.warn(`HTTP ${error.status} for location ${detectedLocationId}, marking failed`)
+          auditWarn(user, 'data', `HTTP ${error.status} for location ${detectedLocationId}, marking failed`)
           await deps.updateDetectedLocation(user, detectedLocationId, {
             geocode_status: 'failed',
           })
         } else {
           // No results - valid response but location has no address
-          console.warn(`No address found for location ${detectedLocationId}`)
+          auditWarn(user, 'data', `No address found for location ${detectedLocationId}`)
           await deps.updateDetectedLocation(user, detectedLocationId, {
             geocode_status: 'failed',
           })
@@ -239,11 +240,11 @@ export const createGeocodeQueue = async (deps: GeocodeQueueDeps): Promise<Geocod
           geocode_status: 'geocoding',
         })
 
-        console.log(`Enqueued geocode job ${jobId} for location ${data.detectedLocationId}`)
         return jobId
       } catch (error) {
-        // Enqueue failed - location stays in 'pending' status for future retry
-        console.error(`Failed to enqueue geocode job for ${data.detectedLocationId}:`, error)
+        auditError(data.user, 'data', `Failed to enqueue geocode job for ${data.detectedLocationId}`, {
+          error: String(error),
+        })
         return null
       }
     },

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -35,6 +35,7 @@ import {
   isValidMetricOrCustom,
   metricToHealthConnectType,
 } from '../schema.ts'
+import { auditError } from './audit-log.ts'
 import { getCustomMetrics } from './custom-metrics.ts'
 import { syncNoteTimesForEntity } from './notes.ts'
 
@@ -173,7 +174,7 @@ export async function addTag(user: string, input: AddTagInput): Promise<AddTagRe
       // Sync inherited times on any notes attached to this tag
       if (existingTag.id) {
         await syncNoteTimesForEntity(user, 'tag', existingTag.id, existingTag.start_time, newEndTime).catch(
-          (err) => console.error('Failed to sync note times for tag:', err),
+          (err) => auditError(user, 'data', 'Failed to sync note times for tag', { error: String(err) }),
         )
       }
 
@@ -325,7 +326,7 @@ export async function addMetric(user: string, input: AddMetricInput): Promise<Ad
       }
     }
   } catch (err) {
-    console.error('Failed to enqueue outbound sync for metric:', err)
+    auditError(user, 'data', 'Failed to enqueue outbound sync for metric', { error: String(err) })
   }
 
   const storedTime = input.time.toISOString()
@@ -457,7 +458,7 @@ export async function addActivity(user: string, input: AddActivityInput): Promis
       }
     }
   } catch (err) {
-    console.error('Failed to enqueue outbound sync for activity:', err)
+    auditError(user, 'data', 'Failed to enqueue outbound sync for activity', { error: String(err) })
   }
 
   return {
@@ -521,7 +522,7 @@ export async function deleteActivity(user: string, id: string): Promise<DeleteAc
       }
     }
   } catch (err) {
-    console.error('Failed to enqueue outbound sync for activity delete:', err)
+    auditError(user, 'data', 'Failed to enqueue outbound sync for activity delete', { error: String(err) })
   }
 
   return {
@@ -587,7 +588,7 @@ export async function updateActivity(
 
   // Sync inherited times on any notes attached to this activity (best-effort)
   syncNoteTimesForEntity(user, 'activity', id, updated.start_time, updated.end_time ?? undefined).catch(
-    (err) => console.error('Failed to sync note times for activity:', err),
+    (err) => auditError(user, 'data', 'Failed to sync note times for activity', { error: String(err) }),
   )
 
   // Enqueue outbound sync if this is an aurboda-owned HC-syncable activity (best-effort)
@@ -613,7 +614,7 @@ export async function updateActivity(
       }
     }
   } catch (err) {
-    console.error('Failed to enqueue outbound sync for activity update:', err)
+    auditError(user, 'data', 'Failed to enqueue outbound sync for activity update', { error: String(err) })
   }
 
   return {

--- a/apps/backend/src/services/screentime-categories.ts
+++ b/apps/backend/src/services/screentime-categories.ts
@@ -26,6 +26,7 @@ import {
   updateScreentimeCategory,
   upsertScreentimeCategory,
 } from '../db/index.ts'
+import { auditError } from './audit-log.ts'
 
 // ============================================================================
 // Category Resolution
@@ -183,7 +184,7 @@ export const createCategory = async (user: string, input: ScreentimeCategoryInpu
   // Fire-and-forget recategorization (only if the new category has a rule)
   if (input.rule_type === 'regex' && input.rule_regex) {
     recategorizeAll(user).catch((err) => {
-      console.error(`Recategorization failed for user ${user}:`, err)
+      auditError(user, 'data', 'Recategorization failed', { error: String(err) })
     })
   }
 
@@ -201,7 +202,7 @@ export const modifyCategory = async (user: string, id: string, input: Partial<Sc
     input.name !== undefined
   ) {
     recategorizeAll(user).catch((err) => {
-      console.error(`Recategorization failed for user ${user}:`, err)
+      auditError(user, 'data', 'Recategorization failed', { error: String(err) })
     })
   }
 
@@ -213,7 +214,7 @@ export const removeCategory = async (user: string, id: string) => {
 
   if (count > 0) {
     recategorizeAll(user).catch((err) => {
-      console.error(`Recategorization failed for user ${user}:`, err)
+      auditError(user, 'data', 'Recategorization failed', { error: String(err) })
     })
   }
 
@@ -228,7 +229,7 @@ export const upsertCategory = async (user: string, id: string, input: Screentime
   // Recategorize if the category has a rule
   if (input.rule_type === 'regex' && input.rule_regex) {
     recategorizeAll(user).catch((err) => {
-      console.error(`Recategorization failed for user ${user}:`, err)
+      auditError(user, 'data', 'Recategorization failed', { error: String(err) })
     })
   }
 
@@ -245,7 +246,7 @@ export const moveCategoryToParent = async (user: string, id: string, newParentId
 
   if (result.updated > 0) {
     recategorizeAll(user).catch((err) => {
-      console.error(`Recategorization after move failed for user ${user}:`, err)
+      auditError(user, 'data', 'Recategorization after move failed', { error: String(err) })
     })
   }
 
@@ -304,7 +305,7 @@ export const importFromActivityWatch = async (
 
   // Fire-and-forget recategorization
   recategorizeAll(user).catch((err) => {
-    console.error(`Recategorization after AW import failed for user ${user}:`, err)
+    auditError(user, 'data', 'Recategorization after AW import failed', { error: String(err) })
   })
 
   return result

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -167,13 +167,6 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       const { data } = req.body
       const user = req.user!
 
-      const metrics = [...new Set(data.map((a) => a.metric))]
-      const dates = [...new Set(data.map((a) => a.date))].sort()
-      console.log(
-        `📊 Daily aggregates received: ${data.length} entries for [${metrics.join(', ')}] ` +
-          `dates ${dates[0]}..${dates[dates.length - 1]}`,
-      )
-
       let deviceTimezone: string | undefined
       for (const aggregate of data) {
         const tz = await deps.processDailyAggregate(user, aggregate)

--- a/apps/backend/src/ui.ts
+++ b/apps/backend/src/ui.ts
@@ -24,8 +24,6 @@ export const getTimeline = async (oura: ReturnType<typeof ouraClient>) => {
   const tags = await oura.getTags(start, end, ouraToken, settings.tag_mappings)
   const meditations = await oura.getSessions(start, end, ouraToken)
 
-  console.log(tags)
-
   const placeColors: Record<string, string> = {
     Genki: 'darkgrey',
     Hökås: 'lightgreen',
@@ -153,9 +151,8 @@ export const getTimeline = async (oura: ReturnType<typeof ouraClient>) => {
     .attr('d', line)
 
   // -- Tags
-  tags.forEach(({ start_time, end_time, tag }) => {
+  tags.forEach(({ start_time, end_time }) => {
     if (end_time) {
-      console.log('=====', tag, start_time, end_time)
       svg
         .append('rect')
         .attr('x', xScale(start_time))
@@ -167,7 +164,6 @@ export const getTimeline = async (oura: ReturnType<typeof ouraClient>) => {
         .attr('stroke-dasharray', '4')
         .attr('opacity', 0.2)
     } else {
-      console.log('-----', start_time, tag)
       svg
         .append('line')
         .attr('x1', xScale(start_time))


### PR DESCRIPTION
## Summary

- Move all remaining user-specific `console.log`/`error`/`warn` calls to the audit log table
- Remove debug dumps (raw Oura API responses, MCP session data, tag objects)
- Only system-level logs remain in stdout: startup, shutdown, webhook infrastructure, geocode queue lifecycle, DB creation, migration script

Affected areas:
- **Sync**: daily aggregates, Garmin sync errors, Oura webhook sync
- **Auth**: Garmin login/MFA flow, Oura auth callback
- **Data**: calorie computation, geocoding jobs, outbound sync errors, screentime recategorization, note sync errors
- **Debug**: removed tag/session dumps from ui.ts, MCP session debug logs, Oura API response dumps

## Test plan

- [ ] Docker logs should now only show startup messages and webhook infra logs
- [ ] All user-specific events visible in `/audit-log` page
- [ ] Garmin login flow still works (logs go to audit log)
- [ ] Calorie recompute logs in audit log, not stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)