### PR TITLE
fix: pg-format empty array causes SQL syntax error in insertLocations

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -685,25 +685,9 @@ const main = async () => {
       syncProvider,
       activityNotifier,
       async (user, activityId, garminActivityId) => {
-        let detail
-        try {
-          detail = await garmin.getActivityDetail(user, garminActivityId)
-        } catch (err) {
-          throw new Error(`Garmin API fetch failed: ${err instanceof Error ? err.message : String(err)}`)
-        }
-        let points
-        try {
-          points = await processActivityDetail(user, detail)
-        } catch (err) {
-          throw new Error(`processActivityDetail failed: ${err instanceof Error ? err.message : String(err)}`)
-        }
-        try {
-          await markActivityDetailSynced(user, activityId)
-        } catch (err) {
-          throw new Error(
-            `markActivityDetailSynced failed: ${err instanceof Error ? err.message : String(err)}`,
-          )
-        }
+        const detail = await garmin.getActivityDetail(user, garminActivityId)
+        const points = await processActivityDetail(user, detail)
+        await markActivityDetailSynced(user, activityId)
         return points
       },
     ),

--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -44,6 +44,11 @@ export const insertLocation = async (user: string, location: Location) => {
 export const insertLocations = async (user: string, locations: Location[]): Promise<void> => {
   if (locations.length === 0) return
 
+  // pg-format %L produces invalid SQL for empty JS arrays (trailing comma before paren),
+  // so convert regions to a PostgreSQL array literal string.
+  const formatRegions = (regions: string[] | undefined): string =>
+    regions?.length ? `{${regions.join(',')}}` : '{}'
+
   const values = locations.map((loc) => [
     loc.source || 'owntracks',
     loc.time,
@@ -52,7 +57,7 @@ export const insertLocations = async (user: string, locations: Location[]): Prom
     loc.accuracy ?? null,
     loc.altitude ?? null,
     loc.velocity ?? null,
-    loc.regions || [],
+    formatRegions(loc.regions),
   ])
 
   await query(


### PR DESCRIPTION
## Summary
- `pg-format`'s `%L` formatter produces invalid SQL for empty JS arrays: `VALUES (..., )` instead of `VALUES (..., '{}')`. This caused the 500 "syntax error at or near `)` " error when re-syncing Garmin activity detail, because GPS points have no `regions` (empty array).
- Fix: convert regions to PostgreSQL array literal string (`'{}'`) before passing to `pg-format`.
- This also explains why the initial Garmin GPS import didn't work for activities that had GPS data — `insertLocations` silently failed.

## Test plan
- [x] 105 garmin-process tests pass
- [x] Lint clean
- [ ] Click "Re-sync Garmin Detail" on the running activity — should succeed and show GPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)