### PR TITLE
fix: rebuild scaffold on fetch range change and increase zoom limits

### DIFF
--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -163,6 +163,8 @@ export const Timeline = () => {
   const scaffoldOrientationRef = useRef<Orientation | null>(null)
   const scaffoldDimsRef = useRef<{ w: number; h: number } | null>(null)
   const scaffoldLayoutKeyRef = useRef<string>('')
+  /** Tracks the fetch range the base scale was built for. */
+  const scaffoldFetchKeyRef = useRef<string>('')
 
   // ── Derived layout data ───────────────────────────────────────────────────
 
@@ -284,13 +286,19 @@ export const Timeline = () => {
         ? `${scrobbles.length > 0 && !hiddenCategories.has('music')}_${!hiddenCategories.has('activity')}_${!hiddenCategories.has('metrics')}_${!hiddenCategories.has('location')}`
         : ''
 
-    // Check if scaffold needs rebuild (orientation change, first render, resize, or layout change)
+    // The base scale domain must match the fetch range (horizontal) or today (vertical).
+    // When the fetch range expands (user zooms past boundary) or contracts (reset to today),
+    // the scaffold must rebuild so the D3 zoom transform stays in sync with the base scale.
+    const fetchKey = `${fromDate.value}_${toDate.value}`
+
+    // Check if scaffold needs rebuild
     const needsSetup =
       scaffoldOrientationRef.current !== orientation ||
       !dims ||
       dims.w !== containerWidth ||
       dims.h !== containerHeight ||
-      scaffoldLayoutKeyRef.current !== layoutKey
+      scaffoldLayoutKeyRef.current !== layoutKey ||
+      scaffoldFetchKeyRef.current !== fetchKey
 
     // ── SCAFFOLD SETUP (only when needed) ──────────────────────────────────
     if (needsSetup) {
@@ -457,6 +465,7 @@ export const Timeline = () => {
       scaffoldOrientationRef.current = orientation
       scaffoldDimsRef.current = { w: containerWidth, h: containerHeight }
       scaffoldLayoutKeyRef.current = layoutKey
+      scaffoldFetchKeyRef.current = fetchKey
     }
 
     // ── CREATE DRAW FUNCTION (always — captures latest data) ────────────────

--- a/apps/web/src/pages/Timeline/useTimelineZoom.ts
+++ b/apps/web/src/pages/Timeline/useTimelineZoom.ts
@@ -74,7 +74,7 @@ export const useTimelineZoom = ({
     if (orientationRef.current === 'vertical') {
       const zoom = d3
         .zoom<SVGSVGElement, unknown>()
-        .scaleExtent([0.1, 20])
+        .scaleExtent([0.1, 200])
         .clickDistance(5)
         .filter((event: Event) => event.type !== 'dblclick')
         .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {
@@ -105,9 +105,11 @@ export const useTimelineZoom = ({
       svg.call(zoom)
       zoomBehaviorRef.current = zoom
     } else {
+      // Scale extent max must be high enough to zoom into a single hour even when
+      // the base scale spans a wide fetch range (e.g. 600 days → need k ≈ 14400).
       const zoom = d3
         .zoom<SVGSVGElement, unknown>()
-        .scaleExtent([0.1, 50])
+        .scaleExtent([0.1, 20000])
         .clickDistance(5)
         .filter((event: Event) => event.type !== 'dblclick')
         .on('zoom', (event: d3.D3ZoomEvent<SVGSVGElement, unknown>) => {


### PR DESCRIPTION
## Summary

Two bugs caused zoom to get stuck after zooming out far in horizontal mode:

### Bug 1: Stale base scale after fetch range change

The scaffold staleness check didn't include the fetch range (`fromDate`/`toDate`). When `handleZoom` expanded the fetch range (zooming past the boundary), the base scale kept its old domain. After "reset to today" contracted the range, the zoom transform was computed against the stale wide base scale — showing the wrong range and making "Today" display a multi-day view.

**Fix**: Track `fromDate_toDate` in `scaffoldFetchKeyRef` and include it in `needsSetup`.

### Bug 2: scaleExtent too restrictive

The horizontal `scaleExtent` max was 50, limiting zoom-in to `fetchRange / 50`. With a 580-day fetch range (from zooming out to Oct 2024), the most zoomed-in view was ~12 days — far less than the default 1-day view.

**Fix**: Increase horizontal max to 20000 (supports zooming to 1 hour within a 2-year range). Vertical increased from 20 to 200 (~7-minute minimum view).

## Test plan

- [ ] Zoom out to multi-month view, then zoom back in to a single day — should work smoothly
- [ ] Click "Today" after zooming far out — should show just today, not a multi-day range
- [ ] Zoom out, zoom in to a specific day, zoom in further to a few hours — no "stuck" zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)