### PR TITLE
fix(web): use activity type icon over title-based match in timeline

### DIFF
--- a/apps/web/src/pages/Timeline/categorize.test.ts
+++ b/apps/web/src/pages/Timeline/categorize.test.ts
@@ -1,8 +1,8 @@
+import type { ScreentimeCategory } from '@aurboda/api-spec'
+
 import { describe, expect, it } from 'vitest'
 
 import type { Activity, Meal, Place } from '../../state/api'
-
-import type { ScreentimeCategory } from '@aurboda/api-spec'
 
 import {
   categorizeLocations,
@@ -78,6 +78,25 @@ describe('categorizeOtherActivities', () => {
     const typeDefsMap = new Map([['custom', { icon: '🎯' }]])
     const items = categorizeOtherActivities([makeActivity()], {}, typeDefsMap)
     expect(items[0]!.icon).toBe('🎯')
+  })
+
+  it('prefers type definition icon over title-based itemIcons match', () => {
+    // Activity originally synced as "meditation" then re-typed to "Pipeceremony".
+    // The user's tag-based itemIcons still has "meditation" → 🧘, but the type
+    // definition for "Pipeceremony" has its own icon — the type icon must win.
+    const typeDefsMap = new Map([['Pipeceremony', { icon: '🪶' }]])
+    const items = categorizeOtherActivities(
+      [makeActivity({ activity_type: 'Pipeceremony', title: 'meditation' })],
+      { meditation: '🧘' },
+      typeDefsMap,
+    )
+    expect(items[0]!.icon).toBe('🪶')
+  })
+
+  it('falls back to title-based icon when type definition has no icon', () => {
+    const typeDefsMap = new Map([['custom', {}]])
+    const items = categorizeOtherActivities([makeActivity({ title: 'Yoga' })], { Yoga: '🧘' }, typeDefsMap)
+    expect(items[0]!.icon).toBe('🧘')
   })
 })
 
@@ -162,20 +181,12 @@ describe('categorizeScreentimeActivities', () => {
   })
 
   it('skips activities of other types', () => {
-    const items = categorizeScreentimeActivities(
-      [makeActivity({ activity_type: 'exercise' })],
-      [],
-      {},
-    )
+    const items = categorizeScreentimeActivities([makeActivity({ activity_type: 'exercise' })], [], {})
     expect(items).toEqual([])
   })
 
   it('matches category by exact path for href and clears entity_id', () => {
-    const items = categorizeScreentimeActivities(
-      [makeActivity()],
-      [makeCategory({ id: 'cat-prog' })],
-      {},
-    )
+    const items = categorizeScreentimeActivities([makeActivity()], [makeCategory({ id: 'cat-prog' })], {})
     expect(items[0]!.href).toBe('/screentime-categories/cat-prog')
     expect(items[0]!.entity_id).toBeUndefined()
   })

--- a/apps/web/src/pages/Timeline/categorize.ts
+++ b/apps/web/src/pages/Timeline/categorize.ts
@@ -39,10 +39,10 @@ export const categorizeOtherActivities = (
       const sourceLabel = a.source ? ` (${a.source})` : ''
       const displayName = a.title ?? toDisplayName(a.activity_type)
       const icon =
+        typeDefsMap?.get(a.activity_type)?.icon ??
         itemIcons[displayName] ??
         itemIcons[displayName.toLowerCase()] ??
-        itemIcons[a.activity_type] ??
-        typeDefsMap?.get(a.activity_type)?.icon
+        itemIcons[a.activity_type]
       return {
         color: getActivityColor(a),
         column: 'Activity' as Column,
@@ -124,9 +124,7 @@ const matchCategoryByPath = (
 ): ScreentimeCategory | undefined => {
   for (let depth = path.length; depth > 0; depth--) {
     const sub = path.slice(0, depth)
-    const match = categories.find(
-      (c) => c.name.length === sub.length && c.name.every((n, i) => n === sub[i]),
-    )
+    const match = categories.find((c) => c.name.length === sub.length && c.name.every((n, i) => n === sub[i]))
     if (match) return match
   }
   return undefined


### PR DESCRIPTION
## Summary

- Timeline activity icons looked up `itemIcons[title]` before the activity type's defined icon. Re-typing an activity (e.g. Garmin synced as `meditation`, then changed to `Pipeceremony`) left the timeline showing the old title-matched icon while the detail page already rendered the new type icon — title editing then flipped the timeline icon.
- Reorder the icon resolution in `categorizeOtherActivities` to prefer the activity type definition's icon, matching how `EntityDetail` resolves it.
- Adds tests covering the bug case and the title fallback.

Repro that surfaced this: https://aurboda.net/detail/activity/fb2fd100-42c5-4e06-9834-3189b58104cd

## Test plan

- [x] `pnpm --filter aurboda-web test categorize.test`
- [x] `pnpm --filter aurboda-web check`
- [ ] Verify in browser: open the activity above, confirm timeline icon matches the activity type (not the title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)