### PR TITLE
Add unit tests for restore, audit-log, and deduction-trigger

### DIFF
--- a/apps/backend/src/services/audit-log.test.ts
+++ b/apps/backend/src/services/audit-log.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import * as db from '../db/index.ts'
+import { auditError, auditInfo, auditLog, auditWarn, getAuditLog, pruneAuditLog } from './audit-log.ts'
+
+vi.mock('../db', () => ({
+  cleanupAuditLog: vi.fn(),
+  insertAuditLog: vi.fn(),
+  queryAuditLog: vi.fn(),
+}))
+
+describe('auditLog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('inserts audit log entry', async () => {
+    vi.mocked(db.insertAuditLog).mockResolvedValue(undefined)
+
+    await auditLog('testuser', 'info', 'sync', 'Oura sync completed', { records: 42 })
+
+    expect(db.insertAuditLog).toHaveBeenCalledWith('testuser', 'info', 'sync', 'Oura sync completed', {
+      records: 42,
+    })
+  })
+
+  test('inserts without details', async () => {
+    vi.mocked(db.insertAuditLog).mockResolvedValue(undefined)
+
+    await auditLog('testuser', 'warn', 'data', 'Something happened')
+
+    expect(db.insertAuditLog).toHaveBeenCalledWith(
+      'testuser',
+      'warn',
+      'data',
+      'Something happened',
+      undefined,
+    )
+  })
+
+  test('swallows errors and logs to stderr', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(db.insertAuditLog).mockRejectedValue(new Error('DB connection failed'))
+
+    await auditLog('testuser', 'error', 'sync', 'Bad thing')
+
+    expect(consoleSpy).toHaveBeenCalledWith('⚠️ Failed to write audit log for testuser:', expect.any(Error))
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('convenience loggers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(db.insertAuditLog).mockResolvedValue(undefined)
+  })
+
+  test('auditInfo passes level=info', async () => {
+    await auditInfo('testuser', 'sync', 'Sync done')
+    expect(db.insertAuditLog).toHaveBeenCalledWith('testuser', 'info', 'sync', 'Sync done', undefined)
+  })
+
+  test('auditWarn passes level=warn', async () => {
+    await auditWarn('testuser', 'data', 'Rate limited', { retry_after: 60 })
+    expect(db.insertAuditLog).toHaveBeenCalledWith('testuser', 'warn', 'data', 'Rate limited', {
+      retry_after: 60,
+    })
+  })
+
+  test('auditError passes level=error', async () => {
+    await auditError('testuser', 'sync', 'Sync failed')
+    expect(db.insertAuditLog).toHaveBeenCalledWith('testuser', 'error', 'sync', 'Sync failed', undefined)
+  })
+})
+
+describe('getAuditLog', () => {
+  test('delegates to queryAuditLog with params', async () => {
+    const mockRows = [{ id: '1', level: 'info', message: 'test' }]
+    vi.mocked(db.queryAuditLog).mockResolvedValue(mockRows as never)
+
+    const result = await getAuditLog('testuser', { category: 'sync', limit: 10 })
+
+    expect(db.queryAuditLog).toHaveBeenCalledWith('testuser', { category: 'sync', limit: 10 })
+    expect(result).toBe(mockRows)
+  })
+
+  test('uses empty params by default', async () => {
+    vi.mocked(db.queryAuditLog).mockResolvedValue([] as never)
+
+    await getAuditLog('testuser')
+
+    expect(db.queryAuditLog).toHaveBeenCalledWith('testuser', {})
+  })
+})
+
+describe('pruneAuditLog', () => {
+  test('delegates to cleanupAuditLog', async () => {
+    vi.mocked(db.cleanupAuditLog).mockResolvedValue(5)
+
+    const result = await pruneAuditLog('testuser', 30)
+
+    expect(db.cleanupAuditLog).toHaveBeenCalledWith('testuser', 30)
+    expect(result).toBe(5)
+  })
+})

--- a/apps/backend/src/services/deduction-trigger.test.ts
+++ b/apps/backend/src/services/deduction-trigger.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createDeductionTrigger } from './deduction-trigger.ts'
+
+type DeductionTriggerDeps = Parameters<typeof createDeductionTrigger>[0]
+
+vi.mock('./audit-log', () => ({
+  auditError: vi.fn(),
+  auditInfo: vi.fn(),
+}))
+
+const d = (h: number, m = 0) =>
+  new Date(`2024-01-15T${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00Z`)
+
+const makeDeps = (overrides: Partial<DeductionTriggerDeps> = {}): DeductionTriggerDeps => ({
+  engineDeps: {
+    deleteStaleRuleActivities: vi.fn(),
+    getActivities: vi.fn(),
+    getScreentime: vi.fn(),
+    getTags: vi.fn(),
+    insertActivity: vi.fn(),
+    insertRuleRun: vi.fn(),
+  },
+  evaluateAllRules: vi.fn().mockResolvedValue({ activities_created: 0, rules_evaluated: 0 }),
+  getEnabledRules: vi.fn().mockResolvedValue([]),
+  ...overrides,
+})
+
+describe('createDeductionTrigger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('getPendingCount starts at 0', () => {
+    const trigger = createDeductionTrigger(makeDeps())
+    expect(trigger.getPendingCount()).toBe(0)
+  })
+
+  test('triggerEvaluation adds a pending evaluation', () => {
+    const trigger = createDeductionTrigger(makeDeps())
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+
+    expect(trigger.getPendingCount()).toBe(1)
+  })
+
+  test('tracks separate evaluations per user', () => {
+    const trigger = createDeductionTrigger(makeDeps())
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+    trigger.triggerEvaluation('user2', { end: d(14), start: d(13) })
+
+    expect(trigger.getPendingCount()).toBe(2)
+  })
+
+  test('debounces evaluation by 5 seconds', async () => {
+    const deps = makeDeps({
+      getEnabledRules: vi.fn().mockResolvedValue([{ id: 'r1' }]),
+    })
+    const trigger = createDeductionTrigger(deps)
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+
+    expect(deps.getEnabledRules).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(deps.getEnabledRules).toHaveBeenCalledWith('user1')
+    expect(trigger.getPendingCount()).toBe(0)
+  })
+
+  test('merges windows when debounced triggers overlap', async () => {
+    const deps = makeDeps({
+      getEnabledRules: vi.fn().mockResolvedValue([{ id: 'r1' }]),
+    })
+    const trigger = createDeductionTrigger(deps)
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+    // Second trigger before debounce expires — should merge windows
+    await vi.advanceTimersByTimeAsync(2000)
+    trigger.triggerEvaluation('user1', { end: d(15), start: d(11) })
+
+    // Still only 1 pending (same user)
+    expect(trigger.getPendingCount()).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    // evaluateAllRules should be called with the merged+buffered window
+    expect(deps.evaluateAllRules).toHaveBeenCalledWith(
+      'user1',
+      [{ id: 'r1' }],
+      {
+        // Merged: start=min(10,11)=10, end=max(12,15)=15, then ±1h buffer
+        end: new Date(d(15).getTime() + 60 * 60 * 1000),
+        start: new Date(d(10).getTime() - 60 * 60 * 1000),
+      },
+      deps.engineDeps,
+    )
+  })
+
+  test('skips evaluation when no enabled rules', async () => {
+    const deps = makeDeps({
+      getEnabledRules: vi.fn().mockResolvedValue([]),
+    })
+    const trigger = createDeductionTrigger(deps)
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(deps.evaluateAllRules).not.toHaveBeenCalled()
+  })
+
+  test('clearPending cancels all pending evaluations', async () => {
+    const deps = makeDeps({
+      getEnabledRules: vi.fn().mockResolvedValue([{ id: 'r1' }]),
+    })
+    const trigger = createDeductionTrigger(deps)
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+    trigger.triggerEvaluation('user2', { end: d(14), start: d(13) })
+
+    expect(trigger.getPendingCount()).toBe(2)
+
+    trigger.clearPending()
+
+    expect(trigger.getPendingCount()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(deps.getEnabledRules).not.toHaveBeenCalled()
+  })
+
+  test('handles evaluation errors gracefully', async () => {
+    const { auditError } = await import('./audit-log.ts')
+    const deps = makeDeps({
+      getEnabledRules: vi.fn().mockRejectedValue(new Error('DB down')),
+    })
+    const trigger = createDeductionTrigger(deps)
+
+    trigger.triggerEvaluation('user1', { end: d(12), start: d(10) })
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(auditError).toHaveBeenCalledWith('user1', 'deduction', 'Rule evaluation failed', {
+      error: 'Error: DB down',
+    })
+  })
+})

--- a/apps/backend/src/services/restore.test.ts
+++ b/apps/backend/src/services/restore.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import * as db from '../db/index.ts'
+import { deleteProductivity, restoreActivity, restoreProductivity } from './restore.ts'
+
+vi.mock('../db', () => ({
+  deleteProductivityRecord: vi.fn(),
+  restoreActivity: vi.fn(),
+  restoreProductivityRecord: vi.fn(),
+}))
+
+describe('restoreActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns success when activity is restored', async () => {
+    vi.mocked(db.restoreActivity).mockResolvedValue(true)
+
+    const result = await restoreActivity('testuser', 'activity-123')
+
+    expect(result).toEqual({ id: 'activity-123', restored: true, success: true })
+    expect(db.restoreActivity).toHaveBeenCalledWith('testuser', 'activity-123')
+  })
+
+  test('returns failure when activity not found', async () => {
+    vi.mocked(db.restoreActivity).mockResolvedValue(false)
+
+    const result = await restoreActivity('testuser', 'nonexistent')
+
+    expect(result).toEqual({ id: 'nonexistent', restored: false, success: false })
+  })
+})
+
+describe('restoreProductivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns success when record is restored', async () => {
+    vi.mocked(db.restoreProductivityRecord).mockResolvedValue(true)
+
+    const result = await restoreProductivity('testuser', 'prod-456')
+
+    expect(result).toEqual({ id: 'prod-456', restored: true, success: true })
+    expect(db.restoreProductivityRecord).toHaveBeenCalledWith('testuser', 'prod-456')
+  })
+
+  test('returns failure when record not found', async () => {
+    vi.mocked(db.restoreProductivityRecord).mockResolvedValue(false)
+
+    const result = await restoreProductivity('testuser', 'nonexistent')
+
+    expect(result).toEqual({ id: 'nonexistent', restored: false, success: false })
+  })
+})
+
+describe('deleteProductivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns success when record is deleted', async () => {
+    vi.mocked(db.deleteProductivityRecord).mockResolvedValue(true)
+
+    const result = await deleteProductivity('testuser', 'prod-789')
+
+    expect(result).toEqual({ deleted: true, id: 'prod-789', success: true })
+    expect(db.deleteProductivityRecord).toHaveBeenCalledWith('testuser', 'prod-789')
+  })
+
+  test('returns failure when record not found', async () => {
+    vi.mocked(db.deleteProductivityRecord).mockResolvedValue(false)
+
+    const result = await deleteProductivity('testuser', 'nonexistent')
+
+    expect(result).toEqual({ deleted: false, id: 'nonexistent', success: false })
+  })
+})


### PR DESCRIPTION
## Summary
- Add tests for `restore.ts` — restoreActivity, restoreProductivity, deleteProductivity (success + failure)
- Add tests for `audit-log.ts` — auditLog (including error swallowing), convenience loggers, getAuditLog, pruneAuditLog
- Add tests for `deduction-trigger.ts` — debouncing, window merging, per-user isolation, clearPending, skip-when-no-rules, error handling

23 new tests across 3 previously untested service files.

## Test plan
- [x] All 23 new tests pass locally
- [ ] CI coverage check passes (should increase coverage above baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)