### PR TITLE
feat: activity form improvements

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/AddDataScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/AddDataScreen.kt
@@ -829,7 +829,10 @@ private fun AddActivityTab(
         DateTimePickerField(
             label = "Start Time",
             epochMillis = startTimeMillis,
-            onChanged = { startTimeMillis = it },
+            onChanged = {
+                startTimeMillis = it
+                endTimeMillis = it + 5 * 60 * 1000
+            },
         )
 
         // Has end time checkbox

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -95,7 +95,7 @@ export interface MergedActivity extends Activity {
 export interface ActivityUpdate {
   activity_type?: ActivityType
   start_time?: Date
-  end_time?: Date
+  end_time?: Date | null
   title?: string
   notes?: string
   data?: Record<string, unknown>

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -484,7 +484,7 @@ export const createActivitiesRouter = (
         {
           activity_type,
           data,
-          end_time: end_time ? new Date(end_time) : undefined,
+          end_time: end_time === null ? null : end_time ? new Date(end_time) : undefined,
           notes,
           start_time: start_time ? new Date(start_time) : undefined,
           title,
@@ -500,7 +500,7 @@ export const createActivitiesRouter = (
       res.json({
         data: {
           activity_type: result.activity_type!,
-          end_time: result.end_time!,
+          end_time: result.end_time ?? undefined,
           id: result.id!,
           notes: result.notes,
           start_time: result.start_time!,

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -110,7 +110,7 @@ export interface DeleteActivityResult {
 export interface UpdateActivityInput {
   activity_type?: ActivityType
   start_time?: Date
-  end_time?: Date
+  end_time?: Date | null
   title?: string
   notes?: string
   data?: Record<string, unknown>
@@ -491,7 +491,7 @@ export async function updateActivity(
 
   // Determine final start and end times
   const finalStartTime = input.start_time ?? existing.start_time
-  const finalEndTime = input.end_time ?? existing.end_time
+  const finalEndTime = input.end_time === null ? null : input.end_time ?? existing.end_time
 
   // Validate that endTime is not before startTime (equal is valid for point-in-time activities)
   if (finalEndTime && finalEndTime < finalStartTime) {

--- a/apps/web/src/components/GoalProgressBar.tsx
+++ b/apps/web/src/components/GoalProgressBar.tsx
@@ -1,6 +1,7 @@
 import { metricUnits } from '@aurboda/api-spec'
 
 import type { GoalProgress } from '../state/api'
+
 import { metricLabels } from '../utils/metricLabels'
 
 // Format value for display (e.g., seconds to hours:minutes)

--- a/apps/web/src/pages/AddData/index.tsx
+++ b/apps/web/src/pages/AddData/index.tsx
@@ -1,11 +1,20 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { DataFieldDefinition } from '@aurboda/api-spec'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation } from 'preact-iso'
 import { useCallback, useState } from 'preact/hooks'
 
 import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { MetricPicker } from '../../components/MetricPicker'
-import { addActivity, addMetric, addNote, uploadFitFile, type ActivityType } from '../../state/api'
+import {
+  addActivity,
+  addMetric,
+  addNote,
+  fetchActivityTypeDefinitions,
+  uploadFitFile,
+  type ActivityType,
+} from '../../state/api'
 import './style.css'
 
 type Tab = 'activity' | 'metric'
@@ -75,6 +84,62 @@ const FitUpload = ({ onCreated }: FormProps) => {
   )
 }
 
+const SchemaFieldInput = ({
+  field,
+  value,
+  onChange,
+}: {
+  field: DataFieldDefinition
+  value: string
+  onChange: (value: string) => void
+}) => {
+  const label = field.label ?? field.name.replaceAll('_', ' ').replace(/^\w/, (c) => c.toUpperCase())
+  const unitSuffix = field.unit ? ` (${field.unit})` : ''
+
+  if (field.type === 'boolean') {
+    return (
+      <div class="form-check">
+        <input
+          type="checkbox"
+          id={`data-${field.name}`}
+          checked={value === 'true'}
+          onChange={(e) => onChange((e.target as HTMLInputElement).checked ? 'true' : '')}
+        />
+        <label for={`data-${field.name}`}>{label}</label>
+      </div>
+    )
+  }
+
+  if (field.type === 'string' && field.enum_values) {
+    return (
+      <div class="form-field">
+        <label>{label}</label>
+        <select value={value} onChange={(e) => onChange((e.target as HTMLSelectElement).value)}>
+          <option value="">-- Select --</option>
+          {field.enum_values.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+
+  return (
+    <div class="form-field">
+      <label>{`${label}${unitSuffix}`}</label>
+      <input
+        type={field.type === 'number' ? 'number' : 'text'}
+        step={field.type === 'number' ? 'any' : undefined}
+        value={value}
+        onInput={(e) => onChange((e.target as HTMLInputElement).value)}
+        placeholder={`Optional ${label.toLowerCase()}`}
+      />
+    </div>
+  )
+}
+
 const AddActivityForm = ({ onCreated }: FormProps) => {
   const queryClient = useQueryClient()
   const [activityType, setActivityType] = useState<ActivityType>('')
@@ -84,14 +149,26 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
   const [hasEndTime, setHasEndTime] = useState(true)
   const [notes, setNotes] = useState('')
   const [comment, setComment] = useState('')
+  const [structuredData, setStructuredData] = useState<Record<string, string>>({})
   const [success, setSuccess] = useState('')
   const [error, setError] = useState('')
+
+  const { data: typeDefs } = useQuery({
+    queryFn: fetchActivityTypeDefinitions,
+    queryKey: ['activity-type-definitions'],
+    staleTime: 30 * 60 * 1000,
+  })
+
+  const selectedTypeDef = typeDefs?.find((t) => t.name === activityType)
+  const dataFields = selectedTypeDef?.data_schema?.fields ?? []
 
   const mutation = useMutation({
     mutationFn: async () => {
       if (!activityType) throw new Error('Please select an activity type')
+      const dataMap = Object.fromEntries(Object.entries(structuredData).filter(([, v]) => v !== ''))
       const result = await addActivity({
         activity_type: activityType,
+        ...(Object.keys(dataMap).length > 0 ? { data: dataMap } : {}),
         ...(hasEndTime ? { end_time: new Date(endTime).toISOString() } : {}),
         ...(notes ? { notes } : {}),
         start_time: new Date(startTime).toISOString(),
@@ -118,6 +195,7 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
       setTitle('')
       setNotes('')
       setComment('')
+      setStructuredData({})
       setStartTime(nowLocal())
       setEndTime(nowLocal())
       setHasEndTime(true)
@@ -131,7 +209,13 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
 
       <div class="form-field">
         <label>Activity Type</label>
-        <ActivityTypePicker value={activityType} onChange={setActivityType} />
+        <ActivityTypePicker
+          value={activityType}
+          onChange={(type) => {
+            setActivityType(type)
+            setStructuredData({})
+          }}
+        />
       </div>
 
       <div class="form-field">
@@ -173,6 +257,16 @@ const AddActivityForm = ({ onCreated }: FormProps) => {
           />
         </div>
       )}
+
+      {dataFields.length > 0 &&
+        dataFields.map((field) => (
+          <SchemaFieldInput
+            key={field.name}
+            field={field}
+            value={structuredData[field.name] ?? ''}
+            onChange={(v) => setStructuredData((prev) => ({ ...prev, [field.name]: v }))}
+          />
+        ))}
 
       <div class="form-field">
         <label>Notes</label>

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -46,9 +46,11 @@ export const EditableActivityFields = ({
 }: EditableActivityFieldsProps) => {
   if (isEditing) {
     const draftStart = new Date(draft.start_time)
-    const draftEnd = new Date(draft.end_time)
+    const draftEnd = draft.end_time ? new Date(draft.end_time) : null
     const draftDuration =
-      isNaN(draftStart.getTime()) || isNaN(draftEnd.getTime()) ? '—' : formatDuration(draftStart, draftEnd)
+      !draftEnd || isNaN(draftStart.getTime()) || isNaN(draftEnd.getTime())
+        ? '—'
+        : formatDuration(draftStart, draftEnd)
 
     return (
       <>
@@ -86,13 +88,42 @@ export const EditableActivityFields = ({
           </div>
           <div class="field-row">
             <span class="field-label">End</span>
-            <span class="field-value">
-              <input
-                type="datetime-local"
-                class="edit-datetime-input"
-                value={draft.end_time}
-                onInput={(e) => onDraftChange({ ...draft, end_time: (e.target as HTMLInputElement).value })}
-              />
+            <span class="field-value" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              {draft.end_time ? (
+                <>
+                  <input
+                    type="datetime-local"
+                    class="edit-datetime-input"
+                    value={draft.end_time}
+                    onInput={(e) =>
+                      onDraftChange({ ...draft, end_time: (e.target as HTMLInputElement).value })
+                    }
+                  />
+                  <button
+                    type="button"
+                    class="btn-secondary"
+                    title="Remove end time"
+                    onClick={() => onDraftChange({ ...draft, end_time: '' })}
+                    style={{ padding: '0.25rem 0.5rem', fontSize: '0.85rem' }}
+                  >
+                    &times;
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  class="btn-secondary"
+                  onClick={() => {
+                    const start = new Date(draft.start_time)
+                    const end = new Date(start.getTime() + 60 * 60000)
+                    const pad = (n: number) => String(n).padStart(2, '0')
+                    const formatted = `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}T${pad(end.getHours())}:${pad(end.getMinutes())}`
+                    onDraftChange({ ...draft, end_time: formatted })
+                  }}
+                >
+                  Set end time
+                </button>
+              )}
             </span>
           </div>
           <div class="field-row">

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -383,13 +383,12 @@ const ActivityDetailContent = ({
 
 const makeDraft = (activity: Activity): ActivityDraft => {
   const displayStart = activity.merged_start_time ?? activity.start_time
-  const displayEnd =
-    activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  const displayEnd = activity.merged_end_time ?? activity.end_time
   const exerciseType = resolveExerciseType(activity)
   return {
     activity_type: activity.activity_type,
     data: (activity.data as Record<string, unknown>) ?? {},
-    end_time: formatDateTimeLocal(displayEnd),
+    end_time: displayEnd ? formatDateTimeLocal(displayEnd) : '',
     exercise_type: exerciseType,
     notes: activity.notes ?? '',
     start_time: formatDateTimeLocal(displayStart),
@@ -507,7 +506,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
       const body: {
         activity_type?: string
         start_time?: string
-        end_time?: string
+        end_time?: string | null
         title?: string
         notes?: string
         exercise_type?: ExerciseTypeName
@@ -520,7 +519,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         body.start_time = new Date(draft.start_time).toISOString()
       }
       if (draft.end_time !== orig.end_time) {
-        body.end_time = new Date(draft.end_time).toISOString()
+        body.end_time = draft.end_time ? new Date(draft.end_time).toISOString() : null
       }
       if (draft.notes !== orig.notes) body.notes = draft.notes
       if (draft.exercise_type !== orig.exercise_type && draft.exercise_type) {

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -278,7 +278,7 @@ export type AddActivityBody = z.infer<typeof addActivityBodySchema>
  */
 const addedActivitySchema = z.object({
   activity_type: activityTypeSchema,
-  end_time: iso8601DateTimeSchema,
+  end_time: iso8601DateTimeSchema.optional(),
   id: z.string().uuid(),
   notes: z.string().optional(),
   start_time: iso8601DateTimeSchema,
@@ -324,7 +324,7 @@ export const updateActivityBodySchema = z
     data: z.record(z.string(), z.unknown()).optional().meta({
       description: 'Updated structured data fields (merged with existing data)',
     }),
-    end_time: iso8601DateTimeSchema.optional().meta({ description: 'New end time of the activity' }),
+    end_time: iso8601DateTimeSchema.nullable().optional().meta({ description: 'New end time of the activity (null to clear)' }),
     exercise_type: exerciseTypeSchema.optional().meta({
       description: 'New exercise type name (only for exercise activities)',
     }),


### PR DESCRIPTION
## Summary
- **Android**: Auto-set end timestamp to start + 5 minutes when user changes start time in Add Activity
- **Web (edit)**: Add ability to remove end timestamp when editing an activity (× button to clear, "Set end time" button to restore). Full stack support for nullable end_time in update API.
- **Web (add)**: Show structured data input fields when adding an activity type that has a data schema (e.g. Partner field for sex activity), matching Android behavior

## Test plan
- [ ] Android: Open Add Activity, change start time → verify end time updates to start + 5min
- [ ] Web: Edit an activity with end time → click × to clear it → save → verify end time is removed
- [ ] Web: Edit an activity without end time → click "Set end time" → save
- [ ] Web: Add activity → select type with data_schema (e.g. sex) → verify structured fields appear
- [ ] Web: Add activity with structured data → submit → verify data is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)