### PR TITLE
fix: use UTC timestamps in Android Add screen

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/AddDataScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/AddDataScreen.kt
@@ -232,10 +232,8 @@ private fun DateTimePickerField(
     }
 }
 
-private fun epochMillisToIso(epochMillis: Long): String {
-    val zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault())
-    return zdt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-}
+private fun epochMillisToIso(epochMillis: Long): String =
+    Instant.ofEpochMilli(epochMillis).toString()
 
 private fun nowEpochMillis(): Long = System.currentTimeMillis()
 


### PR DESCRIPTION
## Summary
- `epochMillisToIso` was producing offset timestamps (`+02:00`) which `z.iso.datetime()` in Zod 4 rejects
- Changed to `Instant.toString()` which produces UTC format (`Z` suffix)
- This was the actual root cause of ALL pending entries failing — not just malformed timestamps

## Test plan
- [x] Android compiles
- [ ] Manual: add a metric and verify it succeeds immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)