### PR TITLE
fix: deduction rules Add Rule showing Rule not found

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -98,7 +98,6 @@ export function App() {
               <Route path="/data-sources/owntracks" component={OwnTracksSource} />
               <Route path="/data-sources/calendars" component={CalendarsSource} />
               <Route path="/activity-types" component={ActivityTypes} />
-              <Route path="/deduction-rules/new" component={DeductionRuleDetail} />
               <Route path="/deduction-rules/:id" component={DeductionRuleDetail} />
               <Route path="/deduction-rules" component={DeductionRules} />
               <Route path="/screentime-categories/:id" component={CategoryDetail} />


### PR DESCRIPTION
## Summary
- The `/deduction-rules/new` route was a static route without an `:id` param, so `useRoute().params.id` was `undefined` instead of `'new'`
- Removed the redundant static route — `/:id` now handles both new and edit cases

## Test plan
- [ ] Navigate to /deduction-rules and click "Add Rule" — should show the new rule form instead of "Rule not found"
- [ ] Navigate to /deduction-rules/:id for an existing rule — should still show the edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)