### PR TITLE
fix(web): render image icons in ActivityTypePicker dropdown

### DIFF
--- a/apps/web/src/components/ActivityTypePicker.tsx
+++ b/apps/web/src/components/ActivityTypePicker.tsx
@@ -7,6 +7,7 @@ import type { ActivityTypeDefinition } from '../state/api'
 
 import { fetchActivityTypeDefinitions } from '../state/api'
 import { toDisplayName } from '../utils/displayName'
+import { IconPreview } from './IconPreview'
 import './MetricPicker.css'
 
 interface ActivityTypePickerProps {
@@ -64,7 +65,7 @@ function DropdownItems({
           onMouseEnter={() => onHighlight(idx)}
         >
           <span class="metric-option-label">
-            {def.icon ? `${def.icon} ` : ''}
+            {def.icon && <IconPreview icon={def.icon} size={20} />}
             {def.display_name || toDisplayName(def.name)}
           </span>
           {def.display_category !== 'other' && <span class="metric-option-key">{def.display_category}</span>}

--- a/apps/web/src/components/MetricPicker.css
+++ b/apps/web/src/components/MetricPicker.css
@@ -71,6 +71,20 @@
 
 .metric-option-label {
   color: #1f2937;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.metric-option-label .icon-preview {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.metric-option-label .icon-preview img {
+  border-radius: 3px;
 }
 
 .metric-option-key {


### PR DESCRIPTION
## Summary
- ActivityTypePicker dropdown was inlining `def.icon` as text, so emoji rendered fine but URL and uploaded icon paths showed the raw long string in suggestions, making them hard to read.
- Swap the inline string for the shared `IconPreview` component (already handles emoji vs URL vs icon-path) and add flex/gap to `.metric-option-label` for clean alignment.

## Test plan
- [ ] Open the Activity Type selector in the web app
- [ ] Verify emoji icons still render
- [ ] Verify URL-based icons render as images (not URLs)
- [ ] Verify uploaded-path icons render as images (not filenames)
- [ ] Confirm spacing between icon and label looks right in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)