### PR TITLE
fix: link activity title to type page and show type icons on timeline

### DIFF
--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -96,6 +96,7 @@ const GenericActivityDetail = ({
         onDraftChange={onDraftChange}
         typeDefinitions={typeDefinitions}
         icon={typeIcon}
+        titleHref={`/activity-type/${activity.activity_type}`}
       />
 
       {!isEditing && activity.avg_hrv !== undefined && (

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -114,11 +114,15 @@ export const createDurationActivityItem = (
   existingItems: ChartItem[],
   overlaps: OverlapWarning[],
   itemIcons: Record<string, string>,
+  typeDefinitions?: Map<string, { icon?: string }>,
 ): ChartItem => {
   const actEnd = activity.end_time!
   const displayName = activity.title ?? toDisplayName(activity.activity_type)
   const icon =
-    itemIcons[displayName] ?? itemIcons[displayName.toLowerCase()] ?? itemIcons[activity.activity_type]
+    itemIcons[displayName] ??
+    itemIcons[displayName.toLowerCase()] ??
+    itemIcons[activity.activity_type] ??
+    typeDefinitions?.get(activity.activity_type)?.icon
 
   // Detect overlaps with existing activity items
   let overlapWarning: string | undefined
@@ -177,7 +181,7 @@ const getActivityMeta = (
   activityColors: Record<string, string>,
   exerciseColor: (a: Activity) => string,
   getExerciseTypeName: (a: Activity) => string,
-  typeDefinitions?: Map<string, { display_name: string; color: string }>,
+  typeDefinitions?: Map<string, { display_name: string; color: string; icon?: string }>,
 ): ActivityMeta | null => {
   const type = a.activity_type
   if (!type) return null
@@ -259,7 +263,7 @@ export const buildActivityColumnItems = (
   sleepMetricsByDate: Map<string, Record<string, number>>,
   buildSleepDetails: (a: Activity, end: Date) => string[],
   scrobbles: { artist: string; track: string; recorded_at: Date }[],
-  typeDefinitions?: Map<string, { display_name: string; color: string }>,
+  typeDefinitions?: Map<string, { display_name: string; color: string; icon?: string }>,
 ): { items: ChartItem[]; overlaps: OverlapWarning[] } => {
   const items: ChartItem[] = []
   const overlaps: OverlapWarning[] = []
@@ -272,9 +276,9 @@ export const buildActivityColumnItems = (
     const end = a.end_time ?? new Date(a.start_time.getTime() + 60 * 60000)
     const details = buildActivityDetails(a, end, buildSleepDetails, scrobbles)
 
-    // Resolve icon from user overrides or defaults
+    // Resolve icon from user overrides, defaults, or type definition
     const iconKey = getActivityIconKey(a, getExerciseTypeName)
-    const icon = resolveItemIcon(iconKey, itemIcons)
+    const icon = resolveItemIcon(iconKey, itemIcons) ?? typeDefinitions?.get(a.activity_type)?.icon
 
     items.push({
       activity_type: meta.actType,
@@ -301,7 +305,7 @@ export const buildActivityColumnItems = (
   for (const act of durationActivities) {
     const merged = tryMergeActivityIntoItem(act, items)
     if (!merged) {
-      items.push(createDurationActivityItem(act, items, overlaps, itemIcons))
+      items.push(createDurationActivityItem(act, items, overlaps, itemIcons, typeDefinitions))
     }
   }
 

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -365,7 +365,11 @@ const categorizeLocations = (places: Place[], uniquePlaceNames: string[]): Chart
     },
   }))
 
-const categorizeTagActivities = (activities: Activity[], itemIcons: Record<string, string>): ChartItem[] =>
+const categorizeTagActivities = (
+  activities: Activity[],
+  itemIcons: Record<string, string>,
+  typeDefsMap?: Map<string, { icon?: string }>,
+): ChartItem[] =>
   activities
     .filter((a) => a.source !== 'lastfm')
     .map((a) => {
@@ -374,7 +378,10 @@ const categorizeTagActivities = (activities: Activity[], itemIcons: Record<strin
       const sourceLabel = a.source ? ` (${a.source})` : ''
       const displayName = a.title ?? toDisplayName(a.activity_type)
       const icon =
-        itemIcons[displayName] ?? itemIcons[displayName.toLowerCase()] ?? itemIcons[a.activity_type]
+        itemIcons[displayName] ??
+        itemIcons[displayName.toLowerCase()] ??
+        itemIcons[a.activity_type] ??
+        typeDefsMap?.get(a.activity_type)?.icon
       return {
         color: getActivityColor(a),
         column: 'Activity' as Column,
@@ -764,6 +771,13 @@ export const Timeline = () => {
     queryKey: ['activityTypeDefinitions'],
     staleTime: 5 * 60_000,
   })
+  const typeDefsMap = useMemo(
+    () =>
+      new Map(
+        activityTypeDefs.map((t) => [t.name, { color: t.color, display_name: t.display_name, icon: t.icon }]),
+      ),
+    [activityTypeDefs],
+  )
   const hiddenTypes = useMemo(
     () => new Set(activityTypeDefs.filter((t) => !t.show_on_timeline).map((t) => t.name)),
     [activityTypeDefs],
@@ -841,8 +855,9 @@ export const Timeline = () => {
         sleepMetricsByDate,
         (a, end) => buildSleepDetails(a, end, sleepMetricsByDate),
         scrobbles,
+        typeDefsMap,
       ),
-    [activities, tagActivities, itemIcons, sleepMetricsByDate, scrobbles],
+    [activities, tagActivities, itemIcons, sleepMetricsByDate, scrobbles, typeDefsMap],
   )
 
   // Tag activities not already included in activityItems (point activities, excluded sources, etc.)
@@ -948,7 +963,7 @@ export const Timeline = () => {
     () => [
       ...activityItems,
       ...categorizeLocations(places, uniquePlaceNames),
-      ...categorizeTagActivities(nonBuiltinTagActivities, itemIcons),
+      ...categorizeTagActivities(nonBuiltinTagActivities, itemIcons, typeDefsMap),
       ...categorizeProductivity(productivity, screentimeCategoriesQuery.data ?? [], itemIcons),
       ...musicItems,
       ...mealItems,
@@ -959,6 +974,7 @@ export const Timeline = () => {
       uniquePlaceNames,
       nonBuiltinTagActivities,
       itemIcons,
+      typeDefsMap,
       productivity,
       screentimeCategoriesQuery.data,
       musicItems,


### PR DESCRIPTION
## Summary
- Activity detail page title now links to the activity type page (`/activity-type/{name}`)
- Timeline icon resolution now falls back to the activity type definition's `icon` field when user overrides and defaults don't have a match — so custom activity types with icons set show them on both the detail page and timeline

## Test plan
- [ ] Open an activity detail page for a custom type (e.g. Yard Work) — title should be a clickable link to the activity type page
- [ ] Verify custom activity type icons appear on the timeline
- [ ] Verify existing built-in type icons (sleep, exercise, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)