### PR TITLE
fix: overlay multi-series in same chart

### DIFF
--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -9,13 +9,21 @@ import { useEffect, useRef } from 'preact/hooks'
 
 import './BarChart.css'
 
+export interface BarSeriesData {
+  name: string
+  color: string
+  data: { bucket_start: string; value: number }[]
+}
+
 export interface BarChartProps {
-  /** Bucketed data points. */
+  /** Bucketed data points (single series). */
   data: { bucket_start: string; value: number }[]
   /** Bar fill colour (default '#8b5cf6'). */
   color?: string
   /** Chart height in pixels (default 300). */
   height?: number
+  /** Multiple named series — renders stacked bars. Overrides data/color when present. */
+  multiSeries?: BarSeriesData[]
 }
 
 interface ParsedBar {
@@ -126,13 +134,15 @@ function renderBars(
     })
 }
 
-export function BarChart({ data, color = '#8b5cf6', height = 300 }: BarChartProps) {
+export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }: BarChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
 
+  const effectiveData = multiSeries ? (multiSeries[0]?.data ?? []) : data
+
   useEffect(() => {
-    if (!svgRef.current || !containerRef.current || data.length === 0) return
+    if (!svgRef.current || !containerRef.current) return
 
     const container = containerRef.current
     const chartWidth = container.clientWidth
@@ -146,38 +156,87 @@ export function BarChart({ data, color = '#8b5cf6', height = 300 }: BarChartProp
     const innerWidth = chartWidth - margin.left - margin.right
     const innerHeight = chartHeight - margin.top - margin.bottom
 
-    const bars: ParsedBar[] = data.map((d) => ({
-      date: new Date(d.bucket_start),
-      value: d.value,
-    }))
+    if (multiSeries && multiSeries.length > 0) {
+      // Grouped (side-by-side) bar chart
+      const allBuckets = [...new Set(multiSeries.flatMap((s) => s.data.map((d) => d.bucket_start)))].sort()
+      if (allBuckets.length === 0) return
 
-    const x = d3
-      .scaleBand<string>()
-      .domain(bars.map((d) => d.date.toISOString()))
-      .range([0, innerWidth])
-      .padding(0.2)
+      const bars: ParsedBar[] = allBuckets.map((b) => ({ date: new Date(b), value: 0 }))
+      const seriesCount = multiSeries.length
 
-    const yMax = d3.max(bars, (d) => d.value) ?? 1
-    const y = d3
-      .scaleLinear()
-      .domain([0, yMax * 1.1])
-      .nice()
-      .range([innerHeight, 0])
+      const x0 = d3.scaleBand<string>().domain(allBuckets).range([0, innerWidth]).padding(0.15)
 
-    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+      const x1 = d3
+        .scaleBand<string>()
+        .domain(multiSeries.map((s) => s.name))
+        .range([0, x0.bandwidth()])
+        .padding(seriesCount > 3 ? 0.02 : 0.08)
 
-    const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
-    const dateFormat = buildBarDateFormat(dateExtent)
+      const yMax = d3.max(multiSeries, (s) => d3.max(s.data, (d) => d.value)) ?? 1
+      const y = d3
+        .scaleLinear()
+        .domain([0, yMax * 1.1])
+        .nice()
+        .range([innerHeight, 0])
 
-    renderGrid(g, y, innerWidth)
-    renderAxes(g, x, y, bars, innerWidth, innerHeight, dateFormat)
+      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
 
-    if (tooltipRef.current) {
-      renderBars(g, bars, x, y, innerHeight, color, tooltipRef.current, container, margin, dateFormat)
+      const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
+      const dateFormat = buildBarDateFormat(dateExtent)
+
+      renderGrid(g, y, innerWidth)
+      renderAxes(g, x0, y, bars, innerWidth, innerHeight, dateFormat)
+
+      // Render grouped bars
+      for (const series of multiSeries) {
+        const dataMap = new Map(series.data.map((d) => [d.bucket_start, d.value]))
+        g.selectAll(`.bar-${series.name}`)
+          .data(allBuckets)
+          .join('rect')
+          .attr('x', (bucket) => (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
+          .attr('y', (bucket) => y(dataMap.get(bucket) ?? 0))
+          .attr('width', x1.bandwidth())
+          .attr('height', (bucket) => innerHeight - y(dataMap.get(bucket) ?? 0))
+          .attr('fill', series.color)
+          .attr('rx', 1)
+      }
+    } else {
+      // Single series
+      if (data.length === 0) return
+
+      const bars: ParsedBar[] = data.map((d) => ({
+        date: new Date(d.bucket_start),
+        value: d.value,
+      }))
+
+      const x = d3
+        .scaleBand<string>()
+        .domain(bars.map((d) => d.date.toISOString()))
+        .range([0, innerWidth])
+        .padding(0.2)
+
+      const yMax = d3.max(bars, (d) => d.value) ?? 1
+      const y = d3
+        .scaleLinear()
+        .domain([0, yMax * 1.1])
+        .nice()
+        .range([innerHeight, 0])
+
+      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+      const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
+      const dateFormat = buildBarDateFormat(dateExtent)
+
+      renderGrid(g, y, innerWidth)
+      renderAxes(g, x, y, bars, innerWidth, innerHeight, dateFormat)
+
+      if (tooltipRef.current) {
+        renderBars(g, bars, x, y, innerHeight, color, tooltipRef.current, container, margin, dateFormat)
+      }
     }
-  }, [data, color, height])
+  }, [data, color, height, multiSeries])
 
-  if (data.length === 0) {
+  if (effectiveData.length === 0) {
     return <div class="bar-chart-placeholder">No data for the selected range</div>
   }
 

--- a/apps/web/src/components/charts/TrendLineChart.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.tsx
@@ -10,6 +10,12 @@ import { useEffect, useRef } from 'preact/hooks'
 
 import './TrendLineChart.css'
 
+export interface LineSeriesData {
+  name: string
+  color: string
+  data: { date: string; value: number }[]
+}
+
 export interface TrendLineChartProps {
   /** Data points to render — must have at least 2 entries. */
   data: { date: string; value: number }[]
@@ -21,6 +27,8 @@ export interface TrendLineChartProps {
   width?: number
   /** Compact mode — hides tooltip crosshair and grid lines (for widgets). */
   compact?: boolean
+  /** Multiple named series — renders overlaid lines. Overrides data/color when present. */
+  multiSeries?: LineSeriesData[]
 }
 
 interface ParsedPoint {
@@ -130,6 +138,46 @@ function renderDots(
     .attr('fill', color)
 }
 
+/** Render multiple overlaid series (area + line for each). */
+function renderMultiSeries(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  series: LineSeriesData[],
+  innerWidth: number,
+  innerHeight: number,
+  compact: boolean,
+) {
+  const allPoints = series.flatMap((s) => s.data.map((d) => ({ date: new Date(d.date), value: d.value })))
+  if (allPoints.length < 2) return
+
+  const x = d3
+    .scaleTime()
+    .domain(d3.extent(allPoints, (d) => d.date) as [Date, Date])
+    .range([0, innerWidth])
+
+  const yExtent = d3.extent(allPoints, (d) => d.value) as [number, number]
+  const yRange = yExtent[1] - yExtent[0]
+  const yPadding = yRange * 0.1 || 1
+  const yMin = yExtent[0] >= 0 ? Math.max(0, yExtent[0] - yPadding) : yExtent[0] - yPadding
+  const y = d3
+    .scaleLinear()
+    .domain([yMin, yExtent[1] + yPadding])
+    .nice()
+    .range([innerHeight, 0])
+
+  const dateExtent = d3.extent(allPoints, (d) => d.date) as [Date, Date]
+  const { axisFormat } = buildDateFormat(dateExtent)
+
+  if (!compact) renderGrid(g, y, innerWidth)
+
+  for (const s of series) {
+    const parsed = s.data.map((d) => ({ date: new Date(d.date), value: d.value }))
+    if (parsed.length < 2) continue
+    renderAreaAndLine(g, parsed, x, y, innerHeight, s.color)
+  }
+
+  renderAxes(g, x, y, innerWidth, innerHeight, axisFormat)
+}
+
 /** Attach tooltip crosshair + highlight dot behaviour. */
 function attachTooltip(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
@@ -204,13 +252,22 @@ function attachTooltip(
     })
 }
 
-export function TrendLineChart({ data, color, height = 200, width, compact = false }: TrendLineChartProps) {
+export function TrendLineChart({
+  data,
+  color,
+  height = 200,
+  width,
+  compact = false,
+  multiSeries,
+}: TrendLineChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
 
+  const effectiveData = multiSeries ? (multiSeries[0]?.data ?? []) : data
+
   useEffect(() => {
-    if (!svgRef.current || !containerRef.current || data.length < 2) return
+    if (!svgRef.current || !containerRef.current) return
 
     const container = containerRef.current
     const chartWidth = width ?? container.clientWidth
@@ -220,67 +277,65 @@ export function TrendLineChart({ data, color, height = 200, width, compact = fal
     svg.selectAll('*').remove()
     svg.attr('width', chartWidth).attr('height', chartHeight)
 
-    const margin = compact
-      ? { bottom: 30, left: 50, right: 20, top: 20 }
-      : { bottom: 30, left: 50, right: 20, top: 20 }
+    const margin = { bottom: 30, left: 50, right: 20, top: 20 }
     const innerWidth = chartWidth - margin.left - margin.right
     const innerHeight = chartHeight - margin.top - margin.bottom
 
-    const parsedData: ParsedPoint[] = data.map((d) => ({
-      date: new Date(d.date),
-      value: d.value,
-    }))
+    if (multiSeries && multiSeries.length > 0) {
+      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+      renderMultiSeries(g, multiSeries, innerWidth, innerHeight, compact)
+    } else {
+      // Single series (original behavior)
+      const parsedData: ParsedPoint[] = data.map((d) => ({
+        date: new Date(d.date),
+        value: d.value,
+      }))
+      if (parsedData.length < 2) return
 
-    const x = d3
-      .scaleTime()
-      .domain(d3.extent(parsedData, (d) => d.date) as [Date, Date])
-      .range([0, innerWidth])
+      const x = d3
+        .scaleTime()
+        .domain(d3.extent(parsedData, (d) => d.date) as [Date, Date])
+        .range([0, innerWidth])
 
-    const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
-    const yRange = yExtent[1] - yExtent[0]
-    const yPadding = yRange * 0.1 || 1
-    const yMin = yExtent[0] >= 0 ? Math.max(0, yExtent[0] - yPadding) : yExtent[0] - yPadding
-    const y = d3
-      .scaleLinear()
-      .domain([yMin, yExtent[1] + yPadding])
-      .nice()
-      .range([innerHeight, 0])
+      const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
+      const yRange = yExtent[1] - yExtent[0]
+      const yPadding = yRange * 0.1 || 1
+      const yMin = yExtent[0] >= 0 ? Math.max(0, yExtent[0] - yPadding) : yExtent[0] - yPadding
+      const y = d3
+        .scaleLinear()
+        .domain([yMin, yExtent[1] + yPadding])
+        .nice()
+        .range([innerHeight, 0])
 
-    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
 
-    const dateExtent = d3.extent(parsedData, (d) => d.date) as [Date, Date]
-    const { axisFormat, tooltipFormat } = buildDateFormat(dateExtent)
+      const dateExtent = d3.extent(parsedData, (d) => d.date) as [Date, Date]
+      const { axisFormat, tooltipFormat } = buildDateFormat(dateExtent)
 
-    if (!compact) {
-      renderGrid(g, y, innerWidth)
+      if (!compact) renderGrid(g, y, innerWidth)
+      renderAreaAndLine(g, parsedData, x, y, innerHeight, color)
+      if (!compact) renderDots(g, parsedData, x, y, color)
+      renderAxes(g, x, y, innerWidth, innerHeight, axisFormat)
+
+      if (!compact && tooltipRef.current) {
+        attachTooltip(
+          g,
+          parsedData,
+          x,
+          y,
+          innerWidth,
+          innerHeight,
+          color,
+          container,
+          tooltipRef.current,
+          margin,
+          tooltipFormat,
+        )
+      }
     }
+  }, [data, color, height, width, compact, multiSeries])
 
-    renderAreaAndLine(g, parsedData, x, y, innerHeight, color)
-
-    if (!compact) {
-      renderDots(g, parsedData, x, y, color)
-    }
-
-    renderAxes(g, x, y, innerWidth, innerHeight, axisFormat)
-
-    if (!compact && tooltipRef.current) {
-      attachTooltip(
-        g,
-        parsedData,
-        x,
-        y,
-        innerWidth,
-        innerHeight,
-        color,
-        container,
-        tooltipRef.current,
-        margin,
-        tooltipFormat,
-      )
-    }
-  }, [data, color, height, width, compact])
-
-  if (data.length < 2) {
+  if (effectiveData.length < 2) {
     return <div class="trend-line-chart-placeholder">Insufficient data for chart</div>
   }
 

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -417,25 +417,78 @@ function ChartControls({
   )
 }
 
-function TrendDisplay({ params }: { params: FetchTrendParams }) {
+const SERIES_COLORS = ['#8b5cf6', '#f97316', '#22c55e', '#3b82f6', '#ef4444', '#f59e0b', '#ec4899', '#14b8a6']
+
+function BreakdownLegend({ series, colors }: { series: string[]; colors: string[] }) {
+  return (
+    <div class="breakdown-legend">
+      {series.map((name, i) => (
+        <span key={name} class="breakdown-legend-item">
+          <span class="breakdown-legend-dot" style={{ background: colors[i % colors.length] }} />
+          {name}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function BreakdownTrendDisplay({ params }: { params: FetchChartDataParams }) {
+  const breakdownQuery = useQuery({
+    enabled: Boolean(params.breakdown_fields?.length),
+    queryFn: () => fetchChartData(params),
+    queryKey: ['chart-data-trend-breakdown', params],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (breakdownQuery.isLoading) return <div class="chart-loading">Loading breakdown data...</div>
+  if (breakdownQuery.isError) return <div class="chart-error">Failed to load breakdown data.</div>
+
+  const result = breakdownQuery.data
+  if (!result?.breakdown_buckets?.length) return <div class="chart-empty">No breakdown data.</div>
+
+  const series = result.breakdown_series ?? []
+  return (
+    <div class="chart-display">
+      <BreakdownLegend series={series} colors={SERIES_COLORS} />
+      <TrendLineChart
+        data={[]}
+        color="#8b5cf6"
+        height={350}
+        multiSeries={series.map((name, i) => ({
+          color: SERIES_COLORS[i % SERIES_COLORS.length],
+          data: result.breakdown_buckets!.map((b) => ({
+            date: b.bucket_start,
+            value: b.series[name] ?? 0,
+          })),
+          name,
+        }))}
+      />
+    </div>
+  )
+}
+
+function TrendDisplay({
+  params,
+  breakdownParams,
+}: {
+  params: FetchTrendParams
+  breakdownParams?: FetchChartDataParams
+}) {
   const trendQuery = useQuery({
-    enabled: Boolean(params.pattern),
+    enabled: Boolean(params.pattern) && !breakdownParams?.breakdown_fields?.length,
     queryFn: () => fetchTrend(params),
     queryKey: ['trend', params],
     staleTime: 5 * 60 * 1000,
   })
 
-  if (!params.pattern) {
-    return <div class="chart-empty">Select a source to view trend data.</div>
+  if (!params.pattern) return <div class="chart-empty">Select a source to view trend data.</div>
+
+  if (breakdownParams?.breakdown_fields?.length) {
+    return <BreakdownTrendDisplay params={breakdownParams} />
   }
 
-  if (trendQuery.isLoading) {
-    return <div class="chart-loading">Loading trend data...</div>
-  }
-
-  if (trendQuery.isError || !trendQuery.data) {
-    return <div class="chart-error">Failed to load trend data.</div>
-  }
+  if (trendQuery.isLoading) return <div class="chart-loading">Loading trend data...</div>
+  if (trendQuery.isError || !trendQuery.data) return <div class="chart-error">Failed to load trend data.</div>
 
   const { current_value, display_unit, history } = trendQuery.data
 
@@ -472,33 +525,24 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
 
   const result = barQuery.data
 
-  // Breakdown mode: render one bar chart per series
+  // Breakdown mode: render grouped bar chart with all series
   if (result?.breakdown_buckets?.length) {
     const series = result.breakdown_series ?? []
-    const colors = ['#8b5cf6', '#f97316', '#22c55e', '#3b82f6', '#ef4444', '#f59e0b', '#ec4899', '#14b8a6']
     return (
       <div class="chart-display">
-        <div class="breakdown-legend">
-          {series.map((name, i) => (
-            <span key={name} class="breakdown-legend-item">
-              <span class="breakdown-legend-dot" style={{ background: colors[i % colors.length] }} />
-              {name}
-            </span>
-          ))}
-        </div>
-        {series.map((name, i) => (
-          <div key={name} class="breakdown-series">
-            <h4 class="breakdown-series-title">{name}</h4>
-            <BarChart
-              data={result.breakdown_buckets!.map((b) => ({
-                bucket_start: b.bucket_start,
-                value: b.series[name] ?? 0,
-              }))}
-              color={colors[i % colors.length]}
-              height={150}
-            />
-          </div>
-        ))}
+        <BreakdownLegend series={series} colors={SERIES_COLORS} />
+        <BarChart
+          data={[]}
+          height={350}
+          multiSeries={series.map((name, i) => ({
+            color: SERIES_COLORS[i % SERIES_COLORS.length],
+            data: result.breakdown_buckets!.map((b) => ({
+              bucket_start: b.bucket_start,
+              value: b.series[name] ?? 0,
+            })),
+            name,
+          }))}
+        />
       </div>
     )
   }
@@ -732,7 +776,7 @@ export function Chart() {
       {state.chart_type === 'trend' ? (
         <TrendDisplay
           params={{
-            aggregation: state.source_type === 'metric' ? state.aggregation : 'count',
+            aggregation: state.aggregation,
             display_period: state.display_period,
             half_life_days: state.half_life_days,
             lookback_days: state.lookback_days,
@@ -740,6 +784,20 @@ export function Chart() {
             source_type: state.source_type,
             ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
           }}
+          breakdownParams={
+            state.breakdown_fields.length > 0
+              ? {
+                  aggregation: state.aggregation,
+                  breakdown_fields: state.breakdown_fields,
+                  bucket_size:
+                    state.display_period === 'daily' ? '1d' : state.display_period === 'weekly' ? '1w' : '1M',
+                  end,
+                  pattern: state.pattern || undefined,
+                  source_type: state.source_type,
+                  start,
+                }
+              : undefined
+          }
         />
       ) : (
         <BarDisplay


### PR DESCRIPTION
## Summary
- **BarChart**: multi-series renders as grouped (side-by-side) colored bars within each bucket, not separate charts
- **TrendLineChart**: multi-series renders as overlaid colored area+line curves with shared axes
- **Trend mode + breakdown**: when breakdown checkboxes are active in trend mode, uses the bar chart data endpoint with matching bucket size to render multi-line overlay
- Both chart components accept optional `multiSeries` prop for backward compatibility

## Test plan
- [x] All 1661 tests pass
- [x] Type checks pass
- [ ] Select `computer_active` with Device breakdown in Bar mode — grouped colored bars in one chart
- [ ] Select `computer_active` with Device breakdown in Trend mode — overlaid colored lines in one chart
- [ ] No breakdown selected — charts render as before (single series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)