### PR TITLE
fix: enriched_by shows rule name with link

### DIFF
--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -132,6 +132,7 @@ const enrichActivities = async (
   ranges: TimeRange[],
   data: Record<string, unknown>,
   ruleId: string,
+  ruleName: string,
 ): Promise<string[]> => {
   if (ranges.length === 0 || Object.keys(data).length === 0) return []
 
@@ -165,7 +166,7 @@ const enrichActivities = async (
       if (Object.keys(patch).length === 0) continue
 
       // Track enrichment provenance
-      patch._enriched_by = ruleId
+      patch._enriched_by = { rule_id: ruleId, rule_name: ruleName }
 
       await query(
         user,

--- a/apps/backend/src/services/deduction-engine.test.ts
+++ b/apps/backend/src/services/deduction-engine.test.ts
@@ -327,6 +327,7 @@ describe('evaluateRule', () => {
       [{ end: d(11), start: d(10) }],
       { partner: 'Sara' },
       'rule-1',
+      'Sauna tag to activity',
     )
     expect(deps.insertActivity).not.toHaveBeenCalled()
   })

--- a/apps/backend/src/services/deduction-engine.ts
+++ b/apps/backend/src/services/deduction-engine.ts
@@ -56,6 +56,7 @@ export interface DeductionEngineDeps {
     ranges: TimeRange[],
     data: Record<string, unknown>,
     ruleId: string,
+    ruleName: string,
   ) => Promise<string[]>
   deleteStaleRuleActivities: (
     user: string,
@@ -264,6 +265,7 @@ export const evaluateRule = async (
       result,
       rule.output_data ?? {},
       rule.id,
+      rule.name,
     )
     return { affected_ids: enrichedIds, would_affect: enrichedIds.length }
   }

--- a/apps/web/src/pages/EntityDetail/SchemaDataFields.tsx
+++ b/apps/web/src/pages/EntityDetail/SchemaDataFields.tsx
@@ -1,8 +1,11 @@
 /**
  * Renders activity data fields based on an activity type's data schema definition.
  * Shows labeled values for declared fields, and a greyed-out section for extra undeclared fields.
+ * Internal fields (_enriched_by, rule_id, rule_name) are rendered specially or hidden.
  */
 import type { DataSchemaDefinition } from '@aurboda/api-spec'
+
+const INTERNAL_KEYS = new Set(['_enriched_by', 'rule_id', 'rule_name'])
 
 const capitalize = (s: string) =>
   s
@@ -15,6 +18,32 @@ const formatValue = (value: unknown, unit?: string): string => {
   return unit ? `${str} ${unit}` : str
 }
 
+const EnrichedByLink = ({ value }: { value: unknown }) => {
+  if (typeof value === 'object' && value !== null && 'rule_id' in value) {
+    const { rule_id, rule_name } = value as { rule_id: string; rule_name: string }
+    return (
+      <div class="field-row" style={{ opacity: 0.7 }}>
+        <span class="field-label">Enriched by</span>
+        <span class="field-value">
+          <a href={`/deduction-rules/${rule_id}`}>{rule_name}</a>
+        </span>
+      </div>
+    )
+  }
+  // Legacy format: just a rule ID string
+  if (typeof value === 'string') {
+    return (
+      <div class="field-row" style={{ opacity: 0.7 }}>
+        <span class="field-label">Enriched by</span>
+        <span class="field-value">
+          <a href={`/deduction-rules/${value}`}>{value.slice(0, 8)}...</a>
+        </span>
+      </div>
+    )
+  }
+  return null
+}
+
 export const SchemaDataFields = ({
   data,
   schema,
@@ -23,7 +52,8 @@ export const SchemaDataFields = ({
   schema: DataSchemaDefinition
 }) => {
   const schemaFieldNames = new Set(schema.fields.map((f) => f.name))
-  const extraKeys = Object.keys(data).filter((k) => !schemaFieldNames.has(k))
+  const extraKeys = Object.keys(data).filter((k) => !schemaFieldNames.has(k) && !INTERNAL_KEYS.has(k))
+  const enrichedBy = data._enriched_by
 
   return (
     <div class="entity-fields">
@@ -47,6 +77,7 @@ export const SchemaDataFields = ({
           </div>
         )
       })}
+      {enrichedBy && <EnrichedByLink value={enrichedBy} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `_enriched_by` now stores `{rule_id, rule_name}` instead of just the rule ID
- SchemaDataFields renders it as a clickable link: "Enriched by [Rule Name](/deduction-rules/:id)"
- Internal fields (`_enriched_by`, `rule_id`, `rule_name`) are hidden from raw data display
- Legacy format (plain UUID string) still renders with a truncated link

## Test plan
- [x] All 1657 tests pass
- [ ] Re-evaluate an enrich rule, verify entity detail shows "Enriched by Rule Name" as a link

🤖 Generated with [Claude Code](https://claude.com/claude-code)