### PR TITLE
feat: add docker-compose healthcheck (#75)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--spider', 'http://localhost/api/version']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     restart: unless-stopped
 
   postgres:


### PR DESCRIPTION
Closes #75

## Summary
- Adds a Docker healthcheck to the combined `aurboda` service in `docker-compose.yml`
- Probes `http://localhost/api/version` via BusyBox `wget --spider`, which exercises both nginx (port 80) and the proxied Node backend (port 3000) in one call
- Postgres already had a `pg_isready` healthcheck — left as is
- Settings: `interval: 30s`, `timeout: 10s`, `retries: 3`, `start_period: 60s` to allow the combined image (nginx + backend + DB readiness wait) time to come up

The compose file only defines a single combined `aurboda` service (the issue mentioned separate backend/web, but the production image fuses them behind nginx), so one healthcheck covers both.

## Test plan
- [ ] `docker compose up` and confirm the service reaches `healthy`
- [ ] `docker inspect --format='{{.State.Health.Status}}' <container>` shows `healthy`
- [ ] Stop the backend process inside the container and confirm the container is marked `unhealthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)