### PR TITLE
fix: trend breakdown uses EMA instead of raw bucketed data

### DIFF
--- a/apps/backend/src/mcp/chart-tools.ts
+++ b/apps/backend/src/mcp/chart-tools.ts
@@ -20,10 +20,20 @@ Examples:
 - Weekly average weight: source_type="metric", pattern="weight", bucket_size="1w", aggregation="mean"
 - Monthly programming hours: source_type="productivity_category", pattern="Work > Programming", bucket_size="1M"`,
     { ...chartDataQuerySchema.shape },
-    async ({ aggregation, bucket_size, end, pattern, source_type, start, tag_definition_id }) => {
+    async ({
+      aggregation,
+      breakdown_fields,
+      bucket_size,
+      end,
+      pattern,
+      source_type,
+      start,
+      tag_definition_id,
+    }) => {
       try {
         const buckets = await getChartData(user, {
           aggregation,
+          breakdown_fields,
           bucket_size,
           end,
           pattern,

--- a/apps/backend/src/mcp/trend-tools.ts
+++ b/apps/backend/src/mcp/trend-tools.ts
@@ -26,6 +26,7 @@ Common half-life values:
     { ...getTrendQuerySchema.shape },
     async ({
       aggregation,
+      breakdown_fields,
       display_period,
       half_life_days,
       lookback_days,
@@ -38,6 +39,7 @@ Common half-life values:
 
         const result = await getTrend(user, {
           aggregation,
+          breakdown_fields,
           custom_metrics: customMetrics,
           display_period,
           half_life_days,

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -22,6 +22,7 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
     async (req, res) => {
       const {
         aggregation,
+        breakdown_fields: breakdownFieldsStr,
         display_period,
         half_life_days,
         lookback_days,
@@ -29,6 +30,12 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
         source_type,
         tag_definition_id,
       } = req.query
+      const breakdown_fields = breakdownFieldsStr
+        ? breakdownFieldsStr
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined
       const user = req.user!
 
       // Require pattern or tag_definition_id
@@ -46,6 +53,7 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
 
         const result = await getTrend(user, {
           aggregation,
+          breakdown_fields,
           custom_metrics: customMetrics,
           display_period,
           half_life_days: halfLifeDays,

--- a/apps/backend/src/services/trends.test.ts
+++ b/apps/backend/src/services/trends.test.ts
@@ -178,4 +178,53 @@ describe('getTrend', () => {
     expect(result.aggregation).toBe('sum')
     expect(result.display_unit).toBe('per day')
   })
+
+  test('returns breakdown trend with per-series EMA histories', async () => {
+    // Mock the breakdown query — returns daily values grouped by field
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [
+        { day: new Date('2026-01-30'), field_0: 'alice', value: 1 },
+        { day: new Date('2026-01-30'), field_0: 'bob', value: 2 },
+        { day: new Date('2026-02-01'), field_0: 'alice', value: 1 },
+      ],
+    } as never)
+
+    const result = await getTrend('testuser', {
+      breakdown_fields: ['partner'],
+      pattern: 'sex',
+      source_type: 'activity_type',
+    })
+
+    expect(result.breakdown_series).toEqual(['alice', 'bob'])
+    expect(result.breakdown_histories).toBeDefined()
+    expect(result.breakdown_histories!['alice'].length).toBeGreaterThan(0)
+    expect(result.breakdown_histories!['bob'].length).toBeGreaterThan(0)
+    expect(result.history).toHaveLength(0)
+    expect(result.current_value).toBe(0)
+  })
+
+  test('returns empty breakdown for invalid field names', async () => {
+    const result = await getTrend('testuser', {
+      breakdown_fields: ['INVALID-FIELD'],
+      pattern: 'sex',
+      source_type: 'activity_type',
+    })
+
+    expect(result.breakdown_series).toEqual([])
+    expect(result.breakdown_histories).toEqual({})
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  test('returns empty breakdown when no data matches', async () => {
+    vi.mocked(db.query).mockResolvedValue({ rows: [] } as never)
+
+    const result = await getTrend('testuser', {
+      breakdown_fields: ['partner'],
+      pattern: 'nonexistent',
+      source_type: 'activity_type',
+    })
+
+    expect(result.breakdown_series).toEqual([])
+    expect(result.breakdown_histories).toEqual({})
+  })
 })

--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -26,6 +26,7 @@ const LN2 = 0.693147
 
 export interface GetTrendInput {
   aggregation?: 'count' | 'mean' | 'sum'
+  breakdown_fields?: string[]
   custom_metrics?: CustomMetricDefinition[]
   display_period?: TrendDisplayPeriod
   half_life_days?: number
@@ -326,6 +327,177 @@ const calculateActivityTypeCountTrend = async (
 }
 
 /**
+ * Compute EMA over daily values using the same formula as the SQL-based functions.
+ * For each day, ema = multiplier * sum(value_i * weight_i) / sum(weight_i)
+ * where weight_i = exp(-LN2 * daysAgo / halfLife) and the lookback window is
+ * min(lookbackDays, 90).
+ */
+const computeEma = (
+  dailyValues: Map<string, number>,
+  days: string[],
+  halfLifeDays: number,
+  lookbackDays: number,
+  multiplier: number,
+): TrendHistoryPoint[] => {
+  const windowDays = Math.min(lookbackDays, 90)
+  const history: TrendHistoryPoint[] = []
+
+  for (let i = 0; i < days.length; i++) {
+    let weightedSum = 0
+    let weightSum = 0
+    const currentDay = new Date(days[i]).getTime()
+
+    for (let j = i; j >= 0 && i - j <= windowDays; j--) {
+      const pastDay = new Date(days[j]).getTime()
+      const daysAgo = (currentDay - pastDay) / (1000 * 60 * 60 * 24)
+      const weight = Math.exp((-LN2 * daysAgo) / halfLifeDays)
+      const value = dailyValues.get(days[j]) ?? 0
+      weightedSum += value * weight
+      weightSum += weight
+    }
+
+    if (weightSum > 0) {
+      history.push({ date: days[i], value: (multiplier * weightedSum) / weightSum })
+    }
+  }
+
+  return history
+}
+
+/**
+ * Calculate EMA-weighted trend for an activity type broken down by one or more data fields.
+ * Groups daily values by breakdown field, then computes EMA independently per series.
+ */
+const calculateActivityTypeBreakdownTrend = async (
+  user: string,
+  pattern: string,
+  breakdownFields: string[],
+  halfLifeDays: number,
+  lookbackDays: number,
+  displayPeriod: TrendDisplayPeriod,
+  aggregation: 'count' | 'sum',
+): Promise<{ series: string[]; histories: Record<string, TrendHistoryPoint[]> }> => {
+  for (const field of breakdownFields) {
+    if (!/^[a-z][a-z0-9_]*$/.test(field)) return { histories: {}, series: [] }
+  }
+
+  const multiplier = displayPeriodMultipliers[displayPeriod]
+  const fieldSelects = breakdownFields.map((f, i) => `COALESCE(data->>'${f}', '(none)') AS field_${i}`)
+  const fieldGroupBys = breakdownFields.map((_, i) => `field_${i}`)
+  const valueExpr =
+    aggregation === 'count'
+      ? 'count(*)'
+      : "SUM(EXTRACT(EPOCH FROM (COALESCE(end_time, start_time + interval '1 hour') - start_time))) / 3600.0"
+
+  const result = await query(
+    user,
+    `SELECT date_trunc('day', start_time AT TIME ZONE 'UTC')::date AS day,
+            ${fieldSelects.join(', ')},
+            ${valueExpr} AS value
+       FROM activities
+      WHERE activity_type = $1
+        AND deleted_at IS NULL
+        AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+      GROUP BY 1, ${fieldGroupBys.join(', ')}
+      ORDER BY 1`,
+    [pattern, lookbackDays],
+  )
+
+  // Build per-series daily values
+  const seriesDaily = new Map<string, Map<string, number>>()
+  for (const row of result.rows) {
+    const keyParts = breakdownFields.map((_, i) => row[`field_${i}`] as string)
+    const seriesKey = keyParts.join(' / ')
+    const day = (row.day as Date).toISOString().split('T')[0]
+    const value = Number(row.value)
+
+    if (!seriesDaily.has(seriesKey)) seriesDaily.set(seriesKey, new Map())
+    seriesDaily.get(seriesKey)!.set(day, value)
+  }
+
+  // Generate full date range
+  const days: string[] = []
+  const now = new Date()
+  now.setUTCHours(0, 0, 0, 0)
+  for (let d = lookbackDays; d >= 0; d--) {
+    const date = new Date(now)
+    date.setUTCDate(date.getUTCDate() - d)
+    days.push(date.toISOString().split('T')[0])
+  }
+
+  // Compute EMA per series
+  const series = [...seriesDaily.keys()].sort()
+  const histories: Record<string, TrendHistoryPoint[]> = {}
+  for (const s of series) {
+    histories[s] = computeEma(seriesDaily.get(s)!, days, halfLifeDays, lookbackDays, multiplier)
+  }
+
+  return { histories, series }
+}
+
+const displayUnits: Record<TrendDisplayPeriod, string> = {
+  daily: 'per day',
+  monthly: 'per month',
+  weekly: 'per week',
+}
+
+/** Build the activity_type trend result, with optional breakdown. */
+const getActivityTypeTrend = async (
+  user: string,
+  input: GetTrendInput & { aggregation: 'count' | 'mean' | 'sum' },
+  halfLifeDays: number,
+  lookbackDays: number,
+  displayPeriod: TrendDisplayPeriod,
+): Promise<TrendResult> => {
+  const effectiveAggregation = input.aggregation === 'mean' ? 'sum' : input.aggregation
+  const displayUnit =
+    effectiveAggregation === 'count' ? displayUnits[displayPeriod] : `hours ${displayUnits[displayPeriod]}`
+
+  if (input.breakdown_fields?.length) {
+    const breakdown = await calculateActivityTypeBreakdownTrend(
+      user,
+      input.pattern,
+      input.breakdown_fields,
+      halfLifeDays,
+      lookbackDays,
+      displayPeriod,
+      effectiveAggregation,
+    )
+
+    return {
+      aggregation: effectiveAggregation,
+      breakdown_histories: breakdown.histories,
+      breakdown_series: breakdown.series,
+      current_value: 0,
+      display_period: displayPeriod,
+      display_unit: displayUnit,
+      half_life_days: halfLifeDays,
+      history: [],
+      lookback_days: lookbackDays,
+      pattern: input.pattern,
+      source_type: 'activity_type',
+    }
+  }
+
+  const { currentValue, history } =
+    effectiveAggregation === 'count'
+      ? await calculateActivityTypeCountTrend(user, input.pattern, halfLifeDays, lookbackDays, displayPeriod)
+      : await calculateActivityTypeTrend(user, input.pattern, halfLifeDays, lookbackDays, displayPeriod)
+
+  return {
+    aggregation: effectiveAggregation,
+    current_value: currentValue,
+    display_period: displayPeriod,
+    display_unit: displayUnit,
+    half_life_days: halfLifeDays,
+    history,
+    lookback_days: lookbackDays,
+    pattern: input.pattern,
+    source_type: 'activity_type',
+  }
+}
+
+/**
  * Get the trend for a tag pattern, metric, productivity category, or activity type.
  */
 export const getTrend = async (user: string, input: GetTrendInput): Promise<TrendResult> => {
@@ -337,12 +509,6 @@ export const getTrend = async (user: string, input: GetTrendInput): Promise<Tren
     pattern,
     source_type: sourceType,
   } = input
-
-  const displayUnits: Record<TrendDisplayPeriod, string> = {
-    daily: 'per day',
-    monthly: 'per month',
-    weekly: 'per week',
-  }
 
   if (sourceType === 'tag') {
     // Tags are now activities — delegate to activity_type count trend
@@ -366,26 +532,7 @@ export const getTrend = async (user: string, input: GetTrendInput): Promise<Tren
       source_type: sourceType,
     }
   } else if (sourceType === 'activity_type') {
-    const effectiveAggregation = aggregation === 'mean' ? 'sum' : aggregation
-    const { currentValue, history } =
-      effectiveAggregation === 'count'
-        ? await calculateActivityTypeCountTrend(user, pattern, halfLifeDays, lookbackDays, displayPeriod)
-        : await calculateActivityTypeTrend(user, pattern, halfLifeDays, lookbackDays, displayPeriod)
-
-    return {
-      aggregation: effectiveAggregation,
-      current_value: currentValue,
-      display_period: displayPeriod,
-      display_unit:
-        effectiveAggregation === 'count'
-          ? displayUnits[displayPeriod]
-          : `hours ${displayUnits[displayPeriod]}`,
-      half_life_days: halfLifeDays,
-      history,
-      lookback_days: lookbackDays,
-      pattern,
-      source_type: sourceType,
-    }
+    return getActivityTypeTrend(user, { ...input, aggregation }, halfLifeDays, lookbackDays, displayPeriod)
   } else if (sourceType === 'productivity_category') {
     const { currentValue, history } = await calculateProductivityCategoryTrend(
       user,

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -102,7 +102,10 @@ function syncUrl(state: ChartState) {
   } else {
     params.set('bucket_size', state.bucket_size)
   }
-  if (state.source_type === 'metric' && state.aggregation !== 'count') {
+  if (
+    (state.source_type === 'metric' || state.source_type === 'activity_type') &&
+    state.aggregation !== 'count'
+  ) {
     params.set('aggregation', state.aggregation)
   }
   if (state.breakdown_fields.length > 0) {
@@ -363,65 +366,37 @@ function BreakdownLegend({ series, colors }: { series: string[]; colors: string[
   )
 }
 
-function BreakdownTrendDisplay({ params }: { params: FetchChartDataParams }) {
-  const breakdownQuery = useQuery({
-    enabled: Boolean(params.breakdown_fields?.length),
-    queryFn: () => fetchChartData(params),
-    queryKey: ['chart-data-trend-breakdown', params],
-    staleTime: 5 * 60 * 1000,
-  })
-
-  if (breakdownQuery.isLoading) return <div class="chart-loading">Loading breakdown data...</div>
-  if (breakdownQuery.isError) return <div class="chart-error">Failed to load breakdown data.</div>
-
-  const result = breakdownQuery.data
-  if (!result?.breakdown_buckets?.length) return <div class="chart-empty">No breakdown data.</div>
-
-  const series = result.breakdown_series ?? []
-  return (
-    <div class="chart-display">
-      <BreakdownLegend series={series} colors={SERIES_COLORS} />
-      <TrendLineChart
-        data={[]}
-        color="#8b5cf6"
-        height={350}
-        multiSeries={series.map((name, i) => ({
-          color: SERIES_COLORS[i % SERIES_COLORS.length],
-          data: result.breakdown_buckets!.map((b) => ({
-            date: b.bucket_start,
-            value: b.series[name] ?? 0,
-          })),
-          name,
-        }))}
-      />
-    </div>
-  )
-}
-
-function TrendDisplay({
-  params,
-  breakdownParams,
-}: {
-  params: FetchTrendParams
-  breakdownParams?: FetchChartDataParams
-}) {
+function TrendDisplay({ params }: { params: FetchTrendParams }) {
   const trendQuery = useQuery({
-    enabled: Boolean(params.pattern) && !breakdownParams?.breakdown_fields?.length,
+    enabled: Boolean(params.pattern),
     queryFn: () => fetchTrend(params),
     queryKey: ['trend', params],
     staleTime: 5 * 60 * 1000,
   })
 
   if (!params.pattern) return <div class="chart-empty">Select a source to view trend data.</div>
-
-  if (breakdownParams?.breakdown_fields?.length) {
-    return <BreakdownTrendDisplay params={breakdownParams} />
-  }
-
   if (trendQuery.isLoading) return <div class="chart-loading">Loading trend data...</div>
   if (trendQuery.isError || !trendQuery.data) return <div class="chart-error">Failed to load trend data.</div>
 
-  const { current_value, display_unit, history } = trendQuery.data
+  const { breakdown_histories, breakdown_series, current_value, display_unit, history } = trendQuery.data
+
+  if (breakdown_series?.length && breakdown_histories) {
+    return (
+      <div class="chart-display">
+        <BreakdownLegend series={breakdown_series} colors={SERIES_COLORS} />
+        <TrendLineChart
+          data={[]}
+          color="#8b5cf6"
+          height={350}
+          multiSeries={breakdown_series.map((name, i) => ({
+            color: SERIES_COLORS[i % SERIES_COLORS.length],
+            data: (breakdown_histories[name] ?? []).map((p) => ({ date: p.date, value: p.value })),
+            name,
+          }))}
+        />
+      </div>
+    )
+  }
 
   return (
     <div class="chart-display">
@@ -711,6 +686,7 @@ export function Chart() {
         <TrendDisplay
           params={{
             aggregation: state.aggregation,
+            breakdown_fields: state.breakdown_fields.length > 0 ? state.breakdown_fields : undefined,
             display_period: state.display_period,
             half_life_days: state.half_life_days,
             lookback_days: state.lookback_days,
@@ -718,19 +694,6 @@ export function Chart() {
             source_type: state.source_type,
             ...(state.tag_definition_id ? { tag_definition_id: state.tag_definition_id } : {}),
           }}
-          breakdownParams={
-            state.breakdown_fields.length > 0
-              ? {
-                  aggregation: state.aggregation,
-                  breakdown_fields: state.breakdown_fields,
-                  bucket_size: '1d',
-                  end,
-                  pattern: state.pattern || undefined,
-                  source_type: state.source_type,
-                  start,
-                }
-              : undefined
-          }
         />
       ) : (
         <BarDisplay

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -1227,6 +1227,7 @@ export interface FetchTrendParams {
   display_period?: TrendDisplayPeriod
   aggregation?: 'count' | 'sum' | 'mean'
   tag_definition_id?: string
+  breakdown_fields?: string[]
 }
 
 // Fetch trend data with EMA calculation
@@ -1242,6 +1243,7 @@ export const fetchTrend = async (params: FetchTrendParams): Promise<TrendResult>
   if (params.half_life_days) query.half_life_days = params.half_life_days.toString()
   if (params.lookback_days) query.lookback_days = params.lookback_days.toString()
   if (params.tag_definition_id) query.tag_definition_id = params.tag_definition_id
+  if (params.breakdown_fields?.length) query.breakdown_fields = params.breakdown_fields.join(',')
 
   const response = await axios.get<TrendResponse>(`${API_URL}/trends`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/packages/api-spec/src/schemas/trends.ts
+++ b/packages/api-spec/src/schemas/trends.ts
@@ -83,6 +83,13 @@ export const getTrendQuerySchema = z
       .uuid()
       .optional()
       .meta({ description: 'Tag definition ID (alternative to pattern for tag trends)' }),
+    breakdown_fields: z
+      .array(z.string())
+      .optional()
+      .meta({
+        description:
+          'Data fields to break down by (for activity_type source). Produces per-series EMA histories.',
+      }),
   })
   .meta({ id: 'GetTrendQuery' })
 
@@ -111,6 +118,14 @@ export const trendResultSchema = z
     display_unit: z.string().meta({ description: 'Human-readable unit (e.g., "per month")' }),
     half_life_days: z.number().meta({ description: 'Half-life used for calculation' }),
     history: z.array(trendHistoryPointSchema).meta({ description: 'Historical trend values' }),
+    breakdown_series: z
+      .array(z.string())
+      .optional()
+      .meta({ description: 'Distinct series names when breakdown is used' }),
+    breakdown_histories: z
+      .record(z.string(), z.array(trendHistoryPointSchema))
+      .optional()
+      .meta({ description: 'Per-series EMA trend histories keyed by series name' }),
     lookback_days: z.number().meta({ description: 'Days of data included' }),
     pattern: z.string().meta({ description: 'Pattern used for matching' }),
     source_type: trendSourceTypeSchema.meta({ description: 'Source type queried' }),
@@ -150,6 +165,10 @@ export const trendQuerySchema = z
       .uuid()
       .optional()
       .meta({ description: 'Tag definition ID (alternative to pattern for tag trends)' }),
+    breakdown_fields: z
+      .string()
+      .optional()
+      .meta({ description: 'Comma-separated data fields to break down by' }),
   })
   .meta({ id: 'TrendQuery' })
 


### PR DESCRIPTION
## Summary

- Trend chart with breakdown now shows proper EMA-smoothed lines (was showing raw daily bucketed data by using the wrong API endpoint)
- Added `breakdown_fields` support to `/trends` API endpoint, computing per-series EMA in TypeScript
- Removed `BreakdownTrendDisplay` component — `TrendDisplay` handles breakdown natively via a single API call
- Fixed `syncUrl` to persist `aggregation` for activity_type source
- Fixed MCP chart tool to pass `breakdown_fields` through

## Test plan

- [x] Backend tests pass (new breakdown trend tests + all existing)
- [x] TypeScript type checks pass for both backend and web
- [ ] Manual: Trend chart with breakdown shows smooth EMA lines
- [ ] Manual: Bar chart with breakdown still works (grouped bars)
- [ ] Manual: URL persists breakdown_fields on reload
- [ ] Manual: Switching between trend/bar with breakdown active works without stale loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)