### PR TITLE
fix: persist garmin_disabled_data_types in settings

### DIFF
--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -293,29 +293,14 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
     await replaceGoals(user, newGoals)
   }
 
-  // Build updates object, converting null to undefined (which clears/resets the field in storage)
-  const settingsFields = [
-    'birth_date',
-    'calendars',
-    'dashboard',
-    'food_sensitivity_map',
-    'garmin_disabled_data_types',
-    'hr_zone_start',
-    'item_icons',
-    'lastfm_username',
-    'meal_slots',
-    'rescue_time_key',
-    'sensitivity_areas',
-    'sex',
-    'tag_icons',
-    'tag_mappings',
-    'training_load',
-  ] as const
+  // Build updates object, converting null to undefined (which clears/resets the field in storage).
+  // Derive field list from the schema to keep it in sync with api-spec.
+  const settingsFields = Object.keys(updateSettingsInputSchema.shape).filter((k) => k !== 'goals')
   const updates: Partial<UserSettings> = {}
   for (const field of settingsFields) {
-    if (parsed.data[field] !== undefined) {
-      ;(updates as Record<string, unknown>)[field] =
-        parsed.data[field] === null ? undefined : parsed.data[field]
+    const value = parsed.data[field as keyof typeof parsed.data]
+    if (value !== undefined) {
+      ;(updates as Record<string, unknown>)[field] = value === null ? undefined : value
     }
   }
 

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -299,6 +299,7 @@ export const validateAndUpdateSettings = async (user: string, input: unknown): P
     'calendars',
     'dashboard',
     'food_sensitivity_map',
+    'garmin_disabled_data_types',
     'hr_zone_start',
     'item_icons',
     'lastfm_username',


### PR DESCRIPTION
## Summary

- `garmin_disabled_data_types` was missing from the `settingsFields` allowlist in `validateAndUpdateSettings`, so PATCH requests validated correctly but the value was silently dropped before saving to the database.

## Test plan

- [ ] Toggle a Garmin data type off, verify it stays off after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)