### PR TITLE
refactor: switch all routers to typedRouter() with explicit ResBody types

### DIFF
--- a/apps/backend/src/owntracks.ts
+++ b/apps/backend/src/owntracks.ts
@@ -1,4 +1,6 @@
-import { Router } from 'express'
+import type { Router } from 'express'
+
+import { typedRouter } from './typed-router.ts'
 
 export interface OwnTracksDeps {
   loginToUserDb: (user: string, password: string) => Promise<void>
@@ -58,9 +60,9 @@ export function parseBasicAuth(
  * Create OwnTracks router with injected dependencies for testability.
  */
 export function createOwnTracksRouter(deps: OwnTracksDeps): Router {
-  const router = Router()
+  const router = typedRouter()
 
-  router.post('/', async (req, res) => {
+  router.post<Record<string, string>, { error: string }>('/', async (req, res) => {
     const credentials = parseBasicAuth(req.headers.authorization)
     if (!credentials) {
       res.status(401).set('WWW-Authenticate', 'Basic realm="OwnTracks"').json({ error: 'Unauthorized' })
@@ -118,5 +120,5 @@ export function createOwnTracksRouter(deps: OwnTracksDeps): Router {
     }
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Activities and productivity route group.
  *
@@ -26,7 +28,6 @@ import {
   updateActivityBodySchema,
   type UpdateActivityResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 import multer from 'multer'
 
 import {
@@ -59,6 +60,7 @@ import {
   type SyncProvider,
 } from '../services/queries.ts'
 import { computeHrZoneSecs, getEffectiveHrZones } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 /** Compute HR zone seconds and avg HRV for an exercise activity time range. */
@@ -154,10 +156,10 @@ export const createActivitiesRouter = (
   authMiddleware: RequestHandler,
   syncProvider?: SyncProvider,
 ): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /activities - Query activities for a time range
-  router.get<Record<string, never>, ActivitiesResponse, unknown, ActivitiesQuery>(
+  router.get<Record<string, string>, ActivitiesResponse, unknown, ActivitiesQuery>(
     '/activities',
     authMiddleware,
     validateQuery(activitiesQuerySchema),
@@ -174,7 +176,7 @@ export const createActivitiesRouter = (
 
   // POST /activities - Add a manual activity
 
-  router.post<Record<string, never>, AddActivityResponse, AddActivityBody>(
+  router.post<Record<string, string>, AddActivityResponse, AddActivityBody>(
     '/activities',
     authMiddleware,
     validateBody(addActivityBodySchema),
@@ -234,7 +236,10 @@ export const createActivitiesRouter = (
     storage: multer.memoryStorage(),
   })
 
-  router.post('/activities/upload-fit', authMiddleware, upload.single('fit_file'), async (req, res) => {
+  router.post<
+    Record<string, string>,
+    { success: boolean; data?: AddActivityResponse['data'] | AddActivityResponse['data'][]; error?: string }
+  >('/activities/upload-fit', authMiddleware, upload.single('fit_file'), async (req, res) => {
     const user = req.user!
     const file = req.file
 
@@ -302,7 +307,7 @@ export const createActivitiesRouter = (
   })
 
   // POST /activities/merge - Merge multiple activities into one
-  router.post<Record<string, never>, MergeActivitiesResponse, MergeActivitiesBody>(
+  router.post<Record<string, string>, MergeActivitiesResponse, MergeActivitiesBody>(
     '/activities/merge',
     authMiddleware,
     validateBody(mergeActivitiesBodySchema),
@@ -332,39 +337,43 @@ export const createActivitiesRouter = (
   )
 
   // GET /activities/:id/nearby - Get nearby same-type activities for merge suggestions
-  router.get<{ id: string }>('/activities/:id/nearby', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
-    const hours = Number(req.query.hours) || 6
+  router.get<{ id: string }, { success: boolean; data: unknown[]; error?: string }>(
+    '/activities/:id/nearby',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
+      const hours = Number(req.query.hours) || 6
 
-    const activity = await getActivityById(user, id)
-    if (!activity) {
-      return res.status(404).json({ data: [], error: 'Activity not found', success: false })
-    }
+      const activity = await getActivityById(user, id)
+      if (!activity) {
+        return res.status(404).json({ data: [], error: 'Activity not found', success: false })
+      }
 
-    const nearby = await getNearbyActivities(
-      user,
-      id,
-      activity.activity_type,
-      activity.start_time,
-      activity.end_time,
-      hours,
-    )
+      const nearby = await getNearbyActivities(
+        user,
+        id,
+        activity.activity_type,
+        activity.start_time,
+        activity.end_time,
+        hours,
+      )
 
-    res.json({
-      data: nearby.map((a) => ({
-        activity_type: a.activity_type,
-        data: a.data,
-        end_time: a.end_time?.toISOString(),
-        id: a.id,
-        notes: a.notes,
-        source: a.source,
-        start_time: a.start_time.toISOString(),
-        title: a.title,
-      })),
-      success: true,
-    })
-  })
+      res.json({
+        data: nearby.map((a) => ({
+          activity_type: a.activity_type,
+          data: a.data,
+          end_time: a.end_time?.toISOString(),
+          id: a.id,
+          notes: a.notes,
+          source: a.source,
+          start_time: a.start_time.toISOString(),
+          title: a.title,
+        })),
+        success: true,
+      })
+    },
+  )
 
   // DELETE /activities/:id - Delete an activity by ID
   router.delete<{ id: string }, DeleteActivityResponse>(
@@ -439,64 +448,72 @@ export const createActivitiesRouter = (
 
   // GET /activities/:id - Get a single activity by ID (for detail page)
   // Supports merged: prefix — merged:<uuid> returns merged view, plain uuid returns raw activity
-  router.get<{ id: string }>('/activities/:id', authMiddleware, async (req, res) => {
-    const rawId = req.params.id
-    const user = req.user!
+  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+    '/activities/:id',
+    authMiddleware,
+    async (req, res) => {
+      const rawId = req.params.id
+      const user = req.user!
 
-    const isMerged = rawId.startsWith('merged:')
-    const realId = isMerged ? rawId.slice('merged:'.length) : rawId
+      const isMerged = rawId.startsWith('merged:')
+      const realId = isMerged ? rawId.slice('merged:'.length) : rawId
 
-    const activity = await getActivityById(user, realId, true)
-    if (!activity) {
-      return res.status(404).json({ error: 'Activity not found', success: false })
-    }
+      const activity = await getActivityById(user, realId, true)
+      if (!activity) {
+        return res.status(404).json({ error: 'Activity not found', success: false })
+      }
 
-    // Compute HR zones and avg HRV for exercise activities
-    let exerciseMetrics: { hr_zone_secs?: Record<number, number>; avg_hrv?: number } = {}
-    if (activity.activity_type === 'exercise' && activity.end_time) {
-      exerciseMetrics = await computeExerciseMetrics(user, activity.start_time, activity.end_time)
-    }
+      // Compute HR zones and avg HRV for exercise activities
+      let exerciseMetrics: { hr_zone_secs?: Record<number, number>; avg_hrv?: number } = {}
+      if (activity.activity_type === 'exercise' && activity.end_time) {
+        exerciseMetrics = await computeExerciseMetrics(user, activity.start_time, activity.end_time)
+      }
 
-    // For merged: prefix, fetch overlapping activities and return merged view
-    if (isMerged && !activity.deleted_at) {
-      const data = await buildMergedResponse(user, activity, exerciseMetrics)
-      return res.json({ data, success: true })
-    }
+      // For merged: prefix, fetch overlapping activities and return merged view
+      if (isMerged && !activity.deleted_at) {
+        const data = await buildMergedResponse(user, activity, exerciseMetrics)
+        return res.json({ data, success: true })
+      }
 
-    // Plain UUID: return raw single activity (no overlap lookup)
-    res.json({
-      data: {
-        activity_type: activity.activity_type,
-        avg_hrv: exerciseMetrics.avg_hrv,
-        data: activity.data,
-        deleted_at: activity.deleted_at?.toISOString(),
-        end_time: activity.end_time?.toISOString(),
-        hr_zone_secs: exerciseMetrics.hr_zone_secs,
-        id: activity.id,
-        notes: activity.notes,
-        source: activity.source,
-        start_time: activity.start_time.toISOString(),
-        title: activity.title,
-      },
-      success: true,
-    })
-  })
+      // Plain UUID: return raw single activity (no overlap lookup)
+      res.json({
+        data: {
+          activity_type: activity.activity_type,
+          avg_hrv: exerciseMetrics.avg_hrv,
+          data: activity.data,
+          deleted_at: activity.deleted_at?.toISOString(),
+          end_time: activity.end_time?.toISOString(),
+          hr_zone_secs: exerciseMetrics.hr_zone_secs,
+          id: activity.id,
+          notes: activity.notes,
+          source: activity.source,
+          start_time: activity.start_time.toISOString(),
+          title: activity.title,
+        },
+        success: true,
+      })
+    },
+  )
 
   // POST /activities/:id/restore - Restore a soft-deleted activity
-  router.post<{ id: string }>('/activities/:id/restore', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
+  router.post<{ id: string }, { success: boolean; error?: string }>(
+    '/activities/:id/restore',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
 
-    const result = await restoreActivity(user, id)
-    if (!result.success) {
-      return res.status(404).json({ error: 'Activity not found or not deleted', success: false })
-    }
+      const result = await restoreActivity(user, id)
+      if (!result.success) {
+        return res.status(404).json({ error: 'Activity not found or not deleted', success: false })
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
   // GET /productivity/bucketed - Get screentime bucketed by time and category
-  router.get<Record<string, never>, ScreentimeBucketedResponse, unknown, ScreentimeBucketedQuery>(
+  router.get<Record<string, string>, ScreentimeBucketedResponse, unknown, ScreentimeBucketedQuery>(
     '/productivity/bucketed',
     authMiddleware,
     validateQuery(screentimeBucketedQuerySchema),
@@ -519,66 +536,82 @@ export const createActivitiesRouter = (
   )
 
   // GET /productivity/apps - Get distinct app names with their categories
-  router.get('/productivity/apps', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const apps = await getDistinctApps(user)
-    res.json({ data: apps, success: true })
-  })
+  router.get<Record<string, string>, { success: boolean; data: unknown[] }>(
+    '/productivity/apps',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const apps = await getDistinctApps(user)
+      res.json({ data: apps, success: true })
+    },
+  )
 
   // GET /productivity/:id - Get a single productivity record by ID
-  router.get<{ id: string }>('/productivity/:id', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const record = await getProductivityById(user, req.params.id)
-    if (!record) {
-      return res.status(404).json({ error: 'Productivity record not found', success: false })
-    }
-    res.json({
-      data: {
-        activity: record.activity,
-        category: record.category,
-        device_name: record.device_name,
-        duration_sec: record.duration_sec,
-        end_time: record.end_time.toISOString(),
-        id: record.id,
-        is_mobile: record.is_mobile,
-        productivity: record.productivity,
-        resolved_category: record.resolved_category,
-        source: record.source,
-        start_time: record.start_time.toISOString(),
-        title: record.title,
-      },
-      success: true,
-    })
-  })
+  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+    '/productivity/:id',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const record = await getProductivityById(user, req.params.id)
+      if (!record) {
+        return res.status(404).json({ error: 'Productivity record not found', success: false })
+      }
+      res.json({
+        data: {
+          activity: record.activity,
+          category: record.category,
+          device_name: record.device_name,
+          duration_sec: record.duration_sec,
+          end_time: record.end_time.toISOString(),
+          id: record.id,
+          is_mobile: record.is_mobile,
+          productivity: record.productivity,
+          resolved_category: record.resolved_category,
+          source: record.source,
+          start_time: record.start_time.toISOString(),
+          title: record.title,
+        },
+        success: true,
+      })
+    },
+  )
 
   // DELETE /productivity/:id - Soft-delete a productivity record
-  router.delete<{ id: string }>('/productivity/:id', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
+  router.delete<{ id: string }, { success: boolean; error?: string }>(
+    '/productivity/:id',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
 
-    const result = await deleteProductivity(user, id)
-    if (!result.success) {
-      return res.status(404).json({ error: 'Productivity record not found', success: false })
-    }
+      const result = await deleteProductivity(user, id)
+      if (!result.success) {
+        return res.status(404).json({ error: 'Productivity record not found', success: false })
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
   // POST /productivity/:id/restore - Restore a soft-deleted productivity record
-  router.post<{ id: string }>('/productivity/:id/restore', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
+  router.post<{ id: string }, { success: boolean; error?: string }>(
+    '/productivity/:id/restore',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
 
-    const result = await restoreProductivity(user, id)
-    if (!result.success) {
-      return res.status(404).json({ error: 'Record not found or not deleted', success: false })
-    }
+      const result = await restoreProductivity(user, id)
+      if (!result.success) {
+        return res.status(404).json({ error: 'Record not found or not deleted', success: false })
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
   // GET /productivity - Query productivity data for a time range
-  router.get<Record<string, never>, ProductivityResponse, unknown, ProductivityQuery>(
+  router.get<Record<string, string>, ProductivityResponse, unknown, ProductivityQuery>(
     '/productivity',
     authMiddleware,
     validateQuery(productivityQuerySchema),
@@ -591,5 +624,5 @@ export const createActivitiesRouter = (
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -1,19 +1,21 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Chart data route group.
  *
  * Handles: /chart-data
  */
 import { type ChartDataHttpQuery, chartDataHttpQuerySchema, type ChartDataResponse } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getChartData } from '../services/chart-data.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
 
 export const createChartDataRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /chart-data — bucketed aggregation for bar charts
-  router.get<Record<string, never>, ChartDataResponse, unknown, ChartDataHttpQuery>(
+  router.get<Record<string, string>, ChartDataResponse, unknown, ChartDataHttpQuery>(
     '/',
     authMiddleware,
     validateQuery(chartDataHttpQuerySchema),
@@ -45,5 +47,5 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/correlations-router.ts
+++ b/apps/backend/src/routes/correlations-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Correlations route group.
  *
@@ -20,7 +22,6 @@ import {
   hrvActivitiesQuerySchema,
   type HrvActivitiesResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import type { SyncProvider } from '../services/queries.ts'
 
@@ -31,16 +32,17 @@ import {
   getGenericCorrelation,
   getHrvActivitiesCorrelation,
 } from '../services/correlations.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createCorrelationsRouter = (
   authMiddleware: RequestHandler,
   syncProvider?: SyncProvider,
 ): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /correlations/baseline - Get HRV baseline statistics
-  router.get<Record<string, never>, BaselineResponse, unknown, BaselineQuery>(
+  router.get<Record<string, string>, BaselineResponse, unknown, BaselineQuery>(
     '/baseline',
     authMiddleware,
     validateQuery(baselineQuerySchema),
@@ -55,7 +57,7 @@ export const createCorrelationsRouter = (
   )
 
   // GET /correlations/hrv-activities - Get HRV correlations with activities
-  router.get<Record<string, never>, HrvActivitiesResponse, unknown, HrvActivitiesQuery>(
+  router.get<Record<string, string>, HrvActivitiesResponse, unknown, HrvActivitiesQuery>(
     '/hrv-activities',
     authMiddleware,
     validateQuery(hrvActivitiesQuerySchema),
@@ -95,7 +97,7 @@ export const createCorrelationsRouter = (
   )
 
   // POST /correlations/event-probability - Get event probability correlation
-  router.post<Record<string, never>, EventProbabilityResponse, EventProbabilityBody>(
+  router.post<Record<string, string>, EventProbabilityResponse, EventProbabilityBody>(
     '/event-probability',
     authMiddleware,
     validateBody(eventProbabilityBodySchema),
@@ -116,7 +118,7 @@ export const createCorrelationsRouter = (
   )
 
   // POST /correlations/generic - Generic correlation analysis
-  router.post<Record<string, never>, GenericCorrelationResponse, GenericCorrelationBody>(
+  router.post<Record<string, string>, GenericCorrelationResponse, GenericCorrelationBody>(
     '/generic',
     authMiddleware,
     validateBody(genericCorrelationBodySchema),
@@ -136,5 +138,5 @@ export const createCorrelationsRouter = (
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/icons-router.ts
+++ b/apps/backend/src/routes/icons-router.ts
@@ -7,11 +7,13 @@
  * GET /icons/:user/:id — serve an icon (public, cached 1 year)
  * DELETE /icons/:id — delete an icon (authenticated)
  */
-import { type RequestHandler, Router } from 'express'
+import type { RequestHandler, Router } from 'express'
+
 import multer from 'multer'
 
 import { getIcon } from '../db/icons.ts'
 import { isAllowedContentType, processAndStoreIcon, removeIcon } from '../services/icons.ts'
+import { typedRouter } from '../typed-router.ts'
 
 const upload = multer({
   limits: { fileSize: 10 * 1024 * 1024 },
@@ -21,71 +23,83 @@ const upload = multer({
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /icons/:user/:id — serve icon (no auth, for <img src>)
-  router.get<{ user: string; id: string }>('/:user/:id', async (req, res) => {
-    const { user, id } = req.params
-    if (!UUID_RE.test(id)) {
-      res.status(400).json({ error: 'Invalid icon ID', success: false })
-      return
-    }
+  router.get<{ user: string; id: string }, { error: string; success: boolean } | Buffer>(
+    '/:user/:id',
+    async (req, res) => {
+      const { user, id } = req.params
+      if (!UUID_RE.test(id)) {
+        res.status(400).json({ error: 'Invalid icon ID', success: false })
+        return
+      }
 
-    const icon = await getIcon(user, id)
-    if (!icon) {
-      res.status(404).json({ error: 'Icon not found', success: false })
-      return
-    }
+      const icon = await getIcon(user, id)
+      if (!icon) {
+        res.status(404).json({ error: 'Icon not found', success: false })
+        return
+      }
 
-    res.set('Content-Type', icon.content_type)
-    res.set('Cache-Control', 'public, max-age=31536000, immutable')
-    res.send(icon.data)
-  })
+      res.set('Content-Type', icon.content_type)
+      res.set('Cache-Control', 'public, max-age=31536000, immutable')
+      res.send(icon.data)
+    },
+  )
 
   // POST /icons — upload an icon
-  router.post('/', authMiddleware, upload.single('icon'), async (req, res) => {
-    const user = req.user!
-    const file = req.file
-    if (!file) {
-      res.status(400).json({ error: 'No file uploaded', success: false })
-      return
-    }
+  router.post<Record<string, string>, { success: boolean; id?: string; url?: string; error?: string }>(
+    '/',
+    authMiddleware,
+    upload.single('icon'),
+    async (req, res) => {
+      const user = req.user!
+      const file = req.file
+      if (!file) {
+        res.status(400).json({ error: 'No file uploaded', success: false })
+        return
+      }
 
-    if (!isAllowedContentType(file.mimetype)) {
-      res.status(400).json({
-        error: `Unsupported file type: ${file.mimetype}. Allowed: PNG, JPEG, WebP, GIF, SVG`,
-        success: false,
-      })
-      return
-    }
+      if (!isAllowedContentType(file.mimetype)) {
+        res.status(400).json({
+          error: `Unsupported file type: ${file.mimetype}. Allowed: PNG, JPEG, WebP, GIF, SVG`,
+          success: false,
+        })
+        return
+      }
 
-    try {
-      const id = await processAndStoreIcon(user, file.buffer, file.mimetype)
-      const url = `/api/icons/${user}/${id}`
-      res.status(201).json({ id, success: true, url })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to process icon'
-      res.status(400).json({ error: message, success: false })
-    }
-  })
+      try {
+        const id = await processAndStoreIcon(user, file.buffer, file.mimetype)
+        const url = `/api/icons/${user}/${id}`
+        res.status(201).json({ id, success: true, url })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to process icon'
+        res.status(400).json({ error: message, success: false })
+      }
+    },
+  )
 
   // DELETE /icons/:id — delete an icon
-  router.delete<{ id: string }>('/:id', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const { id } = req.params
-    if (!UUID_RE.test(id)) {
-      res.status(400).json({ error: 'Invalid icon ID', success: false })
-      return
-    }
+  router.delete<{ id: string }, { success: boolean; error?: string }>(
+    '/:id',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const { id } = req.params
+      if (!UUID_RE.test(id)) {
+        res.status(400).json({ error: 'Invalid icon ID', success: false })
+        return
+      }
 
-    const deleted = await removeIcon(user, id)
-    if (!deleted) {
-      res.status(404).json({ error: 'Icon not found', success: false })
-      return
-    }
+      const deleted = await removeIcon(user, id)
+      if (!deleted) {
+        res.status(404).json({ error: 'Icon not found', success: false })
+        return
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/locations-router.ts
+++ b/apps/backend/src/routes/locations-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Locations route group.
  *
@@ -20,7 +22,6 @@ import {
   type UpdateNamedLocationBody,
   updateNamedLocationBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getDetectedLocations as getStoredDetectedLocations } from '../db/index.ts'
 import {
@@ -31,13 +32,14 @@ import {
   updateNamedLocation,
 } from '../services/locations.ts'
 import { queryLocations } from '../services/queries.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createLocationsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /locations - Query location data for a time range
-  router.get<Record<string, never>, LocationsResponse, unknown, LocationsQuery>(
+  router.get<Record<string, string>, LocationsResponse, unknown, LocationsQuery>(
     '/',
     authMiddleware,
     validateQuery(locationsQuerySchema),
@@ -51,13 +53,13 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // GET /locations/named - List all named locations
-  router.get<Record<string, never>, NamedLocationsResponse>('/named', authMiddleware, async (req, res) => {
+  router.get<Record<string, string>, NamedLocationsResponse>('/named', authMiddleware, async (req, res) => {
     const locations = await getNamedLocations(req.user!)
     res.json({ data: locations, success: true })
   })
 
   // POST /locations/named - Create a named location
-  router.post<Record<string, never>, AddNamedLocationResponse, AddNamedLocationBody>(
+  router.post<Record<string, string>, AddNamedLocationResponse, AddNamedLocationBody>(
     '/named',
     authMiddleware,
     validateBody(addNamedLocationBodySchema),
@@ -104,7 +106,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   })
 
   // GET /locations/detected - Get computed detected location clusters
-  router.get<Record<string, never>, DetectedLocationsResponse, unknown, DetectedLocationsQuery>(
+  router.get<Record<string, string>, DetectedLocationsResponse, unknown, DetectedLocationsQuery>(
     '/detected',
     authMiddleware,
     validateQuery(detectedLocationsQuerySchema),
@@ -131,7 +133,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // GET /locations/detected/stored - Get stored detected locations with addresses
-  router.get<Record<string, never>, DetectedLocationsResponse>(
+  router.get<Record<string, string>, DetectedLocationsResponse>(
     '/detected/stored',
     authMiddleware,
     async (req, res) => {
@@ -148,7 +150,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // POST /locations/detected/promote - Promote detected location to named
-  router.post<Record<string, never>, AddNamedLocationResponse, PromoteDetectedLocationBody>(
+  router.post<Record<string, string>, AddNamedLocationResponse, PromoteDetectedLocationBody>(
     '/detected/promote',
     authMiddleware,
     validateBody(promoteDetectedLocationBodySchema),
@@ -161,5 +163,5 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Metrics route group.
  *
@@ -34,7 +36,6 @@ import {
   type UpdateCustomMetricBody,
   updateCustomMetricBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import type { MetricType } from '../schema.ts'
 
@@ -58,13 +59,14 @@ import {
   type SyncProvider,
 } from '../services/queries.ts'
 import { getLatestMetric } from '../services/reports.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider?: SyncProvider): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /metrics/bucketed - must come before /metrics/:metric to avoid parameter capture
-  router.get<Record<string, never>, QueryMetricsBucketedResponse, unknown, QueryMetricsBucketedQuery>(
+  router.get<Record<string, string>, QueryMetricsBucketedResponse, unknown, QueryMetricsBucketedQuery>(
     '/metrics/bucketed',
     authMiddleware,
     validateQuery(queryMetricsBucketedQuerySchema),
@@ -91,7 +93,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // GET /metrics/custom - List all custom metric types
-  router.get<Record<string, never>, CustomMetricsListResponse>(
+  router.get<Record<string, string>, CustomMetricsListResponse>(
     '/metrics/custom',
     authMiddleware,
     async (req, res) => {
@@ -102,7 +104,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics/custom - Register a new custom metric type
-  router.post<Record<string, never>, CustomMetricResponse, AddCustomMetricBody>(
+  router.post<Record<string, string>, CustomMetricResponse, AddCustomMetricBody>(
     '/metrics/custom',
     authMiddleware,
     validateBody(addCustomMetricBodySchema),
@@ -149,7 +151,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
 
   // POST /metrics/recalculate-calories - Recalculate calorie burn from HR data
   // With start/end: synchronous range recompute. Without: async full recompute.
-  router.post<Record<string, never>, RecalculateCaloriesResponse, Partial<RecalculateCaloriesBody>>(
+  router.post<Record<string, string>, RecalculateCaloriesResponse, Partial<RecalculateCaloriesBody>>(
     '/metrics/recalculate-calories',
     authMiddleware,
     async (req, res) => {
@@ -179,7 +181,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics/bulk - Bulk insert metric data points
-  router.post<Record<string, never>, BulkMetricsResponse, BulkMetricsBody>(
+  router.post<Record<string, string>, BulkMetricsResponse, BulkMetricsBody>(
     '/metrics/bulk',
     authMiddleware,
     validateBody(bulkMetricsBodySchema),
@@ -218,12 +220,16 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // DELETE /metrics/:metric/data - Delete all manual measurements for a metric
-  router.delete<{ metric: string }>('/metrics/:metric/data', authMiddleware, async (req, res) => {
-    const { metric } = req.params
-    const user = req.user!
-    const result = await deleteMetricData(user, metric)
-    res.json({ ...result, success: true })
-  })
+  router.delete<{ metric: string }, { success: boolean; deleted?: number }>(
+    '/metrics/:metric/data',
+    authMiddleware,
+    async (req, res) => {
+      const { metric } = req.params
+      const user = req.user!
+      const result = await deleteMetricData(user, metric)
+      res.json({ ...result, success: true })
+    },
+  )
 
   // DELETE /metrics/:metric - Delete a single measurement (soft delete)
   router.delete<{ metric: string }, unknown, unknown, DeleteMetricQuery>(
@@ -260,7 +266,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics - Add a manual metric measurement
-  router.post<Record<string, never>, AddMetricResponse, AddMetricBody>(
+  router.post<Record<string, string>, AddMetricResponse, AddMetricBody>(
     '/metrics',
     authMiddleware,
     validateBody(addMetricBodySchema),
@@ -276,7 +282,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // GET /daily-summary - Get comprehensive summary for a day
-  router.get<Record<string, never>, DailySummaryResponse, unknown, DailySummaryQuery>(
+  router.get<Record<string, string>, DailySummaryResponse, unknown, DailySummaryQuery>(
     '/daily-summary',
     authMiddleware,
     validateQuery(dailySummaryQuerySchema),
@@ -290,7 +296,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // GET /period-summary - Get aggregated stats for a period
-  router.get<Record<string, never>, PeriodSummaryResponse, unknown, PeriodSummaryQuery>(
+  router.get<Record<string, string>, PeriodSummaryResponse, unknown, PeriodSummaryQuery>(
     '/period-summary',
     authMiddleware,
     validateQuery(periodSummaryQuerySchema),
@@ -305,5 +311,5 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/notes-router.ts
+++ b/apps/backend/src/routes/notes-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Notes route group.
  *
@@ -14,16 +16,16 @@ import {
   type UpdateNoteBody,
   updateNoteBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { addNote, deleteNoteById, getNotesForEntity, updateNoteContent } from '../services/mutations.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /notes - Get notes for an entity
-  router.get<Record<string, never>, NotesResponse, unknown, NotesQuery>(
+  router.get<Record<string, string>, NotesResponse, unknown, NotesQuery>(
     '/',
     authMiddleware,
     validateQuery(notesQuerySchema),
@@ -37,7 +39,7 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
   )
 
   // POST /notes - Add a note
-  router.post<Record<string, never>, NoteResponse, AddNoteBody>(
+  router.post<Record<string, string>, NoteResponse, AddNoteBody>(
     '/',
     authMiddleware,
     validateBody(addNoteBodySchema),
@@ -89,5 +91,5 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/reports-router.ts
+++ b/apps/backend/src/routes/reports-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Reports route group.
  *
@@ -15,16 +17,16 @@ import {
   updateReportBodySchema,
   type UpdateReportResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { addReport, deleteReportById, getReport, queryReports, updateReport } from '../services/reports.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /reports - Query reports with optional filters
-  router.get<Record<string, never>, ReportsResponse, unknown, ReportsQuery>(
+  router.get<Record<string, string>, ReportsResponse, unknown, ReportsQuery>(
     '/',
     authMiddleware,
     validateQuery(reportsQuerySchema),
@@ -52,7 +54,7 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
   })
 
   // POST /reports - Create a new report
-  router.post<Record<string, never>, ReportResponse, AddReportBody>(
+  router.post<Record<string, string>, ReportResponse, AddReportBody>(
     '/',
     authMiddleware,
     validateBody(addReportBodySchema),
@@ -114,5 +116,5 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Screentime categories route group.
  *
@@ -11,7 +13,6 @@ import {
   type UpdateScreentimeCategoryBody,
   updateScreentimeCategoryBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import {
   createCategory,
@@ -25,47 +26,61 @@ import {
   removeCategory,
   upsertCategory,
 } from '../services/screentime-categories.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET / - List all categories
-  router.get('/', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const categories = await listCategories(user)
-    res.json({ data: categories, success: true })
-  })
+  router.get<Record<string, string>, { success: boolean; data: unknown[] }>(
+    '/',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const categories = await listCategories(user)
+      res.json({ data: categories, success: true })
+    },
+  )
 
   // GET /:id - Get a single category
-  router.get<{ id: string }>('/:id', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const category = await getCategoryById(user, req.params.id)
-    if (!category) {
-      res.status(404).json({ error: 'Category not found', success: false })
-      return
-    }
-    res.json({ data: category, success: true })
-  })
+  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+    '/:id',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const category = await getCategoryById(user, req.params.id)
+      if (!category) {
+        res.status(404).json({ error: 'Category not found', success: false })
+        return
+      }
+      res.json({ data: category, success: true })
+    },
+  )
 
   // POST / - Create a category
-  router.post('/', authMiddleware, validateBody(createScreentimeCategoryBodySchema), async (req, res) => {
-    const user = req.user!
-    const body = req.body as CreateScreentimeCategoryBody
-    const category = await createCategory(user, {
-      color: body.color,
-      ignore_case: body.ignore_case ?? true,
-      name: body.name,
-      rule_regex: body.rule_regex,
-      rule_type: body.rule_type ?? 'none',
-      score: body.score,
-      sort_order: body.sort_order,
-    })
-    res.status(201).json({ data: category, success: true })
-  })
+  router.post<Record<string, string>, { success: boolean; data: unknown }>(
+    '/',
+    authMiddleware,
+    validateBody(createScreentimeCategoryBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const body = req.body as CreateScreentimeCategoryBody
+      const category = await createCategory(user, {
+        color: body.color,
+        ignore_case: body.ignore_case ?? true,
+        name: body.name,
+        rule_regex: body.rule_regex,
+        rule_type: body.rule_type ?? 'none',
+        score: body.score,
+        sort_order: body.sort_order,
+      })
+      res.status(201).json({ data: category, success: true })
+    },
+  )
 
   // PUT /:id - Upsert a category (create with client-generated UUID or full update)
-  router.put<{ id: string }>(
+  router.put<{ id: string }, { success: boolean; data: unknown }>(
     '/:id',
     authMiddleware,
     validateBody(createScreentimeCategoryBodySchema),
@@ -87,7 +102,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // PATCH /:id - Partial update a category
-  router.patch<{ id: string }>(
+  router.patch<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
     '/:id',
     authMiddleware,
     validateBody(updateScreentimeCategoryBodySchema),
@@ -104,26 +119,34 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // PATCH /:id/move - Move a category to a new parent
-  router.patch<{ id: string }>('/:id/move', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const { new_parent_id } = req.body as { new_parent_id: string | null }
-    const result = await moveCategoryToParent(user, req.params.id, new_parent_id)
-    res.json({ success: result.updated > 0, updated: result.updated })
-  })
+  router.patch<{ id: string }, { success: boolean; updated: number }>(
+    '/:id/move',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const { new_parent_id } = req.body as { new_parent_id: string | null }
+      const result = await moveCategoryToParent(user, req.params.id, new_parent_id)
+      res.json({ success: result.updated > 0, updated: result.updated })
+    },
+  )
 
   // DELETE /:id - Delete a category and its children
-  router.delete<{ id: string }>('/:id', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const count = await removeCategory(user, req.params.id)
-    if (count === 0) {
-      res.status(404).json({ error: 'Category not found', success: false })
-      return
-    }
-    res.json({ deleted: count, success: true })
-  })
+  router.delete<{ id: string }, { success: boolean; deleted?: number; error?: string }>(
+    '/:id',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const count = await removeCategory(user, req.params.id)
+      if (count === 0) {
+        res.status(404).json({ error: 'Category not found', success: false })
+        return
+      }
+      res.json({ deleted: count, success: true })
+    },
+  )
 
   // POST /import-activitywatch - Import categories from ActivityWatch
-  router.post(
+  router.post<Record<string, string>, { success: boolean; data?: unknown; error?: string }>(
     '/import-activitywatch',
     authMiddleware,
     validateBody(importAwCategoriesBodySchema),
@@ -150,26 +173,34 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // POST /recategorize - Force full recategorization
-  router.post('/recategorize', authMiddleware, async (req, res) => {
-    const user = req.user!
+  router.post<Record<string, string>, { success: boolean; records_updated?: number; error?: string }>(
+    '/recategorize',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
 
-    // Start recategorization and respond immediately
-    const countPromise = recategorizeAll(user)
+      // Start recategorization and respond immediately
+      const countPromise = recategorizeAll(user)
 
-    try {
-      const count = await countPromise
-      res.json({ records_updated: count, success: true })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Recategorization failed'
-      res.status(500).json({ error: message, success: false })
-    }
-  })
+      try {
+        const count = await countPromise
+        res.json({ records_updated: count, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Recategorization failed'
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
 
   // GET /defaults - Get default category suggestions
-  router.get('/defaults', authMiddleware, async (_req, res) => {
-    const { defaultScreentimeCategories } = await import('@aurboda/api-spec')
-    res.json({ data: defaultScreentimeCategories, success: true })
-  })
+  router.get<Record<string, string>, { success: boolean; data: unknown[] }>(
+    '/defaults',
+    authMiddleware,
+    async (_req, res) => {
+      const { defaultScreentimeCategories } = await import('@aurboda/api-spec')
+      res.json({ data: defaultScreentimeCategories, success: true })
+    },
+  )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/tags-router.ts
+++ b/apps/backend/src/routes/tags-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Tags route group.
  *
@@ -27,7 +29,6 @@ import {
   updateTagBodySchema,
   updateTagDefinitionBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import {
   deleteTagDefinition,
@@ -44,13 +45,14 @@ import {
 import { addTag, deleteTag, deleteTagById, restoreTag, updateTag } from '../services/mutations.ts'
 import { queryTags, type SyncProvider } from '../services/queries.ts'
 import { getTagMappings, setTagMapping } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: SyncProvider): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /tags - Query tags for a time range
-  router.get<Record<string, never>, TagsResponse, unknown, TagsQuery>(
+  router.get<Record<string, string>, TagsResponse, unknown, TagsQuery>(
     '/',
     authMiddleware,
     validateQuery(tagsQuerySchema),
@@ -64,7 +66,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // POST /tags - Add a manual tag
-  router.post<Record<string, never>, AddTagResponse, AddTagBody>(
+  router.post<Record<string, string>, AddTagResponse, AddTagBody>(
     '/',
     authMiddleware,
     validateBody(addTagBodySchema),
@@ -99,32 +101,36 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // GET /tags/id/:id - Get a single tag by ID (for detail page)
-  router.get<{ id: string }>('/id/:id', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
+  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+    '/id/:id',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
 
-    const tag = await getTagById(user, id, true)
-    if (!tag) {
-      return res.status(404).json({ error: 'Tag not found', success: false })
-    }
+      const tag = await getTagById(user, id, true)
+      if (!tag) {
+        return res.status(404).json({ error: 'Tag not found', success: false })
+      }
 
-    res.json({
-      data: {
-        deleted_at: tag.deleted_at?.toISOString(),
-        end_time: tag.end_time?.toISOString(),
-        external_id: tag.external_id,
-        id: tag.id,
-        source: tag.source,
-        start_time: tag.start_time.toISOString(),
-        tag: tag.tag,
-        tag_key: tag.tag_key,
-      },
-      success: true,
-    })
-  })
+      res.json({
+        data: {
+          deleted_at: tag.deleted_at?.toISOString(),
+          end_time: tag.end_time?.toISOString(),
+          external_id: tag.external_id,
+          id: tag.id,
+          source: tag.source,
+          start_time: tag.start_time.toISOString(),
+          tag: tag.tag,
+          tag_key: tag.tag_key,
+        },
+        success: true,
+      })
+    },
+  )
 
   // PATCH /tags/id/:id - Update a tag's times
-  router.patch<{ id: string }, unknown, UpdateTagBody>(
+  router.patch<{ id: string }, { success: boolean; error?: string }, UpdateTagBody>(
     '/id/:id',
     authMiddleware,
     validateBody(updateTagBodySchema),
@@ -147,40 +153,48 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // DELETE /tags/id/:id - Soft-delete a tag by UUID (not external_id)
-  router.delete<{ id: string }>('/id/:id', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
+  router.delete<{ id: string }, { success: boolean; error?: string }>(
+    '/id/:id',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
 
-    const result = await deleteTagById(user, id)
-    if (!result.success) {
-      return res.status(404).json({ error: 'Tag not found', success: false })
-    }
+      const result = await deleteTagById(user, id)
+      if (!result.success) {
+        return res.status(404).json({ error: 'Tag not found', success: false })
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
   // POST /tags/id/:id/restore - Restore a soft-deleted tag
-  router.post<{ id: string }>('/id/:id/restore', authMiddleware, async (req, res) => {
-    const { id } = req.params
-    const user = req.user!
+  router.post<{ id: string }, { success: boolean; error?: string }>(
+    '/id/:id/restore',
+    authMiddleware,
+    async (req, res) => {
+      const { id } = req.params
+      const user = req.user!
 
-    const result = await restoreTag(user, id)
-    if (!result.success) {
-      return res.status(404).json({ error: 'Tag not found or not deleted', success: false })
-    }
+      const result = await restoreTag(user, id)
+      if (!result.success) {
+        return res.status(404).json({ error: 'Tag not found or not deleted', success: false })
+      }
 
-    res.json({ success: true })
-  })
+      res.json({ success: true })
+    },
+  )
 
   // GET /tags/unique - Get all unique tag names
-  router.get<Record<string, never>, UniqueTagsResponse>('/unique', authMiddleware, async (req, res) => {
+  router.get<Record<string, string>, UniqueTagsResponse>('/unique', authMiddleware, async (req, res) => {
     const user = req.user!
     const tags = await getUniqueTags(user)
     res.json({ data: tags, success: true })
   })
 
   // GET /tags/programmatic - Get all tags with their current mappings (for tag mapper)
-  router.get<Record<string, never>, ProgrammaticTagsResponse>(
+  router.get<Record<string, string>, ProgrammaticTagsResponse>(
     '/programmatic',
     authMiddleware,
     async (req, res) => {
@@ -203,7 +217,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // POST /tags/mapping - Set a tag mapping
-  router.post<Record<string, never>, SetTagMappingResponse, SetTagMappingBody>(
+  router.post<Record<string, string>, SetTagMappingResponse, SetTagMappingBody>(
     '/mapping',
     authMiddleware,
     validateBody(setTagMappingBodySchema),
@@ -218,7 +232,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // GET /tags/mappings - Get all tag mappings
-  router.get<Record<string, never>, TagMappingsResponse>('/mappings', authMiddleware, async (req, res) => {
+  router.get<Record<string, string>, TagMappingsResponse>('/mappings', authMiddleware, async (req, res) => {
     const user = req.user!
     const result = await getTagMappings(user)
     res.json({ ...result, success: true })
@@ -229,7 +243,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   // ============================================================================
 
   // GET /tags/definitions - List all tag definitions with counts
-  router.get<Record<string, never>, TagDefinitionsResponse>(
+  router.get<Record<string, string>, TagDefinitionsResponse>(
     '/definitions',
     authMiddleware,
     async (req, res) => {
@@ -250,29 +264,33 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // GET /tags/definitions/:id - Get a single tag definition
-  router.get<{ id: string }>('/definitions/:id', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const definition = await getTagDefinitionById(user, req.params.id)
-    if (!definition) {
-      return res.status(404).json({ error: 'Tag definition not found', success: false })
-    }
-    res.json({
-      data: {
-        aliases: definition.aliases,
-        count: definition.count,
-        created_at: definition.created_at.toISOString(),
-        icon: definition.icon ?? null,
-        id: definition.id,
-        latest_time: definition.latest_time?.toISOString(),
-        name: definition.name,
-        updated_at: definition.updated_at.toISOString(),
-      },
-      success: true,
-    })
-  })
+  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+    '/definitions/:id',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const definition = await getTagDefinitionById(user, req.params.id)
+      if (!definition) {
+        return res.status(404).json({ error: 'Tag definition not found', success: false })
+      }
+      res.json({
+        data: {
+          aliases: definition.aliases,
+          count: definition.count,
+          created_at: definition.created_at.toISOString(),
+          icon: definition.icon ?? null,
+          id: definition.id,
+          latest_time: definition.latest_time?.toISOString(),
+          name: definition.name,
+          updated_at: definition.updated_at.toISOString(),
+        },
+        success: true,
+      })
+    },
+  )
 
   // POST /tags/definitions - Create a tag definition
-  router.post<Record<string, never>, unknown, CreateTagDefinitionBody>(
+  router.post<Record<string, string>, { success: boolean; data: unknown }, CreateTagDefinitionBody>(
     '/definitions',
     authMiddleware,
     validateBody(createTagDefinitionBodySchema),
@@ -294,7 +312,7 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // PATCH /tags/definitions/:id - Update a tag definition
-  router.patch<{ id: string }, unknown, UpdateTagDefinitionBody>(
+  router.patch<{ id: string }, { success: boolean; data?: unknown; error?: string }, UpdateTagDefinitionBody>(
     '/definitions/:id',
     authMiddleware,
     validateBody(updateTagDefinitionBodySchema),
@@ -319,17 +337,21 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
   )
 
   // DELETE /tags/definitions/:id - Delete a tag definition
-  router.delete<{ id: string }>('/definitions/:id', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const deleted = await deleteTagDefinition(user, req.params.id)
-    if (!deleted) {
-      return res.status(404).json({ error: 'Tag definition not found', success: false })
-    }
-    res.json({ success: true })
-  })
+  router.delete<{ id: string }, { success: boolean; error?: string }>(
+    '/definitions/:id',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const deleted = await deleteTagDefinition(user, req.params.id)
+      if (!deleted) {
+        return res.status(404).json({ error: 'Tag definition not found', success: false })
+      }
+      res.json({ success: true })
+    },
+  )
 
   // POST /tags/definitions/:id/merge - Merge this definition into another
-  router.post<{ id: string }, unknown, MergeTagDefinitionsBody>(
+  router.post<{ id: string }, { success: boolean; data?: unknown; error?: string }, MergeTagDefinitionsBody>(
     '/definitions/:id/merge',
     authMiddleware,
     validateBody(mergeTagDefinitionsBodySchema),
@@ -356,5 +378,5 @@ export const createTagsRouter = (authMiddleware: RequestHandler, syncProvider?: 
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -1,20 +1,22 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Training load route group.
  *
  * Handles: /training-load
  */
 import { type TrainingLoadQuery, trainingLoadQuerySchema, type TrainingLoadResponse } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { computeTrainingLoad, createTrainingLoadDeps } from '../services/training-load.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
 
 export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
   const deps = createTrainingLoadDeps()
 
   // GET /training-load - Get training load time series (ATL, CTL, TSB, TRIMP)
-  router.get<Record<string, never>, TrainingLoadResponse, unknown, TrainingLoadQuery>(
+  router.get<Record<string, string>, TrainingLoadResponse, unknown, TrainingLoadQuery>(
     '/',
     authMiddleware,
     validateQuery(trainingLoadQuerySchema),
@@ -40,5 +42,5 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -1,20 +1,22 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Trends route group.
  *
  * Handles: /trends
  */
 import { type TrendQuery, trendQuerySchema, type TrendResponse } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getCustomMetrics } from '../services/mutations.ts'
 import { getTrend } from '../services/trends.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
 
 export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // GET /trends - Get time-weighted trend for tags or metrics
-  router.get<Record<string, never>, TrendResponse, unknown, TrendQuery>(
+  router.get<Record<string, string>, TrendResponse, unknown, TrendQuery>(
     '/',
     authMiddleware,
     validateQuery(trendQuerySchema),
@@ -61,5 +63,5 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -1,3 +1,4 @@
+import type { RequestHandler, Router } from 'express'
 import type { ParamsDictionary } from 'express-serve-static-core'
 
 import {
@@ -54,8 +55,8 @@ import {
   type SyncRescueTimeBody,
   type SyncResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
+import { typedRouter } from './typed-router.ts'
 import { validateBody } from './validation.ts'
 
 /**
@@ -156,7 +157,7 @@ export interface SyncRouterDeps {
  * the generic /sync/:recordType route to avoid Express matching issues.
  */
 export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
   // ===========================================================================
   // Specific sync routes - MUST be defined BEFORE /sync/:recordType
@@ -669,5 +670,5 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/typed-router.ts
+++ b/apps/backend/src/typed-router.ts
@@ -12,7 +12,7 @@
  *   router.get<{ id: string }, MyResponse>('/:id', ...)   // OK
  *   router.get('/', (req, res) => res.json({ x: 1 }))    // ERROR: not assignable to never
  */
-import type { ParamsDictionary, RequestHandler, RequestHandlerParams } from 'express-serve-static-core'
+import type { ParamsDictionary, Query, RequestHandler, RequestHandlerParams } from 'express-serve-static-core'
 
 import { Router } from 'express'
 
@@ -21,13 +21,25 @@ import { Router } from 'express'
  * Keeps the same overload structure as Express's IRouterMatcher but with stricter defaults.
  */
 interface StrictRouterMatcher<T> {
-  <P extends ParamsDictionary = ParamsDictionary, ResBody = never, ReqBody = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ReqBody stays `any` for Express compat; ResBody is the enforced contract
+  <
+    P extends ParamsDictionary = ParamsDictionary,
+    ResBody = never,
+    ReqBody = any,
+    ReqQuery extends Query = Query,
+  >(
     path: string,
-    ...handlers: Array<RequestHandler<P, ResBody, ReqBody>>
+    ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery>>
   ): T
-  <P extends ParamsDictionary = ParamsDictionary, ResBody = never, ReqBody = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  <
+    P extends ParamsDictionary = ParamsDictionary,
+    ResBody = never,
+    ReqBody = any,
+    ReqQuery extends Query = Query,
+  >(
     path: string,
-    ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody>>
+    ...handlers: Array<RequestHandlerParams<P, ResBody, ReqBody, ReqQuery>>
   ): T
 }
 


### PR DESCRIPTION
## Summary
- Converted all 14 Express routers + `typed-router.ts` to use `typedRouter()` which defaults `ResBody` to `never`, enforcing explicit response type declarations at compile time
- Added `ReqQuery` type parameter support to `StrictRouterMatcher` so routes with query validation (4th generic param) work correctly
- Added explicit `ResBody` types to all route handlers that previously lacked them (upload-fit, nearby, restore, productivity, screentime categories, tag definitions, etc.)
- Changed `Record<string, never>` to `Record<string, string>` for path params to avoid assignability issues

## Test plan
- [x] `pnpm --filter aurboda-backend check` passes (tsgo --noEmit + oxlint, zero errors)
- [x] No runtime behavior changes -- types only
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)