### PR TITLE
refactor: single activity query in timeline, remove tag remnants

### DIFF
--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -255,7 +255,7 @@ const getActivityIconKey = (a: Activity, getExerciseTypeName: (a: Activity) => s
 
 export const buildActivityColumnItems = (
   activities: Activity[],
-  tagActivities: Activity[],
+  secondaryActivities: Activity[],
   itemIcons: Record<string, string>,
   activityColors: Record<string, string>,
   exerciseColor: (a: Activity) => string,
@@ -305,8 +305,8 @@ export const buildActivityColumnItems = (
     })
   }
 
-  // 2. Handle duration activities (non-builtin)
-  const durationActivities = tagActivities.filter(isDurationActivityLike)
+  // 2. Handle secondary activities (non-main categories like custom types)
+  const durationActivities = secondaryActivities.filter(isDurationActivityLike)
 
   for (const act of durationActivities) {
     const merged = tryMergeActivityIntoItem(act, items)

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -84,7 +84,7 @@ type LegendCategory =
   | 'sleep_rest' // replaces sleep+nap+rest
   | 'meditation'
   | 'exercise'
-  | 'tags'
+  | 'other'
   | 'calendar'
   | 'meal'
   | 'screentime' // vertical only
@@ -336,8 +336,8 @@ const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = 
   sleep_rest: (item) =>
     item.column === 'Activity' && ['sleep', 'nap', 'rest'].includes(item.activity_type ?? ''),
   steps: () => false,
-  tags: (item) =>
-    // Tag activities in Activity column (not calendar, not built-in activity types)
+  other: (item) =>
+    // Other activities in Activity column (not calendar, not main activity categories)
     item.column === 'Activity' &&
     item.entity_type === 'activity' &&
     item.color !== tagSourceColors.calendar &&
@@ -364,7 +364,7 @@ const categorizeLocations = (places: Place[], uniquePlaceNames: string[]): Chart
     },
   }))
 
-const categorizeTagActivities = (
+const categorizeOtherActivities = (
   activities: Activity[],
   itemIcons: Record<string, string>,
   typeDefsMap?: Map<string, { icon?: string }>,
@@ -632,26 +632,18 @@ export const Timeline = () => {
 
   // ── Data queries ───────────────────────────────────────────────────────────
 
-  // Load activity type definitions early so we can derive type lists for queries
+  // Load activity type definitions early for display_category-based rendering
   const { data: activityTypeDefs = [] } = useQuery({
     queryFn: fetchActivityTypeDefinitions,
     queryKey: ['activityTypeDefinitions'],
     staleTime: 5 * 60_000,
   })
 
-  // Activity column: types in sleep_rest, exercise, meditation, wellness categories
-  const ACTIVITY_CATEGORIES = new Set(['sleep_rest', 'exercise', 'meditation', 'wellness'])
-  const activityTypeNames = useMemo(
-    () => activityTypeDefs.filter((t) => ACTIVITY_CATEGORIES.has(t.display_category)).map((t) => t.name),
-    [activityTypeDefs],
-  )
-
+  // Single query for all activities
   const activitiesQuery = useQuery({
-    enabled: !hiddenCategories.has('activity') && activityTypeNames.length > 0,
     placeholderData: keepPreviousData,
-    queryFn: () =>
-      fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), activityTypeNames),
-    queryKey: ['timeline-activities', fromDate.value, toDate.value, activityTypeNames],
+    queryFn: () => fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
+    queryKey: ['timeline-activities', fromDate.value, toDate.value],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -660,16 +652,6 @@ export const Timeline = () => {
     placeholderData: keepPreviousData,
     queryFn: () => fetchPlaces(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['timeline-places', fromDate.value, toDate.value],
-    staleTime: 5 * 60 * 1000,
-  })
-
-  // Tag activities: everything NOT in the activity column categories
-  const tagActivitiesQuery = useQuery({
-    enabled: activityTypeNames.length > 0,
-    placeholderData: keepPreviousData,
-    queryFn: () =>
-      fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5), undefined, activityTypeNames),
-    queryKey: ['timeline-tag-activities', fromDate.value, toDate.value, activityTypeNames],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -779,15 +761,25 @@ export const Timeline = () => {
     [activityTypeDefs],
   )
 
-  const activities = useMemo(
+  // Split all activities by display_category into main activities vs secondary
+  const ACTIVITY_CATEGORIES = new Set(['sleep_rest', 'exercise', 'meditation', 'wellness'])
+  const categoryByType = useMemo(
+    () => new Map(activityTypeDefs.map((t) => [t.name, t.display_category])),
+    [activityTypeDefs],
+  )
+  const allActivities = useMemo(
     () => (activitiesQuery.data ?? []).filter((a) => !hiddenTypes.has(a.activity_type ?? '')),
     [activitiesQuery.data, hiddenTypes],
   )
-  const places = placesQuery.data ?? []
-  const tagActivities = useMemo(
-    () => (tagActivitiesQuery.data ?? []).filter((a) => !hiddenTypes.has(a.activity_type ?? '')),
-    [tagActivitiesQuery.data, hiddenTypes],
+  const activities = useMemo(
+    () => allActivities.filter((a) => ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other')),
+    [allActivities, categoryByType],
   )
+  const secondaryActivities = useMemo(
+    () => allActivities.filter((a) => !ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other')),
+    [allActivities, categoryByType],
+  )
+  const places = placesQuery.data ?? []
   const productivity = productivityQuery.data?.records ?? []
   const scrobbles = scrobblesQuery.data ?? []
 
@@ -843,7 +835,7 @@ export const Timeline = () => {
     () =>
       buildActivityColumnItems(
         activities,
-        tagActivities,
+        secondaryActivities,
         itemIcons,
         activityColors,
         getExerciseColor,
@@ -853,13 +845,13 @@ export const Timeline = () => {
         scrobbles,
         typeDefsMap,
       ),
-    [activities, tagActivities, itemIcons, sleepMetricsByDate, scrobbles, typeDefsMap],
+    [activities, secondaryActivities, itemIcons, sleepMetricsByDate, scrobbles, typeDefsMap],
   )
 
-  // Tag activities not already included in activityItems (point activities, excluded sources, etc.)
-  const nonBuiltinTagActivities = useMemo(
+  // Non-main activities not already in activityItems (point activities, excluded sources, etc.)
+  const otherActivities = useMemo(
     () =>
-      tagActivities.filter((a) => {
+      secondaryActivities.filter((a) => {
         if (!a.end_time) return true // point activities are separate items
         if (a.source && EXCLUDED_ACTIVITY_SOURCES.has(a.source)) return true
         for (const prefix of EXCLUDED_ACTIVITY_PREFIXES) {
@@ -868,7 +860,7 @@ export const Timeline = () => {
         // Check if this activity was placed in the Activity column
         return !activityItems.some((i) => i.entity_id === a.id)
       }),
-    [tagActivities, activityItems],
+    [secondaryActivities, activityItems],
   )
 
   // ── Legend / filtering ─────────────────────────────────────────────────────
@@ -959,7 +951,7 @@ export const Timeline = () => {
     () => [
       ...activityItems,
       ...categorizeLocations(places, uniquePlaceNames),
-      ...categorizeTagActivities(nonBuiltinTagActivities, itemIcons, typeDefsMap),
+      ...categorizeOtherActivities(otherActivities, itemIcons, typeDefsMap),
       ...categorizeProductivity(productivity, screentimeCategoriesQuery.data ?? [], itemIcons),
       ...musicItems,
       ...mealItems,
@@ -968,7 +960,7 @@ export const Timeline = () => {
       activityItems,
       places,
       uniquePlaceNames,
-      nonBuiltinTagActivities,
+      otherActivities,
       itemIcons,
       typeDefsMap,
       productivity,
@@ -1005,7 +997,6 @@ export const Timeline = () => {
   const isFetching =
     activitiesQuery.isFetching ||
     placesQuery.isFetching ||
-    tagActivitiesQuery.isFetching ||
     mealsQuery.isFetching ||
     productivityQuery.isFetching ||
     scrobblesQuery.isFetching ||
@@ -2022,13 +2013,11 @@ export const Timeline = () => {
   const isInitialLoad =
     activitiesQuery.isLoading &&
     placesQuery.isLoading &&
-    tagActivitiesQuery.isLoading &&
     productivityQuery.isLoading
 
   const errorSources = [
     activitiesQuery.isError && 'activities',
     placesQuery.isError && 'places',
-    tagActivitiesQuery.isError && 'tags',
     productivityQuery.isError && 'screen time',
   ].filter(Boolean) as string[]
 
@@ -2202,7 +2191,7 @@ export const Timeline = () => {
                   label: 'Meditation',
                 },
                 { cat: 'exercise' as LegendCategory, color: hrZoneColors[2]!, label: 'Exercise' },
-                { cat: 'tags' as LegendCategory, color: TAG_COLOR, label: 'Tags' },
+                { cat: 'other' as LegendCategory, color: TAG_COLOR, label: 'Other' },
                 { cat: 'calendar' as LegendCategory, color: tagSourceColors.calendar!, label: 'Calendar' },
                 {
                   cat: 'screentime' as LegendCategory,
@@ -2370,7 +2359,7 @@ const mergeSmallItems = (
         'Sleep / Rest': 'activity',
       }
       const dataType = columnToDataType[first.column]
-      const allDataTypes = ['activity', 'tag', 'location', 'music', 'meal', 'report', 'screentime']
+      const allDataTypes = ['activity', 'location', 'music', 'meal', 'report', 'screentime']
       const hideTypes = dataType ? allDataTypes.filter((t) => t !== dataType) : []
       const dataParams = new URLSearchParams({
         date: formatISO(mergedStart, { representation: 'date' }),


### PR DESCRIPTION
## Summary

- **Single activity query**: Timeline now makes one `fetchActivities()` call instead of two (was: one for builtin types, one for "tags"). Activities are split client-side by `display_category`.
- **Tag cleanup**: Renamed `tagActivities` → `secondaryActivities`, `categorizeTagActivities` → `categorizeOtherActivities`, legend "Tags" → "Other", removed `'tag'` from data types.

This eliminates the duplicate rendering issue where migrated exercise types appeared in both queries.

## Test plan

- [x] `pnpm check` passes (0 errors)
- [ ] Manual: verify timeline loads all activities in one request
- [ ] Manual: verify no duplicates, correct icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)