### PR TITLE
fix: normalize enriched_by — resolve rule names at query time

### DIFF
--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -38,6 +38,7 @@ import multer from 'multer'
 import {
   getActivityById,
   getAllActivityTypeNames,
+  getDeductionRule,
   getDistinctApps,
   getNearbyActivities,
   getOverlappingActivities,
@@ -485,6 +486,21 @@ export const createActivitiesRouter = (
       return res.json({ data, success: true })
     }
 
+    // Resolve referenced deduction rules from activity data
+    const referencedRules: Record<string, string> = {}
+    const activityData = activity.data as Record<string, unknown> | undefined
+    if (activityData) {
+      const ruleIds = [
+        typeof activityData._enriched_by === 'string' ? activityData._enriched_by : undefined,
+        typeof activityData.rule_id === 'string' ? activityData.rule_id : undefined,
+      ].filter((id): id is string => id !== undefined)
+
+      for (const ruleId of ruleIds) {
+        const rule = await getDeductionRule(user, ruleId)
+        if (rule) referencedRules[ruleId] = rule.name
+      }
+    }
+
     // Plain UUID: return raw single activity (no overlap lookup)
     res.json({
       data: {
@@ -500,6 +516,7 @@ export const createActivitiesRouter = (
         start_time: activity.start_time.toISOString(),
         title: activity.title,
       },
+      referenced_rules: Object.keys(referencedRules).length > 0 ? referencedRules : undefined,
       success: true,
     })
   })

--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -132,7 +132,6 @@ const enrichActivities = async (
   ranges: TimeRange[],
   data: Record<string, unknown>,
   ruleId: string,
-  ruleName: string,
 ): Promise<string[]> => {
   if (ranges.length === 0 || Object.keys(data).length === 0) return []
 
@@ -165,8 +164,8 @@ const enrichActivities = async (
 
       if (Object.keys(patch).length === 0) continue
 
-      // Track enrichment provenance
-      patch._enriched_by = { rule_id: ruleId, rule_name: ruleName }
+      // Track enrichment provenance (just the ID — name resolved at query time)
+      patch._enriched_by = ruleId
 
       await query(
         user,

--- a/apps/backend/src/services/deduction-engine.test.ts
+++ b/apps/backend/src/services/deduction-engine.test.ts
@@ -327,7 +327,6 @@ describe('evaluateRule', () => {
       [{ end: d(11), start: d(10) }],
       { partner: 'Sara' },
       'rule-1',
-      'Sauna tag to activity',
     )
     expect(deps.insertActivity).not.toHaveBeenCalled()
   })

--- a/apps/backend/src/services/deduction-engine.ts
+++ b/apps/backend/src/services/deduction-engine.ts
@@ -56,7 +56,6 @@ export interface DeductionEngineDeps {
     ranges: TimeRange[],
     data: Record<string, unknown>,
     ruleId: string,
-    ruleName: string,
   ) => Promise<string[]>
   deleteStaleRuleActivities: (
     user: string,
@@ -265,7 +264,6 @@ export const evaluateRule = async (
       result,
       rule.output_data ?? {},
       rule.id,
-      rule.name,
     )
     return { affected_ids: enrichedIds, would_affect: enrichedIds.length }
   }

--- a/apps/web/src/pages/EntityDetail/SchemaDataFields.tsx
+++ b/apps/web/src/pages/EntityDetail/SchemaDataFields.tsx
@@ -18,42 +18,40 @@ const formatValue = (value: unknown, unit?: string): string => {
   return unit ? `${str} ${unit}` : str
 }
 
-const EnrichedByLink = ({ value }: { value: unknown }) => {
-  if (typeof value === 'object' && value !== null && 'rule_id' in value) {
-    const { rule_id, rule_name } = value as { rule_id: string; rule_name: string }
-    return (
-      <div class="field-row" style={{ opacity: 0.7 }}>
-        <span class="field-label">Enriched by</span>
-        <span class="field-value">
-          <a href={`/deduction-rules/${rule_id}`}>{rule_name}</a>
-        </span>
-      </div>
-    )
-  }
-  // Legacy format: just a rule ID string
-  if (typeof value === 'string') {
-    return (
-      <div class="field-row" style={{ opacity: 0.7 }}>
-        <span class="field-label">Enriched by</span>
-        <span class="field-value">
-          <a href={`/deduction-rules/${value}`}>{value.slice(0, 8)}...</a>
-        </span>
-      </div>
-    )
-  }
-  return null
+const RuleLink = ({
+  ruleId,
+  referencedRules,
+  label,
+}: {
+  ruleId: string
+  referencedRules?: Record<string, string>
+  label: string
+}) => {
+  const ruleName = referencedRules?.[ruleId]
+  return (
+    <div class="field-row" style={{ opacity: 0.7 }}>
+      <span class="field-label">{label}</span>
+      <span class="field-value">
+        <a href={`/deduction-rules/${ruleId}`}>{ruleName ?? ruleId.slice(0, 8) + '...'}</a>
+      </span>
+    </div>
+  )
 }
 
 export const SchemaDataFields = ({
   data,
   schema,
+  referencedRules,
 }: {
   data: Record<string, unknown>
   schema: DataSchemaDefinition
+  referencedRules?: Record<string, string>
 }) => {
   const schemaFieldNames = new Set(schema.fields.map((f) => f.name))
   const extraKeys = Object.keys(data).filter((k) => !schemaFieldNames.has(k) && !INTERNAL_KEYS.has(k))
-  const enrichedBy = data._enriched_by
+
+  const enrichedByRuleId = typeof data._enriched_by === 'string' ? data._enriched_by : undefined
+  const createdByRuleId = typeof data.rule_id === 'string' ? data.rule_id : undefined
 
   return (
     <div class="entity-fields">
@@ -77,7 +75,12 @@ export const SchemaDataFields = ({
           </div>
         )
       })}
-      {enrichedBy && <EnrichedByLink value={enrichedBy} />}
+      {enrichedByRuleId && (
+        <RuleLink ruleId={enrichedByRuleId} referencedRules={referencedRules} label="Enriched by" />
+      )}
+      {createdByRuleId && (
+        <RuleLink ruleId={createdByRuleId} referencedRules={referencedRules} label="Created by rule" />
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -168,6 +168,7 @@ const ActivityDetailContent = ({
   onDraftChange,
   itemIcons,
   typeDefinitions,
+  referencedRules,
 }: {
   activity: Activity
   isEditing: boolean
@@ -175,6 +176,7 @@ const ActivityDetailContent = ({
   onDraftChange: (d: ActivityDraft) => void
   itemIcons: Record<string, string>
   typeDefinitions?: ActivityTypeDefinition[]
+  referencedRules?: Record<string, string>
 }) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd =
@@ -339,6 +341,7 @@ const ActivityDetailContent = ({
               <SchemaDataFields
                 data={activity.data as Record<string, unknown>}
                 schema={typeDef.data_schema}
+                referencedRules={referencedRules}
               />
             )}
           </>
@@ -389,7 +392,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
   const rawEntityId = isMerged ? entityId.slice('merged:'.length) : entityId
 
   const {
-    data: activity,
+    data: activityResult,
     isLoading,
     isError,
   } = useQuery({
@@ -397,6 +400,8 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
     queryKey: ['entity-detail', 'activity', entityId],
     staleTime: 60_000,
   })
+  const activity = activityResult?.activity
+  const referencedRules = activityResult?.referenced_rules
 
   const { data: itemIcons = {} } = useQuery({
     queryFn: fetchItemIcons,
@@ -509,6 +514,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         onDraftChange={setDraft}
         itemIcons={itemIcons}
         typeDefinitions={typeDefinitions}
+        referencedRules={referencedRules}
       />
       <NotesSection entityType="activity" entityId={rawEntityId} allEntityIds={allEntityIds} />
     </>

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1354,7 +1354,12 @@ export const restoreProductivity = async (id: string): Promise<void> => {
 // Entity Detail Fetching
 // ============================================================================
 
-export const fetchActivityById = async (id: string): Promise<Activity> => {
+export interface ActivityDetailResult {
+  activity: Activity
+  referenced_rules?: Record<string, string>
+}
+
+export const fetchActivityById = async (id: string): Promise<ActivityDetailResult> => {
   const { token } = auth.value
   const response = await axios.get(`${API_URL}/activities/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -1362,12 +1367,15 @@ export const fetchActivityById = async (id: string): Promise<Activity> => {
 
   const d = response.data.data
   return {
-    ...d,
-    end_time: d.end_time ? new Date(d.end_time) : undefined,
-    merged_end_time: d.merged_end_time ? new Date(d.merged_end_time) : undefined,
-    merged_start_time: d.merged_start_time ? new Date(d.merged_start_time) : undefined,
-    source_records: d.source_records,
-    start_time: new Date(d.start_time),
+    activity: {
+      ...d,
+      end_time: d.end_time ? new Date(d.end_time) : undefined,
+      merged_end_time: d.merged_end_time ? new Date(d.merged_end_time) : undefined,
+      merged_start_time: d.merged_start_time ? new Date(d.merged_start_time) : undefined,
+      source_records: d.source_records,
+      start_time: new Date(d.start_time),
+    },
+    referenced_rules: response.data.referenced_rules,
   }
 }
 

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -400,9 +400,17 @@ export type NearbyActivitiesResponse = z.infer<typeof nearbyActivitiesResponseSc
 
 /**
  * Single activity detail response (for activity detail page).
+ * Includes referenced_rules map for resolving rule IDs to names.
  */
-export const activityDetailResponseSchema = createDataResponseSchema(activitySchema).meta({
-  id: 'ActivityDetailResponse',
-})
+export const activityDetailResponseSchema = createDataResponseSchema(activitySchema)
+  .extend({
+    referenced_rules: z
+      .record(z.string(), z.string())
+      .optional()
+      .meta({ description: 'Map of rule ID to rule name for deduction rules referenced in activity data' }),
+  })
+  .meta({
+    id: 'ActivityDetailResponse',
+  })
 
 export type ActivityDetailResponse = z.infer<typeof activityDetailResponseSchema>


### PR DESCRIPTION
## Summary
- `_enriched_by` now stores just the rule UUID (normalized), not a denormalized `{rule_id, rule_name}` object
- Activity detail endpoint resolves referenced rule IDs into a `referenced_rules` map (ID → name) in the response
- SchemaDataFields uses `referenced_rules` to render "Enriched by [Rule Name]" as a clickable link
- Also shows "Created by rule [Name]" for deduction-rule-created activities
- Added normalized data guideline to CLAUDE.md

## Test plan
- [x] All 1657 tests pass
- [ ] Re-evaluate an enrich rule, view enriched activity — verify "Enriched by" shows rule name as link
- [ ] View a deduction-created activity — verify "Created by rule" shows rule name as link

🤖 Generated with [Claude Code](https://claude.com/claude-code)