### PR TITLE
refactor: rename Oura-specific types to generic names

### DIFF
--- a/apps/backend/src/services/queries.test.ts
+++ b/apps/backend/src/services/queries.test.ts
@@ -325,7 +325,7 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.oura_scores).toEqual({
+    expect(result.scores).toEqual({
       cardiovascular_age: 35,
       readiness_score: 85,
       resilience_score: 75,
@@ -333,7 +333,7 @@ describe('getDailySummary', () => {
     })
   })
 
-  test('returns null ouraScores when no Oura data', async () => {
+  test('returns null scores when no score data', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
     vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
@@ -344,10 +344,10 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.oura_scores).toBeNull()
+    expect(result.scores).toBeNull()
   })
 
-  test('returns partial ouraScores when some metrics are missing', async () => {
+  test('returns partial scores when some metrics are missing', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
     vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([])
@@ -355,7 +355,7 @@ describe('getDailySummary', () => {
     vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
 
-    // Only some Oura metrics available
+    // Only some score metrics available
     vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({
       readiness_score: [[new Date('2024-01-15T00:00:00Z'), 85]],
       sleep_score: [[new Date('2024-01-15T00:00:00Z'), 92]],
@@ -363,7 +363,7 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    expect(result.oura_scores).toEqual({
+    expect(result.scores).toEqual({
       cardiovascular_age: null,
       readiness_score: 85,
       resilience_score: null,

--- a/apps/backend/src/services/queries.ts
+++ b/apps/backend/src/services/queries.ts
@@ -219,7 +219,7 @@ export interface ProductivitySummary {
   categories?: Array<{ path: string[]; duration_sec: number }>
 }
 
-export interface OuraScores {
+export interface Scores {
   sleep_score: number | null
   readiness_score: number | null
   resilience_score: number | null
@@ -248,7 +248,7 @@ export interface DailySummaryResult {
   sleep_sessions: SleepSessionSummary[]
   productivity: ProductivitySummary | null
   places: PlaceSummary[]
-  oura_scores: OuraScores | null
+  scores: Scores | null
   stress_zones: StressZoneSecs | null
 }
 
@@ -897,7 +897,7 @@ export async function getDailySummary(
     allActivities,
     productivity,
     placeVisits,
-    ouraMetrics,
+    scoreMetrics,
     dayNotes,
     dayMeals,
     stepsAggregate,
@@ -993,19 +993,19 @@ export async function getDailySummary(
         })()
       : null
 
-  // Build Oura scores object (get first value for each metric if available)
-  const sleepScoreData = ouraMetrics['sleep_score']
-  const readinessScoreData = ouraMetrics['readiness_score']
-  const resilienceScoreData = ouraMetrics['resilience_score']
-  const cardiovascularAgeData = ouraMetrics['cardiovascular_age']
+  // Build scores object (get first value for each metric if available)
+  const sleepScoreData = scoreMetrics['sleep_score']
+  const readinessScoreData = scoreMetrics['readiness_score']
+  const resilienceScoreData = scoreMetrics['resilience_score']
+  const cardiovascularAgeData = scoreMetrics['cardiovascular_age']
 
-  const hasAnyOuraData =
+  const hasAnyScoreData =
     sleepScoreData?.length ||
     readinessScoreData?.length ||
     resilienceScoreData?.length ||
     cardiovascularAgeData?.length
 
-  const ouraScores: OuraScores | null = hasAnyOuraData
+  const scores: Scores | null = hasAnyScoreData
     ? {
         cardiovascular_age: cardiovascularAgeData?.[0]?.[1] ?? null,
         readiness_score: readinessScoreData?.[0]?.[1] ?? null,
@@ -1144,7 +1144,7 @@ export async function getDailySummary(
       start_time: n.start_time?.toISOString(),
       updated_at: n.updated_at.toISOString(),
     })),
-    oura_scores: ouraScores,
+    scores,
     places: placeVisits
       .filter((p) => p.duration_minutes > 0)
       .map((p) => ({

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -41,10 +41,10 @@ import { SchemaDataFields } from './SchemaDataFields'
 import {
   computeSleepMinutesFromStages,
   formatMinutesAsHM,
-  OURA_METRIC_LABELS,
-  OURA_METRIC_UNITS,
-  OURA_SLEEP_METRICS,
-  type OuraSleepMetricKey,
+  SLEEP_METRIC_LABELS,
+  SLEEP_METRIC_UNITS,
+  SLEEP_METRICS,
+  type SleepMetricKey,
   parseSleepStages,
 } from './sleep-utils'
 import './style.css'
@@ -123,35 +123,35 @@ const HrZoneBar = ({ zones }: { zones: Record<number, number> }) => {
   )
 }
 
-// ── Oura Sleep Metrics ────────────────────────────────────────────────────────
+// ── Sleep Metrics ────────────────────────────────────────────────────────────
 
-const extractOuraMetrics = (
+const extractSleepMetrics = (
   buckets: Array<{ metrics: Record<string, { avg: number }> }>,
-): Partial<Record<OuraSleepMetricKey, number>> => {
-  const result: Partial<Record<OuraSleepMetricKey, number>> = {}
+): Partial<Record<SleepMetricKey, number>> => {
+  const result: Partial<Record<SleepMetricKey, number>> = {}
   for (const bucket of buckets) {
     for (const [metric, stats] of Object.entries(bucket.metrics)) {
-      if (OURA_SLEEP_METRICS.includes(metric as OuraSleepMetricKey)) {
-        result[metric as OuraSleepMetricKey] = stats.avg
+      if (SLEEP_METRICS.includes(metric as SleepMetricKey)) {
+        result[metric as SleepMetricKey] = stats.avg
       }
     }
   }
   return result
 }
 
-const OuraMetricsCards = ({ metrics }: { metrics: Partial<Record<OuraSleepMetricKey, number>> }) => (
+const SleepMetricsCards = ({ metrics }: { metrics: Partial<Record<SleepMetricKey, number>> }) => (
   <div class="detail-section">
-    <h3>Oura Sleep Metrics</h3>
+    <h3>Sleep Metrics</h3>
     <div class="metric-cards">
-      {OURA_SLEEP_METRICS.map((key) => {
+      {SLEEP_METRICS.map((key) => {
         const value = metrics[key]
         if (value === undefined) return null
         return (
           <div class="metric-card" key={key}>
-            <div class="metric-card-label">{OURA_METRIC_LABELS[key]}</div>
+            <div class="metric-card-label">{SLEEP_METRIC_LABELS[key]}</div>
             <div class="metric-card-value">
               {Math.round(value)}
-              {OURA_METRIC_UNITS[key] && <span class="metric-card-unit">{OURA_METRIC_UNITS[key]}</span>}
+              {SLEEP_METRIC_UNITS[key] && <span class="metric-card-unit">{SLEEP_METRIC_UNITS[key]}</span>}
             </div>
           </div>
         )
@@ -219,20 +219,20 @@ const ActivityDetailContent = ({
   const hasExerciseType = Boolean(exerciseType)
   const [hoverTime, setHoverTime] = useState<Date | null>(null)
 
-  // Oura sleep metrics (only fetch when sleep stages exist)
+  // Sleep metrics (only fetch when sleep stages exist)
   const endDateStr = hasSleepStages ? format(displayEnd, 'yyyy-MM-dd') : ''
-  const ouraQuery = useQuery({
+  const sleepMetricsQuery = useQuery({
     enabled: hasSleepStages,
     queryFn: () => {
       const dayStart = new Date(`${endDateStr}T00:00:00`)
       const dayEnd = new Date(`${endDateStr}T23:59:59`)
-      return fetchBucketedMetrics(dayStart, dayEnd, [...OURA_SLEEP_METRICS], '1d')
+      return fetchBucketedMetrics(dayStart, dayEnd, [...SLEEP_METRICS], '1d')
     },
-    queryKey: ['detail-oura-sleep', endDateStr],
+    queryKey: ['detail-sleep-metrics', endDateStr],
     staleTime: 5 * 60 * 1000,
   })
-  const ouraMetrics = hasSleepStages ? extractOuraMetrics(ouraQuery.data?.buckets ?? []) : {}
-  const hasOuraMetrics = Object.keys(ouraMetrics).length > 0
+  const sleepMetrics = hasSleepStages ? extractSleepMetrics(sleepMetricsQuery.data?.buckets ?? []) : {}
+  const hasSleepMetrics = Object.keys(sleepMetrics).length > 0
 
   // Active calories (only fetch when exercise type exists)
   const caloriesQuery = useQuery({
@@ -357,7 +357,7 @@ const ActivityDetailContent = ({
 
       {hasEndTime && !isEditing && <LocationInfo start={displayStart} end={displayEnd} />}
 
-      {hasOuraMetrics && <OuraMetricsCards metrics={ouraMetrics} />}
+      {hasSleepMetrics && <SleepMetricsCards metrics={sleepMetrics} />}
 
       {hasEndTime && (
         <div class="detail-grid-full">

--- a/apps/web/src/pages/EntityDetail/sleep-utils.ts
+++ b/apps/web/src/pages/EntityDetail/sleep-utils.ts
@@ -83,8 +83,8 @@ export const formatMinutesAsHM = (minutes: number): string => {
   return m > 0 ? `${h}h ${m}m` : `${h}h`
 }
 
-/** Oura metric keys used for sleep detail. */
-export const OURA_SLEEP_METRICS = [
+/** Metric keys used for sleep detail. */
+export const SLEEP_METRICS = [
   'sleep_score',
   'sleep_efficiency',
   'sleep_restfulness',
@@ -92,9 +92,9 @@ export const OURA_SLEEP_METRICS = [
   'sleep_rem_score',
 ] as const
 
-export type OuraSleepMetricKey = (typeof OURA_SLEEP_METRICS)[number]
+export type SleepMetricKey = (typeof SLEEP_METRICS)[number]
 
-export const OURA_METRIC_LABELS: Record<OuraSleepMetricKey, string> = {
+export const SLEEP_METRIC_LABELS: Record<SleepMetricKey, string> = {
   sleep_deep_score: 'Deep',
   sleep_efficiency: 'Efficiency',
   sleep_rem_score: 'REM',
@@ -102,7 +102,7 @@ export const OURA_METRIC_LABELS: Record<OuraSleepMetricKey, string> = {
   sleep_score: 'Score',
 }
 
-export const OURA_METRIC_UNITS: Record<OuraSleepMetricKey, string> = {
+export const SLEEP_METRIC_UNITS: Record<SleepMetricKey, string> = {
   sleep_deep_score: '',
   sleep_efficiency: '%',
   sleep_rem_score: '',

--- a/apps/web/src/pages/Timeline/activityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.test.ts
@@ -150,7 +150,7 @@ describe('buildActivityColumnItems', () => {
     sleep: '#3b82f6',
   }
   const itemIcons: Record<string, string> = {}
-  const ouraByDate = new Map<string, Record<string, number>>()
+  const sleepMetricsByDate = new Map<string, Record<string, number>>()
   const buildSleepDetails = () => ['8h sleep']
   const getExerciseTypeName = () => 'Running'
   const exerciseColor = () => '#10b981'
@@ -164,7 +164,7 @@ describe('buildActivityColumnItems', () => {
       activityColors,
       exerciseColor,
       getExerciseTypeName,
-      ouraByDate,
+      sleepMetricsByDate,
       buildSleepDetails,
       scrobbles,
     )
@@ -182,7 +182,7 @@ describe('buildActivityColumnItems', () => {
       activityColors,
       exerciseColor,
       getExerciseTypeName,
-      ouraByDate,
+      sleepMetricsByDate,
       buildSleepDetails,
       scrobbles,
     )
@@ -201,7 +201,7 @@ describe('buildActivityColumnItems', () => {
       activityColors,
       exerciseColor,
       getExerciseTypeName,
-      ouraByDate,
+      sleepMetricsByDate,
       buildSleepDetails,
       scrobbles,
     )
@@ -218,7 +218,7 @@ describe('buildActivityColumnItems', () => {
       activityColors,
       exerciseColor,
       getExerciseTypeName,
-      ouraByDate,
+      sleepMetricsByDate,
       buildSleepDetails,
       scrobbles,
     )
@@ -237,7 +237,7 @@ describe('buildActivityColumnItems', () => {
       activityColors,
       exerciseColor,
       getExerciseTypeName,
-      ouraByDate,
+      sleepMetricsByDate,
       buildSleepDetails,
       scrobbles,
     )
@@ -253,7 +253,7 @@ describe('buildActivityColumnItems', () => {
       activityColors,
       exerciseColor,
       getExerciseTypeName,
-      ouraByDate,
+      sleepMetricsByDate,
       buildSleepDetails,
       scrobbles,
     )

--- a/packages/api-spec/src/schemas/chart-data.ts
+++ b/packages/api-spec/src/schemas/chart-data.ts
@@ -56,7 +56,9 @@ export const chartDataQuerySchema = z
     pattern: z
       .string()
       .optional()
-      .meta({ description: 'Pattern to match (regex for activity types, metric name for metrics, category path)' }),
+      .meta({
+        description: 'Pattern to match (regex for activity types, metric name for metrics, category path)',
+      }),
     source_type: chartDataSourceTypeSchema.meta({ description: 'Type of data source' }),
     start: z.iso.datetime().meta({ description: 'Start of time range (ISO 8601)' }),
     activity_type_id: z

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -186,20 +186,20 @@ export const productivitySummarySchema = z
 export type ProductivitySummary = z.infer<typeof productivitySummarySchema>
 
 /**
- * Oura scores schema.
+ * Scores schema — source-agnostic daily scores (sleep, readiness, etc.).
  */
-export const ouraScoresSchema = z
+export const scoresSchema = z
   .object({
-    cardiovascular_age: z.number().nullable().meta({ description: 'Oura cardiovascular age' }),
-    readiness_score: z.number().nullable().meta({ description: 'Oura readiness score (0-100)' }),
-    resilience_score: z.number().nullable().meta({ description: 'Oura resilience score (0-100)' }),
+    cardiovascular_age: z.number().nullable().meta({ description: 'Cardiovascular age estimate' }),
+    readiness_score: z.number().nullable().meta({ description: 'Readiness score (0-100)' }),
+    resilience_score: z.number().nullable().meta({ description: 'Resilience score (0-100)' }),
     sleep_score: z.number().nullable().meta({
-      description: 'Oura sleep score (0-100). Evaluates the primary sleep session for this date.',
+      description: 'Sleep score (0-100). Evaluates the primary sleep session for this date.',
     }),
   })
-  .meta({ id: 'OuraScores' })
+  .meta({ id: 'Scores' })
 
-export type OuraScores = z.infer<typeof ouraScoresSchema>
+export type Scores = z.infer<typeof scoresSchema>
 
 /**
  * Meal summary schema — lightweight meal info for daily summary.
@@ -241,8 +241,8 @@ export const dailySummaryResultSchema = z
       description:
         'Notes not attached to any activity in the activities list (orphaned or non-activity notes)',
     }),
-    oura_scores: ouraScoresSchema.nullable().meta({
-      description: 'Oura scores for this date.',
+    scores: scoresSchema.nullable().meta({
+      description: 'Daily scores (sleep, readiness, resilience, cardiovascular age).',
     }),
     places: z.array(placeSummarySchema),
     productivity: productivitySummarySchema.nullable(),

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -26,7 +26,11 @@ export const foodItemEntitySchema = nutrientFieldsSchema
       .max(100)
       .optional()
       .meta({ description: 'Default unit (e.g., "g", "ml", "serving", "large slice")' }),
-    icon: z.string().max(2048).optional().meta({ description: 'Icon for this food item (emoji or image URL)' }),
+    icon: z
+      .string()
+      .max(2048)
+      .optional()
+      .meta({ description: 'Icon for this food item (emoji or image URL)' }),
     id: z.string().uuid().meta({ description: 'Food item ID' }),
     name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
     source: z

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -77,7 +77,11 @@ export const foodItemSchema = z
     fat: z.number().optional().meta({ description: 'Fat in grams' }),
     fiber: z.number().optional().meta({ description: 'Dietary fiber in grams' }),
     food_item_id: z.string().uuid().optional().meta({ description: 'Link to canonical food item entity' }),
-    icon: z.string().max(2048).optional().meta({ description: 'Icon for this food item (emoji or image URL)' }),
+    icon: z
+      .string()
+      .max(2048)
+      .optional()
+      .meta({ description: 'Icon for this food item (emoji or image URL)' }),
     micros: microsSchema.meta({ description: 'Micronutrients for this food item' }),
     name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
     protein: z.number().optional().meta({ description: 'Protein in grams' }),

--- a/packages/api-spec/src/schemas/trends.ts
+++ b/packages/api-spec/src/schemas/trends.ts
@@ -15,7 +15,8 @@ import { baseResponseSchema } from './common.ts'
 export const trendSourceTypeSchema = z
   .enum(['tag', 'metric', 'productivity_category', 'activity_type'])
   .meta({
-    description: "Type of data source for trend calculation. 'tag' is a deprecated alias for 'activity_type'.",
+    description:
+      "Type of data source for trend calculation. 'tag' is a deprecated alias for 'activity_type'.",
     example: 'activity_type',
     id: 'TrendSourceType',
   })
@@ -76,7 +77,9 @@ export const getTrendQuerySchema = z
       .positive()
       .default(90)
       .meta({ description: 'How many days of historical data to include' }),
-    pattern: z.string().meta({ description: 'For activity types: regex pattern to match. For metrics: metric name.' }),
+    pattern: z
+      .string()
+      .meta({ description: 'For activity types: regex pattern to match. For metrics: metric name.' }),
     source_type: trendSourceTypeSchema,
     activity_type_id: z
       .string()


### PR DESCRIPTION
## Summary
- Rename `OuraScores`/`oura_scores` to `Scores`/`scores` in daily summary schema and service — these metrics are source-agnostic
- Rename `OURA_SLEEP_METRICS`, `OuraSleepMetricKey`, etc. to `SLEEP_METRICS`, `SleepMetricKey` in frontend EntityDetail
- Rename `ouraByDate` test variable to `sleepMetricsByDate` (matching the function parameter name)
- Includes formatting fixes from `pnpm fix` in a few schema files

## Test plan
- [x] All 1665 backend tests pass
- [x] Type checking passes for api-spec, backend, and web
- [ ] Verify daily summary API response uses `scores` field
- [ ] Verify sleep metrics display on entity detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)