### PR TITLE
feat: ad hoc meals, time slider, nutrient completeness

### DIFF
--- a/apps/backend/src/services/meals.test.ts
+++ b/apps/backend/src/services/meals.test.ts
@@ -1,7 +1,16 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import type { MealFoodItemLink } from '../db/types.ts'
+
 import * as db from '../db/index.ts'
-import { addMeal, deleteMealById, getMeal, queryMeals, updateMealById } from './meals.ts'
+import {
+  addMeal,
+  deleteMealById,
+  getMeal,
+  hasIncompleteNutrients,
+  queryMeals,
+  updateMealById,
+} from './meals.ts'
 
 // Mock the db module
 vi.mock('../db', () => ({
@@ -233,5 +242,113 @@ describe('updateMealById', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toBe('Meal not found')
+  })
+})
+
+// ── hasIncompleteNutrients ─────────────────────────────────────────────────
+
+const makeLink = (overrides: Partial<MealFoodItemLink> = {}): MealFoodItemLink =>
+  ({
+    id: 'link-1',
+    meal_id: 'meal-1',
+    food_item_id: 'fi-1',
+    food_item_name: 'Test food',
+    sort_order: 0,
+    calories: 200,
+    protein: 10,
+    carbs: 25,
+    fat: 8,
+    ...overrides,
+  }) as unknown as MealFoodItemLink
+
+describe('hasIncompleteNutrients', () => {
+  test('returns false when all items have calories', () => {
+    const links = [makeLink({ calories: 200 }), makeLink({ id: 'link-2', calories: 150 })]
+    expect(hasIncompleteNutrients(links)).toBe(false)
+  })
+
+  test('returns true when an item has undefined calories', () => {
+    const links = [makeLink({ calories: 200 }), makeLink({ id: 'link-2', calories: undefined })]
+    expect(hasIncompleteNutrients(links)).toBe(true)
+  })
+
+  test('returns false for empty array', () => {
+    expect(hasIncompleteNutrients([])).toBe(false)
+  })
+
+  test('returns false when calories is zero', () => {
+    const links = [makeLink({ calories: 0 })]
+    expect(hasIncompleteNutrients(links)).toBe(false)
+  })
+})
+
+// ── nutrient_data_incomplete in getMeal ─────────────────────────────────────
+
+const mockGetMealFoodItemsBatch = vi.mocked(db.getMealFoodItemsBatch)
+
+describe('getMeal nutrient_data_incomplete', () => {
+  test('sets nutrient_data_incomplete when a food item lacks calories', async () => {
+    mockGetMealById.mockResolvedValue({
+      created_at: new Date('2025-06-15T10:00:00Z'),
+      id: 'meal-1',
+      meal_type: 'lunch',
+      source: 'manual',
+      time: new Date('2025-06-15T12:00:00Z'),
+    })
+    mockGetMealFoodItemsBatch.mockResolvedValue(
+      new Map([
+        [
+          'meal-1',
+          [
+            makeLink({ calories: 200, food_item_name: 'Apple' }),
+            makeLink({ id: 'link-2', calories: undefined, food_item_name: 'Mystery item' }),
+          ],
+        ],
+      ]),
+    )
+
+    const result = await getMeal('testuser', 'meal-1')
+
+    expect(result.success).toBe(true)
+    expect(result.data!.nutrient_data_incomplete).toBe(true)
+  })
+
+  test('does not set nutrient_data_incomplete when all items have calories', async () => {
+    mockGetMealById.mockResolvedValue({
+      created_at: new Date('2025-06-15T10:00:00Z'),
+      id: 'meal-1',
+      meal_type: 'lunch',
+      source: 'manual',
+      time: new Date('2025-06-15T12:00:00Z'),
+    })
+    mockGetMealFoodItemsBatch.mockResolvedValue(
+      new Map([
+        [
+          'meal-1',
+          [makeLink({ calories: 200, food_item_name: 'Apple' }), makeLink({ id: 'link-2', calories: 150 })],
+        ],
+      ]),
+    )
+
+    const result = await getMeal('testuser', 'meal-1')
+
+    expect(result.success).toBe(true)
+    expect(result.data!.nutrient_data_incomplete).toBeUndefined()
+  })
+
+  test('does not set nutrient_data_incomplete when meal has no food items', async () => {
+    mockGetMealById.mockResolvedValue({
+      created_at: new Date('2025-06-15T10:00:00Z'),
+      id: 'meal-1',
+      meal_type: 'lunch',
+      source: 'manual',
+      time: new Date('2025-06-15T12:00:00Z'),
+    })
+    mockGetMealFoodItemsBatch.mockResolvedValue(new Map())
+
+    const result = await getMeal('testuser', 'meal-1')
+
+    expect(result.success).toBe(true)
+    expect(result.data!.nutrient_data_incomplete).toBeUndefined()
   })
 })

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -84,6 +84,7 @@ interface MealResponse {
   micros?: Micros
   notes?: string
   nutrients?: Record<string, number>
+  nutrient_data_incomplete?: boolean
   sensitivities?: string[]
   created_at: string
 }
@@ -104,7 +105,9 @@ interface MealsResult {
 // Helpers
 // ============================================================================
 
-const formatMeal = (meal: Meal & { nutrients?: Record<string, number> }): MealResponse => ({
+type EnrichedMeal = Meal & { nutrients?: Record<string, number>; nutrient_data_incomplete?: boolean }
+
+const formatMeal = (meal: EnrichedMeal): MealResponse => ({
   calories: meal.calories,
   carbs: meal.carbs,
   created_at: meal.created_at.toISOString(),
@@ -116,6 +119,7 @@ const formatMeal = (meal: Meal & { nutrients?: Record<string, number> }): MealRe
   micros: meal.micros,
   name: meal.name,
   notes: meal.notes,
+  nutrient_data_incomplete: meal.nutrient_data_incomplete,
   nutrients: meal.nutrients,
   protein: meal.protein,
   sensitivities: meal.sensitivities,
@@ -155,11 +159,12 @@ const aggregateNutrients = (links: MealFoodItemLink[]): Record<string, number> =
   return totals
 }
 
+/** Check if any food item in the junction links lacks calorie data. */
+export const hasIncompleteNutrients = (links: MealFoodItemLink[]): boolean =>
+  links.some((link) => link.calories === undefined || link.calories === null)
+
 /** Attach food items and aggregated nutrients from junction table to meals. */
-const attachFoodItems = async (
-  user: string,
-  meals: Meal[],
-): Promise<Array<Meal & { nutrients?: Record<string, number> }>> => {
+const attachFoodItems = async (user: string, meals: Meal[]): Promise<EnrichedMeal[]> => {
   const mealIds = meals.map((m) => m.id)
   const junctionMap = await getMealFoodItemsBatch(user, mealIds)
 
@@ -167,7 +172,13 @@ const attachFoodItems = async (
     const links = junctionMap.get(meal.id)
     if (links && links.length > 0) {
       const nutrients = aggregateNutrients(links)
-      return { ...meal, food_items: linksToFoodItems(links), nutrients }
+      const incomplete = hasIncompleteNutrients(links)
+      return {
+        ...meal,
+        food_items: linksToFoodItems(links),
+        nutrients,
+        ...(incomplete ? { nutrient_data_incomplete: true } : {}),
+      }
     }
     // Fall back to JSONB food_items if no junction rows exist (legacy data)
     return meal

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -390,8 +390,24 @@ a.detail-food-link:hover {
   background: #f3f4f6;
 }
 
+.incomplete-notice {
+  font-size: 0.8rem;
+  color: #d97706;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
+}
+
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
+  .incomplete-notice {
+    color: #f59e0b;
+    background: #1c1917;
+    border-color: #78350f;
+  }
+
   .nutrient-breakdown {
     border-color: #374151;
     background: #1f2937;

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -632,7 +632,14 @@ export function MealDetail() {
         {/* Nutrient sidebar — shown beside the card on wide screens */}
         {!isEditing &&
           (meal.nutrients && Object.keys(meal.nutrients).length > 0 ? (
-            <NutrientBreakdown nutrients={meal.nutrients} />
+            <div>
+              <NutrientBreakdown nutrients={meal.nutrients} />
+              {meal.nutrient_data_incomplete && (
+                <p class="incomplete-notice">
+                  Some food items lack nutrient data — totals may be understated.
+                </p>
+              )}
+            </div>
           ) : (
             <div class="nutrient-breakdown nutrient-placeholder" />
           ))}

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -35,35 +35,11 @@ const DEFAULT_MEAL_SLOTS: MealSlot[] = [
 
 const formatTime = (hour: number, minute: number): string => `${hour}:${String(minute).padStart(2, '0')}`
 
-interface TimeOption {
-  hour: number
-  minute: number
-  label: string
-}
-
-/** Build time selector options: preset hours ± 1, plus the actual meal time if non-round. */
-const buildTimeOptions = (defaultHour: number, mealHour: number, mealMinute: number): TimeOption[] => {
-  const presets: TimeOption[] = [defaultHour - 1, defaultHour, defaultHour + 1]
-    .filter((h) => h >= 0 && h <= 23)
-    .map((h) => ({ hour: h, minute: 0, label: formatTime(h, 0) }))
-
-  // If meal has a non-round time that isn't already a preset, insert it sorted
-  if (mealMinute !== 0) {
-    const mealKey = mealHour * 60 + mealMinute
-    const alreadyPresent = presets.some((p) => p.hour === mealHour && p.minute === mealMinute)
-    if (!alreadyPresent) {
-      const mealOption: TimeOption = {
-        hour: mealHour,
-        minute: mealMinute,
-        label: formatTime(mealHour, mealMinute),
-      }
-      const idx = presets.findIndex((p) => p.hour * 60 + p.minute > mealKey)
-      if (idx === -1) presets.push(mealOption)
-      else presets.splice(idx, 0, mealOption)
-    }
-  }
-
-  return presets
+/** Convert total minutes since midnight to HH:MM string. */
+const minutesToTime = (totalMinutes: number): string => {
+  const h = Math.floor(totalMinutes / 60)
+  const m = totalMinutes % 60
+  return formatTime(h, m)
 }
 
 const formatMealType = (type?: string): string =>
@@ -159,7 +135,16 @@ function MealDetails({
           ))}
         </div>
       )}
-      {hasCalories && <span class="meal-calories">{meal.calories} kcal</span>}
+      {hasCalories && (
+        <span class="meal-calories">
+          {meal.nutrient_data_incomplete && (
+            <span class="incomplete-indicator" title="Some food items lack nutrient data">
+              ~
+            </span>
+          )}
+          {meal.calories} kcal
+        </span>
+      )}
       {meal.notes && <div class="meal-notes">{meal.notes}</div>}
       {meal.source && meal.source !== 'manual' && <span class="meal-source">via {meal.source}</span>}
     </div>
@@ -174,6 +159,7 @@ interface MealSlotRowProps {
   onToggleSensitivity: (slot: MealSlot, area: string, existingMeal?: Meal) => void
   onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
   onChangeTime: (meal: Meal, hour: number, minute?: number) => void
+  onCreateAtTime: (slot: MealSlot, hour: number, minute: number) => void
   onCreateAndOpen: (slot: MealSlot) => void
   onDelete: (id: string) => void
   isDeletePending: boolean
@@ -188,6 +174,7 @@ function MealSlotRow({
   onToggleSensitivity,
   onToggleFoodMapping,
   onChangeTime,
+  onCreateAtTime,
   onCreateAndOpen,
   onDelete,
   isDeletePending,
@@ -201,8 +188,28 @@ function MealSlotRow({
   const mealH = primaryMeal ? primaryMeal.time.getHours() : slot.default_hour
   const mealM = primaryMeal ? primaryMeal.time.getMinutes() : 0
 
-  // Build time options: preset hours + actual meal time if non-round
-  const timeOptions = buildTimeOptions(slot.default_hour, mealH, mealM)
+  // Slider range: ±1.5 hours from default, clamped to 0–23:55
+  const sliderMin = Math.max(0, (slot.default_hour - 1.5) * 60)
+  const sliderMax = Math.min(23 * 60 + 55, (slot.default_hour + 1.5) * 60)
+  const currentMinutes = mealH * 60 + mealM
+  const [sliderValue, setSliderValue] = useState(currentMinutes)
+  const [dragging, setDragging] = useState(false)
+
+  // Sync slider position with actual meal time when not dragging
+  useEffect(() => {
+    if (!dragging) setSliderValue(mealH * 60 + mealM)
+  }, [mealH, mealM, dragging])
+
+  const handleSliderRelease = () => {
+    setDragging(false)
+    const hour = Math.floor(sliderValue / 60)
+    const minute = sliderValue % 60
+    if (primaryMeal) {
+      onChangeTime(primaryMeal, hour, minute)
+    } else {
+      onCreateAtTime(slot, hour, minute)
+    }
+  }
 
   return (
     <div class={`meal-slot-row ${primaryMeal ? 'has-meal' : ''}`}>
@@ -211,21 +218,22 @@ function MealSlotRow({
           {slot.name}
         </a>
 
-        <div class="time-selector">
-          {timeOptions.map((t) => (
-            <button
-              key={t.label}
-              type="button"
-              class={`time-btn ${mealH === t.hour && mealM === t.minute ? 'active' : ''}`}
-              onClick={() => {
-                if (primaryMeal) onChangeTime(primaryMeal, t.hour, t.minute)
-              }}
-              disabled={!primaryMeal && t.hour !== slot.default_hour}
-              title={!primaryMeal ? 'Log a meal first to change the time' : `Set time to ${t.label}`}
-            >
-              {t.label}
-            </button>
-          ))}
+        <div class="time-slider-wrapper">
+          <span class="time-label">{minutesToTime(dragging ? sliderValue : currentMinutes)}</span>
+          <input
+            type="range"
+            class="time-slider"
+            min={sliderMin}
+            max={sliderMax}
+            step={5}
+            value={dragging ? sliderValue : currentMinutes}
+            onInput={(e) => {
+              setDragging(true)
+              setSliderValue(parseInt((e.target as HTMLInputElement).value, 10))
+            }}
+            onMouseUp={handleSliderRelease}
+            onTouchEnd={handleSliderRelease}
+          />
         </div>
 
         {isSaving && <span class="saving-indicator" />}
@@ -314,6 +322,7 @@ const aggregateDayNutrients = (meals: Meal[]): Record<string, number> => {
 function DayNutrientSummary({ meals }: { meals: Meal[] }) {
   const nutrients = aggregateDayNutrients(meals)
   const hasNutrients = Object.keys(nutrients).length > 0
+  const isIncomplete = meals.some((m) => m.nutrient_data_incomplete)
 
   return (
     <div class={`day-nutrient-summary${hasNutrients ? '' : ' empty'}`}>
@@ -322,6 +331,9 @@ function DayNutrientSummary({ meals }: { meals: Meal[] }) {
       ) : (
         <>
           <h3>Day Totals</h3>
+          {isIncomplete && (
+            <p class="incomplete-notice">Some food items lack nutrient data — totals may be understated.</p>
+          )}
           {NUTRIENT_CATEGORIES.map(({ key, label }) => {
             const fields = NUTRIENT_FIELDS.filter(
               (f) => f.category === key && nutrients[f.name] !== undefined,
@@ -577,6 +589,33 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     route(`/meals/${id}?edit=1`)
   }
 
+  const handleCreateAtTime = (slot: MealSlot, hour: number, minute: number) => {
+    const slotName = slot.name.toLowerCase()
+    const id = crypto.randomUUID()
+    const mealTime = new Date(dayKey)
+    mealTime.setHours(hour, minute, 0, 0)
+    upsertMutation.mutate({
+      id,
+      meal_type: slotName,
+      source: 'manual',
+      time: mealTime.toISOString(),
+    })
+  }
+
+  const handleCreateAdHocMeal = async () => {
+    const id = crypto.randomUUID()
+    const mealTime = new Date()
+    const dayDate = new Date(dayKey)
+    mealTime.setFullYear(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate())
+    await addMealApi({
+      id,
+      source: 'manual',
+      time: mealTime.toISOString(),
+    })
+    queryClient.invalidateQueries({ queryKey: ['meals'] })
+    route(`/meals/${id}?edit=1`)
+  }
+
   const otherMeals = getOtherMeals(meals ?? [], mealSlots)
   const foodSensitivityMap: Record<string, string[]> = settings?.food_sensitivity_map ?? {}
   const queryClient = useQueryClient()
@@ -625,6 +664,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
               onToggleSensitivity={handleToggleSensitivity}
               onToggleFoodMapping={handleToggleFoodMapping}
               onChangeTime={handleChangeTime}
+              onCreateAtTime={handleCreateAtTime}
               onCreateAndOpen={handleCreateAndOpen}
               onDelete={(id) => deleteMutation.mutate(id)}
               isDeletePending={deleteMutation.isPending}
@@ -632,6 +672,10 @@ function MealsContent({ dayKey }: { dayKey: string }) {
             />
           ))}
         </div>
+
+        <button type="button" class="btn-add-meal" onClick={handleCreateAdHocMeal}>
+          + Add meal
+        </button>
 
         <OtherMeals
           meals={otherMeals}

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -192,38 +192,104 @@
   }
 }
 
-.time-selector {
+/* Time slider */
+
+.time-slider-wrapper {
   display: flex;
-  gap: 2px;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
 }
 
-.time-btn {
-  padding: 0.25rem 0.5rem;
+.time-label {
   font-size: 0.8rem;
-  border: 1px solid #d1d5db;
-  background: #fff;
+  font-weight: 500;
   color: #374151;
+  min-width: 3.25rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.time-slider {
+  flex: 1;
+  height: 6px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: #d1d5db;
+  border-radius: 3px;
+  outline: none;
   cursor: pointer;
-  border-radius: 4px;
 }
 
-.time-btn:first-child {
-  border-radius: 4px 0 0 4px;
-}
-
-.time-btn:last-child {
-  border-radius: 0 4px 4px 0;
-}
-
-.time-btn.active {
+.time-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
   background: #673ab8;
-  color: white;
-  border-color: #673ab8;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  cursor: grab;
 }
 
-.time-btn:disabled:not(.active) {
-  opacity: 0.4;
-  cursor: not-allowed;
+.time-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #673ab8;
+  border: 2px solid #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  cursor: grab;
+}
+
+.time-slider:active::-webkit-slider-thumb {
+  cursor: grabbing;
+  transform: scale(1.15);
+}
+
+.time-slider:active::-moz-range-thumb {
+  cursor: grabbing;
+  transform: scale(1.15);
+}
+
+/* Ad hoc meal button */
+
+.btn-add-meal {
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  border: 1px dashed #d1d5db;
+  background: transparent;
+  color: #6b7280;
+  border-radius: 8px;
+  cursor: pointer;
+  width: 100%;
+  text-align: center;
+}
+
+.btn-add-meal:hover {
+  border-color: #673ab8;
+  color: #673ab8;
+  background: #faf5ff;
+}
+
+/* Incomplete nutrient indicators */
+
+.incomplete-indicator {
+  color: #d97706;
+  font-weight: 600;
+  margin-left: 0.25rem;
+}
+
+.incomplete-notice {
+  font-size: 0.8rem;
+  color: #d97706;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  margin-top: 0.5rem;
 }
 
 .sensitivity-checks {
@@ -506,16 +572,41 @@ a.meal-name:hover {
     border-color: #6d28d9;
   }
 
-  .time-btn {
-    background: #374151;
-    border-color: #4b5563;
+  .time-label {
     color: #d1d5db;
   }
 
-  .time-btn.active {
-    background: #673ab8;
-    border-color: #673ab8;
-    color: white;
+  .time-slider {
+    background: #4b5563;
+  }
+
+  .time-slider::-webkit-slider-thumb {
+    border-color: #1f2937;
+  }
+
+  .time-slider::-moz-range-thumb {
+    border-color: #1f2937;
+  }
+
+  .btn-add-meal {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+
+  .btn-add-meal:hover {
+    border-color: #7c3aed;
+    color: #c4b5fd;
+    background: #1e1b4b;
+  }
+
+  .incomplete-indicator {
+    color: #f59e0b;
+  }
+
+  .incomplete-notice {
+    color: #f59e0b;
+    background: #1c1917;
+    border-color: #78350f;
   }
 
   .sensitivity-label {

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -117,6 +117,10 @@ export const mealSchema = z
       .optional()
       .meta({ description: 'Meal name/description (e.g., "Rye bread with peanut butter and banana")' }),
     notes: z.string().optional().meta({ description: 'Free text notes' }),
+    nutrient_data_incomplete: z.boolean().optional().meta({
+      description:
+        'True if any food item in the meal lacks calorie data, indicating nutrient totals may be understated',
+    }),
     protein: z.number().optional().meta({ description: 'Total protein in grams' }),
     sensitivities: z
       .array(z.string())


### PR DESCRIPTION
## Summary
- **Ad hoc meal button**: "+ Add meal" below meal slots creates a meal with no type, opens detail page for editing
- **Time slider**: Replaces 3 time-preset buttons with a horizontal range slider (±1.5h from default). Releasing the slider creates or updates the meal — enables quick one-gesture logging
- **Incomplete nutrient indicators**: Meals with food items lacking calorie data are flagged with `nutrient_data_incomplete`. Shows `~` prefix on calories and amber notice in both per-meal and daily nutrient summaries

## Test plan
- [ ] Create ad hoc meal via "+ Add meal" button, verify it opens in edit mode
- [ ] Use time slider to quick-log a meal without clicking "+"
- [ ] Slide an existing meal's time and verify it updates
- [ ] Add a meal with a food item missing calorie data — verify `~` and amber notice
- [ ] Verify day summary shows incomplete notice when any meal is flagged
- [ ] All food items have calories — verify no indicator appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)