### PR TITLE
feat: import Garmin running dynamics + GPS location tracking

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -498,6 +498,9 @@ export const migrateSchema = async (user: string) => {
     await query(db, `ALTER TABLE activity_type_definitions ALTER COLUMN icon TYPE TEXT`)
     await query(db, `ALTER TABLE activity_type_definitions ADD COLUMN IF NOT EXISTS data_schema JSONB`)
   }
+  if (existingTableNames.has('locations')) {
+    await query(db, `ALTER TABLE locations ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
+  }
   if (existingTableNames.has('time_series')) {
     await query(db, `ALTER TABLE time_series ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
   }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -157,6 +157,7 @@ export {
   insertLocation,
   insertNamedLocation,
   insertPlace,
+  softDeleteLocationRange,
   updateDetectedLocation,
   updateNamedLocation,
 } from './locations.ts'

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -155,6 +155,7 @@ export {
   getNamedLocations,
   insertDetectedLocation,
   insertLocation,
+  insertLocations,
   insertNamedLocation,
   insertPlace,
   softDeleteLocationRange,

--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -11,6 +11,8 @@ import type {
 /**
  * Location, Place, Named Location, and Detected Location CRUD operations.
  */
+import format from 'pg-format'
+
 import { query } from './connection.ts'
 import { buildDynamicUpdate, type UpdateEntry } from './dynamic-update.ts'
 import { mapDetectedLocationRow, mapNamedLocationRow } from './row-mappers.ts'
@@ -35,6 +37,33 @@ export const insertLocation = async (user: string, location: Location) => {
       location.velocity,
       location.regions || [],
     ],
+  )
+}
+
+/** Batch-insert multiple locations in a single query. */
+export const insertLocations = async (user: string, locations: Location[]): Promise<void> => {
+  if (locations.length === 0) return
+
+  const values = locations.map((loc) => [
+    loc.source || 'owntracks',
+    loc.time,
+    loc.lon,
+    loc.lat,
+    loc.accuracy ?? null,
+    loc.altitude ?? null,
+    loc.velocity ?? null,
+    loc.regions || [],
+  ])
+
+  await query(
+    user,
+    format(
+      `INSERT INTO locations (source, time, location, accuracy, altitude, velocity, regions)
+       SELECT v.source, v.time, ST_MakePoint(v.lon, v.lat)::geography, v.accuracy, v.altitude, v.velocity, v.regions
+       FROM (VALUES %L) AS v(source, time, lon, lat, accuracy, altitude, velocity, regions)
+       ON CONFLICT (source, time) DO NOTHING`,
+      values,
+    ),
   )
 }
 

--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -38,12 +38,27 @@ export const insertLocation = async (user: string, location: Location) => {
   )
 }
 
+/** Soft-delete locations from a given source within a time range. */
+export const softDeleteLocationRange = async (
+  user: string,
+  source: string,
+  start: Date,
+  end: Date,
+): Promise<void> => {
+  await query(
+    user,
+    `UPDATE locations SET deleted_at = NOW()
+     WHERE source = $1 AND time >= $2 AND time <= $3 AND deleted_at IS NULL`,
+    [source, start, end],
+  )
+}
+
 export const getLocations = async (user: string, start: Date, end: Date) => {
   const result = await query(
     user,
     `SELECT time, ST_AsGeoJSON(location) AS location, regions
      FROM locations
-     WHERE time >= $1 AND time <= $2
+     WHERE time >= $1 AND time <= $2 AND deleted_at IS NULL
      ORDER BY time`,
     [start, end],
   )

--- a/apps/backend/src/garmin-process.test.ts
+++ b/apps/backend/src/garmin-process.test.ts
@@ -3,13 +3,15 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { GarminProcessDeps } from './garmin-process.ts'
 import type { GarminActivityDetailResponse } from './garmin.ts'
 
-import { processActivityDetail, processGarminData } from './garmin-process.ts'
+import { extractNumericValue, processActivityDetail, processGarminData } from './garmin-process.ts'
 
 const mockDeps: GarminProcessDeps = {
   deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   insertActivity: vi.fn().mockResolvedValue(undefined),
+  insertLocation: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn().mockResolvedValue(undefined),
   insertTimeSeries: vi.fn().mockResolvedValue(undefined),
+  softDeleteLocationRange: vi.fn().mockResolvedValue(undefined),
 }
 
 /** Helper: noon UTC for a given date string. */
@@ -1260,5 +1262,231 @@ describe('processActivityDetail', () => {
         expect.objectContaining({ metric: 'heart_rate', value: 80 }),
       ]),
     )
+  })
+
+  test('extracts running dynamics metrics (cadence, stride, power, etc)', async () => {
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [
+        {
+          metrics: [
+            { source: '1.7E12', parsedValue: 1700000001000 }, // directTimestamp
+            { source: '167.0', parsedValue: 167 }, // directDoubleCadence
+            87.3, // directStrideLength (cm)
+            { source: '290.0', parsedValue: 290 }, // directGroundContactTime
+            9.09, // directVerticalRatio
+            161.2, // directElevation
+            { source: '362.0', parsedValue: 362 }, // directPower
+            2.42, // directSpeed
+            7.94, // directVerticalOscillation
+            -0.2, // directVerticalSpeed (negative = descending)
+            2.43, // directGradeAdjustedSpeed
+          ],
+        },
+      ],
+      activityId: 88888,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directDoubleCadence', metricsIndex: 1, unit: { key: 'spm' } },
+        { key: 'directStrideLength', metricsIndex: 2, unit: { key: 'centimeter' } },
+        { key: 'directGroundContactTime', metricsIndex: 3, unit: { key: 'ms' } },
+        { key: 'directVerticalRatio', metricsIndex: 4, unit: { key: 'dimensionless' } },
+        { key: 'directElevation', metricsIndex: 5, unit: { key: 'meter' } },
+        { key: 'directPower', metricsIndex: 6, unit: { key: 'watt' } },
+        { key: 'directSpeed', metricsIndex: 7, unit: { key: 'mps' } },
+        { key: 'directVerticalOscillation', metricsIndex: 8, unit: { key: 'centimeter' } },
+        { key: 'directVerticalSpeed', metricsIndex: 9, unit: { key: 'mps' } },
+        { key: 'directGradeAdjustedSpeed', metricsIndex: 10, unit: { key: 'mps' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    const points = vi.mocked(mockDeps.insertTimeSeries).mock.calls[0]![1]
+    const t = new Date(1700000001000)
+
+    expect(points).toEqual(
+      expect.arrayContaining([
+        { metric: 'run_cadence', source: 'garmin', time: t, unit: 'spm', value: 167 },
+        { metric: 'stride_length', source: 'garmin', time: t, unit: 'm', value: 0.873 },
+        { metric: 'ground_contact_time', source: 'garmin', time: t, unit: 'ms', value: 290 },
+        { metric: 'vertical_ratio', source: 'garmin', time: t, unit: 'percent', value: 9.09 },
+        { metric: 'elevation', source: 'garmin', time: t, unit: 'm', value: 161.2 },
+        { metric: 'power', source: 'garmin', time: t, unit: 'W', value: 362 },
+        { metric: 'speed', source: 'garmin', time: t, unit: 'm/s', value: 2.42 },
+        { metric: 'vertical_oscillation', source: 'garmin', time: t, unit: 'cm', value: 7.94 },
+        { metric: 'vertical_speed', source: 'garmin', time: t, unit: 'm/s', value: -0.2 },
+        { metric: 'grade_adjusted_speed', source: 'garmin', time: t, unit: 'm/s', value: 2.43 },
+      ]),
+    )
+  })
+
+  test('handles parsedValue objects in metric values', async () => {
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [
+        {
+          metrics: [
+            { source: '1.7E12', parsedValue: 1700000001000 },
+            { source: '74.0', parsedValue: 74 },
+          ],
+        },
+      ],
+      activityId: 77777,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directHeartRate', metricsIndex: 1, unit: { key: 'bpm' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    const points = vi.mocked(mockDeps.insertTimeSeries).mock.calls[0]![1]
+    expect(points).toHaveLength(1)
+    expect(points[0]).toMatchObject({ metric: 'heart_rate', value: 74 })
+  })
+
+  test('allows negative elevation values', async () => {
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [{ metrics: [1700000001000, -10.5] }],
+      activityId: 66666,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directElevation', metricsIndex: 1, unit: { key: 'meter' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    const points = vi.mocked(mockDeps.insertTimeSeries).mock.calls[0]![1]
+    expect(points).toHaveLength(1)
+    expect(points[0]).toMatchObject({ metric: 'elevation', value: -10.5 })
+  })
+
+  test('converts stride length from cm to m', async () => {
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [{ metrics: [1700000001000, 95.5] }],
+      activityId: 55555,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directStrideLength', metricsIndex: 1, unit: { key: 'centimeter' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    const points = vi.mocked(mockDeps.insertTimeSeries).mock.calls[0]![1]
+    expect(points).toHaveLength(1)
+    expect(points[0]).toMatchObject({ metric: 'stride_length', value: 0.955 })
+  })
+
+  test('extracts GPS locations and soft-deletes owntracks', async () => {
+    // GPS points 61s apart — both should be included (> 60s downsample interval)
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [
+        { metrics: [1700000001000, 57.65, 12.62] },
+        { metrics: [1700000062000, 57.66, 12.63] },
+      ],
+      activityId: 44444,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directLatitude', metricsIndex: 1, unit: { key: 'dd' } },
+        { key: 'directLongitude', metricsIndex: 2, unit: { key: 'dd' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    // Should soft-delete owntracks in the time range
+    expect(mockDeps.softDeleteLocationRange).toHaveBeenCalledWith(
+      user,
+      'owntracks',
+      new Date(1700000001000),
+      new Date(1700000062000),
+    )
+
+    // Should insert 2 GPS points
+    expect(mockDeps.insertLocation).toHaveBeenCalledTimes(2)
+    expect(mockDeps.insertLocation).toHaveBeenCalledWith(user, {
+      lat: 57.65,
+      lon: 12.62,
+      source: 'garmin',
+      time: new Date(1700000001000),
+    })
+    expect(mockDeps.insertLocation).toHaveBeenCalledWith(user, {
+      lat: 57.66,
+      lon: 12.63,
+      source: 'garmin',
+      time: new Date(1700000062000),
+    })
+  })
+
+  test('downsamples GPS to ~1 point per minute', async () => {
+    // 3 points within 60 seconds — only first should be inserted
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [
+        { metrics: [1700000001000, 57.65, 12.62] },
+        { metrics: [1700000030000, 57.66, 12.63] },
+        { metrics: [1700000059000, 57.67, 12.64] },
+      ],
+      activityId: 33333,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directLatitude', metricsIndex: 1, unit: { key: 'dd' } },
+        { key: 'directLongitude', metricsIndex: 2, unit: { key: 'dd' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    expect(mockDeps.insertLocation).toHaveBeenCalledTimes(1)
+    expect(mockDeps.insertLocation).toHaveBeenCalledWith(user, {
+      lat: 57.65,
+      lon: 12.62,
+      source: 'garmin',
+      time: new Date(1700000001000),
+    })
+  })
+
+  test('does not insert GPS when latitude/longitude are 0', async () => {
+    const detail: GarminActivityDetailResponse = {
+      activityDetailMetrics: [{ metrics: [1700000001000, 0, 0] }],
+      activityId: 22222,
+      metricDescriptors: [
+        { key: 'directTimestamp', metricsIndex: 0, unit: { key: 'gmt' } },
+        { key: 'directLatitude', metricsIndex: 1, unit: { key: 'dd' } },
+        { key: 'directLongitude', metricsIndex: 2, unit: { key: 'dd' } },
+      ],
+    }
+
+    await processActivityDetail(user, detail, mockDeps)
+
+    expect(mockDeps.insertLocation).not.toHaveBeenCalled()
+    expect(mockDeps.softDeleteLocationRange).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
+// extractNumericValue
+// ============================================================================
+
+describe('extractNumericValue', () => {
+  test('returns plain numbers as-is', () => {
+    expect(extractNumericValue(42)).toBe(42)
+    expect(extractNumericValue(0)).toBe(0)
+    expect(extractNumericValue(-5.5)).toBe(-5.5)
+  })
+
+  test('extracts parsedValue from objects', () => {
+    expect(extractNumericValue({ source: '77.0', parsedValue: 77 })).toBe(77)
+    expect(extractNumericValue({ source: '0.0', parsedValue: 0 })).toBe(0)
+  })
+
+  test('returns null for null/undefined', () => {
+    expect(extractNumericValue(null)).toBeNull()
+    expect(extractNumericValue(undefined)).toBeNull()
+  })
+
+  test('returns null for non-numeric types', () => {
+    expect(extractNumericValue('string')).toBeNull()
+    expect(extractNumericValue({})).toBeNull()
   })
 })

--- a/apps/backend/src/garmin-process.test.ts
+++ b/apps/backend/src/garmin-process.test.ts
@@ -8,7 +8,7 @@ import { extractNumericValue, processActivityDetail, processGarminData } from '.
 const mockDeps: GarminProcessDeps = {
   deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   insertActivity: vi.fn().mockResolvedValue(undefined),
-  insertLocation: vi.fn().mockResolvedValue(undefined),
+  insertLocations: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn().mockResolvedValue(undefined),
   insertTimeSeries: vi.fn().mockResolvedValue(undefined),
   softDeleteLocationRange: vi.fn().mockResolvedValue(undefined),
@@ -1403,20 +1403,11 @@ describe('processActivityDetail', () => {
       new Date(1700000062000),
     )
 
-    // Should insert 2 GPS points
-    expect(mockDeps.insertLocation).toHaveBeenCalledTimes(2)
-    expect(mockDeps.insertLocation).toHaveBeenCalledWith(user, {
-      lat: 57.65,
-      lon: 12.62,
-      source: 'garmin',
-      time: new Date(1700000001000),
-    })
-    expect(mockDeps.insertLocation).toHaveBeenCalledWith(user, {
-      lat: 57.66,
-      lon: 12.63,
-      source: 'garmin',
-      time: new Date(1700000062000),
-    })
+    // Should batch-insert 2 GPS points
+    expect(mockDeps.insertLocations).toHaveBeenCalledWith(user, [
+      { lat: 57.65, lon: 12.62, source: 'garmin', time: new Date(1700000001000) },
+      { lat: 57.66, lon: 12.63, source: 'garmin', time: new Date(1700000062000) },
+    ])
   })
 
   test('downsamples GPS to ~1 point per minute', async () => {
@@ -1437,13 +1428,9 @@ describe('processActivityDetail', () => {
 
     await processActivityDetail(user, detail, mockDeps)
 
-    expect(mockDeps.insertLocation).toHaveBeenCalledTimes(1)
-    expect(mockDeps.insertLocation).toHaveBeenCalledWith(user, {
-      lat: 57.65,
-      lon: 12.62,
-      source: 'garmin',
-      time: new Date(1700000001000),
-    })
+    expect(mockDeps.insertLocations).toHaveBeenCalledWith(user, [
+      { lat: 57.65, lon: 12.62, source: 'garmin', time: new Date(1700000001000) },
+    ])
   })
 
   test('does not insert GPS when latitude/longitude are 0', async () => {
@@ -1459,7 +1446,7 @@ describe('processActivityDetail', () => {
 
     await processActivityDetail(user, detail, mockDeps)
 
-    expect(mockDeps.insertLocation).not.toHaveBeenCalled()
+    expect(mockDeps.insertLocations).not.toHaveBeenCalled()
     expect(mockDeps.softDeleteLocationRange).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -24,7 +24,7 @@ import type {
 import {
   deleteGarminActivityWithWrongType,
   insertActivity,
-  insertLocation,
+  insertLocations,
   insertRawRecord,
   insertTimeSeries,
   softDeleteLocationRange,
@@ -68,7 +68,7 @@ export const garminDataTypes: GarminDataType[] = [
 export interface GarminProcessDeps {
   deleteGarminActivityWithWrongType: typeof deleteGarminActivityWithWrongType
   insertActivity: typeof insertActivity
-  insertLocation: typeof insertLocation
+  insertLocations: typeof insertLocations
   insertRawRecord: typeof insertRawRecord
   insertTimeSeries: typeof insertTimeSeries
   softDeleteLocationRange: typeof softDeleteLocationRange
@@ -77,7 +77,7 @@ export interface GarminProcessDeps {
 const defaultDeps: GarminProcessDeps = {
   deleteGarminActivityWithWrongType,
   insertActivity,
-  insertLocation,
+  insertLocations,
   insertRawRecord,
   insertTimeSeries,
   softDeleteLocationRange,
@@ -602,7 +602,8 @@ export const extractNumericValue = (value: unknown): number | null => {
   if (value == null) return null
   if (typeof value === 'number') return value
   if (typeof value === 'object' && 'parsedValue' in (value as Record<string, unknown>)) {
-    return (value as { parsedValue: number }).parsedValue
+    const parsed = (value as { parsedValue: unknown }).parsedValue
+    return typeof parsed === 'number' ? parsed : null
   }
   return null
 }
@@ -683,7 +684,8 @@ export const processActivityDetail = async (
     }
   }
 
-  const firstTs = extractNumericValue(data.activityDetailMetrics[0]!.metrics[tsIdx])!
+  const firstTs = extractNumericValue(data.activityDetailMetrics[0]!.metrics[tsIdx])
+  if (!firstTs) return 0
 
   await deps.insertRawRecord(
     user,
@@ -692,14 +694,12 @@ export const processActivityDetail = async (
 
   if (points.length > 0) await deps.insertTimeSeries(user, points)
 
-  // Insert GPS locations and soft-delete conflicting OwnTracks data
+  // Batch-insert GPS locations and soft-delete conflicting OwnTracks data
   if (gpsPoints.length > 0) {
     const start = gpsPoints[0].time
     const end = gpsPoints[gpsPoints.length - 1].time
     await deps.softDeleteLocationRange(user, 'owntracks', start, end)
-    for (const gps of gpsPoints) {
-      await deps.insertLocation(user, gps)
-    }
+    await deps.insertLocations(user, gpsPoints)
   }
 
   return points.length

--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -8,7 +8,7 @@
 import type { IActivity } from '@flow-js/garmin-connect/dist/garmin/types/activity'
 import type { SleepData } from '@flow-js/garmin-connect/dist/garmin/types/sleep'
 
-import type { Activity, RawRecord, TimeSeriesPoint } from './db/types.ts'
+import type { Activity, Location, RawRecord, TimeSeriesPoint } from './db/types.ts'
 import type {
   GarminActivityDetailResponse,
   GarminBodyBatteryData,
@@ -24,8 +24,10 @@ import type {
 import {
   deleteGarminActivityWithWrongType,
   insertActivity,
+  insertLocation,
   insertRawRecord,
   insertTimeSeries,
+  softDeleteLocationRange,
 } from './db/index.ts'
 
 // ============================================================================
@@ -65,16 +67,20 @@ export const garminDataTypes: GarminDataType[] = [
 
 export interface GarminProcessDeps {
   deleteGarminActivityWithWrongType: typeof deleteGarminActivityWithWrongType
+  insertActivity: typeof insertActivity
+  insertLocation: typeof insertLocation
   insertRawRecord: typeof insertRawRecord
   insertTimeSeries: typeof insertTimeSeries
-  insertActivity: typeof insertActivity
+  softDeleteLocationRange: typeof softDeleteLocationRange
 }
 
 const defaultDeps: GarminProcessDeps = {
   deleteGarminActivityWithWrongType,
   insertActivity,
+  insertLocation,
   insertRawRecord,
   insertTimeSeries,
+  softDeleteLocationRange,
 }
 
 /** Garmin activity typeKeys that map to the 'meditation' activity type. */
@@ -560,12 +566,45 @@ const processIntensityMinutes = async (
 // Activity Detail (per-second metrics from /activity-service/activity/{id}/details)
 // ---------------------------------------------------------------------------
 
+interface DetailMetricMapping {
+  metric: string
+  unit: string
+  /** Allow zero and negative values (e.g. elevation, vertical speed). Default: filter <= 0. */
+  allowNegative?: boolean
+  /** Transform the raw value (e.g. cm → m). */
+  transform?: (v: number) => number
+}
+
 /** Metrics to extract from activity detail, mapped to our metric names. */
-const DETAIL_METRIC_MAP: Record<string, { metric: string; unit: string }> = {
+const DETAIL_METRIC_MAP: Record<string, DetailMetricMapping> = {
   directBodyBattery: { metric: 'body_battery', unit: 'score' },
   directCurrentStress: { metric: 'stress_level', unit: 'score' },
+  directDoubleCadence: { metric: 'run_cadence', unit: 'spm' },
+  directElevation: { allowNegative: true, metric: 'elevation', unit: 'm' },
+  directGradeAdjustedSpeed: { metric: 'grade_adjusted_speed', unit: 'm/s' },
+  directGroundContactTime: { metric: 'ground_contact_time', unit: 'ms' },
   directHeartRate: { metric: 'heart_rate', unit: 'bpm' },
+  directPerformanceCondition: { allowNegative: true, metric: 'performance_condition', unit: 'score' },
+  directPower: { metric: 'power', unit: 'W' },
   directRespirationRate: { metric: 'respiratory_rate', unit: 'brpm' },
+  directSpeed: { metric: 'speed', unit: 'm/s' },
+  directStrideLength: { metric: 'stride_length', transform: (v) => v / 100, unit: 'm' },
+  directVerticalOscillation: { metric: 'vertical_oscillation', unit: 'cm' },
+  directVerticalRatio: { metric: 'vertical_ratio', unit: 'percent' },
+  directVerticalSpeed: { allowNegative: true, metric: 'vertical_speed', unit: 'm/s' },
+}
+
+/**
+ * Extract a numeric value from a Garmin metric entry.
+ * Some values are plain numbers, others are {source, parsedValue} objects.
+ */
+export const extractNumericValue = (value: unknown): number | null => {
+  if (value == null) return null
+  if (typeof value === 'number') return value
+  if (typeof value === 'object' && 'parsedValue' in (value as Record<string, unknown>)) {
+    return (value as { parsedValue: number }).parsedValue
+  }
+  return null
 }
 
 /** Build a map of garminKey → metricsIndex from dynamic metricDescriptors. */
@@ -581,20 +620,33 @@ const buildMetricIndexMap = (
 
 /** Extract time series points from a single activity detail metrics entry. */
 const extractDetailPoints = (
-  metrics: number[],
+  metrics: unknown[],
   time: Date,
   indexMap: Map<string, number>,
 ): TimeSeriesPoint[] => {
   const points: TimeSeriesPoint[] = []
-  for (const [garminKey, { metric, unit }] of Object.entries(DETAIL_METRIC_MAP)) {
+  for (const [garminKey, mapping] of Object.entries(DETAIL_METRIC_MAP)) {
     const idx = indexMap.get(garminKey)
     if (idx === undefined) continue
-    const value = metrics[idx]
-    if (value == null || value <= 0) continue
-    points.push({ metric, source: 'garmin', time, unit, value })
+    const raw = extractNumericValue(metrics[idx])
+    if (raw == null) continue
+    if (!mapping.allowNegative && raw <= 0) continue
+    const value = mapping.transform ? mapping.transform(raw) : raw
+    points.push({ metric: mapping.metric, source: 'garmin', time, unit: mapping.unit, value })
   }
   return points
 }
+
+/** Extract a GPS location point from a detail metrics entry. */
+const extractGpsPoint = (metrics: unknown[], time: Date, latIdx: number, lonIdx: number): Location | null => {
+  const lat = extractNumericValue(metrics[latIdx])
+  const lon = extractNumericValue(metrics[lonIdx])
+  if (lat == null || lon == null || (lat === 0 && lon === 0)) return null
+  return { lat, lon, source: 'garmin' as const, time }
+}
+
+/** GPS downsampling interval in milliseconds (1 point per minute). */
+const GPS_DOWNSAMPLE_MS = 60_000
 
 export const processActivityDetail = async (
   user: string,
@@ -607,24 +659,48 @@ export const processActivityDetail = async (
   const tsIdx = indexMap.get('directTimestamp')
   if (tsIdx === undefined) return 0
 
+  const latIdx = indexMap.get('directLatitude')
+  const lonIdx = indexMap.get('directLongitude')
+
   const points: TimeSeriesPoint[] = []
+  const gpsPoints: Location[] = []
+  let lastGpsTime = 0
+
   for (const entry of data.activityDetailMetrics) {
-    const ts = entry.metrics[tsIdx]
+    const ts = extractNumericValue(entry.metrics[tsIdx])
     if (!ts || ts <= 0) continue
-    points.push(...extractDetailPoints(entry.metrics, new Date(ts), indexMap))
+    const time = new Date(ts)
+
+    points.push(...extractDetailPoints(entry.metrics, time, indexMap))
+
+    // Extract GPS, downsampled to ~1 point per minute
+    if (latIdx !== undefined && lonIdx !== undefined && ts - lastGpsTime >= GPS_DOWNSAMPLE_MS) {
+      const gps = extractGpsPoint(entry.metrics, time, latIdx, lonIdx)
+      if (gps) {
+        gpsPoints.push(gps)
+        lastGpsTime = ts
+      }
+    }
   }
+
+  const firstTs = extractNumericValue(data.activityDetailMetrics[0]!.metrics[tsIdx])!
 
   await deps.insertRawRecord(
     user,
-    makeRaw(
-      'garmin_activity_detail',
-      `garmin-activity-detail-${data.activityId}`,
-      new Date(data.activityDetailMetrics[0]!.metrics[tsIdx]!),
-      data,
-    ),
+    makeRaw('garmin_activity_detail', `garmin-activity-detail-${data.activityId}`, new Date(firstTs), data),
   )
 
   if (points.length > 0) await deps.insertTimeSeries(user, points)
+
+  // Insert GPS locations and soft-delete conflicting OwnTracks data
+  if (gpsPoints.length > 0) {
+    const start = gpsPoints[0].time
+    const end = gpsPoints[gpsPoints.length - 1].time
+    await deps.softDeleteLocationRange(user, 'owntracks', start, end)
+    for (const gps of gpsPoints) {
+      await deps.insertLocation(user, gps)
+    }
+  }
 
   return points.length
 }

--- a/apps/backend/src/garmin-sync.test.ts
+++ b/apps/backend/src/garmin-sync.test.ts
@@ -16,9 +16,11 @@ vi.mock('./db', () => ({
   getActivitiesNeedingDetail: vi.fn().mockResolvedValue([]),
   getSyncState: vi.fn(),
   insertActivity: vi.fn(),
+  insertLocation: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn(),
   insertTimeSeries: vi.fn(),
   markActivityDetailSynced: vi.fn().mockResolvedValue(undefined),
+  softDeleteLocationRange: vi.fn().mockResolvedValue(undefined),
   upsertSyncState: vi.fn(),
 }))
 

--- a/apps/backend/src/garmin-sync.test.ts
+++ b/apps/backend/src/garmin-sync.test.ts
@@ -16,7 +16,7 @@ vi.mock('./db', () => ({
   getActivitiesNeedingDetail: vi.fn().mockResolvedValue([]),
   getSyncState: vi.fn(),
   insertActivity: vi.fn(),
-  insertLocation: vi.fn().mockResolvedValue(undefined),
+  insertLocations: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn(),
   insertTimeSeries: vi.fn(),
   markActivityDetailSynced: vi.fn().mockResolvedValue(undefined),

--- a/apps/backend/src/garmin.ts
+++ b/apps/backend/src/garmin.ts
@@ -100,7 +100,7 @@ export interface GarminActivityDetailResponse {
     unit: { key: string }
   }>
   activityDetailMetrics: Array<{
-    metrics: number[]
+    metrics: unknown[]
   }>
 }
 

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -55,7 +55,7 @@ vi.mock('./db', () => ({
   getUserSettings: vi.fn().mockResolvedValue(null),
   insertActivity: vi.fn().mockResolvedValue(undefined),
   insertActivityTypeDefinition: vi.fn(),
-  insertLocation: vi.fn().mockResolvedValue(undefined),
+  insertLocations: vi.fn().mockResolvedValue(undefined),
   insertDeductionRule: vi.fn().mockResolvedValue({
     conditions: [],
     enabled: true,

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -55,6 +55,7 @@ vi.mock('./db', () => ({
   getUserSettings: vi.fn().mockResolvedValue(null),
   insertActivity: vi.fn().mockResolvedValue(undefined),
   insertActivityTypeDefinition: vi.fn(),
+  insertLocation: vi.fn().mockResolvedValue(undefined),
   insertDeductionRule: vi.fn().mockResolvedValue({
     conditions: [],
     enabled: true,
@@ -66,6 +67,7 @@ vi.mock('./db', () => ({
   insertDeductionRuleRun: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn().mockResolvedValue(undefined),
   insertTimeSeries: vi.fn().mockResolvedValue(undefined),
+  softDeleteLocationRange: vi.fn().mockResolvedValue(undefined),
   updateActivityTypeDefinition: vi.fn(),
   updateDeductionRule: vi.fn().mockResolvedValue(null),
   upsertSyncState: vi.fn().mockResolvedValue(undefined),

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -144,6 +144,7 @@ export const createTableStatements: Record<string, string> = {
       altitude        DOUBLE PRECISION,
       velocity        DOUBLE PRECISION,
       regions         VARCHAR[] DEFAULT '{}',
+      deleted_at      TIMESTAMPTZ,
       CONSTRAINT unique_location UNIQUE (source, time)
     )
   `,

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -238,7 +238,7 @@ export const getLocationPoints = async (user: string, start: Date, end: Date): P
     user,
     `SELECT ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, time
      FROM locations
-     WHERE time >= $1 AND time <= $2
+     WHERE time >= $1 AND time <= $2 AND deleted_at IS NULL
      ORDER BY time`,
     [start, end],
   )

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -372,7 +372,7 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
     user,
     `SELECT ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, time, regions
      FROM locations
-     WHERE time >= $1 AND time <= $2
+     WHERE time >= $1 AND time <= $2 AND deleted_at IS NULL
      ORDER BY time`,
     [start, end],
   )

--- a/apps/web/src/utils/metricLabels.ts
+++ b/apps/web/src/utils/metricLabels.ts
@@ -38,6 +38,16 @@ export const metricLabels: Record<string, string> = {
   intensity_minutes: 'Intensity Minutes',
   respiratory_rate: 'Respiratory Rate',
   cardiovascular_age: 'Cardiovascular Age',
+  // Running dynamics
+  run_cadence: 'Run Cadence',
+  stride_length: 'Stride Length',
+  ground_contact_time: 'Ground Contact Time',
+  vertical_ratio: 'Vertical Ratio',
+  elevation: 'Elevation',
+  vertical_oscillation: 'Vertical Oscillation',
+  vertical_speed: 'Vertical Speed',
+  grade_adjusted_speed: 'Grade Adjusted Speed',
+  performance_condition: 'Performance Condition',
 }
 
 /**

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -62,6 +62,15 @@ export const validMetrics = [
   'intensity_minutes',
   'speed',
   'power',
+  'run_cadence',
+  'stride_length',
+  'ground_contact_time',
+  'vertical_ratio',
+  'elevation',
+  'vertical_oscillation',
+  'vertical_speed',
+  'grade_adjusted_speed',
+  'performance_condition',
 ] as const
 
 export const metricTypeSchema = z.enum(validMetrics).meta({
@@ -266,6 +275,15 @@ export const metricUnits: Record<MetricType, string> = {
   weight: 'kg',
   speed: 'm/s',
   power: 'W',
+  run_cadence: 'spm',
+  stride_length: 'm',
+  ground_contact_time: 'ms',
+  vertical_ratio: 'percent',
+  elevation: 'm',
+  vertical_oscillation: 'cm',
+  vertical_speed: 'm/s',
+  grade_adjusted_speed: 'm/s',
+  performance_condition: 'score',
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract 14 metrics from Garmin activity detail (up from 4): run cadence, stride length, ground contact time, vertical ratio, elevation, power, speed, vertical oscillation, vertical speed, grade adjusted speed, performance condition + existing HR/body battery/stress/respiration
- Fix bug where `{source, parsedValue}` objects from Garmin API were stored as objects instead of numbers
- Extract GPS coordinates (`directLatitude`/`directLongitude`) from activity details, downsampled to ~1 point/min, inserted as location points with `source='garmin'`
- Soft-delete conflicting OwnTracks locations during Garmin activity time windows
- Add `deleted_at` column to `locations` table (migration included)
- Add frontend display labels for all new running dynamics metrics

## Test plan
- [x] Unit tests for `extractNumericValue` (plain numbers, parsedValue objects, null)
- [x] Unit tests for new running dynamics metric extraction
- [x] Unit tests for stride length cm→m conversion
- [x] Unit tests for elevation with negative values
- [x] Unit tests for GPS extraction, downsampling, and soft-delete
- [x] All 1373 non-integration tests pass
- [ ] Trigger `sync_garmin` and verify new metrics appear
- [ ] Verify GPS locations appear with source='garmin'
- [ ] Verify OwnTracks locations soft-deleted during activity windows
- [ ] Verify actual Garmin metric key names match after first sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)