### PR TITLE
feat(passkey): passkey-only signup

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -389,6 +389,7 @@ const main = async () => {
     invitationAuth,
     ouraWebhookManager,
     syncProvider,
+    userDb,
     webAuthn,
     webHost,
     wellKnown,

--- a/apps/backend/src/api/auth-routes.ts
+++ b/apps/backend/src/api/auth-routes.ts
@@ -38,7 +38,7 @@ interface AuthRoutesDeps {
   unauthorized: Error
 }
 
-const RESERVED_USERNAMES = [
+export const RESERVED_USERNAMES = [
   'postgres',
   'admin',
   'root',

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -5,6 +5,7 @@
  * activity-detail fetcher that's plumbed in here.
  */
 import type { Express } from 'express'
+import type { Client } from 'pg'
 
 import type { Auth } from '../auth.ts'
 import type { GarminClient } from '../integrations/garmin/client.ts'
@@ -59,6 +60,7 @@ interface RestRoutesDeps {
   auth: Auth
   webAuthn: WebAuthnService
   wellKnown: WellKnownConfig
+  userDb: Client
 }
 
 export const mountRestRouters = ({
@@ -77,6 +79,7 @@ export const mountRestRouters = ({
   auth,
   webAuthn,
   wellKnown,
+  userDb,
 }: RestRoutesDeps): void => {
   httpd.use(createMetricsRouter(authMiddleware, syncProvider))
   httpd.use('/icons', createIconsRouter(authMiddleware))
@@ -124,6 +127,9 @@ export const mountRestRouters = ({
       ouraWebhookManager,
     ),
   )
-  httpd.use('/webauthn', createWebAuthnRouter({ auth, authMiddleware, centralDb, webAuthn }))
+  httpd.use(
+    '/webauthn',
+    createWebAuthnRouter({ auth, authMiddleware, centralDb, invitationAuth, userDb, webAuthn }),
+  )
   httpd.use(createWellKnownRouter(wellKnown))
 }

--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -109,6 +109,34 @@ export const makeNewUserDb = async (adminClient: Client, user: string, password:
   await initializeSchema(user)
 }
 
+/**
+ * Tear down a user that was just created by `makeNewUserDb`. Used by
+ * passkey-only signup to roll back when something fails after the role
+ * + database exist (e.g. credential persistence). Best-effort: each step
+ * is wrapped so the next still runs even if one throws.
+ */
+export const dropUserDb = async (adminClient: Client, user: string) => {
+  const database = userDbName(user)
+  // Close the per-user client so DROP DATABASE isn't blocked by an open conn.
+  const existing = dbByUser[user]
+  if (existing) {
+    try {
+      await existing.end()
+    } catch {}
+    delete dbByUser[user]
+  }
+  // Also drop any other open connections to the per-user DB.
+  await query(
+    adminClient,
+    format(
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = %L AND pid <> pg_backend_pid()`,
+      database,
+    ),
+  ).catch(() => {})
+  await query(adminClient, format('DROP DATABASE IF EXISTS %I', database)).catch(() => {})
+  await query(adminClient, format('DROP USER IF EXISTS %I', user)).catch(() => {})
+}
+
 export const getDbForUser = async (user: string) => {
   if (dbByUser[user]) return dbByUser[user]
   const client = new Client({ database: userDbName(user) })

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -49,6 +49,7 @@ export type {
 // Connection & schema management
 export {
   _setClientForUser,
+  dropUserDb,
   getDbForUser,
   initializeSchema,
   loginToUserDb,

--- a/apps/backend/src/routes/webauthn-router.test.ts
+++ b/apps/backend/src/routes/webauthn-router.test.ts
@@ -216,7 +216,10 @@ describe('POST /webauthn/signup/options', () => {
   })
 
   test('403 when invite_only and no invitation provided', async () => {
-    const app = buildApp({}, { centralDb: { getSignupMode: vi.fn(async (): Promise<'invite_only'> => 'invite_only') } })
+    const app = buildApp(
+      {},
+      { centralDb: { getSignupMode: vi.fn(async (): Promise<'invite_only'> => 'invite_only') } },
+    )
     const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
     expect(res.status).toBe(403)
   })
@@ -225,7 +228,9 @@ describe('POST /webauthn/signup/options', () => {
     const webAuthn: Partial<WebAuthnService> = {
       getSignupOptions: vi.fn(async () => ({ challenge: 'c' }) as never),
     }
-    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const app = buildApp(webAuthn, {
+      centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') },
+    })
     const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'A!' })
     expect(res.status).toBe(400)
     expect(webAuthn.getSignupOptions).not.toHaveBeenCalled()
@@ -235,7 +240,9 @@ describe('POST /webauthn/signup/options', () => {
     const webAuthn: Partial<WebAuthnService> = {
       getSignupOptions: vi.fn(async () => ({ challenge: 'c' }) as never),
     }
-    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const app = buildApp(webAuthn, {
+      centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') },
+    })
     const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'admin' })
     expect(res.status).toBe(400)
     expect(webAuthn.getSignupOptions).not.toHaveBeenCalled()
@@ -246,7 +253,9 @@ describe('POST /webauthn/signup/options', () => {
     const webAuthn: Partial<WebAuthnService> = {
       getSignupOptions: vi.fn(async () => ({ challenge: 'c' }) as never),
     }
-    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const app = buildApp(webAuthn, {
+      centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') },
+    })
     const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
     expect(res.status).toBe(409)
     expect(webAuthn.getSignupOptions).not.toHaveBeenCalled()
@@ -257,7 +266,9 @@ describe('POST /webauthn/signup/options', () => {
     const webAuthn: Partial<WebAuthnService> = {
       getSignupOptions: vi.fn(async () => ({ challenge: 'sign-c' }) as never),
     }
-    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const app = buildApp(webAuthn, {
+      centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') },
+    })
     const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
     expect(res.status).toBe(200)
     expect(JSON.parse(res.body.options_json)).toEqual({ challenge: 'sign-c' })
@@ -370,6 +381,91 @@ describe('POST /webauthn/signup/verify', () => {
     expect(res.status).toBe(500)
     expect(dbIndex.dropUserDb).toHaveBeenCalledWith(expect.anything(), 'bob')
     expect(deleteHandle).toHaveBeenCalledWith('bob')
+  })
+
+  test('rolls back when makeNewUserDb fails (drops potentially partial role + DB)', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      verifySignup: vi.fn(async () => ({
+        credential: {
+          backedUp: false,
+          counter: 0,
+          credentialId: 'cred-3',
+          deviceType: 'singleDevice',
+          publicKey: Buffer.from([1]),
+          transports: [],
+        },
+        userHandleUuid: '33333333-3333-3333-3333-333333333333',
+        verified: true,
+      })),
+    }
+    vi.mocked(dbIndex.makeNewUserDb).mockRejectedValueOnce(new Error('disk full'))
+
+    const insertHandle = vi.fn(async () => {})
+    const deleteHandle = vi.fn(async () => {})
+    const app = buildApp(webAuthn, {
+      centralDb: {
+        getAdminCount: vi.fn(async () => 1),
+        insertWebAuthnUserHandle: insertHandle,
+        deleteWebAuthnUserHandle: deleteHandle,
+        isAdmin: vi.fn(async () => false),
+      },
+    })
+    const res = await supertest(app)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'carol', response_json: '{}' })
+
+    expect(res.status).toBe(500)
+    // Both rollback steps must run, in case makeNewUserDb partially succeeded.
+    expect(dbIndex.dropUserDb).toHaveBeenCalledWith(expect.anything(), 'carol')
+    expect(deleteHandle).toHaveBeenCalledWith('carol')
+    expect(webauthnDb.insertWebAuthnCredential).not.toHaveBeenCalled()
+  })
+
+  test('insert-handle 23505 → 409, other errors → 500', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      verifySignup: vi.fn(async () => ({
+        credential: {
+          backedUp: false,
+          counter: 0,
+          credentialId: 'cred-4',
+          deviceType: 'singleDevice',
+          publicKey: Buffer.from([1]),
+          transports: [],
+        },
+        userHandleUuid: '44444444-4444-4444-4444-444444444444',
+        verified: true,
+      })),
+    }
+    const conflictErr: Error & { code?: string } = new Error('duplicate key')
+    conflictErr.code = '23505'
+
+    const app1 = buildApp(webAuthn, {
+      centralDb: {
+        insertWebAuthnUserHandle: vi.fn(async () => {
+          throw conflictErr
+        }),
+        isAdmin: vi.fn(async () => false),
+      },
+    })
+    const res1 = await supertest(app1)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'dave', response_json: '{}' })
+    expect(res1.status).toBe(409)
+    expect(res1.body.verified).toBe(true) // verification did succeed; only persist collided
+    expect(dbIndex.makeNewUserDb).not.toHaveBeenCalled()
+
+    const app2 = buildApp(webAuthn, {
+      centralDb: {
+        insertWebAuthnUserHandle: vi.fn(async () => {
+          throw new Error('connection lost')
+        }),
+        isAdmin: vi.fn(async () => false),
+      },
+    })
+    const res2 = await supertest(app2)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'dave', response_json: '{}' })
+    expect(res2.status).toBe(500)
   })
 })
 

--- a/apps/backend/src/routes/webauthn-router.test.ts
+++ b/apps/backend/src/routes/webauthn-router.test.ts
@@ -1,3 +1,5 @@
+import type { Client } from 'pg'
+
 /**
  * Router-level tests for `/webauthn/*`.
  *
@@ -10,9 +12,30 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { Auth } from '../auth.ts'
 import type { CentralDb } from '../services/central-db.ts'
+import type { InvitationAuth } from '../services/invitation.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 
+import * as dbIndex from '../db/index.ts'
+import * as webauthnDb from '../db/webauthn.ts'
 import { createWebAuthnRouter } from './webauthn-router.ts'
+
+vi.mock('../db/index.ts', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...orig,
+    dropUserDb: vi.fn().mockResolvedValue(undefined),
+    makeNewUserDb: vi.fn().mockResolvedValue(undefined),
+    query: vi.fn().mockResolvedValue({ rowCount: 0, rows: [] }),
+  }
+})
+
+vi.mock('../db/webauthn.ts', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...orig,
+    insertWebAuthnCredential: vi.fn().mockResolvedValue(undefined),
+  }
+})
 
 const buildApp = (
   webAuthn: Partial<WebAuthnService>,
@@ -40,6 +63,10 @@ const buildApp = (
       auth: { createToken: vi.fn(() => 'fake-token'), ...options.auth } as Auth,
       authMiddleware,
       centralDb: { isAdmin: vi.fn(async () => false), ...options.centralDb } as unknown as CentralDb,
+      invitationAuth: {
+        validateInvitationToken: vi.fn(() => ({ valid: true })),
+      } as unknown as InvitationAuth,
+      userDb: {} as Client,
       webAuthn: webAuthn as WebAuthnService,
     }),
   )
@@ -177,6 +204,172 @@ describe('GET /webauthn/credentials', () => {
     expect(res.status).toBe(200)
     expect(res.body.credentials).toHaveLength(1)
     expect(webAuthn.listCredentials).toHaveBeenCalledWith('alice')
+  })
+})
+
+describe('POST /webauthn/signup/options', () => {
+  test('403 when signup is closed', async () => {
+    const app = buildApp({}, { centralDb: { getSignupMode: vi.fn(async (): Promise<'closed'> => 'closed') } })
+    const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
+    expect(res.status).toBe(403)
+    expect(res.body.error).toMatch(/closed/i)
+  })
+
+  test('403 when invite_only and no invitation provided', async () => {
+    const app = buildApp({}, { centralDb: { getSignupMode: vi.fn(async (): Promise<'invite_only'> => 'invite_only') } })
+    const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
+    expect(res.status).toBe(403)
+  })
+
+  test('400 when username is invalid', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      getSignupOptions: vi.fn(async () => ({ challenge: 'c' }) as never),
+    }
+    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'A!' })
+    expect(res.status).toBe(400)
+    expect(webAuthn.getSignupOptions).not.toHaveBeenCalled()
+  })
+
+  test('400 when username is reserved', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      getSignupOptions: vi.fn(async () => ({ challenge: 'c' }) as never),
+    }
+    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'admin' })
+    expect(res.status).toBe(400)
+    expect(webAuthn.getSignupOptions).not.toHaveBeenCalled()
+  })
+
+  test('409 when username already exists', async () => {
+    vi.mocked(dbIndex.query).mockResolvedValue({ rowCount: 1, rows: [{ usename: 'alice' }] } as never)
+    const webAuthn: Partial<WebAuthnService> = {
+      getSignupOptions: vi.fn(async () => ({ challenge: 'c' }) as never),
+    }
+    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
+    expect(res.status).toBe(409)
+    expect(webAuthn.getSignupOptions).not.toHaveBeenCalled()
+  })
+
+  test('200 with options_json on success', async () => {
+    vi.mocked(dbIndex.query).mockResolvedValue({ rowCount: 0, rows: [] } as never)
+    const webAuthn: Partial<WebAuthnService> = {
+      getSignupOptions: vi.fn(async () => ({ challenge: 'sign-c' }) as never),
+    }
+    const app = buildApp(webAuthn, { centralDb: { getSignupMode: vi.fn(async (): Promise<'open'> => 'open') } })
+    const res = await supertest(app).post('/webauthn/signup/options').send({ username: 'alice' })
+    expect(res.status).toBe(200)
+    expect(JSON.parse(res.body.options_json)).toEqual({ challenge: 'sign-c' })
+    expect(webAuthn.getSignupOptions).toHaveBeenCalledWith('alice', expect.any(String))
+  })
+})
+
+describe('POST /webauthn/signup/verify', () => {
+  test('400 on invalid response_json', async () => {
+    const app = buildApp({})
+    const res = await supertest(app)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'alice', response_json: 'nope' })
+    expect(res.status).toBe(400)
+  })
+
+  test('400 with generic message when service rejects', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      verifySignup: vi.fn(async () => ({ verified: false })),
+    }
+    const app = buildApp(webAuthn)
+    const res = await supertest(app)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'alice', response_json: '{}' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('Verification failed')
+  })
+
+  test('200 happy path: token issued, no password ever leaves the server', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      verifySignup: vi.fn(async () => ({
+        credential: {
+          backedUp: true,
+          counter: 0,
+          credentialId: 'cred-1',
+          deviceType: 'multiDevice',
+          publicKey: Buffer.from([1]),
+          transports: ['internal'],
+        },
+        userHandleUuid: '11111111-1111-1111-1111-111111111111',
+        verified: true,
+      })),
+    }
+    const insertHandle = vi.fn(async () => {})
+    const addAdmin = vi.fn(async () => {})
+    const app = buildApp(webAuthn, {
+      auth: { createToken: vi.fn(() => 'fresh-token') },
+      centralDb: {
+        addAdmin,
+        getAdminCount: vi.fn(async () => 0),
+        insertWebAuthnUserHandle: insertHandle,
+        isAdmin: vi.fn(async () => false),
+      },
+    })
+    const res = await supertest(app)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'alice', response_json: '{}' })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      is_admin: true,
+      success: true,
+      token: 'fresh-token',
+      username: 'alice',
+      verified: true,
+    })
+
+    expect(insertHandle).toHaveBeenCalledWith('alice', '11111111-1111-1111-1111-111111111111')
+    expect(dbIndex.makeNewUserDb).toHaveBeenCalledWith(expect.anything(), 'alice', expect.any(String))
+    expect(webauthnDb.insertWebAuthnCredential).toHaveBeenCalledWith(
+      'alice',
+      expect.objectContaining({ credentialId: 'cred-1' }),
+    )
+    // The wire payload must not include the random password we generated.
+    expect(JSON.stringify(res.body)).not.toMatch(/password/i)
+    expect(addAdmin).toHaveBeenCalledWith('alice')
+  })
+
+  test('rolls back when credential persistence fails', async () => {
+    const webAuthn: Partial<WebAuthnService> = {
+      verifySignup: vi.fn(async () => ({
+        credential: {
+          backedUp: false,
+          counter: 0,
+          credentialId: 'cred-2',
+          deviceType: 'singleDevice',
+          publicKey: Buffer.from([1]),
+          transports: [],
+        },
+        userHandleUuid: '22222222-2222-2222-2222-222222222222',
+        verified: true,
+      })),
+    }
+    vi.mocked(webauthnDb.insertWebAuthnCredential).mockRejectedValueOnce(new Error('boom'))
+
+    const insertHandle = vi.fn(async () => {})
+    const deleteHandle = vi.fn(async () => {})
+    const app = buildApp(webAuthn, {
+      centralDb: {
+        getAdminCount: vi.fn(async () => 1),
+        insertWebAuthnUserHandle: insertHandle,
+        deleteWebAuthnUserHandle: deleteHandle,
+        isAdmin: vi.fn(async () => false),
+      },
+    })
+    const res = await supertest(app)
+      .post('/webauthn/signup/verify')
+      .send({ username: 'bob', response_json: '{}' })
+
+    expect(res.status).toBe(500)
+    expect(dbIndex.dropUserDb).toHaveBeenCalledWith(expect.anything(), 'bob')
+    expect(deleteHandle).toHaveBeenCalledWith('bob')
   })
 })
 

--- a/apps/backend/src/routes/webauthn-router.ts
+++ b/apps/backend/src/routes/webauthn-router.ts
@@ -146,25 +146,49 @@ export const createWebAuthnRouter = ({
 
       const { credential, userHandleUuid } = verifyResult
 
-      // Step 1: bind the user-handle UUID in central DB. If this fails the
-      // username likely got taken between /options and /verify — surface 409.
+      const logRollbackFailure = (step: string, err: unknown) =>
+        console.error(
+          `Signup rollback ${step} failed; manual cleanup may be needed for username "${username}":`,
+          err,
+        )
+
+      // Step 1: bind the user-handle UUID in central DB.
+      // A unique-violation (23505) means the username got taken between
+      // /options and /verify; report that as 409. Anything else is a
+      // transient/server failure and should be 500 so the client knows
+      // retry-with-the-same-username is valid.
       try {
         await centralDb.insertWebAuthnUserHandle(username, userHandleUuid)
       } catch (err) {
+        const code = (err as { code?: string }).code
+        if (code === '23505') {
+          console.warn('WebAuthn signup: username already taken at insert time:', username)
+          // Verification succeeded — only persistence collided. `verified: true`
+          // matches the API contract (the assertion *was* valid).
+          res.status(409).json({ error: 'Username already exists', success: false, verified: true })
+          return
+        }
         console.error('Failed to insert WebAuthn user handle for signup:', err)
-        res.status(409).json({ error: 'Username already exists', success: false, verified: false })
+        res.status(500).json({ error: 'Signup failed', success: false, verified: true })
         return
       }
 
       // Step 2: create the Postgres role + per-user database. Random password
       // — only Postgres ever sees it; we discard it after the connect call.
+      // makeNewUserDb is multi-step (CREATE USER + CREATE DATABASE +
+      // initializeSchema). A failure mid-way can leave a partial role/DB
+      // that blocks future signup attempts, so always run dropUserDb in
+      // the rollback path as defense-in-depth.
       const randomPassword = randomBytes(32).toString('base64url')
       try {
         await makeNewUserDb(userDb, username, randomPassword)
       } catch (err) {
-        console.error('Failed to create user DB during signup:', err)
-        await centralDb.deleteWebAuthnUserHandle(username).catch(() => {})
-        res.status(500).json({ error: 'Signup failed', success: false, verified: false })
+        console.error('Failed to create user DB during signup; rolling back:', err)
+        await dropUserDb(userDb, username).catch((e) => logRollbackFailure('dropUserDb', e))
+        await centralDb
+          .deleteWebAuthnUserHandle(username)
+          .catch((e) => logRollbackFailure('deleteWebAuthnUserHandle', e))
+        res.status(500).json({ error: 'Signup failed', success: false, verified: true })
         return
       }
 
@@ -182,9 +206,11 @@ export const createWebAuthnRouter = ({
         })
       } catch (err) {
         console.error('Failed to persist credential during signup; rolling back:', err)
-        await dropUserDb(userDb, username).catch(() => {})
-        await centralDb.deleteWebAuthnUserHandle(username).catch(() => {})
-        res.status(500).json({ error: 'Signup failed', success: false, verified: false })
+        await dropUserDb(userDb, username).catch((e) => logRollbackFailure('dropUserDb', e))
+        await centralDb
+          .deleteWebAuthnUserHandle(username)
+          .catch((e) => logRollbackFailure('deleteWebAuthnUserHandle', e))
+        res.status(500).json({ error: 'Signup failed', success: false, verified: true })
         return
       }
 

--- a/apps/backend/src/routes/webauthn-router.ts
+++ b/apps/backend/src/routes/webauthn-router.ts
@@ -6,6 +6,7 @@
  * session (you must be logged in to manage your own passkeys).
  */
 import type { AuthenticationResponseJSON, RegistrationResponseJSON } from '@simplewebauthn/server'
+import type { Client } from 'pg'
 
 import {
   type WebAuthnAuthOptionsBody,
@@ -20,23 +21,38 @@ import {
   type WebAuthnRegistrationVerifyBody,
   webauthnRegistrationVerifyBodySchema,
   type WebAuthnRegistrationVerifyResponse,
+  type WebAuthnSignupOptionsBody,
+  webauthnSignupOptionsBodySchema,
+  type WebAuthnSignupOptionsResponse,
+  type WebAuthnSignupVerifyBody,
+  webauthnSignupVerifyBodySchema,
+  type WebAuthnSignupVerifyResponse,
   type WebAuthnUpdateCredentialBody,
   webauthnUpdateCredentialBodySchema,
 } from '@aurboda/api-spec'
+import { randomBytes, randomUUID } from 'node:crypto'
 
 import type { Auth } from '../auth.ts'
 import type { CentralDb } from '../services/central-db.ts'
+import type { InvitationAuth } from '../services/invitation.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 import type { AnyMiddleware, TypedRouter } from '../typed-router.ts'
 
+import { RESERVED_USERNAMES } from '../api/auth-routes.ts'
+import { dropUserDb, makeNewUserDb, query } from '../db/index.ts'
+import { insertWebAuthnCredential } from '../db/webauthn.ts'
 import { typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
+
+const USERNAME_REGEX = /^[a-z][a-z0-9_]{2,30}$/
 
 interface WebAuthnRouterDeps {
   authMiddleware: AnyMiddleware
   webAuthn: WebAuthnService
   auth: Auth
   centralDb: CentralDb
+  invitationAuth: InvitationAuth
+  userDb: Client
 }
 
 export const createWebAuthnRouter = ({
@@ -44,8 +60,153 @@ export const createWebAuthnRouter = ({
   webAuthn,
   auth,
   centralDb,
+  invitationAuth,
+  userDb,
 }: WebAuthnRouterDeps): TypedRouter => {
   const router = typedRouter()
+
+  router.post<Record<string, never>, WebAuthnSignupOptionsResponse, WebAuthnSignupOptionsBody>(
+    '/signup/options',
+    validateBody(webauthnSignupOptionsBodySchema),
+    async (req, res) => {
+      const { username, invitation } = req.body
+
+      const signupMode = await centralDb.getSignupMode()
+      if (signupMode === 'closed') {
+        res.status(403).json({ error: 'Signup is currently closed', success: false, options_json: '' })
+        return
+      }
+      if (signupMode === 'invite_only') {
+        if (!invitation) {
+          res
+            .status(403)
+            .json({ error: 'An invitation is required to sign up', success: false, options_json: '' })
+          return
+        }
+        const validation = invitationAuth.validateInvitationToken(invitation)
+        if (!validation.valid) {
+          const errorMsg = validation.expired ? 'Invitation has expired' : 'Invalid invitation'
+          res.status(403).json({ error: errorMsg, success: false, options_json: '' })
+          return
+        }
+      }
+
+      if (!USERNAME_REGEX.test(username)) {
+        res.status(400).json({
+          error:
+            'Username must be 3-31 characters, start with a letter, and contain only lowercase letters, numbers, and underscores',
+          options_json: '',
+          success: false,
+        })
+        return
+      }
+      if (RESERVED_USERNAMES.includes(username)) {
+        res.status(400).json({ error: 'This username is reserved', success: false, options_json: '' })
+        return
+      }
+
+      const existing = await query(userDb, 'SELECT usename FROM pg_user WHERE usename=$1', [username])
+      if ((existing.rowCount ?? 0) > 0) {
+        res.status(409).json({ error: 'Username already exists', success: false, options_json: '' })
+        return
+      }
+
+      const userHandleUuid = randomUUID()
+      const options = await webAuthn.getSignupOptions(username, userHandleUuid)
+      res.json({ options_json: JSON.stringify(options), success: true })
+    },
+  )
+
+  router.post<Record<string, never>, WebAuthnSignupVerifyResponse, WebAuthnSignupVerifyBody>(
+    '/signup/verify',
+    validateBody(webauthnSignupVerifyBodySchema),
+    async (req, res) => {
+      const { username, nickname } = req.body
+
+      let response: RegistrationResponseJSON
+      try {
+        response = JSON.parse(req.body.response_json) as RegistrationResponseJSON
+      } catch {
+        res.status(400).json({ error: 'Invalid response_json', success: false, verified: false })
+        return
+      }
+
+      let verifyResult: Awaited<ReturnType<WebAuthnService['verifySignup']>>
+      try {
+        verifyResult = await webAuthn.verifySignup(username, response)
+      } catch (err) {
+        console.error('WebAuthn signup verification failed:', err)
+        res.status(400).json({ error: 'Verification failed', success: false, verified: false })
+        return
+      }
+      if (!verifyResult.verified || !verifyResult.credential || !verifyResult.userHandleUuid) {
+        res.status(400).json({ error: 'Verification failed', success: false, verified: false })
+        return
+      }
+
+      const { credential, userHandleUuid } = verifyResult
+
+      // Step 1: bind the user-handle UUID in central DB. If this fails the
+      // username likely got taken between /options and /verify — surface 409.
+      try {
+        await centralDb.insertWebAuthnUserHandle(username, userHandleUuid)
+      } catch (err) {
+        console.error('Failed to insert WebAuthn user handle for signup:', err)
+        res.status(409).json({ error: 'Username already exists', success: false, verified: false })
+        return
+      }
+
+      // Step 2: create the Postgres role + per-user database. Random password
+      // — only Postgres ever sees it; we discard it after the connect call.
+      const randomPassword = randomBytes(32).toString('base64url')
+      try {
+        await makeNewUserDb(userDb, username, randomPassword)
+      } catch (err) {
+        console.error('Failed to create user DB during signup:', err)
+        await centralDb.deleteWebAuthnUserHandle(username).catch(() => {})
+        res.status(500).json({ error: 'Signup failed', success: false, verified: false })
+        return
+      }
+
+      // Step 3: persist the credential in the user's DB. If this fails we
+      // would orphan an account that has no way to log in — roll back.
+      try {
+        await insertWebAuthnCredential(username, {
+          backedUp: credential.backedUp,
+          counter: credential.counter,
+          credentialId: credential.credentialId,
+          deviceType: credential.deviceType,
+          nickname: nickname ?? null,
+          publicKey: credential.publicKey,
+          transports: credential.transports,
+        })
+      } catch (err) {
+        console.error('Failed to persist credential during signup; rolling back:', err)
+        await dropUserDb(userDb, username).catch(() => {})
+        await centralDb.deleteWebAuthnUserHandle(username).catch(() => {})
+        res.status(500).json({ error: 'Signup failed', success: false, verified: false })
+        return
+      }
+
+      // Step 4: first-user-becomes-admin (mirrors auth-routes.ts /signup).
+      const adminCount = await centralDb.getAdminCount()
+      let isAdmin = false
+      if (adminCount === 0) {
+        await centralDb.addAdmin(username)
+        isAdmin = true
+        console.info(`First user ${username} automatically made admin`)
+      }
+
+      const token = auth.createToken(username)
+      res.json({
+        is_admin: isAdmin,
+        success: true,
+        token,
+        username,
+        verified: true,
+      })
+    },
+  )
 
   router.post<Record<string, never>, WebAuthnRegistrationOptionsResponse>(
     '/register/options',

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -128,6 +128,17 @@ export interface CentralDb {
    * server receives back on a discoverable-credential assertion.
    */
   getOrCreateWebAuthnUserHandle: (username: string) => Promise<string>
+  /**
+   * Insert a user-handle mapping with a *given* UUID. Used by passkey-only
+   * signup so the same handle is bound through the entire ceremony.
+   * Throws on conflict (i.e. username already mapped).
+   */
+  insertWebAuthnUserHandle: (username: string, userHandle: string) => Promise<void>
+  /**
+   * Remove a user-handle mapping. Used by signup rollback when something
+   * fails after the row is inserted.
+   */
+  deleteWebAuthnUserHandle: (username: string) => Promise<void>
   getUsernameByWebAuthnUserHandle: (userHandle: string) => Promise<string | null>
 }
 
@@ -645,6 +656,19 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
         [username],
       )
       return inserted.rows[0].user_handle
+    },
+
+    insertWebAuthnUserHandle: async (username: string, userHandle: string): Promise<void> => {
+      const client = await getClient()
+      await client.query(`INSERT INTO webauthn_user_handles (user_handle, username) VALUES ($1, $2)`, [
+        userHandle,
+        username,
+      ])
+    },
+
+    deleteWebAuthnUserHandle: async (username: string): Promise<void> => {
+      const client = await getClient()
+      await client.query('DELETE FROM webauthn_user_handles WHERE username = $1', [username])
     },
 
     getUsernameByWebAuthnUserHandle: async (userHandle: string): Promise<string | null> => {

--- a/apps/backend/src/services/webauthn.test.ts
+++ b/apps/backend/src/services/webauthn.test.ts
@@ -238,6 +238,89 @@ describe('authentication', () => {
   })
 })
 
+describe('signup', () => {
+  test('options stores pending signup keyed by username and uses given handle', async () => {
+    const handleStore = makeUserHandleStore()
+    const service = createWebAuthnService(config, handleStore)
+    vi.mocked(simplewebauthn.generateRegistrationOptions).mockResolvedValue({
+      challenge: 'signup-c-1',
+    } as never)
+
+    const opts = await service.getSignupOptions('charlie', '12345678-1234-1234-1234-123456789abc')
+    expect(opts.challenge).toBe('signup-c-1')
+    const call = vi.mocked(simplewebauthn.generateRegistrationOptions).mock.calls[0]![0]
+    expect(call.userName).toBe('charlie')
+    expect((call.userID as Uint8Array).length).toBe(16)
+    // The handle store is NOT touched at this stage — central insertion
+    // happens only after verify succeeds.
+    expect(handleStore.getOrCreateWebAuthnUserHandle).not.toHaveBeenCalled()
+  })
+
+  test('verify returns credential + handle on success, does not persist', async () => {
+    const service = createWebAuthnService(config, makeUserHandleStore())
+    vi.mocked(simplewebauthn.generateRegistrationOptions).mockResolvedValue({
+      challenge: 'signup-c-2',
+    } as never)
+    await service.getSignupOptions('charlie', '12345678-1234-1234-1234-123456789abc')
+
+    vi.mocked(simplewebauthn.verifyRegistrationResponse).mockResolvedValue({
+      registrationInfo: {
+        credential: {
+          counter: 0,
+          id: 'new-cred',
+          publicKey: new Uint8Array([7, 8, 9]),
+          transports: ['internal', 'hybrid'],
+        },
+        credentialBackedUp: false,
+        credentialDeviceType: 'singleDevice',
+      },
+      verified: true,
+    } as never)
+
+    const result = await service.verifySignup('charlie', { id: 'new-cred' } as never)
+    expect(result.verified).toBe(true)
+    expect(result.userHandleUuid).toBe('12345678-1234-1234-1234-123456789abc')
+    expect(result.credential).toMatchObject({
+      backedUp: false,
+      counter: 0,
+      credentialId: 'new-cred',
+      deviceType: 'singleDevice',
+      transports: ['internal', 'hybrid'],
+    })
+    // The service must not write through to the credential DB on signup —
+    // the route does that after creating the Postgres user.
+    expect(webauthnDb.insertWebAuthnCredential).not.toHaveBeenCalled()
+  })
+
+  test('verify rejects if no pending signup', async () => {
+    const service = createWebAuthnService(config, makeUserHandleStore())
+    const result = await service.verifySignup('nobody', {} as never)
+    expect(result).toEqual({ verified: false })
+  })
+
+  test('verify consumes the pending signup (cannot replay)', async () => {
+    const service = createWebAuthnService(config, makeUserHandleStore())
+    vi.mocked(simplewebauthn.generateRegistrationOptions).mockResolvedValue({
+      challenge: 'replay-c',
+    } as never)
+    await service.getSignupOptions('charlie', '12345678-1234-1234-1234-123456789abc')
+
+    vi.mocked(simplewebauthn.verifyRegistrationResponse).mockResolvedValue({
+      registrationInfo: {
+        credential: { counter: 0, id: 'x', publicKey: new Uint8Array(), transports: [] },
+        credentialBackedUp: false,
+        credentialDeviceType: 'singleDevice',
+      },
+      verified: true,
+    } as never)
+
+    const first = await service.verifySignup('charlie', {} as never)
+    expect(first.verified).toBe(true)
+    const second = await service.verifySignup('charlie', {} as never)
+    expect(second.verified).toBe(false)
+  })
+})
+
 describe('credential management', () => {
   test('listCredentials maps rows', async () => {
     const service = createWebAuthnService(config, makeUserHandleStore())

--- a/apps/backend/src/services/webauthn.ts
+++ b/apps/backend/src/services/webauthn.ts
@@ -43,6 +43,27 @@ interface AuthenticationChallenge {
   expiresAt: number
 }
 
+interface PendingSignup {
+  username: string
+  userHandleUuid: string
+  challenge: string
+  expiresAt: number
+}
+
+/**
+ * Subset of `VerifiedRegistrationResponse.registrationInfo` that the route
+ * needs to persist after a successful signup. Re-typed here so the route
+ * doesn't need to depend on `@simplewebauthn/server` types.
+ */
+export interface VerifiedSignupCredential {
+  credentialId: string
+  publicKey: Buffer
+  counter: number | bigint
+  transports: string[]
+  deviceType: string
+  backedUp: boolean
+}
+
 const uuidStringToBytes = (uuid: string): Uint8Array<ArrayBuffer> => {
   const hex = uuid.replaceAll('-', '')
   const buf = new ArrayBuffer(16)
@@ -96,6 +117,25 @@ export interface WebAuthnService {
     response: RegistrationResponseJSON,
     nickname?: string,
   ) => Promise<{ verified: boolean; credentialId?: string }>
+  /**
+   * Generate registration options for a *new* user. The user is not created
+   * yet; the route inserts the Postgres role only after `verifySignup`
+   * succeeds. The given `userHandleUuid` is what becomes the WebAuthn
+   * userID (and later the userHandle on assertion).
+   */
+  getSignupOptions: (
+    username: string,
+    userHandleUuid: string,
+  ) => Promise<PublicKeyCredentialCreationOptionsJSON>
+  /**
+   * Verify the registration response for a pending signup. Returns the
+   * unwrapped credential data so the route can create the user + persist
+   * the credential. Does *not* persist anything by itself.
+   */
+  verifySignup: (
+    username: string,
+    response: RegistrationResponseJSON,
+  ) => Promise<{ verified: boolean; credential?: VerifiedSignupCredential; userHandleUuid?: string }>
   getAuthenticationOptions: () => Promise<PublicKeyCredentialRequestOptionsJSON>
   verifyAuthentication: (
     response: AuthenticationResponseJSON,
@@ -114,6 +154,7 @@ export const createWebAuthnService = (
   // discoverable credentials we don't yet know the user.
   const pendingRegistrations = new Map<string, RegistrationChallenge>()
   const pendingAuthentications = new Map<string, AuthenticationChallenge>()
+  const pendingSignups = new Map<string, PendingSignup>()
 
   const sweep = () => {
     const now = Date.now()
@@ -122,6 +163,9 @@ export const createWebAuthnService = (
     }
     for (const [k, v] of pendingAuthentications) {
       if (v.expiresAt < now) pendingAuthentications.delete(k)
+    }
+    for (const [k, v] of pendingSignups) {
+      if (v.expiresAt < now) pendingSignups.delete(k)
     }
   }
 
@@ -206,6 +250,63 @@ export const createWebAuthnService = (
       })
 
       return { verified: true, credentialId: info.credential.id }
+    },
+
+    getSignupOptions: async (username, userHandleUuid) => {
+      sweep()
+      const options = await generateRegistrationOptions({
+        attestationType: 'none',
+        authenticatorSelection: {
+          residentKey: 'preferred',
+          userVerification: 'preferred',
+        },
+        rpID: config.rpID,
+        rpName: config.rpName,
+        userID: uuidStringToBytes(userHandleUuid),
+        userName: username,
+      })
+
+      pendingSignups.set(username, {
+        challenge: options.challenge,
+        expiresAt: Date.now() + CHALLENGE_TTL_MS,
+        userHandleUuid,
+        username,
+      })
+      enforceCap(pendingSignups)
+
+      return options
+    },
+
+    verifySignup: async (username, response) => {
+      sweep()
+      const pending = pendingSignups.get(username)
+      if (!pending) return { verified: false }
+      pendingSignups.delete(username)
+
+      const verification = await verifyRegistrationResponse({
+        expectedChallenge: pending.challenge,
+        expectedOrigin: config.expectedOrigins,
+        expectedRPID: config.rpID,
+        response,
+      })
+
+      if (!verification.verified || !verification.registrationInfo) {
+        return { verified: false }
+      }
+
+      const info = verification.registrationInfo
+      return {
+        credential: {
+          backedUp: info.credentialBackedUp,
+          counter: info.credential.counter,
+          credentialId: info.credential.id,
+          deviceType: info.credentialDeviceType,
+          publicKey: Buffer.from(info.credential.publicKey),
+          transports: info.credential.transports ?? [],
+        },
+        userHandleUuid: pending.userHandleUuid,
+        verified: true,
+      }
     },
 
     getAuthenticationOptions: async () => {

--- a/apps/web/src/pages/Signup/index.tsx
+++ b/apps/web/src/pages/Signup/index.tsx
@@ -1,15 +1,17 @@
 import { useLocation } from 'preact-iso'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 
-import { auth, ensureStatusLoaded, signup, signupMode } from '../../state/auth'
+import { auth, ensureStatusLoaded, signup, signupMode, signupWithPasskey } from '../../state/auth'
 import './style.css'
 
 export function Signup() {
   const { route, query } = useLocation()
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [passkeyLoading, setPasskeyLoading] = useState(false)
+  const [usePassword, setUsePassword] = useState(false)
+  const [username, setUsername] = useState('')
 
-  // Get invitation token from URL query param
   const invitation = useMemo(() => {
     const params = new URLSearchParams(query)
     return params.get('invite') ?? undefined
@@ -24,7 +26,6 @@ export function Signup() {
     return null
   }
 
-  // Show different messages based on signup mode
   if (signupMode.value === 'closed') {
     return (
       <div class="signup-page">
@@ -51,7 +52,23 @@ export function Signup() {
     )
   }
 
-  const onSubmit = async (e: Event) => {
+  const onPasskeySignup = async () => {
+    setError(null)
+    if (!username) {
+      setError('Please enter a username')
+      return
+    }
+    setPasskeyLoading(true)
+    const result = await signupWithPasskey(username, invitation)
+    setPasskeyLoading(false)
+    if (result.success) {
+      route('/')
+    } else {
+      setError(result.error ?? 'Signup failed')
+    }
+  }
+
+  const onPasswordSubmit = async (e: Event) => {
     e.preventDefault()
     setError(null)
     setLoading(true)
@@ -67,8 +84,7 @@ export function Signup() {
         return
       }
 
-      const result = await signup(formData.get('user') as string, password, invitation)
-
+      const result = await signup(username, password, invitation)
       if (result.success) {
         route('/')
       } else {
@@ -84,38 +100,81 @@ export function Signup() {
 
       {invitation && <p class="invitation-notice">You have been invited to create an account.</p>}
 
-      <form onSubmit={onSubmit} class="signup-form">
-        <div class="form-field">
-          <label for="user">Username</label>
-          <input
-            id="user"
-            name="user"
-            type="text"
-            required
-            autoComplete="username"
-            pattern="^[a-z][a-z0-9_]{2,30}$"
-          />
-          <p class="field-hint">
-            3-31 characters, start with a letter, lowercase letters, numbers, and underscores only
+      <div class="form-field">
+        <label for="user">Username</label>
+        <input
+          id="user"
+          name="user"
+          type="text"
+          required
+          autoComplete="username webauthn"
+          pattern="^[a-z][a-z0-9_]{2,30}$"
+          value={username}
+          onInput={(e) => setUsername((e.target as HTMLInputElement).value)}
+        />
+        <p class="field-hint">
+          3-31 characters, start with a letter, lowercase letters, numbers, and underscores only
+        </p>
+      </div>
+
+      {!usePassword ? (
+        <>
+          <button
+            type="button"
+            class="primary"
+            disabled={passkeyLoading || !username}
+            onClick={onPasskeySignup}
+          >
+            {passkeyLoading ? 'Waiting for passkey…' : 'Sign up with passkey'}
+          </button>
+
+          {error && <p class="error">{error}</p>}
+
+          <p class="alt-mode-link">
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                setUsePassword(true)
+                setError(null)
+              }}
+            >
+              Use a password instead
+            </a>
           </p>
-        </div>
+        </>
+      ) : (
+        <form onSubmit={onPasswordSubmit} class="signup-form">
+          <div class="form-field">
+            <label for="pass">Password</label>
+            <input id="pass" name="pass" type="password" required autoComplete="new-password" />
+          </div>
 
-        <div class="form-field">
-          <label for="pass">Password</label>
-          <input id="pass" name="pass" type="password" required autoComplete="new-password" />
-        </div>
+          <div class="form-field">
+            <label for="confirmPass">Confirm Password</label>
+            <input id="confirmPass" name="confirmPass" type="password" required autoComplete="new-password" />
+          </div>
 
-        <div class="form-field">
-          <label for="confirmPass">Confirm Password</label>
-          <input id="confirmPass" name="confirmPass" type="password" required autoComplete="new-password" />
-        </div>
+          {error && <p class="error">{error}</p>}
 
-        {error && <p class="error">{error}</p>}
+          <button type="submit" class="primary" disabled={loading || !username}>
+            {loading ? 'Creating account...' : 'Sign Up'}
+          </button>
 
-        <button type="submit" class="primary" disabled={loading}>
-          {loading ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
+          <p class="alt-mode-link">
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault()
+                setUsePassword(false)
+                setError(null)
+              }}
+            >
+              Sign up with a passkey instead
+            </a>
+          </p>
+        </form>
+      )}
 
       <p class="login-link">
         Already have an account? <a href="/login">Login</a>

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -89,6 +89,31 @@ export const signup = async (
 
 export const logout = () => (auth.value = {})
 
+/**
+ * Map browser WebAuthn errors to user-friendly strings. The raw DOMException
+ * messages ("The operation either timed out or was not allowed.") confuse
+ * users — the underlying causes are usually cancellation or no matching
+ * credential.
+ */
+const friendlyWebAuthnError = (error: unknown, fallback: string): string => {
+  const e = error as { name?: string; message?: string } | undefined
+  if (!e) return fallback
+  switch (e.name) {
+    case 'NotAllowedError':
+      return 'Passkey prompt was cancelled or timed out.'
+    case 'InvalidStateError':
+      return 'A passkey for this account is already registered on this device.'
+    case 'NotSupportedError':
+      return 'This browser or device does not support passkeys.'
+    case 'SecurityError':
+      return 'Passkeys are not available on this origin (server may be misconfigured).'
+    case 'AbortError':
+      return 'Passkey prompt was cancelled.'
+    default:
+      return e.message ?? fallback
+  }
+}
+
 export const signupWithPasskey = async (
   user: string,
   invitation?: string,
@@ -127,7 +152,8 @@ export const signupWithPasskey = async (
     return { error: verifyResp.data.error ?? 'Signup failed', success: false }
   } catch (error) {
     const axiosError = error as AxiosError<{ error?: string }>
-    const message = axiosError.response?.data?.error ?? (error as Error).message ?? 'Passkey signup failed'
+    const apiError = axiosError.response?.data?.error
+    const message = apiError ?? friendlyWebAuthnError(error, 'Passkey signup failed')
     console.error('Passkey signup error:', error)
     return { error: message, success: false }
   }
@@ -166,7 +192,8 @@ export const loginWithPasskey = async (): Promise<{ success: boolean; error?: st
     return { error: verifyResp.data.error ?? 'Verification failed', success: false }
   } catch (error) {
     const axiosError = error as AxiosError<{ error?: string }>
-    const message = axiosError.response?.data?.error ?? (error as Error).message ?? 'Passkey login failed'
+    const apiError = axiosError.response?.data?.error
+    const message = apiError ?? friendlyWebAuthnError(error, 'Passkey login failed')
     console.error('Passkey login error:', error)
     return { error: message, success: false }
   }

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -89,6 +89,50 @@ export const signup = async (
 
 export const logout = () => (auth.value = {})
 
+export const signupWithPasskey = async (
+  user: string,
+  invitation?: string,
+): Promise<{ success: boolean; error?: string }> => {
+  try {
+    const { startRegistration } = await import('@simplewebauthn/browser')
+
+    const optionsResp = await axios.post<{ options_json: string; success: boolean; error?: string }>(
+      `${API_URL}/webauthn/signup/options`,
+      { invitation, username: user },
+    )
+    const optionsJSON = JSON.parse(optionsResp.data.options_json) as Parameters<
+      typeof startRegistration
+    >[0]['optionsJSON']
+    const attestation = await startRegistration({ optionsJSON })
+
+    const verifyResp = await axios.post<{
+      token?: string
+      is_admin?: boolean
+      username?: string
+      verified: boolean
+      error?: string
+    }>(`${API_URL}/webauthn/signup/verify`, {
+      response_json: JSON.stringify(attestation),
+      username: user,
+    })
+
+    if (verifyResp.data.verified && verifyResp.data.token && verifyResp.data.username) {
+      auth.value = {
+        is_admin: verifyResp.data.is_admin,
+        token: verifyResp.data.token,
+        user: verifyResp.data.username,
+      }
+      return { success: true }
+    }
+    return { error: verifyResp.data.error ?? 'Signup failed', success: false }
+  } catch (error) {
+    const axiosError = error as AxiosError<{ error?: string }>
+    const message = axiosError.response?.data?.error ?? (error as Error).message ?? 'Passkey signup failed'
+    console.error('Passkey signup error:', error)
+    return { error: message, success: false }
+  }
+}
+
 export const loginWithPasskey = async (): Promise<{ success: boolean; error?: string }> => {
   try {
     // Lazy-import to keep the WebAuthn dep out of the bundle for users who never use passkeys.

--- a/docs/passkeys.md
+++ b/docs/passkeys.md
@@ -15,18 +15,36 @@ never leave that device — the server only stores the public key.
 - **Cross-platform**: A passkey registered from the web on the same
   domain is also offered to the Android app via Digital Asset Links.
 
-## How users register a passkey
+## How users sign up
 
-1. Sign in with username + password (passkey-only signup is not yet
-   supported — password remains the recovery factor).
-2. Go to **Settings → Passkeys**, optionally type a nickname (e.g. "Work
-   laptop"), and click **Add a passkey**.
-3. Confirm the prompt from your authenticator (Touch ID, Windows Hello,
-   1Password, security key, etc.). The passkey is stored against the
-   server's domain (its **Relying Party ID**).
+There are two paths:
+
+### Passkey-only signup (recommended)
+
+From the **Sign Up** page, enter a username and click **Sign up with
+passkey**. The authenticator (Touch ID, Windows Hello, 1Password, etc.)
+prompts you to create a credential, and on success you're logged in.
+No password is involved at any point.
+
+Behind the scenes, the backend creates the Postgres role with a random
+internal password the user never sees. Login is always passkey-only for
+these users.
+
+### Password signup (fallback)
+
+If a user prefers a password, the **Use a password instead** link on
+the signup page reveals the existing password+confirm fields. They can
+later add a passkey from **Settings → Passkeys**.
+
+## Adding more passkeys to an existing account
+
+Sign in, go to **Settings → Passkeys**, optionally type a nickname (e.g.
+"Work laptop"), and click **Add a passkey**. The passkey is stored
+against the server's domain (its **Relying Party ID**).
 
 A user can register multiple passkeys (e.g. one in 1Password and one
-device-bound on Android).
+device-bound on Android), and we recommend doing so for resilience —
+see Recovery below.
 
 ## How users sign in
 
@@ -52,7 +70,7 @@ WEBAUTHN_ORIGINS=https://aurboda.example.com
 ```
 
 Both default to values derived from `WEB_HOST`, so in many cases you
-don't need to set them explicitly. The Relying Party ID *must* match the
+don't need to set them explicitly. The Relying Party ID _must_ match the
 hostname the user's browser sees — if your API and web frontend live on
 different subdomains, set `WEBAUTHN_RP_ID` to the web one.
 
@@ -118,9 +136,21 @@ this.
 
 A passkey is bound to the device or password manager that holds it.
 Losing access (broken phone, deleted credential) means losing that
-passkey — but **password login is always available** as a fallback. If
-you lose all passkeys, sign in with the password and register a new
-one.
+passkey.
+
+- **If you signed up with a password**, password login is always
+  available as a fallback. Sign in with the password, register a new
+  passkey, optionally delete the old one.
+- **If you signed up passkey-only**, there's no password to fall back
+  to. If you lose every registered passkey, the account is
+  unrecoverable without admin intervention. **Register at least two
+  passkeys** (e.g. one in your password manager that syncs across
+  devices, and one device-bound on Android) to mitigate this.
+
+Self-hosters: there's no built-in admin tool to reset a user's
+passkeys yet — if it happens, the practical workaround is dropping
+the user's Postgres role + database and inviting them to re-sign-up
+(loses their data).
 
 ## Privacy & security notes
 

--- a/packages/api-spec/src/openapi.ts
+++ b/packages/api-spec/src/openapi.ts
@@ -56,6 +56,10 @@ import {
   webauthnRegistrationOptionsResponseSchema,
   webauthnRegistrationVerifyBodySchema,
   webauthnRegistrationVerifyResponseSchema,
+  webauthnSignupOptionsBodySchema,
+  webauthnSignupOptionsResponseSchema,
+  webauthnSignupVerifyBodySchema,
+  webauthnSignupVerifyResponseSchema,
   webauthnUpdateCredentialBodySchema,
 } from './schemas/webauthn.ts'
 
@@ -787,6 +791,52 @@ const openApiDocument = createDocument({
         },
         security: [{ bearerAuth: [] }],
         summary: 'Rename passkey',
+        tags: ['Auth'],
+      },
+    },
+    '/webauthn/signup/options': {
+      post: {
+        description:
+          'Begin a passkey-only signup. Validates the desired username and signup mode (and invitation if required), then returns WebAuthn registration options. The user is not yet created.',
+        requestBody: {
+          content: { 'application/json': { schema: webauthnSignupOptionsBodySchema } },
+        },
+        responses: {
+          200: {
+            content: { 'application/json': { schema: webauthnSignupOptionsResponseSchema } },
+            description: 'Successful response',
+          },
+          400: {
+            content: { 'application/json': { schema: errorResponseSchema } },
+            description: 'Bad request (invalid username, taken username, etc.)',
+          },
+          403: {
+            content: { 'application/json': { schema: errorResponseSchema } },
+            description: 'Signup closed or invitation invalid',
+          },
+        },
+        summary: 'Begin passkey-only signup',
+        tags: ['Auth'],
+      },
+    },
+    '/webauthn/signup/verify': {
+      post: {
+        description:
+          'Complete a passkey-only signup. On success the Postgres user is created with an internally-generated random password, the credential is bound, and an auth token is returned.',
+        requestBody: {
+          content: { 'application/json': { schema: webauthnSignupVerifyBodySchema } },
+        },
+        responses: {
+          200: {
+            content: { 'application/json': { schema: webauthnSignupVerifyResponseSchema } },
+            description: 'Successful signup',
+          },
+          400: {
+            content: { 'application/json': { schema: errorResponseSchema } },
+            description: 'Verification failed',
+          },
+        },
+        summary: 'Complete passkey-only signup',
         tags: ['Auth'],
       },
     },

--- a/packages/api-spec/src/schemas/webauthn.ts
+++ b/packages/api-spec/src/schemas/webauthn.ts
@@ -49,6 +49,62 @@ export const webauthnRegistrationVerifyResponseSchema = baseResponseSchema
 export type WebAuthnRegistrationVerifyResponse = z.infer<typeof webauthnRegistrationVerifyResponseSchema>
 
 // ============================================================================
+// Signup ceremony (unauthenticated — creates the user + first passkey)
+// ============================================================================
+
+/**
+ * Body for `POST /webauthn/signup/options`. The username is checked here
+ * (format, reserved list, not-already-taken) so the user gets early
+ * feedback before the authenticator prompt.
+ */
+export const webauthnSignupOptionsBodySchema = z
+  .object({
+    invitation: z
+      .string()
+      .optional()
+      .meta({ description: 'Invitation token (required in invite_only mode)' }),
+    username: z.string().min(1).meta({ description: 'Desired username' }),
+  })
+  .meta({ id: 'WebAuthnSignupOptionsBody' })
+
+export type WebAuthnSignupOptionsBody = z.infer<typeof webauthnSignupOptionsBodySchema>
+
+export const webauthnSignupOptionsResponseSchema = baseResponseSchema
+  .extend({
+    options_json: z.string().meta({ description: 'JSON-stringified PublicKeyCredentialCreationOptionsJSON' }),
+  })
+  .meta({ id: 'WebAuthnSignupOptionsResponse' })
+
+export type WebAuthnSignupOptionsResponse = z.infer<typeof webauthnSignupOptionsResponseSchema>
+
+export const webauthnSignupVerifyBodySchema = z
+  .object({
+    nickname: z
+      .string()
+      .max(64)
+      .optional()
+      .meta({ description: 'Optional user-chosen label for the new credential' }),
+    response_json: z.string().meta({
+      description: 'JSON-stringified RegistrationResponseJSON returned by the authenticator',
+    }),
+    username: z.string().min(1).meta({ description: 'Username chosen at /signup/options' }),
+  })
+  .meta({ id: 'WebAuthnSignupVerifyBody' })
+
+export type WebAuthnSignupVerifyBody = z.infer<typeof webauthnSignupVerifyBodySchema>
+
+export const webauthnSignupVerifyResponseSchema = baseResponseSchema
+  .extend({
+    is_admin: z.boolean().optional().meta({ description: 'Whether the new user is an admin' }),
+    token: z.string().optional().meta({ description: 'Authentication token' }),
+    username: z.string().optional().meta({ description: 'Created username' }),
+    verified: z.boolean().meta({ description: 'Whether registration was verified' }),
+  })
+  .meta({ id: 'WebAuthnSignupVerifyResponse' })
+
+export type WebAuthnSignupVerifyResponse = z.infer<typeof webauthnSignupVerifyResponseSchema>
+
+// ============================================================================
 // Authentication ceremony (unauthenticated — login)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Adds a new `POST /webauthn/signup/options` + `/signup/verify` flow that lets users create an account with only a passkey — no password ever provided by the user, displayed, or stored
- The backend generates a random Postgres role password internally and discards it; Postgres still authenticates with a password under the hood, but it never crosses the API boundary
- Existing password signup remains available behind a "Use a password instead" link on the signup page

## What's in here

**Backend** — two new endpoints (no auth required, mirroring the password `/signup`). The verify path orchestrates a deliberate sequence: insert the central-DB user-handle row first (where uniqueness conflicts surface as 409), create the Postgres role + per-user database via the existing `makeNewUserDb`, then persist the credential. If credential persistence fails we roll back via a new `dropUserDb` helper so we can never leave an account with zero credentials. First-user-becomes-admin logic is mirrored from the password signup.

**Service** — separate `pendingSignups` map (keyed by username, same TTL + size cap as the existing `pendingRegistrations`). New `getSignupOptions` and `verifySignup` methods. The service intentionally does *not* persist anything on signup — the route owns the cross-DB ordering.

**api-spec** — `WebAuthnSignup*` schemas + OpenAPI paths.

**Web** — passkey-first signup UI. Username input + "Sign up with passkey" button by default; "Use a password instead" link reveals the existing password form. Lazy-imports `@simplewebauthn/browser`.

**Tests** — 4 new service tests, 9 new router tests (incl. an explicit rollback test that asserts `dropUserDb` and `deleteWebAuthnUserHandle` are both called when credential persistence fails).

**Docs** — `docs/passkeys.md` updated with a "How users sign up" section covering both modes, plus a Recovery subsection that explicitly calls out that passkey-only accounts with no remaining passkeys are unrecoverable without admin intervention. Recommends registering ≥ 2 passkeys.

## Notes for review

- Android signup remains out of scope (no signup screen exists today). Login + passkey login on Android continue to work for existing accounts.
- Recovery is a known limitation (called out in docs). An admin "reset user" tool is a useful follow-up but separate from this PR.
- The plan lives at `.claude/plans/passkey-only-signup.md` (gitignored) if you want to reference it.

## Test plan

- [x] `pnpm check` clean
- [x] Service + router tests pass (39 total in `webauthn.test.ts` + `webauthn-router.test.ts`)
- [x] Android `compileDebugKotlin` + `testDebugUnitTest` pass (no Android changes, but verified)
- [ ] Manual on a fresh DB: open signup page → username → "Sign up with passkey" → 1Password → token issued → main page renders
- [ ] Verify in central DB: `webauthn_user_handles` has the new row; `pg_user` has the new role; `webauthn_credentials` (in user DB) has the credential
- [ ] Sign out, "Sign in with passkey" — works
- [ ] Try the same username again → 409
- [ ] `signup_mode = invite_only`: without invite → 403, with invite → success
- [ ] `signup_mode = closed`: → 403
- [ ] Force credential-insert failure mid-flow and verify the user role + DB are dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)