### PR TITLE
feat: Activity Types & Deduction Rules pages

### DIFF
--- a/apps/web/src/components/ConditionBuilder/index.tsx
+++ b/apps/web/src/components/ConditionBuilder/index.tsx
@@ -1,0 +1,172 @@
+/**
+ * ConditionBuilder — editable list of AND-combined deduction rule conditions.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import type { DeductionRuleCondition } from '../../state/api'
+
+import { fetchActivityTypeDefinitions } from '../../state/api'
+import './style.css'
+
+const KIND_LABELS: Record<string, string> = {
+  activity: 'Activity Type',
+  screentime_category: 'Screentime Category',
+  tag: 'Tag Name',
+}
+
+const KINDS: Array<DeductionRuleCondition['kind']> = ['activity', 'tag', 'screentime_category']
+
+// ============================================================================
+// Single condition card
+// ============================================================================
+
+function ConditionCard({
+  condition,
+  index,
+  onChange,
+  onRemove,
+  canRemove,
+}: {
+  condition: DeductionRuleCondition
+  index: number
+  onChange: (index: number, updated: DeductionRuleCondition) => void
+  onRemove: (index: number) => void
+  canRemove: boolean
+}) {
+  const { data: definitions = [] } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activityTypeDefinitions'],
+    staleTime: 5 * 60_000,
+  })
+
+  const handleKindChange = (newKind: DeductionRuleCondition['kind']) => {
+    const base: DeductionRuleCondition = { kind: newKind }
+    if (newKind === 'activity') base.activity_type = ''
+    if (newKind === 'tag') base.tag_name = ''
+    if (newKind === 'screentime_category') base.category = []
+    onChange(index, base)
+  }
+
+  return (
+    <div class="condition-card">
+      <div class="condition-card-header">
+        <select
+          value={condition.kind}
+          onChange={(e) =>
+            handleKindChange((e.target as HTMLSelectElement).value as DeductionRuleCondition['kind'])
+          }
+          class="condition-kind-select"
+        >
+          {KINDS.map((k) => (
+            <option key={k} value={k}>
+              {KIND_LABELS[k]}
+            </option>
+          ))}
+        </select>
+        {canRemove && (
+          <button
+            type="button"
+            class="condition-remove-btn"
+            onClick={() => onRemove(index)}
+            title="Remove condition"
+          >
+            &#x2715;
+          </button>
+        )}
+      </div>
+
+      <div class="condition-card-body">
+        {condition.kind === 'activity' && (
+          <select
+            value={condition.activity_type ?? ''}
+            onChange={(e) =>
+              onChange(index, { ...condition, activity_type: (e.target as HTMLSelectElement).value })
+            }
+            class="condition-field-select"
+          >
+            <option value="">-- select activity type --</option>
+            {definitions.map((d) => (
+              <option key={d.name} value={d.name}>
+                {d.display_name} ({d.name})
+              </option>
+            ))}
+          </select>
+        )}
+
+        {condition.kind === 'tag' && (
+          <input
+            type="text"
+            value={condition.tag_name ?? ''}
+            onInput={(e) => onChange(index, { ...condition, tag_name: (e.target as HTMLInputElement).value })}
+            placeholder="Tag name"
+            class="condition-field-input"
+          />
+        )}
+
+        {condition.kind === 'screentime_category' && (
+          <input
+            type="text"
+            value={condition.category?.join(', ') ?? ''}
+            onInput={(e) =>
+              onChange(index, {
+                ...condition,
+                category: (e.target as HTMLInputElement).value
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              })
+            }
+            placeholder="Category path (comma-separated, e.g. Work, Programming)"
+            class="condition-field-input"
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
+export function ConditionBuilder({
+  conditions,
+  onChange,
+}: {
+  conditions: DeductionRuleCondition[]
+  onChange: (conditions: DeductionRuleCondition[]) => void
+}) {
+  const handleChange = (index: number, updated: DeductionRuleCondition) => {
+    const next = [...conditions]
+    next[index] = updated
+    onChange(next)
+  }
+
+  const handleRemove = (index: number) => {
+    onChange(conditions.filter((_, i) => i !== index))
+  }
+
+  const handleAdd = () => {
+    onChange([...conditions, { kind: 'activity' }])
+  }
+
+  return (
+    <div class="condition-builder">
+      {conditions.map((condition, i) => (
+        <div key={i}>
+          {i > 0 && <div class="condition-and">AND</div>}
+          <ConditionCard
+            condition={condition}
+            index={i}
+            onChange={handleChange}
+            onRemove={handleRemove}
+            canRemove={conditions.length > 1}
+          />
+        </div>
+      ))}
+      <button type="button" class="note-action-btn condition-add-btn" onClick={handleAdd}>
+        Add Condition
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/ConditionBuilder/style.css
+++ b/apps/web/src/components/ConditionBuilder/style.css
@@ -1,0 +1,147 @@
+/* ============================================================================
+ * ConditionBuilder styles
+ * ============================================================================ */
+
+.condition-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.condition-and {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0;
+}
+
+.condition-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: #fafafa;
+}
+
+.condition-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.condition-kind-select {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.condition-kind-select:focus {
+  outline: none;
+  border-color: #673ab8;
+}
+
+.condition-remove-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #9ca3af;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.condition-remove-btn:hover {
+  color: #ef4444;
+}
+
+.condition-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.condition-field-select {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.condition-field-select:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.condition-field-input {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.condition-field-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.condition-add-btn {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .condition-card {
+    border-color: #333;
+    background: #1a1a2e;
+  }
+
+  .condition-kind-select {
+    border-color: #4b5563;
+  }
+
+  .condition-kind-select:focus {
+    border-color: #8b5cf6;
+  }
+
+  .condition-field-select {
+    border-color: #4b5563;
+  }
+
+  .condition-field-select:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .condition-field-input {
+    border-color: #4b5563;
+  }
+
+  .condition-field-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .condition-and {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -8,6 +8,8 @@ export const NAV_LINKS = [
   { href: '/add', label: '+ Add', icon: '➕' },
   { href: '/chart', label: 'Chart', icon: '📈' },
   { href: '/places', label: 'Places', icon: '📍' },
+  { href: '/activity-types', label: 'Types', icon: '🏷' },
+  { href: '/deduction-rules', label: 'Rules', icon: '🔗' },
 ]
 
 export const DATA_SOURCE_LINKS = [

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -7,6 +7,7 @@ import { Footer } from './components/Footer.jsx'
 import { Header } from './components/Header.jsx'
 import { Sidebar } from './components/Sidebar.jsx'
 import { NotFound } from './pages/_404.jsx'
+import { ActivityTypes } from './pages/ActivityTypes/index.jsx'
 import { AddData } from './pages/AddData/index.jsx'
 import { AdminSettings } from './pages/AdminSettings/index.jsx'
 import { AuditLog } from './pages/AuditLog/index.jsx'
@@ -24,6 +25,8 @@ import { LastFmSource } from './pages/DataSources/LastFmSource.jsx'
 import { OuraSource } from './pages/DataSources/OuraSource.jsx'
 import { OwnTracksSource } from './pages/DataSources/OwnTracksSource.jsx'
 import { RescueTimeSource } from './pages/DataSources/RescueTimeSource.jsx'
+import { DeductionRules } from './pages/DeductionRules/index.jsx'
+import { DeductionRuleDetail } from './pages/DeductionRules/RuleDetail.jsx'
 import { EntityDetail } from './pages/EntityDetail/index.jsx'
 import { ExerciseMeta } from './pages/ExerciseMeta/index.jsx'
 import { FoodItemDetail } from './pages/FoodItems/FoodItemDetail.jsx'
@@ -94,6 +97,10 @@ export function App() {
               <Route path="/data-sources/lastfm" component={LastFmSource} />
               <Route path="/data-sources/owntracks" component={OwnTracksSource} />
               <Route path="/data-sources/calendars" component={CalendarsSource} />
+              <Route path="/activity-types" component={ActivityTypes} />
+              <Route path="/deduction-rules/new" component={DeductionRuleDetail} />
+              <Route path="/deduction-rules/:id" component={DeductionRuleDetail} />
+              <Route path="/deduction-rules" component={DeductionRules} />
               <Route path="/screentime-categories/:id" component={CategoryDetail} />
               <Route path="/screentime-categories" component={ScreentimeCategories} />
               <Route path="/settings" component={Settings} />

--- a/apps/web/src/pages/ActivityTypes/index.tsx
+++ b/apps/web/src/pages/ActivityTypes/index.tsx
@@ -1,0 +1,180 @@
+/**
+ * Activity Types page — shows all activity type definitions grouped by display_category,
+ * with show_on_timeline toggle switches and a search filter.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'preact/hooks'
+
+import type { ActivityTypeDefinition } from '../../state/api'
+
+import { fetchActivityTypeDefinitions, updateActivityTypeDefinition } from '../../state/api'
+import { auth } from '../../state/auth'
+import './style.css'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const CATEGORY_LABELS: Record<string, string> = {
+  exercise: 'Exercise',
+  meditation: 'Meditation',
+  other: 'Other',
+  productivity: 'Productivity',
+  sleep_rest: 'Sleep & Rest',
+  travel: 'Travel',
+  wellness: 'Wellness',
+}
+
+const CATEGORY_ORDER = ['sleep_rest', 'exercise', 'meditation', 'wellness', 'productivity', 'travel', 'other']
+
+// ============================================================================
+// Toggle row
+// ============================================================================
+
+function TypeRow({ def }: { def: ActivityTypeDefinition }) {
+  const queryClient = useQueryClient()
+
+  const toggleMutation = useMutation({
+    mutationFn: () => updateActivityTypeDefinition(def.name, { show_on_timeline: !def.show_on_timeline }),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['activityTypeDefinitions'] })
+      const previous = queryClient.getQueryData<ActivityTypeDefinition[]>(['activityTypeDefinitions'])
+      queryClient.setQueryData<ActivityTypeDefinition[]>(['activityTypeDefinitions'], (old) =>
+        old?.map((t) => (t.name === def.name ? { ...t, show_on_timeline: !t.show_on_timeline } : t)),
+      )
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['activityTypeDefinitions'], context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['activityTypeDefinitions'] })
+    },
+  })
+
+  return (
+    <div class="at-row">
+      <div class="at-info">
+        <span class="at-color-dot" style={{ background: def.color }} />
+        <span class="at-display-name">{def.display_name}</span>
+        <span class="at-name-muted">{def.name}</span>
+      </div>
+      <div class="at-actions">
+        <label class="at-toggle">
+          <input
+            type="checkbox"
+            checked={def.show_on_timeline}
+            onChange={() => toggleMutation.mutate()}
+            disabled={toggleMutation.isPending}
+          />
+          <span class="at-toggle-label">Timeline</span>
+        </label>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Collapsible group
+// ============================================================================
+
+function CategoryGroup({ category, types }: { category: string; types: ActivityTypeDefinition[] }) {
+  const [collapsed, setCollapsed] = useState(false)
+  const label = CATEGORY_LABELS[category] ?? category
+
+  return (
+    <div class="at-group">
+      <button type="button" class="at-group-header" onClick={() => setCollapsed(!collapsed)}>
+        <span class={`at-group-chevron ${collapsed ? 'collapsed' : ''}`}>&#9660;</span>
+        <span class="at-group-label">{label}</span>
+        <span class="at-group-count">{types.length}</span>
+      </button>
+      {!collapsed && (
+        <div class="at-group-list">
+          {types.map((def) => (
+            <TypeRow key={def.name} def={def} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Main page
+// ============================================================================
+
+export function ActivityTypes() {
+  const isLoggedIn = auth.value.token
+  const [search, setSearch] = useState('')
+
+  const { data: definitions = [], isLoading } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activityTypeDefinitions'],
+  })
+
+  const filtered = useMemo(() => {
+    if (!search) return definitions
+    const q = search.toLowerCase()
+    return definitions.filter(
+      (d) => d.name.toLowerCase().includes(q) || d.display_name.toLowerCase().includes(q),
+    )
+  }, [definitions, search])
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, ActivityTypeDefinition[]>()
+    for (const def of filtered) {
+      const cat = def.display_category || 'other'
+      const list = groups.get(cat) ?? []
+      list.push(def)
+      groups.set(cat, list)
+    }
+    return CATEGORY_ORDER.filter((cat) => groups.has(cat)).map((cat) => ({
+      category: cat,
+      types: groups.get(cat)!,
+    }))
+  }, [filtered])
+
+  if (!isLoggedIn) {
+    return (
+      <div class="data-sources-page">
+        <p>Please log in to manage activity types.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="data-sources-page">
+      <div class="page-header">
+        <h1>Activity Types</h1>
+        <p class="page-subtitle">
+          Manage activity type definitions. Toggle which types appear on the timeline.
+        </p>
+      </div>
+
+      <div class="at-search">
+        <input
+          type="text"
+          placeholder="Search by name..."
+          value={search}
+          onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
+          class="at-search-input"
+        />
+      </div>
+
+      {isLoading ? (
+        <p class="loading">Loading activity types...</p>
+      ) : grouped.length === 0 ? (
+        <p class="at-empty">{search ? 'No matching activity types.' : 'No activity types defined yet.'}</p>
+      ) : (
+        <div class="at-container">
+          {grouped.map(({ category, types }) => (
+            <CategoryGroup key={category} category={category} types={types} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/ActivityTypes/style.css
+++ b/apps/web/src/pages/ActivityTypes/style.css
@@ -1,0 +1,214 @@
+/* ============================================================================
+ * Activity Types page styles
+ * ============================================================================ */
+
+.at-search {
+  margin-bottom: 1rem;
+}
+
+.at-search-input {
+  width: 100%;
+  max-width: 400px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+}
+
+.at-search-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.at-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Group */
+.at-group {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.at-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: #f9fafb;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #374151;
+  text-align: left;
+}
+
+.at-group-header:hover {
+  background: #f3f4f6;
+}
+
+.at-group-chevron {
+  font-size: 0.65rem;
+  transition: transform 0.15s;
+}
+
+.at-group-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.at-group-label {
+  flex: 1;
+}
+
+.at-group-count {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #6b7280;
+  background: #e5e7eb;
+  padding: 0.1rem 0.4rem;
+  border-radius: 99px;
+}
+
+.at-group-list {
+  border-top: 1px solid #e0e0e0;
+}
+
+/* Row */
+.at-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.at-row:last-child {
+  border-bottom: none;
+}
+
+.at-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.at-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.at-display-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.at-name-muted {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.at-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.at-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.at-toggle input {
+  accent-color: #673ab8;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.at-empty {
+  color: #9ca3af;
+  font-size: 0.9rem;
+  font-style: italic;
+  padding: 1rem 0;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .at-search-input {
+    border-color: #4b5563;
+  }
+
+  .at-search-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .at-group {
+    border-color: #333;
+  }
+
+  .at-group-header {
+    background: #1a1a2e;
+    color: #d1d5db;
+  }
+
+  .at-group-header:hover {
+    background: #1e1e32;
+  }
+
+  .at-group-count {
+    background: #374151;
+    color: #9ca3af;
+  }
+
+  .at-group-list {
+    border-top-color: #333;
+  }
+
+  .at-row {
+    border-bottom-color: #333;
+  }
+
+  .at-display-name {
+    color: #d1d5db;
+  }
+
+  .at-toggle {
+    color: #9ca3af;
+  }
+
+  .at-toggle input {
+    accent-color: #8b5cf6;
+  }
+}
+
+/* Mobile */
+@media (max-width: 639px) {
+  .at-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.375rem;
+  }
+
+  .at-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/apps/web/src/pages/DeductionRules/RuleDetail.tsx
+++ b/apps/web/src/pages/DeductionRules/RuleDetail.tsx
@@ -1,0 +1,421 @@
+/**
+ * Deduction Rule detail/edit page.
+ * Handles both editing existing rules and creating new ones (/deduction-rules/new).
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocation, useRoute } from 'preact-iso'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+
+import type { ActivityTypeDefinition, DeductionRuleCondition } from '../../state/api'
+
+import { ConditionBuilder } from '../../components/ConditionBuilder'
+import { ConfirmButton } from '../../components/ConfirmButton'
+import { SaveStatusIndicator, useSaveStatus } from '../../components/SaveStatusIndicator'
+import {
+  createDeductionRule,
+  deleteDeductionRule,
+  fetchActivityTypeDefinitions,
+  fetchDeductionRules,
+  updateDeductionRule,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+import './style.css'
+
+// ============================================================================
+// Auto-save text input
+// ============================================================================
+
+function AutoSaveText({
+  label,
+  value,
+  onSave,
+  placeholder,
+  type = 'text',
+}: {
+  label: string
+  value: string
+  onSave: (v: string) => void
+  placeholder?: string
+  type?: string
+}) {
+  const [local, setLocal] = useState(value)
+
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+
+  const handleBlur = () => {
+    if (local !== value) onSave(local)
+  }
+
+  return (
+    <div class="rule-field">
+      <span class="rule-field-label">{label}</span>
+      <input
+        type={type}
+        value={local}
+        onInput={(e) => setLocal((e.target as HTMLInputElement).value)}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        class="rule-field-input"
+      />
+    </div>
+  )
+}
+
+// ============================================================================
+// Activity type picker
+// ============================================================================
+
+function ActivityTypePicker({
+  value,
+  onChange,
+  definitions,
+}: {
+  value: string
+  onChange: (v: string) => void
+  definitions: ActivityTypeDefinition[]
+}) {
+  return (
+    <div class="rule-field">
+      <span class="rule-field-label">Output Activity Type</span>
+      <select
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLSelectElement).value)}
+        class="rule-field-select"
+      >
+        <option value="">-- select --</option>
+        {definitions.map((d) => (
+          <option key={d.name} value={d.name}>
+            {d.display_name} ({d.name})
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+// ============================================================================
+// New rule form
+// ============================================================================
+
+function NewRuleForm() {
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
+
+  const [name, setName] = useState('')
+  const [outputType, setOutputType] = useState('')
+  const [outputTitle, setOutputTitle] = useState('')
+  const [mergeGapMinutes, setMergeGapMinutes] = useState('')
+  const [priority, setPriority] = useState(1)
+  const [enabled, setEnabled] = useState(true)
+  const [conditions, setConditions] = useState<DeductionRuleCondition[]>([{ kind: 'activity' }])
+
+  const { data: definitions = [] } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activityTypeDefinitions'],
+    staleTime: 5 * 60_000,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createDeductionRule({
+        conditions,
+        enabled,
+        merge_gap_seconds: mergeGapMinutes ? Number(mergeGapMinutes) * 60 : undefined,
+        name,
+        output_activity_type: outputType,
+        output_title: outputTitle || undefined,
+        priority,
+      }),
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ['deductionRules'] })
+      route(`/deduction-rules/${created.id}`)
+    },
+  })
+
+  return (
+    <div class="data-sources-page">
+      <div class="page-header">
+        <h1>New Deduction Rule</h1>
+      </div>
+
+      <div class="rule-detail">
+        <section class="rule-section">
+          <div class="rule-field">
+            <span class="rule-field-label">Name</span>
+            <input
+              type="text"
+              value={name}
+              onInput={(e) => setName((e.target as HTMLInputElement).value)}
+              placeholder="Rule name"
+              class="rule-field-input"
+            />
+          </div>
+
+          <ActivityTypePicker value={outputType} onChange={setOutputType} definitions={definitions} />
+
+          <div class="rule-field">
+            <span class="rule-field-label">Output Title</span>
+            <input
+              type="text"
+              value={outputTitle}
+              onInput={(e) => setOutputTitle((e.target as HTMLInputElement).value)}
+              placeholder="Optional title"
+              class="rule-field-input"
+            />
+          </div>
+
+          <div class="rule-field">
+            <span class="rule-field-label">Merge Gap (minutes)</span>
+            <input
+              type="number"
+              value={mergeGapMinutes}
+              onInput={(e) => setMergeGapMinutes((e.target as HTMLInputElement).value)}
+              placeholder="e.g. 5"
+              class="rule-field-input"
+            />
+          </div>
+
+          <div class="rule-field">
+            <span class="rule-field-label">Priority</span>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(Number((e.target as HTMLSelectElement).value))}
+              class="rule-field-select"
+            >
+              <option value={0}>0 - Low</option>
+              <option value={1}>1 - Normal</option>
+              <option value={2}>2 - High</option>
+            </select>
+          </div>
+
+          <div class="rule-field">
+            <label class="rule-checkbox">
+              <input type="checkbox" checked={enabled} onChange={() => setEnabled(!enabled)} />
+              <span>Enabled</span>
+            </label>
+          </div>
+        </section>
+
+        <section class="rule-section">
+          <h2>Conditions</h2>
+          <ConditionBuilder conditions={conditions} onChange={setConditions} />
+        </section>
+
+        <div class="rule-footer">
+          <button
+            type="button"
+            class="note-action-btn"
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending || !name || !outputType}
+          >
+            {createMutation.isPending ? 'Creating...' : 'Create Rule'}
+          </button>
+          {createMutation.isError && <p class="rule-error">{(createMutation.error as Error).message}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Edit rule form
+// ============================================================================
+
+function EditRuleForm({ id }: { id: string }) {
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
+  const [saveStatus, setSaveStatus] = useSaveStatus(3000)
+
+  const { data: rule, isLoading } = useQuery({
+    queryFn: fetchDeductionRules,
+    queryKey: ['deductionRules'],
+    select: (data) => data.find((r) => r.id === id),
+  })
+
+  const { data: definitions = [] } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activityTypeDefinitions'],
+    staleTime: 5 * 60_000,
+  })
+
+  const [conditions, setConditions] = useState<DeductionRuleCondition[]>([])
+  const [conditionsDirty, setConditionsDirty] = useState(false)
+
+  useEffect(() => {
+    if (rule) {
+      setConditions(rule.conditions)
+      setConditionsDirty(false)
+    }
+  }, [rule])
+
+  const updateMutation = useMutation({
+    mutationFn: (body: Parameters<typeof updateDeductionRule>[1]) => updateDeductionRule(id, body),
+    onMutate: () => setSaveStatus({ status: 'saving' }),
+    onSuccess: () => {
+      setSaveStatus({ status: 'saved' })
+      queryClient.invalidateQueries({ queryKey: ['deductionRules'] })
+    },
+    onError: () => {
+      setSaveStatus({ status: 'error' })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteDeductionRule(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['deductionRules'] })
+      route('/deduction-rules')
+    },
+  })
+
+  const autoSave = useCallback(
+    (body: Parameters<typeof updateDeductionRule>[1]) => {
+      updateMutation.mutate(body)
+    },
+    [updateMutation.mutate],
+  )
+
+  const handleConditionsChange = useCallback((newConditions: DeductionRuleCondition[]) => {
+    setConditions(newConditions)
+    setConditionsDirty(true)
+  }, [])
+
+  const saveConditions = useCallback(() => {
+    autoSave({ conditions })
+    setConditionsDirty(false)
+  }, [conditions, autoSave])
+
+  if (isLoading) {
+    return (
+      <div class="data-sources-page">
+        <p class="loading">Loading rule...</p>
+      </div>
+    )
+  }
+
+  if (!rule) {
+    return (
+      <div class="data-sources-page">
+        <p>Rule not found.</p>
+        <a href="/deduction-rules">Back to rules</a>
+      </div>
+    )
+  }
+
+  const mergeGapMinutes = rule.merge_gap_seconds ? String(rule.merge_gap_seconds / 60) : ''
+
+  return (
+    <div class="data-sources-page">
+      <div class="page-header">
+        <div class="rule-header-row">
+          <h1>{rule.name}</h1>
+          <SaveStatusIndicator state={saveStatus} variant="compact" />
+        </div>
+        <a href="/deduction-rules" class="rule-back-link">
+          Back to rules
+        </a>
+      </div>
+
+      <div class="rule-detail">
+        <section class="rule-section">
+          <AutoSaveText label="Name" value={rule.name} onSave={(v) => autoSave({ name: v })} />
+
+          <ActivityTypePicker
+            value={rule.output_activity_type}
+            onChange={(v) => autoSave({ output_activity_type: v })}
+            definitions={definitions}
+          />
+
+          <AutoSaveText
+            label="Output Title"
+            value={rule.output_title ?? ''}
+            onSave={(v) => autoSave({ output_title: v || null })}
+            placeholder="Optional title"
+          />
+
+          <AutoSaveText
+            label="Merge Gap (minutes)"
+            value={mergeGapMinutes}
+            onSave={(v) => autoSave({ merge_gap_seconds: v ? Number(v) * 60 : null })}
+            placeholder="e.g. 5"
+            type="number"
+          />
+
+          <div class="rule-field">
+            <span class="rule-field-label">Priority</span>
+            <select
+              value={rule.priority}
+              onChange={(e) => autoSave({ priority: Number((e.target as HTMLSelectElement).value) })}
+              class="rule-field-select"
+            >
+              <option value={0}>0 - Low</option>
+              <option value={1}>1 - Normal</option>
+              <option value={2}>2 - High</option>
+            </select>
+          </div>
+
+          <div class="rule-field">
+            <label class="rule-checkbox">
+              <input
+                type="checkbox"
+                checked={rule.enabled}
+                onChange={() => autoSave({ enabled: !rule.enabled })}
+              />
+              <span>Enabled</span>
+            </label>
+          </div>
+        </section>
+
+        <section class="rule-section">
+          <h2>Conditions</h2>
+          <ConditionBuilder conditions={conditions} onChange={handleConditionsChange} />
+          {conditionsDirty && (
+            <button
+              type="button"
+              class="note-action-btn"
+              onClick={saveConditions}
+              disabled={updateMutation.isPending}
+            >
+              {updateMutation.isPending ? 'Saving...' : 'Save Conditions'}
+            </button>
+          )}
+        </section>
+
+        <section class="rule-section rule-danger-zone">
+          <ConfirmButton
+            label="Delete Rule"
+            confirmMessage={`Delete rule "${rule.name}"?`}
+            onConfirm={() => deleteMutation.mutate()}
+            isPending={deleteMutation.isPending}
+            pendingLabel="Deleting..."
+          />
+        </section>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main export — dispatches between new and edit
+// ============================================================================
+
+export function DeductionRuleDetail() {
+  const { params } = useRoute()
+  const id = params.id as string
+
+  if (!auth.value.token) {
+    return (
+      <div class="data-sources-page">
+        <p>Please log in to manage deduction rules.</p>
+      </div>
+    )
+  }
+
+  if (id === 'new') {
+    return <NewRuleForm />
+  }
+
+  return <EditRuleForm id={id} />
+}

--- a/apps/web/src/pages/DeductionRules/index.tsx
+++ b/apps/web/src/pages/DeductionRules/index.tsx
@@ -1,0 +1,190 @@
+/**
+ * Deduction Rules list page — shows all deduction rules with enable toggles and actions.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocation } from 'preact-iso'
+import { useState } from 'preact/hooks'
+
+import type { DeductionRule, DeductionRuleCondition } from '../../state/api'
+
+import { ConfirmButton } from '../../components/ConfirmButton'
+import {
+  deleteDeductionRule,
+  evaluateDeductionRules,
+  fetchDeductionRules,
+  updateDeductionRule,
+} from '../../state/api'
+import { auth } from '../../state/auth'
+import './style.css'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const formatCondition = (c: DeductionRuleCondition): string => {
+  switch (c.kind) {
+    case 'activity':
+      return `Activity: ${c.activity_type}`
+    case 'tag':
+      return `Tag: ${c.tag_name}`
+    case 'screentime_category':
+      return `Screen: ${c.category?.join(' > ')}`
+    default:
+      return c.kind
+  }
+}
+
+const formatConditions = (conditions: DeductionRuleCondition[]): string =>
+  conditions.map(formatCondition).join(' AND ')
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'Low',
+  1: 'Normal',
+  2: 'High',
+}
+
+// ============================================================================
+// Rule row
+// ============================================================================
+
+function RuleRow({ rule }: { rule: DeductionRule }) {
+  const queryClient = useQueryClient()
+
+  const toggleMutation = useMutation({
+    mutationFn: () => updateDeductionRule(rule.id, { enabled: !rule.enabled }),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['deductionRules'] })
+      const previous = queryClient.getQueryData<DeductionRule[]>(['deductionRules'])
+      queryClient.setQueryData<DeductionRule[]>(['deductionRules'], (old) =>
+        old?.map((r) => (r.id === rule.id ? { ...r, enabled: !r.enabled } : r)),
+      )
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['deductionRules'], context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['deductionRules'] })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteDeductionRule(rule.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['deductionRules'] })
+    },
+  })
+
+  return (
+    <div class="rule-row">
+      <a href={`/deduction-rules/${rule.id}`} class="rule-info">
+        <span class="rule-name">{rule.name}</span>
+        <span class="rule-conditions">{formatConditions(rule.conditions)}</span>
+        <span class="rule-output">{rule.output_activity_type}</span>
+        <span class={`rule-priority priority-${rule.priority}`}>
+          {PRIORITY_LABELS[rule.priority] ?? rule.priority}
+        </span>
+      </a>
+      <div class="rule-actions">
+        <label class="rule-toggle">
+          <input
+            type="checkbox"
+            checked={rule.enabled}
+            onChange={() => toggleMutation.mutate()}
+            disabled={toggleMutation.isPending}
+          />
+          <span class="rule-toggle-label">Enabled</span>
+        </label>
+        <ConfirmButton
+          label="Delete"
+          confirmMessage={`Delete rule "${rule.name}"?`}
+          onConfirm={() => deleteMutation.mutate()}
+          isPending={deleteMutation.isPending}
+          pendingLabel="Deleting..."
+        />
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main page
+// ============================================================================
+
+export function DeductionRules() {
+  const isLoggedIn = auth.value.token
+  const { route } = useLocation()
+  const queryClient = useQueryClient()
+  const [evalResult, setEvalResult] = useState<{
+    rules_evaluated: number
+    activities_created: number
+  } | null>(null)
+
+  const { data: rules = [], isLoading } = useQuery({
+    queryFn: fetchDeductionRules,
+    queryKey: ['deductionRules'],
+  })
+
+  const evalMutation = useMutation({
+    mutationFn: evaluateDeductionRules,
+    onSuccess: (result) => {
+      setEvalResult(result)
+      queryClient.invalidateQueries({ queryKey: ['activities'] })
+    },
+  })
+
+  if (!isLoggedIn) {
+    return (
+      <div class="data-sources-page">
+        <p>Please log in to manage deduction rules.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div class="data-sources-page">
+      <div class="page-header">
+        <h1>Deduction Rules</h1>
+        <p class="page-subtitle">
+          Rules that automatically create activities by combining conditions on existing data.
+        </p>
+      </div>
+
+      <div class="rules-header">
+        <button type="button" class="note-action-btn" onClick={() => route('/deduction-rules/new')}>
+          Add Rule
+        </button>
+        <button
+          type="button"
+          class="note-action-btn"
+          onClick={() => evalMutation.mutate()}
+          disabled={evalMutation.isPending}
+        >
+          {evalMutation.isPending ? 'Evaluating...' : 'Evaluate All'}
+        </button>
+      </div>
+
+      {evalResult && (
+        <div class="eval-result">
+          Evaluated {evalResult.rules_evaluated} rules, created {evalResult.activities_created} activities.
+        </div>
+      )}
+
+      {evalMutation.isError && <p class="rule-error">{(evalMutation.error as Error).message}</p>}
+
+      {isLoading ? (
+        <p class="loading">Loading deduction rules...</p>
+      ) : rules.length === 0 ? (
+        <p class="rules-empty">No deduction rules yet. Create one to get started.</p>
+      ) : (
+        <div class="rules-list">
+          {rules.map((rule) => (
+            <RuleRow key={rule.id} rule={rule} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/DeductionRules/style.css
+++ b/apps/web/src/pages/DeductionRules/style.css
@@ -1,0 +1,351 @@
+/* ============================================================================
+ * Deduction Rules page styles
+ * ============================================================================ */
+
+/* List page */
+.rules-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.rules-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.rule-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.rule-row:last-child {
+  border-bottom: none;
+}
+
+.rule-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+  text-decoration: none;
+  color: inherit;
+}
+
+.rule-info:hover .rule-name {
+  color: #673ab8;
+}
+
+.rule-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: color 0.15s;
+}
+
+.rule-conditions {
+  font-size: 0.8rem;
+  color: #6b7280;
+  background: #f3f4f6;
+  padding: 0.125rem 0.375rem;
+  border-radius: 3px;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rule-output {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.rule-priority {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+}
+
+.rule-priority.priority-0 {
+  background: #e5e7eb;
+  color: #6b7280;
+}
+
+.rule-priority.priority-1 {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.rule-priority.priority-2 {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.rule-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.rule-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.rule-toggle input {
+  accent-color: #673ab8;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.rule-toggle-label {
+  white-space: nowrap;
+}
+
+.rules-empty {
+  color: #9ca3af;
+  font-size: 0.9rem;
+  font-style: italic;
+  padding: 1rem 0;
+}
+
+.eval-result {
+  background: #ecfdf5;
+  color: #065f46;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.rule-error {
+  color: #ef4444;
+  font-size: 0.85rem;
+  margin: 0.5rem 0;
+}
+
+/* Detail page */
+.rule-header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.rule-back-link {
+  color: #673ab8;
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.rule-back-link:hover {
+  text-decoration: underline;
+}
+
+.rule-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.rule-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.rule-section h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0;
+}
+
+.rule-field {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.rule-field-label {
+  min-width: 140px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+.rule-field-input {
+  width: 280px;
+  max-width: 100%;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+}
+
+.rule-field-input:focus {
+  outline: none;
+  border-color: #673ab8;
+  box-shadow: 0 0 0 2px rgba(103, 58, 184, 0.2);
+}
+
+.rule-field-select {
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.rule-field-select:focus {
+  outline: none;
+  border-color: #673ab8;
+}
+
+.rule-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.rule-checkbox input {
+  accent-color: #673ab8;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.rule-footer {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.rule-danger-zone {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  .rules-list {
+    border-color: #333;
+  }
+
+  .rule-row {
+    border-bottom-color: #333;
+  }
+
+  .rule-info:hover .rule-name {
+    color: #8b5cf6;
+  }
+
+  .rule-conditions {
+    background: #374151;
+    color: #9ca3af;
+  }
+
+  .rule-priority.priority-1 {
+    background: #1e3a5f;
+    color: #60a5fa;
+  }
+
+  .rule-priority.priority-2 {
+    background: #3b1111;
+    color: #f87171;
+  }
+
+  .rule-toggle {
+    color: #9ca3af;
+  }
+
+  .rule-toggle input,
+  .rule-checkbox input {
+    accent-color: #8b5cf6;
+  }
+
+  .eval-result {
+    background: #052e16;
+    color: #6ee7b7;
+  }
+
+  .rule-back-link {
+    color: #8b5cf6;
+  }
+
+  .rule-section h2 {
+    color: #d1d5db;
+  }
+
+  .rule-field-label {
+    color: #9ca3af;
+  }
+
+  .rule-field-input {
+    border-color: #4b5563;
+  }
+
+  .rule-field-input:focus {
+    border-color: #8b5cf6;
+    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.3);
+  }
+
+  .rule-field-select {
+    border-color: #4b5563;
+  }
+
+  .rule-field-select:focus {
+    border-color: #8b5cf6;
+  }
+
+  .rule-danger-zone {
+    border-top-color: #333;
+  }
+}
+
+/* Mobile */
+@media (max-width: 639px) {
+  .rule-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.375rem;
+  }
+
+  .rule-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .rule-field {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .rule-field-label {
+    min-width: auto;
+  }
+}

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -16,6 +16,7 @@ import type { ChartItem, Column, Orientation } from './types'
 
 import {
   fetchActivities,
+  fetchActivityTypeDefinitions,
   fetchBucketedMetrics,
   fetchMeals,
   fetchCustomMetrics,
@@ -858,9 +859,25 @@ export const Timeline = () => {
     [todayKey],
   )
 
-  const activities = activitiesQuery.data ?? []
+  const { data: activityTypeDefs = [] } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activityTypeDefinitions'],
+    staleTime: 5 * 60_000,
+  })
+  const hiddenTypes = useMemo(
+    () => new Set(activityTypeDefs.filter((t) => !t.show_on_timeline).map((t) => t.name)),
+    [activityTypeDefs],
+  )
+
+  const activities = useMemo(
+    () => (activitiesQuery.data ?? []).filter((a) => !hiddenTypes.has(a.activity_type ?? '')),
+    [activitiesQuery.data, hiddenTypes],
+  )
   const places = placesQuery.data ?? []
-  const tagActivities = tagActivitiesQuery.data ?? []
+  const tagActivities = useMemo(
+    () => (tagActivitiesQuery.data ?? []).filter((a) => !hiddenTypes.has(a.activity_type ?? '')),
+    [tagActivitiesQuery.data, hiddenTypes],
+  )
   const productivity = productivityQuery.data ?? []
   const scrobbles = scrobblesQuery.data ?? []
 

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -116,7 +116,28 @@ export interface ActivityTypeDefinition {
   display_category: string
   color: string
   icon?: string
+  aliases?: string[]
   is_builtin: boolean
+  show_on_timeline: boolean
+}
+
+export interface DeductionRuleCondition {
+  kind: 'activity' | 'tag' | 'screentime_category'
+  activity_type?: string
+  tag_name?: string
+  category?: string[]
+}
+
+export interface DeductionRule {
+  id: string
+  name: string
+  enabled: boolean
+  priority: number
+  conditions: DeductionRuleCondition[]
+  output_activity_type: string
+  output_title?: string
+  merge_gap_seconds?: number
+  created_at?: string
 }
 
 export interface SourceRecord {
@@ -765,6 +786,104 @@ export const mergeTagDefinitionsApi = async (sourceId: string, targetId: string)
   // Merge is no longer supported at the activity-types level
   // This is a no-op that returns the target definition
   return fetchTagDefinitionById(targetId)
+}
+
+// Update activity type definition (show_on_timeline, color, icon, display_name, etc.)
+export const updateActivityTypeDefinition = async (
+  name: string,
+  body: Partial<{
+    display_name: string
+    display_category: string
+    color: string
+    icon: string
+    show_on_timeline: boolean
+  }>,
+): Promise<ActivityTypeDefinition> => {
+  const { token } = auth.value
+  const response = await axios.patch<{ data: ActivityTypeDefinition; success: boolean }>(
+    `${API_URL}/activity-types/${encodeURIComponent(name)}`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data
+}
+
+// Deduction rules CRUD
+export const fetchDeductionRules = async (): Promise<DeductionRule[]> => {
+  const { token } = auth.value
+  const response = await axios.get<{ success: boolean; data: DeductionRule[] }>(
+    `${API_URL}/deduction-rules`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data ?? []
+}
+
+export const createDeductionRule = async (body: {
+  name: string
+  conditions: DeductionRuleCondition[]
+  output_activity_type: string
+  output_title?: string
+  merge_gap_seconds?: number
+  priority?: number
+  enabled?: boolean
+}): Promise<DeductionRule> => {
+  const { token } = auth.value
+  const response = await axios.post<{ success: boolean; data: DeductionRule }>(
+    `${API_URL}/deduction-rules`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data
+}
+
+export const updateDeductionRule = async (
+  id: string,
+  body: Partial<{
+    name: string
+    conditions: DeductionRuleCondition[]
+    output_activity_type: string
+    output_title: string | null
+    merge_gap_seconds: number | null
+    priority: number
+    enabled: boolean
+  }>,
+): Promise<DeductionRule> => {
+  const { token } = auth.value
+  const response = await axios.patch<{ success: boolean; data: DeductionRule }>(
+    `${API_URL}/deduction-rules/${id}`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  return response.data.data
+}
+
+export const deleteDeductionRule = async (id: string): Promise<void> => {
+  const { token } = auth.value
+  await axios.delete(`${API_URL}/deduction-rules/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export const evaluateDeductionRules = async (): Promise<{
+  rules_evaluated: number
+  activities_created: number
+}> => {
+  const { token } = auth.value
+  const response = await axios.post<{
+    success: boolean
+    rules_evaluated: number
+    activities_created: number
+  }>(
+    `${API_URL}/deduction-rules/evaluate`,
+    {},
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  )
+  return {
+    activities_created: response.data.activities_created,
+    rules_evaluated: response.data.rules_evaluated,
+  }
 }
 
 // Fetch goal progress


### PR DESCRIPTION
## Summary

- **Activity Types page** (`/activity-types`): Shows all activity type definitions grouped by `display_category` with collapsible groups, search filter, and `show_on_timeline` toggle switches with optimistic updates
- **Deduction Rules list** (`/deduction-rules`): Lists all rules with enabled toggle, delete confirmation, "Add Rule" and "Evaluate All" buttons
- **Deduction Rule detail** (`/deduction-rules/:id` and `/deduction-rules/new`): Auto-save fields on blur, ActivityTypePicker, priority dropdown, ConditionBuilder with explicit save, create/edit modes
- **ConditionBuilder component**: Reusable AND-combined condition editor with kind-specific inputs (activity type dropdown, tag text, screentime category path)
- **Timeline integration**: Filters out activities where `show_on_timeline` is false using the activity type definitions query
- **Navigation**: Added Types and Rules links to sidebar

## Test plan

- [ ] Navigate to `/activity-types`, verify types are grouped by category
- [ ] Search filter narrows displayed types
- [ ] Toggle `show_on_timeline` on a type, verify Timeline hides/shows that type
- [ ] Navigate to `/deduction-rules`, verify rules list renders
- [ ] Click "Add Rule", fill form, create rule
- [ ] Click a rule row to edit, verify auto-save on blur
- [ ] Use ConditionBuilder to add/remove/change conditions, save
- [ ] Delete a rule with confirmation
- [ ] "Evaluate All" shows result count
- [ ] Sidebar nav links for Types and Rules work

Generated with [Claude Code](https://claude.com/claude-code)