### PR TITLE
feat: add categorized screen time to daily summary

### DIFF
--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -168,9 +168,7 @@ export const createActivitiesRouter = (
       const user = req.user!
 
       // When no types specified, query all activity types (not just those with definitions)
-      const types = typesParam
-        ? typesParam.split(',')
-        : await getAllActivityTypeNames(user)
+      const types = typesParam ? typesParam.split(',') : await getAllActivityTypeNames(user)
 
       const activities = await queryActivities(user, types, new Date(start), new Date(end), syncProvider)
       res.json({ data: activities, success: true })
@@ -184,7 +182,16 @@ export const createActivitiesRouter = (
     authMiddleware,
     validateBody(addActivityBodySchema),
     async (req, res) => {
-      const { activity_type, start_time, end_time, title, notes, exercise_type, merge_span, data: bodyData } = req.body
+      const {
+        activity_type,
+        start_time,
+        end_time,
+        title,
+        notes,
+        exercise_type,
+        merge_span,
+        data: bodyData,
+      } = req.body
       const user = req.user!
 
       const startDate = new Date(start_time)

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -397,7 +397,12 @@ export async function addActivity(user: string, input: AddActivityInput): Promis
 
   // If merge_span is specified, try to extend an existing activity instead of creating new
   if (input.merge_span) {
-    const existing = await findMergeableActivity(user, input.activity_type, input.start_time, input.merge_span)
+    const existing = await findMergeableActivity(
+      user,
+      input.activity_type,
+      input.start_time,
+      input.merge_span,
+    )
     if (existing?.id) {
       const newEndTime = input.end_time ?? input.start_time
       await dbUpdateActivity(user, existing.id, { end_time: newEndTime })

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -41,6 +41,11 @@ vi.mock('../db', () => ({
   getUserSettings: vi.fn(),
 }))
 
+// Mock the screentime-categories module
+vi.mock('../db/screentime-categories', () => ({
+  getScreentimeCategories: vi.fn().mockResolvedValue([]),
+}))
+
 // Mock the locations service
 vi.mock('./locations', () => ({
   getPlaceVisits: vi.fn(),
@@ -225,6 +230,7 @@ describe('getDailySummary', () => {
 
     // Productivity
     expect(result.productivity).toEqual({
+      categories: [{ duration_sec: 4200, path: [] }],
       distracting_sec: 600,
       productive_sec: 3600,
       total_duration_sec: 4200,

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -42,6 +42,7 @@ vi.mock('../db', () => ({
 }))
 
 // Mock the screentime-categories module
+import * as screentimeCategoriesDb from '../db/screentime-categories.ts'
 vi.mock('../db/screentime-categories', () => ({
   getScreentimeCategories: vi.fn().mockResolvedValue([]),
 }))
@@ -866,6 +867,114 @@ describe('getDailySummary', () => {
     expect(result.exercise_sessions[0]).not.toHaveProperty('data')
     // Sleep sessions should not have raw data blob
     expect(result.sleep_sessions[0]).not.toHaveProperty('data')
+  })
+
+  test('includes category breakdown in productivity summary', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
+    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([
+      {
+        activity: 'VS Code',
+        duration_sec: 3600,
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        productivity: 2,
+        resolved_category: ['Work', 'Programming'],
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity: 'Slack',
+        duration_sec: 1800,
+        end_time: new Date('2024-01-15T12:30:00Z'),
+        productivity: 1,
+        resolved_category: ['Work', 'Communication'],
+        start_time: new Date('2024-01-15T12:00:00Z'),
+      },
+      {
+        activity: 'YouTube',
+        duration_sec: 600,
+        end_time: new Date('2024-01-15T13:10:00Z'),
+        productivity: -1,
+        resolved_category: ['Entertainment'],
+        start_time: new Date('2024-01-15T13:00:00Z'),
+      },
+      {
+        activity: 'Unknown App',
+        duration_sec: 300,
+        end_time: new Date('2024-01-15T14:05:00Z'),
+        productivity: 0,
+        start_time: new Date('2024-01-15T14:00:00Z'),
+      },
+    ])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.productivity!.categories).toEqual([
+      { duration_sec: 3600, path: ['Work', 'Programming'] },
+      { duration_sec: 1800, path: ['Work', 'Communication'] },
+      { duration_sec: 600, path: ['Entertainment'] },
+      { duration_sec: 300, path: [] },
+    ])
+  })
+
+  test('excludes categories marked with exclude_from_screentime', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
+    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([
+      {
+        activity: 'VS Code',
+        duration_sec: 3600,
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        productivity: 2,
+        resolved_category: ['Work', 'Programming'],
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity: 'System Idle',
+        duration_sec: 1200,
+        end_time: new Date('2024-01-15T12:20:00Z'),
+        productivity: 0,
+        resolved_category: ['System'],
+        start_time: new Date('2024-01-15T12:00:00Z'),
+      },
+      {
+        activity: 'System Update',
+        duration_sec: 300,
+        end_time: new Date('2024-01-15T13:05:00Z'),
+        productivity: 0,
+        resolved_category: ['System', 'Updates'],
+        start_time: new Date('2024-01-15T13:00:00Z'),
+      },
+    ])
+    vi.mocked(screentimeCategoriesDb.getScreentimeCategories).mockResolvedValue([
+      {
+        created_at: new Date(),
+        exclude_from_screentime: true,
+        id: 'cat-1',
+        ignore_case: true,
+        name: ['System'],
+        rule_type: 'regex',
+        sort_order: 0,
+        updated_at: new Date(),
+      },
+    ])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    // System and System > Updates should be excluded, totals still include all
+    expect(result.productivity!.total_duration_sec).toBe(5100)
+    expect(result.productivity!.categories).toEqual([
+      { duration_sec: 3600, path: ['Work', 'Programming'] },
+    ])
   })
 })
 

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -33,6 +33,7 @@ import {
   getTimeSeriesWithSource,
   type ProductivityRecord,
 } from '../db/index.ts'
+import { getScreentimeCategories } from '../db/screentime-categories.ts'
 import {
   type ActivityType,
   getMetricAggregation,
@@ -184,6 +185,7 @@ export interface ProductivitySummary {
   productive_sec: number
   very_productive_sec: number
   distracting_sec: number
+  categories?: Array<{ path: string[]; duration_sec: number }>
 }
 
 export interface OuraScores {
@@ -730,6 +732,7 @@ export async function getDailySummary(
     dayNotes,
     dayMeals,
     stepsAggregate,
+    screentimeCategories,
   ] = await Promise.all([
     getTimeSeries(user, 'heart_rate', start, end),
     getTimeSeries(user, 'steps', start, end),
@@ -747,6 +750,7 @@ export async function getDailySummary(
     getNotesForTimeRange(user, start, end),
     getMeals(user, { start, end }),
     getDailyAggregateValue(user, 'steps', date),
+    getScreentimeCategories(user),
   ])
 
   // Calculate heart rate stats
@@ -765,21 +769,48 @@ export async function getDailySummary(
   const totalSteps =
     stepsAggregate !== null ? stepsAggregate : stepsData.reduce((sum, [, value]) => sum + value, 0)
 
-  // Calculate productivity summary
+  // Calculate productivity summary with category breakdown
+  const excludedCategoryPaths = screentimeCategories
+    .filter((c) => c.exclude_from_screentime)
+    .map((c) => c.name)
+
+  const isExcluded = (resolvedCategory: string[] | undefined): boolean =>
+    resolvedCategory !== undefined &&
+    excludedCategoryPaths.some(
+      (excluded) =>
+        resolvedCategory.length >= excluded.length && excluded.every((seg, i) => seg === resolvedCategory[i]),
+    )
+
   const productivitySummary: ProductivitySummary | null =
     productivity.length > 0
-      ? productivity.reduce(
-          (acc, record) => {
-            acc.total_duration_sec += record.duration_sec
+      ? (() => {
+          const categoryMap = new Map<string, number>()
+          const totals = {
+            distracting_sec: 0,
+            productive_sec: 0,
+            total_duration_sec: 0,
+            very_productive_sec: 0,
+          }
+
+          for (const record of productivity) {
+            totals.total_duration_sec += record.duration_sec
             if (record.productivity !== undefined && record.productivity !== null) {
-              if (record.productivity >= 1) acc.productive_sec += record.duration_sec
-              if (record.productivity >= 2) acc.very_productive_sec += record.duration_sec
-              if (record.productivity <= -1) acc.distracting_sec += record.duration_sec
+              if (record.productivity >= 1) totals.productive_sec += record.duration_sec
+              if (record.productivity >= 2) totals.very_productive_sec += record.duration_sec
+              if (record.productivity <= -1) totals.distracting_sec += record.duration_sec
             }
-            return acc
-          },
-          { distracting_sec: 0, productive_sec: 0, total_duration_sec: 0, very_productive_sec: 0 },
-        )
+            if (!isExcluded(record.resolved_category)) {
+              const key = JSON.stringify(record.resolved_category ?? [])
+              categoryMap.set(key, (categoryMap.get(key) ?? 0) + record.duration_sec)
+            }
+          }
+
+          const categories = [...categoryMap.entries()]
+            .map(([key, duration_sec]) => ({ duration_sec, path: JSON.parse(key) as string[] }))
+            .sort((a, b) => b.duration_sec - a.duration_sec)
+
+          return { ...totals, categories }
+        })()
       : null
 
   // Build Oura scores object (get first value for each metric if available)

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -103,7 +103,10 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
   })
 
   const allDefs = activityTypeDefs ?? []
-  const builtinDefs = allDefs.filter((d: ActivityTypeDefinition) => d.is_builtin && ['exercise', 'meditation', 'nap', 'rest', 'sleep'].includes(d.name))
+  const builtinDefs = allDefs.filter(
+    (d: ActivityTypeDefinition) =>
+      d.is_builtin && ['exercise', 'meditation', 'nap', 'rest', 'sleep'].includes(d.name),
+  )
   const customDefs = allDefs.filter((d: ActivityTypeDefinition) => !builtinDefs.includes(d))
 
   const mutation = useMutation({

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -3,6 +3,7 @@
  * in either read mode (plain text) or edit mode (input fields).
  */
 import type { ActivityTypeDefinition } from '../../state/api'
+
 import { IconPreview } from '../../components/IconPreview'
 import { toDisplayName } from '../../utils/displayName'
 import { formatDateTime, formatDuration, formatTime } from './format-utils'
@@ -70,7 +71,9 @@ export const EditableActivityFields = ({
                 <select
                   class="edit-datetime-input"
                   value={draft.activity_type}
-                  onChange={(e) => onDraftChange({ ...draft, activity_type: (e.target as HTMLSelectElement).value })}
+                  onChange={(e) =>
+                    onDraftChange({ ...draft, activity_type: (e.target as HTMLSelectElement).value })
+                  }
                 >
                   {typeDefinitions.map((def) => (
                     <option key={def.name} value={def.name}>

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -147,8 +147,23 @@ export type PlaceSummary = z.infer<typeof placeSummarySchema>
 /**
  * Productivity summary schema.
  */
+export const screentimeCategorySummarySchema = z
+  .object({
+    duration_sec: z.number().meta({ description: 'Total time in this category in seconds' }),
+    path: z
+      .array(z.string())
+      .meta({ description: 'Category path, e.g. ["Work", "Programming"]. Empty array means uncategorized.' }),
+  })
+  .meta({ id: 'ScreentimeCategorySummary' })
+
+export type ScreentimeCategorySummary = z.infer<typeof screentimeCategorySummarySchema>
+
 export const productivitySummarySchema = z
   .object({
+    categories: z
+      .array(screentimeCategorySummarySchema)
+      .optional()
+      .meta({ description: 'Screen time broken down by category, sorted by duration descending' }),
     distracting_sec: z.number().meta({ description: 'Distracting time in seconds' }),
     productive_sec: z.number().meta({ description: 'Productive time in seconds' }),
     total_duration_sec: z.number().meta({ description: 'Total tracked time in seconds' }),


### PR DESCRIPTION
## Summary

- Adds a `categories` array to the `ProductivitySummary` in `get_daily_summary`, breaking down screen time by resolved category with duration in seconds, sorted by duration descending
- Filters out categories marked with `exclude_from_screentime` to keep the summary clean
- No extra DB queries needed beyond one lightweight fetch of screentime category rules (runs in parallel with existing queries)

## Test plan

- [x] Existing `getDailySummary` tests updated and passing
- [ ] Verify via MCP `get_daily_summary` that `productivity.categories` appears with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)