### PR TITLE
fix: shared ActivityTypePicker everywhere with loading + focus fixes

### DIFF
--- a/apps/web/src/components/ActivityTypePicker.tsx
+++ b/apps/web/src/components/ActivityTypePicker.tsx
@@ -1,5 +1,9 @@
+import type { JSX } from 'preact'
+
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'preact/hooks'
+
+import type { ActivityTypeDefinition } from '../state/api'
 
 import { fetchActivityTypeDefinitions } from '../state/api'
 import { toDisplayName } from '../utils/displayName'
@@ -11,7 +15,6 @@ interface ActivityTypePickerProps {
   placeholder?: string
 }
 
-/** Convert a display name to snake_case identifier. */
 const toSnakeCase = (s: string): string =>
   s
     .trim()
@@ -19,6 +22,75 @@ const toSnakeCase = (s: string): string =>
     .replaceAll(/[^a-z0-9]+/g, '_')
     .replaceAll(/^_|_$/g, '')
     .replaceAll(/_+/g, '_') || ''
+
+/** Render dropdown list items. */
+function DropdownItems({
+  flatList,
+  isNewType,
+  snakeInput,
+  highlightedIndex,
+  value,
+  isLoading,
+  userEditing,
+  onSelect,
+  onHighlight,
+}: {
+  flatList: ActivityTypeDefinition[]
+  isNewType: boolean
+  snakeInput: string
+  highlightedIndex: number
+  value: string
+  isLoading: boolean
+  userEditing: boolean
+  onSelect: (name: string) => void
+  onHighlight: (idx: number) => void
+}): JSX.Element {
+  const totalItems = flatList.length + (isNewType ? 1 : 0)
+  return (
+    <ul class="metric-picker-dropdown">
+      {isLoading && (
+        <li class="metric-picker-option">
+          <span class="metric-option-label">Loading activity types...</span>
+        </li>
+      )}
+      {flatList.map((def, idx) => (
+        <li
+          key={def.name}
+          class={`metric-picker-option ${idx === highlightedIndex ? 'highlighted' : ''} ${def.name === value ? 'selected' : ''}`}
+          onMouseDown={(e) => {
+            e.preventDefault()
+            onSelect(def.name)
+          }}
+          onMouseEnter={() => onHighlight(idx)}
+        >
+          <span class="metric-option-label">
+            {def.icon ? `${def.icon} ` : ''}
+            {def.display_name || toDisplayName(def.name)}
+          </span>
+          {def.display_category !== 'other' && <span class="metric-option-key">{def.display_category}</span>}
+        </li>
+      ))}
+      {isNewType && (
+        <li
+          class={`metric-picker-option ${highlightedIndex === flatList.length ? 'highlighted' : ''}`}
+          onMouseDown={(e) => {
+            e.preventDefault()
+            onSelect(snakeInput)
+          }}
+          onMouseEnter={() => onHighlight(flatList.length)}
+        >
+          <span class="metric-option-label">Create "{toDisplayName(snakeInput)}"</span>
+          <span class="metric-option-key">{snakeInput}</span>
+        </li>
+      )}
+      {!isLoading && totalItems === 0 && userEditing && (
+        <li class="metric-picker-option">
+          <span class="metric-option-label">No matching types</span>
+        </li>
+      )}
+    </ul>
+  )
+}
 
 export function ActivityTypePicker({
   value,
@@ -28,9 +100,10 @@ export function ActivityTypePicker({
   const [inputValue, setInputValue] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [userEditing, setUserEditing] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const { data: typeDefs } = useQuery({
+  const { data: typeDefs, isLoading } = useQuery({
     queryFn: fetchActivityTypeDefinitions,
     queryKey: ['activity-type-definitions'],
     staleTime: 30 * 60 * 1000,
@@ -38,17 +111,15 @@ export function ActivityTypePicker({
 
   const allDefs = typeDefs ?? []
   const query = inputValue.toLowerCase()
-
   const filtered = query
     ? allDefs.filter((d) => d.display_name.toLowerCase().includes(query) || d.name.includes(query))
     : allDefs
 
-  // If the user typed something that doesn't match any existing type, offer to create it
   const snakeInput = toSnakeCase(inputValue)
-  const isNewType = query.length > 0 && snakeInput.length > 0 && !allDefs.some((d) => d.name === snakeInput)
+  const isNewType =
+    !isLoading && query.length > 0 && snakeInput.length > 0 && !allDefs.some((d) => d.name === snakeInput)
 
-  const flatList = filtered
-  const totalItems = flatList.length + (isNewType ? 1 : 0)
+  const totalItems = filtered.length + (isNewType ? 1 : 0)
 
   useEffect(() => {
     setHighlightedIndex(0)
@@ -59,6 +130,7 @@ export function ActivityTypePicker({
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false)
         setInputValue('')
+        setUserEditing(false)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
@@ -69,6 +141,7 @@ export function ActivityTypePicker({
     onChange(typeName)
     setInputValue('')
     setIsOpen(false)
+    setUserEditing(false)
   }
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -81,21 +154,22 @@ export function ActivityTypePicker({
       setHighlightedIndex((i) => Math.max(i - 1, 0))
     } else if (e.key === 'Enter' && isOpen && totalItems > 0) {
       e.preventDefault()
-      if (highlightedIndex < flatList.length) {
-        select(flatList[highlightedIndex].name)
+      if (highlightedIndex < filtered.length) {
+        select(filtered[highlightedIndex].name)
       } else if (isNewType) {
         select(snakeInput)
       }
     } else if (e.key === 'Escape') {
       setIsOpen(false)
       setInputValue('')
+      setUserEditing(false)
     }
   }
 
   const displayValue = value
     ? (allDefs.find((d) => d.name === value)?.display_name ?? toDisplayName(value))
     : ''
-  const shownValue = isOpen ? inputValue : displayValue
+  const shownValue = userEditing ? inputValue : displayValue
 
   return (
     <div class="metric-picker" ref={containerRef}>
@@ -105,50 +179,32 @@ export function ActivityTypePicker({
         value={shownValue}
         onInput={(e) => {
           setInputValue((e.target as HTMLInputElement).value)
+          setUserEditing(true)
           setIsOpen(true)
         }}
         onFocus={() => {
+          if (!value) setIsOpen(true)
+        }}
+        onClick={() => {
           setInputValue('')
+          setUserEditing(true)
           setIsOpen(true)
         }}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
       />
-      {isOpen && totalItems > 0 && (
-        <ul class="metric-picker-dropdown">
-          {flatList.map((def, idx) => (
-            <li
-              key={def.name}
-              class={`metric-picker-option ${idx === highlightedIndex ? 'highlighted' : ''} ${def.name === value ? 'selected' : ''}`}
-              onMouseDown={(e) => {
-                e.preventDefault()
-                select(def.name)
-              }}
-              onMouseEnter={() => setHighlightedIndex(idx)}
-            >
-              <span class="metric-option-label">
-                {def.icon ? `${def.icon} ` : ''}
-                {def.display_name || toDisplayName(def.name)}
-              </span>
-              {def.display_category !== 'other' && (
-                <span class="metric-option-key">{def.display_category}</span>
-              )}
-            </li>
-          ))}
-          {isNewType && (
-            <li
-              class={`metric-picker-option ${highlightedIndex === flatList.length ? 'highlighted' : ''}`}
-              onMouseDown={(e) => {
-                e.preventDefault()
-                select(snakeInput)
-              }}
-              onMouseEnter={() => setHighlightedIndex(flatList.length)}
-            >
-              <span class="metric-option-label">Create "{toDisplayName(snakeInput)}"</span>
-              <span class="metric-option-key">{snakeInput}</span>
-            </li>
-          )}
-        </ul>
+      {isOpen && (
+        <DropdownItems
+          flatList={filtered}
+          isNewType={isNewType}
+          snakeInput={snakeInput}
+          highlightedIndex={highlightedIndex}
+          value={value}
+          isLoading={isLoading}
+          userEditing={userEditing}
+          onSelect={select}
+          onHighlight={setHighlightedIndex}
+        />
       )}
     </div>
   )

--- a/apps/web/src/components/ConditionBuilder/index.tsx
+++ b/apps/web/src/components/ConditionBuilder/index.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 import type { DataFilter, DeductionRuleCondition } from '../../state/api'
 
 import { fetchActivityTypeDefinitions, fetchNamedLocations } from '../../state/api'
+import { ActivityTypePicker } from '../ActivityTypePicker'
 import './style.css'
 
 const KIND_LABELS: Record<string, string> = {
@@ -40,41 +41,30 @@ const OPERATOR_LABELS: Record<string, string> = {
 function ActivityTypeSelect({
   condition,
   onChange,
-  definitions,
 }: {
   condition: DeductionRuleCondition
   onChange: (c: DeductionRuleCondition) => void
-  definitions: { name: string; display_name: string }[]
 }) {
   return (
-    <select
+    <ActivityTypePicker
       value={condition.activity_type ?? ''}
-      onChange={(e) => onChange({ ...condition, activity_type: (e.target as HTMLSelectElement).value })}
-      class="condition-field-select"
-    >
-      <option value="">-- select activity type --</option>
-      {definitions.map((d) => (
-        <option key={d.name} value={d.name}>
-          {d.display_name} ({d.name})
-        </option>
-      ))}
-    </select>
+      onChange={(activity_type) => onChange({ ...condition, activity_type })}
+      placeholder="Search activity types..."
+    />
   )
 }
 
 function ActivityDataBody({
   condition,
   onChange,
-  definitions,
 }: {
   condition: DeductionRuleCondition
   onChange: (c: DeductionRuleCondition) => void
-  definitions: { name: string; display_name: string }[]
 }) {
   const needsValue = condition.operator === 'eq' || condition.operator === 'neq'
   return (
     <div class="condition-data-fields">
-      <ActivityTypeSelect condition={condition} onChange={onChange} definitions={definitions} />
+      <ActivityTypeSelect condition={condition} onChange={onChange} />
       <div class="condition-data-row">
         <input
           type="text"
@@ -258,7 +248,7 @@ function ConditionCard({
       <div class="condition-card-body">
         {condition.kind === 'activity' && (
           <>
-            <ActivityTypeSelect condition={condition} onChange={update} definitions={definitions} />
+            <ActivityTypeSelect condition={condition} onChange={update} />
             {(() => {
               const typeDef = definitions.find((d) => d.name === condition.activity_type)
               const schemaFields = (
@@ -304,9 +294,7 @@ function ConditionCard({
           />
         )}
 
-        {condition.kind === 'activity_data' && (
-          <ActivityDataBody condition={condition} onChange={update} definitions={definitions} />
-        )}
+        {condition.kind === 'activity_data' && <ActivityDataBody condition={condition} onChange={update} />}
 
         {condition.kind === 'location' && (
           <>

--- a/apps/web/src/pages/DeductionRules/RuleDetail.tsx
+++ b/apps/web/src/pages/DeductionRules/RuleDetail.tsx
@@ -7,15 +7,15 @@ import { formatISO } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 
-import type { ActivityTypeDefinition, DeductionRule, DeductionRuleCondition } from '../../state/api'
+import type { DeductionRule, DeductionRuleCondition } from '../../state/api'
 
+import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { ConditionBuilder } from '../../components/ConditionBuilder'
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { SaveStatusIndicator, useSaveStatus } from '../../components/SaveStatusIndicator'
 import {
   createDeductionRule,
   deleteDeductionRule,
-  fetchActivityTypeDefinitions,
   fetchDeductionRules,
   previewDeductionRule,
   updateDeductionRule,
@@ -57,30 +57,11 @@ function TextField({
   )
 }
 
-function ActivityTypePicker({
-  value,
-  onChange,
-  definitions,
-}: {
-  value: string
-  onChange: (v: string) => void
-  definitions: ActivityTypeDefinition[]
-}) {
+function OutputActivityTypePicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   return (
     <div class="rule-field">
       <span class="rule-field-label">Output Activity Type</span>
-      <select
-        value={value}
-        onChange={(e) => onChange((e.target as HTMLSelectElement).value)}
-        class="rule-field-select"
-      >
-        <option value="">-- select --</option>
-        {definitions.map((d) => (
-          <option key={d.name} value={d.name}>
-            {d.display_name} ({d.name})
-          </option>
-        ))}
-      </select>
+      <ActivityTypePicker value={value} onChange={onChange} placeholder="Search activity types..." />
     </div>
   )
 }
@@ -218,12 +199,6 @@ function RuleForm({ id, rule }: { id?: string; rule?: DeductionRule }) {
   // Track previous rule values for auto-save field-change detection
   const prevRule = useRef(rule)
 
-  const { data: definitions = [] } = useQuery({
-    queryFn: fetchActivityTypeDefinitions,
-    queryKey: ['activityTypeDefinitions'],
-    staleTime: 5 * 60_000,
-  })
-
   // Sync local state when server data refreshes (edit mode)
   useEffect(() => {
     if (rule) {
@@ -333,13 +308,12 @@ function RuleForm({ id, rule }: { id?: string; rule?: DeductionRule }) {
             </select>
           </div>
 
-          <ActivityTypePicker
+          <OutputActivityTypePicker
             value={fields.outputType}
             onChange={(v) => {
               updateField('outputType', v)
               autoSave({ output_activity_type: v })
             }}
-            definitions={definitions}
           />
 
           <OutputDataEditor

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -2,10 +2,8 @@
  * Shared component that renders activity title, time, duration, and notes
  * in either read mode (plain text) or edit mode (input fields).
  */
-import type { ActivityTypeDefinition } from '../../state/api'
-
+import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { IconPreview } from '../../components/IconPreview'
-import { toDisplayName } from '../../utils/displayName'
 import { formatDateTime, formatDuration, formatTime } from './format-utils'
 
 export interface ActivityDraft {
@@ -26,8 +24,6 @@ interface EditableActivityFieldsProps {
   isEditing: boolean
   draft: ActivityDraft
   onDraftChange: (draft: ActivityDraft) => void
-  /** All available activity type definitions for the type selector. */
-  typeDefinitions?: ActivityTypeDefinition[]
   /** Label for the duration row (e.g. "In Bed" for sleep). Defaults to "Duration". */
   durationLabel?: string
   /** Icon (emoji or URL) to display next to the title. */
@@ -44,7 +40,6 @@ export const EditableActivityFields = ({
   isEditing,
   draft,
   onDraftChange,
-  typeDefinitions,
   durationLabel = 'Duration',
   icon,
   titleHref,
@@ -64,28 +59,18 @@ export const EditableActivityFields = ({
           onInput={(e) => onDraftChange({ ...draft, title: (e.target as HTMLInputElement).value })}
         />
 
-        {typeDefinitions && (
-          <div class="entity-fields" style={{ marginBottom: '0.5rem' }}>
-            <div class="field-row">
-              <span class="field-label">Type</span>
-              <span class="field-value">
-                <select
-                  class="edit-datetime-input"
-                  value={draft.activity_type}
-                  onChange={(e) =>
-                    onDraftChange({ ...draft, activity_type: (e.target as HTMLSelectElement).value })
-                  }
-                >
-                  {typeDefinitions.map((def) => (
-                    <option key={def.name} value={def.name}>
-                      {def.display_name || toDisplayName(def.name)}
-                    </option>
-                  ))}
-                </select>
-              </span>
-            </div>
+        <div class="entity-fields" style={{ marginBottom: '0.5rem' }}>
+          <div class="field-row">
+            <span class="field-label">Type</span>
+            <span class="field-value">
+              <ActivityTypePicker
+                value={draft.activity_type}
+                onChange={(activity_type) => onDraftChange({ ...draft, activity_type })}
+                placeholder="Search activity types..."
+              />
+            </span>
           </div>
-        )}
+        </div>
 
         <div class="entity-fields">
           <div class="field-row">

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -271,7 +271,6 @@ const ActivityDetailContent = ({
           isEditing={isEditing}
           draft={draft}
           onDraftChange={onDraftChange}
-          typeDefinitions={typeDefinitions}
           icon={icon}
           durationLabel={hasSleepStages ? 'In Bed' : undefined}
         />


### PR DESCRIPTION
## Summary

- **ActivityTypePicker improvements**:
  - Shows "Loading activity types..." while fetching definitions
  - Only offers "Create new type" after types have loaded (no false positives)
  - Fix focus: `onFocus` only opens dropdown when empty, `onClick` always opens for editing — prevents spurious autocomplete on form submission refocus
  - `userEditing` state tracks whether user is actively editing vs programmatic focus

- **Replaced all local selectors** with the shared component:
  - Entity detail edit form (`EditableActivityFields`)
  - Deduction rules output type picker
  - Condition builder activity type selector

## Test plan

- [ ] Activity type picker shows "Loading..." before types arrive
- [ ] No "Create new type" shown while loading
- [ ] Selecting a type, then tabbing away, doesn't reopen dropdown
- [ ] Edit activity detail page: type picker is searchable
- [ ] Deduction rule output type: picker is searchable
- [ ] Condition builder activity type: picker is searchable

🤖 Generated with [Claude Code](https://claude.com/claude-code)