### PR TITLE
feat: rework daily summary as AI-friendly unified timeline

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -590,6 +590,30 @@ export const getActivitiesExcludingCategories = async (
   return result.rows.map(mapActivityRow)
 }
 
+/**
+ * Get all non-sleep activities for a time range, with overlapping same-type activities merged.
+ * Used by the daily summary to build a unified activity timeline.
+ */
+export const getNonSleepActivitiesMerged = async (
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<MergedActivity[]> => {
+  const result = await query(
+    user,
+    `SELECT a.id, a.source, a.external_id, a.activity_type, a.start_time, a.end_time, a.title, a.notes, a.data, a.deleted_at
+     FROM activities a
+     LEFT JOIN activity_type_definitions atd ON a.activity_type = atd.name
+     WHERE a.deleted_at IS NULL
+       AND a.start_time >= $1 AND a.start_time <= $2
+       AND (atd.display_category IS NULL OR atd.display_category != 'sleep_rest')
+     ORDER BY a.start_time`,
+    [start, end],
+  )
+  const activities = result.rows.map(mapActivityRow)
+  return mergeOverlappingActivities(activities)
+}
+
 /** Hard-delete all activities from a given source. Used for lastfm-auto retag cleanup. */
 export const hardDeleteActivitiesBySource = async (user: string, source: string): Promise<number> => {
   const result = await query(user, `DELETE FROM activities WHERE source = $1`, [source])

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -121,6 +121,7 @@ export {
   getActivitiesByCategory,
   getActivitiesExcludingCategories,
   getActivitiesNeedingDetail,
+  getNonSleepActivitiesMerged,
   getAllActivityTypeNames,
   getActivityById,
   getNearbyActivities,

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -97,7 +97,7 @@ Use cases:
   // Tool: get_daily_summary
   server.tool(
     'get_daily_summary',
-    'Get a comprehensive summary of health data for a specific day including heart rate, steps, sleep, exercise, meals, tags, productivity, and visited places. Also includes Oura scores (sleep_score, readiness_score, resilience_score, cardiovascular_age) when available.\n\nExercise sessions include a human-readable `exercise_type` name (e.g., "yoga", "running", "weightlifting").\n\nMeals include macros (calories, protein, carbs, fat, fiber) and food item names.\n\nSleep sessions are disambiguated: `primary_sleep` is the session the user woke up from on this date (following Oura convention), `evening_sleep` is the session started this evening that continues to the next day. Each sleep session includes `sleep_date` (the date it belongs to, using wake-up convention) and `sleep_location` (best-guess location). The `oura_scores.sleep_score` evaluates the `primary_sleep` session.',
+    'Get a comprehensive daily timeline of health data. Returns a unified chronological `activities` array combining exercises, meditations, screen time categories, and all other activities — each with optional stress_zone_secs and hr_zone_secs. Screen time entries have a category_path (e.g., ["Work & Dev", "Software Dev"]).\n\nAlso includes: heart_rate stats, steps, sleep_sessions (with stages, location, date attribution), meals (with macros), productivity summary (with category breakdown), places, Oura scores, and day-level stress_zones.\n\nDesigned for AI correlation analysis — overlay activities with stress/HR data to find patterns.',
     {
       date: dateOnlySchema.describe('Date in YYYY-MM-DD format (e.g., 2024-01-15)'),
       tz: tzSchema,

--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -29,6 +29,7 @@ vi.mock('../db', () => ({
   getDistinctMetrics: vi.fn(),
   getLocations: vi.fn(),
   getMeals: vi.fn(),
+  getNonSleepActivitiesMerged: vi.fn(),
   getNotesByEntityIds: vi.fn(),
   getNotesForTimeRange: vi.fn(),
   getProductivity: vi.fn(),
@@ -102,10 +103,12 @@ describe('getDailySummary', () => {
     vi.mocked(db.getUserSettings).mockResolvedValue(null)
     // Default: no notes overlapping the day
     vi.mocked(db.getNotesForTimeRange).mockResolvedValue([])
-    // Default: no notes for tags
+    // Default: no notes for activities
     vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
     // Default: no meals
     vi.mocked(db.getMeals).mockResolvedValue([])
+    // Default: no non-sleep activities
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
   })
 
   test('aggregates all data sources for a day', async () => {
@@ -123,6 +126,7 @@ describe('getDailySummary', () => {
         [new Date('2024-01-15T08:00:00Z'), 5000],
         [new Date('2024-01-15T12:00:00Z'), 3000],
       ])
+      .mockResolvedValueOnce([]) // stress_level
 
     // Sleep sessions now use getSleepSessions with date overlap logic
     vi.mocked(db.getSleepSessions).mockResolvedValue([
@@ -134,7 +138,7 @@ describe('getDailySummary', () => {
       },
     ])
 
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         end_time: new Date('2024-01-15T10:30:00Z'),
@@ -142,9 +146,6 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-01-15T10:00:00Z'),
         title: 'Running',
       },
-    ])
-
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([
       {
         activity_type: 'coffee',
         source: 'aurboda',
@@ -211,23 +212,16 @@ describe('getDailySummary', () => {
       source: 'named',
     })
 
-    // Primary sleep = session that ended on this date
-    expect(result.primary_sleep).not.toBeNull()
-    expect(result.primary_sleep!.end_time).toBe('2024-01-15T07:00:00.000Z')
-    expect(result.primary_sleep!.sleep_date).toBe('2024-01-15')
-    expect(result.primary_sleep!.sleep_location?.name).toBe('Home')
+    // Activities (unified array)
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities).toHaveLength(1)
+    expect(exerciseActivities[0].title).toBe('Running')
 
-    // Evening sleep = no sleep started on Jan 15 that extends to Jan 16
-    expect(result.evening_sleep).toBeNull()
-
-    // Exercise sessions
-    expect(result.exercise_sessions).toHaveLength(1)
-    expect(result.exercise_sessions[0].title).toBe('Running')
-    expect(result.exercise_sessions[0].duration).toBe(30)
-
-    // Tags
-    expect(result.tags).toHaveLength(1)
-    expect(result.tags[0].tag).toBe('coffee')
+    const tagActivities = result.activities.filter(
+      (a) => a.activity_type !== 'exercise' && a.activity_type !== 'screentime',
+    )
+    expect(tagActivities).toHaveLength(1)
+    expect(tagActivities[0].activity_type).toBe('coffee')
 
     // Productivity
     expect(result.productivity).toEqual({
@@ -242,13 +236,15 @@ describe('getDailySummary', () => {
     expect(result.places).toHaveLength(1)
     expect(result.places[0].name).toBe('Home')
     expect(result.places[0].source).toBe('named')
+
+    // Stress zones (no stress data)
+    expect(result.stress_zones).toBeNull()
   })
 
   test('returns null for heartRate when no data', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -268,10 +264,10 @@ describe('getDailySummary', () => {
         [new Date('2024-01-15T08:00:00Z'), 5000],
         [new Date('2024-01-15T12:00:00Z'), 3000], // Total raw: 8000
       ])
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
@@ -292,10 +288,10 @@ describe('getDailySummary', () => {
         [new Date('2024-01-15T08:00:00Z'), 5000],
         [new Date('2024-01-15T12:00:00Z'), 3000],
       ])
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
@@ -312,8 +308,7 @@ describe('getDailySummary', () => {
   test('includes Oura scores when data is present', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -339,8 +334,7 @@ describe('getDailySummary', () => {
   test('returns null ouraScores when no Oura data', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -354,8 +348,7 @@ describe('getDailySummary', () => {
   test('returns partial ouraScores when some metrics are missing', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -376,8 +369,8 @@ describe('getDailySummary', () => {
     })
   })
 
-  test('computes hr_zone_secs for exercise sessions with HR data', async () => {
-    // First call: daily heart rate (includes exercise session data), second call: daily steps
+  test('computes hr_zone_secs for exercise activities with HR data', async () => {
+    // First call: daily heart rate (includes exercise session data), second call: daily steps, third: stress
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([
         // exercise session HR data - in zone 1 (90-107 with default zones)
@@ -386,9 +379,10 @@ describe('getDailySummary', () => {
         [new Date('2024-01-15T10:00:04Z'), 98],
       ]) // daily heart_rate (filtered in memory for exercise sessions)
       .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         end_time: new Date('2024-01-15T10:30:00Z'),
@@ -397,7 +391,6 @@ describe('getDailySummary', () => {
         title: 'Running',
       },
     ])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -405,19 +398,21 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.exercise_sessions).toHaveLength(1)
-    expect(result.exercise_sessions[0].hr_zone_secs).toBeDefined()
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities).toHaveLength(1)
+    expect(exerciseActivities[0].hr_zone_secs).toBeDefined()
     // All HR values (95, 100, 98) are in zone 1 (90-107 with default zones)
-    expect(result.exercise_sessions[0].hr_zone_secs![1]).toBeGreaterThan(0)
+    expect(exerciseActivities[0].hr_zone_secs![1]).toBeGreaterThan(0)
   })
 
   test('does not include hr_zone_secs when exercise has no HR data', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([]) // daily heart_rate (no HR data during exercise)
       .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         end_time: new Date('2024-01-15T10:30:00Z'),
@@ -426,7 +421,6 @@ describe('getDailySummary', () => {
         title: 'Running',
       },
     ])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -434,8 +428,9 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.exercise_sessions).toHaveLength(1)
-    expect(result.exercise_sessions[0].hr_zone_secs).toBeUndefined()
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities).toHaveLength(1)
+    expect(exerciseActivities[0].hr_zone_secs).toBeUndefined()
   })
 
   test('uses custom HR zones from user settings', async () => {
@@ -451,9 +446,10 @@ describe('getDailySummary', () => {
         [new Date('2024-01-15T10:00:02Z'), 85],
       ]) // daily heart_rate (filtered in memory for exercise sessions)
       .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         end_time: new Date('2024-01-15T10:30:00Z'),
@@ -462,7 +458,6 @@ describe('getDailySummary', () => {
         title: 'Walking',
       },
     ])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -470,19 +465,21 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.exercise_sessions[0].hr_zone_secs).toBeDefined()
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities[0].hr_zone_secs).toBeDefined()
     // With custom zones (zone 1 starts at 80), HR of 85 is in zone 1
-    expect(result.exercise_sessions[0].hr_zone_secs![1]).toBeGreaterThan(0)
-    expect(result.exercise_sessions[0].hr_zone_secs![0]).toBe(0)
+    expect(exerciseActivities[0].hr_zone_secs![1]).toBeGreaterThan(0)
+    expect(exerciseActivities[0].hr_zone_secs![0]).toBe(0)
   })
 
   test('does not compute hr_zone_secs for exercise without endTime', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([]) // daily heart_rate
       .mockResolvedValueOnce([]) // daily steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         // No end_time - ongoing session
@@ -491,7 +488,6 @@ describe('getDailySummary', () => {
         title: 'Running',
       },
     ])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -499,13 +495,14 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.exercise_sessions).toHaveLength(1)
-    expect(result.exercise_sessions[0].hr_zone_secs).toBeUndefined()
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities).toHaveLength(1)
+    expect(exerciseActivities[0].hr_zone_secs).toBeUndefined()
     // Should not have called getTimeSeries for the exercise session
-    expect(db.getTimeSeries).toHaveBeenCalledTimes(2) // Only daily HR and steps
+    expect(db.getTimeSeries).toHaveBeenCalledTimes(3) // Daily HR, steps, and stress
   })
 
-  test('classifies overnight sleep as primary_sleep on wake-up date', async () => {
+  test('overnight sleep appears in sleep_sessions on wake-up date', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([
       {
@@ -515,8 +512,7 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-03-07T22:01:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -525,17 +521,16 @@ describe('getDailySummary', () => {
     // Query for March 8 — the date the user woke up
     const result = await getDailySummary('testuser', new Date('2024-03-08'))
 
-    expect(result.primary_sleep).not.toBeNull()
-    expect(result.primary_sleep!.start_time).toBe('2024-03-07T22:01:00.000Z')
-    expect(result.primary_sleep!.end_time).toBe('2024-03-08T06:23:00.000Z')
-    expect(result.primary_sleep!.sleep_date).toBe('2024-03-08')
-    expect(result.evening_sleep).toBeNull()
+    expect(result.sleep_sessions).toHaveLength(1)
+    expect(result.sleep_sessions[0].start_time).toBe('2024-03-07T22:01:00.000Z')
+    expect(result.sleep_sessions[0].end_time).toBe('2024-03-08T06:23:00.000Z')
+    expect(result.sleep_sessions[0].sleep_date).toBe('2024-03-08')
   })
 
-  test('classifies evening sleep that extends past midnight', async () => {
+  test('multiple sleep sessions appear in sleep_sessions', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([
-      // Morning sleep (primary) — woke up on Mar 8
+      // Morning sleep — woke up on Mar 8
       {
         activity_type: 'sleep',
         end_time: new Date('2024-03-08T06:23:00Z'),
@@ -550,35 +545,24 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-03-08T22:30:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
 
     const result = await getDailySummary('testuser', new Date('2024-03-08'))
-
-    // primary_sleep = ended on Mar 8
-    expect(result.primary_sleep).not.toBeNull()
-    expect(result.primary_sleep!.end_time).toBe('2024-03-08T06:23:00.000Z')
-    expect(result.primary_sleep!.sleep_date).toBe('2024-03-08')
-
-    // evening_sleep = started on Mar 8, ends Mar 9
-    expect(result.evening_sleep).not.toBeNull()
-    expect(result.evening_sleep!.start_time).toBe('2024-03-08T22:30:00.000Z')
-    expect(result.evening_sleep!.end_time).toBe('2024-03-09T07:00:00.000Z')
-    expect(result.evening_sleep!.sleep_date).toBe('2024-03-09')
 
     // Both should appear in sleep_sessions
     expect(result.sleep_sessions).toHaveLength(2)
+    expect(result.sleep_sessions[0].sleep_date).toBe('2024-03-08')
+    expect(result.sleep_sessions[1].sleep_date).toBe('2024-03-09')
   })
 
-  test('returns null for primary_sleep and evening_sleep when no sleep data', async () => {
+  test('returns empty sleep_sessions when no sleep data', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -586,8 +570,6 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-03-08'))
 
-    expect(result.primary_sleep).toBeNull()
-    expect(result.evening_sleep).toBeNull()
     expect(result.sleep_sessions).toHaveLength(0)
   })
 
@@ -601,8 +583,7 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-03-07T23:00:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([
       {
@@ -620,8 +601,8 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-03-08'))
 
-    expect(result.primary_sleep).not.toBeNull()
-    expect(result.primary_sleep!.sleep_location).toEqual({
+    expect(result.sleep_sessions).toHaveLength(1)
+    expect(result.sleep_sessions[0].sleep_location).toEqual({
       lat: 57.7,
       lon: 11.97,
       name: 'Hökås',
@@ -639,8 +620,7 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-03-07T23:00:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([
       // Short visit at Office before sleep
@@ -670,7 +650,7 @@ describe('getDailySummary', () => {
     const result = await getDailySummary('testuser', new Date('2024-03-08'))
 
     // Should pick Home (7.5h overlap) over Office (30min overlap)
-    expect(result.primary_sleep!.sleep_location!.name).toBe('Home')
+    expect(result.sleep_sessions[0].sleep_location!.name).toBe('Home')
   })
 
   test('sleep_location is undefined when no place visits overlap', async () => {
@@ -683,8 +663,7 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-03-07T23:00:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -692,16 +671,17 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-03-08'))
 
-    expect(result.primary_sleep!.sleep_location).toBeUndefined()
+    expect(result.sleep_sessions[0].sleep_location).toBeUndefined()
   })
 
   test('includes exercise_type name from numeric Health Connect code', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([]) // heart rate
       .mockResolvedValueOnce([]) // steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         data: { exerciseType: 83 }, // yoga
@@ -717,7 +697,6 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-01-15T11:30:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -725,19 +704,20 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.exercise_sessions).toHaveLength(2)
-    expect(result.exercise_sessions[0].exercise_type).toBe('yoga')
-    expect(result.exercise_sessions[1].exercise_type).toBe('running')
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities).toHaveLength(2)
+    expect(exerciseActivities[0].exercise_type).toBe('yoga')
+    expect(exerciseActivities[1].exercise_type).toBe('running')
   })
 
   test('includes meals with food item names', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([]) // heart rate
       .mockResolvedValueOnce([]) // steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -783,10 +763,10 @@ describe('getDailySummary', () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([]) // heart rate
       .mockResolvedValueOnce([]) // steps
+      .mockResolvedValueOnce([]) // stress_level
 
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -817,8 +797,7 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-01-14T23:00:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -826,8 +805,8 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.primary_sleep).not.toBeNull()
-    expect(result.primary_sleep!.sleep_stages).toEqual({
+    expect(result.sleep_sessions).toHaveLength(1)
+    expect(result.sleep_sessions[0].sleep_stages).toEqual({
       awake_min: 20,
       deep_min: 90,
       light_min: 280,
@@ -835,7 +814,7 @@ describe('getDailySummary', () => {
     })
   })
 
-  test('omits data blob from exercise and sleep sessions', async () => {
+  test('omits data blob from activities and sleep sessions', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([
       {
@@ -846,7 +825,7 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-01-14T23:00:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
         activity_type: 'exercise',
         data: { exerciseType: 83, metadata: { device: 'oura' } },
@@ -855,7 +834,6 @@ describe('getDailySummary', () => {
         start_time: new Date('2024-01-15T07:00:00Z'),
       },
     ])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
@@ -863,8 +841,9 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    // Exercise sessions should not have raw data blob
-    expect(result.exercise_sessions[0]).not.toHaveProperty('data')
+    // Exercise activities should not have raw data blob
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities[0]).not.toHaveProperty('data')
     // Sleep sessions should not have raw data blob
     expect(result.sleep_sessions[0]).not.toHaveProperty('data')
   })
@@ -872,8 +851,7 @@ describe('getDailySummary', () => {
   test('includes category breakdown in productivity summary', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([
       {
         activity: 'VS Code',
@@ -924,8 +902,7 @@ describe('getDailySummary', () => {
   test('excludes categories marked with exclude_from_screentime', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
-    vi.mocked(db.getActivitiesByCategory).mockResolvedValue([])
-    vi.mocked(db.getActivitiesExcludingCategories).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([
       {
         activity: 'VS Code',
@@ -972,9 +949,208 @@ describe('getDailySummary', () => {
 
     // System and System > Updates should be excluded, totals still include all
     expect(result.productivity!.total_duration_sec).toBe(5100)
-    expect(result.productivity!.categories).toEqual([
-      { duration_sec: 3600, path: ['Work', 'Programming'] },
+    expect(result.productivity!.categories).toEqual([{ duration_sec: 3600, path: ['Work', 'Programming'] }])
+  })
+
+  test('adds screen time categories as screentime activities', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([
+      {
+        activity: 'VS Code',
+        duration_sec: 3600,
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        productivity: 2,
+        resolved_category: ['Work', 'Programming'],
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity: 'YouTube',
+        duration_sec: 600,
+        end_time: new Date('2024-01-15T13:10:00Z'),
+        productivity: -1,
+        resolved_category: ['Entertainment'],
+        start_time: new Date('2024-01-15T13:00:00Z'),
+      },
     ])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    const screentimeActivities = result.activities.filter((a) => a.activity_type === 'screentime')
+    expect(screentimeActivities.length).toBeGreaterThan(0)
+    // Each screentime activity should have category_path and title
+    for (const act of screentimeActivities) {
+      expect(act.category_path).toBeDefined()
+      expect(act.title).toBeDefined()
+      expect(act.end_time).toBeDefined()
+    }
+  })
+
+  test('computes stress_zone_secs on activities with time range', async () => {
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([]) // heart_rate
+      .mockResolvedValueOnce([]) // steps
+      .mockResolvedValueOnce([
+        // stress_level data during the exercise
+        [new Date('2024-01-15T10:00:00Z'), 30], // low
+        [new Date('2024-01-15T10:03:00Z'), 60], // medium
+        [new Date('2024-01-15T10:06:00Z'), 80], // high
+      ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+    ])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
+    expect(exerciseActivities).toHaveLength(1)
+    expect(exerciseActivities[0].stress_zone_secs).toBeDefined()
+    // Should have some time in low, medium, and high zones
+    expect(exerciseActivities[0].stress_zone_secs!.low).toBeGreaterThan(0)
+    expect(exerciseActivities[0].stress_zone_secs!.medium).toBeGreaterThan(0)
+    expect(exerciseActivities[0].stress_zone_secs!.high).toBeGreaterThan(0)
+  })
+
+  test('computes day-level stress_zones when stress data exists', async () => {
+    vi.mocked(db.getTimeSeries)
+      .mockResolvedValueOnce([]) // heart_rate
+      .mockResolvedValueOnce([]) // steps
+      .mockResolvedValueOnce([
+        // stress_level data throughout the day
+        [new Date('2024-01-15T08:00:00Z'), 10], // rest
+        [new Date('2024-01-15T08:03:00Z'), 20], // rest
+        [new Date('2024-01-15T10:00:00Z'), 40], // low
+        [new Date('2024-01-15T14:00:00Z'), 65], // medium
+      ])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.stress_zones).not.toBeNull()
+    expect(result.stress_zones!.rest).toBeGreaterThan(0)
+    expect(result.stress_zones!.low).toBeGreaterThan(0)
+    expect(result.stress_zones!.medium).toBeGreaterThan(0)
+  })
+
+  test('returns null stress_zones when no stress data', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.stress_zones).toBeNull()
+  })
+
+  test('filters out notes attached to activities from top-level notes', async () => {
+    const activityId = 'activity-123'
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: activityId,
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+    ])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    // Notes: one attached to an activity, one orphaned
+    vi.mocked(db.getNotesForTimeRange).mockResolvedValue([
+      {
+        content: 'Attached to exercise',
+        created_at: new Date('2024-01-15T11:00:00Z'),
+        entity_id: activityId,
+        entity_type: 'activity',
+        id: 'note-attached',
+        updated_at: new Date('2024-01-15T11:00:00Z'),
+      },
+      {
+        content: 'General note for the day',
+        created_at: new Date('2024-01-15T12:00:00Z'),
+        entity_id: 'some-other-id',
+        entity_type: 'report',
+        id: 'note-orphan',
+        updated_at: new Date('2024-01-15T12:00:00Z'),
+      },
+    ])
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    // Only the orphaned note should appear in top-level notes
+    expect(result.notes).toHaveLength(1)
+    expect(result.notes[0].id).toBe('note-orphan')
+    expect(result.notes[0].content).toBe('General note for the day')
+  })
+
+  test('activities are sorted chronologically', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Running',
+      },
+      {
+        activity_type: 'coffee',
+        source: 'aurboda',
+        start_time: new Date('2024-01-15T08:00:00Z'),
+      },
+      {
+        activity_type: 'meeting',
+        end_time: new Date('2024-01-15T15:00:00Z'),
+        source: 'aurboda',
+        start_time: new Date('2024-01-15T14:00:00Z'),
+        title: 'Standup',
+      },
+    ])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    // Activities should be sorted by start_time
+    const startTimes = result.activities.map((a) => a.start_time)
+    for (let i = 1; i < startTimes.length; i++) {
+      expect(startTimes[i] >= startTimes[i - 1]).toBe(true)
+    }
   })
 })
 

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -16,12 +16,12 @@ import { Temporal } from '@js-temporal/polyfill'
 
 import {
   getActivities,
-  getActivitiesByCategory,
   getActivitiesExcludingCategories,
   getDailyAggregates,
   getDailyAggregateValue,
   getDistinctMetrics,
   getMeals,
+  getNonSleepActivitiesMerged,
   getNotesByEntityIds,
   getNotesForTimeRange,
   getProductivity,
@@ -133,6 +133,25 @@ export interface SessionSummary {
   hr_zone_secs?: HrZoneSecs
 }
 
+export interface StressZoneSecs {
+  rest: number
+  low: number
+  medium: number
+  high: number
+}
+
+export interface ActivitySummary {
+  activity_type: string
+  start_time: string
+  end_time?: string
+  title?: string
+  comments?: CommentSummary[]
+  exercise_type?: ExerciseTypeName
+  hr_zone_secs?: HrZoneSecs
+  stress_zone_secs?: StressZoneSecs
+  category_path?: string[]
+}
+
 export interface SleepLocation {
   name: string
   source: 'named' | 'detected' | 'owntracks' | 'unknown'
@@ -209,18 +228,16 @@ export interface MealSummary {
 
 export interface DailySummaryResult {
   date: string
+  activities: ActivitySummary[]
   heart_rate: HeartRateStats | null
   meals: MealSummary[]
   notes: NoteSummary[]
   steps: { total: number }
-  primary_sleep: SleepSessionSummary | null
-  evening_sleep: SleepSessionSummary | null
   sleep_sessions: SleepSessionSummary[]
-  exercise_sessions: SessionSummary[]
-  tags: TagSummary[]
   productivity: ProductivitySummary | null
   places: PlaceSummary[]
   oura_scores: OuraScores | null
+  stress_zones: StressZoneSecs | null
 }
 
 export interface PeriodMetricStats {
@@ -672,6 +689,135 @@ export const computeSleepStageSummary = (
   }
 }
 
+// ============================================================================
+// Stress zone computation
+// ============================================================================
+
+const STRESS_MAX_GAP_SECONDS = 300 // 5 minutes — stress samples are typically 3 minutes apart
+const STRESS_SINGLE_SAMPLE_SECONDS = 180 // Garmin reports every ~3 minutes
+
+/**
+ * Compute time spent in each stress zone for a time window.
+ * Uses the same gap-based accumulation pattern as computeHrZoneSecs.
+ */
+export const computeStressZoneSecs = (
+  stressData: [Date, number][],
+  start?: Date,
+  end?: Date,
+): StressZoneSecs => {
+  const result: StressZoneSecs = { high: 0, low: 0, medium: 0, rest: 0 }
+
+  // Filter to time window if specified
+  const filtered = start && end ? stressData.filter(([time]) => time >= start && time <= end) : stressData
+
+  if (filtered.length === 0) return result
+
+  const getStressZone = (level: number): keyof StressZoneSecs => {
+    if (level <= 25) return 'rest'
+    if (level <= 50) return 'low'
+    if (level <= 75) return 'medium'
+    return 'high'
+  }
+
+  if (filtered.length === 1) {
+    result[getStressZone(filtered[0][1])] = STRESS_SINGLE_SAMPLE_SECONDS
+    return result
+  }
+
+  const gaps: number[] = []
+  for (let i = 0; i < filtered.length - 1; i++) {
+    const [time, level] = filtered[i]
+    const nextTime = filtered[i + 1][0]
+    const gapSec = Math.min((nextTime.getTime() - time.getTime()) / 1000, STRESS_MAX_GAP_SECONDS)
+    gaps.push(gapSec)
+    result[getStressZone(level)] += gapSec
+  }
+
+  // Last sample: use mean gap
+  const meanGap = gaps.reduce((a, b) => a + b, 0) / gaps.length
+  const lastZone = getStressZone(filtered[filtered.length - 1][1])
+  result[lastZone] += Math.min(meanGap, STRESS_MAX_GAP_SECONDS)
+
+  return result
+}
+
+// ============================================================================
+// Screen time → activity spans
+// ============================================================================
+
+const SCREENTIME_MERGE_GAP_MS = 10 * 60 * 1000 // 10 minutes
+
+interface ScreentimeSpan {
+  category_path: string[]
+  start_time: Date
+  end_time: Date
+  duration_sec: number
+}
+
+/**
+ * Convert productivity records into merged screen time activity spans by category.
+ * Skips uncategorized records and excluded categories.
+ */
+export const buildScreentimeSpans = (
+  records: ProductivityRecord[],
+  excludedPaths: string[][],
+): ScreentimeSpan[] => {
+  const isExcluded = (cat: string[] | undefined): boolean =>
+    cat === undefined ||
+    cat.length === 0 ||
+    excludedPaths.some(
+      (excluded) => cat.length >= excluded.length && excluded.every((seg, i) => seg === cat[i]),
+    )
+
+  // Group by category
+  const byCategory = new Map<string, ProductivityRecord[]>()
+  for (const record of records) {
+    if (isExcluded(record.resolved_category)) continue
+    const key = JSON.stringify(record.resolved_category)
+    const group = byCategory.get(key) ?? []
+    group.push(record)
+    byCategory.set(key, group)
+  }
+
+  const spans: ScreentimeSpan[] = []
+
+  for (const [key, group] of byCategory) {
+    const categoryPath = JSON.parse(key) as string[]
+    const sorted = [...group].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+
+    let current = {
+      category_path: categoryPath,
+      duration_sec: sorted[0].duration_sec,
+      end_time: sorted[0].end_time,
+      start_time: sorted[0].start_time,
+    }
+
+    for (let i = 1; i < sorted.length; i++) {
+      const next = sorted[i]
+      const gap = next.start_time.getTime() - current.end_time.getTime()
+
+      if (gap <= SCREENTIME_MERGE_GAP_MS) {
+        // Merge: extend end time, accumulate duration
+        if (next.end_time > current.end_time) {
+          current.end_time = next.end_time
+        }
+        current.duration_sec += next.duration_sec
+      } else {
+        spans.push(current)
+        current = {
+          category_path: categoryPath,
+          duration_sec: next.duration_sec,
+          end_time: next.end_time,
+          start_time: next.start_time,
+        }
+      }
+    }
+    spans.push(current)
+  }
+
+  return spans.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+}
+
 /**
  * Get a comprehensive summary of health data for a specific day.
  * @param sync Optional sync provider to auto-refresh stale data before querying
@@ -724,8 +870,7 @@ export async function getDailySummary(
     heartRateData,
     stepsData,
     sleepSessions,
-    exerciseSessions,
-    tags,
+    allActivities,
     productivity,
     placeVisits,
     ouraMetrics,
@@ -733,12 +878,12 @@ export async function getDailySummary(
     dayMeals,
     stepsAggregate,
     screentimeCategories,
+    stressData,
   ] = await Promise.all([
     getTimeSeries(user, 'heart_rate', start, end),
     getTimeSeries(user, 'steps', start, end),
     getSleepSessions(user, start, end),
-    getActivitiesByCategory(user, 'exercise', start, end),
-    queryTagActivities(user, start, end),
+    getNonSleepActivitiesMerged(user, start, end),
     getProductivity(user, start, end),
     getPlaceVisits(user, start, end),
     getTimeSeriesMultiMetric(
@@ -751,6 +896,7 @@ export async function getDailySummary(
     getMeals(user, { start, end }),
     getDailyAggregateValue(user, 'steps', date),
     getScreentimeCategories(user),
+    getTimeSeries(user, 'stress_level', start, end),
   ])
 
   // Calculate heart rate stats
@@ -774,13 +920,6 @@ export async function getDailySummary(
     .filter((c) => c.exclude_from_screentime)
     .map((c) => c.name)
 
-  const isExcluded = (resolvedCategory: string[] | undefined): boolean =>
-    resolvedCategory !== undefined &&
-    excludedCategoryPaths.some(
-      (excluded) =>
-        resolvedCategory.length >= excluded.length && excluded.every((seg, i) => seg === resolvedCategory[i]),
-    )
-
   const productivitySummary: ProductivitySummary | null =
     productivity.length > 0
       ? (() => {
@@ -799,8 +938,14 @@ export async function getDailySummary(
               if (record.productivity >= 2) totals.very_productive_sec += record.duration_sec
               if (record.productivity <= -1) totals.distracting_sec += record.duration_sec
             }
-            if (!isExcluded(record.resolved_category)) {
-              const key = JSON.stringify(record.resolved_category ?? [])
+            const cat = record.resolved_category
+            const isExcl =
+              cat !== undefined &&
+              excludedCategoryPaths.some(
+                (excluded) => cat.length >= excluded.length && excluded.every((seg, i) => seg === cat[i]),
+              )
+            if (!isExcl) {
+              const key = JSON.stringify(cat ?? [])
               categoryMap.set(key, (categoryMap.get(key) ?? 0) + record.duration_sec)
             }
           }
@@ -837,53 +982,86 @@ export async function getDailySummary(
   // Get user's HR zones for exercise session HR zone calculation
   const { zones: hrZones } = await getEffectiveHrZones(user)
 
-  // Compute HR zones for exercise sessions (filter already-fetched HR data in memory)
-  const exerciseSessionsWithHrZones: SessionSummary[] = exerciseSessions.map((s) => {
-    // Resolve human-readable exercise type name from numeric Health Connect ID
+  // Fetch comments for all activities
+  const activityIds = allActivities.map((a) => a.id).filter((id): id is string => id !== undefined)
+  const commentsMap = await getCommentsMap(user, 'activity', activityIds)
+
+  // Build unified activities array from DB activities
+  const activities: ActivitySummary[] = allActivities.map((s) => {
     const dataObj = s.data as Record<string, unknown> | undefined
     const exerciseTypeCode = dataObj?.exerciseType
     const exerciseType =
       typeof exerciseTypeCode === 'number' ? getExerciseTypeName(exerciseTypeCode) : undefined
 
-    const sessionSummary: SessionSummary = {
-      duration: s.end_time
-        ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60)
-        : undefined,
+    const activity: ActivitySummary = {
+      activity_type: s.activity_type,
       end_time: s.end_time?.toISOString(),
-      exercise_type: exerciseType,
       start_time: s.start_time.toISOString(),
       title: s.title,
     }
 
-    // Only compute HR zones for sessions with end time
-    if (s.end_time) {
+    if (exerciseType) activity.exercise_type = exerciseType
+
+    // Comments
+    const comments = s.id ? commentsMap.get(s.id) : undefined
+    if (comments && comments.length > 0) activity.comments = comments
+
+    // HR zones for exercise sessions with end time
+    if (s.end_time && s.activity_type === 'exercise') {
       const sessionHrData = heartRateData.filter(([time]) => time >= s.start_time && time <= s.end_time!)
       if (sessionHrData.length > 0) {
-        sessionSummary.hr_zone_secs = computeHrZoneSecs(sessionHrData, hrZones)
+        activity.hr_zone_secs = computeHrZoneSecs(sessionHrData, hrZones)
       }
     }
 
-    return sessionSummary
+    // Stress zones for activities with time range
+    if (s.end_time && stressData.length > 0) {
+      const zones = computeStressZoneSecs(stressData, s.start_time, s.end_time)
+      const hasStressData = zones.rest + zones.low + zones.medium + zones.high > 0
+      if (hasStressData) activity.stress_zone_secs = zones
+    }
+
+    return activity
   })
 
-  // Fetch tag comments
-  const tagIds = tags.map((t) => t.id).filter((id): id is string => id !== undefined)
-  const tagCommentsMap = await getCommentsMap(user, 'activity', tagIds)
+  // Build screen time activity spans and add to activities
+  const screentimeSpans = buildScreentimeSpans(productivity, excludedCategoryPaths)
+  for (const span of screentimeSpans) {
+    const activity: ActivitySummary = {
+      activity_type: 'screentime',
+      category_path: span.category_path,
+      end_time: span.end_time.toISOString(),
+      start_time: span.start_time.toISOString(),
+      title: span.category_path.join(' > '),
+    }
+
+    // Stress zones for screen time spans
+    if (stressData.length > 0) {
+      const zones = computeStressZoneSecs(stressData, span.start_time, span.end_time)
+      const hasStressData = zones.rest + zones.low + zones.medium + zones.high > 0
+      if (hasStressData) activity.stress_zone_secs = zones
+    }
+
+    activities.push(activity)
+  }
+
+  // Sort all activities chronologically
+  activities.sort((a, b) => a.start_time.localeCompare(b.start_time))
+
+  // Day-level stress zones
+  const stressZones: StressZoneSecs | null = stressData.length > 0 ? computeStressZoneSecs(stressData) : null
 
   // Build sleep session summaries with sleep_date and sleep_location
-  const dateStr = date.toISOString().split('T')[0]
   const sleepSessionSummaries: SleepSessionSummary[] = sleepSessions.map((s) => {
     const timeInBed = s.end_time
       ? Math.round((s.end_time.getTime() - s.start_time.getTime()) / 1000 / 60)
       : undefined
     const totalSleep = computeSleepMinutes(s.data as Record<string, unknown> | undefined)
 
-    // sleep_date = wake-up date (end_time date), or start_time date if still sleeping
     const sleepDate = s.end_time
       ? s.end_time.toISOString().split('T')[0]
       : s.start_time.toISOString().split('T')[0]
 
-    // Find the best-guess sleep location from place visits overlapping the sleep window
     const sleepLocation = findSleepLocation(s.start_time, s.end_time ?? end, placeVisits)
 
     return {
@@ -898,19 +1076,17 @@ export async function getDailySummary(
     }
   })
 
-  // Classify sleep sessions:
-  // primary_sleep = session where the user woke up on this date (end_time is on this date)
-  // evening_sleep = session that started on this date but ends on the next day (or is ongoing)
-  const primarySleep = sleepSessionSummaries.find((s) => s.end_time && s.end_time.startsWith(dateStr)) ?? null
-  const eveningSleep =
-    sleepSessionSummaries.find(
-      (s) => s.start_time.startsWith(dateStr) && (!s.end_time || !s.end_time.startsWith(dateStr)),
-    ) ?? null
+  // Filter notes: only include orphaned notes (not attached to an activity in the list)
+  const activityIdSet = new Set(activityIds)
+  const orphanedNotes = dayNotes.filter(
+    (n) => !(n.entity_type === 'activity' && n.entity_id && activityIdSet.has(n.entity_id)),
+  )
+
+  const dateStr = date.toISOString().split('T')[0]
 
   return {
+    activities,
     date: dateStr,
-    evening_sleep: eveningSleep,
-    exercise_sessions: exerciseSessionsWithHrZones,
     heart_rate: heartRateStats,
     meals: dayMeals.map((m) => ({
       calories: m.calories,
@@ -923,7 +1099,7 @@ export async function getDailySummary(
       protein: m.protein,
       time: m.time.toISOString(),
     })),
-    notes: dayNotes.map((n) => ({
+    notes: orphanedNotes.map((n) => ({
       content: n.content,
       created_at: n.created_at.toISOString(),
       end_time: n.end_time?.toISOString(),
@@ -945,16 +1121,10 @@ export async function getDailySummary(
       source: p.source,
       start_time: p.start_time.toISOString(),
     })),
-    primary_sleep: primarySleep,
     productivity: productivitySummary,
     sleep_sessions: sleepSessionSummaries,
     steps: { total: totalSteps },
-    tags: tags.map((t) => ({
-      comments: t.id ? (tagCommentsMap.get(t.id) ?? []) : [],
-      end_time: t.end_time?.toISOString(),
-      start_time: t.start_time.toISOString(),
-      tag: t.title ?? t.activity_type,
-    })),
+    stress_zones: stressZones,
   }
 }
 

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -15,7 +15,6 @@ import {
   latSchema,
   lonSchema,
   placeSourceSchema,
-  tagTextSchema,
 } from './common.ts'
 import { commentSchema, noteSchema } from './notes.ts'
 import { hrZoneSecsSchema } from './settings.ts'
@@ -33,6 +32,21 @@ export const heartRateStatsSchema = z
   .meta({ id: 'HeartRateStats' })
 
 export type HeartRateStats = z.infer<typeof heartRateStatsSchema>
+
+/**
+ * Stress zone seconds schema — time spent in each stress level band.
+ * Based on Garmin stress levels (0-100 scale).
+ */
+export const stressZoneSecsSchema = z
+  .object({
+    high: z.number().meta({ description: 'Seconds at high stress (76-100)' }),
+    low: z.number().meta({ description: 'Seconds at low stress (26-50)' }),
+    medium: z.number().meta({ description: 'Seconds at medium stress (51-75)' }),
+    rest: z.number().meta({ description: 'Seconds at rest/no stress (0-25)' }),
+  })
+  .meta({ description: 'Time spent in each stress level band', id: 'StressZoneSecs' })
+
+export type StressZoneSecs = z.infer<typeof stressZoneSecsSchema>
 
 /**
  * Sleep location schema — best-guess location where the person slept.
@@ -92,38 +106,39 @@ export const sleepSessionSummarySchema = z
 export type SleepSessionSummary = z.infer<typeof sleepSessionSummarySchema>
 
 /**
- * Session summary schema (for exercise, meditation).
+ * Activity summary schema — unified activity in the daily timeline.
+ * Covers exercises, meditations, tags, screen time categories, and all other activities.
  */
-export const sessionSummarySchema = z
+export const activitySummarySchema = z
   .object({
-    duration: durationMinutesSchema.optional(),
+    activity_type: z
+      .string()
+      .meta({ description: 'Activity type (e.g., "exercise", "meditation", "screentime", "coffee")' }),
+    category_path: z
+      .array(z.string())
+      .optional()
+      .meta({
+        description:
+          'Screen time category path (e.g., ["Work & Dev", "Software Dev"]). Only present for screentime activities.',
+      }),
+    comments: z.array(commentSchema).optional().meta({ description: 'Comments attached to this activity' }),
     end_time: iso8601DateTimeSchema.optional(),
     exercise_type: exerciseTypeSchema.optional().meta({
-      description: 'Human-readable exercise type name (e.g., "yoga", "running", "weightlifting")',
+      description:
+        'Human-readable exercise type name (e.g., "yoga", "running"). Only present for exercise activities.',
     }),
     hr_zone_secs: hrZoneSecsSchema.optional().meta({
-      description: 'Time spent in each HR zone during session',
+      description: 'Time spent in each HR zone during this activity',
     }),
     start_time: iso8601DateTimeSchema,
-    title: z.string().optional().meta({ description: 'Session title' }),
+    stress_zone_secs: stressZoneSecsSchema.optional().meta({
+      description: 'Time spent in each stress level band during this activity',
+    }),
+    title: z.string().optional().meta({ description: 'Activity title or display name' }),
   })
-  .meta({ id: 'SessionSummary' })
+  .meta({ description: 'A single activity in the daily timeline', id: 'ActivitySummary' })
 
-export type SessionSummary = z.infer<typeof sessionSummarySchema>
-
-/**
- * Tag summary schema.
- */
-export const tagSummarySchema = z
-  .object({
-    comments: z.array(commentSchema).optional().meta({ description: 'Comments attached to this tag' }),
-    end_time: iso8601DateTimeSchema.optional(),
-    start_time: iso8601DateTimeSchema,
-    tag: tagTextSchema,
-  })
-  .meta({ id: 'TagSummary' })
-
-export type TagSummary = z.infer<typeof tagSummarySchema>
+export type ActivitySummary = z.infer<typeof activitySummarySchema>
 
 /**
  * Place summary schema.
@@ -182,7 +197,7 @@ export const ouraScoresSchema = z
     readiness_score: z.number().nullable().meta({ description: 'Oura readiness score (0-100)' }),
     resilience_score: z.number().nullable().meta({ description: 'Oura resilience score (0-100)' }),
     sleep_score: z.number().nullable().meta({
-      description: 'Oura sleep score (0-100). Evaluates the primary_sleep session for this date.',
+      description: 'Oura sleep score (0-100). Evaluates the primary sleep session for this date.',
     }),
   })
   .meta({ id: 'OuraScores' })
@@ -216,37 +231,34 @@ export type MealSummary = z.infer<typeof mealSummarySchema>
  */
 export const dailySummaryResultSchema = z
   .object({
-    date: dateOnlySchema,
-    evening_sleep: sleepSessionSummarySchema.nullable().meta({
+    activities: z.array(activitySummarySchema).meta({
       description:
-        'Sleep session that started on this date but continues into the next day (fell asleep tonight). Will appear as the primary_sleep on the next day. Null if no evening sleep was started.',
+        'Unified chronological timeline of all activities: exercises, meditations, screen time categories, custom activities, etc. Sorted by start_time. Screen time entries have category_path set. Exercise entries have exercise_type and hr_zone_secs. Activities with stress data have stress_zone_secs.',
     }),
-    exercise_sessions: z.array(sessionSummarySchema),
+    date: dateOnlySchema,
     heart_rate: heartRateStatsSchema.nullable(),
     meals: z.array(mealSummarySchema).meta({
       description: 'Meals logged on this day, with macros and food item names',
     }),
     notes: z.array(noteSchema).meta({
-      description: 'All notes whose time range overlaps this day, across all entity types',
+      description:
+        'Notes not attached to any activity in the activities list (orphaned or non-activity notes)',
     }),
     oura_scores: ouraScoresSchema.nullable().meta({
-      description:
-        'Oura scores for this date. The sleep_score evaluates the primary_sleep session (the sleep the user woke up from on this date).',
+      description: 'Oura scores for this date.',
     }),
     places: z.array(placeSummarySchema),
-    primary_sleep: sleepSessionSummarySchema.nullable().meta({
-      description:
-        'The main sleep session for this date — the one the user woke up from on this date (following Oura convention). The oura_scores.sleep_score evaluates this session. Null if no primary sleep ended on this date.',
-    }),
     productivity: productivitySummarySchema.nullable(),
     sleep_sessions: z.array(sleepSessionSummarySchema).meta({
       description:
-        'All sleep sessions overlapping this date (kept for backward compatibility). Prefer using primary_sleep and evening_sleep for unambiguous sleep attribution.',
+        'All sleep sessions overlapping this date, with sleep stages, location, and date attribution.',
     }),
     steps: z.object({
       total: z.number().meta({ description: 'Total steps for the day' }),
     }),
-    tags: z.array(tagSummarySchema),
+    stress_zones: stressZoneSecsSchema.nullable().meta({
+      description: 'Day-level stress zone summary — total seconds in each stress band for the whole day',
+    }),
   })
   .meta({ id: 'DailySummaryResult' })
 


### PR DESCRIPTION
## Summary

- Replace separate `tags`/`exercise_sessions` with unified chronological `activities` array containing exercises, meditations, screen time categories, and all other activities
- Add `stress_zone_secs` (rest/low/medium/high) per activity and day-level `stress_zones` from Garmin stress data
- Screen time categories appear as activities with `category_path`, merged with 10min gap to reduce fragmentation (excluded categories and uncategorized are skipped)
- Remove `primary_sleep`/`evening_sleep`, keep `sleep_sessions`
- Fix note duplication: top-level `notes` only includes orphaned notes not attached to activities
- Updated MCP tool description to reflect new structure

## Test plan

- [x] All 1638 backend tests pass (31 getDailySummary tests, including 6 new ones)
- [x] TypeScript and lint checks pass across all packages
- [ ] Verify via MCP `get_daily_summary` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)