### PR TITLE
feat: food item icon editing UI

### DIFF
--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -127,6 +127,35 @@
   text-decoration: underline;
 }
 
+.fi-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.fi-icon-label {
+  color: #6b7280;
+  font-weight: 500;
+  min-width: 2.5rem;
+}
+
+.fi-icon-row input[type='text'] {
+  padding: 0.25rem 0.375rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  background: #fff;
+  width: 180px;
+}
+
+.fi-icon-display-img {
+  vertical-align: middle;
+  margin-right: 0.375rem;
+}
+
 .fi-meta {
   display: flex;
   gap: 1.5rem;
@@ -181,10 +210,15 @@
 
   .fi-name-input,
   .fi-default-edit input,
+  .fi-icon-row input[type='text'],
   .nutrient-edit input {
     background: #374151;
     border-color: #4b5563;
     color: #d1d5db;
+  }
+
+  .fi-icon-label {
+    color: #9ca3af;
   }
 
   .btn-secondary {

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -6,7 +6,9 @@ import { useEffect, useState } from 'preact/hooks'
 import type { FoodItemEntity } from '../../state/api'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
+import { IconInput } from '../../components/IconInput'
 import { auth } from '../../state/auth'
+import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import './FoodItemDetail.css'
 
 const API_URL = import.meta.env.VITE_API_URL || '/api'
@@ -158,6 +160,7 @@ export function FoodItemDetail() {
 
   const isEditing = editing !== null
   const editName = (editing?.name as string) ?? item.name
+  const editIcon = (editing?.icon as string) ?? item.icon ?? ''
   const editQty = (editing?.default_quantity as number) ?? item.default_quantity
   const editUnit = (editing?.default_unit as string) ?? item.default_unit
 
@@ -209,7 +212,20 @@ export function FoodItemDetail() {
           onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
         />
       ) : (
-        <h1>{item.name}</h1>
+        <h1>
+          {item.icon && isEmoji(item.icon) && <span class="fi-icon-display">{item.icon} </span>}
+          {item.icon && (isUrl(item.icon) || isIconPath(item.icon)) && (
+            <img src={item.icon} alt="icon" width={24} height={24} class="fi-icon-display-img" />
+          )}
+          {item.name}
+        </h1>
+      )}
+
+      {isEditing && (
+        <div class="fi-icon-row">
+          <label class="fi-icon-label">Icon</label>
+          <IconInput value={editIcon} onChange={(v) => setEditing({ ...editing, icon: v || null })} />
+        </div>
       )}
 
       <div class="fi-meta">


### PR DESCRIPTION
## Summary
- Adds icon display next to the food item name in view mode (emoji inline, image as `<img>`)
- Adds `IconInput` component in edit mode for setting/uploading icons on food items
- Reuses the existing shared `IconInput` component (same as meal type meta, screentime categories, etc.)

## Context
Follow-up to #600 which added the `icon` field to food items and timeline rendering but missed the UI for actually setting icons.

## Test plan
- [ ] Open a food item detail page — verify no icon shown if none set
- [ ] Click Edit — verify the Icon row with `IconInput` appears
- [ ] Enter an emoji or upload an image — save — verify icon persists
- [ ] Verify icon shows next to name in view mode after save
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)