### PR TITLE
fix: preserve activity data on upsert (stop redundant Garmin detail syncs)

### DIFF
--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -6,9 +6,11 @@ import {
   deleteActivity,
   getActivities,
   getActivityById,
+  getActivitiesNeedingDetail,
   getOverlappingActivities,
   getSleepSessions,
   insertActivity,
+  markActivityDetailSynced,
   updateActivity,
 } from './activities.ts'
 
@@ -83,6 +85,49 @@ describe('Activities Integration Tests', () => {
       expect(activities).toHaveLength(1)
       expect(activities[0].title).toBe('Sleep v2')
       expect(activities[0].end_time).toEqual(new Date('2024-01-16T07:00:00Z'))
+    })
+
+    test('merges data on upsert, preserving existing keys like detail_synced', async () => {
+      const user = getTestUser()
+
+      // First insert: Garmin activity with some data
+      const activityId = await insertActivity(user, {
+        activity_type: 'exercise',
+        data: { garmin_activity_id: 123, calories: 200 },
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Run',
+      })
+
+      // Mark detail as synced (simulates what happens after fetching per-second metrics)
+      await markActivityDetailSynced(user, activityId)
+
+      // Re-sync: upsert same activity with updated data (without detail_synced)
+      await insertActivity(user, {
+        activity_type: 'exercise',
+        data: { garmin_activity_id: 123, calories: 250 },
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Run',
+      })
+
+      const activities = await getActivities(
+        user,
+        'exercise',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z'),
+      )
+
+      expect(activities).toHaveLength(1)
+      expect(activities[0].data).toEqual({
+        calories: 250,
+        detail_synced: true,
+        garmin_activity_id: 123,
+      })
+
+      // Should NOT need detail re-sync
+      const needingDetail = await getActivitiesNeedingDetail(user)
+      expect(needingDetail).toHaveLength(0)
     })
   })
 

--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -258,7 +258,7 @@ export const insertActivity = async (user: string, activity: Activity): Promise<
          end_time = EXCLUDED.end_time,
          title = EXCLUDED.title,
          notes = EXCLUDED.notes,
-         data = EXCLUDED.data
+         data = COALESCE(activities.data, '{}'::jsonb) || EXCLUDED.data
        WHERE activities.deleted_at IS NULL
        RETURNING id`,
       [
@@ -285,7 +285,7 @@ export const insertActivity = async (user: string, activity: Activity): Promise<
        end_time = EXCLUDED.end_time,
        title = EXCLUDED.title,
        notes = EXCLUDED.notes,
-       data = EXCLUDED.data
+       data = COALESCE(activities.data, '{}'::jsonb) || EXCLUDED.data
      WHERE activities.deleted_at IS NULL
      RETURNING id`,
     [
@@ -334,7 +334,7 @@ export const insertActivities = async (user: string, activities: Activity[]) => 
            end_time = EXCLUDED.end_time,
            title = EXCLUDED.title,
            notes = EXCLUDED.notes,
-           data = EXCLUDED.data
+           data = COALESCE(activities.data, '{}'::jsonb) || EXCLUDED.data
          WHERE activities.deleted_at IS NULL`,
         values,
       ),
@@ -363,7 +363,7 @@ export const insertActivities = async (user: string, activities: Activity[]) => 
            end_time = EXCLUDED.end_time,
            title = EXCLUDED.title,
            notes = EXCLUDED.notes,
-           data = EXCLUDED.data
+           data = COALESCE(activities.data, '{}'::jsonb) || EXCLUDED.data
          WHERE activities.deleted_at IS NULL`,
         values,
       ),


### PR DESCRIPTION
## Summary

- Activity upserts (`insertActivity`, `insertActivities`) used `data = EXCLUDED.data` which completely replaced the JSONB data column on conflict
- This wiped the `detail_synced` flag set by `markActivityDetailSynced`, causing every Garmin sync to re-fetch per-second detail metrics for recent activities (e.g. "Synced 816 detail metrics for Garmin activity 22450053306" appearing repeatedly)
- Changed to `COALESCE(activities.data, '{}'::jsonb) || EXCLUDED.data` which merges new data on top of existing, preserving keys like `detail_synced` that aren't in the incoming sync data

## Test plan

- [ ] Integration test: `merges data on upsert, preserving existing keys like detail_synced` verifies the fix
- [ ] Verify in audit log after deploy that Garmin activity details are only synced once per activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)