### PR TITLE
feat: multi-field chart breakdown with UI

### DIFF
--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -21,7 +21,7 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
     async (req, res) => {
       const {
         aggregation,
-        breakdown_field,
+        breakdown_fields: breakdownFieldsStr,
         bucket_size,
         end,
         pattern,
@@ -29,6 +29,12 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
         start,
         tag_definition_id,
       } = req.query
+      const breakdown_fields = breakdownFieldsStr
+        ? breakdownFieldsStr
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined
       const user = req.user!
 
       if (!pattern && !tag_definition_id) {
@@ -40,7 +46,7 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
       try {
         const result = await getChartData(user, {
           aggregation: aggregation ?? 'count',
-          breakdown_field,
+          breakdown_fields,
           bucket_size: bucket_size ?? '1d',
           end,
           pattern,
@@ -50,7 +56,7 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
         })
         res.json({
           data: {
-            breakdown_field: result.breakdown_field,
+            breakdown_fields: result.breakdown_fields,
             breakdown_series: result.breakdown_series,
             buckets: result.buckets,
           },

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -269,18 +269,18 @@ describe('getChartData', () => {
     expect(sql).toContain('count(*)')
   })
 
-  test('activity_type with breakdown_field returns breakdown buckets', async () => {
+  test('activity_type with breakdown_fields returns breakdown buckets', async () => {
     vi.mocked(db.query).mockResolvedValue({
       rows: [
-        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_value: 'Sara', value: 2 },
-        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_value: 'Other', value: 1 },
-        { bucket_start: new Date('2026-01-08T00:00:00Z'), field_value: 'Sara', value: 3 },
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_0: 'Sara', value: 2 },
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_0: 'Other', value: 1 },
+        { bucket_start: new Date('2026-01-08T00:00:00Z'), field_0: 'Sara', value: 3 },
       ],
     } as never)
 
     const result = await getChartData('testuser', {
       aggregation: 'count',
-      breakdown_field: 'partner',
+      breakdown_fields: ['partner'],
       bucket_size: '1w',
       end: '2026-01-31T23:59:59Z',
       pattern: 'sex',
@@ -288,7 +288,7 @@ describe('getChartData', () => {
       start: '2026-01-01T00:00:00Z',
     })
 
-    expect(result.breakdown_field).toBe('partner')
+    expect(result.breakdown_fields).toEqual(['partner'])
     expect(result.breakdown_series).toEqual(['Other', 'Sara'])
     expect(result.buckets).toHaveLength(2)
 
@@ -296,10 +296,41 @@ describe('getChartData', () => {
     expect(first.series).toEqual({ Other: 1, Sara: 2 })
   })
 
-  test('breakdown_field with invalid name returns empty', async () => {
+  test('multi-field breakdown produces compound series keys', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        {
+          bucket_start: new Date('2026-01-01T00:00:00Z'),
+          field_0: 'spanda',
+          field_1: 'external',
+          value: 3.5,
+        },
+        { bucket_start: new Date('2026-01-01T00:00:00Z'), field_0: 'spanda', field_1: 'laptop', value: 1.0 },
+      ],
+    } as never)
+
+    const result = await getChartData('testuser', {
+      aggregation: 'sum',
+      breakdown_fields: ['device', 'display'],
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'computer_active',
+      source_type: 'activity_type',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    expect(result.breakdown_fields).toEqual(['device', 'display'])
+    expect(result.breakdown_series).toEqual(['spanda / external', 'spanda / laptop'])
+
+    const first = result.buckets[0] as { series: Record<string, number> }
+    expect(first.series['spanda / external']).toBe(3.5)
+    expect(first.series['spanda / laptop']).toBe(1.0)
+  })
+
+  test('breakdown_fields with invalid name returns empty', async () => {
     const result = await getChartData('testuser', {
       aggregation: 'count',
-      breakdown_field: 'DROP TABLE',
+      breakdown_fields: ['DROP TABLE'],
       bucket_size: '1d',
       end: '2026-01-31T23:59:59Z',
       pattern: 'test',

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -57,7 +57,7 @@ export const buildBucketExpr = (
 
 export interface ChartDataInput {
   aggregation: 'count' | 'mean' | 'sum'
-  breakdown_field?: string
+  breakdown_fields?: string[]
   bucket_size: '1m' | '5m' | '15m' | '1M' | '1d' | '1h' | '1w'
   end: string
   pattern?: string
@@ -209,49 +209,58 @@ const queryActivityTypeBuckets = async (
 }
 
 /**
- * Query activity type data broken down by a data field's distinct values.
+ * Query activity type data broken down by one or more data fields.
+ * Multiple fields produce compound series keys like "spanda / external_monitor".
  */
 const queryActivityTypeBreakdown = async (
   user: string,
   activityType: string,
-  field: string,
+  fields: string[],
   start: string,
   end: string,
   bucketSize: string,
   aggregation = 'sum',
 ): Promise<{ buckets: ChartDataBreakdownBucket[]; series: string[] }> => {
-  // Sanitize field name
-  if (!/^[a-z][a-z0-9_]*$/.test(field)) return { buckets: [], series: [] }
+  // Sanitize all field names
+  for (const field of fields) {
+    if (!/^[a-z][a-z0-9_]*$/.test(field)) return { buckets: [], series: [] }
+  }
 
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const valueExpr =
     aggregation === 'count'
       ? 'count(*)'
       : "SUM(EXTRACT(EPOCH FROM (COALESCE(end_time, start_time + interval '1 hour') - start_time))) / 3600.0"
+
+  // Build SELECT and GROUP BY for each breakdown field
+  const fieldSelects = fields.map((f, i) => `COALESCE(data->>'${f}', '(none)') AS field_${i}`)
+  const fieldGroupBys = fields.map((_, i) => `field_${i}`)
+
   const result = await query(
     user,
     `SELECT ${bucket.expr} AS bucket_start,
-            COALESCE(data->>'${field}', '(none)') AS field_value,
+            ${fieldSelects.join(', ')},
             ${valueExpr} AS value
        FROM activities
       WHERE activity_type = $${bucket.params.length + 1}
         AND deleted_at IS NULL
         AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
-      GROUP BY 1, 2
+      GROUP BY 1, ${fieldGroupBys.join(', ')}
       ORDER BY 1`,
     [...bucket.params, activityType, start, end],
   )
 
-  // Pivot rows into breakdown buckets
+  // Pivot rows into breakdown buckets with compound series keys
   const seriesSet = new Set<string>()
   const bucketMap = new Map<string, Record<string, number>>()
   for (const row of result.rows) {
     const bucketStart = (row.bucket_start as Date).toISOString()
-    const fieldValue = row.field_value as string
+    const keyParts = fields.map((_, i) => row[`field_${i}`] as string)
+    const seriesKey = keyParts.join(' / ')
     const value = Number(row.value)
-    seriesSet.add(fieldValue)
+    seriesSet.add(seriesKey)
     const existing = bucketMap.get(bucketStart) ?? {}
-    existing[fieldValue] = value
+    existing[seriesKey] = value
     bucketMap.set(bucketStart, existing)
   }
 
@@ -272,24 +281,29 @@ export const getChartData = async (
   input: ChartDataInput,
 ): Promise<{
   buckets: (ChartDataBucket | ChartDataBreakdownBucket)[]
-  breakdown_field?: string
+  breakdown_fields?: string[]
   breakdown_series?: string[]
 }> => {
   const { aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id } = input
 
   // Breakdown mode for activity types
-  if (source_type === 'activity_type' && pattern && input.breakdown_field) {
+  if (
+    source_type === 'activity_type' &&
+    pattern &&
+    input.breakdown_fields &&
+    input.breakdown_fields.length > 0
+  ) {
     const result = await queryActivityTypeBreakdown(
       user,
       pattern,
-      input.breakdown_field,
+      input.breakdown_fields,
       start,
       end,
       bucket_size,
       aggregation,
     )
     return {
-      breakdown_field: input.breakdown_field,
+      breakdown_fields: input.breakdown_fields,
       breakdown_series: result.series,
       buckets: result.buckets,
     }

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -63,6 +63,7 @@ const BUCKET_SIZE_OPTIONS: { label: string; value: BucketSize }[] = [
 
 interface ChartState {
   aggregation: 'count' | 'mean' | 'sum'
+  breakdown_fields: string[]
   bucket_size: BucketSize
   chart_type: ChartType
   display_period: TrendDisplayPeriod
@@ -77,13 +78,14 @@ interface ChartState {
 function parseQuery(query: Record<string, string>): ChartState {
   return {
     aggregation: (query.aggregation ?? 'count') as 'count' | 'mean' | 'sum',
+    breakdown_fields: query.breakdown_fields ? query.breakdown_fields.split(',').filter(Boolean) : [],
     bucket_size: (query.bucket_size ?? '1d') as BucketSize,
     chart_type: (query.chart_type ?? 'trend') as ChartType,
     display_period: (query.display_period ?? 'monthly') as TrendDisplayPeriod,
     half_life_days: Number(query.half_life_days) || 15,
     lookback_days: Number(query.lookback_days) || 90,
     pattern: query.pattern ?? '',
-    source_type: (query.source_type ?? 'tag') as SourceType,
+    source_type: (query.source_type ?? 'activity_type') as SourceType,
     tag_definition_id: query.tag_definition_id ?? '',
   }
 }
@@ -246,12 +248,19 @@ function SourcePicker({
         ) : state.source_type === 'activity_type' ? (
           <>
             Activity Type
-            <input
-              type="text"
+            <select
               value={state.pattern}
-              onInput={(e) => onUpdate({ pattern: (e.target as HTMLInputElement).value })}
-              placeholder="e.g. running, cycling..."
-            />
+              onChange={(e) =>
+                onUpdate({ breakdown_fields: [], pattern: (e.target as HTMLSelectElement).value })
+              }
+            >
+              <option value="">-- select --</option>
+              {activityTypes.map((d) => (
+                <option key={d.name} value={d.name}>
+                  {d.display_name} ({d.name})
+                </option>
+              ))}
+            </select>
           </>
         ) : (
           <>
@@ -264,6 +273,34 @@ function SourcePicker({
           </>
         )}
       </label>
+
+      {state.source_type === 'activity_type' &&
+        state.pattern &&
+        (() => {
+          const typeDef = activityTypes.find((d) => d.name === state.pattern)
+          const categoricalFields = typeDef?.data_schema?.fields.filter((f) => f.is_categorical) ?? []
+          if (categoricalFields.length === 0) return null
+          return (
+            <div class="breakdown-fields">
+              <span class="breakdown-label">Breakdown by:</span>
+              {categoricalFields.map((field) => (
+                <label key={field.name} class="breakdown-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={state.breakdown_fields.includes(field.name)}
+                    onChange={() => {
+                      const next = state.breakdown_fields.includes(field.name)
+                        ? state.breakdown_fields.filter((f) => f !== field.name)
+                        : [...state.breakdown_fields, field.name]
+                      onUpdate({ breakdown_fields: next })
+                    }}
+                  />
+                  {field.label ?? field.name}
+                </label>
+              ))}
+            </div>
+          )
+        })()}
     </div>
   )
 }
@@ -360,7 +397,7 @@ function ChartControls({
           </label>
         )}
 
-        {state.source_type === 'metric' && (
+        {(state.source_type === 'metric' || state.source_type === 'activity_type') && (
           <label>
             Aggregation
             <select
@@ -369,8 +406,8 @@ function ChartControls({
                 onUpdate({ aggregation: (e.target as HTMLSelectElement).value as 'count' | 'mean' | 'sum' })
               }
             >
-              <option value="mean">Average</option>
-              <option value="sum">Sum</option>
+              {state.source_type === 'metric' && <option value="mean">Average</option>}
+              <option value="sum">Sum (hours)</option>
               <option value="count">Count</option>
             </select>
           </label>
@@ -434,6 +471,38 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
   }
 
   const result = barQuery.data
+
+  // Breakdown mode: render one bar chart per series
+  if (result?.breakdown_buckets?.length) {
+    const series = result.breakdown_series ?? []
+    const colors = ['#8b5cf6', '#f97316', '#22c55e', '#3b82f6', '#ef4444', '#f59e0b', '#ec4899', '#14b8a6']
+    return (
+      <div class="chart-display">
+        <div class="breakdown-legend">
+          {series.map((name, i) => (
+            <span key={name} class="breakdown-legend-item">
+              <span class="breakdown-legend-dot" style={{ background: colors[i % colors.length] }} />
+              {name}
+            </span>
+          ))}
+        </div>
+        {series.map((name, i) => (
+          <div key={name} class="breakdown-series">
+            <h4 class="breakdown-series-title">{name}</h4>
+            <BarChart
+              data={result.breakdown_buckets!.map((b) => ({
+                bucket_start: b.bucket_start,
+                value: b.series[name] ?? 0,
+              }))}
+              color={colors[i % colors.length]}
+              height={150}
+            />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
   const buckets = result?.buckets ?? []
 
   return (
@@ -675,7 +744,8 @@ export function Chart() {
       ) : (
         <BarDisplay
           params={{
-            aggregation: state.source_type === 'metric' ? state.aggregation : 'count',
+            aggregation: state.aggregation,
+            breakdown_fields: state.breakdown_fields.length > 0 ? state.breakdown_fields : undefined,
             bucket_size: state.bucket_size,
             end,
             pattern: state.pattern || undefined,

--- a/apps/web/src/pages/Chart/style.css
+++ b/apps/web/src/pages/Chart/style.css
@@ -111,6 +111,59 @@
   padding: 1.5rem;
 }
 
+.breakdown-fields {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.breakdown-label {
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.breakdown-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.breakdown-legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.breakdown-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.85rem;
+}
+
+.breakdown-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.breakdown-series {
+  margin-bottom: 0.5rem;
+}
+
+.breakdown-series-title {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #6b7280;
+  margin: 0 0 0.25rem;
+}
+
 .chart-current-value {
   display: flex;
   align-items: baseline;

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1852,12 +1852,12 @@ export interface FetchChartDataParams {
   tag_definition_id?: string
   bucket_size?: '1m' | '5m' | '15m' | '1h' | '1d' | '1w' | '1M'
   aggregation?: 'count' | 'sum' | 'mean'
-  breakdown_field?: string
+  breakdown_fields?: string[]
 }
 
 export interface ChartDataResult {
   buckets: ChartDataBucket[]
-  breakdown_field?: string
+  breakdown_fields?: string[]
   breakdown_series?: string[]
   breakdown_buckets?: Array<{ bucket_start: string; series: Record<string, number> }>
 }
@@ -1873,7 +1873,7 @@ export const fetchChartData = async (params: FetchChartDataParams): Promise<Char
   if (params.tag_definition_id) query.tag_definition_id = params.tag_definition_id
   if (params.bucket_size) query.bucket_size = params.bucket_size
   if (params.aggregation) query.aggregation = params.aggregation
-  if (params.breakdown_field) query.breakdown_field = params.breakdown_field
+  if (params.breakdown_fields?.length) query.breakdown_fields = params.breakdown_fields.join(',')
 
   const response = await axios.get<ChartDataResponse>(`${API_URL}/chart-data`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -1881,10 +1881,10 @@ export const fetchChartData = async (params: FetchChartDataParams): Promise<Char
   })
 
   const data = response.data.data
-  if (data?.breakdown_field) {
+  if (data?.breakdown_fields?.length) {
     return {
       breakdown_buckets: data.buckets as Array<{ bucket_start: string; series: Record<string, number> }>,
-      breakdown_field: data.breakdown_field,
+      breakdown_fields: data.breakdown_fields,
       breakdown_series: data.breakdown_series,
       buckets: [],
     }

--- a/packages/api-spec/src/schemas/chart-data.ts
+++ b/packages/api-spec/src/schemas/chart-data.ts
@@ -64,13 +64,10 @@ export const chartDataQuerySchema = z
       .uuid()
       .optional()
       .meta({ description: 'Tag definition ID (alternative to pattern for tags)' }),
-    breakdown_field: z
-      .string()
-      .optional()
-      .meta({
-        description:
-          'Data field to break down by (for activity_type source). Returns series per distinct value.',
-      }),
+    breakdown_fields: z.array(z.string()).optional().meta({
+      description:
+        'Data fields to break down by (for activity_type source). Multiple fields produce compound series keys.',
+    }),
   })
   .meta({ id: 'ChartDataQuery', description: 'Query parameters for bucketed chart data' })
 
@@ -82,7 +79,10 @@ export type ChartDataQuery = z.infer<typeof chartDataQuerySchema>
 export const chartDataHttpQuerySchema = z
   .object({
     aggregation: z.enum(['count', 'sum', 'mean']).optional(),
-    breakdown_field: z.string().optional().meta({ description: 'Data field to break down by' }),
+    breakdown_fields: z
+      .string()
+      .optional()
+      .meta({ description: 'Comma-separated data fields to break down by' }),
     bucket_size: z.enum(['1m', '5m', '15m', '1h', '1d', '1w', '1M']).optional(),
     end: z.string().meta({ description: 'End of time range (ISO 8601 string)' }),
     pattern: z.string().optional().meta({ description: 'Pattern to match' }),
@@ -129,7 +129,10 @@ export const chartDataResponseSchema = baseResponseSchema
   .extend({
     data: z
       .object({
-        breakdown_field: z.string().optional().meta({ description: 'Field used for breakdown, if any' }),
+        breakdown_fields: z
+          .array(z.string())
+          .optional()
+          .meta({ description: 'Fields used for breakdown, if any' }),
         breakdown_series: z
           .array(z.string())
           .optional()


### PR DESCRIPTION
## Summary
- **Multi-field breakdown**: `breakdown_fields` (array) replaces `breakdown_field` (singular). Multiple fields produce compound series keys like "spanda / external_monitor"
- **Chart explorer UI**: when an activity type with categorical data_schema fields is selected, checkboxes appear for "Breakdown by: [Device] [Display]"
- **Aggregation control**: now shown for `activity_type` source — choose between "Count" and "Sum (hours)"
- **Activity type picker**: uses a dropdown from type definitions instead of free-text input
- **Rendering**: each breakdown series renders as a separate colored bar chart with a color legend

## Test plan
- [x] 1661 tests pass (new: multi-field breakdown compound keys)
- [x] Type checks pass
- [ ] Select `computer_active` in chart explorer, check both Device and Display breakdowns
- [ ] Select `sex`, check Partner breakdown
- [ ] Toggle between Count and Sum aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)