### PR TITLE
fix: move generic exercise merging to DB layer

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -101,7 +101,57 @@ export const mergeOverlappingActivities = (activities: Activity[]): MergedActivi
   }
 
   // Sort final result by start time
-  return result.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+  result.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+
+  // Second pass: absorb generic exercises (other_workout, unknown, no subtype)
+  // into overlapping specific activities of a different type.
+  return absorbGenericExercises(result)
+}
+
+const GENERIC_EXERCISE_CODES = new Set([0, 2]) // UNKNOWN=0, OTHER_WORKOUT=2
+
+const isGenericExercise = (a: MergedActivity): boolean => {
+  if (a.activity_type !== 'exercise') return false
+  const code = (a.data as Record<string, unknown> | undefined)?.exerciseType
+  return !code || GENERIC_EXERCISE_CODES.has(code as number)
+}
+
+/**
+ * Absorb generic exercises into overlapping specific activities.
+ * The specific activity's time range is extended to cover the generic's range.
+ * Requires input sorted by start_time.
+ */
+const absorbGenericExercises = (sorted: MergedActivity[]): MergedActivity[] => {
+  const absorbed = new Set<number>()
+
+  for (let i = 0; i < sorted.length; i++) {
+    if (!isGenericExercise(sorted[i]) || absorbed.has(i)) continue
+
+    const generic = sorted[i]
+    const gStart = generic.start_time.getTime()
+    const gEnd = generic.end_time?.getTime() ?? gStart
+    if (gEnd <= gStart) continue
+
+    // Find a specific activity that overlaps >50% of the generic's duration
+    for (let j = 0; j < sorted.length; j++) {
+      if (j === i || absorbed.has(j) || isGenericExercise(sorted[j])) continue
+      const other = sorted[j]
+      const oStart = other.start_time.getTime()
+      const oEnd = other.end_time?.getTime() ?? oStart
+      const overlapMs = Math.min(gEnd, oEnd) - Math.max(gStart, oStart)
+      if (overlapMs > 0 && overlapMs / (gEnd - gStart) > 0.5) {
+        // Extend the specific activity to cover the generic's range
+        if (generic.start_time < other.start_time) other.start_time = generic.start_time
+        if (generic.end_time && (!other.end_time || generic.end_time > other.end_time)) {
+          other.end_time = generic.end_time
+        }
+        absorbed.add(i)
+        break
+      }
+    }
+  }
+
+  return sorted.filter((_, i) => !absorbed.has(i))
 }
 
 /**

--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -101,7 +101,66 @@ export const mergeOverlappingActivities = (activities: Activity[]): MergedActivi
   }
 
   // Sort final result by start time
-  return result.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+  result.sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+
+  // Second pass: absorb generic exercises (other_workout, unknown, no subtype)
+  // into overlapping specific activities of a different type.
+  return absorbGenericExercises(result)
+}
+
+const GENERIC_EXERCISE_CODES = new Set([0, 2]) // UNKNOWN=0, OTHER_WORKOUT=2
+
+const isGenericExercise = (a: MergedActivity): boolean => {
+  if (a.activity_type !== 'exercise') return false
+  const code = (a.data as Record<string, unknown> | undefined)?.exerciseType
+  return !code || GENERIC_EXERCISE_CODES.has(code as number)
+}
+
+/** Check if generic's duration overlaps >50% with another activity. */
+const findAbsorbingActivity = (
+  gStart: number,
+  gEnd: number,
+  sorted: MergedActivity[],
+  skipIndices: Set<number>,
+  genericIndex: number,
+): MergedActivity | undefined => {
+  for (let j = 0; j < sorted.length; j++) {
+    if (j === genericIndex || skipIndices.has(j) || isGenericExercise(sorted[j])) continue
+    const oStart = sorted[j].start_time.getTime()
+    const oEnd = sorted[j].end_time?.getTime() ?? oStart
+    const overlapMs = Math.min(gEnd, oEnd) - Math.max(gStart, oStart)
+    if (overlapMs > 0 && overlapMs / (gEnd - gStart) > 0.5) return sorted[j]
+  }
+  return undefined
+}
+
+/**
+ * Absorb generic exercises into overlapping specific activities.
+ * The specific activity's time range is extended to cover the generic's range.
+ * Requires input sorted by start_time.
+ */
+const absorbGenericExercises = (sorted: MergedActivity[]): MergedActivity[] => {
+  const absorbed = new Set<number>()
+
+  for (let i = 0; i < sorted.length; i++) {
+    if (!isGenericExercise(sorted[i]) || absorbed.has(i)) continue
+
+    const generic = sorted[i]
+    const gStart = generic.start_time.getTime()
+    const gEnd = generic.end_time?.getTime() ?? gStart
+    if (gEnd <= gStart) continue
+
+    const match = findAbsorbingActivity(gStart, gEnd, sorted, absorbed, i)
+    if (match) {
+      if (generic.start_time < match.start_time) match.start_time = generic.start_time
+      if (generic.end_time && (!match.end_time || generic.end_time > match.end_time)) {
+        match.end_time = generic.end_time
+      }
+      absorbed.add(i)
+    }
+  }
+
+  return sorted.filter((_, i) => !absorbed.has(i))
 }
 
 /**

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -31,7 +31,6 @@ import {
   getTimeSeriesMultiMetric,
   getTimeSeriesStats,
   getTimeSeriesWithSource,
-  type MergedActivity,
   type ProductivityRecord,
 } from '../db/index.ts'
 import { getScreentimeCategories } from '../db/screentime-categories.ts'
@@ -828,66 +827,6 @@ export const buildScreentimeSpans = (
     .sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
 }
 
-// ============================================================================
-// Cross-type activity merging
-// ============================================================================
-
-const isGenericExercise = (a: MergedActivity): boolean => {
-  const dataObj = a.data as Record<string, unknown> | undefined
-  const code = dataObj?.exerciseType
-  return a.activity_type === 'exercise' && (code === 0 || code === 2 || !code)
-}
-
-const hasSubstantialOverlap = (
-  gStart: number,
-  gEnd: number,
-  other: MergedActivity,
-): boolean => {
-  const oStart = other.start_time.getTime()
-  const oEnd = other.end_time?.getTime() ?? oStart
-  const overlapStart = Math.max(gStart, oStart)
-  const overlapEnd = Math.min(gEnd, oEnd)
-  if (overlapEnd <= overlapStart) return false
-  const genericDuration = gEnd - gStart
-  return genericDuration > 0 && (overlapEnd - overlapStart) / genericDuration > 0.5
-}
-
-/**
- * Merge generic "other_workout" exercises with overlapping specific activities.
- * E.g. Garmin syncs Meditation while Health Connect pushes other_workout at the same time.
- * The more specific activity type wins; the generic exercise is absorbed.
- */
-export const mergeGenericExercises = (activities: MergedActivity[]): MergedActivity[] => {
-  const genericExercises: MergedActivity[] = []
-  const others: MergedActivity[] = []
-
-  for (const a of activities) {
-    ;(isGenericExercise(a) ? genericExercises : others).push(a)
-  }
-
-  if (genericExercises.length === 0) return activities
-
-  const absorbed = new Set<MergedActivity>()
-  for (const generic of genericExercises) {
-    const gStart = generic.start_time.getTime()
-    const gEnd = generic.end_time?.getTime() ?? gStart
-
-    const match = others.find((o) => !absorbed.has(o) && hasSubstantialOverlap(gStart, gEnd, o))
-
-    if (match) {
-      if (generic.start_time < match.start_time) match.start_time = generic.start_time
-      if (generic.end_time && (!match.end_time || generic.end_time > match.end_time)) {
-        match.end_time = generic.end_time
-      }
-      absorbed.add(generic)
-    }
-  }
-
-  return [...others, ...genericExercises.filter((g) => !absorbed.has(g))].sort(
-    (a, b) => a.start_time.getTime() - b.start_time.getTime(),
-  )
-}
-
 /**
  * Get a comprehensive summary of health data for a specific day.
  * @param sync Optional sync provider to auto-refresh stale data before querying
@@ -1063,16 +1002,12 @@ export async function getDailySummary(
   // Get user's HR zones for exercise session HR zone calculation
   const { zones: hrZones } = await getEffectiveHrZones(user)
 
-  // Merge generic exercises (other_workout) with overlapping specific activities.
-  // E.g. Garmin syncs Meditation and Health Connect pushes other_workout at the same time.
-  const mergedActivities = mergeGenericExercises(allActivities)
-
-  // Fetch comments for all activities
-  const activityIds = mergedActivities.map((a) => a.id).filter((id): id is string => id !== undefined)
+  // Fetch comments for all activities (generic exercises already absorbed at DB merge level)
+  const activityIds = allActivities.map((a) => a.id).filter((id): id is string => id !== undefined)
   const commentsMap = await getCommentsMap(user, 'activity', activityIds)
 
   // Build unified activities array from DB activities
-  const activities: ActivitySummary[] = mergedActivities.map((s) => {
+  const activities: ActivitySummary[] = allActivities.map((s) => {
     const dataObj = s.data as Record<string, unknown> | undefined
     const exerciseTypeCode = dataObj?.exerciseType
     const exerciseType =


### PR DESCRIPTION
## Summary

- Move absorption of generic exercises (other_workout, unknown) from `getDailySummary` service layer into `mergeOverlappingActivities` in the DB layer
- Now applies everywhere activities are queried: timeline, daily summary, activity queries, correlations
- When a generic exercise (exerciseType 0/2) overlaps >50% with a more specific activity (e.g. meditation), the generic is absorbed and the specific activity's time range is extended
- Removes `mergeGenericExercises` from the service layer (no longer needed)

## Test plan

- [x] All getDailySummary and mergeOverlappingActivities tests pass (53 tests)
- [x] Pre-existing type error in correlations-router.ts is on develop, not from this PR
- [ ] Verify via timeline that duplicate meditation/other_workout no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)