### PR TITLE
feat: inline data filters on activity condition

### DIFF
--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -1,3 +1,8 @@
+/**
+ * Location, Place, Named Location, and Detected Location CRUD operations.
+ */
+import format from 'pg-format'
+
 import type {
   DetectedLocation,
   DetectedLocationInput,
@@ -7,11 +12,6 @@ import type {
   NamedLocationInput,
   Place,
 } from './types.ts'
-
-/**
- * Location, Place, Named Location, and Detected Location CRUD operations.
- */
-import format from 'pg-format'
 
 import { query } from './connection.ts'
 import { buildDynamicUpdate, type UpdateEntry } from './dynamic-update.ts'

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -81,6 +81,7 @@ vi.mock('./services/deduction-deps', () => ({
     enrichActivities: vi.fn().mockResolvedValue([]),
     getActivities: vi.fn().mockResolvedValue([]),
     getActivitiesWithData: vi.fn().mockResolvedValue([]),
+    getActivitiesWithDataFilters: vi.fn().mockResolvedValue([]),
     getEarliestActivityTime: vi.fn().mockResolvedValue(null),
     getLocationVisits: vi.fn().mockResolvedValue([]),
     getScreentime: vi.fn().mockResolvedValue([]),

--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -117,6 +117,55 @@ const getActivitiesWithData = async (
   }))
 }
 
+const getActivitiesWithDataFilters = async (
+  user: string,
+  activityType: string,
+  filters: Array<{ field: string; operator: string; value?: string | number | boolean }>,
+  window: EvaluationWindow,
+): Promise<TimeRange[]> => {
+  const params: unknown[] = [activityType, window.start, window.end]
+  const whereClauses: string[] = []
+
+  for (const filter of filters) {
+    if (!/^[a-z][a-z0-9_]*$/.test(filter.field)) return []
+
+    switch (filter.operator) {
+      case 'eq':
+        whereClauses.push(`AND data->>'${filter.field}' = $${params.length + 1}`)
+        params.push(String(filter.value))
+        break
+      case 'neq':
+        whereClauses.push(
+          `AND (data->>'${filter.field}' IS NULL OR data->>'${filter.field}' != $${params.length + 1})`,
+        )
+        params.push(String(filter.value))
+        break
+      case 'exists':
+        whereClauses.push(`AND data ? '${filter.field}'`)
+        break
+      case 'not_exists':
+        whereClauses.push(`AND (data IS NULL OR NOT data ? '${filter.field}')`)
+        break
+    }
+  }
+
+  const result = await query(
+    user,
+    `SELECT start_time, end_time FROM activities
+     WHERE activity_type = $1
+       AND deleted_at IS NULL
+       AND start_time < $3
+       AND (end_time > $2 OR end_time IS NULL)
+       ${whereClauses.join(' ')}
+     ORDER BY start_time`,
+    params,
+  )
+  return result.rows.map((r) => ({
+    end: (r.end_time as Date) ?? new Date((r.start_time as Date).getTime() + 60 * 60 * 1000),
+    start: r.start_time as Date,
+  }))
+}
+
 const getLocationVisits = async (
   user: string,
   locationName: string,
@@ -192,6 +241,7 @@ export const createDefaultEngineDeps = (): DeductionEngineDeps => ({
   enrichActivities,
   getActivities,
   getActivitiesWithData,
+  getActivitiesWithDataFilters,
   getEarliestActivityTime,
   getLocationVisits,
   getScreentime,

--- a/apps/backend/src/services/deduction-engine.test.ts
+++ b/apps/backend/src/services/deduction-engine.test.ts
@@ -19,6 +19,7 @@ const makeDeps = (): DeductionEngineDeps => ({
   enrichActivities: vi.fn().mockResolvedValue([]),
   getActivities: vi.fn().mockResolvedValue([]),
   getActivitiesWithData: vi.fn().mockResolvedValue([]),
+  getActivitiesWithDataFilters: vi.fn().mockResolvedValue([]),
   getEarliestActivityTime: vi.fn().mockResolvedValue(null),
   getLocationVisits: vi.fn().mockResolvedValue([]),
   getScreentime: vi.fn().mockResolvedValue([]),

--- a/apps/backend/src/services/deduction-engine.ts
+++ b/apps/backend/src/services/deduction-engine.ts
@@ -48,6 +48,12 @@ export interface DeductionEngineDeps {
     value: string | number | boolean | undefined,
     window: EvaluationWindow,
   ) => Promise<TimeRange[]>
+  getActivitiesWithDataFilters: (
+    user: string,
+    activityType: string,
+    filters: Array<{ field: string; operator: string; value?: string | number | boolean }>,
+    window: EvaluationWindow,
+  ) => Promise<TimeRange[]>
   getLocationVisits: (user: string, locationName: string, window: EvaluationWindow) => Promise<TimeRange[]>
   insertActivity: (user: string, activity: Activity) => Promise<string | void>
   enrichActivities: (
@@ -148,6 +154,9 @@ type ConditionResolver = (
 
 const resolveActivity: ConditionResolver = async (user, condition, window, deps) => {
   if (condition.kind !== 'activity') return []
+  if (condition.data_filters?.length) {
+    return deps.getActivitiesWithDataFilters(user, condition.activity_type, condition.data_filters, window)
+  }
   return deps.getActivities(user, condition.activity_type, window)
 }
 

--- a/apps/backend/src/services/deduction-trigger.test.ts
+++ b/apps/backend/src/services/deduction-trigger.test.ts
@@ -18,6 +18,7 @@ const makeDeps = (overrides: Partial<DeductionTriggerDeps> = {}): DeductionTrigg
     enrichActivities: vi.fn(),
     getActivities: vi.fn(),
     getActivitiesWithData: vi.fn(),
+    getActivitiesWithDataFilters: vi.fn(),
     getEarliestActivityTime: vi.fn(),
     getLocationVisits: vi.fn(),
     getScreentime: vi.fn(),

--- a/apps/web/src/components/ConditionBuilder/index.tsx
+++ b/apps/web/src/components/ConditionBuilder/index.tsx
@@ -3,7 +3,7 @@
  */
 import { useQuery } from '@tanstack/react-query'
 
-import type { DeductionRuleCondition } from '../../state/api'
+import type { DataFilter, DeductionRuleCondition } from '../../state/api'
 
 import { fetchActivityTypeDefinitions, fetchNamedLocations } from '../../state/api'
 import './style.css'
@@ -113,6 +113,76 @@ function ActivityDataBody({
   )
 }
 
+function DataFiltersInline({
+  filters,
+  onChange,
+  schemaFields,
+}: {
+  filters: DataFilter[]
+  onChange: (filters: DataFilter[]) => void
+  schemaFields: Array<{ name: string; label?: string }>
+}) {
+  const updateFilter = (i: number, patch: Partial<DataFilter>) => {
+    onChange(filters.map((f, idx) => (idx === i ? { ...f, ...patch } : f)))
+  }
+  const removeFilter = (i: number) => onChange(filters.filter((_, idx) => idx !== i))
+  const addFilter = () =>
+    onChange([...filters, { field: schemaFields[0]?.name ?? '', operator: 'eq', value: '' }])
+
+  return (
+    <div class="condition-data-filters-inline">
+      {filters.map((filter, i) => (
+        <div class="condition-data-row" key={i}>
+          <select
+            value={filter.field}
+            onChange={(e) => updateFilter(i, { field: (e.target as HTMLSelectElement).value })}
+            class="condition-field-select condition-field-narrow"
+          >
+            {schemaFields.map((f) => (
+              <option key={f.name} value={f.name}>
+                {f.label ?? f.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={filter.operator}
+            onChange={(e) =>
+              updateFilter(i, { operator: (e.target as HTMLSelectElement).value as DataFilter['operator'] })
+            }
+            class="condition-field-select condition-field-narrow"
+          >
+            {Object.entries(OPERATOR_LABELS).map(([k, label]) => (
+              <option key={k} value={k}>
+                {label}
+              </option>
+            ))}
+          </select>
+          {(filter.operator === 'eq' || filter.operator === 'neq') && (
+            <input
+              type="text"
+              value={String(filter.value ?? '')}
+              onInput={(e) => updateFilter(i, { value: (e.target as HTMLInputElement).value })}
+              placeholder="Value"
+              class="condition-field-input condition-field-narrow"
+            />
+          )}
+          <button
+            type="button"
+            class="condition-remove-btn"
+            onClick={() => removeFilter(i)}
+            title="Remove filter"
+          >
+            &#x2715;
+          </button>
+        </div>
+      ))}
+      <button type="button" class="condition-add-filter-btn" onClick={addFilter}>
+        + Where...
+      </button>
+    </div>
+  )
+}
+
 // ============================================================================
 // Single condition card
 // ============================================================================
@@ -187,7 +257,23 @@ function ConditionCard({
 
       <div class="condition-card-body">
         {condition.kind === 'activity' && (
-          <ActivityTypeSelect condition={condition} onChange={update} definitions={definitions} />
+          <>
+            <ActivityTypeSelect condition={condition} onChange={update} definitions={definitions} />
+            {(() => {
+              const typeDef = definitions.find((d) => d.name === condition.activity_type)
+              const schemaFields = (
+                typeDef as { data_schema?: { fields: Array<{ name: string; label?: string }> } }
+              )?.data_schema?.fields
+              if (!schemaFields?.length) return null
+              return (
+                <DataFiltersInline
+                  filters={condition.data_filters ?? []}
+                  onChange={(data_filters) => update({ ...condition, data_filters })}
+                  schemaFields={schemaFields}
+                />
+              )
+            })()}
+          </>
         )}
 
         {condition.kind === 'tag' && (

--- a/apps/web/src/components/ConditionBuilder/style.css
+++ b/apps/web/src/components/ConditionBuilder/style.css
@@ -121,6 +121,29 @@
   min-width: 0;
 }
 
+.condition-data-filters-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 0.375rem;
+}
+
+.condition-add-filter-btn {
+  align-self: flex-start;
+  font-size: 0.8rem;
+  color: #6b7280;
+  background: none;
+  border: 1px dashed #d1d5db;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.condition-add-filter-btn:hover {
+  color: #374151;
+  border-color: #9ca3af;
+}
+
 .condition-add-btn {
   align-self: flex-start;
   margin-top: 0.5rem;

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -120,9 +120,16 @@ export interface ActivityTypeDefinition {
   data_schema?: DataSchemaDefinition
 }
 
+export interface DataFilter {
+  field: string
+  operator: 'eq' | 'neq' | 'exists' | 'not_exists'
+  value?: string | number | boolean
+}
+
 export interface DeductionRuleCondition {
   kind: 'activity' | 'tag' | 'screentime_category' | 'activity_data' | 'location' | 'after_date'
   activity_type?: string
+  data_filters?: DataFilter[]
   tag_name?: string
   category?: string[]
   field?: string

--- a/packages/api-spec/src/schemas/deduction-rules.ts
+++ b/packages/api-spec/src/schemas/deduction-rules.ts
@@ -9,12 +9,30 @@ import { activityTypeSchema, baseResponseSchema, createDataArrayResponseSchema }
  * Condition kinds for deduction rules.
  * Each condition resolves to time ranges; multiple conditions are AND-ed (must overlap).
  */
+export const dataFilterSchema = z.object({
+  field: z.string().meta({ description: 'Data field key to match on' }),
+  operator: z.enum(['eq', 'neq', 'exists', 'not_exists']).meta({ description: 'Comparison operator' }),
+  value: z
+    .union([z.string(), z.number(), z.boolean()])
+    .optional()
+    .meta({ description: 'Value to compare against (required for eq/neq)' }),
+})
+
+export type DataFilter = z.infer<typeof dataFilterSchema>
+
 export const activityConditionSchema = z
   .object({
     activity_type: activityTypeSchema,
+    data_filters: z
+      .array(dataFilterSchema)
+      .optional()
+      .meta({ description: 'Optional data field filters — all must match (AND logic)' }),
     kind: z.literal('activity'),
   })
-  .meta({ description: 'Matches time ranges where an activity of the given type exists' })
+  .meta({
+    description:
+      'Matches time ranges where an activity of the given type exists, optionally filtered by data fields',
+  })
 
 export const tagConditionSchema = z
   .object({


### PR DESCRIPTION
## Summary
- Activity condition now accepts optional `data_filters` — an array of `{field, operator, value}` filters
- All filters are applied in a single SQL query (AND logic)
- UI: when an activity type with a data_schema is selected, a "+ Where..." button appears to add field filters inline
- Field dropdown is populated from the type's schema fields
- No need for separate `activity_data` conditions when filtering a specific activity type's data

Example: to create a rule "when computer_active has device=saraswati, create TV activity":
- Condition: Activity Type = computer_active, WHERE device equals saraswati
- One condition card instead of two

## Test plan
- [x] All 1672 tests pass
- [x] Type checks pass
- [ ] Select computer_active in activity condition, click "+ Where...", select device = saraswati
- [ ] Verify the rule preview/creation works with data filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)