### PR TITLE
fix: scrobble-as-activities review follow-ups

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -600,18 +600,22 @@ export const migrateSchema = async (user: string) => {
        VALUES ('music_scrobble', 'Music Scrobble', 'other', '#ec4899', '🎵', true, false, $1::jsonb)
        ON CONFLICT (name) DO NOTHING`,
       [
+        // Field order mirrors the seed in schema.ts for easier eyeball-diffing.
         JSON.stringify({
           fields: [
-            { is_categorical: true, name: 'artist', required: true, show_in_summary: true, type: 'string' },
-            { name: 'track', required: true, show_in_summary: true, type: 'string' },
-            { name: 'album', required: false, type: 'string' },
+            { name: 'artist', type: 'string', required: true, show_in_summary: true, is_categorical: true },
+            { name: 'track', type: 'string', required: true, show_in_summary: true },
+            { name: 'album', type: 'string', required: false },
           ],
         }),
       ],
     )
   }
   // Backfill music_scrobble activities from existing Last.fm raw records.
-  // Idempotent — (source, external_id) unique index makes re-running a no-op.
+  // The NOT EXISTS gate makes this a pure no-op once every raw record has a
+  // matching activity — avoiding a full scan of raw_records on every server
+  // start. The ON CONFLICT clause is a belt-and-suspenders guard against
+  // concurrent inserts.
   if (existingTableNames.has('raw_records') && existingTableNames.has('activities')) {
     await query(
       db,
@@ -631,6 +635,10 @@ export const migrateSchema = async (user: string) => {
         WHERE rr.source = 'lastfm'
           AND rr.record_type = 'scrobble'
           AND rr.external_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM activities a
+             WHERE a.source = 'lastfm' AND a.external_id = rr.external_id
+          )
        ON CONFLICT (source, external_id) WHERE external_id IS NOT NULL DO NOTHING`,
     )
   }

--- a/apps/backend/src/integrations/lastfm/sync.ts
+++ b/apps/backend/src/integrations/lastfm/sync.ts
@@ -64,8 +64,26 @@ export const syncLastFmData = async (
     const client = lastfmClient(apiKey)
     const scrobbles = await client.getRecentTracks(username, start, end)
 
-    // Store raw scrobbles and build parallel activity records.
-    const activities: Activity[] = []
+    // Build activity records first, then persist in two phases:
+    //   1) bulk insert activities — single SQL, all-or-nothing
+    //   2) loop over raw_records — individual upserts
+    // Activities go first so a mid-sync crash can't leave raw records persisted
+    // without matching activities. The raw_records dedup would then skip
+    // re-fetching on the next sync, which is why the backfill migration must
+    // otherwise fix things up later. Doing activities first avoids that gap.
+    const activities: Activity[] = scrobbles.map((scrobble) => ({
+      activity_type: 'music_scrobble',
+      data: {
+        artist: scrobble.artist,
+        ...(scrobble.album ? { album: scrobble.album } : {}),
+        track: scrobble.track,
+      },
+      external_id: `${scrobble.timestamp.getTime()}-${scrobble.track}-${scrobble.artist}`,
+      source: 'lastfm',
+      start_time: scrobble.timestamp,
+    }))
+    await insertActivities(user, activities)
+
     for (const scrobble of scrobbles) {
       const externalId = `${scrobble.timestamp.getTime()}-${scrobble.track}-${scrobble.artist}`
       await insertRawRecord(user, {
@@ -82,19 +100,7 @@ export const syncLastFmData = async (
         recorded_at: scrobble.timestamp,
         source: 'lastfm',
       })
-      activities.push({
-        activity_type: 'music_scrobble',
-        data: {
-          artist: scrobble.artist,
-          ...(scrobble.album ? { album: scrobble.album } : {}),
-          track: scrobble.track,
-        },
-        external_id: externalId,
-        source: 'lastfm',
-        start_time: scrobble.timestamp,
-      })
     }
-    await insertActivities(user, activities)
 
     // Update sync state on success
     await upsertSyncState(user, {


### PR DESCRIPTION
## Summary

Addresses the P2 and P3 issues from the post-merge review of #646.

## Changes

- **Backfill is now self-gating** — the lastfm backfill INSERT is wrapped in `NOT EXISTS (SELECT 1 FROM activities a WHERE a.source = 'lastfm' AND a.external_id = rr.external_id)`. Once the initial reconciliation is done, subsequent calls add zero rows and skip the full scan of raw_records.
- **Sync order reversed** — activities are bulk-inserted first, then raw records are looped individually. A mid-sync crash can no longer leave raw_records persisted without matching activities (and thus invisible to the backfill's dedup).
- **Field order aligned** between the data_schema seed in `schema.ts` and the migration INSERT in `connection.ts` (both now follow the logical order: name, type, required, show_in_summary, is_categorical).

P2b (sort order): verified. Old `getScrobbles` used `ORDER BY recorded_at ASC`; new `getActivities` uses `ORDER BY start_time` (ascending by default). Same direction, same field (start_time mirrors recorded_at for scrobbles). No change needed.

P3 fallback behavior: left as-is. The `typeof data?.x === 'string' ? data.x : ''` fallback is unreachable in practice (inserts always include artist/track), and changing to a hard filter could mask actual data-integrity bugs.

## Test plan

- [ ] CI passes
- [ ] Existing sync tests still green
- [ ] Manual: confirm a second server start with no new scrobbles is fast (backfill NOT EXISTS short-circuits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)