### PR TITLE
feat: sync Garmin naps

### DIFF
--- a/apps/backend/src/db/activity-type-definitions.ts
+++ b/apps/backend/src/db/activity-type-definitions.ts
@@ -80,11 +80,7 @@ const validateParentTypeUpdate = async (
  * a cycle. Walks candidateParent's ancestor chain via recursive CTE; if
  * typeName appears in that chain, the edge would close a loop.
  */
-async function wouldCreateCycle(
-  user: string,
-  typeName: string,
-  candidateParent: string,
-): Promise<boolean> {
+async function wouldCreateCycle(user: string, typeName: string, candidateParent: string): Promise<boolean> {
   const result = await query<{ name: string }>(
     user,
     `WITH RECURSIVE ancestors AS (

--- a/apps/backend/src/db/locations.ts
+++ b/apps/backend/src/db/locations.ts
@@ -167,20 +167,12 @@ export const insertNamedLocation = async (
 }
 
 export const getNamedLocations = async (user: string): Promise<NamedLocation[]> => {
-  const result = await query(
-    user,
-    `SELECT ${NAMED_LOCATION_COLS} FROM named_locations ORDER BY name`,
-    [],
-  )
+  const result = await query(user, `SELECT ${NAMED_LOCATION_COLS} FROM named_locations ORDER BY name`, [])
   return result.rows.map(mapNamedLocationRow)
 }
 
 export const getNamedLocationById = async (user: string, id: string): Promise<NamedLocation | null> => {
-  const result = await query(
-    user,
-    `SELECT ${NAMED_LOCATION_COLS} FROM named_locations WHERE id = $1`,
-    [id],
-  )
+  const result = await query(user, `SELECT ${NAMED_LOCATION_COLS} FROM named_locations WHERE id = $1`, [id])
   if (result.rows.length === 0) return null
   return mapNamedLocationRow(result.rows[0])
 }

--- a/apps/backend/src/integrations/activitywatch/sync.ts
+++ b/apps/backend/src/integrations/activitywatch/sync.ts
@@ -16,10 +16,7 @@ import {
   insertProductivity,
   upsertSyncState,
 } from '../../db/index.ts'
-import {
-  buildScreentimeActivitySpans,
-  spansToActivities,
-} from '../../services/screentime-activities.ts'
+import { buildScreentimeActivitySpans, spansToActivities } from '../../services/screentime-activities.ts'
 import { categorizeRecords, compileRules } from '../../services/screentime-categories.ts'
 
 /**

--- a/apps/backend/src/integrations/garmin/client.test.ts
+++ b/apps/backend/src/integrations/garmin/client.test.ts
@@ -235,15 +235,17 @@ describe('garminClient', () => {
   })
 
   describe('getSleep', () => {
-    it('restores session, calls getSleepData, and saves session', async () => {
-      const sleepData = { dailySleepDTO: { calendarDate: '2024-06-15' } }
-      mockGarminConnect.getSleepData.mockResolvedValueOnce(sleepData)
+    it('fetches dailySleepData with nonSleepBufferMinutes so naps are included', async () => {
+      const sleepData = { dailyNapDTOS: [], dailySleepDTO: { calendarDate: '2024-06-15' } }
+      mockGarminConnect.get.mockResolvedValueOnce(sleepData)
 
       const client = garminClient(deps)
       const date = new Date('2024-06-15')
       const result = await client.getSleep(testUser, date)
 
-      expect(mockGarminConnect.getSleepData).toHaveBeenCalledWith(date)
+      expect(mockGarminConnect.get).toHaveBeenCalledWith(
+        'https://connectapi.garmin.com/sleep-service/sleep/dailySleepData?date=2024-06-15&nonSleepBufferMinutes=60',
+      )
       expect(result).toEqual(sleepData)
       expect(deps.upsertOAuthToken).toHaveBeenCalled()
     })

--- a/apps/backend/src/integrations/garmin/client.ts
+++ b/apps/backend/src/integrations/garmin/client.ts
@@ -311,7 +311,13 @@ export const garminClient = (deps: GarminClientDeps = defaultDeps) => {
 
     async getSleep(user: string, date: Date): Promise<unknown> {
       const gc = await restoreSession(user)
-      const result = await gc.getSleepData(date)
+      // Call the endpoint directly (instead of gc.getSleepData) so we can pass
+      // nonSleepBufferMinutes=60, which ensures daytime naps are included in
+      // dailyNapDTOS, and so network/HTTP errors surface with their actual
+      // message instead of being wrapped as "Invalid or empty sleep data".
+      const result = await gc.get<unknown>(
+        `${GC_API}/sleep-service/sleep/dailySleepData?date=${fmt(date)}&nonSleepBufferMinutes=60`,
+      )
       await saveSession(user, gc)
       return result
     },

--- a/apps/backend/src/integrations/garmin/process.test.ts
+++ b/apps/backend/src/integrations/garmin/process.test.ts
@@ -428,6 +428,91 @@ describe('processGarminData', () => {
     test('returns 1 on success', async () => {
       expect(await processGarminData(user, 'sleep', makeSleepData(), mockDeps)).toBe(1)
     })
+
+    test('creates a nap activity for each entry in dailyNapDTOS', async () => {
+      const data = makeSleepData({
+        dailyNapDTOS: [
+          {
+            calendarDate: '2025-01-15',
+            napEndTimestampGMT: '2025-01-15T12:39:46',
+            napFeedback: 'IDEAL_DURATION_LOW_NEED',
+            napSource: 0,
+            napStartTimestampGMT: '2025-01-15T12:17:46',
+            napTimeSec: 1320,
+          },
+        ],
+      })
+
+      await processGarminData(user, 'sleep', data, mockDeps)
+
+      expect(mockDeps.insertActivity).toHaveBeenCalledWith(user, {
+        activity_type: 'nap',
+        data: { nap_feedback: 'IDEAL_DURATION_LOW_NEED', nap_time_seconds: 1320 },
+        end_time: new Date('2025-01-15T12:39:46Z'),
+        external_id: 'garmin-nap-2025-01-15T12:17:46',
+        source: 'garmin',
+        start_time: new Date('2025-01-15T12:17:46Z'),
+        title: 'Nap',
+      })
+    })
+
+    test('inserts both the sleep activity and multiple naps', async () => {
+      const data = makeSleepData({
+        dailyNapDTOS: [
+          {
+            calendarDate: '2025-01-15',
+            napEndTimestampGMT: '2025-01-15T13:00:00',
+            napStartTimestampGMT: '2025-01-15T12:30:00',
+            napTimeSec: 1800,
+          },
+          {
+            calendarDate: '2025-01-15',
+            napEndTimestampGMT: '2025-01-15T16:30:00',
+            napStartTimestampGMT: '2025-01-15T16:00:00',
+            napTimeSec: 1800,
+          },
+        ],
+      })
+
+      await processGarminData(user, 'sleep', data, mockDeps)
+
+      // 1 sleep + 2 naps
+      expect(mockDeps.insertActivity).toHaveBeenCalledTimes(3)
+      const activityTypes = vi
+        .mocked(mockDeps.insertActivity)
+        .mock.calls.map((call) => (call[1] as { activity_type: string }).activity_type)
+      expect(activityTypes).toEqual(['sleep', 'nap', 'nap'])
+    })
+
+    test('skips nap entries with missing timestamps', async () => {
+      const data = makeSleepData({
+        dailyNapDTOS: [
+          {
+            calendarDate: '2025-01-15',
+            napEndTimestampGMT: null as unknown as string,
+            napStartTimestampGMT: null as unknown as string,
+            napTimeSec: 0,
+          },
+        ],
+      })
+
+      await processGarminData(user, 'sleep', data, mockDeps)
+
+      // Only the main sleep activity should be inserted.
+      expect(mockDeps.insertActivity).toHaveBeenCalledTimes(1)
+      const activity = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activity.activity_type).toBe('sleep')
+    })
+
+    test('handles null/missing dailyNapDTOS without error', async () => {
+      const withNullNaps = makeSleepData({ dailyNapDTOS: null })
+      await expect(processGarminData(user, 'sleep', withNullNaps, mockDeps)).resolves.toBe(1)
+
+      vi.clearAllMocks()
+
+      const withoutField = makeSleepData()
+      await expect(processGarminData(user, 'sleep', withoutField, mockDeps)).resolves.toBe(1)
+    })
   })
 
   // ==========================================================================

--- a/apps/backend/src/integrations/garmin/process.ts
+++ b/apps/backend/src/integrations/garmin/process.ts
@@ -6,7 +6,7 @@
  */
 
 import type { IActivity } from '@flow-js/garmin-connect/dist/garmin/types/activity'
-import type { SleepData } from '@flow-js/garmin-connect/dist/garmin/types/sleep'
+import type { GarminNapDTO, SleepData } from '@flow-js/garmin-connect/dist/garmin/types/sleep'
 
 import type { Activity, Location, RawRecord, TimeSeriesPoint } from '../../db/types.ts'
 import type {
@@ -267,6 +267,34 @@ const buildSleepActivity = (dto: SleepData['dailySleepDTO']): Activity | null =>
   }
 }
 
+// Garmin's nap timestamps come as "YYYY-MM-DDTHH:mm:ss" without a timezone
+// suffix. The field name says GMT, so treat them as UTC by appending "Z".
+const parseNapGmt = (ts: string | null | undefined): Date | null => {
+  if (!ts) return null
+  const d = new Date(`${ts}Z`)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/** Build a nap activity from a Garmin dailyNapDTOS entry. */
+const buildNapActivity = (nap: GarminNapDTO): Activity | null => {
+  const startTime = parseNapGmt(nap.napStartTimestampGMT)
+  const endTime = parseNapGmt(nap.napEndTimestampGMT)
+  if (!startTime || !endTime) return null
+
+  return {
+    activity_type: 'nap',
+    data: {
+      nap_feedback: nap.napFeedback ?? undefined,
+      nap_time_seconds: nap.napTimeSec,
+    },
+    end_time: endTime,
+    external_id: `garmin-nap-${nap.napStartTimestampGMT}`,
+    source: 'garmin',
+    start_time: startTime,
+    title: 'Nap',
+  }
+}
+
 /** Extract time series points from sleep data (score, HR, HRV, sleep HR samples). */
 const buildSleepTimeSeries = (data: SleepData, time: Date): TimeSeriesPoint[] => {
   const dto = data.dailySleepDTO
@@ -319,6 +347,11 @@ const processSleep = async (user: string, data: SleepData, deps: GarminProcessDe
 
   const activity = buildSleepActivity(dto)
   if (activity) await deps.insertActivity(user, activity)
+
+  for (const nap of data.dailyNapDTOS ?? []) {
+    const napActivity = buildNapActivity(nap)
+    if (napActivity) await deps.insertActivity(user, napActivity)
+  }
 
   const points = buildSleepTimeSeries(data, time)
   if (points.length > 0) await deps.insertTimeSeries(user, points)

--- a/apps/backend/src/integrations/garmin/types.d.ts
+++ b/apps/backend/src/integrations/garmin/types.d.ts
@@ -39,6 +39,18 @@ declare module '@flow-js/garmin-connect/dist/garmin/types/activity' {
 }
 
 declare module '@flow-js/garmin-connect/dist/garmin/types/sleep' {
+  export interface GarminNapDTO {
+    userProfilePK?: number
+    deviceId?: number
+    calendarDate: string
+    napTimeSec: number
+    napStartTimestampGMT: string
+    napEndTimestampGMT: string
+    napFeedback?: string | null
+    napSource?: number | null
+    napStartTimeOffset?: number | null
+    napEndTimeOffset?: number | null
+  }
   export interface SleepData {
     dailySleepDTO: {
       id: number
@@ -85,6 +97,7 @@ declare module '@flow-js/garmin-connect/dist/garmin/types/sleep' {
       startTimeGMT: number
       respirationValue: number
     }>
+    dailyNapDTOS?: GarminNapDTO[] | null
     [key: string]: unknown
   }
 }

--- a/apps/backend/src/integrations/rescuetime/sync.ts
+++ b/apps/backend/src/integrations/rescuetime/sync.ts
@@ -17,10 +17,7 @@ import {
   type SyncState,
   upsertSyncState,
 } from '../../db/index.ts'
-import {
-  buildScreentimeActivitySpans,
-  spansToActivities,
-} from '../../services/screentime-activities.ts'
+import { buildScreentimeActivitySpans, spansToActivities } from '../../services/screentime-activities.ts'
 import { categorizeRecords, compileRules } from '../../services/screentime-categories.ts'
 import { rescuetimeClient } from './client.ts'
 

--- a/apps/backend/src/services/location-visit-activities.ts
+++ b/apps/backend/src/services/location-visit-activities.ts
@@ -18,10 +18,7 @@ import type { PlaceVisit } from './locations.ts'
 /** Minimum visit duration before we materialize an activity. */
 const MIN_VISIT_MINUTES = 10
 
-export const visitsToActivities = (
-  visits: PlaceVisit[],
-  namedLocations: NamedLocation[],
-): Activity[] => {
+export const visitsToActivities = (visits: PlaceVisit[], namedLocations: NamedLocation[]): Activity[] => {
   const optedInById = new Map<string, NamedLocation>()
   for (const nl of namedLocations) {
     if (nl.auto_create_activity) optedInById.set(nl.id, nl)

--- a/apps/backend/src/services/queries/daily-summary.ts
+++ b/apps/backend/src/services/queries/daily-summary.ts
@@ -285,6 +285,7 @@ export async function getDailySummary(
       sync.syncGarminIfNeeded(user, 'dailySummary'),
       sync.syncGarminIfNeeded(user, 'heartRate'),
       sync.syncGarminIfNeeded(user, 'hrv'),
+      sync.syncGarminIfNeeded(user, 'sleep'),
       sync.syncGarminIfNeeded(user, 'stress'),
       sync.syncGarminIfNeeded(user, 'bodyBattery'),
       sync.syncGarminIfNeeded(user, 'spo2'),

--- a/apps/backend/src/services/screentime-activities.ts
+++ b/apps/backend/src/services/screentime-activities.ts
@@ -24,8 +24,7 @@ export const categoryPathToString = (path: string[]): string => path.join(' > ')
 const isExcluded = (categoryPath: string[], excludedPaths: string[][]): boolean =>
   excludedPaths.some(
     (excluded) =>
-      categoryPath.length >= excluded.length &&
-      excluded.every((seg, idx) => seg === categoryPath[idx]),
+      categoryPath.length >= excluded.length && excluded.every((seg, idx) => seg === categoryPath[idx]),
   )
 
 interface Span {


### PR DESCRIPTION
## Summary
- Garmin's `/sleep-service/sleep/dailySleepData` endpoint returns a `dailyNapDTOS` array that was never parsed, so naps didn't show up in Aurboda.
- Switch `getSleep` to a direct `gc.get(...)` with `nonSleepBufferMinutes=60` so naps are guaranteed to be present and so network/HTTP errors surface with their real message instead of the library's generic `"Invalid or empty sleep data"` wrapper (what produced the 2026-04-19 audit entry).
- Emit one `nap` activity per entry, keyed by `external_id: garmin-nap-<napStartTimestampGMT>` so repeated syncs during the day upsert rather than duplicate.
- Add `sleep` to the daily-summary auto-sync fan-out so today's naps are picked up on any dashboard visit, not just when sleep is explicitly queried. Combined with the existing 2-day overlap and 30-min sync threshold, a nap logged after the morning sync will appear on the next page load ≥30 min later.

## Test plan
- [x] `pnpm vitest run src/integrations/garmin` — 149 unit tests pass, incl. new nap parsing cases (single nap, multiple naps, missing timestamps, null/missing `dailyNapDTOS`).
- [x] `pnpm check` — clean.
- [ ] On deploy: confirm a recent nap day shows a `nap` activity in Aurboda and that the 2026-04-19 audit message (if it recurs) now contains the real HTTP/network cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)