### PR TITLE
feat: collapse sibling subtypes to parent_type when zoomed out

### DIFF
--- a/apps/web/src/pages/Timeline/activityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.test.ts
@@ -5,10 +5,12 @@ import type { ChartItem } from './types'
 
 import {
   buildActivityColumnItems,
+  collapseToParentType,
   EXCLUDED_ACTIVITY_PREFIXES,
   EXCLUDED_ACTIVITY_SOURCES,
   isDurationActivityLike,
   overlapMinutes,
+  resolveCollapseTarget,
   tryMergeActivityIntoItem,
 } from './activityMerge'
 
@@ -259,5 +261,109 @@ describe('buildActivityColumnItems', () => {
     )
     expect(items).toHaveLength(0)
     expect(overlaps).toHaveLength(0)
+  })
+})
+
+// -- resolveCollapseTarget ----------------------------------------------------
+
+describe('resolveCollapseTarget', () => {
+  const typeDefs = new Map([
+    ['running', { parent_type: 'exercise' }],
+    ['exercise', {}],
+    ['meditation', {}],
+  ])
+
+  it('returns immediate parent for hierarchical type', () => {
+    expect(resolveCollapseTarget('running', typeDefs)).toBe('exercise')
+  })
+
+  it('returns null for top-level type with no parent', () => {
+    expect(resolveCollapseTarget('exercise', typeDefs)).toBeNull()
+    expect(resolveCollapseTarget('meditation', typeDefs)).toBeNull()
+  })
+
+  it('returns null for unknown type', () => {
+    expect(resolveCollapseTarget('nonexistent', typeDefs)).toBeNull()
+  })
+})
+
+// -- collapseToParentType -----------------------------------------------------
+
+describe('collapseToParentType', () => {
+  const typeDefs = new Map([
+    ['running', { parent_type: 'exercise' }],
+    ['strength_training', { parent_type: 'exercise' }],
+    ['yoga', { parent_type: 'exercise' }],
+    ['exercise', {}],
+    ['meditation', {}],
+  ])
+
+  const d = (h: number, m = 0) =>
+    new Date(Date.UTC(2026, 0, 1, h, m, 0))
+
+  it('collapses adjacent exercise subtypes into one exercise bar', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'strength_training', end_time: d(11, 15), id: 'b', start_time: d(10, 35) },
+      { activity_type: 'yoga', end_time: d(11, 40), id: 'c', start_time: d(11, 20) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed).toHaveLength(1)
+    expect(collapsed[0].activity_type).toBe('exercise')
+    expect(collapsed[0].start_time).toEqual(d(10))
+    expect(collapsed[0].end_time).toEqual(d(11, 40))
+  })
+
+  it('does not merge across long gaps', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      // 2-hour gap — exceeds default 30-minute merge gap
+      { activity_type: 'yoga', end_time: d(13, 30), id: 'b', start_time: d(13) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed).toHaveLength(2)
+    expect(collapsed.every((a) => a.activity_type === 'exercise')).toBe(true)
+  })
+
+  it('leaves activities without parent_type unchanged', () => {
+    const activities: Activity[] = [
+      { activity_type: 'meditation', end_time: d(9, 30), id: 'a', start_time: d(9) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed).toEqual(activities)
+  })
+
+  it('does not merge siblings with different parents', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'meditation', end_time: d(11), id: 'b', start_time: d(10, 35) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed).toHaveLength(2)
+    expect(collapsed.map((a) => a.activity_type)).toEqual(['exercise', 'meditation'])
+  })
+
+  it('does not mutate input array', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+    ]
+    const original = [...activities]
+    collapseToParentType(activities, typeDefs)
+    expect(activities).toEqual(original)
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(collapseToParentType([], typeDefs)).toEqual([])
+  })
+
+  it('respects a custom merge gap', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'yoga', end_time: d(11, 30), id: 'b', start_time: d(11) },
+    ]
+    // Default 30-min gap: these are 30 min apart, should merge.
+    expect(collapseToParentType(activities, typeDefs)).toHaveLength(1)
+    // 10-min gap: should not merge.
+    expect(collapseToParentType(activities, typeDefs, 10 * 60 * 1000)).toHaveLength(2)
   })
 })

--- a/apps/web/src/pages/Timeline/activityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.test.ts
@@ -285,6 +285,13 @@ describe('resolveCollapseTarget', () => {
   it('returns null for unknown type', () => {
     expect(resolveCollapseTarget('nonexistent', typeDefs)).toBeNull()
   })
+
+  it('returns null when parent_type references a missing type', () => {
+    // Orphaned parent — guards against stale data retyping activities to
+    // a name that downstream rendering can't resolve.
+    const orphaned = new Map([['some_type', { parent_type: 'deleted_parent' }]])
+    expect(resolveCollapseTarget('some_type', orphaned)).toBeNull()
+  })
 })
 
 // -- collapseToParentType -----------------------------------------------------

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -260,6 +260,76 @@ const getActivityIconKey = (a: Activity, getExerciseTypeName: (a: Activity) => s
   return `activity:${a.activity_type}`
 }
 
+// ============================================================================
+// Hierarchy collapse: merge sibling subtypes into parent when zoomed out.
+// ============================================================================
+
+/** Default gap below which two adjacent same-parent activities merge. */
+export const COLLAPSE_MERGE_GAP_MS = 30 * 60 * 1000 // 30 minutes
+
+/**
+ * Walk the parent_type chain of a type and return the "collapse target" —
+ * the ancestor we fold child activities into. For v1 this is the immediate
+ * parent (one hop). Returns null if the type has no parent.
+ */
+export const resolveCollapseTarget = (
+  typeName: string,
+  typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
+): string | null => {
+  const def = typeDefsByName.get(typeName)
+  return def?.parent_type ?? null
+}
+
+/**
+ * Collapse adjacent activities that share a common parent_type into a single
+ * activity retyped as that parent. Non-hierarchical activities (no parent)
+ * pass through unchanged.
+ *
+ * The collapse happens in two steps:
+ *   1. Re-type each activity to its parent_type (if one exists).
+ *   2. Merge adjacent activities of the same effective type whose start-to-
+ *      previous-end gap is within mergeGapMs.
+ *
+ * Pure function — does not mutate the input array. The returned activities
+ * keep the first member's id and title; end_time is the max across merged
+ * siblings.
+ */
+export const collapseToParentType = (
+  activities: Activity[],
+  typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
+  mergeGapMs: number = COLLAPSE_MERGE_GAP_MS,
+): Activity[] => {
+  if (activities.length === 0) return activities
+
+  // Step 1: decide each activity's "collapsed" type.
+  const retyped = activities.map((a) => {
+    const parent = resolveCollapseTarget(a.activity_type, typeDefsByName)
+    if (!parent) return a
+    return { ...a, activity_type: parent }
+  })
+
+  // Step 2: merge adjacents with the same collapsed type.
+  const sorted = [...retyped].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+  const merged: Activity[] = []
+  for (const current of sorted) {
+    const prev = merged[merged.length - 1]
+    if (
+      prev &&
+      prev.activity_type === current.activity_type &&
+      prev.end_time &&
+      current.end_time &&
+      current.start_time.getTime() - prev.end_time.getTime() <= mergeGapMs
+    ) {
+      // Extend prev's end if current reaches further. The first member's id
+      // and title win; downstream rendering treats this as a single bar.
+      if (current.end_time > prev.end_time) prev.end_time = current.end_time
+      continue
+    }
+    merged.push({ ...current })
+  }
+  return merged
+}
+
 export const buildActivityColumnItems = (
   activities: Activity[],
   secondaryActivities: Activity[],

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -268,16 +268,20 @@ const getActivityIconKey = (a: Activity, getExerciseTypeName: (a: Activity) => s
 export const COLLAPSE_MERGE_GAP_MS = 30 * 60 * 1000 // 30 minutes
 
 /**
- * Walk the parent_type chain of a type and return the "collapse target" —
- * the ancestor we fold child activities into. For v1 this is the immediate
- * parent (one hop). Returns null if the type has no parent.
+ * Look up the immediate parent_type of a type — the "collapse target" we
+ * fold child activities into. Returns null when the type has no parent,
+ * or when the referenced parent isn't itself a known type definition
+ * (stale/orphaned parent_type values shouldn't retype activities to
+ * something downstream rendering can't resolve).
  */
 export const resolveCollapseTarget = (
   typeName: string,
   typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
 ): string | null => {
   const def = typeDefsByName.get(typeName)
-  return def?.parent_type ?? null
+  const parent = def?.parent_type
+  if (!parent || !typeDefsByName.has(parent)) return null
+  return parent
 }
 
 /**

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -25,6 +25,7 @@ import { parseBucketedResponse } from '../../utils/chart'
 import { packLanes } from '../../utils/lanePacking'
 import {
   buildActivityColumnItems,
+  collapseToParentType,
   EXCLUDED_ACTIVITY_PREFIXES,
   EXCLUDED_ACTIVITY_SOURCES,
   EXCLUDED_ACTIVITY_TYPES,
@@ -197,10 +198,26 @@ export const useTimelineData = ({
   const typeDefsMap = useMemo(
     () =>
       new Map(
-        activityTypeDefs.map((t) => [t.name, { color: t.color, display_name: t.display_name, icon: t.icon }]),
+        activityTypeDefs.map((t) => [
+          t.name,
+          { color: t.color, display_name: t.display_name, icon: t.icon, parent_type: t.parent_type },
+        ]),
       ),
     [activityTypeDefs],
   )
+
+  /**
+   * Hierarchy collapse threshold: when the fetched range spans more than 3
+   * days the timeline is zoomed out enough that child-subtype detail is
+   * noise — adjacent siblings of the same parent_type collapse into a
+   * single bar labelled as the parent (e.g. running+strength_training →
+   * exercise for a gym session view).
+   */
+  const shouldCollapseHierarchy = useMemo(() => {
+    const COLLAPSE_THRESHOLD_DAYS = 3
+    const spanDays = (fetchEnd.getTime() - fetchStart.getTime()) / (24 * 60 * 60 * 1000)
+    return spanDays > COLLAPSE_THRESHOLD_DAYS
+  }, [fetchStart, fetchEnd])
   const hiddenTypes = useMemo(
     () => new Set(activityTypeDefs.filter((t) => !t.show_on_timeline).map((t) => t.name)),
     [activityTypeDefs],
@@ -214,11 +231,12 @@ export const useTimelineData = ({
     () => (activitiesQuery.data ?? []).filter((a) => !hiddenTypes.has(a.activity_type ?? '')),
     [activitiesQuery.data, hiddenTypes],
   )
-  const activities = useMemo(
-    () =>
-      allActivities.filter((a) => ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other')),
-    [allActivities, categoryByType],
-  )
+  const activities = useMemo(() => {
+    const filtered = allActivities.filter((a) =>
+      ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other'),
+    )
+    return shouldCollapseHierarchy ? collapseToParentType(filtered, typeDefsMap) : filtered
+  }, [allActivities, categoryByType, shouldCollapseHierarchy, typeDefsMap])
   const secondaryActivities = useMemo(
     () =>
       allActivities.filter((a) => !ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other')),

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -112,6 +112,8 @@ export interface ActivityTypeDefinition {
   is_builtin: boolean
   show_on_timeline: boolean
   data_schema?: DataSchemaDefinition
+  /** Snake-case name of the parent activity type, if this type is a child. */
+  parent_type?: string
 }
 
 export interface DataFilter {


### PR DESCRIPTION
## Summary

Phase 5 — the last of the originally-planned phases. Adjacent activities whose types share a `parent_type` collapse into a single bar rendered as the parent when the timeline shows a wide enough range. The canonical example from the initial design: a gym session with `running` → `strength_training` → `stretching` renders as three distinct bars when zoomed into that day, but merges into one "Exercise" bar when zoomed out to a week-at-a-glance view.

Not auto-merging — waiting for review.

## Design decisions

**Span-based gate, not pixel-based**. The backend's recently-merged `parent_type` field lets us do this collapse purely from data + type metadata. I considered plumbing `pixelsPerHour` through the memoized render pipeline but it lives inside the D3 `draw` closure, and that closure runs on every pan frame — memoizing against it would either recompute too often or force architectural churn to expose a quantized zoom state. Instead, the gate uses `(fetchEnd - fetchStart) > 3 days` — the query range a zoomed-out view naturally widens. Trades continuous responsiveness for simplicity; easy to swap for a real zoom metric later.

**Immediate parent only**. A `yoga` activity with `parent_type='exercise'` collapses to `exercise`. If `exercise` itself has a parent, we don't walk further — v1 keeps it to one hop. Deeper collapse can come later either by iterating the function or by exposing a depth parameter.

**Merge across adjacency, not just overlap**. Activities of the same effective type within a 30-minute gap merge. 30 minutes reflects the "gym session" intuition — a break between treadmill and weights doesn't break the session.

## Changes

- `parent_type?: string` added to frontend `ActivityTypeDefinition` interface in `state/api.ts`. Backend has had this since #645; the frontend hadn't picked it up.
- `typeDefsMap` in `useTimelineData.ts` now carries `parent_type`.
- New pure function `collapseToParentType(activities, typeDefsByName, mergeGapMs)` in `activityMerge.ts`, plus the helper `resolveCollapseTarget`.
- Gated call site in `useTimelineData`'s `activities` useMemo: when `shouldCollapseHierarchy` is true, run activities through the collapse before they flow into `buildActivityColumnItems`.
- 10 new unit tests (file total: 31) covering:
  - resolveCollapseTarget for hierarchical, top-level, and unknown types
  - Sibling collapse into parent
  - Long-gap splitting (2h > 30min gap)
  - Non-hierarchical passthrough (meditation has no parent)
  - Mixed parents don't merge
  - Empty input
  - Input immutability
  - Custom merge gap parameter

## Not in this PR

- **Depth control / full-ancestor collapse**. v1 collapses one level. Users zooming extra far out could benefit from multi-level collapse.
- **Per-type zoom thresholds**. A single 3-day threshold applies to all hierarchies. Could refine per-type later.
- **Visual distinction for merged bars**. Merged bars don't currently indicate "this is actually N subtypes". Tooltip enrichment is an easy follow-up.
- **True pixel-zoom gating**. Range-based gate works well for the common zoom-then-view pattern; pixel-based would let the collapse react to continuous zoom gestures.

## Test plan

- [ ] CI green
- [ ] Manual: with a day-view (span ≤ 3 days) zoom level, gym session shows running + strength + stretching as separate bars.
- [ ] Manual: switch to a week view (span > 3 days); the same gym session collapses into one Exercise bar.
- [ ] Manual: sleep vs nap should still collapse — both nap and rest have `parent_type='sleep'` after Phase 1's seeding.
- [ ] Unrelated activity types (e.g. meditation next to exercise) don't merge across parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)