### PR TITLE
feat: migrate chart-data + deduction rules to read screentime from activities

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -94,6 +94,7 @@ import { createSettingsRouter } from './routes/settings-router.ts'
 import { createTrainingLoadRouter } from './routes/training-load-router.ts'
 import { createTrendsRouter } from './routes/trends-router.ts'
 import { auditError, auditInfo, auditWarn, pruneAuditLog } from './services/audit-log.ts'
+import { backfillScreentimeActivities } from './services/backfill-screentime-activities.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
 import { getCentralDb, initializeCentralDb } from './services/central-db.ts'
 import { createDefaultEngineDeps } from './services/deduction-deps.ts'
@@ -332,9 +333,16 @@ const main = async () => {
 
         // Run schema migration once per user per server lifetime (blocking on first request)
         if (!migratedUsers.has(user)) {
-          const migrationPromise = migrateSchema(user).catch((err) =>
-            console.error(`⚠️ Migration failed for ${user}:`, err),
-          )
+          const migrationPromise = migrateSchema(user)
+            .then(() => {
+              // Fire-and-forget: one-shot backfill of historical screentime activities.
+              // Gated via sync_state so it runs at most once per user, in the background
+              // so the first request isn't blocked on thousands of productivity records.
+              void backfillScreentimeActivities(user).catch((err) =>
+                console.error(`⚠️ Screentime backfill failed for ${user}:`, err),
+              )
+            })
+            .catch((err) => console.error(`⚠️ Migration failed for ${user}:`, err))
           migratedUsers.set(user, migrationPromise)
           await migrationPromise
         } else {

--- a/apps/backend/src/services/backfill-screentime-activities.test.ts
+++ b/apps/backend/src/services/backfill-screentime-activities.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('../db/index', () => ({
+  getScreentimeCategories: vi.fn(),
+  getSyncState: vi.fn(),
+  insertActivities: vi.fn().mockResolvedValue(undefined),
+  upsertSyncState: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../db/connection', () => ({
+  query: vi.fn(),
+}))
+
+import { getScreentimeCategories, getSyncState, insertActivities, upsertSyncState } from '../db/index.ts'
+import { query } from '../db/connection.ts'
+import { backfillScreentimeActivities } from './backfill-screentime-activities.ts'
+
+const mockedGetSyncState = vi.mocked(getSyncState)
+const mockedGetScreentimeCategories = vi.mocked(getScreentimeCategories)
+const mockedQuery = vi.mocked(query)
+const mockedInsertActivities = vi.mocked(insertActivities)
+const mockedUpsertSyncState = vi.mocked(upsertSyncState)
+
+const cat = (name: string[]) => ({
+  created_at: new Date(),
+  id: `cat-${name.join('-')}`,
+  ignore_case: true,
+  name,
+  rule_type: 'regex' as const,
+  sort_order: 0,
+  updated_at: new Date(),
+})
+
+describe('backfillScreentimeActivities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedGetSyncState.mockResolvedValue(null)
+    mockedGetScreentimeCategories.mockResolvedValue([cat(['Work'])])
+  })
+
+  test('short-circuits when sync_state marks backfill as completed', async () => {
+    mockedGetSyncState.mockResolvedValueOnce({
+      last_sync_time: new Date('2026-04-21T00:00:00Z'),
+      status: 'idle',
+    } as never)
+
+    const result = await backfillScreentimeActivities('user')
+
+    expect(result).toEqual({ created: 0, reason: 'already_completed', skipped: true })
+    expect(mockedQuery).not.toHaveBeenCalled()
+    expect(mockedInsertActivities).not.toHaveBeenCalled()
+  })
+
+  test('marks backfill complete when the user has no categories yet', async () => {
+    mockedGetScreentimeCategories.mockResolvedValueOnce([])
+
+    const result = await backfillScreentimeActivities('user')
+
+    expect(result).toEqual({ created: 0, reason: 'no_categories', skipped: true })
+    expect(mockedQuery).not.toHaveBeenCalled()
+    expect(mockedUpsertSyncState).toHaveBeenCalledWith(
+      'user',
+      expect.objectContaining({ data_type: 'screentime_backfill', status: 'idle' }),
+    )
+  })
+
+  test('marks backfill complete when there are no productivity records', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [] } as never)
+
+    const result = await backfillScreentimeActivities('user')
+
+    expect(result).toEqual({ created: 0, reason: 'no_records', skipped: true })
+    expect(mockedInsertActivities).not.toHaveBeenCalled()
+    expect(mockedUpsertSyncState).toHaveBeenCalled()
+  })
+
+  test('builds spans and upserts activities for existing productivity', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          activity: 'vscode',
+          duration_sec: 600,
+          end_time: '2026-04-10T10:10:00Z',
+          resolved_category: ['Work'],
+          source: 'rescuetime',
+          start_time: '2026-04-10T10:00:00Z',
+          title: null,
+        },
+        {
+          activity: 'vscode',
+          duration_sec: 600,
+          end_time: '2026-04-10T10:20:00Z',
+          resolved_category: ['Work'],
+          source: 'rescuetime',
+          start_time: '2026-04-10T10:10:00Z',
+          title: null,
+        },
+      ],
+    } as never)
+
+    const result = await backfillScreentimeActivities('user')
+
+    expect(result.skipped).toBe(false)
+    expect(result.created).toBe(1) // the two records merge into one span
+    expect(mockedInsertActivities).toHaveBeenCalledWith(
+      'user',
+      expect.arrayContaining([
+        expect.objectContaining({
+          activity_type: 'screentime',
+          source: 'rescuetime',
+          data: expect.objectContaining({ category_path: 'Work' }),
+        }),
+      ]),
+    )
+    expect(mockedUpsertSyncState).toHaveBeenCalledWith(
+      'user',
+      expect.objectContaining({ data_type: 'screentime_backfill', status: 'idle' }),
+    )
+  })
+})

--- a/apps/backend/src/services/backfill-screentime-activities.ts
+++ b/apps/backend/src/services/backfill-screentime-activities.ts
@@ -1,0 +1,92 @@
+/**
+ * One-shot backfill: convert historical categorized productivity records
+ * into `screentime` activities.
+ *
+ * Before this existed, the v1 of screentime-as-activities (#648) was
+ * forward-looking only — new RescueTime / ActivityWatch syncs produced
+ * activities, but a user's existing productivity history did not.
+ * Migrating daily summary / chart data / deduction rules to read from
+ * activities (#653) therefore requires a one-shot fill-in of the
+ * historical gap.
+ *
+ * Completion is recorded via `sync_state` (provider='aurboda',
+ * data_type='screentime_backfill'), so subsequent calls short-circuit.
+ * Activity inserts are idempotent via the (source, external_id) unique
+ * index — re-running after a crash is safe.
+ */
+
+import type { ProductivityRecord } from '../db/types.ts'
+
+import { getScreentimeCategories, getSyncState, insertActivities, upsertSyncState } from '../db/index.ts'
+import { query } from '../db/connection.ts'
+import { buildScreentimeActivitySpans, spansToActivities } from './screentime-activities.ts'
+
+export interface BackfillResult {
+  /** How many screentime activities were upserted. */
+  created: number
+  /** True if the backfill short-circuited (already completed or nothing to do). */
+  skipped: boolean
+  reason?: 'already_completed' | 'no_categories' | 'no_records'
+}
+
+const BACKFILL_DATA_TYPE = 'screentime_backfill'
+
+export const backfillScreentimeActivities = async (user: string): Promise<BackfillResult> => {
+  const state = await getSyncState(user, 'aurboda', BACKFILL_DATA_TYPE)
+  if (state?.status === 'idle' && state.last_sync_time) {
+    return { created: 0, reason: 'already_completed', skipped: true }
+  }
+
+  const categories = await getScreentimeCategories(user)
+  if (categories.length === 0) {
+    await upsertSyncState(user, {
+      data_type: BACKFILL_DATA_TYPE,
+      last_sync_time: new Date(),
+      provider: 'aurboda',
+      status: 'idle',
+    })
+    return { created: 0, reason: 'no_categories', skipped: true }
+  }
+
+  const result = await query(
+    user,
+    `SELECT source, start_time, end_time, activity, title, duration_sec, resolved_category
+       FROM productivity
+      WHERE resolved_category IS NOT NULL
+        AND deleted_at IS NULL`,
+  )
+  const records: ProductivityRecord[] = result.rows.map((row) => ({
+    activity: row.activity as string,
+    duration_sec: row.duration_sec as number,
+    end_time: new Date(row.end_time as string),
+    resolved_category: row.resolved_category as string[],
+    source: row.source,
+    start_time: new Date(row.start_time as string),
+    ...(row.title ? { title: row.title as string } : {}),
+  }))
+
+  if (records.length === 0) {
+    await upsertSyncState(user, {
+      data_type: BACKFILL_DATA_TYPE,
+      last_sync_time: new Date(),
+      provider: 'aurboda',
+      status: 'idle',
+    })
+    return { created: 0, reason: 'no_records', skipped: true }
+  }
+
+  const spans = buildScreentimeActivitySpans(records, categories)
+  const activities = spansToActivities(spans)
+  if (activities.length > 0) {
+    await insertActivities(user, activities)
+  }
+
+  await upsertSyncState(user, {
+    data_type: BACKFILL_DATA_TYPE,
+    last_sync_time: new Date(),
+    provider: 'aurboda',
+    status: 'idle',
+  })
+
+  return { created: activities.length, skipped: false }
+}

--- a/apps/backend/src/services/backfill-screentime-activities.ts
+++ b/apps/backend/src/services/backfill-screentime-activities.ts
@@ -48,19 +48,23 @@ export const backfillScreentimeActivities = async (user: string): Promise<Backfi
     return { created: 0, reason: 'no_categories', skipped: true }
   }
 
+  // ORDER BY start_time is load-bearing: buildScreentimeActivitySpans walks
+  // records sequentially and merges adjacent same-category ones within a gap,
+  // so unordered input would produce fragmented / incorrectly-merged spans.
   const result = await query(
     user,
     `SELECT source, start_time, end_time, activity, title, duration_sec, resolved_category
        FROM productivity
       WHERE resolved_category IS NOT NULL
-        AND deleted_at IS NULL`,
+        AND deleted_at IS NULL
+      ORDER BY start_time`,
   )
   const records: ProductivityRecord[] = result.rows.map((row) => ({
     activity: row.activity as string,
     duration_sec: row.duration_sec as number,
     end_time: new Date(row.end_time as string),
     resolved_category: row.resolved_category as string[],
-    source: row.source,
+    source: row.source as ProductivityRecord['source'],
     start_time: new Date(row.start_time as string),
     ...(row.title ? { title: row.title as string } : {}),
   }))

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -165,6 +165,13 @@ describe('getChartData', () => {
     expect(result.buckets).toHaveLength(2)
     expect((result.buckets[0] as { value: number }).value).toBe(3.5)
     expect((result.buckets[1] as { value: number }).value).toBe(4.2)
+
+    // Verify we query from activities (not productivity) after the migration
+    // to screentime activities as the source of truth.
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[1]).toContain('FROM activities')
+    expect(call[1]).toContain("activity_type = 'screentime'")
+    expect(call[1]).not.toContain('FROM productivity')
   })
 
   test('returns bucketed activity type hours', async () => {

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -181,7 +181,7 @@ const queryProductivityCategoryBuckets = async (
         AND end_time IS NOT NULL
         AND (
           data->>'category_path' = $${bucket.params.length + 1}
-          OR data->>'category_path' LIKE $${bucket.params.length + 1} || ' > %'
+          OR starts_with(data->>'category_path', $${bucket.params.length + 1} || ' > ')
         )
         AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -153,7 +153,15 @@ const queryMetricBuckets = async (
   }))
 }
 
-/** Query bucketed productivity category hours. */
+/**
+ * Query bucketed productivity category hours.
+ *
+ * Reads from the `activities` table (activity_type='screentime') so a
+ * prefix match on data->>'category_path' walks the category hierarchy
+ * (e.g. categoryPath='Work' matches 'Work', 'Work > Programming', etc.).
+ * Activities are derived from productivity records during sync (#648) and
+ * historical data is filled in by a one-shot backfill.
+ */
 const queryProductivityCategoryBuckets = async (
   user: string,
   categoryPath: string,
@@ -165,11 +173,16 @@ const queryProductivityCategoryBuckets = async (
   const result = await query(
     user,
     `SELECT ${bucket.expr} AS bucket_start,
-            SUM(duration_sec) / 3600.0 AS value
-       FROM productivity
-      WHERE deleted_at IS NULL
-        AND resolved_category IS NOT NULL
-        AND array_to_string(resolved_category, ' > ') LIKE $${bucket.params.length + 1} || '%'
+            SUM(EXTRACT(EPOCH FROM (end_time - start_time))) / 3600.0 AS value
+       FROM activities
+      WHERE activity_type = 'screentime'
+        AND deleted_at IS NULL
+        AND superseded_by IS NULL
+        AND end_time IS NOT NULL
+        AND (
+          data->>'category_path' = $${bucket.params.length + 1}
+          OR data->>'category_path' LIKE $${bucket.params.length + 1} || ' > %'
+        )
         AND start_time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
       GROUP BY 1
       ORDER BY 1`,

--- a/apps/backend/src/services/deduction-deps.test.ts
+++ b/apps/backend/src/services/deduction-deps.test.ts
@@ -230,7 +230,9 @@ describe('createDefaultEngineDeps', () => {
       expect(params[0]).toBe('Work > Programming')
       const sql = lastCall[1] as string
       expect(sql).toContain("data->>'category_path' = $1")
-      expect(sql).toContain("data->>'category_path' LIKE $1 || ' > %'")
+      // starts_with is used over LIKE to avoid accidental matching on SQL
+      // wildcard chars (%, _) that might appear in user-defined category names.
+      expect(sql).toContain("starts_with(data->>'category_path', $1 || ' > ')")
     })
 
     test('returns TimeRange[] shaped results', async () => {

--- a/apps/backend/src/services/deduction-deps.test.ts
+++ b/apps/backend/src/services/deduction-deps.test.ts
@@ -199,4 +199,58 @@ describe('createDefaultEngineDeps', () => {
       expect(sql).toContain(' OR ')
     })
   })
+
+  describe('getScreentime', () => {
+    const window = {
+      end: new Date('2024-03-15T23:59:59Z'),
+      start: new Date('2024-03-15T00:00:00Z'),
+    }
+
+    test('queries the activities table for screentime activities', async () => {
+      const deps = createDefaultEngineDeps()
+      mockedQuery.mockResolvedValueOnce({ rows: [] } as never)
+
+      await deps.getScreentime('user', ['Work', 'Programming'], window)
+
+      const lastCall = mockedQuery.mock.calls[mockedQuery.mock.calls.length - 1]
+      const sql = lastCall[1] as string
+      expect(sql).toContain('FROM activities')
+      expect(sql).toContain("activity_type = 'screentime'")
+      expect(sql).not.toContain('FROM productivity')
+    })
+
+    test('joins the category path with " > " and matches exact-or-prefix', async () => {
+      const deps = createDefaultEngineDeps()
+      mockedQuery.mockResolvedValueOnce({ rows: [] } as never)
+
+      await deps.getScreentime('user', ['Work', 'Programming'], window)
+
+      const lastCall = mockedQuery.mock.calls[mockedQuery.mock.calls.length - 1]
+      const params = lastCall[2] as unknown[]
+      expect(params[0]).toBe('Work > Programming')
+      const sql = lastCall[1] as string
+      expect(sql).toContain("data->>'category_path' = $1")
+      expect(sql).toContain("data->>'category_path' LIKE $1 || ' > %'")
+    })
+
+    test('returns TimeRange[] shaped results', async () => {
+      const deps = createDefaultEngineDeps()
+      mockedQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            end_time: new Date('2024-03-15T10:30:00Z'),
+            start_time: new Date('2024-03-15T10:00:00Z'),
+          },
+        ],
+      } as never)
+
+      const result = await deps.getScreentime('user', ['Work'], window)
+      expect(result).toEqual([
+        {
+          end: new Date('2024-03-15T10:30:00Z'),
+          start: new Date('2024-03-15T10:00:00Z'),
+        },
+      ])
+    })
+  })
 })

--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -40,15 +40,28 @@ const getScreentime = async (
   category: string[],
   window: EvaluationWindow,
 ): Promise<TimeRange[]> => {
+  // Read from the screentime activities populated by the sync/backfill
+  // pipeline. Category hierarchy is matched via path-prefix on the joined
+  // string: `category=['Work']` matches activities whose category_path is
+  // 'Work' or begins with 'Work > '. This is safer than the old
+  // productivity.resolved_category @> array-containment check, which could
+  // accidentally match records where the category appeared mid-path.
+  const categoryPath = category.join(' > ')
   const result = await query(
     user,
-    `SELECT start_time, end_time FROM productivity
-     WHERE resolved_category @> $1
+    `SELECT start_time, end_time FROM activities
+     WHERE activity_type = 'screentime'
        AND deleted_at IS NULL
+       AND superseded_by IS NULL
+       AND end_time IS NOT NULL
        AND start_time < $3
        AND end_time > $2
+       AND (
+         data->>'category_path' = $1
+         OR data->>'category_path' LIKE $1 || ' > %'
+       )
      ORDER BY start_time`,
-    [category, window.start, window.end],
+    [categoryPath, window.start, window.end],
   )
   return result.rows.map((r) => ({
     end: r.end_time as Date,

--- a/apps/backend/src/services/deduction-deps.ts
+++ b/apps/backend/src/services/deduction-deps.ts
@@ -58,7 +58,7 @@ const getScreentime = async (
        AND end_time > $2
        AND (
          data->>'category_path' = $1
-         OR data->>'category_path' LIKE $1 || ' > %'
+         OR starts_with(data->>'category_path', $1 || ' > ')
        )
      ORDER BY start_time`,
     [categoryPath, window.start, window.end],

--- a/apps/backend/src/services/queries/metrics.test.ts
+++ b/apps/backend/src/services/queries/metrics.test.ts
@@ -625,6 +625,10 @@ describe('parseBucketSize', () => {
     expect(parseBucketSize('1d')).toEqual({ interval: '1 days', ms: 86400000 })
   })
 
+  test('parses weeks', () => {
+    expect(parseBucketSize('1w')).toEqual({ interval: '1 weeks', ms: 7 * 86400000 })
+  })
+
   test('parses months', () => {
     expect(parseBucketSize('1M')).toEqual({ interval: '1 months', ms: 30 * 86400000 })
   })

--- a/apps/backend/src/services/queries/metrics.ts
+++ b/apps/backend/src/services/queries/metrics.ts
@@ -35,7 +35,7 @@ import { classifyHrvByContext, getHrvContextWindows, type HrvContext } from '../
  * - ms: bucket duration in milliseconds (for in-memory bucketing)
  */
 export const parseBucketSize = (bucket: string): { interval: string; ms: number } => {
-  const match = bucket.match(/^(\d+)([smhdM])$/)
+  const match = bucket.match(/^(\d+)([smhdwM])$/)
   if (!match) throw new Error(`Invalid bucket size: ${bucket}`)
   const n = parseInt(match[1], 10)
   const unit = match[2]
@@ -48,6 +48,8 @@ export const parseBucketSize = (bucket: string): { interval: string; ms: number 
       return { interval: `${n} hours`, ms: n * 60 * 60 * 1000 }
     case 'd':
       return { interval: `${n} days`, ms: n * 24 * 60 * 60 * 1000 }
+    case 'w':
+      return { interval: `${n} weeks`, ms: n * 7 * 24 * 60 * 60 * 1000 }
     case 'M':
       // Approximate months as 30 days for in-memory bucketing; PostgreSQL handles months properly
       return { interval: `${n} months`, ms: n * 30 * 24 * 60 * 60 * 1000 }

--- a/packages/api-spec/src/schemas/metrics.ts
+++ b/packages/api-spec/src/schemas/metrics.ts
@@ -261,15 +261,15 @@ export type CustomMetricsListResponse = z.infer<typeof customMetricsListResponse
 
 /**
  * Bucket size for time-based aggregation.
- * Format: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), M (months).
- * Examples: '10s', '5m', '1h', '1d', '1M'
+ * Format: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), w (weeks), M (months).
+ * Examples: '10s', '5m', '1h', '1d', '1w', '1M'
  */
 export const bucketSizeSchema = z
   .string()
-  .regex(/^\d+[smhdM]$/, 'Must be {number}{unit} where unit is s, m, h, d, or M')
+  .regex(/^\d+[smhdwM]$/, 'Must be {number}{unit} where unit is s, m, h, d, w, or M')
   .meta({
     description:
-      'Bucket size: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), M (months)',
+      'Bucket size: {number}{unit} where unit is s (seconds), m (minutes), h (hours), d (days), w (weeks), M (months)',
     example: '15m',
     id: 'BucketSize',
   })


### PR DESCRIPTION
## Summary

First chunk of #653 — migrating the consumers of the raw productivity table onto the unified `activities` pipeline that #648 populated.

Not auto-merging — central functionality, please review.

## Scope

Two of the five consumers flagged in #653 get migrated here:

| Consumer | Before | After |
|---|---|---|
| **chart-data** `productivity_category` source | Queries `productivity.resolved_category` with `array_to_string LIKE` | Queries `activities` where `activity_type='screentime'`, prefix-match on `data->>'category_path'` |
| **Deduction rule** `screentime_category` condition | Queries `productivity.resolved_category @> array` | Queries the same activity rows with exact-or-prefix path match |

Plus a **one-shot backfill** so users who had productivity history before #648 deployed don't see empty charts for historical ranges.

## Deferred to follow-up PRs

- **Daily summary** `buildScreentimeSpans` — the summary has multiple overlapping uses of productivity (category score breakdowns, excluded-path filtering, total-time stats), migrating them all together is its own change.
- **`/productivity` endpoint** — policy question as much as code: it doubles as the raw-record inspector, which might be worth keeping independently of the activity-query path.
- **Correlation / activity-impact** productivity analysis — standalone subsystem, separate migration.

These are still tracked on #653.

## Backfill mechanics

- New `backfill-screentime-activities.ts` service. After `migrateSchema` completes for a user on the first request per server lifetime, fire-and-forget the conversion of categorized productivity records to `screentime` activities.
- Gated by `sync_state` (provider='aurboda', data_type='screentime_backfill'): runs at most once per user.
- Uses the same `buildScreentimeActivitySpans` + `spansToActivities` helpers that the sync path uses, so the derived shape is consistent.
- Inserts are idempotent via `(source, external_id)` — crash-safe.
- Fires in the background so it never blocks a request even when it has thousands of records to process.

## Safety improvements in the migrated queries

The old path matches had subtle bugs that the migration incidentally fixes:

1. **chart-data** old SQL: `array_to_string(resolved_category, ' > ') LIKE 'Work%'` — matched `'WorkFromHome'` category as a false positive.
2. **deduction-rules** old SQL: `resolved_category @> ARRAY['Work']` — array-containment; would match records where 'Work' appeared as a non-root element (e.g. `['Meetings', 'Work']`).

Both are fixed by the new exact-or-` > ` separator match: `data->>'category_path' = 'Work' OR data->>'category_path' LIKE 'Work > %'`.

## Tests

- **Backfill** (4 new tests): sync_state short-circuit, no categories, no records, merge-and-upsert path.
- **Deduction-deps getScreentime** (3 new tests): target is activities table, category joined with ' > ' and matched exact-or-prefix, returns TimeRange[] shape.
- **Chart-data productivity_category**: tightened assertion verifies the query targets `FROM activities` with `activity_type = 'screentime'`, not `FROM productivity`.

## Test plan

- [ ] CI green
- [ ] Dashboard screen-time category charts render identically to pre-change (for a user whose backfill has run — if deploying, wait one request cycle after deploy before checking)
- [ ] Deduction rules with `screentime_category` conditions keep triggering on the same ranges they did before
- [ ] Newly-synced screentime categorized data shows up immediately (unchanged from #648)
- [ ] Old productivity-only history is visible through the unified chart path post-backfill

## Related

- #648 (screen time as activities v1 — the source of the activity data)
- #653 (the umbrella issue — this PR partially closes it; daily-summary and /productivity work remain)
- #661 (one-/activities consolidation on the frontend — this PR's migration is a prerequisite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)