### PR TITLE
feat: async Garmin sync and per-activity re-sync detail

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -23,6 +23,7 @@ import { createAuth } from './auth.ts'
 import {
   ackOutboundSync,
   deleteHealthConnectRecords,
+  getActivityById,
   getAllSyncStates,
   getDetectedLocationById,
   getOutboundSyncHistory,
@@ -34,6 +35,7 @@ import {
   insertPlace,
   loginToUserDb,
   makeNewUserDb,
+  markActivityDetailSynced,
   migrateSchema,
   processDailyAggregate,
   processHealthConnectBatch,
@@ -47,6 +49,7 @@ import {
   updateDetectedLocation,
   upsertUserSettings,
 } from './db/index.ts'
+import { processActivityDetail } from './garmin-process.ts'
 import { syncAllGarminData } from './garmin-sync.ts'
 import { garminClient } from './garmin.ts'
 import { syncAllCalendars } from './ical-sync.ts'
@@ -677,7 +680,20 @@ const main = async () => {
   httpd.use('/meals', createMealsRouter(authMiddleware))
   httpd.use('/food-items', createFoodItemsRouter(authMiddleware))
   httpd.use('/reports', createReportsRouter(authMiddleware))
-  httpd.use(createActivitiesRouter(authMiddleware, syncProvider, activityNotifier))
+  httpd.use(
+    createActivitiesRouter(authMiddleware, syncProvider, activityNotifier, async (user, activityId) => {
+      const activity = await getActivityById(user, activityId)
+      if (!activity) throw new Error('Activity not found')
+      const garminActivityId = (activity.data as Record<string, unknown> | undefined)?.garmin_activity_id as
+        | number
+        | undefined
+      if (!garminActivityId) throw new Error('Activity has no Garmin activity ID')
+      const detail = await garmin.getActivityDetail(user, garminActivityId)
+      const points = await processActivityDetail(user, detail)
+      await markActivityDetailSynced(user, activityId)
+      return points
+    }),
+  )
   httpd.use('/activity-types', createActivityTypesRouter(authMiddleware))
   httpd.use(
     '/deduction-rules',

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -23,6 +23,7 @@ import {
   type MergeActivitiesResponse,
   type NearbyActivitiesResponse,
   type ProductivityQuery,
+  type ResyncActivityDetailResponse,
   productivityQuerySchema,
   type ProductivityRecordResponse,
   type ProductivityResponse,
@@ -164,6 +165,7 @@ export const createActivitiesRouter = (
   authMiddleware: RequestHandler,
   syncProvider?: SyncProvider,
   onActivityMutated?: ActivityNotifier,
+  resyncActivityDetail?: (user: string, activityId: string) => Promise<number>,
 ): Router => {
   const router = typedRouter()
 
@@ -674,6 +676,40 @@ export const createActivitiesRouter = (
       }
 
       res.json({ success: true })
+    },
+  )
+
+  router.post<{ id: string }, ResyncActivityDetailResponse>(
+    '/activities/:id/resync-detail',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const { id } = req.params
+
+      if (!resyncActivityDetail) {
+        res.status(501).json({ points: 0, success: false, error: 'Garmin sync not configured' })
+        return
+      }
+
+      const activity = await getActivityById(user, id)
+      if (!activity) {
+        res.status(404).json({ points: 0, success: false, error: 'Activity not found' })
+        return
+      }
+
+      const garminActivityId = (activity.data as Record<string, unknown> | undefined)?.garmin_activity_id
+      if (!garminActivityId) {
+        res.status(400).json({ points: 0, success: false, error: 'Activity has no Garmin activity ID' })
+        return
+      }
+
+      try {
+        const points = await resyncActivityDetail(user, id)
+        res.json({ points, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.status(500).json({ points: 0, success: false, error: message })
+      }
     },
   )
 

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -308,11 +308,12 @@ describe('sync router', () => {
   })
 
   describe('garmin endpoints', () => {
-    test('POST /sync/garmin calls syncGarmin', async () => {
+    test('POST /sync/garmin starts async sync and returns 202', async () => {
       const app = createTestApp()
       const response = await request(app).post('/sync/garmin').send({})
 
-      expect(response.status).toBe(200)
+      expect(response.status).toBe(202)
+      expect(response.body).toMatchObject({ status: 'syncing', success: true })
       expect(mockDeps.syncGarmin).toHaveBeenCalledWith('testuser', {
         disabledTypes: undefined,
         fullResync: undefined,
@@ -326,12 +327,32 @@ describe('sync router', () => {
         .post('/sync/garmin')
         .send({ full_resync: true, start_date: '2024-01-01' })
 
-      expect(response.status).toBe(200)
+      expect(response.status).toBe(202)
+      expect(response.body).toMatchObject({ status: 'syncing', success: true })
       expect(mockDeps.syncGarmin).toHaveBeenCalledWith('testuser', {
         disabledTypes: undefined,
         fullResync: true,
         startDate: new Date('2024-01-01'),
       })
+    })
+
+    test('POST /sync/garmin returns already_syncing when sync is in progress', async () => {
+      vi.mocked(mockDeps.getGarminSyncStates).mockResolvedValueOnce([
+        {
+          error_message: null,
+          last_sync_time: null,
+          provider: 'garmin',
+          retry_after: null,
+          status: 'syncing',
+        },
+      ])
+
+      const app = createTestApp()
+      const response = await request(app).post('/sync/garmin').send({})
+
+      expect(response.status).toBe(202)
+      expect(response.body).toMatchObject({ status: 'already_syncing', success: true })
+      expect(mockDeps.syncGarmin).not.toHaveBeenCalled()
     })
 
     test('GET /sync/garmin/status returns sync states', async () => {

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -259,20 +259,36 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       const { full_resync, start_date } = req.body
 
       try {
+        // Prevent concurrent syncs
+        const states = await deps.getGarminSyncStates(user)
+        if (states.some((s) => s.status === 'syncing')) {
+          res.status(202).json({ status: 'already_syncing', success: true })
+          return
+        }
+
         const settings = await deps.getSettings(user)
-        const results = await deps.syncGarmin(user, {
+        const syncOptions = {
           disabledTypes: settings.garmin_disabled_data_types,
           fullResync: full_resync,
           startDate: start_date ? new Date(start_date) : undefined,
-        })
+        }
 
-        deps.onActivitySynced?.(
-          user,
-          '*',
-          start_date ? new Date(start_date) : new Date(Date.now() - DEFAULT_SYNC_LOOKBACK_MS),
-          new Date(),
-        )
-        res.json({ results, success: true })
+        // Fire-and-forget: run sync in background, return immediately
+        deps
+          .syncGarmin(user, syncOptions)
+          .then(() => {
+            deps.onActivitySynced?.(
+              user,
+              '*',
+              start_date ? new Date(start_date) : new Date(Date.now() - DEFAULT_SYNC_LOOKBACK_MS),
+              new Date(),
+            )
+          })
+          .catch(() => {
+            // Errors are already recorded in sync_state by syncGarminDataType
+          })
+
+        res.status(202).json({ status: 'syncing', success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'
         res.status(500).json({ error: message, success: false })

--- a/apps/web/src/pages/DataSources/GarminSource.tsx
+++ b/apps/web/src/pages/DataSources/GarminSource.tsx
@@ -1,7 +1,7 @@
 import type { GarminDataType, ProviderSyncStatus } from '@aurboda/api-spec'
 
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useState } from 'preact/hooks'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 
 import {
   connectGarmin,
@@ -381,20 +381,38 @@ export function GarminSource() {
 
   const isConnected = userSettings?.garmin_connected ?? false
 
+  // Sync state
+  const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
+  const [syncMessage, setSyncMessage] = useState('')
+
+  // Detect if any data type is currently syncing (drives auto-polling)
+  const shouldPoll = syncStatus === 'syncing'
+
   const { data: syncStatusData, isLoading: syncStatusLoading } = useQuery({
     enabled: !!isLoggedIn && isConnected,
     queryFn: fetchGarminSyncStatus,
     queryKey: ['garminSyncStatus'],
+    refetchInterval: shouldPoll ? 3000 : false,
   })
+
+  const isSyncing = syncStatusData?.states?.some((s) => s.status === 'syncing') ?? false
 
   const [loginStatus, setLoginStatus] = useState<LoginStatus>('idle')
 
   // Disconnect state
   const [disconnecting, setDisconnecting] = useState(false)
 
-  // Sync state
-  const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
-  const [syncMessage, setSyncMessage] = useState('')
+  // When polling detects sync finished, update local state
+  const prevSyncingRef = useRef(false)
+  useEffect(() => {
+    if (prevSyncingRef.current && !isSyncing && syncStatus === 'syncing') {
+      const hasError = syncStatusData?.states?.some((s) => s.status === 'error')
+      setSyncStatus(hasError ? 'error' : 'done')
+      setSyncMessage(hasError ? 'Sync completed with errors' : 'Sync complete')
+      queryClient.invalidateQueries()
+    }
+    prevSyncingRef.current = isSyncing
+  }, [isSyncing, syncStatus, syncStatusData, queryClient])
 
   const handleLoginSuccess = useCallback(async () => {
     setLoginStatus('idle')
@@ -414,19 +432,24 @@ export function GarminSource() {
   }, [queryClient])
 
   const handleSyncNow = useCallback(async () => {
-    await syncGarmin(false)
-    await queryClient.invalidateQueries({ queryKey: ['garminSyncStatus'] })
+    setSyncStatus('syncing')
+    setSyncMessage('')
+    try {
+      await syncGarmin(false)
+      await queryClient.invalidateQueries({ queryKey: ['garminSyncStatus'] })
+    } catch (err) {
+      setSyncStatus('error')
+      setSyncMessage(err instanceof Error ? err.message : 'Sync failed')
+    }
   }, [queryClient])
 
   const handleFullResync = useCallback(async () => {
     setSyncStatus('syncing')
     setSyncMessage('')
     try {
-      const response = await syncGarmin(true)
-      const totalRecords = (response.results ?? []).reduce((sum, r) => sum + (r.records_processed ?? 0), 0)
-      setSyncStatus('done')
-      setSyncMessage(`Synced ${totalRecords} records`)
-      await queryClient.invalidateQueries()
+      await syncGarmin(true)
+      // Sync runs in background — polling will detect completion
+      await queryClient.invalidateQueries({ queryKey: ['garminSyncStatus'] })
     } catch (err) {
       setSyncStatus('error')
       setSyncMessage(err instanceof Error ? err.message : 'Sync failed')

--- a/apps/web/src/pages/DataSources/shared.tsx
+++ b/apps/web/src/pages/DataSources/shared.tsx
@@ -71,6 +71,32 @@ const formatSyncTime = (iso: string): string => {
   })
 }
 
+function SyncStatusText({
+  syncing,
+  lastSyncTime,
+  hasError,
+  warningCount,
+}: {
+  syncing: boolean
+  lastSyncTime?: string | null
+  hasError: boolean
+  warningCount: number
+}) {
+  if (syncing) return <span class="sync-status-time">Syncing...</span>
+
+  const timeText = lastSyncTime ? `Last synced ${formatSyncTime(lastSyncTime)}` : 'Never synced'
+
+  return (
+    <span class="sync-status-time">
+      {timeText}
+      {hasError && <span class="sync-status-error"> (some data types have errors)</span>}
+      {!hasError && warningCount > 0 && (
+        <span class="sync-status-warning"> ({warningCount} data type(s) had partial failures)</span>
+      )}
+    </span>
+  )
+}
+
 /** Shows the most recent sync time across all data types, with a "Sync Now" button. */
 export function SyncStatusBar({
   states,
@@ -81,19 +107,22 @@ export function SyncStatusBar({
   isLoading: boolean
   onSyncNow: () => Promise<void>
 }) {
-  const [syncing, setSyncing] = useState(false)
+  const [localSyncing, setLocalSyncing] = useState(false)
   const [syncResult, setSyncResult] = useState<{ status: 'done' | 'error'; message: string } | null>(null)
 
+  // Detect syncing from backend status (e.g. navigated to page while sync in progress)
+  const backendSyncing = states?.some((s) => s.status === 'syncing') ?? false
+  const syncing = localSyncing || backendSyncing
+
   const handleSync = useCallback(async () => {
-    setSyncing(true)
+    setLocalSyncing(true)
     setSyncResult(null)
     try {
       await onSyncNow()
-      setSyncResult({ status: 'done', message: 'Sync complete' })
     } catch (err) {
       setSyncResult({ status: 'error', message: err instanceof Error ? err.message : 'Sync failed' })
     } finally {
-      setSyncing(false)
+      setLocalSyncing(false)
     }
   }, [onSyncNow])
 
@@ -108,13 +137,12 @@ export function SyncStatusBar({
 
   return (
     <div class="sync-status-bar">
-      <span class="sync-status-time">
-        {lastSync?.last_sync_time ? `Last synced ${formatSyncTime(lastSync.last_sync_time)}` : 'Never synced'}
-        {hasError && <span class="sync-status-error"> (some data types have errors)</span>}
-        {!hasError && warnings.length > 0 && (
-          <span class="sync-status-warning"> ({warnings.length} data type(s) had partial failures)</span>
-        )}
-      </span>
+      <SyncStatusText
+        syncing={syncing}
+        lastSyncTime={lastSync?.last_sync_time}
+        hasError={hasError ?? false}
+        warningCount={warnings.length}
+      />
       <button type="button" class="sync-now-button" disabled={syncing} onClick={handleSync}>
         {syncing && <span class="sync-spinner" />}
         {syncing ? 'Syncing...' : 'Sync Now'}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -21,6 +21,7 @@ import {
   fetchMetricTimeSeries,
   fetchProductivityById,
   fetchScreentimeCategories,
+  resyncActivityDetail,
   updateActivity,
 } from '../../state/api'
 import { toDisplayName } from '../../utils/displayName'
@@ -398,6 +399,45 @@ const makeDraft = (activity: Activity): ActivityDraft => {
 }
 
 /** Activity entity content with edit/save logic. */
+const ResyncDetailButton = ({
+  activity,
+  activityId,
+  onSuccess,
+  isEditing,
+}: {
+  activity: Activity
+  activityId: string
+  onSuccess: () => void
+  isEditing: boolean
+}) => {
+  const mutation = useMutation({
+    mutationFn: () => resyncActivityDetail(activityId),
+    onSuccess,
+  })
+
+  const hasGarminId = Boolean((activity.data as Record<string, unknown> | undefined)?.garmin_activity_id)
+  if (!hasGarminId || isEditing) return null
+
+  return (
+    <div class="entity-actions">
+      <button
+        type="button"
+        class="btn-secondary"
+        disabled={mutation.isPending}
+        onClick={() => mutation.mutate()}
+      >
+        {mutation.isPending ? 'Re-syncing...' : 'Re-sync Garmin Detail'}
+      </button>
+      {mutation.isSuccess && <span class="sync-result done">Synced {mutation.data.points} data points</span>}
+      {mutation.isError && (
+        <span class="sync-result error">
+          {mutation.error instanceof Error ? mutation.error.message : 'Re-sync failed'}
+        </span>
+      )}
+    </div>
+  )
+}
+
 const ActivityContent = ({ entityId }: { entityId: string }) => {
   const queryClient = useQueryClient()
   const isMerged = entityId.startsWith('merged:')
@@ -522,6 +562,12 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         onSave={() => saveMutation.mutate()}
         isSaving={saveMutation.isPending}
         onStartMerging={!activity.deleted_at && !isMergedActivity ? () => setIsMerging(true) : undefined}
+      />
+      <ResyncDetailButton
+        activity={activity}
+        activityId={rawEntityId}
+        onSuccess={invalidate}
+        isEditing={isEditing}
       />
       {isMerging && <MergePanel activityId={rawEntityId} onCancel={() => setIsMerging(false)} />}
       <ActivityDetailContent

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -77,6 +77,7 @@ import type {
   Report as ApiReport,
   ReportResponse,
   ReportsResponse,
+  ResyncActivityDetailResponse,
   ScreentimeCategory,
   ScreentimeCategoryListResponse,
   ScreentimeCategoryResponse,
@@ -1944,5 +1945,15 @@ export const fetchAuditLog = async (params: FetchAuditLogParams = {}): Promise<A
     headers: { Authorization: `Bearer ${token}` },
     params,
   })
+  return response.data
+}
+
+export const resyncActivityDetail = async (activityId: string): Promise<ResyncActivityDetailResponse> => {
+  const { token } = auth.value
+  const response = await axios.post<ResyncActivityDetailResponse>(
+    `${API_URL}/activities/${activityId}/resync-detail`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
   return response.data
 }

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -422,3 +422,14 @@ export const activityDetailResponseSchema = createDataResponseSchema(activitySch
   })
 
 export type ActivityDetailResponse = z.infer<typeof activityDetailResponseSchema>
+
+/**
+ * Re-sync activity detail response.
+ */
+export const resyncActivityDetailResponseSchema = baseResponseSchema
+  .extend({
+    points: z.number().int().meta({ description: 'Number of detail data points synced' }),
+  })
+  .meta({ id: 'ResyncActivityDetailResponse' })
+
+export type ResyncActivityDetailResponse = z.infer<typeof resyncActivityDetailResponseSchema>

--- a/packages/api-spec/src/schemas/sync.ts
+++ b/packages/api-spec/src/schemas/sync.ts
@@ -389,6 +389,10 @@ export type OuraSyncResponse = z.infer<typeof ouraSyncResponseSchema>
 export const garminSyncResponseSchema = baseResponseSchema
   .extend({
     results: z.array(garminSyncResultSchema).optional().meta({ description: 'Sync results per data type' }),
+    status: z
+      .enum(['syncing', 'already_syncing'])
+      .optional()
+      .meta({ description: 'Async sync status — present when sync runs in the background' }),
   })
   .meta({ id: 'GarminSyncResponse' })
 


### PR DESCRIPTION
## Summary
- **Async sync**: `POST /sync/garmin` now returns 202 immediately, runs sync in background. Guards against concurrent syncs (returns `already_syncing`). Frontend polls `GET /sync/garmin/status` every 3s while syncing to show progress.
- **Per-activity re-sync**: New `POST /activities/:id/resync-detail` endpoint re-fetches Garmin detail data (GPS, per-second metrics) for a single activity. "Re-sync Garmin Detail" button on activity detail page for activities with `garmin_activity_id`.
- **SyncStatusBar**: Shows "Syncing..." state when backend reports any data type is syncing (also handles navigating to the page mid-sync).

## Test plan
- [x] sync-router tests pass (44 tests including new concurrent guard test)
- [x] Frontend type check passes
- [x] Backend lint passes
- [ ] Click "Full Re-sync" on Garmin page — returns immediately, shows syncing state
- [ ] Open activity detail for a Garmin activity, click "Re-sync Garmin Detail"

🤖 Generated with [Claude Code](https://claude.com/claude-code)