### PR TITLE
fix: resync-detail searches merged sources for garmin ID

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -23,7 +23,6 @@ import { createAuth } from './auth.ts'
 import {
   ackOutboundSync,
   deleteHealthConnectRecords,
-  getActivityById,
   getAllSyncStates,
   getDetectedLocationById,
   getOutboundSyncHistory,
@@ -681,18 +680,17 @@ const main = async () => {
   httpd.use('/food-items', createFoodItemsRouter(authMiddleware))
   httpd.use('/reports', createReportsRouter(authMiddleware))
   httpd.use(
-    createActivitiesRouter(authMiddleware, syncProvider, activityNotifier, async (user, activityId) => {
-      const activity = await getActivityById(user, activityId)
-      if (!activity) throw new Error('Activity not found')
-      const garminActivityId = (activity.data as Record<string, unknown> | undefined)?.garmin_activity_id as
-        | number
-        | undefined
-      if (!garminActivityId) throw new Error('Activity has no Garmin activity ID')
-      const detail = await garmin.getActivityDetail(user, garminActivityId)
-      const points = await processActivityDetail(user, detail)
-      await markActivityDetailSynced(user, activityId)
-      return points
-    }),
+    createActivitiesRouter(
+      authMiddleware,
+      syncProvider,
+      activityNotifier,
+      async (user, activityId, garminActivityId) => {
+        const detail = await garmin.getActivityDetail(user, garminActivityId)
+        const points = await processActivityDetail(user, detail)
+        await markActivityDetailSynced(user, activityId)
+        return points
+      },
+    ),
   )
   httpd.use('/activity-types', createActivityTypesRouter(authMiddleware))
   httpd.use(

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -685,9 +685,25 @@ const main = async () => {
       syncProvider,
       activityNotifier,
       async (user, activityId, garminActivityId) => {
-        const detail = await garmin.getActivityDetail(user, garminActivityId)
-        const points = await processActivityDetail(user, detail)
-        await markActivityDetailSynced(user, activityId)
+        let detail
+        try {
+          detail = await garmin.getActivityDetail(user, garminActivityId)
+        } catch (err) {
+          throw new Error(`Garmin API fetch failed: ${err instanceof Error ? err.message : String(err)}`)
+        }
+        let points
+        try {
+          points = await processActivityDetail(user, detail)
+        } catch (err) {
+          throw new Error(`processActivityDetail failed: ${err instanceof Error ? err.message : String(err)}`)
+        }
+        try {
+          await markActivityDetailSynced(user, activityId)
+        } catch (err) {
+          throw new Error(
+            `markActivityDetailSynced failed: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
         return points
       },
     ),

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -166,7 +166,7 @@ export const createActivitiesRouter = (
   authMiddleware: RequestHandler,
   syncProvider?: SyncProvider,
   onActivityMutated?: ActivityNotifier,
-  resyncActivityDetail?: (user: string, activityId: string) => Promise<number>,
+  resyncActivityDetail?: (user: string, activityId: string, garminActivityId: number) => Promise<number>,
 ): Router => {
   const router = typedRouter()
 
@@ -700,14 +700,38 @@ export const createActivitiesRouter = (
         return
       }
 
-      const garminActivityId = (activity.data as Record<string, unknown> | undefined)?.garmin_activity_id
+      // Look for garmin_activity_id in this activity and its overlapping (merged) sources
+      const getData = (a: { data?: unknown }) =>
+        (a.data as Record<string, unknown> | undefined)?.garmin_activity_id as number | undefined
+
+      let garminActivityId = getData(activity)
+      let garminSourceId = activity.id!
+
       if (!garminActivityId) {
-        res.status(400).json({ points: 0, success: false, error: 'Activity has no Garmin activity ID' })
+        const overlapping = await getOverlappingActivities(user, activity)
+        for (const src of overlapping) {
+          const gid = getData(src)
+          if (gid) {
+            garminActivityId = gid
+            garminSourceId = src.id!
+            break
+          }
+        }
+      }
+
+      if (!garminActivityId) {
+        res
+          .status(400)
+          .json({
+            points: 0,
+            success: false,
+            error: 'No Garmin activity ID found in activity or its merged sources',
+          })
         return
       }
 
       try {
-        const points = await resyncActivityDetail(user, id)
+        const points = await resyncActivityDetail(user, garminSourceId, garminActivityId)
         res.json({ points, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'


### PR DESCRIPTION
## Summary
- Resync-detail endpoint now searches overlapping (merged) source activities for `garmin_activity_id`, not just the individual activity. Fixes the 400 error on merged activities.
- Simplified dep: passes `garminActivityId` directly instead of re-fetching the activity.
- For the 500 error on individual garmin activities: once this is deployed, can you try again? The simplified dep (no redundant DB fetch) might resolve the issue. If it persists, we'll need to check the Garmin API response for that specific activity.

## Test plan
- [x] sync-router tests pass
- [x] Backend lint passes
- [ ] Click "Re-sync Garmin Detail" on a merged activity → should find garmin ID from source records
- [ ] Click on individual garmin activity → should work without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)