### PR TITLE
refactor: API type safety and routing cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,49 @@ All field names use **snake_case** everywhere: schemas, REST API, MCP tools, DB 
 
 ### How each layer uses api-spec
 
-**REST API routers** (`apps/backend/src/routes/`) — import schemas for request validation:
+**REST API routers** (`apps/backend/src/routes/`) — use `typedRouter()` with fully typed route definitions:
 
 ```typescript
-import { addTagBodySchema, type AddTagBody } from '@aurboda/api-spec'
-// Use with validation middleware:
-router.post('/', authMiddleware, validateBody(addTagBodySchema), async (req, res) => { ... })
+import { type AddTagBody, addTagBodySchema, type TagResponse } from '@aurboda/api-spec'
+import { typedRouter } from '../typed-router.ts'
+
+const router = typedRouter()
+
+// All 4 generic params: <PathParams, ResponseBody, RequestBody, QueryParams>
+router.post<Record<string, never>, TagResponse, AddTagBody>(
+  '/',
+  authMiddleware,
+  validateBody(addTagBodySchema),
+  async (req, res) => {
+    // req.body is typed as AddTagBody, res.json() expects TagResponse
+  },
+)
+
+// Route with path params:
+router.get<{ id: string }, TagResponse>('/:id', authMiddleware, async (req, res) => { ... })
+
+// Route with query params (GET — no request body):
+router.get<Record<string, never>, TagsResponse, unknown, TagsQuery>(
+  '/',
+  authMiddleware,
+  validateQuery(tagsQuerySchema),
+  async (req, res) => { ... },
+)
+
+return router as unknown as Router
 ```
+
+**Routing conventions:**
+
+- Always use `typedRouter()` (never plain `Router()`)
+- Handlers are inline in the route definition (not separate `const handleX` functions)
+- `PathParams`: `Record<string, never>` for no params, `{ id: string }` for `/:id`. Never `Record<string, string>`.
+- `ResponseBody`: Must be an api-spec response type. Never `unknown`, `any`, or inline `{ success: boolean; data: unknown }`.
+- `RequestBody`: api-spec body type for POST/PUT/PATCH. `unknown` for GET/DELETE (no body).
+- `QueryParams`: api-spec query type when the route accepts query params.
+- No `as Type` casts on `req.body` — set the `ReqBody` generic instead.
+- No `// GET /path - description` comments above routes — the method and path are already visible in the code.
+- DB types with `Date` must be serialized to ISO strings before responding (use a serializer function at the boundary).
 
 **MCP tools** (`apps/backend/src/mcp/`) — use `.shape` to extract the flat field record that `server.tool()` expects:
 

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -351,11 +351,6 @@ const main = async () => {
     res.end(JSON.stringify({ is_admin: isAdmin, refresh: token, token }))
   })
 
-  httpd.post('/refresh', async (req, res) => {
-    const { refresh } = req.body
-    res.end(JSON.stringify({ refresh, token: refresh }))
-  })
-
   // Generate a fresh API token for the authenticated user (e.g. for push agents like ActivityWatch)
   httpd.get('/auth/token', authMiddleware, (req, res) => {
     const user = req.user!

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -4,7 +4,13 @@
  * Route handlers are split into focused modules under routes/.
  * This file handles: server setup, middleware, auth routes, and router mounting.
  */
-import type { LoginResponse, ServerStatusResponse, SignupResponse } from '@aurboda/api-spec'
+import type {
+  AuthTokenResponse,
+  LoginResponse,
+  ServerStatusResponse,
+  SignupResponse,
+  VersionResponse,
+} from '@aurboda/api-spec'
 
 import cors from 'cors'
 import express, { json, type RequestHandler } from 'express'
@@ -210,7 +216,7 @@ const main = async () => {
   // Auth routes (stay here - tightly coupled to server setup)
   // ==========================================================================
 
-  httpd.get('/version', (_req, res) => {
+  httpd.get<Record<string, never>, VersionResponse>('/version', (_req, res) => {
     res.json({
       build_sha: process.env.BUILD_SHA ?? 'dev',
       success: true,
@@ -352,7 +358,7 @@ const main = async () => {
   })
 
   // Generate a fresh API token for the authenticated user (e.g. for push agents like ActivityWatch)
-  httpd.get('/auth/token', authMiddleware, (req, res) => {
+  httpd.get<Record<string, never>, AuthTokenResponse>('/auth/token', authMiddleware, (req, res) => {
     const user = req.user!
     const token = auth.createToken(user)
     res.json({ success: true, token })

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -159,7 +159,7 @@ export const createActivitiesRouter = (
   const router = typedRouter()
 
   // GET /activities - Query activities for a time range
-  router.get<Record<string, string>, ActivitiesResponse, unknown, ActivitiesQuery>(
+  router.get<Record<string, never>, ActivitiesResponse, unknown, ActivitiesQuery>(
     '/activities',
     authMiddleware,
     validateQuery(activitiesQuerySchema),
@@ -177,7 +177,7 @@ export const createActivitiesRouter = (
 
   // POST /activities - Add a manual activity
 
-  router.post<Record<string, string>, AddActivityResponse, AddActivityBody>(
+  router.post<Record<string, never>, AddActivityResponse, AddActivityBody>(
     '/activities',
     authMiddleware,
     validateBody(addActivityBodySchema),
@@ -249,7 +249,7 @@ export const createActivitiesRouter = (
   })
 
   router.post<
-    Record<string, string>,
+    Record<string, never>,
     { success: boolean; data?: AddActivityResponse['data'] | AddActivityResponse['data'][]; error?: string }
   >('/activities/upload-fit', authMiddleware, upload.single('fit_file'), async (req, res) => {
     const user = req.user!
@@ -319,7 +319,7 @@ export const createActivitiesRouter = (
   })
 
   // POST /activities/merge - Merge multiple activities into one
-  router.post<Record<string, string>, MergeActivitiesResponse, MergeActivitiesBody>(
+  router.post<Record<string, never>, MergeActivitiesResponse, MergeActivitiesBody>(
     '/activities/merge',
     authMiddleware,
     validateBody(mergeActivitiesBodySchema),
@@ -525,7 +525,7 @@ export const createActivitiesRouter = (
   )
 
   // GET /productivity/bucketed - Get screentime bucketed by time and category
-  router.get<Record<string, string>, ScreentimeBucketedResponse, unknown, ScreentimeBucketedQuery>(
+  router.get<Record<string, never>, ScreentimeBucketedResponse, unknown, ScreentimeBucketedQuery>(
     '/productivity/bucketed',
     authMiddleware,
     validateQuery(screentimeBucketedQuerySchema),
@@ -548,7 +548,7 @@ export const createActivitiesRouter = (
   )
 
   // GET /productivity/apps - Get distinct app names with their categories
-  router.get<Record<string, string>, { success: boolean; data: unknown[] }>(
+  router.get<Record<string, never>, { success: boolean; data: unknown[] }>(
     '/productivity/apps',
     authMiddleware,
     async (req, res) => {
@@ -623,7 +623,7 @@ export const createActivitiesRouter = (
   )
 
   // GET /productivity - Query productivity data for a time range
-  router.get<Record<string, string>, ProductivityResponse, unknown, ProductivityQuery>(
+  router.get<Record<string, never>, ProductivityResponse, unknown, ProductivityQuery>(
     '/productivity',
     authMiddleware,
     validateQuery(productivityQuerySchema),

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -9,17 +9,22 @@ import {
   type ActivitiesQuery,
   activitiesQuerySchema,
   type ActivitiesResponse,
+  type ActivityDetailResponse,
   type AddActivityBody,
+  type HrZoneSecs,
   addActivityBodySchema,
   type AddActivityResponse,
   type DeleteActivityResponse,
+  type DistinctAppsResponse,
   getExerciseTypeValue,
   isValidExerciseType,
   type MergeActivitiesBody,
   mergeActivitiesBodySchema,
   type MergeActivitiesResponse,
+  type NearbyActivitiesResponse,
   type ProductivityQuery,
   productivityQuerySchema,
+  type ProductivityRecordResponse,
   type ProductivityResponse,
   type ScreentimeBucketedQuery,
   screentimeBucketedQuerySchema,
@@ -68,7 +73,7 @@ const computeExerciseMetrics = async (
   user: string,
   start: Date,
   end: Date,
-): Promise<{ hr_zone_secs?: Record<number, number>; avg_hrv?: number }> => {
+): Promise<{ hr_zone_secs?: HrZoneSecs; avg_hrv?: number }> => {
   const [hrData, { zones: hrZones }, hrvData] = await Promise.all([
     getTimeSeries(user, 'heart_rate', start, end),
     getEffectiveHrZones(user),
@@ -90,7 +95,7 @@ type ActivityRow = Awaited<ReturnType<typeof getActivityById>> & {}
 const buildMergedResponse = async (
   user: string,
   activity: NonNullable<ActivityRow>,
-  exerciseMetrics: { hr_zone_secs?: Record<number, number>; avg_hrv?: number },
+  exerciseMetrics: { hr_zone_secs?: HrZoneSecs; avg_hrv?: number },
 ) => {
   const overlapping = await getOverlappingActivities(user, activity)
   const hasMultipleSources = overlapping.length > 1
@@ -349,7 +354,7 @@ export const createActivitiesRouter = (
   )
 
   // GET /activities/:id/nearby - Get nearby same-type activities for merge suggestions
-  router.get<{ id: string }, { success: boolean; data: unknown[]; error?: string }>(
+  router.get<{ id: string }, NearbyActivitiesResponse>(
     '/activities/:id/nearby',
     authMiddleware,
     async (req, res) => {
@@ -460,52 +465,48 @@ export const createActivitiesRouter = (
 
   // GET /activities/:id - Get a single activity by ID (for detail page)
   // Supports merged: prefix — merged:<uuid> returns merged view, plain uuid returns raw activity
-  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
-    '/activities/:id',
-    authMiddleware,
-    async (req, res) => {
-      const rawId = req.params.id
-      const user = req.user!
+  router.get<{ id: string }, ActivityDetailResponse>('/activities/:id', authMiddleware, async (req, res) => {
+    const rawId = req.params.id
+    const user = req.user!
 
-      const isMerged = rawId.startsWith('merged:')
-      const realId = isMerged ? rawId.slice('merged:'.length) : rawId
+    const isMerged = rawId.startsWith('merged:')
+    const realId = isMerged ? rawId.slice('merged:'.length) : rawId
 
-      const activity = await getActivityById(user, realId, true)
-      if (!activity) {
-        return res.status(404).json({ error: 'Activity not found', success: false })
-      }
+    const activity = await getActivityById(user, realId, true)
+    if (!activity) {
+      return res.status(404).json({ error: 'Activity not found', success: false })
+    }
 
-      // Compute HR zones and avg HRV for exercise activities
-      let exerciseMetrics: { hr_zone_secs?: Record<number, number>; avg_hrv?: number } = {}
-      if (activity.activity_type === 'exercise' && activity.end_time) {
-        exerciseMetrics = await computeExerciseMetrics(user, activity.start_time, activity.end_time)
-      }
+    // Compute HR zones and avg HRV for exercise activities
+    let exerciseMetrics: { hr_zone_secs?: HrZoneSecs; avg_hrv?: number } = {}
+    if (activity.activity_type === 'exercise' && activity.end_time) {
+      exerciseMetrics = await computeExerciseMetrics(user, activity.start_time, activity.end_time)
+    }
 
-      // For merged: prefix, fetch overlapping activities and return merged view
-      if (isMerged && !activity.deleted_at) {
-        const data = await buildMergedResponse(user, activity, exerciseMetrics)
-        return res.json({ data, success: true })
-      }
+    // For merged: prefix, fetch overlapping activities and return merged view
+    if (isMerged && !activity.deleted_at) {
+      const data = await buildMergedResponse(user, activity, exerciseMetrics)
+      return res.json({ data, success: true })
+    }
 
-      // Plain UUID: return raw single activity (no overlap lookup)
-      res.json({
-        data: {
-          activity_type: activity.activity_type,
-          avg_hrv: exerciseMetrics.avg_hrv,
-          data: activity.data,
-          deleted_at: activity.deleted_at?.toISOString(),
-          end_time: activity.end_time?.toISOString(),
-          hr_zone_secs: exerciseMetrics.hr_zone_secs,
-          id: activity.id,
-          notes: activity.notes,
-          source: activity.source,
-          start_time: activity.start_time.toISOString(),
-          title: activity.title,
-        },
-        success: true,
-      })
-    },
-  )
+    // Plain UUID: return raw single activity (no overlap lookup)
+    res.json({
+      data: {
+        activity_type: activity.activity_type,
+        avg_hrv: exerciseMetrics.avg_hrv,
+        data: activity.data,
+        deleted_at: activity.deleted_at?.toISOString(),
+        end_time: activity.end_time?.toISOString(),
+        hr_zone_secs: exerciseMetrics.hr_zone_secs,
+        id: activity.id,
+        notes: activity.notes,
+        source: activity.source,
+        start_time: activity.start_time.toISOString(),
+        title: activity.title,
+      },
+      success: true,
+    })
+  })
 
   // POST /activities/:id/restore - Restore a soft-deleted activity
   router.post<{ id: string }, { success: boolean; error?: string }>(
@@ -548,18 +549,21 @@ export const createActivitiesRouter = (
   )
 
   // GET /productivity/apps - Get distinct app names with their categories
-  router.get<Record<string, never>, { success: boolean; data: unknown[] }>(
+  router.get<Record<string, never>, DistinctAppsResponse>(
     '/productivity/apps',
     authMiddleware,
     async (req, res) => {
       const user = req.user!
       const apps = await getDistinctApps(user)
-      res.json({ data: apps, success: true })
+      res.json({
+        data: apps.map((a) => ({ ...a, last_seen: a.last_seen.toISOString() })),
+        success: true,
+      })
     },
   )
 
   // GET /productivity/:id - Get a single productivity record by ID
-  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+  router.get<{ id: string }, ProductivityRecordResponse>(
     '/productivity/:id',
     authMiddleware,
     async (req, res) => {

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -163,7 +163,6 @@ export const createActivitiesRouter = (
 ): Router => {
   const router = typedRouter()
 
-  // GET /activities - Query activities for a time range
   router.get<Record<string, never>, ActivitiesResponse, unknown, ActivitiesQuery>(
     '/activities',
     authMiddleware,
@@ -179,8 +178,6 @@ export const createActivitiesRouter = (
       res.json({ data: activities, success: true })
     },
   )
-
-  // POST /activities - Add a manual activity
 
   router.post<Record<string, never>, AddActivityResponse, AddActivityBody>(
     '/activities',
@@ -245,8 +242,6 @@ export const createActivitiesRouter = (
       })
     },
   )
-
-  // POST /activities/upload-fit - Import activities from a FIT file
 
   const upload = multer({
     limits: { fileSize: 10 * 1024 * 1024 },
@@ -323,7 +318,6 @@ export const createActivitiesRouter = (
     }
   })
 
-  // POST /activities/merge - Merge multiple activities into one
   router.post<Record<string, never>, MergeActivitiesResponse, MergeActivitiesBody>(
     '/activities/merge',
     authMiddleware,
@@ -353,7 +347,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // GET /activities/:id/nearby - Get nearby same-type activities for merge suggestions
   router.get<{ id: string }, NearbyActivitiesResponse>(
     '/activities/:id/nearby',
     authMiddleware,
@@ -392,7 +385,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // DELETE /activities/:id - Delete an activity by ID
   router.delete<{ id: string }, DeleteActivityResponse>(
     '/activities/:id',
     authMiddleware,
@@ -410,7 +402,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // PATCH /activities/:id - Update an activity by ID
   router.patch<{ id: string }, UpdateActivityResponse, UpdateActivityBody>(
     '/activities/:id',
     authMiddleware,
@@ -463,8 +454,7 @@ export const createActivitiesRouter = (
     },
   )
 
-  // GET /activities/:id - Get a single activity by ID (for detail page)
-  // Supports merged: prefix — merged:<uuid> returns merged view, plain uuid returns raw activity
+  // Supports merged: prefix -- merged:<uuid> returns merged view, plain uuid returns raw activity
   router.get<{ id: string }, ActivityDetailResponse>('/activities/:id', authMiddleware, async (req, res) => {
     const rawId = req.params.id
     const user = req.user!
@@ -508,7 +498,6 @@ export const createActivitiesRouter = (
     })
   })
 
-  // POST /activities/:id/restore - Restore a soft-deleted activity
   router.post<{ id: string }, { success: boolean; error?: string }>(
     '/activities/:id/restore',
     authMiddleware,
@@ -525,7 +514,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // GET /productivity/bucketed - Get screentime bucketed by time and category
   router.get<Record<string, never>, ScreentimeBucketedResponse, unknown, ScreentimeBucketedQuery>(
     '/productivity/bucketed',
     authMiddleware,
@@ -548,7 +536,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // GET /productivity/apps - Get distinct app names with their categories
   router.get<Record<string, never>, DistinctAppsResponse>(
     '/productivity/apps',
     authMiddleware,
@@ -562,7 +549,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // GET /productivity/:id - Get a single productivity record by ID
   router.get<{ id: string }, ProductivityRecordResponse>(
     '/productivity/:id',
     authMiddleware,
@@ -592,7 +578,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // DELETE /productivity/:id - Soft-delete a productivity record
   router.delete<{ id: string }, { success: boolean; error?: string }>(
     '/productivity/:id',
     authMiddleware,
@@ -609,7 +594,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // POST /productivity/:id/restore - Restore a soft-deleted productivity record
   router.post<{ id: string }, { success: boolean; error?: string }>(
     '/productivity/:id/restore',
     authMiddleware,
@@ -626,7 +610,6 @@ export const createActivitiesRouter = (
     },
   )
 
-  // GET /productivity - Query productivity data for a time range
   router.get<Record<string, never>, ProductivityResponse, unknown, ProductivityQuery>(
     '/productivity',
     authMiddleware,

--- a/apps/backend/src/routes/activity-types-router.ts
+++ b/apps/backend/src/routes/activity-types-router.ts
@@ -34,7 +34,6 @@ import { validateBody } from '../validation.ts'
 export const createActivityTypesRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET / - List all activity type definitions
   router.get<Record<string, never>, ActivityTypeDefinitionsResponse>(
     '/',
     authMiddleware,
@@ -45,7 +44,6 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
     },
   )
 
-  // POST / - Create a custom activity type
   router.post<Record<string, never>, ActivityTypeDefinitionResponse, AddActivityTypeDefinitionBody>(
     '/',
     authMiddleware,
@@ -69,7 +67,6 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
     },
   )
 
-  // POST /merge - Merge a custom activity type into another
   router.post<Record<string, never>, MergeActivityTypeResponse, MergeActivityTypeBody>(
     '/merge',
     authMiddleware,
@@ -86,7 +83,6 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
     },
   )
 
-  // POST /:name/rename - Rename a custom activity type
   router.post<{ name: string }, RenameActivityTypeResponse, RenameActivityTypeBody>(
     '/:name/rename',
     authMiddleware,
@@ -111,7 +107,6 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
     },
   )
 
-  // PATCH /:name - Update an activity type definition
   router.patch<{ name: string }, ActivityTypeDefinitionResponse, UpdateActivityTypeDefinitionBody>(
     '/:name',
     authMiddleware,
@@ -130,7 +125,6 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
     },
   )
 
-  // DELETE /:name - Delete a custom activity type
   router.delete<{ name: string }, ActivityTypeDefinitionResponse>(
     '/:name',
     authMiddleware,

--- a/apps/backend/src/routes/activity-types-router.ts
+++ b/apps/backend/src/routes/activity-types-router.ts
@@ -35,7 +35,7 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
   const router = typedRouter()
 
   // GET / - List all activity type definitions
-  router.get<Record<string, string>, ActivityTypeDefinitionsResponse>(
+  router.get<Record<string, never>, ActivityTypeDefinitionsResponse>(
     '/',
     authMiddleware,
     async (req, res) => {
@@ -46,7 +46,7 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
   )
 
   // POST / - Create a custom activity type
-  router.post<Record<string, string>, ActivityTypeDefinitionResponse, AddActivityTypeDefinitionBody>(
+  router.post<Record<string, never>, ActivityTypeDefinitionResponse, AddActivityTypeDefinitionBody>(
     '/',
     authMiddleware,
     validateBody(addActivityTypeDefinitionBodySchema),
@@ -70,7 +70,7 @@ export const createActivityTypesRouter = (authMiddleware: RequestHandler): Route
   )
 
   // POST /merge - Merge a custom activity type into another
-  router.post<Record<string, string>, MergeActivityTypeResponse, MergeActivityTypeBody>(
+  router.post<Record<string, never>, MergeActivityTypeResponse, MergeActivityTypeBody>(
     '/merge',
     authMiddleware,
     validateBody(mergeActivityTypeBodySchema),

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Admin route group.
  *
@@ -11,12 +13,12 @@ import {
   type UpdateAdminSettingsBody,
   updateAdminSettingsBodySchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import type { CentralDb } from '../services/central-db.ts'
 import type { InvitationAuth } from '../services/invitation.ts'
 import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
 
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createAdminRouter = (
@@ -27,9 +29,7 @@ export const createAdminRouter = (
   webHost: string,
   ouraWebhookManager?: OuraWebhookManager | null,
 ): Router => {
-  const router = Router()
-
-  // GET /admin/settings - Get admin settings
+  const router = typedRouter()
   router.get<Record<string, never>, AdminSettingsResponse>(
     '/settings',
     authMiddleware,
@@ -116,5 +116,5 @@ export const createAdminRouter = (
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -52,7 +52,6 @@ export const createAdminRouter = (
     },
   )
 
-  // PATCH /admin/settings - Update admin settings
   router.patch<Record<string, never>, AdminSettingsResponse, UpdateAdminSettingsBody>(
     '/settings',
     authMiddleware,
@@ -96,7 +95,6 @@ export const createAdminRouter = (
     },
   )
 
-  // POST /admin/invitations - Create a new invitation
   router.post<Record<string, never>, InvitationResponse, CreateInvitationBody>(
     '/invitations',
     authMiddleware,

--- a/apps/backend/src/routes/audit-log-router.ts
+++ b/apps/backend/src/routes/audit-log-router.ts
@@ -1,18 +1,19 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Audit log route group.
  *
  * Handles: /user/audit-log
  */
-import { auditLogQuerySchema } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
+import { type AuditLogResponse, auditLogQuerySchema } from '@aurboda/api-spec'
 
 import { getAuditLog } from '../services/audit-log.ts'
+import { typedRouter } from '../typed-router.ts'
 
 export const createAuditLogRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
-  // GET /user/audit-log - Get audit log entries
-  router.get('/user/audit-log', authMiddleware, async (req, res) => {
+  router.get<Record<string, never>, AuditLogResponse>('/user/audit-log', authMiddleware, async (req, res) => {
     const parsed = auditLogQuerySchema.safeParse(req.query)
     if (!parsed.success) {
       res.status(400).json({ data: [], error: 'Invalid query parameters', success: false, total: 0 })
@@ -42,5 +43,5 @@ export const createAuditLogRouter = (authMiddleware: RequestHandler): Router => 
     })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -15,7 +15,7 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
   const router = typedRouter()
 
   // GET /chart-data — bucketed aggregation for bar charts
-  router.get<Record<string, string>, ChartDataResponse, unknown, ChartDataHttpQuery>(
+  router.get<Record<string, never>, ChartDataResponse, unknown, ChartDataHttpQuery>(
     '/',
     authMiddleware,
     validateQuery(chartDataHttpQuerySchema),

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -14,7 +14,6 @@ import { validateQuery } from '../validation.ts'
 export const createChartDataRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET /chart-data — bucketed aggregation for bar charts
   router.get<Record<string, never>, ChartDataResponse, unknown, ChartDataHttpQuery>(
     '/',
     authMiddleware,

--- a/apps/backend/src/routes/correlations-router.ts
+++ b/apps/backend/src/routes/correlations-router.ts
@@ -41,7 +41,6 @@ export const createCorrelationsRouter = (
 ): Router => {
   const router = typedRouter()
 
-  // GET /correlations/baseline - Get HRV baseline statistics
   router.get<Record<string, never>, BaselineResponse, unknown, BaselineQuery>(
     '/baseline',
     authMiddleware,
@@ -56,7 +55,6 @@ export const createCorrelationsRouter = (
     },
   )
 
-  // GET /correlations/hrv-activities - Get HRV correlations with activities
   router.get<Record<string, never>, HrvActivitiesResponse, unknown, HrvActivitiesQuery>(
     '/hrv-activities',
     authMiddleware,
@@ -71,7 +69,6 @@ export const createCorrelationsRouter = (
     },
   )
 
-  // GET /correlations/activity-impact/:activity - Get activity impact on metrics
   router.get<{ activity: string }, ActivityImpactResponse, unknown, ActivityImpactQuery>(
     '/activity-impact/:activity',
     authMiddleware,
@@ -96,7 +93,6 @@ export const createCorrelationsRouter = (
     },
   )
 
-  // POST /correlations/event-probability - Get event probability correlation
   router.post<Record<string, never>, EventProbabilityResponse, EventProbabilityBody>(
     '/event-probability',
     authMiddleware,
@@ -117,7 +113,6 @@ export const createCorrelationsRouter = (
     },
   )
 
-  // POST /correlations/generic - Generic correlation analysis
   router.post<Record<string, never>, GenericCorrelationResponse, GenericCorrelationBody>(
     '/generic',
     authMiddleware,

--- a/apps/backend/src/routes/correlations-router.ts
+++ b/apps/backend/src/routes/correlations-router.ts
@@ -42,7 +42,7 @@ export const createCorrelationsRouter = (
   const router = typedRouter()
 
   // GET /correlations/baseline - Get HRV baseline statistics
-  router.get<Record<string, string>, BaselineResponse, unknown, BaselineQuery>(
+  router.get<Record<string, never>, BaselineResponse, unknown, BaselineQuery>(
     '/baseline',
     authMiddleware,
     validateQuery(baselineQuerySchema),
@@ -57,7 +57,7 @@ export const createCorrelationsRouter = (
   )
 
   // GET /correlations/hrv-activities - Get HRV correlations with activities
-  router.get<Record<string, string>, HrvActivitiesResponse, unknown, HrvActivitiesQuery>(
+  router.get<Record<string, never>, HrvActivitiesResponse, unknown, HrvActivitiesQuery>(
     '/hrv-activities',
     authMiddleware,
     validateQuery(hrvActivitiesQuerySchema),
@@ -97,7 +97,7 @@ export const createCorrelationsRouter = (
   )
 
   // POST /correlations/event-probability - Get event probability correlation
-  router.post<Record<string, string>, EventProbabilityResponse, EventProbabilityBody>(
+  router.post<Record<string, never>, EventProbabilityResponse, EventProbabilityBody>(
     '/event-probability',
     authMiddleware,
     validateBody(eventProbabilityBodySchema),
@@ -118,7 +118,7 @@ export const createCorrelationsRouter = (
   )
 
   // POST /correlations/generic - Generic correlation analysis
-  router.post<Record<string, string>, GenericCorrelationResponse, GenericCorrelationBody>(
+  router.post<Record<string, never>, GenericCorrelationResponse, GenericCorrelationBody>(
     '/generic',
     authMiddleware,
     validateBody(genericCorrelationBodySchema),

--- a/apps/backend/src/routes/dashboard-router.ts
+++ b/apps/backend/src/routes/dashboard-router.ts
@@ -25,7 +25,6 @@ export const createDashboardRouter = (authMiddleware: RequestHandler): Router =>
     res.json({ dashboard, success: true })
   })
 
-  // PUT /dashboard - Replace entire dashboard configuration
   router.put<Record<string, never>, DashboardResponse, UpdateDashboardInput>(
     '/',
     authMiddleware,
@@ -37,7 +36,6 @@ export const createDashboardRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // POST /dashboard/reset - Reset dashboard to default configuration
   router.post<Record<string, never>, DashboardResponse>('/reset', authMiddleware, async (req, res) => {
     const user = req.user!
     await upsertUserSettings(user, { dashboard: undefined })

--- a/apps/backend/src/routes/dashboard-router.ts
+++ b/apps/backend/src/routes/dashboard-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Dashboard route group.
  *
@@ -9,16 +11,14 @@ import {
   type UpdateDashboardInput,
   updateDashboardInputSchema,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { upsertUserSettings } from '../db/index.ts'
 import { getSettings } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createDashboardRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
-
-  // GET /dashboard - Get user's dashboard configuration
+  const router = typedRouter()
   router.get<Record<string, never>, DashboardResponse>('/', authMiddleware, async (req, res) => {
     const settings = await getSettings(req.user!)
     const dashboard = settings.dashboard ?? defaultDashboardConfig
@@ -44,5 +44,5 @@ export const createDashboardRouter = (authMiddleware: RequestHandler): Router =>
     res.json({ dashboard: defaultDashboardConfig, success: true })
   })
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/deduction-rules-router.ts
+++ b/apps/backend/src/routes/deduction-rules-router.ts
@@ -36,14 +36,12 @@ export const createDeductionRulesRouter = (
 ): Router => {
   const router = typedRouter()
 
-  // GET / - List all deduction rules
   router.get<Record<string, never>, DeductionRulesResponse>('/', authMiddleware, async (req, res) => {
     const user = req.user!
     const rules = await getDeductionRules(user)
     res.json({ data: rules, success: true })
   })
 
-  // POST / - Create a deduction rule
   router.post<Record<string, never>, DeductionRuleResponse, AddDeductionRuleBody>(
     '/',
     authMiddleware,
@@ -81,7 +79,6 @@ export const createDeductionRulesRouter = (
     },
   )
 
-  // PATCH /:id - Update a deduction rule
   router.patch<{ id: string }, DeductionRuleResponse, UpdateDeductionRuleBody>(
     '/:id',
     authMiddleware,
@@ -115,7 +112,6 @@ export const createDeductionRulesRouter = (
     },
   )
 
-  // DELETE /:id - Delete a deduction rule
   router.delete<{ id: string }, DeductionRuleResponse>('/:id', authMiddleware, async (req, res) => {
     const { id } = req.params
     const user = req.user!
@@ -131,7 +127,6 @@ export const createDeductionRulesRouter = (
     res.json({ success: true })
   })
 
-  // POST /evaluate - Manually trigger rule evaluation
   router.post<Record<string, never>, EvaluateDeductionRulesResponse>(
     '/evaluate',
     authMiddleware,

--- a/apps/backend/src/routes/deduction-rules-router.ts
+++ b/apps/backend/src/routes/deduction-rules-router.ts
@@ -37,14 +37,14 @@ export const createDeductionRulesRouter = (
   const router = typedRouter()
 
   // GET / - List all deduction rules
-  router.get<Record<string, string>, DeductionRulesResponse>('/', authMiddleware, async (req, res) => {
+  router.get<Record<string, never>, DeductionRulesResponse>('/', authMiddleware, async (req, res) => {
     const user = req.user!
     const rules = await getDeductionRules(user)
     res.json({ data: rules, success: true })
   })
 
   // POST / - Create a deduction rule
-  router.post<Record<string, string>, DeductionRuleResponse, AddDeductionRuleBody>(
+  router.post<Record<string, never>, DeductionRuleResponse, AddDeductionRuleBody>(
     '/',
     authMiddleware,
     validateBody(addDeductionRuleBodySchema),
@@ -132,7 +132,7 @@ export const createDeductionRulesRouter = (
   })
 
   // POST /evaluate - Manually trigger rule evaluation
-  router.post<Record<string, string>, EvaluateDeductionRulesResponse>(
+  router.post<Record<string, never>, EvaluateDeductionRulesResponse>(
     '/evaluate',
     authMiddleware,
     async (req, res) => {

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -4,59 +4,92 @@
  * CRUD + search for canonical food item library.
  */
 
-import { addFoodItemBodySchema, foodItemsQuerySchema, updateFoodItemBodySchema } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
+import type { RequestHandler, Router } from 'express'
+
+import {
+  type AddFoodItemBody,
+  addFoodItemBodySchema,
+  type DeleteFoodItemResponse,
+  type FoodItemEntity,
+  type FoodItemResponse,
+  type FoodItemsQuery,
+  type FoodItemsResponse,
+  foodItemsQuerySchema,
+  type UpdateFoodItemBody,
+  updateFoodItemBodySchema,
+} from '@aurboda/api-spec'
 
 import {
   deleteFoodItem,
+  type FoodItemEntity as DbFoodItemEntity,
   getFoodItemById,
   listFoodItems,
   searchFoodItems,
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
-const handleSearch: RequestHandler = async (req, res) => {
-  const { q, limit } = req.query as Record<string, string | undefined>
-  const user = req.user!
-  const maxResults = limit ? parseInt(limit, 10) : 20
-
-  const items = q ? await searchFoodItems(user, q, maxResults) : await listFoodItems(user, maxResults)
-  res.json({ data: items, success: true })
-}
-
-const handleGetById: RequestHandler<{ id: string }> = async (req, res) => {
-  const item = await getFoodItemById(req.user!, req.params.id)
-  if (!item) return res.status(404).json({ error: 'Food item not found', success: false })
-  res.json({ data: item, success: true })
-}
-
-const handleCreate: RequestHandler = async (req, res) => {
-  const item = await upsertFoodItem(req.user!, req.body)
-  res.json({ data: item, success: true })
-}
-
-const handleUpdate: RequestHandler<{ id: string }> = async (req, res) => {
-  const item = await updateFoodItem(req.user!, req.params.id, req.body)
-  if (!item) return res.status(404).json({ error: 'Food item not found', success: false })
-  res.json({ data: item, success: true })
-}
-
-const handleDelete: RequestHandler<{ id: string }> = async (req, res) => {
-  const deleted = await deleteFoodItem(req.user!, req.params.id)
-  if (!deleted) return res.status(404).json({ error: 'Food item not found', success: false })
-  res.json({ success: true })
+/** Serialize a DB food item entity (Date timestamps) to API format (ISO strings). */
+const serializeFoodItem = (item: DbFoodItemEntity): FoodItemEntity => {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(item)) {
+    if (key === 'name_lower') continue
+    result[key] = value instanceof Date ? value.toISOString() : value
+  }
+  return result as FoodItemEntity
 }
 
 export const createFoodItemsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
-  router.get('/', authMiddleware, validateQuery(foodItemsQuerySchema), handleSearch)
-  router.get('/:id', authMiddleware, handleGetById)
-  router.post('/', authMiddleware, validateBody(addFoodItemBodySchema), handleCreate)
-  router.patch('/:id', authMiddleware, validateBody(updateFoodItemBodySchema), handleUpdate)
-  router.delete('/:id', authMiddleware, handleDelete)
+  router.get<Record<string, never>, FoodItemsResponse, unknown, FoodItemsQuery>(
+    '/',
+    authMiddleware,
+    validateQuery(foodItemsQuerySchema),
+    async (req, res) => {
+      const { q, limit } = req.query
+      const user = req.user!
+      const maxResults = limit ? parseInt(limit, 10) : 20
 
-  return router
+      const items = q ? await searchFoodItems(user, q, maxResults) : await listFoodItems(user, maxResults)
+      res.json({ data: items.map(serializeFoodItem), success: true })
+    },
+  )
+
+  router.get<{ id: string }, FoodItemResponse>('/:id', authMiddleware, async (req, res) => {
+    const item = await getFoodItemById(req.user!, req.params.id)
+    if (!item) return res.status(404).json({ error: 'Food item not found', success: false })
+    res.json({ data: serializeFoodItem(item), success: true })
+  })
+
+  router.post<Record<string, never>, FoodItemResponse, AddFoodItemBody>(
+    '/',
+    authMiddleware,
+    validateBody(addFoodItemBodySchema),
+    async (req, res) => {
+      const item = await upsertFoodItem(req.user!, req.body)
+      res.json({ data: serializeFoodItem(item), success: true })
+    },
+  )
+
+  router.patch<{ id: string }, FoodItemResponse, UpdateFoodItemBody>(
+    '/:id',
+    authMiddleware,
+    validateBody(updateFoodItemBodySchema),
+    async (req, res) => {
+      const item = await updateFoodItem(req.user!, req.params.id, req.body)
+      if (!item) return res.status(404).json({ error: 'Food item not found', success: false })
+      res.json({ data: serializeFoodItem(item), success: true })
+    },
+  )
+
+  router.delete<{ id: string }, DeleteFoodItemResponse>('/:id', authMiddleware, async (req, res) => {
+    const deleted = await deleteFoodItem(req.user!, req.params.id)
+    if (!deleted) return res.status(404).json({ error: 'Food item not found', success: false })
+    res.json({ success: true })
+  })
+
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/icons-router.ts
+++ b/apps/backend/src/routes/icons-router.ts
@@ -48,7 +48,7 @@ export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
   )
 
   // POST /icons — upload an icon
-  router.post<Record<string, string>, { success: boolean; id?: string; url?: string; error?: string }>(
+  router.post<Record<string, never>, { success: boolean; id?: string; url?: string; error?: string }>(
     '/',
     authMiddleware,
     upload.single('icon'),

--- a/apps/backend/src/routes/icons-router.ts
+++ b/apps/backend/src/routes/icons-router.ts
@@ -25,7 +25,6 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET /icons/:user/:id — serve icon (no auth, for <img src>)
   router.get<{ user: string; id: string }, { error: string; success: boolean } | Buffer>(
     '/:user/:id',
     async (req, res) => {
@@ -47,7 +46,6 @@ export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // POST /icons — upload an icon
   router.post<Record<string, never>, { success: boolean; id?: string; url?: string; error?: string }>(
     '/',
     authMiddleware,
@@ -79,7 +77,6 @@ export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // DELETE /icons/:id — delete an icon
   router.delete<{ id: string }, { success: boolean; error?: string }>(
     '/:id',
     authMiddleware,

--- a/apps/backend/src/routes/locations-router.ts
+++ b/apps/backend/src/routes/locations-router.ts
@@ -37,7 +37,6 @@ import { validateBody, validateQuery } from '../validation.ts'
 export const createLocationsRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET /locations - Query location data for a time range
   router.get<Record<string, never>, LocationsResponse, unknown, LocationsQuery>(
     '/',
     authMiddleware,
@@ -51,13 +50,11 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // GET /locations/named - List all named locations
   router.get<Record<string, never>, NamedLocationsResponse>('/named', authMiddleware, async (req, res) => {
     const locations = await getNamedLocations(req.user!)
     res.json({ data: locations, success: true })
   })
 
-  // POST /locations/named - Create a named location
   router.post<Record<string, never>, AddNamedLocationResponse, AddNamedLocationBody>(
     '/named',
     authMiddleware,
@@ -71,7 +68,6 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // PATCH /locations/named/:id - Update a named location
   router.patch<{ id: string }, AddNamedLocationResponse, UpdateNamedLocationBody>(
     '/named/:id',
     authMiddleware,
@@ -94,7 +90,6 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // DELETE /locations/named/:id - Delete a named location
   router.delete<{ id: string }, { success: boolean; error?: string }>(
     '/named/:id',
     authMiddleware,
@@ -108,7 +103,6 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // GET /locations/detected - Get computed detected location clusters
   router.get<Record<string, never>, DetectedLocationsResponse, unknown, DetectedLocationsQuery>(
     '/detected',
     authMiddleware,
@@ -135,7 +129,6 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // GET /locations/detected/stored - Get stored detected locations with addresses
   router.get<Record<string, never>, DetectedLocationsResponse>(
     '/detected/stored',
     authMiddleware,
@@ -152,7 +145,6 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
     },
   )
 
-  // POST /locations/detected/promote - Promote detected location to named
   router.post<Record<string, never>, AddNamedLocationResponse, PromoteDetectedLocationBody>(
     '/detected/promote',
     authMiddleware,

--- a/apps/backend/src/routes/locations-router.ts
+++ b/apps/backend/src/routes/locations-router.ts
@@ -38,7 +38,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   const router = typedRouter()
 
   // GET /locations - Query location data for a time range
-  router.get<Record<string, string>, LocationsResponse, unknown, LocationsQuery>(
+  router.get<Record<string, never>, LocationsResponse, unknown, LocationsQuery>(
     '/',
     authMiddleware,
     validateQuery(locationsQuerySchema),
@@ -52,13 +52,13 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // GET /locations/named - List all named locations
-  router.get<Record<string, string>, NamedLocationsResponse>('/named', authMiddleware, async (req, res) => {
+  router.get<Record<string, never>, NamedLocationsResponse>('/named', authMiddleware, async (req, res) => {
     const locations = await getNamedLocations(req.user!)
     res.json({ data: locations, success: true })
   })
 
   // POST /locations/named - Create a named location
-  router.post<Record<string, string>, AddNamedLocationResponse, AddNamedLocationBody>(
+  router.post<Record<string, never>, AddNamedLocationResponse, AddNamedLocationBody>(
     '/named',
     authMiddleware,
     validateBody(addNamedLocationBodySchema),
@@ -109,7 +109,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // GET /locations/detected - Get computed detected location clusters
-  router.get<Record<string, string>, DetectedLocationsResponse, unknown, DetectedLocationsQuery>(
+  router.get<Record<string, never>, DetectedLocationsResponse, unknown, DetectedLocationsQuery>(
     '/detected',
     authMiddleware,
     validateQuery(detectedLocationsQuerySchema),
@@ -136,7 +136,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // GET /locations/detected/stored - Get stored detected locations with addresses
-  router.get<Record<string, string>, DetectedLocationsResponse>(
+  router.get<Record<string, never>, DetectedLocationsResponse>(
     '/detected/stored',
     authMiddleware,
     async (req, res) => {
@@ -153,7 +153,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
   )
 
   // POST /locations/detected/promote - Promote detected location to named
-  router.post<Record<string, string>, AddNamedLocationResponse, PromoteDetectedLocationBody>(
+  router.post<Record<string, never>, AddNamedLocationResponse, PromoteDetectedLocationBody>(
     '/detected/promote',
     authMiddleware,
     validateBody(promoteDetectedLocationBodySchema),

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -1,13 +1,25 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Meals route group.
  *
  * Handles: /meals/*
  */
-import { addMealBodySchema, mealsQuerySchema, updateMealBodySchema } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
+import {
+  type AddMealBody,
+  addMealBodySchema,
+  type DeleteMealResponse,
+  type MealResponse,
+  type MealsQuery,
+  type MealsResponse,
+  mealsQuerySchema,
+  type UpdateMealBody,
+  updateMealBodySchema,
+} from '@aurboda/api-spec'
 
 import { getMealLogCompleted, setMealLogCompleted, unsetMealLogCompleted } from '../db/index.ts'
 import { addMeal, deleteMealById, getMeal, queryMeals, updateMealById } from '../services/meals.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
 /** Check if a date is marked as logging-complete. Returns undefined if no date provided. */
@@ -18,67 +30,84 @@ const checkLogCompleted = async (user: string, start?: string): Promise<boolean 
   return completed.includes(dateStr)
 }
 
-const handleQueryMeals: RequestHandler = async (req, res) => {
-  const { meal_type, start, end, date } = req.query as Record<string, string | undefined>
-  const user = req.user!
-  const result = await queryMeals(user, { end, meal_type, start })
-  // Use explicit `date` param (local date from frontend) for log_completed check,
-  // not `start` which is UTC and may be a different calendar date due to timezone offset
-  const log_completed = await checkLogCompleted(user, date)
-  res.json({ data: result.data, log_completed, success: true })
-}
-
-const handleGetMeal: RequestHandler<{ id: string }> = async (req, res) => {
-  const result = await getMeal(req.user!, req.params.id)
-  if (!result.success) return res.status(404).json({ error: result.error, success: false })
-  res.json({ data: result.data, success: true })
-}
-
-const handleUpsertMeal: RequestHandler = async (req, res) => {
-  const user = req.user!
-  const result = await addMeal(user, { ...req.body })
-  if (!result.success) return res.status(400).json({ error: result.error, success: false })
-  res.json({ data: result.data, success: true })
-}
-
-const handleUpdateMeal: RequestHandler<{ id: string }> = async (req, res) => {
-  const result = await updateMealById(req.user!, req.params.id, req.body)
-  if (!result.success) return res.status(404).json({ error: result.error, success: false })
-  res.json({ data: result.data, success: true })
-}
-
-const handleDeleteMeal: RequestHandler<{ id: string }> = async (req, res) => {
-  const result = await deleteMealById(req.user!, req.params.id)
-  if (!result.success) return res.status(404).json({ error: result.error, success: false })
-  res.json({ success: true })
-}
-
-const handleSetLogCompleted: RequestHandler<{ date: string }> = async (req, res) => {
-  await setMealLogCompleted(req.user!, req.params.date)
-  res.json({ success: true })
-}
-
-const handleUnsetLogCompleted: RequestHandler<{ date: string }> = async (req, res) => {
-  await unsetMealLogCompleted(req.user!, req.params.date)
-  res.json({ success: true })
-}
-
 export const createMealsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
+  const router = typedRouter()
 
-  router.get('/', authMiddleware, validateQuery(mealsQuerySchema), handleQueryMeals)
+  router.get<Record<string, never>, MealsResponse, unknown, MealsQuery>(
+    '/',
+    authMiddleware,
+    validateQuery(mealsQuerySchema),
+    async (req, res) => {
+      const { meal_type, start, end, date } = req.query
+      const user = req.user!
+      const result = await queryMeals(user, { end, meal_type, start })
+      // Use explicit `date` param (local date from frontend) for log_completed check,
+      // not `start` which is UTC and may be a different calendar date due to timezone offset
+      const log_completed = await checkLogCompleted(user, date)
+      res.json({ data: result.data, log_completed, success: true })
+    },
+  )
 
-  router.put('/log-completed/:date', authMiddleware, handleSetLogCompleted)
-  router.delete('/log-completed/:date', authMiddleware, handleUnsetLogCompleted)
+  router.put<{ date: string }, DeleteMealResponse>(
+    '/log-completed/:date',
+    authMiddleware,
+    async (req, res) => {
+      await setMealLogCompleted(req.user!, req.params.date)
+      res.json({ success: true })
+    },
+  )
 
-  router.get('/:id', authMiddleware, handleGetMeal)
+  router.delete<{ date: string }, DeleteMealResponse>(
+    '/log-completed/:date',
+    authMiddleware,
+    async (req, res) => {
+      await unsetMealLogCompleted(req.user!, req.params.date)
+      res.json({ success: true })
+    },
+  )
 
-  const upsertMiddleware = [authMiddleware, validateBody(addMealBodySchema), handleUpsertMeal]
-  router.put('/', ...upsertMiddleware)
-  router.post('/', ...upsertMiddleware)
+  router.get<{ id: string }, MealResponse>('/:id', authMiddleware, async (req, res) => {
+    const result = await getMeal(req.user!, req.params.id)
+    if (!result.success) return res.status(404).json({ error: result.error, success: false })
+    res.json({ data: result.data, success: true })
+  })
 
-  router.patch('/:id', authMiddleware, validateBody(updateMealBodySchema), handleUpdateMeal)
-  router.delete('/:id', authMiddleware, handleDeleteMeal)
+  const handleUpsert: RequestHandler<Record<string, never>, MealResponse, AddMealBody> = async (req, res) => {
+    const user = req.user!
+    const result = await addMeal(user, { ...req.body })
+    if (!result.success) return res.status(400).json({ error: result.error, success: false })
+    res.json({ data: result.data, success: true })
+  }
 
-  return router
+  router.put<Record<string, never>, MealResponse, AddMealBody>(
+    '/',
+    authMiddleware,
+    validateBody(addMealBodySchema),
+    handleUpsert,
+  )
+  router.post<Record<string, never>, MealResponse, AddMealBody>(
+    '/',
+    authMiddleware,
+    validateBody(addMealBodySchema),
+    handleUpsert,
+  )
+
+  router.patch<{ id: string }, MealResponse, UpdateMealBody>(
+    '/:id',
+    authMiddleware,
+    validateBody(updateMealBodySchema),
+    async (req, res) => {
+      const result = await updateMealById(req.user!, req.params.id, req.body)
+      if (!result.success) return res.status(404).json({ error: result.error, success: false })
+      res.json({ data: result.data, success: true })
+    },
+  )
+
+  router.delete<{ id: string }, DeleteMealResponse>('/:id', authMiddleware, async (req, res) => {
+    const result = await deleteMealById(req.user!, req.params.id)
+    if (!result.success) return res.status(404).json({ error: result.error, success: false })
+    res.json({ success: true })
+  })
+
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -21,6 +21,7 @@ import {
   type DailySummaryResponse,
   type DeleteMetricQuery,
   deleteMetricQuerySchema,
+  type DeleteMetricResponse,
   type LatestMetricResponse,
   type MergeCustomMetricBody,
   mergeCustomMetricBodySchema,
@@ -252,7 +253,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // DELETE /metrics/:metric - Delete a single measurement (soft delete)
-  router.delete<{ metric: string }, unknown, unknown, DeleteMetricQuery>(
+  router.delete<{ metric: string }, DeleteMetricResponse, unknown, DeleteMetricQuery>(
     '/metrics/:metric',
     authMiddleware,
     validateQuery(deleteMetricQuerySchema),
@@ -262,7 +263,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
       const user = req.user!
       const result = await deleteMetric(user, metric, new Date(time), source)
       if (!result.deleted) {
-        return res.status(404).json({ error: 'Measurement not found', success: false })
+        return res.status(404).json({ deleted: false, error: 'Measurement not found', success: false })
       }
       res.json({ ...result, success: true })
     },

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -70,7 +70,7 @@ import { validateBody, validateQuery } from '../validation.ts'
 export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider?: SyncProvider): Router => {
   const router = typedRouter()
 
-  // GET /metrics/bucketed - must come before /metrics/:metric to avoid parameter capture
+  // Must come before /metrics/:metric to avoid parameter capture
   router.get<Record<string, never>, QueryMetricsBucketedResponse, unknown, QueryMetricsBucketedQuery>(
     '/metrics/bucketed',
     authMiddleware,
@@ -97,7 +97,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // GET /metrics/custom - List all custom metric types
   router.get<Record<string, never>, CustomMetricsListResponse>(
     '/metrics/custom',
     authMiddleware,
@@ -108,7 +107,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // POST /metrics/custom - Register a new custom metric type
   router.post<Record<string, never>, CustomMetricResponse, AddCustomMetricBody>(
     '/metrics/custom',
     authMiddleware,
@@ -123,7 +121,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // DELETE /metrics/custom/:name - Delete a custom metric type
   router.delete<{ name: string }, CustomMetricResponse>(
     '/metrics/custom/:name',
     authMiddleware,
@@ -138,7 +135,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // POST /metrics/custom/merge - Merge a custom metric into another metric
   router.post<Record<string, never>, MergeCustomMetricResponse, MergeCustomMetricBody>(
     '/metrics/custom/merge',
     authMiddleware,
@@ -154,7 +150,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // PATCH /metrics/custom/:name - Update a custom metric definition
   router.patch<{ name: string }, CustomMetricResponse, UpdateCustomMetricBody>(
     '/metrics/custom/:name',
     authMiddleware,
@@ -170,7 +165,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // POST /metrics/recalculate-calories - Recalculate calorie burn from HR data
   // With start/end: synchronous range recompute. Without: async full recompute.
   router.post<Record<string, never>, RecalculateCaloriesResponse, Partial<RecalculateCaloriesBody>>(
     '/metrics/recalculate-calories',
@@ -201,7 +195,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // POST /metrics/bulk - Bulk insert metric data points
   router.post<Record<string, never>, BulkMetricsResponse, BulkMetricsBody>(
     '/metrics/bulk',
     authMiddleware,
@@ -222,7 +215,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // GET /metrics/latest/:metric - Get the most recent value for a metric regardless of age
   router.get<{ metric: string }, LatestMetricResponse>(
     '/metrics/latest/:metric',
     authMiddleware,
@@ -240,7 +232,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // DELETE /metrics/:metric/data - Delete all manual measurements for a metric
   router.delete<{ metric: string }, { success: boolean; deleted?: number }>(
     '/metrics/:metric/data',
     authMiddleware,
@@ -252,7 +243,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // DELETE /metrics/:metric - Delete a single measurement (soft delete)
   router.delete<{ metric: string }, DeleteMetricResponse, unknown, DeleteMetricQuery>(
     '/metrics/:metric',
     authMiddleware,
@@ -269,7 +259,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // GET /metrics/:metric - Query time series metrics
   router.get<{ metric: string }, QueryMetricsResponse, unknown, QueryMetricsQuery>(
     '/metrics/:metric',
     authMiddleware,
@@ -286,7 +275,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // POST /metrics - Add a manual metric measurement
   router.post<Record<string, never>, AddMetricResponse, AddMetricBody>(
     '/metrics',
     authMiddleware,
@@ -302,7 +290,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // GET /daily-summary - Get comprehensive summary for a day
   router.get<Record<string, never>, DailySummaryResponse, unknown, DailySummaryQuery>(
     '/daily-summary',
     authMiddleware,
@@ -316,7 +303,6 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
     },
   )
 
-  // GET /period-summary - Get aggregated stats for a period
   router.get<Record<string, never>, PeriodSummaryResponse, unknown, PeriodSummaryQuery>(
     '/period-summary',
     authMiddleware,

--- a/apps/backend/src/routes/metrics-router.ts
+++ b/apps/backend/src/routes/metrics-router.ts
@@ -70,7 +70,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   const router = typedRouter()
 
   // GET /metrics/bucketed - must come before /metrics/:metric to avoid parameter capture
-  router.get<Record<string, string>, QueryMetricsBucketedResponse, unknown, QueryMetricsBucketedQuery>(
+  router.get<Record<string, never>, QueryMetricsBucketedResponse, unknown, QueryMetricsBucketedQuery>(
     '/metrics/bucketed',
     authMiddleware,
     validateQuery(queryMetricsBucketedQuerySchema),
@@ -97,7 +97,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // GET /metrics/custom - List all custom metric types
-  router.get<Record<string, string>, CustomMetricsListResponse>(
+  router.get<Record<string, never>, CustomMetricsListResponse>(
     '/metrics/custom',
     authMiddleware,
     async (req, res) => {
@@ -108,7 +108,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics/custom - Register a new custom metric type
-  router.post<Record<string, string>, CustomMetricResponse, AddCustomMetricBody>(
+  router.post<Record<string, never>, CustomMetricResponse, AddCustomMetricBody>(
     '/metrics/custom',
     authMiddleware,
     validateBody(addCustomMetricBodySchema),
@@ -138,7 +138,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics/custom/merge - Merge a custom metric into another metric
-  router.post<Record<string, string>, MergeCustomMetricResponse, MergeCustomMetricBody>(
+  router.post<Record<string, never>, MergeCustomMetricResponse, MergeCustomMetricBody>(
     '/metrics/custom/merge',
     authMiddleware,
     validateBody(mergeCustomMetricBodySchema),
@@ -171,7 +171,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
 
   // POST /metrics/recalculate-calories - Recalculate calorie burn from HR data
   // With start/end: synchronous range recompute. Without: async full recompute.
-  router.post<Record<string, string>, RecalculateCaloriesResponse, Partial<RecalculateCaloriesBody>>(
+  router.post<Record<string, never>, RecalculateCaloriesResponse, Partial<RecalculateCaloriesBody>>(
     '/metrics/recalculate-calories',
     authMiddleware,
     async (req, res) => {
@@ -201,7 +201,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics/bulk - Bulk insert metric data points
-  router.post<Record<string, string>, BulkMetricsResponse, BulkMetricsBody>(
+  router.post<Record<string, never>, BulkMetricsResponse, BulkMetricsBody>(
     '/metrics/bulk',
     authMiddleware,
     validateBody(bulkMetricsBodySchema),
@@ -286,7 +286,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // POST /metrics - Add a manual metric measurement
-  router.post<Record<string, string>, AddMetricResponse, AddMetricBody>(
+  router.post<Record<string, never>, AddMetricResponse, AddMetricBody>(
     '/metrics',
     authMiddleware,
     validateBody(addMetricBodySchema),
@@ -302,7 +302,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // GET /daily-summary - Get comprehensive summary for a day
-  router.get<Record<string, string>, DailySummaryResponse, unknown, DailySummaryQuery>(
+  router.get<Record<string, never>, DailySummaryResponse, unknown, DailySummaryQuery>(
     '/daily-summary',
     authMiddleware,
     validateQuery(dailySummaryQuerySchema),
@@ -316,7 +316,7 @@ export const createMetricsRouter = (authMiddleware: RequestHandler, syncProvider
   )
 
   // GET /period-summary - Get aggregated stats for a period
-  router.get<Record<string, string>, PeriodSummaryResponse, unknown, PeriodSummaryQuery>(
+  router.get<Record<string, never>, PeriodSummaryResponse, unknown, PeriodSummaryQuery>(
     '/period-summary',
     authMiddleware,
     validateQuery(periodSummaryQuerySchema),

--- a/apps/backend/src/routes/notes-router.ts
+++ b/apps/backend/src/routes/notes-router.ts
@@ -24,7 +24,6 @@ import { validateBody, validateQuery } from '../validation.ts'
 export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET /notes - Get notes for an entity
   router.get<Record<string, never>, NotesResponse, unknown, NotesQuery>(
     '/',
     authMiddleware,
@@ -38,7 +37,6 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // POST /notes - Add a note
   router.post<Record<string, never>, NoteResponse, AddNoteBody>(
     '/',
     authMiddleware,
@@ -57,7 +55,6 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // PATCH /notes/:id - Update a note
   router.patch<{ id: string }, NoteResponse, UpdateNoteBody>(
     '/:id',
     authMiddleware,
@@ -77,7 +74,6 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // DELETE /notes/:id - Delete a note
   router.delete<{ id: string }, DeleteNoteResponse>('/:id', authMiddleware, async (req, res) => {
     const { id } = req.params
     const user = req.user!

--- a/apps/backend/src/routes/notes-router.ts
+++ b/apps/backend/src/routes/notes-router.ts
@@ -25,7 +25,7 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
   // GET /notes - Get notes for an entity
-  router.get<Record<string, string>, NotesResponse, unknown, NotesQuery>(
+  router.get<Record<string, never>, NotesResponse, unknown, NotesQuery>(
     '/',
     authMiddleware,
     validateQuery(notesQuerySchema),
@@ -39,7 +39,7 @@ export const createNotesRouter = (authMiddleware: RequestHandler): Router => {
   )
 
   // POST /notes - Add a note
-  router.post<Record<string, string>, NoteResponse, AddNoteBody>(
+  router.post<Record<string, never>, NoteResponse, AddNoteBody>(
     '/',
     authMiddleware,
     validateBody(addNoteBodySchema),

--- a/apps/backend/src/routes/reports-router.ts
+++ b/apps/backend/src/routes/reports-router.ts
@@ -26,7 +26,7 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
   // GET /reports - Query reports with optional filters
-  router.get<Record<string, string>, ReportsResponse, unknown, ReportsQuery>(
+  router.get<Record<string, never>, ReportsResponse, unknown, ReportsQuery>(
     '/',
     authMiddleware,
     validateQuery(reportsQuerySchema),
@@ -54,7 +54,7 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
   })
 
   // POST /reports - Create a new report
-  router.post<Record<string, string>, ReportResponse, AddReportBody>(
+  router.post<Record<string, never>, ReportResponse, AddReportBody>(
     '/',
     authMiddleware,
     validateBody(addReportBodySchema),

--- a/apps/backend/src/routes/reports-router.ts
+++ b/apps/backend/src/routes/reports-router.ts
@@ -25,7 +25,6 @@ import { validateBody, validateQuery } from '../validation.ts'
 export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET /reports - Query reports with optional filters
   router.get<Record<string, never>, ReportsResponse, unknown, ReportsQuery>(
     '/',
     authMiddleware,
@@ -39,7 +38,6 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // GET /reports/:id - Get a single report
   router.get<{ id: string }, ReportResponse>('/:id', authMiddleware, async (req, res) => {
     const { id } = req.params
     const user = req.user!
@@ -53,7 +51,6 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
     res.json({ data: result.data, success: true })
   })
 
-  // POST /reports - Create a new report
   router.post<Record<string, never>, ReportResponse, AddReportBody>(
     '/',
     authMiddleware,
@@ -77,7 +74,6 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // PATCH /reports/:id - Update a report
   router.patch<{ id: string }, UpdateReportResponse, UpdateReportBody>(
     '/:id',
     authMiddleware,
@@ -102,7 +98,6 @@ export const createReportsRouter = (authMiddleware: RequestHandler): Router => {
     },
   )
 
-  // DELETE /reports/:id - Delete a report
   router.delete<{ id: string }, DeleteReportResponse>('/:id', authMiddleware, async (req, res) => {
     const { id } = req.params
     const user = req.user!

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -8,11 +8,21 @@ import type { RequestHandler, Router } from 'express'
 import {
   type CreateScreentimeCategoryBody,
   createScreentimeCategoryBodySchema,
+  type DeleteScreentimeCategoryResponse,
   type ImportAwCategoriesBody,
   importAwCategoriesBodySchema,
+  type MoveScreentimeCategoryBody,
+  moveScreentimeCategoryBodySchema,
+  type MoveScreentimeCategoryResponse,
+  type RecategorizeScreentimeResponse,
+  type ScreentimeCategoryDefaultsResponse,
+  type ScreentimeCategoryListResponse,
+  type ScreentimeCategoryResponse,
   type UpdateScreentimeCategoryBody,
   updateScreentimeCategoryBodySchema,
 } from '@aurboda/api-spec'
+
+import type { ScreentimeCategory as DbScreentimeCategory } from '../db/index.ts'
 
 import {
   createCategory,
@@ -29,109 +39,98 @@ import {
 import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
+/** Serialize DB screentime category (Date timestamps) to API format (ISO strings). */
+const serializeCategory = (cat: DbScreentimeCategory) => ({
+  ...cat,
+  created_at: cat.created_at.toISOString(),
+  updated_at: cat.updated_at.toISOString(),
+})
+
 export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET / - List all categories
-  router.get<Record<string, never>, { success: boolean; data: unknown[] }>(
-    '/',
-    authMiddleware,
-    async (req, res) => {
-      const user = req.user!
-      const categories = await listCategories(user)
-      res.json({ data: categories, success: true })
-    },
-  )
+  router.get<Record<string, never>, ScreentimeCategoryListResponse>('/', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const categories = await listCategories(user)
+    res.json({ data: categories.map(serializeCategory), success: true })
+  })
 
-  // GET /:id - Get a single category
-  router.get<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
-    '/:id',
-    authMiddleware,
-    async (req, res) => {
-      const user = req.user!
-      const category = await getCategoryById(user, req.params.id)
-      if (!category) {
-        res.status(404).json({ error: 'Category not found', success: false })
-        return
-      }
-      res.json({ data: category, success: true })
-    },
-  )
+  router.get<{ id: string }, ScreentimeCategoryResponse>('/:id', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const category = await getCategoryById(user, req.params.id)
+    if (!category) {
+      res.status(404).json({ error: 'Category not found', success: false })
+      return
+    }
+    res.json({ data: serializeCategory(category), success: true })
+  })
 
-  // POST / - Create a category
-  router.post<Record<string, never>, { success: boolean; data: unknown }>(
+  router.post<Record<string, never>, ScreentimeCategoryResponse, CreateScreentimeCategoryBody>(
     '/',
     authMiddleware,
     validateBody(createScreentimeCategoryBodySchema),
     async (req, res) => {
       const user = req.user!
-      const body = req.body as CreateScreentimeCategoryBody
       const category = await createCategory(user, {
-        color: body.color,
-        ignore_case: body.ignore_case ?? true,
-        name: body.name,
-        rule_regex: body.rule_regex,
-        rule_type: body.rule_type ?? 'none',
-        score: body.score,
-        sort_order: body.sort_order,
+        color: req.body.color,
+        ignore_case: req.body.ignore_case ?? true,
+        name: req.body.name,
+        rule_regex: req.body.rule_regex,
+        rule_type: req.body.rule_type ?? 'none',
+        score: req.body.score,
+        sort_order: req.body.sort_order,
       })
-      res.status(201).json({ data: category, success: true })
+      res.status(201).json({ data: serializeCategory(category), success: true })
     },
   )
 
-  // PUT /:id - Upsert a category (create with client-generated UUID or full update)
-  router.put<{ id: string }, { success: boolean; data: unknown }>(
+  router.put<{ id: string }, ScreentimeCategoryResponse, CreateScreentimeCategoryBody>(
     '/:id',
     authMiddleware,
     validateBody(createScreentimeCategoryBodySchema),
     async (req, res) => {
       const user = req.user!
-      const body = req.body as CreateScreentimeCategoryBody
       const category = await upsertCategory(user, req.params.id, {
-        color: body.color,
-        exclude_from_screentime: body.exclude_from_screentime,
-        ignore_case: body.ignore_case ?? true,
-        name: body.name,
-        rule_regex: body.rule_regex,
-        rule_type: body.rule_type ?? 'none',
-        score: body.score,
-        sort_order: body.sort_order,
+        color: req.body.color,
+        exclude_from_screentime: req.body.exclude_from_screentime,
+        ignore_case: req.body.ignore_case ?? true,
+        name: req.body.name,
+        rule_regex: req.body.rule_regex,
+        rule_type: req.body.rule_type ?? 'none',
+        score: req.body.score,
+        sort_order: req.body.sort_order,
       })
-      res.json({ data: category, success: true })
+      res.json({ data: serializeCategory(category), success: true })
     },
   )
 
-  // PATCH /:id - Partial update a category
-  router.patch<{ id: string }, { success: boolean; data?: unknown; error?: string }>(
+  router.patch<{ id: string }, ScreentimeCategoryResponse, UpdateScreentimeCategoryBody>(
     '/:id',
     authMiddleware,
     validateBody(updateScreentimeCategoryBodySchema),
     async (req, res) => {
       const user = req.user!
-      const body = req.body as UpdateScreentimeCategoryBody
-      const category = await modifyCategory(user, req.params.id, body)
+      const category = await modifyCategory(user, req.params.id, req.body)
       if (!category) {
         res.status(404).json({ error: 'Category not found', success: false })
         return
       }
-      res.json({ data: category, success: true })
+      res.json({ data: serializeCategory(category), success: true })
     },
   )
 
-  // PATCH /:id/move - Move a category to a new parent
-  router.patch<{ id: string }, { success: boolean; updated: number }>(
+  router.patch<{ id: string }, MoveScreentimeCategoryResponse, MoveScreentimeCategoryBody>(
     '/:id/move',
     authMiddleware,
+    validateBody(moveScreentimeCategoryBodySchema),
     async (req, res) => {
       const user = req.user!
-      const { new_parent_id } = req.body as { new_parent_id: string | null }
-      const result = await moveCategoryToParent(user, req.params.id, new_parent_id)
+      const result = await moveCategoryToParent(user, req.params.id, req.body.new_parent_id)
       res.json({ success: result.updated > 0, updated: result.updated })
     },
   )
 
-  // DELETE /:id - Delete a category and its children
-  router.delete<{ id: string }, { success: boolean; deleted?: number; error?: string }>(
+  router.delete<{ id: string }, DeleteScreentimeCategoryResponse>(
     '/:id',
     authMiddleware,
     async (req, res) => {
@@ -145,26 +144,23 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     },
   )
 
-  // POST /import-activitywatch - Import categories from ActivityWatch
-  router.post<Record<string, never>, { success: boolean; data?: unknown; error?: string }>(
+  router.post<Record<string, never>, ScreentimeCategoryListResponse, ImportAwCategoriesBody>(
     '/import-activitywatch',
     authMiddleware,
     validateBody(importAwCategoriesBodySchema),
     async (req, res) => {
       const user = req.user!
-      const body = req.body as ImportAwCategoriesBody
 
       try {
-        let awCategories = body.categories
+        let awCategories = req.body.categories
 
         if (!awCategories) {
-          // Fetch from ActivityWatch server
-          const serverUrl = body.url || 'http://localhost:5600'
+          const serverUrl = req.body.url || 'http://localhost:5600'
           awCategories = await fetchAwCategories(serverUrl)
         }
 
-        const result = await importFromActivityWatch(user, awCategories, body.replace ?? false)
-        res.json({ data: result, success: true })
+        const result = await importFromActivityWatch(user, awCategories, req.body.replace ?? false)
+        res.json({ data: result.map(serializeCategory), success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Import failed'
         res.status(400).json({ error: message, success: false })
@@ -172,18 +168,14 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     },
   )
 
-  // POST /recategorize - Force full recategorization
-  router.post<Record<string, never>, { success: boolean; records_updated?: number; error?: string }>(
+  router.post<Record<string, never>, RecategorizeScreentimeResponse>(
     '/recategorize',
     authMiddleware,
     async (req, res) => {
       const user = req.user!
 
-      // Start recategorization and respond immediately
-      const countPromise = recategorizeAll(user)
-
       try {
-        const count = await countPromise
+        const count = await recategorizeAll(user)
         res.json({ records_updated: count, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Recategorization failed'
@@ -192,8 +184,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     },
   )
 
-  // GET /defaults - Get default category suggestions
-  router.get<Record<string, never>, { success: boolean; data: unknown[] }>(
+  router.get<Record<string, never>, ScreentimeCategoryDefaultsResponse>(
     '/defaults',
     authMiddleware,
     async (_req, res) => {

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -33,7 +33,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   const router = typedRouter()
 
   // GET / - List all categories
-  router.get<Record<string, string>, { success: boolean; data: unknown[] }>(
+  router.get<Record<string, never>, { success: boolean; data: unknown[] }>(
     '/',
     authMiddleware,
     async (req, res) => {
@@ -59,7 +59,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // POST / - Create a category
-  router.post<Record<string, string>, { success: boolean; data: unknown }>(
+  router.post<Record<string, never>, { success: boolean; data: unknown }>(
     '/',
     authMiddleware,
     validateBody(createScreentimeCategoryBodySchema),
@@ -146,7 +146,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // POST /import-activitywatch - Import categories from ActivityWatch
-  router.post<Record<string, string>, { success: boolean; data?: unknown; error?: string }>(
+  router.post<Record<string, never>, { success: boolean; data?: unknown; error?: string }>(
     '/import-activitywatch',
     authMiddleware,
     validateBody(importAwCategoriesBodySchema),
@@ -173,7 +173,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // POST /recategorize - Force full recategorization
-  router.post<Record<string, string>, { success: boolean; records_updated?: number; error?: string }>(
+  router.post<Record<string, never>, { success: boolean; records_updated?: number; error?: string }>(
     '/recategorize',
     authMiddleware,
     async (req, res) => {
@@ -193,7 +193,7 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
   )
 
   // GET /defaults - Get default category suggestions
-  router.get<Record<string, string>, { success: boolean; data: unknown[] }>(
+  router.get<Record<string, never>, { success: boolean; data: unknown[] }>(
     '/defaults',
     authMiddleware,
     async (_req, res) => {

--- a/apps/backend/src/routes/settings-router.ts
+++ b/apps/backend/src/routes/settings-router.ts
@@ -1,3 +1,5 @@
+import type { RequestHandler, Router } from 'express'
+
 /**
  * Settings and goals route group.
  *
@@ -9,16 +11,14 @@ import {
   updateSettingsInputSchema,
   type UserSettingsResponse,
 } from '@aurboda/api-spec'
-import { type RequestHandler, Router } from 'express'
 
 import { getGoalsProgress } from '../services/goals.ts'
 import { getSettingsResponse, validateAndUpdateSettings } from '../services/settings.ts'
+import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 export const createSettingsRouter = (authMiddleware: RequestHandler): Router => {
-  const router = Router()
-
-  // GET /user/settings - Get user settings with effective HR zones
+  const router = typedRouter()
   router.get<Record<string, never>, UserSettingsResponse>(
     '/user/settings',
     authMiddleware,
@@ -52,5 +52,5 @@ export const createSettingsRouter = (authMiddleware: RequestHandler): Router => 
     },
   )
 
-  return router
+  return router as unknown as Router
 }

--- a/apps/backend/src/routes/settings-router.ts
+++ b/apps/backend/src/routes/settings-router.ts
@@ -28,7 +28,6 @@ export const createSettingsRouter = (authMiddleware: RequestHandler): Router => 
     },
   )
 
-  // PATCH /user/settings - Update user settings
   router.patch<Record<string, never>, UserSettingsResponse, UpdateSettingsInput>(
     '/user/settings',
     authMiddleware,
@@ -42,7 +41,6 @@ export const createSettingsRouter = (authMiddleware: RequestHandler): Router => 
     },
   )
 
-  // GET /goals/progress - Get progress toward all user goals
   router.get<Record<string, never>, GoalsProgressResponse>(
     '/goals/progress',
     authMiddleware,

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -15,7 +15,6 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
   const router = typedRouter()
   const deps = createTrainingLoadDeps()
 
-  // GET /training-load - Get training load time series (ATL, CTL, TSB, TRIMP)
   router.get<Record<string, never>, TrainingLoadResponse, unknown, TrainingLoadQuery>(
     '/',
     authMiddleware,

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -16,7 +16,7 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
   const deps = createTrainingLoadDeps()
 
   // GET /training-load - Get training load time series (ATL, CTL, TSB, TRIMP)
-  router.get<Record<string, string>, TrainingLoadResponse, unknown, TrainingLoadQuery>(
+  router.get<Record<string, never>, TrainingLoadResponse, unknown, TrainingLoadQuery>(
     '/',
     authMiddleware,
     validateQuery(trainingLoadQuerySchema),

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -15,7 +15,6 @@ import { validateQuery } from '../validation.ts'
 export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
-  // GET /trends - Get time-weighted trend for tags or metrics
   router.get<Record<string, never>, TrendResponse, unknown, TrendQuery>(
     '/',
     authMiddleware,

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -16,7 +16,7 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
   const router = typedRouter()
 
   // GET /trends - Get time-weighted trend for tags or metrics
-  router.get<Record<string, string>, TrendResponse, unknown, TrendQuery>(
+  router.get<Record<string, never>, TrendResponse, unknown, TrendQuery>(
     '/',
     authMiddleware,
     validateQuery(trendQuerySchema),

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1697,7 +1697,7 @@ export interface MealsResult {
 
 export const fetchMeals = async (params?: MealsQuery): Promise<MealsResult> => {
   const { token } = auth.value
-  const response = await axios.get<MealsResponse & { log_completed?: boolean }>(`${API_URL}/meals`, {
+  const response = await axios.get<MealsResponse>(`${API_URL}/meals`, {
     headers: { Authorization: `Bearer ${token}` },
     params,
   })

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -8,6 +8,7 @@ import {
   activityTypeSchema,
   baseResponseSchema,
   createDataArrayResponseSchema,
+  createDataResponseSchema,
   durationMinutesSchema,
   iso8601DateTimeSchema,
   timeRangeQuerySchema,
@@ -392,3 +393,12 @@ export const nearbyActivitiesResponseSchema = createDataArrayResponseSchema(acti
 })
 
 export type NearbyActivitiesResponse = z.infer<typeof nearbyActivitiesResponseSchema>
+
+/**
+ * Single activity detail response (for activity detail page).
+ */
+export const activityDetailResponseSchema = createDataResponseSchema(activitySchema).meta({
+  id: 'ActivityDetailResponse',
+})
+
+export type ActivityDetailResponse = z.infer<typeof activityDetailResponseSchema>

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -102,6 +102,32 @@ export const loginResponseSchema = z
 export type LoginResponse = z.infer<typeof loginResponseSchema>
 
 // ============================================================================
+// Version and auth token endpoints
+// ============================================================================
+
+/**
+ * Version response schema.
+ */
+export const versionResponseSchema = baseResponseSchema
+  .extend({
+    build_sha: z.string().meta({ description: 'Build commit SHA or "dev"' }),
+  })
+  .meta({ id: 'VersionResponse' })
+
+export type VersionResponse = z.infer<typeof versionResponseSchema>
+
+/**
+ * Auth token response schema.
+ */
+export const authTokenResponseSchema = baseResponseSchema
+  .extend({
+    token: z.string().meta({ description: 'Fresh API token' }),
+  })
+  .meta({ id: 'AuthTokenResponse' })
+
+export type AuthTokenResponse = z.infer<typeof authTokenResponseSchema>
+
+// ============================================================================
 // Admin settings endpoints
 // ============================================================================
 

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -230,9 +230,14 @@ export type MealResponse = z.infer<typeof mealResponseSchema>
 /**
  * Multiple meals response.
  */
-export const mealsResponseSchema = createDataArrayResponseSchema(mealSchema).meta({
-  id: 'MealsResponse',
-})
+export const mealsResponseSchema = createDataArrayResponseSchema(mealSchema)
+  .extend({
+    log_completed: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Whether meal logging is marked complete for the queried date' }),
+  })
+  .meta({ id: 'MealsResponse' })
 
 export type MealsResponse = z.infer<typeof mealsResponseSchema>
 

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -220,6 +220,20 @@ export const deleteMetricQuerySchema = z
 export type DeleteMetricQuery = z.infer<typeof deleteMetricQuerySchema>
 
 /**
+ * Delete metric response.
+ */
+export const deleteMetricResponseSchema = baseResponseSchema
+  .extend({
+    deleted: z.boolean().meta({ description: 'Whether the measurement was deleted' }),
+    metric: z.string().optional().meta({ description: 'Metric name' }),
+    source: z.string().optional().meta({ description: 'Data source' }),
+    time: iso8601DateTimeSchema.optional().meta({ description: 'Measurement time' }),
+  })
+  .meta({ id: 'DeleteMetricResponse' })
+
+export type DeleteMetricResponse = z.infer<typeof deleteMetricResponseSchema>
+
+/**
  * Custom metric response.
  */
 export const customMetricResponseSchema = baseResponseSchema

--- a/packages/api-spec/src/schemas/nutrients.ts
+++ b/packages/api-spec/src/schemas/nutrients.ts
@@ -24,7 +24,7 @@ export interface NutrientFieldDef {
  * All nutrient fields, in display order.
  * This is the single source of truth for nutrient columns across the system.
  */
-export const NUTRIENT_FIELDS: NutrientFieldDef[] = [
+export const NUTRIENT_FIELDS = [
   // Macros (also on meals table directly)
   { category: 'macro', label: 'Calories', name: 'calories', unit: 'kcal' },
   { category: 'macro', label: 'Protein', name: 'protein', unit: 'g' },
@@ -103,7 +103,7 @@ export const NUTRIENT_FIELDS: NutrientFieldDef[] = [
   { category: 'other', label: 'Phytate', name: 'phytate', unit: 'mg' },
   { category: 'other', label: 'Ash', name: 'ash', unit: 'g' },
   { category: 'other', label: 'Salt', name: 'salt', unit: 'g' },
-]
+] as const satisfies readonly NutrientFieldDef[]
 
 /** All nutrient field names. */
 export const NUTRIENT_FIELD_NAMES = NUTRIENT_FIELDS.map((f) => f.name)
@@ -115,7 +115,16 @@ export const nutrientColumnsDDL = (): string =>
 /**
  * Zod schema with all nutrient fields as optional numbers.
  * Used for food item and meal_food_item validation.
+ *
+ * The type assertion ensures TypeScript infers individual named fields
+ * (e.g. `{ calories?: number; protein?: number; ... }`) instead of a
+ * `Record<string, number | undefined>` index signature. Without this,
+ * extending the schema with non-number fields (like FoodItemEntity.name)
+ * would create an impossible type.
  */
+type NutrientFieldName = (typeof NUTRIENT_FIELDS)[number]['name']
+type NutrientSchemaShape = { [K in NutrientFieldName]: z.ZodOptional<z.ZodNumber> }
+
 export const nutrientFieldsSchema = z.object(
   Object.fromEntries(
     NUTRIENT_FIELDS.map((f) => [
@@ -125,7 +134,7 @@ export const nutrientFieldsSchema = z.object(
         .optional()
         .meta({ description: `${f.label} (${f.unit})` }),
     ]),
-  ),
+  ) as unknown as NutrientSchemaShape,
 )
 
 export type NutrientFields = z.infer<typeof nutrientFieldsSchema>

--- a/packages/api-spec/src/schemas/productivity.ts
+++ b/packages/api-spec/src/schemas/productivity.ts
@@ -24,6 +24,7 @@ export const productivityRecordSchema = z
     category: z.string().optional().meta({ description: 'Original category (from RescueTime)' }),
     comments: z.array(commentSchema).optional().meta({ description: 'Attached comments' }),
     deleted_at: iso8601DateTimeSchema.optional().meta({ description: 'Soft-delete timestamp' }),
+    device_name: z.string().optional().meta({ description: 'Device name (from ActivityWatch)' }),
     duration_sec: z.number().int().meta({ description: 'Duration in seconds' }),
     end_time: iso8601DateTimeSchema,
     id: z.string().uuid().optional().meta({ description: 'Productivity record ID' }),

--- a/packages/api-spec/src/schemas/productivity.ts
+++ b/packages/api-spec/src/schemas/productivity.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import {
   baseResponseSchema,
   createDataArrayResponseSchema,
+  createDataResponseSchema,
   dataSourceSchema,
   iso8601DateTimeSchema,
   timeRangeQuerySchema,
@@ -61,6 +62,42 @@ export const productivityResponseSchema = createDataArrayResponseSchema(producti
 })
 
 export type ProductivityResponse = z.infer<typeof productivityResponseSchema>
+
+/**
+ * Single productivity record response.
+ */
+export const productivityRecordResponseSchema = createDataResponseSchema(productivityRecordSchema).meta({
+  id: 'ProductivityRecordResponse',
+})
+
+export type ProductivityRecordResponse = z.infer<typeof productivityRecordResponseSchema>
+
+/**
+ * Distinct app/title combination with usage stats.
+ */
+export const distinctAppSchema = z
+  .object({
+    activity: z.string().meta({ description: 'Application name' }),
+    last_seen: iso8601DateTimeSchema.meta({ description: 'Most recent occurrence' }),
+    record_count: z.number().int().meta({ description: 'Number of productivity records' }),
+    resolved_category: z.array(z.string()).optional().meta({
+      description: 'Resolved category path from screentime rules',
+    }),
+    title: z.string().optional().meta({ description: 'Window title' }),
+    total_duration_sec: z.number().int().meta({ description: 'Total duration in seconds' }),
+  })
+  .meta({ id: 'DistinctApp' })
+
+export type DistinctApp = z.infer<typeof distinctAppSchema>
+
+/**
+ * Distinct apps response.
+ */
+export const distinctAppsResponseSchema = createDataArrayResponseSchema(distinctAppSchema).meta({
+  id: 'DistinctAppsResponse',
+})
+
+export type DistinctAppsResponse = z.infer<typeof distinctAppsResponseSchema>
 
 /**
  * Category duration within a screentime bucket.

--- a/packages/api-spec/src/schemas/screentime-categories.ts
+++ b/packages/api-spec/src/schemas/screentime-categories.ts
@@ -10,7 +10,7 @@
 
 import { z } from 'zod'
 
-import { createDataArrayResponseSchema, createDataResponseSchema } from './common.ts'
+import { baseResponseSchema, createDataArrayResponseSchema, createDataResponseSchema } from './common.ts'
 
 /**
  * Rule type for screentime categories.
@@ -166,6 +166,63 @@ export const importAwCategoriesBodySchema = z
   .meta({ description: 'Import categories from ActivityWatch', id: 'ImportAwCategoriesBody' })
 
 export type ImportAwCategoriesBody = z.infer<typeof importAwCategoriesBodySchema>
+
+/**
+ * Move category body schema.
+ */
+export const moveScreentimeCategoryBodySchema = z
+  .object({
+    new_parent_id: z
+      .string()
+      .uuid()
+      .nullable()
+      .meta({ description: 'New parent category ID, or null for root' }),
+  })
+  .meta({ description: 'Move a category to a new parent', id: 'MoveScreentimeCategoryBody' })
+
+export type MoveScreentimeCategoryBody = z.infer<typeof moveScreentimeCategoryBodySchema>
+
+/**
+ * Delete screentime category response.
+ */
+export const deleteScreentimeCategoryResponseSchema = baseResponseSchema
+  .extend({
+    deleted: z.number().int().optional().meta({ description: 'Number of categories deleted' }),
+  })
+  .meta({ id: 'DeleteScreentimeCategoryResponse' })
+
+export type DeleteScreentimeCategoryResponse = z.infer<typeof deleteScreentimeCategoryResponseSchema>
+
+/**
+ * Move screentime category response.
+ */
+export const moveScreentimeCategoryResponseSchema = baseResponseSchema
+  .extend({
+    updated: z.number().int().meta({ description: 'Number of categories updated' }),
+  })
+  .meta({ id: 'MoveScreentimeCategoryResponse' })
+
+export type MoveScreentimeCategoryResponse = z.infer<typeof moveScreentimeCategoryResponseSchema>
+
+/**
+ * Recategorize screentime response.
+ */
+export const recategorizeScreentimeResponseSchema = baseResponseSchema
+  .extend({
+    records_updated: z.number().int().optional().meta({ description: 'Number of records recategorized' }),
+  })
+  .meta({ id: 'RecategorizeScreentimeResponse' })
+
+export type RecategorizeScreentimeResponse = z.infer<typeof recategorizeScreentimeResponseSchema>
+
+/**
+ * Default screentime categories response.
+ */
+export const screentimeCategoryDefaultsResponseSchema = createDataArrayResponseSchema(
+  createScreentimeCategoryBodySchema,
+).meta({ id: 'ScreentimeCategoryDefaultsResponse' })
+
+export type ScreentimeCategoryDefaultsResponse = z.infer<typeof screentimeCategoryDefaultsResponseSchema>
 
 /**
  * Default categories (matching ActivityWatch defaults) that can be suggested to users.


### PR DESCRIPTION
## Summary

- Remove dead `/refresh` endpoint (never called by any client)
- Add missing api-spec response types: VersionResponse, AuthTokenResponse, MealsResponse.log_completed, screentime category CRUD responses, ProductivityRecordResponse, DistinctAppsResponse, ActivityDetailResponse, DeleteMetricResponse, device_name on ProductivityRecord
- Fix nutrient schema to use `as const` + mapped type assertion (eliminates index signature that conflicted with non-number fields in FoodItemEntity)
- Migrate 6 remaining routers to `typedRouter()`: admin, audit-log, dashboard, settings, food-items (full rewrite), meals (full rewrite)
- Replace `Record<string, string>` with `Record<string, never>` on 44 parameterless routes across 13 files
- Replace all `unknown`/`any` response types with api-spec types in screentime-categories, activities, metrics, and api.ts auth routes
- Add Date-to-ISO serialization at DB-to-API boundary in food-items and screentime-categories routers
- Remove `as Type` casts on `req.body` — use `ReqBody` generic instead
- Remove 73 redundant `// METHOD /path` endpoint comments
- Document TypedRouter conventions in AGENTS.md

## Test plan

- [ ] `pnpm check` passes (tsgo + oxlint) across all packages
- [ ] `pnpm --filter aurboda-backend exec vitest run` — backend tests pass
- [ ] Spot-check via MCP: query_activities, list_screentime_categories, search_food_items, query_meals
- [ ] Add note to a report (the fix from #541 is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)