### PR TITLE
fix: align Garmin/HC type names, fix wellness display_category

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -637,6 +637,25 @@ export const migrateSchema = async (user: string) => {
     )
   }
 
+  // Step 3: Align Garmin typeKey names with HC exercise type names.
+  // Garmin uses modifier_noun (e.g., treadmill_running), HC uses noun_modifier (running_treadmill).
+  if (existingTableNames.has('activities')) {
+    const garminNameAliases: [string, string][] = [
+      ['indoor_rowing', 'rowing_machine'],
+      ['open_water_swimming', 'swimming_open_water'],
+      ['pool_swimming', 'swimming_pool'],
+      ['stair_stepper', 'stair_climbing_machine'],
+      ['stationary_biking', 'biking_stationary'],
+      ['treadmill_running', 'running_treadmill'],
+    ]
+    for (const [oldName, newName] of garminNameAliases) {
+      await query(db, `UPDATE activities SET activity_type = $1 WHERE activity_type = $2 AND deleted_at IS NULL`, [
+        newName,
+        oldName,
+      ])
+    }
+  }
+
   // Ensure every activity_type in use has a corresponding definition (idempotent)
   if (existingTableNames.has('activity_type_definitions') && existingTableNames.has('activities')) {
     await query(

--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -656,6 +656,19 @@ export const migrateSchema = async (user: string) => {
     }
   }
 
+  // Fix display_category for activity types that were auto-created as 'other' but should be wellness
+  if (existingTableNames.has('activity_type_definitions')) {
+    const wellnessTypes = ['breathwork', 'cold_exposure', 'hot_bath', 'sauna']
+    for (const name of wellnessTypes) {
+      await query(
+        db,
+        `UPDATE activity_type_definitions SET display_category = 'wellness'
+         WHERE name = $1 AND display_category = 'other'`,
+        [name],
+      )
+    }
+  }
+
   // Ensure every activity_type in use has a corresponding definition (idempotent)
   if (existingTableNames.has('activity_type_definitions') && existingTableNames.has('activities')) {
     await query(

--- a/apps/backend/src/garmin-process.ts
+++ b/apps/backend/src/garmin-process.ts
@@ -83,9 +83,20 @@ const defaultDeps: GarminProcessDeps = {
   softDeleteLocationRange,
 }
 
-/** Garmin activity typeKeys that should be mapped to a different activity type name. */
+/**
+ * Garmin activity typeKeys that should be mapped to a different activity type name.
+ * Aligns Garmin naming with Health Connect exercise type names from api-spec
+ * so cross-source merge and same-type merge work correctly.
+ */
 const garminTypeKeyOverrides: Record<string, string> = {
   breathwork: 'meditation',
+  // Garmin uses modifier_noun, HC uses noun_modifier
+  indoor_rowing: 'rowing_machine',
+  pool_swimming: 'swimming_pool',
+  open_water_swimming: 'swimming_open_water',
+  stair_stepper: 'stair_climbing_machine',
+  stationary_biking: 'biking_stationary',
+  treadmill_running: 'running_treadmill',
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Garmin/HC naming alignment**: Garmin uses `treadmill_running`, HC uses `running_treadmill` (and similar for pool_swimming, stationary_biking, etc.). Added overrides so Garmin maps to the HC-standard names. Migration renames existing activities.
- **Wellness display_category fix**: `breathwork`, `cold_exposure`, `hot_bath`, `sauna` were auto-created with `display_category: 'other'` which excluded them from cross-source merge. Migration updates them to `'wellness'`.

This unblocks cross-source merge for:
- Treadmill running (Garmin + HC now use same type name → same-type merge)
- Breathwork/yoga (breathwork now in wellness category → cross-source merge eligible)

## Test plan

- [x] `pnpm check` passes
- [x] Garmin process tests pass (105/105)
- [ ] Manual: verify treadmill running merges after re-login
- [ ] Manual: verify breathwork/yoga cross-merge after re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)