### PR TITLE
fix(web): share timeline detail-URL helper so meal links work in vertical view

### DIFF
--- a/apps/web/src/pages/Timeline/drawItems.test.ts
+++ b/apps/web/src/pages/Timeline/drawItems.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChartItem } from './types'
+
+import { getDetailUrl } from './drawItems'
+
+const baseItem: ChartItem = {
+  color: '#000',
+  column: 'Activity',
+  end: new Date(0),
+  isPoint: false,
+  label: 'x',
+  start: new Date(0),
+  tooltip: { details: [], time: '', title: '' },
+}
+
+describe('getDetailUrl', () => {
+  it('prefers explicit href over entity-based URL', () => {
+    const item: ChartItem = { ...baseItem, entity_id: 'm1', entity_type: 'meal', href: '/meals/m1' }
+    expect(getDetailUrl(item)).toBe('/meals/m1')
+  })
+
+  it('falls back to /detail/{type}/{id} when no href is set', () => {
+    const item: ChartItem = { ...baseItem, entity_id: 'a1', entity_type: 'activity' }
+    expect(getDetailUrl(item)).toBe('/detail/activity/a1')
+  })
+
+  it('encodes the entity id', () => {
+    const item: ChartItem = { ...baseItem, entity_id: 'a/1 b', entity_type: 'activity' }
+    expect(getDetailUrl(item)).toBe('/detail/activity/a%2F1%20b')
+  })
+
+  it('returns undefined when no href and no entity info is available', () => {
+    expect(getDetailUrl(baseItem)).toBeUndefined()
+  })
+
+  it('returns undefined when entity_type is missing', () => {
+    const item: ChartItem = { ...baseItem, entity_id: 'x' }
+    expect(getDetailUrl(item)).toBeUndefined()
+  })
+})

--- a/apps/web/src/pages/Timeline/drawItems.ts
+++ b/apps/web/src/pages/Timeline/drawItems.ts
@@ -8,6 +8,17 @@ import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 type SvgParent = d3.Selection<any, unknown, null, undefined>
 
 /**
+ * Resolve the detail URL for a chart item. An explicit `href` wins over the
+ * generic `/detail/{type}/{id}` route — some entity types (e.g. meals) live
+ * outside the EntityDetail page and set `href` to their own route.
+ */
+export const getDetailUrl = (item: ChartItem): string | undefined =>
+  item.href ??
+  (item.entity_id && item.entity_type
+    ? `/detail/${item.entity_type}/${encodeURIComponent(item.entity_id)}`
+    : undefined)
+
+/**
  * Render an emoji or image icon centered at (cx, cy).
  * Returns the created SVG element selection, or null if no icon was available.
  */

--- a/apps/web/src/pages/Timeline/drawVerticalHelpers.ts
+++ b/apps/web/src/pages/Timeline/drawVerticalHelpers.ts
@@ -5,7 +5,7 @@ import { formatISO } from 'date-fns'
 import type { ChartItem, Column } from './types'
 
 import { NOW_COLOR } from './colors'
-import { attachHoverHandlers, drawItemIcon, truncateLabel } from './drawItems'
+import { attachHoverHandlers, drawItemIcon, getDetailUrl, truncateLabel } from './drawItems'
 import { formatTime } from './formatting'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -245,10 +245,7 @@ export const drawItem = (
   const x = colX + lane * (laneWidth + colPadding) + xOffset
   const blockHeight = Math.max(y2 - y1, 2)
 
-  const detailUrl =
-    item.entity_id && item.entity_type
-      ? `/detail/${item.entity_type}/${encodeURIComponent(item.entity_id)}`
-      : (item.href ?? undefined)
+  const detailUrl = getDetailUrl(item)
 
   const parent: SvgParent = detailUrl
     ? chartGroup.append('a').attr('href', detailUrl).attr('data-clickable', 'true')

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -10,7 +10,7 @@ import { aggregateBucketsAligned } from '../../utils/chart'
 import { packLanes } from '../../utils/lanePacking'
 import { computeBarLayout, type BarSlot } from './barLayout'
 import { drawActivitySparklines } from './drawActivitySparklines'
-import { attachHoverHandlers, drawItemIcon, truncateLabel } from './drawItems'
+import { attachHoverHandlers, drawItemIcon, getDetailUrl, truncateLabel } from './drawItems'
 import { computeYScales, drawMetricsTrack, HR_COLOR, HRV_COLOR } from './drawMetricsTrack'
 import {
   buildMusicTooltipHtml,
@@ -754,12 +754,6 @@ export const Timeline = () => {
             pixelsPerHour,
           )
         }
-
-        const getDetailUrl = (item: ChartItem): string | undefined =>
-          item.href ??
-          (item.entity_id && item.entity_type
-            ? `/detail/${item.entity_type}/${encodeURIComponent(item.entity_id)}`
-            : undefined)
 
         for (const { item, lane } of packedActivityItems.items) {
           if (!isInViewport(item)) continue


### PR DESCRIPTION
## Summary

- Meals set both `entity_id`/`entity_type` (= `meal`) and an explicit `href` of `/meals/<id>`. The vertical timeline view preferred the entity-based URL, which routes to `/detail/meal/<id>` — but `EntityDetail` only handles `activity`/`productivity`/`metric`, so meal clicks rendered "Unknown entity type". The horizontal view already preferred `href` and worked correctly.
- Extracted `getDetailUrl()` into the shared `drawItems` module and use it from both `drawVerticalHelpers.ts` and `index.tsx`. `href` wins over the entity URL since it is the explicit per-item override.
- Added a unit test covering the priority order, encoding, and the no-link fallback.

## Test plan

- [x] `pnpm --filter aurboda-web exec vitest run src/pages/Timeline/drawItems.test.ts src/pages/Timeline/drawVerticalHelpers.test.ts`
- [x] `pnpm --filter aurboda-web check` — 0 errors
- [ ] Manual: open the timeline in vertical mode, click a meal, confirm it lands on `/meals/<id>`.
- [ ] Manual: confirm the horizontal view still navigates to `/meals/<id>` (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)