### PR TITLE
perf: batch activity HR/HRV fetches and consolidate music in timeline (#661)

### DIFF
--- a/apps/backend/src/services/queries/activities.test.ts
+++ b/apps/backend/src/services/queries/activities.test.ts
@@ -82,4 +82,48 @@ describe('queryActivities with comments', () => {
 
     expect(result[0].comments).toEqual([])
   })
+
+  test('batches heart_rate and hrv_rmssd fetches across activities (no N+1)', async () => {
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T11:00:00Z'),
+        id: 'ex-1',
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2024-01-15T15:00:00Z'),
+        id: 'ex-2',
+        source: 'health_connect',
+        start_time: new Date('2024-01-15T14:00:00Z'),
+      },
+      {
+        activity_type: 'sleep',
+        end_time: new Date('2024-01-15T07:00:00Z'),
+        id: 'sl-1',
+        source: 'oura',
+        start_time: new Date('2024-01-14T23:00:00Z'),
+      },
+      {
+        activity_type: 'meditation',
+        end_time: new Date('2024-01-15T09:30:00Z'),
+        id: 'med-1',
+        source: 'oura',
+        start_time: new Date('2024-01-15T09:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+
+    await queryActivities('testuser', ['exercise', 'sleep', 'meditation'], new Date('2024-01-14'), new Date('2024-01-16'))
+
+    // Should fire heart_rate ONCE and hrv_rmssd ONCE — not once per activity.
+    const calls = vi.mocked(db.getTimeSeries).mock.calls
+    const hrCalls = calls.filter(([, metric]) => metric === 'heart_rate')
+    const hrvCalls = calls.filter(([, metric]) => metric === 'hrv_rmssd')
+    expect(hrCalls).toHaveLength(1)
+    expect(hrvCalls).toHaveLength(1)
+  })
 })

--- a/apps/backend/src/services/queries/activities.ts
+++ b/apps/backend/src/services/queries/activities.ts
@@ -10,13 +10,21 @@ import { computeHrZoneSecs, getEffectiveHrZones, type HrZoneThresholds } from '.
 import { computeSleepMinutes } from '../sleep-duration.ts'
 import { buildCategoryMap, getCommentsMap } from './types.ts'
 
+type TimeSeriesPoint = [Date, number]
+
+/** Filter pre-fetched time series points to those inside [start, end] (inclusive). */
+const pointsInRange = (points: TimeSeriesPoint[], start: Date, end: Date): TimeSeriesPoint[] =>
+  points.filter(([time]) => time >= start && time <= end)
+
 /**
- * Get average HRV for an activity, using embedded Oura data or time series.
+ * Compute average HRV for an activity using either embedded Oura data or
+ * pre-fetched time-series points. Caller is responsible for batching the
+ * `hrvSeries` fetch — passing it in avoids one round-trip per activity.
  */
-async function getAvgHrvForActivity(
-  user: string,
+function avgHrvForActivity(
   activity: { data?: Record<string, unknown>; start_time: Date; end_time?: Date },
-): Promise<number | undefined> {
+  hrvSeries: TimeSeriesPoint[],
+): number | undefined {
   // Try embedded Oura HRV data first (meditation sessions have hrv.items)
   const hrv = activity.data?.hrv as { items?: (number | null)[] } | undefined
   const items = hrv?.items?.filter((v): v is number => v !== null && v > 0)
@@ -24,11 +32,10 @@ async function getAvgHrvForActivity(
     return Math.round(items.reduce((sum, v) => sum + v, 0) / items.length)
   }
 
-  // Fall back to time series HRV data
   if (!activity.end_time) return undefined
-  const hrvData = await getTimeSeries(user, 'hrv_rmssd', activity.start_time, activity.end_time)
-  if (hrvData.length === 0) return undefined
-  return Math.round(hrvData.reduce((sum, [, v]) => sum + v, 0) / hrvData.length)
+  const window = pointsInRange(hrvSeries, activity.start_time, activity.end_time)
+  if (window.length === 0) return undefined
+  return Math.round(window.reduce((sum, [, v]) => sum + v, 0) / window.length)
 }
 
 /** Add sleep-specific fields (time_in_bed, total_sleep) to an activity result. */
@@ -41,16 +48,21 @@ export function enrichSleepFields(result: ActivityResult, data: Record<string, u
   }
 }
 
+interface EnrichmentContext {
+  hrZones: HrZoneThresholds | null
+  hrSeries: TimeSeriesPoint[]
+  hrvSeries: TimeSeriesPoint[]
+  commentsMap: Map<string, CommentSummary[]>
+}
+
 /** Enrich a raw activity record into an ActivityResult with computed fields. */
-async function enrichActivity(
-  user: string,
+function enrichActivity(
   a: Awaited<ReturnType<typeof getActivities>>[number],
-  hrZones: HrZoneThresholds | null,
-  commentsMap: Map<string, CommentSummary[]>,
-): Promise<ActivityResult> {
+  ctx: EnrichmentContext,
+): ActivityResult {
   const result: ActivityResult = {
     activity_type: a.activity_type,
-    comments: a.id ? (commentsMap.get(a.id) ?? []) : [],
+    comments: a.id ? (ctx.commentsMap.get(a.id) ?? []) : [],
     data: a.data,
     duration: a.end_time
       ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60)
@@ -64,20 +76,20 @@ async function enrichActivity(
   }
 
   if (a.activity_type === 'sleep') {
-    enrichSleepFields(result, a.data as Record<string, unknown> | undefined)
+    enrichSleepFields(result, a.data)
   }
 
   // Compute HR zones for exercise activities with end time
-  if (hrZones && a.activity_type === 'exercise' && a.end_time) {
-    const hrData = await getTimeSeries(user, 'heart_rate', a.start_time, a.end_time)
-    if (hrData.length > 0) {
-      result.hr_zone_secs = computeHrZoneSecs(hrData, hrZones)
+  if (ctx.hrZones && a.activity_type === 'exercise' && a.end_time) {
+    const hrWindow = pointsInRange(ctx.hrSeries, a.start_time, a.end_time)
+    if (hrWindow.length > 0) {
+      result.hr_zone_secs = computeHrZoneSecs(hrWindow, ctx.hrZones)
     }
   }
 
   // Compute average HRV for sleep and meditation
   if ((a.activity_type === 'sleep' || a.activity_type === 'meditation') && a.end_time) {
-    result.avg_hrv = await getAvgHrvForActivity(user, a)
+    result.avg_hrv = avgHrvForActivity(a, ctx.hrvSeries)
   }
 
   return result
@@ -117,15 +129,43 @@ export async function queryActivities(
     categoryMap,
   )
 
-  // Get HR zones if any exercise subtype is included (parent 'exercise' or any descendant).
-  // expandActivityTypes always includes the input types in its output, so checking the
-  // expanded set alone is sufficient.
-  const includesExercise = expandedTypes.includes('exercise')
-  const hrZones = includesExercise ? (await getEffectiveHrZones(user)).zones : null
+  // Determine which time-series we'll need based on the activity types present.
+  // Batching the heart_rate / hrv_rmssd fetches across the full activity span
+  // avoids one DB round-trip per activity (was N+1 before).
+  const needsHr = activities.some((a) => a.activity_type === 'exercise' && a.end_time)
+  const needsHrv = activities.some(
+    (a) => (a.activity_type === 'sleep' || a.activity_type === 'meditation') && a.end_time,
+  )
 
-  // Fetch comments for all activities
+  // Compute the actual span across activities (may extend past `end` for
+  // long-running sessions). Falls back to [start, end] when nothing matches.
+  const activitySpan = (): { from: Date; to: Date } => {
+    let minStart = start.getTime()
+    let maxEnd = end.getTime()
+    for (const a of activities) {
+      if (!a.end_time) continue
+      if (a.start_time.getTime() < minStart) minStart = a.start_time.getTime()
+      if (a.end_time.getTime() > maxEnd) maxEnd = a.end_time.getTime()
+    }
+    return { from: new Date(minStart), to: new Date(maxEnd) }
+  }
+  const span = needsHr || needsHrv ? activitySpan() : { from: start, to: end }
+
   const activityIds = activities.map((a) => a.id).filter((id): id is string => id !== undefined)
-  const commentsMap = await getCommentsMap(user, 'activity', activityIds)
 
-  return Promise.all(activities.map((a) => enrichActivity(user, a, hrZones, commentsMap)))
+  const [hrZonesResult, hrSeries, hrvSeries, commentsMap] = await Promise.all([
+    expandedTypes.includes('exercise') ? getEffectiveHrZones(user) : Promise.resolve(null),
+    needsHr ? getTimeSeries(user, 'heart_rate', span.from, span.to) : Promise.resolve([]),
+    needsHrv ? getTimeSeries(user, 'hrv_rmssd', span.from, span.to) : Promise.resolve([]),
+    getCommentsMap(user, 'activity', activityIds),
+  ])
+
+  const ctx: EnrichmentContext = {
+    commentsMap,
+    hrSeries,
+    hrvSeries,
+    hrZones: hrZonesResult?.zones ?? null,
+  }
+
+  return activities.map((a) => enrichActivity(a, ctx))
 }

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -4,7 +4,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { addDays, format, subDays } from 'date-fns'
 import { useCallback, useMemo } from 'preact/hooks'
 
-import type { Activity } from '../../state/api'
+import type { Activity, Scrobble } from '../../state/api'
 import type { ChartItem, Column } from './types'
 
 import {
@@ -16,7 +16,6 @@ import {
   fetchProductivity,
   fetchScreentimeCategories,
   fetchScreentimeBucketed,
-  fetchScrobbles,
   fetchItemIcons,
   fetchTrainingLoad,
   fetchUserSettings,
@@ -48,10 +47,19 @@ const TIMELINE_EXCLUDED_METRICS = ['training_impulse', 'activity_impulse']
 
 const ACTIVITY_CATEGORIES = new Set(['sleep_rest', 'exercise', 'meditation', 'wellness'])
 
+/**
+ * Activity types fetched via dedicated endpoints (productivity, locations) and
+ * therefore excluded from the unified `/activities` payload to avoid sending
+ * the same rows twice. `music_scrobble` is intentionally NOT excluded — the
+ * timeline derives its scrobble list directly from this fetch (one round-trip
+ * instead of two).
+ */
+const TIMELINE_EXCLUDED_ACTIVITY_TYPES = ['screentime', 'location_visit']
+
 export interface TimelineData {
   // Raw query results needed by rendering
   activities: Activity[]
-  scrobbles: ReturnType<typeof fetchScrobbles> extends Promise<infer T> ? T : never
+  scrobbles: Scrobble[]
   // Derived chart data
   chartItems: ChartItem[]
   activityItems: ChartItem[]
@@ -104,7 +112,13 @@ export const useTimelineData = ({
   const activitiesQuery = useQuery({
     enabled: !hiddenCategories.has('activity'),
     placeholderData: keepPreviousData,
-    queryFn: () => fetchActivities(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
+    queryFn: () =>
+      fetchActivities(
+        subDays(fetchStart, 0.5),
+        addDays(fetchEnd, 0.5),
+        undefined,
+        TIMELINE_EXCLUDED_ACTIVITY_TYPES,
+      ),
     queryKey: ['timeline-activities', fromDateKey, toDateKey],
     staleTime: 5 * 60 * 1000,
   })
@@ -147,14 +161,6 @@ export const useTimelineData = ({
   })
 
   const hasLastFm = Boolean(settingsQuery.data?.lastfm_username)
-
-  const scrobblesQuery = useQuery({
-    enabled: hasLastFm && !hiddenCategories.has('music'),
-    placeholderData: keepPreviousData,
-    queryFn: () => fetchScrobbles(subDays(fetchStart, 0.5), addDays(fetchEnd, 0.5)),
-    queryKey: ['timeline-scrobbles', fromDateKey, toDateKey],
-    staleTime: 5 * 60 * 1000,
-  })
 
   const bucketedMetricsQuery = useQuery({
     enabled: !hiddenCategories.has('metrics'),
@@ -244,7 +250,23 @@ export const useTimelineData = ({
   )
   const places = placesQuery.data ?? []
   const productivity = productivityQuery.data?.records ?? []
-  const scrobbles = scrobblesQuery.data ?? []
+  // Music scrobbles are derived from `music_scrobble` activities — they live
+  // in the activities table and are already returned by the activities fetch,
+  // so no separate /lastfm/scrobbles network call is needed.
+  const scrobbles = useMemo<Scrobble[]>(() => {
+    if (!hasLastFm) return []
+    return (activitiesQuery.data ?? [])
+      .filter((a) => a.activity_type === 'music_scrobble')
+      .map((a) => {
+        const data = a.data
+        return {
+          album: typeof data?.album === 'string' ? data.album : '',
+          artist: typeof data?.artist === 'string' ? data.artist : '',
+          recorded_at: a.start_time,
+          track: typeof data?.track === 'string' ? data.track : '',
+        }
+      })
+  }, [hasLastFm, activitiesQuery.data])
 
   const sleepMetricsByDate = useMemo<SleepMetricsByDate>(() => {
     const map: SleepMetricsByDate = new Map()
@@ -398,7 +420,6 @@ export const useTimelineData = ({
     placesQuery.isFetching ||
     mealsQuery.isFetching ||
     productivityQuery.isFetching ||
-    scrobblesQuery.isFetching ||
     bucketedMetricsQuery.isFetching
 
   const isInitialLoad = activitiesQuery.isLoading && placesQuery.isLoading && productivityQuery.isLoading


### PR DESCRIPTION
## Summary

Two Timeline-loading speedups landing together:

### 1. Backend N+1 fix in `queryActivities`

`enrichActivity` was firing a separate `getTimeSeries('heart_rate')` per exercise activity and a separate `getTimeSeries('hrv_rmssd')` per sleep/meditation. For a week with ~50 exercise sessions that's 50 DB round-trips fired in parallel — fans out the connection pool and serialises on Postgres.

Now batches both into single queries spanning all activities and filters per-activity in memory. New test verifies one `getTimeSeries(heart_rate)` call regardless of activity count.

### 2. Music consolidation in Timeline (partial #661)

`music_scrobble` activities have lived in the activities table since PR #646 and are already returned by `/activities`. The Timeline was fetching them again via `/lastfm/scrobbles` and discarding the duplicates client-side. Now derives `Scrobble[]` directly from the activities response — **one fewer network round-trip per Timeline load**.

The Timeline also now passes `excludeTypes=screentime,location_visit` to `/activities`. Screentime can be hundreds of spans/day; cutting them from the wire payload is a meaningful bandwidth win.

## What's not in this PR

The full #661 consolidation (drop `/productivity` and `/locations` Timeline calls too) is still blocked:
- `screentime` activities don't carry per-app names or `category_id` — the productivity endpoint enriches with those for the screen-time tooltip.
- `location_visit` activities are opt-in and only cover named locations — detected (auto-promoted) places still need `/locations` until #654 lands.

Music has all the data it needs in `data.{artist,track,album}`, so it's the safe one to consolidate now.

## Test plan
- [x] All 110 backend query tests pass (incl. new N+1 verification)
- [x] All 292 web tests pass
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)