### PR TITLE
feat: hierarchical activity types with parent_type

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/DataApi.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DataApi.kt
@@ -225,6 +225,7 @@ data class ActivityTypeDefinition(
     val icon: String? = null,
     @SerialName("is_builtin") val isBuiltin: Boolean = false,
     @SerialName("data_schema") val dataSchema: DataSchemaDefinition? = null,
+    @SerialName("parent_type") val parentType: String? = null,
 )
 
 @Serializable

--- a/apps/backend/src/db/activity-type-definitions.integration.test.ts
+++ b/apps/backend/src/db/activity-type-definitions.integration.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Integration tests for the hierarchical activity type definitions.
+ *
+ * Verifies parent_type relationships: CRUD, cycle prevention, descendant
+ * expansion, reparenting on delete and merge.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import {
+  deleteActivityTypeDefinition,
+  expandActivityTypes,
+  getActivityTypeDefinition,
+  getDescendantTypes,
+  insertActivityTypeDefinition,
+  mergeActivityTypeDefinition,
+  updateActivityTypeDefinition,
+} from './activity-type-definitions.ts'
+import { query } from './connection.ts'
+
+const CONTAINER_TIMEOUT = 60_000
+
+describe('Hierarchical activity types', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+    // Seed test-specific custom types with hierarchy.
+    // The built-in exercise subtypes are already seeded by initializeSchema.
+  })
+
+  describe('seed hierarchy', () => {
+    test('exercise subtypes have parent_type = exercise', async () => {
+      const user = getTestUser()
+      const running = await getActivityTypeDefinition(user, 'running')
+      expect(running?.parent_type).toBe('exercise')
+      const yoga = await getActivityTypeDefinition(user, 'yoga')
+      expect(yoga?.parent_type).toBe('exercise')
+    })
+
+    test('nap and rest have parent_type = sleep', async () => {
+      const user = getTestUser()
+      const nap = await getActivityTypeDefinition(user, 'nap')
+      expect(nap?.parent_type).toBe('sleep')
+      const rest = await getActivityTypeDefinition(user, 'rest')
+      expect(rest?.parent_type).toBe('sleep')
+    })
+
+    test('root types have no parent_type', async () => {
+      const user = getTestUser()
+      const exercise = await getActivityTypeDefinition(user, 'exercise')
+      expect(exercise?.parent_type).toBeUndefined()
+      const sleep = await getActivityTypeDefinition(user, 'sleep')
+      expect(sleep?.parent_type).toBeUndefined()
+    })
+  })
+
+  describe('insertActivityTypeDefinition with parent_type', () => {
+    test('creates a type with a valid parent', async () => {
+      const user = getTestUser()
+      const result = await insertActivityTypeDefinition(user, {
+        name: 'hatha_yoga',
+        display_name: 'Hatha Yoga',
+        display_category: 'exercise',
+        parent_type: 'yoga',
+      })
+      expect(result.parent_type).toBe('yoga')
+    })
+
+    test('rejects non-existent parent', async () => {
+      const user = getTestUser()
+      await expect(
+        insertActivityTypeDefinition(user, {
+          name: 'foo_bar',
+          display_name: 'Foo',
+          display_category: 'other',
+          parent_type: 'nonexistent_parent',
+        }),
+      ).rejects.toThrow(/does not exist/)
+    })
+
+    test('rejects self as parent', async () => {
+      const user = getTestUser()
+      await expect(
+        insertActivityTypeDefinition(user, {
+          name: 'self_ref',
+          display_name: 'Self',
+          display_category: 'other',
+          parent_type: 'self_ref',
+        }),
+      ).rejects.toThrow(/cannot reference the type itself/)
+    })
+  })
+
+  describe('updateActivityTypeDefinition parent_type', () => {
+    test('sets parent_type on existing type', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'my_exercise',
+        display_name: 'My Exercise',
+        display_category: 'exercise',
+      })
+      const updated = await updateActivityTypeDefinition(user, 'my_exercise', {
+        parent_type: 'exercise',
+      })
+      expect(updated?.parent_type).toBe('exercise')
+    })
+
+    test('clears parent_type when set to null', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'temp_type',
+        display_name: 'Temp',
+        display_category: 'other',
+        parent_type: 'exercise',
+      })
+      const cleared = await updateActivityTypeDefinition(user, 'temp_type', {
+        parent_type: null,
+      })
+      expect(cleared?.parent_type).toBeUndefined()
+    })
+
+    test('rejects cycle', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'a_type',
+        display_name: 'A',
+        display_category: 'other',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'b_type',
+        display_name: 'B',
+        display_category: 'other',
+        parent_type: 'a_type',
+      })
+      // Trying to set a_type.parent = b_type would create a cycle
+      await expect(updateActivityTypeDefinition(user, 'a_type', { parent_type: 'b_type' })).rejects.toThrow(
+        /cycle/,
+      )
+    })
+  })
+
+  describe('getDescendantTypes', () => {
+    test('returns all descendants including grandchildren', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'cardio',
+        display_name: 'Cardio',
+        display_category: 'exercise',
+        parent_type: 'exercise',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'sprint',
+        display_name: 'Sprint',
+        display_category: 'exercise',
+        parent_type: 'cardio',
+      })
+      const descendants = await getDescendantTypes(user, 'cardio')
+      expect(descendants).toContain('sprint')
+      expect(descendants).not.toContain('cardio')
+    })
+
+    test('returns empty array for leaf type', async () => {
+      const user = getTestUser()
+      const descendants = await getDescendantTypes(user, 'running')
+      expect(descendants).toEqual([])
+    })
+
+    test('exercise parent includes all builtin subtypes', async () => {
+      const user = getTestUser()
+      const descendants = await getDescendantTypes(user, 'exercise')
+      expect(descendants).toContain('running')
+      expect(descendants).toContain('yoga')
+      expect(descendants.length).toBeGreaterThan(50)
+    })
+  })
+
+  describe('expandActivityTypes', () => {
+    test('includes self and all descendants', async () => {
+      const user = getTestUser()
+      const expanded = await expandActivityTypes(user, ['exercise'])
+      expect(expanded).toContain('exercise')
+      expect(expanded).toContain('running')
+      expect(expanded).toContain('yoga')
+    })
+
+    test('leaf type expands to itself', async () => {
+      const user = getTestUser()
+      const expanded = await expandActivityTypes(user, ['running'])
+      expect(expanded).toEqual(['running'])
+    })
+
+    test('multiple types combine without duplicates', async () => {
+      const user = getTestUser()
+      const expanded = await expandActivityTypes(user, ['sleep', 'meditation'])
+      expect(expanded).toContain('sleep')
+      expect(expanded).toContain('nap')
+      expect(expanded).toContain('rest')
+      expect(expanded).toContain('meditation')
+      expect(new Set(expanded).size).toBe(expanded.length)
+    })
+
+    test('unknown type returns empty', async () => {
+      const user = getTestUser()
+      const expanded = await expandActivityTypes(user, ['nonexistent'])
+      expect(expanded).toEqual([])
+    })
+  })
+
+  describe('deleteActivityTypeDefinition reparents children', () => {
+    test('children of deleted type get parent of the deleted type', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'mid_level',
+        display_name: 'Mid',
+        display_category: 'exercise',
+        parent_type: 'exercise',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'child_leaf',
+        display_name: 'Child',
+        display_category: 'exercise',
+        parent_type: 'mid_level',
+      })
+      await deleteActivityTypeDefinition(user, 'mid_level')
+      const child = await getActivityTypeDefinition(user, 'child_leaf')
+      expect(child?.parent_type).toBe('exercise')
+    })
+
+    test('children become top-level if deleted type had no parent', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'top',
+        display_name: 'Top',
+        display_category: 'other',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'child',
+        display_name: 'Child',
+        display_category: 'other',
+        parent_type: 'top',
+      })
+      await deleteActivityTypeDefinition(user, 'top')
+      const child = await getActivityTypeDefinition(user, 'child')
+      expect(child?.parent_type).toBeUndefined()
+    })
+  })
+
+  describe('mergeActivityTypeDefinition reparents children', () => {
+    test('children of source become children of target', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'parent_a',
+        display_name: 'A',
+        display_category: 'other',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'parent_b',
+        display_name: 'B',
+        display_category: 'other',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'leaf_x',
+        display_name: 'X',
+        display_category: 'other',
+        parent_type: 'parent_a',
+      })
+      await mergeActivityTypeDefinition(user, 'parent_a', 'parent_b')
+      const leaf = await getActivityTypeDefinition(user, 'leaf_x')
+      expect(leaf?.parent_type).toBe('parent_b')
+    })
+  })
+
+  describe('rename with FK cascade', () => {
+    test('renaming a parent updates children parent_type via CASCADE', async () => {
+      const user = getTestUser()
+      await insertActivityTypeDefinition(user, {
+        name: 'old_parent',
+        display_name: 'Old',
+        display_category: 'other',
+      })
+      await insertActivityTypeDefinition(user, {
+        name: 'a_child',
+        display_name: 'Child',
+        display_category: 'other',
+        parent_type: 'old_parent',
+      })
+      await query(user, `UPDATE activity_type_definitions SET name = 'new_parent' WHERE name = 'old_parent'`)
+      const child = await getActivityTypeDefinition(user, 'a_child')
+      expect(child?.parent_type).toBe('new_parent')
+    })
+  })
+})

--- a/apps/backend/src/db/activity-type-definitions.integration.test.ts
+++ b/apps/backend/src/db/activity-type-definitions.integration.test.ts
@@ -207,10 +207,10 @@ describe('Hierarchical activity types', () => {
       expect(new Set(expanded).size).toBe(expanded.length)
     })
 
-    test('unknown type returns empty', async () => {
+    test('unknown type is returned as-is (no descendants to add)', async () => {
       const user = getTestUser()
       const expanded = await expandActivityTypes(user, ['nonexistent'])
-      expect(expanded).toEqual([])
+      expect(expanded).toEqual(['nonexistent'])
     })
   })
 
@@ -250,6 +250,16 @@ describe('Hierarchical activity types', () => {
       await deleteActivityTypeDefinition(user, 'top')
       const child = await getActivityTypeDefinition(user, 'child')
       expect(child?.parent_type).toBeUndefined()
+    })
+
+    test('refusing to delete a builtin does not reparent its children', async () => {
+      // Regression test: the delete guard must refuse builtin types *before*
+      // reparenting, or the hierarchy gets silently flattened on a failed delete.
+      const user = getTestUser()
+      const deleted = await deleteActivityTypeDefinition(user, 'exercise')
+      expect(deleted).toBe(false)
+      const running = await getActivityTypeDefinition(user, 'running')
+      expect(running?.parent_type).toBe('exercise')
     })
   })
 

--- a/apps/backend/src/db/activity-type-definitions.test.ts
+++ b/apps/backend/src/db/activity-type-definitions.test.ts
@@ -202,14 +202,14 @@ describe('activity-type-definitions db', () => {
   })
 
   test('deleteActivityTypeDefinition returns true on success', async () => {
-    // 1. SELECT parent_type, 2. UPDATE reparent children, 3. DELETE the type
+    // 1. SELECT parent_type+is_builtin, 2. UPDATE reparent children, 3. DELETE the type
     mockQuery
       .mockResolvedValueOnce({
         command: 'SELECT',
         fields: [],
         oid: 0,
         rowCount: 1,
-        rows: [{ parent_type: null }],
+        rows: [{ is_builtin: false, parent_type: null }],
       })
       .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 0, rows: [] })
       .mockResolvedValueOnce({ command: 'DELETE', fields: [], oid: 0, rowCount: 1, rows: [] })
@@ -222,6 +222,20 @@ describe('activity-type-definitions db', () => {
     mockQuery.mockResolvedValueOnce({ command: 'SELECT', fields: [], oid: 0, rowCount: 0, rows: [] })
 
     expect(await deleteActivityTypeDefinition(user, 'nonexistent')).toBe(false)
+  })
+
+  test('deleteActivityTypeDefinition returns false for builtin without reparenting', async () => {
+    // Only one query: SELECT returns is_builtin=true; no UPDATE / DELETE should run.
+    mockQuery.mockResolvedValueOnce({
+      command: 'SELECT',
+      fields: [],
+      oid: 0,
+      rowCount: 1,
+      rows: [{ is_builtin: true, parent_type: null }],
+    })
+
+    expect(await deleteActivityTypeDefinition(user, 'exercise')).toBe(false)
+    expect(mockQuery).toHaveBeenCalledTimes(1)
   })
 
   test('getActivityTypeNames returns name array', async () => {

--- a/apps/backend/src/db/activity-type-definitions.test.ts
+++ b/apps/backend/src/db/activity-type-definitions.test.ts
@@ -202,13 +202,24 @@ describe('activity-type-definitions db', () => {
   })
 
   test('deleteActivityTypeDefinition returns true on success', async () => {
-    mockQuery.mockResolvedValue({ command: 'DELETE', fields: [], oid: 0, rowCount: 1, rows: [] })
+    // 1. SELECT parent_type, 2. UPDATE reparent children, 3. DELETE the type
+    mockQuery
+      .mockResolvedValueOnce({
+        command: 'SELECT',
+        fields: [],
+        oid: 0,
+        rowCount: 1,
+        rows: [{ parent_type: null }],
+      })
+      .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ command: 'DELETE', fields: [], oid: 0, rowCount: 1, rows: [] })
 
     expect(await deleteActivityTypeDefinition(user, 'sauna')).toBe(true)
   })
 
   test('deleteActivityTypeDefinition returns false when not found', async () => {
-    mockQuery.mockResolvedValue({ command: 'DELETE', fields: [], oid: 0, rowCount: 0, rows: [] })
+    // First SELECT returns no rows → type does not exist
+    mockQuery.mockResolvedValueOnce({ command: 'SELECT', fields: [], oid: 0, rowCount: 0, rows: [] })
 
     expect(await deleteActivityTypeDefinition(user, 'nonexistent')).toBe(false)
   })
@@ -405,13 +416,15 @@ describe('activity-type-definitions db', () => {
       .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 1, rows: [] })
       // 4. Reassign activities
       .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 3, rows: [] })
-      // 5. Update deduction rules output_activity_type
-      .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 1, rows: [] })
-      // 6. Update deduction rules conditions
+      // 5. Reparent children of source to target
       .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 0, rows: [] })
-      // 7. Delete source
+      // 6. Update deduction rules output_activity_type
+      .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 1, rows: [] })
+      // 7. Update deduction rules conditions
+      .mockResolvedValueOnce({ command: 'UPDATE', fields: [], oid: 0, rowCount: 0, rows: [] })
+      // 8. Delete source
       .mockResolvedValueOnce({ command: 'DELETE', fields: [], oid: 0, rowCount: 1, rows: [] })
-      // 8. Get updated target (getActivityTypeDefinition)
+      // 9. Get updated target (getActivityTypeDefinition)
       .mockResolvedValueOnce({
         command: 'SELECT',
         fields: [],

--- a/apps/backend/src/db/activity-type-definitions.ts
+++ b/apps/backend/src/db/activity-type-definitions.ts
@@ -56,20 +56,9 @@ const normalizeAliases = (name: string, aliases: string[] = []): string[] => {
 }
 
 /**
- * Check if setting parent_type=candidateParent on the type named typeName would
- * introduce a cycle. Walks up the candidate parent's chain; if we encounter
- * typeName before hitting a null parent, a cycle would form.
+ * Validate a parent_type value for an insert or update. Throws on self-reference,
+ * missing parent, or a change that would create a cycle.
  */
-const lookupParentType = async (user: string, name: string): Promise<string | null> => {
-  const result = await query<{ parent_type: string | null }>(
-    user,
-    `SELECT parent_type FROM activity_type_definitions WHERE name = $1`,
-    [name],
-  )
-  if (result.rows.length === 0) return null
-  return result.rows[0].parent_type ?? null
-}
-
 const validateParentTypeUpdate = async (
   user: string,
   name: string,
@@ -86,16 +75,29 @@ const validateParentTypeUpdate = async (
   }
 }
 
-async function wouldCreateCycle(user: string, typeName: string, candidateParent: string): Promise<boolean> {
-  const visited = new Set<string>()
-  let currentName: string | null = candidateParent
-  while (currentName !== null) {
-    if (currentName === typeName) return true
-    if (visited.has(currentName)) return false
-    visited.add(currentName)
-    currentName = await lookupParentType(user, currentName)
-  }
-  return false
+/**
+ * Check whether setting typeName's parent to candidateParent would introduce
+ * a cycle. Walks candidateParent's ancestor chain via recursive CTE; if
+ * typeName appears in that chain, the edge would close a loop.
+ */
+async function wouldCreateCycle(
+  user: string,
+  typeName: string,
+  candidateParent: string,
+): Promise<boolean> {
+  const result = await query<{ name: string }>(
+    user,
+    `WITH RECURSIVE ancestors AS (
+       SELECT name, parent_type FROM activity_type_definitions WHERE name = $1
+       UNION ALL
+       SELECT atd.name, atd.parent_type
+         FROM activity_type_definitions atd
+         JOIN ancestors a ON atd.name = a.parent_type
+     )
+     SELECT name FROM ancestors WHERE name = $2 LIMIT 1`,
+    [candidateParent, typeName],
+  )
+  return result.rows.length > 0
 }
 
 /**
@@ -120,15 +122,15 @@ export const getDescendantTypes = async (user: string, parentName: string): Prom
 
 /**
  * Expand a list of activity type names to include all descendants.
- * Each input type is returned along with its recursive children.
- * Returns deduplicated names.
+ * Each input type is returned (whether it exists in the definitions table
+ * or not) along with its recursive children. Returns deduplicated names.
  */
 export const expandActivityTypes = async (user: string, types: string[]): Promise<string[]> => {
   if (types.length === 0) return []
   const result = await query(
     user,
     `WITH RECURSIVE tree AS (
-       SELECT name FROM activity_type_definitions WHERE name = ANY($1)
+       SELECT unnest($1::text[]) AS name
        UNION ALL
        SELECT atd.name
          FROM activity_type_definitions atd
@@ -528,13 +530,17 @@ export const renameActivityTypeDefinition = async (
 }
 
 export const deleteActivityTypeDefinition = async (user: string, name: string): Promise<boolean> => {
-  // Reparent children to the deleted type's parent (may be null, which makes them top-level).
+  // Refuse to delete built-in types (and skip reparenting in that case — otherwise
+  // a failed delete would leave children orphaned from their deleted parent).
   const parentResult = await query(
     user,
-    `SELECT parent_type FROM activity_type_definitions WHERE name = $1`,
+    `SELECT parent_type, is_builtin FROM activity_type_definitions WHERE name = $1`,
     [name],
   )
   if (parentResult.rows.length === 0) return false
+  if (parentResult.rows[0].is_builtin === true) return false
+
+  // Reparent children to the deleted type's parent (may be null, which makes them top-level).
   const grandparent = (parentResult.rows[0].parent_type as string | null) ?? null
   await query(
     user,

--- a/apps/backend/src/db/activity-type-definitions.ts
+++ b/apps/backend/src/db/activity-type-definitions.ts
@@ -14,11 +14,12 @@ const mapRow = (row: Record<string, unknown>): ActivityTypeDefinition => ({
   ...(row.icon != null ? { icon: row.icon as string } : {}),
   is_builtin: row.is_builtin as boolean,
   name: row.name as string,
+  ...(row.parent_type != null ? { parent_type: row.parent_type as string } : {}),
   show_on_timeline: (row.show_on_timeline as boolean) ?? true,
 })
 
 const SELECT_COLS =
-  'name, display_name, display_category, color, icon, aliases, health_connect_record_type, health_connect_exercise_type, is_builtin, show_on_timeline, data_schema'
+  'name, display_name, display_category, color, icon, aliases, health_connect_record_type, health_connect_exercise_type, is_builtin, show_on_timeline, data_schema, parent_type'
 
 export const getActivityTypeDefinitions = async (user: string): Promise<ActivityTypeDefinition[]> => {
   const result = await query(
@@ -54,6 +55,91 @@ const normalizeAliases = (name: string, aliases: string[] = []): string[] => {
   return [...uniqueAliases]
 }
 
+/**
+ * Check if setting parent_type=candidateParent on the type named typeName would
+ * introduce a cycle. Walks up the candidate parent's chain; if we encounter
+ * typeName before hitting a null parent, a cycle would form.
+ */
+const lookupParentType = async (user: string, name: string): Promise<string | null> => {
+  const result = await query<{ parent_type: string | null }>(
+    user,
+    `SELECT parent_type FROM activity_type_definitions WHERE name = $1`,
+    [name],
+  )
+  if (result.rows.length === 0) return null
+  return result.rows[0].parent_type ?? null
+}
+
+const validateParentTypeUpdate = async (
+  user: string,
+  name: string,
+  candidateParent: string | null,
+): Promise<void> => {
+  if (candidateParent === null) return
+  if (candidateParent === name) {
+    throw new Error('parent_type cannot reference the type itself')
+  }
+  const parentExists = await activityTypeExists(user, candidateParent)
+  if (!parentExists) throw new Error(`parent_type "${candidateParent}" does not exist`)
+  if (await wouldCreateCycle(user, name, candidateParent)) {
+    throw new Error(`setting parent_type to "${candidateParent}" would create a cycle`)
+  }
+}
+
+async function wouldCreateCycle(user: string, typeName: string, candidateParent: string): Promise<boolean> {
+  const visited = new Set<string>()
+  let currentName: string | null = candidateParent
+  while (currentName !== null) {
+    if (currentName === typeName) return true
+    if (visited.has(currentName)) return false
+    visited.add(currentName)
+    currentName = await lookupParentType(user, currentName)
+  }
+  return false
+}
+
+/**
+ * Return all descendant type names for a given parent (recursive).
+ * Does NOT include the parent itself.
+ */
+export const getDescendantTypes = async (user: string, parentName: string): Promise<string[]> => {
+  const result = await query(
+    user,
+    `WITH RECURSIVE descendants AS (
+       SELECT name FROM activity_type_definitions WHERE parent_type = $1
+       UNION ALL
+       SELECT atd.name
+         FROM activity_type_definitions atd
+         JOIN descendants d ON atd.parent_type = d.name
+     )
+     SELECT name FROM descendants`,
+    [parentName],
+  )
+  return result.rows.map((r) => r.name as string)
+}
+
+/**
+ * Expand a list of activity type names to include all descendants.
+ * Each input type is returned along with its recursive children.
+ * Returns deduplicated names.
+ */
+export const expandActivityTypes = async (user: string, types: string[]): Promise<string[]> => {
+  if (types.length === 0) return []
+  const result = await query(
+    user,
+    `WITH RECURSIVE tree AS (
+       SELECT name FROM activity_type_definitions WHERE name = ANY($1)
+       UNION ALL
+       SELECT atd.name
+         FROM activity_type_definitions atd
+         JOIN tree t ON atd.parent_type = t.name
+     )
+     SELECT DISTINCT name FROM tree`,
+    [types],
+  )
+  return result.rows.map((r) => r.name as string)
+}
+
 export const insertActivityTypeDefinition = async (
   user: string,
   def: {
@@ -65,13 +151,21 @@ export const insertActivityTypeDefinition = async (
     aliases?: string[]
     show_on_timeline?: boolean
     data_schema?: DataSchemaDefinition
+    parent_type?: string
   },
 ): Promise<ActivityTypeDefinition> => {
   const aliases = normalizeAliases(def.name, def.aliases)
+  if (def.parent_type) {
+    if (def.parent_type === def.name) {
+      throw new Error('parent_type cannot reference the type itself')
+    }
+    const parentExists = await activityTypeExists(user, def.parent_type)
+    if (!parentExists) throw new Error(`parent_type "${def.parent_type}" does not exist`)
+  }
   const result = await query(
     user,
-    `INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, aliases, show_on_timeline, data_schema)
-     VALUES ($1, $2, $3, COALESCE($4, '#6b7280'), $5, $6, COALESCE($7, true), $8)
+    `INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, aliases, show_on_timeline, data_schema, parent_type)
+     VALUES ($1, $2, $3, COALESCE($4, '#6b7280'), $5, $6, COALESCE($7, true), $8, $9)
      RETURNING ${SELECT_COLS}`,
     [
       def.name,
@@ -82,6 +176,7 @@ export const insertActivityTypeDefinition = async (
       aliases,
       def.show_on_timeline ?? null,
       def.data_schema ? JSON.stringify(def.data_schema) : null,
+      def.parent_type ?? null,
     ],
   )
   return mapRow(result.rows[0])
@@ -98,6 +193,7 @@ export const updateActivityTypeDefinition = async (
     aliases?: string[]
     show_on_timeline?: boolean
     data_schema?: DataSchemaDefinition | null
+    parent_type?: string | null
   },
 ): Promise<ActivityTypeDefinition | null> => {
   const setClauses: string[] = []
@@ -131,6 +227,11 @@ export const updateActivityTypeDefinition = async (
   if (updates.data_schema !== undefined) {
     setClauses.push(`data_schema = $${paramIndex++}`)
     values.push(updates.data_schema ? JSON.stringify(updates.data_schema) : null)
+  }
+  if (updates.parent_type !== undefined) {
+    await validateParentTypeUpdate(user, name, updates.parent_type)
+    setClauses.push(`parent_type = $${paramIndex++}`)
+    values.push(updates.parent_type)
   }
 
   if (setClauses.length === 0) return getActivityTypeDefinition(user, name)
@@ -286,6 +387,13 @@ export const mergeActivityTypeDefinition = async (
   )
   const activities_reassigned = activitiesResult.rowCount ?? 0
 
+  // Reparent any children of the source to the target
+  await query(
+    user,
+    `UPDATE activity_type_definitions SET parent_type = $1, updated_at = NOW() WHERE parent_type = $2`,
+    [targetName, sourceName],
+  )
+
   // Update deduction rules: output_activity_type
   const outputResult = await query(
     user,
@@ -420,6 +528,20 @@ export const renameActivityTypeDefinition = async (
 }
 
 export const deleteActivityTypeDefinition = async (user: string, name: string): Promise<boolean> => {
+  // Reparent children to the deleted type's parent (may be null, which makes them top-level).
+  const parentResult = await query(
+    user,
+    `SELECT parent_type FROM activity_type_definitions WHERE name = $1`,
+    [name],
+  )
+  if (parentResult.rows.length === 0) return false
+  const grandparent = (parentResult.rows[0].parent_type as string | null) ?? null
+  await query(
+    user,
+    `UPDATE activity_type_definitions SET parent_type = $1, updated_at = NOW() WHERE parent_type = $2`,
+    [grandparent, name],
+  )
+
   const result = await query(
     user,
     `DELETE FROM activity_type_definitions WHERE name = $1 AND is_builtin = false`,

--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -569,6 +569,30 @@ export const migrateSchema = async (user: string) => {
     // Widen icon from VARCHAR(50) to TEXT to support URLs
     await query(db, `ALTER TABLE activity_type_definitions ALTER COLUMN icon TYPE TEXT`)
     await query(db, `ALTER TABLE activity_type_definitions ADD COLUMN IF NOT EXISTS data_schema JSONB`)
+    await query(
+      db,
+      `ALTER TABLE activity_type_definitions ADD COLUMN IF NOT EXISTS parent_type VARCHAR(100) REFERENCES activity_type_definitions(name) ON UPDATE CASCADE`,
+    )
+    await query(db, `CREATE INDEX IF NOT EXISTS idx_atd_parent ON activity_type_definitions (parent_type)`)
+    // Seed hierarchy: exercise subtypes → 'exercise', nap/rest → 'sleep'.
+    // Only applies when parent_type is NULL so user overrides are preserved.
+    await query(
+      db,
+      `UPDATE activity_type_definitions
+         SET parent_type = 'exercise'
+       WHERE is_builtin = true
+         AND display_category = 'exercise'
+         AND name != 'exercise'
+         AND parent_type IS NULL`,
+    )
+    await query(
+      db,
+      `UPDATE activity_type_definitions
+         SET parent_type = 'sleep'
+       WHERE is_builtin = true
+         AND name IN ('nap', 'rest')
+         AND parent_type IS NULL`,
+    )
   }
   if (existingTableNames.has('locations')) {
     await query(db, `ALTER TABLE locations ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -95,9 +95,11 @@ export {
 export {
   activityTypeExists,
   deleteActivityTypeDefinition,
+  expandActivityTypes,
   getActivityTypeDefinition,
   getActivityTypeDefinitions,
   getActivityTypeNames,
+  getDescendantTypes,
   getHealthConnectExerciseType,
   insertActivityTypeDefinition,
   mergeActivityTypeDefinition,

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -1216,11 +1216,7 @@ describe('MCP Server', () => {
   })
 
   describe('Tool: reset_sync_state', () => {
-    async function callResetSyncState(
-      app: express.Express,
-      token: string,
-      args: Record<string, unknown>,
-    ) {
+    async function callResetSyncState(app: express.Express, token: string, args: Record<string, unknown>) {
       const response = await mcpPost(app)
         .set('Authorization', `Bearer ${token}`)
         .send({

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -549,12 +549,14 @@ export const createTableStatements: Record<string, string> = {
       health_connect_exercise_type INTEGER,
       is_builtin        BOOLEAN NOT NULL DEFAULT false,
       show_on_timeline  BOOLEAN NOT NULL DEFAULT true,
+      parent_type       VARCHAR(100) REFERENCES activity_type_definitions(name) ON UPDATE CASCADE,
       created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `,
   activity_type_definitions_indexes: `
-    CREATE INDEX IF NOT EXISTS idx_atd_aliases ON activity_type_definitions USING GIN (aliases)
+    CREATE INDEX IF NOT EXISTS idx_atd_aliases ON activity_type_definitions USING GIN (aliases);
+    CREATE INDEX IF NOT EXISTS idx_atd_parent ON activity_type_definitions (parent_type)
   `,
   activity_type_definitions_seed: `
     INSERT INTO activity_type_definitions (name, display_name, display_category, color, is_builtin, health_connect_record_type, health_connect_exercise_type) VALUES
@@ -647,7 +649,19 @@ export const createTableStatements: Record<string, string> = {
       ('weightlifting', 'Weightlifting', 'exercise', '#22c55e', true, 'ExerciseSessionRecord', 81),
       ('wheelchair', 'Wheelchair', 'exercise', '#22c55e', true, 'ExerciseSessionRecord', 82),
       ('yoga', 'Yoga', 'exercise', '#22c55e', true, 'ExerciseSessionRecord', 83)
-    ON CONFLICT (name) DO NOTHING
+    ON CONFLICT (name) DO NOTHING;
+    -- Seed the built-in hierarchy: exercise subtypes → 'exercise', nap/rest → 'sleep'.
+    UPDATE activity_type_definitions
+       SET parent_type = 'exercise'
+     WHERE is_builtin = true
+       AND display_category = 'exercise'
+       AND name != 'exercise'
+       AND parent_type IS NULL;
+    UPDATE activity_type_definitions
+       SET parent_type = 'sleep'
+     WHERE is_builtin = true
+       AND name IN ('nap', 'rest')
+       AND parent_type IS NULL
   `,
 
   // Deduction rules — automatically create activities from data conditions

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -549,6 +549,7 @@ export const createTableStatements: Record<string, string> = {
       health_connect_exercise_type INTEGER,
       is_builtin        BOOLEAN NOT NULL DEFAULT false,
       show_on_timeline  BOOLEAN NOT NULL DEFAULT true,
+      data_schema       JSONB,
       parent_type       VARCHAR(100) REFERENCES activity_type_definitions(name) ON UPDATE CASCADE,
       created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -5,6 +5,7 @@ import { buildBucketExpr, getChartData } from './chart-data.ts'
 
 // Mock the db module
 vi.mock('../db', () => ({
+  expandActivityTypes: vi.fn().mockImplementation((_user: string, types: string[]) => Promise.resolve(types)),
   query: vi.fn(),
 }))
 

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -7,7 +7,7 @@
 
 import type { ChartDataBreakdownBucket, ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
 
-import { query } from '../db/index.ts'
+import { expandActivityTypes, query } from '../db/index.ts'
 
 /** Map bucket_size parameter to PostgreSQL date_trunc interval name (day and above). */
 const bucketToTrunc: Record<string, string> = {
@@ -76,19 +76,21 @@ const queryActivitiesByType = async (
   end: string,
   bucketSize: string,
 ): Promise<ChartDataBucket[]> => {
+  const expanded = await expandActivityTypes(user, [activityType])
+  const types = expanded.length > 0 ? expanded : [activityType]
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const result = await query(
     user,
     `SELECT ${bucket.expr} AS bucket_start,
             count(*) AS value
        FROM activities
-      WHERE activity_type = $${bucket.params.length + 1}
+      WHERE activity_type = ANY($${bucket.params.length + 1})
         AND deleted_at IS NULL
         AND superseded_by IS NULL
         AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [...bucket.params, activityType, start, end],
+    [...bucket.params, types, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -189,6 +191,8 @@ const queryActivityTypeBuckets = async (
   bucketSize: string,
   aggregation = 'sum',
 ): Promise<ChartDataBucket[]> => {
+  const expanded = await expandActivityTypes(user, [pattern])
+  const types = expanded.length > 0 ? expanded : [pattern]
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const valueExpr =
     aggregation === 'count'
@@ -199,13 +203,13 @@ const queryActivityTypeBuckets = async (
     `SELECT ${bucket.expr} AS bucket_start,
             ${valueExpr} AS value
        FROM activities
-      WHERE activity_type = $${bucket.params.length + 1}
+      WHERE activity_type = ANY($${bucket.params.length + 1})
         AND deleted_at IS NULL
         AND superseded_by IS NULL
         AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,
-    [...bucket.params, pattern, start, end],
+    [...bucket.params, types, start, end],
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),
@@ -231,6 +235,8 @@ const queryActivityTypeBreakdown = async (
     if (!/^[a-z][a-z0-9_]*$/.test(field)) return { buckets: [], series: [] }
   }
 
+  const expanded = await expandActivityTypes(user, [activityType])
+  const types = expanded.length > 0 ? expanded : [activityType]
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const valueExpr =
     aggregation === 'count'
@@ -247,13 +253,13 @@ const queryActivityTypeBreakdown = async (
             ${fieldSelects.join(', ')},
             ${valueExpr} AS value
        FROM activities
-      WHERE activity_type = $${bucket.params.length + 1}
+      WHERE activity_type = ANY($${bucket.params.length + 1})
         AND deleted_at IS NULL
         AND superseded_by IS NULL
         AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1, ${fieldGroupBys.join(', ')}
       ORDER BY 1`,
-    [...bucket.params, activityType, start, end],
+    [...bucket.params, types, start, end],
   )
 
   // Pivot rows into breakdown buckets with compound series keys

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -76,8 +76,7 @@ const queryActivitiesByType = async (
   end: string,
   bucketSize: string,
 ): Promise<ChartDataBucket[]> => {
-  const expanded = await expandActivityTypes(user, [activityType])
-  const types = expanded.length > 0 ? expanded : [activityType]
+  const types = await expandActivityTypes(user, [activityType])
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const result = await query(
     user,
@@ -191,8 +190,7 @@ const queryActivityTypeBuckets = async (
   bucketSize: string,
   aggregation = 'sum',
 ): Promise<ChartDataBucket[]> => {
-  const expanded = await expandActivityTypes(user, [pattern])
-  const types = expanded.length > 0 ? expanded : [pattern]
+  const types = await expandActivityTypes(user, [pattern])
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const valueExpr =
     aggregation === 'count'
@@ -235,8 +233,7 @@ const queryActivityTypeBreakdown = async (
     if (!/^[a-z][a-z0-9_]*$/.test(field)) return { buckets: [], series: [] }
   }
 
-  const expanded = await expandActivityTypes(user, [activityType])
-  const types = expanded.length > 0 ? expanded : [activityType]
+  const types = await expandActivityTypes(user, [activityType])
   const bucket = buildBucketExpr(bucketSize, 'start_time', 1)
   const valueExpr =
     aggregation === 'count'

--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -7,25 +7,32 @@ import { query } from '../db/connection.ts'
  */
 import {
   deleteStaleRuleActivities,
+  expandActivityTypes,
   insertActivity as dbInsertActivity,
   insertDeductionRuleRun,
 } from '../db/index.ts'
 import { getPlaceVisits } from './locations.ts'
+
+const expandForQuery = async (user: string, activityType: string): Promise<string[]> => {
+  const expanded = await expandActivityTypes(user, [activityType])
+  return expanded.length > 0 ? expanded : [activityType]
+}
 
 const getActivities = async (
   user: string,
   activityType: string,
   window: EvaluationWindow,
 ): Promise<TimeRange[]> => {
+  const types = await expandForQuery(user, activityType)
   const result = await query(
     user,
     `SELECT start_time, end_time FROM activities
-     WHERE activity_type = $1
+     WHERE activity_type = ANY($1)
        AND deleted_at IS NULL
        AND start_time < $3
        AND (end_time > $2 OR end_time IS NULL)
      ORDER BY start_time`,
-    [activityType, window.start, window.end],
+    [types, window.start, window.end],
   )
   return result.rows.map((r) => ({
     end: (r.end_time as Date) ?? new Date((r.start_time as Date).getTime() + 60 * 60 * 1000),
@@ -65,8 +72,9 @@ const getActivitiesWithData = async (
   // Sanitize field name to prevent injection (only allow snake_case identifiers)
   if (!/^[a-z][a-z0-9_]*$/.test(field)) return []
 
+  const types = await expandForQuery(user, activityType)
   let whereClause: string
-  const params: unknown[] = [activityType, window.start, window.end]
+  const params: unknown[] = [types, window.start, window.end]
 
   switch (operator) {
     case 'eq':
@@ -90,7 +98,7 @@ const getActivitiesWithData = async (
   const result = await query(
     user,
     `SELECT start_time, end_time FROM activities
-     WHERE activity_type = $1
+     WHERE activity_type = ANY($1)
        AND deleted_at IS NULL
        AND start_time < $3
        AND (end_time > $2 OR end_time IS NULL)
@@ -110,7 +118,8 @@ const getActivitiesWithDataFilters = async (
   filters: Array<{ field: string; operator: string; value?: string | number | boolean }>,
   window: EvaluationWindow,
 ): Promise<TimeRange[]> => {
-  const params: unknown[] = [activityType, window.start, window.end]
+  const types = await expandForQuery(user, activityType)
+  const params: unknown[] = [types, window.start, window.end]
   const whereClauses: string[] = []
 
   for (const filter of filters) {
@@ -139,7 +148,7 @@ const getActivitiesWithDataFilters = async (
   const result = await query(
     user,
     `SELECT start_time, end_time FROM activities
-     WHERE activity_type = $1
+     WHERE activity_type = ANY($1)
        AND deleted_at IS NULL
        AND start_time < $3
        AND (end_time > $2 OR end_time IS NULL)

--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -13,17 +13,12 @@ import {
 } from '../db/index.ts'
 import { getPlaceVisits } from './locations.ts'
 
-const expandForQuery = async (user: string, activityType: string): Promise<string[]> => {
-  const expanded = await expandActivityTypes(user, [activityType])
-  return expanded.length > 0 ? expanded : [activityType]
-}
-
 const getActivities = async (
   user: string,
   activityType: string,
   window: EvaluationWindow,
 ): Promise<TimeRange[]> => {
-  const types = await expandForQuery(user, activityType)
+  const types = await expandActivityTypes(user, [activityType])
   const result = await query(
     user,
     `SELECT start_time, end_time FROM activities
@@ -72,7 +67,7 @@ const getActivitiesWithData = async (
   // Sanitize field name to prevent injection (only allow snake_case identifiers)
   if (!/^[a-z][a-z0-9_]*$/.test(field)) return []
 
-  const types = await expandForQuery(user, activityType)
+  const types = await expandActivityTypes(user, [activityType])
   let whereClause: string
   const params: unknown[] = [types, window.start, window.end]
 
@@ -118,7 +113,7 @@ const getActivitiesWithDataFilters = async (
   filters: Array<{ field: string; operator: string; value?: string | number | boolean }>,
   window: EvaluationWindow,
 ): Promise<TimeRange[]> => {
-  const types = await expandForQuery(user, activityType)
+  const types = await expandActivityTypes(user, [activityType])
   const params: unknown[] = [types, window.start, window.end]
   const whereClauses: string[] = []
 

--- a/apps/backend/src/services/queries/activities.test.ts
+++ b/apps/backend/src/services/queries/activities.test.ts
@@ -5,6 +5,7 @@ import { queryActivities } from './activities.ts'
 
 // Mock the db module
 vi.mock('../../db', () => ({
+  expandActivityTypes: vi.fn().mockImplementation((_user: string, types: string[]) => Promise.resolve(types)),
   getActivities: vi.fn(),
   getActivityTypeDefinitions: vi.fn().mockResolvedValue([]),
   getNotesByEntityIds: vi.fn(),

--- a/apps/backend/src/services/queries/activities.ts
+++ b/apps/backend/src/services/queries/activities.ts
@@ -117,8 +117,10 @@ export async function queryActivities(
     categoryMap,
   )
 
-  // Get HR zones if any exercise subtype is included (parent 'exercise' or any descendant)
-  const includesExercise = expandedTypes.includes('exercise') || types.includes('exercise')
+  // Get HR zones if any exercise subtype is included (parent 'exercise' or any descendant).
+  // expandActivityTypes always includes the input types in its output, so checking the
+  // expanded set alone is sufficient.
+  const includesExercise = expandedTypes.includes('exercise')
   const hrZones = includesExercise ? (await getEffectiveHrZones(user)).zones : null
 
   // Fetch comments for all activities

--- a/apps/backend/src/services/queries/activities.ts
+++ b/apps/backend/src/services/queries/activities.ts
@@ -5,7 +5,7 @@
 import type { ActivityType } from '../../schema.ts'
 import type { ActivityResult, CommentSummary, SyncProvider } from './types.ts'
 
-import { getActivities, getTimeSeries } from '../../db/index.ts'
+import { expandActivityTypes, getActivities, getTimeSeries } from '../../db/index.ts'
 import { computeHrZoneSecs, getEffectiveHrZones, type HrZoneThresholds } from '../settings.ts'
 import { computeSleepMinutes } from '../sleep-duration.ts'
 import { buildCategoryMap, getCommentsMap } from './types.ts'
@@ -106,10 +106,19 @@ export async function queryActivities(
   }
 
   const categoryMap = await buildCategoryMap(user)
-  const activities = await getActivities(user, types, start, end, dataFilters, deductionRuleId, categoryMap)
+  const expandedTypes = (await expandActivityTypes(user, types)) as ActivityType[]
+  const activities = await getActivities(
+    user,
+    expandedTypes,
+    start,
+    end,
+    dataFilters,
+    deductionRuleId,
+    categoryMap,
+  )
 
-  // Get HR zones only if exercise activities are included
-  const includesExercise = types.includes('exercise')
+  // Get HR zones if any exercise subtype is included (parent 'exercise' or any descendant)
+  const includesExercise = expandedTypes.includes('exercise') || types.includes('exercise')
   const hrZones = includesExercise ? (await getEffectiveHrZones(user)).zones : null
 
   // Fetch comments for all activities

--- a/packages/api-spec/src/schemas/activity-type-definitions.ts
+++ b/packages/api-spec/src/schemas/activity-type-definitions.ts
@@ -30,6 +30,14 @@ export const activityTypeDefinitionSchema = z
       .string()
       .regex(/^[a-z][a-z0-9_]*$/)
       .meta({ description: 'Snake_case identifier used as activity_type value' }),
+    parent_type: z
+      .string()
+      .regex(/^[a-z][a-z0-9_]*$/)
+      .optional()
+      .meta({
+        description:
+          'Parent activity type name — queries for the parent include activities of this type and all descendants',
+      }),
     health_connect_exercise_type: z
       .number()
       .int()
@@ -69,6 +77,11 @@ export const addActivityTypeDefinitionBodySchema = z
       .string()
       .regex(/^[a-z][a-z0-9_]*$/)
       .meta({ description: 'Snake_case identifier (e.g. "sauna", "driving")' }),
+    parent_type: z
+      .string()
+      .regex(/^[a-z][a-z0-9_]*$/)
+      .optional()
+      .meta({ description: 'Optional parent activity type name (must already exist)' }),
     show_on_timeline: z
       .boolean()
       .optional()
@@ -99,6 +112,12 @@ export const updateActivityTypeDefinitionBodySchema = z
     display_category: displayCategorySchema.optional().meta({ description: 'New display category' }),
     display_name: z.string().optional().meta({ description: 'New display name' }),
     icon: z.string().nullable().optional().meta({ description: 'New icon (null to clear)' }),
+    parent_type: z
+      .string()
+      .regex(/^[a-z][a-z0-9_]*$/)
+      .nullable()
+      .optional()
+      .meta({ description: 'New parent activity type (null to clear)' }),
     show_on_timeline: z.boolean().optional().meta({ description: 'Whether to show on the timeline' }),
   })
   .meta({ id: 'UpdateActivityTypeDefinitionBody' })


### PR DESCRIPTION
## Summary

Add a `parent_type` column to `activity_type_definitions` so activity types can form a tree (e.g. `running` is a child of `exercise`). Queries for a parent type automatically include all descendants — charts, activity queries, and deduction-rule activity conditions that target `exercise` now aggregate across all 80+ exercise subtypes.

This is Phase 1 of the unified-activities initiative. Later phases (scrobbles, screen time, locations as activities) build on hierarchical types for merge-on-zoom rendering and parent-level aggregation.

## Changes

- **api-spec**: `parent_type?: string` on `ActivityTypeDefinition`, `AddActivityTypeDefinitionBody`, `UpdateActivityTypeDefinitionBody` (nullable in updates to clear).
- **Schema**: New `parent_type VARCHAR(100) REFERENCES activity_type_definitions(name) ON UPDATE CASCADE` column with index. Idempotent migration adds the column to existing DBs.
- **Seed**: Built-in exercise subtypes get `parent_type='exercise'`; `nap` and `rest` get `parent_type='sleep'`.
- **DB helpers**: `getDescendantTypes` (recursive CTE), `expandActivityTypes` (self + descendants deduplicated).
- **Type expansion in queries**: `queryActivities`, chart-data (`queryActivitiesByType`, `queryActivityTypeBuckets`, `queryActivityTypeBreakdown`), and deduction-engine deps (`getActivities`, `getActivitiesWithData`, `getActivitiesWithDataFilters`) all expand the requested type to include descendants.
- **CRUD**: Insert/update validate parent exists, reject self-reference and cycles. Delete reparents children to the deleted type's parent. Merge reparents children to the merge target. Rename already works via FK `ON UPDATE CASCADE`.
- **Android**: Kotlin `ActivityTypeDefinition` gets an optional `parentType` field (forward-compatible; UI changes deferred to Phase 5).
- **Tests**: New integration-test file covering seed hierarchy, CRUD with parent_type, cycle rejection, descendant/expansion queries, and reparenting on delete/merge. Updated existing unit tests to mock the new query sequence.

## Not in this PR

- Timeline merge-on-zoom rendering (Phase 5 — frontend-only)
- UI for editing parent_type in the activity type management page
- Scrobbles / screen time / locations as activities (later phases)

## Test plan

- [ ] CI passes (tsgo, lint, unit tests, integration tests)
- [ ] Query `query_activities` with `types: ['exercise']` returns subtype activities like `running` and `yoga`
- [ ] Chart data with `activity_type_id: 'exercise'` aggregates across all exercise subtypes
- [ ] Deduction rule with activity condition `activity_type: 'exercise'` matches child-type activities
- [ ] Custom type with `parent_type='exercise'` appears in `exercise` queries
- [ ] Cycle rejection: setting parent_type to a descendant throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)