### PR TITLE
feat: derive timeline screentime from activities, drop /productivity fetch (#661)

### DIFF
--- a/apps/web/src/pages/Timeline/categorize.test.ts
+++ b/apps/web/src/pages/Timeline/categorize.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import type { Activity, Meal, Place, ProductivityRecord } from '../../state/api'
 
+import type { ScreentimeCategory } from '@aurboda/api-spec'
+
 import {
   categorizeLocations,
   categorizeMeals,
   categorizeOtherActivities,
   categorizeProductivity,
+  categorizeScreentimeActivities,
 } from './categorize'
 
 describe('categorizeLocations', () => {
@@ -160,5 +163,89 @@ describe('categorizeProductivity', () => {
   it('generates href for records with category_id', () => {
     const items = categorizeProductivity([makeRecord({ category_id: 'cat-1' })], [], {})
     expect(items[0]!.href).toBe('/screentime-categories/cat-1')
+  })
+})
+
+describe('categorizeScreentimeActivities', () => {
+  const makeActivity = (overrides: Partial<Activity> = {}): Activity =>
+    ({
+      activity_type: 'screentime',
+      data: { category_path: 'Work > Programming' },
+      end_time: new Date('2026-01-01T09:00:00Z'),
+      id: 'act-1',
+      source: 'rescuetime',
+      start_time: new Date('2026-01-01T08:00:00Z'),
+      ...overrides,
+    }) as Activity
+
+  const makeCategory = (overrides: Partial<ScreentimeCategory>): ScreentimeCategory =>
+    ({
+      id: 'cat-1',
+      name: ['Work', 'Programming'],
+      ...overrides,
+    }) as ScreentimeCategory
+
+  it('returns Screen Time column items routed to the activity entity', () => {
+    const items = categorizeScreentimeActivities([makeActivity()], [], {})
+    expect(items).toHaveLength(1)
+    expect(items[0]!.column).toBe('Screen Time')
+    expect(items[0]!.entity_type).toBe('activity')
+  })
+
+  it('uses last category-path segment as label', () => {
+    const items = categorizeScreentimeActivities([makeActivity()], [], {})
+    expect(items[0]!.label).toBe('Programming')
+  })
+
+  it('skips activities without an end_time', () => {
+    const items = categorizeScreentimeActivities([makeActivity({ end_time: undefined })], [], {})
+    expect(items).toEqual([])
+  })
+
+  it('skips activities of other types', () => {
+    const items = categorizeScreentimeActivities(
+      [makeActivity({ activity_type: 'exercise' })],
+      [],
+      {},
+    )
+    expect(items).toEqual([])
+  })
+
+  it('matches category by exact path for href and clears entity_id', () => {
+    const items = categorizeScreentimeActivities(
+      [makeActivity()],
+      [makeCategory({ id: 'cat-prog' })],
+      {},
+    )
+    expect(items[0]!.href).toBe('/screentime-categories/cat-prog')
+    expect(items[0]!.entity_id).toBeUndefined()
+  })
+
+  it('walks up the path to find a parent-category match', () => {
+    const items = categorizeScreentimeActivities(
+      [makeActivity()],
+      [makeCategory({ id: 'cat-work', name: ['Work'], color: '#abc' })],
+      {},
+    )
+    expect(items[0]!.color).toBe('#abc')
+    expect(items[0]!.href).toBe('/screentime-categories/cat-work')
+  })
+
+  it('keeps the activity id as entity_id when no category matches', () => {
+    const items = categorizeScreentimeActivities([makeActivity()], [], {})
+    expect(items[0]!.entity_id).toBe('act-1')
+    expect(items[0]!.href).toBeUndefined()
+  })
+
+  it('uses category icon from itemIcons', () => {
+    const items = categorizeScreentimeActivities([makeActivity()], [], {
+      'category:Work > Programming': '💻',
+    })
+    expect(items[0]!.icon).toBe('💻')
+  })
+
+  it('handles missing category_path gracefully', () => {
+    const items = categorizeScreentimeActivities([makeActivity({ data: {} })], [], {})
+    expect(items[0]!.label).toBe('Screen time')
   })
 })

--- a/apps/web/src/pages/Timeline/categorize.ts
+++ b/apps/web/src/pages/Timeline/categorize.ts
@@ -7,7 +7,13 @@ import type { ChartItem, Column } from './types'
 
 import { toDisplayName } from '../../utils/displayName'
 import { resolveItemIcon } from '../../utils/emojiLookup'
-import { getActivityColor, getPlaceColor, getResolvedColor, resolveCategoryIcon } from './colors'
+import {
+  getActivityColor,
+  getPlaceColor,
+  getProductivityColor,
+  getResolvedColor,
+  resolveCategoryIcon,
+} from './colors'
 import { formatDuration, formatTime } from './formatting'
 
 export const categorizeLocations = (places: Place[], uniquePlaceNames: string[]): ChartItem[] =>
@@ -148,3 +154,66 @@ export const categorizeProductivity = (
       },
     }
   })
+
+/**
+ * Match a category-path array against the user's screentime categories,
+ * walking from deepest match upward. Returns the most specific match (or
+ * undefined if nothing in the path matches a defined category).
+ */
+const matchCategoryByPath = (
+  path: string[],
+  categories: ScreentimeCategory[],
+): ScreentimeCategory | undefined => {
+  for (let depth = path.length; depth > 0; depth--) {
+    const sub = path.slice(0, depth)
+    const match = categories.find(
+      (c) => c.name.length === sub.length && c.name.every((n, i) => n === sub[i]),
+    )
+    if (match) return match
+  }
+  return undefined
+}
+
+/**
+ * Categorize `screentime` activities into Screen Time lane items. The
+ * underlying activity rows are pre-merged spans (one per category-source
+ * window), so per-app names are not available in the tooltip — the lane
+ * still shows category, time range, and duration.
+ */
+export const categorizeScreentimeActivities = (
+  activities: Activity[],
+  categories: ScreentimeCategory[],
+  itemIcons: Record<string, string>,
+): ChartItem[] =>
+  activities
+    .filter((a): a is Activity & { end_time: Date } =>
+      Boolean(a.activity_type === 'screentime' && a.end_time),
+    )
+    .map((a) => {
+      const categoryPathStr = typeof a.data?.category_path === 'string' ? a.data.category_path : ''
+      const path = categoryPathStr ? categoryPathStr.split(' > ') : []
+      const label = path.at(-1) ?? 'Screen time'
+      const score = typeof a.data?.score === 'number' ? a.data.score : undefined
+
+      const matched = matchCategoryByPath(path, categories)
+      const color = matched?.color ?? getProductivityColor(score)
+      const href = matched ? `/screentime-categories/${matched.id}` : undefined
+
+      return {
+        color,
+        column: 'Screen Time' as Column,
+        end: a.end_time,
+        entity_id: matched ? undefined : a.id,
+        entity_type: 'activity' as const,
+        href,
+        icon: resolveCategoryIcon(path, itemIcons),
+        isPoint: false,
+        label,
+        start: a.start_time,
+        tooltip: {
+          details: [categoryPathStr, formatDuration(a.start_time, a.end_time)].filter(Boolean),
+          time: `${formatTime(a.start_time)} – ${formatTime(a.end_time)}`,
+          title: label,
+        },
+      }
+    })

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -53,7 +53,6 @@ export const Timeline = () => {
     viewLabel,
     bucketSize,
     barBucketSize,
-    screentimeMergeGapMs,
   } = nav
 
   // ── Orientation state ──────────────────────────────────────────────────────
@@ -105,7 +104,6 @@ export const Timeline = () => {
     fetchStart,
     fromDateKey: fromDate.value,
     hiddenCategories,
-    screentimeMergeGapMs,
     toDateKey: toDate.value,
   })
   const {

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -12,7 +12,6 @@ import {
   fetchActivityTypeDefinitions,
   fetchBucketedMetrics,
   fetchMeals,
-  fetchProductivity,
   fetchScreentimeCategories,
   fetchScreentimeBucketed,
   fetchItemIcons,
@@ -32,7 +31,7 @@ import {
   categorizeLocations,
   categorizeMeals,
   categorizeOtherActivities,
-  categorizeProductivity,
+  categorizeScreentimeActivities,
 } from './categorize'
 import { categorizeMusic } from './categorizeMusic'
 import { activityColors, getExerciseColor } from './colors'
@@ -47,13 +46,12 @@ const TIMELINE_EXCLUDED_METRICS = ['training_impulse', 'activity_impulse']
 const ACTIVITY_CATEGORIES = new Set(['sleep_rest', 'exercise', 'meditation', 'wellness'])
 
 /**
- * Activity types fetched via dedicated endpoints (productivity) and therefore
- * excluded from the unified `/activities` payload to avoid sending the same
- * rows twice. `music_scrobble` and `location_visit` are intentionally NOT
- * excluded — the timeline derives the music staff and location lane directly
- * from this fetch.
+ * The Timeline now fetches every activity-sourced track in a single
+ * `/activities` call. `music_scrobble`, `location_visit`, and `screentime`
+ * are all in the unified payload and dispatched to their respective lanes
+ * by `activity_type`.
  */
-const TIMELINE_EXCLUDED_ACTIVITY_TYPES = ['screentime']
+const TIMELINE_EXCLUDED_ACTIVITY_TYPES: string[] = []
 
 export interface TimelineData {
   // Raw query results needed by rendering
@@ -86,7 +84,6 @@ export interface UseTimelineDataOptions {
   hiddenCategories: Set<LegendCategory>
   bucketSize: string
   barBucketSize: '1h' | '1d' | '1w'
-  screentimeMergeGapMs: number
 }
 
 // eslint-disable-next-line complexity -- data hook aggregating multiple queries
@@ -98,7 +95,6 @@ export const useTimelineData = ({
   hiddenCategories,
   bucketSize,
   barBucketSize,
-  screentimeMergeGapMs,
 }: UseTimelineDataOptions): TimelineData => {
   // ── Data queries ───────────────────────────────────────────────────────────
 
@@ -127,14 +123,6 @@ export const useTimelineData = ({
     placeholderData: keepPreviousData,
     queryFn: () => fetchMeals({ start: fetchStart.toISOString(), end: fetchEnd.toISOString() }),
     queryKey: ['timeline-meals', fromDateKey, toDateKey],
-    staleTime: 5 * 60 * 1000,
-  })
-
-  const productivityQuery = useQuery({
-    enabled: !hiddenCategories.has('activity') && !hiddenCategories.has('screentime'),
-    placeholderData: keepPreviousData,
-    queryFn: () => fetchProductivity(fetchStart, fetchEnd, 'category', screentimeMergeGapMs),
-    queryKey: ['timeline-productivity', fromDateKey, toDateKey, screentimeMergeGapMs],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -260,7 +248,15 @@ export const useTimelineData = ({
         }),
     [activitiesQuery.data],
   )
-  const productivity = productivityQuery.data?.records ?? []
+  // Screentime spans are derived from `screentime` activities. The backend
+  // pre-merges adjacent records into spans at sync/backfill time (2-min gap),
+  // so the per-app names that the old /productivity endpoint enriched the
+  // tooltip with are not available — the lane still shows category, range,
+  // and duration.
+  const screentimeActivities = useMemo<Activity[]>(
+    () => (activitiesQuery.data ?? []).filter((a) => a.activity_type === 'screentime'),
+    [activitiesQuery.data],
+  )
   // Music scrobbles are derived from `music_scrobble` activities — they live
   // in the activities table and are already returned by the activities fetch,
   // so no separate /lastfm/scrobbles network call is needed.
@@ -384,7 +380,11 @@ export const useTimelineData = ({
       ...activityItems,
       ...categorizeLocations(places, uniquePlaceNames),
       ...categorizeOtherActivities(otherActivities, itemIcons, typeDefsMap),
-      ...categorizeProductivity(productivity, screentimeCategoriesQuery.data ?? [], itemIcons),
+      ...categorizeScreentimeActivities(
+        screentimeActivities,
+        screentimeCategoriesQuery.data ?? [],
+        itemIcons,
+      ),
       ...musicItems,
       ...mealItems,
     ],
@@ -395,7 +395,7 @@ export const useTimelineData = ({
       otherActivities,
       itemIcons,
       typeDefsMap,
-      productivity,
+      screentimeActivities,
       screentimeCategoriesQuery.data,
       musicItems,
       mealItems,
@@ -427,17 +427,11 @@ export const useTimelineData = ({
   )
 
   const isFetching =
-    activitiesQuery.isFetching ||
-    mealsQuery.isFetching ||
-    productivityQuery.isFetching ||
-    bucketedMetricsQuery.isFetching
+    activitiesQuery.isFetching || mealsQuery.isFetching || bucketedMetricsQuery.isFetching
 
-  const isInitialLoad = activitiesQuery.isLoading && productivityQuery.isLoading
+  const isInitialLoad = activitiesQuery.isLoading
 
-  const errorSources = [
-    activitiesQuery.isError && 'activities',
-    productivityQuery.isError && 'screen time',
-  ].filter(Boolean) as string[]
+  const errorSources = [activitiesQuery.isError && 'activities'].filter(Boolean) as string[]
 
   return {
     activities,


### PR DESCRIPTION
## Summary

Closes the consolidation work in #661. The Timeline now fetches **every** activity-sourced track in a single `/activities` round-trip and dispatches by `activity_type` on the frontend:

| Lane | Source |
|---|---|
| Activity | activities (the bulk) |
| Music staff | `music_scrobble` activities |
| Location | `location_visit` activities |
| Screen Time | `screentime` activities ← this PR |

## What's new

- **`categorizeScreentimeActivities(activities, categories, icons)`** — renders Screen Time lane items from `screentime` activities. Color and href come from matching `data.category_path` against the user's configured categories, walking up the hierarchy until a defined category is found.
- **`TIMELINE_EXCLUDED_ACTIVITY_TYPES` is now empty** — every activity-typed row arrives in the unified payload.
- **Drops `productivityQuery`** from `useTimelineData`.
- **Drops `screentimeMergeGapMs`** prop — it only fed the removed `/productivity` fetch. Screentime activities are pre-merged with a fixed 2-min gap at sync time.

## Behavior changes

- Tooltip no longer shows per-app names (`activity` field) or per-record titles. Underlying screentime spans were merged at sync time and don't carry that detail. Lane still shows category, time range, and duration — the load-bearing info for the screen-time view.
- Click-through routes to the activity detail page (entity_type `activity`) instead of the old productivity-record page.

## Test plan
- [x] All 301 web tests pass (9 new)
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)