### PR TITLE
fix: constrain time slider input within its flex container

### DIFF
--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -213,6 +213,8 @@
 
 .time-slider {
   flex: 1;
+  min-width: 0;
+  width: 0;
   height: 6px;
   -webkit-appearance: none;
   appearance: none;
@@ -539,14 +541,6 @@ a.meal-name:hover {
     min-width: unset;
   }
 
-  .time-slider-wrapper {
-    order: 1;
-    flex-basis: 100%;
-  }
-
-  .slot-actions {
-    margin-left: auto;
-  }
 }
 
 /* Dark mode */


### PR DESCRIPTION
## Summary
- Added `min-width: 0; width: 0` to `.time-slider` input so it respects `flex: 1` and stays within its wrapper
- Range inputs have a browser-imposed minimum width that causes overflow — this overrides it
- Removed mobile-only workarounds (order/flex-basis) that are no longer needed

## Test plan
- [ ] On mobile: verify slider stays within its row and doesn't overlap "..." / Delete
- [ ] On desktop: verify slider still fills available space normally
- [ ] Test slider interaction works on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)