### PR TITLE
feat: add Strava credentials to admin settings page

### DIFF
--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -35,11 +35,23 @@ export const createAdminRouter = (
     authMiddleware,
     adminMiddleware,
     async (_req, res) => {
-      const signupMode = await centralDb.getSignupMode()
-      const adminCount = await centralDb.getAdminCount()
-      const lastFmApiKey = await centralDb.getLastFmApiKey()
-      const ouraWebhookEnabled = await centralDb.getOuraWebhookEnabled()
-      const auditLogRetentionDays = await centralDb.getAuditLogRetentionDays()
+      const [
+        signupMode,
+        adminCount,
+        lastFmApiKey,
+        ouraWebhookEnabled,
+        auditLogRetentionDays,
+        stravaClientId,
+        stravaClientSecret,
+      ] = await Promise.all([
+        centralDb.getSignupMode(),
+        centralDb.getAdminCount(),
+        centralDb.getLastFmApiKey(),
+        centralDb.getOuraWebhookEnabled(),
+        centralDb.getAuditLogRetentionDays(),
+        centralDb.getServerSetting('strava_client_id'),
+        centralDb.getServerSetting('strava_client_secret'),
+      ])
       res.json({
         admin_count: adminCount,
         audit_log_retention_days: auditLogRetentionDays,
@@ -47,6 +59,8 @@ export const createAdminRouter = (
         oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
         oura_webhook_enabled: ouraWebhookEnabled,
         signup_mode: signupMode,
+        strava_client_id_set: !!stravaClientId,
+        strava_client_secret_set: !!stravaClientSecret,
         success: true,
       })
     },
@@ -58,7 +72,14 @@ export const createAdminRouter = (
     adminMiddleware,
     validateBody(updateAdminSettingsBodySchema),
     async (req, res) => {
-      const { audit_log_retention_days, lastfm_api_key, oura_webhook_enabled, signup_mode } = req.body
+      const {
+        audit_log_retention_days,
+        lastfm_api_key,
+        oura_webhook_enabled,
+        signup_mode,
+        strava_client_id,
+        strava_client_secret,
+      } = req.body
       if (signup_mode) {
         await centralDb.setSignupMode(signup_mode)
       }
@@ -78,11 +99,29 @@ export const createAdminRouter = (
           }
         }
       }
-      const currentMode = await centralDb.getSignupMode()
-      const adminCount = await centralDb.getAdminCount()
-      const lastFmApiKey = await centralDb.getLastFmApiKey()
-      const ouraWebhookEnabledValue = await centralDb.getOuraWebhookEnabled()
-      const currentRetentionDays = await centralDb.getAuditLogRetentionDays()
+      if (strava_client_id !== undefined) {
+        await centralDb.setServerSetting('strava_client_id', strava_client_id ?? '')
+      }
+      if (strava_client_secret !== undefined) {
+        await centralDb.setServerSetting('strava_client_secret', strava_client_secret ?? '')
+      }
+      const [
+        currentMode,
+        adminCount,
+        lastFmApiKey,
+        ouraWebhookEnabledValue,
+        currentRetentionDays,
+        currentStravaClientId,
+        currentStravaClientSecret,
+      ] = await Promise.all([
+        centralDb.getSignupMode(),
+        centralDb.getAdminCount(),
+        centralDb.getLastFmApiKey(),
+        centralDb.getOuraWebhookEnabled(),
+        centralDb.getAuditLogRetentionDays(),
+        centralDb.getServerSetting('strava_client_id'),
+        centralDb.getServerSetting('strava_client_secret'),
+      ])
       res.json({
         admin_count: adminCount,
         audit_log_retention_days: currentRetentionDays,
@@ -90,6 +129,8 @@ export const createAdminRouter = (
         oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
         oura_webhook_enabled: ouraWebhookEnabledValue,
         signup_mode: currentMode,
+        strava_client_id_set: !!currentStravaClientId,
+        strava_client_secret_set: !!currentStravaClientSecret,
         success: true,
       })
     },

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -31,6 +31,101 @@ const formatExpiryTime = (expiresAt: Date): string => {
   return `${minutes} minute${minutes > 1 ? 's' : ''}`
 }
 
+// eslint-disable-next-line complexity -- simple form with save/clear handlers
+function StravaApiSection() {
+  const queryClient = useQueryClient()
+  const { data: settings } = useQuery({
+    queryFn: fetchAdminSettings,
+    queryKey: ['adminSettings'],
+  })
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
+
+  const idSet = settings?.strava_client_id_set ?? false
+  const secretSet = settings?.strava_client_secret_set ?? false
+
+  const saveStrava = useCallback(
+    async (params: { strava_client_id?: string | null; strava_client_secret?: string | null }) => {
+      setSaveStatus({ status: 'saving' })
+      try {
+        const result = await updateAdminSettings(params)
+        queryClient.setQueryData(['adminSettings'], result)
+        setClientId('')
+        setClientSecret('')
+        setSaveStatus({ status: 'saved', time: new Date() })
+      } catch (err) {
+        setSaveStatus({ error: getErrorMessage(err), status: 'error' })
+      }
+    },
+    [queryClient],
+  )
+
+  const handleSave = useCallback(() => {
+    if (!clientId && !clientSecret) return
+    saveStrava({
+      ...(clientId ? { strava_client_id: clientId } : {}),
+      ...(clientSecret ? { strava_client_secret: clientSecret } : {}),
+    })
+  }, [clientId, clientSecret, saveStrava])
+
+  const handleClear = useCallback(
+    () => saveStrava({ strava_client_id: null, strava_client_secret: null }),
+    [saveStrava],
+  )
+
+  return (
+    <div class="form-field">
+      <div class="section-header-row">
+        <label>Strava API</label>
+        <SaveStatusIndicator state={saveStatus} />
+      </div>
+      {(idSet || secretSet) && (
+        <p class={`connected-status${idSet && secretSet ? '' : ' warning'}`}>
+          {idSet && secretSet ? 'Configured' : 'Partially configured'}
+        </p>
+      )}
+      <div class="api-key-input-row">
+        <input
+          type="text"
+          value={clientId}
+          onInput={(e) => setClientId((e.target as HTMLInputElement).value)}
+          placeholder={idSet ? 'Enter new client ID to update' : 'Client ID'}
+        />
+      </div>
+      <div class="api-key-input-row">
+        <input
+          type="password"
+          value={clientSecret}
+          onInput={(e) => setClientSecret((e.target as HTMLInputElement).value)}
+          placeholder={secretSet ? 'Enter new client secret to update' : 'Client Secret'}
+        />
+        {(idSet || secretSet) && (
+          <button type="button" class="clear-button" onClick={handleClear}>
+            Clear
+          </button>
+        )}
+      </div>
+      <button
+        type="button"
+        class="generate-button"
+        onClick={handleSave}
+        disabled={!clientId && !clientSecret}
+      >
+        Save Strava Credentials
+      </button>
+      <p class="field-description">
+        Strava OAuth credentials for activity syncing.{' '}
+        <a href="https://www.strava.com/settings/api" target="_blank" rel="noopener noreferrer">
+          Register a Strava API application
+        </a>
+        . Only the Client ID and Client Secret are needed.
+      </p>
+    </div>
+  )
+}
+
 function IntegrationsSection() {
   const queryClient = useQueryClient()
   const { data: settings } = useQuery({
@@ -133,6 +228,8 @@ function IntegrationsSection() {
           </p>
         </div>
       )}
+
+      <StravaApiSection />
     </section>
   )
 }

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -966,6 +966,8 @@ export interface AdminSettings {
   lastfm_api_key_set: boolean
   oura_webhook_available: boolean
   oura_webhook_enabled: boolean
+  strava_client_id_set: boolean
+  strava_client_secret_set: boolean
 }
 
 export interface InvitationResult {
@@ -987,6 +989,8 @@ export const fetchAdminSettings = async (): Promise<AdminSettings> => {
     oura_webhook_available: response.data.oura_webhook_available,
     oura_webhook_enabled: response.data.oura_webhook_enabled,
     signup_mode: response.data.signup_mode,
+    strava_client_id_set: response.data.strava_client_id_set,
+    strava_client_secret_set: response.data.strava_client_secret_set,
   }
 }
 
@@ -995,6 +999,8 @@ export const updateAdminSettings = async (params: {
   signup_mode?: SignupMode
   lastfm_api_key?: string | null
   oura_webhook_enabled?: boolean
+  strava_client_id?: string | null
+  strava_client_secret?: string | null
 }): Promise<AdminSettings> => {
   const { token } = auth.value
   const response = await axios.patch<{ success: boolean } & AdminSettings>(
@@ -1011,6 +1017,8 @@ export const updateAdminSettings = async (params: {
     oura_webhook_available: response.data.oura_webhook_available,
     oura_webhook_enabled: response.data.oura_webhook_enabled,
     signup_mode: response.data.signup_mode,
+    strava_client_id_set: response.data.strava_client_id_set,
+    strava_client_secret_set: response.data.strava_client_secret_set,
   }
 }
 

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -147,6 +147,10 @@ export const adminSettingsResponseSchema = baseResponseSchema
     }),
     oura_webhook_enabled: z.boolean().meta({ description: 'Whether Oura webhook push sync is enabled' }),
     signup_mode: signupModeSchema.meta({ description: 'Current signup mode' }),
+    strava_client_id_set: z.boolean().meta({ description: 'Whether a Strava client ID is configured' }),
+    strava_client_secret_set: z
+      .boolean()
+      .meta({ description: 'Whether a Strava client secret is configured' }),
   })
   .meta({ id: 'AdminSettingsResponse' })
 
@@ -174,6 +178,16 @@ export const updateAdminSettingsBodySchema = z
       .optional()
       .meta({ description: 'Enable or disable Oura webhook push sync' }),
     signup_mode: signupModeSchema.optional().meta({ description: 'New signup mode' }),
+    strava_client_id: z
+      .string()
+      .nullable()
+      .optional()
+      .meta({ description: 'Strava API client ID (set to null to clear)' }),
+    strava_client_secret: z
+      .string()
+      .nullable()
+      .optional()
+      .meta({ description: 'Strava API client secret (set to null to clear)' }),
   })
   .meta({ id: 'UpdateAdminSettingsBody' })
 


### PR DESCRIPTION
## Summary

- Adds Strava Client ID and Client Secret fields to the admin settings Integrations section
- Extends `PATCH /admin/settings` API to accept `strava_client_id` and `strava_client_secret`
- Shows "Configured" / "Partially configured" status with save and clear buttons

This was missing from the Strava integration PR — the credentials had no UI for setting them.

## Test plan

- [ ] Go to /admin, see Strava API section under Integrations
- [ ] Enter client ID and secret, click Save — verify "Configured" appears
- [ ] Click Clear — verify fields reset and status disappears
- [ ] Go to /data-sources/strava — verify "Connect Strava" button is now enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)