### PR TITLE
feat: editable schema data fields on activity detail

### DIFF
--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -414,11 +414,11 @@ export const createActivitiesRouter = (
     validateBody(updateActivityBodySchema),
     async (req, res) => {
       const { id } = req.params
-      const { activity_type, start_time, end_time, title, notes, exercise_type } = req.body
+      const { activity_type, start_time, end_time, title, notes, exercise_type, data: bodyData } = req.body
       const user = req.user!
 
-      // Convert exercise_type name to data object if provided
-      let data: Record<string, unknown> | undefined
+      // Merge exercise_type into data if provided
+      let data: Record<string, unknown> | undefined = bodyData as Record<string, unknown> | undefined
       if (exercise_type !== undefined) {
         if (!isValidExerciseType(exercise_type)) {
           return res.status(400).json({
@@ -427,6 +427,7 @@ export const createActivitiesRouter = (
           })
         }
         data = {
+          ...data,
           exerciseType: getExerciseTypeValue(exercise_type),
           exerciseTypeName: exercise_type,
         }

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -15,6 +15,7 @@ export interface ActivityDraft {
   end_time: string
   notes: string
   exercise_type?: string
+  data?: Record<string, unknown>
 }
 
 interface EditableActivityFieldsProps {

--- a/apps/web/src/pages/EntityDetail/SchemaDataFields.tsx
+++ b/apps/web/src/pages/EntityDetail/SchemaDataFields.tsx
@@ -2,8 +2,9 @@
  * Renders activity data fields based on an activity type's data schema definition.
  * Shows labeled values for declared fields, and a greyed-out section for extra undeclared fields.
  * Internal fields (_enriched_by, rule_id, rule_name) are rendered specially or hidden.
+ * In edit mode, renders appropriate inputs per field type.
  */
-import type { DataSchemaDefinition } from '@aurboda/api-spec'
+import type { DataFieldDefinition, DataSchemaDefinition } from '@aurboda/api-spec'
 
 const INTERNAL_KEYS = new Set(['_enriched_by', 'rule_id', 'rule_name'])
 
@@ -44,16 +45,131 @@ const EnrichedByLink = ({ value }: { value: unknown }) => {
   return null
 }
 
+const FieldInput = ({
+  field,
+  value,
+  onChange,
+}: {
+  field: DataFieldDefinition
+  value: unknown
+  onChange: (value: unknown) => void
+}) => {
+  if (field.type === 'boolean') {
+    return (
+      <input
+        type="checkbox"
+        checked={Boolean(value)}
+        onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+      />
+    )
+  }
+
+  if (field.type === 'string' && field.enum_values) {
+    return (
+      <select
+        class="edit-datetime-input"
+        value={(value as string) ?? ''}
+        onChange={(e) => {
+          const v = (e.target as HTMLSelectElement).value
+          onChange(v || null)
+        }}
+      >
+        <option value="">-- Select --</option>
+        {field.enum_values.map((v) => (
+          <option key={v} value={v}>
+            {v}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
+  if (field.type === 'number') {
+    return (
+      <span style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <input
+          type="number"
+          class="edit-datetime-input"
+          value={value != null ? String(value) : ''}
+          onInput={(e) => {
+            const raw = (e.target as HTMLInputElement).value
+            if (raw === '') {
+              onChange(null)
+            } else {
+              const num = parseFloat(raw)
+              if (!isNaN(num)) onChange(num)
+            }
+          }}
+        />
+        {field.unit && <span style={{ opacity: 0.6 }}>{field.unit}</span>}
+      </span>
+    )
+  }
+
+  // Default: string text input
+  return (
+    <input
+      type="text"
+      class="edit-datetime-input"
+      value={(value as string) ?? ''}
+      onInput={(e) => {
+        const v = (e.target as HTMLInputElement).value
+        onChange(v || null)
+      }}
+    />
+  )
+}
+
 export const SchemaDataFields = ({
   data,
   schema,
+  isEditing,
+  onDataChange,
 }: {
   data: Record<string, unknown>
   schema: DataSchemaDefinition
+  isEditing?: boolean
+  onDataChange?: (data: Record<string, unknown>) => void
 }) => {
   const schemaFieldNames = new Set(schema.fields.map((f) => f.name))
   const extraKeys = Object.keys(data).filter((k) => !schemaFieldNames.has(k) && !INTERNAL_KEYS.has(k))
   const enrichedBy = data._enriched_by
+
+  const updateField = (name: string, value: unknown) => {
+    if (!onDataChange) return
+    const updated = { ...data, [name]: value }
+    onDataChange(updated)
+  }
+
+  if (isEditing) {
+    return (
+      <div class="entity-fields">
+        {schema.fields.map((field) => (
+          <div class="field-row" key={field.name}>
+            <span class="field-label">{field.label ?? capitalize(field.name)}</span>
+            <span class="field-value">
+              <FieldInput
+                field={field}
+                value={data[field.name]}
+                onChange={(value) => updateField(field.name, value)}
+              />
+            </span>
+          </div>
+        ))}
+        {extraKeys.map((key) => {
+          const value = data[key]
+          if (value === undefined || value === null) return null
+          return (
+            <div class="field-row" key={key} style={{ opacity: 0.6 }}>
+              <span class="field-label">{capitalize(key)}</span>
+              <span class="field-value">{String(value)}</span>
+            </div>
+          )
+        })}
+        {enrichedBy && <EnrichedByLink value={enrichedBy} />}
+      </div>
+    )
+  }
 
   return (
     <div class="entity-fields">

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -295,6 +295,16 @@ const ActivityDetailContent = ({
           </div>
         )}
 
+        {/* Schema data fields — editable in edit mode, read-only otherwise */}
+        {typeDef?.data_schema && (isEditing || activity.data) && (
+          <SchemaDataFields
+            data={isEditing ? (draft.data ?? {}) : ((activity.data as Record<string, unknown>) ?? {})}
+            schema={typeDef.data_schema}
+            isEditing={isEditing}
+            onDataChange={isEditing ? (newData) => onDraftChange({ ...draft, data: newData }) : undefined}
+          />
+        )}
+
         {/* Read-only stats — shown based on data presence, not activity type */}
         {!isEditing && (
           <>
@@ -335,12 +345,6 @@ const ActivityDetailContent = ({
               </div>
             )}
             {hasHrZones && <HrZoneBar zones={hrZoneSecs!} />}
-            {typeDef?.data_schema && activity.data && (
-              <SchemaDataFields
-                data={activity.data as Record<string, unknown>}
-                schema={typeDef.data_schema}
-              />
-            )}
           </>
         )}
       </div>
@@ -374,6 +378,7 @@ const makeDraft = (activity: Activity): ActivityDraft => {
   const exerciseType = resolveExerciseType(activity)
   return {
     activity_type: activity.activity_type,
+    data: (activity.data as Record<string, unknown>) ?? {},
     end_time: formatDateTimeLocal(displayEnd),
     exercise_type: exerciseType,
     notes: activity.notes ?? '',
@@ -429,6 +434,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
   const [isMerging, setIsMerging] = useState(false)
   const emptyDraft: ActivityDraft = {
     activity_type: '',
+    data: {},
     end_time: '',
     notes: '',
     start_time: '',
@@ -454,6 +460,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         title?: string
         notes?: string
         exercise_type?: ExerciseTypeName
+        data?: Record<string, unknown>
       } = {}
       const orig = makeDraft(activity)
       if (draft.activity_type !== orig.activity_type) body.activity_type = draft.activity_type
@@ -467,6 +474,9 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
       if (draft.notes !== orig.notes) body.notes = draft.notes
       if (draft.exercise_type !== orig.exercise_type && draft.exercise_type) {
         body.exercise_type = draft.exercise_type as ExerciseTypeName
+      }
+      if (draft.data && JSON.stringify(draft.data) !== JSON.stringify(orig.data)) {
+        body.data = draft.data
       }
       if (Object.keys(body).length === 0) return Promise.resolve()
       return updateActivity(rawEntityId, body)

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -313,6 +313,9 @@ export type DeleteActivityResponse = z.infer<typeof deleteActivityResponseSchema
 export const updateActivityBodySchema = z
   .object({
     activity_type: activityTypeSchema.optional().meta({ description: 'New activity type' }),
+    data: z.record(z.string(), z.unknown()).optional().meta({
+      description: 'Updated structured data fields (merged with existing data)',
+    }),
     end_time: iso8601DateTimeSchema.optional().meta({ description: 'New end time of the activity' }),
     exercise_type: exerciseTypeSchema.optional().meta({
       description: 'New exercise type name (only for exercise activities)',


### PR DESCRIPTION
## Summary
- Add edit-mode support for `data_schema`-defined fields on activity detail page
- Renders appropriate inputs per field type: text for strings, number inputs, checkboxes for booleans, selects for enum-constrained strings
- Adds `data` to `updateActivityBodySchema` and PATCH handler so data fields can be saved

## Test plan
- [ ] Open a `sex` activity detail page, click edit pencil
- [ ] Verify `Partner` field input appears (from data_schema)
- [ ] Fill in the partner field, save, reload — confirm it persists
- [ ] Test with other field types (number, boolean, enum) if configured
- [ ] Verify read-only mode still displays schema fields correctly
- [ ] Verify extra undeclared data fields still show greyed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)