### PR TITLE
fix: move time slider to own row on mobile meals page

### DIFF
--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -234,9 +234,8 @@ function MealSlotRow({
             onMouseUp={handleSliderRelease}
             onTouchEnd={handleSliderRelease}
           />
+          {isSaving && <span class="saving-indicator" />}
         </div>
-
-        {isSaving && <span class="saving-indicator" />}
 
         <div class="slot-actions">
           {primaryMeal ? (

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -540,12 +540,12 @@ a.meal-name:hover {
   }
 
   .time-slider-wrapper {
-    flex: 1 1 0;
-    max-width: 50%;
+    order: 1;
+    flex-basis: 100%;
   }
 
-  .meal-edit-link {
-    padding: 0.25rem 0.5rem;
+  .slot-actions {
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- On mobile, move the time slider to its own full-width row below the slot name and action buttons
- Uses flex `order: 1` and `flex-basis: 100%` to force the slider to a second line
- Action buttons ("..." and Delete) now sit on the same row as the slot name with clear tap targets

Mobile layout becomes:
```
[Breakfast]           [...] [Delete]
[7:10] [--------slider--------]
```

## Test plan
- [ ] On mobile: verify slider is on its own row below name and buttons
- [ ] On desktop: verify layout is unchanged (single row)
- [ ] Verify slider still adjusts meal time

🤖 Generated with [Claude Code](https://claude.com/claude-code)