### PR TITLE
feat: time-positioned bars, EMA warmup, all-time lookback

### DIFF
--- a/apps/backend/src/services/trends.ts
+++ b/apps/backend/src/services/trends.ts
@@ -50,13 +50,14 @@ const calculateMetricTrend = async (
   aggregation: 'mean' | 'sum',
 ): Promise<{ currentValue: number; history: TrendHistoryPoint[] }> => {
   const multiplier = aggregation === 'sum' ? displayPeriodMultipliers[displayPeriod] : 1
+  const warmupDays = lookbackDays + 3 * halfLifeDays
 
   const result = await query(
     user,
     `
     WITH date_range AS (
       SELECT generate_series(
-        CURRENT_DATE - INTERVAL '1 day' * $2::integer,
+        CURRENT_DATE - INTERVAL '1 day' * $6::integer,
         CURRENT_DATE,
         '1 day'
       )::date AS day
@@ -72,29 +73,29 @@ const calculateMetricTrend = async (
           ${aggregation === 'sum' ? 'SUM(value)' : 'AVG(value)'} as daily_value
         FROM time_series
         WHERE metric = $1
-          AND time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+          AND time > CURRENT_DATE - INTERVAL '1 day' * ($6::integer + 1)
         GROUP BY 1
       ) t ON d.day = t.day
     ),
     ema_calc AS (
       SELECT
         dv.day,
-        -- Calculate EMA as weighted average, excluding days with no data
         $4::float * SUM(dv2.daily_value * EXP(-$3::float * (dv.day - dv2.day)::float / $5::float)) /
         NULLIF(SUM(CASE WHEN dv2.daily_value IS NOT NULL THEN EXP(-$3::float * (dv.day - dv2.day)::float / $5::float) ELSE 0 END), 0) as ema_value
       FROM daily_values dv
       CROSS JOIN LATERAL (
         SELECT day, daily_value
         FROM daily_values
-        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * LEAST($2::integer, 90)
+        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * 90
       ) dv2
       GROUP BY dv.day
     )
     SELECT day, ema_value
     FROM ema_calc
+    WHERE day >= CURRENT_DATE - INTERVAL '1 day' * $2::integer
     ORDER BY day
     `,
-    [metric, lookbackDays, LN2, multiplier, halfLifeDays],
+    [metric, lookbackDays, LN2, multiplier, halfLifeDays, warmupDays],
   )
 
   const history: TrendHistoryPoint[] = result.rows
@@ -124,15 +125,14 @@ const calculateProductivityCategoryTrend = async (
   displayPeriod: TrendDisplayPeriod,
 ): Promise<{ currentValue: number; history: TrendHistoryPoint[] }> => {
   const multiplier = displayPeriodMultipliers[displayPeriod]
+  const warmupDays = lookbackDays + 3 * halfLifeDays
 
-  // Convert "Work > Programming" to a PostgreSQL array prefix match.
-  // We use array_to_string to convert resolved_category to a string that starts with the path.
   const result = await query(
     user,
     `
     WITH date_range AS (
       SELECT generate_series(
-        CURRENT_DATE - INTERVAL '1 day' * $2::integer,
+        CURRENT_DATE - INTERVAL '1 day' * $6::integer,
         CURRENT_DATE,
         '1 day'
       )::date AS day
@@ -150,7 +150,7 @@ const calculateProductivityCategoryTrend = async (
         WHERE deleted_at IS NULL
           AND resolved_category IS NOT NULL
           AND array_to_string(resolved_category, ' > ') LIKE $1 || '%'
-          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($6::integer + 1)
         GROUP BY 1
       ) t ON d.day = t.day
     ),
@@ -163,15 +163,16 @@ const calculateProductivityCategoryTrend = async (
       CROSS JOIN LATERAL (
         SELECT day, daily_hours
         FROM daily_values
-        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * LEAST($2::integer, 90)
+        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * 90
       ) dv2
       GROUP BY dv.day
     )
     SELECT day, COALESCE(ema_value, 0) as ema_value
     FROM ema_calc
+    WHERE day >= CURRENT_DATE - INTERVAL '1 day' * $2::integer
     ORDER BY day
     `,
-    [categoryPath, lookbackDays, LN2, multiplier, halfLifeDays],
+    [categoryPath, lookbackDays, LN2, multiplier, halfLifeDays, warmupDays],
   )
 
   const history: TrendHistoryPoint[] = result.rows.map((row) => ({
@@ -199,13 +200,14 @@ const calculateActivityTypeTrend = async (
   displayPeriod: TrendDisplayPeriod,
 ): Promise<{ currentValue: number; history: TrendHistoryPoint[] }> => {
   const multiplier = displayPeriodMultipliers[displayPeriod]
+  const warmupDays = lookbackDays + 3 * halfLifeDays
 
   const result = await query(
     user,
     `
     WITH date_range AS (
       SELECT generate_series(
-        CURRENT_DATE - INTERVAL '1 day' * $2::integer,
+        CURRENT_DATE - INTERVAL '1 day' * $6::integer,
         CURRENT_DATE,
         '1 day'
       )::date AS day
@@ -222,7 +224,7 @@ const calculateActivityTypeTrend = async (
         FROM activities
         WHERE activity_type = $1
           AND deleted_at IS NULL
-          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($6::integer + 1)
         GROUP BY 1
       ) t ON d.day = t.day
     ),
@@ -235,15 +237,16 @@ const calculateActivityTypeTrend = async (
       CROSS JOIN LATERAL (
         SELECT day, daily_hours
         FROM daily_values
-        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * LEAST($2::integer, 90)
+        WHERE day <= dv.day AND day > dv.day - INTERVAL '1 day' * 90
       ) dv2
       GROUP BY dv.day
     )
     SELECT day, COALESCE(ema_value, 0) as ema_value
     FROM ema_calc
+    WHERE day >= CURRENT_DATE - INTERVAL '1 day' * $2::integer
     ORDER BY day
     `,
-    [pattern, lookbackDays, LN2, multiplier, halfLifeDays],
+    [pattern, lookbackDays, LN2, multiplier, halfLifeDays, warmupDays],
   )
 
   const history: TrendHistoryPoint[] = result.rows.map((row) => ({
@@ -269,13 +272,14 @@ const calculateActivityTypeCountTrend = async (
   displayPeriod: TrendDisplayPeriod,
 ): Promise<{ currentValue: number; history: TrendHistoryPoint[] }> => {
   const multiplier = displayPeriodMultipliers[displayPeriod]
+  const warmupDays = lookbackDays + 3 * halfLifeDays
 
   const result = await query(
     user,
     `
     WITH date_range AS (
       SELECT generate_series(
-        CURRENT_DATE - INTERVAL '1 day' * $2::integer,
+        CURRENT_DATE - INTERVAL '1 day' * $6::integer,
         CURRENT_DATE,
         '1 day'
       )::date AS day
@@ -292,7 +296,7 @@ const calculateActivityTypeCountTrend = async (
         FROM activities
         WHERE activity_type = $1
           AND deleted_at IS NULL
-          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
+          AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($6::integer + 1)
         GROUP BY 1
       ) t ON d.day = t.day
     ),
@@ -305,15 +309,16 @@ const calculateActivityTypeCountTrend = async (
       CROSS JOIN LATERAL (
         SELECT day, cnt
         FROM daily_counts
-        WHERE day <= dc.day AND day > dc.day - INTERVAL '1 day' * LEAST($2::integer, 90)
+        WHERE day <= dc.day AND day > dc.day - INTERVAL '1 day' * 90
       ) dc2
       GROUP BY dc.day
     )
     SELECT day, COALESCE(ema_value, 0) as ema_value
     FROM ema_calc
+    WHERE day >= CURRENT_DATE - INTERVAL '1 day' * $2::integer
     ORDER BY day
     `,
-    [pattern, lookbackDays, LN2, multiplier, halfLifeDays],
+    [pattern, lookbackDays, LN2, multiplier, halfLifeDays, warmupDays],
   )
 
   const history: TrendHistoryPoint[] = result.rows.map((row) => ({
@@ -332,14 +337,17 @@ const calculateActivityTypeCountTrend = async (
  * where weight_i = exp(-LN2 * daysAgo / halfLife) and the lookback window is
  * min(lookbackDays, 90).
  */
+/**
+ * @param displayStartIdx Index in `days` where the display range starts. EMA is computed
+ *   from index 0 (warmup period) but only points from displayStartIdx onward are returned.
+ */
 const computeEma = (
   dailyValues: Map<string, number>,
   days: string[],
   halfLifeDays: number,
-  lookbackDays: number,
   multiplier: number,
+  displayStartIdx = 0,
 ): TrendHistoryPoint[] => {
-  const windowDays = Math.min(lookbackDays, 90)
   const history: TrendHistoryPoint[] = []
 
   for (let i = 0; i < days.length; i++) {
@@ -347,7 +355,7 @@ const computeEma = (
     let weightSum = 0
     const currentDay = new Date(days[i]).getTime()
 
-    for (let j = i; j >= 0 && i - j <= windowDays; j--) {
+    for (let j = i; j >= 0 && i - j <= 90; j--) {
       const pastDay = new Date(days[j]).getTime()
       const daysAgo = (currentDay - pastDay) / (1000 * 60 * 60 * 24)
       const weight = Math.exp((-LN2 * daysAgo) / halfLifeDays)
@@ -356,7 +364,7 @@ const computeEma = (
       weightSum += weight
     }
 
-    if (weightSum > 0) {
+    if (weightSum > 0 && i >= displayStartIdx) {
       history.push({ date: days[i], value: (multiplier * weightedSum) / weightSum })
     }
   }
@@ -389,6 +397,7 @@ const calculateActivityTypeBreakdownTrend = async (
       ? 'count(*)'
       : "SUM(EXTRACT(EPOCH FROM (COALESCE(end_time, start_time + interval '1 hour') - start_time))) / 3600.0"
 
+  const warmupDays = lookbackDays + 3 * halfLifeDays
   const result = await query(
     user,
     `SELECT date_trunc('day', start_time AT TIME ZONE 'UTC')::date AS day,
@@ -400,7 +409,7 @@ const calculateActivityTypeBreakdownTrend = async (
         AND start_time > CURRENT_DATE - INTERVAL '1 day' * ($2::integer + 1)
       GROUP BY 1, ${fieldGroupBys.join(', ')}
       ORDER BY 1`,
-    [pattern, lookbackDays],
+    [pattern, warmupDays],
   )
 
   // Build per-series daily values
@@ -415,21 +424,23 @@ const calculateActivityTypeBreakdownTrend = async (
     seriesDaily.get(seriesKey)!.set(day, value)
   }
 
-  // Generate full date range
+  // Generate full date range including warmup period
+  const warmupCount = 3 * halfLifeDays
   const days: string[] = []
   const now = new Date()
   now.setUTCHours(0, 0, 0, 0)
-  for (let d = lookbackDays; d >= 0; d--) {
+  for (let d = warmupDays; d >= 0; d--) {
     const date = new Date(now)
     date.setUTCDate(date.getUTCDate() - d)
     days.push(date.toISOString().split('T')[0])
   }
 
-  // Compute EMA per series
+  // Compute EMA per series — warmup period is excluded from output
+  const displayStartIdx = warmupCount
   const series = [...seriesDaily.keys()].sort()
   const histories: Record<string, TrendHistoryPoint[]> = {}
   for (const s of series) {
-    histories[s] = computeEma(seriesDaily.get(s)!, days, halfLifeDays, lookbackDays, multiplier)
+    histories[s] = computeEma(seriesDaily.get(s)!, days, halfLifeDays, multiplier, displayStartIdx)
   }
 
   return { histories, series }

--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -1,9 +1,8 @@
 /**
  * D3 bar chart component for bucketed chart data.
  *
- * Renders vertical bars with responsive width, tooltip on hover,
- * real <a> links for navigation (middle-click, right-click, URL preview),
- * and smart date formatting based on data density.
+ * Uses time-based x-axis positioning so bars are placed at their actual dates
+ * with proportional widths and gaps for missing buckets.
  */
 import * as d3 from 'd3'
 import { useEffect, useRef } from 'preact/hooks'
@@ -21,16 +20,16 @@ export interface BarClickInfo {
   series_name?: string
 }
 
+export type BucketSize = '1m' | '5m' | '15m' | '1h' | '1d' | '1w' | '1M'
+
 export interface BarChartProps {
-  /** Bucketed data points (single series). */
   data: { bucket_start: string; value: number }[]
-  /** Bar fill colour (default '#8b5cf6'). */
   color?: string
-  /** Chart height in pixels (default 300). */
   height?: number
-  /** Multiple named series — renders grouped bars. Overrides data/color when present. */
+  bucketSize?: BucketSize
+  rangeStart?: string
+  rangeEnd?: string
   multiSeries?: BarSeriesData[]
-  /** Returns an href for a bar click — enables real <a> links with middle-click support. */
   getBarHref?: (info: BarClickInfo) => string
 }
 
@@ -39,48 +38,28 @@ interface ParsedBar {
   value: number
 }
 
-/** Pick a d3 time format based on total time span. */
+/** Bucket size in milliseconds (approximate for month). */
+const bucketSizeMs = (size: BucketSize): number => {
+  const ms = {
+    '1M': 30 * 86400000,
+    '1d': 86400000,
+    '1h': 3600000,
+    '1m': 60000,
+    '1w': 7 * 86400000,
+    '5m': 300000,
+    '15m': 900000,
+  }
+  return ms[size] ?? 86400000
+}
+
 const buildBarDateFormat = (extent: [Date, Date]) => {
-  const spanMs = extent[1].getTime() - extent[0].getTime()
-  const spanDays = spanMs / (1000 * 60 * 60 * 24)
+  const spanDays = (extent[1].getTime() - extent[0].getTime()) / 86400000
   if (spanDays < 2) return d3.timeFormat('%H:%M')
   if (spanDays < 7) return d3.timeFormat('%b %d %H:%M')
   if (spanDays > 365) return d3.timeFormat("%b '%y")
-  if (spanDays > 60) return d3.timeFormat('%b %d')
   return d3.timeFormat('%b %d')
 }
 
-/** Render axes. */
-function renderAxes(
-  g: d3.Selection<SVGGElement, unknown, null, undefined>,
-  x: d3.ScaleBand<string>,
-  y: d3.ScaleLinear<number, number>,
-  bars: ParsedBar[],
-  innerWidth: number,
-  innerHeight: number,
-  dateFormat: (date: Date) => string,
-) {
-  const maxTicks = Math.min(bars.length, 10)
-  const tickInterval = Math.max(1, Math.ceil(bars.length / maxTicks))
-  const tickValues = bars.filter((_, i) => i % tickInterval === 0).map((d) => d.date.toISOString())
-
-  g.append('g')
-    .attr('transform', `translate(0,${innerHeight})`)
-    .call(
-      d3
-        .axisBottom(x)
-        .tickValues(tickValues)
-        .tickFormat((d) => dateFormat(new Date(d))),
-    )
-    .selectAll('text')
-    .attr('font-size', '11px')
-    .attr('text-anchor', 'end')
-    .attr('transform', 'rotate(-35)')
-
-  g.append('g').call(d3.axisLeft(y).ticks(5)).selectAll('text').attr('font-size', '11px')
-}
-
-/** Render grid lines behind bars. */
 function renderGrid(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   y: d3.ScaleLinear<number, number>,
@@ -99,7 +78,24 @@ function renderGrid(
     .attr('stroke-dasharray', '3,3')
 }
 
-/** Position a tooltip with smart left/right flip. */
+function renderTimeAxes(
+  g: d3.Selection<SVGGElement, unknown, null, undefined>,
+  x: d3.ScaleTime<number, number>,
+  y: d3.ScaleLinear<number, number>,
+  innerWidth: number,
+  innerHeight: number,
+) {
+  g.append('g')
+    .attr('transform', `translate(0,${innerHeight})`)
+    .call(d3.axisBottom(x).ticks(8))
+    .selectAll('text')
+    .attr('font-size', '11px')
+    .attr('text-anchor', 'end')
+    .attr('transform', 'rotate(-35)')
+
+  g.append('g').call(d3.axisLeft(y).ticks(5)).selectAll('text').attr('font-size', '11px')
+}
+
 function positionTooltip(
   event: MouseEvent,
   container: HTMLDivElement,
@@ -114,11 +110,10 @@ function positionTooltip(
   tooltip.style.top = `${margin.top + 8}px`
 }
 
-/** Create an SVG <a> wrapper for a bar, or a <g> if no href. Returns d3 selection. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- D3 selection type unions are unwieldy
 function createBarWrapper(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   href: string | undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- D3 selection type unions are unwieldy
 ): d3.Selection<any, unknown, null, undefined> {
   if (href) {
     const a = document.createElementNS('http://www.w3.org/2000/svg', 'a')
@@ -129,13 +124,13 @@ function createBarWrapper(
   return g.append('g')
 }
 
-/** Render single-series bars wrapped in <a> links when getBarHref is provided. */
 function renderBars(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   bars: ParsedBar[],
-  x: d3.ScaleBand<string>,
+  x: d3.ScaleTime<number, number>,
   y: d3.ScaleLinear<number, number>,
   innerHeight: number,
+  barWidth: number,
   color: string,
   tooltip: HTMLDivElement,
   container: HTMLDivElement,
@@ -149,10 +144,10 @@ function renderBars(
     wrapper
       .append('rect')
       .attr('class', 'bar')
-      .attr('x', x(d.date.toISOString()) ?? 0)
+      .attr('x', x(d.date))
       .attr('y', y(d.value))
-      .attr('width', x.bandwidth())
-      .attr('height', innerHeight - y(d.value))
+      .attr('width', Math.max(barWidth, 1))
+      .attr('height', Math.max(innerHeight - y(d.value), 0))
       .attr('fill', color)
       .attr('rx', 2)
       .style('cursor', getBarHref ? 'pointer' : 'default')
@@ -169,22 +164,23 @@ function renderBars(
   }
 }
 
-/** Render multi-series grouped bars wrapped in <a> links. */
 function renderMultiSeriesBars(
   g: d3.Selection<SVGGElement, unknown, null, undefined>,
   multiSeries: BarSeriesData[],
-  allBuckets: string[],
-  x0: d3.ScaleBand<string>,
-  x1: d3.ScaleBand<string>,
+  allBuckets: Date[],
+  x: d3.ScaleTime<number, number>,
   y: d3.ScaleLinear<number, number>,
   innerHeight: number,
+  barWidth: number,
   tooltip: HTMLDivElement,
   container: HTMLDivElement,
   margin: { left: number; top: number },
   dateFormat: (date: Date) => string,
   getBarHref?: (info: BarClickInfo) => string,
 ) {
-  // Build lookup: bucket -> series -> value
+  const seriesCount = multiSeries.length
+  const subBarWidth = Math.max(barWidth / seriesCount - 1, 1)
+
   const bucketValues = new Map<string, Map<string, number>>()
   for (const series of multiSeries) {
     for (const d of series.data) {
@@ -193,12 +189,12 @@ function renderMultiSeriesBars(
     }
   }
 
-  const showBucketTooltip = (bucket: string) => {
-    g.selectAll<SVGRectElement, string>('[data-bucket]').attr('fill-opacity', (b) =>
-      b === bucket ? 0.8 : 0.3,
-    )
-    const dateLabel = dateFormat(new Date(bucket))
-    const values = bucketValues.get(bucket)
+  const showBucketTooltip = (bucketIso: string) => {
+    g.selectAll<SVGRectElement, unknown>('[data-bucket]').attr('fill-opacity', function () {
+      return this.getAttribute('data-bucket') === bucketIso ? 0.8 : 0.3
+    })
+    const dateLabel = dateFormat(new Date(bucketIso))
+    const values = bucketValues.get(bucketIso)
     const lines = multiSeries
       .map((s) => {
         const v = values?.get(s.name) ?? 0
@@ -218,29 +214,39 @@ function renderMultiSeriesBars(
     const series = multiSeries[si]
     const dataMap = new Map(series.data.map((d) => [d.bucket_start, d.value]))
 
-    for (const bucket of allBuckets) {
-      const href = getBarHref?.({ bucket_start: bucket, series_name: series.name })
+    for (const bucketDate of allBuckets) {
+      const bucketIso = bucketDate.toISOString()
+      const value = dataMap.get(bucketIso) ?? 0
+      const href = getBarHref?.({ bucket_start: bucketIso, series_name: series.name })
       const wrapper = createBarWrapper(g, href)
-      const value = dataMap.get(bucket) ?? 0
       wrapper
         .append('rect')
         .attr('class', `bar-s${si}`)
-        .attr('data-bucket', bucket)
-        .attr('x', (x0(bucket) ?? 0) + (x1(series.name) ?? 0))
+        .attr('data-bucket', bucketIso)
+        .attr('x', x(bucketDate) + si * (subBarWidth + 1))
         .attr('y', y(value))
-        .attr('width', x1.bandwidth())
-        .attr('height', innerHeight - y(value))
+        .attr('width', Math.max(subBarWidth, 1))
+        .attr('height', Math.max(innerHeight - y(value), 0))
         .attr('fill', series.color)
         .attr('rx', 1)
         .style('cursor', getBarHref ? 'pointer' : 'default')
-        .on('mouseenter', () => showBucketTooltip(bucket))
+        .on('mouseenter', () => showBucketTooltip(bucketIso))
         .on('mousemove', (event: MouseEvent) => positionTooltip(event, container, tooltip, margin))
         .on('mouseleave', () => hideBucketTooltip())
     }
   }
 }
 
-export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, getBarHref }: BarChartProps) {
+export function BarChart({
+  data,
+  color = '#8b5cf6',
+  height = 300,
+  bucketSize = '1d',
+  rangeStart,
+  rangeEnd,
+  multiSeries,
+  getBarHref,
+}: BarChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
@@ -261,21 +267,20 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, g
     const margin = { bottom: 50, left: 50, right: 20, top: 20 }
     const innerWidth = chartWidth - margin.left - margin.right
     const innerHeight = chartHeight - margin.top - margin.bottom
+    const bMs = bucketSizeMs(bucketSize)
 
     if (multiSeries && multiSeries.length > 0) {
-      const allBuckets = [...new Set(multiSeries.flatMap((s) => s.data.map((d) => d.bucket_start)))].sort()
-      if (allBuckets.length === 0) return
+      const allBucketStrs = [...new Set(multiSeries.flatMap((s) => s.data.map((d) => d.bucket_start)))].sort()
+      if (allBucketStrs.length === 0) return
+      const allBuckets = allBucketStrs.map((s) => new Date(s))
 
-      const bars: ParsedBar[] = allBuckets.map((b) => ({ date: new Date(b), value: 0 }))
-      const seriesCount = multiSeries.length
+      const xMin = rangeStart ? new Date(rangeStart) : new Date(allBuckets[0].getTime() - bMs * 0.5)
+      const xMax = rangeEnd
+        ? new Date(rangeEnd)
+        : new Date(allBuckets[allBuckets.length - 1].getTime() + bMs * 1.5)
+      const x = d3.scaleTime().domain([xMin, xMax]).range([0, innerWidth])
 
-      const x0 = d3.scaleBand<string>().domain(allBuckets).range([0, innerWidth]).padding(0.15)
-      const x1 = d3
-        .scaleBand<string>()
-        .domain(multiSeries.map((s) => s.name))
-        .range([0, x0.bandwidth()])
-        .padding(seriesCount > 3 ? 0.02 : 0.08)
-
+      const barWidth = Math.max(x(new Date(xMin.getTime() + bMs)) - x(xMin) - 2, 2)
       const yMax = d3.max(multiSeries, (s) => d3.max(s.data, (d) => d.value)) ?? 1
       const y = d3
         .scaleLinear()
@@ -284,25 +289,22 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, g
         .range([innerHeight, 0])
 
       const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-      const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
-      const dateFormat = buildBarDateFormat(dateExtent)
-
       renderGrid(g, y, innerWidth)
-      renderAxes(g, x0, y, bars, innerWidth, innerHeight, dateFormat)
+      renderTimeAxes(g, x, y, innerWidth, innerHeight)
 
       if (tooltipRef.current) {
         renderMultiSeriesBars(
           g,
           multiSeries,
           allBuckets,
-          x0,
-          x1,
+          x,
           y,
           innerHeight,
+          barWidth,
           tooltipRef.current,
           container,
           margin,
-          dateFormat,
+          buildBarDateFormat([xMin, xMax]),
           getBarHref,
         )
       }
@@ -310,12 +312,11 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, g
       if (data.length === 0) return
 
       const bars: ParsedBar[] = data.map((d) => ({ date: new Date(d.bucket_start), value: d.value }))
-      const x = d3
-        .scaleBand<string>()
-        .domain(bars.map((d) => d.date.toISOString()))
-        .range([0, innerWidth])
-        .padding(0.2)
+      const xMin = rangeStart ? new Date(rangeStart) : new Date(bars[0].date.getTime() - bMs * 0.5)
+      const xMax = rangeEnd ? new Date(rangeEnd) : new Date(bars[bars.length - 1].date.getTime() + bMs * 1.5)
+      const x = d3.scaleTime().domain([xMin, xMax]).range([0, innerWidth])
 
+      const barWidth = Math.max(x(new Date(xMin.getTime() + bMs)) - x(xMin) - 2, 2)
       const yMax = d3.max(bars, (d) => d.value) ?? 1
       const y = d3
         .scaleLinear()
@@ -324,11 +325,8 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, g
         .range([innerHeight, 0])
 
       const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-      const dateExtent = d3.extent(bars, (d) => d.date) as [Date, Date]
-      const dateFormat = buildBarDateFormat(dateExtent)
-
       renderGrid(g, y, innerWidth)
-      renderAxes(g, x, y, bars, innerWidth, innerHeight, dateFormat)
+      renderTimeAxes(g, x, y, innerWidth, innerHeight)
 
       if (tooltipRef.current) {
         renderBars(
@@ -337,16 +335,17 @@ export function BarChart({ data, color = '#8b5cf6', height = 300, multiSeries, g
           x,
           y,
           innerHeight,
+          barWidth,
           color,
           tooltipRef.current,
           container,
           margin,
-          dateFormat,
+          buildBarDateFormat([xMin, xMax]),
           getBarHref,
         )
       }
     }
-  }, [data, color, height, multiSeries, getBarHref])
+  }, [data, color, height, multiSeries, getBarHref, bucketSize, rangeStart, rangeEnd])
 
   if (effectiveData.length === 0) {
     return <div class="bar-chart-placeholder">No data for the selected range</div>

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -41,6 +41,7 @@ const LOOKBACK_OPTIONS = [
   { label: '180 days', value: 180 },
   { label: '1 year', value: 365 },
   { label: '2 years', value: 730 },
+  { label: 'All time', value: 3650 },
 ]
 
 const HALF_LIFE_OPTIONS = [
@@ -502,6 +503,9 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
         <BarChart
           data={[]}
           height={350}
+          bucketSize={params.bucket_size}
+          rangeStart={params.start}
+          rangeEnd={params.end}
           getBarHref={getBarHref}
           multiSeries={series.map((name, i) => ({
             color: SERIES_COLORS[i % SERIES_COLORS.length],
@@ -520,7 +524,15 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
 
   return (
     <div class="chart-display">
-      <BarChart data={buckets} color="#8b5cf6" height={350} getBarHref={getBarHref} />
+      <BarChart
+        data={buckets}
+        color="#8b5cf6"
+        height={350}
+        bucketSize={params.bucket_size}
+        rangeStart={params.start}
+        rangeEnd={params.end}
+        getBarHref={getBarHref}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Time-positioned bar chart**: Bars are now placed at their actual dates using `scaleTime` instead of `scaleBand`. Empty time periods show as gaps. Bar widths are proportional to bucket_size.
- **EMA warmup**: Trend calculations now extend the date range by 3x half_life beyond the display range, so trend lines start at a realistic value instead of 0. Applied to all 4 SQL trend functions and the TypeScript breakdown EMA.
- **All-time lookback**: Added "All time" (10 years) option to the lookback selector.

## Test plan

- [x] All 1683 backend tests pass
- [x] TypeScript checks pass for backend and web
- [ ] Manual: bar chart shows gaps for days without data
- [ ] Manual: hourly buckets show narrow bars at correct positions
- [ ] Manual: trend lines no longer start from 0 on first day
- [ ] Manual: "All time" lookback shows full history

🤖 Generated with [Claude Code](https://claude.com/claude-code)