### PR TITLE
refactor: migrate all Express routers to typedRouter()

### DIFF
--- a/apps/backend/src/lastfm-router.ts
+++ b/apps/backend/src/lastfm-router.ts
@@ -4,6 +4,7 @@
  * Provides REST API endpoints for managing Last.fm auto-tagging rules.
  */
 
+import type { RequestHandler, Router } from 'express'
 import type { ParamsDictionary } from 'express-serve-static-core'
 
 import {
@@ -18,7 +19,6 @@ import {
   type UpdateLastFmTagRuleBody,
   type UpdateLastFmTagRuleResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import {
   deleteLastFmTagRule,
@@ -30,13 +30,14 @@ import {
   type LastFmMatchType,
 } from './db/index.ts'
 import { applyRuleRetroactively, cleanupRuleTags, retagAllScrobbles } from './lastfm-sync.ts'
+import { typedRouter } from './typed-router.ts'
 import { validateBody } from './validation.ts'
 
 /**
  * Creates the Last.fm router with tag rules CRUD endpoints.
  */
 export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /lastfm/scrobbles - Query scrobbles by time range
   router.get<ParamsDictionary, ScrobblesResponse>('/scrobbles', authMiddleware, async (req, res) => {
@@ -261,5 +262,5 @@ export const createLastFmRouter = (authMiddleware: RequestHandler): Router => {
     }
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/owntracks.ts
+++ b/apps/backend/src/owntracks.ts
@@ -1,4 +1,6 @@
-import { Router } from 'express'
+import type { Router } from 'express'
+
+import { typedRouter } from './typed-router.ts'
 
 export interface OwnTracksDeps {
   loginToUserDb: (user: string, password: string) => Promise<void>
@@ -58,7 +60,7 @@ export function parseBasicAuth(
  * Create OwnTracks router with injected dependencies for testability.
  */
 export function createOwnTracksRouter(deps: OwnTracksDeps): Router {
-  const router = Router()
+  const router = typedRouter()
 
   router.post('/', async (req, res) => {
     const credentials = parseBasicAuth(req.headers.authorization)
@@ -118,5 +120,5 @@ export function createOwnTracksRouter(deps: OwnTracksDeps): Router {
     }
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Activities and productivity route group.
  *
@@ -26,7 +28,6 @@ import {
   updateActivityBodySchema,
   type UpdateActivityResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 import multer from 'multer'
 
 import {
@@ -59,6 +60,7 @@ import {
   type SyncProvider,
 } from '../services/queries.ts'
 import { computeHrZoneSecs, getEffectiveHrZones } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 /** Compute HR zone seconds and avg HRV for an exercise activity time range. */
@@ -154,7 +156,7 @@ export const createActivitiesRouter = (
   authMiddleware: RequestHandler,
   syncProvider?: SyncProvider,
 ): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /activities - Query activities for a time range
   router.get<Record<string, never>, ActivitiesResponse, unknown, ActivitiesQuery>(
@@ -591,5 +593,5 @@ export const createActivitiesRouter = (
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Admin route group.
  *
@@ -11,12 +13,12 @@ import {
   type UpdateAdminSettingsBody,
   updateAdminSettingsBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import type { CentralDb } from '../services/central-db.ts'
 import type { InvitationAuth } from '../services/invitation.ts'
 import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
 
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createAdminRouter = (
@@ -27,7 +29,7 @@ export const createAdminRouter = (
   webHost: string,
   ouraWebhookManager?: OuraWebhookManager | null,
 ): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /admin/settings - Get admin settings
   router.get<Record<string, never>, AdminSettingsResponse>(
@@ -116,5 +118,5 @@ export const createAdminRouter = (
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/audit-log-router.ts
+++ b/apps/backend/src/routes/audit-log-router.ts
@@ -1,15 +1,17 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Audit log route group.
  *
  * Handles: /user/audit-log
  */
 import { auditLogQuerySchema } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getAuditLog } from '../services/audit-log.ts'
+import { typedRouter } from '../typed-router.ts'
 
 export const createAuditLogRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /user/audit-log - Get audit log entries
   router.get('/user/audit-log', authMiddleware, async (req, res) => {
@@ -42,5 +44,5 @@ export const createAuditLogRouter = (authMiddleware: RequestHandler): Router => 
     })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -1,16 +1,18 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Chart data route group.
  *
  * Handles: /chart-data
  */
 import { type ChartDataHttpQuery, chartDataHttpQuerySchema, type ChartDataResponse } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getChartData } from '../services/chart-data.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
 
 export const createChartDataRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /chart-data — bucketed aggregation for bar charts
   router.get<Record<string, never>, ChartDataResponse, unknown, ChartDataHttpQuery>(
@@ -45,5 +47,5 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/correlations-router.ts
+++ b/apps/backend/src/routes/correlations-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Correlations route group.
  *
@@ -20,7 +22,6 @@ import {
   hrvActivitiesQuerySchema,
   type HrvActivitiesResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import type { SyncProvider } from '../services/queries.ts'
 
@@ -31,13 +32,14 @@ import {
   getGenericCorrelation,
   getHrvActivitiesCorrelation,
 } from '../services/correlations.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createCorrelationsRouter = (
   authMiddleware: RequestHandler,
   syncProvider?: SyncProvider,
 ): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /correlations/baseline - Get HRV baseline statistics
   router.get<Record<string, never>, BaselineResponse, unknown, BaselineQuery>(
@@ -136,5 +138,5 @@ export const createCorrelationsRouter = (
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/dashboard-router.ts
+++ b/apps/backend/src/routes/dashboard-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Dashboard route group.
  *
@@ -9,14 +11,14 @@ import {
   type UpdateDashboardInput,
   updateDashboardInputSchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { upsertUserSettings } from '../db/index.ts'
 import { getSettings } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createDashboardRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /dashboard - Get user's dashboard configuration
   router.get<Record<string, never>, DashboardResponse>('/', authMiddleware, async (req, res) => {
@@ -44,5 +46,5 @@ export const createDashboardRouter = (authMiddleware: RequestHandler): Router =>
     res.json({ dashboard: defaultDashboardConfig, success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -4,8 +4,9 @@
  * CRUD + search for canonical food item library.
  */
 
+import type { RequestHandler, Router } from 'express'
+
 import { addFoodItemBodySchema, foodItemsQuerySchema, updateFoodItemBodySchema } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import {
   deleteFoodItem,
@@ -15,6 +16,7 @@ import {
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 const handleSearch: RequestHandler = async (req, res) => {
@@ -50,7 +52,7 @@ const handleDelete: RequestHandler<{ id: string }> = async (req, res) => {
 }
 
 export const createFoodItemsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   router.get('/', authMiddleware, validateQuery(foodItemsQuerySchema), handleSearch)
   router.get('/:id', authMiddleware, handleGetById)
@@ -58,5 +60,5 @@ export const createFoodItemsRouter = (authMiddleware: RequestHandler): Router =>
   router.patch('/:id', authMiddleware, validateBody(updateFoodItemBodySchema), handleUpdate)
   router.delete('/:id', authMiddleware, handleDelete)
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/icons-router.ts
+++ b/apps/backend/src/routes/icons-router.ts
@@ -7,11 +7,13 @@
  * GET /icons/:user/:id — serve an icon (public, cached 1 year)
  * DELETE /icons/:id — delete an icon (authenticated)
  */
-import { type RequestHandler, Router } from 'express'
+import type { RequestHandler, Router } from 'express'
+
 import multer from 'multer'
 
 import { getIcon } from '../db/icons.ts'
 import { isAllowedContentType, processAndStoreIcon, removeIcon } from '../services/icons.ts'
+import { typedRouter } from '../typed-router.ts'
 
 const upload = multer({
   limits: { fileSize: 10 * 1024 * 1024 },
@@ -21,7 +23,7 @@ const upload = multer({
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /icons/:user/:id — serve icon (no auth, for <img src>)
   router.get<{ user: string; id: string }>('/:user/:id', async (req, res) => {
@@ -87,5 +89,5 @@ export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/locations-router.ts
+++ b/apps/backend/src/routes/locations-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Locations route group.
  *
@@ -20,7 +22,6 @@ import {
   type UpdateNamedLocationBody,
   updateNamedLocationBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getDetectedLocations as getStoredDetectedLocations } from '../db/index.ts'
 import {
@@ -31,10 +32,11 @@ import {
   updateNamedLocation,
 } from '../services/locations.ts'
 import { queryLocations } from '../services/queries.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createLocationsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /locations - Query location data for a time range
   router.get<Record<string, never>, LocationsResponse, unknown, LocationsQuery>(
@@ -161,5 +163,5 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -1,13 +1,15 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Meals route group.
  *
  * Handles: /meals/*
  */
 import { addMealBodySchema, mealsQuerySchema, updateMealBodySchema } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getMealLogCompleted, setMealLogCompleted, unsetMealLogCompleted } from '../db/index.ts'
 import { addMeal, deleteMealById, getMeal, queryMeals, updateMealById } from '../services/meals.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 /** Check if a date is marked as logging-complete. Returns undefined if no date provided. */
@@ -64,7 +66,7 @@ const handleUnsetLogCompleted: RequestHandler<{ date: string }> = async (req, re
 }
 
 export const createMealsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   router.get('/', authMiddleware, validateQuery(mealsQuerySchema), handleQueryMeals)
 
@@ -80,5 +82,5 @@ export const createMealsRouter = (authMiddleware: RequestHandler): Router => {
   router.patch('/:id', authMiddleware, validateBody(updateMealBodySchema), handleUpdateMeal)
   router.delete('/:id', authMiddleware, handleDeleteMeal)
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Metrics route group.
  *
@@ -34,7 +36,6 @@ import {
   type UpdateCustomMetricBody,
   updateCustomMetricBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import type { MetricType } from '../schema.ts'
 
@@ -58,10 +59,11 @@ import {
   type SyncProvider,
 } from '../services/queries.ts'
 import { getLatestMetric } from '../services/reports.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider?: SyncProvider): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /metrics/bucketed - must come before /metrics/:metric to avoid parameter capture
   router.get<Record<string, never>, QueryMetricsBucketedResponse, unknown, QueryMetricsBucketedQuery>(
@@ -305,5 +307,5 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/notes-router.ts
+++ b/apps/backend/src/routes/notes-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Notes route group.
  *
@@ -14,13 +16,13 @@ import {
   type UpdateNoteBody,
   updateNoteBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { addNote, deleteNoteById, getNotesForEntity, updateNoteContent } from '../services/mutations.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /notes - Get notes for an entity
   router.get<Record<string, never>, NotesResponse, unknown, NotesQuery>(
@@ -89,5 +91,5 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/oauth-router.ts
+++ b/apps/backend/src/routes/oauth-router.ts
@@ -5,7 +5,7 @@
  * server discovery, authorization, token exchange, and dynamic client
  * registration. Endpoints are mounted at the domain root level.
  */
-import express, { Router, type Request, type Response } from 'express'
+import express, { type Router, type Request, type Response } from 'express'
 
 import type { CentralDb } from '../services/central-db.ts'
 
@@ -15,6 +15,7 @@ import {
   refreshAccessToken,
   registerClient,
 } from '../services/oauth.ts'
+import { typedRouter } from '../typed-router.ts'
 
 // ============================================================================
 // Types
@@ -87,7 +88,7 @@ const escapeHtml = (str: string): string =>
 
 export const createOAuthRouter = (deps: OAuthRouterDeps): Router => {
   const { centralDb, loginToUserDb, webHost } = deps
-  const router = Router()
+  const router = typedRouter()
   const oauthDeps = { centralDb }
 
   // OAuth metadata discovery
@@ -242,5 +243,5 @@ export const createOAuthRouter = (deps: OAuthRouterDeps): Router => {
     }
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/reports-router.ts
+++ b/apps/backend/src/routes/reports-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Reports route group.
  *
@@ -15,13 +17,13 @@ import {
   updateReportBodySchema,
   type UpdateReportResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { addReport, deleteReportById, getReport, queryReports, updateReport } from '../services/reports.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /reports - Query reports with optional filters
   router.get<Record<string, never>, ReportsResponse, unknown, ReportsQuery>(
@@ -114,5 +116,5 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Screentime categories route group.
  *
@@ -11,7 +13,6 @@ import {
   type UpdateScreentimeCategoryBody,
   updateScreentimeCategoryBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import {
   createCategory,
@@ -25,10 +26,11 @@ import {
   removeCategory,
   upsertCategory,
 } from '../services/screentime-categories.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET / - List all categories
   router.get('/', authMiddleware, async (req, res) => {
@@ -171,5 +173,5 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     res.json({ data: defaultScreentimeCategories, success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/settings-router.ts
+++ b/apps/backend/src/routes/settings-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Settings and goals route group.
  *
@@ -9,14 +11,14 @@ import {
   updateSettingsInputSchema,
   type UserSettingsResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getGoalsProgress } from '../services/goals.ts'
 import { getSettingsResponse, validateAndUpdateSettings } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createSettingsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /user/settings - Get user settings with effective HR zones
   router.get<Record<string, never>, UserSettingsResponse>(
@@ -52,5 +54,5 @@ export const createSettingsRouter = (authMiddleware: RequestHandler): Router => 
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/tags-router.ts
+++ b/apps/backend/src/routes/tags-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Tags route group.
  *
@@ -27,7 +29,6 @@ import {
   updateTagBodySchema,
   updateTagDefinitionBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import {
   deleteTagDefinition,
@@ -44,10 +45,11 @@ import {
 import { addTag, deleteTag, deleteTagById, restoreTag, updateTag } from '../services/mutations.ts'
 import { queryTags, type SyncProvider } from '../services/queries.ts'
 import { getTagMappings, setTagMapping } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: SyncProvider): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /tags - Query tags for a time range
   router.get<Record<string, never>, TagsResponse, unknown, TagsQuery>(
@@ -356,5 +358,5 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -1,16 +1,18 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Training load route group.
  *
  * Handles: /training-load
  */
 import { type TrainingLoadQuery, trainingLoadQuerySchema, type TrainingLoadResponse } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { computeTrainingLoad, createTrainingLoadDeps } from '../services/training-load.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
 
 export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
   const deps = createTrainingLoadDeps()
 
   // GET /training-load - Get training load time series (ATL, CTL, TSB, TRIMP)
@@ -40,5 +42,5 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -1,17 +1,19 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Trends route group.
  *
  * Handles: /trends
  */
 import { type TrendQuery, trendQuerySchema, type TrendResponse } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getCustomMetrics } from '../services/mutations.ts'
 import { getTrend } from '../services/trends.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
 
 export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /trends - Get time-weighted trend for tags or metrics
   router.get<Record<string, never>, TrendResponse, unknown, TrendQuery>(
@@ -61,5 +63,5 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -1,3 +1,4 @@
+import type { RequestHandler, Router } from 'express'
 import type { ParamsDictionary } from 'express-serve-static-core'
 
 import {
@@ -54,8 +55,8 @@ import {
   type SyncRescueTimeBody,
   type SyncResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
+import { typedRouter } from './typed-router.ts'
 import { validateBody } from './validation.ts'
 
 /**
@@ -156,7 +157,7 @@ export interface SyncRouterDeps {
  * the generic /sync/:recordType route to avoid Express matching issues.
  */
 export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // ===========================================================================
   // Specific sync routes - MUST be defined BEFORE /sync/:recordType
@@ -669,5 +670,5 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     },
   )
 
-  return router
+  return router as unknown as Router
 }


### PR DESCRIPTION
## Summary
- Migrated all 22 Express router files to use `typedRouter()` from `typed-router.ts` instead of `Router()` from express
- `typedRouter()` defaults ResBody to `never`, enforcing explicit response types at compile time
- Excluded `activity-types-router.ts` (already migrated), `mcp.ts` (SSE transport), and `oura-webhook-router.ts` (custom type)

## Details
Each file was changed mechanically:
1. Import `typedRouter` from `typed-router.ts` and make `Router` a type-only import
2. Replace `Router()` with `typedRouter()`
3. Cast `return router as unknown as Router` for Express `app.use()` compatibility

Route handlers that lack explicit ResBody type parameters will now fail type checks — this is intentional and will be addressed in follow-up PRs.

## Test plan
- [ ] Verify build succeeds (runtime behavior is unchanged — `typedRouter()` returns a real Express Router)
- [ ] Type errors on untyped routes are expected and will be fixed incrementally

🤖 Generated with [Claude Code](https://claude.com/claude-code)