### PR TITLE
fix(passkey): route assetlinks.json through nginx, fix package default

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -120,7 +120,7 @@ const main = async () => {
   const webAuthn = createWebAuthnService({ expectedOrigins, rpID, rpName }, centralDb)
   console.info(`🔐 WebAuthn rpID=${rpID} origins=${expectedOrigins.join(',')}`)
 
-  const androidPackageName = process.env.ANDROID_APP_PACKAGE ?? 'net.aurboda.app'
+  const androidPackageName = process.env.ANDROID_APP_PACKAGE ?? 'net.aurboda'
   const androidFingerprints = (process.env.ANDROID_APP_FINGERPRINTS ?? '')
     .split(',')
     .map((s) => s.trim())

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -52,7 +52,7 @@ This mounts your source code and watches for changes.
 | `WEBAUTHN_RP_ID`           | Passkey Relying Party ID (must be the public hostname the browser sees)                        | derived from `WEB_HOST`                |
 | `WEBAUTHN_RP_NAME`         | Display name shown by the user's authenticator                                                 | `Aurboda`                              |
 | `WEBAUTHN_ORIGINS`         | Comma-separated list of allowed origins for assertions                                         | `WEB_HOST`                             |
-| `ANDROID_APP_PACKAGE`      | Android app package name in `assetlinks.json`                                                  | `net.aurboda.app`                      |
+| `ANDROID_APP_PACKAGE`      | Android app package name in `assetlinks.json`                                                  | `net.aurboda`                          |
 | `ANDROID_APP_FINGERPRINTS` | Comma-separated SHA-256 cert fingerprints (colon-separated hex) for the Android APKs you trust | (empty — `assetlinks.json` returns []) |
 
 ### Generating a Session Secret

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,16 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Digital Asset Links for Android passkey sharing
+    location = /.well-known/assetlinks.json {
+        proxy_pass http://127.0.0.1:3000/.well-known/assetlinks.json;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /authorize {
         proxy_pass http://127.0.0.1:3000/authorize;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

- The Android app's `applicationId` is `net.aurboda` (`apps/android/app/build.gradle.kts:43`), but the backend default in `apps/backend/src/api.ts` was `net.aurboda.app`.
- nginx was not proxying `/.well-known/assetlinks.json` to the backend at all — only `/.well-known/oauth-authorization-server` had an explicit `location =` block. Everything else under `/.well-known/` fell through to the SPA's `try_files` fallback.

The combined effect: `https://aurboda.net/.well-known/assetlinks.json` returned the SPA HTML (404 page), so 1Password / Android Credential Manager could not verify the app via Digital Asset Links and rejected passkey use with "The associated URL for this passkey does not match the selected app".

## Changes

- `nginx.conf`: add `location = /.well-known/assetlinks.json` proxying to the backend on `127.0.0.1:3000`.
- `apps/backend/src/api.ts`: default `ANDROID_APP_PACKAGE` to `net.aurboda` (was `net.aurboda.app`).
- `docs/docker.md`: update documented default to `net.aurboda`.

## Required follow-up by self-hosters

`ANDROID_APP_FINGERPRINTS` still has to be set in the deployment env for `assetlinks.json` to return a non-empty statement. Without it, the route now succeeds but returns `[]`. The fingerprint is the SHA-256 of the APK signing cert (uppercase hex with colons) — for this repo the APK is signed in CI with the keystore stored in the `ANDROID_KEYSTORE_BASE64` GitHub secret.

Easiest way to recover it without touching the secret: download `aurboda.apk` from the latest GitHub release and run `keytool -printcert -jarfile aurboda.apk` — the SHA-256 line is the value for `ANDROID_APP_FINGERPRINTS`.

## Test plan

- [ ] After merge + redeploy, `curl https://aurboda.net/.well-known/assetlinks.json` returns a JSON statement with `package_name: net.aurboda` and the configured fingerprint (no longer the SPA HTML / 404).
- [ ] Verify with Google's checker: `https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://aurboda.net&relation=delegate_permission/common.get_login_creds`
- [ ] Sign in with passkey from the Android app via 1Password — the "associated URL does not match" error should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)