### PR TITLE
refactor: extract api.ts orchestration helpers into api/ (#585)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -1,104 +1,55 @@
 /**
  * Express server entry point.
  *
- * Route handlers are split into focused modules under routes/.
- * This file handles: server setup, middleware, auth routes, and router mounting.
+ * Setup is split across helpers in `api/`:
+ *   - middleware.ts  — audit log, auth, admin
+ *   - auth-routes.ts — /version, /status, /signup, /login, /auth/token
+ *   - oauth-routes.ts — Garmin / Strava / Oura connect+disconnect
+ *   - sync-setup.ts  — `/sync` router wiring
+ *   - webhooks-setup.ts — Strava + Oura push integrations
+ *   - rest-routes.ts — per-domain REST router mounts
+ *
+ * This file orchestrates: clients, queues, central DB, auth, error handler,
+ * server lifecycle.
  */
-import type {
-  AuthTokenResponse,
-  LoginResponse,
-  ServerStatusResponse,
-  SignupResponse,
-  VersionResponse,
-} from '@aurboda/api-spec'
-
 import cors from 'cors'
-import express, { json, type NextFunction, type Request, type RequestHandler, type Response } from 'express'
+import express, { json, type NextFunction, type Request, type Response } from 'express'
 import { Client } from 'pg'
 
-import type { OuraDataType } from './integrations/oura/sync.ts'
-import type { AnyMiddleware } from './typed-router.ts'
-
+import { registerAuthRoutes } from './api/auth-routes.ts'
+import { createAdminMiddleware, createAuditLogMiddleware, createAuthMiddleware } from './api/middleware.ts'
+import { registerOAuthRoutes } from './api/oauth-routes.ts'
+import { mountRestRouters } from './api/rest-routes.ts'
+import { mountSyncRouter } from './api/sync-setup.ts'
+import { setupOuraWebhook, setupStravaWebhook } from './api/webhooks-setup.ts'
 import { createAuth } from './auth.ts'
 import {
-  ackOutboundSync,
-  deleteHealthConnectRecords,
-  getAllSyncStates,
-  getDetectedLocationById,
-  getNamedLocations,
-  getOutboundSyncHistory,
-  getPendingOutboundSync,
-  insertActivities,
-  insertActivity,
-  insertLocations,
-  insertRawRecord,
-  insertTimeSeries,
-  reportSyncFailure,
-  requeueOutboundSync,
-  initializeSchema,
-  insertLocation,
-  insertPlace,
-  loginToUserDb,
-  makeNewUserDb,
-  markActivityDetailSynced,
-  migrateSchema,
-  processDailyAggregate,
-  processHealthConnectBatch,
-  processHealthConnectData,
-  query,
-  resolveOrCreateActivityType,
-  resetSyncState,
-  schemaInitialized,
-  softDeleteActivityByExternalId,
-  softDeleteLocationRange,
   deleteRuleActivities,
   getDeductionRulesByIds,
+  getDetectedLocationById,
   getEnabledDeductionRules,
+  getNamedLocations,
+  insertActivities,
+  insertActivity,
+  insertLocation,
+  insertLocations,
+  insertPlace,
+  insertRawRecord,
+  insertTimeSeries,
+  loginToUserDb,
+  resolveOrCreateActivityType,
+  softDeleteLocationRange,
   updateDetectedLocation,
-  upsertOAuthToken,
   upsertSyncState,
-  upsertUserSettings,
 } from './db/index.ts'
 import { httpError, isHttpError } from './http-error.ts'
-import { processActivityWatchEvents } from './integrations/activitywatch/sync.ts'
 import { garminClient } from './integrations/garmin/client.ts'
-import { processActivityDetail } from './integrations/garmin/process.ts'
-import { syncAllGarminData } from './integrations/garmin/sync.ts'
-import { syncAllCalendars } from './integrations/ical/sync.ts'
-import { syncLastFmData } from './integrations/lastfm/sync.ts'
 import { ouraClient } from './integrations/oura/client.ts'
-import { syncAllOuraData, syncOuraDataType } from './integrations/oura/sync.ts'
 import { createOwnTracksRouter } from './integrations/owntracks/router.ts'
-import { syncRescueTimeData } from './integrations/rescuetime/sync.ts'
 import { stravaClient } from './integrations/strava/client.ts'
-import { getStravaSyncStates, resetStravaSyncState, syncStrava } from './integrations/strava/sync.ts'
-import { createStravaWebhookRouter } from './integrations/strava/webhook-router.ts'
 import { createMcpRouter } from './mcp.ts'
-import { createActivitiesRouter } from './routes/activities-router.ts'
-import { createActivityTypesRouter } from './routes/activity-types-router.ts'
-import { createAdminRouter } from './routes/admin-router.ts'
-import { createAuditLogRouter } from './routes/audit-log-router.ts'
-import { createChartDataRouter } from './routes/chart-data-router.ts'
-import { createCorrelationsRouter } from './routes/correlations-router.ts'
-import { createDashboardRouter } from './routes/dashboard-router.ts'
-import { createDeductionRulesRouter } from './routes/deduction-rules-router.ts'
-import { createFoodItemsRouter } from './routes/food-items-router.ts'
-import { createIconsRouter } from './routes/icons-router.ts'
-import { createLocationsRouter } from './routes/locations-router.ts'
-import { createMealsRouter } from './routes/meals-router.ts'
-import { createMetricsRouter } from './routes/metrics-router.ts'
-import { createNotesRouter } from './routes/notes-router.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
-import { createRawRecordsRouter } from './routes/raw-records-router.ts'
-import { createReportsRouter } from './routes/reports-router.ts'
-import { createScreentimeCategoriesRouter } from './routes/screentime-categories-router.ts'
-import { createSettingsRouter } from './routes/settings-router.ts'
-// tags-router removed: tags are now activities
-import { createTrainingLoadRouter } from './routes/training-load-router.ts'
-import { createTrendsRouter } from './routes/trends-router.ts'
-import { auditError, auditInfo, auditWarn, pruneAuditLog } from './services/audit-log.ts'
-import { backfillScreentimeActivities } from './services/backfill-screentime-activities.ts'
-import { triggerCalorieComputation } from './services/calorie-computation.ts'
+import { auditError } from './services/audit-log.ts'
 import { getCentralDb, initializeCentralDb } from './services/central-db.ts'
 import { createDefaultEngineDeps } from './services/deduction-deps.ts'
 import { buildFullWindow, evaluateAllRules } from './services/deduction-engine.ts'
@@ -112,13 +63,9 @@ import { runDetectionForUser } from './services/detection-worker.ts'
 import { createGeocodeQueue } from './services/geocode-queue.ts'
 import { createInvitationAuth } from './services/invitation.ts'
 import { getPlaceVisits } from './services/locations.ts'
-import { createOuraWebhookManager, type OuraWebhookManager } from './services/oura-webhook-manager.ts'
 import { createPgBoss } from './services/pg-boss.ts'
-import { getSettings } from './services/settings.ts'
 import { createStravaQueue, type StravaQueue } from './services/strava-queue.ts'
-import { createStravaWebhookManager } from './services/strava-webhook-manager.ts'
 import { createSyncProvider } from './services/sync-provider.ts'
-import { createSyncRouter } from './sync-router.ts'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -302,517 +249,65 @@ const main = async () => {
 
   httpd.use(json({ limit: '10mb' }))
 
-  // Log mutations to the user's audit log (GET requests are silent)
-  // Log level is based on response status: 4xx → warn, 5xx → error, otherwise → info
-  httpd.use((req, res, next) => {
-    if (req.method !== 'GET' && req.method !== 'OPTIONS' && req.method !== 'HEAD') {
-      const user = (() => {
-        try {
-          const authHeader = req.headers.authorization
-          if (typeof authHeader === 'string') {
-            return auth.getUsernameFromToken(authHeader.slice('bearer '.length))
-          }
-        } catch {}
-        return undefined
-      })()
+  // Audit-log middleware: records non-GET requests with response status / body
+  httpd.use(createAuditLogMiddleware(auth))
 
-      if (user) {
-        const sanitizedBody =
-          req.body && typeof req.body === 'object'
-            ? Object.fromEntries(
-                Object.entries(req.body as Record<string, unknown>).map(([k, v]) =>
-                  k === 'password' ? [k, '[REDACTED]'] : [k, v],
-                ),
-              )
-            : undefined
+  const authMiddleware = createAuthMiddleware(auth, unauthorized)
+  const adminMiddleware = createAdminMiddleware(centralDb, unauthorized, forbidden)
 
-        // Capture response body for error logging by intercepting res.json()
-        let responseBody: unknown
-        const originalJson = res.json.bind(res)
-        res.json = (body: unknown) => {
-          responseBody = body
-          return originalJson(body)
-        }
-
-        res.on('finish', () => {
-          if (res.statusCode >= 500) {
-            auditError(user, 'data', `${req.method} ${req.path}`, {
-              ...sanitizedBody,
-              status: res.statusCode,
-              response: responseBody,
-            })
-          } else if (res.statusCode >= 400) {
-            auditWarn(user, 'data', `${req.method} ${req.path}`, {
-              ...sanitizedBody,
-              status: res.statusCode,
-              response: responseBody,
-            })
-          } else {
-            auditInfo(user, 'data', `${req.method} ${req.path}`, sanitizedBody)
-          }
-        })
-      }
-    }
-    next()
+  // Auth-related routes (version, status, signup, login, /auth/token)
+  registerAuthRoutes({
+    httpd,
+    auth,
+    authMiddleware,
+    centralDb,
+    invitationAuth,
+    userDb,
+    unauthorized,
   })
 
-  // Track which users have been migrated this server lifetime
-  const migratedUsers = new Map<string, Promise<void>>()
-
-  const authMiddleware: AnyMiddleware = async (req, res, next) => {
-    try {
-      if (typeof req.headers.authorization === 'string') {
-        const token = req.headers.authorization.slice('bearer '.length)
-        const user = auth.getUsernameFromToken(token)
-        req.user = user
-
-        // Run schema migration once per user per server lifetime (blocking on first request)
-        if (!migratedUsers.has(user)) {
-          const migrationPromise = migrateSchema(user)
-            .then(() => {
-              // Fire-and-forget: one-shot backfill of historical screentime activities.
-              // Gated via sync_state so it runs at most once per user, in the background
-              // so the first request isn't blocked on thousands of productivity records.
-              void backfillScreentimeActivities(user).catch((err) =>
-                console.error(`⚠️ Screentime backfill failed for ${user}:`, err),
-              )
-            })
-            .catch((err) => console.error(`⚠️ Migration failed for ${user}:`, err))
-          migratedUsers.set(user, migrationPromise)
-          await migrationPromise
-        } else {
-          // Subsequent requests wait if migration is still in progress
-          await migratedUsers.get(user)
-        }
-
-        return next()
-      }
-    } catch {
-      return next(unauthorized)
-    }
-    return next(unauthorized)
-  }
-
-  const adminMiddleware: RequestHandler = async (req, res, next) => {
-    if (!req.user) {
-      return next(unauthorized)
-    }
-    const isAdmin = await centralDb.isAdmin(req.user)
-    if (!isAdmin) {
-      return next(forbidden)
-    }
-    next()
-  }
-
-  // ==========================================================================
-  // Auth routes (stay here - tightly coupled to server setup)
-  // ==========================================================================
-
-  httpd.get<Record<string, never>, VersionResponse>('/version', (_req, res) => {
-    res.json({
-      build_sha: process.env.BUILD_SHA ?? 'dev',
-      success: true,
-    })
+  // /sync router (cross-provider sync orchestration)
+  mountSyncRouter({
+    httpd,
+    authMiddleware,
+    centralDb,
+    oura,
+    garmin,
+    stravaQueue,
+    activityNotifier,
   })
 
-  httpd.get<Record<string, never>, ServerStatusResponse>('/status', async (_req, res) => {
-    const signupMode = await centralDb.getSignupMode()
-    res.json({
-      signup_allowed: signupMode === 'open',
-      signup_mode: signupMode,
-      success: true,
-    })
+  // Per-provider OAuth/connect endpoints
+  registerOAuthRoutes({
+    httpd,
+    authMiddleware,
+    centralDb,
+    garmin,
+    oura,
+    strava,
   })
 
-  // eslint-disable-next-line complexity -- signup validation logic
-  httpd.post<Record<string, never>, SignupResponse>('/signup', async (req, res, next) => {
-    const signupMode = await centralDb.getSignupMode()
-
-    if (signupMode === 'closed') {
-      res.status(403).json({ error: 'Signup is currently closed', success: false })
-      return
-    }
-
-    const { username: user, password, invitation } = req.body
-
-    // In invite_only mode, require valid invitation token
-    if (signupMode === 'invite_only') {
-      if (!invitation || typeof invitation !== 'string') {
-        res.status(403).json({
-          error: 'An invitation is required to sign up',
-          success: false,
-        })
-        return
-      }
-      const validation = invitationAuth.validateInvitationToken(invitation)
-      if (!validation.valid) {
-        const errorMsg = validation.expired ? 'Invitation has expired' : 'Invalid invitation'
-        res.status(403).json({ error: errorMsg, success: false })
-        return
-      }
-    }
-
-    if (!user || typeof user !== 'string' || !password || typeof password !== 'string') {
-      res.status(400).json({
-        error: 'Username and password are required',
-        success: false,
-      })
-      return
-    }
-
-    // Validate username format (alphanumeric, lowercase, no special chars for PostgreSQL role)
-    if (!/^[a-z][a-z0-9_]{2,30}$/.test(user)) {
-      res.status(400).json({
-        error:
-          'Username must be 3-31 characters, start with a letter, and contain only lowercase letters, numbers, and underscores',
-        success: false,
-      })
-      return
-    }
-
-    // Block reserved PostgreSQL and system usernames
-    const reservedUsernames = [
-      'postgres',
-      'admin',
-      'root',
-      'administrator',
-      'superuser',
-      'system',
-      'public',
-      'guest',
-      'test',
-      'aurboda',
-    ]
-    if (reservedUsernames.includes(user)) {
-      res.status(400).json({ error: 'This username is reserved', success: false })
-      return
-    }
-
-    // Check if user already exists
-    const existingUser = await query(userDb, 'SELECT usename FROM pg_user WHERE usename=$1', [user])
-    if (existingUser.rowCount && existingUser.rowCount > 0) {
-      res.status(409).json({ error: 'Username already exists', success: false })
-      return
-    }
-
-    try {
-      await makeNewUserDb(userDb, user, password)
-      const token = auth.createToken(user)
-
-      // First user becomes admin automatically
-      const adminCount = await centralDb.getAdminCount()
-      let isAdmin = false
-      if (adminCount === 0) {
-        await centralDb.addAdmin(user)
-        isAdmin = true
-        console.info(`First user ${user} automatically made admin`)
-      }
-
-      res.json({ is_admin: isAdmin, success: true, token })
-    } catch (err) {
-      console.error('Signup error:', err)
-      next(err)
-    }
-  })
-
-  httpd.post<Record<string, never>, LoginResponse>('/login', async (req, res, next) => {
-    const { username: user, password } = req.body
-    if (!user) return next(unauthorized)
-
-    // Check if user exists as a PSQL user role
-    const userRows = await query(userDb, 'SELECT usename FROM pg_user WHERE usename=$1', [user])
-    if (userRows.rowCount === 1) {
-      try {
-        await loginToUserDb(user, password)
-        // Ensure schema is initialized and migrated
-        if (!(await schemaInitialized(user))) {
-          await initializeSchema(user)
-        } else {
-          // Run migrations for existing databases
-          await migrateSchema(user)
-        }
-      } catch {
-        return next(unauthorized)
-      }
-    } else return next(unauthorized)
-
-    const token = auth.createToken(user)
-    const isAdmin = await centralDb.isAdmin(user)
-
-    // Prune old audit log entries in the background
-    centralDb
-      .getAuditLogRetentionDays()
-      .then((days) => pruneAuditLog(user, days))
-      .catch(() => {})
-
-    res.writeHead(200, { 'Content-Type': 'application/json' })
-    res.end(JSON.stringify({ is_admin: isAdmin, refresh: token, token }))
-  })
-
-  // Generate a fresh API token for the authenticated user (e.g. for push agents like ActivityWatch)
-  httpd.get<Record<string, never>, AuthTokenResponse>('/auth/token', authMiddleware, (req, res) => {
-    const user = req.user!
-    const token = auth.createToken(user)
-    res.json({ success: true, token })
-  })
-
-  // ==========================================================================
-  // External service routers (already extracted)
-  // ==========================================================================
-
-  // Transform SyncState to ProviderSyncStatus format (undefined -> null)
-  const transformSyncStates = async (user: string, provider: string) => {
-    const states = await getAllSyncStates(user, provider)
-    return states.map((s) => ({
-      error_message: s.error_message ?? null,
-      last_sync_time: s.last_sync_time?.toISOString() ?? null,
-      provider: s.provider,
-      retry_after: s.retry_after?.toISOString() ?? null,
-      status: s.status === 'rate_limited' ? ('error' as const) : s.status,
-    }))
-  }
-
-  const transformOuraSyncResults = async (
-    user: string,
-    options: { fullResync?: boolean; startDate?: Date },
-  ) => {
-    const results = await syncAllOuraData(user, oura, options)
-    return results.map((r) => ({
-      ...r,
-      retry_after: r.retry_after?.toISOString(),
-    }))
-  }
-
-  const transformRescueTimeSyncResult = async (
-    user: string,
-    apiKey: string,
-    options: { fullResync?: boolean; startDate?: Date },
-  ) => {
-    const result = await syncRescueTimeData(user, apiKey, options)
-    return {
-      ...result,
-      retry_after: result.retry_after?.toISOString(),
-    }
-  }
-
-  const transformLastFmSyncResult = async (
-    user: string,
-    apiKey: string,
-    username: string,
-    options: { fullResync?: boolean; startDate?: Date },
-  ) => {
-    return await syncLastFmData(user, apiKey, username, options)
-  }
-
-  httpd.use(
-    '/sync',
-    createSyncRouter(
-      {
-        ackOutboundSync,
-        deleteHealthConnectRecords,
-        getOutboundSyncHistory,
-        getActivityWatchSyncStates: (user) => transformSyncStates(user, 'activitywatch'),
-        getCalendarSyncStates: (user) => transformSyncStates(user, 'calendar'),
-        getGarminSyncStates: (user) => transformSyncStates(user, 'garmin'),
-        getLastFmApiKey: () => centralDb.getLastFmApiKey(),
-        getLastFmSyncStates: (user) => transformSyncStates(user, 'lastfm'),
-        getOuraSyncStates: (user) => transformSyncStates(user, 'oura'),
-        getPendingOutboundSync,
-        getRescueTimeSyncStates: (user) => transformSyncStates(user, 'rescuetime'),
-        getSettings,
-        processActivityWatchEvents,
-        processDailyAggregate,
-        processHealthConnectBatch,
-        processHealthConnectData,
-        reportSyncFailure,
-        requeueOutboundSync,
-        resetCalendarSyncState: (user) => resetSyncState(user, 'calendar'),
-        resetGarminSyncState: (user, dataType) => resetSyncState(user, 'garmin', dataType),
-        resetLastFmSyncState: (user) => resetSyncState(user, 'lastfm'),
-        resetOuraSyncState: (user, dataType) => resetSyncState(user, 'oura', dataType),
-        resetRescueTimeSyncState: (user) => resetSyncState(user, 'rescuetime'),
-        resetStravaSyncState,
-        getStravaSyncStates,
-        getStravaQueueStatus: stravaQueue ? () => stravaQueue.getStatus() : undefined,
-        syncStrava: async (user, options) => {
-          if (!stravaQueue) throw new Error('Strava integration not configured')
-          return syncStrava(user, stravaQueue, options)
-        },
-        syncCalendars: (user, calendars) => syncAllCalendars(user, calendars),
-        syncGarmin: async (user, options) => {
-          const results = await syncAllGarminData(user, garmin, options)
-          return results.map((r) => ({
-            ...r,
-            retry_after: r.retry_after?.toISOString(),
-          }))
-        },
-        syncLastFm: transformLastFmSyncResult,
-        syncOura: transformOuraSyncResults,
-        syncRescueTime: transformRescueTimeSyncResult,
-        triggerCalorieComputation: (user: string, start: Date, end: Date) =>
-          triggerCalorieComputation(user, start, end),
-        upsertUserSettings: (user: string, settings: Record<string, unknown>) =>
-          upsertUserSettings(user, settings),
-        onActivitySynced: activityNotifier,
-      },
-      authMiddleware,
-    ),
-  )
-
-  httpd.get('/auth/oura/connect', authMiddleware, oura.getAuthorizeUrl)
-  httpd.get('/auth/ouracb', oura.authCb)
-
-  // Garmin Connect auth endpoints (login with credentials, tokens-only stored)
-  httpd.post('/auth/garmin/login', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const { email, password } = req.body ?? {}
-
-    if (!email || !password) {
-      res.status(400).json({ error: 'Email and password are required', success: false })
-      return
-    }
-
-    try {
-      const result = await garmin.login(user, email, password)
-      if ('mfa_required' in result) {
-        res.json({ mfa_required: true, success: false })
-      } else {
-        res.json({ success: true })
-      }
-    } catch (error) {
-      auditError(user, 'auth', 'Garmin login endpoint error', { error: String(error) })
-      const message = error instanceof Error ? error.message : 'Login failed'
-      res.status(401).json({ error: message, success: false })
-    }
-  })
-
-  httpd.post('/auth/garmin/mfa', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const { mfa_code } = req.body ?? {}
-
-    if (!mfa_code) {
-      res.status(400).json({ error: 'MFA code is required', success: false })
-      return
-    }
-
-    try {
-      await garmin.verifyMfa(user, mfa_code)
-      res.json({ success: true })
-    } catch (error) {
-      auditError(user, 'auth', 'Garmin MFA endpoint error', { error: String(error) })
-      const message = error instanceof Error ? error.message : 'MFA verification failed'
-      res.status(401).json({ error: message, success: false })
-    }
-  })
-
-  httpd.post('/auth/garmin/disconnect', authMiddleware, async (req, res) => {
-    const user = req.user!
-    try {
-      await garmin.disconnect(user)
-      res.json({ success: true })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Disconnect failed'
-      res.status(500).json({ error: message, success: false })
-    }
-  })
-
-  // Strava OAuth endpoints (always registered — credentials checked dynamically)
-  httpd.get('/auth/strava/connect', authMiddleware, strava.getAuthorizeUrl)
-  httpd.get('/auth/stravacb', strava.authCb)
-
-  httpd.post('/auth/strava/disconnect', authMiddleware, async (req, res) => {
-    const user = req.user!
-    try {
-      // Clear tokens and athlete mapping
-      await upsertOAuthToken(user, { access_token: '', provider: 'strava' })
-      await centralDb.deleteStravaAthleteMappingByUsername(user)
-      res.json({ success: true })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Disconnect failed'
-      res.status(500).json({ error: message, success: false })
-    }
-  })
-
-  // ==========================================================================
   // Strava webhook push integration
-  // ==========================================================================
-
   if (stravaQueue) {
-    const stravaVerifyToken = `aurboda-strava-${sessionSecret.slice(0, 8)}`
-
-    httpd.use(
-      '/webhooks/strava',
-      createStravaWebhookRouter({
-        enqueueActivityFetch: (user, activityId, priority) =>
-          stravaQueue.enqueueActivityFetch(user, activityId, priority),
-        getUsernameByStravaAthleteId: (stravaAthleteId) =>
-          centralDb.getUsernameByStravaAthleteId(stravaAthleteId),
-        handleDeauthorization: async (stravaAthleteId) => {
-          const username = await centralDb.getUsernameByStravaAthleteId(stravaAthleteId)
-          if (username) {
-            await upsertOAuthToken(username, { access_token: '', provider: 'strava' })
-            await centralDb.deleteStravaAthleteMapping(stravaAthleteId)
-            auditInfo(username, 'auth', '🏃 Strava: deauthorized via webhook')
-          }
-        },
-        softDeleteStravaActivity: async (user, stravaActivityId) => {
-          await softDeleteActivityByExternalId(user, 'strava', `strava-activity-${stravaActivityId}`)
-        },
-        verifyToken: stravaVerifyToken,
-      }),
-    )
-
-    // Strava webhook subscription is created after httpd.listen() so the
-    // server is ready to respond to Strava's verification GET request.
-    const stravaWebhookCallbackUrl = `${apiBaseUrl}/webhooks/strava`
-    const ensureStravaWebhook = () =>
-      getStravaCredentials()
-        .then(({ clientId, clientSecret }) => {
-          const stravaWebhookMgr = createStravaWebhookManager({
-            callbackUrl: stravaWebhookCallbackUrl,
-            clientId,
-            clientSecret,
-            verifyToken: stravaVerifyToken,
-          })
-          return stravaWebhookMgr.ensureSubscription()
-        })
-        .catch((error) => {
-          console.warn(
-            '⚠️ Strava webhook subscription setup failed:',
-            error instanceof Error ? error.message : error,
-          )
-        })
+    const ensureStravaWebhook = setupStravaWebhook({
+      httpd,
+      apiBaseUrl,
+      sessionSecret,
+      centralDb,
+      stravaQueue,
+      getStravaCredentials,
+    })
     postListenCallbacks.push(ensureStravaWebhook)
   }
 
-  // ==========================================================================
   // Oura webhook push integration (admin-configurable via Web UI)
-  // ==========================================================================
-
-  const syncOuraDataTypeForUser = async (username: string, dataType: OuraDataType) => {
-    const accessToken = await oura.getAccessToken(username)
-    await syncOuraDataType(username, oura, dataType, accessToken)
-  }
-
-  const ouraWebhookManager: OuraWebhookManager = createOuraWebhookManager({
+  const ouraWebhookManager = await setupOuraWebhook({
+    httpd,
     apiBaseUrl,
     centralDb,
-    getCredentials: getOuraCredentials,
-    syncOuraDataTypeForUser,
+    oura,
+    getOuraCredentials,
   })
-
-  // Mount proxy handler (delegates to inner router when enabled, 404 when disabled)
-  httpd.use('/webhooks/oura', (req, res, next) => ouraWebhookManager.handleWebhookRequest(req, res, next))
-
-  // Enable if previously configured and host supports it
-  const ouraWebhookEnabled = await centralDb.getOuraWebhookEnabled()
-  if (ouraWebhookEnabled && (await ouraWebhookManager.canEnable())) {
-    try {
-      await ouraWebhookManager.enable()
-    } catch (error) {
-      console.error('Oura webhook: failed to enable on startup:', error)
-    }
-  }
 
   // Initialize geocode queue (uses shared boss)
   let geocodeQueue: Awaited<ReturnType<typeof createGeocodeQueue>> | null = null
@@ -849,61 +344,23 @@ const main = async () => {
     }),
   )
 
-  // ==========================================================================
-  // REST API route modules
-  // ==========================================================================
+  // Per-domain REST routers
+  mountRestRouters({
+    httpd,
+    authMiddleware,
+    adminMiddleware,
+    centralDb,
+    invitationAuth,
+    webHost,
+    garmin,
+    syncProvider,
+    activityNotifier,
+    engineDeps,
+    deductionQueue,
+    ouraWebhookManager,
+  })
 
-  httpd.use(createMetricsRouter(authMiddleware, syncProvider))
-  // /tags routes removed: tags are now activities
-  httpd.use('/icons', createIconsRouter(authMiddleware))
-  httpd.use('/notes', createNotesRouter(authMiddleware))
-  httpd.use('/meals', createMealsRouter(authMiddleware))
-  httpd.use('/food-items', createFoodItemsRouter(authMiddleware))
-  httpd.use('/reports', createReportsRouter(authMiddleware))
-  httpd.use(
-    createActivitiesRouter(
-      authMiddleware,
-      syncProvider,
-      activityNotifier,
-      async (user, activityId, garminActivityId) => {
-        const detail = await garmin.getActivityDetail(user, garminActivityId)
-        const points = await processActivityDetail(user, detail)
-        await markActivityDetailSynced(user, activityId)
-        return points
-      },
-    ),
-  )
-  httpd.use('/activity-types', createActivityTypesRouter(authMiddleware))
-  httpd.use(
-    '/deduction-rules',
-    createDeductionRulesRouter(authMiddleware, engineDeps, deductionQueue ?? undefined),
-  )
-  httpd.use('/locations', createLocationsRouter(authMiddleware))
-  httpd.use(createSettingsRouter(authMiddleware))
-  httpd.use(createAuditLogRouter(authMiddleware))
-  httpd.use(createRawRecordsRouter(authMiddleware))
-  httpd.use('/dashboard', createDashboardRouter(authMiddleware))
-  httpd.use('/correlations', createCorrelationsRouter(authMiddleware, syncProvider))
-  httpd.use('/training-load', createTrainingLoadRouter(authMiddleware))
-  httpd.use('/trends', createTrendsRouter(authMiddleware))
-  httpd.use('/chart-data', createChartDataRouter(authMiddleware))
-  httpd.use('/screentime-categories', createScreentimeCategoriesRouter(authMiddleware))
-  httpd.use(
-    '/admin',
-    createAdminRouter(
-      authMiddleware,
-      adminMiddleware,
-      centralDb,
-      invitationAuth,
-      webHost,
-      ouraWebhookManager,
-    ),
-  )
-
-  // ==========================================================================
   // Centralized error handler
-  // ==========================================================================
-
   httpd.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
     const status = isHttpError(err) ? err.status : 500
     if (status >= 500) console.error(err)
@@ -918,10 +375,7 @@ const main = async () => {
     res.status(status).json({ success: false, error: err.message })
   })
 
-  // ==========================================================================
   // Server startup
-  // ==========================================================================
-
   const port = Number(process.env.PORT ?? 80)
   const server = httpd.listen(port, () => {
     console.info(`> Running on localhost:${port}`)

--- a/apps/backend/src/api/auth-routes.ts
+++ b/apps/backend/src/api/auth-routes.ts
@@ -1,0 +1,196 @@
+/**
+ * Auth-related HTTP routes: /version, /status, /signup, /login, /auth/token.
+ * These stay close to server setup (vs being moved into a Router) because they
+ * directly use the central DB, user DB connection, and the Auth instance.
+ */
+import type {
+  AuthTokenResponse,
+  LoginResponse,
+  ServerStatusResponse,
+  SignupResponse,
+  VersionResponse,
+} from '@aurboda/api-spec'
+import type { Express } from 'express'
+import type { Client } from 'pg'
+
+import type { Auth } from '../auth.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { InvitationAuth } from '../services/invitation.ts'
+import type { AnyMiddleware } from '../typed-router.ts'
+
+import {
+  initializeSchema,
+  loginToUserDb,
+  makeNewUserDb,
+  migrateSchema,
+  query,
+  schemaInitialized,
+} from '../db/index.ts'
+import { pruneAuditLog } from '../services/audit-log.ts'
+
+interface AuthRoutesDeps {
+  httpd: Express
+  auth: Auth
+  authMiddleware: AnyMiddleware
+  centralDb: CentralDb
+  invitationAuth: InvitationAuth
+  userDb: Client
+  unauthorized: Error
+}
+
+const RESERVED_USERNAMES = [
+  'postgres',
+  'admin',
+  'root',
+  'administrator',
+  'superuser',
+  'system',
+  'public',
+  'guest',
+  'test',
+  'aurboda',
+]
+
+export const registerAuthRoutes = ({
+  httpd,
+  auth,
+  authMiddleware,
+  centralDb,
+  invitationAuth,
+  userDb,
+  unauthorized,
+}: AuthRoutesDeps): void => {
+  httpd.get<Record<string, never>, VersionResponse>('/version', (_req, res) => {
+    res.json({
+      build_sha: process.env.BUILD_SHA ?? 'dev',
+      success: true,
+    })
+  })
+
+  httpd.get<Record<string, never>, ServerStatusResponse>('/status', async (_req, res) => {
+    const signupMode = await centralDb.getSignupMode()
+    res.json({
+      signup_allowed: signupMode === 'open',
+      signup_mode: signupMode,
+      success: true,
+    })
+  })
+
+  // eslint-disable-next-line complexity -- signup validation logic
+  httpd.post<Record<string, never>, SignupResponse>('/signup', async (req, res, next) => {
+    const signupMode = await centralDb.getSignupMode()
+
+    if (signupMode === 'closed') {
+      res.status(403).json({ error: 'Signup is currently closed', success: false })
+      return
+    }
+
+    const { username: user, password, invitation } = req.body
+
+    // In invite_only mode, require valid invitation token
+    if (signupMode === 'invite_only') {
+      if (!invitation || typeof invitation !== 'string') {
+        res.status(403).json({
+          error: 'An invitation is required to sign up',
+          success: false,
+        })
+        return
+      }
+      const validation = invitationAuth.validateInvitationToken(invitation)
+      if (!validation.valid) {
+        const errorMsg = validation.expired ? 'Invitation has expired' : 'Invalid invitation'
+        res.status(403).json({ error: errorMsg, success: false })
+        return
+      }
+    }
+
+    if (!user || typeof user !== 'string' || !password || typeof password !== 'string') {
+      res.status(400).json({
+        error: 'Username and password are required',
+        success: false,
+      })
+      return
+    }
+
+    // Validate username format (alphanumeric, lowercase, no special chars for PostgreSQL role)
+    if (!/^[a-z][a-z0-9_]{2,30}$/.test(user)) {
+      res.status(400).json({
+        error:
+          'Username must be 3-31 characters, start with a letter, and contain only lowercase letters, numbers, and underscores',
+        success: false,
+      })
+      return
+    }
+
+    if (RESERVED_USERNAMES.includes(user)) {
+      res.status(400).json({ error: 'This username is reserved', success: false })
+      return
+    }
+
+    // Check if user already exists
+    const existingUser = await query(userDb, 'SELECT usename FROM pg_user WHERE usename=$1', [user])
+    if (existingUser.rowCount && existingUser.rowCount > 0) {
+      res.status(409).json({ error: 'Username already exists', success: false })
+      return
+    }
+
+    try {
+      await makeNewUserDb(userDb, user, password)
+      const token = auth.createToken(user)
+
+      // First user becomes admin automatically
+      const adminCount = await centralDb.getAdminCount()
+      let isAdmin = false
+      if (adminCount === 0) {
+        await centralDb.addAdmin(user)
+        isAdmin = true
+        console.info(`First user ${user} automatically made admin`)
+      }
+
+      res.json({ is_admin: isAdmin, success: true, token })
+    } catch (err) {
+      console.error('Signup error:', err)
+      next(err)
+    }
+  })
+
+  httpd.post<Record<string, never>, LoginResponse>('/login', async (req, res, next) => {
+    const { username: user, password } = req.body
+    if (!user) return next(unauthorized)
+
+    // Check if user exists as a PSQL user role
+    const userRows = await query(userDb, 'SELECT usename FROM pg_user WHERE usename=$1', [user])
+    if (userRows.rowCount === 1) {
+      try {
+        await loginToUserDb(user, password)
+        // Ensure schema is initialized and migrated
+        if (!(await schemaInitialized(user))) {
+          await initializeSchema(user)
+        } else {
+          await migrateSchema(user)
+        }
+      } catch {
+        return next(unauthorized)
+      }
+    } else return next(unauthorized)
+
+    const token = auth.createToken(user)
+    const isAdmin = await centralDb.isAdmin(user)
+
+    // Prune old audit log entries in the background
+    centralDb
+      .getAuditLogRetentionDays()
+      .then((days) => pruneAuditLog(user, days))
+      .catch(() => {})
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ is_admin: isAdmin, refresh: token, token }))
+  })
+
+  // Generate a fresh API token for the authenticated user (e.g. for push agents like ActivityWatch)
+  httpd.get<Record<string, never>, AuthTokenResponse>('/auth/token', authMiddleware, (req, res) => {
+    const user = req.user!
+    const token = auth.createToken(user)
+    res.json({ success: true, token })
+  })
+}

--- a/apps/backend/src/api/middleware.ts
+++ b/apps/backend/src/api/middleware.ts
@@ -1,0 +1,125 @@
+/**
+ * Express middleware factories for the API server: request audit logging,
+ * authentication (Bearer token → req.user), and admin authorization.
+ */
+import type { RequestHandler } from 'express'
+
+import type { Auth } from '../auth.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { AnyMiddleware } from '../typed-router.ts'
+
+import { migrateSchema } from '../db/index.ts'
+import { auditError, auditInfo, auditWarn } from '../services/audit-log.ts'
+import { backfillScreentimeActivities } from '../services/backfill-screentime-activities.ts'
+
+/**
+ * Audit log middleware: records non-GET requests to the user's audit log.
+ * Log level is based on response status: 4xx → warn, 5xx → error, otherwise → info.
+ * Sanitizes `password` field from request bodies; captures response body for error logs.
+ */
+export const createAuditLogMiddleware =
+  (auth: Auth): RequestHandler =>
+  (req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'OPTIONS' && req.method !== 'HEAD') {
+      const user = (() => {
+        try {
+          const authHeader = req.headers.authorization
+          if (typeof authHeader === 'string') {
+            return auth.getUsernameFromToken(authHeader.slice('bearer '.length))
+          }
+        } catch {}
+        return undefined
+      })()
+
+      if (user) {
+        const sanitizedBody =
+          req.body && typeof req.body === 'object'
+            ? Object.fromEntries(
+                Object.entries(req.body as Record<string, unknown>).map(([k, v]) =>
+                  k === 'password' ? [k, '[REDACTED]'] : [k, v],
+                ),
+              )
+            : undefined
+
+        // Capture response body for error logging by intercepting res.json()
+        let responseBody: unknown
+        const originalJson = res.json.bind(res)
+        res.json = (body: unknown) => {
+          responseBody = body
+          return originalJson(body)
+        }
+
+        res.on('finish', () => {
+          if (res.statusCode >= 500) {
+            auditError(user, 'data', `${req.method} ${req.path}`, {
+              ...sanitizedBody,
+              status: res.statusCode,
+              response: responseBody,
+            })
+          } else if (res.statusCode >= 400) {
+            auditWarn(user, 'data', `${req.method} ${req.path}`, {
+              ...sanitizedBody,
+              status: res.statusCode,
+              response: responseBody,
+            })
+          } else {
+            auditInfo(user, 'data', `${req.method} ${req.path}`, sanitizedBody)
+          }
+        })
+      }
+    }
+    next()
+  }
+
+/**
+ * Auth middleware: extracts Bearer token, sets `req.user`, and runs schema migration
+ * once per user per server lifetime. First request blocks on migration; subsequent
+ * requests wait if migration is still in flight. Also kicks off a one-shot background
+ * backfill of historical screentime activities, gated via sync_state.
+ */
+export const createAuthMiddleware = (auth: Auth, unauthorized: Error): AnyMiddleware => {
+  const migratedUsers = new Map<string, Promise<void>>()
+
+  return async (req, res, next) => {
+    try {
+      if (typeof req.headers.authorization === 'string') {
+        const token = req.headers.authorization.slice('bearer '.length)
+        const user = auth.getUsernameFromToken(token)
+        req.user = user
+
+        if (!migratedUsers.has(user)) {
+          const migrationPromise = migrateSchema(user)
+            .then(() => {
+              void backfillScreentimeActivities(user).catch((err) =>
+                console.error(`⚠️ Screentime backfill failed for ${user}:`, err),
+              )
+            })
+            .catch((err) => console.error(`⚠️ Migration failed for ${user}:`, err))
+          migratedUsers.set(user, migrationPromise)
+          await migrationPromise
+        } else {
+          await migratedUsers.get(user)
+        }
+
+        return next()
+      }
+    } catch {
+      return next(unauthorized)
+    }
+    return next(unauthorized)
+  }
+}
+
+/** Admin authorization middleware: requires `req.user` set and admin status in central DB. */
+export const createAdminMiddleware =
+  (centralDb: CentralDb, unauthorized: Error, forbidden: Error): RequestHandler =>
+  async (req, _res, next) => {
+    if (!req.user) {
+      return next(unauthorized)
+    }
+    const isAdmin = await centralDb.isAdmin(req.user)
+    if (!isAdmin) {
+      return next(forbidden)
+    }
+    next()
+  }

--- a/apps/backend/src/api/oauth-routes.ts
+++ b/apps/backend/src/api/oauth-routes.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-provider OAuth/auth endpoints: Oura connect+callback, Garmin login/MFA/disconnect,
+ * Strava connect+callback+disconnect. Uses each integration's client + the central DB
+ * for credential mapping cleanup.
+ */
+import type { Express } from 'express'
+
+import type { GarminClient } from '../integrations/garmin/client.ts'
+import type { ouraClient } from '../integrations/oura/client.ts'
+import type { StravaClient } from '../integrations/strava/client.ts'
+
+type OuraClient = ReturnType<typeof ouraClient>
+import type { CentralDb } from '../services/central-db.ts'
+import type { AnyMiddleware } from '../typed-router.ts'
+
+import { upsertOAuthToken } from '../db/index.ts'
+import { auditError } from '../services/audit-log.ts'
+
+interface OAuthRoutesDeps {
+  httpd: Express
+  authMiddleware: AnyMiddleware
+  centralDb: CentralDb
+  garmin: GarminClient
+  oura: OuraClient
+  strava: StravaClient
+}
+
+export const registerOAuthRoutes = ({
+  httpd,
+  authMiddleware,
+  centralDb,
+  garmin,
+  oura,
+  strava,
+}: OAuthRoutesDeps): void => {
+  // Oura
+  httpd.get('/auth/oura/connect', authMiddleware, oura.getAuthorizeUrl)
+  httpd.get('/auth/ouracb', oura.authCb)
+
+  // Garmin Connect (login with credentials, tokens-only stored)
+  httpd.post('/auth/garmin/login', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { email, password } = req.body ?? {}
+
+    if (!email || !password) {
+      res.status(400).json({ error: 'Email and password are required', success: false })
+      return
+    }
+
+    try {
+      const result = await garmin.login(user, email, password)
+      if ('mfa_required' in result) {
+        res.json({ mfa_required: true, success: false })
+      } else {
+        res.json({ success: true })
+      }
+    } catch (error) {
+      auditError(user, 'auth', 'Garmin login endpoint error', { error: String(error) })
+      const message = error instanceof Error ? error.message : 'Login failed'
+      res.status(401).json({ error: message, success: false })
+    }
+  })
+
+  httpd.post('/auth/garmin/mfa', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const { mfa_code } = req.body ?? {}
+
+    if (!mfa_code) {
+      res.status(400).json({ error: 'MFA code is required', success: false })
+      return
+    }
+
+    try {
+      await garmin.verifyMfa(user, mfa_code)
+      res.json({ success: true })
+    } catch (error) {
+      auditError(user, 'auth', 'Garmin MFA endpoint error', { error: String(error) })
+      const message = error instanceof Error ? error.message : 'MFA verification failed'
+      res.status(401).json({ error: message, success: false })
+    }
+  })
+
+  httpd.post('/auth/garmin/disconnect', authMiddleware, async (req, res) => {
+    const user = req.user!
+    try {
+      await garmin.disconnect(user)
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Disconnect failed'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+
+  // Strava (always registered — credentials checked dynamically)
+  httpd.get('/auth/strava/connect', authMiddleware, strava.getAuthorizeUrl)
+  httpd.get('/auth/stravacb', strava.authCb)
+
+  httpd.post('/auth/strava/disconnect', authMiddleware, async (req, res) => {
+    const user = req.user!
+    try {
+      // Clear tokens and athlete mapping
+      await upsertOAuthToken(user, { access_token: '', provider: 'strava' })
+      await centralDb.deleteStravaAthleteMappingByUsername(user)
+      res.json({ success: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Disconnect failed'
+      res.status(500).json({ error: message, success: false })
+    }
+  })
+}

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -1,0 +1,115 @@
+/**
+ * Mounts the per-domain REST routers under the Express app. Each router lives
+ * in `routes/` and is instantiated with the auth middleware (and any service
+ * dependencies). The `activities` router additionally needs a Garmin
+ * activity-detail fetcher that's plumbed in here.
+ */
+import type { Express } from 'express'
+
+import type { GarminClient } from '../integrations/garmin/client.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { DeductionEngineDeps } from '../services/deduction-engine.ts'
+import type { ActivityNotifier, DeductionQueue } from '../services/deduction-queue.ts'
+import type { InvitationAuth } from '../services/invitation.ts'
+import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
+import type { SyncProvider } from '../services/queries/index.ts'
+import type { AnyMiddleware } from '../typed-router.ts'
+
+import { markActivityDetailSynced } from '../db/index.ts'
+import { processActivityDetail } from '../integrations/garmin/process.ts'
+import { createActivitiesRouter } from '../routes/activities-router.ts'
+import { createActivityTypesRouter } from '../routes/activity-types-router.ts'
+import { createAdminRouter } from '../routes/admin-router.ts'
+import { createAuditLogRouter } from '../routes/audit-log-router.ts'
+import { createChartDataRouter } from '../routes/chart-data-router.ts'
+import { createCorrelationsRouter } from '../routes/correlations-router.ts'
+import { createDashboardRouter } from '../routes/dashboard-router.ts'
+import { createDeductionRulesRouter } from '../routes/deduction-rules-router.ts'
+import { createFoodItemsRouter } from '../routes/food-items-router.ts'
+import { createIconsRouter } from '../routes/icons-router.ts'
+import { createLocationsRouter } from '../routes/locations-router.ts'
+import { createMealsRouter } from '../routes/meals-router.ts'
+import { createMetricsRouter } from '../routes/metrics-router.ts'
+import { createNotesRouter } from '../routes/notes-router.ts'
+import { createRawRecordsRouter } from '../routes/raw-records-router.ts'
+import { createReportsRouter } from '../routes/reports-router.ts'
+import { createScreentimeCategoriesRouter } from '../routes/screentime-categories-router.ts'
+import { createSettingsRouter } from '../routes/settings-router.ts'
+import { createTrainingLoadRouter } from '../routes/training-load-router.ts'
+import { createTrendsRouter } from '../routes/trends-router.ts'
+
+interface RestRoutesDeps {
+  httpd: Express
+  authMiddleware: AnyMiddleware
+  adminMiddleware: AnyMiddleware
+  centralDb: CentralDb
+  invitationAuth: InvitationAuth
+  webHost: string
+  garmin: GarminClient
+  syncProvider: SyncProvider
+  activityNotifier: ActivityNotifier
+  engineDeps: DeductionEngineDeps
+  deductionQueue: DeductionQueue | null
+  ouraWebhookManager: OuraWebhookManager
+}
+
+export const mountRestRouters = ({
+  httpd,
+  authMiddleware,
+  adminMiddleware,
+  centralDb,
+  invitationAuth,
+  webHost,
+  garmin,
+  syncProvider,
+  activityNotifier,
+  engineDeps,
+  deductionQueue,
+  ouraWebhookManager,
+}: RestRoutesDeps): void => {
+  httpd.use(createMetricsRouter(authMiddleware, syncProvider))
+  httpd.use('/icons', createIconsRouter(authMiddleware))
+  httpd.use('/notes', createNotesRouter(authMiddleware))
+  httpd.use('/meals', createMealsRouter(authMiddleware))
+  httpd.use('/food-items', createFoodItemsRouter(authMiddleware))
+  httpd.use('/reports', createReportsRouter(authMiddleware))
+  httpd.use(
+    createActivitiesRouter(
+      authMiddleware,
+      syncProvider,
+      activityNotifier,
+      async (user, activityId, garminActivityId) => {
+        const detail = await garmin.getActivityDetail(user, garminActivityId)
+        const points = await processActivityDetail(user, detail)
+        await markActivityDetailSynced(user, activityId)
+        return points
+      },
+    ),
+  )
+  httpd.use('/activity-types', createActivityTypesRouter(authMiddleware))
+  httpd.use(
+    '/deduction-rules',
+    createDeductionRulesRouter(authMiddleware, engineDeps, deductionQueue ?? undefined),
+  )
+  httpd.use('/locations', createLocationsRouter(authMiddleware))
+  httpd.use(createSettingsRouter(authMiddleware))
+  httpd.use(createAuditLogRouter(authMiddleware))
+  httpd.use(createRawRecordsRouter(authMiddleware))
+  httpd.use('/dashboard', createDashboardRouter(authMiddleware))
+  httpd.use('/correlations', createCorrelationsRouter(authMiddleware, syncProvider))
+  httpd.use('/training-load', createTrainingLoadRouter(authMiddleware))
+  httpd.use('/trends', createTrendsRouter(authMiddleware))
+  httpd.use('/chart-data', createChartDataRouter(authMiddleware))
+  httpd.use('/screentime-categories', createScreentimeCategoriesRouter(authMiddleware))
+  httpd.use(
+    '/admin',
+    createAdminRouter(
+      authMiddleware,
+      adminMiddleware,
+      centralDb,
+      invitationAuth,
+      webHost,
+      ouraWebhookManager,
+    ),
+  )
+}

--- a/apps/backend/src/api/sync-setup.ts
+++ b/apps/backend/src/api/sync-setup.ts
@@ -1,0 +1,160 @@
+/**
+ * `/sync` router wiring: assembles the dependency object passed to
+ * `createSyncRouter` from per-provider sync functions and central-DB-backed
+ * settings. Each transform here normalizes the per-provider sync result
+ * (Date → ISO string, undefined → null) for the cross-provider response shape.
+ */
+import type { Express } from 'express'
+
+import type { GarminClient } from '../integrations/garmin/client.ts'
+import type { ouraClient } from '../integrations/oura/client.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { ActivityNotifier } from '../services/deduction-queue.ts'
+import type { StravaQueue } from '../services/strava-queue.ts'
+import type { AnyMiddleware } from '../typed-router.ts'
+
+import {
+  ackOutboundSync,
+  deleteHealthConnectRecords,
+  getAllSyncStates,
+  getOutboundSyncHistory,
+  getPendingOutboundSync,
+  processDailyAggregate,
+  processHealthConnectBatch,
+  processHealthConnectData,
+  reportSyncFailure,
+  requeueOutboundSync,
+  resetSyncState,
+  upsertUserSettings,
+} from '../db/index.ts'
+import { processActivityWatchEvents } from '../integrations/activitywatch/sync.ts'
+import { syncAllGarminData } from '../integrations/garmin/sync.ts'
+import { syncAllCalendars } from '../integrations/ical/sync.ts'
+import { syncLastFmData } from '../integrations/lastfm/sync.ts'
+import { syncAllOuraData } from '../integrations/oura/sync.ts'
+import { syncRescueTimeData } from '../integrations/rescuetime/sync.ts'
+import { getStravaSyncStates, resetStravaSyncState, syncStrava } from '../integrations/strava/sync.ts'
+import { triggerCalorieComputation } from '../services/calorie-computation.ts'
+import { getSettings } from '../services/settings.ts'
+import { createSyncRouter } from '../sync-router.ts'
+
+type OuraClient = ReturnType<typeof ouraClient>
+
+interface SyncSetupDeps {
+  httpd: Express
+  authMiddleware: AnyMiddleware
+  centralDb: CentralDb
+  oura: OuraClient
+  garmin: GarminClient
+  stravaQueue: StravaQueue | null
+  activityNotifier: ActivityNotifier
+}
+
+export const mountSyncRouter = ({
+  httpd,
+  authMiddleware,
+  centralDb,
+  oura,
+  garmin,
+  stravaQueue,
+  activityNotifier,
+}: SyncSetupDeps): void => {
+  // Transform SyncState to ProviderSyncStatus format (undefined -> null)
+  const transformSyncStates = async (user: string, provider: string) => {
+    const states = await getAllSyncStates(user, provider)
+    return states.map((s) => ({
+      error_message: s.error_message ?? null,
+      last_sync_time: s.last_sync_time?.toISOString() ?? null,
+      provider: s.provider,
+      retry_after: s.retry_after?.toISOString() ?? null,
+      status: s.status === 'rate_limited' ? ('error' as const) : s.status,
+    }))
+  }
+
+  const transformOuraSyncResults = async (
+    user: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => {
+    const results = await syncAllOuraData(user, oura, options)
+    return results.map((r) => ({
+      ...r,
+      retry_after: r.retry_after?.toISOString(),
+    }))
+  }
+
+  const transformRescueTimeSyncResult = async (
+    user: string,
+    apiKey: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => {
+    const result = await syncRescueTimeData(user, apiKey, options)
+    return {
+      ...result,
+      retry_after: result.retry_after?.toISOString(),
+    }
+  }
+
+  const transformLastFmSyncResult = async (
+    user: string,
+    apiKey: string,
+    username: string,
+    options: { fullResync?: boolean; startDate?: Date },
+  ) => {
+    return await syncLastFmData(user, apiKey, username, options)
+  }
+
+  httpd.use(
+    '/sync',
+    createSyncRouter(
+      {
+        ackOutboundSync,
+        deleteHealthConnectRecords,
+        getOutboundSyncHistory,
+        getActivityWatchSyncStates: (user) => transformSyncStates(user, 'activitywatch'),
+        getCalendarSyncStates: (user) => transformSyncStates(user, 'calendar'),
+        getGarminSyncStates: (user) => transformSyncStates(user, 'garmin'),
+        getLastFmApiKey: () => centralDb.getLastFmApiKey(),
+        getLastFmSyncStates: (user) => transformSyncStates(user, 'lastfm'),
+        getOuraSyncStates: (user) => transformSyncStates(user, 'oura'),
+        getPendingOutboundSync,
+        getRescueTimeSyncStates: (user) => transformSyncStates(user, 'rescuetime'),
+        getSettings,
+        processActivityWatchEvents,
+        processDailyAggregate,
+        processHealthConnectBatch,
+        processHealthConnectData,
+        reportSyncFailure,
+        requeueOutboundSync,
+        resetCalendarSyncState: (user) => resetSyncState(user, 'calendar'),
+        resetGarminSyncState: (user, dataType) => resetSyncState(user, 'garmin', dataType),
+        resetLastFmSyncState: (user) => resetSyncState(user, 'lastfm'),
+        resetOuraSyncState: (user, dataType) => resetSyncState(user, 'oura', dataType),
+        resetRescueTimeSyncState: (user) => resetSyncState(user, 'rescuetime'),
+        resetStravaSyncState,
+        getStravaSyncStates,
+        getStravaQueueStatus: stravaQueue ? () => stravaQueue.getStatus() : undefined,
+        syncStrava: async (user, options) => {
+          if (!stravaQueue) throw new Error('Strava integration not configured')
+          return syncStrava(user, stravaQueue, options)
+        },
+        syncCalendars: (user, calendars) => syncAllCalendars(user, calendars),
+        syncGarmin: async (user, options) => {
+          const results = await syncAllGarminData(user, garmin, options)
+          return results.map((r) => ({
+            ...r,
+            retry_after: r.retry_after?.toISOString(),
+          }))
+        },
+        syncLastFm: transformLastFmSyncResult,
+        syncOura: transformOuraSyncResults,
+        syncRescueTime: transformRescueTimeSyncResult,
+        triggerCalorieComputation: (user: string, start: Date, end: Date) =>
+          triggerCalorieComputation(user, start, end),
+        upsertUserSettings: (user: string, settings: Record<string, unknown>) =>
+          upsertUserSettings(user, settings),
+        onActivitySynced: activityNotifier,
+      },
+      authMiddleware,
+    ),
+  )
+}

--- a/apps/backend/src/api/webhooks-setup.ts
+++ b/apps/backend/src/api/webhooks-setup.ts
@@ -1,0 +1,138 @@
+/**
+ * Webhook integrations: Strava push (always-on when stravaQueue available) and
+ * Oura push (admin-configurable). Returns post-listen callbacks that need to
+ * run after `httpd.listen()` so the server is reachable when external
+ * verification requests arrive.
+ */
+import type { Express } from 'express'
+
+import type { ouraClient } from '../integrations/oura/client.ts'
+import type { OuraDataType } from '../integrations/oura/sync.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
+import type { StravaQueue } from '../services/strava-queue.ts'
+
+import { softDeleteActivityByExternalId, upsertOAuthToken } from '../db/index.ts'
+import { syncOuraDataType } from '../integrations/oura/sync.ts'
+import { createStravaWebhookRouter } from '../integrations/strava/webhook-router.ts'
+import { auditInfo } from '../services/audit-log.ts'
+import { createOuraWebhookManager } from '../services/oura-webhook-manager.ts'
+import { createStravaWebhookManager } from '../services/strava-webhook-manager.ts'
+
+type OuraClient = ReturnType<typeof ouraClient>
+type StravaCredentialGetter = () => Promise<{ clientId: string; clientSecret: string }>
+
+interface StravaWebhookSetupDeps {
+  httpd: Express
+  apiBaseUrl: string
+  sessionSecret: string
+  centralDb: CentralDb
+  stravaQueue: StravaQueue
+  getStravaCredentials: StravaCredentialGetter
+}
+
+/**
+ * Mount the Strava webhook router and return a post-listen callback that
+ * ensures the Strava webhook subscription exists. The callback must run after
+ * `httpd.listen()` so Strava's GET verification request can reach us.
+ */
+export const setupStravaWebhook = ({
+  httpd,
+  apiBaseUrl,
+  sessionSecret,
+  centralDb,
+  stravaQueue,
+  getStravaCredentials,
+}: StravaWebhookSetupDeps): (() => Promise<void>) => {
+  const stravaVerifyToken = `aurboda-strava-${sessionSecret.slice(0, 8)}`
+
+  httpd.use(
+    '/webhooks/strava',
+    createStravaWebhookRouter({
+      enqueueActivityFetch: (user, activityId, priority) =>
+        stravaQueue.enqueueActivityFetch(user, activityId, priority),
+      getUsernameByStravaAthleteId: (stravaAthleteId) =>
+        centralDb.getUsernameByStravaAthleteId(stravaAthleteId),
+      handleDeauthorization: async (stravaAthleteId) => {
+        const username = await centralDb.getUsernameByStravaAthleteId(stravaAthleteId)
+        if (username) {
+          await upsertOAuthToken(username, { access_token: '', provider: 'strava' })
+          await centralDb.deleteStravaAthleteMapping(stravaAthleteId)
+          auditInfo(username, 'auth', '🏃 Strava: deauthorized via webhook')
+        }
+      },
+      softDeleteStravaActivity: async (user, stravaActivityId) => {
+        await softDeleteActivityByExternalId(user, 'strava', `strava-activity-${stravaActivityId}`)
+      },
+      verifyToken: stravaVerifyToken,
+    }),
+  )
+
+  const stravaWebhookCallbackUrl = `${apiBaseUrl}/webhooks/strava`
+  return () =>
+    getStravaCredentials()
+      .then(({ clientId, clientSecret }) => {
+        const stravaWebhookMgr = createStravaWebhookManager({
+          callbackUrl: stravaWebhookCallbackUrl,
+          clientId,
+          clientSecret,
+          verifyToken: stravaVerifyToken,
+        })
+        return stravaWebhookMgr.ensureSubscription()
+      })
+      .catch((error) => {
+        console.warn(
+          '⚠️ Strava webhook subscription setup failed:',
+          error instanceof Error ? error.message : error,
+        )
+      })
+}
+
+interface OuraWebhookSetupDeps {
+  httpd: Express
+  apiBaseUrl: string
+  centralDb: CentralDb
+  oura: OuraClient
+  getOuraCredentials: () => Promise<{ clientId: string; clientSecret: string }>
+}
+
+/**
+ * Mount the Oura webhook proxy handler and return the manager. Caller is
+ * expected to enable the subscription if previously enabled and the host
+ * supports it (this is async + needs central-DB access, so we don't do it
+ * automatically).
+ */
+export const setupOuraWebhook = async ({
+  httpd,
+  apiBaseUrl,
+  centralDb,
+  oura,
+  getOuraCredentials,
+}: OuraWebhookSetupDeps): Promise<OuraWebhookManager> => {
+  const syncOuraDataTypeForUser = async (username: string, dataType: OuraDataType) => {
+    const accessToken = await oura.getAccessToken(username)
+    await syncOuraDataType(username, oura, dataType, accessToken)
+  }
+
+  const ouraWebhookManager: OuraWebhookManager = createOuraWebhookManager({
+    apiBaseUrl,
+    centralDb,
+    getCredentials: getOuraCredentials,
+    syncOuraDataTypeForUser,
+  })
+
+  // Mount proxy handler (delegates to inner router when enabled, 404 when disabled)
+  httpd.use('/webhooks/oura', (req, res, next) => ouraWebhookManager.handleWebhookRequest(req, res, next))
+
+  // Enable if previously configured and host supports it
+  const ouraWebhookEnabled = await centralDb.getOuraWebhookEnabled()
+  if (ouraWebhookEnabled && (await ouraWebhookManager.canEnable())) {
+    try {
+      await ouraWebhookManager.enable()
+    } catch (error) {
+      console.error('Oura webhook: failed to enable on startup:', error)
+    }
+  }
+
+  return ouraWebhookManager
+}


### PR DESCRIPTION
## Summary

Pure refactor of `apps/backend/src/api.ts` (957 lines) — extracts six focused setup helpers into a new `api/` directory, slimming the entry point to 416 lines. Part of issue #585 (Phase 3: Break Up Large Files). The issue suggested \"Extract middleware setup, route mounting, and job queue init into separate modules\".

## Split

| File | Lines | Responsibility |
|------|-------|----------------|
| api.ts | 416 | Server entry point — orchestrates clients, job queues, central DB, error handler, graceful shutdown |
| api/auth-routes.ts | 196 | \`/version\`, \`/status\`, \`/signup\`, \`/login\`, \`/auth/token\` |
| api/sync-setup.ts | 160 | \`/sync\` router wiring with per-provider transforms |
| api/webhooks-setup.ts | 138 | Strava + Oura push webhook setup |
| api/middleware.ts | 125 | Audit log, auth (Bearer → req.user + per-user migration), admin middleware factories |
| api/rest-routes.ts | 115 | Per-domain REST router mounts (metrics, activities, meals, etc.) |
| api/oauth-routes.ts | 110 | Garmin / Strava / Oura connect+disconnect endpoints |

api.ts retains: env handling, client construction (oura/garmin/strava), job queue init (pg-boss + deduction + strava + geocode queues), MCP mount, OwnTracks mount, geocode/detection trigger, error handler, server startup + graceful shutdown.

## Verification

- [x] \`pnpm check\` clean (0 errors; 469 pre-existing warnings unchanged)
- [x] All 1513 backend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)