### PR TITLE
fix: bar chart crash with special chars in breakdown series names

### DIFF
--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -187,12 +187,14 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }:
       renderGrid(g, y, innerWidth)
       renderAxes(g, x0, y, bars, innerWidth, innerHeight, dateFormat)
 
-      // Render grouped bars
-      for (const series of multiSeries) {
+      // Render grouped bars (use index for selector to avoid invalid CSS from special chars in names)
+      for (let si = 0; si < multiSeries.length; si++) {
+        const series = multiSeries[si]
         const dataMap = new Map(series.data.map((d) => [d.bucket_start, d.value]))
-        g.selectAll(`.bar-${series.name}`)
+        g.selectAll(`.bar-s${si}`)
           .data(allBuckets)
           .join('rect')
+          .attr('class', `bar-s${si}`)
           .attr('x', (bucket) => (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
           .attr('y', (bucket) => y(dataMap.get(bucket) ?? 0))
           .attr('width', x1.bandwidth())


### PR DESCRIPTION
## Summary

- Bar chart breakdown was completely empty because D3's `selectAll` used series names directly in CSS selectors
- Series name `(none)` produced selector `.bar-(none)` — parentheses are invalid CSS, causing `querySelectorAll` to throw `DOMException`
- This crashed the entire bar rendering loop, so no bars were drawn for ANY series
- Fix: use series index (`bar-s0`, `bar-s1`, ...) instead of name for CSS class selectors

## Test plan

- [ ] Bar chart with breakdown renders bars (test with activity types that have `(none)` values)
- [ ] Bar chart without breakdown still works
- [ ] Switching between trend and bar with breakdown works

🤖 Generated with [Claude Code](https://claude.com/claude-code)