### PR TITLE
fix(meals): derive food item nutrition from canonical × quantity

### DIFF
--- a/apps/backend/src/services/meals.integration.test.ts
+++ b/apps/backend/src/services/meals.integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration tests for the meals service.
+ *
+ * Covers the canonical-food + scaling pipeline: add_meal/update_meal must
+ * snapshot canonical nutrient values into meal_food_items scaled by quantity,
+ * and the meal's macro columns must auto-fill from the snapshot sum unless
+ * the caller explicitly provided meal-level macros.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { upsertFoodItem } from '../db/food-items.ts'
+import { getMealFoodItemsBatch } from '../db/meal-food-items.ts'
+import { getMealById } from '../db/meals.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { addMeal, updateMealById } from './meals.ts'
+
+const CONTAINER_TIMEOUT = 60_000
+
+describe('Meals service integration tests', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('scales canonical nutrients by quantity into junction snapshots', async () => {
+    const user = getTestUser()
+    const canonical = await upsertFoodItem(user, {
+      calories: 200,
+      carbs: 40,
+      default_quantity: 100,
+      default_unit: 'g',
+      fat: 2,
+      fiber: 5,
+      name: 'Rye bread',
+      protein: 8,
+    })
+
+    const result = await addMeal(user, {
+      food_items: [{ food_item_id: canonical.id, name: 'Rye bread', quantity: 500, unit: 'g' }],
+      time: '2025-06-15T08:00:00Z',
+    })
+
+    expect(result.success).toBe(true)
+    const mealId = result.data!.id
+
+    const links = (await getMealFoodItemsBatch(user, [mealId])).get(mealId) ?? []
+    expect(links).toHaveLength(1)
+    expect(links[0].calories).toBe(1000)
+    expect(links[0].protein).toBe(40)
+    expect(links[0].carbs).toBe(200)
+    expect(links[0].fat).toBe(10)
+    expect(links[0].fiber).toBe(25)
+  })
+
+  test('auto-fills meal-level macros from junction sum when not provided', async () => {
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Rye bread',
+      protein: 8,
+    })
+    const pb = await upsertFoodItem(user, {
+      calories: 600,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Peanut butter',
+      protein: 25,
+    })
+
+    const result = await addMeal(user, {
+      food_items: [
+        { food_item_id: bread.id, name: 'Rye bread', quantity: 50, unit: 'g' },
+        { food_item_id: pb.id, name: 'Peanut butter', quantity: 30, unit: 'g' },
+      ],
+      time: '2025-06-15T08:00:00Z',
+    })
+
+    const meal = await getMealById(user, result.data!.id)
+    expect(meal!.calories).toBe(280)
+    expect(meal!.protein).toBe(11.5)
+  })
+
+  test('honors explicit meal-level macros when caller provides them', async () => {
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Rye bread',
+      protein: 8,
+    })
+
+    const result = await addMeal(user, {
+      calories: 1234,
+      food_items: [{ food_item_id: bread.id, name: 'Rye bread', quantity: 100, unit: 'g' }],
+      time: '2025-06-15T08:00:00Z',
+    })
+
+    const meal = await getMealById(user, result.data!.id)
+    expect(meal!.calories).toBe(1234)
+    expect(meal!.protein).toBe(8)
+  })
+
+  test('rescales snapshots when a meal is updated with a new quantity', async () => {
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Rye bread',
+      protein: 8,
+    })
+
+    const created = await addMeal(user, {
+      food_items: [{ food_item_id: bread.id, name: 'Rye bread', quantity: 100, unit: 'g' }],
+      time: '2025-06-15T08:00:00Z',
+    })
+    const mealId = created.data!.id
+
+    const updated = await updateMealById(user, mealId, {
+      food_items: [{ food_item_id: bread.id, name: 'Rye bread', quantity: 500, unit: 'g' }],
+    })
+
+    expect(updated.success).toBe(true)
+    const links = (await getMealFoodItemsBatch(user, [mealId])).get(mealId) ?? []
+    expect(links[0].calories).toBe(1000)
+    expect(links[0].protein).toBe(40)
+
+    const meal = await getMealById(user, mealId)
+    expect(meal!.calories).toBe(1000)
+  })
+})

--- a/apps/backend/src/services/meals.test.ts
+++ b/apps/backend/src/services/meals.test.ts
@@ -5,6 +5,7 @@ import type { MealFoodItemLink } from '../db/types.ts'
 import * as db from '../db/index.ts'
 import {
   addMeal,
+  buildScaledJunctionItem,
   deleteMealById,
   getMeal,
   hasIncompleteNutrients,
@@ -16,6 +17,7 @@ import {
 vi.mock('../db', () => ({
   deleteMeal: vi.fn(),
   findOrCreateFoodItem: vi.fn().mockResolvedValue({ id: 'fi-1', name: 'test' }),
+  getFoodItemById: vi.fn().mockResolvedValue(null),
   getMealById: vi.fn(),
   getMealFoodItems: vi.fn().mockResolvedValue([]),
   getMealFoodItemsBatch: vi.fn().mockResolvedValue(new Map()),
@@ -65,8 +67,8 @@ describe('addMeal', () => {
       fat: 25,
       fiber: 8,
       food_items: [
-        { calories: 200, carbs: 40, name: 'Rye bread', protein: 6 },
-        { calories: 180, fat: 16, name: 'Peanut butter', protein: 7 },
+        { name: 'Rye bread', quantity: 100, unit: 'g' },
+        { name: 'Peanut butter', quantity: 30, unit: 'g' },
       ],
       meal_type: 'breakfast',
       micros: { iron: 3.2 },
@@ -242,6 +244,84 @@ describe('updateMealById', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toBe('Meal not found')
+  })
+})
+
+// ── buildScaledJunctionItem ───────────────────────────────────────────────
+
+const canonicalFoodItem = (overrides: Record<string, unknown> = {}) =>
+  ({
+    calories: 200,
+    carbs: 40,
+    created_at: new Date('2025-01-01T00:00:00Z'),
+    default_quantity: 100,
+    default_unit: 'g',
+    fat: 2,
+    fiber: 5,
+    id: 'canonical-1',
+    name: 'Rye bread',
+    name_lower: 'rye bread',
+    protein: 8,
+    source: 'manual',
+    updated_at: new Date('2025-01-01T00:00:00Z'),
+    ...overrides,
+  }) as unknown as Parameters<typeof buildScaledJunctionItem>[1]
+
+describe('buildScaledJunctionItem', () => {
+  test('scales nutrients linearly when quantity differs from default', () => {
+    const canonical = canonicalFoodItem()
+    const item = buildScaledJunctionItem({ name: 'Rye bread', quantity: 500, unit: 'g' }, canonical, 0)
+    expect(item.calories).toBe(1000)
+    expect(item.protein).toBe(40)
+    expect(item.carbs).toBe(200)
+    expect(item.fat).toBe(10)
+    expect(item.fiber).toBe(25)
+    expect(item.food_item_id).toBe('canonical-1')
+    expect(item.quantity).toBe(500)
+    expect(item.sort_order).toBe(0)
+  })
+
+  test('scales down for smaller quantities', () => {
+    const item = buildScaledJunctionItem(
+      { name: 'Rye bread', quantity: 50, unit: 'g' },
+      canonicalFoodItem(),
+      1,
+    )
+    expect(item.calories).toBe(100)
+    expect(item.protein).toBe(4)
+  })
+
+  test('uses raw canonical values when quantity is missing', () => {
+    const item = buildScaledJunctionItem({ name: 'Rye bread' }, canonicalFoodItem(), 0)
+    expect(item.calories).toBe(200)
+  })
+
+  test('uses raw canonical values when default_quantity is missing', () => {
+    const item = buildScaledJunctionItem(
+      { name: 'Rye bread', quantity: 500 },
+      canonicalFoodItem({ default_quantity: undefined }),
+      0,
+    )
+    expect(item.calories).toBe(200)
+  })
+
+  test('falls back to scale=1 when units differ', () => {
+    const item = buildScaledJunctionItem(
+      { name: 'Rye bread', quantity: 2, unit: 'slice' },
+      canonicalFoodItem(),
+      0,
+    )
+    expect(item.calories).toBe(200)
+  })
+
+  test('rounds to two decimal places', () => {
+    const item = buildScaledJunctionItem(
+      { name: 'Rye bread', quantity: 33, unit: 'g' },
+      canonicalFoodItem(),
+      0,
+    )
+    expect(item.calories).toBe(66)
+    expect(item.protein).toBe(2.64)
   })
 })
 

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -10,12 +10,14 @@ import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 import {
   deleteMeal as dbDeleteMeal,
   findOrCreateFoodItem,
+  getFoodItemById,
   getMealById as dbGetMealById,
   getMealFoodItemsBatch,
   getMeals as dbGetMeals,
   setMealFoodItems,
   updateMeal as dbUpdateMeal,
   upsertMeal as dbUpsertMeal,
+  type FoodItemEntity,
   type Meal,
   type MealFoodItem,
   type MealFoodItemLink,
@@ -27,14 +29,11 @@ import {
 // ============================================================================
 
 interface FoodItemInput {
+  food_item_id?: string
   name: string
   quantity?: number
   unit?: string
-  calories?: number
-  protein?: number
-  carbs?: number
-  fat?: number
-  fiber?: number
+  icon?: string
 }
 
 export interface AddMealInput {
@@ -160,6 +159,20 @@ const aggregateNutrients = (links: MealFoodItemLink[]): Record<string, number> =
   return totals
 }
 
+/**
+ * Extract the macro fields the caller explicitly provided so the recompute
+ * step can leave them alone (manual override wins).
+ */
+const pickExplicitMacros = (
+  input: Partial<Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', number | null | undefined>>,
+): Partial<Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', number | null>> => {
+  const out: Partial<Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', number | null>> = {}
+  for (const key of ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const) {
+    if (input[key] !== undefined) out[key] = input[key] as number | null
+  }
+  return out
+}
+
 /** Check if any food item in the junction links lacks calorie data. */
 export const hasIncompleteNutrients = (links: MealFoodItemLink[]): boolean =>
   links.some((link) => link.calories === undefined || link.calories === null)
@@ -186,6 +199,73 @@ const attachFoodItems = async (user: string, meals: Meal[]): Promise<EnrichedMea
   })
 }
 
+/**
+ * Compute the scale factor between a request's quantity and the canonical
+ * food item's default quantity. Same-unit assumption — if the request unit
+ * differs from the canonical default, fall back to scale = 1 (use raw values).
+ */
+const computeScale = (fi: FoodItemInput, canonical: FoodItemEntity): number => {
+  const reqQty = fi.quantity
+  const defaultQty = canonical.default_quantity
+  if (reqQty === undefined || reqQty === null) return 1
+  if (defaultQty === undefined || defaultQty === null || defaultQty === 0) return 1
+  if (fi.unit && canonical.default_unit && fi.unit !== canonical.default_unit) return 1
+  return reqQty / defaultQty
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100
+
+/**
+ * Build a junction row by snapshotting the canonical food item's nutrient
+ * values scaled by quantity. The snapshot is what gets stored on
+ * meal_food_items so that reads remain stable even if the canonical food
+ * is later edited.
+ */
+export const buildScaledJunctionItem = (
+  fi: FoodItemInput,
+  canonical: FoodItemEntity,
+  sortOrder: number,
+): Record<string, unknown> => {
+  const scale = computeScale(fi, canonical)
+  const junctionItem: Record<string, unknown> = {
+    food_item_id: canonical.id,
+    quantity: fi.quantity,
+    sort_order: sortOrder,
+    unit: fi.unit,
+  }
+  for (const field of NUTRIENT_FIELD_NAMES) {
+    const canonicalVal = canonical[field]
+    if (typeof canonicalVal === 'number') {
+      junctionItem[field] = round2(canonicalVal * scale)
+    }
+  }
+  return junctionItem
+}
+
+/**
+ * Resolve a food item input to the canonical food_items row.
+ *
+ * Prefer food_item_id when present; otherwise look up by name (creating a
+ * new canonical entry on first use, with the request's quantity/unit as the
+ * defaults so subsequent uses can scale from the same base).
+ */
+const resolveCanonical = async (
+  user: string,
+  fi: FoodItemInput,
+  source: string,
+): Promise<FoodItemEntity | null> => {
+  if (fi.food_item_id) {
+    const byId = await getFoodItemById(user, fi.food_item_id)
+    if (byId) return byId
+  }
+  return findOrCreateFoodItem(user, fi.name, {
+    default_quantity: fi.quantity,
+    default_unit: fi.unit,
+    icon: fi.icon,
+    source,
+  })
+}
+
 /** Write food items to the junction table for a meal. */
 const syncFoodItemsToJunction = async (
   user: string,
@@ -196,41 +276,37 @@ const syncFoodItemsToJunction = async (
   const junctionItems = []
   for (let i = 0; i < foodItems.length; i++) {
     const fi = foodItems[i]
-    // Find or create canonical food item with the macro defaults
-    const canonical = await findOrCreateFoodItem(user, fi.name, {
-      source,
-      default_quantity: fi.quantity,
-      default_unit: fi.unit,
-      calories: fi.calories,
-      protein: fi.protein,
-      carbs: fi.carbs,
-      fat: fi.fat,
-      fiber: fi.fiber,
-    })
-
-    // Copy ALL nutrients from canonical food item as snapshot, then override with any
-    // explicit values from the input (the input may have manually adjusted macros)
-    const junctionItem: Record<string, unknown> = {
-      food_item_id: canonical.id,
-      quantity: fi.quantity,
-      unit: fi.unit,
-      sort_order: i,
-    }
-    // First: copy all nutrients from canonical item
-    for (const field of NUTRIENT_FIELD_NAMES) {
-      const canonicalVal = canonical[field]
-      if (typeof canonicalVal === 'number') junctionItem[field] = canonicalVal
-    }
-    // Then: override with any explicit input values (manual edits)
-    if (fi.calories !== undefined) junctionItem.calories = fi.calories
-    if (fi.protein !== undefined) junctionItem.protein = fi.protein
-    if (fi.carbs !== undefined) junctionItem.carbs = fi.carbs
-    if (fi.fat !== undefined) junctionItem.fat = fi.fat
-    if (fi.fiber !== undefined) junctionItem.fiber = fi.fiber
-    junctionItems.push(junctionItem)
+    const canonical = await resolveCanonical(user, fi, source)
+    if (!canonical) continue
+    junctionItems.push(buildScaledJunctionItem(fi, canonical, i))
   }
 
   await setMealFoodItems(user, mealId, junctionItems as Parameters<typeof setMealFoodItems>[2])
+}
+
+/**
+ * Recompute meal-level macros (calories/protein/carbs/fat/fiber) from the
+ * current junction rows and persist them on the meal row.
+ *
+ * Macro keys present in `explicit` are skipped — the caller's request body
+ * wins (manual override).
+ */
+const recomputeMealMacros = async (
+  user: string,
+  mealId: string,
+  explicit: Partial<Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', number | null>> = {},
+): Promise<Meal | null> => {
+  const map = await getMealFoodItemsBatch(user, [mealId])
+  const links = map.get(mealId) ?? []
+  const totals = aggregateNutrients(links)
+  const macroKeys = ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const
+  const update: Record<string, number | null> = {}
+  for (const key of macroKeys) {
+    if (key in explicit) continue
+    update[key] = links.length === 0 ? null : (totals[key] ?? 0)
+  }
+  if (Object.keys(update).length === 0) return null
+  return dbUpdateMeal(user, mealId, update)
 }
 
 // ============================================================================
@@ -243,7 +319,7 @@ const syncFoodItemsToJunction = async (
 export async function addMeal(user: string, input: AddMealInput): Promise<MealResult> {
   const mealTime = new Date(input.time)
 
-  const meal = await dbUpsertMeal(user, {
+  const initialMeal = await dbUpsertMeal(user, {
     id: input.id,
     calories: input.calories,
     carbs: input.carbs,
@@ -260,9 +336,11 @@ export async function addMeal(user: string, input: AddMealInput): Promise<MealRe
     time: mealTime,
   })
 
-  // Write junction table rows for food items
+  let meal = initialMeal
   if (input.food_items && input.food_items.length > 0) {
     await syncFoodItemsToJunction(user, meal.id, input.food_items, input.source)
+    const recomputed = await recomputeMealMacros(user, meal.id, pickExplicitMacros(input))
+    if (recomputed) meal = recomputed
   }
 
   return { data: formatMeal(meal), success: true }
@@ -272,24 +350,26 @@ export async function addMeal(user: string, input: AddMealInput): Promise<MealRe
  * Update an existing meal record.
  */
 export async function updateMealById(user: string, id: string, input: UpdateMealInput): Promise<MealResult> {
-  const meal = await dbUpdateMeal(user, id, {
+  const initialMeal = await dbUpdateMeal(user, id, {
     ...input,
     food_items: input.food_items === null ? null : input.food_items,
     micros: input.micros === null ? null : input.micros,
     time: input.time ? new Date(input.time) : undefined,
   })
 
-  if (!meal) {
+  if (!initialMeal) {
     return { error: 'Meal not found', success: false }
   }
 
-  // Update junction table if food items changed
+  let meal = initialMeal
   if (input.food_items !== undefined) {
     if (input.food_items === null || input.food_items.length === 0) {
       await setMealFoodItems(user, id, [])
     } else {
       await syncFoodItemsToJunction(user, id, input.food_items, meal.source)
     }
+    const recomputed = await recomputeMealMacros(user, id, pickExplicitMacros(input))
+    if (recomputed) meal = recomputed
   }
 
   return { data: formatMeal(meal), success: true }

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -276,6 +276,19 @@
   flex-wrap: wrap;
 }
 
+.food-row-macros-display {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+  padding-left: 0.25rem;
+}
+
+.food-row-macros-display span {
+  white-space: nowrap;
+}
+
 .food-row-macros label {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -18,15 +18,42 @@ import './MealDetail.css'
 
 // ── Sub-components ───────────────────────────────────────────────────────────
 
-interface FoodItemEdit {
-  name: string
+interface FoodItemRef {
   quantity?: number
-  unit?: string
   calories?: number
   protein?: number
   carbs?: number
   fat?: number
   fiber?: number
+}
+
+interface FoodItemEdit {
+  food_item_id?: string
+  name: string
+  quantity?: number
+  unit?: string
+  /**
+   * Reference values for live display scaling. Captured at row creation
+   * (autocomplete pick: canonical default_quantity + canonical nutrients;
+   * existing item edit: server snapshot quantity + snapshot nutrients).
+   * Stripped before save — the backend re-derives the snapshot from the
+   * canonical food item × quantity.
+   */
+  ref?: FoodItemRef
+}
+
+/** Linearly scale a reference nutrient value to the current quantity. */
+const scaleNutrient = (
+  ref: FoodItemRef | undefined,
+  field: keyof Omit<FoodItemRef, 'quantity'>,
+  currentQuantity: number | undefined,
+): number | undefined => {
+  if (!ref) return undefined
+  const baseValue = ref[field]
+  if (typeof baseValue !== 'number') return undefined
+  if (ref.quantity === undefined || ref.quantity === 0) return baseValue
+  if (currentQuantity === undefined) return baseValue
+  return Math.round(((baseValue * currentQuantity) / ref.quantity) * 10) / 10
 }
 
 const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack', 'drink']
@@ -137,8 +164,16 @@ function FoodItemRow({
   onChange: (index: number, item: FoodItemEdit) => void
   onRemove: (index: number) => void
 }) {
-  const update = (field: string, value: unknown) => onChange(index, { ...item, [field]: value })
+  const update = (field: keyof FoodItemEdit, value: unknown) => onChange(index, { ...item, [field]: value })
   const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
+
+  const kcal = scaleNutrient(item.ref, 'calories', item.quantity)
+  const prot = scaleNutrient(item.ref, 'protein', item.quantity)
+  const carbs = scaleNutrient(item.ref, 'carbs', item.quantity)
+  const fat = scaleNutrient(item.ref, 'fat', item.quantity)
+  const fiber = scaleNutrient(item.ref, 'fiber', item.quantity)
+  const hasMacros = [kcal, prot, carbs, fat, fiber].some((v) => typeof v === 'number')
+
   return (
     <div class="food-item-edit-row">
       <div class="food-row-top">
@@ -148,14 +183,18 @@ function FoodItemRow({
           onSelect={(fi: FoodItemEntity) => {
             onChange(index, {
               ...item,
+              food_item_id: fi.id,
               name: fi.name,
               quantity: fi.default_quantity ?? 1,
               unit: fi.default_unit ?? item.unit,
-              calories: fi.calories ?? item.calories,
-              protein: fi.protein ?? item.protein,
-              carbs: fi.carbs ?? item.carbs,
-              fat: fi.fat ?? item.fat,
-              fiber: fi.fiber ?? item.fiber,
+              ref: {
+                calories: fi.calories,
+                carbs: fi.carbs,
+                fat: fi.fat,
+                fiber: fi.fiber,
+                protein: fi.protein,
+                quantity: fi.default_quantity,
+              },
             })
           }}
         />
@@ -178,53 +217,15 @@ function FoodItemRow({
           &times;
         </button>
       </div>
-      <div class="food-row-macros">
-        <label>
-          <span>kcal</span>
-          <input
-            type="number"
-            step="0.1"
-            value={item.calories ?? ''}
-            onInput={(e) => update('calories', parseNum((e.target as HTMLInputElement).value))}
-          />
-        </label>
-        <label>
-          <span>prot</span>
-          <input
-            type="number"
-            step="0.1"
-            value={item.protein ?? ''}
-            onInput={(e) => update('protein', parseNum((e.target as HTMLInputElement).value))}
-          />
-        </label>
-        <label>
-          <span>carbs</span>
-          <input
-            type="number"
-            step="0.1"
-            value={item.carbs ?? ''}
-            onInput={(e) => update('carbs', parseNum((e.target as HTMLInputElement).value))}
-          />
-        </label>
-        <label>
-          <span>fat</span>
-          <input
-            type="number"
-            step="0.1"
-            value={item.fat ?? ''}
-            onInput={(e) => update('fat', parseNum((e.target as HTMLInputElement).value))}
-          />
-        </label>
-        <label>
-          <span>fiber</span>
-          <input
-            type="number"
-            step="0.1"
-            value={item.fiber ?? ''}
-            onInput={(e) => update('fiber', parseNum((e.target as HTMLInputElement).value))}
-          />
-        </label>
-      </div>
+      {hasMacros && (
+        <div class="food-row-macros-display">
+          {typeof kcal === 'number' && <span>{kcal} kcal</span>}
+          {typeof prot === 'number' && <span>P {prot}g</span>}
+          {typeof carbs === 'number' && <span>C {carbs}g</span>}
+          {typeof fat === 'number' && <span>F {fat}g</span>}
+          {typeof fiber === 'number' && <span>Fib {fiber}g</span>}
+        </div>
+      )}
     </div>
   )
 }
@@ -318,7 +319,14 @@ interface EditState {
   sensitivities?: string[]
 }
 
-/** Build the PATCH body from edit state, auto-summing macros from food items. */
+/**
+ * Build the PATCH body from edit state.
+ *
+ * Per-item nutrient values are not sent — the backend re-derives them from
+ * the canonical food item × quantity. Meal-level macros are sent only if the
+ * user typed an explicit value; otherwise the backend auto-fills from the
+ * (newly scaled) item snapshots.
+ */
 const buildSaveBody = (editing: EditState): Record<string, unknown> => {
   const body: Record<string, unknown> = {}
   if (editing.name !== undefined) body.name = editing.name || null
@@ -329,24 +337,19 @@ const buildSaveBody = (editing: EditState): Record<string, unknown> => {
 
   const items = editing.food_items?.filter((fi) => fi.name.trim())
   if (items !== undefined) {
-    body.food_items = items
-    // Auto-sum macros from food items
-    const sumField = (field: keyof FoodItemEdit) => {
-      const total = items.reduce((s, fi) => s + ((fi[field] as number) ?? 0), 0)
-      return total > 0 ? Math.round(total * 100) / 100 : null
-    }
-    body.calories = sumField('calories')
-    body.protein = sumField('protein')
-    body.carbs = sumField('carbs')
-    body.fat = sumField('fat')
-    body.fiber = sumField('fiber')
-  } else {
-    if (editing.calories !== undefined) body.calories = editing.calories
-    if (editing.protein !== undefined) body.protein = editing.protein
-    if (editing.carbs !== undefined) body.carbs = editing.carbs
-    if (editing.fat !== undefined) body.fat = editing.fat
-    if (editing.fiber !== undefined) body.fiber = editing.fiber
+    body.food_items = items.map((fi) => ({
+      food_item_id: fi.food_item_id,
+      name: fi.name,
+      quantity: fi.quantity,
+      unit: fi.unit,
+    }))
   }
+
+  if (editing.calories !== undefined) body.calories = editing.calories
+  if (editing.protein !== undefined) body.protein = editing.protein
+  if (editing.carbs !== undefined) body.carbs = editing.carbs
+  if (editing.fat !== undefined) body.fat = editing.fat
+  if (editing.fiber !== undefined) body.fiber = editing.fiber
 
   return body
 }
@@ -421,17 +424,21 @@ export function MealDetail() {
   const editCarbs = editing?.carbs !== undefined ? editing.carbs : meal.carbs
   const editFat = editing?.fat !== undefined ? editing.fat : meal.fat
   const editFiber = editing?.fiber !== undefined ? editing.fiber : meal.fiber
-  const editItems =
+  const editItems: FoodItemEdit[] =
     editing?.food_items ??
     (meal.food_items ?? []).map((fi) => ({
+      food_item_id: fi.food_item_id,
       name: fi.name,
       quantity: fi.quantity,
+      ref: {
+        calories: fi.calories,
+        carbs: fi.carbs,
+        fat: fi.fat,
+        fiber: fi.fiber,
+        protein: fi.protein,
+        quantity: fi.quantity,
+      },
       unit: fi.unit,
-      calories: fi.calories,
-      protein: fi.protein,
-      carbs: fi.carbs,
-      fat: fi.fat,
-      fiber: fi.fiber,
     }))
   const editFlags = editing?.sensitivities ?? meal.sensitivities ?? []
 

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -68,7 +68,11 @@ export type Micros = z.infer<typeof microsSchema>
 // ============================================================================
 
 /**
- * An individual food item within a meal.
+ * An individual food item within a meal — response shape.
+ *
+ * Nutrient values are returned as the snapshot stored on the meal_food_items
+ * junction row (canonical × scale at the time of save). They are NOT accepted
+ * on input — see foodItemInputSchema.
  */
 export const foodItemSchema = z
   .object({
@@ -95,6 +99,33 @@ export const foodItemSchema = z
   .meta({ description: 'An individual food item within a meal', id: 'FoodItem' })
 
 export type FoodItem = z.infer<typeof foodItemSchema>
+
+/**
+ * Input shape for a food item in a meal request body.
+ *
+ * Per-item nutrient values are derived server-side from the canonical food
+ * item entity scaled by quantity. Callers identify the food via food_item_id
+ * (preferred) or name (auto-creates a canonical entry if no match).
+ */
+export const foodItemInputSchema = z
+  .object({
+    food_item_id: z.string().uuid().optional().meta({ description: 'Link to canonical food item entity' }),
+    icon: z
+      .string()
+      .max(2048)
+      .optional()
+      .meta({ description: 'Icon for this food item (emoji or image URL)' }),
+    name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
+    quantity: z.number().optional().meta({ description: 'Quantity consumed' }),
+    unit: z
+      .string()
+      .max(100)
+      .optional()
+      .meta({ description: 'Unit for quantity (e.g., "g", "ml", "large slice", "full recipe")' }),
+  })
+  .meta({ description: 'Input shape for a food item in a meal request body', id: 'FoodItemInput' })
+
+export type FoodItemInput = z.infer<typeof foodItemInputSchema>
 
 // ============================================================================
 // Meal
@@ -160,7 +191,10 @@ export const addMealBodySchema = z
     carbs: z.number().optional().meta({ description: 'Total carbohydrates in grams' }),
     fat: z.number().optional().meta({ description: 'Total fat in grams' }),
     fiber: z.number().optional().meta({ description: 'Total dietary fiber in grams' }),
-    food_items: z.array(foodItemSchema).optional().meta({ description: 'Individual food items in the meal' }),
+    food_items: z
+      .array(foodItemInputSchema)
+      .optional()
+      .meta({ description: 'Individual food items in the meal' }),
     meal_type: mealTypeSchema.optional().meta({ description: 'Type of meal' }),
     micros: microsSchema.meta({ description: 'Micronutrients' }),
     name: z.string().max(255).optional().meta({ description: 'Meal name/description' }),
@@ -189,7 +223,11 @@ export const updateMealBodySchema = z
     carbs: z.number().nullable().optional().meta({ description: 'Total carbohydrates in grams' }),
     fat: z.number().nullable().optional().meta({ description: 'Total fat in grams' }),
     fiber: z.number().nullable().optional().meta({ description: 'Total dietary fiber in grams' }),
-    food_items: z.array(foodItemSchema).nullable().optional().meta({ description: 'Individual food items' }),
+    food_items: z
+      .array(foodItemInputSchema)
+      .nullable()
+      .optional()
+      .meta({ description: 'Individual food items' }),
     meal_type: mealTypeSchema.optional().meta({ description: 'Type of meal' }),
     micros: microsSchema.nullable().meta({ description: 'Micronutrients' }),
     name: z.string().max(255).nullable().optional().meta({ description: 'Meal name/description' }),


### PR DESCRIPTION
## Summary

- Per-food-item nutrients in a meal are now derived server-side from the canonical `FoodItem` × `(quantity / canonical.default_quantity)`, snapshotted into `meal_food_items` at save time, and re-summed back onto the meal row.
- Fixes the bug where changing a food item from 100 g → 500 g left kcal / macros stuck at the original value (e.g. https://aurboda.net/meals/57eede93-290b-485f-85f4-27d790c063fd?edit=1).
- API contract change: `addMeal` / `updateMeal` request bodies no longer accept `calories`/`protein`/`carbs`/`fat`/`fiber`/`micros` per food item — clients send `food_item_id` + `name` + `quantity` + `unit` and the server snapshots scaled nutrients. Response shape is unchanged.
- Meal-level macros remain editable: backend auto-fills from the (newly scaled) item snapshots, but explicit body values from the caller win.
- Existing `meal_food_items` rows are left as-is — no migration. Only future add/edit operations use the scaled snapshot.

## What changed

- `packages/api-spec/src/schemas/meals.ts` — split `foodItemSchema` (response, full nutrients) from `foodItemInputSchema` (request, just `food_item_id`/`name`/`quantity`/`unit`/`icon`); both `addMealBody` and `updateMealBody` now take the input variant.
- `apps/backend/src/services/meals.ts` — `buildScaledJunctionItem(fi, canonical, sortOrder)` does the scaling math; `resolveCanonical` prefers `food_item_id` over name lookup; new `recomputeMealMacros` fills meal-row macros from junction rows post-sync, skipping fields the caller provided explicitly.
- `apps/web/src/pages/Meals/MealDetail.tsx` — `FoodItemEdit` now carries `food_item_id` + a `ref` snapshot of `{quantity, calories, protein, carbs, fat, fiber}`; per-item nutrient inputs replaced by a read-only macro display that scales linearly as the user types a new quantity; `buildSaveBody` no longer sums or sends per-item nutrients.

## Test plan

- [x] `pnpm check` (root) — 0 errors.
- [x] `pnpm --filter aurboda-backend test` — 1873/1873 pass, including 6 new unit tests for `buildScaledJunctionItem` (5× / 0.5× / no-default / unit-mismatch / rounding) and 4 new integration tests for `addMeal` / `updateMealById` (snapshot scaling, macro auto-fill, explicit override, rescale on update).
- [x] `pnpm --filter aurboda-web test` — 298/298 pass.
- [ ] Manual web test on dev: open a meal in `?edit=1`, add a 100 g item, change to 500 g, verify the macro display jumps to 5× live and the saved meal has matching totals.
- [ ] MCP smoke: `add_meal` with `{ food_items: [{ food_item_id, quantity: 500, unit: 'g' }] }`, fetch the meal back, confirm scaled snapshots and meal totals.
- [ ] Confirm an old meal renders unchanged (no migration applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)