### PR TITLE
fix: cap time slider width on mobile meals page

### DIFF
--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -534,6 +534,11 @@ a.meal-name:hover {
     min-width: unset;
   }
 
+  .time-slider-wrapper {
+    flex: 1 1 0;
+    max-width: 50%;
+  }
+
   .meal-edit-link {
     padding: 0.25rem 0.5rem;
   }


### PR DESCRIPTION
## Summary
- Cap `.time-slider-wrapper` at `max-width: 50%` on mobile so the "..." edit link and Delete button aren't overlapped by the slider thumb

## Test plan
- [ ] Open meals page on mobile — verify "..." and Delete are clearly separated from the slider
- [ ] Verify slider still works for adjusting meal time

🤖 Generated with [Claude Code](https://claude.com/claude-code)