### PR TITLE
feat: garmin meditation recognition + mutable activity type

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -289,6 +289,8 @@ export const updateActivity = async (
   updates: ActivityUpdate,
 ): Promise<Activity | null> => {
   const fields: UpdateEntry[] = []
+  if (updates.activity_type !== undefined)
+    {fields.push({ column: 'activity_type', value: updates.activity_type })}
   if (updates.start_time !== undefined) fields.push({ column: 'start_time', value: updates.start_time })
   if (updates.end_time !== undefined) fields.push({ column: 'end_time', value: updates.end_time })
   if (updates.title !== undefined) fields.push({ column: 'title', value: updates.title })
@@ -362,7 +364,7 @@ export const getActivitiesNeedingDetail = async (user: string, limit = 10): Prom
     user,
     `SELECT id, source, activity_type, start_time, end_time, title, notes, data, deleted_at
      FROM activities
-     WHERE source = 'garmin' AND activity_type = 'exercise'
+     WHERE source = 'garmin' AND activity_type IN ('exercise', 'meditation')
        AND data->>'garmin_activity_id' IS NOT NULL
        AND (data->>'detail_synced') IS NULL
        AND deleted_at IS NULL
@@ -405,6 +407,52 @@ export const getNearbyActivities = async (
   )
 
   return result.rows.map(mapActivityRow)
+}
+
+/**
+ * Check if an activity with the same (source, activity_type, start_time) already exists,
+ * excluding the given activity ID. Used to preemptively detect unique constraint violations
+ * before changing an activity's type.
+ */
+export const checkActivityConflict = async (
+  user: string,
+  source: string,
+  activityType: string,
+  startTime: Date,
+  excludeId: string,
+): Promise<boolean> => {
+  const result = await query(
+    user,
+    `SELECT 1 FROM activities
+     WHERE source = $1 AND activity_type = $2 AND start_time = $3
+       AND id != $4 AND deleted_at IS NULL
+     LIMIT 1`,
+    [source, activityType, startTime, excludeId],
+  )
+  return result.rows.length > 0
+}
+
+/**
+ * Delete a Garmin activity that has the given garmin_activity_id but a different activity_type.
+ * Used during re-sync to prevent duplicates when the type mapping changes
+ * (e.g., meditation activities previously imported as exercise).
+ */
+export const deleteGarminActivityWithWrongType = async (
+  user: string,
+  garminActivityId: number,
+  correctType: string,
+): Promise<string | null> => {
+  const result = await query(
+    user,
+    `DELETE FROM activities
+     WHERE source = 'garmin'
+       AND (data->>'garmin_activity_id')::int = $1
+       AND activity_type != $2
+       AND deleted_at IS NULL
+     RETURNING id`,
+    [garminActivityId, correctType],
+  )
+  return result.rows.length > 0 ? (result.rows[0].id as string) : null
 }
 
 /** Mark an activity's detail data as synced using JSONB merge (preserves existing data). */

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -84,7 +84,9 @@ export {
 
 // Activities
 export {
+  checkActivityConflict,
   deleteActivity,
+  deleteGarminActivityWithWrongType,
   findMergedGroupForActivity,
   getActivities,
   getActivitiesNeedingDetail,

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -87,6 +87,7 @@ export interface MergedActivity extends Activity {
 }
 
 export interface ActivityUpdate {
+  activity_type?: ActivityType
   start_time?: Date
   end_time?: Date
   title?: string

--- a/apps/backend/src/garmin-process.test.ts
+++ b/apps/backend/src/garmin-process.test.ts
@@ -6,6 +6,7 @@ import type { GarminActivityDetailResponse } from './garmin.ts'
 import { processActivityDetail, processGarminData } from './garmin-process.ts'
 
 const mockDeps: GarminProcessDeps = {
+  deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   insertActivity: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn().mockResolvedValue(undefined),
   insertTimeSeries: vi.fn().mockResolvedValue(undefined),
@@ -757,6 +758,53 @@ describe('processGarminData', () => {
       const startTime = new Date('2025-01-15T07:00:00.000')
       const expectedEnd = new Date(startTime.getTime() + 3600 * 1000)
       expect(activityArg.end_time).toEqual(expectedEnd)
+    })
+
+    test('maps meditation typeKey to meditation activity_type', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityType: { typeKey: 'meditation' }, activityName: 'Meditation' })],
+        mockDeps,
+      )
+
+      const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activityArg.activity_type).toBe('meditation')
+      expect(activityArg.title).toBe('Meditation')
+    })
+
+    test('maps breathwork typeKey to meditation activity_type', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityType: { typeKey: 'breathwork' }, activityName: 'Breathwork' })],
+        mockDeps,
+      )
+
+      const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activityArg.activity_type).toBe('meditation')
+    })
+
+    test('maps running typeKey to exercise activity_type', async () => {
+      await processGarminData(user, 'activities', [makeActivity()], mockDeps)
+
+      const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activityArg.activity_type).toBe('exercise')
+    })
+
+    test('calls deleteGarminActivityWithWrongType before insert', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityType: { typeKey: 'meditation' } })],
+        mockDeps,
+      )
+
+      expect(mockDeps.deleteGarminActivityWithWrongType).toHaveBeenCalledWith(user, 12345, 'meditation')
+      // Verify delete is called before insert
+      const deleteOrder = vi.mocked(mockDeps.deleteGarminActivityWithWrongType).mock.invocationCallOrder[0]
+      const insertOrder = vi.mocked(mockDeps.insertActivity).mock.invocationCallOrder[0]
+      expect(deleteOrder).toBeLessThan(insertOrder!)
     })
   })
 

--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -21,7 +21,12 @@ import type {
   GarminTrainingReadiness,
 } from './garmin.ts'
 
-import { insertActivity, insertRawRecord, insertTimeSeries } from './db/index.ts'
+import {
+  deleteGarminActivityWithWrongType,
+  insertActivity,
+  insertRawRecord,
+  insertTimeSeries,
+} from './db/index.ts'
 
 // ============================================================================
 // Types
@@ -59,12 +64,21 @@ export const garminDataTypes: GarminDataType[] = [
 // ============================================================================
 
 export interface GarminProcessDeps {
+  deleteGarminActivityWithWrongType: typeof deleteGarminActivityWithWrongType
   insertRawRecord: typeof insertRawRecord
   insertTimeSeries: typeof insertTimeSeries
   insertActivity: typeof insertActivity
 }
 
-const defaultDeps: GarminProcessDeps = { insertActivity, insertRawRecord, insertTimeSeries }
+const defaultDeps: GarminProcessDeps = {
+  deleteGarminActivityWithWrongType,
+  insertActivity,
+  insertRawRecord,
+  insertTimeSeries,
+}
+
+/** Garmin activity typeKeys that map to the 'meditation' activity type. */
+const meditationTypeKeys = new Set(['meditation', 'breathwork'])
 
 // ============================================================================
 // Main dispatcher
@@ -392,10 +406,14 @@ const processActivities = async (
     await deps.insertRawRecord(user, makeRaw('garmin_activity', externalId, startTime, act))
 
     const activityTypeKey = act.activityType?.typeKey ?? 'unknown'
+    const activityType = meditationTypeKeys.has(activityTypeKey) ? 'meditation' : 'exercise'
     const exerciseTitle = act.activityName || activityTypeKey
 
+    // Clean up any existing activity with a different type (handles re-sync after type mapping changes)
+    await deps.deleteGarminActivityWithWrongType(user, act.activityId, activityType)
+
     const activity: Activity = {
-      activity_type: 'exercise',
+      activity_type: activityType,
       data: {
         activity_type_key: activityTypeKey,
         average_hr: act.averageHR,

--- a/apps/backend/src/garmin-sync.test.ts
+++ b/apps/backend/src/garmin-sync.test.ts
@@ -12,6 +12,7 @@ import {
 
 // Mock the db module (include all exports used by garmin-process.ts too)
 vi.mock('./db', () => ({
+  deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   getActivitiesNeedingDetail: vi.fn().mockResolvedValue([]),
   getSyncState: vi.fn(),
   insertActivity: vi.fn(),

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -34,6 +34,7 @@ vi.mock('./services/mutations', () => ({
 
 // Mock db for sync status and stored detected locations
 vi.mock('./db', () => ({
+  deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   getAllSyncStates: vi.fn(),
   getDetectedLocations: vi.fn(),
   getOAuthToken: vi.fn().mockResolvedValue(null),

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -96,7 +96,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
   // Tool: update_activity
   server.tool(
     'update_activity',
-    'Update an existing activity. Can modify start_time, end_time, title, notes, and exercise_type. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
+    'Update an existing activity. Can modify activity_type, start_time, end_time, title, notes, and exercise_type. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
     {
       id: z.string().uuid().describe('The ID of the activity to update'),
       ...updateActivityBodySchema.shape,
@@ -109,7 +109,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
         ),
       tz: tzSchema,
     },
-    async ({ id, start_time, end_time, title, notes, exercise_type, tz }) => {
+    async ({ id, activity_type, start_time, end_time, title, notes, exercise_type, tz }) => {
       let data: Record<string, unknown> | undefined
       if (exercise_type !== undefined) {
         if (!isValidExerciseType(exercise_type)) {
@@ -124,6 +124,7 @@ export const registerActivityTools = (server: McpServer, user: string) => {
       }
 
       const result = await updateActivity(user, id, {
+        activity_type,
         data,
         end_time: end_time ? new Date(end_time) : undefined,
         notes,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -341,35 +341,34 @@ export const createActivitiesRouter = (
     const user = req.user!
     const hours = Number(req.query.hours) || 6
 
-      const activity = await getActivityById(user, id)
-      if (!activity) {
-        return res.status(404).json({ data: [], error: 'Activity not found', success: false })
-      }
+    const activity = await getActivityById(user, id)
+    if (!activity) {
+      return res.status(404).json({ data: [], error: 'Activity not found', success: false })
+    }
 
-      const nearby = await getNearbyActivities(
-        user,
-        id,
-        activity.activity_type,
-        activity.start_time,
-        activity.end_time,
-        hours,
-      )
+    const nearby = await getNearbyActivities(
+      user,
+      id,
+      activity.activity_type,
+      activity.start_time,
+      activity.end_time,
+      hours,
+    )
 
-      res.json({
-        data: nearby.map((a) => ({
-          activity_type: a.activity_type,
-          data: a.data,
-          end_time: a.end_time?.toISOString(),
-          id: a.id,
-          notes: a.notes,
-          source: a.source,
-          start_time: a.start_time.toISOString(),
-          title: a.title,
-        })),
-        success: true,
-      })
-    },
-  )
+    res.json({
+      data: nearby.map((a) => ({
+        activity_type: a.activity_type,
+        data: a.data,
+        end_time: a.end_time?.toISOString(),
+        id: a.id,
+        notes: a.notes,
+        source: a.source,
+        start_time: a.start_time.toISOString(),
+        title: a.title,
+      })),
+      success: true,
+    })
+  })
 
   // DELETE /activities/:id - Delete an activity by ID
   router.delete<{ id: string }, DeleteActivityResponse>(
@@ -396,7 +395,7 @@ export const createActivitiesRouter = (
     validateBody(updateActivityBodySchema),
     async (req, res) => {
       const { id } = req.params
-      const { start_time, end_time, title, notes, exercise_type } = req.body
+      const { activity_type, start_time, end_time, title, notes, exercise_type } = req.body
       const user = req.user!
 
       // Convert exercise_type name to data object if provided
@@ -415,6 +414,7 @@ export const createActivitiesRouter = (
       }
 
       const result = await updateActivity(user, id, {
+        activity_type,
         data,
         end_time: end_time ? new Date(end_time) : undefined,
         notes,

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -21,12 +21,14 @@ import {
 
 // Mock the db module
 vi.mock('../db', () => ({
+  checkActivityConflict: vi.fn().mockResolvedValue(false),
   deleteActivity: vi.fn(),
   deleteCustomMetricDefinition: vi.fn(),
   deleteTag: vi.fn(),
   deleteTimeSeriesMetric: vi.fn(),
   deleteTimeSeriesPoint: vi.fn(),
   enqueueOutboundSync: vi.fn().mockResolvedValue(undefined),
+  findHcRecordId: vi.fn().mockResolvedValue(null),
   findMergeableTag: vi.fn(),
   getActivityById: vi.fn(),
   getCustomMetricByName: vi.fn(),
@@ -855,6 +857,7 @@ describe('updateActivity', () => {
     expect(result.start_time).toBe('2024-03-15T09:00:00.000Z')
     expect(result.end_time).toBe('2024-03-15T12:00:00.000Z')
     expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: undefined,
       end_time: new Date('2024-03-15T12:00:00Z'),
       notes: undefined,
       start_time: new Date('2024-03-15T09:00:00Z'),
@@ -981,6 +984,7 @@ describe('updateActivity', () => {
     })
 
     expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: undefined,
       data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
       end_time: undefined,
       notes: undefined,
@@ -1013,6 +1017,7 @@ describe('updateActivity', () => {
 
     // Should merge: existing {calories, exerciseType, exerciseTypeName} + new {exerciseType, exerciseTypeName}
     expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: undefined,
       data: { calories: 300, exerciseType: 81, exerciseTypeName: 'weightlifting' },
       end_time: undefined,
       notes: undefined,
@@ -1043,6 +1048,7 @@ describe('updateActivity', () => {
     })
 
     expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: undefined,
       data: { exerciseType: 56, exerciseTypeName: 'running' },
       end_time: undefined,
       notes: undefined,
@@ -1076,6 +1082,7 @@ describe('updateActivity', () => {
 
     // data should be undefined (not touched) when not provided in input
     expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: undefined,
       data: undefined,
       end_time: undefined,
       notes: 'Updated notes',
@@ -1110,11 +1117,151 @@ describe('updateActivity', () => {
     expect(result.success).toBe(true)
     expect(result.title).toBe('Heavy lifting')
     expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: undefined,
       data: { exerciseType: 81, exerciseTypeName: 'weightlifting' },
       end_time: undefined,
       notes: undefined,
       start_time: undefined,
       title: 'Heavy lifting',
+    })
+  })
+
+  test('updates activity_type successfully', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'garmin',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.checkActivityConflict).mockResolvedValue(false)
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'meditation',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'garmin',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      activity_type: 'meditation',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.activity_type).toBe('meditation')
+    expect(db.updateActivity).toHaveBeenCalledWith('testuser', 'activity-123', {
+      activity_type: 'meditation',
+      data: undefined,
+      end_time: undefined,
+      notes: undefined,
+      start_time: undefined,
+      title: undefined,
+    })
+  })
+
+  test('returns error when activity_type change would violate unique constraint', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'garmin',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.checkActivityConflict).mockResolvedValue(true)
+
+    const result = await updateActivity('testuser', 'activity-123', {
+      activity_type: 'meditation',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Cannot change activity type')
+    expect(db.updateActivity).not.toHaveBeenCalled()
+  })
+
+  test('skips conflict check when activity_type is not changing', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'aurboda',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'aurboda',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+      title: 'Updated',
+    })
+
+    await updateActivity('testuser', 'activity-123', { title: 'Updated' })
+
+    expect(db.checkActivityConflict).not.toHaveBeenCalled()
+  })
+
+  test('enqueues HC delete when changing from exercise to meditation (aurboda source)', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'aurboda',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.checkActivityConflict).mockResolvedValue(false)
+    vi.mocked(db.findHcRecordId).mockResolvedValue('hc-record-456')
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'meditation',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'aurboda',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    await updateActivity('testuser', 'activity-123', {
+      activity_type: 'meditation',
+    })
+
+    // Should enqueue a delete for the old exercise HC record
+    expect(db.enqueueOutboundSync).toHaveBeenCalledWith('testuser', {
+      entity_id: 'activity-123',
+      entity_type: 'activity',
+      hc_record_type: 'ExerciseSessionRecord',
+      operation: 'delete',
+      payload: { hc_record_id: 'hc-record-456' },
+    })
+    // Should NOT enqueue an insert for meditation (not HC-syncable)
+    expect(db.enqueueOutboundSync).toHaveBeenCalledTimes(1)
+  })
+
+  test('enqueues HC insert when changing from meditation to exercise (aurboda source)', async () => {
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'meditation',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'aurboda',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+    vi.mocked(db.checkActivityConflict).mockResolvedValue(false)
+    vi.mocked(db.updateActivity).mockResolvedValue({
+      activity_type: 'exercise',
+      end_time: new Date('2024-03-15T11:00:00Z'),
+      id: 'activity-123',
+      source: 'aurboda',
+      start_time: new Date('2024-03-15T10:00:00Z'),
+    })
+
+    await updateActivity('testuser', 'activity-123', {
+      activity_type: 'exercise',
+    })
+
+    // Should enqueue an insert for the new exercise HC record
+    expect(db.enqueueOutboundSync).toHaveBeenCalledWith('testuser', {
+      entity_id: 'activity-123',
+      entity_type: 'activity',
+      hc_record_type: 'ExerciseSessionRecord',
+      operation: 'insert',
+      payload: expect.objectContaining({ activity_type: 'exercise' }),
     })
   })
 })

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'node:crypto'
 import type { Activity } from '../db/types.ts'
 
 import {
+  checkActivityConflict,
   deleteActivity as dbDeleteActivity,
   deleteTag as dbDeleteTag,
   getActivityById as dbGetActivityById,
@@ -130,6 +131,7 @@ export interface DeleteActivityResult {
 }
 
 export interface UpdateActivityInput {
+  activity_type?: ActivityType
   start_time?: Date
   end_time?: Date
   title?: string
@@ -570,10 +572,30 @@ export async function updateActivity(
     }
   }
 
+  // Check for unique constraint conflict when changing activity_type
+  const isTypeChanging = input.activity_type && input.activity_type !== existing.activity_type
+  if (isTypeChanging) {
+    const conflict = await checkActivityConflict(
+      user,
+      existing.source,
+      input.activity_type!,
+      finalStartTime,
+      id,
+    )
+    if (conflict) {
+      return {
+        error: `Cannot change activity type: a ${input.activity_type} activity from ${existing.source} already exists at that start time`,
+        id,
+        success: false,
+      }
+    }
+  }
+
   // Merge new data fields into existing data (preserving fields not being updated)
   const mergedData = input.data ? { ...(existing.data as Record<string, unknown>), ...input.data } : undefined
 
   const updated = await dbUpdateActivity(user, id, {
+    activity_type: input.activity_type,
     data: mergedData,
     end_time: input.end_time,
     notes: input.notes,
@@ -594,26 +616,51 @@ export async function updateActivity(
     (err) => auditError(user, 'data', 'Failed to sync note times for activity', { error: String(err) }),
   )
 
-  // Enqueue outbound sync if this is an aurboda-owned HC-syncable activity (best-effort)
+  // Enqueue outbound sync if this is an aurboda-owned activity (best-effort)
   try {
-    if (updated.source === 'aurboda' && isHealthConnectSyncableActivity(updated.activity_type)) {
-      const hcRecordType =
-        activityTypeToHealthConnectType[updated.activity_type as keyof typeof activityTypeToHealthConnectType]
-      if (hcRecordType) {
-        await enqueueOutboundSync(user, {
-          entity_id: id,
-          entity_type: 'activity',
-          hc_record_type: hcRecordType,
-          operation: 'update',
-          payload: {
-            activity_type: updated.activity_type,
-            data: updated.data,
-            end_time: updated.end_time?.toISOString(),
-            notes: updated.notes,
-            start_time: updated.start_time.toISOString(),
-            title: updated.title,
-          },
-        })
+    if (updated.source === 'aurboda') {
+      const oldWasSyncable = isHealthConnectSyncableActivity(existing.activity_type)
+      const newIsSyncable = isHealthConnectSyncableActivity(updated.activity_type)
+
+      if (isTypeChanging && oldWasSyncable) {
+        // Type changed away from an HC-syncable type — delete the old HC record
+        const oldHcType =
+          activityTypeToHealthConnectType[
+            existing.activity_type as keyof typeof activityTypeToHealthConnectType
+          ]
+        const hcRecordId = await findHcRecordId(user, 'activity', id)
+        if (oldHcType && hcRecordId) {
+          await enqueueOutboundSync(user, {
+            entity_id: id,
+            entity_type: 'activity',
+            hc_record_type: oldHcType,
+            operation: 'delete',
+            payload: { hc_record_id: hcRecordId },
+          })
+        }
+      }
+
+      if (newIsSyncable) {
+        const hcRecordType =
+          activityTypeToHealthConnectType[
+            updated.activity_type as keyof typeof activityTypeToHealthConnectType
+          ]
+        if (hcRecordType) {
+          await enqueueOutboundSync(user, {
+            entity_id: id,
+            entity_type: 'activity',
+            hc_record_type: hcRecordType,
+            operation: isTypeChanging ? 'insert' : 'update',
+            payload: {
+              activity_type: updated.activity_type,
+              data: updated.data,
+              end_time: updated.end_time?.toISOString(),
+              notes: updated.notes,
+              start_time: updated.start_time.toISOString(),
+              title: updated.title,
+            },
+          })
+        }
       }
     }
   } catch (err) {

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -297,6 +297,7 @@ export type DeleteActivityResponse = z.infer<typeof deleteActivityResponseSchema
  */
 export const updateActivityBodySchema = z
   .object({
+    activity_type: activityTypeSchema.optional().meta({ description: 'New activity type' }),
     end_time: iso8601DateTimeSchema.optional().meta({ description: 'New end time of the activity' }),
     exercise_type: exerciseTypeSchema.optional().meta({
       description: 'New exercise type name (only for exercise activities)',


### PR DESCRIPTION
## Summary
- Garmin activities with typeKey `meditation` or `breathwork` are now imported as `activity_type: 'meditation'` instead of `exercise`
- On re-sync, previously misclassified activities are cleaned up (old exercise row deleted before inserting meditation)
- Meditation activities now included in Garmin detail sync (per-second HR/stress data)
- `activity_type` can now be changed on existing activities via PATCH `/activities/:id` and the `update_activity` MCP tool
- Unique constraint conflicts are checked before type changes
- Health Connect sync handles type transitions (delete old HC record, insert new one as needed)

## Test plan
- [x] Unit tests for garmin meditation/breathwork type mapping
- [x] Unit tests for duplicate cleanup on re-sync
- [x] Unit tests for activity_type update (success, conflict, HC sync transitions)
- [ ] Manual: trigger garmin sync, verify new meditation sessions get correct type
- [ ] Manual: use MCP `update_activity` to change an exercise to meditation

🤖 Generated with [Claude Code](https://claude.com/claude-code)