### PR TITLE
fix: derive EntityType from api-spec to prevent runtime/type mismatch

### DIFF
--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -5,7 +5,19 @@ import type { QueryResultRow } from 'pg'
  *
  * Replaces inline `as Type` casts with validated type guards.
  */
-import { entityTypes, type ActivityType, type DataSource, type MetricType } from '@aurboda/api-spec'
+import {
+  confidenceSchema,
+  dataSourceSchema,
+  entityTypes,
+  geocodeStatusSchema,
+  lastFmMatchModeSchema,
+  lastFmMatchTypeSchema,
+  reportFlagSchema,
+  syncStatusSchema,
+  type ActivityType,
+  type DataSource,
+  type MetricType,
+} from '@aurboda/api-spec'
 
 import type {
   Activity,
@@ -31,29 +43,12 @@ import type {
 // Type Guards
 // ============================================================================
 
-const VALID_DATA_SOURCES = [
-  'activitywatch',
-  'aurboda',
-  'aurboda_gap_fill',
-  'deduction-rule',
-  'health_connect',
-  'health_connect_aggregate',
-  'lab_report',
-  'oura',
-  'garmin',
-  'rescuetime',
-  'owntracks',
-  'calendar',
-  'manual',
-  'lastfm',
-  'lastfm-auto',
-] as const
-
-const VALID_GEOCODE_STATUSES = ['pending', 'geocoding', 'success', 'failed'] as const
-const VALID_SYNC_STATUSES = ['idle', 'syncing', 'error', 'rate_limited'] as const
+const VALID_DATA_SOURCES = dataSourceSchema.options
+const VALID_GEOCODE_STATUSES = geocodeStatusSchema.options
+const VALID_SYNC_STATUSES = syncStatusSchema.options
 const VALID_ENTITY_TYPES = entityTypes
-const VALID_LASTFM_MATCH_TYPES = ['track', 'artist', 'track_artist'] as const
-const VALID_LASTFM_MATCH_MODES = ['exact', 'contains'] as const
+const VALID_LASTFM_MATCH_TYPES = lastFmMatchTypeSchema.options
+const VALID_LASTFM_MATCH_MODES = lastFmMatchModeSchema.options
 
 export const parseActivityType = (value: unknown): ActivityType => {
   if (typeof value === 'string' && /^[a-z][a-z0-9_]*$/.test(value)) {
@@ -224,8 +219,8 @@ export const mapMealRow = (row: QueryResultRow): Meal => ({
 // Report Row Mappers
 // ============================================================================
 
-const VALID_CONFIDENCES = ['measured', 'estimated', 'derived'] as const
-const VALID_REPORT_FLAGS = ['critical_low', 'low', 'normal', 'high', 'critical_high'] as const
+const VALID_CONFIDENCES = confidenceSchema.options
+const VALID_REPORT_FLAGS = reportFlagSchema.options
 
 const parseConfidence = (value: unknown): ReportConfidence | undefined => {
   if (typeof value === 'string' && (VALID_CONFIDENCES as readonly string[]).includes(value)) {

--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -1,10 +1,11 @@
+import type { QueryResultRow } from 'pg'
+
 /**
  * Row mapper functions for converting PostgreSQL rows to typed objects.
  *
  * Replaces inline `as Type` casts with validated type guards.
  */
-import type { ActivityType, DataSource, MetricType } from '@aurboda/api-spec'
-import type { QueryResultRow } from 'pg'
+import { entityTypes, type ActivityType, type DataSource, type MetricType } from '@aurboda/api-spec'
 
 import type {
   Activity,
@@ -50,7 +51,7 @@ const VALID_DATA_SOURCES = [
 
 const VALID_GEOCODE_STATUSES = ['pending', 'geocoding', 'success', 'failed'] as const
 const VALID_SYNC_STATUSES = ['idle', 'syncing', 'error', 'rate_limited'] as const
-const VALID_ENTITY_TYPES = ['activity', 'tag', 'productivity', 'metric'] as const
+const VALID_ENTITY_TYPES = entityTypes
 const VALID_LASTFM_MATCH_TYPES = ['track', 'artist', 'track_artist'] as const
 const VALID_LASTFM_MATCH_MODES = ['exact', 'contains'] as const
 

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -7,11 +7,17 @@
 import type {
   ActivityType,
   BiologicalSex,
+  Confidence,
   DashboardConfig,
   DataSource,
   EntityType,
   GarminDataType,
+  GeocodeStatus,
+  LastFmMatchMode,
+  LastFmMatchType,
   MetricType,
+  ReportFlag,
+  SyncStatus,
   TrainingLoadSettings,
 } from '@aurboda/api-spec'
 
@@ -140,7 +146,7 @@ export interface NamedLocationInput {
   radius?: number
 }
 
-export type GeocodeStatus = 'pending' | 'geocoding' | 'success' | 'failed'
+export type { GeocodeStatus }
 
 export interface DetectedLocation {
   id: string
@@ -271,8 +277,8 @@ export interface LabResult {
 // Reports (structured lab results)
 // ============================================================================
 
-export type ReportConfidence = 'measured' | 'estimated' | 'derived'
-export type ReportFlag = 'critical_low' | 'low' | 'normal' | 'high' | 'critical_high'
+export type ReportConfidence = Confidence
+export type { ReportFlag }
 
 export interface ReportEntry {
   id: string
@@ -382,7 +388,7 @@ export interface OAuthToken {
 // Sync State
 // ============================================================================
 
-export type SyncStatus = 'idle' | 'syncing' | 'error' | 'rate_limited'
+export type { SyncStatus }
 
 export interface SyncState {
   id?: string
@@ -439,8 +445,7 @@ export interface UserSettings {
 // Last.fm Tag Rules
 // ============================================================================
 
-export type LastFmMatchType = 'track' | 'artist' | 'track_artist'
-export type LastFmMatchMode = 'exact' | 'contains'
+export type { LastFmMatchType, LastFmMatchMode }
 
 export interface LastFmTagRule {
   id: string

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -9,6 +9,7 @@ import type {
   BiologicalSex,
   DashboardConfig,
   DataSource,
+  EntityType,
   GarminDataType,
   MetricType,
   TrainingLoadSettings,
@@ -231,7 +232,7 @@ export interface ScreentimeCategoryInput {
 // Notes
 // ============================================================================
 
-export type EntityType = 'activity' | 'tag' | 'productivity' | 'metric' | 'report'
+export type { EntityType }
 
 export interface Note {
   id: string

--- a/apps/backend/src/services/notes.ts
+++ b/apps/backend/src/services/notes.ts
@@ -6,8 +6,6 @@
  * inherited times since they reference a point in time already encoded in the entity_id.
  */
 
-import type { EntityType as ApiEntityType } from '@aurboda/api-spec'
-
 import {
   deleteNote as dbDeleteNote,
   getNotesForEntity as dbGetNotesForEntity,
@@ -30,7 +28,7 @@ export interface NoteResult {
   success: boolean
   data?: {
     id: string
-    entity_type: ApiEntityType
+    entity_type: EntityType
     entity_id: string
     content: string
     start_time?: string
@@ -127,8 +125,8 @@ export async function deleteNoteById(
   return { deleted, success: deleted }
 }
 
-export async function getNotesForEntity(user: string, entityType: ApiEntityType, entityId: string) {
-  const notes = await dbGetNotesForEntity(user, entityType as EntityType, entityId)
+export async function getNotesForEntity(user: string, entityType: EntityType, entityId: string) {
+  const notes = await dbGetNotesForEntity(user, entityType, entityId)
   return notes.map((n) => ({
     content: n.content,
     created_at: n.created_at.toISOString(),

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -424,7 +424,7 @@ export type HrZoneSource = z.infer<typeof hrZoneSourceSchema>
 /**
  * Sync status schema.
  */
-export const syncStatusSchema = z.enum(['idle', 'syncing', 'error']).meta({
+export const syncStatusSchema = z.enum(['idle', 'syncing', 'error', 'rate_limited']).meta({
   description: 'Status of sync operation',
   example: 'idle',
   id: 'SyncStatus',


### PR DESCRIPTION
## Summary

- `VALID_ENTITY_TYPES` in `row-mappers.ts` was a hardcoded array missing `'report'`, causing `Invalid EntityType: "report"` at runtime when adding notes to reports
- `EntityType` in `db/types.ts` was a manually duplicated union type matching api-spec but not enforced
- Now both derive from `@aurboda/api-spec`'s `entityTypes` array and `EntityType` type — single source of truth, compile-time safe
- Removed redundant `ApiEntityType` alias and unsafe cast in `services/notes.ts`

## Why it wasn't caught

The TypeScript type `EntityType` in `db/types.ts` included `'report'`, so all type checking passed. But the runtime validation array `VALID_ENTITY_TYPES` in `row-mappers.ts` was a separate copy that was never updated. This is exactly the kind of bug that happens when types and runtime checks are maintained independently.

## Test plan

- [ ] Add a note to a report via the UI — should work without error
- [ ] Add a note to an activity — verify no regression
- [ ] Verify `pnpm check` passes (existing unrelated errors in `activity-types-router.ts` remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)