### PR TITLE
refactor: simplify deduction rule target + add after_date condition

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -542,7 +542,6 @@ export const migrateSchema = async (user: string) => {
       `ALTER TABLE deduction_rules ADD COLUMN IF NOT EXISTS mode VARCHAR(10) NOT NULL DEFAULT 'create'`,
     )
     await query(db, `ALTER TABLE deduction_rules ADD COLUMN IF NOT EXISTS output_data JSONB`)
-    await query(db, `ALTER TABLE deduction_rules ADD COLUMN IF NOT EXISTS target_activity_type VARCHAR(100)`)
   }
 
   // Migrate notes entity_id from UUID to TEXT (supports composite keys for metrics)

--- a/apps/backend/src/db/deduction-rules.ts
+++ b/apps/backend/src/db/deduction-rules.ts
@@ -17,11 +17,10 @@ const mapRow = (row: Record<string, unknown>): DeductionRule => ({
   ...(row.output_data != null ? { output_data: row.output_data as Record<string, unknown> } : {}),
   ...(row.output_title != null ? { output_title: row.output_title as string } : {}),
   priority: row.priority as number,
-  ...(row.target_activity_type != null ? { target_activity_type: row.target_activity_type as string } : {}),
 })
 
 const SELECT_COLS =
-  'id, name, enabled, priority, conditions, output_activity_type, output_title, merge_gap_seconds, mode, output_data, target_activity_type, created_at'
+  'id, name, enabled, priority, conditions, output_activity_type, output_title, merge_gap_seconds, mode, output_data, created_at'
 
 export const getDeductionRules = async (user: string): Promise<DeductionRule[]> => {
   const result = await query(user, `SELECT ${SELECT_COLS} FROM deduction_rules ORDER BY priority, name`)
@@ -54,13 +53,12 @@ export const insertDeductionRule = async (
     enabled?: boolean
     mode?: DeductionRuleMode
     output_data?: Record<string, unknown>
-    target_activity_type?: string
   },
 ): Promise<DeductionRule> => {
   const result = await query(
     user,
-    `INSERT INTO deduction_rules (name, enabled, priority, conditions, output_activity_type, output_title, merge_gap_seconds, mode, output_data, target_activity_type)
-     VALUES ($1, COALESCE($2, true), COALESCE($3, 0), $4, $5, $6, $7, COALESCE($8, 'create'), $9, $10)
+    `INSERT INTO deduction_rules (name, enabled, priority, conditions, output_activity_type, output_title, merge_gap_seconds, mode, output_data)
+     VALUES ($1, COALESCE($2, true), COALESCE($3, 0), $4, $5, $6, $7, COALESCE($8, 'create'), $9)
      RETURNING ${SELECT_COLS}`,
     [
       rule.name,
@@ -72,7 +70,6 @@ export const insertDeductionRule = async (
       rule.merge_gap_seconds ?? null,
       rule.mode ?? null,
       rule.output_data ? JSON.stringify(rule.output_data) : null,
-      rule.target_activity_type ?? null,
     ],
   )
   return mapRow(result.rows[0])
@@ -91,7 +88,6 @@ export const updateDeductionRule = async (
     merge_gap_seconds?: number | null
     mode?: DeductionRuleMode
     output_data?: Record<string, unknown> | null
-    target_activity_type?: string | null
   },
 ): Promise<DeductionRule | null> => {
   const setClauses: string[] = []
@@ -134,11 +130,6 @@ export const updateDeductionRule = async (
     setClauses.push(`output_data = $${paramIndex++}`)
     values.push(updates.output_data ? JSON.stringify(updates.output_data) : null)
   }
-  if (updates.target_activity_type !== undefined) {
-    setClauses.push(`target_activity_type = $${paramIndex++}`)
-    values.push(updates.target_activity_type)
-  }
-
   if (setClauses.length === 0) return getDeductionRule(user, id)
 
   setClauses.push(`updated_at = NOW()`)

--- a/apps/backend/src/mcp/deduction-rule-tools.ts
+++ b/apps/backend/src/mcp/deduction-rule-tools.ts
@@ -46,7 +46,7 @@ Condition kinds:
 
 Modes:
 - "create" (default): creates new activities of output_activity_type
-- "enrich": patches output_data onto existing activities of target_activity_type (only fills missing fields)
+- "enrich": patches output_data onto existing activities of output_activity_type (only fills missing fields)
 
 Use output_data to set custom data fields on created/enriched activities.
 Multiple conditions use AND logic — all must overlap in time. The rule is applied retroactively to all historical data.`,
@@ -56,10 +56,6 @@ Multiple conditions use AND logic — all must overlap in time. The rule is appl
         return errorResponse(
           `Unknown activity type: "${params.output_activity_type}". Create it first with add_activity_type.`,
         )
-      }
-
-      if (params.mode === 'enrich' && !params.target_activity_type) {
-        return errorResponse('target_activity_type is required when mode is "enrich"')
       }
 
       const rule = await insertDeductionRule(user, params)
@@ -148,7 +144,6 @@ Multiple conditions use AND logic — all must overlap in time. The rule is appl
         output_data: params.output_data as Record<string, unknown> | undefined,
         output_title: params.output_title,
         priority: params.priority ?? 0,
-        target_activity_type: params.target_activity_type,
       }
 
       const window = { end: new Date(), start: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000) }

--- a/apps/backend/src/routes/deduction-rules-router.ts
+++ b/apps/backend/src/routes/deduction-rules-router.ts
@@ -59,19 +59,12 @@ export const createDeductionRulesRouter = (
         enabled,
         mode,
         output_data,
-        target_activity_type,
       } = req.body
 
       if (!(await activityTypeExists(user, output_activity_type))) {
         return res
           .status(400)
           .json({ error: `Unknown activity type: "${output_activity_type}"`, success: false })
-      }
-
-      if (mode === 'enrich' && !target_activity_type) {
-        return res
-          .status(400)
-          .json({ error: 'target_activity_type is required when mode is "enrich"', success: false })
       }
 
       const rule = await insertDeductionRule(user, {
@@ -84,7 +77,6 @@ export const createDeductionRulesRouter = (
         output_data: output_data as Record<string, unknown> | undefined,
         output_title,
         priority,
-        target_activity_type,
       })
 
       // Retroactive evaluation over full history
@@ -104,14 +96,12 @@ export const createDeductionRulesRouter = (
       const { output_activity_type } = req.body
 
       if (!(await activityTypeExists(user, output_activity_type))) {
-        return res
-          .status(400)
-          .json({
-            error: `Unknown activity type: "${output_activity_type}"`,
-            sample_days: 0,
-            success: false,
-            would_affect: 0,
-          })
+        return res.status(400).json({
+          error: `Unknown activity type: "${output_activity_type}"`,
+          sample_days: 0,
+          success: false,
+          would_affect: 0,
+        })
       }
 
       const tempRule = {
@@ -125,7 +115,6 @@ export const createDeductionRulesRouter = (
         output_data: req.body.output_data as Record<string, unknown> | undefined,
         output_title: req.body.output_title,
         priority: req.body.priority ?? 0,
-        target_activity_type: req.body.target_activity_type,
       }
 
       const window = { end: new Date(), start: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000) }

--- a/apps/backend/src/services/deduction-engine.test.ts
+++ b/apps/backend/src/services/deduction-engine.test.ts
@@ -314,8 +314,8 @@ describe('evaluateRule', () => {
 
     const rule = makeRule({
       mode: 'enrich',
+      output_activity_type: 'sex',
       output_data: { partner: 'Sara' },
-      target_activity_type: 'sex',
     })
 
     const { affected_ids } = await evaluateRule(user, rule, window, deps)
@@ -352,8 +352,8 @@ describe('evaluateRule', () => {
 
     const rule = makeRule({
       mode: 'enrich',
+      output_activity_type: 'sex',
       output_data: { partner: 'Sara' },
-      target_activity_type: 'sex',
     })
 
     const { affected_ids, would_affect } = await evaluateRule(user, rule, window, deps, true)
@@ -465,10 +465,9 @@ describe('evaluateAllRules', () => {
         id: 'rule-1',
         mode: 'enrich',
         name: 'Enrich rule',
-        output_activity_type: 'sauna',
+        output_activity_type: 'sex',
         output_data: { partner: 'Sara' },
         priority: 0,
-        target_activity_type: 'sex',
       },
     ]
 

--- a/apps/backend/src/services/deduction-engine.ts
+++ b/apps/backend/src/services/deduction-engine.ts
@@ -178,9 +178,17 @@ const resolveLocation: ConditionResolver = async (user, condition, window, deps)
   return deps.getLocationVisits(user, condition.location_name, window)
 }
 
+const resolveAfterDate: ConditionResolver = async (_user, condition, window) => {
+  if (condition.kind !== 'after_date') return []
+  const since = new Date(condition.date)
+  if (since >= window.end) return []
+  return [{ start: since > window.start ? since : window.start, end: window.end }]
+}
+
 const conditionResolvers: Record<string, ConditionResolver> = {
   activity: resolveActivity,
   activity_data: resolveActivityData,
+  after_date: resolveAfterDate,
   location: resolveLocation,
   screentime_category: resolveScreentimeCategory,
   tag: resolveTag,
@@ -243,16 +251,16 @@ export const evaluateRule = async (
   if (result.length === 0) return { affected_ids: [], would_affect: 0 }
 
   // Enrich mode: patch existing activities
-  if (rule.mode === 'enrich' && rule.target_activity_type) {
+  if (rule.mode === 'enrich') {
     if (dryRun) {
       // Count how many target activities overlap the ranges without modifying them
-      const targetRanges = await deps.getActivities(user, rule.target_activity_type, window)
+      const targetRanges = await deps.getActivities(user, rule.output_activity_type, window)
       const overlapping = intersectTimeRanges(result, targetRanges)
       return { affected_ids: [], would_affect: overlapping.length }
     }
     const enrichedIds = await deps.enrichActivities(
       user,
-      rule.target_activity_type,
+      rule.output_activity_type,
       result,
       rule.output_data ?? {},
       rule.id,

--- a/apps/web/src/components/ConditionBuilder/index.tsx
+++ b/apps/web/src/components/ConditionBuilder/index.tsx
@@ -5,12 +5,13 @@ import { useQuery } from '@tanstack/react-query'
 
 import type { DeductionRuleCondition } from '../../state/api'
 
-import { fetchActivityTypeDefinitions } from '../../state/api'
+import { fetchActivityTypeDefinitions, fetchNamedLocations } from '../../state/api'
 import './style.css'
 
 const KIND_LABELS: Record<string, string> = {
   activity: 'Activity Type',
   activity_data: 'Activity Data Field',
+  after_date: 'Since Date',
   location: 'Location',
   screentime_category: 'Screentime Category',
   tag: 'Tag Name',
@@ -22,6 +23,7 @@ const KINDS: Array<DeductionRuleCondition['kind']> = [
   'screentime_category',
   'activity_data',
   'location',
+  'after_date',
 ]
 
 const OPERATOR_LABELS: Record<string, string> = {
@@ -118,6 +120,7 @@ function ActivityDataBody({
 const KIND_DEFAULTS: Record<string, Partial<DeductionRuleCondition>> = {
   activity: { activity_type: '' },
   activity_data: { activity_type: '', field: '', operator: 'eq', value: '' },
+  after_date: { date: new Date().toISOString().slice(0, 10) },
   location: { location_name: '' },
   screentime_category: { category: [] },
   tag: { tag_name: '' },
@@ -139,6 +142,12 @@ function ConditionCard({
   const { data: definitions = [] } = useQuery({
     queryFn: fetchActivityTypeDefinitions,
     queryKey: ['activityTypeDefinitions'],
+    staleTime: 5 * 60_000,
+  })
+
+  const { data: namedLocations = [] } = useQuery({
+    queryFn: fetchNamedLocations,
+    queryKey: ['namedLocations'],
     staleTime: 5 * 60_000,
   })
 
@@ -214,11 +223,28 @@ function ConditionCard({
         )}
 
         {condition.kind === 'location' && (
+          <>
+            <input
+              type="text"
+              list="named-locations-list"
+              value={condition.location_name ?? ''}
+              onInput={(e) => update({ ...condition, location_name: (e.target as HTMLInputElement).value })}
+              placeholder="Start typing a location name..."
+              class="condition-field-input"
+            />
+            <datalist id="named-locations-list">
+              {namedLocations.map((loc) => (
+                <option key={loc.name} value={loc.name} />
+              ))}
+            </datalist>
+          </>
+        )}
+
+        {condition.kind === 'after_date' && (
           <input
-            type="text"
-            value={condition.location_name ?? ''}
-            onInput={(e) => update({ ...condition, location_name: (e.target as HTMLInputElement).value })}
-            placeholder="Named location (e.g. Home, Office)"
+            type="date"
+            value={condition.date ?? ''}
+            onInput={(e) => update({ ...condition, date: (e.target as HTMLInputElement).value })}
             class="condition-field-input"
           />
         )}

--- a/apps/web/src/pages/DeductionRules/RuleDetail.tsx
+++ b/apps/web/src/pages/DeductionRules/RuleDetail.tsx
@@ -181,7 +181,6 @@ function NewRuleForm() {
   const [conditions, setConditions] = useState<DeductionRuleCondition[]>([{ kind: 'activity' }])
   const [mode, setMode] = useState<'create' | 'enrich'>('create')
   const [outputData, setOutputData] = useState<Record<string, unknown>>({})
-  const [targetActivityType, setTargetActivityType] = useState('')
   const [previewResult, setPreviewResult] = useState<{ would_affect: number; sample_days: number } | null>(
     null,
   )
@@ -202,7 +201,6 @@ function NewRuleForm() {
     output_data: Object.keys(outputData).length > 0 ? outputData : undefined,
     output_title: outputTitle || undefined,
     priority,
-    target_activity_type: mode === 'enrich' ? targetActivityType || undefined : undefined,
   })
 
   const createMutation = useMutation({
@@ -250,24 +248,6 @@ function NewRuleForm() {
           </div>
 
           <ActivityTypePicker value={outputType} onChange={setOutputType} definitions={definitions} />
-
-          {mode === 'enrich' && (
-            <div class="rule-field">
-              <span class="rule-field-label">Target Activity Type</span>
-              <select
-                value={targetActivityType}
-                onChange={(e) => setTargetActivityType((e.target as HTMLSelectElement).value)}
-                class="rule-field-select"
-              >
-                <option value="">-- select target --</option>
-                {definitions.map((d) => (
-                  <option key={d.name} value={d.name}>
-                    {d.display_name} ({d.name})
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
 
           <OutputDataEditor data={outputData} onChange={setOutputData} />
 

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -120,7 +120,7 @@ export interface ActivityTypeDefinition {
 }
 
 export interface DeductionRuleCondition {
-  kind: 'activity' | 'tag' | 'screentime_category' | 'activity_data' | 'location'
+  kind: 'activity' | 'tag' | 'screentime_category' | 'activity_data' | 'location' | 'after_date'
   activity_type?: string
   tag_name?: string
   category?: string[]
@@ -128,6 +128,7 @@ export interface DeductionRuleCondition {
   operator?: 'eq' | 'neq' | 'exists' | 'not_exists'
   value?: string | number | boolean
   location_name?: string
+  date?: string
 }
 
 export interface DeductionRule {
@@ -141,7 +142,6 @@ export interface DeductionRule {
   merge_gap_seconds?: number
   mode?: 'create' | 'enrich'
   output_data?: Record<string, unknown>
-  target_activity_type?: string
   created_at?: string
 }
 
@@ -807,7 +807,6 @@ export const previewDeductionRule = async (body: {
   priority?: number
   mode?: 'create' | 'enrich'
   output_data?: Record<string, unknown>
-  target_activity_type?: string
 }): Promise<{ would_affect: number; sample_days: number }> => {
   const { token } = auth.value
   const response = await axios.post<{ success: boolean; would_affect: number; sample_days: number }>(
@@ -828,7 +827,6 @@ export const createDeductionRule = async (body: {
   enabled?: boolean
   mode?: 'create' | 'enrich'
   output_data?: Record<string, unknown>
-  target_activity_type?: string
 }): Promise<DeductionRule> => {
   const { token } = auth.value
   const response = await axios.post<{ success: boolean; data: DeductionRule }>(
@@ -851,7 +849,6 @@ export const updateDeductionRule = async (
     enabled: boolean
     mode: 'create' | 'enrich'
     output_data: Record<string, unknown> | null
-    target_activity_type: string | null
   }>,
 ): Promise<DeductionRule> => {
   const { token } = auth.value

--- a/packages/api-spec/src/schemas/deduction-rules.ts
+++ b/packages/api-spec/src/schemas/deduction-rules.ts
@@ -52,12 +52,20 @@ export const locationConditionSchema = z
   })
   .meta({ description: 'Matches time ranges where the user is at a named location' })
 
+export const afterDateConditionSchema = z
+  .object({
+    date: z.string().meta({ description: 'ISO 8601 date (e.g. "2024-06-01") — only match after this date' }),
+    kind: z.literal('after_date'),
+  })
+  .meta({ description: 'Restricts matches to after a given date' })
+
 export const conditionSchema = z.discriminatedUnion('kind', [
   activityConditionSchema,
   tagConditionSchema,
   screentimeCategoryConditionSchema,
   activityDataConditionSchema,
   locationConditionSchema,
+  afterDateConditionSchema,
 ])
 
 export type Condition = z.infer<typeof conditionSchema>
@@ -90,7 +98,8 @@ export const deductionRuleSchema = z
     }),
     name: z.string().meta({ description: 'Human-readable rule name' }),
     output_activity_type: activityTypeSchema.meta({
-      description: 'Activity type to create when conditions match (used in create mode)',
+      description:
+        'In create mode: activity type to create. In enrich mode: activity type to patch data onto.',
     }),
     output_data: z
       .record(z.string(), z.unknown())
@@ -103,9 +112,6 @@ export const deductionRuleSchema = z
       .min(0)
       .max(2)
       .meta({ description: 'Evaluation order (0=first, max 2 for chaining)' }),
-    target_activity_type: activityTypeSchema
-      .optional()
-      .meta({ description: 'Activity type to enrich (required when mode=enrich)' }),
   })
   .meta({
     id: 'DeductionRule',
@@ -134,7 +140,9 @@ export const addDeductionRuleBodySchema = z
       .optional()
       .meta({ description: 'create (default) or enrich existing activities' }),
     name: z.string().meta({ description: 'Human-readable rule name' }),
-    output_activity_type: activityTypeSchema.meta({ description: 'Activity type to create' }),
+    output_activity_type: activityTypeSchema.meta({
+      description: 'In create mode: type to create. In enrich mode: type to patch data onto.',
+    }),
     output_data: z
       .record(z.string(), z.unknown())
       .optional()
@@ -147,9 +155,6 @@ export const addDeductionRuleBodySchema = z
       .max(2)
       .optional()
       .meta({ description: 'Evaluation order (0=first, max 2). Defaults to 0.' }),
-    target_activity_type: activityTypeSchema
-      .optional()
-      .meta({ description: 'Activity type to enrich (required when mode=enrich)' }),
   })
   .meta({ id: 'AddDeductionRuleBody' })
 
@@ -179,10 +184,6 @@ export const updateDeductionRuleBodySchema = z
       .meta({ description: 'New output data (null to clear)' }),
     output_title: z.string().nullable().optional().meta({ description: 'New title (null to remove)' }),
     priority: z.number().int().min(0).max(2).optional().meta({ description: 'New priority' }),
-    target_activity_type: activityTypeSchema
-      .nullable()
-      .optional()
-      .meta({ description: 'New target activity type (null to clear)' }),
   })
   .meta({ id: 'UpdateDeductionRuleBody' })
 


### PR DESCRIPTION
## Summary
- **Remove `target_activity_type`**: `output_activity_type` now serves as both the type to create (create mode) and the type to enrich (enrich mode) — one field, clear intent per mode
- **Add `after_date` condition**: restricts rule matches to after a given date (e.g. only match activities from 2025-01-01 onwards)
- **Location autocomplete**: location condition input now uses `<datalist>` populated from named locations for quick selection

## Test plan
- [x] All 1657 backend tests pass
- [x] Type checks pass
- [ ] Verify enrich mode UI only shows "Output Activity Type" (no target field)
- [ ] Verify "Since Date" condition shows date picker
- [ ] Verify location condition shows autocomplete suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)