### PR TITLE
feat: autocomplete activity type picker + fix missing type definitions

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -428,23 +428,7 @@ const migrateTagsToActivities = async (db: Client, existingTableNames: Set<strin
      ON CONFLICT DO NOTHING`,
   )
 
-  // Step 4: Create activity_type_definitions for any activity_type that doesn't have one yet
-  await query(
-    db,
-    `INSERT INTO activity_type_definitions (name, display_name, display_category)
-     SELECT DISTINCT a.activity_type,
-       initcap(replace(a.activity_type, '_', ' ')),
-       'other'
-     FROM activities a
-     WHERE NOT EXISTS (
-       SELECT 1 FROM activity_type_definitions atd WHERE atd.name = a.activity_type
-     )
-       AND a.activity_type ~ '^[a-z][a-z0-9_]*$'
-       AND a.deleted_at IS NULL
-     ON CONFLICT (name) DO NOTHING`,
-  )
-
-  // Step 5: Update notes entity_type from 'tag' to 'activity'
+  // Step 4: Update notes entity_type from 'tag' to 'activity'
   if (existingTableNames.has('notes')) {
     await query(db, `UPDATE notes SET entity_type = 'activity' WHERE entity_type = 'tag'`)
   }
@@ -601,6 +585,24 @@ export const migrateSchema = async (user: string) => {
 
   // Migrate tags into activities and tag_definitions into activity_type_definitions
   await migrateTagsToActivities(db, existingTableNames)
+
+  // Ensure every activity_type in use has a corresponding definition (idempotent)
+  if (existingTableNames.has('activity_type_definitions') && existingTableNames.has('activities')) {
+    await query(
+      db,
+      `INSERT INTO activity_type_definitions (name, display_name, display_category)
+       SELECT DISTINCT a.activity_type,
+         initcap(replace(a.activity_type, '_', ' ')),
+         'other'
+       FROM activities a
+       WHERE NOT EXISTS (
+         SELECT 1 FROM activity_type_definitions atd WHERE atd.name = a.activity_type
+       )
+         AND a.activity_type ~ '^[a-z][a-z0-9_]*$'
+         AND a.deleted_at IS NULL
+       ON CONFLICT (name) DO NOTHING`,
+    )
+  }
 
   // Migrate goals and custom_metrics from user_settings JSONB to their own tables
   await migrateGoalsAndCustomMetrics(db, existingTableNames)

--- a/apps/web/src/components/ActivityTypePicker.tsx
+++ b/apps/web/src/components/ActivityTypePicker.tsx
@@ -1,0 +1,161 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'preact/hooks'
+
+import { fetchActivityTypeDefinitions } from '../state/api'
+import { toDisplayName } from '../utils/displayName'
+import './MetricPicker.css'
+
+interface ActivityTypePickerProps {
+  value: string
+  onChange: (activityType: string) => void
+  placeholder?: string
+}
+
+/** Convert a display name to snake_case identifier. */
+const toSnakeCase = (s: string): string =>
+  s
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '_')
+    .replaceAll(/^_|_$/g, '')
+    .replaceAll(/_+/g, '_') || ''
+
+export function ActivityTypePicker({
+  value,
+  onChange,
+  placeholder = 'Search or type new...',
+}: ActivityTypePickerProps) {
+  const [inputValue, setInputValue] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const { data: typeDefs } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activity-type-definitions'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const allDefs = typeDefs ?? []
+  const query = inputValue.toLowerCase()
+
+  const filtered = query
+    ? allDefs.filter(
+        (d) =>
+          d.display_name.toLowerCase().includes(query) ||
+          d.name.includes(query),
+      )
+    : allDefs
+
+  // If the user typed something that doesn't match any existing type, offer to create it
+  const snakeInput = toSnakeCase(inputValue)
+  const isNewType = query.length > 0 && snakeInput.length > 0 && !allDefs.some((d) => d.name === snakeInput)
+
+  const flatList = filtered
+  const totalItems = flatList.length + (isNewType ? 1 : 0)
+
+  useEffect(() => {
+    setHighlightedIndex(0)
+  }, [inputValue])
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+        setInputValue('')
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const select = (typeName: string) => {
+    onChange(typeName)
+    setInputValue('')
+    setIsOpen(false)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setIsOpen(true)
+      setHighlightedIndex((i) => Math.min(i + 1, totalItems - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter' && isOpen && totalItems > 0) {
+      e.preventDefault()
+      if (highlightedIndex < flatList.length) {
+        select(flatList[highlightedIndex].name)
+      } else if (isNewType) {
+        select(snakeInput)
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false)
+      setInputValue('')
+    }
+  }
+
+  const displayValue = value
+    ? (allDefs.find((d) => d.name === value)?.display_name ?? toDisplayName(value))
+    : ''
+  const shownValue = isOpen ? inputValue : displayValue
+
+  return (
+    <div class="metric-picker" ref={containerRef}>
+      <input
+        type="text"
+        class="metric-picker-input"
+        value={shownValue}
+        onInput={(e) => {
+          setInputValue((e.target as HTMLInputElement).value)
+          setIsOpen(true)
+        }}
+        onFocus={() => {
+          setInputValue('')
+          setIsOpen(true)
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+      />
+      {isOpen && totalItems > 0 && (
+        <ul class="metric-picker-dropdown">
+          {flatList.map((def, idx) => (
+            <li
+              key={def.name}
+              class={`metric-picker-option ${idx === highlightedIndex ? 'highlighted' : ''} ${def.name === value ? 'selected' : ''}`}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                select(def.name)
+              }}
+              onMouseEnter={() => setHighlightedIndex(idx)}
+            >
+              <span class="metric-option-label">
+                {def.icon ? `${def.icon} ` : ''}
+                {def.display_name || toDisplayName(def.name)}
+              </span>
+              {def.display_category !== 'other' && (
+                <span class="metric-option-key">{def.display_category}</span>
+              )}
+            </li>
+          ))}
+          {isNewType && (
+            <li
+              class={`metric-picker-option ${highlightedIndex === flatList.length ? 'highlighted' : ''}`}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                select(snakeInput)
+              }}
+              onMouseEnter={() => setHighlightedIndex(flatList.length)}
+            >
+              <span class="metric-option-label">
+                Create "{toDisplayName(snakeInput)}"
+              </span>
+              <span class="metric-option-key">{snakeInput}</span>
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -1,18 +1,16 @@
-import { exerciseTypeNames, type ExerciseTypeName } from '@aurboda/api-spec'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 
+import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { MetricPicker } from '../../components/MetricPicker'
 import {
   addActivity,
   addMetric,
   addNote,
-  fetchActivityTypeDefinitions,
   uploadFitFile,
   type ActivityType,
-  type ActivityTypeDefinition,
 } from '../../state/api'
 import './style.css'
 
@@ -85,8 +83,7 @@ const FitUpload = ({ onCreated }: FormProps) => {
 
 const AddActivityForm = ({ onCreated }: FormProps) => {
   const queryClient = useQueryClient()
-  const [activityType, setActivityType] = useState<ActivityType>('exercise')
-  const [exerciseType, setExerciseType] = useState<ExerciseTypeName>('other_workout')
+  const [activityType, setActivityType] = useState<ActivityType>('')
   const [title, setTitle] = useState('')
   const [startTime, setStartTime] = useState(nowLocal())
   const [endTime, setEndTime] = useState(nowLocal())
@@ -96,22 +93,12 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')
 
-  const { data: activityTypeDefs } = useQuery({
-    queryFn: fetchActivityTypeDefinitions,
-    queryKey: ['activity-type-definitions'],
-    staleTime: 5 * 60 * 1000,
-  })
-
-  const allDefs = activityTypeDefs ?? []
-  const builtinDefs = allDefs.filter((d: ActivityTypeDefinition) => d.is_builtin && ['exercise', 'meditation', 'nap', 'rest', 'sleep'].includes(d.name))
-  const customDefs = allDefs.filter((d: ActivityTypeDefinition) => !builtinDefs.includes(d))
-
   const mutation = useMutation({
     mutationFn: async () => {
+      if (!activityType) throw new Error('Please select an activity type')
       const result = await addActivity({
         activity_type: activityType,
         ...(hasEndTime ? { end_time: new Date(endTime).toISOString() } : {}),
-        ...(activityType === 'exercise' ? { exercise_type: exerciseType } : {}),
         ...(notes ? { notes } : {}),
         start_time: new Date(startTime).toISOString(),
         ...(title ? { title } : {}),
@@ -150,49 +137,8 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
 
       <div class="form-field">
         <label>Activity Type</label>
-        <select
-          value={activityType}
-          onChange={(e) => {
-            const val = (e.target as HTMLSelectElement).value as ActivityType
-            setActivityType(val)
-            // Default to having end time for most types
-            setHasEndTime(true)
-          }}
-        >
-          <optgroup label="Built-in">
-            {builtinDefs.map((d: ActivityTypeDefinition) => (
-              <option key={d.name} value={d.name}>
-                {d.display_name || d.name}
-              </option>
-            ))}
-          </optgroup>
-          {customDefs.length > 0 && (
-            <optgroup label="Other">
-              {customDefs.map((d: ActivityTypeDefinition) => (
-                <option key={d.name} value={d.name}>
-                  {d.display_name || d.name}
-                </option>
-              ))}
-            </optgroup>
-          )}
-        </select>
+        <ActivityTypePicker value={activityType} onChange={setActivityType} />
       </div>
-
-      {activityType === 'exercise' && (
-        <div class="form-field">
-          <label>Exercise Type</label>
-          <select
-            value={exerciseType}
-            onChange={(e) => setExerciseType((e.target as HTMLSelectElement).value as ExerciseTypeName)}
-          >
-            {exerciseTypeNames.map((name) => (
-              <option key={name} value={name}>
-                {name.replaceAll('_', ' ')}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
 
       <div class="form-field">
         <label>Title</label>


### PR DESCRIPTION
## Summary
- Replace dropdown with autocomplete input (like MetricPicker) for activity type selection in Add Data
- Shows all activity types with search/filter, allows creating new types inline
- Remove redundant Exercise Type selector (exercise types are now first-class activity types)
- Fix migration: create type definitions for migrated tags as a separate idempotent step outside the guarded tag migration block

## Root cause for missing types
Migration step 4 (create definitions) was inside `migrateTagsToActivities` which has an early-return guard (`if any activity has external_id, skip`). After the first migration ran, subsequent runs skipped everything including the definition creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)