### PR TITLE
feat: enrich activity queries with summary metrics + add deep-dive detail tool

### DIFF
--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -147,8 +147,8 @@ export const getTimeSeriesMultiMetric = async (
   metrics: MetricType[],
   start: Date,
   end: Date,
-): Promise<Record<MetricType, [Date, number][]>> => {
-  if (metrics.length === 0) return {} as Record<MetricType, [Date, number][]>
+): Promise<Partial<Record<MetricType, [Date, number][]>>> => {
+  if (metrics.length === 0) return {}
 
   const rows = await querySplitByCumulative<{ metric: string; time: Date; value: number }>({
     cumulativeExtraParams: [cumulativeSources],
@@ -165,13 +165,14 @@ export const getTimeSeriesMultiMetric = async (
        ORDER BY metric, time`,
   })
 
-  const data: Record<string, [Date, number][]> = {}
+  const data: Partial<Record<MetricType, [Date, number][]>> = {}
   for (const row of rows) {
-    if (!data[row.metric]) data[row.metric] = []
-    data[row.metric].push([row.time, row.value])
+    const metric = row.metric as MetricType
+    const list = data[metric] ?? []
+    list.push([row.time, row.value])
+    data[metric] = list
   }
-
-  return data as Record<MetricType, [Date, number][]>
+  return data
 }
 
 // ============================================================================

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -12,20 +12,22 @@ import {
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
-import { getActivityById, getAllActivityTypeNames, getOverlappingActivities } from '../db/index.ts'
+import { getActivityById, getAllActivityTypeNames } from '../db/index.ts'
 import { getCustomMetrics } from '../services/mutations.ts'
 import {
-  ALL_METRICS_SENTINEL,
   computeActivityDetailMetrics,
   getActivityFullDetail,
   getDailySummary,
   getPeriodSummary,
+  parseActivityId,
+  parseMetricsParam,
   queryActivities,
   queryLocations,
   queryMetrics,
   queryMetricsBucketed,
   queryProductivity,
   queryTags,
+  resolveActivityWindow,
 } from '../services/queries/index.ts'
 import {
   errorResponse,
@@ -221,44 +223,17 @@ Source-agnostic: works for any activity that has time-series and/or GPS populate
         ),
       tz: tzSchema,
     },
-    async ({ id, include_gps, metrics, tz }) => {
-      const isMerged = id.startsWith('merged:')
-      const realId = isMerged ? id.slice('merged:'.length) : id
-
-      const activity = await getActivityById(user, realId, true)
+    async ({ id: rawId, include_gps, metrics, tz }) => {
+      const { id, isMerged } = parseActivityId(rawId)
+      const activity = await getActivityById(user, id, true)
       if (!activity) return errorResponse('Activity not found')
 
-      // Expand window for merged view across overlapping sources.
-      let detailRange = { end_time: activity.end_time, start_time: activity.start_time }
-      let effectiveData = activity.data
-      if (isMerged && !activity.deleted_at) {
-        const overlapping = await getOverlappingActivities(user, activity)
-        if (overlapping.length > 1) {
-          detailRange = {
-            end_time: new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))),
-            start_time: new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))),
-          }
-          effectiveData = overlapping
-            .toSorted((a, b) => a.start_time.getTime() - b.start_time.getTime())
-            .reduce<Record<string, unknown>>((acc, a) => (a.data ? { ...acc, ...a.data } : acc), {})
-        }
-      }
-
-      const requestedMetrics =
-        metrics === ALL_METRICS_SENTINEL
-          ? [ALL_METRICS_SENTINEL]
-          : metrics
-            ? metrics
-                .split(',')
-                .map((s) => s.trim())
-                .filter(Boolean)
-            : undefined
-
+      const window = await resolveActivityWindow(user, activity, isMerged)
       const [summary, fullDetail] = await Promise.all([
-        computeActivityDetailMetrics(user, { ...detailRange, data: effectiveData }),
-        getActivityFullDetail(user, detailRange, {
+        computeActivityDetailMetrics(user, window),
+        getActivityFullDetail(user, window, {
           includeGps: include_gps,
-          metrics: requestedMetrics,
+          metrics: parseMetricsParam(metrics),
         }),
       ])
 
@@ -268,7 +243,7 @@ Source-agnostic: works for any activity that has time-series and/or GPS populate
             ...summary,
             ...fullDetail,
             activity_type: activity.activity_type,
-            data: effectiveData,
+            data: window.data,
             end_time: activity.end_time?.toISOString(),
             id: activity.id,
             notes: activity.notes,

--- a/apps/backend/src/mcp/query-tools.ts
+++ b/apps/backend/src/mcp/query-tools.ts
@@ -12,9 +12,12 @@ import {
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
-import { getAllActivityTypeNames } from '../db/index.ts'
+import { getActivityById, getAllActivityTypeNames, getOverlappingActivities } from '../db/index.ts'
 import { getCustomMetrics } from '../services/mutations.ts'
 import {
+  ALL_METRICS_SENTINEL,
+  computeActivityDetailMetrics,
+  getActivityFullDetail,
   getDailySummary,
   getPeriodSummary,
   queryActivities,
@@ -187,6 +190,96 @@ Use cases:
         dataFilters,
       )
       return tzJsonResponse({ data: activities, success: true }, tz)
+    },
+  )
+
+  // Tool: get_activity_detail
+  server.tool(
+    'get_activity_detail',
+    `Deep-dive detail for a single activity: summary metrics (distance, avg pace, avg cadence, avg power, avg ground contact time, body battery before/after, elevation gain/loss, HR zones), GPS trace, and per-metric time-series.
+
+Pass id with the "merged:" prefix to include all overlapping cross-source data in the time window.
+
+The 'metrics' parameter controls time-series payload size:
+- omit it for summary + GPS only (compact)
+- pass 'all' for every metric with data in the activity range
+- pass a comma-separated list (e.g. 'heart_rate,speed,elevation') for specific metrics
+
+Source-agnostic: works for any activity that has time-series and/or GPS populated within its time range.`,
+    {
+      id: z.string().describe('Activity ID. Prefix with "merged:" to get the merged cross-source view.'),
+      include_gps: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe('Include GPS trace if locations exist for the activity time range.'),
+      metrics: z
+        .string()
+        .optional()
+        .describe(
+          `Comma-separated metric names, or 'all' for every available metric. Omit for summary + GPS only.`,
+        ),
+      tz: tzSchema,
+    },
+    async ({ id, include_gps, metrics, tz }) => {
+      const isMerged = id.startsWith('merged:')
+      const realId = isMerged ? id.slice('merged:'.length) : id
+
+      const activity = await getActivityById(user, realId, true)
+      if (!activity) return errorResponse('Activity not found')
+
+      // Expand window for merged view across overlapping sources.
+      let detailRange = { end_time: activity.end_time, start_time: activity.start_time }
+      let effectiveData = activity.data
+      if (isMerged && !activity.deleted_at) {
+        const overlapping = await getOverlappingActivities(user, activity)
+        if (overlapping.length > 1) {
+          detailRange = {
+            end_time: new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))),
+            start_time: new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))),
+          }
+          effectiveData = overlapping
+            .toSorted((a, b) => a.start_time.getTime() - b.start_time.getTime())
+            .reduce<Record<string, unknown>>((acc, a) => (a.data ? { ...acc, ...a.data } : acc), {})
+        }
+      }
+
+      const requestedMetrics =
+        metrics === ALL_METRICS_SENTINEL
+          ? [ALL_METRICS_SENTINEL]
+          : metrics
+            ? metrics
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+            : undefined
+
+      const [summary, fullDetail] = await Promise.all([
+        computeActivityDetailMetrics(user, { ...detailRange, data: effectiveData }),
+        getActivityFullDetail(user, detailRange, {
+          includeGps: include_gps,
+          metrics: requestedMetrics,
+        }),
+      ])
+
+      return tzJsonResponse(
+        {
+          data: {
+            ...summary,
+            ...fullDetail,
+            activity_type: activity.activity_type,
+            data: effectiveData,
+            end_time: activity.end_time?.toISOString(),
+            id: activity.id,
+            notes: activity.notes,
+            source: activity.source,
+            start_time: activity.start_time.toISOString(),
+            title: activity.title,
+          },
+          success: true,
+        },
+        tz,
+      )
     },
   )
 

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -1,5 +1,3 @@
-import type { RequestHandler } from 'express'
-
 /**
  * Activities and productivity route group.
  *
@@ -10,8 +8,10 @@ import {
   activitiesQuerySchema,
   type ActivitiesResponse,
   type ActivityDetailResponse,
+  type ActivityFullDetailQuery,
+  activityFullDetailQuerySchema,
+  type ActivityFullDetailResponse,
   type AddActivityBody,
-  type HrZoneSecs,
   addActivityBodySchema,
   type AddActivityResponse,
   type DeleteActivityResponse,
@@ -47,7 +47,6 @@ import {
   getOverlappingActivities,
   getProductivityBucketed,
   getProductivityById,
-  getTimeSeries,
   insertTimeSeries,
   type TimeSeriesPoint,
 } from '../db/index.ts'
@@ -63,36 +62,18 @@ import {
   updateActivity,
 } from '../services/mutations.ts'
 import {
+  type ActivityDetailMetrics,
   assembleScreentimeBuckets,
+  computeActivityDetailMetrics,
+  getActivityFullDetail,
   parseBucketSize,
+  parseMetricsParam,
   queryActivities,
   queryProductivity,
   type SyncProvider,
 } from '../services/queries/index.ts'
-import { computeHrZoneSecs, getEffectiveHrZones } from '../services/settings.ts'
-import { type TypedRouter, typedRouter } from '../typed-router.ts'
+import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
-
-/** Compute HR zone seconds and avg HRV for any activity time range. */
-const computeActivityMetrics = async (
-  user: string,
-  start: Date,
-  end: Date,
-): Promise<{ hr_zone_secs?: HrZoneSecs; avg_hrv?: number }> => {
-  const [hrData, { zones: hrZones }, hrvData] = await Promise.all([
-    getTimeSeries(user, 'heart_rate', start, end),
-    getEffectiveHrZones(user),
-    getTimeSeries(user, 'hrv_rmssd', start, end),
-  ])
-
-  return {
-    avg_hrv:
-      hrvData.length > 0
-        ? Math.round(hrvData.reduce((sum, [, v]) => sum + v, 0) / hrvData.length)
-        : undefined,
-    hr_zone_secs: hrData.length > 0 ? computeHrZoneSecs(hrData, hrZones) : undefined,
-  }
-}
 
 type ActivityRow = Awaited<ReturnType<typeof getActivityById>> & {}
 
@@ -100,7 +81,7 @@ type ActivityRow = Awaited<ReturnType<typeof getActivityById>> & {}
 const buildMergedResponse = async (
   user: string,
   activity: NonNullable<ActivityRow>,
-  activityMetrics: { hr_zone_secs?: HrZoneSecs; avg_hrv?: number },
+  activityMetrics: ActivityDetailMetrics,
 ) => {
   const overlapping = await getOverlappingActivities(user, activity)
   const hasMultipleSources = overlapping.length > 1
@@ -139,18 +120,22 @@ const buildMergedResponse = async (
     {},
   )
 
-  // For merged activities, recompute HR zones using full merged time range
+  // For merged activities, recompute over the full merged time range — HR
+  // zones, HRV, and summary metrics all need the wider window.
   let metrics = activityMetrics
   if (mergedStartTime && mergedEndTime) {
-    metrics = await computeActivityMetrics(user, new Date(mergedStartTime), new Date(mergedEndTime))
+    metrics = await computeActivityDetailMetrics(user, {
+      data: Object.keys(mergedData).length > 0 ? mergedData : activity.data,
+      end_time: new Date(mergedEndTime),
+      start_time: new Date(mergedStartTime),
+    })
   }
 
   return {
+    ...metrics,
     activity_type: activity.activity_type,
-    avg_hrv: metrics.avg_hrv,
     data: Object.keys(mergedData).length > 0 ? mergedData : activity.data,
     end_time: activity.end_time?.toISOString(),
-    hr_zone_secs: metrics.hr_zone_secs,
     id: activity.id,
     merged_end_time: mergedEndTime,
     merged_start_time: mergedStartTime,
@@ -163,7 +148,7 @@ const buildMergedResponse = async (
 }
 
 export const createActivitiesRouter = (
-  authMiddleware: RequestHandler,
+  authMiddleware: AnyMiddleware,
   syncProvider?: SyncProvider,
   onActivityMutated?: ActivityNotifier,
   resyncActivityDetail?: (user: string, activityId: string, garminActivityId: number) => Promise<number>,
@@ -524,11 +509,8 @@ export const createActivitiesRouter = (
       return res.status(404).json({ error: 'Activity not found', success: false })
     }
 
-    // Compute HR zones and avg HRV for any activity with a time range
-    let activityMetrics: { hr_zone_secs?: HrZoneSecs; avg_hrv?: number } = {}
-    if (activity.end_time) {
-      activityMetrics = await computeActivityMetrics(user, activity.start_time, activity.end_time)
-    }
+    // Compute HR zones, avg HRV, and summary metrics for any activity with a time range
+    const activityMetrics = await computeActivityDetailMetrics(user, activity)
 
     // For merged: prefix, fetch overlapping activities and return merged view
     if (isMerged && !activity.deleted_at) {
@@ -554,12 +536,11 @@ export const createActivitiesRouter = (
     // Plain UUID: return raw single activity (no overlap lookup)
     res.json({
       data: {
+        ...activityMetrics,
         activity_type: activity.activity_type,
-        avg_hrv: activityMetrics.avg_hrv,
         data: activity.data,
         deleted_at: activity.deleted_at?.toISOString(),
         end_time: activity.end_time?.toISOString(),
-        hr_zone_secs: activityMetrics.hr_zone_secs,
         id: activity.id,
         notes: activity.notes,
         source: activity.source,
@@ -570,6 +551,73 @@ export const createActivitiesRouter = (
       success: true,
     })
   })
+
+  router.get<{ id: string }, ActivityFullDetailResponse, unknown, ActivityFullDetailQuery>(
+    '/activities/:id/full',
+    authMiddleware,
+    validateQuery(activityFullDetailQuerySchema),
+    async (req, res) => {
+      const rawId = req.params.id
+      const user = req.user!
+      const { metrics: metricsParam, include_gps } = req.query
+
+      const isMerged = rawId.startsWith('merged:')
+      const realId = isMerged ? rawId.slice('merged:'.length) : rawId
+
+      const activity = await getActivityById(user, realId, true)
+      if (!activity) {
+        return res.status(404).json({ error: 'Activity not found', success: false })
+      }
+
+      // For merged activities, expand the time window to cover all overlapping sources.
+      let detailRange = { end_time: activity.end_time, start_time: activity.start_time }
+      let mergedData: Record<string, unknown> = {}
+      if (isMerged && !activity.deleted_at) {
+        const overlapping = await getOverlappingActivities(user, activity)
+        if (overlapping.length > 1) {
+          detailRange = {
+            end_time: new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))),
+            start_time: new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))),
+          }
+        }
+        mergedData = overlapping
+          .toSorted((a, b) => a.start_time.getTime() - b.start_time.getTime())
+          .reduce<Record<string, unknown>>((acc, a) => (a.data ? { ...acc, ...a.data } : acc), {})
+      }
+
+      const effectiveData = Object.keys(mergedData).length > 0 ? mergedData : activity.data
+
+      // 'all' is shorthand for "every metric with data in the activity range".
+      // omitting metrics returns just summary + GPS (callers must opt-in).
+      const requestedMetrics = parseMetricsParam(metricsParam)
+
+      const [activityMetrics, fullDetail] = await Promise.all([
+        computeActivityDetailMetrics(user, { ...detailRange, data: effectiveData }),
+        getActivityFullDetail(
+          user,
+          { end_time: detailRange.end_time, start_time: detailRange.start_time },
+          { includeGps: include_gps !== false, metrics: requestedMetrics },
+        ),
+      ])
+
+      res.json({
+        data: {
+          ...activityMetrics,
+          ...fullDetail,
+          activity_type: activity.activity_type,
+          data: effectiveData,
+          deleted_at: activity.deleted_at?.toISOString(),
+          end_time: activity.end_time?.toISOString(),
+          id: activity.id,
+          notes: activity.notes,
+          source: activity.source,
+          start_time: activity.start_time.toISOString(),
+          title: activity.title,
+        },
+        success: true,
+      })
+    },
+  )
 
   router.post<{ id: string }, { success: boolean; error?: string }>(
     '/activities/:id/restore',

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -7,6 +7,7 @@ import {
   type ActivitiesQuery,
   activitiesQuerySchema,
   type ActivitiesResponse,
+  type ActivityComputedMetrics,
   type ActivityDetailResponse,
   type ActivityFullDetailQuery,
   activityFullDetailQuerySchema,
@@ -62,14 +63,15 @@ import {
   updateActivity,
 } from '../services/mutations.ts'
 import {
-  type ActivityDetailMetrics,
   assembleScreentimeBuckets,
   computeActivityDetailMetrics,
   getActivityFullDetail,
+  parseActivityId,
   parseBucketSize,
   parseMetricsParam,
   queryActivities,
   queryProductivity,
+  resolveActivityWindow,
   type SyncProvider,
 } from '../services/queries/index.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
@@ -81,7 +83,7 @@ type ActivityRow = Awaited<ReturnType<typeof getActivityById>> & {}
 const buildMergedResponse = async (
   user: string,
   activity: NonNullable<ActivityRow>,
-  activityMetrics: ActivityDetailMetrics,
+  activityMetrics: ActivityComputedMetrics,
 ) => {
   const overlapping = await getOverlappingActivities(user, activity)
   const hasMultipleSources = overlapping.length > 1
@@ -557,47 +559,22 @@ export const createActivitiesRouter = (
     authMiddleware,
     validateQuery(activityFullDetailQuerySchema),
     async (req, res) => {
-      const rawId = req.params.id
       const user = req.user!
-      const { metrics: metricsParam, include_gps } = req.query
+      const { id, isMerged } = parseActivityId(req.params.id)
+      const { metrics, include_gps } = req.query
 
-      const isMerged = rawId.startsWith('merged:')
-      const realId = isMerged ? rawId.slice('merged:'.length) : rawId
-
-      const activity = await getActivityById(user, realId, true)
+      const activity = await getActivityById(user, id, true)
       if (!activity) {
         return res.status(404).json({ error: 'Activity not found', success: false })
       }
 
-      // For merged activities, expand the time window to cover all overlapping sources.
-      let detailRange = { end_time: activity.end_time, start_time: activity.start_time }
-      let mergedData: Record<string, unknown> = {}
-      if (isMerged && !activity.deleted_at) {
-        const overlapping = await getOverlappingActivities(user, activity)
-        if (overlapping.length > 1) {
-          detailRange = {
-            end_time: new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime()))),
-            start_time: new Date(Math.min(...overlapping.map((a) => a.start_time.getTime()))),
-          }
-        }
-        mergedData = overlapping
-          .toSorted((a, b) => a.start_time.getTime() - b.start_time.getTime())
-          .reduce<Record<string, unknown>>((acc, a) => (a.data ? { ...acc, ...a.data } : acc), {})
-      }
-
-      const effectiveData = Object.keys(mergedData).length > 0 ? mergedData : activity.data
-
-      // 'all' is shorthand for "every metric with data in the activity range".
-      // omitting metrics returns just summary + GPS (callers must opt-in).
-      const requestedMetrics = parseMetricsParam(metricsParam)
-
+      const window = await resolveActivityWindow(user, activity, isMerged)
       const [activityMetrics, fullDetail] = await Promise.all([
-        computeActivityDetailMetrics(user, { ...detailRange, data: effectiveData }),
-        getActivityFullDetail(
-          user,
-          { end_time: detailRange.end_time, start_time: detailRange.start_time },
-          { includeGps: include_gps !== false, metrics: requestedMetrics },
-        ),
+        computeActivityDetailMetrics(user, window),
+        getActivityFullDetail(user, window, {
+          includeGps: include_gps,
+          metrics: parseMetricsParam(metrics),
+        }),
       ])
 
       res.json({
@@ -605,7 +582,7 @@ export const createActivitiesRouter = (
           ...activityMetrics,
           ...fullDetail,
           activity_type: activity.activity_type,
-          data: effectiveData,
+          data: window.data,
           deleted_at: activity.deleted_at?.toISOString(),
           end_time: activity.end_time?.toISOString(),
           id: activity.id,

--- a/apps/backend/src/services/queries/activities.test.ts
+++ b/apps/backend/src/services/queries/activities.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../db', () => ({
   getActivityTypeDefinitions: vi.fn().mockResolvedValue([]),
   getNotesByEntityIds: vi.fn(),
   getTimeSeries: vi.fn(),
+  getTimeSeriesMultiMetric: vi.fn().mockResolvedValue({}),
   getUserSettings: vi.fn(),
 }))
 
@@ -83,7 +84,7 @@ describe('queryActivities with comments', () => {
     expect(result[0].comments).toEqual([])
   })
 
-  test('batches heart_rate and hrv_rmssd fetches across activities (no N+1)', async () => {
+  test('batches heart_rate / summary metrics and hrv_rmssd fetches across activities (no N+1)', async () => {
     vi.mocked(db.getActivities).mockResolvedValue([
       {
         activity_type: 'exercise',
@@ -116,14 +117,69 @@ describe('queryActivities with comments', () => {
     ])
     vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof db.getTimeSeriesMultiMetric>>,
+    )
 
-    await queryActivities('testuser', ['exercise', 'sleep', 'meditation'], new Date('2024-01-14'), new Date('2024-01-16'))
+    await queryActivities(
+      'testuser',
+      ['exercise', 'sleep', 'meditation'],
+      new Date('2024-01-14'),
+      new Date('2024-01-16'),
+    )
 
-    // Should fire heart_rate ONCE and hrv_rmssd ONCE — not once per activity.
-    const calls = vi.mocked(db.getTimeSeries).mock.calls
-    const hrCalls = calls.filter(([, metric]) => metric === 'heart_rate')
-    const hrvCalls = calls.filter(([, metric]) => metric === 'hrv_rmssd')
-    expect(hrCalls).toHaveLength(1)
+    // Should fire summary-metric multi-fetch ONCE and hrv_rmssd ONCE — not once per activity.
+    const multi = vi.mocked(db.getTimeSeriesMultiMetric).mock.calls
+    expect(multi).toHaveLength(1)
+    const hrvCalls = vi.mocked(db.getTimeSeries).mock.calls.filter(([, metric]) => metric === 'hrv_rmssd')
     expect(hrvCalls).toHaveLength(1)
+  })
+
+  test('exposes summary metrics on the activity result (distance, avg pace, body battery)', async () => {
+    vi.mocked(db.getActivities).mockResolvedValue([
+      {
+        activity_type: 'exercise',
+        data: { calories: 230, distance: 2671.9, max_hr: 172 },
+        end_time: new Date('2024-01-15T10:30:00Z'),
+        id: 'ex-1',
+        source: 'garmin',
+        start_time: new Date('2024-01-15T10:00:00Z'),
+        title: 'Morning run',
+      },
+    ])
+    vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({
+      body_battery: [
+        [new Date('2024-01-15T10:00:00Z'), 78],
+        [new Date('2024-01-15T10:29:00Z'), 55],
+      ],
+      heart_rate: [
+        [new Date('2024-01-15T10:05:00Z'), 130],
+        [new Date('2024-01-15T10:15:00Z'), 150],
+      ],
+      speed: [
+        [new Date('2024-01-15T10:05:00Z'), 4],
+        [new Date('2024-01-15T10:15:00Z'), 5],
+      ],
+    } as Awaited<ReturnType<typeof db.getTimeSeriesMultiMetric>>)
+
+    const result = await queryActivities(
+      'testuser',
+      ['exercise'],
+      new Date('2024-01-15'),
+      new Date('2024-01-16'),
+    )
+
+    expect(result).toHaveLength(1)
+    const a = result[0]
+    expect(a.distance).toBe(2671.9)
+    expect(a.calories).toBe(230)
+    expect(a.max_hr).toBe(172) // from data, not overridden
+    expect(a.avg_speed).toBe(4.5)
+    expect(a.avg_pace).toBeGreaterThan(0)
+    expect(a.body_battery_before).toBe(78)
+    expect(a.body_battery_after).toBe(55)
+    expect(a.avg_hr).toBe(140) // from time-series since data has no average_hr
   })
 })

--- a/apps/backend/src/services/queries/activities.test.ts
+++ b/apps/backend/src/services/queries/activities.test.ts
@@ -117,9 +117,7 @@ describe('queryActivities with comments', () => {
     ])
     vi.mocked(db.getNotesByEntityIds).mockResolvedValue(new Map())
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
-    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue(
-      {} as Awaited<ReturnType<typeof db.getTimeSeriesMultiMetric>>,
-    )
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({})
 
     await queryActivities(
       'testuser',
@@ -162,7 +160,7 @@ describe('queryActivities with comments', () => {
         [new Date('2024-01-15T10:05:00Z'), 4],
         [new Date('2024-01-15T10:15:00Z'), 5],
       ],
-    } as Awaited<ReturnType<typeof db.getTimeSeriesMultiMetric>>)
+    })
 
     const result = await queryActivities(
       'testuser',

--- a/apps/backend/src/services/queries/activities.ts
+++ b/apps/backend/src/services/queries/activities.ts
@@ -169,11 +169,12 @@ export async function queryActivities(
 
   const activityIds = activities.map((a) => a.id).filter((id): id is string => id !== undefined)
 
-  const [hrZonesResult, summarySeriesByMetric, hrvSeries, commentsMap] = await Promise.all([
+  const emptySeries: SummaryMetricSeries = {}
+  const [hrZonesResult, summarySeries, hrvSeries, commentsMap] = await Promise.all([
     expandedTypes.includes('exercise') ? getEffectiveHrZones(user) : Promise.resolve(null),
     hasExerciseLike
       ? getTimeSeriesMultiMetric(user, [...SUMMARY_METRICS], span.from, span.to)
-      : Promise.resolve({} as Record<string, [Date, number][]>),
+      : Promise.resolve(emptySeries),
     needsHrv ? getTimeSeries(user, 'hrv_rmssd', span.from, span.to) : Promise.resolve([]),
     getCommentsMap(user, 'activity', activityIds),
   ])
@@ -182,7 +183,7 @@ export async function queryActivities(
     commentsMap,
     hrvSeries,
     hrZones: hrZonesResult?.zones ?? null,
-    summarySeries: summarySeriesByMetric as SummaryMetricSeries,
+    summarySeries,
   }
 
   return activities.map((a) => enrichActivity(a, ctx))

--- a/apps/backend/src/services/queries/activities.ts
+++ b/apps/backend/src/services/queries/activities.ts
@@ -5,9 +5,19 @@
 import type { ActivityType } from '../../schema.ts'
 import type { ActivityResult, CommentSummary, SyncProvider } from './types.ts'
 
-import { expandActivityTypes, getActivities, getTimeSeries } from '../../db/index.ts'
+import {
+  expandActivityTypes,
+  getActivities,
+  getTimeSeries,
+  getTimeSeriesMultiMetric,
+} from '../../db/index.ts'
 import { computeHrZoneSecs, getEffectiveHrZones, type HrZoneThresholds } from '../settings.ts'
 import { computeSleepMinutes } from '../sleep-duration.ts'
+import {
+  computeActivitySummaryMetrics,
+  SUMMARY_METRICS,
+  type SummaryMetricSeries,
+} from './activity-summary-metrics.ts'
 import { buildCategoryMap, getCommentsMap } from './types.ts'
 
 type TimeSeriesPoint = [Date, number]
@@ -50,9 +60,20 @@ export function enrichSleepFields(result: ActivityResult, data: Record<string, u
 
 interface EnrichmentContext {
   hrZones: HrZoneThresholds | null
-  hrSeries: TimeSeriesPoint[]
   hrvSeries: TimeSeriesPoint[]
+  summarySeries: SummaryMetricSeries
   commentsMap: Map<string, CommentSummary[]>
+}
+
+/** Compute HR zone seconds from the HR samples within an activity window. */
+function hrZonesForActivity(
+  a: Awaited<ReturnType<typeof getActivities>>[number],
+  ctx: EnrichmentContext,
+): ActivityResult['hr_zone_secs'] {
+  if (!ctx.hrZones || a.activity_type !== 'exercise' || !a.end_time) return undefined
+  const hrSeries = ctx.summarySeries.heart_rate ?? []
+  const hrWindow = pointsInRange(hrSeries, a.start_time, a.end_time)
+  return hrWindow.length > 0 ? computeHrZoneSecs(hrWindow, ctx.hrZones) : undefined
 }
 
 /** Enrich a raw activity record into an ActivityResult with computed fields. */
@@ -60,6 +81,7 @@ function enrichActivity(
   a: Awaited<ReturnType<typeof getActivities>>[number],
   ctx: EnrichmentContext,
 ): ActivityResult {
+  const isMerged = 'source_ids' in a && Boolean(a.source_ids)
   const result: ActivityResult = {
     activity_type: a.activity_type,
     comments: a.id ? (ctx.commentsMap.get(a.id) ?? []) : [],
@@ -68,23 +90,17 @@ function enrichActivity(
       ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60)
       : undefined,
     end_time: a.end_time?.toISOString(),
-    id: 'source_ids' in a && a.source_ids ? `merged:${a.id}` : a.id,
+    hr_zone_secs: hrZonesForActivity(a, ctx),
+    id: isMerged ? `merged:${a.id}` : a.id,
     notes: a.notes,
     source: a.source,
     start_time: a.start_time.toISOString(),
     title: a.title,
+    ...computeActivitySummaryMetrics(a, ctx.summarySeries),
   }
 
   if (a.activity_type === 'sleep') {
     enrichSleepFields(result, a.data)
-  }
-
-  // Compute HR zones for exercise activities with end time
-  if (ctx.hrZones && a.activity_type === 'exercise' && a.end_time) {
-    const hrWindow = pointsInRange(ctx.hrSeries, a.start_time, a.end_time)
-    if (hrWindow.length > 0) {
-      result.hr_zone_secs = computeHrZoneSecs(hrWindow, ctx.hrZones)
-    }
   }
 
   // Compute average HRV for sleep and meditation
@@ -130,9 +146,9 @@ export async function queryActivities(
   )
 
   // Determine which time-series we'll need based on the activity types present.
-  // Batching the heart_rate / hrv_rmssd fetches across the full activity span
-  // avoids one DB round-trip per activity (was N+1 before).
-  const needsHr = activities.some((a) => a.activity_type === 'exercise' && a.end_time)
+  // Batching fetches across the full activity span avoids one DB round-trip per
+  // activity (was N+1 before).
+  const hasExerciseLike = activities.some((a) => a.activity_type === 'exercise' && a.end_time)
   const needsHrv = activities.some(
     (a) => (a.activity_type === 'sleep' || a.activity_type === 'meditation') && a.end_time,
   )
@@ -149,22 +165,24 @@ export async function queryActivities(
     }
     return { from: new Date(minStart), to: new Date(maxEnd) }
   }
-  const span = needsHr || needsHrv ? activitySpan() : { from: start, to: end }
+  const span = hasExerciseLike || needsHrv ? activitySpan() : { from: start, to: end }
 
   const activityIds = activities.map((a) => a.id).filter((id): id is string => id !== undefined)
 
-  const [hrZonesResult, hrSeries, hrvSeries, commentsMap] = await Promise.all([
+  const [hrZonesResult, summarySeriesByMetric, hrvSeries, commentsMap] = await Promise.all([
     expandedTypes.includes('exercise') ? getEffectiveHrZones(user) : Promise.resolve(null),
-    needsHr ? getTimeSeries(user, 'heart_rate', span.from, span.to) : Promise.resolve([]),
+    hasExerciseLike
+      ? getTimeSeriesMultiMetric(user, [...SUMMARY_METRICS], span.from, span.to)
+      : Promise.resolve({} as Record<string, [Date, number][]>),
     needsHrv ? getTimeSeries(user, 'hrv_rmssd', span.from, span.to) : Promise.resolve([]),
     getCommentsMap(user, 'activity', activityIds),
   ])
 
   const ctx: EnrichmentContext = {
     commentsMap,
-    hrSeries,
     hrvSeries,
     hrZones: hrZonesResult?.zones ?? null,
+    summarySeries: summarySeriesByMetric as SummaryMetricSeries,
   }
 
   return activities.map((a) => enrichActivity(a, ctx))

--- a/apps/backend/src/services/queries/activity-detail.ts
+++ b/apps/backend/src/services/queries/activity-detail.ts
@@ -1,0 +1,134 @@
+/**
+ * Activity detail enrichment — for the single-activity detail endpoint.
+ *
+ * Computes HR zone seconds, average HRV, and the generic summary metrics
+ * (distance, avg pace/cadence/power, body battery before/after, etc.) by
+ * fetching the relevant time-series for the activity's time window.
+ */
+
+import type { ActivitySummaryMetrics, HrZoneSecs } from '@aurboda/api-spec'
+
+import { getDistinctMetrics, getLocations, getTimeSeries, getTimeSeriesMultiMetric } from '../../db/index.ts'
+import { computeHrZoneSecs, getEffectiveHrZones } from '../settings.ts'
+import {
+  computeActivitySummaryMetrics,
+  SUMMARY_METRICS,
+  type SummaryMetricSeries,
+} from './activity-summary-metrics.ts'
+
+/** Sentinel used to opt into "every metric with data in the activity range". */
+export const ALL_METRICS_SENTINEL = 'all'
+
+/**
+ * Parse the `metrics` query/MCP parameter to a list of metric names.
+ *
+ * - `undefined` / empty → return undefined (caller should skip time-series)
+ * - `'all'` → return undefined here; resolveMetrics() will discover them
+ * - comma-separated → split and trim
+ */
+export const parseMetricsParam = (raw: string | undefined): string[] | undefined => {
+  if (!raw) return undefined
+  if (raw === ALL_METRICS_SENTINEL) return [ALL_METRICS_SENTINEL]
+  const list = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  return list.length > 0 ? list : undefined
+}
+
+export interface ActivityDetailMetrics extends ActivitySummaryMetrics {
+  hr_zone_secs?: HrZoneSecs
+  avg_hrv?: number
+}
+
+/**
+ * Compute hr_zone_secs, avg_hrv, and the generic summary metrics for an
+ * activity's time range. Pulls all required time-series in parallel.
+ */
+export const computeActivityDetailMetrics = async (
+  user: string,
+  activity: { start_time: Date; end_time?: Date; data?: Record<string, unknown> },
+): Promise<ActivityDetailMetrics> => {
+  const end = activity.end_time
+  if (!end) return {}
+
+  const [{ zones: hrZones }, summarySeriesByMetric, hrvData] = await Promise.all([
+    getEffectiveHrZones(user),
+    getTimeSeriesMultiMetric(user, [...SUMMARY_METRICS], activity.start_time, end),
+    getTimeSeries(user, 'hrv_rmssd', activity.start_time, end),
+  ])
+
+  const summarySeries = summarySeriesByMetric as SummaryMetricSeries
+  const summary = computeActivitySummaryMetrics(activity, summarySeries)
+
+  const hrData = summarySeries.heart_rate ?? []
+  const hr_zone_secs = hrData.length > 0 ? computeHrZoneSecs(hrData, hrZones) : undefined
+  const avg_hrv =
+    hrvData.length > 0 ? Math.round(hrvData.reduce((sum, [, v]) => sum + v, 0) / hrvData.length) : undefined
+
+  return { ...summary, avg_hrv, hr_zone_secs }
+}
+
+export interface ActivityFullDetailOptions {
+  /** Optional list of metric names to include time-series for. Empty array = none. */
+  metrics?: string[]
+  /** Include GPS trace if locations are available in the activity range. */
+  includeGps?: boolean
+}
+
+export interface ActivityFullDetail {
+  gps?: Array<{ time: string; lat: number; lon: number }>
+  metric_series?: Array<{ metric: string; unit: string; count: number; data: Array<[string, number]> }>
+}
+
+/**
+ * Fetch deep-dive detail for an activity: GPS trace + per-metric time-series.
+ *
+ * Source-agnostic: works for any activity that has time-series and/or GPS
+ * locations populated within its time range, regardless of which integration
+ * produced them (Garmin, Strava, FIT upload, manual).
+ */
+export const getActivityFullDetail = async (
+  user: string,
+  activity: { start_time: Date; end_time?: Date },
+  options: ActivityFullDetailOptions,
+): Promise<ActivityFullDetail> => {
+  const end = activity.end_time
+  if (!end) return {}
+  const { includeGps = true, metrics } = options
+
+  const result: ActivityFullDetail = {}
+
+  // GPS trace from any source covering this activity time range.
+  if (includeGps) {
+    const { locations } = await getLocations(user, activity.start_time, end)
+    if (locations.length > 0) {
+      result.gps = locations.map((l) => ({
+        lat: l.coordinates[1],
+        lon: l.coordinates[0],
+        time: l.time.toISOString(),
+      }))
+    }
+  }
+
+  // Time-series — when no metrics requested, omit the series array entirely.
+  if (metrics && metrics.length > 0) {
+    const resolvedMetrics =
+      metrics.length === 1 && metrics[0] === ALL_METRICS_SENTINEL
+        ? await getDistinctMetrics(user, activity.start_time, end)
+        : metrics
+    const { metricUnits } = await import('@aurboda/api-spec')
+    const series = await Promise.all(
+      resolvedMetrics.map(async (metric) => ({
+        data: (await getTimeSeries(user, metric, activity.start_time, end)).map(
+          ([time, value]) => [time.toISOString(), value] as [string, number],
+        ),
+        metric,
+        unit: (metricUnits as Record<string, string>)[metric] ?? '',
+      })),
+    )
+    result.metric_series = series.map((s) => ({ ...s, count: s.data.length }))
+  }
+
+  return result
+}

--- a/apps/backend/src/services/queries/activity-detail.ts
+++ b/apps/backend/src/services/queries/activity-detail.ts
@@ -1,30 +1,35 @@
 /**
- * Activity detail enrichment — for the single-activity detail endpoint.
- *
- * Computes HR zone seconds, average HRV, and the generic summary metrics
- * (distance, avg pace/cadence/power, body battery before/after, etc.) by
- * fetching the relevant time-series for the activity's time window.
+ * Activity detail enrichment — computes the per-activity fields that aren't
+ * stored on the activities row (HR-zone seconds, average HRV, generic summary
+ * metrics) and assembles the deep-dive payload (GPS trace + per-metric
+ * time-series) for the full-detail endpoint and MCP tool.
  */
 
-import type { ActivitySummaryMetrics, HrZoneSecs } from '@aurboda/api-spec'
-
-import { getDistinctMetrics, getLocations, getTimeSeries, getTimeSeriesMultiMetric } from '../../db/index.ts'
-import { computeHrZoneSecs, getEffectiveHrZones } from '../settings.ts'
 import {
-  computeActivitySummaryMetrics,
-  SUMMARY_METRICS,
-  type SummaryMetricSeries,
-} from './activity-summary-metrics.ts'
+  type ActivityComputedMetrics,
+  type ActivityFullDetail,
+  ALL_METRICS_SENTINEL,
+  getMetricUnit,
+} from '@aurboda/api-spec'
 
-/** Sentinel used to opt into "every metric with data in the activity range". */
-export const ALL_METRICS_SENTINEL = 'all'
+import type { Activity as ActivityRow } from '../../db/types.ts'
+
+import {
+  getDistinctMetrics,
+  getLocations,
+  getOverlappingActivities,
+  getTimeSeries,
+  getTimeSeriesMultiMetric,
+} from '../../db/index.ts'
+import { computeHrZoneSecs, getEffectiveHrZones } from '../settings.ts'
+import { computeActivitySummaryMetrics, SUMMARY_METRICS } from './activity-summary-metrics.ts'
 
 /**
- * Parse the `metrics` query/MCP parameter to a list of metric names.
+ * Parse the `metrics` query/MCP parameter into a list of metric names.
  *
- * - `undefined` / empty → return undefined (caller should skip time-series)
- * - `'all'` → return undefined here; resolveMetrics() will discover them
- * - comma-separated → split and trim
+ * - `undefined` / empty → `undefined` (caller skips time-series fetch)
+ * - the `'all'` sentinel → `[ALL_METRICS_SENTINEL]` (resolved later by db lookup)
+ * - comma-separated → trimmed list
  */
 export const parseMetricsParam = (raw: string | undefined): string[] | undefined => {
   if (!raw) return undefined
@@ -36,11 +41,6 @@ export const parseMetricsParam = (raw: string | undefined): string[] | undefined
   return list.length > 0 ? list : undefined
 }
 
-export interface ActivityDetailMetrics extends ActivitySummaryMetrics {
-  hr_zone_secs?: HrZoneSecs
-  avg_hrv?: number
-}
-
 /**
  * Compute hr_zone_secs, avg_hrv, and the generic summary metrics for an
  * activity's time range. Pulls all required time-series in parallel.
@@ -48,17 +48,16 @@ export interface ActivityDetailMetrics extends ActivitySummaryMetrics {
 export const computeActivityDetailMetrics = async (
   user: string,
   activity: { start_time: Date; end_time?: Date; data?: Record<string, unknown> },
-): Promise<ActivityDetailMetrics> => {
+): Promise<ActivityComputedMetrics> => {
   const end = activity.end_time
   if (!end) return {}
 
-  const [{ zones: hrZones }, summarySeriesByMetric, hrvData] = await Promise.all([
+  const [{ zones: hrZones }, summarySeries, hrvData] = await Promise.all([
     getEffectiveHrZones(user),
     getTimeSeriesMultiMetric(user, [...SUMMARY_METRICS], activity.start_time, end),
     getTimeSeries(user, 'hrv_rmssd', activity.start_time, end),
   ])
 
-  const summarySeries = summarySeriesByMetric as SummaryMetricSeries
   const summary = computeActivitySummaryMetrics(activity, summarySeries)
 
   const hrData = summarySeries.heart_rate ?? []
@@ -70,15 +69,10 @@ export const computeActivityDetailMetrics = async (
 }
 
 export interface ActivityFullDetailOptions {
-  /** Optional list of metric names to include time-series for. Empty array = none. */
+  /** Metric names to include time-series for. The single-element [ALL_METRICS_SENTINEL] expands to all available. */
   metrics?: string[]
   /** Include GPS trace if locations are available in the activity range. */
   includeGps?: boolean
-}
-
-export interface ActivityFullDetail {
-  gps?: Array<{ time: string; lat: number; lon: number }>
-  metric_series?: Array<{ metric: string; unit: string; count: number; data: Array<[string, number]> }>
 }
 
 /**
@@ -92,14 +86,13 @@ export const getActivityFullDetail = async (
   user: string,
   activity: { start_time: Date; end_time?: Date },
   options: ActivityFullDetailOptions,
-): Promise<ActivityFullDetail> => {
+): Promise<Pick<ActivityFullDetail, 'gps' | 'metric_series'>> => {
   const end = activity.end_time
   if (!end) return {}
   const { includeGps = true, metrics } = options
 
-  const result: ActivityFullDetail = {}
+  const result: Pick<ActivityFullDetail, 'gps' | 'metric_series'> = {}
 
-  // GPS trace from any source covering this activity time range.
   if (includeGps) {
     const { locations } = await getLocations(user, activity.start_time, end)
     if (locations.length > 0) {
@@ -111,24 +104,69 @@ export const getActivityFullDetail = async (
     }
   }
 
-  // Time-series — when no metrics requested, omit the series array entirely.
   if (metrics && metrics.length > 0) {
     const resolvedMetrics =
       metrics.length === 1 && metrics[0] === ALL_METRICS_SENTINEL
         ? await getDistinctMetrics(user, activity.start_time, end)
         : metrics
-    const { metricUnits } = await import('@aurboda/api-spec')
-    const series = await Promise.all(
-      resolvedMetrics.map(async (metric) => ({
-        data: (await getTimeSeries(user, metric, activity.start_time, end)).map(
-          ([time, value]) => [time.toISOString(), value] as [string, number],
-        ),
-        metric,
-        unit: (metricUnits as Record<string, string>)[metric] ?? '',
-      })),
+    result.metric_series = await Promise.all(
+      resolvedMetrics.map(async (metric) => {
+        const data = await getTimeSeries(user, metric, activity.start_time, end)
+        return {
+          count: data.length,
+          data: data.map(([time, value]): [string, number] => [time.toISOString(), value]),
+          metric,
+          unit: getMetricUnit(metric) ?? '',
+        }
+      }),
     )
-    result.metric_series = series.map((s) => ({ ...s, count: s.data.length }))
   }
 
   return result
+}
+
+/**
+ * Resolved time range and merged data JSONB for an activity, expanded across
+ * its overlapping cross-source records when the caller passed a `merged:` id.
+ */
+export interface ResolvedActivityWindow {
+  start_time: Date
+  end_time?: Date
+  data?: Record<string, unknown>
+}
+
+/**
+ * For activities fetched via a `merged:` id prefix, expand the time window to
+ * cover all overlapping cross-source records and merge their `data` JSONB.
+ * Plain (non-merged) activities pass through unchanged.
+ */
+export const resolveActivityWindow = async (
+  user: string,
+  activity: ActivityRow,
+  isMerged: boolean,
+): Promise<ResolvedActivityWindow> => {
+  if (!isMerged || activity.deleted_at) {
+    return { data: activity.data, end_time: activity.end_time, start_time: activity.start_time }
+  }
+
+  const overlapping = await getOverlappingActivities(user, activity)
+  if (overlapping.length <= 1) {
+    return { data: activity.data, end_time: activity.end_time, start_time: activity.start_time }
+  }
+
+  const start_time = new Date(Math.min(...overlapping.map((a) => a.start_time.getTime())))
+  const end_time = new Date(Math.max(...overlapping.map((a) => (a.end_time ?? a.start_time).getTime())))
+  const data = overlapping
+    .toSorted((a, b) => a.start_time.getTime() - b.start_time.getTime())
+    .reduce<Record<string, unknown>>((acc, a) => (a.data ? { ...acc, ...a.data } : acc), {})
+
+  return { data: Object.keys(data).length > 0 ? data : activity.data, end_time, start_time }
+}
+
+/**
+ * Strip the optional `merged:` id prefix and report whether it was present.
+ */
+export const parseActivityId = (rawId: string): { id: string; isMerged: boolean } => {
+  const isMerged = rawId.startsWith('merged:')
+  return { id: isMerged ? rawId.slice('merged:'.length) : rawId, isMerged }
 }

--- a/apps/backend/src/services/queries/activity-summary-metrics.test.ts
+++ b/apps/backend/src/services/queries/activity-summary-metrics.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'vitest'
+
+import { computeActivitySummaryMetrics, type SummaryMetricSeries } from './activity-summary-metrics.ts'
+
+const start = new Date('2024-01-15T10:00:00Z')
+const end = new Date('2024-01-15T10:10:00Z') // 10 minutes
+
+const at = (offsetSec: number): Date => new Date(start.getTime() + offsetSec * 1000)
+
+describe('computeActivitySummaryMetrics', () => {
+  test('returns empty result for an activity with no end_time and no data', () => {
+    const result = computeActivitySummaryMetrics({ start_time: start }, {})
+    expect(result).toEqual({})
+  })
+
+  test('passes through summary fields stored in activity.data', () => {
+    const result = computeActivitySummaryMetrics(
+      {
+        data: {
+          average_hr: 145,
+          calories: 230,
+          distance: 2671.9,
+          elevation_gain: 44,
+          max_hr: 172,
+          steps: 3446,
+          vo2_max: 38,
+        },
+        end_time: end,
+        start_time: start,
+      },
+      {},
+    )
+    expect(result).toMatchObject({
+      avg_hr: 145,
+      calories: 230,
+      distance: 2671.9,
+      elevation_gain: 44,
+      max_hr: 172,
+      steps: 3446,
+      vo2_max: 38,
+    })
+  })
+
+  test('ignores non-numeric data fields', () => {
+    const result = computeActivitySummaryMetrics(
+      { data: { calories: 'lots', distance: null }, end_time: end, start_time: start },
+      {},
+    )
+    expect(result).toEqual({})
+  })
+
+  test('computes avg pace from speed time-series (preferred over distance/duration)', () => {
+    const series: SummaryMetricSeries = {
+      speed: [
+        [at(60), 4],
+        [at(120), 5],
+        [at(180), 6],
+      ],
+    }
+    const result = computeActivitySummaryMetrics(
+      { data: { distance: 3000 }, end_time: end, start_time: start },
+      series,
+    )
+    expect(result.avg_speed).toBe(5)
+    expect(result.avg_pace).toBe(200) // 1000 / 5 m/s = 200 s/km
+  })
+
+  test('falls back to distance/duration when no speed series', () => {
+    const result = computeActivitySummaryMetrics(
+      { data: { distance: 3000 }, end_time: end, start_time: start },
+      {},
+    )
+    // 600 sec / 3000 m * 1000 = 200 sec/km
+    expect(result.avg_pace).toBe(200)
+  })
+
+  test('computes elevation gain and loss from elevation series', () => {
+    const series: SummaryMetricSeries = {
+      elevation: [
+        [at(60), 100],
+        [at(120), 110], // +10
+        [at(180), 105], // -5
+        [at(240), 130], // +25
+        [at(300), 100], // -30
+      ],
+    }
+    const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
+    expect(result.elevation_gain).toBe(35)
+    expect(result.elevation_loss).toBe(35)
+  })
+
+  test('time-series elevation overrides data.elevation_gain when both present', () => {
+    const series: SummaryMetricSeries = {
+      elevation: [
+        [at(0), 0],
+        [at(60), 50],
+      ],
+    }
+    const result = computeActivitySummaryMetrics(
+      { data: { elevation_gain: 999 }, end_time: end, start_time: start },
+      series,
+    )
+    expect(result.elevation_gain).toBe(50)
+  })
+
+  test('records body battery before and after', () => {
+    const series: SummaryMetricSeries = {
+      body_battery: [
+        [at(0), 78],
+        [at(120), 70],
+        [at(599), 55],
+      ],
+    }
+    const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
+    expect(result.body_battery_before).toBe(78)
+    expect(result.body_battery_after).toBe(55)
+  })
+
+  test('computes avg cadence, stride length, power, GCT from series', () => {
+    const series: SummaryMetricSeries = {
+      ground_contact_time: [
+        [at(60), 220],
+        [at(120), 240],
+      ],
+      power: [
+        [at(60), 300],
+        [at(120), 320],
+      ],
+      run_cadence: [
+        [at(60), 170],
+        [at(120), 180],
+      ],
+      stride_length: [
+        [at(60), 1.2],
+        [at(120), 1.4],
+      ],
+    }
+    const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
+    expect(result.avg_cadence).toBe(175)
+    expect(result.avg_stride_length).toBe(1.3)
+    expect(result.avg_power).toBe(310)
+    expect(result.avg_ground_contact_time).toBe(230)
+  })
+
+  test('filters non-positive values from movement metrics', () => {
+    // Cadence/power/etc. drop to 0 when stopped — those samples shouldn't drag
+    // the moving average down.
+    const series: SummaryMetricSeries = {
+      run_cadence: [
+        [at(60), 0],
+        [at(120), 180],
+        [at(180), 0],
+        [at(240), 180],
+      ],
+    }
+    const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
+    expect(result.avg_cadence).toBe(180)
+  })
+
+  test('fills in HR from time-series when not in data, takes max from samples', () => {
+    const series: SummaryMetricSeries = {
+      heart_rate: [
+        [at(60), 130],
+        [at(120), 150],
+        [at(180), 172],
+      ],
+    }
+    const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
+    expect(result.avg_hr).toBe(151) // (130 + 150 + 172) / 3 = 150.67 → 151
+    expect(result.max_hr).toBe(172)
+  })
+
+  test('does not override avg_hr/max_hr from data with time-series values', () => {
+    const series: SummaryMetricSeries = {
+      heart_rate: [
+        [at(60), 200],
+        [at(120), 200],
+      ],
+    }
+    const result = computeActivitySummaryMetrics(
+      { data: { average_hr: 145, max_hr: 172 }, end_time: end, start_time: start },
+      series,
+    )
+    expect(result.avg_hr).toBe(145)
+    expect(result.max_hr).toBe(172)
+  })
+
+  test('only considers time-series points within the activity window', () => {
+    const series: SummaryMetricSeries = {
+      heart_rate: [
+        [new Date('2024-01-15T09:00:00Z'), 200], // before
+        [at(60), 130],
+        [at(180), 140],
+        [new Date('2024-01-15T11:00:00Z'), 200], // after
+      ],
+    }
+    const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
+    expect(result.avg_hr).toBe(135)
+  })
+})

--- a/apps/backend/src/services/queries/activity-summary-metrics.ts
+++ b/apps/backend/src/services/queries/activity-summary-metrics.ts
@@ -1,0 +1,163 @@
+/**
+ * Computes generic summary metrics for an activity.
+ *
+ * Generic over data source: any source that populates the underlying time-series
+ * (Garmin, Strava, Health Connect, FIT upload, manual) produces these values.
+ * Source-specific summary fields stored in `activity.data` (distance, calories,
+ * vo2_max, etc.) are passed through, while computed averages and elevation
+ * gain/loss are derived from per-second time-series.
+ */
+
+import type { ActivitySummaryMetrics } from '@aurboda/api-spec'
+
+type TimeSeriesPoint = [Date, number]
+
+/** Time-series metrics needed to compute summary fields. */
+export const SUMMARY_METRICS = [
+  'heart_rate',
+  'speed',
+  'run_cadence',
+  'stride_length',
+  'power',
+  'ground_contact_time',
+  'elevation',
+  'body_battery',
+] as const
+
+export type SummaryMetric = (typeof SUMMARY_METRICS)[number]
+
+export type SummaryMetricSeries = Partial<Record<SummaryMetric, TimeSeriesPoint[]>>
+
+const round = (value: number, decimals: number): number => {
+  const f = 10 ** decimals
+  return Math.round(value * f) / f
+}
+
+const positiveValues = (points: TimeSeriesPoint[]): number[] => points.flatMap(([, v]) => (v > 0 ? [v] : []))
+
+const mean = (values: number[]): number | undefined =>
+  values.length === 0 ? undefined : values.reduce((s, v) => s + v, 0) / values.length
+
+const inRange = (points: TimeSeriesPoint[], start: Date, end: Date): TimeSeriesPoint[] =>
+  points.filter(([t]) => t >= start && t <= end)
+
+/** Sum the positive deltas (gain) and negated negative deltas (loss). */
+const elevationGainLoss = (points: TimeSeriesPoint[]): { gain: number; loss: number } => {
+  let gain = 0
+  let loss = 0
+  for (let i = 1; i < points.length; i++) {
+    const delta = points[i][1] - points[i - 1][1]
+    if (delta > 0) gain += delta
+    else if (delta < 0) loss -= delta
+  }
+  return { gain, loss }
+}
+
+const numericFromData = (data: Record<string, unknown> | undefined, key: string): number | undefined => {
+  const v = data?.[key]
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
+}
+
+/**
+ * Mapping from source-data JSONB key → ActivitySummaryMetrics field.
+ * These pass through unchanged (no decimal rounding) when present.
+ */
+const DATA_FIELD_MAP: Array<[string, keyof ActivitySummaryMetrics]> = [
+  ['distance', 'distance'],
+  ['steps', 'steps'],
+  ['calories', 'calories'],
+  ['vo2_max', 'vo2_max'],
+  ['elevation_gain', 'elevation_gain'],
+  ['average_hr', 'avg_hr'],
+  ['max_hr', 'max_hr'],
+]
+
+const passthroughDataFields = (data: Record<string, unknown> | undefined): ActivitySummaryMetrics => {
+  const out: ActivitySummaryMetrics = {}
+  for (const [src, dst] of DATA_FIELD_MAP) {
+    const v = numericFromData(data, src)
+    if (v !== undefined) out[dst] = v
+  }
+  return out
+}
+
+const computePace = (
+  speedAvg: number | undefined,
+  distance: number | undefined,
+  durationSec: number,
+): { avg_speed?: number; avg_pace?: number } => {
+  if (speedAvg !== undefined) return { avg_pace: round(1000 / speedAvg, 1), avg_speed: round(speedAvg, 3) }
+  if (distance && distance > 0 && durationSec > 0) {
+    return { avg_pace: round((durationSec / distance) * 1000, 1) }
+  }
+  return {}
+}
+
+const computeHrFromSeries = (
+  current: { avg_hr?: number; max_hr?: number },
+  hrValues: number[],
+): { avg_hr?: number; max_hr?: number } => {
+  if (hrValues.length === 0) return {}
+  const out: { avg_hr?: number; max_hr?: number } = {}
+  if (current.avg_hr === undefined) {
+    out.avg_hr = Math.round(hrValues.reduce((s, v) => s + v, 0) / hrValues.length)
+  }
+  if (current.max_hr === undefined) out.max_hr = Math.max(...hrValues)
+  return out
+}
+
+const computeElevationFromSeries = (
+  points: TimeSeriesPoint[],
+): { elevation_gain?: number; elevation_loss?: number } => {
+  if (points.length < 2) return {}
+  const { gain, loss } = elevationGainLoss(points)
+  const out: { elevation_gain?: number; elevation_loss?: number } = {}
+  if (gain > 0) out.elevation_gain = round(gain, 1)
+  if (loss > 0) out.elevation_loss = round(loss, 1)
+  return out
+}
+
+const computeBodyBatteryFromSeries = (
+  points: TimeSeriesPoint[],
+): { body_battery_before?: number; body_battery_after?: number } => {
+  if (points.length === 0) return {}
+  return { body_battery_after: points[points.length - 1][1], body_battery_before: points[0][1] }
+}
+
+/**
+ * Compute summary metrics for an activity.
+ *
+ * @param activity Activity record (start_time required, end_time optional)
+ * @param series   Per-metric time-series. Caller should pre-filter to the
+ *                 activity's time window or pass full series — this function
+ *                 trims to [start_time, end_time].
+ */
+export const computeActivitySummaryMetrics = (
+  activity: { start_time: Date; end_time?: Date; data?: Record<string, unknown> },
+  series: SummaryMetricSeries,
+): ActivitySummaryMetrics => {
+  const result = passthroughDataFields(activity.data)
+  const end = activity.end_time
+  if (!end) return result
+
+  const window = (metric: SummaryMetric): TimeSeriesPoint[] =>
+    inRange(series[metric] ?? [], activity.start_time, end)
+  const avgPositive = (metric: SummaryMetric, decimals: number): number | undefined => {
+    const v = mean(positiveValues(window(metric)))
+    return v === undefined ? undefined : round(v, decimals)
+  }
+
+  const speedAvgRaw = mean(positiveValues(window('speed')))
+  Object.assign(
+    result,
+    computePace(speedAvgRaw, result.distance, (end.getTime() - activity.start_time.getTime()) / 1000),
+    computeHrFromSeries(result, positiveValues(window('heart_rate'))),
+    computeElevationFromSeries(window('elevation')),
+    computeBodyBatteryFromSeries(window('body_battery')),
+  )
+  result.avg_cadence = avgPositive('run_cadence', 1) ?? result.avg_cadence
+  result.avg_stride_length = avgPositive('stride_length', 2) ?? result.avg_stride_length
+  result.avg_power = avgPositive('power', 1) ?? result.avg_power
+  result.avg_ground_contact_time = avgPositive('ground_contact_time', 1) ?? result.avg_ground_contact_time
+  return result
+}

--- a/apps/backend/src/services/queries/activity-summary-metrics.ts
+++ b/apps/backend/src/services/queries/activity-summary-metrics.ts
@@ -8,7 +8,7 @@
  * gain/loss are derived from per-second time-series.
  */
 
-import type { ActivitySummaryMetrics } from '@aurboda/api-spec'
+import type { ActivitySummaryMetrics, MetricType } from '@aurboda/api-spec'
 
 type TimeSeriesPoint = [Date, number]
 
@@ -22,11 +22,16 @@ export const SUMMARY_METRICS = [
   'ground_contact_time',
   'elevation',
   'body_battery',
-] as const
+] as const satisfies readonly MetricType[]
 
 export type SummaryMetric = (typeof SUMMARY_METRICS)[number]
 
-export type SummaryMetricSeries = Partial<Record<SummaryMetric, TimeSeriesPoint[]>>
+/**
+ * Per-metric time-series fetched in bulk for an activity time range. Matches
+ * the shape returned by `getTimeSeriesMultiMetric` — only metrics with data
+ * are present.
+ */
+export type SummaryMetricSeries = Partial<Record<MetricType, TimeSeriesPoint[]>>
 
 const round = (value: number, decimals: number): number => {
   const f = 10 ** decimals

--- a/apps/backend/src/services/queries/index.ts
+++ b/apps/backend/src/services/queries/index.ts
@@ -51,6 +51,16 @@ export { queryTags } from './tags.ts'
 export { queryActivities } from './activities.ts'
 
 export {
+  ALL_METRICS_SENTINEL,
+  computeActivityDetailMetrics,
+  type ActivityDetailMetrics,
+  type ActivityFullDetail,
+  type ActivityFullDetailOptions,
+  getActivityFullDetail,
+  parseMetricsParam,
+} from './activity-detail.ts'
+
+export {
   assembleScreentimeBuckets,
   mergeByCategorySpans,
   mergeProductivitySpans,

--- a/apps/backend/src/services/queries/index.ts
+++ b/apps/backend/src/services/queries/index.ts
@@ -51,13 +51,12 @@ export { queryTags } from './tags.ts'
 export { queryActivities } from './activities.ts'
 
 export {
-  ALL_METRICS_SENTINEL,
-  computeActivityDetailMetrics,
-  type ActivityDetailMetrics,
-  type ActivityFullDetail,
   type ActivityFullDetailOptions,
+  computeActivityDetailMetrics,
   getActivityFullDetail,
+  parseActivityId,
   parseMetricsParam,
+  resolveActivityWindow,
 } from './activity-detail.ts'
 
 export {

--- a/apps/backend/src/services/queries/types.ts
+++ b/apps/backend/src/services/queries/types.ts
@@ -2,7 +2,7 @@
  * Shared types and helpers for query services.
  */
 
-import type { DataSource, ExerciseTypeName } from '@aurboda/api-spec'
+import type { ActivitySummaryMetrics, DataSource, ExerciseTypeName } from '@aurboda/api-spec'
 
 import type { MetricType } from '../../schema.ts'
 import type { HrZoneSecs } from '../settings.ts'
@@ -278,7 +278,7 @@ export interface PeriodSummaryResult {
 /**
  * Activity query result with formatted timestamps.
  */
-export interface ActivityResult {
+export interface ActivityResult extends ActivitySummaryMetrics {
   id?: string
   start_time: string
   end_time?: string

--- a/apps/backend/src/services/queries/types.ts
+++ b/apps/backend/src/services/queries/types.ts
@@ -2,7 +2,7 @@
  * Shared types and helpers for query services.
  */
 
-import type { ActivitySummaryMetrics, DataSource, ExerciseTypeName } from '@aurboda/api-spec'
+import type { ActivityComputedMetrics, DataSource, ExerciseTypeName } from '@aurboda/api-spec'
 
 import type { MetricType } from '../../schema.ts'
 import type { HrZoneSecs } from '../settings.ts'
@@ -276,9 +276,11 @@ export interface PeriodSummaryResult {
 }
 
 /**
- * Activity query result with formatted timestamps.
+ * Activity query result with formatted timestamps. Inherits all computed
+ * metric fields (avg pace, body battery before/after, hr_zone_secs, avg_hrv,
+ * etc.) from the api-spec ActivityComputedMetrics contract.
  */
-export interface ActivityResult extends ActivitySummaryMetrics {
+export interface ActivityResult extends ActivityComputedMetrics {
   id?: string
   start_time: string
   end_time?: string
@@ -290,8 +292,6 @@ export interface ActivityResult extends ActivitySummaryMetrics {
   notes?: string
   source: string
   data?: Record<string, unknown>
-  hr_zone_secs?: HrZoneSecs
-  avg_hrv?: number
   comments: CommentSummary[]
 }
 

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -11,6 +11,9 @@ import {
   createDataResponseSchema,
   durationMinutesSchema,
   iso8601DateTimeSchema,
+  latSchema,
+  lonSchema,
+  metricTypeSchema,
   timeRangeQuerySchema,
 } from './common.ts'
 import { commentSchema } from './notes.ts'
@@ -133,10 +136,51 @@ export const getExerciseTypeName = (value: number): ExerciseTypeName | undefined
 export const getExerciseTypeValue = (name: ExerciseTypeName): number => exerciseTypes[name]
 
 /**
+ * Computed/extracted summary metrics for an activity.
+ *
+ * These are surface-level aggregates derived from per-second time-series data
+ * and/or summary fields stored in `data` JSONB. They are data-source-agnostic:
+ * any source that populates the underlying time-series (Garmin, Strava,
+ * Health Connect, FIT upload, etc.) will produce these values.
+ */
+export const activitySummaryMetricsSchema = z
+  .object({
+    avg_cadence: z.number().optional().meta({ description: 'Average run cadence (spm)' }),
+    avg_ground_contact_time: z.number().optional().meta({ description: 'Average ground contact time (ms)' }),
+    avg_hr: z.number().optional().meta({ description: 'Average heart rate (bpm)' }),
+    avg_pace: z.number().optional().meta({ description: 'Average pace (seconds per kilometer)' }),
+    avg_power: z.number().optional().meta({ description: 'Average power (W)' }),
+    avg_speed: z.number().optional().meta({ description: 'Average speed (m/s)' }),
+    avg_stride_length: z.number().optional().meta({ description: 'Average stride length (m)' }),
+    body_battery_after: z
+      .number()
+      .optional()
+      .meta({ description: 'Body battery score at activity end (0-100)' }),
+    body_battery_before: z
+      .number()
+      .optional()
+      .meta({ description: 'Body battery score at activity start (0-100)' }),
+    calories: z.number().optional().meta({ description: 'Total calories burned (kcal)' }),
+    distance: z.number().optional().meta({ description: 'Total distance (m)' }),
+    elevation_gain: z.number().optional().meta({ description: 'Total elevation gain (m)' }),
+    elevation_loss: z.number().optional().meta({ description: 'Total elevation loss (m)' }),
+    max_hr: z.number().optional().meta({ description: 'Maximum heart rate (bpm)' }),
+    steps: z.number().optional().meta({ description: 'Total step count' }),
+    vo2_max: z.number().optional().meta({ description: 'VO2 max (mL/kg/min)' }),
+  })
+  .meta({
+    description:
+      'Summary metrics derived from per-second time-series and stored summary fields. Fields are populated only when underlying data is available.',
+    id: 'ActivitySummaryMetrics',
+  })
+
+export type ActivitySummaryMetrics = z.infer<typeof activitySummaryMetricsSchema>
+
+/**
  * Activity schema.
  */
-export const activitySchema = z
-  .object({
+export const activitySchema = activitySummaryMetricsSchema
+  .extend({
     activity_type: z.string().meta({ description: 'Activity type' }),
     avg_hrv: z.number().optional().meta({ description: 'Average HRV (ms) during the activity' }),
     comments: z.array(commentSchema).optional().meta({ description: 'Attached comments' }),
@@ -439,3 +483,96 @@ export const resyncActivityDetailResponseSchema = baseResponseSchema
   .meta({ id: 'ResyncActivityDetailResponse' })
 
 export type ResyncActivityDetailResponse = z.infer<typeof resyncActivityDetailResponseSchema>
+
+/**
+ * Query parameters for the activity full-detail endpoint.
+ *
+ * Lets callers opt in/out of expensive payload pieces (GPS, time-series) and
+ * restrict to specific metrics to keep responses manageable.
+ */
+export const activityFullDetailQuerySchema = z
+  .object({
+    bucket: z.string().optional().meta({
+      description:
+        'Bucket size for time-series aggregation (e.g. "10s", "1m"). Omit to get raw per-sample points.',
+      example: '10s',
+    }),
+    include_gps: z.coerce.boolean().optional().default(true).meta({
+      description: 'Include GPS trace if any locations exist for the activity time range. Default: true.',
+    }),
+    metrics: z.string().optional().meta({
+      description:
+        'Comma-separated metric names to include time-series for. Omit to include all metrics with data in the activity time range.',
+      example: 'heart_rate,speed,run_cadence',
+    }),
+  })
+  .meta({ id: 'ActivityFullDetailQuery' })
+
+export type ActivityFullDetailQuery = z.infer<typeof activityFullDetailQuerySchema>
+
+/**
+ * GPS trace point for an activity.
+ */
+export const activityGpsPointSchema = z
+  .object({
+    lat: latSchema,
+    lon: lonSchema,
+    time: iso8601DateTimeSchema,
+  })
+  .meta({ id: 'ActivityGpsPoint' })
+
+export type ActivityGpsPoint = z.infer<typeof activityGpsPointSchema>
+
+/**
+ * Per-metric time-series for an activity.
+ *
+ * `data` is a packed array of [time, value] tuples sorted by time.
+ * If `bucket` was specified in the query the values are bucketed averages.
+ */
+export const activityMetricSeriesSchema = z
+  .object({
+    bucket: z.string().optional().meta({ description: 'Bucket size used (omitted for raw samples).' }),
+    count: z.number().int().meta({ description: 'Number of points in the series' }),
+    data: z
+      .array(z.tuple([iso8601DateTimeSchema, z.number()]))
+      .meta({ description: 'Array of [time, value] tuples sorted by time' }),
+    metric: metricTypeSchema.or(z.string()).meta({ description: 'Metric name' }),
+    unit: z.string().meta({ description: 'Unit of measurement' }),
+  })
+  .meta({ id: 'ActivityMetricSeries' })
+
+export type ActivityMetricSeries = z.infer<typeof activityMetricSeriesSchema>
+
+/**
+ * Full activity detail with optional GPS trace and per-metric time-series.
+ *
+ * Designed for deep-dive analysis (route comparison, form analysis,
+ * pace-by-grade studies). Lean fields (summary metrics, HR zones, comments)
+ * are inherited from the regular activity-detail schema.
+ */
+export const activityFullDetailSchema = activityDetailSchema
+  .extend({
+    gps: z.array(activityGpsPointSchema).optional().meta({
+      description: 'GPS trace covering the activity time range, if any locations are available.',
+    }),
+    metric_series: z.array(activityMetricSeriesSchema).optional().meta({
+      description: 'Per-metric time-series during the activity time range.',
+    }),
+  })
+  .meta({ id: 'ActivityFullDetail' })
+
+export type ActivityFullDetail = z.infer<typeof activityFullDetailSchema>
+
+/**
+ * Response for the activity full-detail endpoint.
+ */
+export const activityFullDetailResponseSchema = createDataResponseSchema(activityFullDetailSchema)
+  .extend({
+    referenced_rules: z
+      .record(z.string(), z.string())
+      .optional()
+      .meta({ description: 'Map of rule ID to rule name for deduction rules referenced in activity data' }),
+  })
+  .meta({ id: 'ActivityFullDetailResponse' })
+
+export type ActivityFullDetailResponse = z.infer<typeof activityFullDetailResponseSchema>

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -177,21 +177,36 @@ export const activitySummaryMetricsSchema = z
 export type ActivitySummaryMetrics = z.infer<typeof activitySummaryMetricsSchema>
 
 /**
+ * All metrics computed for an activity at query time: HR-zone seconds,
+ * average HRV, and the generic summary metrics. Returned by both the
+ * single-activity detail endpoint and embedded into list-query results.
+ *
+ * "Computed" = derived from time-series and/or activity.data, not stored
+ * directly on the activities row.
+ */
+export const activityComputedMetricsSchema = activitySummaryMetricsSchema
+  .extend({
+    avg_hrv: z.number().optional().meta({ description: 'Average HRV (ms) during the activity' }),
+    hr_zone_secs: hrZoneSecsSchema.optional().meta({
+      description: 'Time spent in each HR zone (for exercise)',
+    }),
+  })
+  .meta({ id: 'ActivityComputedMetrics' })
+
+export type ActivityComputedMetrics = z.infer<typeof activityComputedMetricsSchema>
+
+/**
  * Activity schema.
  */
-export const activitySchema = activitySummaryMetricsSchema
+export const activitySchema = activityComputedMetricsSchema
   .extend({
     activity_type: z.string().meta({ description: 'Activity type' }),
-    avg_hrv: z.number().optional().meta({ description: 'Average HRV (ms) during the activity' }),
     comments: z.array(commentSchema).optional().meta({ description: 'Attached comments' }),
     data: z.record(z.string(), z.unknown()).optional(),
     deleted_at: iso8601DateTimeSchema.optional().meta({ description: 'Soft-delete timestamp' }),
     duration: durationMinutesSchema.optional(),
     end_time: iso8601DateTimeSchema.optional(),
     external_id: z.string().optional().meta({ description: 'External ID from source system' }),
-    hr_zone_secs: hrZoneSecsSchema.optional().meta({
-      description: 'Time spent in each HR zone (for exercise)',
-    }),
     id: z.string().uuid().optional().meta({ description: 'Activity ID' }),
     notes: z.string().optional().meta({ description: 'Activity notes' }),
     source: z.string().optional().meta({ description: 'Data source' }),
@@ -485,6 +500,13 @@ export const resyncActivityDetailResponseSchema = baseResponseSchema
 export type ResyncActivityDetailResponse = z.infer<typeof resyncActivityDetailResponseSchema>
 
 /**
+ * Sentinel value for the activity full-detail `metrics` parameter that means
+ * "every metric with data in the activity range". Defined as a constant so the
+ * schema description, parser, and clients all agree.
+ */
+export const ALL_METRICS_SENTINEL = 'all'
+
+/**
  * Query parameters for the activity full-detail endpoint.
  *
  * Lets callers opt in/out of expensive payload pieces (GPS, time-series) and
@@ -492,19 +514,16 @@ export type ResyncActivityDetailResponse = z.infer<typeof resyncActivityDetailRe
  */
 export const activityFullDetailQuerySchema = z
   .object({
-    bucket: z.string().optional().meta({
-      description:
-        'Bucket size for time-series aggregation (e.g. "10s", "1m"). Omit to get raw per-sample points.',
-      example: '10s',
-    }),
     include_gps: z.coerce.boolean().optional().default(true).meta({
       description: 'Include GPS trace if any locations exist for the activity time range. Default: true.',
     }),
-    metrics: z.string().optional().meta({
-      description:
-        'Comma-separated metric names to include time-series for. Omit to include all metrics with data in the activity time range.',
-      example: 'heart_rate,speed,run_cadence',
-    }),
+    metrics: z
+      .string()
+      .optional()
+      .meta({
+        description: `Comma-separated metric names to include time-series for, or '${ALL_METRICS_SENTINEL}' for every metric with data. Omit for summary + GPS only.`,
+        example: 'heart_rate,speed,run_cadence',
+      }),
   })
   .meta({ id: 'ActivityFullDetailQuery' })
 


### PR DESCRIPTION
Closes #621.

## Summary

- Adds source-agnostic summary metrics (avg pace, cadence, stride length, power, ground contact time, elevation gain/loss, body battery before/after, distance, calories, max/avg HR, vo2_max, steps) to every activity returned by `query_activities` and `GET /activities/:id`. Derived from per-second time-series and `activity.data` JSONB — works for any source that populates the underlying metrics (Garmin, Strava, Health Connect, FIT upload, manual).
- Adds a `get_activity_detail` MCP tool and matching `GET /activities/:id/full` REST endpoint for deep-dive analysis: GPS trace + per-metric time-series. Callers opt into time-series via the `metrics` param (`'all'` or comma list) to keep response sizes manageable. Both endpoints support the `merged:` id prefix to expand the window across overlapping cross-source records.

## Implementation notes

- New schemas live in `packages/api-spec/src/schemas/activities.ts`: `ActivitySummaryMetrics`, `ActivityFullDetailQuery`, `ActivityFullDetailResponse`, `ActivityGpsPoint`, `ActivityMetricSeries`. The base `Activity` schema extends `ActivitySummaryMetrics`.
- Computation lives in `apps/backend/src/services/queries/activity-summary-metrics.ts` and `activity-detail.ts`. Both services are pure-ish — generic helpers compose well and stay testable.
- `queryActivities` now batches summary-metric fetches via the existing `getTimeSeriesMultiMetric`, preserving the no-N+1 property of the recent HR/HRV refactor.
- The merged-activity detail path recomputes over the full overlapping time window so HR zones, HRV, and the new summary metrics use the wider span.

## Test plan

- [x] `pnpm --filter aurboda-backend test` (unit) — 1506 passed
- [x] `pnpm --filter aurboda-backend check` — 0 errors
- [x] `pnpm --filter @aurboda/api-spec check` — 0 errors / 0 warnings
- [x] Activities integration tests pass (`activities.integration` — 27 passed)
- [ ] Sanity-check `get_activity_detail` against a real Garmin run on aurboda.net once deployed
- [ ] Spot-check the detail endpoint against the existing web UI's chart data

🤖 Generated with [Claude Code](https://claude.com/claude-code)