### PR TITLE
feat: display stress_level in correlations page

### DIFF
--- a/apps/backend/src/services/correlations.test.ts
+++ b/apps/backend/src/services/correlations.test.ts
@@ -73,7 +73,7 @@ describe('correlations service', () => {
           unit: 'ms',
         }) // previous 30-day sleep HRV (avg = 43.0)
 
-      // Mock resting HR stats (3 calls: 7-day, 30-day, prev-30)
+      // Mock resting HR stats (3 calls: 7-day, 30-day, prev-30) and stress stats (3 calls)
       vi.mocked(db.getTimeSeriesStats)
         .mockResolvedValueOnce([
           { avg: 60.3, count: 100, max: 70, metric: 'resting_heart_rate', min: 52, stddev: 3, unit: 'bpm' },
@@ -84,6 +84,15 @@ describe('correlations service', () => {
         .mockResolvedValueOnce([
           { avg: 62.5, count: 400, max: 73, metric: 'resting_heart_rate', min: 51, stddev: 4, unit: 'bpm' },
         ]) // previous 30-day HR
+        .mockResolvedValueOnce([
+          { avg: 35.2, count: 100, max: 80, metric: 'stress_level', min: 10, stddev: 12, unit: '' },
+        ]) // 7-day stress
+        .mockResolvedValueOnce([
+          { avg: 37.5, count: 400, max: 85, metric: 'stress_level', min: 8, stddev: 14, unit: '' },
+        ]) // 30-day stress
+        .mockResolvedValueOnce([
+          { avg: 40.0, count: 400, max: 90, metric: 'stress_level', min: 12, stddev: 15, unit: '' },
+        ]) // previous 30-day stress
 
       const result = await getBaseline('testuser')
 
@@ -98,10 +107,13 @@ describe('correlations service', () => {
       expect(result.hrv.avg30day).toBe(44.2) // (42 + 46.4) / 2
       expect(result.resting_hr.avg7day).toBe(60.3)
       expect(result.resting_hr.avg30day).toBe(61.1)
+      expect(result.stress.avg7day).toBe(35.2)
+      expect(result.stress.avg30day).toBe(37.5)
 
       // Verify trends are calculated (30-day vs previous 30-day)
       expect(result.hrv.trend_percent).not.toBeNull()
       expect(result.resting_hr.trend_percent).not.toBeNull()
+      expect(result.stress.trend_percent).not.toBeNull()
       expect(result.period.start).toBeDefined()
       expect(result.period.end).toBeDefined()
     })
@@ -119,6 +131,8 @@ describe('correlations service', () => {
       expect(result.hrv.avg30day).toBeNull()
       expect(result.resting_hr.avg7day).toBeNull()
       expect(result.resting_hr.avg30day).toBeNull()
+      expect(result.stress.avg7day).toBeNull()
+      expect(result.stress.avg30day).toBeNull()
     })
 
     test('uses reference date when provided', async () => {
@@ -136,10 +150,10 @@ describe('correlations service', () => {
       expect(metric).toBe('hrv_sleep')
       expect(endDate.toISOString().split('T')[0]).toBe('2024-01-15')
 
-      // getTimeSeriesStats called for resting HR with dates from reference date
-      expect(db.getTimeSeriesStats).toHaveBeenCalled()
-      const hrCalls = vi.mocked(db.getTimeSeriesStats).mock.calls
-      const [, , , hrEndDate] = hrCalls[0]
+      // getTimeSeriesStats called for resting HR and stress with dates from reference date
+      expect(db.getTimeSeriesStats).toHaveBeenCalledTimes(6) // 3 for HR + 3 for stress
+      const statsCalls = vi.mocked(db.getTimeSeriesStats).mock.calls
+      const [, , , hrEndDate] = statsCalls[0]
       expect(new Date(hrEndDate).toISOString().split('T')[0]).toBe('2024-01-15')
     })
   })
@@ -253,9 +267,13 @@ describe('correlations service', () => {
       expect(result.occurrences).toBe(1)
       expect(result.hrv_timeline).toBeDefined()
       expect(result.hr_timeline).toBeDefined()
+      expect(result.stress_timeline).toBeDefined()
       expect(result.hrv_timeline.before30min).toBeDefined()
       expect(result.hrv_timeline.during).toBeDefined()
       expect(result.hrv_timeline.after30min).toBeDefined()
+      expect(result.stress_timeline.before30min).toBeDefined()
+      expect(result.stress_timeline.during).toBeDefined()
+      expect(result.stress_timeline.after30min).toBeDefined()
     })
 
     test('returns zero occurrences when no matching tags', async () => {

--- a/apps/backend/src/services/correlations.ts
+++ b/apps/backend/src/services/correlations.ts
@@ -47,6 +47,11 @@ export interface BaselineResult {
     avg30day: number | null
     trend_percent: number | null
   }
+  stress: {
+    avg7day: number | null
+    avg30day: number | null
+    trend_percent: number | null
+  }
   period: {
     start: string
     end: string
@@ -114,6 +119,13 @@ export interface ActivityImpactResult {
     after30min: TimeWindowStats
   }
   hr_timeline: {
+    before30min: TimeWindowStats
+    before15min: TimeWindowStats
+    during: TimeWindowStats
+    after15min: TimeWindowStats
+    after30min: TimeWindowStats
+  }
+  stress_timeline: {
     before30min: TimeWindowStats
     before15min: TimeWindowStats
     during: TimeWindowStats
@@ -458,16 +470,28 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
     return sum / result.count
   }
 
-  // Fetch sleep HRV and resting HR stats in parallel
-  const [hrvAvg7day, hrvAvg30day, hrvAvgPrev30day, hrStats7day, hrStats30day, hrStatsPrev30day] =
-    await Promise.all([
-      getSleepHrvAvg(start7day, end7day),
-      getSleepHrvAvg(start30day, end30day),
-      getSleepHrvAvg(prevStart30day, prevEnd30day),
-      getTimeSeriesStats(user, ['resting_heart_rate'], start7day, end7day),
-      getTimeSeriesStats(user, ['resting_heart_rate'], start30day, end30day),
-      getTimeSeriesStats(user, ['resting_heart_rate'], prevStart30day, prevEnd30day),
-    ])
+  // Fetch sleep HRV, resting HR, and stress stats in parallel
+  const [
+    hrvAvg7day,
+    hrvAvg30day,
+    hrvAvgPrev30day,
+    hrStats7day,
+    hrStats30day,
+    hrStatsPrev30day,
+    stressStats7day,
+    stressStats30day,
+    stressStatsPrev30day,
+  ] = await Promise.all([
+    getSleepHrvAvg(start7day, end7day),
+    getSleepHrvAvg(start30day, end30day),
+    getSleepHrvAvg(prevStart30day, prevEnd30day),
+    getTimeSeriesStats(user, ['resting_heart_rate'], start7day, end7day),
+    getTimeSeriesStats(user, ['resting_heart_rate'], start30day, end30day),
+    getTimeSeriesStats(user, ['resting_heart_rate'], prevStart30day, prevEnd30day),
+    getTimeSeriesStats(user, ['stress_level'], start7day, end7day),
+    getTimeSeriesStats(user, ['stress_level'], start30day, end30day),
+    getTimeSeriesStats(user, ['stress_level'], prevStart30day, prevEnd30day),
+  ])
 
   // Calculate trends
   const hrvTrend =
@@ -478,6 +502,11 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
   const hrTrend =
     hrStats30day[0]?.avg && hrStatsPrev30day[0]?.avg
       ? ((hrStats30day[0].avg - hrStatsPrev30day[0].avg) / hrStatsPrev30day[0].avg) * 100
+      : null
+
+  const stressTrend =
+    stressStats30day[0]?.avg && stressStatsPrev30day[0]?.avg
+      ? ((stressStats30day[0].avg - stressStatsPrev30day[0].avg) / stressStatsPrev30day[0].avg) * 100
       : null
 
   return {
@@ -494,6 +523,11 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
       avg7day: hrStats7day[0]?.avg ? Math.round(hrStats7day[0].avg * 10) / 10 : null,
       avg30day: hrStats30day[0]?.avg ? Math.round(hrStats30day[0].avg * 10) / 10 : null,
       trend_percent: hrTrend !== null ? Math.round(hrTrend * 10) / 10 : null,
+    },
+    stress: {
+      avg7day: stressStats7day[0]?.avg ? Math.round(stressStats7day[0].avg * 10) / 10 : null,
+      avg30day: stressStats30day[0]?.avg ? Math.round(stressStats30day[0].avg * 10) / 10 : null,
+      trend_percent: stressTrend !== null ? Math.round(stressTrend * 10) / 10 : null,
     },
   }
 }
@@ -549,7 +583,13 @@ export async function getHrvActivitiesCorrelation(
   for (const record of productivity) {
     const category = record.resolved_category?.join(' > ') || record.category || 'Uncategorized'
     if (!productivityByCategory.has(category)) {
-      productivityByCategory.set(category, { hrValues: [], hrvValues: [], minutes: 0, scores: [], stressValues: [] })
+      productivityByCategory.set(category, {
+        hrValues: [],
+        hrvValues: [],
+        minutes: 0,
+        scores: [],
+        stressValues: [],
+      })
     }
     const cat = productivityByCategory.get(category)!
     cat.minutes += record.duration_sec / 60
@@ -633,13 +673,27 @@ export async function getHrvActivitiesCorrelation(
   // === Activity correlations (unified — includes former tags) ===
   const activityByType = new Map<
     string,
-    { hrvValues: number[]; hrValues: number[]; stressValues: number[]; minutes: number; count: number; hasDuration: boolean }
+    {
+      hrvValues: number[]
+      hrValues: number[]
+      stressValues: number[]
+      minutes: number
+      count: number
+      hasDuration: boolean
+    }
   >()
 
   for (const activity of activities) {
     const type = activity.activity_type
     if (!activityByType.has(type)) {
-      activityByType.set(type, { count: 0, hasDuration: false, hrValues: [], hrvValues: [], minutes: 0, stressValues: [] })
+      activityByType.set(type, {
+        count: 0,
+        hasDuration: false,
+        hrValues: [],
+        hrvValues: [],
+        minutes: 0,
+        stressValues: [],
+      })
     }
     const act = activityByType.get(type)!
     act.count++
@@ -731,10 +785,11 @@ export async function getActivityImpact(
     ])
   }
 
-  // Fetch HRV/HR data
-  const [hrvData, hrData] = await Promise.all([
+  // Fetch HRV/HR/stress data
+  const [hrvData, hrData, stressData] = await Promise.all([
     getTimeSeries(user, 'hrv_rmssd', start, end),
     getTimeSeries(user, 'heart_rate', start, end),
+    getTimeSeries(user, 'stress_level', start, end),
   ])
 
   // Find activity occurrences based on type
@@ -788,13 +843,13 @@ export async function getActivityImpact(
     }
   }
 
-  // Collect HRV/HR for each time window
+  // Collect HRV/HR/stress for each time window
   const windows = {
-    after15min: { hr: [] as number[], hrv: [] as number[] },
-    after30min: { hr: [] as number[], hrv: [] as number[] },
-    before15min: { hr: [] as number[], hrv: [] as number[] },
-    before30min: { hr: [] as number[], hrv: [] as number[] },
-    during: { hr: [] as number[], hrv: [] as number[] },
+    after15min: { hr: [] as number[], hrv: [] as number[], stress: [] as number[] },
+    after30min: { hr: [] as number[], hrv: [] as number[], stress: [] as number[] },
+    before15min: { hr: [] as number[], hrv: [] as number[], stress: [] as number[] },
+    before30min: { hr: [] as number[], hrv: [] as number[], stress: [] as number[] },
+    during: { hr: [] as number[], hrv: [] as number[], stress: [] as number[] },
   }
 
   let totalDurationMin = 0
@@ -807,25 +862,30 @@ export async function getActivityImpact(
     const before30End = new Date(occ.startTime.getTime() - (windowMinutes / 2) * 60 * 1000)
     windows.before30min.hrv.push(...getDataInRange(hrvData, before30Start, before30End))
     windows.before30min.hr.push(...getDataInRange(hrData, before30Start, before30End))
+    windows.before30min.stress.push(...getDataInRange(stressData, before30Start, before30End))
 
     // Before 15 min (from -15 to 0)
     const before15Start = new Date(occ.startTime.getTime() - (windowMinutes / 2) * 60 * 1000)
     windows.before15min.hrv.push(...getDataInRange(hrvData, before15Start, occ.startTime))
     windows.before15min.hr.push(...getDataInRange(hrData, before15Start, occ.startTime))
+    windows.before15min.stress.push(...getDataInRange(stressData, before15Start, occ.startTime))
 
     // During
     windows.during.hrv.push(...getDataInRange(hrvData, occ.startTime, occ.endTime))
     windows.during.hr.push(...getDataInRange(hrData, occ.startTime, occ.endTime))
+    windows.during.stress.push(...getDataInRange(stressData, occ.startTime, occ.endTime))
 
     // After 15 min (from end to +15)
     const after15End = new Date(occ.endTime.getTime() + (windowMinutes / 2) * 60 * 1000)
     windows.after15min.hrv.push(...getDataInRange(hrvData, occ.endTime, after15End))
     windows.after15min.hr.push(...getDataInRange(hrData, occ.endTime, after15End))
+    windows.after15min.stress.push(...getDataInRange(stressData, occ.endTime, after15End))
 
     // After 30 min (from +15 to +30)
     const after30End = new Date(occ.endTime.getTime() + windowMinutes * 60 * 1000)
     windows.after30min.hrv.push(...getDataInRange(hrvData, after15End, after30End))
     windows.after30min.hr.push(...getDataInRange(hrData, after15End, after30End))
+    windows.after30min.stress.push(...getDataInRange(stressData, after15End, after30End))
   }
 
   const calculateWindowStats = (values: number[]): TimeWindowStats => ({
@@ -853,6 +913,13 @@ export async function getActivityImpact(
       during: calculateWindowStats(windows.during.hrv),
     },
     occurrences: occurrences.length,
+    stress_timeline: {
+      after15min: calculateWindowStats(windows.after15min.stress),
+      after30min: calculateWindowStats(windows.after30min.stress),
+      before15min: calculateWindowStats(windows.before15min.stress),
+      before30min: calculateWindowStats(windows.before30min.stress),
+      during: calculateWindowStats(windows.during.stress),
+    },
   }
 }
 
@@ -898,7 +965,9 @@ export async function getEventProbability(
   }
 
   // Get all outcome events (activities matching pattern)
-  const outcomeEvents = allActivities.filter((a) => outcomeRegex.test(a.activity_type)).map((a) => a.start_time)
+  const outcomeEvents = allActivities
+    .filter((a) => outcomeRegex.test(a.activity_type))
+    .map((a) => a.start_time)
 
   // Calculate baseline probability (outcome on any given day)
   const daysWithOutcome = new Set<string>()
@@ -1067,7 +1136,8 @@ export async function getGenericCorrelation(
   }
 
   // Determine which data we need based on triggers and outcome
-  const needsActivities = triggers.some((t) => t.type === 'activity' || t.type === 'tag') || outcome.type === 'tag'
+  const needsActivities =
+    triggers.some((t) => t.type === 'activity' || t.type === 'tag') || outcome.type === 'tag'
   const needsProductivity =
     triggers.some((t) => t.type === 'productivity_category' || t.type === 'productivity_app') ||
     outcome.type === 'productivity'

--- a/apps/web/src/pages/Correlations/index.tsx
+++ b/apps/web/src/pages/Correlations/index.tsx
@@ -53,6 +53,7 @@ function ImpactTimelineChart({
 
     const hrvData = windows.map((w) => data.hrv_timeline[w].mean)
     const hrData = windows.map((w) => data.hr_timeline[w].mean)
+    const stressData = windows.map((w) => data.stress_timeline[w].mean)
 
     const g = svg
       .attr('width', width)
@@ -77,6 +78,18 @@ function ImpactTimelineChart({
     const yHr = d3
       .scaleLinear()
       .domain([hrExtent[0] - hrPadding, hrExtent[1] + hrPadding])
+      .range([innerHeight, 0])
+
+    // Stress Y scale (hidden axis, own range)
+    const stressFiltered = stressData.filter((d): d is number => d !== null)
+    const stressExtent = d3.extent(stressFiltered) as [number, number]
+    const stressPadding = stressFiltered.length > 0 ? (stressExtent[1] - stressExtent[0]) * 0.3 || 10 : 10
+    const yStress = d3
+      .scaleLinear()
+      .domain([
+        stressFiltered.length > 0 ? stressExtent[0] - stressPadding : 0,
+        stressFiltered.length > 0 ? stressExtent[1] + stressPadding : 100,
+      ])
       .range([innerHeight, 0])
 
     // Baseline lines
@@ -148,6 +161,36 @@ function ImpactTimelineChart({
       }
     })
 
+    // Stress line
+    if (stressFiltered.length > 0) {
+      const stressLine = d3
+        .line<number | null>()
+        .defined((d) => d !== null)
+        .x((_, i) => x(i)!)
+        .y((d) => yStress(d!))
+        .curve(d3.curveMonotoneX)
+
+      g.append('path')
+        .datum(stressData)
+        .attr('fill', 'none')
+        .attr('stroke', '#f59e0b')
+        .attr('stroke-width', 2)
+        .attr('d', stressLine)
+
+      // Stress points
+      stressData.forEach((d, i) => {
+        if (d !== null) {
+          g.append('circle')
+            .attr('cx', x(i)!)
+            .attr('cy', yStress(d))
+            .attr('r', 5)
+            .attr('fill', '#f59e0b')
+            .attr('stroke', 'white')
+            .attr('stroke-width', 2)
+        }
+      })
+    }
+
     // Activity zone highlight
     g.append('rect')
       .attr('x', x(2)! - 30)
@@ -197,7 +240,7 @@ function ImpactTimelineChart({
   )
 }
 
-// Delta class: positive delta = good for HRV, bad for HR (inverted)
+// Delta class: positive delta = good for HRV, bad for HR/stress (inverted)
 const getDeltaClass = (value: number | null, inverted: boolean): string => {
   if (value === null) return ''
   if (value === 0) return ''
@@ -249,6 +292,10 @@ function CorrelationRow({
       <td class="value-cell">{stats.mean_hr?.toFixed(0) ?? '--'}</td>
       <td class={`delta-cell ${getDeltaClass(stats.hr_delta_from_baseline, true)}`}>
         {formatDelta(stats.hr_delta_from_baseline, 0)}
+      </td>
+      <td class="value-cell">{stats.mean_stress?.toFixed(0) ?? '--'}</td>
+      <td class={`delta-cell ${getDeltaClass(stats.stress_delta_from_baseline, true)}`}>
+        {formatDelta(stats.stress_delta_from_baseline, 0)}
       </td>
       <td class="samples-cell">{stats.sample_minutes} min</td>
     </tr>
@@ -331,6 +378,10 @@ export function Correlations() {
               <span class="baseline-label">Resting HR (30-day avg)</span>
               <span class="baseline-value hr">{formatValue(baseline.resting_hr.avg30day, 0)} bpm</span>
             </div>
+            <div class="baseline-card">
+              <span class="baseline-label">Stress (30-day avg)</span>
+              <span class="baseline-value stress">{formatValue(baseline.stress.avg30day, 0)}</span>
+            </div>
           </div>
         </section>
       )}
@@ -351,6 +402,9 @@ export function Correlations() {
             </span>
             <span>
               <span class="dot hr" /> Heart Rate
+            </span>
+            <span>
+              <span class="dot stress" /> Stress
             </span>
             <span>
               <span class="zone" /> Activity period
@@ -376,6 +430,8 @@ export function Correlations() {
                       <th>Δ HRV</th>
                       <th>HR</th>
                       <th>Δ HR</th>
+                      <th>Stress</th>
+                      <th>Δ Stress</th>
                       <th>Samples</th>
                     </tr>
                   </thead>
@@ -415,6 +471,8 @@ export function Correlations() {
                       <th>Δ HRV</th>
                       <th>HR</th>
                       <th>Δ HR</th>
+                      <th>Stress</th>
+                      <th>Δ Stress</th>
                       <th>Samples</th>
                     </tr>
                   </thead>
@@ -450,6 +508,8 @@ export function Correlations() {
                       <th>Δ HRV</th>
                       <th>HR</th>
                       <th>Δ HR</th>
+                      <th>Stress</th>
+                      <th>Δ Stress</th>
                       <th>Samples</th>
                     </tr>
                   </thead>
@@ -492,8 +552,8 @@ export function Correlations() {
             lower stress.
           </li>
           <li>
-            <strong>Δ HRV / Δ HR:</strong> Change from your personal baseline. Positive HRV delta is typically
-            good.
+            <strong>Δ HRV / Δ HR / Δ Stress:</strong> Change from your personal baseline. Positive HRV delta
+            is typically good; negative HR/stress delta is typically good.
           </li>
           <li>
             <strong>Correlation coefficient (r):</strong> For productivity, this shows how the productivity

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -96,6 +96,10 @@
   color: #ef4444;
 }
 
+.correlations-page .baseline-value.stress {
+  color: #f59e0b;
+}
+
 /* Impact section */
 .correlations-page .impact-section {
   margin-bottom: 2rem;
@@ -146,6 +150,10 @@
 
 .correlations-page .impact-legend .dot.hr {
   background: #ef4444;
+}
+
+.correlations-page .impact-legend .dot.stress {
+  background: #f59e0b;
 }
 
 .correlations-page .impact-legend .zone {

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -31,7 +31,10 @@ export const hrvStatsWithDeltaSchema = hrvStatsSchema
   .extend({
     hr_delta_from_baseline: z.number().nullable().meta({ description: 'HR change from baseline' }),
     hrv_delta_from_baseline: z.number().nullable().meta({ description: 'HRV change from baseline' }),
-    stress_delta_from_baseline: z.number().nullable().meta({ description: 'Stress level change from baseline' }),
+    stress_delta_from_baseline: z
+      .number()
+      .nullable()
+      .meta({ description: 'Stress level change from baseline' }),
   })
   .meta({ id: 'HrvStatsWithDelta' })
 
@@ -69,6 +72,11 @@ export const baselineDataSchema = z
       avg7day: z.number().nullable(),
       avg30day: z.number().nullable(),
       trend_percent: z.number().nullable(),
+    }),
+    stress: z.object({
+      avg7day: z.number().nullable(),
+      avg30day: z.number().nullable(),
+      trend_percent: z.number().nullable().meta({ description: 'Change from previous 30-day period' }),
     }),
   })
   .meta({ id: 'BaselineData' })
@@ -122,7 +130,10 @@ export type LocationCorrelation = z.infer<typeof locationCorrelationSchema>
 export const activityCorrelationSchema = hrvStatsWithDeltaSchema
   .extend({
     activity_type: z.string().meta({ description: 'Activity type' }),
-    avg_duration_min: z.number().optional().meta({ description: 'Average duration in minutes (undefined for point activities)' }),
+    avg_duration_min: z
+      .number()
+      .optional()
+      .meta({ description: 'Average duration in minutes (undefined for point activities)' }),
     occurrences: z.number().int().meta({ description: 'Number of occurrences' }),
   })
   .meta({ id: 'ActivityCorrelation' })
@@ -216,6 +227,13 @@ export const activityImpactDataSchema = z
       during: timeWindowStatsSchema,
     }),
     occurrences: z.number().int().meta({ description: 'Number of activity occurrences found' }),
+    stress_timeline: z.object({
+      after15min: timeWindowStatsSchema,
+      after30min: timeWindowStatsSchema,
+      before15min: timeWindowStatsSchema,
+      before30min: timeWindowStatsSchema,
+      during: timeWindowStatsSchema,
+    }),
   })
   .meta({ id: 'ActivityImpactData' })
 


### PR DESCRIPTION
## Summary
- Add stress_level to baseline computation and display (7/30-day avg + trend)
- Add Stress and Δ Stress columns to all correlation tables (activities, locations, productivity)
- Add stress_timeline to activity impact endpoint and render as amber line in the before/during/after chart
- Update api-spec schemas (BaselineData, ActivityImpactData) and backend result interfaces

## Test plan
- [x] Backend type checks pass (`pnpm check`)
- [x] All 1304 unit tests pass
- [x] Frontend type checks pass
- [ ] Verify stress baseline card shows on correlations page
- [ ] Verify Stress / Δ Stress columns appear in correlation tables
- [ ] Verify amber stress line appears in impact timeline chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)