### PR TITLE
fix: remove duplicate Activity (count) source type from chart explorer

### DIFF
--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -1,3 +1,8 @@
+/**
+ * Location, Place, Named Location, and Detected Location CRUD operations.
+ */
+import format from 'pg-format'
+
 import type {
   DetectedLocation,
   DetectedLocationInput,
@@ -7,11 +12,6 @@ import type {
   NamedLocationInput,
   Place,
 } from './types.ts'
-
-/**
- * Location, Place, Named Location, and Detected Location CRUD operations.
- */
-import format from 'pg-format'
 
 import { query } from './connection.ts'
 import { buildDynamicUpdate, type UpdateEntry } from './dynamic-update.ts'

--- a/apps/web/src/components/DashboardEditor/index.tsx
+++ b/apps/web/src/components/DashboardEditor/index.tsx
@@ -259,7 +259,6 @@ export function DashboardEditor({ sectionType, onAddWidget, onClose }: Dashboard
                 onChange={(e) => updateConfig('source_type', (e.target as HTMLSelectElement).value)}
               >
                 <option value="activity_type">Activity Type</option>
-                <option value="tag">Activity (count)</option>
                 <option value="metric">Metric</option>
               </select>
             </div>

--- a/apps/web/src/components/charts/TrendLineChart.tsx
+++ b/apps/web/src/components/charts/TrendLineChart.tsx
@@ -138,16 +138,21 @@ function renderDots(
     .attr('fill', color)
 }
 
-/** Render multiple overlaid series (area + line for each). */
+/** Render multiple overlaid series (area + line for each). Returns scales for tooltip attachment. */
 function renderMultiSeries(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   series: LineSeriesData[],
   innerWidth: number,
   innerHeight: number,
   compact: boolean,
-) {
+): {
+  x: d3.ScaleTime<number, number>
+  y: d3.ScaleLinear<number, number>
+  parsedSeries: { name: string; color: string; data: ParsedPoint[] }[]
+  tooltipFormat: (date: Date) => string
+} | null {
   const allPoints = series.flatMap((s) => s.data.map((d) => ({ date: new Date(d.date), value: d.value })))
-  if (allPoints.length < 2) return
+  if (allPoints.length < 2) return null
 
   const x = d3
     .scaleTime()
@@ -165,17 +170,24 @@ function renderMultiSeries(
     .range([innerHeight, 0])
 
   const dateExtent = d3.extent(allPoints, (d) => d.date) as [Date, Date]
-  const { axisFormat } = buildDateFormat(dateExtent)
+  const { axisFormat, tooltipFormat } = buildDateFormat(dateExtent)
 
   if (!compact) renderGrid(g, y, innerWidth)
 
-  for (const s of series) {
-    const parsed = s.data.map((d) => ({ date: new Date(d.date), value: d.value }))
-    if (parsed.length < 2) continue
-    renderAreaAndLine(g, parsed, x, y, innerHeight, s.color)
+  const parsedSeries = series.map((s) => ({
+    color: s.color,
+    data: s.data.map((d) => ({ date: new Date(d.date), value: d.value })),
+    name: s.name,
+  }))
+
+  for (const s of parsedSeries) {
+    if (s.data.length < 2) continue
+    renderAreaAndLine(g, s.data, x, y, innerHeight, s.color)
   }
 
   renderAxes(g, x, y, innerWidth, innerHeight, axisFormat)
+
+  return { parsedSeries, tooltipFormat, x, y }
 }
 
 /** Attach tooltip crosshair + highlight dot behaviour. */
@@ -252,6 +264,153 @@ function attachTooltip(
     })
 }
 
+/** Attach tooltip for multi-series: shows all series values at the hovered date. */
+function attachMultiSeriesTooltip(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  parsedSeries: { name: string; color: string; data: ParsedPoint[] }[],
+  x: d3.ScaleTime<number, number>,
+  y: d3.ScaleLinear<number, number>,
+  innerWidth: number,
+  innerHeight: number,
+  container: HTMLDivElement,
+  tooltip: HTMLDivElement,
+  margin: { top: number; left: number },
+  tooltipFormat: (date: Date) => string,
+) {
+  const crosshair = g
+    .append('line')
+    .attr('y1', 0)
+    .attr('y2', innerHeight)
+    .attr('stroke', 'currentColor')
+    .attr('stroke-opacity', 0.4)
+    .attr('stroke-dasharray', '4 3')
+    .attr('pointer-events', 'none')
+    .style('display', 'none')
+
+  // One highlight dot per series
+  const dots = parsedSeries.map((s) =>
+    g
+      .append('circle')
+      .attr('r', 4)
+      .attr('fill', s.color)
+      .attr('stroke', '#fff')
+      .attr('stroke-width', 2)
+      .attr('pointer-events', 'none')
+      .style('display', 'none'),
+  )
+
+  const bisector = d3.bisector<ParsedPoint, Date>((d) => d.date).left
+
+  g.append('rect')
+    .attr('width', innerWidth)
+    .attr('height', innerHeight)
+    .attr('fill', 'transparent')
+    .attr('pointer-events', 'all')
+    .on('mousemove', (event: MouseEvent) => {
+      const [mx] = d3.pointer(event)
+      const dateAtMouse = x.invert(mx)
+
+      crosshair.attr('x1', mx).attr('x2', mx).style('display', null)
+
+      const lines: string[] = []
+      let dateLabel = ''
+
+      for (let i = 0; i < parsedSeries.length; i++) {
+        const s = parsedSeries[i]
+        if (s.data.length === 0) continue
+        const idx = bisector(s.data, dateAtMouse, 1)
+        const d0 = s.data[idx - 1]
+        const d1 = s.data[idx]
+        if (!d0) continue
+        const nearest =
+          d1 && dateAtMouse.getTime() - d0.date.getTime() > d1.date.getTime() - dateAtMouse.getTime()
+            ? d1
+            : d0
+
+        if (!dateLabel) dateLabel = tooltipFormat(nearest.date)
+
+        const cx = x(nearest.date)
+        const cy = y(nearest.value)
+        dots[i].attr('cx', cx).attr('cy', cy).style('display', null)
+
+        lines.push(`${s.name}: ${nearest.value.toFixed(1)}`)
+      }
+
+      tooltip.innerHTML = `<strong>${dateLabel}</strong><br/>${lines.join('<br/>')}`
+      tooltip.style.display = 'block'
+
+      const containerRect = container.getBoundingClientRect()
+      const tooltipX = mx + margin.left
+      const tooltipWidth = tooltip.offsetWidth
+      const left =
+        tooltipX + tooltipWidth + 12 > containerRect.width ? tooltipX - tooltipWidth - 12 : tooltipX + 12
+      tooltip.style.left = `${left}px`
+      tooltip.style.top = `${margin.top + 8}px`
+    })
+    .on('mouseleave', () => {
+      crosshair.style('display', 'none')
+      for (const dot of dots) dot.style('display', 'none')
+      tooltip.style.display = 'none'
+    })
+}
+
+/** Render a single series with optional tooltip. */
+function renderSingleSeries(
+  svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+  data: { date: string; value: number }[],
+  color: string,
+  innerWidth: number,
+  innerHeight: number,
+  margin: { top: number; bottom: number; left: number; right: number },
+  compact: boolean,
+  container: HTMLDivElement,
+  tooltip: HTMLDivElement | null,
+) {
+  const parsedData: ParsedPoint[] = data.map((d) => ({ date: new Date(d.date), value: d.value }))
+  if (parsedData.length < 2) return
+
+  const x = d3
+    .scaleTime()
+    .domain(d3.extent(parsedData, (d) => d.date) as [Date, Date])
+    .range([0, innerWidth])
+
+  const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
+  const yRange = yExtent[1] - yExtent[0]
+  const yPadding = yRange * 0.1 || 1
+  const yMin = yExtent[0] >= 0 ? Math.max(0, yExtent[0] - yPadding) : yExtent[0] - yPadding
+  const y = d3
+    .scaleLinear()
+    .domain([yMin, yExtent[1] + yPadding])
+    .nice()
+    .range([innerHeight, 0])
+
+  const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+  const dateExtent = d3.extent(parsedData, (d) => d.date) as [Date, Date]
+  const { axisFormat, tooltipFormat } = buildDateFormat(dateExtent)
+
+  if (!compact) renderGrid(g, y, innerWidth)
+  renderAreaAndLine(g, parsedData, x, y, innerHeight, color)
+  if (!compact) renderDots(g, parsedData, x, y, color)
+  renderAxes(g, x, y, innerWidth, innerHeight, axisFormat)
+
+  if (!compact && tooltip) {
+    attachTooltip(
+      g,
+      parsedData,
+      x,
+      y,
+      innerWidth,
+      innerHeight,
+      color,
+      container,
+      tooltip,
+      margin,
+      tooltipFormat,
+    )
+  }
+}
+
 export function TrendLineChart({
   data,
   color,
@@ -283,55 +442,34 @@ export function TrendLineChart({
 
     if (multiSeries && multiSeries.length > 0) {
       const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-      renderMultiSeries(g, multiSeries, innerWidth, innerHeight, compact)
-    } else {
-      // Single series (original behavior)
-      const parsedData: ParsedPoint[] = data.map((d) => ({
-        date: new Date(d.date),
-        value: d.value,
-      }))
-      if (parsedData.length < 2) return
+      const result = renderMultiSeries(g, multiSeries, innerWidth, innerHeight, compact)
 
-      const x = d3
-        .scaleTime()
-        .domain(d3.extent(parsedData, (d) => d.date) as [Date, Date])
-        .range([0, innerWidth])
-
-      const yExtent = d3.extent(parsedData, (d) => d.value) as [number, number]
-      const yRange = yExtent[1] - yExtent[0]
-      const yPadding = yRange * 0.1 || 1
-      const yMin = yExtent[0] >= 0 ? Math.max(0, yExtent[0] - yPadding) : yExtent[0] - yPadding
-      const y = d3
-        .scaleLinear()
-        .domain([yMin, yExtent[1] + yPadding])
-        .nice()
-        .range([innerHeight, 0])
-
-      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-
-      const dateExtent = d3.extent(parsedData, (d) => d.date) as [Date, Date]
-      const { axisFormat, tooltipFormat } = buildDateFormat(dateExtent)
-
-      if (!compact) renderGrid(g, y, innerWidth)
-      renderAreaAndLine(g, parsedData, x, y, innerHeight, color)
-      if (!compact) renderDots(g, parsedData, x, y, color)
-      renderAxes(g, x, y, innerWidth, innerHeight, axisFormat)
-
-      if (!compact && tooltipRef.current) {
-        attachTooltip(
+      if (!compact && tooltipRef.current && result) {
+        attachMultiSeriesTooltip(
           g,
-          parsedData,
-          x,
-          y,
+          result.parsedSeries,
+          result.x,
+          result.y,
           innerWidth,
           innerHeight,
-          color,
           container,
           tooltipRef.current,
           margin,
-          tooltipFormat,
+          result.tooltipFormat,
         )
       }
+    } else {
+      renderSingleSeries(
+        svg,
+        data,
+        color,
+        innerWidth,
+        innerHeight,
+        margin,
+        compact,
+        container,
+        tooltipRef.current,
+      )
     }
   }, [data, color, height, width, compact, multiSeries])
 

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -105,6 +105,9 @@ function syncUrl(state: ChartState) {
   if (state.source_type === 'metric' && state.aggregation !== 'count') {
     params.set('aggregation', state.aggregation)
   }
+  if (state.breakdown_fields.length > 0) {
+    params.set('breakdown_fields', state.breakdown_fields.join(','))
+  }
   history.replaceState(null, '', `${window.location.pathname}?${params}`)
 }
 
@@ -720,8 +723,7 @@ export function Chart() {
               ? {
                   aggregation: state.aggregation,
                   breakdown_fields: state.breakdown_fields,
-                  bucket_size:
-                    state.display_period === 'daily' ? '1d' : state.display_period === 'weekly' ? '1w' : '1M',
+                  bucket_size: '1d',
                   end,
                   pattern: state.pattern || undefined,
                   source_type: state.source_type,

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -2,22 +2,20 @@
  * Chart exploration page — configurable trend + bar chart with URL-driven state.
  *
  * Reads/writes config via query params so charts are shareable/bookmarkable:
- *   /chart?source_type=tag&tag_definition_id=<name>&lookback_days=90&display_period=monthly&half_life_days=15
+ *   /chart?source_type=activity_type&pattern=coffee&lookback_days=90&display_period=monthly&half_life_days=15
  *   /chart?source_type=metric&pattern=weight&lookback_days=180&aggregation=mean
- *   /chart?source_type=tag&pattern=coffee&chart_type=bar&bucket_size=1d&lookback_days=30
+ *   /chart?source_type=activity_type&pattern=coffee&chart_type=bar&bucket_size=1d&lookback_days=30
  */
 import type { DashboardConfig, DashboardSection, DashboardWidget, SectionType } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation } from 'preact-iso'
-import { useCallback, useMemo, useState } from 'preact/hooks'
+import { useCallback, useState } from 'preact/hooks'
 
 import { BarChart } from '../../components/charts/BarChart'
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { MetricPicker } from '../../components/MetricPicker'
-import { TagPicker } from '../../components/TagPicker'
 import {
-  type ActivityTypeDefinition,
   fetchActivityTypeDefinitions,
   fetchChartData,
   type FetchChartDataParams,
@@ -138,58 +136,6 @@ function CategoryPicker({ value, onChange }: { value: string; onChange: (v: stri
   )
 }
 
-/** Activity type picker -- searchable dropdown of all activity type definitions. */
-function ActivityTypePicker({
-  definitions,
-  selectedId,
-  onChange,
-}: {
-  definitions: ActivityTypeDefinition[]
-  selectedId: string
-  onChange: (id: string, pattern: string) => void
-}) {
-  const [search, setSearch] = useState('')
-  const filtered = useMemo(
-    () =>
-      search
-        ? definitions.filter(
-            (d) =>
-              (d.display_name || d.name).toLowerCase().includes(search.toLowerCase()) ||
-              (d.aliases ?? []).some((a) => a.toLowerCase().includes(search.toLowerCase())),
-          )
-        : definitions,
-    [definitions, search],
-  )
-
-  return (
-    <div>
-      <input
-        type="text"
-        value={search}
-        onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
-        placeholder="Search activity types..."
-      />
-      <select
-        value={selectedId}
-        onChange={(e) => {
-          const name = (e.target as HTMLSelectElement).value
-          const def = definitions.find((d) => d.name === name)
-          onChange(name, def ? (def.aliases ?? []).join('|') : '')
-        }}
-        style={{ marginTop: '0.25rem' }}
-      >
-        <option value="">Select an activity type...</option>
-        {filtered.map((def) => (
-          <option key={def.name} value={def.name}>
-            {def.icon ? `${def.icon} ` : ''}
-            {def.display_name || def.name}
-          </option>
-        ))}
-      </select>
-    </div>
-  )
-}
-
 /** Source picker shared between both chart modes. */
 function SourcePicker({
   state,
@@ -216,31 +162,13 @@ function SourcePicker({
           }}
         >
           <option value="activity_type">Activity Type</option>
-          <option value="tag">Activity (count)</option>
           <option value="metric">Metric</option>
           <option value="productivity_category">Screentime Category</option>
         </select>
       </label>
 
       <label class="source-picker">
-        {state.source_type === 'tag' && activityTypes.length > 0 ? (
-          <>
-            Activity Type
-            <ActivityTypePicker
-              definitions={activityTypes}
-              selectedId={state.tag_definition_id}
-              onChange={(id, pattern) => onUpdate({ tag_definition_id: id, pattern })}
-            />
-          </>
-        ) : state.source_type === 'tag' ? (
-          <>
-            Tags
-            <TagPicker
-              selectedTags={state.pattern ? state.pattern.split('|').filter(Boolean) : []}
-              onChange={(tags) => onUpdate({ pattern: tags.join('|') })}
-            />
-          </>
-        ) : state.source_type === 'productivity_category' ? (
+        {state.source_type === 'productivity_category' ? (
           <>
             Category
             <CategoryPicker value={state.pattern} onChange={(pattern) => onUpdate({ pattern })} />
@@ -584,7 +512,10 @@ function buildWidgetFromState(state: ChartState, title: string): DashboardWidget
       half_life_days: state.half_life_days,
       lookback_days: state.lookback_days,
       pattern: state.pattern,
-      source_type: state.source_type === 'tag' || state.source_type === 'metric' ? state.source_type : 'tag',
+      source_type:
+        state.source_type === 'activity_type' || state.source_type === 'metric'
+          ? state.source_type
+          : 'activity_type',
       ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
       ...(title ? { title } : {}),
     },

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -108,7 +108,7 @@ export const trendChartConfigSchema = z
     half_life_days: z.number().int().positive().optional().meta({ description: 'EMA half-life in days' }),
     lookback_days: z.number().int().positive().optional().meta({ description: 'Days of data to analyze' }),
     pattern: z.string().min(1).meta({ description: 'Tag pattern (regex) or metric name' }),
-    source_type: z.enum(['tag', 'metric']).meta({ description: 'Data source type' }),
+    source_type: z.enum(['tag', 'metric', 'activity_type']).meta({ description: 'Data source type' }),
     tag_definition_id: z
       .string()
       .uuid()


### PR DESCRIPTION
## Summary
- Remove the redundant "Activity (count)" source type from the Chart Explorer and Dashboard Editor
- "Activity Type" already supports count aggregation, making this a confusing duplicate
- Add `activity_type` to the trend chart dashboard config schema so trend widgets can use it directly
- Backend still accepts `tag` source_type for backward compatibility with existing saved widgets

## Test plan
- [ ] Open Chart Explorer, verify only Activity Type / Metric / Screentime Category appear
- [ ] Verify Activity Type with count aggregation works as before
- [ ] Verify existing dashboard widgets with `tag` source_type still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)