### PR TITLE
feat: Last.fm scrobbles as activities

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -593,6 +593,46 @@ export const migrateSchema = async (user: string) => {
          AND name IN ('nap', 'rest')
          AND parent_type IS NULL`,
     )
+    // Seed music_scrobble activity type (for Last.fm scrobbles as activities).
+    await query(
+      db,
+      `INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, is_builtin, show_on_timeline, data_schema)
+       VALUES ('music_scrobble', 'Music Scrobble', 'other', '#ec4899', '🎵', true, false, $1::jsonb)
+       ON CONFLICT (name) DO NOTHING`,
+      [
+        JSON.stringify({
+          fields: [
+            { is_categorical: true, name: 'artist', required: true, show_in_summary: true, type: 'string' },
+            { name: 'track', required: true, show_in_summary: true, type: 'string' },
+            { name: 'album', required: false, type: 'string' },
+          ],
+        }),
+      ],
+    )
+  }
+  // Backfill music_scrobble activities from existing Last.fm raw records.
+  // Idempotent — (source, external_id) unique index makes re-running a no-op.
+  if (existingTableNames.has('raw_records') && existingTableNames.has('activities')) {
+    await query(
+      db,
+      `INSERT INTO activities (source, external_id, activity_type, start_time, data)
+       SELECT 'lastfm',
+              rr.external_id,
+              'music_scrobble',
+              rr.recorded_at,
+              jsonb_strip_nulls(
+                jsonb_build_object(
+                  'artist', rr.data->>'artist',
+                  'track',  rr.data->>'track',
+                  'album',  rr.data->>'album'
+                )
+              )
+         FROM raw_records rr
+        WHERE rr.source = 'lastfm'
+          AND rr.record_type = 'scrobble'
+          AND rr.external_id IS NOT NULL
+       ON CONFLICT (source, external_id) WHERE external_id IS NOT NULL DO NOTHING`,
+    )
   }
   if (existingTableNames.has('locations')) {
     await query(db, `ALTER TABLE locations ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)

--- a/apps/backend/src/integrations/lastfm/sync.test.ts
+++ b/apps/backend/src/integrations/lastfm/sync.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 
 vi.mock('../../db/index.ts', () => ({
   getSyncState: vi.fn().mockResolvedValue(null),
+  insertActivities: vi.fn().mockResolvedValue(undefined),
   insertRawRecord: vi.fn().mockResolvedValue(undefined),
   upsertSyncState: vi.fn().mockResolvedValue(undefined),
 }))
@@ -12,7 +13,7 @@ vi.mock('./client', () => ({
   }),
 }))
 
-import { getSyncState, insertRawRecord, upsertSyncState } from '../../db/index.ts'
+import { getSyncState, insertActivities, insertRawRecord, upsertSyncState } from '../../db/index.ts'
 import { lastfmClient } from './client.ts'
 import { syncLastFmData } from './sync.ts'
 
@@ -37,6 +38,51 @@ describe('syncLastFmData', () => {
       expect.objectContaining({ source: 'lastfm', record_type: 'scrobble' }),
     )
     expect(upsertSyncState).toHaveBeenCalledWith('user', expect.objectContaining({ status: 'idle' }))
+  })
+
+  test('creates music_scrobble activities alongside raw records', async () => {
+    const scrobble = {
+      album: 'Album',
+      artist: 'Artist',
+      timestamp: new Date('2024-01-15T10:00:00Z'),
+      track: 'Track',
+    }
+    vi.mocked(lastfmClient).mockReturnValue({
+      getRecentTracks: vi.fn().mockResolvedValue([scrobble]),
+    } as never)
+
+    await syncLastFmData('user', 'key', 'username')
+
+    expect(insertActivities).toHaveBeenCalledWith('user', [
+      {
+        activity_type: 'music_scrobble',
+        data: { album: 'Album', artist: 'Artist', track: 'Track' },
+        external_id: `${scrobble.timestamp.getTime()}-Track-Artist`,
+        source: 'lastfm',
+        start_time: scrobble.timestamp,
+      },
+    ])
+  })
+
+  test('omits album from activity data when not present', async () => {
+    const scrobble = {
+      artist: 'Artist',
+      timestamp: new Date('2024-01-15T10:00:00Z'),
+      track: 'Track',
+    }
+    vi.mocked(lastfmClient).mockReturnValue({
+      getRecentTracks: vi.fn().mockResolvedValue([scrobble]),
+    } as never)
+
+    await syncLastFmData('user', 'key', 'username')
+
+    expect(insertActivities).toHaveBeenCalledWith('user', [
+      expect.objectContaining({
+        activity_type: 'music_scrobble',
+        data: { artist: 'Artist', track: 'Track' },
+        source: 'lastfm',
+      }),
+    ])
   })
 
   test('uses last sync time when available', async () => {

--- a/apps/backend/src/integrations/lastfm/sync.ts
+++ b/apps/backend/src/integrations/lastfm/sync.ts
@@ -1,13 +1,21 @@
 /**
  * Last.fm data sync module.
  *
- * Handles fetching scrobbles from Last.fm API and storing them in the database.
- * Activity creation from scrobbles is handled by deduction rules with scrobble conditions.
+ * Fetches scrobbles from Last.fm and stores them in two places:
+ *   - raw_records (kept for sync dedup and as the data source for the
+ *     `scrobble` condition in deduction rules)
+ *   - activities with activity_type='music_scrobble', so scrobbles can be
+ *     queried, charted, and broken down by artist via the unified activity
+ *     pipeline. These are excluded from the main activity-column timeline
+ *     rendering (see EXCLUDED_ACTIVITY_SOURCES on the frontend) and rendered
+ *     separately on the music staff track.
  */
 
 import { subDays } from 'date-fns'
 
-import { getSyncState, insertRawRecord, upsertSyncState } from '../../db/index.ts'
+import type { Activity } from '../../db/types.ts'
+
+import { getSyncState, insertActivities, insertRawRecord, upsertSyncState } from '../../db/index.ts'
 import { lastfmClient } from './client.ts'
 
 /** Default start date for historical sync (30 days back) */
@@ -56,7 +64,8 @@ export const syncLastFmData = async (
     const client = lastfmClient(apiKey)
     const scrobbles = await client.getRecentTracks(username, start, end)
 
-    // Store raw scrobbles
+    // Store raw scrobbles and build parallel activity records.
+    const activities: Activity[] = []
     for (const scrobble of scrobbles) {
       const externalId = `${scrobble.timestamp.getTime()}-${scrobble.track}-${scrobble.artist}`
       await insertRawRecord(user, {
@@ -73,7 +82,19 @@ export const syncLastFmData = async (
         recorded_at: scrobble.timestamp,
         source: 'lastfm',
       })
+      activities.push({
+        activity_type: 'music_scrobble',
+        data: {
+          artist: scrobble.artist,
+          ...(scrobble.album ? { album: scrobble.album } : {}),
+          track: scrobble.track,
+        },
+        external_id: externalId,
+        source: 'lastfm',
+        start_time: scrobble.timestamp,
+      })
     }
+    await insertActivities(user, activities)
 
     // Update sync state on success
     await upsertSyncState(user, {

--- a/apps/backend/src/routes/scrobbles-router.ts
+++ b/apps/backend/src/routes/scrobbles-router.ts
@@ -1,10 +1,15 @@
 /**
  * Scrobbles route group — Last.fm scrobble queries.
+ *
+ * Reads from the activities table (activity_type='music_scrobble'), which is
+ * populated during Last.fm sync alongside raw_records. The response shape
+ * matches the legacy raw_records-based endpoint so the frontend music staff
+ * renderer needs no changes.
  */
 import type { ScrobblesResponse } from '@aurboda/api-spec'
 import type { RequestHandler, Router } from 'express'
 
-import { getScrobbles } from '../db/index.ts'
+import { getActivities } from '../db/index.ts'
 import { typedRouter } from '../typed-router.ts'
 
 export const createScrobblesRouter = (authMiddleware: RequestHandler): Router => {
@@ -22,13 +27,16 @@ export const createScrobblesRouter = (authMiddleware: RequestHandler): Router =>
       }
 
       try {
-        const scrobbles = await getScrobbles(user, new Date(start), new Date(end))
-        const serialized = scrobbles.map((s) => ({
-          album: s.album,
-          artist: s.artist,
-          recorded_at: s.recorded_at.toISOString(),
-          track: s.track,
-        }))
+        const activities = await getActivities(user, ['music_scrobble'], new Date(start), new Date(end))
+        const serialized = activities.map((a) => {
+          const data = a.data as Record<string, unknown> | undefined
+          return {
+            album: typeof data?.album === 'string' ? data.album : '',
+            artist: typeof data?.artist === 'string' ? data.artist : '',
+            recorded_at: a.start_time.toISOString(),
+            track: typeof data?.track === 'string' ? data.track : '',
+          }
+        })
         res.json({ data: serialized, success: true })
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error'

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -662,7 +662,19 @@ export const createTableStatements: Record<string, string> = {
        SET parent_type = 'sleep'
      WHERE is_builtin = true
        AND name IN ('nap', 'rest')
-       AND parent_type IS NULL
+       AND parent_type IS NULL;
+    -- music_scrobble type: point-in-time activity for a Last.fm scrobble.
+    -- show_on_timeline=false because scrobbles are rendered on the dedicated
+    -- music staff track, not the main activity lane.
+    INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, is_builtin, show_on_timeline, data_schema) VALUES
+      ('music_scrobble', 'Music Scrobble', 'other', '#ec4899', '🎵', true, false, $json$
+        {"fields":[
+          {"name":"artist","type":"string","required":true,"show_in_summary":true,"is_categorical":true},
+          {"name":"track","type":"string","required":true,"show_in_summary":true},
+          {"name":"album","type":"string","required":false}
+        ]}
+      $json$::jsonb)
+    ON CONFLICT (name) DO NOTHING
   `,
 
   // Deduction rules — automatically create activities from data conditions


### PR DESCRIPTION
## Summary

Phase 2 of the unified-activities initiative (after #645). Each Last.fm scrobble now creates an activity with `activity_type='music_scrobble'` (point-in-time, `source='lastfm'`) alongside the existing `raw_records` row. This unlocks unified charting (e.g. "top artists this week") via the standard activity pipeline without changing the specialized music-staff renderer.

## Changes

- **Built-in type**: `music_scrobble` with `display_category='other'`, `color='#ec4899'`, `icon='🎵'`, `show_on_timeline=false`, data schema for artist/track/album (artist marked `is_categorical: true` so chart breakdowns just work).
- **Last.fm sync**: After writing raw records, bulk-insert the parallel activities via `insertActivities`. Same `external_id` format as raw_records (`{ts}-{track}-{artist}`), so re-syncs are idempotent thanks to the unique (source, external_id) index.
- **Backfill migration**: Idempotent `INSERT … ON CONFLICT DO NOTHING` from existing lastfm raw records into activities, running once per user during `migrateSchema`.
- **Scrobbles endpoint**: `/scrobbles` now reads from the activities table via `getActivities(user, ['music_scrobble'], …)`. Response shape unchanged, so the frontend music staff renderer needs no updates.
- **Deduction rules unchanged**: The `scrobble` condition in the deduction engine still queries raw_records (text matching artist/track), since raw_records remains the source of truth for sync dedup.

## Not in this PR

- Migrating the music staff renderer itself to consume activities (it works as-is against the updated endpoint).
- Exposing scrobble counts in dashboards (can be added via existing BarChartWidget with `source_type='activity_type'`, `activity_type_id='music_scrobble'`, optional `breakdown_fields=['artist']`).

## Test plan

- [ ] CI passes (unit, integration, check, lint, build)
- [ ] After deploy: `query_activities types=['music_scrobble']` returns recent scrobbles
- [ ] `query_chart_data source_type='activity_type' activity_type_id='music_scrobble' breakdown_fields=['artist']` returns per-artist counts
- [ ] Timeline music staff still renders correctly (same response shape from `/scrobbles`)
- [ ] Scrobble deduction rules (if any) still trigger as before
- [ ] Backfill is one-shot: second call should be a no-op (ON CONFLICT DO NOTHING)

🤖 Generated with [Claude Code](https://claude.com/claude-code)