### PR TITLE
fix: metric detail handles sourceless entity IDs from timeline

### DIFF
--- a/apps/web/src/pages/EntityDetail/EntityActions.tsx
+++ b/apps/web/src/pages/EntityDetail/EntityActions.tsx
@@ -37,6 +37,7 @@ const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> =
   if (entityType === 'metric') {
     const parsed = parseMetricEntityId(entityId)
     if (!parsed) return Promise.reject(new Error('Invalid metric entity ID'))
+    if (!parsed.source) return Promise.reject(new Error('Cannot delete metric without source'))
     return deleteMetricPoint(parsed.metric, parsed.time, parsed.source)
   }
   return Promise.reject(new Error('Unsupported entity type for delete'))

--- a/apps/web/src/pages/EntityDetail/MetricContent.tsx
+++ b/apps/web/src/pages/EntityDetail/MetricContent.tsx
@@ -52,7 +52,7 @@ export const MetricContent = ({ entityId }: { entityId: string }) => {
 
       // Only delete the old point if the time actually changed, otherwise
       // we'd delete the point we just upserted.
-      if (newTime !== parsed.time) {
+      if (newTime !== parsed.time && parsed.source) {
         await deleteMetricPoint(parsed.metric, parsed.time, parsed.source)
       }
     },

--- a/apps/web/src/pages/EntityDetail/MetricDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/MetricDetail.tsx
@@ -89,90 +89,146 @@ export const MetricDetail = ({
   const metricLabel = formatMetricLabel(parsed.metric)
   const customUnit = customMetricsQuery.data?.find((m) => m.name === parsed.metric)?.unit
   const unit = customUnit ?? (builtinMetricUnits as Record<string, string>)[parsed.metric] ?? ''
-  const time = new Date(parsed.time)
-  const displayValue = point ? Number(point.value.toFixed(2)) : null
+  const source = parsed.source ?? point?.source ?? '…'
 
   if (isEditing && draft && onDraftChange) {
     return (
-      <div class="entity-info">
-        <div class="entity-meta">
-          <span class="entity-type-badge">metric</span>
-          <span class="entity-source">Source: {parsed.source ?? point?.source ?? '…'}</span>
-        </div>
-
-        <h2>
-          <a href={`/metric/${encodeURIComponent(parsed.metric)}`} class="entity-meta-link">
-            {metricLabel}
-          </a>
-        </h2>
-
-        <div class="entity-fields">
-          <div class="field-row">
-            <span class="field-label">Time</span>
-            <span class="field-value">
-              <input
-                type="datetime-local"
-                class="edit-datetime-input"
-                value={draft.time}
-                onInput={(e) => onDraftChange({ ...draft, time: (e.target as HTMLInputElement).value })}
-              />
-            </span>
-          </div>
-          <div class="field-row">
-            <span class="field-label">Value</span>
-            <span class="field-value">
-              <input
-                type="number"
-                step="any"
-                class="edit-value-input"
-                value={draft.value}
-                onInput={(e) => onDraftChange({ ...draft, value: (e.target as HTMLInputElement).value })}
-              />
-              {unit && <span class="edit-value-unit">{unit}</span>}
-            </span>
-          </div>
-          <div class="field-row">
-            <span class="field-label">Metric</span>
-            <span class="field-value">{parsed.metric}</span>
-          </div>
-        </div>
-      </div>
+      <MetricEditView
+        metric={parsed.metric}
+        metricLabel={metricLabel}
+        source={source}
+        unit={unit}
+        draft={draft}
+        onDraftChange={onDraftChange}
+      />
     )
   }
 
+  const time = new Date(parsed.time)
+  const displayValue = point ? Number(point.value.toFixed(2)) : null
+
   return (
-    <div class="entity-info">
-      <div class="entity-meta">
-        <span class="entity-type-badge">metric</span>
-        <span class="entity-source">Source: {parsed.source ?? point?.source ?? '…'}</span>
-      </div>
-
-      <h2>
-        <a href={`/metric/${encodeURIComponent(parsed.metric)}`} class="entity-meta-link">
-          {metricLabel}
-        </a>
-      </h2>
-
-      <div class="entity-fields">
-        <div class="field-row">
-          <span class="field-label">Time</span>
-          <span class="field-value">{formatDateTime(time)}</span>
-        </div>
-        <div class="field-row">
-          <span class="field-label">Value</span>
-          <span class="field-value">
-            {pointQuery.isLoading
-              ? 'Loading...'
-              : displayValue !== null
-                ? `${displayValue}${unit ? ` ${unit}` : ''}`
-                : 'Not found'}
-          </span>
-        </div>
-        <div class="field-row">
-          <span class="field-label">Metric</span>
-          <span class="field-value">{parsed.metric}</span>
-        </div>
-      </div>
-    </div>
+    <MetricReadView
+      metric={parsed.metric}
+      metricLabel={metricLabel}
+      source={source}
+      unit={unit}
+      time={time}
+      displayValue={displayValue}
+      isLoading={pointQuery.isLoading}
+    />
   )
 }
+
+const MetricEditView = ({
+  metric,
+  metricLabel,
+  source,
+  unit,
+  draft,
+  onDraftChange,
+}: {
+  metric: string
+  metricLabel: string
+  source: string
+  unit: string
+  draft: MetricDraft
+  onDraftChange: (draft: MetricDraft) => void
+}) => (
+  <div class="entity-info">
+    <div class="entity-meta">
+      <span class="entity-type-badge">metric</span>
+      <span class="entity-source">Source: {source}</span>
+    </div>
+
+    <h2>
+      <a href={`/metric/${encodeURIComponent(metric)}`} class="entity-meta-link">
+        {metricLabel}
+      </a>
+    </h2>
+
+    <div class="entity-fields">
+      <div class="field-row">
+        <span class="field-label">Time</span>
+        <span class="field-value">
+          <input
+            type="datetime-local"
+            class="edit-datetime-input"
+            value={draft.time}
+            onInput={(e) => onDraftChange({ ...draft, time: (e.target as HTMLInputElement).value })}
+          />
+        </span>
+      </div>
+      <div class="field-row">
+        <span class="field-label">Value</span>
+        <span class="field-value">
+          <input
+            type="number"
+            step="any"
+            class="edit-value-input"
+            value={draft.value}
+            onInput={(e) => onDraftChange({ ...draft, value: (e.target as HTMLInputElement).value })}
+          />
+          {unit && <span class="edit-value-unit">{unit}</span>}
+        </span>
+      </div>
+      <div class="field-row">
+        <span class="field-label">Metric</span>
+        <span class="field-value">{metric}</span>
+      </div>
+    </div>
+  </div>
+)
+
+const formatValueDisplay = (displayValue: number | null, unit: string): string => {
+  if (displayValue === null) return 'Not found'
+  return `${displayValue}${unit ? ` ${unit}` : ''}`
+}
+
+const MetricReadView = ({
+  metric,
+  metricLabel,
+  source,
+  unit,
+  time,
+  displayValue,
+  isLoading,
+}: {
+  metric: string
+  metricLabel: string
+  source: string
+  unit: string
+  time: Date
+  displayValue: number | null
+  isLoading: boolean
+}) => (
+  <div class="entity-info">
+    <div class="entity-meta">
+      <span class="entity-type-badge">metric</span>
+      <span class="entity-source">Source: {source}</span>
+    </div>
+
+    <h2>
+      <a href={`/metric/${encodeURIComponent(metric)}`} class="entity-meta-link">
+        {metricLabel}
+      </a>
+    </h2>
+
+    <div class="entity-fields">
+      <div class="field-row">
+        <span class="field-label">Time</span>
+        <span class="field-value">{formatDateTime(time)}</span>
+      </div>
+      <div class="field-row">
+        <span class="field-label">Value</span>
+        <span class="field-value">
+          {isLoading ? 'Loading...' : formatValueDisplay(displayValue, unit)}
+        </span>
+      </div>
+      <div class="field-row">
+        <span class="field-label">Metric</span>
+        <span class="field-value">{metric}</span>
+      </div>
+    </div>
+  </div>
+)

--- a/apps/web/src/pages/EntityDetail/MetricDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/MetricDetail.tsx
@@ -18,14 +18,14 @@ export interface MetricDraft {
   value: string // string so input binding works naturally
 }
 
-/** Parse a metric entity ID (format: "iso_time|metric_name|source"). */
+/** Parse a metric entity ID (format: "iso_time|metric_name|source" or "iso_time|metric_name"). */
 export const parseMetricEntityId = (
   entityId: string,
-): { time: string; metric: string; source: string } | null => {
+): { time: string; metric: string; source: string | undefined } | null => {
   const parts = entityId.split('|')
-  if (parts.length !== 3) return null
+  if (parts.length < 2 || parts.length > 3) return null
   const [time, metric, source] = parts
-  if (!time || !metric || !source) return null
+  if (!time || !metric) return null
   const d = new Date(time)
   if (isNaN(d.getTime())) return null
   return { metric, source, time }
@@ -97,7 +97,7 @@ export const MetricDetail = ({
       <div class="entity-info">
         <div class="entity-meta">
           <span class="entity-type-badge">metric</span>
-          <span class="entity-source">Source: {parsed.source}</span>
+          <span class="entity-source">Source: {parsed.source ?? point?.source ?? '…'}</span>
         </div>
 
         <h2>
@@ -144,7 +144,7 @@ export const MetricDetail = ({
     <div class="entity-info">
       <div class="entity-meta">
         <span class="entity-type-badge">metric</span>
-        <span class="entity-source">Source: {parsed.source}</span>
+        <span class="entity-source">Source: {parsed.source ?? point?.source ?? '…'}</span>
       </div>
 
       <h2>


### PR DESCRIPTION
## Summary
- Timeline creates metric entity IDs as `timestamp|metric_name` (2 parts) since bucketed API data doesn't include source
- `parseMetricEntityId` required exactly 3 parts, causing "Invalid metric reference" when clicking metrics in the timeline
- Now accepts 2-part IDs with source as optional; source display falls back to the fetched data point

## Test plan
- [ ] Click a green metric dot in the timeline — detail page should load correctly
- [ ] Verify source shows after data point loads
- [ ] Verify delete/edit actions are hidden for sourceless metrics (expected, since source is needed for those)
- [ ] Metrics opened from other contexts (with full 3-part IDs) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)