### PR TITLE
fix: make Strava pagination chain resilient to job failures

### DIFF
--- a/apps/backend/src/services/strava-queue.test.ts
+++ b/apps/backend/src/services/strava-queue.test.ts
@@ -44,7 +44,7 @@ describe('createStravaQueue', () => {
     updateSyncState: vi.fn(),
   }
 
-  test('creates queue and registers worker', async () => {
+  test('creates main queue + dead-letter queue and registers both workers', async () => {
     const boss = createMockBoss()
     const queue = await createStravaQueue(boss as never, mockDeps)
 
@@ -52,14 +52,20 @@ describe('createStravaQueue', () => {
     expect(queue.enqueueSync).toBeDefined()
     expect(queue.enqueueActivityFetch).toBeDefined()
     expect(boss.createQueue).toHaveBeenCalledWith('strava-sync')
+    expect(boss.createQueue).toHaveBeenCalledWith('strava-sync-dead-letter')
     expect(boss.work).toHaveBeenCalledWith(
       'strava-sync',
       { batchSize: 1, pollingIntervalSeconds: 2 },
       expect.any(Function),
     )
+    expect(boss.work).toHaveBeenCalledWith(
+      'strava-sync-dead-letter',
+      { batchSize: 1, pollingIntervalSeconds: 5 },
+      expect.any(Function),
+    )
   })
 
-  test('enqueueSync sends incremental sync job', async () => {
+  test('enqueueSync sends incremental sync job with list retry limit and deadLetter', async () => {
     const boss = createMockBoss()
     const queue = await createStravaQueue(boss as never, mockDeps)
 
@@ -72,7 +78,11 @@ describe('createStravaQueue', () => {
         request_type: 'list_activities',
         user: 'testuser',
       },
-      expect.objectContaining({ priority: 5, retryLimit: 3 }),
+      expect.objectContaining({
+        deadLetter: 'strava-sync-dead-letter',
+        priority: 5,
+        retryLimit: 10,
+      }),
     )
   })
 
@@ -89,11 +99,15 @@ describe('createStravaQueue', () => {
         request_type: 'list_activities',
         user: 'testuser',
       },
-      expect.objectContaining({ priority: 10 }),
+      expect.objectContaining({
+        deadLetter: 'strava-sync-dead-letter',
+        priority: 10,
+        retryLimit: 10,
+      }),
     )
   })
 
-  test('enqueueActivityFetch sends fetch job with given priority', async () => {
+  test('enqueueActivityFetch sends fetch job with fetch retry limit and deadLetter', async () => {
     const boss = createMockBoss()
     const queue = await createStravaQueue(boss as never, mockDeps)
 
@@ -106,7 +120,11 @@ describe('createStravaQueue', () => {
         strava_activity_id: 999,
         user: 'testuser',
       },
-      expect.objectContaining({ priority: 1 }),
+      expect.objectContaining({
+        deadLetter: 'strava-sync-dead-letter',
+        priority: 1,
+        retryLimit: 3,
+      }),
     )
   })
 
@@ -132,5 +150,83 @@ describe('createStravaQueue', () => {
     const status = await queue.getStatus()
 
     expect(status).toEqual({ active_count: 0, queued_count: 0 })
+  })
+
+  describe('dead-letter handler', () => {
+    // Extract the dead-letter handler by finding the boss.work() call for the DLQ
+    const getDeadLetterHandler = (boss: ReturnType<typeof createMockBoss>) => {
+      const dlqCall = boss.work.mock.calls.find((args) => args[0] === 'strava-sync-dead-letter')
+      if (!dlqCall) throw new Error('dead-letter worker not registered')
+      return dlqCall[2] as (jobs: { data: unknown }[]) => Promise<void>
+    }
+
+    test('sets sync_state to error when a list_activities job dies', async () => {
+      const boss = createMockBoss()
+      const updateSyncState = vi.fn().mockResolvedValue(undefined)
+      await createStravaQueue(boss as never, { ...mockDeps, updateSyncState })
+
+      const handler = getDeadLetterHandler(boss)
+      await handler([
+        {
+          data: {
+            list_params: undefined,
+            request_type: 'list_activities',
+            user: 'testuser',
+          },
+        },
+      ])
+
+      expect(updateSyncState).toHaveBeenCalledWith(
+        'testuser',
+        'activities',
+        expect.objectContaining({
+          error_message: expect.stringContaining('Pagination stopped'),
+          status: 'error',
+        }),
+      )
+    })
+
+    test('does not touch sync_state when a fetch_activity job dies', async () => {
+      const boss = createMockBoss()
+      const updateSyncState = vi.fn().mockResolvedValue(undefined)
+      await createStravaQueue(boss as never, { ...mockDeps, updateSyncState })
+
+      const handler = getDeadLetterHandler(boss)
+      await handler([
+        {
+          data: {
+            request_type: 'fetch_activity',
+            strava_activity_id: 42,
+            user: 'testuser',
+          },
+        },
+      ])
+
+      expect(updateSyncState).not.toHaveBeenCalled()
+    })
+
+    test('handles multiple dead-letter jobs in one batch', async () => {
+      const boss = createMockBoss()
+      const updateSyncState = vi.fn().mockResolvedValue(undefined)
+      await createStravaQueue(boss as never, { ...mockDeps, updateSyncState })
+
+      const handler = getDeadLetterHandler(boss)
+      await handler([
+        {
+          data: { request_type: 'list_activities', user: 'alice' },
+        },
+        {
+          data: { request_type: 'fetch_activity', strava_activity_id: 1, user: 'alice' },
+        },
+        {
+          data: { request_type: 'list_activities', user: 'bob' },
+        },
+      ])
+
+      // Only the two list_activities failures should trigger sync_state updates
+      expect(updateSyncState).toHaveBeenCalledTimes(2)
+      expect(updateSyncState).toHaveBeenCalledWith('alice', 'activities', expect.any(Object))
+      expect(updateSyncState).toHaveBeenCalledWith('bob', 'activities', expect.any(Object))
+    })
   })
 })

--- a/apps/backend/src/services/strava-queue.test.ts
+++ b/apps/backend/src/services/strava-queue.test.ts
@@ -186,6 +186,42 @@ describe('createStravaQueue', () => {
       )
     })
 
+    test('error message includes list_params for debugging', async () => {
+      const boss = createMockBoss()
+      const updateSyncState = vi.fn().mockResolvedValue(undefined)
+      await createStravaQueue(boss as never, { ...mockDeps, updateSyncState })
+
+      const handler = getDeadLetterHandler(boss)
+      await handler([
+        {
+          data: {
+            list_params: { before: 1700000000 },
+            request_type: 'list_activities',
+            user: 'testuser',
+          },
+        },
+      ])
+
+      const updates = updateSyncState.mock.calls[0][2] as { error_message: string }
+      expect(updates.error_message).toContain('before')
+      expect(updates.error_message).toContain('1700000000')
+    })
+
+    test('swallows updateSyncState failures to avoid DLQ retry loop', async () => {
+      const boss = createMockBoss()
+      const updateSyncState = vi.fn().mockRejectedValue(new Error('DB down'))
+      await createStravaQueue(boss as never, { ...mockDeps, updateSyncState })
+
+      const handler = getDeadLetterHandler(boss)
+      await expect(
+        handler([
+          {
+            data: { list_params: undefined, request_type: 'list_activities', user: 'testuser' },
+          },
+        ]),
+      ).resolves.toBeUndefined()
+    })
+
     test('does not touch sync_state when a fetch_activity job dies', async () => {
       const boss = createMockBoss()
       const updateSyncState = vi.fn().mockResolvedValue(undefined)

--- a/apps/backend/src/services/strava-queue.ts
+++ b/apps/backend/src/services/strava-queue.ts
@@ -61,11 +61,36 @@ export interface StravaQueue {
 // ============================================================================
 
 const QUEUE_NAME = 'strava-sync'
+const DEAD_LETTER_QUEUE = 'strava-sync-dead-letter'
 
 /** Priority levels: lower = higher priority */
 export const PRIORITY_WEBHOOK = 1
 export const PRIORITY_INCREMENTAL = 5
 export const PRIORITY_BACKFILL = 10
+
+/**
+ * Retry limits per job type. List jobs form the pagination chain — if one
+ * dies permanently, the chain breaks and missing pages never get enumerated,
+ * so give them more retries. Fetch failures only lose one activity each.
+ */
+const LIST_RETRY_LIMIT = 10
+const FETCH_RETRY_LIMIT = 3
+
+const listSendOptions = (priority: number) => ({
+  deadLetter: DEAD_LETTER_QUEUE,
+  priority,
+  retryBackoff: true,
+  retryDelay: 60,
+  retryLimit: LIST_RETRY_LIMIT,
+})
+
+const fetchSendOptions = (priority: number) => ({
+  deadLetter: DEAD_LETTER_QUEUE,
+  priority,
+  retryBackoff: true,
+  retryDelay: 60,
+  retryLimit: FETCH_RETRY_LIMIT,
+})
 
 /** Safety margins — leave headroom for webhook requests */
 const MAX_READS_15MIN = 90
@@ -111,12 +136,9 @@ const createJobHandler = (deps: StravaQueueDeps, boss: PgBoss) => {
   }
 
   const enqueueJob = async (data: StravaSyncJobData, priority: number): Promise<void> => {
-    await boss.send(QUEUE_NAME, data, {
-      priority,
-      retryBackoff: true,
-      retryDelay: 60,
-      retryLimit: 3,
-    })
+    const options =
+      data.request_type === 'list_activities' ? listSendOptions(priority) : fetchSendOptions(priority)
+    await boss.send(QUEUE_NAME, data, options)
   }
 
   const handleListActivities = async (
@@ -216,21 +238,54 @@ const createJobHandler = (deps: StravaQueueDeps, boss: PgBoss) => {
 }
 
 // ============================================================================
+// Dead-letter handler
+// ============================================================================
+
+/**
+ * Receives jobs that exhausted their retry limit. Audit-logs the permanent
+ * failure, and for list_activities jobs also marks sync_state as 'error' —
+ * otherwise a broken pagination chain leaves the status stuck on 'syncing'
+ * and subsequent sync_strava calls return 'already_syncing'.
+ */
+const createDeadLetterHandler =
+  (deps: StravaQueueDeps) =>
+  async (jobs: Job<StravaSyncJobData>[]): Promise<void> => {
+    for (const job of jobs) {
+      const { user, request_type } = job.data
+      auditError(user, 'sync', `☠️ Strava job permanently failed: ${request_type} (exhausted retries)`)
+
+      if (request_type === 'list_activities') {
+        await deps.updateSyncState(user, 'activities', {
+          error_message:
+            'Pagination stopped — list_activities job exhausted retries. Trigger a new sync to resume.',
+          status: 'error',
+        })
+      }
+    }
+  }
+
+// ============================================================================
 // Queue factory
 // ============================================================================
 
 export const createStravaQueue = async (boss: PgBoss, deps: StravaQueueDeps): Promise<StravaQueue> => {
   await boss.createQueue(QUEUE_NAME)
+  await boss.createQueue(DEAD_LETTER_QUEUE)
 
   await boss.work(QUEUE_NAME, { batchSize: 1, pollingIntervalSeconds: 2 }, createJobHandler(deps, boss))
-  console.info('🏃 Strava sync queue ready')
+  await boss.work(
+    DEAD_LETTER_QUEUE,
+    { batchSize: 1, pollingIntervalSeconds: 5 },
+    createDeadLetterHandler(deps),
+  )
+  console.info('🏃 Strava sync queue ready (with dead-letter handler)')
 
   return {
     enqueueActivityFetch: async (user: string, activityId: number, priority: number): Promise<void> => {
       await boss.send(
         QUEUE_NAME,
         { request_type: 'fetch_activity', strava_activity_id: activityId, user } satisfies StravaSyncJobData,
-        { priority, retryBackoff: true, retryDelay: 60, retryLimit: 3 },
+        fetchSendOptions(priority),
       )
     },
 
@@ -244,7 +299,7 @@ export const createStravaQueue = async (boss: PgBoss, deps: StravaQueueDeps): Pr
           request_type: 'list_activities',
           user,
         } satisfies StravaSyncJobData,
-        { priority, retryBackoff: true, retryDelay: 60, retryLimit: 3 },
+        listSendOptions(priority),
       )
 
       auditInfo(user, 'sync', `🏃 Strava: enqueued ${options.fullResync ? 'full' : 'incremental'} sync`)

--- a/apps/backend/src/services/strava-queue.ts
+++ b/apps/backend/src/services/strava-queue.ts
@@ -76,20 +76,12 @@ export const PRIORITY_BACKFILL = 10
 const LIST_RETRY_LIMIT = 10
 const FETCH_RETRY_LIMIT = 3
 
-const listSendOptions = (priority: number) => ({
+const sendOptions = (priority: number, retryLimit: number) => ({
   deadLetter: DEAD_LETTER_QUEUE,
   priority,
   retryBackoff: true,
   retryDelay: 60,
-  retryLimit: LIST_RETRY_LIMIT,
-})
-
-const fetchSendOptions = (priority: number) => ({
-  deadLetter: DEAD_LETTER_QUEUE,
-  priority,
-  retryBackoff: true,
-  retryDelay: 60,
-  retryLimit: FETCH_RETRY_LIMIT,
+  retryLimit,
 })
 
 /** Safety margins — leave headroom for webhook requests */
@@ -136,9 +128,8 @@ const createJobHandler = (deps: StravaQueueDeps, boss: PgBoss) => {
   }
 
   const enqueueJob = async (data: StravaSyncJobData, priority: number): Promise<void> => {
-    const options =
-      data.request_type === 'list_activities' ? listSendOptions(priority) : fetchSendOptions(priority)
-    await boss.send(QUEUE_NAME, data, options)
+    const retryLimit = data.request_type === 'list_activities' ? LIST_RETRY_LIMIT : FETCH_RETRY_LIMIT
+    await boss.send(QUEUE_NAME, data, sendOptions(priority, retryLimit))
   }
 
   const handleListActivities = async (
@@ -246,20 +237,30 @@ const createJobHandler = (deps: StravaQueueDeps, boss: PgBoss) => {
  * failure, and for list_activities jobs also marks sync_state as 'error' —
  * otherwise a broken pagination chain leaves the status stuck on 'syncing'
  * and subsequent sync_strava calls return 'already_syncing'.
+ *
+ * Errors from updateSyncState are caught and audit-logged rather than
+ * re-thrown: this queue has no onward deadLetter, so propagating would just
+ * leave the user stuck on 'syncing' — the exact failure mode this handler
+ * exists to prevent.
  */
 const createDeadLetterHandler =
   (deps: StravaQueueDeps) =>
   async (jobs: Job<StravaSyncJobData>[]): Promise<void> => {
     for (const job of jobs) {
-      const { user, request_type } = job.data
+      const { user, request_type, list_params } = job.data
       auditError(user, 'sync', `☠️ Strava job permanently failed: ${request_type} (exhausted retries)`)
 
       if (request_type === 'list_activities') {
-        await deps.updateSyncState(user, 'activities', {
-          error_message:
-            'Pagination stopped — list_activities job exhausted retries. Trigger a new sync to resume.',
-          status: 'error',
-        })
+        const paramsDetail = list_params ? ` Params: ${JSON.stringify(list_params)}.` : ''
+        try {
+          await deps.updateSyncState(user, 'activities', {
+            error_message: `Pagination stopped — list_activities job exhausted retries.${paramsDetail} Trigger a new sync to resume.`,
+            status: 'error',
+          })
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          auditError(user, 'sync', `☠️ Failed to mark sync_state as error after DLQ: ${msg}`)
+        }
       }
     }
   }
@@ -285,7 +286,7 @@ export const createStravaQueue = async (boss: PgBoss, deps: StravaQueueDeps): Pr
       await boss.send(
         QUEUE_NAME,
         { request_type: 'fetch_activity', strava_activity_id: activityId, user } satisfies StravaSyncJobData,
-        fetchSendOptions(priority),
+        sendOptions(priority, FETCH_RETRY_LIMIT),
       )
     },
 
@@ -299,7 +300,7 @@ export const createStravaQueue = async (boss: PgBoss, deps: StravaQueueDeps): Pr
           request_type: 'list_activities',
           user,
         } satisfies StravaSyncJobData,
-        listSendOptions(priority),
+        sendOptions(priority, LIST_RETRY_LIMIT),
       )
 
       auditInfo(user, 'sync', `🏃 Strava: enqueued ${options.fullResync ? 'full' : 'incremental'} sync`)


### PR DESCRIPTION
## Summary
- Raise `list_activities` retry limit from 3 to 10 — pagination jobs are rare (~7 per full resync) and critical, so more retries make transient failures (token refresh races, network blips, 429 timing) less likely to permanently break the chain
- Add a pg-boss dead-letter queue (`strava-sync-dead-letter`) for jobs that still exhaust retries. A handler audit-logs the failure, and for `list_activities` failures flips `sync_state.status` from `syncing` to `error` — unblocking the next `sync_strava` call instead of leaving the user stuck on `already_syncing`
- Fetch jobs keep `retryLimit: 3` (losing one activity is acceptable; they're not part of any chain)

## Context
Observed twice in production: full resync triggered, queue drained to zero over 3–4 days, but `activities` sync state stayed at `syncing` forever and many years of activities were missing. Root cause: a single mid-chain `list_activities` job hit its retry limit, pg-boss abandoned it, and the pagination stopped mid-way. Only the final-page code path (`activities.length < 200`) sets status back to `idle`, so a broken chain means stuck state and no way to retrigger without a manual reset.

## Test plan
- [x] All 1792 backend tests pass
- [x] `pnpm check` clean
- [x] New tests cover: queue creation of both queues, send options include `deadLetter` + correct retry limit per job type, DLQ handler sets sync_state to `error` for list failures, DLQ handler does NOT touch sync_state for fetch failures, handler processes multiple jobs in one batch correctly
- [ ] After deploy: next full resync completes without getting stuck; if a list job does hit its retry limit, sync state shows `error` instead of stuck `syncing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)