### PR TITLE
Phase 2: Backend Error Handling Consistency

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -13,7 +13,7 @@ import type {
 } from '@aurboda/api-spec'
 
 import cors from 'cors'
-import express, { json, type RequestHandler } from 'express'
+import express, { json, type NextFunction, type Request, type RequestHandler, type Response } from 'express'
 import { Client } from 'pg'
 
 import type { OuraDataType } from './oura-sync.ts'
@@ -51,6 +51,7 @@ import {
 import { processActivityDetail } from './garmin-process.ts'
 import { syncAllGarminData } from './garmin-sync.ts'
 import { garminClient } from './garmin.ts'
+import { httpError, isHttpError } from './http-error.ts'
 import { syncAllCalendars } from './ical-sync.ts'
 import { createLastFmRouter } from './lastfm-router.ts'
 import { syncLastFmData } from './lastfm-sync.ts'
@@ -111,10 +112,8 @@ declare global {
 
 // eslint-disable-next-line complexity -- server setup orchestration
 const main = async () => {
-  const unauthorized = Object.assign(new Error('Unauthorized'), {
-    status: 401,
-  })
-  const forbidden = Object.assign(new Error('Forbidden'), { status: 403 })
+  const unauthorized = httpError(401, 'Unauthorized')
+  const forbidden = httpError(403, 'Forbidden')
 
   const sessionSecret = process.env.SESSION_SECRET ?? ''
   const auth = createAuth(sessionSecret)
@@ -717,6 +716,24 @@ const main = async () => {
       ouraWebhookManager,
     ),
   )
+
+  // ==========================================================================
+  // Centralized error handler
+  // ==========================================================================
+
+  httpd.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+    const status = isHttpError(err) ? err.status : 500
+    if (status >= 500) console.error(err)
+
+    if (req.user) {
+      auditError(req.user, 'system', `${req.method} ${req.path}: ${err.message}`, {
+        status,
+        ...(status >= 500 && { stack: err.stack }),
+      })
+    }
+
+    res.status(status).json({ success: false, error: err.message })
+  })
 
   // ==========================================================================
   // Server startup

--- a/apps/backend/src/http-error.test.ts
+++ b/apps/backend/src/http-error.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { httpError, isHttpError } from './http-error.ts'
+
+describe('httpError', () => {
+  it('creates an Error with the given status and message', () => {
+    const err = httpError(404, 'Not found')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.status).toBe(404)
+    expect(err.message).toBe('Not found')
+  })
+
+  it('has a stack trace', () => {
+    const err = httpError(500, 'boom')
+    expect(err.stack).toBeDefined()
+  })
+})
+
+describe('isHttpError', () => {
+  it('returns true for httpError instances', () => {
+    expect(isHttpError(httpError(400, 'bad'))).toBe(true)
+  })
+
+  it('returns true for errors with a numeric status property', () => {
+    const err = Object.assign(new Error('test'), { status: 401 })
+    expect(isHttpError(err)).toBe(true)
+  })
+
+  it('returns false for plain Error without status', () => {
+    expect(isHttpError(new Error('plain'))).toBe(false)
+  })
+
+  it('returns false for non-Error objects', () => {
+    expect(isHttpError({ status: 400, message: 'not an error' })).toBe(false)
+  })
+
+  it('returns false for null/undefined', () => {
+    expect(isHttpError(null)).toBe(false)
+    expect(isHttpError(undefined)).toBe(false)
+  })
+})

--- a/apps/backend/src/http-error.ts
+++ b/apps/backend/src/http-error.ts
@@ -1,0 +1,18 @@
+/**
+ * HTTP error utilities for centralized error handling.
+ *
+ * Provides a factory function and type guard for errors with HTTP status codes.
+ * Uses Object.assign rather than a class to align with the project's functional style.
+ */
+
+export interface HttpError extends Error {
+  status: number
+}
+
+/** Create an Error with an HTTP status code attached. */
+export const httpError = (status: number, message: string): HttpError =>
+  Object.assign(new Error(message), { status })
+
+/** Type guard: does this error carry an HTTP status code? */
+export const isHttpError = (err: unknown): err is HttpError =>
+  err instanceof Error && typeof (err as HttpError).status === 'number'

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -51,6 +51,7 @@ import {
   insertTimeSeries,
   type TimeSeriesPoint,
 } from '../db/index.ts'
+import { httpError } from '../http-error.ts'
 import { parseFitBuffer } from '../services/fit-parser.ts'
 import {
   addActivity,
@@ -305,66 +306,67 @@ export const createActivitiesRouter = (
       return
     }
 
+    let fitActivities
     try {
-      const fitActivities = await parseFitBuffer(file.buffer.buffer as ArrayBuffer)
-      const results: AddActivityResponse['data'][] = []
+      fitActivities = await parseFitBuffer(file.buffer.buffer as ArrayBuffer)
+    } catch (error) {
+      throw httpError(400, error instanceof Error ? error.message : 'Failed to parse FIT file')
+    }
 
-      for (const fitAct of fitActivities) {
-        // Map exercise type name to Health Connect value
-        const data = {
-          ...fitAct.data,
-          exerciseType: isValidExerciseType(fitAct.exercise_type)
-            ? getExerciseTypeValue(fitAct.exercise_type)
-            : undefined,
-        }
+    const results: AddActivityResponse['data'][] = []
 
-        const result = await addActivity(
-          user,
-          {
-            activity_type: fitAct.activity_type,
-            data,
-            end_time: fitAct.end_time,
-            notes: fitAct.notes,
-            start_time: fitAct.start_time,
-            title: fitAct.title,
-          },
-          onActivityMutated,
-        )
-
-        if (!result.success) {
-          res.status(400).json({ error: result.error, success: false })
-          return
-        }
-
-        // Insert time series data (heart rate, power, cadence, speed)
-        if (fitAct.timeSeries.length > 0 && result.id) {
-          const points: TimeSeriesPoint[] = fitAct.timeSeries.map((ts) => ({
-            metric: ts.metric,
-            source: 'aurboda' as const,
-            time: ts.time,
-            value: ts.value,
-          }))
-          await insertTimeSeries(user, points)
-        }
-
-        results.push({
-          activity_type: fitAct.activity_type,
-          end_time: fitAct.end_time.toISOString(),
-          id: result.id!,
-          notes: fitAct.notes,
-          start_time: fitAct.start_time.toISOString(),
-          title: fitAct.title,
-        })
+    for (const fitAct of fitActivities) {
+      // Map exercise type name to Health Connect value
+      const data = {
+        ...fitAct.data,
+        exerciseType: isValidExerciseType(fitAct.exercise_type)
+          ? getExerciseTypeValue(fitAct.exercise_type)
+          : undefined,
       }
 
-      res.json({
-        data: results.length === 1 ? results[0] : results,
-        success: true,
+      const result = await addActivity(
+        user,
+        {
+          activity_type: fitAct.activity_type,
+          data,
+          end_time: fitAct.end_time,
+          notes: fitAct.notes,
+          start_time: fitAct.start_time,
+          title: fitAct.title,
+        },
+        onActivityMutated,
+      )
+
+      if (!result.success) {
+        res.status(400).json({ error: result.error, success: false })
+        return
+      }
+
+      // Insert time series data (heart rate, power, cadence, speed)
+      if (fitAct.timeSeries.length > 0 && result.id) {
+        const points: TimeSeriesPoint[] = fitAct.timeSeries.map((ts) => ({
+          metric: ts.metric,
+          source: 'aurboda' as const,
+          time: ts.time,
+          value: ts.value,
+        }))
+        await insertTimeSeries(user, points)
+      }
+
+      results.push({
+        activity_type: fitAct.activity_type,
+        end_time: fitAct.end_time.toISOString(),
+        id: result.id!,
+        notes: fitAct.notes,
+        start_time: fitAct.start_time.toISOString(),
+        title: fitAct.title,
       })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to parse FIT file'
-      res.status(400).json({ error: message, success: false })
     }
+
+    res.json({
+      data: results.length === 1 ? results[0] : results,
+      success: true,
+    })
   })
 
   router.post<Record<string, never>, MergeActivitiesResponse, MergeActivitiesBody>(
@@ -727,13 +729,8 @@ export const createActivitiesRouter = (
         return
       }
 
-      try {
-        const points = await resyncActivityDetail(user, garminSourceId, garminActivityId)
-        res.json({ points, success: true })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error'
-        res.status(500).json({ points: 0, success: false, error: message })
-      }
+      const points = await resyncActivityDetail(user, garminSourceId, garminActivityId)
+      res.json({ points, success: true })
     },
   )
 

--- a/apps/backend/src/routes/chart-data-router.ts
+++ b/apps/backend/src/routes/chart-data-router.ts
@@ -43,29 +43,24 @@ export const createChartDataRouter = (authMiddleware: RequestHandler): Router =>
           .json({ error: 'Either pattern or tag_definition_id is required', success: false })
       }
 
-      try {
-        const result = await getChartData(user, {
-          aggregation: aggregation ?? 'count',
-          breakdown_fields,
-          bucket_size: bucket_size ?? '1d',
-          end,
-          pattern,
-          source_type,
-          start,
-          tag_definition_id,
-        })
-        res.json({
-          data: {
-            breakdown_fields: result.breakdown_fields,
-            breakdown_series: result.breakdown_series,
-            buckets: result.buckets,
-          },
-          success: true,
-        })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error'
-        res.status(400).json({ error: message, success: false })
-      }
+      const result = await getChartData(user, {
+        aggregation: aggregation ?? 'count',
+        breakdown_fields,
+        bucket_size: bucket_size ?? '1d',
+        end,
+        pattern,
+        source_type,
+        start,
+        tag_definition_id,
+      })
+      res.json({
+        data: {
+          breakdown_fields: result.breakdown_fields,
+          breakdown_series: result.breakdown_series,
+          buckets: result.buckets,
+        },
+        success: true,
+      })
     },
   )
 

--- a/apps/backend/src/routes/icons-router.ts
+++ b/apps/backend/src/routes/icons-router.ts
@@ -66,14 +66,9 @@ export const createIconsRouter = (authMiddleware: RequestHandler): Router => {
         return
       }
 
-      try {
-        const id = await processAndStoreIcon(user, file.buffer, file.mimetype)
-        const url = `/api/icons/${user}/${id}`
-        res.status(201).json({ id, success: true, url })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Failed to process icon'
-        res.status(400).json({ error: message, success: false })
-      }
+      const id = await processAndStoreIcon(user, file.buffer, file.mimetype)
+      const url = `/api/icons/${user}/${id}`
+      res.status(201).json({ id, success: true, url })
     },
   )
 

--- a/apps/backend/src/routes/screentime-categories-router.ts
+++ b/apps/backend/src/routes/screentime-categories-router.ts
@@ -151,20 +151,15 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     async (req, res) => {
       const user = req.user!
 
-      try {
-        let awCategories = req.body.categories
+      let awCategories = req.body.categories
 
-        if (!awCategories) {
-          const serverUrl = req.body.url || 'http://localhost:5600'
-          awCategories = await fetchAwCategories(serverUrl)
-        }
-
-        const result = await importFromActivityWatch(user, awCategories, req.body.replace ?? false)
-        res.json({ data: result.map(serializeCategory), success: true })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Import failed'
-        res.status(400).json({ error: message, success: false })
+      if (!awCategories) {
+        const serverUrl = req.body.url || 'http://localhost:5600'
+        awCategories = await fetchAwCategories(serverUrl)
       }
+
+      const result = await importFromActivityWatch(user, awCategories, req.body.replace ?? false)
+      res.json({ data: result.map(serializeCategory), success: true })
     },
   )
 
@@ -174,13 +169,8 @@ export const createScreentimeCategoriesRouter = (authMiddleware: RequestHandler)
     async (req, res) => {
       const user = req.user!
 
-      try {
-        const count = await recategorizeAll(user)
-        res.json({ records_updated: count, success: true })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Recategorization failed'
-        res.status(500).json({ error: message, success: false })
-      }
+      const count = await recategorizeAll(user)
+      res.json({ records_updated: count, success: true })
     },
   )
 

--- a/apps/backend/src/routes/training-load-router.ts
+++ b/apps/backend/src/routes/training-load-router.ts
@@ -23,21 +23,16 @@ export const createTrainingLoadRouter = (authMiddleware: RequestHandler): Router
       const { start, end, bucket_size, tz } = req.query
       const user = req.user!
 
-      try {
-        const startDate = new Date(start)
-        const endDate = new Date(end)
+      const startDate = new Date(start)
+      const endDate = new Date(end)
 
-        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-          res.status(400).json({ error: 'Invalid date format', success: false })
-          return
-        }
-
-        const result = await computeTrainingLoad(deps, user, startDate, endDate, bucket_size, tz)
-        res.json({ data: result, success: true })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error'
-        res.status(400).json({ error: message, success: false })
+      if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+        res.status(400).json({ error: 'Invalid date format', success: false })
+        return
       }
+
+      const result = await computeTrainingLoad(deps, user, startDate, endDate, bucket_size, tz)
+      res.json({ data: result, success: true })
     },
   )
 

--- a/apps/backend/src/routes/trends-router.ts
+++ b/apps/backend/src/routes/trends-router.ts
@@ -48,25 +48,20 @@ export const createTrendsRouter = (authMiddleware: RequestHandler): Router => {
       const halfLifeDays = half_life_days ? parseInt(half_life_days, 10) : undefined
       const lookbackDays = lookback_days ? parseInt(lookback_days, 10) : undefined
 
-      try {
-        const customMetrics = await getCustomMetrics(user)
+      const customMetrics = await getCustomMetrics(user)
 
-        const result = await getTrend(user, {
-          aggregation,
-          breakdown_fields,
-          custom_metrics: customMetrics,
-          display_period,
-          half_life_days: halfLifeDays,
-          lookback_days: lookbackDays,
-          pattern: pattern ?? '',
-          source_type,
-          tag_definition_id,
-        })
-        res.json({ data: result, success: true })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error'
-        res.status(400).json({ error: message, success: false })
-      }
+      const result = await getTrend(user, {
+        aggregation,
+        breakdown_fields,
+        custom_metrics: customMetrics,
+        display_period,
+        half_life_days: halfLifeDays,
+        lookback_days: lookbackDays,
+        pattern: pattern ?? '',
+        source_type,
+        tag_definition_id,
+      })
+      res.json({ data: result, success: true })
     },
   )
 


### PR DESCRIPTION
## Summary

Closes #584

- Add `httpError` factory function and `isHttpError` type guard in `http-error.ts` (functional style, no class)
- Add centralized Express error middleware in `api.ts` that:
  - Formats all errors as `{ success: false, error: message }`
  - Logs 500+ errors to `console.error`
  - Logs **all errors** (400+) to user's audit log for visibility
  - Respects `.status` on HttpError for proper HTTP status codes
- Replace inline `Object.assign(new Error(...), { status })` with `httpError()`
- Remove redundant try/catch from 6 route files (chart-data, trends, training-load, icons, screentime-categories x2, activities resync)
- Keep FIT file parse catch (re-throws as `httpError(400)` — parse failures are client errors)
- OAuth router catches untouched — they produce OAuth 2.0 RFC compliant error responses

## Test plan

- [x] `pnpm check` passes with 0 errors
- [x] All 69 unit test files pass (1405 tests)
- [x] New unit tests for `httpError` and `isHttpError`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)