### PR TITLE
feat: chart tag cleanup, aggregation control, and breakdown by data field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ Row mappers in `db/row-mappers.ts` use type guards with api-spec constants (e.g.
 
 - Prefer code that is testable without heavy mocking.
 - Prefer functional style, no classes.
+- Store data in normalized form: reference entities by ID, not by duplicating names or other mutable fields. Resolve names at query time (e.g. in the API response layer) so data stays consistent when referenced entities are renamed.
 
 ## Testing
 

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -19,7 +19,16 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
     authMiddleware,
     validateQuery(chartDataHttpQuerySchema),
     async (req, res) => {
-      const { aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id } = req.query
+      const {
+        aggregation,
+        breakdown_field,
+        bucket_size,
+        end,
+        pattern,
+        source_type,
+        start,
+        tag_definition_id,
+      } = req.query
       const user = req.user!
 
       if (!pattern && !tag_definition_id) {
@@ -29,8 +38,9 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
       }
 
       try {
-        const buckets = await getChartData(user, {
+        const result = await getChartData(user, {
           aggregation: aggregation ?? 'count',
+          breakdown_field,
           bucket_size: bucket_size ?? '1d',
           end,
           pattern,
@@ -38,7 +48,14 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
           start,
           tag_definition_id,
         })
-        res.json({ data: { buckets }, success: true })
+        res.json({
+          data: {
+            breakdown_field: result.breakdown_field,
+            breakdown_series: result.breakdown_series,
+            buckets: result.buckets,
+          },
+          success: true,
+        })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         res.status(400).json({ error: message, success: false })

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -248,6 +248,68 @@ describe('getChartData', () => {
     expect(result.buckets).toEqual([])
     expect(db.query).not.toHaveBeenCalled()
   })
+
+  test('activity_type with count aggregation uses count(*)', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [{ bucket_start: new Date('2026-01-01T00:00:00Z'), value: 5n }],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'sex',
+      source_type: 'activity_type',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result.buckets).toHaveLength(1)
+    expect((result.buckets[0] as { value: number }).value).toBe(5)
+    const sql = vi.mocked(db.query).mock.calls[0][1] as string
+    expect(sql).toContain('count(*)')
+  })
+
+  test('activity_type with breakdown_field returns breakdown buckets', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_value: 'Sara', value: 2 },
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_value: 'Other', value: 1 },
+        { bucket_start: new Date('2026-01-08T00:00:00Z'), field_value: 'Sara', value: 3 },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      breakdown_field: 'partner',
+      bucket_size: '1w',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'sex',
+      source_type: 'activity_type',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result.breakdown_field).toBe('partner')
+    expect(result.breakdown_series).toEqual(['Other', 'Sara'])
+    expect(result.buckets).toHaveLength(2)
+
+    const first = result.buckets[0] as { series: Record<string, number> }
+    expect(first.series).toEqual({ Other: 1, Sara: 2 })
+  })
+
+  test('breakdown_field with invalid name returns empty', async () => {
+    const result = await getChartData('testuser', {
+      aggregation: 'count',
+      breakdown_field: 'DROP TABLE',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'test',
+      source_type: 'activity_type',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result.buckets).toEqual([])
+    expect(db.query).not.toHaveBeenCalled()
+  })
 })
 
 describe('buildBucketExpr', () => {

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -30,10 +30,10 @@ describe('getChartData', () => {
       tag_definition_id: '550e8400-e29b-41d4-a716-446655440000',
     })
 
-    expect(result).toHaveLength(2)
-    expect(result[0].bucket_start).toBe('2026-01-01T00:00:00.000Z')
-    expect(result[0].value).toBe(3)
-    expect(result[1].value).toBe(5)
+    expect(result.buckets).toHaveLength(2)
+    expect(result.buckets[0].bucket_start).toBe('2026-01-01T00:00:00.000Z')
+    expect((result.buckets[0] as { value: number }).value).toBe(3)
+    expect((result.buckets[1] as { value: number }).value).toBe(5)
 
     // Verify the SQL uses date_trunc with 'day'
     const call = vi.mocked(db.query).mock.calls[0]
@@ -54,15 +54,15 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(1)
-    expect(result[0].value).toBe(7)
+    expect(result.buckets).toHaveLength(1)
+    expect((result.buckets[0] as { value: number }).value).toBe(7)
 
     // Verify the SQL uses date_trunc with 'week'
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[2]![0]).toBe('week')
   })
 
-  test('returns empty array for tag source without pattern or tag_definition_id', async () => {
+  test('returns empty buckets for tag source without pattern or tag_definition_id', async () => {
     const result = await getChartData('testuser', {
       aggregation: 'count',
       bucket_size: '1d',
@@ -71,7 +71,7 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toEqual([])
+    expect(result.buckets).toEqual([])
     expect(db.query).not.toHaveBeenCalled()
   })
 
@@ -92,8 +92,8 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(2)
-    expect(result[0].value).toBe(72.5)
+    expect(result.buckets).toHaveLength(2)
+    expect((result.buckets[0] as { value: number }).value).toBe(72.5)
 
     // Verify the SQL uses date_trunc with 'month'
     const call = vi.mocked(db.query).mock.calls[0]
@@ -116,8 +116,8 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(1)
-    expect(result[0].value).toBe(8500)
+    expect(result.buckets).toHaveLength(1)
+    expect((result.buckets[0] as { value: number }).value).toBe(8500)
 
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[1]).toContain('SUM(value)')
@@ -137,8 +137,8 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(1)
-    expect(result[0].value).toBe(24)
+    expect(result.buckets).toHaveLength(1)
+    expect((result.buckets[0] as { value: number }).value).toBe(24)
 
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[1]).toContain('COUNT(*)')
@@ -161,9 +161,9 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(2)
-    expect(result[0].value).toBe(3.5)
-    expect(result[1].value).toBe(4.2)
+    expect(result.buckets).toHaveLength(2)
+    expect((result.buckets[0] as { value: number }).value).toBe(3.5)
+    expect((result.buckets[1] as { value: number }).value).toBe(4.2)
   })
 
   test('returns bucketed activity type hours', async () => {
@@ -180,8 +180,8 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(1)
-    expect(result[0].value).toBe(2.75)
+    expect(result.buckets).toHaveLength(1)
+    expect((result.buckets[0] as { value: number }).value).toBe(2.75)
   })
 
   test('uses date_trunc with hour for 1h bucket size', async () => {
@@ -201,9 +201,9 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(2)
-    expect(result[0].bucket_start).toBe('2026-01-01T10:00:00.000Z')
-    expect(result[0].value).toBe(2)
+    expect(result.buckets).toHaveLength(2)
+    expect(result.buckets[0].bucket_start).toBe('2026-01-01T10:00:00.000Z')
+    expect((result.buckets[0] as { value: number }).value).toBe(2)
 
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[1]).toContain('date_trunc')
@@ -227,16 +227,16 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toHaveLength(2)
-    expect(result[0].bucket_start).toBe('2026-01-01T10:00:00.000Z')
-    expect(result[1].value).toBe(2)
+    expect(result.buckets).toHaveLength(2)
+    expect(result.buckets[0].bucket_start).toBe('2026-01-01T10:00:00.000Z')
+    expect((result.buckets[1] as { value: number }).value).toBe(2)
 
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[1]).toContain('date_bin')
     expect(call[2]![0]).toBe('15 minutes')
   })
 
-  test('returns empty array for metric without pattern', async () => {
+  test('returns empty buckets for metric without pattern', async () => {
     const result = await getChartData('testuser', {
       aggregation: 'mean',
       bucket_size: '1d',
@@ -245,7 +245,7 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result).toEqual([])
+    expect(result.buckets).toEqual([])
     expect(db.query).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -5,7 +5,7 @@
  * Returns time-bucketed data for bar chart visualizations.
  */
 
-import type { ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
+import type { ChartDataBreakdownBucket, ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
 
 import { query } from '../db/index.ts'
 
@@ -57,6 +57,7 @@ export const buildBucketExpr = (
 
 export interface ChartDataInput {
   aggregation: 'count' | 'mean' | 'sum'
+  breakdown_field?: string
   bucket_size: '1m' | '5m' | '15m' | '1M' | '1d' | '1h' | '1w'
   end: string
   pattern?: string
@@ -182,12 +183,17 @@ const queryActivityTypeBuckets = async (
   start: string,
   end: string,
   bucketSize: string,
+  aggregation = 'sum',
 ): Promise<ChartDataBucket[]> => {
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
+  const valueExpr =
+    aggregation === 'count'
+      ? 'count(*)'
+      : "SUM(EXTRACT(EPOCH FROM (COALESCE(end_time, start_time + interval '1 hour') - start_time))) / 3600.0"
   const result = await query(
     user,
     `SELECT ${bucket.expr} AS bucket_start,
-            SUM(EXTRACT(EPOCH FROM (end_time - start_time))) / 3600.0 AS value
+            ${valueExpr} AS value
        FROM activities
       WHERE activity_type = $${bucket.params.length + 1}
         AND deleted_at IS NULL
@@ -203,29 +209,122 @@ const queryActivityTypeBuckets = async (
 }
 
 /**
+ * Query activity type data broken down by a data field's distinct values.
+ */
+const queryActivityTypeBreakdown = async (
+  user: string,
+  activityType: string,
+  field: string,
+  start: string,
+  end: string,
+  bucketSize: string,
+  aggregation = 'sum',
+): Promise<{ buckets: ChartDataBreakdownBucket[]; series: string[] }> => {
+  // Sanitize field name
+  if (!/^[a-z][a-z0-9_]*$/.test(field)) return { buckets: [], series: [] }
+
+  const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
+  const valueExpr =
+    aggregation === 'count'
+      ? 'count(*)'
+      : "SUM(EXTRACT(EPOCH FROM (COALESCE(end_time, start_time + interval '1 hour') - start_time))) / 3600.0"
+  const result = await query(
+    user,
+    `SELECT ${bucket.expr} AS bucket_start,
+            COALESCE(data->>'${field}', '(none)') AS field_value,
+            ${valueExpr} AS value
+       FROM activities
+      WHERE activity_type = $${bucket.params.length + 1}
+        AND deleted_at IS NULL
+        AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
+      GROUP BY 1, 2
+      ORDER BY 1`,
+    [...bucket.params, activityType, start, end],
+  )
+
+  // Pivot rows into breakdown buckets
+  const seriesSet = new Set<string>()
+  const bucketMap = new Map<string, Record<string, number>>()
+  for (const row of result.rows) {
+    const bucketStart = (row.bucket_start as Date).toISOString()
+    const fieldValue = row.field_value as string
+    const value = Number(row.value)
+    seriesSet.add(fieldValue)
+    const existing = bucketMap.get(bucketStart) ?? {}
+    existing[fieldValue] = value
+    bucketMap.set(bucketStart, existing)
+  }
+
+  const series = [...seriesSet].sort()
+  const buckets: ChartDataBreakdownBucket[] = [...bucketMap.entries()].map(([bucketStart, seriesData]) => ({
+    bucket_start: bucketStart,
+    series: seriesData,
+  }))
+
+  return { buckets, series }
+}
+
+/**
  * Get bucketed chart data for the given source type and parameters.
  */
-export const getChartData = async (user: string, input: ChartDataInput): Promise<ChartDataBucket[]> => {
+export const getChartData = async (
+  user: string,
+  input: ChartDataInput,
+): Promise<{
+  buckets: (ChartDataBucket | ChartDataBreakdownBucket)[]
+  breakdown_field?: string
+  breakdown_series?: string[]
+}> => {
   const { aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id } = input
+
+  // Breakdown mode for activity types
+  if (source_type === 'activity_type' && pattern && input.breakdown_field) {
+    const result = await queryActivityTypeBreakdown(
+      user,
+      pattern,
+      input.breakdown_field,
+      start,
+      end,
+      bucket_size,
+      aggregation,
+    )
+    return {
+      breakdown_field: input.breakdown_field,
+      breakdown_series: result.series,
+      buckets: result.buckets,
+    }
+  }
+
+  let buckets: ChartDataBucket[]
 
   switch (source_type) {
     case 'tag':
       if (tag_definition_id) {
-        return queryActivitiesByType(user, tag_definition_id, start, end, bucket_size)
+        buckets = await queryActivitiesByType(user, tag_definition_id, start, end, bucket_size)
+      } else if (pattern) {
+        buckets = await queryActivitiesByTypePattern(user, pattern, start, end, bucket_size)
+      } else {
+        buckets = []
       }
-      if (!pattern) return []
-      return queryActivitiesByTypePattern(user, pattern, start, end, bucket_size)
+      break
 
     case 'metric':
-      if (!pattern) return []
-      return queryMetricBuckets(user, pattern, start, end, bucket_size, aggregation)
+      buckets = pattern ? await queryMetricBuckets(user, pattern, start, end, bucket_size, aggregation) : []
+      break
 
     case 'productivity_category':
-      if (!pattern) return []
-      return queryProductivityCategoryBuckets(user, pattern, start, end, bucket_size)
+      buckets = pattern ? await queryProductivityCategoryBuckets(user, pattern, start, end, bucket_size) : []
+      break
 
     case 'activity_type':
-      if (!pattern) return []
-      return queryActivityTypeBuckets(user, pattern, start, end, bucket_size)
+      buckets = pattern
+        ? await queryActivityTypeBuckets(user, pattern, start, end, bucket_size, aggregation)
+        : []
+      break
+
+    default:
+      buckets = []
   }
+
+  return { buckets }
 }

--- a/apps/web/src/components/DashboardEditor/index.tsx
+++ b/apps/web/src/components/DashboardEditor/index.tsx
@@ -68,9 +68,9 @@ const widgetTemplates: WidgetTemplate[] = [
       half_life_days: 15,
       lookback_days: 90,
       pattern: 'coffee',
-      source_type: 'tag',
+      source_type: 'activity_type',
     }),
-    description: 'EMA trend visualization for tags or metrics',
+    description: 'EMA trend visualization for activity types or metrics',
     label: 'Trend Chart',
     type: 'trend_chart',
   },
@@ -80,9 +80,9 @@ const widgetTemplates: WidgetTemplate[] = [
       bucket_size: '1d',
       lookback_days: 30,
       pattern: 'coffee',
-      source_type: 'tag',
+      source_type: 'activity_type',
     }),
-    description: 'Bucketed bar chart for tags, metrics, or categories',
+    description: 'Bucketed bar chart for activity types, metrics, or categories',
     label: 'Bar Chart',
     type: 'bar_chart',
   },
@@ -255,10 +255,11 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
             <div class="form-group">
               <label>Source Type</label>
               <select
-                value={(configValues.source_type as string) ?? 'tag'}
+                value={(configValues.source_type as string) ?? 'activity_type'}
                 onChange={(e) => updateConfig('source_type', (e.target as HTMLSelectElement).value)}
               >
-                <option value="tag">Tag</option>
+                <option value="activity_type">Activity Type</option>
+                <option value="tag">Activity (count)</option>
                 <option value="metric">Metric</option>
               </select>
             </div>
@@ -299,11 +300,10 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
             <div class="form-group">
               <label>Activity Type</label>
               <select
-                value={(configValues.activity_type as string) ?? 'tag'}
+                value={(configValues.activity_type as string) ?? 'activity_type'}
                 onChange={(e) => updateConfig('activity_type', (e.target as HTMLSelectElement).value)}
               >
-                <option value="tag">Tag</option>
-                <option value="activity_type">Activity</option>
+                <option value="activity_type">Activity Type</option>
                 <option value="location">Location</option>
               </select>
             </div>

--- a/apps/web/src/components/widgets/BarChartWidget.tsx
+++ b/apps/web/src/components/widgets/BarChartWidget.tsx
@@ -91,7 +91,7 @@ export function BarChartWidget({ config }: BarChartWidgetProps) {
   return (
     <a href={chartUrl} class="chart-widget chart-widget-link">
       <h4>{displayTitle}</h4>
-      <BarChart data={chartQuery.data} color="#8b5cf6" height={200} />
+      <BarChart data={chartQuery.data.buckets} color="#8b5cf6" height={200} />
     </a>
   )
 }

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -213,10 +213,10 @@ function SourcePicker({
             onUpdate({ source_type, pattern: '', tag_definition_id: '' })
           }}
         >
-          <option value="tag">Tag</option>
+          <option value="activity_type">Activity Type</option>
+          <option value="tag">Activity (count)</option>
           <option value="metric">Metric</option>
           <option value="productivity_category">Screentime Category</option>
-          <option value="activity_type">Activity Type</option>
         </select>
       </label>
 
@@ -433,7 +433,8 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
     return <div class="chart-error">Failed to load chart data.</div>
   }
 
-  const buckets = barQuery.data ?? []
+  const result = barQuery.data
+  const buckets = result?.buckets ?? []
 
   return (
     <div class="chart-display">

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1852,9 +1852,17 @@ export interface FetchChartDataParams {
   tag_definition_id?: string
   bucket_size?: '1m' | '5m' | '15m' | '1h' | '1d' | '1w' | '1M'
   aggregation?: 'count' | 'sum' | 'mean'
+  breakdown_field?: string
 }
 
-export const fetchChartData = async (params: FetchChartDataParams): Promise<ChartDataBucket[]> => {
+export interface ChartDataResult {
+  buckets: ChartDataBucket[]
+  breakdown_field?: string
+  breakdown_series?: string[]
+  breakdown_buckets?: Array<{ bucket_start: string; series: Record<string, number> }>
+}
+
+export const fetchChartData = async (params: FetchChartDataParams): Promise<ChartDataResult> => {
   const { token } = auth.value
   const query: Record<string, string> = {
     source_type: params.source_type,
@@ -1865,13 +1873,24 @@ export const fetchChartData = async (params: FetchChartDataParams): Promise<Char
   if (params.tag_definition_id) query.tag_definition_id = params.tag_definition_id
   if (params.bucket_size) query.bucket_size = params.bucket_size
   if (params.aggregation) query.aggregation = params.aggregation
+  if (params.breakdown_field) query.breakdown_field = params.breakdown_field
 
   const response = await axios.get<ChartDataResponse>(`${API_URL}/chart-data`, {
     headers: { Authorization: `Bearer ${token}` },
     params: query,
   })
 
-  return response.data.data?.buckets ?? []
+  const data = response.data.data
+  if (data?.breakdown_field) {
+    return {
+      breakdown_buckets: data.buckets as Array<{ bucket_start: string; series: Record<string, number> }>,
+      breakdown_field: data.breakdown_field,
+      breakdown_series: data.breakdown_series,
+      buckets: [],
+    }
+  }
+
+  return { buckets: (data?.buckets ?? []) as ChartDataBucket[] }
 }
 
 // ============================================================================

--- a/packages/api-spec/src/schemas/chart-data.ts
+++ b/packages/api-spec/src/schemas/chart-data.ts
@@ -64,6 +64,13 @@ export const chartDataQuerySchema = z
       .uuid()
       .optional()
       .meta({ description: 'Tag definition ID (alternative to pattern for tags)' }),
+    breakdown_field: z
+      .string()
+      .optional()
+      .meta({
+        description:
+          'Data field to break down by (for activity_type source). Returns series per distinct value.',
+      }),
   })
   .meta({ id: 'ChartDataQuery', description: 'Query parameters for bucketed chart data' })
 
@@ -75,6 +82,7 @@ export type ChartDataQuery = z.infer<typeof chartDataQuerySchema>
 export const chartDataHttpQuerySchema = z
   .object({
     aggregation: z.enum(['count', 'sum', 'mean']).optional(),
+    breakdown_field: z.string().optional().meta({ description: 'Data field to break down by' }),
     bucket_size: z.enum(['1m', '5m', '15m', '1h', '1d', '1w', '1M']).optional(),
     end: z.string().meta({ description: 'End of time range (ISO 8601 string)' }),
     pattern: z.string().optional().meta({ description: 'Pattern to match' }),
@@ -103,13 +111,30 @@ export const chartDataBucketSchema = z
 export type ChartDataBucket = z.infer<typeof chartDataBucketSchema>
 
 /**
+ * A breakdown bucket — one bucket with multiple series (keyed by field value).
+ */
+export const chartDataBreakdownBucketSchema = z
+  .object({
+    bucket_start: z.string().meta({ description: 'Start of the bucket (ISO 8601 datetime)' }),
+    series: z.record(z.string(), z.number()).meta({ description: 'Map of field value to aggregated value' }),
+  })
+  .meta({ id: 'ChartDataBreakdownBucket', description: 'A bucket with breakdown by data field value' })
+
+export type ChartDataBreakdownBucket = z.infer<typeof chartDataBreakdownBucketSchema>
+
+/**
  * Response schema for chart data endpoint.
  */
 export const chartDataResponseSchema = baseResponseSchema
   .extend({
     data: z
       .object({
-        buckets: z.array(chartDataBucketSchema),
+        breakdown_field: z.string().optional().meta({ description: 'Field used for breakdown, if any' }),
+        breakdown_series: z
+          .array(z.string())
+          .optional()
+          .meta({ description: 'Distinct field values in breakdown' }),
+        buckets: z.array(z.union([chartDataBucketSchema, chartDataBreakdownBucketSchema])),
       })
       .optional(),
   })


### PR DESCRIPTION
## Summary
- Rename "Tag" source type to "Activity (count)" in chart explorer and dashboard editor
- Default dashboard widgets to `activity_type` source instead of `tag`
- `activity_type` source now respects `aggregation` param: `count` for occurrence count, `sum` (default) for duration hours
- **Breakdown charting**: new `breakdown_field` query param breaks activity type data by a categorical field
  - e.g. `?source_type=activity_type&pattern=sex&breakdown_field=partner` returns per-partner series
  - Response includes `breakdown_series` (distinct values) and `breakdown_buckets` (per-bucket series map)
- New `ChartDataBreakdownBucket` schema type

## Test plan
- [x] All 1657 tests pass
- [x] Type checks pass
- [ ] Chart explorer no longer shows "Tag" — shows "Activity (count)" and "Activity Type"
- [ ] API: `GET /chart-data?source_type=activity_type&pattern=sex&breakdown_field=partner&bucket_size=1w` returns breakdown data

🤖 Generated with [Claude Code](https://claude.com/claude-code)