### PR TITLE
feat: merge non-overlapping activities

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -348,6 +348,39 @@ export const getActivitiesNeedingDetail = async (user: string, limit = 10): Prom
   return result.rows.map(mapActivityRow)
 }
 
+/**
+ * Find nearby same-type activities for merge suggestions.
+ * Returns non-deleted activities of the same type within ±hoursWindow of the given time range,
+ * excluding the given activity ID.
+ */
+export const getNearbyActivities = async (
+  user: string,
+  activityId: string,
+  activityType: string,
+  startTime: Date,
+  endTime: Date | undefined,
+  hoursWindow: number,
+): Promise<Activity[]> => {
+  const windowMs = hoursWindow * 60 * 60 * 1000
+  const windowStart = new Date(startTime.getTime() - windowMs)
+  const windowEnd = new Date((endTime ?? startTime).getTime() + windowMs)
+
+  const result = await query(
+    user,
+    `SELECT id, source, activity_type, start_time, end_time, title, notes, data, deleted_at
+     FROM activities
+     WHERE activity_type = $1
+       AND id != $2
+       AND deleted_at IS NULL
+       AND start_time >= $3
+       AND start_time <= $4
+     ORDER BY start_time`,
+    [activityType, activityId, windowStart, windowEnd],
+  )
+
+  return result.rows.map(mapActivityRow)
+}
+
 /** Mark an activity's detail data as synced using JSONB merge (preserves existing data). */
 export const markActivityDetailSynced = async (user: string, id: string): Promise<void> => {
   await query(user, `UPDATE activities SET data = data || '{"detail_synced": true}'::jsonb WHERE id = $1`, [

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -89,6 +89,7 @@ export {
   getActivities,
   getActivitiesNeedingDetail,
   getActivityById,
+  getNearbyActivities,
   getOverlappingActivities,
   getSleepSessions,
   insertActivity,

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -12,7 +12,13 @@ import {
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
-import { addActivity, deleteActivity, restoreActivity, updateActivity } from '../services/mutations.ts'
+import {
+  addActivity,
+  deleteActivity,
+  mergeActivities,
+  restoreActivity,
+  updateActivity,
+} from '../services/mutations.ts'
 import { errorResponse, jsonResponse, type McpServer, tzJsonResponse } from './helpers.ts'
 
 export const registerActivityTools = (server: McpServer, user: string) => {
@@ -127,6 +133,27 @@ export const registerActivityTools = (server: McpServer, user: string) => {
 
       if (!result.success) {
         return errorResponse(result.error ?? 'Failed to update activity')
+      }
+
+      return tzJsonResponse(result, tz)
+    },
+  )
+
+  // Tool: merge_activities
+  server.tool(
+    'merge_activities',
+    'Permanently merge 2+ activities of the same type into one. Creates a new merged activity spanning the full time range and soft-deletes the originals. Useful for fixing split activities (e.g., a run that got recorded as two separate activities).',
+    {
+      activity_ids: z.array(z.string().uuid()).min(2).describe('IDs of activities to merge (minimum 2)'),
+      notes: z.string().optional().describe('Optional notes override for the merged activity'),
+      title: z.string().optional().describe('Optional title override for the merged activity'),
+      tz: tzSchema,
+    },
+    async ({ activity_ids, notes, title, tz }) => {
+      const result = await mergeActivities(user, { activity_ids, notes, title })
+
+      if (!result.success) {
+        return errorResponse(result.error ?? 'Failed to merge activities')
       }
 
       return tzJsonResponse(result, tz)

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -13,6 +13,12 @@ import {
   type DeleteActivityResponse,
   getExerciseTypeValue,
   isValidExerciseType,
+  type MergeActivitiesBody,
+  mergeActivitiesBodySchema,
+  type MergeActivitiesResponse,
+  type NearbyActivitiesQuery,
+  nearbyActivitiesQuerySchema,
+  type NearbyActivitiesResponse,
   type ProductivityQuery,
   productivityQuerySchema,
   type ProductivityResponse,
@@ -29,6 +35,7 @@ import multer from 'multer'
 import {
   getActivityById,
   getDistinctApps,
+  getNearbyActivities,
   getOverlappingActivities,
   getProductivityBucketed,
   getProductivityById,
@@ -41,6 +48,7 @@ import {
   addActivity,
   deleteActivity,
   deleteProductivity,
+  mergeActivities,
   restoreActivity,
   restoreProductivity,
   updateActivity,
@@ -299,6 +307,76 @@ export const createActivitiesRouter = (
       res.status(400).json({ error: message, success: false })
     }
   })
+
+  // POST /activities/merge - Merge multiple activities into one
+  router.post<Record<string, never>, MergeActivitiesResponse, MergeActivitiesBody>(
+    '/activities/merge',
+    authMiddleware,
+    validateBody(mergeActivitiesBodySchema),
+    async (req, res) => {
+      const { activity_ids, title, notes } = req.body
+      const user = req.user!
+
+      const result = await mergeActivities(user, { activity_ids, notes, title })
+
+      if (!result.success) {
+        return res.status(400).json({ error: result.error, success: false })
+      }
+
+      res.json({
+        data: {
+          activity_type: result.activity_type!,
+          end_time: result.end_time,
+          id: result.id,
+          notes: result.notes,
+          source: 'aurboda',
+          start_time: result.start_time!,
+          title: result.title,
+        },
+        success: true,
+      })
+    },
+  )
+
+  // GET /activities/:id/nearby - Get nearby same-type activities for merge suggestions
+  router.get<{ id: string }, NearbyActivitiesResponse, unknown, NearbyActivitiesQuery>(
+    '/activities/:id/nearby',
+    authMiddleware,
+    validateQuery(nearbyActivitiesQuerySchema),
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
+      const hours = req.query.hours ?? 6
+
+      const activity = await getActivityById(user, id)
+      if (!activity) {
+        return res.status(404).json({ data: [], error: 'Activity not found', success: false })
+      }
+
+      const nearby = await getNearbyActivities(
+        user,
+        id,
+        activity.activity_type,
+        activity.start_time,
+        activity.end_time,
+        hours,
+      )
+
+      res.json({
+        data: nearby.map((a) => ({
+          activity_type: a.activity_type,
+          data: a.data,
+          end_time: a.end_time?.toISOString(),
+          id: a.id,
+          notes: a.notes,
+          source: a.source,
+          start_time: a.start_time.toISOString(),
+          title: a.title,
+        })),
+        success: true,
+      })
+    },
+  )
 
   // DELETE /activities/:id - Delete an activity by ID
   router.delete<{ id: string }, DeleteActivityResponse>(

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -16,9 +16,6 @@ import {
   type MergeActivitiesBody,
   mergeActivitiesBodySchema,
   type MergeActivitiesResponse,
-  type NearbyActivitiesQuery,
-  nearbyActivitiesQuerySchema,
-  type NearbyActivitiesResponse,
   type ProductivityQuery,
   productivityQuerySchema,
   type ProductivityResponse,
@@ -339,14 +336,10 @@ export const createActivitiesRouter = (
   )
 
   // GET /activities/:id/nearby - Get nearby same-type activities for merge suggestions
-  router.get<{ id: string }, NearbyActivitiesResponse, unknown, NearbyActivitiesQuery>(
-    '/activities/:id/nearby',
-    authMiddleware,
-    validateQuery(nearbyActivitiesQuerySchema),
-    async (req, res) => {
-      const { id } = req.params
-      const user = req.user!
-      const hours = req.query.hours ?? 6
+  router.get<{ id: string }>('/activities/:id/nearby', authMiddleware, async (req, res) => {
+    const { id } = req.params
+    const user = req.user!
+    const hours = Number(req.query.hours) || 6
 
       const activity = await getActivityById(user, id)
       if (!activity) {

--- a/apps/backend/src/services/merge-activities.test.ts
+++ b/apps/backend/src/services/merge-activities.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import type { Activity } from '../db/types.ts'
+
+import { buildMergedActivityData, mergeActivities } from './mutations.ts'
+
+const makeActivity = (overrides: Partial<Activity> & { id: string }): Activity => ({
+  activity_type: 'exercise',
+  source: 'garmin',
+  start_time: new Date('2026-04-02T10:00:00Z'),
+  ...overrides,
+})
+
+describe('buildMergedActivityData', () => {
+  test('uses earliest start_time and latest end_time', () => {
+    const activities = [
+      makeActivity({
+        id: 'a1',
+        start_time: new Date('2026-04-02T10:00:00Z'),
+        end_time: new Date('2026-04-02T10:30:00Z'),
+      }),
+      makeActivity({
+        id: 'a2',
+        start_time: new Date('2026-04-02T10:40:00Z'),
+        end_time: new Date('2026-04-02T11:00:00Z'),
+      }),
+    ]
+    const result = buildMergedActivityData(activities)
+    expect(result.start_time).toEqual(new Date('2026-04-02T10:00:00Z'))
+    expect(result.end_time).toEqual(new Date('2026-04-02T11:00:00Z'))
+  })
+
+  test('uses first non-empty title', () => {
+    const activities = [
+      makeActivity({ id: 'a1', title: undefined }),
+      makeActivity({ id: 'a2', title: 'Treadmill Run' }),
+    ]
+    const result = buildMergedActivityData(activities)
+    expect(result.title).toBe('Treadmill Run')
+  })
+
+  test('title override wins over source titles', () => {
+    const activities = [
+      makeActivity({ id: 'a1', title: 'Run 1' }),
+      makeActivity({ id: 'a2', title: 'Run 2' }),
+    ]
+    const result = buildMergedActivityData(activities, { title: 'Combined Run' })
+    expect(result.title).toBe('Combined Run')
+  })
+
+  test('concatenates notes from all sources', () => {
+    const activities = [
+      makeActivity({ id: 'a1', notes: 'First part' }),
+      makeActivity({ id: 'a2', notes: 'Second part' }),
+    ]
+    const result = buildMergedActivityData(activities)
+    expect(result.notes).toBe('First part\nSecond part')
+  })
+
+  test('notes override wins over concatenation', () => {
+    const activities = [
+      makeActivity({ id: 'a1', notes: 'First part' }),
+      makeActivity({ id: 'a2', notes: 'Second part' }),
+    ]
+    const result = buildMergedActivityData(activities, { notes: 'Merged notes' })
+    expect(result.notes).toBe('Merged notes')
+  })
+
+  test('merges data objects with later overriding earlier', () => {
+    const activities = [
+      makeActivity({ id: 'a1', data: { exerciseType: 57, garmin_activity_id: '111' } }),
+      makeActivity({ id: 'a2', data: { exerciseType: 57, garmin_activity_id: '222' } }),
+    ]
+    const result = buildMergedActivityData(activities)
+    expect(result.data.exerciseType).toBe(57)
+    expect(result.data.garmin_activity_id).toBe('222')
+  })
+
+  test('stores merged_from provenance', () => {
+    const activities = [
+      makeActivity({
+        id: 'a1',
+        source: 'garmin',
+        start_time: new Date('2026-04-02T10:00:00Z'),
+        end_time: new Date('2026-04-02T10:30:00Z'),
+      }),
+      makeActivity({
+        id: 'a2',
+        source: 'garmin',
+        start_time: new Date('2026-04-02T10:40:00Z'),
+        end_time: new Date('2026-04-02T11:00:00Z'),
+      }),
+    ]
+    const result = buildMergedActivityData(activities)
+    expect(result.data.merged_from).toEqual([
+      {
+        end_time: '2026-04-02T10:30:00.000Z',
+        id: 'a1',
+        source: 'garmin',
+        start_time: '2026-04-02T10:00:00.000Z',
+      },
+      {
+        end_time: '2026-04-02T11:00:00.000Z',
+        id: 'a2',
+        source: 'garmin',
+        start_time: '2026-04-02T10:40:00.000Z',
+      },
+    ])
+  })
+
+  test('handles activities without end_time', () => {
+    const activities = [
+      makeActivity({ id: 'a1', start_time: new Date('2026-04-02T10:00:00Z') }),
+      makeActivity({
+        id: 'a2',
+        start_time: new Date('2026-04-02T10:40:00Z'),
+        end_time: new Date('2026-04-02T11:00:00Z'),
+      }),
+    ]
+    const result = buildMergedActivityData(activities)
+    expect(result.end_time).toEqual(new Date('2026-04-02T11:00:00Z'))
+  })
+})
+
+describe('mergeActivities', () => {
+  const makeDeps = (activitiesMap: Record<string, Activity>) => ({
+    deleteActivity: vi.fn().mockResolvedValue(true),
+    getActivityById: vi
+      .fn()
+      .mockImplementation((_user: string, id: string) => Promise.resolve(activitiesMap[id] ?? null)),
+    insertActivity: vi.fn().mockResolvedValue(undefined),
+  })
+
+  test('merges two same-type activities', async () => {
+    const deps = makeDeps({
+      a1: makeActivity({
+        id: 'a1',
+        start_time: new Date('2026-04-02T10:00:00Z'),
+        end_time: new Date('2026-04-02T10:30:00Z'),
+      }),
+      a2: makeActivity({
+        id: 'a2',
+        start_time: new Date('2026-04-02T10:40:00Z'),
+        end_time: new Date('2026-04-02T11:00:00Z'),
+      }),
+    })
+
+    const result = await mergeActivities('user1', { activity_ids: ['a1', 'a2'] }, deps)
+
+    expect(result.success).toBe(true)
+    expect(result.activity_type).toBe('exercise')
+    expect(result.start_time).toBe('2026-04-02T10:00:00.000Z')
+    expect(result.end_time).toBe('2026-04-02T11:00:00.000Z')
+    expect(result.id).toBeDefined()
+
+    // Should insert one new activity
+    expect(deps.insertActivity).toHaveBeenCalledOnce()
+    const inserted = deps.insertActivity.mock.calls[0][1]
+    expect(inserted.source).toBe('aurboda')
+    expect(inserted.data.merged_from).toHaveLength(2)
+
+    // Should delete both originals
+    expect(deps.deleteActivity).toHaveBeenCalledTimes(2)
+  })
+
+  test('errors on different activity types', async () => {
+    const deps = makeDeps({
+      a1: makeActivity({ id: 'a1', activity_type: 'exercise' }),
+      a2: makeActivity({ id: 'a2', activity_type: 'sleep' }),
+    })
+
+    const result = await mergeActivities('user1', { activity_ids: ['a1', 'a2'] }, deps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('different types')
+  })
+
+  test('errors on fewer than 2 IDs', async () => {
+    const deps = makeDeps({})
+    const result = await mergeActivities('user1', { activity_ids: ['a1'] }, deps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('At least 2')
+  })
+
+  test('errors on missing activity', async () => {
+    const deps = makeDeps({
+      a1: makeActivity({ id: 'a1' }),
+    })
+
+    const result = await mergeActivities('user1', { activity_ids: ['a1', 'missing'] }, deps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+
+  test('errors on deleted activity', async () => {
+    const deps = makeDeps({
+      a1: makeActivity({ id: 'a1' }),
+      a2: makeActivity({ id: 'a2', deleted_at: new Date() }),
+    })
+
+    const result = await mergeActivities('user1', { activity_ids: ['a1', 'a2'] }, deps)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('deleted')
+  })
+
+  test('applies title and notes overrides', async () => {
+    const deps = makeDeps({
+      a1: makeActivity({ id: 'a1', title: 'Run 1', end_time: new Date('2026-04-02T10:30:00Z') }),
+      a2: makeActivity({
+        id: 'a2',
+        title: 'Run 2',
+        start_time: new Date('2026-04-02T10:40:00Z'),
+        end_time: new Date('2026-04-02T11:00:00Z'),
+      }),
+    })
+
+    const result = await mergeActivities(
+      'user1',
+      { activity_ids: ['a1', 'a2'], title: 'Combined Run', notes: 'Merged' },
+      deps,
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.title).toBe('Combined Run')
+    expect(result.notes).toBe('Merged')
+  })
+})

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -9,6 +9,8 @@ import type { ActivityType, CustomMetricDefinition, DataSource } from '@aurboda/
 
 import { randomUUID } from 'node:crypto'
 
+import type { Activity } from '../db/types.ts'
+
 import {
   deleteActivity as dbDeleteActivity,
   deleteTag as dbDeleteTag,
@@ -625,6 +627,159 @@ export async function updateActivity(
     start_time: updated.start_time.toISOString(),
     success: true,
     title: updated.title,
+  }
+}
+
+// ============================================================================
+// Merge Activities
+// ============================================================================
+
+export interface MergeActivitiesInput {
+  activity_ids: string[]
+  title?: string
+  notes?: string
+}
+
+export interface MergeActivitiesResult {
+  success: boolean
+  id?: string
+  activity_type?: ActivityType
+  start_time?: string
+  end_time?: string
+  title?: string
+  notes?: string
+  error?: string
+}
+
+/**
+ * Build the merged data object from a list of activities sorted by start_time.
+ * Pure function — easy to unit-test independently.
+ */
+export const buildMergedActivityData = (
+  sortedActivities: Activity[],
+  overrides?: { title?: string; notes?: string },
+): {
+  start_time: Date
+  end_time: Date | undefined
+  title: string | undefined
+  notes: string | undefined
+  data: Record<string, unknown>
+} => {
+  const startTime = sortedActivities[0].start_time
+  let endTime: Date | undefined
+
+  for (const a of sortedActivities) {
+    if (a.end_time && (!endTime || a.end_time > endTime)) {
+      endTime = a.end_time
+    }
+  }
+
+  // Merge data objects: earlier first, later overrides
+  let mergedData: Record<string, unknown> = {}
+  for (const a of sortedActivities) {
+    if (a.data) {
+      mergedData = { ...mergedData, ...(a.data as Record<string, unknown>) }
+    }
+  }
+
+  // Record provenance
+  mergedData.merged_from = sortedActivities.map((a) => ({
+    end_time: a.end_time?.toISOString(),
+    id: a.id,
+    source: a.source,
+    start_time: a.start_time.toISOString(),
+  }))
+
+  // Title: override > first non-empty from sources
+  const title = overrides?.title || sortedActivities.find((a) => a.title)?.title
+
+  // Notes: override > concatenation
+  const notes =
+    overrides?.notes ||
+    sortedActivities
+      .filter((a) => a.notes)
+      .map((a) => a.notes)
+      .join('\n') ||
+    undefined
+
+  return { data: mergedData, end_time: endTime, notes, start_time: startTime, title }
+}
+
+/**
+ * Permanently merge 2+ activities of the same type into one.
+ *
+ * Creates a new aurboda-owned activity spanning the full time range,
+ * soft-deletes the originals, and stores merged_from metadata.
+ */
+export async function mergeActivities(
+  user: string,
+  input: MergeActivitiesInput,
+  deps: {
+    getActivityById: (user: string, id: string) => Promise<Activity | null>
+    insertActivity: (user: string, activity: Activity) => Promise<void>
+    deleteActivity: (user: string, id: string) => Promise<boolean>
+  } = {
+    deleteActivity: dbDeleteActivity,
+    getActivityById: dbGetActivityById,
+    insertActivity: dbInsertActivity,
+  },
+): Promise<MergeActivitiesResult> {
+  if (input.activity_ids.length < 2) {
+    return { error: 'At least 2 activity IDs are required', success: false }
+  }
+
+  // Fetch all activities
+  const activities: Activity[] = []
+  for (const id of input.activity_ids) {
+    const activity = await deps.getActivityById(user, id)
+    if (!activity) {
+      return { error: `Activity not found: ${id}`, success: false }
+    }
+    if (activity.deleted_at) {
+      return { error: `Activity is deleted: ${id}`, success: false }
+    }
+    activities.push(activity)
+  }
+
+  // Validate all same type
+  const types = new Set(activities.map((a) => a.activity_type))
+  if (types.size > 1) {
+    return { error: `Cannot merge activities of different types: ${[...types].join(', ')}`, success: false }
+  }
+
+  // Sort by start_time
+  const sorted = [...activities].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+
+  const merged = buildMergedActivityData(sorted, { notes: input.notes, title: input.title })
+
+  const id = randomUUID()
+
+  await deps.insertActivity(user, {
+    activity_type: sorted[0].activity_type,
+    data: merged.data,
+    end_time: merged.end_time,
+    id,
+    notes: merged.notes,
+    source: 'aurboda',
+    start_time: merged.start_time,
+    title: merged.title,
+  })
+
+  // Soft-delete originals
+  for (const activity of sorted) {
+    if (activity.id) {
+      await deps.deleteActivity(user, activity.id)
+    }
+  }
+
+  return {
+    activity_type: sorted[0].activity_type,
+    end_time: merged.end_time?.toISOString(),
+    id,
+    notes: merged.notes,
+    start_time: merged.start_time.toISOString(),
+    success: true,
+    title: merged.title,
   }
 }
 

--- a/apps/web/src/pages/EntityDetail/EntityActions.tsx
+++ b/apps/web/src/pages/EntityDetail/EntityActions.tsx
@@ -28,6 +28,7 @@ export interface EntityActionsProps {
   onCancelEditing: () => void
   onSave: () => void
   isSaving: boolean
+  onStartMerging?: () => void
 }
 
 const deleteEntity = (entityType: EntityType, entityId: string): Promise<void> => {
@@ -69,6 +70,7 @@ export const EntityActions = ({
   onCancelEditing,
   onSave,
   isSaving,
+  onStartMerging,
 }: EntityActionsProps) => {
   const deleteMutation = useMutation({
     mutationFn: () => deleteEntity(entityType, entityId),
@@ -118,6 +120,17 @@ export const EntityActions = ({
             Cancel
           </button>
         </>
+      )}
+      {!isEditing && onStartMerging && (
+        <button
+          class="btn-secondary"
+          onClick={onStartMerging}
+          disabled={isMerged}
+          title={isMerged ? 'Cannot merge display-merged activities' : 'Merge with nearby activity'}
+          type="button"
+        >
+          Merge
+        </button>
       )}
       {!isEditing && (
         <button

--- a/apps/web/src/pages/EntityDetail/MergePanel.tsx
+++ b/apps/web/src/pages/EntityDetail/MergePanel.tsx
@@ -2,7 +2,7 @@
  * Panel for selecting nearby activities to merge with the current activity.
  */
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { route } from 'preact-router'
+import { useLocation } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import type { Activity } from '../../state/api'
@@ -23,6 +23,7 @@ interface MergePanelProps {
 }
 
 export const MergePanel = ({ activityId, onCancel }: MergePanelProps) => {
+  const { route } = useLocation()
   const [selected, setSelected] = useState<Set<string>>(new Set())
 
   const nearbyQuery = useQuery({

--- a/apps/web/src/pages/EntityDetail/MergePanel.tsx
+++ b/apps/web/src/pages/EntityDetail/MergePanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * Panel for selecting nearby activities to merge with the current activity.
+ */
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { route } from 'preact-router'
+import { useState } from 'preact/hooks'
+
+import type { Activity } from '../../state/api'
+
+import { fetchNearbyActivities, mergeActivities } from '../../state/api'
+import { formatDateTimeLocal } from './format-utils'
+
+const formatDuration = (start: Date, end?: Date): string => {
+  if (!end) return ''
+  const mins = Math.round((end.getTime() - start.getTime()) / 60000)
+  if (mins < 60) return `${mins}m`
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`
+}
+
+interface MergePanelProps {
+  activityId: string
+  onCancel: () => void
+}
+
+export const MergePanel = ({ activityId, onCancel }: MergePanelProps) => {
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  const nearbyQuery = useQuery({
+    queryFn: () => fetchNearbyActivities(activityId),
+    queryKey: ['nearbyActivities', activityId],
+  })
+
+  const mergeMutation = useMutation({
+    mutationFn: () => mergeActivities([activityId, ...selected]),
+    onSuccess: (merged) => {
+      if (merged.id) {
+        route(`/detail/activity/${merged.id}`)
+      }
+    },
+  })
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const nearby = nearbyQuery.data ?? []
+
+  return (
+    <div class="merge-panel">
+      <h3>Merge with nearby activity</h3>
+
+      {nearbyQuery.isLoading && <p class="merge-loading">Loading nearby activities...</p>}
+
+      {nearbyQuery.isSuccess && nearby.length === 0 && (
+        <p class="merge-empty">No nearby activities of the same type found.</p>
+      )}
+
+      {nearby.length > 0 && (
+        <ul class="merge-list">
+          {nearby.map((a: Activity) => (
+            <li key={a.id} class="merge-item">
+              <label class="merge-label">
+                <input type="checkbox" checked={selected.has(a.id!)} onChange={() => toggle(a.id!)} />
+                <span class="merge-item-info">
+                  <span class="merge-item-title">{a.title ?? a.activity_type}</span>
+                  <span class="merge-item-time">
+                    {formatDateTimeLocal(a.start_time)}
+                    {a.end_time ? ` – ${formatDateTimeLocal(a.end_time)}` : ''}
+                  </span>
+                  <span class="merge-item-meta">
+                    {a.source} · {formatDuration(a.start_time, a.end_time)}
+                  </span>
+                </span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {mergeMutation.isError && (
+        <p class="merge-error">
+          {mergeMutation.error instanceof Error ? mergeMutation.error.message : 'Merge failed'}
+        </p>
+      )}
+
+      <div class="merge-actions">
+        <button
+          class="btn-primary"
+          onClick={() => mergeMutation.mutate()}
+          disabled={selected.size === 0 || mergeMutation.isPending}
+          type="button"
+        >
+          {mergeMutation.isPending ? 'Merging...' : `Merge ${selected.size + 1} activities`}
+        </button>
+        <button class="btn-secondary" onClick={onCancel} type="button">
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -28,6 +28,7 @@ import { type ActivityDraft, EditableActivityFields } from './EditableActivityFi
 import { EntityActions, type EntityType } from './EntityActions'
 import { ExerciseDetail, resolveExerciseType } from './ExerciseDetail'
 import { formatDateTimeLocal, formatTime } from './format-utils'
+import { MergePanel } from './MergePanel'
 import { MetricContent } from './MetricContent'
 import { MusicPlaylist } from './MusicPlaylist'
 import { NotesSection } from './NotesSection'
@@ -227,6 +228,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
   )
 
   const [isEditing, setIsEditing] = useState(false)
+  const [isMerging, setIsMerging] = useState(false)
   const emptyDraft: ActivityDraft = {
     end_time: '',
     notes: '',
@@ -296,7 +298,9 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         }}
         onSave={() => saveMutation.mutate()}
         isSaving={saveMutation.isPending}
+        onStartMerging={!activity.deleted_at && !isMergedActivity ? () => setIsMerging(true) : undefined}
       />
+      {isMerging && <MergePanel activityId={rawEntityId} onCancel={() => setIsMerging(false)} />}
       <ActivityDetailDispatch
         activity={activity}
         isEditing={isEditing}

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -924,6 +924,101 @@ a.entity-type-badge:hover {
   }
 }
 
+/* Merge panel */
+.merge-panel {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.merge-panel h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.merge-loading,
+.merge-empty {
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin: 0.5rem 0;
+}
+
+.merge-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+
+.merge-item {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.merge-item:last-child {
+  border-bottom: none;
+}
+
+.merge-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.merge-label input[type='checkbox'] {
+  margin-top: 0.2rem;
+}
+
+.merge-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.merge-item-title {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.merge-item-time {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.merge-item-meta {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.merge-error {
+  color: #ef4444;
+  font-size: 0.85rem;
+  margin: 0.5rem 0;
+}
+
+.merge-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .merge-panel {
+    border-color: #4b5563;
+    background: #1f2937;
+  }
+
+  .merge-item {
+    border-color: #374151;
+  }
+
+  .merge-item-title {
+    color: #e5e7eb;
+  }
+}
+
 /* Responsive */
 @media (max-width: 639px) {
   .entity-detail-page {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1301,6 +1301,40 @@ export const fetchActivityById = async (id: string): Promise<Activity> => {
   }
 }
 
+export const fetchNearbyActivities = async (id: string, hours = 6): Promise<Activity[]> => {
+  const { token } = auth.value
+  const response = await axios.get(`${API_URL}/activities/${id}/nearby`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { hours },
+  })
+
+  return response.data.data.map((d: Record<string, unknown>) => ({
+    ...d,
+    end_time: d.end_time ? new Date(d.end_time as string) : undefined,
+    start_time: new Date(d.start_time as string),
+  }))
+}
+
+export const mergeActivities = async (
+  activityIds: string[],
+  title?: string,
+  notes?: string,
+): Promise<Activity> => {
+  const { token } = auth.value
+  const response = await axios.post(
+    `${API_URL}/activities/merge`,
+    { activity_ids: activityIds, notes, title },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+
+  const d = response.data.data
+  return {
+    ...d,
+    end_time: d.end_time ? new Date(d.end_time) : undefined,
+    start_time: new Date(d.start_time),
+  }
+}
+
 export const fetchTagById = async (id: string): Promise<Tag> => {
   const { token } = auth.value
   const response = await axios.get(`${API_URL}/tags/id/${id}`, {

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -330,3 +330,54 @@ export const updateActivityResponseSchema = baseResponseSchema
   .meta({ id: 'UpdateActivityResponse' })
 
 export type UpdateActivityResponse = z.infer<typeof updateActivityResponseSchema>
+
+/**
+ * Merge activities request body schema.
+ */
+export const mergeActivitiesBodySchema = z
+  .object({
+    activity_ids: z
+      .array(z.string().uuid())
+      .min(2)
+      .meta({ description: 'IDs of activities to merge (minimum 2)' }),
+    notes: z.string().optional().meta({ description: 'Optional notes override for the merged activity' }),
+    title: z.string().optional().meta({ description: 'Optional title override for the merged activity' }),
+  })
+  .meta({ id: 'MergeActivitiesBody', description: 'Request body for merging multiple activities into one' })
+
+export type MergeActivitiesBody = z.infer<typeof mergeActivitiesBodySchema>
+
+/**
+ * Merge activities response schema.
+ */
+export const mergeActivitiesResponseSchema = baseResponseSchema
+  .extend({
+    data: activitySchema.optional(),
+  })
+  .meta({ id: 'MergeActivitiesResponse' })
+
+export type MergeActivitiesResponse = z.infer<typeof mergeActivitiesResponseSchema>
+
+/**
+ * Nearby activities query schema.
+ */
+export const nearbyActivitiesQuerySchema = z
+  .object({
+    hours: z.coerce
+      .number()
+      .optional()
+      .default(6)
+      .meta({ description: 'Hours before/after to search for nearby activities' }),
+  })
+  .meta({ id: 'NearbyActivitiesQuery' })
+
+export type NearbyActivitiesQuery = z.infer<typeof nearbyActivitiesQuerySchema>
+
+/**
+ * Nearby activities response schema.
+ */
+export const nearbyActivitiesResponseSchema = createDataArrayResponseSchema(activitySchema).meta({
+  id: 'NearbyActivitiesResponse',
+})
+
+export type NearbyActivitiesResponse = z.infer<typeof nearbyActivitiesResponseSchema>


### PR DESCRIPTION
## Summary
- Adds ability to permanently merge 2+ activities of the same type into one activity
- Useful for fixing split activities (e.g., treadmill runs split by Garmin watch disconnection)
- Creates a new `source: 'aurboda'` activity spanning the full time range, soft-deletes the originals, stores `merged_from` metadata for auditability

## Changes
- **Schema**: `mergeActivitiesBody`, `nearbyActivitiesQuery/Response` in api-spec
- **Backend**: `mergeActivities` service (with DI for testability), `POST /activities/merge` endpoint, `GET /activities/:id/nearby` for merge suggestions, `merge_activities` MCP tool
- **Frontend**: "Merge" button on activity detail page → shows nearby same-type activities in a checkbox panel → confirm to merge
- **Tests**: 14 unit tests for `buildMergedActivityData` and `mergeActivities`

## Test plan
- [ ] Unit tests pass (`pnpm check`)
- [ ] Use MCP `merge_activities` tool to merge the two split treadmill activities
- [ ] Verify in web UI: navigate to activity detail → click Merge → select nearby activity → confirm → lands on new merged activity
- [ ] Verify soft-deleted originals can still be found/restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)