### PR TITLE
fix: disable activity and meal queries when tracks are hidden

### DIFF
--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -100,6 +100,7 @@ export const useTimelineData = ({
   })
 
   const activitiesQuery = useQuery({
+    enabled: !hiddenCategories.has('activity'),
     placeholderData: keepPreviousData,
     queryFn: () => fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
     queryKey: ['timeline-activities', fromDateKey, toDateKey],
@@ -115,7 +116,7 @@ export const useTimelineData = ({
   })
 
   const mealsQuery = useQuery({
-    enabled: !hiddenCategories.has('meal'),
+    enabled: !hiddenCategories.has('activity') && !hiddenCategories.has('meal'),
     placeholderData: keepPreviousData,
     queryFn: () => fetchMeals({ start: fetchStart.toISOString(), end: fetchEnd.toISOString() }),
     queryKey: ['timeline-meals', fromDateKey, toDateKey],


### PR DESCRIPTION
## Summary

The activities query had no `enabled` guard — it always fetched even when the activity track was toggled off. The meals query was only gated by the `meal` sub-toggle, not the parent `activity` toggle.

When viewing only training load metrics with everything else hidden, the timeline was still fetching activities, meals, and related data unnecessarily.

### Changes

- `activitiesQuery`: added `enabled: !hiddenCategories.has('activity')`
- `mealsQuery`: added `!hiddenCategories.has('activity')` to existing guard

## Test plan

- [ ] With only training load visible, network tab shows no activity/meal/place requests
- [ ] Re-enabling activity track fetches activities on demand
- [ ] Meals appear when activity + meal toggles are both on

🤖 Generated with [Claude Code](https://claude.com/claude-code)