### PR TITLE
refactor: extract shared icon/hover/truncate helpers

### DIFF
--- a/apps/web/src/pages/Timeline/drawItems.ts
+++ b/apps/web/src/pages/Timeline/drawItems.ts
@@ -1,0 +1,85 @@
+import * as d3 from 'd3'
+
+import type { ChartItem } from './types'
+
+import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SvgParent = d3.Selection<any, unknown, null, undefined>
+
+/**
+ * Render an emoji or image icon centered at (cx, cy).
+ * Returns the created SVG element selection, or null if no icon was available.
+ */
+export const drawItemIcon = (
+  parent: SvgParent,
+  icon: string | undefined,
+  cx: number,
+  cy: number,
+  iconSize: number,
+  opts?: {
+    pointerEvents?: 'all' | 'none'
+    cursor?: string
+  },
+): SvgParent | null => {
+  const pointerEvents = opts?.pointerEvents ?? 'none'
+  const cursor = opts?.cursor ?? 'default'
+
+  if (icon && isEmoji(icon)) {
+    return parent
+      .append('text')
+      .attr('x', cx)
+      .attr('y', cy)
+      .attr('dominant-baseline', 'central')
+      .attr('text-anchor', 'middle')
+      .attr('font-size', `${iconSize * 0.75}px`)
+      .attr('pointer-events', pointerEvents)
+      .attr('cursor', cursor)
+      .text(icon)
+  }
+
+  if (icon && (isUrl(icon) || isIconPath(icon))) {
+    return parent
+      .append('image')
+      .attr('href', icon)
+      .attr('x', cx - iconSize / 2)
+      .attr('y', cy - iconSize / 2)
+      .attr('width', iconSize)
+      .attr('height', iconSize)
+      .attr('pointer-events', pointerEvents)
+      .attr('cursor', cursor)
+  }
+
+  return null
+}
+
+/**
+ * Attach mouseenter/mouseleave hover handlers that toggle opacity and show/hide tooltip.
+ */
+export const attachHoverHandlers = (
+  selection: SvgParent,
+  item: ChartItem,
+  showTooltip: (event: MouseEvent, item: ChartItem) => void,
+  hideTooltip: () => void,
+  restOpacity = 0.7,
+  hoverOpacity = 0.9,
+): void => {
+  selection
+    .on('mouseenter', function (event: MouseEvent) {
+      d3.select(this).attr('opacity', hoverOpacity)
+      showTooltip(event, item)
+    })
+    .on('mouseleave', function () {
+      d3.select(this).attr('opacity', restOpacity)
+      hideTooltip()
+    })
+}
+
+/**
+ * Truncate a label to fit within a pixel width, assuming a fixed character width.
+ */
+export const truncateLabel = (label: string, widthPx: number, charWidth = 6): string => {
+  const maxChars = Math.floor(widthPx / charWidth)
+  if (label.length <= maxChars) return label
+  return label.slice(0, Math.max(maxChars - 1, 0)) + '…'
+}

--- a/apps/web/src/pages/Timeline/drawVerticalHelpers.ts
+++ b/apps/web/src/pages/Timeline/drawVerticalHelpers.ts
@@ -1,10 +1,10 @@
-import * as d3 from 'd3'
+import type * as d3 from 'd3'
 import { formatISO } from 'date-fns'
 
 import type { ChartItem, Column } from './types'
 
-import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import { NOW_COLOR } from './colors'
+import { attachHoverHandlers, drawItemIcon, truncateLabel } from './drawItems'
 import { formatTime } from './formatting'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -168,37 +168,11 @@ export const drawPointMarker = (
   hideTooltip: () => void,
 ): void => {
   const cursor = detailUrl ? 'pointer' : 'default'
-
   const iconSize = Math.max(18, Math.min(laneWidth, boxHeight))
 
-  if (item.icon && isEmoji(item.icon)) {
-    parent
-      .append('text')
-      .attr('x', cx)
-      .attr('y', cy)
-      .attr('dominant-baseline', 'central')
-      .attr('text-anchor', 'middle')
-      .attr('font-size', `${iconSize * 0.75}px`)
-      .attr('pointer-events', 'all')
-      .attr('cursor', cursor)
-      .text(item.icon)
-      .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
-      .on('mouseleave', hideTooltip)
-    return
-  }
-
-  if (item.icon && (isUrl(item.icon) || isIconPath(item.icon))) {
-    parent
-      .append('image')
-      .attr('href', item.icon)
-      .attr('x', cx - iconSize / 2)
-      .attr('y', cy - iconSize / 2)
-      .attr('width', iconSize)
-      .attr('height', iconSize)
-      .attr('pointer-events', 'all')
-      .attr('cursor', cursor)
-      .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
-      .on('mouseleave', hideTooltip)
+  const iconEl = drawItemIcon(parent, item.icon, cx, cy, iconSize, { cursor, pointerEvents: 'all' })
+  if (iconEl) {
+    iconEl.on('mouseenter', (event: MouseEvent) => showTooltip(event, item)).on('mouseleave', hideTooltip)
     return
   }
 
@@ -213,9 +187,6 @@ export const drawPointMarker = (
   const labelX = x + 2 * size + 6
   const availableWidth = laneWidth - 2 * size - 8
   if (availableWidth > 20) {
-    const charWidth = 5.5
-    const maxChars = Math.floor(availableWidth / charWidth)
-    const text = item.label.length > maxChars ? item.label.slice(0, maxChars) + '…' : item.label
     parent
       .append('text')
       .attr('x', labelX)
@@ -225,7 +196,7 @@ export const drawPointMarker = (
       .attr('font-size', '0.6rem')
       .attr('opacity', 0.8)
       .attr('pointer-events', 'none')
-      .text(text)
+      .text(truncateLabel(item.label, availableWidth, 5.5))
   }
 }
 
@@ -238,36 +209,12 @@ export const drawBlockOverlay = (
   blockHeight: number,
 ): void => {
   const iconSize = Math.max(18, Math.min(laneWidth, blockHeight))
-  if (item.icon && isEmoji(item.icon)) {
-    parent
-      .append('text')
-      .attr('x', x + laneWidth / 2)
-      .attr('y', y1 + blockHeight / 2)
-      .attr('dominant-baseline', 'central')
-      .attr('text-anchor', 'middle')
-      .attr('font-size', `${iconSize * 0.75}px`)
-      .attr('pointer-events', 'none')
-      .text(item.icon)
-    return
-  }
-
-  if (item.icon && (isUrl(item.icon) || isIconPath(item.icon))) {
-    parent
-      .append('image')
-      .attr('href', item.icon)
-      .attr('x', x + laneWidth / 2 - iconSize / 2)
-      .attr('y', y1 + blockHeight / 2 - iconSize / 2)
-      .attr('width', iconSize)
-      .attr('height', iconSize)
-      .attr('pointer-events', 'none')
-    return
-  }
+  if (drawItemIcon(parent, item.icon, x + laneWidth / 2, y1 + blockHeight / 2, iconSize)) return
 
   if (blockHeight > 30) {
-    const fontSize = laneWidth > 100 ? '0.8rem' : '0.65rem'
     const charWidth = laneWidth > 100 ? 7.5 : 6
-    const maxChars = Math.floor(laneWidth / charWidth)
-    const text = item.label.length > maxChars ? item.label.slice(0, maxChars) + '…' : item.label
+    const fontSize = laneWidth > 100 ? '0.8rem' : '0.65rem'
+    const text = truncateLabel(item.label, laneWidth, charWidth)
     parent
       .append('text')
       .attr('x', x + 4)
@@ -324,7 +271,7 @@ export const drawItem = (
     return
   }
 
-  parent
+  const rect = parent
     .append('rect')
     .attr('x', x)
     .attr('y', y1)
@@ -334,14 +281,7 @@ export const drawItem = (
     .attr('ry', 3)
     .attr('fill', item.color)
     .attr('opacity', 0.75)
-    .on('mouseenter', function (event: MouseEvent) {
-      d3.select(this).attr('opacity', 0.95)
-      showTooltip(event, item)
-    })
-    .on('mouseleave', function () {
-      d3.select(this).attr('opacity', 0.75)
-      hideTooltip()
-    })
+  attachHoverHandlers(rect, item, showTooltip, hideTooltip, 0.75, 0.95)
 
   drawBlockOverlay(parent, item, x, y1, laneWidth, blockHeight)
 }

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -24,7 +24,6 @@ import {
   fetchUserSettings,
 } from '../../state/api'
 import { aggregateBucketsAligned, parseBucketedResponse } from '../../utils/chart'
-import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import { packLanes } from '../../utils/lanePacking'
 import {
   buildActivityColumnItems,
@@ -50,6 +49,7 @@ import {
   tagSourceColors,
 } from './colors'
 import { drawActivitySparklines, parseBucketedData } from './drawActivitySparklines'
+import { attachHoverHandlers, drawItemIcon, truncateLabel } from './drawItems'
 import {
   CALORIES_COLOR,
   computeYScales,
@@ -1197,27 +1197,13 @@ export const Timeline = () => {
               ? chartGroup.append('a').attr('href', detailUrl).attr('data-clickable', 'true')
               : chartGroup
 
-            if (icon && isEmoji(icon)) {
-              parent
-                .append('text')
-                .attr('x', tagCx)
-                .attr('y', tagCy)
-                .attr('dominant-baseline', 'central')
-                .attr('font-size', `${iconSize * 0.75}px`)
-                .attr('text-anchor', 'middle')
-                .attr('cursor', detailUrl ? 'pointer' : 'default')
-                .text(icon)
-                .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
-                .on('mouseleave', hideTooltip)
-            } else if (icon && (isUrl(icon) || isIconPath(icon))) {
-              parent
-                .append('image')
-                .attr('href', icon)
-                .attr('x', tagCx - iconSize / 2)
-                .attr('y', tagCy - iconSize / 2)
-                .attr('width', iconSize)
-                .attr('height', iconSize)
-                .attr('cursor', detailUrl ? 'pointer' : 'default')
+            const cursor = detailUrl ? 'pointer' : 'default'
+            const iconEl = drawItemIcon(parent, icon, tagCx, tagCy, iconSize, {
+              cursor,
+              pointerEvents: 'all',
+            })
+            if (iconEl) {
+              iconEl
                 .on('mouseenter', (event: MouseEvent) => showTooltip(event, item))
                 .on('mouseleave', hideTooltip)
             } else {
@@ -1244,7 +1230,7 @@ export const Timeline = () => {
             ? chartGroup.append('a').attr('href', detailUrl).attr('data-clickable', 'true')
             : chartGroup
 
-          parent
+          const rect = parent
             .append('rect')
             .attr('x', rx)
             .attr('y', laneY)
@@ -1254,38 +1240,10 @@ export const Timeline = () => {
             .attr('opacity', 0.7)
             .attr('rx', 2)
             .attr('cursor', detailUrl ? 'pointer' : 'default')
-            .on('mouseenter', function (event: MouseEvent) {
-              d3.select(this).attr('opacity', 0.9)
-              showTooltip(event, item)
-            })
-            .on('mouseleave', function () {
-              d3.select(this).attr('opacity', 0.7)
-              hideTooltip()
-            })
+          attachHoverHandlers(rect, item, showTooltip, hideTooltip)
 
           const blockIconSize = Math.max(ICON_SIZE, Math.min(laneH, rw))
-          if (item.icon && isEmoji(item.icon)) {
-            parent
-              .append('text')
-              .attr('x', rx + rw / 2)
-              .attr('y', laneY + laneH / 2)
-              .attr('dominant-baseline', 'central')
-              .attr('text-anchor', 'middle')
-              .attr('font-size', `${blockIconSize * 0.75}px`)
-              .attr('pointer-events', 'none')
-              .text(item.icon)
-          } else if (item.icon && (isUrl(item.icon) || isIconPath(item.icon))) {
-            parent
-              .append('image')
-              .attr('href', item.icon)
-              .attr('x', rx + rw / 2 - blockIconSize / 2)
-              .attr('y', laneY + laneH / 2 - blockIconSize / 2)
-              .attr('width', blockIconSize)
-              .attr('height', blockIconSize)
-              .attr('pointer-events', 'none')
-          } else if (rw > 40) {
-            const maxChars = Math.floor(rw / 6)
-            const text = item.label.length > maxChars ? item.label.slice(0, maxChars) + '…' : item.label
+          if (!drawItemIcon(parent, item.icon, rx + rw / 2, laneY + laneH / 2, blockIconSize) && rw > 40) {
             parent
               .append('text')
               .attr('x', rx + 4)
@@ -1293,7 +1251,7 @@ export const Timeline = () => {
               .attr('fill', 'white')
               .attr('font-size', '0.65rem')
               .attr('pointer-events', 'none')
-              .text(text)
+              .text(truncateLabel(item.label, rw))
           }
         }
 
@@ -1309,7 +1267,7 @@ export const Timeline = () => {
             ? chartGroup.append('a').attr('href', placeUrl).attr('data-clickable', 'true')
             : chartGroup
 
-          parent
+          const placeRect = parent
             .append('rect')
             .attr('x', px)
             .attr('y', trackPlaces)
@@ -1319,19 +1277,9 @@ export const Timeline = () => {
             .attr('opacity', 0.7)
             .attr('rx', 2)
             .attr('cursor', placeUrl ? 'pointer' : 'default')
-            .on('mouseenter', function (event: MouseEvent) {
-              d3.select(this).attr('opacity', 0.9)
-              showTooltip(event, place)
-            })
-            .on('mouseleave', function () {
-              d3.select(this).attr('opacity', 0.7)
-              hideTooltip()
-            })
+          attachHoverHandlers(placeRect, place, showTooltip, hideTooltip)
 
           if (pw > 30) {
-            const maxChars = Math.floor(pw / 6)
-            const text =
-              place.label.length > maxChars ? place.label.slice(0, maxChars - 1) + '…' : place.label
             parent
               .append('text')
               .attr('x', px + 4)
@@ -1340,7 +1288,7 @@ export const Timeline = () => {
               .attr('fill', 'white')
               .attr('font-size', '0.6rem')
               .attr('pointer-events', 'none')
-              .text(text)
+              .text(truncateLabel(place.label, pw))
           }
         }
 


### PR DESCRIPTION
## Summary

Phase 2 of the Timeline rewrite plan — unify duplicated D3 rendering patterns into shared helpers.

### New file: `drawItems.ts`

Three shared helpers that both vertical and horizontal modes now use:

- **`drawItemIcon(parent, icon, cx, cy, iconSize, opts?)`** — renders emoji (with 0.75x font-size + `dominant-baseline: central`) or image icon centered at a point. Returns the created SVG selection for event attachment, or null if no icon. Replaces 5 copy-pasted emoji/image rendering blocks.

- **`attachHoverHandlers(selection, item, showTooltip, hideTooltip, restOpacity?, hoverOpacity?)`** — attaches mouseenter/mouseleave handlers that toggle opacity and show/hide tooltip. Replaces 5+ duplicated handler blocks with varying opacity values.

- **`truncateLabel(label, widthPx, charWidth?)`** — truncates text to fit within a pixel width. Replaces 4 duplicated `Math.floor(width / charWidth)` + slice blocks.

### Changes to existing files

- **`drawVerticalHelpers.ts`** — `drawPointMarker`, `drawBlockOverlay`, `drawItem` now use shared helpers instead of inline icon/hover/truncation code
- **`index.tsx`** — horizontal draw function uses the same shared helpers for activity items, block icons, and place rects
- Removed direct `isEmoji`/`isUrl`/`isIconPath` imports from `index.tsx` (now only used through `drawItems.ts`)

### Why this matters

Previously, fixes like the emoji font-size scaling had to be applied in 5 separate places across 2 files. Now there's a single `drawItemIcon` function — any icon rendering fix applies everywhere automatically.

Net change: -27 lines (+111 new, -138 removed)

## Test plan

- [ ] `pnpm check` passes (0 errors)
- [ ] `pnpm --filter aurboda-web exec vitest run` — 274 tests pass
- [ ] Both orientations render icons (emoji + images) correctly
- [ ] Hover effects work on activity blocks, place blocks
- [ ] Text truncation works on narrow items

🤖 Generated with [Claude Code](https://claude.com/claude-code)