### PR TITLE
feat: Garmin auto-sync and per-data-type toggles

### DIFF
--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -9,6 +9,7 @@ import type {
   BiologicalSex,
   DashboardConfig,
   DataSource,
+  GarminDataType,
   MetricType,
   TrainingLoadSettings,
 } from '@aurboda/api-spec'
@@ -457,6 +458,7 @@ export interface UserSettings {
   sensitivity_areas?: string[] // Sensitivity areas to track in meals
   tag_mappings?: Record<string, string> // Tag name mappings from UUIDs to display names
   training_load?: TrainingLoadSettings // Training load (Banister model) parameters
+  garmin_disabled_data_types?: GarminDataType[] // Garmin data types to skip during sync
 }
 
 // ============================================================================

--- a/apps/backend/src/garmin-sync.test.ts
+++ b/apps/backend/src/garmin-sync.test.ts
@@ -279,6 +279,32 @@ describe('syncAllGarminData', () => {
     }
   })
 
+  test('skips disabled data types', async () => {
+    vi.mocked(db.getSyncState).mockResolvedValue({
+      data_type: 'dailySummary',
+      last_sync_time: new Date(),
+      provider: 'garmin',
+      status: 'idle',
+    })
+
+    const mockGarmin = createMockGarmin()
+    const results = await syncAllGarminData(user, mockGarmin as never, {
+      disabledTypes: ['heartRate', 'sleep', 'activities'],
+    })
+
+    expect(results).toHaveLength(garminDataTypes.length)
+
+    const skippedTypes = results.filter((r) => r.status === 'skipped').map((r) => r.data_type)
+    expect(skippedTypes).toContain('heartRate')
+    expect(skippedTypes).toContain('sleep')
+    expect(skippedTypes).toContain('activities')
+
+    // Non-disabled types should have been synced
+    const syncedTypes = results.filter((r) => r.status === 'success').map((r) => r.data_type)
+    expect(syncedTypes).toContain('dailySummary')
+    expect(syncedTypes).toContain('stress')
+  })
+
   test('skips remaining data types after hitting rate limit', async () => {
     // Return rate_limited sync state for all data types (mock returns same value)
     vi.mocked(db.getSyncState).mockResolvedValue({

--- a/apps/backend/src/garmin-sync.ts
+++ b/apps/backend/src/garmin-sync.ts
@@ -177,12 +177,18 @@ export const syncGarminDataType = async (
 export const syncAllGarminData = async (
   user: string,
   garmin: GarminClient,
-  options?: { fullResync?: boolean; startDate?: Date },
+  options?: { disabledTypes?: GarminDataType[]; fullResync?: boolean; startDate?: Date },
 ): Promise<SyncResult[]> => {
   const results: SyncResult[] = []
   let hitRateLimit = false
+  const disabled = new Set(options?.disabledTypes ?? [])
 
   for (const dataType of garminDataTypes) {
+    if (disabled.has(dataType)) {
+      results.push({ data_type: dataType, records_processed: 0, status: 'skipped' })
+      continue
+    }
+
     if (hitRateLimit) {
       results.push({ data_type: dataType, records_processed: 0, status: 'skipped' })
       continue

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -24,7 +24,7 @@ import {
   getPendingOutboundSync,
   requeueOutboundSync,
 } from '../db/index.ts'
-import { syncAllGarminData } from '../garmin-sync.ts'
+import { type GarminDataType, syncAllGarminData } from '../garmin-sync.ts'
 import { syncAllCalendars } from '../ical-sync.ts'
 import { syncLastFmData } from '../lastfm-sync.ts'
 import { syncAllOuraData } from '../oura-sync.ts'
@@ -90,7 +90,9 @@ export const registerSyncTools = (
       }
 
       try {
+        const settings = await getSettings(user)
         const results = await syncAllGarminData(user, garmin, {
+          disabledTypes: settings.garmin_disabled_data_types as GarminDataType[],
           fullResync: full_resync,
           startDate: start_date ? new Date(start_date) : undefined,
         })

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -689,6 +689,15 @@ export async function getDailySummary(
       sync.syncRescueTimeIfNeeded(user),
       sync.syncCalendarsIfNeeded(user),
       sync.syncLastFmIfNeeded(user),
+      sync.syncGarminIfNeeded(user, 'dailySummary'),
+      sync.syncGarminIfNeeded(user, 'heartRate'),
+      sync.syncGarminIfNeeded(user, 'hrv'),
+      sync.syncGarminIfNeeded(user, 'stress'),
+      sync.syncGarminIfNeeded(user, 'bodyBattery'),
+      sync.syncGarminIfNeeded(user, 'spo2'),
+      sync.syncGarminIfNeeded(user, 'respiration'),
+      sync.syncGarminIfNeeded(user, 'trainingReadiness'),
+      sync.syncGarminIfNeeded(user, 'intensityMinutes'),
     ])
   }
 
@@ -1371,9 +1380,13 @@ export async function queryActivities(
   end: Date,
   sync?: SyncProvider,
 ): Promise<ActivityResult[]> {
-  // Fire-and-forget: trigger background sync so meditation data is fresh for the next request
-  if (sync && types.includes('meditation')) {
-    void sync.syncOuraIfNeeded(user, 'sessions')
+  // Fire-and-forget: trigger background sync so activity data is fresh for the next request
+  if (sync) {
+    const promises: Promise<void>[] = []
+    if (types.includes('meditation')) promises.push(sync.syncOuraIfNeeded(user, 'sessions'))
+    if (types.includes('sleep')) promises.push(sync.syncGarminIfNeeded(user, 'sleep'))
+    if (types.includes('exercise')) promises.push(sync.syncGarminIfNeeded(user, 'activities'))
+    if (promises.length > 0) void Promise.all(promises)
   }
 
   const activities = await getActivities(user, types, start, end)

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -201,20 +201,25 @@ export const getTagMappings = async (
 /**
  * Get settings response in the format used by both API and MCP.
  */
-/** Apply defaults for nullable settings fields. */
-const withDefaults = (settings: UserSettings) => ({
-  birth_date: settings.birth_date ?? null,
+/** Apply defaults for nullable/array settings fields. */
+const emptyArrayDefaults = (settings: UserSettings) => ({
   calendars: settings.calendars ?? [],
-  dashboard: settings.dashboard ?? null,
   food_sensitivity_map: settings.food_sensitivity_map ?? {},
+  garmin_disabled_data_types: settings.garmin_disabled_data_types ?? [],
   item_icons: settings.item_icons ?? {},
-  lastfm_username: settings.lastfm_username ?? null,
   meal_slots: settings.meal_slots ?? [],
-  rescue_time_key: settings.rescue_time_key ?? null,
   sensitivity_areas: settings.sensitivity_areas ?? [],
-  sex: settings.sex ?? null,
   tag_icons: settings.item_icons ?? {},
   tag_mappings: settings.tag_mappings ?? {},
+})
+
+const withDefaults = (settings: UserSettings) => ({
+  ...emptyArrayDefaults(settings),
+  birth_date: settings.birth_date ?? null,
+  dashboard: settings.dashboard ?? null,
+  lastfm_username: settings.lastfm_username ?? null,
+  rescue_time_key: settings.rescue_time_key ?? null,
+  sex: settings.sex ?? null,
   training_load: settings.training_load ?? null,
   tz: settings.device_timezone ?? null,
 })
@@ -251,6 +256,7 @@ const EMPTY_SETTINGS_DEFAULTS = {
   dashboard: null,
   food_sensitivity_map: {},
   garmin_connected: false,
+  garmin_disabled_data_types: [],
   goals: defaultGoals,
   hr_zone_start_source: 'default' as const,
   item_icons: {},

--- a/apps/backend/src/services/sync-provider.ts
+++ b/apps/backend/src/services/sync-provider.ts
@@ -76,6 +76,10 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
       if (!config.garmin) return
 
       try {
+        // Check if this data type is disabled in user settings
+        const settings = await getSettings(user)
+        if (settings.garmin_disabled_data_types?.includes(dataType as GarminDataType)) return
+
         const syncState = await getSyncState(user, 'garmin', dataType)
 
         if (isGarminRateLimited(syncState)) {

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -313,6 +313,7 @@ describe('sync router', () => {
 
       expect(response.status).toBe(200)
       expect(mockDeps.syncGarmin).toHaveBeenCalledWith('testuser', {
+        disabledTypes: undefined,
         fullResync: undefined,
         startDate: undefined,
       })
@@ -326,6 +327,7 @@ describe('sync router', () => {
 
       expect(response.status).toBe(200)
       expect(mockDeps.syncGarmin).toHaveBeenCalledWith('testuser', {
+        disabledTypes: undefined,
         fullResync: true,
         startDate: new Date('2024-01-01'),
       })

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -1,6 +1,7 @@
 import type { ParamsDictionary } from 'express-serve-static-core'
 
 import {
+  type GarminDataType,
   dailyAggregatesBodySchema,
   healthConnectDeletionsBodySchema,
   healthConnectSyncBodySchema,
@@ -96,7 +97,7 @@ export interface SyncRouterDeps {
   resetOuraSyncState: (user: string, dataType?: string) => Promise<void>
   syncGarmin: (
     user: string,
-    options: { fullResync?: boolean; startDate?: Date },
+    options: { disabledTypes?: GarminDataType[]; fullResync?: boolean; startDate?: Date },
   ) => Promise<GarminSyncResult[]>
   getGarminSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   resetGarminSyncState: (user: string, dataType?: string) => Promise<void>
@@ -124,7 +125,12 @@ export interface SyncRouterDeps {
   resetLastFmSyncState: (user: string) => Promise<void>
   getSettings: (
     user: string,
-  ) => Promise<{ rescue_time_key?: string; calendars?: CalendarConfig[]; lastfm_username?: string }>
+  ) => Promise<{
+    rescue_time_key?: string
+    calendars?: CalendarConfig[]
+    lastfm_username?: string
+    garmin_disabled_data_types?: GarminDataType[]
+  }>
   getLastFmApiKey: () => Promise<string | null>
   processActivityWatchEvents: (
     user: string,
@@ -244,7 +250,9 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       const { full_resync, start_date } = req.body
 
       try {
+        const settings = await deps.getSettings(user)
         const results = await deps.syncGarmin(user, {
+          disabledTypes: settings.garmin_disabled_data_types,
           fullResync: full_resync,
           startDate: start_date ? new Date(start_date) : undefined,
         })

--- a/apps/web/src/pages/DataSources/GarminSource.tsx
+++ b/apps/web/src/pages/DataSources/GarminSource.tsx
@@ -1,3 +1,5 @@
+import type { GarminDataType, ProviderSyncStatus } from '@aurboda/api-spec'
+
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
 
@@ -7,25 +9,55 @@ import {
   fetchGarminSyncStatus,
   fetchUserSettings,
   syncGarmin,
+  updateUserSettings,
   verifyGarminMfa,
 } from '../../state/api'
 import { auth } from '../../state/auth'
 import { type DataTypeItem, DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
 
-const DATA_TYPES: DataTypeItem[] = [
-  { label: 'Daily summary (steps, distance, calories, floors)', href: '/metric/steps' },
-  { label: 'Heart rate (resting + samples)', href: '/metric/heart_rate' },
-  { label: 'HRV (last night average)', href: '/metric/hrv_rmssd' },
-  { label: 'Sleep (duration, stages, score)', href: '/sleep' },
-  { label: 'Stress level', href: '/metric/stress_level' },
-  { label: 'Body Battery', href: '/metric/body_battery' },
-  { label: 'Activities (exercise with HR, VO2 max)' },
-  { label: 'SpO2 (blood oxygen)', href: '/metric/spo2' },
-  { label: 'Respiration rate', href: '/metric/respiratory_rate' },
-  { label: 'Training readiness', href: '/metric/training_readiness' },
-  { label: 'Intensity minutes', href: '/metric/intensity_minutes' },
+interface GarminDataTypeInfo {
+  type: GarminDataType
+  label: string
+  href?: string
+  hc_note?: string // Health Connect overlap note (undefined = Garmin only)
+}
+
+const GARMIN_DATA_TYPES: GarminDataTypeInfo[] = [
+  {
+    type: 'dailySummary',
+    label: 'Daily summary (steps, distance, calories, floors)',
+    href: '/metric/steps',
+    hc_note: 'Also available via Health Connect',
+  },
+  {
+    type: 'heartRate',
+    label: 'Heart rate (resting + samples)',
+    href: '/metric/heart_rate',
+    hc_note: 'Also available via Health Connect',
+  },
+  { type: 'hrv', label: 'HRV (last night average)', href: '/metric/hrv_rmssd' },
+  {
+    type: 'sleep',
+    label: 'Sleep (duration, stages, score)',
+    href: '/sleep',
+    hc_note: 'Also available via Health Connect. Garmin adds sleep score.',
+  },
+  { type: 'stress', label: 'Stress level', href: '/metric/stress_level' },
+  { type: 'bodyBattery', label: 'Body Battery', href: '/metric/body_battery' },
+  {
+    type: 'activities',
+    label: 'Activities (exercise with HR, VO2 max)',
+    hc_note: 'Also available via Health Connect. Garmin adds VO2 max, activity type detail.',
+  },
+  { type: 'spo2', label: 'SpO2 (blood oxygen)', href: '/metric/spo2' },
+  { type: 'respiration', label: 'Respiration rate', href: '/metric/respiratory_rate' },
+  { type: 'trainingReadiness', label: 'Training readiness', href: '/metric/training_readiness' },
+  { type: 'intensityMinutes', label: 'Intensity minutes', href: '/metric/intensity_minutes' },
 ]
+
+// Static list for when not connected (no toggles)
+const DATA_TYPES: DataTypeItem[] = GARMIN_DATA_TYPES.map(({ label, href }) => ({ label, href }))
 
 type LoginStatus = 'idle' | 'loading' | 'mfa' | 'mfa_loading' | 'error'
 
@@ -159,6 +191,178 @@ function GarminLoginForm({ onMfaRequired, onSuccess }: { onMfaRequired: () => vo
   )
 }
 
+function GarminDataTypeToggles({
+  disabledTypes,
+  onToggle,
+}: {
+  disabledTypes: GarminDataType[]
+  onToggle: (disabledTypes: GarminDataType[]) => Promise<void>
+}) {
+  const [saving, setSaving] = useState(false)
+  const disabledSet = new Set(disabledTypes)
+
+  const handleToggle = useCallback(
+    async (type: GarminDataType) => {
+      setSaving(true)
+      try {
+        const newDisabled = disabledSet.has(type)
+          ? disabledTypes.filter((t) => t !== type)
+          : [...disabledTypes, type]
+        await onToggle(newDisabled)
+      } finally {
+        setSaving(false)
+      }
+    },
+    [disabledTypes, disabledSet, onToggle],
+  )
+
+  return (
+    <div class="data-types-section">
+      <h2>Data types</h2>
+      <p class="field-description">
+        Toggle which data types to sync from Garmin. Disable types that are already synced via Health Connect
+        to avoid duplicates.
+      </p>
+      <div class="garmin-data-types-grid">
+        {GARMIN_DATA_TYPES.map((dt) => {
+          const enabled = !disabledSet.has(dt.type)
+          return (
+            <label key={dt.type} class={`garmin-data-type-row ${enabled ? '' : 'disabled'}`}>
+              <input
+                type="checkbox"
+                checked={enabled}
+                disabled={saving}
+                onChange={() => handleToggle(dt.type)}
+              />
+              <div class="garmin-data-type-info">
+                {dt.href ? (
+                  <a class="garmin-data-type-label" href={dt.href}>
+                    {dt.label}
+                  </a>
+                ) : (
+                  <span class="garmin-data-type-label">{dt.label}</span>
+                )}
+                <span class="garmin-data-type-note">{dt.hc_note ?? 'Garmin only'}</span>
+              </div>
+            </label>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function GarminDataTypesSection({
+  isConnected,
+  disabledTypes,
+  queryClient,
+}: {
+  isConnected: boolean
+  disabledTypes: GarminDataType[]
+  queryClient: ReturnType<typeof useQueryClient>
+}) {
+  if (!isConnected) return <DataTypesList types={DATA_TYPES} />
+
+  return (
+    <GarminDataTypeToggles
+      disabledTypes={disabledTypes}
+      onToggle={async (types) => {
+        await updateUserSettings({ garmin_disabled_data_types: types })
+        await queryClient.invalidateQueries({ queryKey: ['userSettings'] })
+      }}
+    />
+  )
+}
+
+function GarminConnectionSection({
+  isConnected,
+  syncStatusData,
+  syncStatusLoading,
+  loginStatus,
+  setLoginStatus,
+  disconnecting,
+  syncStatus,
+  syncMessage,
+  handleLoginSuccess,
+  handleDisconnect,
+  handleSyncNow,
+  handleFullResync,
+}: {
+  isConnected: boolean
+  syncStatusData: { states?: ProviderSyncStatus[] } | undefined
+  syncStatusLoading: boolean
+  loginStatus: LoginStatus
+  setLoginStatus: (s: LoginStatus) => void
+  disconnecting: boolean
+  syncStatus: string
+  syncMessage: string
+  handleLoginSuccess: () => Promise<void>
+  handleDisconnect: () => Promise<void>
+  handleSyncNow: () => Promise<void>
+  handleFullResync: () => Promise<void>
+}) {
+  return (
+    <>
+      <StatusBanner
+        connected={isConnected}
+        label={isConnected ? 'Garmin Connect is connected' : 'Garmin Connect not connected'}
+      />
+
+      {isConnected && (
+        <SyncStatusBar
+          states={syncStatusData?.states}
+          isLoading={syncStatusLoading}
+          onSyncNow={handleSyncNow}
+        />
+      )}
+
+      <div class="links-row">
+        <a
+          href="https://github.com/fiddur/aurboda/blob/develop/docs/garmin.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="doc-link"
+        >
+          Garmin integration documentation
+        </a>
+      </div>
+
+      <section class="settings-section">
+        <h2>Connection</h2>
+
+        {isConnected ? (
+          <div class="garmin-connected-actions">
+            <p class="connected-status">Connected</p>
+            <div class="garmin-button-row">
+              <button
+                type="button"
+                class="connect-button"
+                disabled={syncStatus === 'syncing'}
+                onClick={handleFullResync}
+              >
+                {syncStatus === 'syncing' ? 'Syncing...' : 'Full Re-sync'}
+              </button>
+              <button
+                type="button"
+                class="connect-button disconnect-button"
+                disabled={disconnecting}
+                onClick={handleDisconnect}
+              >
+                {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+              </button>
+            </div>
+            {syncMessage && <p class={`garmin-sync-message ${syncStatus}`}>{syncMessage}</p>}
+          </div>
+        ) : loginStatus === 'mfa' ? (
+          <GarminMfaForm onCancel={() => setLoginStatus('idle')} onSuccess={handleLoginSuccess} />
+        ) : (
+          <GarminLoginForm onMfaRequired={() => setLoginStatus('mfa')} onSuccess={handleLoginSuccess} />
+        )}
+      </section>
+    </>
+  )
+}
+
 export function GarminSource() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()
@@ -241,69 +445,29 @@ export function GarminSource() {
           only session tokens are persisted.
         </p>
 
-        <DataTypesList types={DATA_TYPES} />
+        <GarminDataTypesSection
+          isConnected={isConnected}
+          disabledTypes={userSettings?.garmin_disabled_data_types ?? []}
+          queryClient={queryClient}
+        />
 
         {isLoading ? (
           <div class="loading">Loading...</div>
         ) : (
-          <>
-            <StatusBanner
-              connected={isConnected}
-              label={isConnected ? 'Garmin Connect is connected' : 'Garmin Connect not connected'}
-            />
-
-            {isConnected && (
-              <SyncStatusBar
-                states={syncStatusData?.states}
-                isLoading={syncStatusLoading}
-                onSyncNow={handleSyncNow}
-              />
-            )}
-
-            <div class="links-row">
-              <a
-                href="https://github.com/fiddur/aurboda/blob/develop/docs/garmin.md"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="doc-link"
-              >
-                Garmin integration documentation
-              </a>
-            </div>
-
-            <section class="settings-section">
-              <h2>Connection</h2>
-
-              {isConnected ? (
-                <div class="garmin-connected-actions">
-                  <p class="connected-status">Connected</p>
-                  <div class="garmin-button-row">
-                    <button
-                      type="button"
-                      class="connect-button"
-                      disabled={syncStatus === 'syncing'}
-                      onClick={handleFullResync}
-                    >
-                      {syncStatus === 'syncing' ? 'Syncing...' : 'Full Re-sync'}
-                    </button>
-                    <button
-                      type="button"
-                      class="connect-button disconnect-button"
-                      disabled={disconnecting}
-                      onClick={handleDisconnect}
-                    >
-                      {disconnecting ? 'Disconnecting...' : 'Disconnect'}
-                    </button>
-                  </div>
-                  {syncMessage && <p class={`garmin-sync-message ${syncStatus}`}>{syncMessage}</p>}
-                </div>
-              ) : loginStatus === 'mfa' ? (
-                <GarminMfaForm onCancel={() => setLoginStatus('idle')} onSuccess={handleLoginSuccess} />
-              ) : (
-                <GarminLoginForm onMfaRequired={() => setLoginStatus('mfa')} onSuccess={handleLoginSuccess} />
-              )}
-            </section>
-          </>
+          <GarminConnectionSection
+            isConnected={isConnected}
+            syncStatusData={syncStatusData}
+            syncStatusLoading={syncStatusLoading}
+            loginStatus={loginStatus}
+            setLoginStatus={setLoginStatus}
+            disconnecting={disconnecting}
+            syncStatus={syncStatus}
+            syncMessage={syncMessage}
+            handleLoginSuccess={handleLoginSuccess}
+            handleDisconnect={handleDisconnect}
+            handleSyncNow={handleSyncNow}
+            handleFullResync={handleFullResync}
+          />
         )}
       </div>
     </div>

--- a/apps/web/src/pages/DataSources/style.css
+++ b/apps/web/src/pages/DataSources/style.css
@@ -181,6 +181,63 @@
   border-color: #673ab8;
 }
 
+/* Garmin data type toggles */
+.garmin-data-types-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.garmin-data-type-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.garmin-data-type-row:hover {
+  background: #f3f4f6;
+}
+
+.garmin-data-type-row.disabled {
+  opacity: 0.55;
+}
+
+.garmin-data-type-row input[type='checkbox'] {
+  margin-top: 0.15rem;
+  accent-color: #673ab8;
+}
+
+.garmin-data-type-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.garmin-data-type-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+a.garmin-data-type-label {
+  color: #673ab8;
+  text-decoration: none;
+}
+
+a.garmin-data-type-label:hover {
+  text-decoration: underline;
+}
+
+.garmin-data-type-note {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
 .data-source-detail .doc-link {
   display: inline-flex;
   align-items: center;
@@ -824,6 +881,22 @@
 
   .data-sources-page .sync-now-button:hover:not(:disabled) {
     background: #6d28d9;
+  }
+
+  .garmin-data-type-row:hover {
+    background: #374151;
+  }
+
+  .garmin-data-type-label {
+    color: #f9fafb;
+  }
+
+  a.garmin-data-type-label {
+    color: #a78bfa;
+  }
+
+  .garmin-data-type-note {
+    color: #9ca3af;
   }
 }
 

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { baseResponseSchema, hrZoneSourceSchema } from './common.ts'
 import { dashboardConfigSchema } from './dashboard.ts'
 import { goalsSchema } from './goals.ts'
+import { garminDataTypeSchema } from './sync.ts'
 import { trainingLoadSettingsSchema } from './training-load.ts'
 
 // Shared HR zone threshold field
@@ -227,6 +228,9 @@ export const updateSettingsInputSchema = z
     training_load: trainingLoadSettingsSchema.nullable().optional().meta({
       description: 'Training load (Banister model) parameters (set to null to reset to defaults)',
     }),
+    garmin_disabled_data_types: z.array(garminDataTypeSchema).nullable().optional().meta({
+      description: 'Garmin data types to skip during sync (set to null to clear, enabling all)',
+    }),
   })
   .meta({ id: 'UpdateSettingsInput' })
 
@@ -254,6 +258,9 @@ export const userSettingsResponseSchema = baseResponseSchema
     garmin_connected: z
       .boolean()
       .meta({ description: 'Whether Garmin Connect is connected via stored session' }),
+    garmin_disabled_data_types: z.array(garminDataTypeSchema).meta({
+      description: 'Garmin data types currently disabled for sync',
+    }),
     food_sensitivity_map: foodSensitivityMapSchema.meta({ description: 'Food-to-sensitivity mapping' }),
     meal_slots: mealSlotsSchema.meta({ description: 'Configured meal slots for quick-logging' }),
     lastfm_configured: z.boolean().meta({ description: 'Whether Last.fm API key is configured on server' }),


### PR DESCRIPTION
## Summary

- **Garmin auto-sync**: Add Garmin to query-triggered auto-sync (30-min stale threshold). `getDailySummary()` now triggers sync for all 9 metric-producing Garmin data types, and `queryActivities()` triggers sync for sleep and exercises. Previously, Garmin data only updated via manual "Sync Now".
- **Per-data-type toggles**: New `garmin_disabled_data_types` user setting. Users can disable specific Garmin data types that overlap with Health Connect (heartRate, sleep, activities, dailySummary) to avoid duplicates. The setting is respected by both auto-sync and manual sync.
- **Frontend UI**: Interactive data type toggles on the Garmin page (when connected), showing each type with a note about Health Connect overlap status.

## Test plan

- [x] Unit test: `syncAllGarminData` skips disabled types with `status: 'skipped'`
- [x] Existing sync-router tests updated for `disabledTypes` parameter
- [x] All 1546 backend tests pass
- [x] TypeScript and oxlint checks pass
- [ ] Manual: load timeline, verify Garmin auto-syncs (check server logs for "Auto-syncing Garmin...")
- [ ] Manual: connect Garmin, disable heartRate, trigger sync, verify heartRate is skipped
- [ ] Manual: verify toggle UI on Garmin data source page

🤖 Generated with [Claude Code](https://claude.com/claude-code)