### PR TITLE
fix: restore /lastfm/scrobbles query endpoint

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -55,6 +55,7 @@ import { httpError, isHttpError } from './http-error.ts'
 import { syncAllCalendars } from './ical-sync.ts'
 import { syncLastFmData } from './lastfm-sync.ts'
 import { createMcpRouter } from './mcp.ts'
+import { createScrobblesRouter } from './routes/scrobbles-router.ts'
 import { syncAllOuraData, syncOuraDataType } from './oura-sync.ts'
 import { ouraClient } from './oura.ts'
 import { createOwnTracksRouter } from './owntracks.ts'
@@ -702,6 +703,7 @@ const main = async () => {
   httpd.use('/trends', createTrendsRouter(authMiddleware))
   httpd.use('/chart-data', createChartDataRouter(authMiddleware))
   httpd.use('/screentime-categories', createScreentimeCategoriesRouter(authMiddleware))
+  httpd.use('/lastfm', createScrobblesRouter(authMiddleware))
   httpd.use(
     '/admin',
     createAdminRouter(

--- a/apps/backend/src/routes/scrobbles-router.ts
+++ b/apps/backend/src/routes/scrobbles-router.ts
@@ -1,0 +1,43 @@
+/**
+ * Scrobbles route group — Last.fm scrobble queries.
+ */
+import type { ScrobblesResponse } from '@aurboda/api-spec'
+
+import type { RequestHandler } from 'express'
+import type { Router } from 'express'
+
+import { getScrobbles } from '../db/index.ts'
+import { typedRouter } from '../typed-router.ts'
+
+export const createScrobblesRouter = (authMiddleware: RequestHandler): Router => {
+  const router = typedRouter()
+
+  router.get<Record<string, never>, ScrobblesResponse, unknown, { start?: string; end?: string }>(
+    '/scrobbles',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const { start, end } = req.query
+
+      if (!start || !end) {
+        return res.status(400).json({ error: 'start and end query parameters are required', success: false })
+      }
+
+      try {
+        const scrobbles = await getScrobbles(user, new Date(start), new Date(end))
+        const serialized = scrobbles.map((s) => ({
+          album: s.album,
+          artist: s.artist,
+          recorded_at: s.recorded_at.toISOString(),
+          track: s.track,
+        }))
+        res.json({ data: serialized, success: true })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        res.status(500).json({ error: message, success: false })
+      }
+    },
+  )
+
+  return router as unknown as Router
+}

--- a/apps/backend/src/routes/scrobbles-router.ts
+++ b/apps/backend/src/routes/scrobbles-router.ts
@@ -3,8 +3,7 @@
  */
 import type { ScrobblesResponse } from '@aurboda/api-spec'
 
-import type { RequestHandler } from 'express'
-import type { Router } from 'express'
+import type { RequestHandler, Router } from 'express'
 
 import { getScrobbles } from '../db/index.ts'
 import { typedRouter } from '../typed-router.ts'


### PR DESCRIPTION
## Summary
- The scrobbles query endpoint (`GET /lastfm/scrobbles`) was accidentally removed with the lastfm-router when removing lastfm tag rules
- Restores it as `routes/scrobbles-router.ts` mounted at `/lastfm`
- Fixes the missing music track on the horizontal timeline

## Test plan
- [ ] Deploy and verify music track appears on timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)