### PR TITLE
feat: location visits as activities (opt-in per named location)

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -631,6 +631,28 @@ export const migrateSchema = async (user: string) => {
         }),
       ],
     )
+    // Seed location_visit activity type (visits to opted-in named locations).
+    await query(
+      db,
+      `INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, is_builtin, show_on_timeline, data_schema)
+       VALUES ('location_visit', 'Location Visit', 'travel', '#0ea5e9', '📍', true, false, $1::jsonb)
+       ON CONFLICT (name) DO NOTHING`,
+      [
+        JSON.stringify({
+          fields: [
+            {
+              name: 'location_name',
+              type: 'string',
+              required: true,
+              show_in_summary: true,
+              is_categorical: true,
+            },
+            { name: 'lat', type: 'number', required: false },
+            { name: 'lon', type: 'number', required: false },
+          ],
+        }),
+      ],
+    )
   }
   // Backfill music_scrobble activities from existing Last.fm raw records.
   // The NOT EXISTS gate makes this a pure no-op once every raw record has a
@@ -665,6 +687,12 @@ export const migrateSchema = async (user: string) => {
   }
   if (existingTableNames.has('locations')) {
     await query(db, `ALTER TABLE locations ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
+  }
+  if (existingTableNames.has('named_locations')) {
+    await query(
+      db,
+      `ALTER TABLE named_locations ADD COLUMN IF NOT EXISTS auto_create_activity BOOLEAN NOT NULL DEFAULT false`,
+    )
   }
   if (existingTableNames.has('time_series')) {
     await query(db, `ALTER TABLE time_series ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)

--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -143,16 +143,25 @@ export const insertPlace = async (user: string, place: Place) => {
 // Named Locations (user-defined via Aurboda)
 // ============================================================================
 
+const NAMED_LOCATION_COLS =
+  'id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, auto_create_activity, created_at, updated_at'
+
 export const insertNamedLocation = async (
   user: string,
   location: NamedLocationInput,
 ): Promise<NamedLocation> => {
   const result = await query(
     user,
-    `INSERT INTO named_locations (name, location, radius)
-     VALUES ($1, ST_MakePoint($2, $3)::geography, $4)
-     RETURNING id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at`,
-    [location.name, location.lon, location.lat, location.radius ?? 200],
+    `INSERT INTO named_locations (name, location, radius, auto_create_activity)
+     VALUES ($1, ST_MakePoint($2, $3)::geography, $4, COALESCE($5, false))
+     RETURNING ${NAMED_LOCATION_COLS}`,
+    [
+      location.name,
+      location.lon,
+      location.lat,
+      location.radius ?? 200,
+      location.auto_create_activity ?? null,
+    ],
   )
   return mapNamedLocationRow(result.rows[0])
 }
@@ -160,9 +169,7 @@ export const insertNamedLocation = async (
 export const getNamedLocations = async (user: string): Promise<NamedLocation[]> => {
   const result = await query(
     user,
-    `SELECT id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at
-     FROM named_locations
-     ORDER BY name`,
+    `SELECT ${NAMED_LOCATION_COLS} FROM named_locations ORDER BY name`,
     [],
   )
   return result.rows.map(mapNamedLocationRow)
@@ -171,9 +178,7 @@ export const getNamedLocations = async (user: string): Promise<NamedLocation[]> 
 export const getNamedLocationById = async (user: string, id: string): Promise<NamedLocation | null> => {
   const result = await query(
     user,
-    `SELECT id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at
-     FROM named_locations
-     WHERE id = $1`,
+    `SELECT ${NAMED_LOCATION_COLS} FROM named_locations WHERE id = $1`,
     [id],
   )
   if (result.rows.length === 0) return null
@@ -194,11 +199,13 @@ export const updateNamedLocation = async (
     })
   }
   if (updates.radius !== undefined) fields.push({ column: 'radius', value: updates.radius })
+  if (updates.auto_create_activity !== undefined) {
+    fields.push({ column: 'auto_create_activity', value: updates.auto_create_activity })
+  }
 
   const update = buildDynamicUpdate('named_locations', id, fields, {
     defaultClauses: ['updated_at = NOW()'],
-    returning:
-      'id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as lon, radius, created_at, updated_at',
+    returning: NAMED_LOCATION_COLS,
   })
   if (!update) return null
 

--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -153,14 +153,14 @@ export const insertNamedLocation = async (
   const result = await query(
     user,
     `INSERT INTO named_locations (name, location, radius, auto_create_activity)
-     VALUES ($1, ST_MakePoint($2, $3)::geography, $4, COALESCE($5, false))
+     VALUES ($1, ST_MakePoint($2, $3)::geography, $4, $5)
      RETURNING ${NAMED_LOCATION_COLS}`,
     [
       location.name,
       location.lon,
       location.lat,
       location.radius ?? 200,
-      location.auto_create_activity ?? null,
+      location.auto_create_activity ?? false,
     ],
   )
   return mapNamedLocationRow(result.rows[0])

--- a/apps/backend/src/db/row-mappers.test.ts
+++ b/apps/backend/src/db/row-mappers.test.ts
@@ -184,6 +184,7 @@ describe('mapActivityRow', () => {
 describe('mapNamedLocationRow', () => {
   test('maps a database row to NamedLocation', () => {
     const row = {
+      auto_create_activity: false,
       created_at: '2024-01-15T10:00:00Z',
       id: 'loc-1',
       lat: 59.3293,
@@ -196,6 +197,7 @@ describe('mapNamedLocationRow', () => {
     const result = mapNamedLocationRow(row)
 
     expect(result).toEqual({
+      auto_create_activity: false,
       created_at: new Date('2024-01-15T10:00:00Z'),
       id: 'loc-1',
       lat: 59.3293,
@@ -204,6 +206,19 @@ describe('mapNamedLocationRow', () => {
       radius: 200,
       updated_at: new Date('2024-01-15T10:00:00Z'),
     })
+  })
+
+  test('defaults auto_create_activity to false when missing/null', () => {
+    const row = {
+      created_at: '2024-01-15T10:00:00Z',
+      id: 'loc-2',
+      lat: 0,
+      lon: 0,
+      name: 'X',
+      radius: 200,
+      updated_at: '2024-01-15T10:00:00Z',
+    }
+    expect(mapNamedLocationRow(row).auto_create_activity).toBe(false)
   })
 })
 

--- a/apps/backend/src/db/row-mappers.ts
+++ b/apps/backend/src/db/row-mappers.ts
@@ -106,6 +106,7 @@ export const mapActivityRow = (row: QueryResultRow): Activity => ({
 })
 
 export const mapNamedLocationRow = (row: QueryResultRow): NamedLocation => ({
+  auto_create_activity: row.auto_create_activity === true,
   created_at: new Date(row.created_at),
   id: row.id,
   lat: row.lat,

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -135,6 +135,7 @@ export interface NamedLocation {
   lat: number
   lon: number
   radius: number
+  auto_create_activity: boolean
   created_at: Date
   updated_at: Date
 }
@@ -144,6 +145,7 @@ export interface NamedLocationInput {
   lat: number
   lon: number
   radius?: number
+  auto_create_activity?: boolean
 }
 
 export type { GeocodeStatus }

--- a/apps/backend/src/routes/locations-router.ts
+++ b/apps/backend/src/routes/locations-router.ts
@@ -76,10 +76,16 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): TypedRout
     authMiddleware,
     validateBody(addNamedLocationBodySchema),
     async (req, res) => {
-      const { name, lat, lon, radius } = req.body
+      const { auto_create_activity, lat, lon, name, radius } = req.body
       const user = req.user!
 
-      const location = await insertNamedLocation(user, { lat, lon, name, radius })
+      const location = await insertNamedLocation(user, {
+        auto_create_activity,
+        lat,
+        lon,
+        name,
+        radius,
+      })
       res.json({ data: location, success: true })
     },
   )
@@ -90,7 +96,7 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): TypedRout
     validateBody(updateNamedLocationBodySchema),
     async (req, res) => {
       const { id } = req.params
-      const { name, lat, lon, radius } = req.body
+      const { auto_create_activity, lat, lon, name, radius } = req.body
       const user = req.user!
 
       // lat and lon must be updated together
@@ -98,7 +104,13 @@ export const createLocationsRouter = (authMiddleware: RequestHandler): TypedRout
         return res.status(400).json({ error: 'lat and lon must be updated together', success: false })
       }
 
-      const location = await updateNamedLocation(user, id, { lat, lon, name, radius })
+      const location = await updateNamedLocation(user, id, {
+        auto_create_activity,
+        lat,
+        lon,
+        name,
+        radius,
+      })
       if (!location) {
         return res.status(404).json({ error: 'Named location not found', success: false })
       }

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -350,12 +350,13 @@ export const createTableStatements: Record<string, string> = {
   // User-defined named locations (detected and named via Aurboda)
   named_locations: `
     CREATE TABLE IF NOT EXISTS named_locations (
-      id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      name            VARCHAR(255) NOT NULL,
-      location        GEOGRAPHY(POINT, 4326) NOT NULL,
-      radius          INTEGER NOT NULL DEFAULT 200,
-      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name                  VARCHAR(255) NOT NULL,
+      location              GEOGRAPHY(POINT, 4326) NOT NULL,
+      radius                INTEGER NOT NULL DEFAULT 200,
+      auto_create_activity  BOOLEAN NOT NULL DEFAULT false,
+      created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `,
   named_locations_indexes: `
@@ -684,6 +685,17 @@ export const createTableStatements: Record<string, string> = {
         {"fields":[
           {"name":"category_path","type":"string","required":true,"show_in_summary":true,"is_categorical":true},
           {"name":"score","type":"number","required":false,"show_in_summary":true,"unit":""}
+        ]}
+      $json$::jsonb)
+    ON CONFLICT (name) DO NOTHING;
+    -- location_visit type: time-span activity for a visit to an opted-in
+    -- named location. Rendered on the dedicated location track (show_on_timeline=false).
+    INSERT INTO activity_type_definitions (name, display_name, display_category, color, icon, is_builtin, show_on_timeline, data_schema) VALUES
+      ('location_visit', 'Location Visit', 'travel', '#0ea5e9', '📍', true, false, $json$
+        {"fields":[
+          {"name":"location_name","type":"string","required":true,"show_in_summary":true,"is_categorical":true},
+          {"name":"lat","type":"number","required":false},
+          {"name":"lon","type":"number","required":false}
         ]}
       $json$::jsonb)
     ON CONFLICT (name) DO NOTHING

--- a/apps/backend/src/services/location-visit-activities.test.ts
+++ b/apps/backend/src/services/location-visit-activities.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+
+import type { NamedLocation } from '../db/types.ts'
+import type { PlaceVisit } from './locations.ts'
+
+import { visitsToActivities } from './location-visit-activities.ts'
+
+const nl = (overrides: Partial<NamedLocation>): NamedLocation => ({
+  auto_create_activity: false,
+  created_at: new Date(),
+  id: 'nl-1',
+  lat: 59.33,
+  lon: 18.07,
+  name: 'Office',
+  radius: 200,
+  updated_at: new Date(),
+  ...overrides,
+})
+
+const visit = (overrides: Partial<PlaceVisit>): PlaceVisit => ({
+  duration_minutes: 60,
+  end_time: new Date('2026-04-19T11:00:00Z'),
+  lat: 59.33,
+  lon: 18.07,
+  name: 'Office',
+  source: 'named',
+  start_time: new Date('2026-04-19T10:00:00Z'),
+  ...overrides,
+})
+
+describe('visitsToActivities', () => {
+  test('creates activity for visit to opted-in named location', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: true })]
+    const visits = [visit({ named_location_id: 'office-id' })]
+    const activities = visitsToActivities(visits, named)
+    expect(activities).toHaveLength(1)
+    expect(activities[0]).toMatchObject({
+      activity_type: 'location_visit',
+      data: { location_name: 'Office', lat: 59.33, lon: 18.07 },
+      source: 'location-detection',
+    })
+  })
+
+  test('deterministic external_id based on location id and start time', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: true })]
+    const startTime = new Date('2026-04-19T10:00:00Z')
+    const visits = [visit({ named_location_id: 'office-id', start_time: startTime })]
+    const activities = visitsToActivities(visits, named)
+    expect(activities[0].external_id).toBe(`locvisit_office-id_${startTime.getTime()}`)
+  })
+
+  test('skips visits to non-opted-in locations', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: false })]
+    const visits = [visit({ named_location_id: 'office-id' })]
+    expect(visitsToActivities(visits, named)).toEqual([])
+  })
+
+  test('skips visits whose named_location_id is not in the opted-in set', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: true })]
+    // Visit to a different named location that isn't opted in
+    const visits = [visit({ named_location_id: 'home-id', name: 'Home' })]
+    expect(visitsToActivities(visits, named)).toEqual([])
+  })
+
+  test('skips visits shorter than 10 minutes', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: true })]
+    const visits = [visit({ named_location_id: 'office-id', duration_minutes: 5 })]
+    expect(visitsToActivities(visits, named)).toEqual([])
+  })
+
+  test('skips detected / owntracks / unknown visits even if "near" an opted-in location', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: true })]
+    const visits = [
+      visit({ source: 'detected', named_location_id: undefined }),
+      visit({ source: 'owntracks', named_location_id: undefined }),
+      visit({ source: 'unknown', named_location_id: undefined }),
+    ]
+    expect(visitsToActivities(visits, named)).toEqual([])
+  })
+
+  test('returns empty when no named locations are opted in', () => {
+    const named = [nl({ auto_create_activity: false })]
+    const visits = [visit({ named_location_id: 'nl-1' })]
+    expect(visitsToActivities(visits, named)).toEqual([])
+  })
+})

--- a/apps/backend/src/services/location-visit-activities.test.ts
+++ b/apps/backend/src/services/location-visit-activities.test.ts
@@ -68,6 +68,12 @@ describe('visitsToActivities', () => {
     expect(visitsToActivities(visits, named)).toEqual([])
   })
 
+  test('includes visits of exactly 10 minutes (boundary)', () => {
+    const named = [nl({ id: 'office-id', auto_create_activity: true })]
+    const visits = [visit({ named_location_id: 'office-id', duration_minutes: 10 })]
+    expect(visitsToActivities(visits, named)).toHaveLength(1)
+  })
+
   test('skips detected / owntracks / unknown visits even if "near" an opted-in location', () => {
     const named = [nl({ id: 'office-id', auto_create_activity: true })]
     const visits = [

--- a/apps/backend/src/services/location-visit-activities.ts
+++ b/apps/backend/src/services/location-visit-activities.ts
@@ -1,0 +1,51 @@
+/**
+ * Convert place visits to `location_visit` activities, for named locations
+ * the user has opted into with `auto_create_activity=true`.
+ *
+ * Place visits are computed on-demand from raw GPS data via getPlaceVisits;
+ * they are not persisted. This module turns the ephemeral visits into
+ * first-class activities so they show up in charts, daily summaries, and
+ * deduction-rule queries that read from the unified activities table.
+ *
+ * Idempotent: external_id is `locvisit_${named_location_id}_${startEpochMs}`,
+ * so re-running for the same range upserts cleanly via the
+ * (source, external_id) unique index.
+ */
+
+import type { Activity, NamedLocation } from '../db/types.ts'
+import type { PlaceVisit } from './locations.ts'
+
+/** Minimum visit duration before we materialize an activity. */
+const MIN_VISIT_MINUTES = 10
+
+export const visitsToActivities = (
+  visits: PlaceVisit[],
+  namedLocations: NamedLocation[],
+): Activity[] => {
+  const optedInById = new Map<string, NamedLocation>()
+  for (const nl of namedLocations) {
+    if (nl.auto_create_activity) optedInById.set(nl.id, nl)
+  }
+  if (optedInById.size === 0) return []
+
+  const activities: Activity[] = []
+  for (const visit of visits) {
+    if (visit.source !== 'named' || !visit.named_location_id) continue
+    const named = optedInById.get(visit.named_location_id)
+    if (!named) continue
+    if (visit.duration_minutes < MIN_VISIT_MINUTES) continue
+    activities.push({
+      activity_type: 'location_visit',
+      data: {
+        lat: visit.lat,
+        location_name: visit.name,
+        lon: visit.lon,
+      },
+      end_time: visit.end_time,
+      external_id: `locvisit_${visit.named_location_id}_${visit.start_time.getTime()}`,
+      source: 'location-detection',
+      start_time: visit.start_time,
+    })
+  }
+  return activities
+}

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -466,7 +466,10 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
       }
     }
 
-    // Check if this is a continuation of the same visit
+    // Check if this is a continuation of the same visit.
+    // named_location_id is part of the key so two named locations with the
+    // same name (e.g. different "Home" entries) correctly split into
+    // separate visits rather than being merged by display name alone.
     const samePlace =
       currentVisit &&
       currentVisit.named_location_id === namedLocationId &&

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -324,6 +324,8 @@ export interface PlaceVisit {
   source: 'named' | 'detected' | 'owntracks' | 'unknown'
   address?: string
   detected_location_id?: string
+  /** Set when source='named' — the id of the matched named_location. */
+  named_location_id?: string
 }
 
 /**
@@ -430,6 +432,7 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
     source: 'named' | 'detected' | 'owntracks' | 'unknown'
     address?: string
     detected_location_id?: string
+    named_location_id?: string
   } | null = null
 
   for (const loc of locations) {
@@ -440,10 +443,12 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
     let source: 'named' | 'detected' | 'owntracks' | 'unknown'
     let address: string | undefined
     let detectedLocationId: string | undefined
+    let namedLocationId: string | undefined
 
     if (namedMatch) {
       placeName = namedMatch.name
       source = 'named'
+      namedLocationId = namedMatch.id
     } else {
       // Try to match against detected locations
       const detectedMatch = matchLocationToDetected(loc.lat, loc.lon, detectedLocations)
@@ -464,6 +469,7 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
     // Check if this is a continuation of the same visit
     const samePlace =
       currentVisit &&
+      currentVisit.named_location_id === namedLocationId &&
       currentVisit.name === placeName &&
       currentVisit.detected_location_id === detectedLocationId
 
@@ -488,6 +494,7 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
         lat: loc.lat,
         lon: loc.lon,
         name: placeName,
+        named_location_id: namedLocationId,
         source,
         start_time: loc.time,
       }

--- a/apps/backend/src/services/queries/locations.ts
+++ b/apps/backend/src/services/queries/locations.ts
@@ -19,17 +19,26 @@ export async function queryLocations(user: string, start: Date, end: Date): Prom
   const visits = await getPlaceVisits(user, start, end)
 
   // Fire-and-forget: upsert activities for opted-in named-location visits.
-  void (async () => {
-    try {
-      const namedLocations = await getNamedLocations(user)
-      const activities = visitsToActivities(visits, namedLocations)
-      if (activities.length > 0) await insertActivities(user, activities)
-    } catch (err) {
-      // Don't let activity materialization failures surface to the user —
-      // the /locations endpoint still returned valid data.
-      console.error('location_visit activity materialization failed:', err)
-    }
-  })()
+  // Skip the whole thing if the user has no visits matched to a named
+  // location — avoids the getNamedLocations round-trip on the common case
+  // where a query lands on GPS data that didn't resolve to anything named.
+  const hasNamedVisit = visits.some((v) => v.source === 'named')
+  if (hasNamedVisit) {
+    void (async () => {
+      try {
+        const namedLocations = await getNamedLocations(user)
+        const optedIn = namedLocations.filter((nl) => nl.auto_create_activity)
+        if (optedIn.length === 0) return
+        const activities = visitsToActivities(visits, optedIn)
+        if (activities.length === 0) return
+        await insertActivities(user, activities)
+      } catch (err) {
+        // Don't let activity materialization failures surface to the user —
+        // the /locations endpoint still returned valid data.
+        console.error('location_visit activity materialization failed:', err)
+      }
+    })()
+  }
 
   return visits.map((p) => ({
     address: p.address,

--- a/apps/backend/src/services/queries/locations.ts
+++ b/apps/backend/src/services/queries/locations.ts
@@ -4,13 +4,33 @@
 
 import type { PlaceSummary } from './types.ts'
 
+import { getNamedLocations, insertActivities } from '../../db/index.ts'
+import { visitsToActivities } from '../location-visit-activities.ts'
 import { getPlaceVisits } from '../locations.ts'
 
 /**
  * Query locations/places for a time range.
+ *
+ * Side effect: visits to named locations with auto_create_activity=true are
+ * fire-and-forget materialized as location_visit activities. Idempotent via
+ * (source, external_id) upsert, so repeat calls are safe.
  */
 export async function queryLocations(user: string, start: Date, end: Date): Promise<PlaceSummary[]> {
   const visits = await getPlaceVisits(user, start, end)
+
+  // Fire-and-forget: upsert activities for opted-in named-location visits.
+  void (async () => {
+    try {
+      const namedLocations = await getNamedLocations(user)
+      const activities = visitsToActivities(visits, namedLocations)
+      if (activities.length > 0) await insertActivities(user, activities)
+    } catch (err) {
+      // Don't let activity materialization failures surface to the user —
+      // the /locations endpoint still returned valid data.
+      console.error('location_visit activity materialization failed:', err)
+    }
+  })()
+
   return visits.map((p) => ({
     address: p.address,
     detected_location_id: p.detected_location_id,

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -31,7 +31,7 @@ export const EXCLUDED_ACTIVITY_SOURCES = new Set(['lastfm'])
  * Activity types that are rendered on dedicated timeline tracks and should
  * not appear in the main Activity lane.
  */
-export const EXCLUDED_ACTIVITY_TYPES = new Set(['screentime'])
+export const EXCLUDED_ACTIVITY_TYPES = new Set(['screentime', 'location_visit'])
 
 /** Activity types that start with these prefixes are excluded from duration merging. */
 export const EXCLUDED_ACTIVITY_PREFIXES = ['computer:']

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -183,6 +183,7 @@ export const dataSourceSchema = z
     'manual',
     'lastfm',
     'lastfm-auto',
+    'location-detection',
   ])
   .meta({
     description: 'Source of the data',

--- a/packages/api-spec/src/schemas/locations.ts
+++ b/packages/api-spec/src/schemas/locations.ts
@@ -30,6 +30,9 @@ const locationNameSchema = z.string().meta({ description: 'Location name', examp
  */
 export const namedLocationSchema = z
   .object({
+    auto_create_activity: z.boolean().optional().meta({
+      description: 'If true, visits here create a location_visit activity',
+    }),
     id: z.string().uuid().meta({ description: 'Location ID' }),
     lat: latSchema,
     lon: lonSchema,
@@ -156,6 +159,9 @@ export type DetectedLocationsQuery = z.infer<typeof detectedLocationsQuerySchema
  */
 export const addNamedLocationBodySchema = z
   .object({
+    auto_create_activity: z.boolean().optional().meta({
+      description: 'If true, visits create a location_visit activity (defaults to false)',
+    }),
     lat: latWithValidationSchema,
     lon: lonWithValidationSchema,
     name: z.string().min(1).meta({ description: 'Location name', example: 'Office' }),
@@ -181,6 +187,9 @@ export type AddNamedLocationResponse = z.infer<typeof addNamedLocationResponseSc
  */
 export const updateNamedLocationBodySchema = z
   .object({
+    auto_create_activity: z.boolean().optional().meta({
+      description: 'Toggle auto-creation of location_visit activities on visits here',
+    }),
     lat: latWithValidationSchema.optional().meta({ description: 'New latitude' }),
     lon: lonWithValidationSchema.optional().meta({ description: 'New longitude' }),
     name: z.string().min(1).optional().meta({ description: 'New location name' }),


### PR DESCRIPTION
## Summary

Phase 4 of the unified-activities initiative. Named locations gain an `auto_create_activity` flag; when enabled, visits to that location materialize as `location_visit` activities alongside the ephemeral place-visit list that `getPlaceVisits` already computes on demand. A visit must be ≥10 minutes to qualify (filters GPS jitter / brief passes).

Not auto-merging — waiting for review.

## Design decisions

**Opt-in per named location**, not per user and not globally. A user typically cares about "time at Office" but not "5 minutes at the coffee shop I wandered past." The flag lives on the named_location row.

**Materialize at query time, fire-and-forget**. Place visits are computed fresh from GPS every time `getPlaceVisits` runs — there's no persistent "visit" table. I hooked into `queryLocations` (the `/locations` endpoint) to fire an async upsert after the query returns. Failures are logged but never surface to the user; the endpoint still returns its authoritative visit list. No new worker / cron was introduced.

**Named-only for v1**. Detected (unnamed) visits don't produce activities yet; a user would have to promote them to a named location first. Keeps the opt-in model consistent.

**Deterministic external_id** = `locvisit_{named_location_id}_{startEpochMs}`. Re-syncs and repeated queries upsert cleanly via the `(source, external_id)` index.

## Changes

- `auto_create_activity BOOLEAN NOT NULL DEFAULT false` column on `named_locations`. Idempotent ALTER for existing deployed DBs.
- `location_visit` built-in activity type, `show_on_timeline=false`, icon 📍, color #0ea5e9, data schema for `location_name` / `lat` / `lon`.
- `'location-detection'` added to the DataSource enum.
- `PlaceVisit` gains `named_location_id` (set when `source='named'`) so visits tie back to the specific opted-in named_location.
- `visitsToActivities(visits, namedLocations)` — produces Activity records for opted-in named locations, filtered by MIN_VISIT_MINUTES=10.
- `queryLocations` (`/locations` endpoint) — fire-and-forget `insertActivities` after fetching visits.
- `named_locations` schema updated in `@aurboda/api-spec`: `auto_create_activity?: boolean` on the response schema and both add/update bodies. Router wired through.
- Frontend: `location_visit` added to `EXCLUDED_ACTIVITY_TYPES` so visits don't pollute the main Activity lane — they continue to render on the dedicated Location track (unchanged).

## Tests

- 7 new unit tests in `location-visit-activities.test.ts` covering:
  - Creates activity for a visit to an opted-in named location
  - Deterministic `external_id`
  - Skips visits to non-opted-in locations
  - Skips visits whose `named_location_id` isn't in the opted-in set
  - Skips visits <10 minutes
  - Skips detected / owntracks / unknown visits (source isn't 'named')
  - Returns empty when no named locations are opted in

## Not in this PR (deferred)

1. **Daily summary hook** — currently only `/locations` triggers materialization. Could add a hook in `getDailySummary` but it would need a new `getNamedLocations` fetch, and daily summary is already a busy query. Easy follow-up.
2. **Deduction-rule location condition** — continues to query place visits directly (not activities). The `location_visit` activity type is additive; rules keep working. Can migrate later.
3. **Detected-location visits** — not materialized in v1. Users promote detected → named first, then opt in.
4. **Backfill** — historical visits don't produce activities retroactively. Since `queryLocations` re-runs and upserts, browsing any past date range with the flag enabled will materialize activities for that range.
5. **UI toggle** — the flag is currently API-only. Frontend toggle on the named-location management page is a follow-up.

## Test plan

- [ ] CI green (unit, integration, check, lint, build)
- [ ] After deploy: opt a named location into `auto_create_activity=true`, then call `/locations?start=…&end=…` for a time range containing a visit. A moment later, `query_activities types=['location_visit']` should return that visit as an activity.
- [ ] Idempotent: repeat the /locations call — no duplicate activities, the upsert lands on the same (source, external_id).
- [ ] Timeline: main Activity lane doesn't show `location_visit` bars (the Location track continues to render them).
- [ ] Existing location queries and deduction rules with `location` condition still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)