### PR TITLE
fix: show decimals for trend goals in Android widget

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/GoalsWidgetService.kt
@@ -200,7 +200,15 @@ class GoalsRemoteViewsFactory(private val context: Context) : RemoteViewsService
             "sec", "seconds" -> formatZoneTime(value)
             "count" -> value.toLong().toString()
             "m" -> "${(value / 1000).toInt()} km"
-            else -> "${value.toInt()} $unit"
+            else -> {
+                // Show decimals for small values (trend goals like "0.7 per month")
+                val formatted = if (value < 100 && value != value.toLong().toDouble()) {
+                    "%.1f".format(value)
+                } else {
+                    value.toLong().toString()
+                }
+                "$formatted $unit"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Trend goals like "0.7 per month" were displayed as "1 per month" in the Android widget because `formatGoalValue` truncated to integer for unknown units.

Now shows one decimal place for values under 100 that aren't whole numbers (e.g., "1.5 per month", "0.7 per month"). Large whole numbers (steps, seconds) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)