### PR TITLE
feat: screen time as activities (v1)

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -610,6 +610,27 @@ export const migrateSchema = async (user: string) => {
         }),
       ],
     )
+    // Seed screentime activity type (for merged categorized screen time as activities).
+    await query(
+      db,
+      `INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, is_builtin, show_on_timeline, data_schema)
+       VALUES ('screentime', 'Screen Time', 'productivity', '#64748b', '💻', true, false, $1::jsonb)
+       ON CONFLICT (name) DO NOTHING`,
+      [
+        JSON.stringify({
+          fields: [
+            {
+              name: 'category_path',
+              type: 'string',
+              required: true,
+              show_in_summary: true,
+              is_categorical: true,
+            },
+            { name: 'score', type: 'number', required: false, show_in_summary: true, unit: '' },
+          ],
+        }),
+      ],
+    )
   }
   // Backfill music_scrobble activities from existing Last.fm raw records.
   // The NOT EXISTS gate makes this a pure no-op once every raw record has a

--- a/apps/backend/src/integrations/activitywatch/sync.ts
+++ b/apps/backend/src/integrations/activitywatch/sync.ts
@@ -10,7 +10,16 @@ import type { ActivityWatchEvent, ActivityWatchSyncResult } from '@aurboda/api-s
 
 import type { ProductivityRecord } from '../../db/types.ts'
 
-import { getScreentimeCategories, insertProductivity, upsertSyncState } from '../../db/index.ts'
+import {
+  getScreentimeCategories,
+  insertActivities,
+  insertProductivity,
+  upsertSyncState,
+} from '../../db/index.ts'
+import {
+  buildScreentimeActivitySpans,
+  spansToActivities,
+} from '../../services/screentime-activities.ts'
 import { categorizeRecords, compileRules } from '../../services/screentime-categories.ts'
 
 /**
@@ -55,6 +64,13 @@ export const processActivityWatchEvents = async (
     }
 
     await insertProductivity(user, records)
+
+    // Also create merged-span activities so screentime participates in the
+    // unified activity pipeline (charts, queries, deduction rules).
+    if (categories.length > 0) {
+      const spans = buildScreentimeActivitySpans(records, categories)
+      if (spans.length > 0) await insertActivities(user, spansToActivities(spans))
+    }
 
     // Track last push time per device in sync_state
     const dataType = deviceName ? `productivity:${deviceName}` : 'productivity'

--- a/apps/backend/src/integrations/rescuetime/sync.ts
+++ b/apps/backend/src/integrations/rescuetime/sync.ts
@@ -12,10 +12,15 @@ import type { ProductivityRecord } from '../../db/types.ts'
 import {
   getScreentimeCategories,
   getSyncState,
+  insertActivities,
   insertProductivity,
   type SyncState,
   upsertSyncState,
 } from '../../db/index.ts'
+import {
+  buildScreentimeActivitySpans,
+  spansToActivities,
+} from '../../services/screentime-activities.ts'
 import { categorizeRecords, compileRules } from '../../services/screentime-categories.ts'
 import { rescuetimeClient } from './client.ts'
 
@@ -113,6 +118,13 @@ export const syncRescueTimeData = async (
         categorizeRecords(productivityRecords, compiledRules)
       }
       await insertProductivity(user, productivityRecords)
+
+      // Also create merged-span activities so screentime participates in the
+      // unified activity pipeline (charts, queries, deduction rules).
+      if (categories.length > 0) {
+        const spans = buildScreentimeActivitySpans(productivityRecords, categories)
+        if (spans.length > 0) await insertActivities(user, spansToActivities(spans))
+      }
     }
 
     // Update sync state on success

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -674,6 +674,18 @@ export const createTableStatements: Record<string, string> = {
           {"name":"album","type":"string","required":false}
         ]}
       $json$::jsonb)
+    ON CONFLICT (name) DO NOTHING;
+    -- screentime type: time-span activity for merged categorized screen time.
+    -- show_on_timeline=false because screentime is rendered on its own
+    -- dedicated track, not the main activity lane. category_path is stored
+    -- as joined string so chart breakdowns by the field just work.
+    INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, is_builtin, show_on_timeline, data_schema) VALUES
+      ('screentime', 'Screen Time', 'productivity', '#64748b', '💻', true, false, $json$
+        {"fields":[
+          {"name":"category_path","type":"string","required":true,"show_in_summary":true,"is_categorical":true},
+          {"name":"score","type":"number","required":false,"show_in_summary":true,"unit":""}
+        ]}
+      $json$::jsonb)
     ON CONFLICT (name) DO NOTHING
   `,
 

--- a/apps/backend/src/services/screentime-activities.test.ts
+++ b/apps/backend/src/services/screentime-activities.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'vitest'
+
+import type { ProductivityRecord, ScreentimeCategory } from '../db/index.ts'
+
+import { buildScreentimeActivitySpans, spansToActivities } from './screentime-activities.ts'
+
+const cat = (overrides: Partial<ScreentimeCategory>): ScreentimeCategory => ({
+  created_at: new Date(),
+  id: overrides.id ?? 'cat-id',
+  ignore_case: true,
+  name: overrides.name ?? ['Work'],
+  rule_type: 'regex',
+  sort_order: 0,
+  updated_at: new Date(),
+  ...overrides,
+})
+
+const rec = (overrides: Partial<ProductivityRecord>): ProductivityRecord => ({
+  activity: overrides.activity ?? 'app',
+  duration_sec: overrides.duration_sec ?? 120,
+  end_time: overrides.end_time ?? new Date('2026-04-19T10:02:00Z'),
+  source: overrides.source ?? 'rescuetime',
+  start_time: overrides.start_time ?? new Date('2026-04-19T10:00:00Z'),
+  ...overrides,
+})
+
+describe('buildScreentimeActivitySpans', () => {
+  test('skips uncategorized records', () => {
+    const records = [rec({ resolved_category: undefined }), rec({ resolved_category: [] })]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans).toEqual([])
+  })
+
+  test('skips records under excluded categories', () => {
+    const categories = [cat({ name: ['Idle'], exclude_from_screentime: true })]
+    const records = [
+      rec({
+        resolved_category: ['Idle'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:03:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, categories)
+    expect(spans).toEqual([])
+  })
+
+  test('skips excluded parent category even for deeper paths', () => {
+    const categories = [cat({ name: ['Idle'], exclude_from_screentime: true })]
+    const records = [
+      rec({
+        resolved_category: ['Idle', 'plasmashell'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:03:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, categories)
+    expect(spans).toEqual([])
+  })
+
+  test('merges adjacent same-category records within 2 minutes', () => {
+    const records = [
+      rec({
+        resolved_category: ['Work', 'Programming'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+      rec({
+        resolved_category: ['Work', 'Programming'],
+        start_time: new Date('2026-04-19T10:06:00Z'),
+        end_time: new Date('2026-04-19T10:10:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans).toHaveLength(1)
+    expect(spans[0].start_time).toEqual(new Date('2026-04-19T10:00:00Z'))
+    expect(spans[0].end_time).toEqual(new Date('2026-04-19T10:10:00Z'))
+  })
+
+  test('splits records with gaps longer than 2 minutes', () => {
+    const records = [
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:10:00Z'),
+        end_time: new Date('2026-04-19T10:15:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans).toHaveLength(2)
+  })
+
+  test('does not merge records of different categories', () => {
+    const records = [
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+      rec({
+        resolved_category: ['Entertainment'],
+        start_time: new Date('2026-04-19T10:05:00Z'),
+        end_time: new Date('2026-04-19T10:10:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans).toHaveLength(2)
+  })
+
+  test('does not merge records from different sources', () => {
+    const records = [
+      rec({
+        resolved_category: ['Work'],
+        source: 'rescuetime',
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+      rec({
+        resolved_category: ['Work'],
+        source: 'activitywatch',
+        start_time: new Date('2026-04-19T10:05:00Z'),
+        end_time: new Date('2026-04-19T10:10:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans).toHaveLength(2)
+  })
+
+  test('filters out spans shorter than 1 minute', () => {
+    const records = [
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:00:30Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans).toEqual([])
+  })
+
+  test('attaches score from category when present', () => {
+    const categories = [cat({ name: ['Work'], score: 2 })]
+    const records = [
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:03:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, categories)
+    expect(spans[0].score).toBe(2)
+  })
+
+  test('sorts spans by start_time', () => {
+    const records = [
+      rec({
+        resolved_category: ['Entertainment'],
+        start_time: new Date('2026-04-19T11:00:00Z'),
+        end_time: new Date('2026-04-19T11:05:00Z'),
+      }),
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, [])
+    expect(spans[0].start_time.getTime()).toBeLessThan(spans[1].start_time.getTime())
+  })
+})
+
+describe('spansToActivities', () => {
+  test('maps spans to Activity records with stable external_id', () => {
+    const startTime = new Date('2026-04-19T10:00:00Z')
+    const spans = [
+      {
+        category_path: ['Work', 'Programming'],
+        end_time: new Date('2026-04-19T10:15:00Z'),
+        source: 'rescuetime',
+        start_time: startTime,
+        score: 2,
+      },
+    ]
+    const activities = spansToActivities(spans)
+    expect(activities).toEqual([
+      {
+        activity_type: 'screentime',
+        data: { category_path: 'Work > Programming', score: 2 },
+        end_time: new Date('2026-04-19T10:15:00Z'),
+        external_id: `rescuetime_${startTime.getTime()}_Work > Programming`,
+        source: 'rescuetime',
+        start_time: startTime,
+      },
+    ])
+  })
+
+  test('omits score when not present', () => {
+    const spans = [
+      {
+        category_path: ['Work'],
+        end_time: new Date('2026-04-19T10:05:00Z'),
+        source: 'activitywatch',
+        start_time: new Date('2026-04-19T10:00:00Z'),
+      },
+    ]
+    const activities = spansToActivities(spans)
+    expect(activities[0].data).toEqual({ category_path: 'Work' })
+  })
+})

--- a/apps/backend/src/services/screentime-activities.ts
+++ b/apps/backend/src/services/screentime-activities.ts
@@ -1,0 +1,116 @@
+/**
+ * Convert categorized productivity records into `screentime` activities.
+ *
+ * We mirror the frontend `productivityMerge.ts` contract: adjacent records of
+ * the same resolved category within MERGE_GAP_MS collapse into a single span.
+ * Each span becomes an activity with activity_type='screentime' and
+ * data.category_path set to the full category path joined by ' > '.
+ *
+ * Uncategorized records and records under categories flagged
+ * exclude_from_screentime are skipped — they remain in the productivity table
+ * but do not produce activities.
+ */
+
+import type { ProductivityRecord, ScreentimeCategory } from '../db/index.ts'
+import type { Activity } from '../db/types.ts'
+
+import { getScoreForCategory } from './screentime-categories.ts'
+
+const MERGE_GAP_MS = 2 * 60 * 1000 // Mirrors productivityMerge.ts
+const MIN_SPAN_MS = 60_000 // Skip spans shorter than 1 minute
+
+export const categoryPathToString = (path: string[]): string => path.join(' > ')
+
+const isExcluded = (categoryPath: string[], excludedPaths: string[][]): boolean =>
+  excludedPaths.some(
+    (excluded) =>
+      categoryPath.length >= excluded.length &&
+      excluded.every((seg, idx) => seg === categoryPath[idx]),
+  )
+
+interface Span {
+  category_path: string[]
+  source: string
+  start_time: Date
+  end_time: Date
+  score?: number
+}
+
+/**
+ * Group records by (source, resolved_category) and merge adjacent same-group
+ * records within MERGE_GAP_MS. Records are grouped by source so rescuetime and
+ * activitywatch spans for the same category don't conflate — they have
+ * different source attribution and different authoritative views of the hour.
+ */
+export const buildScreentimeActivitySpans = (
+  records: ProductivityRecord[],
+  categories: ScreentimeCategory[],
+): Span[] => {
+  const excludedPaths = categories.filter((c) => c.exclude_from_screentime).map((c) => c.name)
+
+  const groups = new Map<string, ProductivityRecord[]>()
+  for (const record of records) {
+    const cat = record.resolved_category
+    if (!cat || cat.length === 0) continue
+    if (!record.source) continue
+    if (isExcluded(cat, excludedPaths)) continue
+    const key = `${record.source}:${categoryPathToString(cat)}`
+    const bucket = groups.get(key) ?? []
+    bucket.push(record)
+    groups.set(key, bucket)
+  }
+
+  const spans: Span[] = []
+  for (const group of groups.values()) {
+    const sorted = [...group].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+    const first = sorted[0]
+    const score = getScoreForCategory(first.resolved_category!, categories)
+    const makeSpan = (r: ProductivityRecord): Span => ({
+      category_path: r.resolved_category!,
+      end_time: r.end_time,
+      source: r.source!,
+      start_time: r.start_time,
+      ...(score !== undefined ? { score } : {}),
+    })
+
+    let current = makeSpan(first)
+    for (let i = 1; i < sorted.length; i++) {
+      const next = sorted[i]
+      const gap = next.start_time.getTime() - current.end_time.getTime()
+      if (gap <= MERGE_GAP_MS) {
+        if (next.end_time > current.end_time) current.end_time = next.end_time
+      } else {
+        spans.push(current)
+        current = makeSpan(next)
+      }
+    }
+    spans.push(current)
+  }
+
+  return spans
+    .filter((s) => s.end_time.getTime() - s.start_time.getTime() >= MIN_SPAN_MS)
+    .sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+}
+
+/**
+ * Convert spans to Activity records for bulk insert.
+ *
+ * external_id is deterministic: `${source}_${startEpoch}_${categoryPath}`.
+ * Re-running sync or regenerating after category changes upserts cleanly
+ * thanks to the (source, external_id) unique index.
+ */
+export const spansToActivities = (spans: Span[]): Activity[] =>
+  spans.map((span) => {
+    const categoryPath = categoryPathToString(span.category_path)
+    return {
+      activity_type: 'screentime',
+      data: {
+        category_path: categoryPath,
+        ...(span.score !== undefined ? { score: span.score } : {}),
+      },
+      end_time: span.end_time,
+      external_id: `${span.source}_${span.start_time.getTime()}_${categoryPath}`,
+      source: span.source as Activity['source'],
+      start_time: span.start_time,
+    }
+  })

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -27,6 +27,12 @@ export const ACTIVITY_TYPE_MERGE_MAP: Record<string, string[]> = {
  */
 export const EXCLUDED_ACTIVITY_SOURCES = new Set(['lastfm'])
 
+/**
+ * Activity types that are rendered on dedicated timeline tracks and should
+ * not appear in the main Activity lane.
+ */
+export const EXCLUDED_ACTIVITY_TYPES = new Set(['screentime'])
+
 /** Activity types that start with these prefixes are excluded from duration merging. */
 export const EXCLUDED_ACTIVITY_PREFIXES = ['computer:']
 
@@ -34,6 +40,7 @@ export const EXCLUDED_ACTIVITY_PREFIXES = ['computer:']
 export const isDurationActivityLike = (activity: Activity): boolean => {
   if (!activity.end_time) return false
   if (activity.source && EXCLUDED_ACTIVITY_SOURCES.has(activity.source)) return false
+  if (EXCLUDED_ACTIVITY_TYPES.has(activity.activity_type)) return false
   for (const prefix of EXCLUDED_ACTIVITY_PREFIXES) {
     if (activity.activity_type.startsWith(prefix)) return false
   }

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -27,6 +27,7 @@ import {
   buildActivityColumnItems,
   EXCLUDED_ACTIVITY_PREFIXES,
   EXCLUDED_ACTIVITY_SOURCES,
+  EXCLUDED_ACTIVITY_TYPES,
 } from './activityMerge'
 import {
   categorizeLocations,
@@ -294,6 +295,7 @@ export const useTimelineData = ({
       secondaryActivities.filter((a) => {
         if (!a.end_time) return true
         if (a.source && EXCLUDED_ACTIVITY_SOURCES.has(a.source)) return true
+        if (EXCLUDED_ACTIVITY_TYPES.has(a.activity_type)) return true
         for (const prefix of EXCLUDED_ACTIVITY_PREFIXES) {
           if (a.activity_type.startsWith(prefix)) return true
         }


### PR DESCRIPTION
## Summary

Phase 3 of the unified-activities initiative, **v1 / forward-looking only**. Merge-on-write during RescueTime and ActivityWatch sync creates `screentime` activities alongside the existing productivity rows. Each categorized span within a 2-minute gap becomes a single activity (mirroring the frontend `productivityMerge` contract), with `data.category_path` carrying the full hierarchy as a joined string so chart breakdowns by category work natively.

Not auto-merging — central functionality, please review.

## Why this scope

The fuller vision is each screentime category → its own activity type with `parent_type` mirroring the category hierarchy (leveraging #645). That's significantly more moving parts: stable-name generation, keeping activity types in sync with category CRUD, cascading on delete, and regenerating data on rename. It also couples two independent hierarchies that have different renaming semantics.

v1 instead uses a single `screentime` type with `category_path` as a categorical data field. This:

- Gets activities flowing through the unified pipeline today (charts, queries, deduction rules can all see screen time as activities).
- Leaves the category model untouched — a rename of "Work → Programming" to "Work → Coding" takes effect on the next sync without schema gymnastics.
- Keeps the `productivity` table and all its consumers (daily summary, `/productivity` endpoint, `queryProductivityCategoryBuckets`, deduction-rule `screentime_category` condition) working unchanged.
- Can be upgraded to per-category activity types in a later phase without breaking the data shape (category_path stays informative even if types become hierarchical).

## Changes

**Backend**
- `screentime` built-in activity type with `display_category=productivity`, `show_on_timeline=false`, icon 💻, color #64748b. Data schema declares `category_path` (string, categorical, show_in_summary) and `score` (number).
- New service module `services/screentime-activities.ts`:
  - `buildScreentimeActivitySpans(records, categories)` — groups by (source, resolved_category), merges within 2-min gap, filters <1min, attaches category score.
  - `spansToActivities(spans)` — deterministic `external_id = {source}_{startEpoch}_{categoryPath}`, so re-sync or regeneration upserts cleanly via the existing (source, external_id) unique index.
- RescueTime and ActivityWatch sync: after categorizing + persisting productivity records, bulk-insert the derived activities.
- Migration seeds the `screentime` type idempotently (same pattern as `music_scrobble`).

**Frontend**
- `EXCLUDED_ACTIVITY_TYPES = new Set(['screentime'])` added in `activityMerge.ts` and respected in `useTimelineData.ts`. Keeps screentime activities out of the main Activity lane — the dedicated screen time track (fed by `/productivity`) continues to render them.

**Tests**
- 12 new unit tests in `screentime-activities.test.ts` covering: uncategorized/excluded filtering (including excluded parent with deeper path), 2-min gap merge, gap split, different-category non-merging, different-source non-merging, <1min filtering, score propagation, sort order, and the activity shape/external_id format.

## Not in this PR (explicitly deferred)

1. **Backfill**: existing historical productivity records are not converted to activities. New syncs from here forward produce activities. A follow-up can add either a one-shot backfill migration or a user-triggered regenerate action.
2. **Regenerate on category change**: renaming/moving/deleting a category does not update existing screentime activities. New syncs will use the current categories, but historical activities retain the old `category_path`. Follow-up will hook into `recategorizeAll` so rules changes also re-derive activities.
3. **Consumer migration**: daily summary, `/productivity` endpoint, chart's `queryProductivityCategoryBuckets`, and the deduction-rule `screentime_category` condition all continue to read the productivity table. They keep working. A follow-up can migrate them to read from activities and eventually retire the dedicated screentime query paths.
4. **Per-category activity types with hierarchy**: the bigger design (screentime categories → activity type per category with parent_type). Can be layered on top later; the category_path data field stays useful either way.

## Test plan

- [ ] CI green (unit, integration, check, lint, build)
- [ ] After deploy: next RescueTime sync on a user with categories defined creates `screentime` activities
- [ ] `query_chart_data source_type=activity_type activity_type_id=screentime breakdown_fields=[category_path]` returns per-category time
- [ ] Timeline's screen-time track still renders the same (unchanged data source)
- [ ] Screentime activities don't show up as bars in the main Activity lane
- [ ] Deduction rules with `screentime_category` conditions keep triggering correctly

## Open questions

- Merge gap: picked 2 min to match the frontend `productivityMerge`. Daily summary uses 10 min. Worth reconciling eventually — I lean toward 2 min everywhere and letting the caller aggregate further if desired.
- Score unit: the data schema says `unit: ""` (dimensionless). Open to a better representation for the -2..2 productivity score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)