### PR TITLE
fix: add 5-minute delay to AW sync for AFK filtering

### DIFF
--- a/docs/activitywatch.md
+++ b/docs/activitywatch.md
@@ -96,7 +96,9 @@ else
   START_TIME=$(date -u -d "${LOOKBACK_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
     || date -u -v-${LOOKBACK_HOURS}H +%Y-%m-%dT%H:%M:%SZ)  # macOS fallback
 fi
-END_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Use 5 minutes ago to give AFK watcher time to finalize heartbeats
+END_TIME=$(date -u -d "5 minutes ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)  # macOS fallback
 
 # Find the aw-watcher-window and aw-watcher-afk buckets for this host
 BUCKETS_JSON=$(curl -sf "${AW_URL}/api/0/buckets/" || true)


### PR DESCRIPTION
## Summary
- The AFK watcher uses heartbeats to extend event duration, so querying "up to now" can miss recent AFK coverage
- Sets `END_TIME` to 5 minutes ago, matching the cron interval for a clean predictable delay
- The gap is picked up on the next sync cycle via the state file

## Test plan
- [ ] Check logs on next cron run: nighttime events should show as filtered
- [ ] Verify no data loss — events from the 5-minute gap appear in the following run

🤖 Generated with [Claude Code](https://claude.com/claude-code)