### PR TITLE
feat: bar chart tooltips + click-to-navigate to data page

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -444,17 +444,32 @@ export const getActivities = async (
   activityType: ActivityType | ActivityType[],
   start: Date,
   end: Date,
+  dataFilters?: Array<{ field: string; value: string | null }>,
 ): Promise<MergedActivity[]> => {
   const types = Array.isArray(activityType) ? activityType : [activityType]
+  const params: unknown[] = [types, start, end]
+
+  let filterClauses = ''
+  if (dataFilters?.length) {
+    for (const filter of dataFilters) {
+      if (!/^[a-z][a-z0-9_]*$/.test(filter.field)) continue
+      if (filter.value === null) {
+        filterClauses += `\n       AND (data->>'${filter.field}' IS NULL OR data->>'${filter.field}' = '')`
+      } else {
+        params.push(filter.value)
+        filterClauses += `\n       AND data->>'${filter.field}' = $${params.length}`
+      }
+    }
+  }
 
   const result = await query(
     user,
     `SELECT id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at
      FROM activities
      WHERE activity_type = ANY($1) AND start_time >= $2 AND start_time <= $3
-       AND deleted_at IS NULL
+       AND deleted_at IS NULL${filterClauses}
      ORDER BY start_time`,
-    [types, start, end],
+    params,
   )
 
   const activities = result.rows.map(mapActivityRow)

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -619,6 +619,7 @@ describe('MCP Server', () => {
         expect.any(Date),
         expect.any(Date),
         undefined,
+        undefined,
       )
     })
   })

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -156,11 +156,36 @@ Use cases:
         .describe(
           'Activity types to include. Defaults to all types (sleep, exercise, meditation, nap, rest).',
         ),
+      data_filter: z
+        .string()
+        .optional()
+        .describe(
+          'Filter by JSONB data field values. Format: "field:value" (comma-separated). Use "(none)" for null/empty.',
+        ),
       tz: tzSchema,
     },
-    async ({ end, start, types, tz }) => {
+    async ({ data_filter, end, start, types, tz }) => {
       const requestedTypes = types ?? (await getAllActivityTypeNames(user))
-      const activities = await queryActivities(user, requestedTypes, new Date(start), new Date(end), sync)
+      const dataFilters = data_filter
+        ? data_filter
+            .split(',')
+            .map((segment) => {
+              const colonIdx = segment.indexOf(':')
+              if (colonIdx === -1) return null
+              const field = segment.slice(0, colonIdx).trim()
+              const rawValue = segment.slice(colonIdx + 1).trim()
+              return { field, value: rawValue === '(none)' ? null : rawValue }
+            })
+            .filter((f): f is { field: string; value: string | null } => f !== null)
+        : undefined
+      const activities = await queryActivities(
+        user,
+        requestedTypes,
+        new Date(start),
+        new Date(end),
+        sync,
+        dataFilters,
+      )
       return tzJsonResponse({ data: activities, success: true }, tz)
     },
   )

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -169,7 +169,13 @@ export const createActivitiesRouter = (
     authMiddleware,
     validateQuery(activitiesQuerySchema),
     async (req, res) => {
-      const { start, end, types: typesParam, exclude_types: excludeTypesParam } = req.query
+      const {
+        start,
+        end,
+        types: typesParam,
+        exclude_types: excludeTypesParam,
+        data_filter: dataFilterStr,
+      } = req.query
       const user = req.user!
 
       // When no types specified, query all activity types (not just those with definitions)
@@ -181,7 +187,28 @@ export const createActivitiesRouter = (
         types = types.filter((t) => !excludeSet.has(t))
       }
 
-      const activities = await queryActivities(user, types, new Date(start), new Date(end), syncProvider)
+      // Parse data field filters (format: "field:value,field2:value2")
+      const dataFilters = dataFilterStr
+        ? dataFilterStr
+            .split(',')
+            .map((segment) => {
+              const colonIdx = segment.indexOf(':')
+              if (colonIdx === -1) return null
+              const field = segment.slice(0, colonIdx).trim()
+              const rawValue = segment.slice(colonIdx + 1).trim()
+              return { field, value: rawValue === '(none)' ? null : rawValue }
+            })
+            .filter((f): f is { field: string; value: string | null } => f !== null)
+        : undefined
+
+      const activities = await queryActivities(
+        user,
+        types,
+        new Date(start),
+        new Date(end),
+        syncProvider,
+        dataFilters,
+      )
       res.json({ data: activities, success: true })
     },
   )

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -1607,6 +1607,7 @@ export async function queryActivities(
   start: Date,
   end: Date,
   sync?: SyncProvider,
+  dataFilters?: Array<{ field: string; value: string | null }>,
 ): Promise<ActivityResult[]> {
   // Fire-and-forget: trigger background sync so activity data is fresh for the next request
   if (sync) {
@@ -1617,7 +1618,7 @@ export async function queryActivities(
     if (promises.length > 0) void Promise.all(promises)
   }
 
-  const activities = await getActivities(user, types, start, end)
+  const activities = await getActivities(user, types, start, end, dataFilters)
 
   // Get HR zones only if exercise activities are included
   const includesExercise = types.includes('exercise')

--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -2,7 +2,7 @@
  * D3 bar chart component for bucketed chart data.
  *
  * Renders vertical bars with responsive width, tooltip on hover,
- * and smart date formatting based on data density.
+ * click-to-navigate support, and smart date formatting based on data density.
  */
 import * as d3 from 'd3'
 import { useEffect, useRef } from 'preact/hooks'
@@ -15,6 +15,11 @@ export interface BarSeriesData {
   data: { bucket_start: string; value: number }[]
 }
 
+export interface BarClickInfo {
+  bucket_start: string
+  series_name?: string
+}
+
 export interface BarChartProps {
   /** Bucketed data points (single series). */
   data: { bucket_start: string; value: number }[]
@@ -22,8 +27,10 @@ export interface BarChartProps {
   color?: string
   /** Chart height in pixels (default 300). */
   height?: number
-  /** Multiple named series — renders stacked bars. Overrides data/color when present. */
+  /** Multiple named series — renders grouped bars. Overrides data/color when present. */
   multiSeries?: BarSeriesData[]
+  /** Called when a bar is clicked with bucket and optional series info. */
+  onBarClick?: (info: BarClickInfo) => void
 }
 
 interface ParsedBar {
@@ -52,7 +59,6 @@ function renderAxes(
   innerHeight: number,
   dateFormat: (date: Date) => string,
 ) {
-  // Show at most ~10 tick labels to avoid overlap
   const maxTicks = Math.min(bars.length, 10)
   const tickInterval = Math.max(1, Math.ceil(bars.length / maxTicks))
   const tickValues = bars.filter((_, i) => i % tickInterval === 0).map((d) => d.date.toISOString())
@@ -92,7 +98,22 @@ function renderGrid(
     .attr('stroke-dasharray', '3,3')
 }
 
-/** Render bars with tooltip interaction. */
+/** Position a tooltip with smart left/right flip. */
+function positionTooltip(
+  event: MouseEvent,
+  container: HTMLDivElement,
+  tooltip: HTMLDivElement,
+  margin: { left: number; top: number },
+) {
+  const containerRect = container.getBoundingClientRect()
+  const [mx] = d3.pointer(event, container)
+  const tooltipWidth = tooltip.offsetWidth
+  const left = mx + tooltipWidth + 12 > containerRect.width ? mx - tooltipWidth - 12 : mx + 12
+  tooltip.style.left = `${left}px`
+  tooltip.style.top = `${margin.top + 8}px`
+}
+
+/** Render single-series bars with tooltip and click. */
 function renderBars(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   bars: ParsedBar[],
@@ -104,6 +125,7 @@ function renderBars(
   container: HTMLDivElement,
   margin: { left: number; top: number },
   dateFormat: (date: Date) => string,
+  onBarClick?: (info: BarClickInfo) => void,
 ) {
   g.selectAll('.bar')
     .data(bars)
@@ -115,26 +137,94 @@ function renderBars(
     .attr('height', (d) => innerHeight - y(d.value))
     .attr('fill', color)
     .attr('rx', 2)
+    .style('cursor', onBarClick ? 'pointer' : 'default')
     .on('mouseenter', (event: MouseEvent, d) => {
       d3.select(event.target as SVGRectElement).attr('fill-opacity', 0.8)
       tooltip.textContent = `${dateFormat(d.date)}: ${d.value.toFixed(1)}`
       tooltip.style.display = 'block'
     })
-    .on('mousemove', (event: MouseEvent) => {
-      const containerRect = container.getBoundingClientRect()
-      const [mx] = d3.pointer(event, container)
-      const tooltipWidth = tooltip.offsetWidth
-      const left = mx + tooltipWidth + 12 > containerRect.width ? mx - tooltipWidth - 12 : mx + 12
-      tooltip.style.left = `${left}px`
-      tooltip.style.top = `${margin.top + 8}px`
-    })
+    .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
     .on('mouseleave', (event: MouseEvent) => {
       d3.select(event.target as SVGRectElement).attr('fill-opacity', 1)
       tooltip.style.display = 'none'
     })
+    .on('click', (_event: MouseEvent, d) => {
+      onBarClick?.({ bucket_start: d.date.toISOString() })
+    })
 }
 
-export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }: BarChartProps) {
+/** Render multi-series grouped bars with tooltip and click. */
+function renderMultiSeriesBars(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  multiSeries: BarSeriesData[],
+  allBuckets: string[],
+  x0: d3.ScaleBand<string>,
+  x1: d3.ScaleBand<string>,
+  y: d3.ScaleLinear<number, number>,
+  innerHeight: number,
+  tooltip: HTMLDivElement,
+  container: HTMLDivElement,
+  margin: { left: number; top: number },
+  dateFormat: (date: Date) => string,
+  onBarClick?: (info: BarClickInfo) => void,
+) {
+  // Build lookup: bucket -> series -> value
+  const bucketValues = new Map<string, Map<string, number>>()
+  for (const series of multiSeries) {
+    for (const d of series.data) {
+      if (!bucketValues.has(d.bucket_start)) bucketValues.set(d.bucket_start, new Map())
+      bucketValues.get(d.bucket_start)!.set(series.name, d.value)
+    }
+  }
+
+  const showBucketTooltip = (bucket: string) => {
+    // Highlight all bars in this bucket
+    g.selectAll<SVGRectElement, string>('[data-bucket]').attr('fill-opacity', (b) =>
+      b === bucket ? 0.8 : 0.3,
+    )
+    // Build tooltip HTML
+    const dateLabel = dateFormat(new Date(bucket))
+    const values = bucketValues.get(bucket)
+    const lines = multiSeries
+      .map((s) => {
+        const v = values?.get(s.name) ?? 0
+        return `<span style="color:${s.color}">&#9679;</span> ${s.name}: ${v.toFixed(1)}`
+      })
+      .join('<br/>')
+    tooltip.innerHTML = `<strong>${dateLabel}</strong><br/>${lines}`
+    tooltip.style.display = 'block'
+  }
+
+  const hideBucketTooltip = () => {
+    g.selectAll('[data-bucket]').attr('fill-opacity', 1)
+    tooltip.style.display = 'none'
+  }
+
+  for (let si = 0; si < multiSeries.length; si++) {
+    const series = multiSeries[si]
+    const dataMap = new Map(series.data.map((d) => [d.bucket_start, d.value]))
+    g.selectAll(`.bar-s${si}`)
+      .data(allBuckets)
+      .join('rect')
+      .attr('class', `bar-s${si}`)
+      .attr('data-bucket', (bucket) => bucket)
+      .attr('x', (bucket) => (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
+      .attr('y', (bucket) => y(dataMap.get(bucket) ?? 0))
+      .attr('width', x1.bandwidth())
+      .attr('height', (bucket) => innerHeight - y(dataMap.get(bucket) ?? 0))
+      .attr('fill', series.color)
+      .attr('rx', 1)
+      .style('cursor', onBarClick ? 'pointer' : 'default')
+      .on('mouseenter', (_event: MouseEvent, bucket) => showBucketTooltip(bucket))
+      .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
+      .on('mouseleave', () => hideBucketTooltip())
+      .on('click', (_event: MouseEvent, bucket) => {
+        onBarClick?.({ bucket_start: bucket, series_name: series.name })
+      })
+  }
+}
+
+export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, onBarClick }: BarChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
@@ -157,7 +247,6 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }:
     const innerHeight = chartHeight - margin.top - margin.bottom
 
     if (multiSeries && multiSeries.length > 0) {
-      // Grouped (side-by-side) bar chart
       const allBuckets = [...new Set(multiSeries.flatMap((s) => s.data.map((d) => d.bucket_start)))].sort()
       if (allBuckets.length === 0) return
 
@@ -165,7 +254,6 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }:
       const seriesCount = multiSeries.length
 
       const x0 = d3.scaleBand<string>().domain(allBuckets).range([0, innerWidth]).padding(0.15)
-
       const x1 = d3
         .scaleBand<string>()
         .domain(multiSeries.map((s) => s.name))
@@ -180,37 +268,32 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }:
         .range([innerHeight, 0])
 
       const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-
       const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
       const dateFormat = buildBarDateFormat(dateExtent)
 
       renderGrid(g, y, innerWidth)
       renderAxes(g, x0, y, bars, innerWidth, innerHeight, dateFormat)
 
-      // Render grouped bars (use index for selector to avoid invalid CSS from special chars in names)
-      for (let si = 0; si < multiSeries.length; si++) {
-        const series = multiSeries[si]
-        const dataMap = new Map(series.data.map((d) => [d.bucket_start, d.value]))
-        g.selectAll(`.bar-s${si}`)
-          .data(allBuckets)
-          .join('rect')
-          .attr('class', `bar-s${si}`)
-          .attr('x', (bucket) => (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
-          .attr('y', (bucket) => y(dataMap.get(bucket) ?? 0))
-          .attr('width', x1.bandwidth())
-          .attr('height', (bucket) => innerHeight - y(dataMap.get(bucket) ?? 0))
-          .attr('fill', series.color)
-          .attr('rx', 1)
+      if (tooltipRef.current) {
+        renderMultiSeriesBars(
+          g,
+          multiSeries,
+          allBuckets,
+          x0,
+          x1,
+          y,
+          innerHeight,
+          tooltipRef.current,
+          container,
+          margin,
+          dateFormat,
+          onBarClick,
+        )
       }
     } else {
-      // Single series
       if (data.length === 0) return
 
-      const bars: ParsedBar[] = data.map((d) => ({
-        date: new Date(d.bucket_start),
-        value: d.value,
-      }))
-
+      const bars: ParsedBar[] = data.map((d) => ({ date: new Date(d.bucket_start), value: d.value }))
       const x = d3
         .scaleBand<string>()
         .domain(bars.map((d) => d.date.toISOString()))
@@ -225,7 +308,6 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }:
         .range([innerHeight, 0])
 
       const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-
       const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
       const dateFormat = buildBarDateFormat(dateExtent)
 
@@ -233,10 +315,22 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries }:
       renderAxes(g, x, y, bars, innerWidth, innerHeight, dateFormat)
 
       if (tooltipRef.current) {
-        renderBars(g, bars, x, y, innerHeight, color, tooltipRef.current, container, margin, dateFormat)
+        renderBars(
+          g,
+          bars,
+          x,
+          y,
+          innerHeight,
+          color,
+          tooltipRef.current,
+          container,
+          margin,
+          dateFormat,
+          onBarClick,
+        )
       }
     }
-  }, [data, color, height, multiSeries])
+  }, [data, color, height, multiSeries, onBarClick])
 
   if (effectiveData.length === 0) {
     return <div class="bar-chart-placeholder">No data for the selected range</div>

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -12,7 +12,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation } from 'preact-iso'
 import { useCallback, useMemo, useState } from 'preact/hooks'
 
-import { BarChart } from '../../components/charts/BarChart'
+import { BarChart, type BarClickInfo } from '../../components/charts/BarChart'
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { MetricPicker } from '../../components/MetricPicker'
 import {
@@ -411,7 +411,64 @@ function TrendDisplay({ params }: { params: FetchTrendParams }) {
   )
 }
 
+/** Compute the end of a bucket given its start and size. */
+const computeBucketEnd = (start: Date, bucketSize: string): Date => {
+  const end = new Date(start)
+  switch (bucketSize) {
+    case '1m':
+      end.setMinutes(end.getMinutes() + 1)
+      break
+    case '5m':
+      end.setMinutes(end.getMinutes() + 5)
+      break
+    case '15m':
+      end.setMinutes(end.getMinutes() + 15)
+      break
+    case '1h':
+      end.setHours(end.getHours() + 1)
+      break
+    case '1d':
+      end.setDate(end.getDate() + 1)
+      break
+    case '1w':
+      end.setDate(end.getDate() + 7)
+      break
+    case '1M':
+      end.setMonth(end.getMonth() + 1)
+      break
+  }
+  return end
+}
+
 function BarDisplay({ params }: { params: FetchChartDataParams }) {
+  const { route } = useLocation()
+
+  const handleBarClick = useCallback(
+    (info: BarClickInfo) => {
+      if (params.source_type !== 'activity_type' || !params.pattern) return
+
+      const bucketStart = new Date(info.bucket_start)
+      const bucketEnd = computeBucketEnd(bucketStart, params.bucket_size ?? '1d')
+
+      const urlParams = new URLSearchParams()
+      urlParams.set('from', bucketStart.toISOString())
+      urlParams.set('to', bucketEnd.toISOString())
+      urlParams.set('date', bucketStart.toISOString().slice(0, 10))
+      urlParams.set('types', params.pattern)
+
+      if (info.series_name && params.breakdown_fields?.length) {
+        const values = info.series_name.split(' / ')
+        const filters = params.breakdown_fields
+          .map((field, i) => `${field}:${values[i] ?? '(none)'}`)
+          .join(',')
+        urlParams.set('data_filter', filters)
+      }
+
+      route(`/data?${urlParams}`)
+    },
+    [params, route],
+  )
+
   const barQuery = useQuery({
     enabled: Boolean(params.pattern || params.tag_definition_id),
     queryFn: () => fetchChartData(params),
@@ -432,8 +489,8 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
   }
 
   const result = barQuery.data
+  const onBarClick = params.source_type === 'activity_type' ? handleBarClick : undefined
 
-  // Breakdown mode: render grouped bar chart with all series
   if (result?.breakdown_buckets?.length) {
     const series = result.breakdown_series ?? []
     return (
@@ -442,6 +499,7 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
         <BarChart
           data={[]}
           height={350}
+          onBarClick={onBarClick}
           multiSeries={series.map((name, i) => ({
             color: SERIES_COLORS[i % SERIES_COLORS.length],
             data: result.breakdown_buckets!.map((b) => ({
@@ -459,7 +517,7 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
 
   return (
     <div class="chart-display">
-      <BarChart data={buckets} color="#8b5cf6" height={350} />
+      <BarChart data={buckets} color="#8b5cf6" height={350} onBarClick={onBarClick} />
     </div>
   )
 }

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -207,23 +207,41 @@ const buildItems = (
   return items.sort((a, b) => a.start.getTime() - b.start.getTime())
 }
 
-const parseUrlState = (
-  query: Record<string, string>,
-): { date: string; from: string | undefined; hidden: Set<ItemType>; to: string | undefined } => {
+interface UrlState {
+  dataFilter: string | undefined
+  date: string
+  from: string | undefined
+  hidden: Set<ItemType>
+  to: string | undefined
+  types: string | undefined
+}
+
+const parseUrlState = (query: Record<string, string>): UrlState => {
   const date = query.date ?? formatISO(new Date(), { representation: 'date' })
   const hideStr = query.hide ?? ''
   const hidden = new Set<ItemType>(hideStr ? (hideStr.split(',') as ItemType[]) : [])
   const from = query.from || undefined
   const to = query.to || undefined
-  return { date, from, hidden, to }
+  const types = query.types || undefined
+  const dataFilter = query.data_filter || undefined
+  return { dataFilter, date, from, hidden, to, types }
 }
 
-const syncUrl = (dateStr: string, hidden: Set<ItemType>, from?: string, to?: string) => {
+const syncUrl = (
+  dateStr: string,
+  hidden: Set<ItemType>,
+  from?: string,
+  to?: string,
+  types?: string,
+  dataFilter?: string,
+) => {
   const params = new URLSearchParams()
   params.set('date', dateStr)
   if (hidden.size > 0) params.set('hide', [...hidden].join(','))
   if (from) params.set('from', from)
   if (to) params.set('to', to)
+  if (types) params.set('types', types)
+  if (dataFilter) params.set('data_filter', dataFilter)
   history.replaceState(null, '', `${window.location.pathname}?${params}`)
 }
 
@@ -236,14 +254,17 @@ export const Data = () => {
   const [hiddenTypes, setHiddenTypes] = useState<Set<ItemType>>(initial.hidden)
   const [timeFrom, setTimeFrom] = useState<string | undefined>(initial.from)
   const [timeTo, setTimeTo] = useState<string | undefined>(initial.to)
+  const [typesFilter, setTypesFilter] = useState<string | undefined>(initial.types)
+  const [dataFilter, setDataFilter] = useState<string | undefined>(initial.dataFilter)
 
   const hasTimeFilter = Boolean(timeFrom || timeTo)
+  const hasDataFilter = Boolean(typesFilter || dataFilter)
   const activeTypes = new Set(ALL_TYPES.filter((t) => !hiddenTypes.has(t)))
 
   // Sync URL on state changes
   useEffect(() => {
-    syncUrl(dateStr, hiddenTypes, timeFrom, timeTo)
-  }, [dateStr, hiddenTypes, timeFrom, timeTo])
+    syncUrl(dateStr, hiddenTypes, timeFrom, timeTo, typesFilter, dataFilter)
+  }, [dateStr, hiddenTypes, timeFrom, timeTo, typesFilter, dataFilter])
 
   // Compute query boundaries — use time filter if present, otherwise full day.
   const start = timeFrom ? new Date(timeFrom) : new Date(`${dateStr}T00:00:00`)
@@ -271,10 +292,16 @@ export const Data = () => {
     setTimeTo(undefined)
   }, [])
 
+  const clearDataFilter = useCallback(() => {
+    setTypesFilter(undefined)
+    setDataFilter(undefined)
+  }, [])
+
+  const activityTypes = typesFilter ? typesFilter.split(',') : undefined
   const activitiesQuery = useQuery({
     enabled: activeTypes.has('activity'),
-    queryFn: () => fetchActivities(start, end),
-    queryKey: ['data-activities', dateStr, timeFrom, timeTo],
+    queryFn: () => fetchActivities(start, end, activityTypes, undefined, dataFilter),
+    queryKey: ['data-activities', dateStr, timeFrom, timeTo, typesFilter, dataFilter],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -357,6 +384,16 @@ export const Data = () => {
               {format(start, 'HH:mm')} – {format(end, 'HH:mm')}
             </span>
             <button type="button" onClick={clearTimeFilter} title="Clear time filter">
+              &times;
+            </button>
+          </div>
+        )}
+        {hasDataFilter && (
+          <div class="data-time-filter">
+            <span>
+              {typesFilter ?? ''} {dataFilter ? `(${dataFilter})` : ''}
+            </span>
+            <button type="button" onClick={clearDataFilter} title="Clear data filter">
               &times;
             </button>
           </div>

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -341,6 +341,7 @@ export const fetchActivities = async (
   end: Date,
   types?: ActivityType[],
   excludeTypes?: string[],
+  dataFilter?: string,
 ): Promise<Activity[]> => {
   const { token } = auth.value
   const params: ActivitiesQuery = {
@@ -348,6 +349,7 @@ export const fetchActivities = async (
     exclude_types: excludeTypes?.join(','),
     start: start.toISOString(),
     types: types?.join(','),
+    ...(dataFilter ? { data_filter: dataFilter } : {}),
   }
   const response = await axios.get<ActivitiesResponse>(`${API_URL}/activities`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -218,6 +218,11 @@ export const activitiesQuerySchema = timeRangeQuerySchema
       description: 'Comma-separated activity types to exclude',
       example: 'sleep,exercise,nap,rest',
     }),
+    data_filter: z.string().optional().meta({
+      description:
+        'Filter by JSONB data field values. Format: "field:value" (comma-separated for multiple). Use "(none)" for null/empty.',
+      example: 'partner:Sara',
+    }),
   })
   .meta({ id: 'ActivitiesQuery' })
 


### PR DESCRIPTION
## Summary

- **Bar chart multi-series tooltips**: Hovering a grouped bar now shows a tooltip with all series values for that bucket, matching the TrendLineChart's tooltip pattern. Non-hovered bars are dimmed for visual focus.
- **Click-to-navigate**: Clicking a bar in the chart navigates to the `/data` page filtered to the matching time range, activity type, and breakdown field value (e.g., `partner:Sara`).
- **Data page filtering**: New `types` and `data_filter` URL params. `data_filter` supports `field:value` format with `(none)` for null values. Active filters shown with a clear button.
- **Backend `data_filter`**: Activities endpoint and MCP tool support JSONB data field filtering with field name sanitization.

## Test plan

- [x] Backend tests pass (1680 tests)
- [x] TypeScript checks pass for backend and web
- [ ] Manual: hover grouped bars → tooltip shows all series values
- [ ] Manual: click a breakdown bar → navigates to /data with correct filters
- [ ] Manual: data page shows filtered activities, clear button works
- [ ] Manual: `data_filter=partner:(none)` shows activities without partner

🤖 Generated with [Claude Code](https://claude.com/claude-code)