### PR TITLE
feat: display location on entity details and interactive GPS map

### DIFF
--- a/apps/backend/src/routes/locations-router.ts
+++ b/apps/backend/src/routes/locations-router.ts
@@ -16,6 +16,7 @@ import {
   locationsQuerySchema,
   type LocationsResponse,
   type NamedLocationsResponse,
+  type RawLocationsResponse,
   type PromoteDetectedLocationBody,
   promoteDetectedLocationBodySchema,
   type UpdateNamedLocationBody,
@@ -27,6 +28,7 @@ import {
   deleteNamedLocation,
   getDetectedLocations,
   getNamedLocations,
+  getRawLocationPoints,
   insertNamedLocation,
   updateNamedLocation,
 } from '../services/locations.ts'
@@ -47,6 +49,20 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): Router =>
 
       const places = await queryLocations(user, new Date(start), new Date(end))
       res.json({ data: places, success: true })
+    },
+  )
+
+  router.get<Record<string, never>, RawLocationsResponse, unknown, LocationsQuery>(
+    '/raw',
+    authMiddleware,
+    validateQuery(locationsQuerySchema),
+    async (req, res) => {
+      const { start, end } = req.query
+      const points = await getRawLocationPoints(req.user!, new Date(start), new Date(end))
+      res.json({
+        data: points.map((p) => ({ lat: p.lat, lon: p.lon, time: p.time.toISOString() })),
+        success: true,
+      })
     },
   )
 

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -363,6 +363,30 @@ export const matchLocationToDetected = (
 }
 
 /**
+ * Get raw GPS points for a time range, suitable for rendering a path on a map.
+ */
+export const getRawLocationPoints = async (
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<{ lat: number; lon: number; time: Date }[]> => {
+  const result = await query(
+    user,
+    `SELECT ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, time
+     FROM locations
+     WHERE time >= $1 AND time <= $2
+     ORDER BY time`,
+    [start, end],
+  )
+
+  return result.rows.map((row) => ({
+    lat: Number(row.lat),
+    lon: Number(row.lon),
+    time: new Date(row.time),
+  }))
+}
+
+/**
  * Get place visits for a time range, using named locations when available.
  * Falls back to detected locations, then OwnTracks regions.
  */

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -61,12 +61,28 @@ const formatDuration = (start: Date, end: Date): string => {
   return m > 0 ? `${h}h ${m}m` : `${h}h`
 }
 
-const activityToItem = (a: Activity): DataItem => {
+/** Find the place with the most overlap for a given time window. */
+const findPrimaryPlace = (start: Date, end: Date, places: Place[]): string | undefined => {
+  let best: { name: string; overlap: number } | undefined
+  for (const p of places) {
+    const overlapStart = Math.max(start.getTime(), p.start_time.getTime())
+    const overlapEnd = Math.min(end.getTime(), p.end_time.getTime())
+    const overlap = overlapEnd - overlapStart
+    if (overlap > 0 && (!best || overlap > best.overlap)) {
+      best = { name: p.region, overlap }
+    }
+  }
+  return best?.name
+}
+
+const activityToItem = (a: Activity, places: Place[]): DataItem => {
   const end = a.end_time ?? new Date(a.start_time.getTime() + 60 * 60000)
   const label = a.title ?? toDisplayName(a.activity_type)
+  const location = findPrimaryPlace(a.start_time, end, places)
+  const timeStr = `${format(a.start_time, 'HH:mm')} – ${format(end, 'HH:mm')} · ${formatDuration(a.start_time, end)}`
   return {
     color: ACTIVITY_COLORS[a.activity_type] ?? '#6b7280',
-    detail: `${format(a.start_time, 'HH:mm')} – ${format(end, 'HH:mm')} · ${formatDuration(a.start_time, end)}`,
+    detail: location ? `${timeStr} · @ ${location}` : timeStr,
     end,
     href: a.id ? `/detail/activity/${encodeURIComponent(a.id)}` : undefined,
     label,
@@ -85,10 +101,12 @@ const placeToItem = (p: Place, dateStr: string): DataItem => ({
   type: 'location',
 })
 
-const mealToItem = (m: Meal): DataItem => {
+const mealToItem = (m: Meal, places: Place[]): DataItem => {
   const parts = [format(m.time, 'HH:mm')]
   if (m.meal_type) parts.push(m.meal_type)
   if (m.calories) parts.push(`${Math.round(m.calories)} kcal`)
+  const location = findPrimaryPlace(m.time, new Date(m.time.getTime() + 30 * 60000), places)
+  if (location) parts.push(`@ ${location}`)
   return {
     color: MEAL_COLOR,
     detail: parts.join(' · '),
@@ -108,12 +126,16 @@ const reportToItem = (r: Report): DataItem => ({
   type: 'report',
 })
 
-const productivityToItem = (p: ProductivityRecord): DataItem => {
+const productivityToItem = (p: ProductivityRecord, places: Place[]): DataItem => {
   const dur = Math.round(p.duration_sec / 60)
   const category = p.resolved_category?.join(' > ') ?? p.category ?? ''
+  const location = findPrimaryPlace(p.start_time, p.end_time, places)
+  const parts = [`${format(p.start_time, 'HH:mm')} – ${format(p.end_time, 'HH:mm')} · ${dur}m`]
+  if (category) parts.push(category)
+  if (location) parts.push(`@ ${location}`)
   return {
     color: SCREENTIME_COLOR,
-    detail: `${format(p.start_time, 'HH:mm')} – ${format(p.end_time, 'HH:mm')} · ${dur}m${category ? ` · ${category}` : ''}`,
+    detail: parts.join(' · '),
     end: p.end_time,
     href: p.id ? `/detail/productivity/${encodeURIComponent(p.id)}` : undefined,
     label: p.activity,
@@ -156,7 +178,7 @@ const buildItems = (
 ): DataItem[] => {
   const items: DataItem[] = []
   if (activeTypes.has('activity')) {
-    for (const a of activities) items.push(activityToItem(a))
+    for (const a of activities) items.push(activityToItem(a, places))
   }
   if (activeTypes.has('location')) {
     for (const p of places) items.push(placeToItem(p, dateStr))
@@ -173,13 +195,13 @@ const buildItems = (
     }
   }
   if (activeTypes.has('meal')) {
-    for (const m of meals) items.push(mealToItem(m))
+    for (const m of meals) items.push(mealToItem(m, places))
   }
   if (activeTypes.has('report')) {
     for (const r of reports) items.push(reportToItem(r))
   }
   if (activeTypes.has('screentime')) {
-    for (const p of productivity) items.push(productivityToItem(p))
+    for (const p of productivity) items.push(productivityToItem(p, places))
   }
   return items.sort((a, b) => a.start.getTime() - b.start.getTime())
 }

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -18,6 +18,7 @@ import {
   type Report,
 } from '../../state/api'
 import { toDisplayName } from '../../utils/displayName'
+import { MEAL_LOCATION_WINDOW_MS } from '../EntityDetail/LocationInfo'
 import './style.css'
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -105,7 +106,7 @@ const mealToItem = (m: Meal, places: Place[]): DataItem => {
   const parts = [format(m.time, 'HH:mm')]
   if (m.meal_type) parts.push(m.meal_type)
   if (m.calories) parts.push(`${Math.round(m.calories)} kcal`)
-  const location = findPrimaryPlace(m.time, new Date(m.time.getTime() + 30 * 60000), places)
+  const location = findPrimaryPlace(m.time, new Date(m.time.getTime() + MEAL_LOCATION_WINDOW_MS), places)
   if (location) parts.push(`@ ${location}`)
   return {
     color: MEAL_COLOR,

--- a/apps/web/src/pages/EntityDetail/ActivityChart.tsx
+++ b/apps/web/src/pages/EntityDetail/ActivityChart.tsx
@@ -22,6 +22,7 @@ interface ActivityChartProps {
   end: Date
   stages?: SleepStage[]
   defaultMetrics?: string[]
+  onHoverTime?: (time: Date | null) => void
 }
 
 const CHART_HEIGHT = 260
@@ -337,6 +338,7 @@ const renderChart = ({
   end,
   svgRef,
   tooltipRef,
+  onHoverTimeRef,
 }: {
   containerRef: { current: HTMLDivElement | null }
   hasHypnogram: boolean
@@ -346,6 +348,7 @@ const renderChart = ({
   end: Date
   svgRef: { current: SVGSVGElement | null }
   tooltipRef: { current: HTMLDivElement | null }
+  onHoverTimeRef: { current: ((time: Date | null) => void) | undefined }
 }) => {
   if (!svgRef.current || !containerRef.current) return
 
@@ -400,6 +403,7 @@ const renderChart = ({
     .on('mousemove', (event: MouseEvent) => {
       const [mx] = d3.pointer(event)
       const time = xScale.invert(mx)
+      onHoverTimeRef.current?.(time)
 
       crosshair.attr('x1', mx).attr('x2', mx).style('display', null)
 
@@ -424,6 +428,7 @@ const renderChart = ({
     .on('mouseleave', () => {
       crosshair.style('display', 'none')
       if (tooltip) tooltip.style.display = 'none'
+      onHoverTimeRef.current?.(null)
     })
 }
 
@@ -521,10 +526,19 @@ const useMetricChartData = (start: Date, end: Date, chartWidthPx: number) => {
   })
 }
 
-export const ActivityChart = ({ start, end, stages, defaultMetrics = [] }: ActivityChartProps) => {
+export const ActivityChart = ({
+  start,
+  end,
+  stages,
+  defaultMetrics = [],
+  onHoverTime,
+}: ActivityChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
+  const onHoverTimeRef = useRef(onHoverTime)
+
+  onHoverTimeRef.current = onHoverTime
 
   // Measure chart inner width (container minus margins) for pixel-accurate bucket sizing
   const [chartWidthPx, setChartWidthPx] = useState(0)
@@ -617,6 +631,7 @@ export const ActivityChart = ({ start, end, stages, defaultMetrics = [] }: Activ
         end,
         svgRef,
         tooltipRef,
+        onHoverTimeRef,
       }),
     [start, end, stages, hasHypnogram, overlays],
   )

--- a/apps/web/src/pages/EntityDetail/ActivityMap.tsx
+++ b/apps/web/src/pages/EntityDetail/ActivityMap.tsx
@@ -1,0 +1,105 @@
+/**
+ * Interactive GPS path map for activity detail.
+ * Shows the GPS track as a polyline and highlights the position nearest to the chart crosshair.
+ */
+import 'leaflet/dist/leaflet.css'
+import { useQuery } from '@tanstack/react-query'
+import L from 'leaflet'
+import { useEffect, useRef } from 'preact/hooks'
+
+import { fetchRawLocations } from '../../state/api'
+import { interpolatePosition } from './chart-utils'
+
+// Fix Leaflet default marker icon path issue with bundlers
+// @ts-expect-error - Leaflet marker icon fix
+delete L.Icon.Default.prototype._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+})
+
+const HIGHLIGHT_ICON = L.divIcon({
+  className: 'activity-map-highlight',
+  iconSize: [14, 14],
+  iconAnchor: [7, 7],
+})
+
+interface ActivityMapProps {
+  start: Date
+  end: Date
+  hoverTime: Date | null
+}
+
+export const ActivityMap = ({ start, end, hoverTime }: ActivityMapProps) => {
+  const mapContainerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<L.Map | null>(null)
+  const highlightMarkerRef = useRef<L.Marker | null>(null)
+
+  const { data: points } = useQuery({
+    queryFn: () => fetchRawLocations(start, end),
+    queryKey: ['raw-locations', start.toISOString(), end.toISOString()],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Initialize map + draw polyline when points load
+  useEffect(() => {
+    if (!mapContainerRef.current || !points || points.length < 2) return
+
+    // Clean up previous map if any
+    if (mapRef.current) {
+      mapRef.current.remove()
+      mapRef.current = null
+      highlightMarkerRef.current = null
+    }
+
+    const map = L.map(mapContainerRef.current, {
+      zoomControl: true,
+    })
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      maxZoom: 19,
+    }).addTo(map)
+
+    const latLngs: L.LatLngExpression[] = points.map((p) => [p.lat, p.lon])
+    const polyline = L.polyline(latLngs, { color: '#673ab8', weight: 3, opacity: 0.8 }).addTo(map)
+    map.fitBounds(polyline.getBounds(), { padding: [20, 20] })
+
+    mapRef.current = map
+
+    return () => {
+      map.remove()
+      mapRef.current = null
+      highlightMarkerRef.current = null
+    }
+  }, [points])
+
+  // Move highlight marker when hoverTime changes
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !points || points.length < 2) return
+
+    if (!hoverTime) {
+      if (highlightMarkerRef.current) {
+        highlightMarkerRef.current.remove()
+        highlightMarkerRef.current = null
+      }
+      return
+    }
+
+    const pos = interpolatePosition(points, hoverTime)
+    if (!pos) return
+
+    if (highlightMarkerRef.current) {
+      highlightMarkerRef.current.setLatLng([pos.lat, pos.lon])
+    } else {
+      highlightMarkerRef.current = L.marker([pos.lat, pos.lon], { icon: HIGHLIGHT_ICON }).addTo(map)
+    }
+  }, [hoverTime, points])
+
+  // Don't render if no GPS data
+  if (!points || points.length < 2) return null
+
+  return <div ref={mapContainerRef} class="activity-map-container" />
+}

--- a/apps/web/src/pages/EntityDetail/ActivityMap.tsx
+++ b/apps/web/src/pages/EntityDetail/ActivityMap.tsx
@@ -10,19 +10,18 @@ import { useEffect, useRef } from 'preact/hooks'
 import { fetchRawLocations } from '../../state/api'
 import { interpolatePosition } from './chart-utils'
 
-// Fix Leaflet default marker icon path issue with bundlers
-// @ts-expect-error - Leaflet marker icon fix
-delete L.Icon.Default.prototype._getIconUrl
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
-  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-})
+const MIN_POINTS_FOR_PATH = 2
+const LOCATION_STALE_TIME_MS = 5 * 60_000 // 5 minutes
+const PATH_COLOR = '#673ab8'
+const PATH_WEIGHT = 3
+const PATH_OPACITY = 0.8
+const FIT_BOUNDS_PADDING = 20
 
+const HIGHLIGHT_MARKER_SIZE = 14
 const HIGHLIGHT_ICON = L.divIcon({
   className: 'activity-map-highlight',
-  iconSize: [14, 14],
-  iconAnchor: [7, 7],
+  iconSize: [HIGHLIGHT_MARKER_SIZE, HIGHLIGHT_MARKER_SIZE],
+  iconAnchor: [HIGHLIGHT_MARKER_SIZE / 2, HIGHLIGHT_MARKER_SIZE / 2],
 })
 
 interface ActivityMapProps {
@@ -39,12 +38,12 @@ export const ActivityMap = ({ start, end, hoverTime }: ActivityMapProps) => {
   const { data: points } = useQuery({
     queryFn: () => fetchRawLocations(start, end),
     queryKey: ['raw-locations', start.toISOString(), end.toISOString()],
-    staleTime: 5 * 60 * 1000,
+    staleTime: LOCATION_STALE_TIME_MS,
   })
 
   // Initialize map + draw polyline when points load
   useEffect(() => {
-    if (!mapContainerRef.current || !points || points.length < 2) return
+    if (!mapContainerRef.current || !points || points.length < MIN_POINTS_FOR_PATH) return
 
     // Clean up previous map if any
     if (mapRef.current) {
@@ -53,9 +52,7 @@ export const ActivityMap = ({ start, end, hoverTime }: ActivityMapProps) => {
       highlightMarkerRef.current = null
     }
 
-    const map = L.map(mapContainerRef.current, {
-      zoomControl: true,
-    })
+    const map = L.map(mapContainerRef.current, { zoomControl: true })
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
@@ -63,8 +60,12 @@ export const ActivityMap = ({ start, end, hoverTime }: ActivityMapProps) => {
     }).addTo(map)
 
     const latLngs: L.LatLngExpression[] = points.map((p) => [p.lat, p.lon])
-    const polyline = L.polyline(latLngs, { color: '#673ab8', weight: 3, opacity: 0.8 }).addTo(map)
-    map.fitBounds(polyline.getBounds(), { padding: [20, 20] })
+    const polyline = L.polyline(latLngs, {
+      color: PATH_COLOR,
+      weight: PATH_WEIGHT,
+      opacity: PATH_OPACITY,
+    }).addTo(map)
+    map.fitBounds(polyline.getBounds(), { padding: [FIT_BOUNDS_PADDING, FIT_BOUNDS_PADDING] })
 
     mapRef.current = map
 
@@ -78,7 +79,7 @@ export const ActivityMap = ({ start, end, hoverTime }: ActivityMapProps) => {
   // Move highlight marker when hoverTime changes
   useEffect(() => {
     const map = mapRef.current
-    if (!map || !points || points.length < 2) return
+    if (!map || !points || points.length < MIN_POINTS_FOR_PATH) return
 
     if (!hoverTime) {
       if (highlightMarkerRef.current) {
@@ -99,7 +100,7 @@ export const ActivityMap = ({ start, end, hoverTime }: ActivityMapProps) => {
   }, [hoverTime, points])
 
   // Don't render if no GPS data
-  if (!points || points.length < 2) return null
+  if (!points || points.length < MIN_POINTS_FOR_PATH) return null
 
   return <div ref={mapContainerRef} class="activity-map-container" />
 }

--- a/apps/web/src/pages/EntityDetail/LocationInfo.tsx
+++ b/apps/web/src/pages/EntityDetail/LocationInfo.tsx
@@ -1,0 +1,83 @@
+/**
+ * Displays named location(s) overlapping an entity's time range.
+ * Uses the existing fetchPlaceVisits API to resolve time ranges to place visits.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { format } from 'date-fns'
+
+import { fetchPlaceVisits, type PlaceVisit } from '../../state/api'
+
+const SOURCE_COLORS: Record<string, string> = {
+  detected: '#f97316',
+  named: '#22c55e',
+  owntracks: '#3b82f6',
+  unknown: '#9ca3af',
+}
+
+const formatDuration = (minutes: number): string => {
+  if (minutes < 60) return `${Math.round(minutes)}m`
+  const h = Math.floor(minutes / 60)
+  const m = Math.round(minutes % 60)
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}
+
+const PlaceEntry = ({ place }: { place: PlaceVisit }) => {
+  const color = SOURCE_COLORS[place.source] ?? SOURCE_COLORS.unknown
+  const dateStr = format(place.start_time, 'yyyy-MM-dd')
+  const href = `/places?date=${dateStr}&name=${encodeURIComponent(place.name)}`
+
+  return (
+    <a href={href} class="location-entry" title={place.address ?? undefined}>
+      <span class="location-dot" style={{ backgroundColor: color }} />
+      <span class="location-name">{place.source === 'unknown' ? 'Unknown' : place.name}</span>
+      <span class="location-duration">{formatDuration(place.durationMinutes)}</span>
+    </a>
+  )
+}
+
+export const LocationInfo = ({ start, end }: { start: Date; end: Date }) => {
+  const { data: places } = useQuery({
+    enabled: end > start,
+    queryFn: () => fetchPlaceVisits(start, end),
+    queryKey: ['entity-places', start.toISOString(), end.toISOString()],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (!places || places.length === 0) return null
+
+  // Single location — render inline as a field row
+  if (places.length === 1) {
+    const p = places[0]
+    const color = SOURCE_COLORS[p.source] ?? SOURCE_COLORS.unknown
+    const dateStr = format(p.start_time, 'yyyy-MM-dd')
+    const href = `/places?date=${dateStr}&name=${encodeURIComponent(p.name)}`
+
+    return (
+      <div class="entity-fields">
+        <div class="field-row">
+          <span class="field-label">Location</span>
+          <span class="field-value">
+            <a href={href} class="location-link">
+              <span class="location-dot" style={{ backgroundColor: color }} />
+              {p.source === 'unknown' ? 'Unknown' : p.name}
+            </a>
+          </span>
+        </div>
+      </div>
+    )
+  }
+
+  // Multiple locations — render as a list
+  return (
+    <div class="entity-fields">
+      <div class="field-row field-row-top">
+        <span class="field-label">Locations</span>
+        <div class="location-list">
+          {places.map((p, i) => (
+            <PlaceEntry key={i} place={p} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/EntityDetail/LocationInfo.tsx
+++ b/apps/web/src/pages/EntityDetail/LocationInfo.tsx
@@ -7,6 +7,11 @@ import { format } from 'date-fns'
 
 import { fetchPlaceVisits, type PlaceVisit } from '../../state/api'
 
+/** How far after a meal's time to look for location data (meals have no end_time). */
+export const MEAL_LOCATION_WINDOW_MS = 60 * 60_000 // 1 hour
+
+const LOCATION_STALE_TIME_MS = 5 * 60_000 // 5 minutes
+
 const SOURCE_COLORS: Record<string, string> = {
   detected: '#f97316',
   named: '#22c55e',
@@ -40,7 +45,7 @@ export const LocationInfo = ({ start, end }: { start: Date; end: Date }) => {
     enabled: end > start,
     queryFn: () => fetchPlaceVisits(start, end),
     queryKey: ['entity-places', start.toISOString(), end.toISOString()],
-    staleTime: 5 * 60 * 1000,
+    staleTime: LOCATION_STALE_TIME_MS,
   })
 
   if (!places || places.length === 0) return null

--- a/apps/web/src/pages/EntityDetail/chart-utils.ts
+++ b/apps/web/src/pages/EntityDetail/chart-utils.ts
@@ -33,6 +33,47 @@ export const findNearest = (data: [Date, number][], targetTime: Date): [Date, nu
 }
 
 /**
+ * Interpolate a GPS position for a given time between sorted location points.
+ * Uses binary search + linear interpolation between bracketing points.
+ */
+export const interpolatePosition = (
+  points: { lat: number; lon: number; time: Date }[],
+  targetTime: Date,
+): { lat: number; lon: number } | undefined => {
+  if (points.length === 0) return undefined
+  if (points.length === 1) return { lat: points[0].lat, lon: points[0].lon }
+
+  const t = targetTime.getTime()
+
+  // Clamp to first/last point
+  if (t <= points[0].time.getTime()) return { lat: points[0].lat, lon: points[0].lon }
+  if (t >= points[points.length - 1].time.getTime()) {
+    const last = points[points.length - 1]
+    return { lat: last.lat, lon: last.lon }
+  }
+
+  // Binary search for bracketing interval
+  let lo = 0
+  let hi = points.length - 1
+  while (lo < hi - 1) {
+    const mid = (lo + hi) >> 1
+    if (points[mid].time.getTime() <= t) lo = mid
+    else hi = mid
+  }
+
+  const p0 = points[lo]
+  const p1 = points[hi]
+  const span = p1.time.getTime() - p0.time.getTime()
+  if (span === 0) return { lat: p0.lat, lon: p0.lon }
+
+  const ratio = (t - p0.time.getTime()) / span
+  return {
+    lat: p0.lat + (p1.lat - p0.lat) * ratio,
+    lon: p0.lon + (p1.lon - p0.lon) * ratio,
+  }
+}
+
+/**
  * Find the sleep stage active at a given time.
  * Returns the stage label string, or undefined if no stage covers that time.
  */

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -26,9 +26,11 @@ import {
 import { toDisplayName } from '../../utils/displayName'
 import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
+import { ActivityMap } from './ActivityMap'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { EntityActions, type EntityType } from './EntityActions'
 import { formatDateTimeLocal, formatTime } from './format-utils'
+import { LocationInfo } from './LocationInfo'
 import { MergePanel } from './MergePanel'
 import { MetricContent } from './MetricContent'
 import { MusicPlaylist } from './MusicPlaylist'
@@ -214,6 +216,7 @@ const ActivityDetailContent = ({
     activity.total_sleep ?? (hasSleepStages ? computeSleepMinutesFromStages(stages) : undefined)
   const hasEndTime = Boolean(activity.end_time || activity.merged_end_time)
   const hasExerciseType = Boolean(exerciseType)
+  const [hoverTime, setHoverTime] = useState<Date | null>(null)
 
   // Oura sleep metrics (only fetch when sleep stages exist)
   const endDateStr = hasSleepStages ? format(displayEnd, 'yyyy-MM-dd') : ''
@@ -352,6 +355,8 @@ const ActivityDetailContent = ({
         )}
       </div>
 
+      {hasEndTime && !isEditing && <LocationInfo start={displayStart} end={displayEnd} />}
+
       {hasOuraMetrics && <OuraMetricsCards metrics={ouraMetrics} />}
 
       {hasEndTime && (
@@ -361,7 +366,9 @@ const ActivityDetailContent = ({
             end={displayEnd}
             stages={hasSleepStages ? stages : undefined}
             defaultMetrics={['heart_rate', 'hrv_rmssd']}
+            onHoverTime={setHoverTime}
           />
+          <ActivityMap start={displayStart} end={displayEnd} hoverTime={hoverTime} />
         </div>
       )}
 
@@ -587,6 +594,7 @@ const ProductivityContent = ({ entityId }: { entityId: string }) => {
         isSaving={false}
       />
       <ProductivityDetail record={record} categories={categories} itemIcons={itemIcons} />
+      <LocationInfo start={record.start_time} end={record.end_time} />
       <NotesSection entityType="productivity" entityId={entityId} allEntityIds={allEntityIds} />
     </>
   )

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -728,6 +728,86 @@ a.entity-type-badge:hover {
   color: #dc2626;
 }
 
+/* Location info */
+.location-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.location-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #374151;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+
+.location-link:hover {
+  border-bottom-color: #673ab8;
+}
+
+.location-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.location-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #374151;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.location-entry:hover {
+  color: #673ab8;
+}
+
+.location-name {
+  flex-shrink: 0;
+}
+
+.location-duration {
+  color: #9ca3af;
+  font-size: 0.8rem;
+}
+
+.field-row-top {
+  align-items: flex-start;
+}
+
+/* Activity GPS map */
+.activity-map-container {
+  width: 100%;
+  height: 300px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 1rem;
+}
+
+.activity-map-container .leaflet-container {
+  height: 100%;
+  width: 100%;
+}
+
+.activity-map-highlight {
+  width: 14px;
+  height: 14px;
+  background: #673ab8;
+  border: 2px solid white;
+  border-radius: 50%;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+}
+
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
   .deleted-banner {
@@ -758,6 +838,30 @@ a.entity-type-badge:hover {
 
   .field-value {
     color: #d1d5db;
+  }
+
+  .location-link {
+    color: #d1d5db;
+  }
+
+  .location-link:hover {
+    border-bottom-color: #8b5cf6;
+  }
+
+  .location-entry {
+    color: #d1d5db;
+  }
+
+  .location-entry:hover {
+    color: #8b5cf6;
+  }
+
+  .location-duration {
+    color: #6b7280;
+  }
+
+  .activity-map-container {
+    border-color: #374151;
   }
 
   .entity-actions {

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -13,6 +13,7 @@ import {
   type FoodItemEntity,
   updateMealApi,
 } from '../../state/api'
+import { LocationInfo } from '../EntityDetail/LocationInfo'
 import './MealDetail.css'
 
 // ── Sub-components ───────────────────────────────────────────────────────────
@@ -555,6 +556,9 @@ export function MealDetail() {
               <span class="detail-value">—</span>
             )}
           </div>
+
+          {/* Location */}
+          {!isEditing && <LocationInfo start={meal.time} end={new Date(meal.time.getTime() + 60 * 60000)} />}
 
           {/* Food Items */}
           <div class="detail-row detail-row-block">

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -13,7 +13,7 @@ import {
   type FoodItemEntity,
   updateMealApi,
 } from '../../state/api'
-import { LocationInfo } from '../EntityDetail/LocationInfo'
+import { LocationInfo, MEAL_LOCATION_WINDOW_MS } from '../EntityDetail/LocationInfo'
 import './MealDetail.css'
 
 // ── Sub-components ───────────────────────────────────────────────────────────
@@ -558,7 +558,9 @@ export function MealDetail() {
           </div>
 
           {/* Location */}
-          {!isEditing && <LocationInfo start={meal.time} end={new Date(meal.time.getTime() + 60 * 60000)} />}
+          {!isEditing && (
+            <LocationInfo start={meal.time} end={new Date(meal.time.getTime() + MEAL_LOCATION_WINDOW_MS)} />
+          )}
 
           {/* Food Items */}
           <div class="detail-row detail-row-block">

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -54,6 +54,7 @@ import type {
   LocationsResponse,
   NamedLocation,
   NamedLocationsResponse,
+  RawLocationsResponse,
   OuraSyncResponse,
   OuraSyncStatusResponse,
   PeriodMetricStats,
@@ -526,6 +527,27 @@ export const fetchPlaceVisits = async (start: Date, end: Date): Promise<PlaceVis
     durationMinutes: place.duration,
     end_time: new Date(place.end_time),
     start_time: new Date(place.start_time),
+  }))
+}
+
+// Fetch raw GPS location points for the specified date range
+export const fetchRawLocations = async (
+  start: Date,
+  end: Date,
+): Promise<{ lat: number; lon: number; time: Date }[]> => {
+  const { token } = auth.value
+  const params: LocationsQuery = {
+    end: end.toISOString(),
+    start: start.toISOString(),
+  }
+  const response = await axios.get<RawLocationsResponse>(`${API_URL}/locations/raw`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params,
+  })
+
+  return (response.data.data ?? []).map((point) => ({
+    ...point,
+    time: new Date(point.time),
   }))
 }
 

--- a/packages/api-spec/src/schemas/locations.ts
+++ b/packages/api-spec/src/schemas/locations.ts
@@ -81,6 +81,28 @@ export const placeVisitSchema = z
 export type PlaceVisit = z.infer<typeof placeVisitSchema>
 
 /**
+ * Raw GPS location point schema.
+ */
+export const rawLocationPointSchema = z
+  .object({
+    lat: latSchema,
+    lon: lonSchema,
+    time: iso8601DateTimeSchema,
+  })
+  .meta({ id: 'RawLocationPoint', description: 'Raw GPS location point' })
+
+export type RawLocationPoint = z.infer<typeof rawLocationPointSchema>
+
+/**
+ * Raw locations response schema.
+ */
+export const rawLocationsResponseSchema = createDataArrayResponseSchema(rawLocationPointSchema).meta({
+  id: 'RawLocationsResponse',
+})
+
+export type RawLocationsResponse = z.infer<typeof rawLocationsResponseSchema>
+
+/**
  * Locations query schema.
  */
 export const locationsQuerySchema = timeRangeQuerySchema.meta({ id: 'LocationsQuery' })


### PR DESCRIPTION
## Summary
- Show named/detected/unknown locations on activity, productivity, and meal detail pages with colored dots and links to the Places page
- Add primary location context (@ PlaceName) to daily summary items (activities, meals, screentime)
- New `GET /locations/raw` backend endpoint returning raw GPS lat/lon/time points
- Interactive Leaflet map on activity details showing the GPS path as a polyline, with chart crosshair hover syncing a highlighted marker position via interpolation

## New files
- `LocationInfo.tsx` — reusable location display component using existing `fetchPlaceVisits` API
- `ActivityMap.tsx` — Leaflet map with GPS polyline and hover-synced position marker
- `RawLocationPoint` schema in api-spec

## Test plan
- [ ] Open an activity detail page → location(s) appear with colored dots and links
- [ ] Open an activity with GPS data → map shows path below the chart
- [ ] Hover on the metric chart → marker moves along the GPS path on the map
- [ ] Open Data page → activities/meals show `@ LocationName` in their detail line
- [ ] Open a meal detail → location appears between Flags and Food Items
- [ ] Open a productivity detail → location appears below the record info
- [ ] Test activities spanning multiple locations (multiple entries listed)
- [ ] Test entities with no GPS data (map hidden gracefully, location section hidden)
- [ ] `curl /api/locations/raw?start=...&end=...` returns raw GPS points

🤖 Generated with [Claude Code](https://claude.com/claude-code)