### PR TITLE
fix: exercise type migration runs automatically in migrateSchema

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -633,6 +633,21 @@ export const migrateSchema = async (user: string) => {
 
   // Migrate goals and custom_metrics from user_settings JSONB to their own tables
   await migrateGoalsAndCustomMetrics(db, existingTableNames)
+
+  // Migrate generic 'exercise' activities to their specific type from data.activity_type_key
+  // (idempotent — only updates activities that still have the generic type)
+  if (existingTableNames.has('activities')) {
+    await query(
+      db,
+      `UPDATE activities
+       SET activity_type = data->>'activity_type_key',
+           data = data - 'activity_type_key' - 'exerciseType' - 'exerciseTypeName'
+       WHERE activity_type = 'exercise'
+         AND data->>'activity_type_key' IS NOT NULL
+         AND data->>'activity_type_key' != 'unknown'
+         AND deleted_at IS NULL`,
+    )
+  }
 }
 
 /**

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -43,7 +43,6 @@ import {
   getAllActivityTypeNames,
   getDeductionRule,
   getDistinctApps,
-  migrateExerciseTypes,
   getNearbyActivities,
   getOverlappingActivities,
   getProductivityBucketed,
@@ -736,12 +735,6 @@ export const createActivitiesRouter = (
       res.json({ categories: result.categories, data: result.data, success: true })
     },
   )
-
-  router.post('/activities/migrate-exercise-types', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const count = await migrateExerciseTypes(user)
-    res.json({ data: { updated: count }, success: true })
-  })
 
   return router as unknown as Router
 }


### PR DESCRIPTION
## Summary

Move the exercise type data migration from a manual POST endpoint into `migrateSchema()` so it runs automatically on login or SQL error, like all other migrations.

- Idempotent: only updates activities where `activity_type = 'exercise'` and `data->>'activity_type_key'` is set
- Removes the manual `POST /activities/migrate-exercise-types` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)