### PR TITLE
fix: Strava OAuth callback, nav menu, and activity type FK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ export RESCUETIME_KEY=
 # Backend server
 export PORT=3000
 export WEB_HOST=http://localhost:5173
+export API_BASE_URL=http://localhost:3000
 
 # Frontend (Vite)
 VITE_API_URL=http://localhost:3000

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -43,6 +43,7 @@ import {
   processHealthConnectBatch,
   processHealthConnectData,
   query,
+  resolveOrCreateActivityType,
   resetSyncState,
   schemaInitialized,
   softDeleteActivityByExternalId,
@@ -137,30 +138,27 @@ const main = async () => {
   const centralDb = getCentralDb()
 
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
-  const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', webHost, {
+  const apiBaseUrl = process.env.API_BASE_URL ?? 'http://localhost:3000'
+  const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', apiBaseUrl, {
     onUserAuthenticated: (ouraUserId, username) => centralDb.upsertOuraUserMapping(ouraUserId, username),
   })
 
   // Create Garmin client (no server-side credentials needed - uses per-user session tokens)
   const garmin = garminClient()
 
-  // Create Strava client (from server settings — may not be configured yet)
-  const stravaClientId = await centralDb.getServerSetting('strava_client_id')
-  const stravaClientSecret = await centralDb.getServerSetting('strava_client_secret')
-
-  const strava =
-    stravaClientId && stravaClientSecret
-      ? stravaClient(stravaClientId, stravaClientSecret, webHost, {
-          onUserAuthenticated: (stravaAthleteId, username) =>
-            centralDb.upsertStravaAthleteMapping(stravaAthleteId, username),
-        })
-      : null
-
-  if (!strava) {
-    console.warn(
-      '⚠️ Strava integration disabled — set strava_client_id and strava_client_secret in server settings',
-    )
+  // Create Strava client with dynamic credentials (reads from DB on each request)
+  const getStravaCredentials = async () => {
+    const clientId = await centralDb.getServerSetting('strava_client_id')
+    const clientSecret = await centralDb.getServerSetting('strava_client_secret')
+    if (!clientId || !clientSecret)
+      {throw new Error('Strava not configured — set credentials in Admin Settings')}
+    return { clientId, clientSecret }
   }
+
+  const strava = stravaClient(getStravaCredentials, apiBaseUrl, {
+    onUserAuthenticated: (stravaAthleteId, username) =>
+      centralDb.upsertStravaAthleteMapping(stravaAthleteId, username),
+  })
 
   // Create sync provider for auto-syncing data before queries
   const syncProvider = createSyncProvider({
@@ -204,7 +202,7 @@ const main = async () => {
 
   // Initialize Strava queue (uses shared boss + strava client)
   let stravaQueue: StravaQueue | null = null
-  if (boss && strava) {
+  if (boss) {
     try {
       stravaQueue = await createStravaQueue(boss, {
         getAccessToken: (user) => strava.getAccessToken(user),
@@ -216,6 +214,7 @@ const main = async () => {
           insertLocations,
           insertRawRecord,
           insertTimeSeries,
+          resolveOrCreateActivityType,
           softDeleteLocationRange,
         },
         updateSyncState: async (user, dataType, updates) => {
@@ -611,7 +610,7 @@ const main = async () => {
     ),
   )
 
-  httpd.get('/auth/connectOura', oura.redirectToAuthorize)
+  httpd.get('/auth/oura/connect', authMiddleware, oura.getAuthorizeUrl)
   httpd.get('/auth/ouracb', oura.authCb)
 
   // Garmin Connect auth endpoints (login with credentials, tokens-only stored)
@@ -668,30 +667,28 @@ const main = async () => {
     }
   })
 
-  // Strava OAuth endpoints
-  if (strava) {
-    httpd.get('/auth/connectStrava', strava.redirectToAuthorize)
-    httpd.get('/auth/stravacb', strava.authCb)
+  // Strava OAuth endpoints (always registered — credentials checked dynamically)
+  httpd.get('/auth/strava/connect', authMiddleware, strava.getAuthorizeUrl)
+  httpd.get('/auth/stravacb', strava.authCb)
 
-    httpd.post('/auth/strava/disconnect', authMiddleware, async (req, res) => {
-      const user = req.user!
-      try {
-        // Clear tokens and athlete mapping
-        await upsertOAuthToken(user, { access_token: '', provider: 'strava' })
-        await centralDb.deleteStravaAthleteMappingByUsername(user)
-        res.json({ success: true })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Disconnect failed'
-        res.status(500).json({ error: message, success: false })
-      }
-    })
-  }
+  httpd.post('/auth/strava/disconnect', authMiddleware, async (req, res) => {
+    const user = req.user!
+    try {
+      // Clear tokens and athlete mapping
+      await upsertOAuthToken(user, { access_token: '', provider: 'strava' })
+      await centralDb.deleteStravaAthleteMappingByUsername(user)
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Disconnect failed'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
 
   // ==========================================================================
   // Strava webhook push integration
   // ==========================================================================
 
-  if (strava && stravaQueue) {
+  if (stravaQueue) {
     const stravaVerifyToken = `aurboda-strava-${sessionSecret.slice(0, 8)}`
 
     httpd.use(
@@ -716,20 +713,26 @@ const main = async () => {
       }),
     )
 
-    // Ensure webhook subscription exists (stravaClientId/Secret guaranteed non-null since strava is truthy)
-    const stravaWebhookCallbackUrl = `${webHost}/webhooks/strava`
-    const stravaWebhookMgr = createStravaWebhookManager({
-      callbackUrl: stravaWebhookCallbackUrl,
-      clientId: stravaClientId ?? '',
-      clientSecret: stravaClientSecret ?? '',
-      verifyToken: stravaVerifyToken,
-    })
-    stravaWebhookMgr.ensureSubscription().catch((error) => {
-      console.warn(
-        '⚠️ Strava webhook subscription setup failed:',
-        error instanceof Error ? error.message : error,
-      )
-    })
+    // Ensure webhook subscription exists (credentials read dynamically)
+    const stravaWebhookCallbackUrl = `${apiBaseUrl}/webhooks/strava`
+    getStravaCredentials()
+      .then(({ clientId, clientSecret }) => {
+        const stravaWebhookMgr = createStravaWebhookManager({
+          callbackUrl: stravaWebhookCallbackUrl,
+          clientId,
+          clientSecret,
+          verifyToken: stravaVerifyToken,
+        })
+        stravaWebhookMgr.ensureSubscription().catch((error) => {
+          console.warn(
+            '⚠️ Strava webhook subscription setup failed:',
+            error instanceof Error ? error.message : error,
+          )
+        })
+      })
+      .catch(() => {
+        console.warn('⚠️ Strava webhook disabled — credentials not configured yet')
+      })
   }
 
   // ==========================================================================
@@ -747,11 +750,11 @@ const main = async () => {
     }
 
     ouraWebhookManager = createOuraWebhookManager({
+      apiBaseUrl,
       centralDb,
       ouraClientId,
       ouraClientSecret,
       syncOuraDataTypeForUser,
-      webHost,
     })
 
     // Mount proxy handler (delegates to inner router when enabled, 404 when disabled)

--- a/apps/backend/src/integrations/oura/client.ts
+++ b/apps/backend/src/integrations/oura/client.ts
@@ -56,9 +56,14 @@ export interface OuraClientOptions {
   onUserAuthenticated?: (ouraUserId: string, username: string) => Promise<void>
 }
 
-export const ouraClient = (client: string, secret: string, webHost: string, options?: OuraClientOptions) => {
+export const ouraClient = (
+  client: string,
+  secret: string,
+  apiBaseUrl: string,
+  options?: OuraClientOptions,
+) => {
   if (!client || !secret) throw new Error('Oura missing client or secret')
-  const redirectUri = `${webHost}/auth/ouracb`
+  const redirectUri = `${apiBaseUrl}/auth/ouracb`
 
   const getGeneric = async (type: string, start: Date, end: Date, token: string) => {
     const response = await axios.get(
@@ -238,11 +243,10 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
         )
       return tags
     },
-    redirectToAuthorize(req: Request, res: Response) {
-      const { username } = req.query as Record<string, string | undefined>
-      if (!username) {
-        res.statusCode = 400
-        res.end('No username')
+    getAuthorizeUrl(req: Request, res: Response) {
+      const user = req.user
+      if (!user) {
+        res.status(401).json({ error: 'Not authenticated', success: false })
         return
       }
 
@@ -250,13 +254,8 @@ export const ouraClient = (client: string, secret: string, webHost: string, opti
       location.searchParams.append('response_type', 'code')
       location.searchParams.append('client_id', client)
       location.searchParams.append('redirect_uri', redirectUri)
-      location.searchParams.append('state', username)
-      res.writeHead(302, {
-        'Content-Length': 0,
-        'Content-Type': 'text/plain',
-        Location: location.toString(),
-      })
-      res.end()
+      location.searchParams.append('state', user)
+      res.json({ success: true, url: location.toString() })
     },
   }
 }

--- a/apps/backend/src/integrations/strava/client.ts
+++ b/apps/backend/src/integrations/strava/client.ts
@@ -11,8 +11,8 @@
 import type { Request, Response } from 'express'
 
 import axios, { type AxiosResponse } from 'axios'
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 import { addSeconds, isFuture } from 'date-fns'
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 
 import type {
   StravaAthleteProfile,
@@ -34,6 +34,8 @@ const STRAVA_SCOPES = 'activity:read_all,profile:read_all,read'
 export interface StravaClientOptions {
   onUserAuthenticated?: (stravaAthleteId: number, username: string) => Promise<void>
 }
+
+export type StravaCredentialGetter = () => Promise<{ clientId: string; clientSecret: string }>
 
 // HMAC-signed OAuth state parameter to prevent CSRF.
 // Format: base64url(nonce.username.hmac) — the HMAC covers nonce+username
@@ -73,13 +75,11 @@ export interface StravaApiResponse<T> {
 }
 
 export const stravaClient = (
-  clientId: string,
-  clientSecret: string,
-  webHost: string,
+  getCredentials: StravaCredentialGetter,
+  apiBaseUrl: string,
   options?: StravaClientOptions,
 ) => {
-  if (!clientId || !clientSecret) throw new Error('Strava missing client_id or client_secret')
-  const redirectUri = `${webHost}/auth/stravacb`
+  const redirectUri = `${apiBaseUrl}/auth/stravacb`
 
   const apiGet = async <T>(path: string, token: string): Promise<StravaApiResponse<T>> => {
     const response: AxiosResponse<T> = await axios.get(`${STRAVA_API_BASE}${path}`, {
@@ -97,6 +97,14 @@ export const stravaClient = (
 
       if (error || !state) {
         return res.redirect('/data-sources/strava?error=auth_failed')
+      }
+
+      let clientId: string
+      let clientSecret: string
+      try {
+        ;({ clientId, clientSecret } = await getCredentials())
+      } catch {
+        return res.redirect('/data-sources/strava?error=not_configured')
       }
 
       const user = verifySignedState(state, clientSecret)
@@ -146,6 +154,7 @@ export const stravaClient = (
       }
 
       // Refresh the token
+      const { clientId, clientSecret } = await getCredentials()
       const response = await axios.post<StravaTokenResponse>(STRAVA_TOKEN_URL, {
         client_id: clientId,
         client_secret: clientSecret,
@@ -183,6 +192,38 @@ export const stravaClient = (
       return apiGet('/athlete', token)
     },
 
+    // Returns the OAuth authorize URL as JSON (called with authMiddleware, uses req.user)
+    async getAuthorizeUrl(req: Request, res: Response) {
+      const user = req.user
+      if (!user) {
+        res.status(401).json({ error: 'Not authenticated', success: false })
+        return
+      }
+
+      let clientId: string
+      let clientSecret: string
+      try {
+        ;({ clientId, clientSecret } = await getCredentials())
+      } catch {
+        res
+          .status(400)
+          .json({ error: 'Strava not configured — set credentials in Admin Settings', success: false })
+        return
+      }
+
+      const state = createSignedState(user, clientSecret)
+
+      const location = new URL(STRAVA_AUTH_URL)
+      location.searchParams.append('client_id', clientId)
+      location.searchParams.append('redirect_uri', redirectUri)
+      location.searchParams.append('response_type', 'code')
+      location.searchParams.append('scope', STRAVA_SCOPES)
+      location.searchParams.append('state', state)
+      location.searchParams.append('approval_prompt', 'auto')
+
+      res.json({ success: true, url: location.toString() })
+    },
+
     async listActivities(
       token: string,
       params: { before?: number; after?: number; page?: number; per_page?: number },
@@ -195,32 +236,6 @@ export const stravaClient = (
 
       const qs = searchParams.toString()
       return apiGet(`/athlete/activities${qs ? `?${qs}` : ''}`, token)
-    },
-
-    redirectToAuthorize(req: Request, res: Response) {
-      const { username } = req.query as Record<string, string | undefined>
-      if (!username) {
-        res.statusCode = 400
-        res.end('No username')
-        return
-      }
-
-      const state = createSignedState(username, clientSecret)
-
-      const location = new URL(STRAVA_AUTH_URL)
-      location.searchParams.append('client_id', clientId)
-      location.searchParams.append('redirect_uri', redirectUri)
-      location.searchParams.append('response_type', 'code')
-      location.searchParams.append('scope', STRAVA_SCOPES)
-      location.searchParams.append('state', state)
-      location.searchParams.append('approval_prompt', 'auto')
-
-      res.writeHead(302, {
-        'Content-Length': 0,
-        'Content-Type': 'text/plain',
-        Location: location.toString(),
-      })
-      res.end()
     },
   }
 }

--- a/apps/backend/src/integrations/strava/process.test.ts
+++ b/apps/backend/src/integrations/strava/process.test.ts
@@ -10,6 +10,7 @@ const createMockDeps = (): StravaProcessDeps => ({
   insertLocations: vi.fn(),
   insertRawRecord: vi.fn(),
   insertTimeSeries: vi.fn(),
+  resolveOrCreateActivityType: vi.fn(async (_user: string, name: string) => name),
   softDeleteLocationRange: vi.fn(),
 })
 

--- a/apps/backend/src/integrations/strava/process.ts
+++ b/apps/backend/src/integrations/strava/process.ts
@@ -8,6 +8,7 @@ import type {
   insertLocations,
   insertRawRecord,
   insertTimeSeries,
+  resolveOrCreateActivityType,
   softDeleteLocationRange,
 } from '../../db/index.ts'
 import type { Activity, Location, RawRecord, TimeSeriesPoint } from '../../db/types.ts'
@@ -23,6 +24,7 @@ export interface StravaProcessDeps {
   insertLocations: typeof insertLocations
   insertRawRecord: typeof insertRawRecord
   insertTimeSeries: typeof insertTimeSeries
+  resolveOrCreateActivityType: typeof resolveOrCreateActivityType
   softDeleteLocationRange: typeof softDeleteLocationRange
 }
 
@@ -46,7 +48,8 @@ export const processStravaActivity = async (
   const externalId = `strava-activity-${activity.id}`
   const startTime = new Date(activity.start_date)
   const endTime = new Date(startTime.getTime() + activity.elapsed_time * 1000)
-  const activityType = mapStravaSportType(activity.sport_type)
+  const mappedType = mapStravaSportType(activity.sport_type)
+  const activityType = await deps.resolveOrCreateActivityType(user, mappedType, 'exercise')
 
   // Raw record
   await deps.insertRawRecord(user, makeRaw('strava_activity', externalId, startTime, activity))

--- a/apps/backend/src/integrations/strava/sport-type-map.test.ts
+++ b/apps/backend/src/integrations/strava/sport-type-map.test.ts
@@ -25,9 +25,10 @@ describe('mapStravaSportType', () => {
   })
 
   test('maps gym activities', () => {
-    expect(mapStravaSportType('WeightTraining')).toBe('weight_training')
+    expect(mapStravaSportType('WeightTraining')).toBe('strength_training')
     expect(mapStravaSportType('Yoga')).toBe('yoga')
     expect(mapStravaSportType('Elliptical')).toBe('elliptical')
+    expect(mapStravaSportType('HIIT')).toBe('high_intensity_interval_training')
   })
 
   test('maps winter sports', () => {

--- a/apps/backend/src/integrations/strava/sport-type-map.ts
+++ b/apps/backend/src/integrations/strava/sport-type-map.ts
@@ -29,7 +29,7 @@ export const stravaSportTypeMap: Record<string, string> = {
   Walk: 'walking',
   Hike: 'hiking',
 
-  // Winter sports
+  // Winter sports (more granular than Health Connect's generic 'skiing')
   AlpineSki: 'skiing_downhill',
   BackcountrySki: 'skiing_cross_country',
   NordicSki: 'skiing_cross_country',
@@ -48,7 +48,7 @@ export const stravaSportTypeMap: Record<string, string> = {
   Sail: 'sailing',
 
   // Gym / Indoor
-  WeightTraining: 'weight_training',
+  WeightTraining: 'strength_training',
   Yoga: 'yoga',
   Pilates: 'pilates',
   Crossfit: 'high_intensity_interval_training',
@@ -60,7 +60,12 @@ export const stravaSportTypeMap: Record<string, string> = {
   Skateboard: 'skateboarding',
   InlineSkate: 'roller_skating',
   Golf: 'golf',
-  Soccer: 'football',
+  Soccer: 'soccer',
+  HIIT: 'high_intensity_interval_training',
+  MMA: 'martial_arts',
+  Wrestling: 'martial_arts',
+  Workout: 'other_workout',
+  Lacrosse: 'other_workout',
   Tennis: 'tennis',
   TableTennis: 'table_tennis',
   Badminton: 'badminton',

--- a/apps/backend/src/services/oura-webhook-manager.test.ts
+++ b/apps/backend/src/services/oura-webhook-manager.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createOuraWebhookManager, type OuraWebhookManagerDeps } from './oura-webhook-manager.ts'
 
 describe('oura-webhook-manager', () => {
-  const createDeps = (webHost = 'https://example.com'): OuraWebhookManagerDeps => ({
+  const createDeps = (apiBaseUrl = 'https://example.com'): OuraWebhookManagerDeps => ({
     centralDb: {
       deleteAllOuraWebhookSubscriptions: vi.fn().mockResolvedValue(0),
       deleteOuraWebhookSubscription: vi.fn().mockResolvedValue(true),
@@ -16,7 +16,7 @@ describe('oura-webhook-manager', () => {
     ouraClientId: 'test-client-id',
     ouraClientSecret: 'test-client-secret',
     syncOuraDataTypeForUser: vi.fn().mockResolvedValue(undefined),
-    webHost,
+    apiBaseUrl,
   })
 
   beforeEach(() => {

--- a/apps/backend/src/services/oura-webhook-manager.ts
+++ b/apps/backend/src/services/oura-webhook-manager.ts
@@ -34,7 +34,7 @@ export interface OuraWebhookManagerDeps {
   ouraClientId: string
   ouraClientSecret: string
   syncOuraDataTypeForUser: (username: string, dataType: OuraDataType) => Promise<void>
-  webHost: string
+  apiBaseUrl: string
 }
 
 export interface OuraWebhookManager {
@@ -51,11 +51,11 @@ export const createOuraWebhookManager = (deps: OuraWebhookManagerDeps): OuraWebh
   let webhookService: OuraWebhookService | null = null
   let enabled = false
 
-  const callbackUrl = `${deps.webHost}/api/webhooks/oura`
+  const callbackUrl = `${deps.apiBaseUrl}/webhooks/oura`
 
   const canEnable = (): boolean => {
     try {
-      const url = new URL(deps.webHost)
+      const url = new URL(deps.apiBaseUrl)
       return url.protocol === 'https:'
     } catch {
       return false

--- a/apps/backend/src/services/strava-queue.test.ts
+++ b/apps/backend/src/services/strava-queue.test.ts
@@ -37,6 +37,7 @@ describe('createStravaQueue', () => {
       insertLocations: vi.fn(),
       insertRawRecord: vi.fn(),
       insertTimeSeries: vi.fn(),
+      resolveOrCreateActivityType: vi.fn(async (_user: string, name: string) => name),
       softDeleteLocationRange: vi.fn(),
     },
     updateSyncState: vi.fn(),

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -18,6 +18,7 @@ export const DATA_SOURCE_LINKS = [
   { label: 'Aurboda Android', path: '/data-sources/android-app' },
   { label: 'Oura Ring', path: '/data-sources/oura' },
   { label: 'Garmin Connect', path: '/data-sources/garmin' },
+  { label: 'Strava', path: '/data-sources/strava' },
   { label: 'ActivityWatch (Desktop)', path: '/data-sources/activitywatch-desktop' },
   { label: 'ActivityWatch (Android)', path: '/data-sources/activitywatch-android' },
   { label: 'RescueTime', path: '/data-sources/rescue-time' },

--- a/apps/web/src/pages/DataSources/OuraSource.tsx
+++ b/apps/web/src/pages/DataSources/OuraSource.tsx
@@ -3,8 +3,7 @@ import type { ProviderSyncStatus, UserSettingsResponse } from '@aurboda/api-spec
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'preact/hooks'
 
-import { API_URL } from '../../config'
-import { fetchOuraSyncStatus, fetchUserSettings, syncOura } from '../../state/api'
+import { fetchOuraSyncStatus, fetchUserSettings, getOuraConnectUrl, syncOura } from '../../state/api'
 import { auth } from '../../state/auth'
 import { type DataTypeItem, DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
@@ -35,9 +34,15 @@ function OuraConnection({
   const [ouraSyncStatus, setOuraSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
   const [ouraSyncMessage, setOuraSyncMessage] = useState<string>('')
 
-  const handleConnectOura = () => {
-    window.location.href = `${API_URL}/auth/connectOura`
-  }
+  const handleConnectOura = useCallback(async () => {
+    try {
+      const url = await getOuraConnectUrl()
+      window.location.href = url
+    } catch (err) {
+      setOuraSyncStatus('error')
+      setOuraSyncMessage(err instanceof Error ? err.message : 'Failed to start Oura connection')
+    }
+  }, [])
 
   const handleSyncNow = useCallback(async () => {
     await syncOura(false)

--- a/apps/web/src/pages/DataSources/StravaSource.tsx
+++ b/apps/web/src/pages/DataSources/StravaSource.tsx
@@ -3,8 +3,13 @@ import type { ProviderSyncStatus } from '@aurboda/api-spec'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 
-import { API_URL } from '../../config'
-import { disconnectStrava, fetchStravaSyncStatus, fetchUserSettings, syncStrava } from '../../state/api'
+import {
+  disconnectStrava,
+  fetchStravaSyncStatus,
+  fetchUserSettings,
+  getStravaConnectUrl,
+  syncStrava,
+} from '../../state/api'
 import { auth } from '../../state/auth'
 import { type DataTypeItem, DataTypesList, LoginRequired, StatusBanner, SyncStatusBar } from './shared'
 import './style.css'
@@ -29,7 +34,6 @@ function StravaConnection({
   syncStatusLoading: boolean
 }) {
   const queryClient = useQueryClient()
-  const username = auth.value.user
 
   const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
   const [syncMessage, setSyncMessage] = useState('')
@@ -48,9 +52,15 @@ function StravaConnection({
     prevSyncingRef.current = isSyncing
   }, [isSyncing, syncStatus, syncStates, queryClient])
 
-  const handleConnectStrava = () => {
-    window.location.href = `${API_URL}/auth/connectStrava?username=${username}`
-  }
+  const handleConnectStrava = useCallback(async () => {
+    try {
+      const url = await getStravaConnectUrl()
+      window.location.href = url
+    } catch (err) {
+      setSyncStatus('error')
+      setSyncMessage(err instanceof Error ? err.message : 'Failed to start Strava connection')
+    }
+  }, [])
 
   const handleSync = useCallback(
     async (fullResync: boolean) => {

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -661,6 +661,15 @@ export const uploadIcon = async (file: File): Promise<{ id: string; url: string 
   return { id: response.data.id, url: response.data.url }
 }
 
+// Oura OAuth
+export const getOuraConnectUrl = async (): Promise<string> => {
+  const { token } = auth.value
+  const response = await axios.get<{ success: boolean; url: string }>(`${API_URL}/auth/oura/connect`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return response.data.url
+}
+
 // Trigger Oura sync
 export const syncOura = async (fullResync?: boolean): Promise<OuraSyncResponse> => {
   const { token } = auth.value
@@ -733,6 +742,14 @@ export const fetchGarminSyncStatus = async (): Promise<GarminSyncStatusResponse>
 }
 
 // Strava OAuth + sync
+export const getStravaConnectUrl = async (): Promise<string> => {
+  const { token } = auth.value
+  const response = await axios.get<{ success: boolean; url: string }>(`${API_URL}/auth/strava/connect`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  return response.data.url
+}
+
 export const disconnectStrava = async (): Promise<{ success: boolean }> => {
   const { token } = auth.value
   const response = await axios.post(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - SESSION_SECRET=REPLACE_SESSION_SECRET
       - ALLOW_SIGNUP=${ALLOW_SIGNUP:-true}
       - WEB_HOST=http://localhost:8080
+      - API_BASE_URL=http://localhost:8080/api
       - NODE_ENV=production
     depends_on:
       postgres:

--- a/docs/strava.md
+++ b/docs/strava.md
@@ -38,7 +38,7 @@ These are stored as server settings in the central database (set via admin setti
 
 **Note:** Strava also shows an access_token and refresh_token when you register the app -- these are your personal tokens as the app owner and are **not needed** for server configuration. Each user gets their own tokens through the OAuth flow.
 
-The OAuth callback URL is: `{WEB_HOST}/auth/stravacb`
+The OAuth callback URL is: `{API_BASE_URL}/auth/stravacb` (e.g., `https://aurboda.net/api/auth/stravacb`)
 
 If these are not set, the "Connect Strava" button will be disabled with a message asking the admin to configure them.
 


### PR DESCRIPTION
## Summary

- **OAuth callback 404**: OAuth redirect URIs used `WEB_HOST` (web root), but in production the API is behind `/api`. Added `API_BASE_URL` env var for the externally-reachable API URL.
- **Username query param → auth**: Changed OAuth connect from browser redirect (`window.location.href`) to authenticated fetch-then-redirect. Fixes both Strava and Oura — no more `?username=` in URL.
- **Dynamic Strava credentials**: Strava client now reads credentials from DB on each request, so admin settings changes take effect without a server restart.
- **Missing nav menu entry**: Added Strava to the data sources dropdown.
- **FK constraint on activities**: `processStravaActivity` now calls `resolveOrCreateActivityType` before insert, so unmapped sport types (e.g. `skiing_downhill`, `weight_training`) are auto-created.
- **Oura webhook URL**: Updated to use `apiBaseUrl` instead of hardcoded `${webHost}/api/`.

## Test plan

- [ ] Verify Strava appears in navigation dropdown
- [ ] Verify OAuth connect flow works (fetch URL → redirect → callback → connected)
- [ ] Verify Strava sync doesn't hit FK constraint errors
- [ ] Verify Oura connect still works
- [ ] All 1701 backend tests pass
- [ ] `pnpm check` passes (type check + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)