### PR TITLE
fix: use specific activity types from Garmin sync

### DIFF
--- a/apps/backend/src/db/activities.ts
+++ b/apps/backend/src/db/activities.ts
@@ -800,3 +800,22 @@ export const updateActivityTypeByTagKey = async (
   )
   return result.rowCount ?? 0
 }
+
+/**
+ * Migrate activities with generic 'exercise' type to their specific type from data.activity_type_key.
+ * Also cleans up redundant exercise type fields from the data JSONB.
+ * Returns the number of activities updated.
+ */
+export const migrateExerciseTypes = async (user: string): Promise<number> => {
+  const result = await query(
+    user,
+    `UPDATE activities
+     SET activity_type = data->>'activity_type_key',
+         data = data - 'activity_type_key' - 'exerciseType' - 'exerciseTypeName'
+     WHERE activity_type = 'exercise'
+       AND data->>'activity_type_key' IS NOT NULL
+       AND data->>'activity_type_key' != 'unknown'
+       AND deleted_at IS NULL`,
+  )
+  return result.rowCount ?? 0
+}

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -124,6 +124,7 @@ export {
   getActivitiesExcludingCategories,
   getActivitiesNeedingDetail,
   getAllActivitiesInRange,
+  migrateExerciseTypes,
   getNonSleepActivitiesMerged,
   getAllActivityTypeNames,
   getActivityById,

--- a/apps/backend/src/garmin-process.test.ts
+++ b/apps/backend/src/garmin-process.test.ts
@@ -674,9 +674,8 @@ describe('processGarminData', () => {
       const endTime = new Date(startTime.getTime() + 1800 * 1000)
 
       expect(mockDeps.insertActivity).toHaveBeenCalledWith(user, {
-        activity_type: 'exercise',
+        activity_type: 'running',
         data: {
-          activity_type_key: 'running',
           average_hr: 145,
           calories: 350,
           distance: 5000,
@@ -720,11 +719,11 @@ describe('processGarminData', () => {
       expect(activityArg.title).toBe('running')
     })
 
-    test('uses "unknown" when activityType is missing', async () => {
+    test('uses "unknown" as activity_type when activityType is missing', async () => {
       await processGarminData(user, 'activities', [makeActivity({ activityType: null })], mockDeps)
 
       const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
-      expect((activityArg.data as Record<string, unknown>).activity_type_key).toBe('unknown')
+      expect(activityArg.activity_type).toBe('unknown')
     })
 
     test('processes multiple activities and returns count', async () => {
@@ -787,11 +786,11 @@ describe('processGarminData', () => {
       expect(activityArg.activity_type).toBe('meditation')
     })
 
-    test('maps running typeKey to exercise activity_type', async () => {
+    test('maps running typeKey to running activity_type', async () => {
       await processGarminData(user, 'activities', [makeActivity()], mockDeps)
 
       const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
-      expect(activityArg.activity_type).toBe('exercise')
+      expect(activityArg.activity_type).toBe('running')
     })
 
     test('calls deleteGarminActivityWithWrongType before insert', async () => {

--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -83,8 +83,10 @@ const defaultDeps: GarminProcessDeps = {
   softDeleteLocationRange,
 }
 
-/** Garmin activity typeKeys that map to the 'meditation' activity type. */
-const meditationTypeKeys = new Set(['meditation', 'breathwork'])
+/** Garmin activity typeKeys that should be mapped to a different activity type name. */
+const garminTypeKeyOverrides: Record<string, string> = {
+  breathwork: 'meditation',
+}
 
 // ============================================================================
 // Main dispatcher
@@ -412,7 +414,7 @@ const processActivities = async (
     await deps.insertRawRecord(user, makeRaw('garmin_activity', externalId, startTime, act))
 
     const activityTypeKey = act.activityType?.typeKey ?? 'unknown'
-    const activityType = meditationTypeKeys.has(activityTypeKey) ? 'meditation' : 'exercise'
+    const activityType = garminTypeKeyOverrides[activityTypeKey] ?? activityTypeKey
     const exerciseTitle = act.activityName || activityTypeKey
 
     // Clean up any existing activity with a different type (handles re-sync after type mapping changes)
@@ -421,7 +423,6 @@ const processActivities = async (
     const activity: Activity = {
       activity_type: activityType,
       data: {
-        activity_type_key: activityTypeKey,
         average_hr: act.averageHR,
         calories: act.calories,
         distance: act.distance,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -43,6 +43,7 @@ import {
   getAllActivityTypeNames,
   getDeductionRule,
   getDistinctApps,
+  migrateExerciseTypes,
   getNearbyActivities,
   getOverlappingActivities,
   getProductivityBucketed,
@@ -735,6 +736,12 @@ export const createActivitiesRouter = (
       res.json({ categories: result.categories, data: result.data, success: true })
     },
   )
+
+  router.post('/activities/migrate-exercise-types', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const count = await migrateExerciseTypes(user)
+    res.json({ data: { updated: count }, success: true })
+  })
 
   return router as unknown as Router
 }


### PR DESCRIPTION
## Summary

Garmin sync was mapping all activities to generic `exercise` type, with the specific type only stored in `data.activity_type_key`. This caused charts for specific types (like `strength_training`) to miss activities.

- **Garmin sync fix**: Now maps each activity to its specific type (`yoga`, `running`, `walking`, `strength_training`, etc.) directly in the `activity_type` column. Only `breathwork` is remapped to `meditation`.
- **Removed `activity_type_key`** from the data JSONB field (redundant with `activity_type`)
- **Migration endpoint**: `POST /activities/migrate-exercise-types` updates existing activities, moving `data.activity_type_key` to `activity_type` and cleaning up `exerciseType`/`exerciseTypeName` from data

After deploying, call the migration endpoint to fix existing activities.

## Test plan

- [x] All 1684 backend tests pass
- [ ] Manual: trigger Garmin re-sync → new activities get specific types
- [ ] Manual: call POST /activities/migrate-exercise-types → existing activities updated
- [ ] Manual: strength_training chart now shows all historical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)