### PR TITLE
fix: merge_span matches on data fields

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -704,18 +704,29 @@ export const hardDeleteActivitiesByExternalIdPrefix = async (
   return result.rowCount ?? 0
 }
 
-/** Find a mergeable activity of the same type near a given time. */
+/** Find a mergeable activity of the same type near a given time.
+ *  When matchData is provided, only matches activities whose data contains all the same key-value pairs. */
 export const findMergeableActivity = async (
   user: string,
   activityType: string,
   startTime: Date,
   mergeSpanSeconds: number,
   source?: string,
+  matchData?: Record<string, unknown>,
 ): Promise<Activity | null> => {
   const windowStart = new Date(startTime.getTime() - mergeSpanSeconds * 1000)
-  const sourceClause = source ? ' AND source = $4' : ''
   const params: unknown[] = [activityType, windowStart, startTime]
-  if (source) params.push(source)
+  let nextParam = 4
+
+  const clauses: string[] = []
+  if (source) {
+    clauses.push(`AND source = $${nextParam++}`)
+    params.push(source)
+  }
+  if (matchData && Object.keys(matchData).length > 0) {
+    clauses.push(`AND data @> $${nextParam++}::jsonb`)
+    params.push(JSON.stringify(matchData))
+  }
 
   const result = await query(
     user,
@@ -726,7 +737,7 @@ export const findMergeableActivity = async (
        AND (
          (end_time IS NOT NULL AND end_time >= $2 AND end_time <= $3)
          OR (end_time IS NULL AND start_time >= $2 AND start_time <= $3)
-       )${sourceClause}
+       )${clauses.join(' ')}
      ORDER BY COALESCE(end_time, start_time) DESC
      LIMIT 1`,
     params,

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -328,6 +328,8 @@ export async function addActivity(user: string, input: AddActivityInput): Promis
       input.activity_type,
       input.start_time,
       input.merge_span,
+      undefined,
+      input.data,
     )
     if (existing?.id) {
       const newEndTime = input.end_time ?? input.start_time


### PR DESCRIPTION
## Summary
When `merge_span` is used with `data`, `findMergeableActivity` now requires the existing activity's data to contain all the same key-value pairs (PostgreSQL `@>` jsonb containment).

Previously, two computers both sending `computer_active` with different `device`/`display` values and a 180s merge_span would incorrectly merge into the same activity. Now each device+display combination produces its own activity chain.

## Test plan
- [x] All 1672 tests pass
- [ ] Send computer_active from two devices with merge_span — verify two separate activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)