### PR TITLE
fix: render activities without end time as point-in-time

### DIFF
--- a/apps/web/src/pages/Data/index.tsx
+++ b/apps/web/src/pages/Data/index.tsx
@@ -81,14 +81,16 @@ const findPrimaryPlace = (start: Date, end: Date, places: Place[]): string | und
 }
 
 const activityToItem = (a: Activity, places: Place[], multiDay: boolean): DataItem => {
-  const end = a.end_time ?? new Date(a.start_time.getTime() + 60 * 60000)
   const label = a.title ?? toDisplayName(a.activity_type)
-  const location = findPrimaryPlace(a.start_time, end, places)
-  const timeStr = `${formatTime(a.start_time, multiDay)} – ${formatTime(end, multiDay)} · ${formatDuration(a.start_time, end)}`
+  const locationWindowEnd = a.end_time ?? new Date(a.start_time.getTime() + MEAL_LOCATION_WINDOW_MS)
+  const location = findPrimaryPlace(a.start_time, locationWindowEnd, places)
+  const timeStr = a.end_time
+    ? `${formatTime(a.start_time, multiDay)} – ${formatTime(a.end_time, multiDay)} · ${formatDuration(a.start_time, a.end_time)}`
+    : formatTime(a.start_time, multiDay)
   return {
     color: ACTIVITY_COLORS[a.activity_type] ?? '#6b7280',
     detail: location ? `${timeStr} · @ ${location}` : timeStr,
-    end,
+    end: a.end_time,
     href: a.id ? `/detail/activity/${encodeURIComponent(a.id)}` : undefined,
     label,
     start: a.start_time,

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -182,8 +182,8 @@ const ActivityDetailContent = ({
   referencedRules?: Record<string, string>
 }) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
-  const displayEnd =
-    activity.merged_end_time ?? activity.end_time ?? new Date(activity.start_time.getTime() + 60 * 60000)
+  const realEnd = activity.merged_end_time ?? activity.end_time
+  const displayEnd = realEnd ?? new Date(activity.start_time.getTime() + 60 * 60000)
   const musicStart = displayStart
   const musicEnd = displayEnd
   const hasSourceRecords = activity.source_records && activity.source_records.length > 1
@@ -215,7 +215,7 @@ const ActivityDetailContent = ({
   const hasHrZones = hrZoneSecs && Object.values(hrZoneSecs).some((v) => v > 0)
   const sleepMinutes =
     activity.total_sleep ?? (hasSleepStages ? computeSleepMinutesFromStages(stages) : undefined)
-  const hasEndTime = Boolean(activity.end_time || activity.merged_end_time)
+  const hasEndTime = Boolean(realEnd)
   const hasExerciseType = Boolean(exerciseType)
   const [hoverTime, setHoverTime] = useState<Date | null>(null)
 
@@ -266,7 +266,7 @@ const ActivityDetailContent = ({
         <EditableActivityFields
           title={activity.title || exerciseDisplayName || typeDisplayName}
           displayStart={displayStart}
-          displayEnd={displayEnd}
+          displayEnd={realEnd}
           notes={activity.notes}
           isEditing={isEditing}
           draft={draft}


### PR DESCRIPTION
## Summary

Activities with `end_time: null` (e.g. created on Android with "Has end time" unchecked) were displayed with a spurious 1-hour duration on the data list and detail pages. The stored data was correct — this was a frontend display bug where `end_time ?? start + 1h` was used unconditionally for rendering.

- `apps/web/src/pages/Data/index.tsx` — `activityToItem` now renders just the start time (no range/duration) when `end_time` is null. Location lookup still uses a 1-hour window after start, mirroring how `mealToItem` handles point-in-time items.
- `apps/web/src/pages/EntityDetail/index.tsx` — `ActivityDetailContent` now passes the real (optional) end to `EditableActivityFields` so the existing conditional rendering in that component shows only the start time and omits the duration row. The `start + 1h` fallback is kept for the `<MusicPlaylist>` window (it already requires a range) and everything else is gated on `hasEndTime`, which now reflects the real end.

Fixes the symptom where e.g. https://aurboda.net/detail/activity/95fb8cf5-9280-4311-bf25-1d2031a3f279 showed "00:15 – 01:15 · 1h" despite having no end_time.

## Test plan

- [ ] Create an Android activity with "Has end time" unchecked
- [ ] Confirm data page (`/data`) shows only start time, no duration, no fake end
- [ ] Confirm detail page shows only start timestamp in header, no Duration row
- [ ] Confirm edit mode still shows empty end with "Set end time" button (unchanged)
- [ ] Confirm existing activities with end_time still render range + duration as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)