### PR TITLE
feat: improve metric meta page UX and soft delete

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -357,6 +357,9 @@ export const migrateSchema = async (user: string) => {
   if (existingTableNames.has('activities')) {
     await query(db, `ALTER TABLE activities ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
   }
+  if (existingTableNames.has('time_series')) {
+    await query(db, `ALTER TABLE time_series ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
+  }
   if (existingTableNames.has('productivity')) {
     await query(db, `ALTER TABLE productivity ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
     await query(

--- a/apps/backend/src/db/time-series.integration.test.ts
+++ b/apps/backend/src/db/time-series.integration.test.ts
@@ -527,14 +527,14 @@ describe('Time Series Integration Tests', () => {
   // ==========================================================================
 
   describe('deleteTimeSeriesPoint', () => {
-    test('deletes a user-created measurement and returns true', async () => {
+    test('soft-deletes a measurement and returns true', async () => {
       const user = getTestUser()
 
       await insertTimeSeries(user, [
         { metric: 'weight', source: 'aurboda', time: new Date('2024-01-15T08:00:00Z'), value: 75.5 },
       ])
 
-      const result = await deleteTimeSeriesPoint(user, 'weight', new Date('2024-01-15T08:00:00Z'))
+      const result = await deleteTimeSeriesPoint(user, 'weight', new Date('2024-01-15T08:00:00Z'), 'aurboda')
 
       expect(result).toBe(true)
 
@@ -547,16 +547,21 @@ describe('Time Series Integration Tests', () => {
       expect(data).toHaveLength(0)
     })
 
-    test('does not delete external source data', async () => {
+    test('soft-deletes external source data', async () => {
       const user = getTestUser()
 
       await insertTimeSeries(user, [
         { metric: 'weight', source: 'health_connect', time: new Date('2024-01-15T08:00:00Z'), value: 75.5 },
       ])
 
-      const result = await deleteTimeSeriesPoint(user, 'weight', new Date('2024-01-15T08:00:00Z'))
+      const result = await deleteTimeSeriesPoint(
+        user,
+        'weight',
+        new Date('2024-01-15T08:00:00Z'),
+        'health_connect',
+      )
 
-      expect(result).toBe(false)
+      expect(result).toBe(true)
 
       const data = await getTimeSeries(
         user,
@@ -564,15 +569,60 @@ describe('Time Series Integration Tests', () => {
         new Date('2024-01-15T00:00:00Z'),
         new Date('2024-01-15T23:59:59Z'),
       )
-      expect(data).toHaveLength(1)
+      expect(data).toHaveLength(0)
     })
 
     test('returns false when no matching measurement found', async () => {
       const user = getTestUser()
 
-      const result = await deleteTimeSeriesPoint(user, 'weight', new Date('2024-01-15T08:00:00Z'))
+      const result = await deleteTimeSeriesPoint(user, 'weight', new Date('2024-01-15T08:00:00Z'), 'manual')
 
       expect(result).toBe(false)
+    })
+
+    test('sync does not resurrect a soft-deleted point', async () => {
+      const user = getTestUser()
+
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+      ])
+
+      // Soft delete it
+      await deleteTimeSeriesPoint(user, 'heart_rate', new Date('2024-01-15T10:00:00Z'), 'oura')
+
+      // Re-insert the same point (simulating a sync)
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+      ])
+
+      // Should still be invisible
+      const data = await getTimeSeries(
+        user,
+        'heart_rate',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(data).toHaveLength(0)
+    })
+
+    test('does not affect other sources for the same metric and time', async () => {
+      const user = getTestUser()
+
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'oura', time: new Date('2024-01-15T10:00:00Z'), value: 72 },
+        { metric: 'heart_rate', source: 'garmin', time: new Date('2024-01-15T10:00:00Z'), value: 74 },
+      ])
+
+      await deleteTimeSeriesPoint(user, 'heart_rate', new Date('2024-01-15T10:00:00Z'), 'oura')
+
+      const data = await getTimeSeriesWithSource(
+        user,
+        'heart_rate',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+      expect(data).toHaveLength(1)
+      expect(data[0].source).toBe('garmin')
     })
   })
 

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -48,7 +48,8 @@ export const insertTimeSeries = async (user: string, points: TimeSeriesPoint[]) 
     format(
       `INSERT INTO time_series (time, metric, value, unit, source)
        VALUES %L
-       ON CONFLICT (time, metric, source) DO UPDATE SET value = EXCLUDED.value`,
+       ON CONFLICT (time, metric, source) DO UPDATE SET value = EXCLUDED.value
+       WHERE time_series.deleted_at IS NULL`,
       values,
     ),
   )
@@ -66,11 +67,11 @@ export const getTimeSeries = async (
     user,
     sources
       ? `SELECT time, value FROM time_series
-       WHERE metric = $1 AND time >= $2 AND time <= $3
+       WHERE metric = $1 AND time >= $2 AND time <= $3 AND deleted_at IS NULL
          AND source = ANY($4)
        ORDER BY time`
       : `SELECT time, value FROM time_series
-       WHERE metric = $1 AND time >= $2 AND time <= $3
+       WHERE metric = $1 AND time >= $2 AND time <= $3 AND deleted_at IS NULL
        ORDER BY time`,
     sources ? [metric, start, end, sources] : [metric, start, end],
   )
@@ -91,11 +92,11 @@ export const getTimeSeriesWithSource = async (
     user,
     sources
       ? `SELECT time, value, source FROM time_series
-       WHERE metric = $1 AND time >= $2 AND time <= $3
+       WHERE metric = $1 AND time >= $2 AND time <= $3 AND deleted_at IS NULL
          AND source = ANY($4)
        ORDER BY time`
       : `SELECT time, value, source FROM time_series
-       WHERE metric = $1 AND time >= $2 AND time <= $3
+       WHERE metric = $1 AND time >= $2 AND time <= $3 AND deleted_at IS NULL
        ORDER BY time`,
     sources ? [metric, start, end, sources] : [metric, start, end],
   )
@@ -114,7 +115,7 @@ export const getTimeSeriesBySource = async (
   const result = await query(
     user,
     `SELECT time, value FROM time_series
-     WHERE metric = $1 AND source = $2 AND time >= $3 AND time <= $4
+     WHERE metric = $1 AND source = $2 AND time >= $3 AND time <= $4 AND deleted_at IS NULL
      ORDER BY time`,
     [metric, source, start, end],
   )
@@ -135,7 +136,7 @@ export const getRawDailySum = async (
   const result = await query(
     user,
     `SELECT COALESCE(SUM(value), 0) as total FROM time_series
-     WHERE metric = $1 AND time >= $2 AND time <= $3`,
+     WHERE metric = $1 AND time >= $2 AND time <= $3 AND deleted_at IS NULL`,
     [metric, start, end],
   )
   return Number(result.rows[0].total)
@@ -156,11 +157,11 @@ export const getTimeSeriesMultiMetric = async (
     params: [start, end],
     queryFn: (sql, params) => query(user, sql, params),
     sqlCumulative: `SELECT time, metric, value FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3 AND deleted_at IS NULL
          AND source = ANY($4)
        ORDER BY metric, time`,
     sqlNonCumulative: `SELECT time, metric, value FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3 AND deleted_at IS NULL
        ORDER BY metric, time`,
   })
 
@@ -194,7 +195,7 @@ export const getTimeSeriesStats = async (
          STDDEV_POP(value) as stddev,
          MAX(unit) as unit
        FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3${sourceFilter}
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3 AND deleted_at IS NULL${sourceFilter}
        GROUP BY metric
        ORDER BY metric`
 
@@ -236,7 +237,7 @@ export const getDailyAggregates = async (
          AVG(value) as avg,
          SUM(value) as sum
        FROM time_series
-       WHERE metric = ANY($1) AND time >= $2 AND time <= $3${sourceFilter}
+       WHERE metric = ANY($1) AND time >= $2 AND time <= $3 AND deleted_at IS NULL${sourceFilter}
        GROUP BY DATE(time), metric
        ORDER BY metric, date`
 
@@ -292,7 +293,7 @@ export const getMetricTimeRange = async (
 ): Promise<{ min: Date; max: Date } | null> => {
   const result = await query(
     user,
-    `SELECT MIN(time) as min_time, MAX(time) as max_time FROM time_series WHERE metric = $1`,
+    `SELECT MIN(time) as min_time, MAX(time) as max_time FROM time_series WHERE metric = $1 AND deleted_at IS NULL`,
     [metric],
   )
   if (result.rows.length === 0 || result.rows[0].min_time === null) return null
@@ -300,14 +301,19 @@ export const getMetricTimeRange = async (
 }
 
 // ============================================================================
-// Time Series Deletion (manual source only)
+// Time Series Deletion (soft delete)
 // ============================================================================
 
-export const deleteTimeSeriesPoint = async (user: string, metric: string, time: Date): Promise<boolean> => {
+export const deleteTimeSeriesPoint = async (
+  user: string,
+  metric: string,
+  time: Date,
+  source: string,
+): Promise<boolean> => {
   const result = await query(
     user,
-    `DELETE FROM time_series WHERE metric = $1 AND time = $2 AND source IN ('manual', 'aurboda', 'aurboda_gap_fill')`,
-    [metric, time],
+    `UPDATE time_series SET deleted_at = NOW() WHERE metric = $1 AND time = $2 AND source = $3 AND deleted_at IS NULL`,
+    [metric, time, source],
   )
   return (result.rowCount ?? 0) > 0
 }
@@ -315,7 +321,7 @@ export const deleteTimeSeriesPoint = async (user: string, metric: string, time: 
 export const deleteTimeSeriesMetric = async (user: string, metric: string): Promise<number> => {
   const result = await query(
     user,
-    `DELETE FROM time_series WHERE metric = $1 AND source IN ('manual', 'aurboda', 'aurboda_gap_fill')`,
+    `UPDATE time_series SET deleted_at = NOW() WHERE metric = $1 AND source IN ('manual', 'aurboda', 'aurboda_gap_fill') AND deleted_at IS NULL`,
     [metric],
   )
   return result.rowCount ?? 0
@@ -330,7 +336,7 @@ export const deleteTimeSeriesBySource = async (
 ): Promise<number> => {
   const result = await query(
     user,
-    `DELETE FROM time_series WHERE metric = $1 AND source = $2 AND time >= $3 AND time < $4`,
+    `UPDATE time_series SET deleted_at = NOW() WHERE metric = $1 AND source = $2 AND time >= $3 AND time < $4 AND deleted_at IS NULL`,
     [metric, source, start, end],
   )
   return result.rowCount ?? 0
@@ -358,7 +364,7 @@ export const getTimeSeriesBucketed = async (
        SUM(value) as sum,
        COUNT(*)::integer as count
      FROM time_series
-     WHERE metric = ANY($1) AND time >= $2 AND time < $3${sourceFilter}
+     WHERE metric = ANY($1) AND time >= $2 AND time < $3 AND deleted_at IS NULL${sourceFilter}
      GROUP BY bucket_start, metric
      ORDER BY bucket_start, metric`
 
@@ -387,9 +393,10 @@ export const getTimeSeriesBucketed = async (
 
 /** Get distinct metric names that have data in the given time range. */
 export const getDistinctMetrics = async (user: string, start: Date, end: Date): Promise<string[]> => {
-  const result = await query(user, 'SELECT DISTINCT metric FROM time_series WHERE time >= $1 AND time < $2', [
-    start,
-    end,
-  ])
+  const result = await query(
+    user,
+    'SELECT DISTINCT metric FROM time_series WHERE time >= $1 AND time < $2 AND deleted_at IS NULL',
+    [start, end],
+  )
   return result.rows.map((row) => row.metric as string).sort()
 }

--- a/apps/backend/src/mcp/metric-tools.ts
+++ b/apps/backend/src/mcp/metric-tools.ts
@@ -163,18 +163,21 @@ export const registerMetricTools = (server: McpServer, user: string) => {
   // Tool: delete_metric
   server.tool(
     'delete_metric',
-    'Delete a single manual metric measurement by metric name and time. Only manual entries can be deleted.',
+    'Delete a single metric measurement by metric name, time, and source (soft delete). Works for any source.',
     {
       metric: z.string().describe(metricDescription),
+      source: z
+        .string()
+        .describe('Data source of the measurement (e.g. manual, oura, garmin, health_connect)'),
       time: z.string().describe('Measurement time in ISO 8601 format (must match exactly)'),
     },
-    async ({ metric, time }) => {
+    async ({ metric, source, time }) => {
       const measurementTime = parseOptionalDate(time)
       if (!measurementTime) {
         return errorResponse('Invalid time format. Use ISO 8601 format.')
       }
 
-      const result = await deleteMetric(user, metric, measurementTime)
+      const result = await deleteMetric(user, metric, measurementTime, source)
       return jsonResponse(result)
     },
   )

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -225,20 +225,18 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     res.json({ ...result, success: true })
   })
 
-  // DELETE /metrics/:metric - Delete a single manual measurement
+  // DELETE /metrics/:metric - Delete a single measurement (soft delete)
   router.delete<{ metric: string }, unknown, unknown, DeleteMetricQuery>(
     '/metrics/:metric',
     authMiddleware,
     validateQuery(deleteMetricQuerySchema),
     async (req, res) => {
       const { metric } = req.params
-      const { time } = req.query
+      const { time, source } = req.query
       const user = req.user!
-      const result = await deleteMetric(user, metric, new Date(time))
+      const result = await deleteMetric(user, metric, new Date(time), source)
       if (!result.deleted) {
-        return res
-          .status(404)
-          .json({ error: 'Measurement not found (only manual entries can be deleted)', success: false })
+        return res.status(404).json({ error: 'Measurement not found', success: false })
       }
       res.json({ ...result, success: true })
     },

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -655,6 +655,7 @@ export const createTableStatements: Record<string, string> = {
       value           DOUBLE PRECISION NOT NULL,
       unit            VARCHAR(20) NOT NULL,
       source          VARCHAR(50) NOT NULL,
+      deleted_at      TIMESTAMPTZ,
       PRIMARY KEY (time, metric, source)
     )
   `,

--- a/apps/backend/src/services/custom-metrics.ts
+++ b/apps/backend/src/services/custom-metrics.ts
@@ -129,10 +129,15 @@ export async function updateCustomMetric(
 }
 
 /**
- * Delete a single manual metric measurement by metric name and time.
+ * Delete a single metric measurement by metric name, time, and source (soft delete).
  */
-export async function deleteMetric(user: string, metric: string, time: Date): Promise<DeleteMetricResult> {
-  const deleted = await deleteTimeSeriesPoint(user, metric, time)
+export async function deleteMetric(
+  user: string,
+  metric: string,
+  time: Date,
+  source: string,
+): Promise<DeleteMetricResult> {
+  const deleted = await deleteTimeSeriesPoint(user, metric, time, source)
 
   return {
     deleted,

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -1210,10 +1210,10 @@ describe('deleteMetric', () => {
     vi.clearAllMocks()
   })
 
-  test('deletes a manual measurement and returns success', async () => {
+  test('deletes a measurement and returns success', async () => {
     vi.mocked(db.deleteTimeSeriesPoint).mockResolvedValue(true)
 
-    const result = await deleteMetric('testuser', 'weight', new Date('2024-01-15T08:00:00Z'))
+    const result = await deleteMetric('testuser', 'weight', new Date('2024-01-15T08:00:00Z'), 'manual')
 
     expect(result.success).toBe(true)
     expect(result.deleted).toBe(true)
@@ -1223,13 +1223,14 @@ describe('deleteMetric', () => {
       'testuser',
       'weight',
       new Date('2024-01-15T08:00:00Z'),
+      'manual',
     )
   })
 
   test('returns false when measurement not found', async () => {
     vi.mocked(db.deleteTimeSeriesPoint).mockResolvedValue(false)
 
-    const result = await deleteMetric('testuser', 'weight', new Date('2024-01-15T08:00:00Z'))
+    const result = await deleteMetric('testuser', 'weight', new Date('2024-01-15T08:00:00Z'), 'manual')
 
     expect(result.success).toBe(false)
     expect(result.deleted).toBe(false)

--- a/apps/web/src/pages/EntityDetail/EntityActions.tsx
+++ b/apps/web/src/pages/EntityDetail/EntityActions.tsx
@@ -37,7 +37,7 @@ const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> =
   if (entityType === 'metric') {
     const parsed = parseMetricEntityId(entityId)
     if (!parsed) return Promise.reject(new Error('Invalid metric entity ID'))
-    return deleteMetricPoint(parsed.metric, parsed.time)
+    return deleteMetricPoint(parsed.metric, parsed.time, parsed.source)
   }
   return Promise.reject(new Error('Unsupported entity type for delete'))
 }

--- a/apps/web/src/pages/EntityDetail/MetricContent.tsx
+++ b/apps/web/src/pages/EntityDetail/MetricContent.tsx
@@ -53,7 +53,7 @@ export const MetricContent = ({ entityId }: { entityId: string }) => {
       // Only delete the old point if the time actually changed, otherwise
       // we'd delete the point we just upserted.
       if (newTime !== parsed.time) {
-        await deleteMetricPoint(parsed.metric, parsed.time)
+        await deleteMetricPoint(parsed.metric, parsed.time, parsed.source)
       }
     },
     onSuccess: () => {

--- a/apps/web/src/pages/MetricMeta/index.tsx
+++ b/apps/web/src/pages/MetricMeta/index.tsx
@@ -8,8 +8,8 @@ import { useRoute } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import {
+  deleteMetricPoint,
   fetchCustomMetrics,
-  fetchMetricTimeSeries,
   fetchMetricTimeSeriesWithSource,
   fetchTrend,
   updateCustomMetric,
@@ -17,6 +17,8 @@ import {
   type FetchTrendParams,
   type MetricDataPointWithSource,
 } from '../../state/api'
+import { buildChartUrl } from '../../utils/chart-url'
+import { formatDateTime } from '../EntityDetail/format-utils'
 import { MiniTrendChart } from '../TagMeta/MiniTrendChart'
 import './style.css'
 
@@ -111,13 +113,24 @@ function SourceFilteredChart({ metric, unit, lookback }: { metric: string; unit:
 }
 
 function RecentValues({ metric, unit }: { metric: string; unit: string }) {
+  const queryClient = useQueryClient()
   const end = new Date()
   const start = new Date(end.getTime() - 30 * 86400000)
 
   const { data, isLoading } = useQuery({
-    queryFn: () => fetchMetricTimeSeries(metric, start, end),
+    queryFn: () => fetchMetricTimeSeriesWithSource(metric, start, end),
     queryKey: ['metric-recent', metric],
     staleTime: 5 * 60 * 1000,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ time, source }: { time: string; source: string }) =>
+      deleteMetricPoint(metric, time, source),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['metric-recent', metric] })
+      queryClient.invalidateQueries({ queryKey: ['trend'] })
+      queryClient.invalidateQueries({ queryKey: ['metric-with-source', metric] })
+    },
   })
 
   if (isLoading) return <p class="loading">Loading...</p>
@@ -128,18 +141,33 @@ function RecentValues({ metric, unit }: { metric: string; unit: string }) {
 
   return (
     <div class="metric-meta-recent-list">
-      {recent.map(([date, value]) => (
-        <div key={date.toISOString()} class="metric-meta-recent-item">
-          <span class="metric-meta-recent-time">
-            {date.toLocaleDateString()}{' '}
-            {date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
-          </span>
-          <span class="metric-meta-recent-value">
-            {formatValue(value)}
-            {unit ? ` ${unit}` : ''}
-          </span>
-        </div>
-      ))}
+      {recent.map((point) => {
+        const entityId = `${point.time.toISOString()}|${metric}|${point.source}`
+        return (
+          <div key={point.time.toISOString() + point.source} class="metric-meta-recent-item">
+            <a href={`/detail/metric/${encodeURIComponent(entityId)}`} class="metric-meta-recent-link">
+              <span class="metric-meta-recent-time">{formatDateTime(point.time)}</span>
+              <span class="metric-meta-recent-value">
+                {formatValue(point.value)}
+                {unit ? ` ${unit}` : ''}
+              </span>
+            </a>
+            <button
+              type="button"
+              class="metric-meta-delete-btn"
+              title="Delete this measurement"
+              disabled={deleteMutation.isPending}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                deleteMutation.mutate({ source: point.source, time: point.time.toISOString() })
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )
+      })}
       {data.length > 10 && (
         <p class="metric-meta-more">
           +{data.length - 10} more in last 30 days ({data.length} total)
@@ -344,6 +372,18 @@ export function MetricMeta() {
       <section class="metric-meta-section">
         <div class="metric-meta-section-header">
           <h2>Trend</h2>
+          <a
+            href={buildChartUrl({
+              aggregation: 'mean',
+              chart_type: 'bar',
+              lookback_days: lookback,
+              pattern: metricName,
+              source_type: 'metric',
+            })}
+            class="metric-meta-chart-link"
+          >
+            Explore in Chart
+          </a>
           <select
             value={lookback}
             onChange={(e) => setLookback(Number((e.target as HTMLSelectElement).value))}
@@ -387,7 +427,10 @@ export function MetricMeta() {
       <section class="metric-meta-section">
         <h2>Related</h2>
         <div class="metric-meta-links">
-          <a href="/chart" class="metric-meta-link">
+          <a
+            href={`/chart?source_type=metric&pattern=${encodeURIComponent(metricName)}`}
+            class="metric-meta-link"
+          >
             Chart Explorer
           </a>
           <a href="/correlations" class="metric-meta-link">

--- a/apps/web/src/pages/MetricMeta/style.css
+++ b/apps/web/src/pages/MetricMeta/style.css
@@ -81,6 +81,18 @@
   margin: 0;
 }
 
+.metric-meta-chart-link {
+  font-size: 0.85rem;
+  color: #7c3aed;
+  text-decoration: none;
+  margin-left: auto;
+  margin-right: 0.75rem;
+}
+
+.metric-meta-chart-link:hover {
+  text-decoration: underline;
+}
+
 .metric-meta-section-header select {
   padding: 0.375rem 0.75rem;
   border: 1px solid #d1d5db;
@@ -187,9 +199,8 @@
 
 .metric-meta-recent-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0.75rem;
+  padding: 0;
   border: 1px solid #f3f4f6;
   border-radius: 6px;
   font-size: 0.85rem;
@@ -199,6 +210,16 @@
   background: #f9fafb;
 }
 
+.metric-meta-recent-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  color: inherit;
+}
+
 .metric-meta-recent-time {
   color: #6b7280;
 }
@@ -206,6 +227,27 @@
 .metric-meta-recent-value {
   font-weight: 600;
   color: #374151;
+}
+
+.metric-meta-delete-btn {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 0.5rem 0.75rem;
+  line-height: 1;
+  border-left: 1px solid #f3f4f6;
+}
+
+.metric-meta-delete-btn:hover {
+  color: #ef4444;
+  background: #fef2f2;
+}
+
+.metric-meta-delete-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .metric-meta-empty {
@@ -399,6 +441,20 @@
 
   .metric-meta-recent-value {
     color: #e5e7eb;
+  }
+
+  .metric-meta-chart-link {
+    color: #a78bfa;
+  }
+
+  .metric-meta-delete-btn {
+    color: #6b7280;
+    border-left-color: #374151;
+  }
+
+  .metric-meta-delete-btn:hover {
+    color: #f87171;
+    background: #1f1215;
   }
 
   .metric-meta-link {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1390,12 +1390,12 @@ export const addMetric = async (body: AddMetricBody): Promise<AddMetricResponse>
   return response.data
 }
 
-/** Delete a single manual metric measurement. */
-export const deleteMetricPoint = async (metric: string, time: string): Promise<void> => {
+/** Delete a single metric measurement (soft delete). */
+export const deleteMetricPoint = async (metric: string, time: string, source: string): Promise<void> => {
   const { token } = auth.value
   await axios.delete(`${API_URL}/metrics/${encodeURIComponent(metric)}`, {
     headers: { Authorization: `Bearer ${token}` },
-    params: { time },
+    params: { source, time },
   })
 }
 

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -212,6 +212,7 @@ export type UpdateCustomMetricBody = z.infer<typeof updateCustomMetricBodySchema
  */
 export const deleteMetricQuerySchema = z
   .object({
+    source: z.string().describe('Data source of the measurement'),
     time: iso8601DateTimeSchema,
   })
   .meta({ id: 'DeleteMetricQuery' })


### PR DESCRIPTION
## Summary
- **Soft delete for time_series**: Added `deleted_at` column so any metric point (including synced data) can be hidden without re-appearing on next sync. All reads filter `WHERE deleted_at IS NULL`, and `ON CONFLICT` skips soft-deleted rows.
- **Metric meta page improvements**: Added "Explore in Chart" link next to Trend header (opens bar chart), linked recent values to detail page, added delete button on each recent value, fixed 12h→24h time display, pre-selected metric in Chart Explorer link.
- **Updated delete API**: `DELETE /metrics/:metric` now requires `source` param and works for any source (not just manual).

## Test plan
- [x] Integration tests pass (31 tests including new soft-delete and sync-resistance tests)
- [x] `pnpm check` passes
- [ ] Verify on https://aurboda.net after deploy:
  - "Explore in Chart" link opens bar chart view
  - Recent values show 24h format (e.g. `2026-03-30 17:45`)
  - Recent values link to `/detail/metric/...`
  - Delete button works on all entries
  - Deleted synced data stays hidden after re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)