### PR TITLE
feat: store Oura OAuth credentials in admin settings DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ export PGHOST=
 export PGPASSWORD=
 
 # External services
-export OURA_CLIENT=
-export OURA_SECRET=
+# OURA_CLIENT/OURA_SECRET are deprecated — configure in Admin Settings UI.
+# If set here and the DB is empty, they are migrated once at startup.
 export RESCUETIME_KEY=
 
 # Backend server

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -144,7 +144,38 @@ const main = async () => {
   const webHost = process.env.WEB_HOST ?? 'http://localhost:5173'
   const apiBaseUrl = process.env.API_BASE_URL ?? 'http://localhost:3000'
   console.info(`🌐 WEB_HOST=${webHost} API_BASE_URL=${apiBaseUrl}`)
-  const oura = ouraClient(process.env.OURA_CLIENT ?? '', process.env.OURA_SECRET ?? '', apiBaseUrl, {
+
+  // Migrate legacy OURA_CLIENT/OURA_SECRET env vars into server_settings if DB empty
+  const envOuraClientId = process.env.OURA_CLIENT
+  const envOuraClientSecret = process.env.OURA_SECRET
+  if (envOuraClientId || envOuraClientSecret) {
+    const [existingId, existingSecret] = await Promise.all([
+      centralDb.getServerSetting('oura_client_id'),
+      centralDb.getServerSetting('oura_client_secret'),
+    ])
+    if (!existingId && envOuraClientId) {
+      await centralDb.setServerSetting('oura_client_id', envOuraClientId)
+      console.info('Migrated OURA_CLIENT env → server_settings.oura_client_id')
+    }
+    if (!existingSecret && envOuraClientSecret) {
+      await centralDb.setServerSetting('oura_client_secret', envOuraClientSecret)
+      console.info('Migrated OURA_SECRET env → server_settings.oura_client_secret')
+    }
+    console.info('DEPRECATION: OURA_CLIENT/OURA_SECRET envs are deprecated. Use Admin Settings.')
+  }
+
+  const getOuraCredentials = async () => {
+    const [clientId, clientSecret] = await Promise.all([
+      centralDb.getServerSetting('oura_client_id'),
+      centralDb.getServerSetting('oura_client_secret'),
+    ])
+    if (!clientId || !clientSecret) {
+      throw new Error('Oura not configured — set credentials in Admin Settings')
+    }
+    return { clientId, clientSecret }
+  }
+
+  const oura = ouraClient(getOuraCredentials, apiBaseUrl, {
     onUserAuthenticated: (ouraUserId, username) => centralDb.upsertOuraUserMapping(ouraUserId, username),
   })
 
@@ -754,35 +785,28 @@ const main = async () => {
   // Oura webhook push integration (admin-configurable via Web UI)
   // ==========================================================================
 
-  const ouraClientId = process.env.OURA_CLIENT ?? ''
-  const ouraClientSecret = process.env.OURA_SECRET ?? ''
+  const syncOuraDataTypeForUser = async (username: string, dataType: OuraDataType) => {
+    const accessToken = await oura.getAccessToken(username)
+    await syncOuraDataType(username, oura, dataType, accessToken)
+  }
 
-  let ouraWebhookManager: OuraWebhookManager | null = null
-  if (ouraClientId && ouraClientSecret) {
-    const syncOuraDataTypeForUser = async (username: string, dataType: OuraDataType) => {
-      const accessToken = await oura.getAccessToken(username)
-      await syncOuraDataType(username, oura, dataType, accessToken)
-    }
+  const ouraWebhookManager: OuraWebhookManager = createOuraWebhookManager({
+    apiBaseUrl,
+    centralDb,
+    getCredentials: getOuraCredentials,
+    syncOuraDataTypeForUser,
+  })
 
-    ouraWebhookManager = createOuraWebhookManager({
-      apiBaseUrl,
-      centralDb,
-      ouraClientId,
-      ouraClientSecret,
-      syncOuraDataTypeForUser,
-    })
+  // Mount proxy handler (delegates to inner router when enabled, 404 when disabled)
+  httpd.use('/webhooks/oura', (req, res, next) => ouraWebhookManager.handleWebhookRequest(req, res, next))
 
-    // Mount proxy handler (delegates to inner router when enabled, 404 when disabled)
-    httpd.use('/webhooks/oura', (req, res, next) => ouraWebhookManager!.handleWebhookRequest(req, res, next))
-
-    // Enable if previously configured and host supports it
-    const webhookEnabled = await centralDb.getOuraWebhookEnabled()
-    if (webhookEnabled && ouraWebhookManager.canEnable()) {
-      try {
-        await ouraWebhookManager.enable()
-      } catch (error) {
-        console.error('Oura webhook: failed to enable on startup:', error)
-      }
+  // Enable if previously configured and host supports it
+  const ouraWebhookEnabled = await centralDb.getOuraWebhookEnabled()
+  if (ouraWebhookEnabled && (await ouraWebhookManager.canEnable())) {
+    try {
+      await ouraWebhookManager.enable()
+    } catch (error) {
+      console.error('Oura webhook: failed to enable on startup:', error)
     }
   }
 

--- a/apps/backend/src/integrations/oura/client.ts
+++ b/apps/backend/src/integrations/oura/client.ts
@@ -56,13 +56,13 @@ export interface OuraClientOptions {
   onUserAuthenticated?: (ouraUserId: string, username: string) => Promise<void>
 }
 
+export type OuraCredentialGetter = () => Promise<{ clientId: string; clientSecret: string }>
+
 export const ouraClient = (
-  client: string,
-  secret: string,
+  getCredentials: OuraCredentialGetter,
   apiBaseUrl: string,
   options?: OuraClientOptions,
 ) => {
-  if (!client || !secret) throw new Error('Oura missing client or secret')
   const redirectUri = `${apiBaseUrl}/auth/ouracb`
 
   const getGeneric = async (type: string, start: Date, end: Date, token: string) => {
@@ -94,6 +94,15 @@ export const ouraClient = (
         return res.end('{"success":false}')
       }
 
+      let clientId: string
+      let clientSecret: string
+      try {
+        ;({ clientId, clientSecret } = await getCredentials())
+      } catch {
+        res.statusCode = 500
+        return res.end('{"success":false,"error":"Oura not configured"}')
+      }
+
       const user = state as string
 
       // Ensure schema is initialized for this user
@@ -103,8 +112,8 @@ export const ouraClient = (
 
       const tokenUrl = new URL('https://cloud.ouraring.com/oauth/token')
       tokenUrl.searchParams.append('grant_type', 'authorization_code')
-      tokenUrl.searchParams.append('client_id', client)
-      tokenUrl.searchParams.append('client_secret', secret)
+      tokenUrl.searchParams.append('client_id', clientId)
+      tokenUrl.searchParams.append('client_secret', clientSecret)
       tokenUrl.searchParams.append('code', code as string)
       tokenUrl.searchParams.append('redirect_uri', redirectUri)
 
@@ -141,11 +150,12 @@ export const ouraClient = (
       }
 
       // Refresh the token
+      const { clientId, clientSecret } = await getCredentials()
       const tokenUrl = new URL('https://cloud.ouraring.com/oauth/token')
       tokenUrl.searchParams.append('grant_type', 'refresh_token')
       tokenUrl.searchParams.append('refresh_token', token.refresh_token!)
-      tokenUrl.searchParams.append('client_id', client)
-      tokenUrl.searchParams.append('client_secret', secret)
+      tokenUrl.searchParams.append('client_id', clientId)
+      tokenUrl.searchParams.append('client_secret', clientSecret)
 
       const response = await axios.post(tokenUrl.toString())
       const { access_token, refresh_token, expires_in } = response.data
@@ -243,16 +253,26 @@ export const ouraClient = (
         )
       return tags
     },
-    getAuthorizeUrl(req: Request, res: Response) {
+    async getAuthorizeUrl(req: Request, res: Response) {
       const user = req.user
       if (!user) {
         res.status(401).json({ error: 'Not authenticated', success: false })
         return
       }
 
+      let clientId: string
+      try {
+        ;({ clientId } = await getCredentials())
+      } catch {
+        res
+          .status(400)
+          .json({ error: 'Oura not configured — set credentials in Admin Settings', success: false })
+        return
+      }
+
       const location = new URL('https://cloud.ouraring.com/oauth/authorize')
       location.searchParams.append('response_type', 'code')
-      location.searchParams.append('client_id', client)
+      location.searchParams.append('client_id', clientId)
       location.searchParams.append('redirect_uri', redirectUri)
       location.searchParams.append('state', user)
       res.json({ success: true, url: location.toString() })

--- a/apps/backend/src/routes/admin-router.ts
+++ b/apps/backend/src/routes/admin-router.ts
@@ -41,22 +41,30 @@ export const createAdminRouter = (
         lastFmApiKey,
         ouraWebhookEnabled,
         auditLogRetentionDays,
+        ouraClientId,
+        ouraClientSecret,
         stravaClientId,
         stravaClientSecret,
+        ouraWebhookAvailable,
       ] = await Promise.all([
         centralDb.getSignupMode(),
         centralDb.getAdminCount(),
         centralDb.getLastFmApiKey(),
         centralDb.getOuraWebhookEnabled(),
         centralDb.getAuditLogRetentionDays(),
+        centralDb.getServerSetting('oura_client_id'),
+        centralDb.getServerSetting('oura_client_secret'),
         centralDb.getServerSetting('strava_client_id'),
         centralDb.getServerSetting('strava_client_secret'),
+        ouraWebhookManager ? ouraWebhookManager.canEnable() : Promise.resolve(false),
       ])
       res.json({
         admin_count: adminCount,
         audit_log_retention_days: auditLogRetentionDays,
         lastfm_api_key_set: !!lastFmApiKey,
-        oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
+        oura_client_id_set: !!ouraClientId,
+        oura_client_secret_set: !!ouraClientSecret,
+        oura_webhook_available: ouraWebhookAvailable,
         oura_webhook_enabled: ouraWebhookEnabled,
         signup_mode: signupMode,
         strava_client_id_set: !!stravaClientId,
@@ -71,10 +79,13 @@ export const createAdminRouter = (
     authMiddleware,
     adminMiddleware,
     validateBody(updateAdminSettingsBodySchema),
+    // eslint-disable-next-line complexity -- sequential independent setting updates
     async (req, res) => {
       const {
         audit_log_retention_days,
         lastfm_api_key,
+        oura_client_id,
+        oura_client_secret,
         oura_webhook_enabled,
         signup_mode,
         strava_client_id,
@@ -88,6 +99,12 @@ export const createAdminRouter = (
       }
       if (lastfm_api_key !== undefined) {
         await centralDb.setLastFmApiKey(lastfm_api_key)
+      }
+      if (oura_client_id !== undefined) {
+        await centralDb.setServerSetting('oura_client_id', oura_client_id ?? '')
+      }
+      if (oura_client_secret !== undefined) {
+        await centralDb.setServerSetting('oura_client_secret', oura_client_secret ?? '')
       }
       if (oura_webhook_enabled !== undefined) {
         await centralDb.setOuraWebhookEnabled(oura_webhook_enabled)
@@ -111,22 +128,30 @@ export const createAdminRouter = (
         lastFmApiKey,
         ouraWebhookEnabledValue,
         currentRetentionDays,
+        currentOuraClientId,
+        currentOuraClientSecret,
         currentStravaClientId,
         currentStravaClientSecret,
+        ouraWebhookAvailable,
       ] = await Promise.all([
         centralDb.getSignupMode(),
         centralDb.getAdminCount(),
         centralDb.getLastFmApiKey(),
         centralDb.getOuraWebhookEnabled(),
         centralDb.getAuditLogRetentionDays(),
+        centralDb.getServerSetting('oura_client_id'),
+        centralDb.getServerSetting('oura_client_secret'),
         centralDb.getServerSetting('strava_client_id'),
         centralDb.getServerSetting('strava_client_secret'),
+        ouraWebhookManager ? ouraWebhookManager.canEnable() : Promise.resolve(false),
       ])
       res.json({
         admin_count: adminCount,
         audit_log_retention_days: currentRetentionDays,
         lastfm_api_key_set: !!lastFmApiKey,
-        oura_webhook_available: ouraWebhookManager?.canEnable() ?? false,
+        oura_client_id_set: !!currentOuraClientId,
+        oura_client_secret_set: !!currentOuraClientSecret,
+        oura_webhook_available: ouraWebhookAvailable,
         oura_webhook_enabled: ouraWebhookEnabledValue,
         signup_mode: currentMode,
         strava_client_id_set: !!currentStravaClientId,

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -17,6 +17,8 @@ export type SignupMode = 'open' | 'invite_only' | 'closed'
 export interface ServerSettings {
   audit_log_retention_days: number
   lastfm_api_key: string
+  oura_client_id: string
+  oura_client_secret: string
   oura_webhook_enabled: boolean
   oura_webhook_verification_token: string
   signup_mode: SignupMode

--- a/apps/backend/src/services/oura-webhook-manager.test.ts
+++ b/apps/backend/src/services/oura-webhook-manager.test.ts
@@ -13,8 +13,9 @@ describe('oura-webhook-manager', () => {
       setServerSetting: vi.fn().mockResolvedValue(undefined),
       upsertOuraWebhookSubscription: vi.fn().mockResolvedValue(undefined),
     },
-    ouraClientId: 'test-client-id',
-    ouraClientSecret: 'test-client-secret',
+    getCredentials: vi
+      .fn()
+      .mockResolvedValue({ clientId: 'test-client-id', clientSecret: 'test-client-secret' }),
     syncOuraDataTypeForUser: vi.fn().mockResolvedValue(undefined),
     apiBaseUrl,
   })
@@ -29,19 +30,26 @@ describe('oura-webhook-manager', () => {
   })
 
   describe('canEnable', () => {
-    test('returns true for HTTPS host', () => {
+    test('returns true for HTTPS host with credentials', async () => {
       const manager = createOuraWebhookManager(createDeps('https://aurboda.net'))
-      expect(manager.canEnable()).toBe(true)
+      expect(await manager.canEnable()).toBe(true)
     })
 
-    test('returns false for HTTP host', () => {
+    test('returns false for HTTP host', async () => {
       const manager = createOuraWebhookManager(createDeps('http://localhost:5173'))
-      expect(manager.canEnable()).toBe(false)
+      expect(await manager.canEnable()).toBe(false)
     })
 
-    test('returns false for invalid URL', () => {
+    test('returns false for invalid URL', async () => {
       const manager = createOuraWebhookManager(createDeps('not-a-url'))
-      expect(manager.canEnable()).toBe(false)
+      expect(await manager.canEnable()).toBe(false)
+    })
+
+    test('returns false when credentials are missing', async () => {
+      const deps = createDeps('https://aurboda.net')
+      vi.mocked(deps.getCredentials).mockRejectedValue(new Error('not configured'))
+      const manager = createOuraWebhookManager(deps)
+      expect(await manager.canEnable()).toBe(false)
     })
   })
 

--- a/apps/backend/src/services/oura-webhook-manager.ts
+++ b/apps/backend/src/services/oura-webhook-manager.ts
@@ -13,6 +13,7 @@ import type { NextFunction, Request, Response } from 'express'
 
 import { randomBytes } from 'node:crypto'
 
+import type { OuraCredentialGetter } from '../integrations/oura/client.ts'
 import type { OuraDataType } from '../integrations/oura/sync.ts'
 import type { CentralDb } from './central-db.ts'
 
@@ -31,14 +32,13 @@ export interface OuraWebhookManagerDeps {
     | 'deleteOuraWebhookSubscription'
     | 'deleteAllOuraWebhookSubscriptions'
   >
-  ouraClientId: string
-  ouraClientSecret: string
+  getCredentials: OuraCredentialGetter
   syncOuraDataTypeForUser: (username: string, dataType: OuraDataType) => Promise<void>
   apiBaseUrl: string
 }
 
 export interface OuraWebhookManager {
-  canEnable: () => boolean
+  canEnable: () => Promise<boolean>
   enable: () => Promise<void>
   disable: () => Promise<void>
   isEnabled: () => boolean
@@ -53,10 +53,16 @@ export const createOuraWebhookManager = (deps: OuraWebhookManagerDeps): OuraWebh
 
   const callbackUrl = `${deps.apiBaseUrl}/webhooks/oura`
 
-  const canEnable = (): boolean => {
+  const canEnable = async (): Promise<boolean> => {
     try {
       const url = new URL(deps.apiBaseUrl)
-      return url.protocol === 'https:'
+      if (url.protocol !== 'https:') return false
+    } catch {
+      return false
+    }
+    try {
+      await deps.getCredentials()
+      return true
     } catch {
       return false
     }
@@ -76,11 +82,12 @@ export const createOuraWebhookManager = (deps: OuraWebhookManagerDeps): OuraWebh
       console.info('Oura webhook: generated new verification token')
     }
 
-    // Create webhook API client
+    // Create webhook API client (reads current credentials from DB)
+    const { clientId, clientSecret } = await deps.getCredentials()
     const webhookApi = createOuraWebhookApi({
       callbackUrl,
-      clientId: deps.ouraClientId,
-      clientSecret: deps.ouraClientSecret,
+      clientId,
+      clientSecret,
       verificationToken,
     })
 

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -235,8 +235,11 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
   const ouraToken = await getOAuthToken(user, 'oura')
   const garminToken = await getOAuthToken(user, 'garmin')
   const stravaToken = await getOAuthToken(user, 'strava')
-  const lastFmConfigured = !!(await getCentralDb().getLastFmApiKey())
   const centralDb = getCentralDb()
+  const lastFmConfigured = !!(await centralDb.getLastFmApiKey())
+  const ouraConfigured =
+    !!(await centralDb.getServerSetting('oura_client_id')) &&
+    !!(await centralDb.getServerSetting('oura_client_secret'))
   const stravaConfigured =
     !!(await centralDb.getServerSetting('strava_client_id')) &&
     !!(await centralDb.getServerSetting('strava_client_secret'))
@@ -250,7 +253,7 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
     hr_zone_start: zones,
     hr_zone_start_source: source,
     lastfm_configured: lastFmConfigured,
-    oura_configured: !!(process.env.OURA_CLIENT && process.env.OURA_SECRET),
+    oura_configured: ouraConfigured,
     oura_connected: ouraToken !== null,
     strava_configured: stravaConfigured,
     strava_connected: stravaToken !== null && stravaToken.access_token !== '',
@@ -258,20 +261,27 @@ export const getSettingsResponse = async (user: string): Promise<SettingsRespons
   }
 }
 
-const buildErrorSettingsResponse = async (errorMessage: string): Promise<SettingsResponse> => ({
-  ...settingsWithDefaultsSchema.parse({}),
-  error: errorMessage,
-  goals: defaultGoals,
-  hr_zone_start: calculateDefaultHrZones(null),
-  hr_zone_start_source: 'default' as const,
-  lastfm_configured: !!(await getCentralDb().getLastFmApiKey()),
-  oura_configured: !!(process.env.OURA_CLIENT && process.env.OURA_SECRET),
-  garmin_connected: false,
-  oura_connected: false,
-  strava_configured: false,
-  strava_connected: false,
-  success: false,
-})
+const buildErrorSettingsResponse = async (errorMessage: string): Promise<SettingsResponse> => {
+  const centralDb = getCentralDb()
+  const lastFmConfigured = !!(await centralDb.getLastFmApiKey())
+  const ouraConfigured =
+    !!(await centralDb.getServerSetting('oura_client_id')) &&
+    !!(await centralDb.getServerSetting('oura_client_secret'))
+  return {
+    ...settingsWithDefaultsSchema.parse({}),
+    error: errorMessage,
+    goals: defaultGoals,
+    hr_zone_start: calculateDefaultHrZones(null),
+    hr_zone_start_source: 'default' as const,
+    lastfm_configured: lastFmConfigured,
+    oura_configured: ouraConfigured,
+    garmin_connected: false,
+    oura_connected: false,
+    strava_configured: false,
+    strava_connected: false,
+    success: false,
+  }
+}
 
 export const validateAndUpdateSettings = async (user: string, input: unknown): Promise<SettingsResponse> => {
   const parsed = updateSettingsInputSchema.safeParse(input)

--- a/apps/web/src/pages/AdminSettings/index.tsx
+++ b/apps/web/src/pages/AdminSettings/index.tsx
@@ -126,6 +126,101 @@ function StravaApiSection() {
   )
 }
 
+// eslint-disable-next-line complexity -- simple form with save/clear handlers
+function OuraApiSection() {
+  const queryClient = useQueryClient()
+  const { data: settings } = useQuery({
+    queryFn: fetchAdminSettings,
+    queryKey: ['adminSettings'],
+  })
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
+
+  const idSet = settings?.oura_client_id_set ?? false
+  const secretSet = settings?.oura_client_secret_set ?? false
+
+  const saveOura = useCallback(
+    async (params: { oura_client_id?: string | null; oura_client_secret?: string | null }) => {
+      setSaveStatus({ status: 'saving' })
+      try {
+        const result = await updateAdminSettings(params)
+        queryClient.setQueryData(['adminSettings'], result)
+        setClientId('')
+        setClientSecret('')
+        setSaveStatus({ status: 'saved', time: new Date() })
+      } catch (err) {
+        setSaveStatus({ error: getErrorMessage(err), status: 'error' })
+      }
+    },
+    [queryClient],
+  )
+
+  const handleSave = useCallback(() => {
+    if (!clientId && !clientSecret) return
+    saveOura({
+      ...(clientId ? { oura_client_id: clientId } : {}),
+      ...(clientSecret ? { oura_client_secret: clientSecret } : {}),
+    })
+  }, [clientId, clientSecret, saveOura])
+
+  const handleClear = useCallback(
+    () => saveOura({ oura_client_id: null, oura_client_secret: null }),
+    [saveOura],
+  )
+
+  return (
+    <div class="form-field">
+      <div class="section-header-row">
+        <label>Oura API</label>
+        <SaveStatusIndicator state={saveStatus} />
+      </div>
+      {(idSet || secretSet) && (
+        <p class={`connected-status${idSet && secretSet ? '' : ' warning'}`}>
+          {idSet && secretSet ? 'Configured' : 'Partially configured'}
+        </p>
+      )}
+      <div class="api-key-input-row">
+        <input
+          type="text"
+          value={clientId}
+          onInput={(e) => setClientId((e.target as HTMLInputElement).value)}
+          placeholder={idSet ? 'Enter new client ID to update' : 'Client ID'}
+        />
+      </div>
+      <div class="api-key-input-row">
+        <input
+          type="password"
+          value={clientSecret}
+          onInput={(e) => setClientSecret((e.target as HTMLInputElement).value)}
+          placeholder={secretSet ? 'Enter new client secret to update' : 'Client Secret'}
+        />
+        {(idSet || secretSet) && (
+          <button type="button" class="clear-button" onClick={handleClear}>
+            Clear
+          </button>
+        )}
+      </div>
+      <button
+        type="button"
+        class="generate-button"
+        onClick={handleSave}
+        disabled={!clientId && !clientSecret}
+      >
+        Save Oura Credentials
+      </button>
+      <p class="field-description">
+        Oura OAuth credentials for ring data syncing.{' '}
+        <a href="https://cloud.ouraring.com/oauth/applications" target="_blank" rel="noopener noreferrer">
+          Register an Oura API application
+        </a>
+        . Only the Client ID and Client Secret are needed.
+      </p>
+    </div>
+  )
+}
+
 function IntegrationsSection() {
   const queryClient = useQueryClient()
   const { data: settings } = useQuery({
@@ -207,6 +302,8 @@ function IntegrationsSection() {
           . Saves automatically when you leave the field.
         </p>
       </div>
+
+      <OuraApiSection />
 
       {settings?.oura_webhook_available && (
         <div class="form-field">

--- a/apps/web/src/pages/DataSources/OuraSource.tsx
+++ b/apps/web/src/pages/DataSources/OuraSource.tsx
@@ -97,8 +97,8 @@ function OuraConnection({
               Connect Oura
             </button>
             <p class="field-description warning">
-              Oura OAuth is not configured on the server. Ask your administrator to set up OURA_CLIENT and
-              OURA_SECRET environment variables.
+              Oura OAuth is not configured on the server. Ask your administrator to set the Oura Client ID and
+              Client Secret in Admin Settings.
             </p>
           </>
         ) : (

--- a/apps/web/src/state/api.ts
+++ b/apps/web/src/state/api.ts
@@ -983,6 +983,8 @@ export interface AdminSettings {
   signup_mode: SignupMode
   admin_count: number
   lastfm_api_key_set: boolean
+  oura_client_id_set: boolean
+  oura_client_secret_set: boolean
   oura_webhook_available: boolean
   oura_webhook_enabled: boolean
   strava_client_id_set: boolean
@@ -1005,6 +1007,8 @@ export const fetchAdminSettings = async (): Promise<AdminSettings> => {
   return {
     admin_count: response.data.admin_count,
     lastfm_api_key_set: response.data.lastfm_api_key_set,
+    oura_client_id_set: response.data.oura_client_id_set,
+    oura_client_secret_set: response.data.oura_client_secret_set,
     oura_webhook_available: response.data.oura_webhook_available,
     oura_webhook_enabled: response.data.oura_webhook_enabled,
     signup_mode: response.data.signup_mode,
@@ -1017,6 +1021,8 @@ export const fetchAdminSettings = async (): Promise<AdminSettings> => {
 export const updateAdminSettings = async (params: {
   signup_mode?: SignupMode
   lastfm_api_key?: string | null
+  oura_client_id?: string | null
+  oura_client_secret?: string | null
   oura_webhook_enabled?: boolean
   strava_client_id?: string | null
   strava_client_secret?: string | null
@@ -1033,6 +1039,8 @@ export const updateAdminSettings = async (params: {
   return {
     admin_count: response.data.admin_count,
     lastfm_api_key_set: response.data.lastfm_api_key_set,
+    oura_client_id_set: response.data.oura_client_id_set,
+    oura_client_secret_set: response.data.oura_client_secret_set,
     oura_webhook_available: response.data.oura_webhook_available,
     oura_webhook_enabled: response.data.oura_webhook_enabled,
     signup_mode: response.data.signup_mode,

--- a/docs/oura.md
+++ b/docs/oura.md
@@ -18,17 +18,24 @@ All data is also preserved as raw JSON in the `raw_records` table.
 
 ## Admin Setup
 
-The server administrator must register an Oura developer application and configure:
+The server administrator must register an Oura developer application at the
+[Oura Developer Portal](https://cloud.ouraring.com/oauth/applications) and then
+configure the credentials in **Admin Settings > Integrations > Oura API**:
 
-| Environment Variable | Description                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------------------- |
-| `OURA_CLIENT`        | OAuth client ID from [Oura Developer Portal](https://cloud.ouraring.com/oauth/applications) |
-| `OURA_SECRET`        | OAuth client secret                                                                         |
-| `WEB_HOST`           | Public URL of the server (e.g., `https://aurboda.net`). Must be HTTPS for webhooks.         |
+- **Client ID** — OAuth client ID from the Oura application
+- **Client Secret** — OAuth client secret
 
-The OAuth callback URL to register with Oura is: `{WEB_HOST}/auth/ouracb`
+The OAuth callback URL to register with Oura is: `{WEB_HOST}/auth/ouracb`, where
+`WEB_HOST` (env var) is the public URL of the server (e.g., `https://aurboda.net`).
+`WEB_HOST` must be HTTPS for webhooks.
 
-If these are not set, the "Connect Oura" button in user settings will be disabled with a message asking the admin to configure them.
+If credentials are not configured, the "Connect Oura" button in user settings
+will be disabled with a message asking the admin to configure them. Oura-related
+sync jobs simply skip when credentials are missing — the backend will not crash.
+
+> **Deprecated:** The `OURA_CLIENT` and `OURA_SECRET` environment variables are
+> deprecated. On startup, if these env vars are set and the DB has no Oura
+> credentials, they are migrated into the database once and then ignored.
 
 ## User Setup
 
@@ -85,7 +92,7 @@ Webhooks are a **system-level** feature, not per-user. Once the admin enables we
 ### Requirements
 
 - `WEB_HOST` must use HTTPS (the toggle is hidden if HTTP)
-- `OURA_CLIENT` and `OURA_SECRET` must be configured
+- Oura Client ID and Client Secret must be configured in Admin Settings
 - The webhook endpoint must be publicly accessible
 
 ### Disabling

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -142,6 +142,8 @@ export const adminSettingsResponseSchema = baseResponseSchema
       .int()
       .meta({ description: 'Number of days to keep audit log entries (default: 3)' }),
     lastfm_api_key_set: z.boolean().meta({ description: 'Whether a Last.fm API key is configured' }),
+    oura_client_id_set: z.boolean().meta({ description: 'Whether an Oura client ID is configured' }),
+    oura_client_secret_set: z.boolean().meta({ description: 'Whether an Oura client secret is configured' }),
     oura_webhook_available: z.boolean().meta({
       description: 'Whether Oura webhook push can be enabled (requires HTTPS and Oura credentials)',
     }),
@@ -173,6 +175,16 @@ export const updateAdminSettingsBodySchema = z
       .nullable()
       .optional()
       .meta({ description: 'Last.fm API key (set to null to clear)' }),
+    oura_client_id: z
+      .string()
+      .nullable()
+      .optional()
+      .meta({ description: 'Oura API client ID (set to null to clear)' }),
+    oura_client_secret: z
+      .string()
+      .nullable()
+      .optional()
+      .meta({ description: 'Oura API client secret (set to null to clear)' }),
     oura_webhook_enabled: z
       .boolean()
       .optional()


### PR DESCRIPTION
## Summary

- Oura client ID/secret move from `OURA_CLIENT` / `OURA_SECRET` env vars to `server_settings` (same pattern as Strava).
- Backend no longer crashes on startup when Oura creds are absent — the API is created with a lazy credential getter.
- When creds are missing: "Connect Oura" is disabled, auto-sync skips, and the webhook toggle reports unavailable. No exceptions.
- Admin Settings > Integrations now has an "Oura API" section to save/clear Client ID and Secret.
- Legacy env vars are migrated into the DB on first boot (one-shot, then ignored).

## Test plan

- [x] Backend unit tests pass (1484 passed)
- [x] Web unit tests pass (292 passed)
- [x] `pnpm check` clean across all packages
- [ ] Manual: start backend without `OURA_CLIENT`/`OURA_SECRET` set — server should come up without crashing
- [ ] Manual: set Oura credentials via Admin Settings UI, then connect Oura from user settings
- [ ] Manual: clear Oura credentials — Connect Oura button disabled with admin-settings message

🤖 Generated with [Claude Code](https://claude.com/claude-code)