### PR TITLE
fix: weekly tooltip, shared activity picker, auto-redirect single

### DIFF
--- a/apps/web/src/components/charts/BarChart.tsx
+++ b/apps/web/src/components/charts/BarChart.tsx
@@ -52,7 +52,9 @@ const bucketSizeMs = (size: BucketSize): number => {
   return ms[size] ?? 86400000
 }
 
-const buildBarDateFormat = (extent: [Date, Date]) => {
+const buildBarDateFormat = (extent: [Date, Date], bucketSize: BucketSize) => {
+  if (bucketSize === '1w') return (d: Date) => `Week of ${d3.timeFormat('%b %d')(d)}`
+  if (bucketSize === '1M') return d3.timeFormat("%b '%y")
   const spanDays = (extent[1].getTime() - extent[0].getTime()) / 86400000
   if (spanDays < 2) return d3.timeFormat('%H:%M')
   if (spanDays < 7) return d3.timeFormat('%b %d %H:%M')
@@ -304,7 +306,7 @@ export function BarChart({
           tooltipRef.current,
           container,
           margin,
-          buildBarDateFormat([xMin, xMax]),
+          buildBarDateFormat([xMin, xMax], bucketSize),
           getBarHref,
         )
       }
@@ -340,7 +342,7 @@ export function BarChart({
           tooltipRef.current,
           container,
           margin,
-          buildBarDateFormat([xMin, xMax]),
+          buildBarDateFormat([xMin, xMax], bucketSize),
           getBarHref,
         )
       }

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -12,6 +12,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation } from 'preact-iso'
 import { useCallback, useMemo, useState } from 'preact/hooks'
 
+import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { BarChart, type BarClickInfo } from '../../components/charts/BarChart'
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { MetricPicker } from '../../components/MetricPicker'
@@ -185,19 +186,11 @@ function SourcePicker({
         ) : state.source_type === 'activity_type' ? (
           <>
             Activity Type
-            <select
+            <ActivityTypePicker
               value={state.pattern}
-              onChange={(e) =>
-                onUpdate({ breakdown_fields: [], pattern: (e.target as HTMLSelectElement).value })
-              }
-            >
-              <option value="">-- select --</option>
-              {activityTypes.map((d) => (
-                <option key={d.name} value={d.name}>
-                  {d.display_name} ({d.name})
-                </option>
-              ))}
-            </select>
+              onChange={(pattern) => onUpdate({ breakdown_fields: [], pattern })}
+              placeholder="Search activity types..."
+            />
           </>
         ) : (
           <>

--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -256,7 +256,7 @@ const syncUrl = (
 
 // eslint-disable-next-line complexity -- data page with multiple query sources
 export const Data = () => {
-  const { query } = useLocation()
+  const { query, route } = useLocation()
   const initial = parseUrlState(query)
 
   const [dateStr, setDateStr] = useState(initial.date)
@@ -378,6 +378,15 @@ export const Data = () => {
       return next
     })
   }
+
+  // Auto-redirect to detail page when chart click leads to exactly 1 activity
+  const activitiesLoaded = !activitiesQuery.isLoading && activitiesQuery.data
+  useEffect(() => {
+    if (hasDataFilter && activitiesLoaded && activitiesQuery.data?.length === 1) {
+      const activity = activitiesQuery.data[0]
+      if (activity.id) route(`/detail/activity/${activity.id}`)
+    }
+  }, [hasDataFilter, activitiesLoaded, activitiesQuery.data, route])
 
   const multiDay = end.getTime() - start.getTime() > 24 * 60 * 60 * 1000
   const allItems = buildItems(


### PR DESCRIPTION
## Summary

- **Weekly tooltip format**: Bar chart tooltip shows "Week of Nov 14" for weekly buckets instead of ambiguous "Nov '24". Monthly shows "Nov '24" regardless of span.
- **Shared ActivityTypePicker**: Chart page now uses the same searchable activity type picker as the Add page — with search, icons, and create-new support.
- **Auto-redirect to detail**: When navigating from a chart bar click and only 1 activity matches, auto-redirects to the activity detail page.

## Test plan

- [ ] Weekly bucket tooltip shows "Week of Nov 14" format
- [ ] Monthly bucket tooltip shows "Nov '24"
- [ ] Chart activity type selector is searchable
- [ ] Click bar with single activity → auto-redirects to detail page
- [ ] Click bar with multiple activities → stays on data listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)