### PR TITLE
fix: use plain INSERT for activity merge

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -160,6 +160,32 @@ export const getOverlappingActivities = async (user: string, activity: Activity)
   return findMergedGroupForActivity(merged, rawActivities, activity.id!)
 }
 
+/**
+ * Insert a new activity with a guaranteed new row (no upsert).
+ * Used for merge operations where we need to ensure the activity is created.
+ * Throws on conflict instead of silently doing nothing.
+ */
+export const insertNewActivity = async (user: string, activity: Activity): Promise<string> => {
+  const result = await query(
+    user,
+    `INSERT INTO activities (id, source, activity_type, start_time, end_time, title, notes, data)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id`,
+    [
+      activity.id,
+      activity.source,
+      activity.activity_type,
+      activity.start_time,
+      activity.end_time,
+      activity.title,
+      activity.notes,
+      activity.data,
+    ],
+  )
+
+  return result.rows[0].id as string
+}
+
 export const insertActivity = async (user: string, activity: Activity) => {
   await query(
     user,

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -93,6 +93,7 @@ export {
   getOverlappingActivities,
   getSleepSessions,
   insertActivity,
+  insertNewActivity,
   markActivityDetailSynced,
   mergeOverlappingActivities,
   restoreActivity,

--- a/apps/backend/src/services/merge-activities.test.ts
+++ b/apps/backend/src/services/merge-activities.test.ts
@@ -128,7 +128,11 @@ describe('mergeActivities', () => {
     getActivityById: vi
       .fn()
       .mockImplementation((_user: string, id: string) => Promise.resolve(activitiesMap[id] ?? null)),
-    insertActivity: vi.fn().mockResolvedValue(undefined),
+    insertNewActivity: vi
+      .fn()
+      .mockImplementation((_user: string, activity: Activity) =>
+        Promise.resolve(activity.id ?? 'generated-id'),
+      ),
   })
 
   test('merges two same-type activities', async () => {
@@ -154,8 +158,8 @@ describe('mergeActivities', () => {
     expect(result.id).toBeDefined()
 
     // Should insert one new activity
-    expect(deps.insertActivity).toHaveBeenCalledOnce()
-    const inserted = deps.insertActivity.mock.calls[0][1]
+    expect(deps.insertNewActivity).toHaveBeenCalledOnce()
+    const inserted = deps.insertNewActivity.mock.calls[0][1]
     expect(inserted.source).toBe('aurboda')
     expect(inserted.data.merged_from).toHaveLength(2)
 

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -16,6 +16,7 @@ import {
   deleteTag as dbDeleteTag,
   getActivityById as dbGetActivityById,
   insertActivity as dbInsertActivity,
+  insertNewActivity as dbInsertNewActivity,
   updateActivity as dbUpdateActivity,
   enqueueOutboundSync,
   findHcRecordId,
@@ -716,12 +717,12 @@ export async function mergeActivities(
   input: MergeActivitiesInput,
   deps: {
     getActivityById: (user: string, id: string) => Promise<Activity | null>
-    insertActivity: (user: string, activity: Activity) => Promise<void>
+    insertNewActivity: (user: string, activity: Activity) => Promise<string>
     deleteActivity: (user: string, id: string) => Promise<boolean>
   } = {
     deleteActivity: dbDeleteActivity,
     getActivityById: dbGetActivityById,
-    insertActivity: dbInsertActivity,
+    insertNewActivity: dbInsertNewActivity,
   },
 ): Promise<MergeActivitiesResult> {
   if (input.activity_ids.length < 2) {
@@ -752,13 +753,11 @@ export async function mergeActivities(
 
   const merged = buildMergedActivityData(sorted, { notes: input.notes, title: input.title })
 
-  const id = randomUUID()
-
-  await deps.insertActivity(user, {
+  const id = await deps.insertNewActivity(user, {
     activity_type: sorted[0].activity_type,
     data: merged.data,
     end_time: merged.end_time,
-    id,
+    id: randomUUID(),
     notes: merged.notes,
     source: 'aurboda',
     start_time: merged.start_time,


### PR DESCRIPTION
## Summary
- `insertActivity` uses `ON CONFLICT ... DO UPDATE ... WHERE deleted_at IS NULL` which silently does nothing when a soft-deleted row exists with the same `(source, activity_type, start_time)` tuple
- The merge service thought the insert succeeded (no error thrown) but no row was actually created
- This caused: merged activity not found on redirect, original activities soft-deleted but new one missing from timeline

## Fix
- Added `insertNewActivity` — plain INSERT with RETURNING, no upsert. Throws on conflict instead of silently failing.
- `mergeActivities` now uses `insertNewActivity` instead of `insertActivity`
- Updated DI interface and tests to match

## Test plan
- [ ] Unit tests pass
- [ ] Merge two activities via UI → new activity is created and visible
- [ ] Redirect after merge lands on the new activity detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)