### PR TITLE
fix: insertLocations type casting for PostGIS + integration test

### DIFF
--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -60,11 +60,15 @@ export const insertLocations = async (user: string, locations: Location[]): Prom
     formatRegions(loc.regions),
   ])
 
+  // pg-format %L quotes all values as text; cast to correct types for PostGIS and numeric columns
   await query(
     user,
     format(
       `INSERT INTO locations (source, time, location, accuracy, altitude, velocity, regions)
-       SELECT v.source, v.time, ST_MakePoint(v.lon, v.lat)::geography, v.accuracy, v.altitude, v.velocity, v.regions
+       SELECT v.source, v.time::timestamptz,
+              ST_MakePoint(v.lon::double precision, v.lat::double precision)::geography,
+              v.accuracy::double precision, v.altitude::double precision,
+              v.velocity::double precision, v.regions::text[]
        FROM (VALUES %L) AS v(source, time, lon, lat, accuracy, altitude, velocity, regions)
        ON CONFLICT (source, time) DO NOTHING`,
       values,

--- a/apps/backend/src/garmin-resync.integration.test.ts
+++ b/apps/backend/src/garmin-resync.integration.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+/**
+ * Integration test for Garmin activity detail resync flow.
+ *
+ * Tests processActivityDetail against a real PostgreSQL instance with PostGIS,
+ * using a real (trimmed) Garmin API response as fixture.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { GarminActivityDetailResponse } from './garmin.ts'
+
+import { getTimeSeries, insertLocations, insertRawRecord, insertTimeSeries } from './db/index.ts'
+import { softDeleteLocationRange } from './db/locations.ts'
+import { processActivityDetail } from './garmin-process.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from './test/db-test-helper.ts'
+
+const garminDetailFixture = JSON.parse(
+  readFileSync(resolve(__dirname, 'test/fixtures/garmin-activity-detail.json'), 'utf-8'),
+) as GarminActivityDetailResponse
+
+const CONTAINER_TIMEOUT = 60_000
+
+describe('Garmin resync integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  const realDeps = {
+    deleteGarminActivityWithWrongType: async () => null as string | null,
+    insertActivity: async () => {},
+    insertLocations,
+    insertRawRecord,
+    insertTimeSeries,
+    softDeleteLocationRange,
+  }
+
+  test('processActivityDetail inserts time series and GPS from real Garmin response', async () => {
+    const user = getTestUser()
+    const data = garminDetailFixture as unknown as GarminActivityDetailResponse
+
+    const points = await processActivityDetail(user, data, realDeps)
+
+    // Should have extracted per-second metrics (HR, speed, elevation, etc.)
+    expect(points).toBeGreaterThan(0)
+
+    // Verify time series data was actually inserted into the DB
+    const latIdx = data.metricDescriptors.findIndex((d) => d.key === 'directLatitude')
+    const lonIdx = data.metricDescriptors.findIndex((d) => d.key === 'directLongitude')
+    expect(latIdx).toBeGreaterThanOrEqual(0)
+    expect(lonIdx).toBeGreaterThanOrEqual(0)
+
+    // Check heart rate time series was stored
+    const firstMetrics = data.activityDetailMetrics[0].metrics
+    const tsIdx = data.metricDescriptors.findIndex((d) => d.key === 'directTimestamp')
+    const hrIdx = data.metricDescriptors.findIndex((d) => d.key === 'directHeartRate')
+    const firstTs =
+      typeof firstMetrics[tsIdx] === 'object'
+        ? (firstMetrics[tsIdx] as { parsedValue: number }).parsedValue
+        : (firstMetrics[tsIdx] as number)
+    const lastEntry = data.activityDetailMetrics[data.activityDetailMetrics.length - 1].metrics
+    const lastTs =
+      typeof lastEntry[tsIdx] === 'object'
+        ? (lastEntry[tsIdx] as { parsedValue: number }).parsedValue
+        : (lastEntry[tsIdx] as number)
+
+    const hrData = await getTimeSeries(user, 'heart_rate', new Date(firstTs - 1000), new Date(lastTs + 1000))
+    expect(hrData.length).toBeGreaterThan(0)
+
+    // Verify the first HR value matches the fixture
+    const expectedHr =
+      typeof firstMetrics[hrIdx] === 'object'
+        ? (firstMetrics[hrIdx] as { parsedValue: number }).parsedValue
+        : (firstMetrics[hrIdx] as number)
+    if (expectedHr > 0) {
+      expect(hrData[0][1]).toBe(expectedHr)
+    }
+  })
+
+  test('processActivityDetail extracts GPS from per-second metrics', async () => {
+    const user = getTestUser()
+    const data = garminDetailFixture as unknown as GarminActivityDetailResponse
+
+    await processActivityDetail(user, data, realDeps)
+
+    // The fixture has directLatitude/directLongitude in metrics — GPS should be extracted
+    // GPS is downsampled to ~1 point per minute, so 120 seconds of data = ~2 GPS points
+    const latIdx = data.metricDescriptors.findIndex((d) => d.key === 'directLatitude')
+    expect(latIdx).toBeGreaterThanOrEqual(0)
+
+    // Query locations from DB to verify GPS was inserted
+    const { query } = await import('./db/connection.ts')
+    const result = await query(
+      user,
+      `SELECT source, time, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon
+       FROM locations WHERE source = 'garmin' ORDER BY time`,
+      [],
+    )
+
+    expect(result.rows.length).toBeGreaterThan(0)
+    // Verify coordinates are in the expected area (Bollebygd, Sweden ~57.65°N, 12.62°E)
+    const firstLoc = result.rows[0]
+    expect(Number(firstLoc.lat)).toBeCloseTo(57.65, 1)
+    expect(Number(firstLoc.lon)).toBeCloseTo(12.63, 1)
+  })
+
+  test('processActivityDetail is idempotent (can be called twice)', async () => {
+    const user = getTestUser()
+    const data = garminDetailFixture as unknown as GarminActivityDetailResponse
+
+    const points1 = await processActivityDetail(user, data, realDeps)
+    const points2 = await processActivityDetail(user, data, realDeps)
+
+    expect(points1).toBe(points2)
+  })
+
+  test('insertLocations works with Garmin GPS points (no regions)', async () => {
+    const user = getTestUser()
+
+    // Simulate what extractGpsPoint produces — no regions field
+    await insertLocations(user, [
+      { lat: 57.65, lon: 12.62, source: 'garmin', time: new Date('2024-04-10T11:11:33Z') },
+      { lat: 57.66, lon: 12.63, source: 'garmin', time: new Date('2024-04-10T11:12:33Z') },
+    ])
+
+    const { query } = await import('./db/connection.ts')
+    const result = await query(
+      user,
+      `SELECT source, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon FROM locations ORDER BY time`,
+      [],
+    )
+
+    expect(result.rows).toHaveLength(2)
+    expect(Number(result.rows[0].lat)).toBeCloseTo(57.65, 4)
+    expect(Number(result.rows[0].lon)).toBeCloseTo(12.62, 4)
+  })
+})

--- a/apps/backend/src/garmin-resync.integration.test.ts
+++ b/apps/backend/src/garmin-resync.integration.test.ts
@@ -36,7 +36,7 @@ describe('Garmin resync integration', () => {
 
   const realDeps = {
     deleteGarminActivityWithWrongType: async () => null as string | null,
-    insertActivity: async () => {},
+    insertActivity: async () => '' as string,
     insertLocations,
     insertRawRecord,
     insertTimeSeries,

--- a/apps/backend/src/test/fixtures/garmin-activity-detail.json
+++ b/apps/backend/src/test/fixtures/garmin-activity-detail.json
@@ -1,0 +1,7906 @@
+{
+  "activityId": 22474789590,
+  "metricDescriptors": [
+    {
+      "metricsIndex": 0,
+      "key": "directLongitude",
+      "unit": {
+        "id": 60,
+        "key": "dd",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 1,
+      "key": "sumMovingDuration",
+      "unit": {
+        "id": 40,
+        "key": "second",
+        "factor": {
+          "source": "1000.0",
+          "parsedValue": 1000
+        }
+      }
+    },
+    {
+      "metricsIndex": 2,
+      "key": "directBodyBattery",
+      "unit": {
+        "id": 6,
+        "key": "dimensionless",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 3,
+      "key": "sumElapsedDuration",
+      "unit": {
+        "id": 40,
+        "key": "second",
+        "factor": {
+          "source": "1000.0",
+          "parsedValue": 1000
+        }
+      }
+    },
+    {
+      "metricsIndex": 4,
+      "key": "directTimestamp",
+      "unit": {
+        "id": 120,
+        "key": "gmt",
+        "factor": {
+          "source": "0.0",
+          "parsedValue": 0
+        }
+      }
+    },
+    {
+      "metricsIndex": 5,
+      "key": "directElevation",
+      "unit": {
+        "id": 1,
+        "key": "meter",
+        "factor": {
+          "source": "100.0",
+          "parsedValue": 100
+        }
+      }
+    },
+    {
+      "metricsIndex": 6,
+      "key": "sumDistance",
+      "unit": {
+        "id": 1,
+        "key": "meter",
+        "factor": {
+          "source": "100.0",
+          "parsedValue": 100
+        }
+      }
+    },
+    {
+      "metricsIndex": 7,
+      "key": "directGradeAdjustedSpeed",
+      "unit": {
+        "id": 20,
+        "key": "mps",
+        "factor": 0.1
+      }
+    },
+    {
+      "metricsIndex": 8,
+      "key": "directDoubleCadence",
+      "unit": {
+        "id": 92,
+        "key": "stepsPerMinute",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 9,
+      "key": "directLatitude",
+      "unit": {
+        "id": 60,
+        "key": "dd",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 10,
+      "key": "directHeartRate",
+      "unit": {
+        "id": 100,
+        "key": "bpm",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 11,
+      "key": "directFractionalCadence",
+      "unit": {
+        "id": 92,
+        "key": "stepsPerMinute",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 12,
+      "key": "sumDuration",
+      "unit": {
+        "id": 40,
+        "key": "second",
+        "factor": {
+          "source": "1000.0",
+          "parsedValue": 1000
+        }
+      }
+    },
+    {
+      "metricsIndex": 13,
+      "key": "directRunCadence",
+      "unit": {
+        "id": 92,
+        "key": "stepsPerMinute",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 14,
+      "key": "directSpeed",
+      "unit": {
+        "id": 20,
+        "key": "mps",
+        "factor": 0.1
+      }
+    },
+    {
+      "metricsIndex": 15,
+      "key": "directPower",
+      "unit": {
+        "id": 10,
+        "key": "watt",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 16,
+      "key": "directVerticalSpeed",
+      "unit": {
+        "id": 20,
+        "key": "mps",
+        "factor": 0.1
+      }
+    },
+    {
+      "metricsIndex": 17,
+      "key": "directVerticalOscillation",
+      "unit": {
+        "id": 5,
+        "key": "centimeter",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 18,
+      "key": "sumAccumulatedPower",
+      "unit": {
+        "id": 10,
+        "key": "watt",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 19,
+      "key": "directVerticalRatio",
+      "unit": {
+        "id": 6,
+        "key": "dimensionless",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 20,
+      "key": "directStrideLength",
+      "unit": {
+        "id": 5,
+        "key": "centimeter",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 21,
+      "key": "directGroundContactTime",
+      "unit": {
+        "id": 41,
+        "key": "ms",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    },
+    {
+      "metricsIndex": 22,
+      "key": "directPerformanceCondition",
+      "unit": {
+        "id": 6,
+        "key": "dimensionless",
+        "factor": {
+          "source": "1.0",
+          "parsedValue": 1
+        }
+      }
+    }
+  ],
+  "activityDetailMetrics": [
+    {
+      "metrics": [
+        12.625318933278322,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "1.775812293E12",
+          "parsedValue": 1775812293000
+        },
+        161.39999389648438,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        4.263999938964844,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        57.65198587439954,
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        4.263999938964844,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625272246077657,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "1.0",
+          "parsedValue": 1
+        },
+        {
+          "source": "1.775812294E12",
+          "parsedValue": 1775812294000
+        },
+        161.1999969482422,
+        1.090000033378601,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        57.65197983942926,
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "1.0",
+          "parsedValue": 1
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        -0.20000000298023224,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625243412330747,
+        {
+          "source": "1.0",
+          "parsedValue": 1
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "2.0",
+          "parsedValue": 2
+        },
+        {
+          "source": "1.775812295E12",
+          "parsedValue": 1775812295000
+        },
+        {
+          "source": "161.0",
+          "parsedValue": 161
+        },
+        3.6500000953674316,
+        1.6890000104904175,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        57.65199978835881,
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "2.0",
+          "parsedValue": 2
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        1.6890000104904175,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        -0.20000000298023224,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625212566927075,
+        {
+          "source": "2.0",
+          "parsedValue": 2
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "3.0",
+          "parsedValue": 3
+        },
+        {
+          "source": "1.775812296E12",
+          "parsedValue": 1775812296000
+        },
+        {
+          "source": "161.0",
+          "parsedValue": 161
+        },
+        7.090000152587891,
+        2.500999927520752,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        57.65202384442091,
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "3.0",
+          "parsedValue": 3
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        2.500999927520752,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625197814777493,
+        {
+          "source": "3.0",
+          "parsedValue": 3
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "4.0",
+          "parsedValue": 4
+        },
+        {
+          "source": "1.775812297E12",
+          "parsedValue": 1775812297000
+        },
+        {
+          "source": "161.0",
+          "parsedValue": 161
+        },
+        8.329999923706055,
+        2.500999927520752,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        57.652034908533096,
+        {
+          "source": "75.0",
+          "parsedValue": 75
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "4.0",
+          "parsedValue": 4
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        2.500999927520752,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62518105097115,
+        {
+          "source": "4.0",
+          "parsedValue": 4
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "5.0",
+          "parsedValue": 5
+        },
+        {
+          "source": "1.775812298E12",
+          "parsedValue": 1775812298000
+        },
+        {
+          "source": "161.0",
+          "parsedValue": 161
+        },
+        10.8100004196167,
+        2.5139999389648438,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        57.65205452218652,
+        {
+          "source": "76.0",
+          "parsedValue": 76
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "5.0",
+          "parsedValue": 5
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        2.500999927520752,
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62515313923359,
+        {
+          "source": "5.0",
+          "parsedValue": 5
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "6.0",
+          "parsedValue": 6
+        },
+        {
+          "source": "1.775812299E12",
+          "parsedValue": 1775812299000
+        },
+        161.1999969482422,
+        14.289999961853027,
+        2.430000066757202,
+        {
+          "source": "167.0",
+          "parsedValue": 167
+        },
+        57.652080757543445,
+        {
+          "source": "77.0",
+          "parsedValue": 77
+        },
+        0.5,
+        {
+          "source": "6.0",
+          "parsedValue": 6
+        },
+        {
+          "source": "83.0",
+          "parsedValue": 83
+        },
+        2.4170000553131104,
+        {
+          "source": "362.0",
+          "parsedValue": 362
+        },
+        0.20000000298023224,
+        7.940000152587891,
+        {
+          "source": "362.0",
+          "parsedValue": 362
+        },
+        9.09000015258789,
+        87.30000000000001,
+        {
+          "source": "290.0",
+          "parsedValue": 290
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625137967988849,
+        {
+          "source": "6.0",
+          "parsedValue": 6
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "7.0",
+          "parsedValue": 7
+        },
+        {
+          "source": "1.7758123E12",
+          "parsedValue": 1775812300000
+        },
+        161.39999389648438,
+        17.969999313354492,
+        2.430000066757202,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.65210640616715,
+        {
+          "source": "78.0",
+          "parsedValue": 78
+        },
+        0.5,
+        {
+          "source": "7.0",
+          "parsedValue": 7
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.4170000553131104,
+        {
+          "source": "334.0",
+          "parsedValue": 334
+        },
+        0.20000000298023224,
+        7.590000152587891,
+        {
+          "source": "696.0",
+          "parsedValue": 696
+        },
+        {
+          "source": "9.0",
+          "parsedValue": 9
+        },
+        84.30000000000001,
+        {
+          "source": "282.0",
+          "parsedValue": 282
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625124724581838,
+        {
+          "source": "7.0",
+          "parsedValue": 7
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "1.775812301E12",
+          "parsedValue": 1775812301000
+        },
+        161.39999389648438,
+        19.90999984741211,
+        2.8989999294281006,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.652122750878334,
+        {
+          "source": "80.0",
+          "parsedValue": 80
+        },
+        0.5,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.882999897003174,
+        {
+          "source": "420.0",
+          "parsedValue": 420
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.219999694824219,
+        {
+          "source": "1116.0",
+          "parsedValue": 1116
+        },
+        8.170000076293945,
+        100.5,
+        {
+          "source": "270.0",
+          "parsedValue": 270
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62510284781456,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "9.0",
+          "parsedValue": 9
+        },
+        {
+          "source": "1.775812302E12",
+          "parsedValue": 1775812302000
+        },
+        161.39999389648438,
+        22.149999618530273,
+        2.8989999294281006,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.65214395709336,
+        {
+          "source": "81.0",
+          "parsedValue": 81
+        },
+        0.5,
+        {
+          "source": "9.0",
+          "parsedValue": 9
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.882999897003174,
+        {
+          "source": "420.0",
+          "parsedValue": 420
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.219999694824219,
+        {
+          "source": "1536.0",
+          "parsedValue": 1536
+        },
+        8.170000076293945,
+        100.5,
+        {
+          "source": "270.0",
+          "parsedValue": 270
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625086335465312,
+        {
+          "source": "9.0",
+          "parsedValue": 9
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "10.0",
+          "parsedValue": 10
+        },
+        {
+          "source": "1.775812303E12",
+          "parsedValue": 1775812303000
+        },
+        {
+          "source": "161.0",
+          "parsedValue": 161
+        },
+        24.549999237060547,
+        2.4110000133514404,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.652163906022906,
+        {
+          "source": "83.0",
+          "parsedValue": 83
+        },
+        0.5,
+        {
+          "source": "10.0",
+          "parsedValue": 10
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.3980000019073486,
+        {
+          "source": "329.0",
+          "parsedValue": 329
+        },
+        -0.4000000059604645,
+        7.580000305175782,
+        {
+          "source": "1865.0",
+          "parsedValue": 1865
+        },
+        9.0600004196167,
+        83.60000000000001,
+        {
+          "source": "282.0",
+          "parsedValue": 282
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625081222504377,
+        {
+          "source": "10.0",
+          "parsedValue": 10
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "11.0",
+          "parsedValue": 11
+        },
+        {
+          "source": "1.775812304E12",
+          "parsedValue": 1775812304000
+        },
+        160.60000610351562,
+        27.809999465942383,
+        2.4019999504089355,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.65219491906464,
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        0.5,
+        {
+          "source": "11.0",
+          "parsedValue": 11
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.3889999389648438,
+        {
+          "source": "323.0",
+          "parsedValue": 323
+        },
+        -0.4000000059604645,
+        7.569999694824219,
+        {
+          "source": "2188.0",
+          "parsedValue": 2188
+        },
+        9.09000015258789,
+        83.30000000000001,
+        {
+          "source": "282.0",
+          "parsedValue": 282
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625074768438935,
+        {
+          "source": "11.0",
+          "parsedValue": 11
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "12.0",
+          "parsedValue": 12
+        },
+        {
+          "source": "1.775812305E12",
+          "parsedValue": 1775812305000
+        },
+        160.39999389648438,
+        31.510000228881836,
+        2.4110000133514404,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65222727321088,
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "12.0",
+          "parsedValue": 12
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        2.3980000019073486,
+        {
+          "source": "320.0",
+          "parsedValue": 320
+        },
+        -0.20000000298023224,
+        7.1199996948242195,
+        {
+          "source": "2508.0",
+          "parsedValue": 2508
+        },
+        8.899999618530273,
+        79.9,
+        {
+          "source": "273.0",
+          "parsedValue": 273
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625084659084678,
+        {
+          "source": "12.0",
+          "parsedValue": 12
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "13.0",
+          "parsedValue": 13
+        },
+        {
+          "source": "1.775812306E12",
+          "parsedValue": 1775812306000
+        },
+        160.1999969482422,
+        35.13999938964844,
+        2.805000066757202,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65225920826197,
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "13.0",
+          "parsedValue": 13
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        2.7899999618530273,
+        {
+          "source": "368.0",
+          "parsedValue": 368
+        },
+        -0.20000000298023224,
+        7.55999984741211,
+        {
+          "source": "2876.0",
+          "parsedValue": 2876
+        },
+        8.130000114440918,
+        92.9,
+        {
+          "source": "264.0",
+          "parsedValue": 264
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625091364607215,
+        {
+          "source": "13.0",
+          "parsedValue": 13
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "14.0",
+          "parsedValue": 14
+        },
+        {
+          "source": "1.775812307E12",
+          "parsedValue": 1775812307000
+        },
+        159.8000030517578,
+        38.369998931884766,
+        2.9210000038146973,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.652288377285004,
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "14.0",
+          "parsedValue": 14
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.0789999961853027,
+        {
+          "source": "434.0",
+          "parsedValue": 434
+        },
+        -0.4000000059604645,
+        7.880000305175781,
+        {
+          "source": "3310.0",
+          "parsedValue": 3310
+        },
+        7.670000076293945,
+        102.60000000000001,
+        {
+          "source": "257.0",
+          "parsedValue": 257
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625101925805211,
+        {
+          "source": "14.0",
+          "parsedValue": 14
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "15.0",
+          "parsedValue": 15
+        },
+        {
+          "source": "1.775812308E12",
+          "parsedValue": 1775812308000
+        },
+        159.60000610351562,
+        41.59000015258789,
+        3.0190000534057617,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65231712721288,
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "15.0",
+          "parsedValue": 15
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.181999921798706,
+        {
+          "source": "446.0",
+          "parsedValue": 446
+        },
+        -0.20000000298023224,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "3756.0",
+          "parsedValue": 3756
+        },
+        7.539999961853027,
+        {
+          "source": "106.0",
+          "parsedValue": 106
+        },
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62510435655713,
+        {
+          "source": "15.0",
+          "parsedValue": 15
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "16.0",
+          "parsedValue": 16
+        },
+        {
+          "source": "1.775812309E12",
+          "parsedValue": 1775812309000
+        },
+        159.39999389648438,
+        45.130001068115234,
+        3.0269999504089355,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.652347134426236,
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "16.0",
+          "parsedValue": 16
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.190999984741211,
+        {
+          "source": "445.0",
+          "parsedValue": 445
+        },
+        -0.20000000298023224,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "4201.0",
+          "parsedValue": 4201
+        },
+        7.519999980926514,
+        106.30000000000001,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625111313536763,
+        {
+          "source": "16.0",
+          "parsedValue": 16
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "17.0",
+          "parsedValue": 17
+        },
+        {
+          "source": "1.77581231E12",
+          "parsedValue": 1775812310000
+        },
+        {
+          "source": "159.0",
+          "parsedValue": 159
+        },
+        48.61000061035156,
+        3.0269999504089355,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65237915329635,
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        0.5,
+        {
+          "source": "17.0",
+          "parsedValue": 17
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.190999984741211,
+        {
+          "source": "435.0",
+          "parsedValue": 435
+        },
+        -0.4000000059604645,
+        7.8599998474121096,
+        {
+          "source": "4636.0",
+          "parsedValue": 4636
+        },
+        7.46999979019165,
+        105.2,
+        {
+          "source": "252.0",
+          "parsedValue": 252
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625104105100036,
+        {
+          "source": "17.0",
+          "parsedValue": 17
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "18.0",
+          "parsedValue": 18
+        },
+        {
+          "source": "1.775812311E12",
+          "parsedValue": 1775812311000
+        },
+        158.60000610351562,
+        51.689998626708984,
+        3.0280001163482666,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65240530483425,
+        {
+          "source": "92.0",
+          "parsedValue": 92
+        },
+        0.5,
+        {
+          "source": "18.0",
+          "parsedValue": 18
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.246999979019165,
+        {
+          "source": "420.0",
+          "parsedValue": 420
+        },
+        -0.4000000059604645,
+        7.909999847412109,
+        {
+          "source": "5056.0",
+          "parsedValue": 5056
+        },
+        7.389999866485596,
+        {
+          "source": "107.0",
+          "parsedValue": 107
+        },
+        {
+          "source": "251.0",
+          "parsedValue": 251
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62509941123426,
+        {
+          "source": "18.0",
+          "parsedValue": 18
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "19.0",
+          "parsedValue": 19
+        },
+        {
+          "source": "1.775812312E12",
+          "parsedValue": 1775812312000
+        },
+        158.39999389648438,
+        54.849998474121094,
+        3.0369999408721924,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65243464149535,
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        0.5,
+        {
+          "source": "19.0",
+          "parsedValue": 19
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.25600004196167,
+        {
+          "source": "410.0",
+          "parsedValue": 410
+        },
+        -0.20000000298023224,
+        7.940000152587891,
+        {
+          "source": "5466.0",
+          "parsedValue": 5466
+        },
+        7.400000095367432,
+        107.30000000000001,
+        {
+          "source": "250.0",
+          "parsedValue": 250
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625089101493359,
+        {
+          "source": "19.0",
+          "parsedValue": 19
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "20.0",
+          "parsedValue": 20
+        },
+        {
+          "source": "1.775812313E12",
+          "parsedValue": 1775812313000
+        },
+        {
+          "source": "158.0",
+          "parsedValue": 158
+        },
+        57.79999923706055,
+        3.0369999408721924,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65245886519551,
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "20.0",
+          "parsedValue": 20
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.25600004196167,
+        {
+          "source": "397.0",
+          "parsedValue": 397
+        },
+        -0.4000000059604645,
+        8.080000305175782,
+        {
+          "source": "5863.0",
+          "parsedValue": 5863
+        },
+        7.449999809265137,
+        108.5,
+        {
+          "source": "252.0",
+          "parsedValue": 252
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625069487839937,
+        {
+          "source": "20.0",
+          "parsedValue": 20
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "21.0",
+          "parsedValue": 21
+        },
+        {
+          "source": "1.775812314E12",
+          "parsedValue": 1775812314000
+        },
+        157.8000030517578,
+        60.7400016784668,
+        3.0369999408721924,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65248451381922,
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        0.5,
+        {
+          "source": "21.0",
+          "parsedValue": 21
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.25600004196167,
+        {
+          "source": "386.0",
+          "parsedValue": 386
+        },
+        -0.20000000298023224,
+        8.080000305175782,
+        {
+          "source": "6249.0",
+          "parsedValue": 6249
+        },
+        7.449999809265137,
+        108.5,
+        {
+          "source": "252.0",
+          "parsedValue": 252
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625053310766816,
+        {
+          "source": "21.0",
+          "parsedValue": 21
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "22.0",
+          "parsedValue": 22
+        },
+        {
+          "source": "1.775812315E12",
+          "parsedValue": 1775812315000
+        },
+        157.8000030517578,
+        63.66999816894531,
+        2.984999895095825,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65250940807164,
+        {
+          "source": "94.0",
+          "parsedValue": 94
+        },
+        0.5,
+        {
+          "source": "22.0",
+          "parsedValue": 22
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.2279999256134033,
+        {
+          "source": "368.0",
+          "parsedValue": 368
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.040000152587892,
+        {
+          "source": "6617.0",
+          "parsedValue": 6617
+        },
+        7.480000019073486,
+        107.60000000000001,
+        {
+          "source": "253.0",
+          "parsedValue": 253
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625043168663979,
+        {
+          "source": "22.0",
+          "parsedValue": 22
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "23.0",
+          "parsedValue": 23
+        },
+        {
+          "source": "1.775812316E12",
+          "parsedValue": 1775812316000
+        },
+        157.60000610351562,
+        66.58000183105469,
+        2.950000047683716,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.652536146342754,
+        {
+          "source": "95.0",
+          "parsedValue": 95
+        },
+        0.5,
+        {
+          "source": "23.0",
+          "parsedValue": 23
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.190999984741211,
+        {
+          "source": "356.0",
+          "parsedValue": 356
+        },
+        -0.20000000298023224,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "6973.0",
+          "parsedValue": 6973
+        },
+        7.519999980926514,
+        106.30000000000001,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625030931085348,
+        {
+          "source": "23.0",
+          "parsedValue": 23
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "24.0",
+          "parsedValue": 24
+        },
+        {
+          "source": "1.775812317E12",
+          "parsedValue": 1775812317000
+        },
+        157.39999389648438,
+        69.44000244140625,
+        2.9240000247955322,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.652562130242586,
+        {
+          "source": "95.0",
+          "parsedValue": 95
+        },
+        0.5,
+        {
+          "source": "24.0",
+          "parsedValue": 24
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.1630001068115234,
+        {
+          "source": "346.0",
+          "parsedValue": 346
+        },
+        -0.20000000298023224,
+        7.95999984741211,
+        {
+          "source": "7319.0",
+          "parsedValue": 7319
+        },
+        7.550000190734863,
+        105.4,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625037301331758,
+        {
+          "source": "24.0",
+          "parsedValue": 24
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "25.0",
+          "parsedValue": 25
+        },
+        {
+          "source": "1.775812318E12",
+          "parsedValue": 1775812318000
+        },
+        157.39999389648438,
+        72.45999908447266,
+        2.9070000648498535,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65259104780853,
+        {
+          "source": "97.0",
+          "parsedValue": 97
+        },
+        0.5,
+        {
+          "source": "25.0",
+          "parsedValue": 25
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.1440000534057617,
+        {
+          "source": "338.0",
+          "parsedValue": 338
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.819999694824219,
+        {
+          "source": "7657.0",
+          "parsedValue": 7657
+        },
+        7.539999961853027,
+        103.60000000000001,
+        {
+          "source": "253.0",
+          "parsedValue": 253
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62504124082625,
+        {
+          "source": "25.0",
+          "parsedValue": 25
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "26.0",
+          "parsedValue": 26
+        },
+        {
+          "source": "1.775812319E12",
+          "parsedValue": 1775812319000
+        },
+        157.1999969482422,
+        75.36000061035156,
+        2.8540000915527344,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65261745080352,
+        {
+          "source": "101.0",
+          "parsedValue": 101
+        },
+        0.5,
+        {
+          "source": "26.0",
+          "parsedValue": 26
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.115999937057495,
+        {
+          "source": "330.0",
+          "parsedValue": 330
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "7987.0",
+          "parsedValue": 7987
+        },
+        7.570000171661377,
+        102.7,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625069739297032,
+        {
+          "source": "26.0",
+          "parsedValue": 26
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "27.0",
+          "parsedValue": 27
+        },
+        {
+          "source": "1.77581232E12",
+          "parsedValue": 1775812320000
+        },
+        {
+          "source": "157.0",
+          "parsedValue": 157
+        },
+        78.55000305175781,
+        2.8459999561309814,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.652645111083984,
+        {
+          "source": "106.0",
+          "parsedValue": 106
+        },
+        0.5,
+        {
+          "source": "27.0",
+          "parsedValue": 27
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.1070001125335693,
+        {
+          "source": "326.0",
+          "parsedValue": 326
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "8313.0",
+          "parsedValue": 8313
+        },
+        7.590000152587891,
+        102.4,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625098153948784,
+        {
+          "source": "27.0",
+          "parsedValue": 27
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "28.0",
+          "parsedValue": 28
+        },
+        {
+          "source": "1.775812321E12",
+          "parsedValue": 1775812321000
+        },
+        156.8000030517578,
+        82.0199966430664,
+        2.802999973297119,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.652673525735736,
+        {
+          "source": "110.0",
+          "parsedValue": 110
+        },
+        0.5,
+        {
+          "source": "28.0",
+          "parsedValue": 28
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.059999942779541,
+        {
+          "source": "317.0",
+          "parsedValue": 317
+        },
+        -0.20000000298023224,
+        7.730000305175782,
+        {
+          "source": "8630.0",
+          "parsedValue": 8630
+        },
+        7.659999847412109,
+        100.80000000000001,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625128580257297,
+        {
+          "source": "28.0",
+          "parsedValue": 28
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "29.0",
+          "parsedValue": 29
+        },
+        {
+          "source": "1.775812322E12",
+          "parsedValue": 1775812322000
+        },
+        156.60000610351562,
+        85.51000213623047,
+        2.802999973297119,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65270059928298,
+        {
+          "source": "114.0",
+          "parsedValue": 114
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "29.0",
+          "parsedValue": 29
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.059999942779541,
+        {
+          "source": "314.0",
+          "parsedValue": 314
+        },
+        -0.20000000298023224,
+        7.730000305175782,
+        {
+          "source": "8944.0",
+          "parsedValue": 8944
+        },
+        7.659999847412109,
+        100.80000000000001,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625163281336427,
+        {
+          "source": "29.0",
+          "parsedValue": 29
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "30.0",
+          "parsedValue": 30
+        },
+        {
+          "source": "1.775812323E12",
+          "parsedValue": 1775812323000
+        },
+        156.39999389648438,
+        89.20999908447266,
+        2.861999988555908,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.652728175744414,
+        {
+          "source": "116.0",
+          "parsedValue": 116
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "30.0",
+          "parsedValue": 30
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.125999927520752,
+        {
+          "source": "320.0",
+          "parsedValue": 320
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "9264.0",
+          "parsedValue": 9264
+        },
+        7.550000190734863,
+        {
+          "source": "103.0",
+          "parsedValue": 103
+        },
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62520200572908,
+        {
+          "source": "30.0",
+          "parsedValue": 30
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "31.0",
+          "parsedValue": 31
+        },
+        {
+          "source": "1.775812324E12",
+          "parsedValue": 1775812324000
+        },
+        156.1999969482422,
+        93.05999755859375,
+        2.921999931335449,
+        {
+          "source": "183.0",
+          "parsedValue": 183
+        },
+        57.65275449492037,
+        {
+          "source": "118.0",
+          "parsedValue": 118
+        },
+        0.5,
+        {
+          "source": "31.0",
+          "parsedValue": 31
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.190999984741211,
+        {
+          "source": "332.0",
+          "parsedValue": 332
+        },
+        -0.20000000298023224,
+        7.730000305175782,
+        {
+          "source": "9596.0",
+          "parsedValue": 9596
+        },
+        7.429999828338623,
+        {
+          "source": "104.0",
+          "parsedValue": 104
+        },
+        {
+          "source": "250.0",
+          "parsedValue": 250
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625245591625571,
+        {
+          "source": "31.0",
+          "parsedValue": 31
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "32.0",
+          "parsedValue": 32
+        },
+        {
+          "source": "1.775812325E12",
+          "parsedValue": 1775812325000
+        },
+        {
+          "source": "156.0",
+          "parsedValue": 156
+        },
+        97.0199966430664,
+        2.9809999465942383,
+        {
+          "source": "184.0",
+          "parsedValue": 184
+        },
+        57.65278383158147,
+        {
+          "source": "119.0",
+          "parsedValue": 119
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "32.0",
+          "parsedValue": 32
+        },
+        {
+          "source": "92.0",
+          "parsedValue": 92
+        },
+        3.25600004196167,
+        {
+          "source": "348.0",
+          "parsedValue": 348
+        },
+        -0.20000000298023224,
+        7.80999984741211,
+        {
+          "source": "9944.0",
+          "parsedValue": 9944
+        },
+        7.349999904632568,
+        106.10000000000001,
+        {
+          "source": "248.0",
+          "parsedValue": 248
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62528171762824,
+        {
+          "source": "32.0",
+          "parsedValue": 32
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "33.0",
+          "parsedValue": 33
+        },
+        {
+          "source": "1.775812326E12",
+          "parsedValue": 1775812326000
+        },
+        155.8000030517578,
+        101.01000213623047,
+        3.0239999294281006,
+        {
+          "source": "186.0",
+          "parsedValue": 186
+        },
+        57.65280914492905,
+        {
+          "source": "119.0",
+          "parsedValue": 119
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "33.0",
+          "parsedValue": 33
+        },
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        3.302999973297119,
+        {
+          "source": "357.0",
+          "parsedValue": 357
+        },
+        -0.20000000298023224,
+        7.70999984741211,
+        {
+          "source": "10301.0",
+          "parsedValue": 10301
+        },
+        7.239999771118164,
+        106.5,
+        {
+          "source": "245.0",
+          "parsedValue": 245
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625329243019223,
+        {
+          "source": "33.0",
+          "parsedValue": 33
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "34.0",
+          "parsedValue": 34
+        },
+        {
+          "source": "1.775812327E12",
+          "parsedValue": 1775812327000
+        },
+        155.60000610351562,
+        105.02999877929688,
+        3.066999912261963,
+        {
+          "source": "186.0",
+          "parsedValue": 186
+        },
+        57.65283730812371,
+        {
+          "source": "120.0",
+          "parsedValue": 120
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "34.0",
+          "parsedValue": 34
+        },
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        3.3499999046325684,
+        {
+          "source": "365.0",
+          "parsedValue": 365
+        },
+        -0.20000000298023224,
+        7.75,
+        {
+          "source": "10666.0",
+          "parsedValue": 10666
+        },
+        7.179999828338623,
+        {
+          "source": "108.0",
+          "parsedValue": 108
+        },
+        {
+          "source": "244.0",
+          "parsedValue": 244
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625358579680324,
+        {
+          "source": "34.0",
+          "parsedValue": 34
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "35.0",
+          "parsedValue": 35
+        },
+        {
+          "source": "1.775812328E12",
+          "parsedValue": 1775812328000
+        },
+        155.60000610351562,
+        108.08000183105469,
+        3.1010000705718994,
+        {
+          "source": "186.0",
+          "parsedValue": 186
+        },
+        57.652854742482305,
+        {
+          "source": "120.0",
+          "parsedValue": 120
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "35.0",
+          "parsedValue": 35
+        },
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        3.38700008392334,
+        {
+          "source": "371.0",
+          "parsedValue": 371
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.790000152587891,
+        {
+          "source": "11037.0",
+          "parsedValue": 11037
+        },
+        7.130000114440918,
+        109.2,
+        {
+          "source": "243.0",
+          "parsedValue": 243
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625400489196181,
+        {
+          "source": "35.0",
+          "parsedValue": 35
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "36.0",
+          "parsedValue": 36
+        },
+        {
+          "source": "1.775812329E12",
+          "parsedValue": 1775812329000
+        },
+        155.60000610351562,
+        111.26000213623047,
+        3.11299991607666,
+        {
+          "source": "183.0",
+          "parsedValue": 183
+        },
+        57.6528756134212,
+        {
+          "source": "120.0",
+          "parsedValue": 120
+        },
+        0.5,
+        {
+          "source": "36.0",
+          "parsedValue": 36
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.38700008392334,
+        {
+          "source": "371.0",
+          "parsedValue": 371
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.930000305175781,
+        {
+          "source": "11408.0",
+          "parsedValue": 11408
+        },
+        7.179999828338623,
+        110.4,
+        {
+          "source": "245.0",
+          "parsedValue": 245
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625423958525062,
+        {
+          "source": "36.0",
+          "parsedValue": 36
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "37.0",
+          "parsedValue": 37
+        },
+        {
+          "source": "1.77581233E12",
+          "parsedValue": 1775812330000
+        },
+        155.60000610351562,
+        113.88999938964844,
+        3.11299991607666,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65289128758013,
+        {
+          "source": "121.0",
+          "parsedValue": 121
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "37.0",
+          "parsedValue": 37
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.38700008392334,
+        {
+          "source": "373.0",
+          "parsedValue": 373
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.069999694824219,
+        {
+          "source": "11781.0",
+          "parsedValue": 11781
+        },
+        7.21999979019165,
+        111.60000000000001,
+        {
+          "source": "247.0",
+          "parsedValue": 247
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625475591048598,
+        {
+          "source": "37.0",
+          "parsedValue": 37
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "38.0",
+          "parsedValue": 38
+        },
+        {
+          "source": "1.775812331E12",
+          "parsedValue": 1775812331000
+        },
+        155.60000610351562,
+        116.94000244140625,
+        3.0959999561309814,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.652908051386476,
+        {
+          "source": "121.0",
+          "parsedValue": 121
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "38.0",
+          "parsedValue": 38
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.368000030517578,
+        {
+          "source": "371.0",
+          "parsedValue": 371
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.030000305175781,
+        {
+          "source": "12152.0",
+          "parsedValue": 12152
+        },
+        7.230000019073486,
+        {
+          "source": "111.0",
+          "parsedValue": 111
+        },
+        {
+          "source": "248.0",
+          "parsedValue": 248
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.6255118008703,
+        {
+          "source": "38.0",
+          "parsedValue": 38
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "39.0",
+          "parsedValue": 39
+        },
+        {
+          "source": "1.775812332E12",
+          "parsedValue": 1775812332000
+        },
+        155.39999389648438,
+        120.0999984741211,
+        3.0450000762939453,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65292297117412,
+        {
+          "source": "122.0",
+          "parsedValue": 122
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "39.0",
+          "parsedValue": 39
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.312000036239624,
+        {
+          "source": "368.0",
+          "parsedValue": 368
+        },
+        -0.20000000298023224,
+        7.990000152587891,
+        {
+          "source": "12520.0",
+          "parsedValue": 12520
+        },
+        7.309999942779541,
+        109.10000000000001,
+        {
+          "source": "249.0",
+          "parsedValue": 249
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625560835003853,
+        {
+          "source": "39.0",
+          "parsedValue": 39
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "40.0",
+          "parsedValue": 40
+        },
+        {
+          "source": "1.775812333E12",
+          "parsedValue": 1775812333000
+        },
+        155.39999389648438,
+        123.13999938964844,
+        3.0929999351501465,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65294040553272,
+        {
+          "source": "123.0",
+          "parsedValue": 123
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "40.0",
+          "parsedValue": 40
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.2939999103546143,
+        {
+          "source": "371.0",
+          "parsedValue": 371
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.980000305175782,
+        {
+          "source": "12891.0",
+          "parsedValue": 12891
+        },
+        7.349999904632568,
+        108.5,
+        {
+          "source": "249.0",
+          "parsedValue": 249
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625600062310696,
+        {
+          "source": "40.0",
+          "parsedValue": 40
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "41.0",
+          "parsedValue": 41
+        },
+        {
+          "source": "1.775812334E12",
+          "parsedValue": 1775812334000
+        },
+        155.39999389648438,
+        126.2300033569336,
+        3.0850000381469727,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.652954906225204,
+        {
+          "source": "123.0",
+          "parsedValue": 123
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "41.0",
+          "parsedValue": 41
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.2839999198913574,
+        {
+          "source": "374.0",
+          "parsedValue": 374
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.95,
+        {
+          "source": "13265.0",
+          "parsedValue": 13265
+        },
+        7.340000152587891,
+        108.2,
+        {
+          "source": "250.0",
+          "parsedValue": 250
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625647084787488,
+        {
+          "source": "41.0",
+          "parsedValue": 41
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "42.0",
+          "parsedValue": 42
+        },
+        {
+          "source": "1.775812335E12",
+          "parsedValue": 1775812335000
+        },
+        155.39999389648438,
+        129.22000122070312,
+        3.066999912261963,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65296873636544,
+        {
+          "source": "123.0",
+          "parsedValue": 123
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "42.0",
+          "parsedValue": 42
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.2660000324249268,
+        {
+          "source": "378.0",
+          "parsedValue": 378
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.95,
+        {
+          "source": "13643.0",
+          "parsedValue": 13643
+        },
+        7.380000114440918,
+        107.60000000000001,
+        {
+          "source": "250.0",
+          "parsedValue": 250
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625680025666952,
+        {
+          "source": "42.0",
+          "parsedValue": 42
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "43.0",
+          "parsedValue": 43
+        },
+        {
+          "source": "1.775812336E12",
+          "parsedValue": 1775812336000
+        },
+        155.39999389648438,
+        131.75999450683594,
+        3.058000087738037,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.652976363897324,
+        {
+          "source": "124.0",
+          "parsedValue": 124
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "43.0",
+          "parsedValue": 43
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.25600004196167,
+        {
+          "source": "382.0",
+          "parsedValue": 382
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.940000152587891,
+        {
+          "source": "14025.0",
+          "parsedValue": 14025
+        },
+        7.400000095367432,
+        107.30000000000001,
+        {
+          "source": "250.0",
+          "parsedValue": 250
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625730903819203,
+        {
+          "source": "43.0",
+          "parsedValue": 43
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "44.0",
+          "parsedValue": 44
+        },
+        {
+          "source": "1.775812337E12",
+          "parsedValue": 1775812337000
+        },
+        155.1999969482422,
+        134.61000061035156,
+        3.0850000381469727,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65298776328564,
+        {
+          "source": "124.0",
+          "parsedValue": 124
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "44.0",
+          "parsedValue": 44
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.246999979019165,
+        {
+          "source": "388.0",
+          "parsedValue": 388
+        },
+        -0.20000000298023224,
+        7.909999847412109,
+        {
+          "source": "14413.0",
+          "parsedValue": 14413
+        },
+        7.389999866485596,
+        {
+          "source": "107.0",
+          "parsedValue": 107
+        },
+        {
+          "source": "251.0",
+          "parsedValue": 251
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625765185803175,
+        {
+          "source": "44.0",
+          "parsedValue": 44
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "45.0",
+          "parsedValue": 45
+        },
+        {
+          "source": "1.775812338E12",
+          "parsedValue": 1775812338000
+        },
+        155.1999969482422,
+        137.25,
+        3.059000015258789,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65299765393138,
+        {
+          "source": "125.0",
+          "parsedValue": 125
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "45.0",
+          "parsedValue": 45
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.2190001010894775,
+        {
+          "source": "390.0",
+          "parsedValue": 390
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.9,
+        {
+          "source": "14803.0",
+          "parsedValue": 14803
+        },
+        7.449999809265137,
+        106.10000000000001,
+        {
+          "source": "251.0",
+          "parsedValue": 251
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625803323462605,
+        {
+          "source": "45.0",
+          "parsedValue": 45
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "46.0",
+          "parsedValue": 46
+        },
+        {
+          "source": "1.775812339E12",
+          "parsedValue": 1775812339000
+        },
+        155.1999969482422,
+        139.83999633789062,
+        3.0409998893737793,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65301181934774,
+        {
+          "source": "125.0",
+          "parsedValue": 125
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "46.0",
+          "parsedValue": 46
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.200000047683716,
+        {
+          "source": "394.0",
+          "parsedValue": 394
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.8699996948242195,
+        {
+          "source": "15197.0",
+          "parsedValue": 15197
+        },
+        7.460000038146973,
+        105.5,
+        {
+          "source": "252.0",
+          "parsedValue": 252
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625842383131385,
+        {
+          "source": "46.0",
+          "parsedValue": 46
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "47.0",
+          "parsedValue": 47
+        },
+        {
+          "source": "1.77581234E12",
+          "parsedValue": 1775812340000
+        },
+        155.39999389648438,
+        142.60000610351562,
+        3.0230000019073486,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65303084626794,
+        {
+          "source": "126.0",
+          "parsedValue": 126
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "47.0",
+          "parsedValue": 47
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.181999921798706,
+        {
+          "source": "397.0",
+          "parsedValue": 397
+        },
+        0.20000000298023224,
+        7.8599998474121096,
+        {
+          "source": "15594.0",
+          "parsedValue": 15594
+        },
+        7.489999771118164,
+        104.80000000000001,
+        {
+          "source": "252.0",
+          "parsedValue": 252
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625872977077961,
+        {
+          "source": "47.0",
+          "parsedValue": 47
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "48.0",
+          "parsedValue": 48
+        },
+        {
+          "source": "1.775812341E12",
+          "parsedValue": 1775812341000
+        },
+        155.39999389648438,
+        145.42999267578125,
+        3.0329999923706055,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65304953791201,
+        {
+          "source": "127.0",
+          "parsedValue": 127
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "48.0",
+          "parsedValue": 48
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.171999931335449,
+        {
+          "source": "401.0",
+          "parsedValue": 401
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "15995.0",
+          "parsedValue": 15995
+        },
+        7.559999942779541,
+        105.7,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625898458063602,
+        {
+          "source": "48.0",
+          "parsedValue": 48
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "49.0",
+          "parsedValue": 49
+        },
+        {
+          "source": "1.775812342E12",
+          "parsedValue": 1775812342000
+        },
+        155.60000610351562,
+        148.39999389648438,
+        3.015000104904175,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.653071247041225,
+        {
+          "source": "127.0",
+          "parsedValue": 127
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "49.0",
+          "parsedValue": 49
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.1540000438690186,
+        {
+          "source": "401.0",
+          "parsedValue": 401
+        },
+        0.20000000298023224,
+        7.95999984741211,
+        {
+          "source": "16396.0",
+          "parsedValue": 16396
+        },
+        7.570000171661377,
+        105.10000000000001,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62592175975442,
+        {
+          "source": "49.0",
+          "parsedValue": 49
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "50.0",
+          "parsedValue": 50
+        },
+        {
+          "source": "1.775812343E12",
+          "parsedValue": 1775812343000
+        },
+        155.60000610351562,
+        151.10000610351562,
+        3.00600004196167,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65309236943722,
+        {
+          "source": "128.0",
+          "parsedValue": 128
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "50.0",
+          "parsedValue": 50
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.1440000534057617,
+        {
+          "source": "403.0",
+          "parsedValue": 403
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.95999984741211,
+        {
+          "source": "16799.0",
+          "parsedValue": 16799
+        },
+        7.590000152587891,
+        104.80000000000001,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625945815816522,
+        {
+          "source": "50.0",
+          "parsedValue": 50
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "51.0",
+          "parsedValue": 51
+        },
+        {
+          "source": "1.775812344E12",
+          "parsedValue": 1775812344000
+        },
+        155.8000030517578,
+        153.82000732421875,
+        3.00600004196167,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65311164781451,
+        {
+          "source": "129.0",
+          "parsedValue": 129
+        },
+        0.5,
+        {
+          "source": "51.0",
+          "parsedValue": 51
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.1440000534057617,
+        {
+          "source": "407.0",
+          "parsedValue": 407
+        },
+        0.20000000298023224,
+        7.95999984741211,
+        {
+          "source": "17206.0",
+          "parsedValue": 17206
+        },
+        7.590000152587891,
+        104.80000000000001,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625972051173449,
+        {
+          "source": "51.0",
+          "parsedValue": 51
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "52.0",
+          "parsedValue": 52
+        },
+        {
+          "source": "1.775812345E12",
+          "parsedValue": 1775812345000
+        },
+        155.8000030517578,
+        156.52000427246094,
+        3.0940001010894775,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65313453041017,
+        {
+          "source": "130.0",
+          "parsedValue": 130
+        },
+        0.5,
+        {
+          "source": "52.0",
+          "parsedValue": 52
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.125999927520752,
+        {
+          "source": "407.0",
+          "parsedValue": 407
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.919999694824219,
+        {
+          "source": "17613.0",
+          "parsedValue": 17613
+        },
+        7.599999904632568,
+        104.10000000000001,
+        {
+          "source": "256.0",
+          "parsedValue": 256
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.625993927940726,
+        {
+          "source": "52.0",
+          "parsedValue": 52
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "53.0",
+          "parsedValue": 53
+        },
+        {
+          "source": "1.775812346E12",
+          "parsedValue": 1775812346000
+        },
+        155.8000030517578,
+        159.14999389648438,
+        3.0850000381469727,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65315456315875,
+        {
+          "source": "130.0",
+          "parsedValue": 130
+        },
+        0.5,
+        {
+          "source": "53.0",
+          "parsedValue": 53
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.115999937057495,
+        {
+          "source": "409.0",
+          "parsedValue": 409
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.919999694824219,
+        {
+          "source": "18022.0",
+          "parsedValue": 18022
+        },
+        7.619999885559082,
+        103.80000000000001,
+        {
+          "source": "256.0",
+          "parsedValue": 256
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62602100148797,
+        {
+          "source": "53.0",
+          "parsedValue": 53
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "54.0",
+          "parsedValue": 54
+        },
+        {
+          "source": "1.775812347E12",
+          "parsedValue": 1775812347000
+        },
+        155.8000030517578,
+        162.24000549316406,
+        3.0759999752044678,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.653181133791804,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "54.0",
+          "parsedValue": 54
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.1070001125335693,
+        {
+          "source": "411.0",
+          "parsedValue": 411
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.909999847412109,
+        {
+          "source": "18433.0",
+          "parsedValue": 18433
+        },
+        7.639999866485596,
+        103.5,
+        {
+          "source": "256.0",
+          "parsedValue": 256
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626044554635882,
+        {
+          "source": "54.0",
+          "parsedValue": 54
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "55.0",
+          "parsedValue": 55
+        },
+        {
+          "source": "1.775812348E12",
+          "parsedValue": 1775812348000
+        },
+        155.8000030517578,
+        165.3800048828125,
+        3.065999984741211,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.653205441311,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "55.0",
+          "parsedValue": 55
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.0980000495910645,
+        {
+          "source": "414.0",
+          "parsedValue": 414
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.909999847412109,
+        {
+          "source": "18847.0",
+          "parsedValue": 18847
+        },
+        7.659999847412109,
+        103.2,
+        {
+          "source": "256.0",
+          "parsedValue": 256
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626076824963093,
+        {
+          "source": "55.0",
+          "parsedValue": 55
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "56.0",
+          "parsedValue": 56
+        },
+        {
+          "source": "1.775812349E12",
+          "parsedValue": 1775812349000
+        },
+        155.60000610351562,
+        168.88999938964844,
+        3.056999921798706,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65323167666793,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "56.0",
+          "parsedValue": 56
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.0880000591278076,
+        {
+          "source": "415.0",
+          "parsedValue": 415
+        },
+        -0.20000000298023224,
+        7.880000305175781,
+        {
+          "source": "19262.0",
+          "parsedValue": 19262
+        },
+        7.650000095367432,
+        102.9,
+        {
+          "source": "257.0",
+          "parsedValue": 257
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62610943056643,
+        {
+          "source": "56.0",
+          "parsedValue": 56
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "57.0",
+          "parsedValue": 57
+        },
+        {
+          "source": "1.77581235E12",
+          "parsedValue": 1775812350000
+        },
+        155.39999389648438,
+        172.49000549316406,
+        3.056999921798706,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.653257409110665,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "57.0",
+          "parsedValue": 57
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.0880000591278076,
+        {
+          "source": "414.0",
+          "parsedValue": 414
+        },
+        -0.20000000298023224,
+        7.740000152587891,
+        {
+          "source": "19676.0",
+          "parsedValue": 19676
+        },
+        7.599999904632568,
+        101.80000000000001,
+        {
+          "source": "255.0",
+          "parsedValue": 255
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62614262290299,
+        {
+          "source": "57.0",
+          "parsedValue": 57
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "58.0",
+          "parsedValue": 58
+        },
+        {
+          "source": "1.775812351E12",
+          "parsedValue": 1775812351000
+        },
+        155.1999969482422,
+        175.97999572753906,
+        3.065999984741211,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.65328397974372,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "58.0",
+          "parsedValue": 58
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.0980000495910645,
+        {
+          "source": "413.0",
+          "parsedValue": 413
+        },
+        -0.20000000298023224,
+        7.769999694824219,
+        {
+          "source": "20089.0",
+          "parsedValue": 20089
+        },
+        7.610000133514404,
+        102.10000000000001,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626172043383121,
+        {
+          "source": "58.0",
+          "parsedValue": 58
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "59.0",
+          "parsedValue": 59
+        },
+        {
+          "source": "1.775812352E12",
+          "parsedValue": 1775812352000
+        },
+        {
+          "source": "155.0",
+          "parsedValue": 155
+        },
+        179.07000732421875,
+        3.0759999752044678,
+        {
+          "source": "182.0",
+          "parsedValue": 182
+        },
+        57.653304347768426,
+        {
+          "source": "130.0",
+          "parsedValue": 130
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "59.0",
+          "parsedValue": 59
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        3.1070001125335693,
+        {
+          "source": "414.0",
+          "parsedValue": 414
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "20503.0",
+          "parsedValue": 20503
+        },
+        7.590000152587891,
+        102.4,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62620666064322,
+        {
+          "source": "59.0",
+          "parsedValue": 59
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "60.0",
+          "parsedValue": 60
+        },
+        {
+          "source": "1.775812353E12",
+          "parsedValue": 1775812353000
+        },
+        154.8000030517578,
+        182.3300018310547,
+        3.0220000743865967,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65332848764956,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "60.0",
+          "parsedValue": 60
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.1070001125335693,
+        {
+          "source": "414.0",
+          "parsedValue": 414
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "20917.0",
+          "parsedValue": 20917
+        },
+        7.590000152587891,
+        102.4,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626232393085957,
+        {
+          "source": "60.0",
+          "parsedValue": 60
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "61.0",
+          "parsedValue": 61
+        },
+        {
+          "source": "1.775812354E12",
+          "parsedValue": 1775812354000
+        },
+        154.60000610351562,
+        185.4600067138672,
+        3.0220000743865967,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65335095115006,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "61.0",
+          "parsedValue": 61
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.1070001125335693,
+        {
+          "source": "413.0",
+          "parsedValue": 413
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "21330.0",
+          "parsedValue": 21330
+        },
+        7.590000152587891,
+        102.4,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626262148842216,
+        {
+          "source": "61.0",
+          "parsedValue": 61
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "1.775812355E12",
+          "parsedValue": 1775812355000
+        },
+        154.60000610351562,
+        188.5399932861328,
+        3.0309998989105225,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65337542630732,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.115999937057495,
+        {
+          "source": "412.0",
+          "parsedValue": 412
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.780000305175782,
+        {
+          "source": "21742.0",
+          "parsedValue": 21742
+        },
+        7.570000171661377,
+        102.7,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626292742788792,
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "63.0",
+          "parsedValue": 63
+        },
+        {
+          "source": "1.775812356E12",
+          "parsedValue": 1775812356000
+        },
+        154.39999389648438,
+        191.55999755859375,
+        3.0309998989105225,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.653397135436535,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        0.5,
+        {
+          "source": "63.0",
+          "parsedValue": 63
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.115999937057495,
+        {
+          "source": "409.0",
+          "parsedValue": 409
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "22151.0",
+          "parsedValue": 22151
+        },
+        7.570000171661377,
+        102.7,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62631956487894,
+        {
+          "source": "63.0",
+          "parsedValue": 63
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "64.0",
+          "parsedValue": 64
+        },
+        {
+          "source": "1.775812357E12",
+          "parsedValue": 1775812357000
+        },
+        154.1999969482422,
+        194.74000549316406,
+        2.9619998931884766,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65342077240348,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        0.5,
+        {
+          "source": "64.0",
+          "parsedValue": 64
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.115999937057495,
+        {
+          "source": "406.0",
+          "parsedValue": 406
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "22557.0",
+          "parsedValue": 22557
+        },
+        7.570000171661377,
+        102.7,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626348901540041,
+        {
+          "source": "64.0",
+          "parsedValue": 64
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "65.0",
+          "parsedValue": 65
+        },
+        {
+          "source": "1.775812358E12",
+          "parsedValue": 1775812358000
+        },
+        {
+          "source": "154.0",
+          "parsedValue": 154
+        },
+        197.9600067138672,
+        2.9619998931884766,
+        {
+          "source": "181.0",
+          "parsedValue": 181
+        },
+        57.65344365499914,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "65.0",
+          "parsedValue": 65
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.115999937057495,
+        {
+          "source": "403.0",
+          "parsedValue": 403
+        },
+        -0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "22960.0",
+          "parsedValue": 22960
+        },
+        7.570000171661377,
+        102.7,
+        {
+          "source": "254.0",
+          "parsedValue": 254
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626373628154397,
+        {
+          "source": "65.0",
+          "parsedValue": 65
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "66.0",
+          "parsedValue": 66
+        },
+        {
+          "source": "1.775812359E12",
+          "parsedValue": 1775812359000
+        },
+        153.8000030517578,
+        200.8000030517578,
+        2.9619998931884766,
+        {
+          "source": "180.0",
+          "parsedValue": 180
+        },
+        57.65346435829997,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "66.0",
+          "parsedValue": 66
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        3.115999937057495,
+        {
+          "source": "399.0",
+          "parsedValue": 399
+        },
+        -0.20000000298023224,
+        7.919999694824219,
+        {
+          "source": "23359.0",
+          "parsedValue": 23359
+        },
+        7.619999885559082,
+        103.80000000000001,
+        {
+          "source": "256.0",
+          "parsedValue": 256
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626403970643878,
+        {
+          "source": "66.0",
+          "parsedValue": 66
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "67.0",
+          "parsedValue": 67
+        },
+        {
+          "source": "1.77581236E12",
+          "parsedValue": 1775812360000
+        },
+        153.39999389648438,
+        203.67999267578125,
+        2.9619998931884766,
+        {
+          "source": "179.0",
+          "parsedValue": 179
+        },
+        57.65348497778177,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "67.0",
+          "parsedValue": 67
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.115999937057495,
+        {
+          "source": "396.0",
+          "parsedValue": 396
+        },
+        -0.4000000059604645,
+        7.919999694824219,
+        {
+          "source": "23755.0",
+          "parsedValue": 23755
+        },
+        7.619999885559082,
+        103.80000000000001,
+        {
+          "source": "256.0",
+          "parsedValue": 256
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626423249021173,
+        {
+          "source": "67.0",
+          "parsedValue": 67
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "68.0",
+          "parsedValue": 68
+        },
+        {
+          "source": "1.775812361E12",
+          "parsedValue": 1775812361000
+        },
+        {
+          "source": "153.0",
+          "parsedValue": 153
+        },
+        205.9499969482422,
+        2.9130001068115234,
+        {
+          "source": "177.0",
+          "parsedValue": 177
+        },
+        57.65349998138845,
+        {
+          "source": "131.0",
+          "parsedValue": 131
+        },
+        0.5,
+        {
+          "source": "68.0",
+          "parsedValue": 68
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.1070001125335693,
+        {
+          "source": "391.0",
+          "parsedValue": 391
+        },
+        -0.4000000059604645,
+        8.05999984741211,
+        {
+          "source": "24146.0",
+          "parsedValue": 24146
+        },
+        7.690000057220459,
+        104.7,
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626462979242206,
+        {
+          "source": "68.0",
+          "parsedValue": 68
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "69.0",
+          "parsedValue": 69
+        },
+        {
+          "source": "1.775812362E12",
+          "parsedValue": 1775812362000
+        },
+        152.8000030517578,
+        208.6999969482422,
+        2.9049999713897705,
+        {
+          "source": "177.0",
+          "parsedValue": 177
+        },
+        57.653520768508315,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        0.5,
+        {
+          "source": "69.0",
+          "parsedValue": 69
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.0980000495910645,
+        {
+          "source": "378.0",
+          "parsedValue": 378
+        },
+        -0.20000000298023224,
+        8.05,
+        {
+          "source": "24524.0",
+          "parsedValue": 24524
+        },
+        7.710000038146973,
+        104.4,
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626491729170084,
+        {
+          "source": "69.0",
+          "parsedValue": 69
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "70.0",
+          "parsedValue": 70
+        },
+        {
+          "source": "1.775812363E12",
+          "parsedValue": 1775812363000
+        },
+        152.39999389648438,
+        211.94000244140625,
+        2.8959999084472656,
+        {
+          "source": "177.0",
+          "parsedValue": 177
+        },
+        57.65354432165623,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        0.5,
+        {
+          "source": "70.0",
+          "parsedValue": 70
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.0880000591278076,
+        {
+          "source": "366.0",
+          "parsedValue": 366
+        },
+        -0.4000000059604645,
+        8.01999969482422,
+        {
+          "source": "24890.0",
+          "parsedValue": 24890
+        },
+        7.699999809265137,
+        104.10000000000001,
+        {
+          "source": "259.0",
+          "parsedValue": 259
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626540176570415,
+        {
+          "source": "70.0",
+          "parsedValue": 70
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "71.0",
+          "parsedValue": 71
+        },
+        {
+          "source": "1.775812364E12",
+          "parsedValue": 1775812364000
+        },
+        {
+          "source": "152.0",
+          "parsedValue": 152
+        },
+        215.5,
+        2.88700008392334,
+        {
+          "source": "177.0",
+          "parsedValue": 177
+        },
+        57.65356929972768,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        0.5,
+        {
+          "source": "71.0",
+          "parsedValue": 71
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.0789999961853027,
+        {
+          "source": "356.0",
+          "parsedValue": 356
+        },
+        -0.4000000059604645,
+        8.01999969482422,
+        {
+          "source": "25246.0",
+          "parsedValue": 25246
+        },
+        7.71999979019165,
+        103.7,
+        {
+          "source": "259.0",
+          "parsedValue": 259
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626573788002133,
+        {
+          "source": "71.0",
+          "parsedValue": 71
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "72.0",
+          "parsedValue": 72
+        },
+        {
+          "source": "1.775812365E12",
+          "parsedValue": 1775812365000
+        },
+        151.60000610351562,
+        219.07000732421875,
+        2.7980000972747803,
+        {
+          "source": "176.0",
+          "parsedValue": 176
+        },
+        57.65359151177108,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "72.0",
+          "parsedValue": 72
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.0789999961853027,
+        {
+          "source": "347.0",
+          "parsedValue": 347
+        },
+        -0.4000000059604645,
+        8.15999984741211,
+        {
+          "source": "25593.0",
+          "parsedValue": 25593
+        },
+        7.769999980926514,
+        104.9,
+        {
+          "source": "261.0",
+          "parsedValue": 261
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626626342535019,
+        {
+          "source": "72.0",
+          "parsedValue": 72
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "73.0",
+          "parsedValue": 73
+        },
+        {
+          "source": "1.775812366E12",
+          "parsedValue": 1775812366000
+        },
+        151.39999389648438,
+        222.67999267578125,
+        2.805999994277954,
+        {
+          "source": "175.0",
+          "parsedValue": 175
+        },
+        57.65360802412033,
+        {
+          "source": "133.0",
+          "parsedValue": 133
+        },
+        0.5,
+        {
+          "source": "73.0",
+          "parsedValue": 73
+        },
+        {
+          "source": "87.0",
+          "parsedValue": 87
+        },
+        3.0880000591278076,
+        {
+          "source": "341.0",
+          "parsedValue": 341
+        },
+        -0.20000000298023224,
+        8.169999694824218,
+        {
+          "source": "25934.0",
+          "parsedValue": 25934
+        },
+        7.75,
+        105.2,
+        {
+          "source": "261.0",
+          "parsedValue": 261
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626655763015151,
+        {
+          "source": "73.0",
+          "parsedValue": 73
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "1.775812367E12",
+          "parsedValue": 1775812367000
+        },
+        151.1999969482422,
+        225.7100067138672,
+        2.815000057220459,
+        {
+          "source": "175.0",
+          "parsedValue": 175
+        },
+        57.65362797304988,
+        {
+          "source": "133.0",
+          "parsedValue": 133
+        },
+        0.5,
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "87.0",
+          "parsedValue": 87
+        },
+        3.0980000495910645,
+        {
+          "source": "335.0",
+          "parsedValue": 335
+        },
+        -0.20000000298023224,
+        8.200000000000001,
+        {
+          "source": "26269.0",
+          "parsedValue": 26269
+        },
+        7.760000228881836,
+        105.60000000000001,
+        {
+          "source": "260.0",
+          "parsedValue": 260
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626700270920992,
+        {
+          "source": "74.0",
+          "parsedValue": 74
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "75.0",
+          "parsedValue": 75
+        },
+        {
+          "source": "1.775812368E12",
+          "parsedValue": 1775812368000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        228.8800048828125,
+        2.8320000171661377,
+        {
+          "source": "178.0",
+          "parsedValue": 178
+        },
+        57.653647335246205,
+        {
+          "source": "133.0",
+          "parsedValue": 133
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "75.0",
+          "parsedValue": 75
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.115999937057495,
+        {
+          "source": "334.0",
+          "parsedValue": 334
+        },
+        -0.20000000298023224,
+        8.05999984741211,
+        {
+          "source": "26603.0",
+          "parsedValue": 26603
+        },
+        7.670000076293945,
+        {
+          "source": "105.0",
+          "parsedValue": 105
+        },
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626728350296617,
+        {
+          "source": "75.0",
+          "parsedValue": 75
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "76.0",
+          "parsedValue": 76
+        },
+        {
+          "source": "1.775812369E12",
+          "parsedValue": 1775812369000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        231.77000427246094,
+        2.8320000171661377,
+        {
+          "source": "178.0",
+          "parsedValue": 178
+        },
+        57.65366426669061,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "76.0",
+          "parsedValue": 76
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.115999937057495,
+        {
+          "source": "332.0",
+          "parsedValue": 332
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.05999984741211,
+        {
+          "source": "26935.0",
+          "parsedValue": 26935
+        },
+        7.670000076293945,
+        {
+          "source": "105.0",
+          "parsedValue": 105
+        },
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626772774383426,
+        {
+          "source": "76.0",
+          "parsedValue": 76
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "77.0",
+          "parsedValue": 77
+        },
+        {
+          "source": "1.77581237E12",
+          "parsedValue": 1775812370000
+        },
+        150.8000030517578,
+        234.77000427246094,
+        2.8320000171661377,
+        {
+          "source": "178.0",
+          "parsedValue": 178
+        },
+        57.653683545067906,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "77.0",
+          "parsedValue": 77
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        3.115999937057495,
+        {
+          "source": "331.0",
+          "parsedValue": 331
+        },
+        -0.20000000298023224,
+        8.05999984741211,
+        {
+          "source": "27266.0",
+          "parsedValue": 27266
+        },
+        7.670000076293945,
+        {
+          "source": "105.0",
+          "parsedValue": 105
+        },
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626798925921321,
+        {
+          "source": "77.0",
+          "parsedValue": 77
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "78.0",
+          "parsedValue": 78
+        },
+        {
+          "source": "1.775812371E12",
+          "parsedValue": 1775812371000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        237.3300018310547,
+        2.822999954223633,
+        {
+          "source": "177.0",
+          "parsedValue": 177
+        },
+        57.653698632493615,
+        {
+          "source": "132.0",
+          "parsedValue": 132
+        },
+        0.5,
+        {
+          "source": "78.0",
+          "parsedValue": 78
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.1070001125335693,
+        {
+          "source": "328.0",
+          "parsedValue": 328
+        },
+        0.20000000298023224,
+        8.05999984741211,
+        {
+          "source": "27594.0",
+          "parsedValue": 27594
+        },
+        7.690000057220459,
+        104.7,
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626831447705626,
+        {
+          "source": "78.0",
+          "parsedValue": 78
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "79.0",
+          "parsedValue": 79
+        },
+        {
+          "source": "1.775812372E12",
+          "parsedValue": 1775812372000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        240.08999633789062,
+        2.822999954223633,
+        {
+          "source": "177.0",
+          "parsedValue": 177
+        },
+        57.65371858142316,
+        {
+          "source": "133.0",
+          "parsedValue": 133
+        },
+        0.5,
+        {
+          "source": "79.0",
+          "parsedValue": 79
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.1070001125335693,
+        {
+          "source": "328.0",
+          "parsedValue": 328
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.05999984741211,
+        {
+          "source": "27922.0",
+          "parsedValue": 27922
+        },
+        7.690000057220459,
+        104.7,
+        {
+          "source": "258.0",
+          "parsedValue": 258
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626853995025158,
+        {
+          "source": "79.0",
+          "parsedValue": 79
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "80.0",
+          "parsedValue": 80
+        },
+        {
+          "source": "1.775812373E12",
+          "parsedValue": 1775812373000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        242.3800048828125,
+        2.8340001106262207,
+        {
+          "source": "176.0",
+          "parsedValue": 176
+        },
+        57.65373710542917,
+        {
+          "source": "133.0",
+          "parsedValue": 133
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "80.0",
+          "parsedValue": 80
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.0880000591278076,
+        {
+          "source": "329.0",
+          "parsedValue": 329
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.169999694824218,
+        {
+          "source": "28251.0",
+          "parsedValue": 28251
+        },
+        7.75,
+        105.2,
+        {
+          "source": "261.0",
+          "parsedValue": 261
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626866064965725,
+        {
+          "source": "80.0",
+          "parsedValue": 80
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "81.0",
+          "parsedValue": 81
+        },
+        {
+          "source": "1.775812374E12",
+          "parsedValue": 1775812374000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        244.72999572753906,
+        2.8259999752044678,
+        {
+          "source": "176.0",
+          "parsedValue": 176
+        },
+        57.65375655144453,
+        {
+          "source": "134.0",
+          "parsedValue": 134
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "81.0",
+          "parsedValue": 81
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        3.0789999961853027,
+        {
+          "source": "332.0",
+          "parsedValue": 332
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.15999984741211,
+        {
+          "source": "28583.0",
+          "parsedValue": 28583
+        },
+        7.769999980926514,
+        104.9,
+        {
+          "source": "261.0",
+          "parsedValue": 261
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626882493495941,
+        {
+          "source": "81.0",
+          "parsedValue": 81
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "82.0",
+          "parsedValue": 82
+        },
+        {
+          "source": "1.775812375E12",
+          "parsedValue": 1775812375000
+        },
+        {
+          "source": "151.0",
+          "parsedValue": 151
+        },
+        246.85000610351562,
+        2.809000015258789,
+        {
+          "source": "174.0",
+          "parsedValue": 174
+        },
+        57.65377515926957,
+        {
+          "source": "134.0",
+          "parsedValue": 134
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "82.0",
+          "parsedValue": 82
+        },
+        {
+          "source": "87.0",
+          "parsedValue": 87
+        },
+        3.059999942779541,
+        {
+          "source": "336.0",
+          "parsedValue": 336
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.26999969482422,
+        {
+          "source": "28919.0",
+          "parsedValue": 28919
+        },
+        7.840000152587891,
+        105.5,
+        {
+          "source": "264.0",
+          "parsedValue": 264
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626886935904622,
+        {
+          "source": "82.0",
+          "parsedValue": 82
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "83.0",
+          "parsedValue": 83
+        },
+        {
+          "source": "1.775812376E12",
+          "parsedValue": 1775812376000
+        },
+        151.1999969482422,
+        248.9499969482422,
+        2.7909998893737793,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.65378974378109,
+        {
+          "source": "134.0",
+          "parsedValue": 134
+        },
+        0.5,
+        {
+          "source": "83.0",
+          "parsedValue": 83
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        3.0420000553131104,
+        {
+          "source": "341.0",
+          "parsedValue": 341
+        },
+        0.20000000298023224,
+        8.26999969482422,
+        {
+          "source": "29260.0",
+          "parsedValue": 29260
+        },
+        7.880000114440918,
+        104.80000000000001,
+        {
+          "source": "264.0",
+          "parsedValue": 264
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626895904541016,
+        {
+          "source": "83.0",
+          "parsedValue": 83
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        {
+          "source": "1.775812377E12",
+          "parsedValue": 1775812377000
+        },
+        151.39999389648438,
+        251.16000366210938,
+        2.7739999294281006,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.65381279401481,
+        {
+          "source": "135.0",
+          "parsedValue": 135
+        },
+        0.5,
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        3.0230000019073486,
+        {
+          "source": "346.0",
+          "parsedValue": 346
+        },
+        0.20000000298023224,
+        8.230000305175782,
+        {
+          "source": "29606.0",
+          "parsedValue": 29606
+        },
+        7.889999866485596,
+        104.2,
+        {
+          "source": "265.0",
+          "parsedValue": 265
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62689271941781,
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        {
+          "source": "1.775812378E12",
+          "parsedValue": 1775812378000
+        },
+        151.60000610351562,
+        253.47000122070312,
+        2.431999921798706,
+        {
+          "source": "172.0",
+          "parsedValue": 172
+        },
+        57.65383039601147,
+        {
+          "source": "135.0",
+          "parsedValue": 135
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.6500000953674316,
+        {
+          "source": "312.0",
+          "parsedValue": 312
+        },
+        0.20000000298023224,
+        7.909999847412109,
+        {
+          "source": "29918.0",
+          "parsedValue": 29918
+        },
+        8.5600004196167,
+        92.4,
+        {
+          "source": "276.0",
+          "parsedValue": 276
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626883247867227,
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        {
+          "source": "1.775812379E12",
+          "parsedValue": 1775812379000
+        },
+        151.8000030517578,
+        255.74000549316406,
+        2.4709999561309814,
+        {
+          "source": "172.0",
+          "parsedValue": 172
+        },
+        57.65385093167424,
+        {
+          "source": "135.0",
+          "parsedValue": 135
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.63100004196167,
+        {
+          "source": "318.0",
+          "parsedValue": 318
+        },
+        0.20000000298023224,
+        7.9,
+        {
+          "source": "30236.0",
+          "parsedValue": 30236
+        },
+        8.609999656677246,
+        91.7,
+        {
+          "source": "276.0",
+          "parsedValue": 276
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626877129077911,
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "87.0",
+          "parsedValue": 87
+        },
+        {
+          "source": "1.77581238E12",
+          "parsedValue": 1775812380000
+        },
+        {
+          "source": "152.0",
+          "parsedValue": 152
+        },
+        257.9599914550781,
+        2.427000045776367,
+        {
+          "source": "171.0",
+          "parsedValue": 171
+        },
+        57.65387146733701,
+        {
+          "source": "135.0",
+          "parsedValue": 135
+        },
+        0.5,
+        {
+          "source": "87.0",
+          "parsedValue": 87
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        2.5850000381469727,
+        {
+          "source": "321.0",
+          "parsedValue": 321
+        },
+        0.20000000298023224,
+        7.95,
+        {
+          "source": "30557.0",
+          "parsedValue": 30557
+        },
+        8.720000267028809,
+        91.2,
+        {
+          "source": "280.0",
+          "parsedValue": 280
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626865059137344,
+        {
+          "source": "87.0",
+          "parsedValue": 87
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        {
+          "source": "1.775812381E12",
+          "parsedValue": 1775812381000
+        },
+        152.1999969482422,
+        259.7900085449219,
+        2.382999897003174,
+        {
+          "source": "170.0",
+          "parsedValue": 170
+        },
+        57.653883788734674,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        2.5380001068115234,
+        {
+          "source": "323.0",
+          "parsedValue": 323
+        },
+        0.20000000298023224,
+        7.890000152587891,
+        {
+          "source": "30880.0",
+          "parsedValue": 30880
+        },
+        8.8100004196167,
+        89.5,
+        {
+          "source": "281.0",
+          "parsedValue": 281
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626852067187428,
+        {
+          "source": "88.0",
+          "parsedValue": 88
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        {
+          "source": "1.775812382E12",
+          "parsedValue": 1775812382000
+        },
+        152.39999389648438,
+        262.4200134277344,
+        2.374000072479248,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.653908766806126,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        0.5,
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.5290000438690186,
+        {
+          "source": "330.0",
+          "parsedValue": 330
+        },
+        0.20000000298023224,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "31210.0",
+          "parsedValue": 31210
+        },
+        8.859999656677246,
+        90.30000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626837566494942,
+        {
+          "source": "89.0",
+          "parsedValue": 89
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        {
+          "source": "1.775812383E12",
+          "parsedValue": 1775812383000
+        },
+        152.60000610351562,
+        264.7300109863281,
+        2.374000072479248,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.653925362974405,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        0.5,
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.5290000438690186,
+        {
+          "source": "337.0",
+          "parsedValue": 337
+        },
+        0.20000000298023224,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "31547.0",
+          "parsedValue": 31547
+        },
+        8.859999656677246,
+        90.30000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626817617565393,
+        {
+          "source": "90.0",
+          "parsedValue": 90
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        {
+          "source": "1.775812384E12",
+          "parsedValue": 1775812384000
+        },
+        152.60000610351562,
+        267.1700134277344,
+        2.5910000801086426,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.6539462339133,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.556999921798706,
+        {
+          "source": "350.0",
+          "parsedValue": 350
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.05,
+        {
+          "source": "31897.0",
+          "parsedValue": 31897
+        },
+        8.819999694824219,
+        91.30000000000001,
+        {
+          "source": "283.0",
+          "parsedValue": 283
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626801189035177,
+        {
+          "source": "91.0",
+          "parsedValue": 91
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "92.0",
+          "parsedValue": 92
+        },
+        {
+          "source": "1.775812385E12",
+          "parsedValue": 1775812385000
+        },
+        152.60000610351562,
+        269.5899963378906,
+        2.6010000705718994,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65396618284285,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "92.0",
+          "parsedValue": 92
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.565999984741211,
+        {
+          "source": "358.0",
+          "parsedValue": 358
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.05999984741211,
+        {
+          "source": "32255.0",
+          "parsedValue": 32255
+        },
+        8.789999961853027,
+        91.60000000000001,
+        {
+          "source": "283.0",
+          "parsedValue": 283
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626782497391105,
+        {
+          "source": "92.0",
+          "parsedValue": 92
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        {
+          "source": "1.775812386E12",
+          "parsedValue": 1775812386000
+        },
+        152.8000030517578,
+        271.7200012207031,
+        2.6010000705718994,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.65398026444018,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        0.5,
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.565999984741211,
+        {
+          "source": "365.0",
+          "parsedValue": 365
+        },
+        0.20000000298023224,
+        8.05999984741211,
+        {
+          "source": "32620.0",
+          "parsedValue": 32620
+        },
+        8.789999961853027,
+        91.60000000000001,
+        {
+          "source": "283.0",
+          "parsedValue": 283
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626759614795446,
+        {
+          "source": "93.0",
+          "parsedValue": 93
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "94.0",
+          "parsedValue": 94
+        },
+        {
+          "source": "1.775812387E12",
+          "parsedValue": 1775812387000
+        },
+        152.8000030517578,
+        274.19000244140625,
+        2.5910000801086426,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.65400281175971,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        0.5,
+        {
+          "source": "94.0",
+          "parsedValue": 94
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.556999921798706,
+        {
+          "source": "369.0",
+          "parsedValue": 369
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.05,
+        {
+          "source": "32989.0",
+          "parsedValue": 32989
+        },
+        8.819999694824219,
+        91.30000000000001,
+        {
+          "source": "283.0",
+          "parsedValue": 283
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626743521541357,
+        {
+          "source": "94.0",
+          "parsedValue": 94
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "95.0",
+          "parsedValue": 95
+        },
+        {
+          "source": "1.775812388E12",
+          "parsedValue": 1775812388000
+        },
+        152.8000030517578,
+        276.5400085449219,
+        2.572000026702881,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.654018737375736,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "95.0",
+          "parsedValue": 95
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.5380001068115234,
+        {
+          "source": "369.0",
+          "parsedValue": 369
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        8.009999847412109,
+        {
+          "source": "33358.0",
+          "parsedValue": 33358
+        },
+        8.829999923706055,
+        90.60000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626721141859889,
+        {
+          "source": "95.0",
+          "parsedValue": 95
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "96.0",
+          "parsedValue": 96
+        },
+        {
+          "source": "1.775812389E12",
+          "parsedValue": 1775812389000
+        },
+        152.8000030517578,
+        279.2099914550781,
+        2.5940001010894775,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65404203906655,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "96.0",
+          "parsedValue": 96
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.5290000438690186,
+        {
+          "source": "372.0",
+          "parsedValue": 372
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "33730.0",
+          "parsedValue": 33730
+        },
+        8.859999656677246,
+        90.30000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62670018710196,
+        {
+          "source": "96.0",
+          "parsedValue": 96
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "97.0",
+          "parsedValue": 97
+        },
+        {
+          "source": "1.77581239E12",
+          "parsedValue": 1775812390000
+        },
+        {
+          "source": "153.0",
+          "parsedValue": 153
+        },
+        281.3699951171875,
+        2.6040000915527344,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65405662357807,
+        {
+          "source": "136.0",
+          "parsedValue": 136
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "97.0",
+          "parsedValue": 97
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.5380001068115234,
+        {
+          "source": "377.0",
+          "parsedValue": 377
+        },
+        0.20000000298023224,
+        8.009999847412109,
+        {
+          "source": "34107.0",
+          "parsedValue": 34107
+        },
+        8.829999923706055,
+        90.60000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62667621485889,
+        {
+          "source": "97.0",
+          "parsedValue": 97
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "98.0",
+          "parsedValue": 98
+        },
+        {
+          "source": "1.775812391E12",
+          "parsedValue": 1775812391000
+        },
+        153.1999969482422,
+        283.6700134277344,
+        2.5940001010894775,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65406928025186,
+        {
+          "source": "137.0",
+          "parsedValue": 137
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "98.0",
+          "parsedValue": 98
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.5290000438690186,
+        {
+          "source": "382.0",
+          "parsedValue": 382
+        },
+        0.20000000298023224,
+        {
+          "source": "8.0",
+          "parsedValue": 8
+        },
+        {
+          "source": "34489.0",
+          "parsedValue": 34489
+        },
+        8.859999656677246,
+        90.30000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.6266498118639,
+        {
+          "source": "98.0",
+          "parsedValue": 98
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "99.0",
+          "parsedValue": 99
+        },
+        {
+          "source": "1.775812392E12",
+          "parsedValue": 1775812392000
+        },
+        153.39999389648438,
+        285.8299865722656,
+        2.575000047683716,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65408570878208,
+        {
+          "source": "137.0",
+          "parsedValue": 137
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "99.0",
+          "parsedValue": 99
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.509999990463257,
+        {
+          "source": "385.0",
+          "parsedValue": 385
+        },
+        0.20000000298023224,
+        7.990000152587891,
+        {
+          "source": "34874.0",
+          "parsedValue": 34874
+        },
+        8.90999984741211,
+        89.60000000000001,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626634137704968,
+        {
+          "source": "99.0",
+          "parsedValue": 99
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "100.0",
+          "parsedValue": 100
+        },
+        {
+          "source": "1.775812393E12",
+          "parsedValue": 1775812393000
+        },
+        153.60000610351562,
+        287.489990234375,
+        2.5460000038146973,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65409258194268,
+        {
+          "source": "138.0",
+          "parsedValue": 138
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "100.0",
+          "parsedValue": 100
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.4820001125335693,
+        {
+          "source": "400.0",
+          "parsedValue": 400
+        },
+        0.20000000298023224,
+        7.940000152587891,
+        {
+          "source": "35274.0",
+          "parsedValue": 35274
+        },
+        8.960000038146973,
+        88.60000000000001,
+        {
+          "source": "285.0",
+          "parsedValue": 285
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626612847670913,
+        {
+          "source": "100.0",
+          "parsedValue": 100
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "101.0",
+          "parsedValue": 101
+        },
+        {
+          "source": "1.775812394E12",
+          "parsedValue": 1775812394000
+        },
+        153.8000030517578,
+        289.3299865722656,
+        2.5179998874664307,
+        {
+          "source": "171.0",
+          "parsedValue": 171
+        },
+        57.6541103515774,
+        {
+          "source": "138.0",
+          "parsedValue": 138
+        },
+        0.5,
+        {
+          "source": "101.0",
+          "parsedValue": 101
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        2.4539999961853027,
+        {
+          "source": "413.0",
+          "parsedValue": 413
+        },
+        0.20000000298023224,
+        7.780000305175782,
+        {
+          "source": "35687.0",
+          "parsedValue": 35687
+        },
+        8.979999542236328,
+        86.60000000000001,
+        {
+          "source": "283.0",
+          "parsedValue": 283
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62658728286624,
+        {
+          "source": "101.0",
+          "parsedValue": 101
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "102.0",
+          "parsedValue": 102
+        },
+        {
+          "source": "1.775812395E12",
+          "parsedValue": 1775812395000
+        },
+        {
+          "source": "154.0",
+          "parsedValue": 154
+        },
+        291.5199890136719,
+        2.509999990463257,
+        {
+          "source": "171.0",
+          "parsedValue": 171
+        },
+        57.6541240978986,
+        {
+          "source": "138.0",
+          "parsedValue": 138
+        },
+        0.5,
+        {
+          "source": "102.0",
+          "parsedValue": 102
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        2.4070000648498535,
+        {
+          "source": "423.0",
+          "parsedValue": 423
+        },
+        0.20000000298023224,
+        7.719999694824219,
+        {
+          "source": "36110.0",
+          "parsedValue": 36110
+        },
+        9.079999923706055,
+        84.9,
+        {
+          "source": "284.0",
+          "parsedValue": 284
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626558281481266,
+        {
+          "source": "102.0",
+          "parsedValue": 102
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "103.0",
+          "parsedValue": 103
+        },
+        {
+          "source": "1.775812396E12",
+          "parsedValue": 1775812396000
+        },
+        154.1999969482422,
+        293.70001220703125,
+        2.4709999561309814,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.654136922210455,
+        {
+          "source": "139.0",
+          "parsedValue": 139
+        },
+        0.5,
+        {
+          "source": "103.0",
+          "parsedValue": 103
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.369999885559082,
+        {
+          "source": "433.0",
+          "parsedValue": 433
+        },
+        0.20000000298023224,
+        7.769999694824219,
+        {
+          "source": "36543.0",
+          "parsedValue": 36543
+        },
+        9.180000305175781,
+        84.60000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626529447734356,
+        {
+          "source": "103.0",
+          "parsedValue": 103
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "104.0",
+          "parsedValue": 104
+        },
+        {
+          "source": "1.775812397E12",
+          "parsedValue": 1775812397000
+        },
+        154.39999389648438,
+        296.30999755859375,
+        2.4609999656677246,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.654155949130654,
+        {
+          "source": "139.0",
+          "parsedValue": 139
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "104.0",
+          "parsedValue": 104
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.3610000610351562,
+        {
+          "source": "442.0",
+          "parsedValue": 442
+        },
+        0.20000000298023224,
+        7.75999984741211,
+        {
+          "source": "36985.0",
+          "parsedValue": 36985
+        },
+        9.210000038146973,
+        84.30000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62650522403419,
+        {
+          "source": "104.0",
+          "parsedValue": 104
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "105.0",
+          "parsedValue": 105
+        },
+        {
+          "source": "1.775812398E12",
+          "parsedValue": 1775812398000
+        },
+        154.39999389648438,
+        298.6300048828125,
+        2.4609999656677246,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65416642650962,
+        {
+          "source": "139.0",
+          "parsedValue": 139
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "105.0",
+          "parsedValue": 105
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.3610000610351562,
+        {
+          "source": "448.0",
+          "parsedValue": 448
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.75999984741211,
+        {
+          "source": "37433.0",
+          "parsedValue": 37433
+        },
+        9.210000038146973,
+        84.30000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626477479934692,
+        {
+          "source": "105.0",
+          "parsedValue": 105
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "106.0",
+          "parsedValue": 106
+        },
+        {
+          "source": "1.775812399E12",
+          "parsedValue": 1775812399000
+        },
+        154.60000610351562,
+        301.2300109863281,
+        2.4709999561309814,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.65418930910528,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        0.5,
+        {
+          "source": "106.0",
+          "parsedValue": 106
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.369999885559082,
+        {
+          "source": "454.0",
+          "parsedValue": 454
+        },
+        0.20000000298023224,
+        7.769999694824219,
+        {
+          "source": "37887.0",
+          "parsedValue": 37887
+        },
+        9.180000305175781,
+        84.60000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626463063061237,
+        {
+          "source": "106.0",
+          "parsedValue": 106
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "107.0",
+          "parsedValue": 107
+        },
+        {
+          "source": "1.7758124E12",
+          "parsedValue": 1775812400000
+        },
+        154.60000610351562,
+        303.3399963378906,
+        2.638000011444092,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.6542036421597,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        0.5,
+        {
+          "source": "107.0",
+          "parsedValue": 107
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.369999885559082,
+        {
+          "source": "455.0",
+          "parsedValue": 455
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.769999694824219,
+        {
+          "source": "38342.0",
+          "parsedValue": 38342
+        },
+        9.180000305175781,
+        84.60000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626438420265913,
+        {
+          "source": "107.0",
+          "parsedValue": 107
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "108.0",
+          "parsedValue": 108
+        },
+        {
+          "source": "1.775812401E12",
+          "parsedValue": 1775812401000
+        },
+        154.60000610351562,
+        305.6700134277344,
+        2.6480000019073486,
+        {
+          "source": "169.0",
+          "parsedValue": 169
+        },
+        57.65422124415636,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        0.5,
+        {
+          "source": "108.0",
+          "parsedValue": 108
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.378999948501587,
+        {
+          "source": "457.0",
+          "parsedValue": 457
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.769999694824219,
+        {
+          "source": "38799.0",
+          "parsedValue": 38799
+        },
+        9.149999618530273,
+        84.9,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626414112746716,
+        {
+          "source": "108.0",
+          "parsedValue": 108
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "109.0",
+          "parsedValue": 109
+        },
+        {
+          "source": "1.775812402E12",
+          "parsedValue": 1775812402000
+        },
+        154.60000610351562,
+        307.8299865722656,
+        2.6480000019073486,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65423423610628,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "109.0",
+          "parsedValue": 109
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.378999948501587,
+        {
+          "source": "458.0",
+          "parsedValue": 458
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.769999694824219,
+        {
+          "source": "39257.0",
+          "parsedValue": 39257
+        },
+        9.149999618530273,
+        84.9,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626390978693962,
+        {
+          "source": "109.0",
+          "parsedValue": 109
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "110.0",
+          "parsedValue": 110
+        },
+        {
+          "source": "1.775812403E12",
+          "parsedValue": 1775812403000
+        },
+        154.8000030517578,
+        309.67999267578125,
+        2.638000011444092,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65424471348524,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "110.0",
+          "parsedValue": 110
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.369999885559082,
+        {
+          "source": "458.0",
+          "parsedValue": 458
+        },
+        0.20000000298023224,
+        7.769999694824219,
+        {
+          "source": "39715.0",
+          "parsedValue": 39715
+        },
+        9.180000305175781,
+        84.60000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626366084441543,
+        {
+          "source": "110.0",
+          "parsedValue": 110
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "111.0",
+          "parsedValue": 111
+        },
+        {
+          "source": "1.775812404E12",
+          "parsedValue": 1775812404000
+        },
+        {
+          "source": "155.0",
+          "parsedValue": 155
+        },
+        311.8500061035156,
+        2.6059999465942383,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65426306985319,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "111.0",
+          "parsedValue": 111
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.3420000076293945,
+        {
+          "source": "455.0",
+          "parsedValue": 455
+        },
+        0.20000000298023224,
+        7.75,
+        {
+          "source": "40170.0",
+          "parsedValue": 40170
+        },
+        9.260000228881836,
+        83.60000000000001,
+        {
+          "source": "288.0",
+          "parsedValue": 288
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626346303150058,
+        {
+          "source": "111.0",
+          "parsedValue": 111
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "112.0",
+          "parsedValue": 112
+        },
+        {
+          "source": "1.775812405E12",
+          "parsedValue": 1775812405000
+        },
+        {
+          "source": "155.0",
+          "parsedValue": 155
+        },
+        313.9200134277344,
+        2.5230000019073486,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65427497215569,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "112.0",
+          "parsedValue": 112
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.2669999599456787,
+        {
+          "source": "443.0",
+          "parsedValue": 443
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.630000305175781,
+        {
+          "source": "40613.0",
+          "parsedValue": 40613
+        },
+        9.430000305175781,
+        80.9,
+        {
+          "source": "290.0",
+          "parsedValue": 290
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62632048688829,
+        {
+          "source": "112.0",
+          "parsedValue": 112
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "113.0",
+          "parsedValue": 113
+        },
+        {
+          "source": "1.775812406E12",
+          "parsedValue": 1775812406000
+        },
+        155.1999969482422,
+        316.57000732421875,
+        2.513000011444092,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.6542985253036,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "113.0",
+          "parsedValue": 113
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.257999897003174,
+        {
+          "source": "440.0",
+          "parsedValue": 440
+        },
+        0.20000000298023224,
+        7.6199996948242195,
+        {
+          "source": "41053.0",
+          "parsedValue": 41053
+        },
+        9.460000038146973,
+        80.60000000000001,
+        {
+          "source": "290.0",
+          "parsedValue": 290
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.62629995122552,
+        {
+          "source": "113.0",
+          "parsedValue": 113
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "114.0",
+          "parsedValue": 114
+        },
+        {
+          "source": "1.775812407E12",
+          "parsedValue": 1775812407000
+        },
+        155.1999969482422,
+        318.739990234375,
+        2.513000011444092,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.654312774538994,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "114.0",
+          "parsedValue": 114
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.257999897003174,
+        {
+          "source": "438.0",
+          "parsedValue": 438
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        7.6199996948242195,
+        {
+          "source": "41491.0",
+          "parsedValue": 41491
+        },
+        9.460000038146973,
+        80.60000000000001,
+        {
+          "source": "290.0",
+          "parsedValue": 290
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626276900991797,
+        {
+          "source": "114.0",
+          "parsedValue": 114
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "115.0",
+          "parsedValue": 115
+        },
+        {
+          "source": "1.775812408E12",
+          "parsedValue": 1775812408000
+        },
+        155.39999389648438,
+        321.07000732421875,
+        2.5339999198913574,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65433012507856,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "115.0",
+          "parsedValue": 115
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.2769999504089355,
+        {
+          "source": "440.0",
+          "parsedValue": 440
+        },
+        0.20000000298023224,
+        7.640000152587891,
+        {
+          "source": "41931.0",
+          "parsedValue": 41931
+        },
+        9.399999618530273,
+        81.30000000000001,
+        {
+          "source": "290.0",
+          "parsedValue": 290
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626249240711331,
+        {
+          "source": "115.0",
+          "parsedValue": 115
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "116.0",
+          "parsedValue": 116
+        },
+        {
+          "source": "1.775812409E12",
+          "parsedValue": 1775812409000
+        },
+        155.60000610351562,
+        323.4100036621094,
+        2.5339999198913574,
+        {
+          "source": "168.0",
+          "parsedValue": 168
+        },
+        57.65434663742781,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "116.0",
+          "parsedValue": 116
+        },
+        {
+          "source": "84.0",
+          "parsedValue": 84
+        },
+        2.2769999504089355,
+        {
+          "source": "442.0",
+          "parsedValue": 442
+        },
+        0.20000000298023224,
+        7.640000152587891,
+        {
+          "source": "42373.0",
+          "parsedValue": 42373
+        },
+        9.399999618530273,
+        81.30000000000001,
+        {
+          "source": "290.0",
+          "parsedValue": 290
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626225184649229,
+        {
+          "source": "116.0",
+          "parsedValue": 116
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "117.0",
+          "parsedValue": 117
+        },
+        {
+          "source": "1.77581241E12",
+          "parsedValue": 1775812410000
+        },
+        155.8000030517578,
+        325.54998779296875,
+        2.5339999198913574,
+        {
+          "source": "170.0",
+          "parsedValue": 170
+        },
+        57.654356276616454,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "117.0",
+          "parsedValue": 117
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        2.2769999504089355,
+        {
+          "source": "443.0",
+          "parsedValue": 443
+        },
+        0.20000000298023224,
+        7.540000152587891,
+        {
+          "source": "42816.0",
+          "parsedValue": 42816
+        },
+        9.380000114440918,
+        80.30000000000001,
+        {
+          "source": "287.0",
+          "parsedValue": 287
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626200541853905,
+        {
+          "source": "117.0",
+          "parsedValue": 117
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "118.0",
+          "parsedValue": 118
+        },
+        {
+          "source": "1.775812411E12",
+          "parsedValue": 1775812411000
+        },
+        {
+          "source": "156.0",
+          "parsedValue": 156
+        },
+        327.95001220703125,
+        2.5339999198913574,
+        {
+          "source": "170.0",
+          "parsedValue": 170
+        },
+        57.654377315193415,
+        {
+          "source": "140.0",
+          "parsedValue": 140
+        },
+        {
+          "source": "0.0",
+          "parsedValue": 0
+        },
+        {
+          "source": "118.0",
+          "parsedValue": 118
+        },
+        {
+          "source": "85.0",
+          "parsedValue": 85
+        },
+        2.2769999504089355,
+        {
+          "source": "446.0",
+          "parsedValue": 446
+        },
+        0.20000000298023224,
+        7.540000152587891,
+        {
+          "source": "43262.0",
+          "parsedValue": 43262
+        },
+        9.380000114440918,
+        80.30000000000001,
+        {
+          "source": "287.0",
+          "parsedValue": 287
+        },
+        null
+      ]
+    },
+    {
+      "metrics": [
+        12.626185035333037,
+        {
+          "source": "118.0",
+          "parsedValue": 118
+        },
+        {
+          "source": "62.0",
+          "parsedValue": 62
+        },
+        {
+          "source": "119.0",
+          "parsedValue": 119
+        },
+        {
+          "source": "1.775812412E12",
+          "parsedValue": 1775812412000
+        },
+        156.1999969482422,
+        329.7300109863281,
+        2.5439999103546143,
+        {
+          "source": "173.0",
+          "parsedValue": 173
+        },
+        57.65438913367689,
+        {
+          "source": "141.0",
+          "parsedValue": 141
+        },
+        0.5,
+        {
+          "source": "119.0",
+          "parsedValue": 119
+        },
+        {
+          "source": "86.0",
+          "parsedValue": 86
+        },
+        2.2860000133514404,
+        {
+          "source": "449.0",
+          "parsedValue": 449
+        },
+        0.20000000298023224,
+        7.419999694824219,
+        {
+          "source": "43711.0",
+          "parsedValue": 43711
+        },
+        9.300000190734863,
+        79.7,
+        {
+          "source": "285.0",
+          "parsedValue": 285
+        },
+        null
+      ]
+    }
+  ],
+  "geoPolylineDTO": {
+    "startPoint": null,
+    "endPoint": null,
+    "minLat": null,
+    "maxLat": null,
+    "minLon": null,
+    "maxLon": null,
+    "polyline": []
+  }
+}


### PR DESCRIPTION
## Summary
- `pg-format %L` quotes all values as text, but `ST_MakePoint` requires `double precision`. Added explicit casts (`::double precision`, `::timestamptz`, `::text[]`) in the batch INSERT query.
- New integration test (`garmin-resync.integration.test.ts`) runs `processActivityDetail` against a real PostGIS database using a real Garmin API response fixture (trimmed to 120 entries). Verifies time series, GPS locations, idempotency, and the `insertLocations` batch path.

## Root cause chain
1. `insertLocations` used `pg-format %L` which quotes everything as text
2. `ST_MakePoint('12.62', '57.65')` fails: "function st_makepoint(text, text) does not exist"
3. Previously, empty `[]` for regions produced `VALUES (..., )` syntax error (fixed in #594)
4. This PR fixes the remaining type mismatch

## Test plan
- [x] 4 integration tests pass against real PostGIS (testcontainers)
- [x] 105 garmin-process unit tests pass
- [x] Lint clean
- [ ] Click "Re-sync Garmin Detail" on the running activity — GPS map should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)