### PR TITLE
feat: recent entries on category page + bug fixes

### DIFF
--- a/apps/web/src/components/IconInput.css
+++ b/apps/web/src/components/IconInput.css
@@ -4,6 +4,7 @@
   border: 1px solid var(--border-color, #ccc);
   border-radius: 4px;
   background: var(--bg-secondary, #f5f5f5);
+  color: var(--text-color, #222);
   cursor: pointer;
   white-space: nowrap;
 }

--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query'
 import type { Activity, ActivityTypeDefinition } from '../../state/api'
 
 import { fetchMetricTimeSeries } from '../../state/api'
+import { toDisplayName } from '../../utils/displayName'
 import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
@@ -178,13 +179,12 @@ export const ExerciseDetail = ({
     <>
       <div class="entity-info">
         <div class="entity-meta">
-          {exerciseType ? (
-            <a href={`/activity-type/${encodeURIComponent(exerciseType)}`} class="entity-type-badge">
-              {formatExerciseTypeName(exerciseType)}
-            </a>
-          ) : (
-            <span class="entity-type-badge">{activity.activity_type}</span>
-          )}
+          <a
+            href={`/activity-type/${encodeURIComponent(exerciseType ?? activity.activity_type)}`}
+            class="entity-type-badge"
+          >
+            {exerciseType ? formatExerciseTypeName(exerciseType) : toDisplayName(activity.activity_type)}
+          </a>
           {activity.source && <span class="entity-source">Source: {activity.source}</span>}
         </div>
 

--- a/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/ExerciseDetail.tsx
@@ -116,7 +116,7 @@ const ExerciseStats = ({
         <div class="field-row">
           <span class="field-label">Exercise Type</span>
           <span class="field-value">
-            <a href={`/exercise/${encodeURIComponent(exerciseType)}`} class="entity-meta-link">
+            <a href={`/activity-type/${encodeURIComponent(exerciseType)}`} class="entity-meta-link">
               {formatExerciseTypeName(exerciseType)}
             </a>
           </span>
@@ -179,7 +179,7 @@ export const ExerciseDetail = ({
       <div class="entity-info">
         <div class="entity-meta">
           {exerciseType ? (
-            <a href={`/exercise/${encodeURIComponent(exerciseType)}`} class="entity-type-badge">
+            <a href={`/activity-type/${encodeURIComponent(exerciseType)}`} class="entity-type-badge">
               {formatExerciseTypeName(exerciseType)}
             </a>
           ) : (

--- a/apps/web/src/pages/EntityDetail/SleepDetail.tsx
+++ b/apps/web/src/pages/EntityDetail/SleepDetail.tsx
@@ -106,7 +106,9 @@ export const SleepDetail = ({
     <>
       <div class="entity-info">
         <div class="entity-meta">
-          <span class="entity-type-badge">{activity.activity_type}</span>
+          <a href={`/activity-type/${encodeURIComponent(activity.activity_type)}`} class="entity-type-badge">
+            {activity.activity_type}
+          </a>
           {activity.source && <span class="entity-source">Source: {activity.source}</span>}
         </div>
 

--- a/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
+++ b/apps/web/src/pages/ScreentimeCategories/CategoryDetail.tsx
@@ -8,8 +8,9 @@
 import type { ScreentimeCategory } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format, subDays } from 'date-fns'
 import { useRoute } from 'preact-iso'
-import { useCallback, useEffect, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
 
 import { IconInput } from '../../components/IconInput'
 import { MiniTrendChart } from '../../components/MiniTrendChart'
@@ -17,6 +18,7 @@ import {
   type DistinctApp,
   type FetchTrendParams,
   fetchDistinctApps,
+  fetchProductivity,
   fetchScreentimeCategories,
   fetchScreentimeCategoryById,
   fetchTrend,
@@ -748,6 +750,63 @@ function AddConfirmDialog({
 }
 
 // ============================================================================
+// Recent entries section
+// ============================================================================
+
+function RecentEntries({ categoryPath }: { categoryPath: string[] }) {
+  const now = new Date()
+  const start = subDays(now, 7)
+
+  const query = useQuery({
+    queryFn: () => fetchProductivity(start, now),
+    queryKey: ['category-recent-entries', categoryPath.join('>')],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const entries = useMemo(() => {
+    const records = query.data?.records ?? []
+    return records
+      .filter((r) => {
+        if (!r.resolved_category || r.resolved_category.length < categoryPath.length) return false
+        return categoryPath.every((seg, i) => r.resolved_category![i] === seg)
+      })
+      .sort((a, b) => b.start_time.getTime() - a.start_time.getTime())
+      .slice(0, 50)
+  }, [query.data, categoryPath])
+
+  if (query.isLoading) return <div class="category-section"><p class="loading">Loading recent entries...</p></div>
+  if (entries.length === 0) return null
+
+  return (
+    <div class="category-section">
+      <h3>Recent entries <span class="count-badge">{entries.length}</span></h3>
+      <ul class="category-apps-list">
+        {entries.map((entry) => (
+          <li key={`${entry.start_time.toISOString()}-${entry.activity}`}>
+            <a
+              href={entry.id ? `/detail/productivity/${encodeURIComponent(entry.id)}` : undefined}
+              class="category-app-row"
+            >
+              <span class="category-app-name">{entry.activity}</span>
+              <span class="category-app-stats">
+                {format(entry.start_time, 'MMM d HH:mm')} – {format(entry.end_time, 'HH:mm')}
+                {' · '}
+                {formatDuration(entry.duration_sec)}
+                {entry.resolved_category && entry.resolved_category.length > categoryPath.length && (
+                  <span style={{ color: 'var(--text-muted)', marginLeft: '4px' }}>
+                    {entry.resolved_category.slice(categoryPath.length).join(' > ')}
+                  </span>
+                )}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+// ============================================================================
 // Trend section
 // ============================================================================
 
@@ -1103,6 +1162,7 @@ function ExistingCategoryPage({
         onMoved={onFieldSaved}
       />
       <CategoryTrendSection categoryPath={category.name.join(' > ')} color={category.color ?? '#673ab8'} />
+      <RecentEntries categoryPath={category.name} />
       <ChildCategoriesList children={children} distinctApps={distinctApps} icons={icons} />
       <MatchedAppList apps={matchedApps} category={category} onAppRemoved={onFieldSaved} />
       <UncategorizedAppList apps={uncategorized} category={category} onAppAdded={onFieldSaved} />

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -276,9 +276,15 @@ export const buildActivityColumnItems = (
     const end = a.end_time ?? new Date(a.start_time.getTime() + 60 * 60000)
     const details = buildActivityDetails(a, end, buildSleepDetails, scrobbles)
 
-    // Resolve icon from user overrides, defaults, or type definition
+    // Resolve icon from user overrides, defaults, or type definition.
+    // For exercises, also check the sub-type key (e.g. "strength_training") in type definitions.
     const iconKey = getActivityIconKey(a, getExerciseTypeName)
-    const icon = resolveItemIcon(iconKey, itemIcons) ?? typeDefinitions?.get(a.activity_type)?.icon
+    const exerciseSubType = a.activity_type === 'exercise'
+      ? (a.data as Record<string, unknown> | undefined)?.activity_type_key as string | undefined
+      : undefined
+    const icon = resolveItemIcon(iconKey, itemIcons)
+      ?? (exerciseSubType && typeDefinitions?.get(exerciseSubType)?.icon)
+      ?? typeDefinitions?.get(a.activity_type)?.icon
 
     items.push({
       activity_type: meta.actType,


### PR DESCRIPTION
## Summary
- **Recent entries** section on screentime category detail page: shows last 7 days of productivity records matching the category (and subcategories), with app name, time range, duration, and link to detail page
- **Fix**: Exercise detail badge links to `/activity-type/` instead of broken `/exercise/`
- **Fix**: Icon upload button now has explicit `color: var(--text-color)` for dark mode visibility

## Test plan
- [ ] Visit a screentime category page (e.g. "Work & Dev") — see recent entries with app names and times
- [ ] Subcategory entries show their sub-path (e.g. "Software Dev") next to the time
- [ ] Click an entry → navigates to `/detail/productivity/:id`
- [ ] Exercise detail page → click exercise type badge → goes to `/activity-type/strength_training`
- [ ] Dark mode: icon upload button text is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)