### PR TITLE
refactor: centralize activity-subtype types + guards in api-spec

### DIFF
--- a/apps/backend/src/routes/scrobbles-router.ts
+++ b/apps/backend/src/routes/scrobbles-router.ts
@@ -9,6 +9,8 @@
 import type { ScrobblesResponse } from '@aurboda/api-spec'
 import type { RequestHandler, Router } from 'express'
 
+import { isMusicScrobbleActivity } from '@aurboda/api-spec'
+
 import { getActivities } from '../db/index.ts'
 import { typedRouter } from '../typed-router.ts'
 
@@ -28,14 +30,16 @@ export const createScrobblesRouter = (authMiddleware: RequestHandler): Router =>
 
       try {
         const activities = await getActivities(user, ['music_scrobble'], new Date(start), new Date(end))
-        const serialized = activities.map((a) => {
-          const data = a.data as Record<string, unknown> | undefined
-          return {
-            album: typeof data?.album === 'string' ? data.album : '',
-            artist: typeof data?.artist === 'string' ? data.artist : '',
-            recorded_at: a.start_time.toISOString(),
-            track: typeof data?.track === 'string' ? data.track : '',
-          }
+        const serialized = activities.flatMap((a) => {
+          if (!isMusicScrobbleActivity(a)) return []
+          return [
+            {
+              album: a.data.album ?? '',
+              artist: a.data.artist,
+              recorded_at: a.start_time.toISOString(),
+              track: a.data.track,
+            },
+          ]
         })
         res.json({ data: serialized, success: true })
       } catch (error) {

--- a/apps/backend/src/services/screentime-activities.ts
+++ b/apps/backend/src/services/screentime-activities.ts
@@ -11,6 +11,8 @@
  * but do not produce activities.
  */
 
+import { isScreentimeActivity } from '@aurboda/api-spec'
+
 import type { ProductivityRecord, ScreentimeCategory } from '../db/index.ts'
 import type { Activity } from '../db/types.ts'
 
@@ -23,11 +25,14 @@ export const categoryPathToString = (path: string[]): string => path.join(' > ')
 
 export const categoryPathFromString = (s: string): string[] => s.split(' > ')
 
-/** Extract the parsed category_path from a screentime activity, if present. */
-export const getScreentimeCategoryPath = (activity: Activity): string[] | undefined => {
-  const path = activity.data?.category_path
-  return typeof path === 'string' ? categoryPathFromString(path) : undefined
-}
+/**
+ * Extract the parsed `category_path` array from a screentime activity, if it
+ * carries one. Layered on the shared `isScreentimeActivity` type guard from
+ * api-spec — the parsing (string → array) is the only piece this helper adds
+ * on top of the guard.
+ */
+export const getScreentimeCategoryPath = (activity: Activity): string[] | undefined =>
+  isScreentimeActivity(activity) ? categoryPathFromString(activity.data.category_path) : undefined
 
 /** True if `categoryPath` is at or under one of the excluded paths (prefix match). */
 export const isCategoryExcluded = (categoryPath: string[], excludedPaths: string[][]): boolean =>

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -1,12 +1,12 @@
 import type { ScreentimeCategory } from '@aurboda/api-spec'
 
+import { isLocationVisitActivity, isMusicScrobbleActivity } from '@aurboda/api-spec'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { addDays, format, subDays } from 'date-fns'
 import { useCallback, useMemo } from 'preact/hooks'
 
 import type { Activity, Place, Scrobble } from '../../state/api'
 import type { ChartItem, Column } from './types'
-
 import {
   fetchActivities,
   fetchActivityTypeDefinitions,
@@ -246,18 +246,10 @@ export const useTimelineData = ({
   // visually nothing is lost).
   const places = useMemo<Place[]>(
     () =>
-      (activitiesQuery.data ?? [])
-        .filter((a): a is Activity & { end_time: Date } =>
-          Boolean(a.activity_type === 'location_visit' && a.end_time),
-        )
-        .map((a) => {
-          const name = a.data?.location_name
-          return {
-            end_time: a.end_time,
-            region: typeof name === 'string' ? name : '',
-            start_time: a.start_time,
-          }
-        }),
+      (activitiesQuery.data ?? []).flatMap((a) => {
+        if (!isLocationVisitActivity(a) || !a.end_time) return []
+        return [{ end_time: a.end_time, region: a.data.location_name, start_time: a.start_time }]
+      }),
     [activitiesQuery.data],
   )
   const productivity = productivityQuery.data?.records ?? []
@@ -266,17 +258,17 @@ export const useTimelineData = ({
   // so no separate /lastfm/scrobbles network call is needed.
   const scrobbles = useMemo<Scrobble[]>(() => {
     if (!hasLastFm) return []
-    return (activitiesQuery.data ?? [])
-      .filter((a) => a.activity_type === 'music_scrobble')
-      .map((a) => {
-        const data = a.data
-        return {
-          album: typeof data?.album === 'string' ? data.album : '',
-          artist: typeof data?.artist === 'string' ? data.artist : '',
+    return (activitiesQuery.data ?? []).flatMap((a) => {
+      if (!isMusicScrobbleActivity(a)) return []
+      return [
+        {
+          album: a.data.album ?? '',
+          artist: a.data.artist,
           recorded_at: a.start_time,
-          track: typeof data?.track === 'string' ? data.track : '',
-        }
-      })
+          track: a.data.track,
+        },
+      ]
+    })
   }, [hasLastFm, activitiesQuery.data])
 
   const sleepMetricsByDate = useMemo<SleepMetricsByDate>(() => {

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -1,6 +1,8 @@
-import type { ScreentimeCategory } from '@aurboda/api-spec'
-
-import { isLocationVisitActivity, isMusicScrobbleActivity } from '@aurboda/api-spec'
+import {
+  isLocationVisitActivity,
+  isMusicScrobbleActivity,
+  type ScreentimeCategory,
+} from '@aurboda/api-spec'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { addDays, format, subDays } from 'date-fns'
 import { useCallback, useMemo } from 'preact/hooks'

--- a/packages/api-spec/src/schemas/activity-subtypes.ts
+++ b/packages/api-spec/src/schemas/activity-subtypes.ts
@@ -1,0 +1,57 @@
+/**
+ * Discriminated subtypes + type guards for the activity types whose `data`
+ * shape is fixed by system code (not user-defined). Lets both the backend and
+ * the frontend narrow `Activity` into a properly-typed subtype without
+ * repeating ad-hoc `typeof a.data?.X === 'string' ? ... : ''` checks at every
+ * call site.
+ *
+ * Type guards are generic over the activity shape so they work with either
+ * the wire format (`Activity` with ISO-string timestamps) or consumer-side
+ * variants (e.g. the frontend's `Activity` with `Date` fields).
+ *
+ * Activity types not listed here (exercise, sleep, custom user-defined,
+ * etc.) keep the generic `Activity` shape with `data?: Record<string, unknown>`.
+ */
+
+/** `data` shape for `music_scrobble` activities. */
+export interface MusicScrobbleData {
+  artist: string
+  track: string
+  album?: string
+}
+
+/** `data` shape for `screentime` activities. `category_path` is `' > '`-joined. */
+export interface ScreentimeData {
+  category_path: string
+  score?: number
+}
+
+/** `data` shape for `location_visit` activities. */
+export interface LocationVisitData {
+  lat: number
+  lon: number
+  location_name: string
+}
+
+/** Minimum surface a value must have before any of the type guards can run. */
+type ActivityLike = { activity_type: string; data?: Record<string, unknown> }
+
+export const isMusicScrobbleActivity = <A extends ActivityLike>(
+  a: A,
+): a is A & { activity_type: 'music_scrobble'; data: MusicScrobbleData } =>
+  a.activity_type === 'music_scrobble' &&
+  typeof a.data?.artist === 'string' &&
+  typeof a.data?.track === 'string'
+
+export const isScreentimeActivity = <A extends ActivityLike>(
+  a: A,
+): a is A & { activity_type: 'screentime'; data: ScreentimeData } =>
+  a.activity_type === 'screentime' && typeof a.data?.category_path === 'string'
+
+export const isLocationVisitActivity = <A extends ActivityLike>(
+  a: A,
+): a is A & { activity_type: 'location_visit'; data: LocationVisitData } =>
+  a.activity_type === 'location_visit' &&
+  typeof a.data?.lat === 'number' &&
+  typeof a.data?.lon === 'number' &&
+  typeof a.data?.location_name === 'string'

--- a/packages/api-spec/src/schemas/index.ts
+++ b/packages/api-spec/src/schemas/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './activities.ts'
+export * from './activity-subtypes.ts'
 export * from './activity-type-definitions.ts'
 export * from './admin.ts'
 export * from './audit-log.ts'


### PR DESCRIPTION
## Summary

Review-and-tidy pass on the activity consolidation refactor. The big finding: every consumer was narrowing `Activity.data` ad-hoc with repeated \`typeof a.data?.X === 'string' ? ... : ''\` checks. Backend already had \`getScreentimeCategoryPath\` in one place; frontend + other backend code didn't have an equivalent.

Centralized in **api-spec** so backend, frontend, and any future consumer share one definition:

- **\`MusicScrobbleData\`, \`ScreentimeData\`, \`LocationVisitData\`** interfaces
- **\`isMusicScrobbleActivity\`, \`isScreentimeActivity\`, \`isLocationVisitActivity\`** type guards — generic over the activity shape so they work with both the wire-format \`Activity\` (ISO-string timestamps) and the frontend's \`Date\`-narrowed variant

## Refactored call sites

- **\`useTimelineData\`**: places + scrobbles derivations use the guards directly. Drops per-field \`typeof\` checks and the \`Activity & { end_time: Date }\` type assertion.
- **\`scrobbles-router\`**: drops \`data as Record<string, unknown>\` cast and four per-field \`typeof\` checks.
- **\`getScreentimeCategoryPath\`**: now layered on \`isScreentimeActivity\`. The \`' > '\` parsing is the only piece this helper still adds.

## What's *not* changed

Activity types not in this set — exercise, sleep, custom user-defined types — keep the generic \`data?: Record<string, unknown>\` shape and their existing reads. Those are dynamic per-user schemas defined via \`data_schema\` on \`activity_type_definitions\`, not fixed by system code.

## Audit summary (other things considered, decided to leave)

- \`/productivity\`, \`/locations\`, \`/lastfm/scrobbles\` REST endpoints — still consumed by Data, DataSources, Help, ScreentimeCategories/CategoryDetail, EntityDetail/MusicPlaylist for raw-record inspection. Legitimate use, not Timeline.
- \`ProductivityRecord\`, \`Place\`, \`Scrobble\` types — same consumers.
- \`entity_type: 'productivity'\` route in EntityDetail — needed for direct links to old productivity records.
- DB row mappers (\`row.X as Type\`) — boundary code; full safety needs Zod/runtime validation, larger change.
- \`categorizeProductivity\` (Timeline) + \`screentimeMergeGapMs\` in \`useTimelineNavigation\` — will become dead code once #671 lands. Will land as a separate post-#671 cleanup PR.

## Test plan
- [x] Backend type check clean
- [x] Web type check clean
- [x] Backend unit tests pass (54 in affected files)
- [x] Web tests pass (292)

🤖 Generated with [Claude Code](https://claude.com/claude-code)