### PR TITLE
feat: add 1-minute and 5-minute chart bucket sizes

### DIFF
--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -31,10 +31,15 @@ export const buildBucketExpr = (
   column: string,
   startIdx: number,
 ): { expr: string; params: string[] } => {
-  if (bucketSize === '15m') {
+  const dateBinIntervals: Record<string, string> = {
+    '1m': '1 minute',
+    '5m': '5 minutes',
+    '15m': '15 minutes',
+  }
+  if (dateBinIntervals[bucketSize]) {
     return {
       expr: `date_bin($${startIdx}::interval, ${column} AT TIME ZONE 'UTC', '2000-01-01'::timestamptz)`,
-      params: ['15 minutes'],
+      params: [dateBinIntervals[bucketSize]],
     }
   }
   if (bucketSize === '1h') {
@@ -52,7 +57,7 @@ export const buildBucketExpr = (
 
 export interface ChartDataInput {
   aggregation: 'count' | 'mean' | 'sum'
-  bucket_size: '15m' | '1M' | '1d' | '1h' | '1w'
+  bucket_size: '1m' | '5m' | '15m' | '1M' | '1d' | '1h' | '1w'
   end: string
   pattern?: string
   source_type: ChartDataSourceType

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -38,7 +38,7 @@ import './style.css'
 
 type SourceType = 'tag' | 'metric' | 'productivity_category' | 'activity_type'
 type ChartType = 'trend' | 'bar'
-type BucketSize = '15m' | '1h' | '1d' | '1w' | '1M'
+type BucketSize = '1m' | '5m' | '15m' | '1h' | '1d' | '1w' | '1M'
 
 const LOOKBACK_OPTIONS = [
   { label: '1 day', value: 1 },
@@ -57,6 +57,8 @@ const HALF_LIFE_OPTIONS = [
 ]
 
 const BUCKET_SIZE_OPTIONS: { label: string; value: BucketSize }[] = [
+  { label: '1 min', value: '1m' },
+  { label: '5 min', value: '5m' },
   { label: '15 min', value: '15m' },
   { label: 'Hourly', value: '1h' },
   { label: 'Daily', value: '1d' },

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1732,7 +1732,7 @@ export interface FetchChartDataParams {
   end: string
   pattern?: string
   tag_definition_id?: string
-  bucket_size?: '15m' | '1h' | '1d' | '1w' | '1M'
+  bucket_size?: '1m' | '5m' | '15m' | '1h' | '1d' | '1w' | '1M'
   aggregation?: 'count' | 'sum' | 'mean'
 }
 

--- a/packages/api-spec/src/schemas/chart-data.ts
+++ b/packages/api-spec/src/schemas/chart-data.ts
@@ -25,8 +25,9 @@ export type ChartDataSourceType = z.infer<typeof chartDataSourceTypeSchema>
 /**
  * Bucket size for chart data aggregation.
  */
-export const chartDataBucketSizeSchema = z.enum(['15m', '1h', '1d', '1w', '1M']).meta({
-  description: 'Bucket size for aggregation: 15 minutes, hourly, daily, weekly, or monthly',
+export const chartDataBucketSizeSchema = z.enum(['1m', '5m', '15m', '1h', '1d', '1w', '1M']).meta({
+  description:
+    'Bucket size for aggregation: 1 minute, 5 minutes, 15 minutes, hourly, daily, weekly, or monthly',
   example: '1d',
   id: 'ChartDataBucketSize',
 })
@@ -74,7 +75,7 @@ export type ChartDataQuery = z.infer<typeof chartDataQuerySchema>
 export const chartDataHttpQuerySchema = z
   .object({
     aggregation: z.enum(['count', 'sum', 'mean']).optional(),
-    bucket_size: z.enum(['15m', '1h', '1d', '1w', '1M']).optional(),
+    bucket_size: z.enum(['1m', '5m', '15m', '1h', '1d', '1w', '1M']).optional(),
     end: z.string().meta({ description: 'End of time range (ISO 8601 string)' }),
     pattern: z.string().optional().meta({ description: 'Pattern to match' }),
     source_type: chartDataSourceTypeSchema,

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -124,7 +124,9 @@ export const trendChartConfigSchema = z
 export const barChartConfigSchema = z
   .object({
     aggregation: z.enum(['count', 'sum', 'mean']).optional().meta({ description: 'Aggregation method' }),
-    bucket_size: z.enum(['15m', '1h', '1d', '1w', '1M']).meta({ description: 'Time bucket size' }),
+    bucket_size: z
+      .enum(['1m', '5m', '15m', '1h', '1d', '1w', '1M'])
+      .meta({ description: 'Time bucket size' }),
     lookback_days: z.number().int().positive().meta({ description: 'Days of data to display' }),
     pattern: z.string().min(1).optional().meta({ description: 'Tag pattern (regex) or metric name' }),
     source_type: z


### PR DESCRIPTION
## Summary
- Add 1m and 5m bucket sizes to Chart Explorer for high-resolution intra-day data
- Uses PostgreSQL `date_bin()` (same as 15m buckets)

## Test plan
- [ ] Chart page shows 1 min and 5 min options in bucket size selector
- [ ] Selecting 5 min with stress_level metric and 1 day lookback shows detailed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)