### PR TITLE
feat: proactive location_visit activity materialization (#654)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -25,8 +25,10 @@ import {
   deleteHealthConnectRecords,
   getAllSyncStates,
   getDetectedLocationById,
+  getNamedLocations,
   getOutboundSyncHistory,
   getPendingOutboundSync,
+  insertActivities,
   insertActivity,
   insertLocations,
   insertRawRecord,
@@ -110,6 +112,7 @@ import { createDetectionTrigger, type DetectionTrigger } from './services/detect
 import { runDetectionForUser } from './services/detection-worker.ts'
 import { createGeocodeQueue } from './services/geocode-queue.ts'
 import { createInvitationAuth } from './services/invitation.ts'
+import { getPlaceVisits } from './services/locations.ts'
 import { createOuraWebhookManager, type OuraWebhookManager } from './services/oura-webhook-manager.ts'
 import { createPgBoss } from './services/pg-boss.ts'
 import { getSettings } from './services/settings.ts'
@@ -825,10 +828,15 @@ const main = async () => {
     console.warn('⚠️ Geocoding disabled - detected locations will not be reverse geocoded')
   }
 
-  // Create detection trigger with geocode queue
+  // Create detection trigger with geocode queue. The proactive
+  // location_visit materialization piggy-backs on this same debounced
+  // post-GPS-ingestion path (see #654).
   const detectionTrigger: DetectionTrigger = createDetectionTrigger({
     geocodeQueue,
     getDetectedLocationById,
+    getNamedLocations,
+    getPlaceVisits,
+    insertActivities,
     runDetectionForUser,
   })
 

--- a/apps/backend/src/services/detection-trigger.test.ts
+++ b/apps/backend/src/services/detection-trigger.test.ts
@@ -20,6 +20,9 @@ describe('createDetectionTrigger', () => {
       lat: 59.3293,
       lon: 18.0686,
     }),
+    getNamedLocations: vi.fn().mockResolvedValue([]),
+    getPlaceVisits: vi.fn().mockResolvedValue([]),
+    insertActivities: vi.fn().mockResolvedValue(undefined),
     runDetectionForUser: vi.fn().mockResolvedValue({
       created: 1,
       needsGeocode: ['loc-1'],
@@ -214,5 +217,93 @@ describe('createDetectionTrigger', () => {
 
     expect(trigger1.getPendingDetectionCount()).toBe(1)
     expect(trigger2.getPendingDetectionCount()).toBe(0)
+  })
+
+  test('proactively materializes location_visit activities for opted-in named visits', async () => {
+    const deps = createMockDeps()
+    const start = new Date('2026-04-20T08:00:00Z')
+    const end = new Date('2026-04-20T09:30:00Z')
+    vi.mocked(deps.getPlaceVisits).mockResolvedValue([
+      {
+        duration_minutes: 90,
+        end_time: end,
+        lat: 59.33,
+        lon: 18.07,
+        name: 'Home',
+        named_location_id: 'nl-home',
+        source: 'named',
+        start_time: start,
+      },
+    ] as never)
+    vi.mocked(deps.getNamedLocations).mockResolvedValue([
+      {
+        auto_create_activity: true,
+        id: 'nl-home',
+        lat: 59.33,
+        lon: 18.07,
+        name: 'Home',
+        radius: 100,
+      },
+    ] as never)
+
+    const trigger = createDetectionTrigger(deps)
+    trigger.triggerDetectionForUser('testuser')
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(deps.insertActivities).toHaveBeenCalledWith(
+      'testuser',
+      expect.arrayContaining([
+        expect.objectContaining({
+          activity_type: 'location_visit',
+          external_id: `locvisit_nl-home_${start.getTime()}`,
+        }),
+      ]),
+    )
+  })
+
+  test('skips materialization when no opted-in named locations exist', async () => {
+    const deps = createMockDeps()
+    vi.mocked(deps.getPlaceVisits).mockResolvedValue([
+      {
+        duration_minutes: 30,
+        end_time: new Date(),
+        lat: 0,
+        lon: 0,
+        name: 'X',
+        named_location_id: 'nl-x',
+        source: 'named',
+        start_time: new Date(),
+      },
+    ] as never)
+    // No opted-in locations
+    vi.mocked(deps.getNamedLocations).mockResolvedValue([
+      { auto_create_activity: false, id: 'nl-x', lat: 0, lon: 0, name: 'X', radius: 100 },
+    ] as never)
+
+    const trigger = createDetectionTrigger(deps)
+    trigger.triggerDetectionForUser('testuser')
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(deps.insertActivities).not.toHaveBeenCalled()
+  })
+
+  test('materialization failure does not derail detection bookkeeping', async () => {
+    const { auditError } = await import('./audit-log.ts')
+    const deps = createMockDeps()
+    vi.mocked(deps.getPlaceVisits).mockRejectedValue(new Error('boom'))
+
+    const trigger = createDetectionTrigger(deps)
+    trigger.triggerDetectionForUser('testuser')
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(deps.runDetectionForUser).toHaveBeenCalled()
+    expect(auditError).toHaveBeenCalledWith(
+      'testuser',
+      'data',
+      'location_visit materialization failed',
+      expect.objectContaining({ error: expect.stringContaining('boom') }),
+    )
+    // Pending tracker still cleans up
+    expect(trigger.hasPendingDetection('testuser')).toBe(false)
   })
 })

--- a/apps/backend/src/services/detection-trigger.ts
+++ b/apps/backend/src/services/detection-trigger.ts
@@ -5,10 +5,12 @@
  * This prevents running detection on every single location update.
  */
 
-import type { DetectedLocation } from '../db/index.ts'
+import type { Activity, DetectedLocation, NamedLocation } from '../db/index.ts'
 import type { GeocodeQueue } from './geocode-queue.ts'
+import type { PlaceVisit } from './locations.ts'
 
 import { auditError, auditInfo } from './audit-log.ts'
+import { materializeForRange } from './location-visit-activities.ts'
 
 // ============================================================================
 // Types
@@ -18,6 +20,11 @@ export interface DetectionTriggerDeps {
   runDetectionForUser: (user: string) => Promise<{ created: number; updated: number; needsGeocode: string[] }>
   getDetectedLocationById: (user: string, id: string) => Promise<DetectedLocation | null>
   geocodeQueue: GeocodeQueue | null
+  /** Lookback window for location_visit activity materialization. Default 7 days. */
+  materializeLookbackDays?: number
+  getPlaceVisits: (user: string, start: Date, end: Date) => Promise<PlaceVisit[]>
+  getNamedLocations: (user: string) => Promise<NamedLocation[]>
+  insertActivities: (user: string, activities: Activity[]) => Promise<unknown>
 }
 
 export interface DetectionTrigger {
@@ -32,6 +39,7 @@ export interface DetectionTrigger {
 // ============================================================================
 
 const DEBOUNCE_MS = 5000 // 5 seconds
+const DEFAULT_MATERIALIZE_LOOKBACK_DAYS = 7
 
 // ============================================================================
 // Factory
@@ -53,6 +61,28 @@ export const createDetectionTrigger = (deps: DetectionTriggerDeps): DetectionTri
    * - The geocode queue (pg-boss) persists jobs, so no geocoding work is lost
    */
   const pendingDetections: Map<string, NodeJS.Timeout> = new Map()
+
+  const lookbackDays = deps.materializeLookbackDays ?? DEFAULT_MATERIALIZE_LOOKBACK_DAYS
+
+  /**
+   * Materialize location_visit activities for the recent window. Runs after
+   * detection so opted-in named-location visits become activities without
+   * waiting for someone to browse /locations for the range.
+   */
+  const materializeRecentVisits = async (user: string): Promise<void> => {
+    const end = new Date()
+    const start = new Date(end.getTime() - lookbackDays * 24 * 60 * 60 * 1000)
+    const result = await materializeForRange(user, start, end, {
+      getNamedLocations: deps.getNamedLocations,
+      getPlaceVisits: deps.getPlaceVisits,
+      insertActivities: deps.insertActivities,
+    })
+    if (result.upserted > 0) {
+      auditInfo(user, 'data', 'location_visit activities materialized', {
+        upserted: result.upserted,
+      })
+    }
+  }
 
   /**
    * Execute detection and queue geocoding for a user.
@@ -83,6 +113,15 @@ export const createDetectionTrigger = (deps: DetectionTriggerDeps): DetectionTri
             })
           }
         }
+      }
+
+      // Proactive location_visit materialization. Don't let failures here
+      // affect detection bookkeeping — the /locations on-read backstop will
+      // catch up next time someone browses the range.
+      try {
+        await materializeRecentVisits(user)
+      } catch (error) {
+        auditError(user, 'data', 'location_visit materialization failed', { error: String(error) })
       }
     } catch (error) {
       auditError(user, 'data', 'Location detection failed', { error: String(error) })

--- a/apps/backend/src/services/location-visit-activities.test.ts
+++ b/apps/backend/src/services/location-visit-activities.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import type { NamedLocation } from '../db/types.ts'
 import type { PlaceVisit } from './locations.ts'
 
-import { visitsToActivities } from './location-visit-activities.ts'
+import {
+  materializeForRange,
+  materializeFromVisits,
+  visitsToActivities,
+} from './location-visit-activities.ts'
 
 const nl = (overrides: Partial<NamedLocation>): NamedLocation => ({
   auto_create_activity: false,
@@ -88,5 +92,70 @@ describe('visitsToActivities', () => {
     const named = [nl({ auto_create_activity: false })]
     const visits = [visit({ named_location_id: 'nl-1' })]
     expect(visitsToActivities(visits, named)).toEqual([])
+  })
+})
+
+describe('materializeFromVisits', () => {
+  test('upserts activities for opted-in named visits', async () => {
+    const named = [nl({ id: 'nl-1', auto_create_activity: true })]
+    const visits = [visit({ named_location_id: 'nl-1' })]
+    const insertActivities = vi.fn().mockResolvedValue(undefined)
+    const getNamedLocations = vi.fn().mockResolvedValue(named)
+
+    const result = await materializeFromVisits('user', visits, { getNamedLocations, insertActivities })
+
+    expect(result).toEqual({ upserted: 1 })
+    expect(insertActivities).toHaveBeenCalledWith(
+      'user',
+      expect.arrayContaining([expect.objectContaining({ activity_type: 'location_visit' })]),
+    )
+  })
+
+  test('short-circuits without fetching named locations when no named visits present', async () => {
+    const visits = [visit({ source: 'detected', named_location_id: undefined })]
+    const getNamedLocations = vi.fn()
+    const insertActivities = vi.fn()
+
+    const result = await materializeFromVisits('user', visits, { getNamedLocations, insertActivities })
+
+    expect(result).toEqual({ upserted: 0 })
+    expect(getNamedLocations).not.toHaveBeenCalled()
+    expect(insertActivities).not.toHaveBeenCalled()
+  })
+
+  test('returns 0 when named locations exist but none are opted in', async () => {
+    const named = [nl({ id: 'nl-1', auto_create_activity: false })]
+    const visits = [visit({ named_location_id: 'nl-1' })]
+    const insertActivities = vi.fn()
+
+    const result = await materializeFromVisits('user', visits, {
+      getNamedLocations: vi.fn().mockResolvedValue(named),
+      insertActivities,
+    })
+
+    expect(result).toEqual({ upserted: 0 })
+    expect(insertActivities).not.toHaveBeenCalled()
+  })
+})
+
+describe('materializeForRange', () => {
+  test('fetches visits then delegates to materializeFromVisits', async () => {
+    const named = [nl({ id: 'nl-1', auto_create_activity: true })]
+    const visits = [visit({ named_location_id: 'nl-1' })]
+    const start = new Date('2026-04-19T00:00:00Z')
+    const end = new Date('2026-04-20T00:00:00Z')
+
+    const getPlaceVisits = vi.fn().mockResolvedValue(visits)
+    const getNamedLocations = vi.fn().mockResolvedValue(named)
+    const insertActivities = vi.fn().mockResolvedValue(undefined)
+
+    const result = await materializeForRange('user', start, end, {
+      getNamedLocations,
+      getPlaceVisits,
+      insertActivities,
+    })
+
+    expect(getPlaceVisits).toHaveBeenCalledWith('user', start, end)
+    expect(result).toEqual({ upserted: 1 })
   })
 })

--- a/apps/backend/src/services/location-visit-activities.ts
+++ b/apps/backend/src/services/location-visit-activities.ts
@@ -46,3 +46,55 @@ export const visitsToActivities = (visits: PlaceVisit[], namedLocations: NamedLo
   }
   return activities
 }
+
+/**
+ * Dependencies for the materialize helpers, kept narrow so callers can
+ * inject mocks in tests.
+ */
+export interface MaterializeDeps {
+  getNamedLocations: (user: string) => Promise<NamedLocation[]>
+  insertActivities: (user: string, activities: Activity[]) => Promise<unknown>
+}
+
+/**
+ * Upsert `location_visit` activities for any visits to opted-in named
+ * locations. Caller supplies the already-computed visits (typically from a
+ * preceding `getPlaceVisits` call).
+ *
+ * Idempotent: external_id is `locvisit_${named_location_id}_${startEpochMs}`,
+ * so the (source, external_id) unique index makes re-runs safe.
+ */
+export const materializeFromVisits = async (
+  user: string,
+  visits: PlaceVisit[],
+  deps: MaterializeDeps,
+): Promise<{ upserted: number }> => {
+  if (!visits.some((v) => v.source === 'named')) return { upserted: 0 }
+
+  const namedLocations = await deps.getNamedLocations(user)
+  const optedIn = namedLocations.filter((nl) => nl.auto_create_activity)
+  if (optedIn.length === 0) return { upserted: 0 }
+
+  const activities = visitsToActivities(visits, optedIn)
+  if (activities.length === 0) return { upserted: 0 }
+
+  await deps.insertActivities(user, activities)
+  return { upserted: activities.length }
+}
+
+/**
+ * Convenience wrapper for the proactive-materialization path: fetch visits
+ * for [start, end] then materialize. Use `materializeFromVisits` directly
+ * when the caller already has the visits in hand.
+ */
+export const materializeForRange = async (
+  user: string,
+  start: Date,
+  end: Date,
+  deps: MaterializeDeps & {
+    getPlaceVisits: (user: string, start: Date, end: Date) => Promise<PlaceVisit[]>
+  },
+): Promise<{ upserted: number }> => {
+  const visits = await deps.getPlaceVisits(user, start, end)
+  return materializeFromVisits(user, visits, deps)
+}

--- a/apps/backend/src/services/queries/locations.ts
+++ b/apps/backend/src/services/queries/locations.ts
@@ -5,40 +5,26 @@
 import type { PlaceSummary } from './types.ts'
 
 import { getNamedLocations, insertActivities } from '../../db/index.ts'
-import { visitsToActivities } from '../location-visit-activities.ts'
+import { materializeFromVisits } from '../location-visit-activities.ts'
 import { getPlaceVisits } from '../locations.ts'
 
 /**
  * Query locations/places for a time range.
  *
  * Side effect: visits to named locations with auto_create_activity=true are
- * fire-and-forget materialized as location_visit activities. Idempotent via
- * (source, external_id) upsert, so repeat calls are safe.
+ * fire-and-forget materialized as location_visit activities. This is a
+ * backstop — the proactive path runs after each GPS ingestion (see
+ * detection-trigger). Idempotent via (source, external_id) upsert, so the
+ * two paths can't double-insert.
  */
 export async function queryLocations(user: string, start: Date, end: Date): Promise<PlaceSummary[]> {
   const visits = await getPlaceVisits(user, start, end)
 
-  // Fire-and-forget: upsert activities for opted-in named-location visits.
-  // Skip the whole thing if the user has no visits matched to a named
-  // location — avoids the getNamedLocations round-trip on the common case
-  // where a query lands on GPS data that didn't resolve to anything named.
-  const hasNamedVisit = visits.some((v) => v.source === 'named')
-  if (hasNamedVisit) {
-    void (async () => {
-      try {
-        const namedLocations = await getNamedLocations(user)
-        const optedIn = namedLocations.filter((nl) => nl.auto_create_activity)
-        if (optedIn.length === 0) return
-        const activities = visitsToActivities(visits, optedIn)
-        if (activities.length === 0) return
-        await insertActivities(user, activities)
-      } catch (err) {
-        // Don't let activity materialization failures surface to the user —
-        // the /locations endpoint still returned valid data.
-        console.error('location_visit activity materialization failed:', err)
-      }
-    })()
-  }
+  // Fire-and-forget. Don't let materialization failures surface to the user —
+  // the /locations response is still valid GPS data either way.
+  void materializeFromVisits(user, visits, { getNamedLocations, insertActivities }).catch((err) => {
+    console.error('location_visit activity materialization failed:', err)
+  })
 
   return visits.map((p) => ({
     address: p.address,


### PR DESCRIPTION
## Summary

Closes #654. `location_visit` activities now materialize whenever new GPS arrives, not only when someone browses `/locations`.

### How

Hooks into the existing post-GPS-ingestion debounce trigger (`detection-trigger.ts`). After `runDetectionForUser` finishes (5 s after the last OwnTracks location post), `materializeForRange` runs over a 7-day lookback. Anything already materialized is upserted via the deterministic `external_id = locvisit_{named_location_id}_{startEpochMs}`, so re-runs are safe.

### Refactor

Split materialization into two:

- **`materializeFromVisits(user, visits, deps)`** — caller already has visits. Used by `queryLocations` to avoid redoing the `getPlaceVisits` round-trip it already did.
- **`materializeForRange(user, start, end, deps)`** — convenience wrapper that fetches visits first. Used by the proactive trigger.

The on-read materialization in `queryLocations` stays as a backstop — the (source, external_id) unique index makes the two paths double-insert-safe.

### Tests

New tests cover:
- Proactive materialization happy path (opted-in named visit → location_visit activity inserted)
- No-op when no opted-in locations
- Graceful degradation when `getPlaceVisits` throws (detection bookkeeping must not be left in a half-state)
- Both new helpers (`materializeFromVisits`, `materializeForRange`)

## Test plan
- [x] All 1499 unit tests pass
- [x] TypeScript clean
- [x] Existing detection-trigger tests still pass with the new dep wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)