### PR TITLE
fix: bar chart real links, hide other types, multi-day dates

### DIFF
--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -2,7 +2,8 @@
  * D3 bar chart component for bucketed chart data.
  *
  * Renders vertical bars with responsive width, tooltip on hover,
- * click-to-navigate support, and smart date formatting based on data density.
+ * real <a> links for navigation (middle-click, right-click, URL preview),
+ * and smart date formatting based on data density.
  */
 import * as d3 from 'd3'
 import { useEffect, useRef } from 'preact/hooks'
@@ -29,8 +30,8 @@ export interface BarChartProps {
   height?: number
   /** Multiple named series — renders grouped bars. Overrides data/color when present. */
   multiSeries?: BarSeriesData[]
-  /** Called when a bar is clicked with bucket and optional series info. */
-  onBarClick?: (info: BarClickInfo) => void
+  /** Returns an href for a bar click — enables real <a> links with middle-click support. */
+  getBarHref?: (info: BarClickInfo) => string
 }
 
 interface ParsedBar {
@@ -113,7 +114,22 @@ function positionTooltip(
   tooltip.style.top = `${margin.top + 8}px`
 }
 
-/** Render single-series bars with tooltip and click. */
+/** Create an SVG <a> wrapper for a bar, or a <g> if no href. Returns d3 selection. */
+function createBarWrapper(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  href: string | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- D3 selection type unions are unwieldy
+): d3.Selection<any, unknown, null, undefined> {
+  if (href) {
+    const a = document.createElementNS('http://www.w3.org/2000/svg', 'a')
+    a.setAttribute('href', href)
+    g.node()!.appendChild(a)
+    return d3.select(a)
+  }
+  return g.append('g')
+}
+
+/** Render single-series bars wrapped in <a> links when getBarHref is provided. */
 function renderBars(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   bars: ParsedBar[],
@@ -125,35 +141,35 @@ function renderBars(
   container: HTMLDivElement,
   margin: { left: number; top: number },
   dateFormat: (date: Date) => string,
-  onBarClick?: (info: BarClickInfo) => void,
+  getBarHref?: (info: BarClickInfo) => string,
 ) {
-  g.selectAll('.bar')
-    .data(bars)
-    .join('rect')
-    .attr('class', 'bar')
-    .attr('x', (d) => x(d.date.toISOString()) ?? 0)
-    .attr('y', (d) => y(d.value))
-    .attr('width', x.bandwidth())
-    .attr('height', (d) => innerHeight - y(d.value))
-    .attr('fill', color)
-    .attr('rx', 2)
-    .style('cursor', onBarClick ? 'pointer' : 'default')
-    .on('mouseenter', (event: MouseEvent, d) => {
-      d3.select(event.target as SVGRectElement).attr('fill-opacity', 0.8)
-      tooltip.textContent = `${dateFormat(d.date)}: ${d.value.toFixed(1)}`
-      tooltip.style.display = 'block'
-    })
-    .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
-    .on('mouseleave', (event: MouseEvent) => {
-      d3.select(event.target as SVGRectElement).attr('fill-opacity', 1)
-      tooltip.style.display = 'none'
-    })
-    .on('click', (_event: MouseEvent, d) => {
-      onBarClick?.({ bucket_start: d.date.toISOString() })
-    })
+  for (const d of bars) {
+    const href = getBarHref?.({ bucket_start: d.date.toISOString() })
+    const wrapper = createBarWrapper(g, href)
+    wrapper
+      .append('rect')
+      .attr('class', 'bar')
+      .attr('x', x(d.date.toISOString()) ?? 0)
+      .attr('y', y(d.value))
+      .attr('width', x.bandwidth())
+      .attr('height', innerHeight - y(d.value))
+      .attr('fill', color)
+      .attr('rx', 2)
+      .style('cursor', getBarHref ? 'pointer' : 'default')
+      .on('mouseenter', (event: MouseEvent) => {
+        d3.select(event.target as SVGRectElement).attr('fill-opacity', 0.8)
+        tooltip.textContent = `${dateFormat(d.date)}: ${d.value.toFixed(1)}`
+        tooltip.style.display = 'block'
+      })
+      .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
+      .on('mouseleave', (event: MouseEvent) => {
+        d3.select(event.target as SVGRectElement).attr('fill-opacity', 1)
+        tooltip.style.display = 'none'
+      })
+  }
 }
 
-/** Render multi-series grouped bars with tooltip and click. */
+/** Render multi-series grouped bars wrapped in <a> links. */
 function renderMultiSeriesBars(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   multiSeries: BarSeriesData[],
@@ -166,7 +182,7 @@ function renderMultiSeriesBars(
   container: HTMLDivElement,
   margin: { left: number; top: number },
   dateFormat: (date: Date) => string,
-  onBarClick?: (info: BarClickInfo) => void,
+  getBarHref?: (info: BarClickInfo) => string,
 ) {
   // Build lookup: bucket -> series -> value
   const bucketValues = new Map<string, Map<string, number>>()
@@ -178,11 +194,9 @@ function renderMultiSeriesBars(
   }
 
   const showBucketTooltip = (bucket: string) => {
-    // Highlight all bars in this bucket
     g.selectAll<SVGRectElement, string>('[data-bucket]').attr('fill-opacity', (b) =>
       b === bucket ? 0.8 : 0.3,
     )
-    // Build tooltip HTML
     const dateLabel = dateFormat(new Date(bucket))
     const values = bucketValues.get(bucket)
     const lines = multiSeries
@@ -203,28 +217,30 @@ function renderMultiSeriesBars(
   for (let si = 0; si < multiSeries.length; si++) {
     const series = multiSeries[si]
     const dataMap = new Map(series.data.map((d) => [d.bucket_start, d.value]))
-    g.selectAll(`.bar-s${si}`)
-      .data(allBuckets)
-      .join('rect')
-      .attr('class', `bar-s${si}`)
-      .attr('data-bucket', (bucket) => bucket)
-      .attr('x', (bucket) => (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
-      .attr('y', (bucket) => y(dataMap.get(bucket) ?? 0))
-      .attr('width', x1.bandwidth())
-      .attr('height', (bucket) => innerHeight - y(dataMap.get(bucket) ?? 0))
-      .attr('fill', series.color)
-      .attr('rx', 1)
-      .style('cursor', onBarClick ? 'pointer' : 'default')
-      .on('mouseenter', (_event: MouseEvent, bucket) => showBucketTooltip(bucket))
-      .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
-      .on('mouseleave', () => hideBucketTooltip())
-      .on('click', (_event: MouseEvent, bucket) => {
-        onBarClick?.({ bucket_start: bucket, series_name: series.name })
-      })
+
+    for (const bucket of allBuckets) {
+      const href = getBarHref?.({ bucket_start: bucket, series_name: series.name })
+      const wrapper = createBarWrapper(g, href)
+      const value = dataMap.get(bucket) ?? 0
+      wrapper
+        .append('rect')
+        .attr('class', `bar-s${si}`)
+        .attr('data-bucket', bucket)
+        .attr('x', (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
+        .attr('y', y(value))
+        .attr('width', x1.bandwidth())
+        .attr('height', innerHeight - y(value))
+        .attr('fill', series.color)
+        .attr('rx', 1)
+        .style('cursor', getBarHref ? 'pointer' : 'default')
+        .on('mouseenter', () => showBucketTooltip(bucket))
+        .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
+        .on('mouseleave', () => hideBucketTooltip())
+    }
   }
 }
 
-export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, onBarClick }: BarChartProps) {
+export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, getBarHref }: BarChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
@@ -287,7 +303,7 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, o
           container,
           margin,
           dateFormat,
-          onBarClick,
+          getBarHref,
         )
       }
     } else {
@@ -326,11 +342,11 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, o
           container,
           margin,
           dateFormat,
-          onBarClick,
+          getBarHref,
         )
       }
     }
-  }, [data, color, height, multiSeries, onBarClick])
+  }, [data, color, height, multiSeries, getBarHref])
 
   if (effectiveData.length === 0) {
     return <div class="bar-chart-placeholder">No data for the selected range</div>

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -440,34 +440,38 @@ const computeBucketEnd = (start: Date, bucketSize: string): Date => {
   return end
 }
 
+/** Build a /data URL for a bar click. */
+const buildBarDataHref = (
+  info: BarClickInfo,
+  pattern: string,
+  bucketSize: string,
+  breakdownFields?: string[],
+): string => {
+  const bucketStart = new Date(info.bucket_start)
+  const bucketEnd = computeBucketEnd(bucketStart, bucketSize)
+
+  const urlParams = new URLSearchParams()
+  urlParams.set('from', bucketStart.toISOString())
+  urlParams.set('to', bucketEnd.toISOString())
+  urlParams.set('date', bucketStart.toISOString().slice(0, 10))
+  urlParams.set('types', pattern)
+  urlParams.set('hide', 'location,music,meal,report,screentime')
+
+  if (info.series_name && breakdownFields?.length) {
+    const values = info.series_name.split(' / ')
+    const filters = breakdownFields.map((field, i) => `${field}:${values[i] ?? '(none)'}`).join(',')
+    urlParams.set('data_filter', filters)
+  }
+
+  return `/data?${urlParams}`
+}
+
 function BarDisplay({ params }: { params: FetchChartDataParams }) {
-  const { route } = useLocation()
-
-  const handleBarClick = useCallback(
-    (info: BarClickInfo) => {
-      if (params.source_type !== 'activity_type' || !params.pattern) return
-
-      const bucketStart = new Date(info.bucket_start)
-      const bucketEnd = computeBucketEnd(bucketStart, params.bucket_size ?? '1d')
-
-      const urlParams = new URLSearchParams()
-      urlParams.set('from', bucketStart.toISOString())
-      urlParams.set('to', bucketEnd.toISOString())
-      urlParams.set('date', bucketStart.toISOString().slice(0, 10))
-      urlParams.set('types', params.pattern)
-
-      if (info.series_name && params.breakdown_fields?.length) {
-        const values = info.series_name.split(' / ')
-        const filters = params.breakdown_fields
-          .map((field, i) => `${field}:${values[i] ?? '(none)'}`)
-          .join(',')
-        urlParams.set('data_filter', filters)
-      }
-
-      route(`/data?${urlParams}`)
-    },
-    [params, route],
-  )
+  const getBarHref =
+    params.source_type === 'activity_type' && params.pattern
+      ? (info: BarClickInfo) =>
+          buildBarDataHref(info, params.pattern!, params.bucket_size ?? '1d', params.breakdown_fields)
+      : undefined
 
   const barQuery = useQuery({
     enabled: Boolean(params.pattern || params.tag_definition_id),
@@ -489,7 +493,6 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
   }
 
   const result = barQuery.data
-  const onBarClick = params.source_type === 'activity_type' ? handleBarClick : undefined
 
   if (result?.breakdown_buckets?.length) {
     const series = result.breakdown_series ?? []
@@ -499,7 +502,7 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
         <BarChart
           data={[]}
           height={350}
-          onBarClick={onBarClick}
+          getBarHref={getBarHref}
           multiSeries={series.map((name, i) => ({
             color: SERIES_COLORS[i % SERIES_COLORS.length],
             data: result.breakdown_buckets!.map((b) => ({
@@ -517,7 +520,7 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
 
   return (
     <div class="chart-display">
-      <BarChart data={buckets} color="#8b5cf6" height={350} onBarClick={onBarClick} />
+      <BarChart data={buckets} color="#8b5cf6" height={350} getBarHref={getBarHref} />
     </div>
   )
 }

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -53,6 +53,10 @@ const SCREENTIME_COLOR = '#8b5cf6'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+/** Format a time, including date prefix when the view spans multiple days. */
+const formatTime = (date: Date, multiDay: boolean): string =>
+  multiDay ? format(date, 'MMM d HH:mm') : format(date, 'HH:mm')
+
 const formatDuration = (start: Date, end: Date): string => {
   const ms = end.getTime() - start.getTime()
   const totalMin = Math.round(ms / 60000)
@@ -76,11 +80,11 @@ const findPrimaryPlace = (start: Date, end: Date, places: Place[]): string | und
   return best?.name
 }
 
-const activityToItem = (a: Activity, places: Place[]): DataItem => {
+const activityToItem = (a: Activity, places: Place[], multiDay: boolean): DataItem => {
   const end = a.end_time ?? new Date(a.start_time.getTime() + 60 * 60000)
   const label = a.title ?? toDisplayName(a.activity_type)
   const location = findPrimaryPlace(a.start_time, end, places)
-  const timeStr = `${format(a.start_time, 'HH:mm')} – ${format(end, 'HH:mm')} · ${formatDuration(a.start_time, end)}`
+  const timeStr = `${formatTime(a.start_time, multiDay)} – ${formatTime(end, multiDay)} · ${formatDuration(a.start_time, end)}`
   return {
     color: ACTIVITY_COLORS[a.activity_type] ?? '#6b7280',
     detail: location ? `${timeStr} · @ ${location}` : timeStr,
@@ -92,9 +96,9 @@ const activityToItem = (a: Activity, places: Place[]): DataItem => {
   }
 }
 
-const placeToItem = (p: Place, dateStr: string): DataItem => ({
+const placeToItem = (p: Place, dateStr: string, multiDay: boolean): DataItem => ({
   color: LOCATION_COLOR,
-  detail: `${format(p.start_time, 'HH:mm')} – ${format(p.end_time, 'HH:mm')} · ${formatDuration(p.start_time, p.end_time)}`,
+  detail: `${formatTime(p.start_time, multiDay)} – ${formatTime(p.end_time, multiDay)} · ${formatDuration(p.start_time, p.end_time)}`,
   end: p.end_time,
   href: `/places?date=${dateStr}&name=${encodeURIComponent(p.region)}`,
   label: p.region,
@@ -102,8 +106,8 @@ const placeToItem = (p: Place, dateStr: string): DataItem => ({
   type: 'location',
 })
 
-const mealToItem = (m: Meal, places: Place[]): DataItem => {
-  const parts = [format(m.time, 'HH:mm')]
+const mealToItem = (m: Meal, places: Place[], multiDay: boolean): DataItem => {
+  const parts = [formatTime(m.time, multiDay)]
   if (m.meal_type) parts.push(m.meal_type)
   if (m.calories) parts.push(`${Math.round(m.calories)} kcal`)
   const location = findPrimaryPlace(m.time, new Date(m.time.getTime() + MEAL_LOCATION_WINDOW_MS), places)
@@ -118,20 +122,20 @@ const mealToItem = (m: Meal, places: Place[]): DataItem => {
   }
 }
 
-const reportToItem = (r: Report): DataItem => ({
+const reportToItem = (r: Report, multiDay: boolean): DataItem => ({
   color: REPORT_COLOR,
-  detail: `${format(r.date, 'HH:mm')} · ${r.entries?.length ?? 0} entries`,
+  detail: `${formatTime(r.date, multiDay)} · ${r.entries?.length ?? 0} entries`,
   href: `/reports/${r.id}`,
   label: r.report_type,
   start: r.date,
   type: 'report',
 })
 
-const productivityToItem = (p: ProductivityRecord, places: Place[]): DataItem => {
+const productivityToItem = (p: ProductivityRecord, places: Place[], multiDay: boolean): DataItem => {
   const dur = Math.round(p.duration_sec / 60)
   const category = p.resolved_category?.join(' > ') ?? p.category ?? ''
   const location = findPrimaryPlace(p.start_time, p.end_time, places)
-  const parts = [`${format(p.start_time, 'HH:mm')} – ${format(p.end_time, 'HH:mm')} · ${dur}m`]
+  const parts = [`${formatTime(p.start_time, multiDay)} – ${formatTime(p.end_time, multiDay)} · ${dur}m`]
   if (category) parts.push(category)
   if (location) parts.push(`@ ${location}`)
   return {
@@ -176,19 +180,20 @@ const buildItems = (
   reports: Report[],
   productivity: ProductivityRecord[],
   dateStr: string,
+  multiDay: boolean,
 ): DataItem[] => {
   const items: DataItem[] = []
   if (activeTypes.has('activity')) {
-    for (const a of activities) items.push(activityToItem(a, places))
+    for (const a of activities) items.push(activityToItem(a, places, multiDay))
   }
   if (activeTypes.has('location')) {
-    for (const p of places) items.push(placeToItem(p, dateStr))
+    for (const p of places) items.push(placeToItem(p, dateStr, multiDay))
   }
   if (activeTypes.has('music')) {
     for (const s of scrobbles) {
       items.push({
         color: MUSIC_COLOR,
-        detail: `${format(s.recorded_at, 'HH:mm')} · ${s.artist}`,
+        detail: `${formatTime(s.recorded_at, multiDay)} · ${s.artist}`,
         label: s.track,
         start: s.recorded_at,
         type: 'music',
@@ -196,13 +201,13 @@ const buildItems = (
     }
   }
   if (activeTypes.has('meal')) {
-    for (const m of meals) items.push(mealToItem(m, places))
+    for (const m of meals) items.push(mealToItem(m, places, multiDay))
   }
   if (activeTypes.has('report')) {
-    for (const r of reports) items.push(reportToItem(r))
+    for (const r of reports) items.push(reportToItem(r, multiDay))
   }
   if (activeTypes.has('screentime')) {
-    for (const p of productivity) items.push(productivityToItem(p, places))
+    for (const p of productivity) items.push(productivityToItem(p, places, multiDay))
   }
   return items.sort((a, b) => a.start.getTime() - b.start.getTime())
 }
@@ -363,6 +368,7 @@ export const Data = () => {
     })
   }
 
+  const multiDay = end.getTime() - start.getTime() > 24 * 60 * 60 * 1000
   const allItems = buildItems(
     activeTypes,
     activitiesQuery.data ?? [],
@@ -372,6 +378,7 @@ export const Data = () => {
     reportsQuery.data ?? [],
     productivityQuery.data?.records ?? [],
     dateStr,
+    multiDay,
   )
 
   return (


### PR DESCRIPTION
## Summary

- **Real `<a>` links**: Bar chart bars are now wrapped in SVG `<a>` elements with proper `href`. Middle-click opens in new tab, right-click shows context menu, URL shows in status bar on hover.
- **Hide other data types**: Navigating from bar chart to `/data` now includes `hide=location,music,meal,report,screentime` so only activities are shown.
- **Multi-day date display**: When the data page view spans multiple days (e.g., from bar chart monthly bucket), timestamps show `MMM d HH:mm` instead of just `HH:mm`.

## Test plan

- [ ] Hover bar → URL shows in browser status bar
- [ ] Middle-click bar → opens /data in new tab with correct filters
- [ ] Left-click bar → navigates to /data showing only activities (other types hidden)
- [ ] Multi-day data view shows date prefix in timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)