### PR TITLE
feat(android): structured sync-page progress with chunk + page hints

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
@@ -9,6 +9,8 @@ private const val PREFS_NAME = "AurbodaAppPrefs"
 private const val BACKGROUND_SYNC_ENABLED_KEY = "backgroundSyncEnabled"
 
 class AurbodaApplication : Application() {
+  val syncProgress: SyncProgressReporter = DefaultSyncProgressReporter()
+
   override fun onCreate() {
     super.onCreate()
 

--- a/apps/android/app/src/main/java/net/aurboda/DailyAggregateSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/DailyAggregateSync.kt
@@ -129,11 +129,28 @@ suspend fun sendDailyAggregates(
   serverUrl: String,
   authToken: String,
   httpClient: HttpClient,
+  reporter: SyncProgressReporter = NoOpSyncProgressReporter,
 ): Boolean {
   if (aggregates.isEmpty()) {
     Log.d(TAG, "No aggregates to send")
+    reporter.updateStage(SyncStage.DailyAggregates) {
+      it.copy(status = SyncStageStatus.Done, message = "Up to date")
+    }
     return true
   }
+
+  reporter.updateStage(SyncStage.DailyAggregates) {
+    it.copy(
+      status = SyncStageStatus.Active,
+      message = "Sending ${aggregates.size} day-aggregates",
+      sentRecords = 0,
+    )
+  }
+  aggregates
+    .mapNotNull {
+      runCatching { LocalDate.parse(it.date).atStartOfDay(ZoneId.systemDefault()).toInstant() }.getOrNull()
+    }.minOrNull()
+    ?.let(reporter::reportDataInstant)
 
   val postData = DailyAggregatesBody(data = aggregates)
   return try {
@@ -143,10 +160,21 @@ suspend fun sendDailyAggregates(
         headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
         setBody(postData)
       }
+    val ok = response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
     Log.d(TAG, "Daily aggregates response: ${response.status} (${aggregates.size} aggregates)")
-    response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created
+    reporter.updateStage(SyncStage.DailyAggregates) {
+      if (ok) {
+        it.copy(status = SyncStageStatus.Done, sentRecords = aggregates.size, message = "${aggregates.size} aggregates sent")
+      } else {
+        it.copy(status = SyncStageStatus.Failed, errorMessage = "HTTP ${response.status.value}")
+      }
+    }
+    ok
   } catch (e: Exception) {
     Log.e(TAG, "Error posting daily aggregates: ${e.message}", e)
+    reporter.updateStage(SyncStage.DailyAggregates) {
+      it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+    }
     false
   }
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -74,7 +75,9 @@ import net.aurboda.allRecordTypes
 import net.aurboda.writableRecordTypes
 import java.io.File
 import java.time.Instant
+import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import kotlin.reflect.KClass
 
 private const val PREFS_NAME = "AurbodaAppPrefs"
@@ -364,8 +367,10 @@ fun HealthConnectScreen(
     derivedStateOf { getCategoryStatuses(grantedPermissions) }
   }
 
-  var isProcessing by remember { mutableStateOf(false) }
-  var statusMessage by remember { mutableStateOf("Checking permissions...") }
+  val reporter = remember(context) { context.syncProgressReporter() }
+  val progressState by reporter.state.collectAsState()
+  val isProcessing = progressState.isRunning
+  var permissionStatusMessage by remember { mutableStateOf("Checking permissions...") }
   var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
   var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
 
@@ -402,31 +407,28 @@ fun HealthConnectScreen(
    */
   suspend fun syncHealthData(currentActiveContext: Context) {
     if (grantedRecordTypes.isEmpty()) {
-      statusMessage = "No permissions granted. Cannot sync."
+      reporter.updateStage(SyncStage.HealthConnect) {
+        it.copy(status = SyncStageStatus.Skipped, message = "No permissions granted")
+      }
       Log.d("SyncData", "syncHealthData called but no granted types.")
       return
     }
-    if (isProcessing) {
-      Log.d("SyncData", "syncHealthData called while already processing. Bailing.")
-      return
-    }
-    isProcessing = true
-    statusMessage = "Syncing..."
     val typesToFetch = grantedRecordTypes
     Log.d("SyncData", "Starting sync for ${typesToFetch.size} granted types...")
-
-    // Invalidate token if the set of granted types has changed
     invalidateTokenIfGrantedTypesChanged(currentActiveContext, typesToFetch)
-
     val lastTokenFromPrefs = loadChangesToken(currentActiveContext)
 
+    reporter.updateStage(SyncStage.HealthConnect) {
+      it.copy(status = SyncStageStatus.Active, message = "Reading from Health Connect…", sentRecords = 0, sentDeletions = 0)
+    }
+
     if (lastTokenFromPrefs == null) {
-      // Initial sync: read last 7 days per record type and send each immediately
       Log.d("SyncData", "No token found. Performing initial sync.")
       try {
         val sevenDaysAgo = ZonedDateTime.now().minusDays(7).toInstant()
         val now = Instant.now()
         var totalSent = 0
+        reporter.reportDataInstant(sevenDaysAgo)
 
         for (recordType: KClass<out Record> in typesToFetch) {
           try {
@@ -446,37 +448,46 @@ fun HealthConnectScreen(
 
             if (recordsOfType.isNotEmpty()) {
               Log.d("SyncData", "Fetched ${recordsOfType.size} ${recordType.simpleName} records, sending...")
-              statusMessage = "Syncing ${recordType.simpleName}... ($totalSent records sent so far)"
-              val result = sendRecords(recordsOfType, apiUrl, authToken, ktorHttpClient, "SyncData")
+              recordsOfType.oldestEventInstant()?.let(reporter::reportDataInstant)
+              val result = sendRecords(recordsOfType, apiUrl, authToken, ktorHttpClient, reporter, "SyncData")
               if (!result.isSuccess) {
-                statusMessage = "Sync failed on ${recordType.simpleName}: ${result.errorMessage()}"
+                reporter.updateStage(SyncStage.HealthConnect) {
+                  it.copy(status = SyncStageStatus.Failed, errorMessage = result.errorMessage())
+                }
                 Log.w("SyncData", "Failed to send ${recordType.simpleName}: ${result.errorMessage()}")
-                isProcessing = false
                 return
               }
               totalSent += recordsOfType.size
+              reporter.updateStage(SyncStage.HealthConnect) { it.copy(sentRecords = totalSent) }
             }
           } catch (e: Exception) {
             Log.w("SyncData", "Error fetching ${recordType.simpleName}: ${e.message}")
           }
         }
 
-        // All types sent successfully -- get and save the initial changes token
         try {
           val initialToken = healthConnectClient.getChangesToken(ChangesTokenRequest(typesToFetch.toSet()))
           saveChangesToken(currentActiveContext, initialToken)
           Log.d("SyncData", "Initial sync complete. Sent $totalSent records. Token saved.")
-          statusMessage = if (totalSent > 0) "Synced $totalSent records." else "No records found."
+          reporter.updateStage(SyncStage.HealthConnect) {
+            it.copy(
+              status = SyncStageStatus.Done,
+              message = if (totalSent > 0) "Initial sync: $totalSent records" else "No records found",
+            )
+          }
         } catch (e: Exception) {
           Log.e("SyncData", "Failed to get/save initial changes token.", e)
-          statusMessage = "Sync completed but token error: ${e.message}"
+          reporter.updateStage(SyncStage.HealthConnect) {
+            it.copy(status = SyncStageStatus.Failed, errorMessage = "token error: ${e.message}")
+          }
         }
       } catch (e: Exception) {
         Log.e("SyncData", "Error during initial sync.", e)
-        statusMessage = "Sync error: ${e.message}"
+        reporter.updateStage(SyncStage.HealthConnect) {
+          it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+        }
       }
     } else {
-      // Incremental sync: process each getChanges() page and send immediately
       Log.d("SyncData", "Token found: ${lastTokenFromPrefs.take(10)}... Fetching changes.")
       try {
         var currentToken: String = lastTokenFromPrefs
@@ -501,41 +512,59 @@ fun HealthConnectScreen(
 
           if (upsertions.isNotEmpty() || deletionIds.isNotEmpty()) {
             Log.d("SyncData", "Page $pageNum: ${upsertions.size} records, ${deletionIds.size} deletions")
-            statusMessage = "Syncing... ($totalRecords records, $totalDeletions deletions sent)"
-            val result = sendPage(upsertions, deletionIds, apiUrl, authToken, ktorHttpClient, "SyncData")
+            upsertions.oldestEventInstant()?.let(reporter::reportDataInstant)
+            reporter.updateStage(SyncStage.HealthConnect) {
+              it.copy(
+                currentPage = pageNum,
+                message = "Page $pageNum (${upsertions.size} records, ${deletionIds.size} deletions)",
+              )
+            }
+            val result = sendPage(upsertions, deletionIds, apiUrl, authToken, ktorHttpClient, reporter, "SyncData")
             if (!result.isSuccess) {
-              statusMessage = "Sync failed on page $pageNum: ${result.errorMessage()}"
+              reporter.updateStage(SyncStage.HealthConnect) {
+                it.copy(status = SyncStageStatus.Failed, errorMessage = result.errorMessage())
+              }
               Log.w("SyncData", "Page $pageNum failed: ${result.errorMessage()}")
-              isProcessing = false
               return
             }
             totalRecords += upsertions.size
             totalDeletions += deletionIds.size
+            reporter.updateStage(SyncStage.HealthConnect) {
+              it.copy(sentRecords = totalRecords, sentDeletions = totalDeletions)
+            }
           }
 
-          // Save intermediate token -- this page is permanently done
           currentToken = changesResponse.nextChangesToken
           saveChangesToken(currentActiveContext, currentToken)
           hasMore = changesResponse.hasMore
         }
 
         if (totalRecords > 0 || totalDeletions > 0) {
-          val parts = mutableListOf<String>()
-          if (totalRecords > 0) parts.add("$totalRecords records")
-          if (totalDeletions > 0) parts.add("$totalDeletions deletions")
-          statusMessage = "Synced ${parts.joinToString(", ")}."
+          val parts = buildList {
+            if (totalRecords > 0) add("$totalRecords records")
+            if (totalDeletions > 0) add("$totalDeletions deletions")
+          }
+          reporter.updateStage(SyncStage.HealthConnect) {
+            it.copy(
+              status = SyncStageStatus.Done,
+              totalPages = pageNum,
+              message = "${parts.joinToString(", ")} ($pageNum pages)",
+            )
+          }
           Log.d("SyncData", "Incremental sync complete: ${parts.joinToString(", ")} across $pageNum pages")
         } else {
-          statusMessage = "Up to date."
+          reporter.updateStage(SyncStage.HealthConnect) {
+            it.copy(status = SyncStageStatus.Done, message = "Up to date")
+          }
           Log.d("SyncData", "No new changes found")
         }
       } catch (e: Exception) {
         Log.e("SyncData", "Error during incremental sync.", e)
-        statusMessage = "Sync error: ${e.message}"
+        reporter.updateStage(SyncStage.HealthConnect) {
+          it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+        }
       }
     }
-
-    isProcessing = false
   }
 
   /** Re-query actual granted permissions from system after launcher returns. */
@@ -543,11 +572,9 @@ fun HealthConnectScreen(
     grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
     val count = grantedRecordTypes.size
     Log.d("HealthConnect", "Permissions refreshed: $count/${allRecordTypes.size} types granted")
-    if (count > 0) {
-      statusMessage = "$count of ${allRecordTypes.size} data types authorized."
-    } else {
-      statusMessage = "No permissions granted."
-    }
+    permissionStatusMessage =
+      if (count > 0) "$count of ${allRecordTypes.size} data types authorized."
+      else "No permissions granted."
   }
 
   val requestPermissionLauncher =
@@ -557,10 +584,13 @@ fun HealthConnectScreen(
       // Don't trust the launcher result -- re-query actual permissions from system
       scope.launch {
         refreshPermissions()
-        if (grantedRecordTypes.isNotEmpty()) {
-          syncHealthData(context)
-        } else {
-          isProcessing = false
+        if (grantedRecordTypes.isNotEmpty() && !reporter.state.value.isRunning) {
+          reporter.begin()
+          try {
+            syncHealthData(context)
+          } finally {
+            reporter.end()
+          }
         }
       }
     }
@@ -574,81 +604,96 @@ fun HealthConnectScreen(
     Log.d("HealthConnect", "Permission check: $grantedCount/${allRecordTypes.size} types granted")
 
     if (grantedCount > 0) {
-      statusMessage = "$grantedCount of ${allRecordTypes.size} data types authorized."
-      coroutineScope.launch { syncHealthData(currentContext) }
+      permissionStatusMessage = "$grantedCount of ${allRecordTypes.size} data types authorized."
+      coroutineScope.launch {
+        if (reporter.state.value.isRunning) return@launch
+        reporter.begin()
+        try {
+          syncHealthData(currentContext)
+        } finally {
+          reporter.end()
+        }
+      }
     } else {
-      // No permissions at all -- request everything
-      statusMessage = "No permissions granted. Requesting access..."
-      isProcessing = false
+      permissionStatusMessage = "No permissions granted. Requesting access..."
       requestPermissionLauncher.launch(allPermissions.toTypedArray())
     }
   }
 
   /** Perform full sync: aggregates + Health Connect data + outbound + ActivityWatch. */
   suspend fun syncNow(currentContext: Context) {
-    // Fetch and send daily aggregates for cumulative metrics (steps, distance, etc.)
+    if (reporter.state.value.isRunning) return
+    reporter.begin()
+    var fatal: String? = null
     try {
-      val aggregates = fetchDailyAggregates(healthConnectClient, grantedRecordTypes.toSet(), days = 7)
-      if (aggregates.isNotEmpty()) {
-        val success = sendDailyAggregates(aggregates, apiUrl, authToken, ktorHttpClient)
-        if (success) {
-          Log.d("SyncNow", "Sent ${aggregates.size} daily aggregates")
+      // Daily aggregates
+      try {
+        val aggregates = fetchDailyAggregates(healthConnectClient, grantedRecordTypes.toSet(), days = 7)
+        if (aggregates.isNotEmpty()) {
+          sendDailyAggregates(aggregates, apiUrl, authToken, ktorHttpClient, reporter)
         } else {
-          Log.w("SyncNow", "Failed to send daily aggregates")
-          statusMessage = "Failed to send daily aggregates."
+          reporter.updateStage(SyncStage.DailyAggregates) {
+            it.copy(status = SyncStageStatus.Done, message = "Nothing to send")
+          }
+        }
+      } catch (e: Exception) {
+        Log.w("SyncNow", "Daily aggregate sync failed: ${e.message}", e)
+        reporter.updateStage(SyncStage.DailyAggregates) {
+          it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
         }
       }
-    } catch (e: Exception) {
-      Log.w("SyncNow", "Daily aggregate sync failed: ${e.message}", e)
-      statusMessage = "Daily aggregate sync error: ${e.message}"
-    }
 
-    // Incremental Health Connect sync (fetch and send page by page)
-    syncHealthData(currentContext)
+      syncHealthData(currentContext)
 
-    // Process outbound sync: write backend changes to Health Connect
-    try {
-      val result =
+      try {
         processOutboundSync(
           apiUrl = apiUrl,
           authToken = authToken,
           httpClient = ktorHttpClient,
           healthConnectClient = healthConnectClient,
           grantedPermissions = grantedPermissions,
+          reporter = reporter,
         )
-      if (result.fetched > 0) {
-        val parts = mutableListOf<String>()
-        if (result.written > 0) parts.add("${result.written} written to HC")
-        if (result.skipped > 0) parts.add("${result.skipped} skipped")
-        if (result.transientFailures > 0) parts.add("${result.transientFailures} transient failures")
-        if (!result.acknowledged) parts.add("ack failed")
-        val msg = "Outbound: ${parts.joinToString(", ")} (of ${result.fetched} pending)"
-        val details = result.skipReasons + result.failReasons
-        statusMessage =
-          if (details.isNotEmpty()) {
-            "$msg\n${details.joinToString("\n")}"
-          } else {
-            msg
+      } catch (e: Exception) {
+        Log.w("OutboundSync", "Outbound sync failed in syncNow: ${e.message}", e)
+        reporter.updateStage(SyncStage.Outbound) {
+          it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+        }
+      }
+
+      if (awSyncEnabled) {
+        reporter.updateStage(SyncStage.ActivityWatch) {
+          it.copy(status = SyncStageStatus.Active, message = "Syncing app usage…")
+        }
+        try {
+          val r =
+            processActivityWatchSync(
+              apiUrl = apiUrl,
+              authToken = authToken,
+              httpClient = ktorHttpClient,
+              context = currentContext,
+            )
+          awSyncResult = r
+          reporter.updateStage(SyncStage.ActivityWatch) {
+            when {
+              r.error != null -> it.copy(status = SyncStageStatus.Failed, errorMessage = r.error)
+              !r.available -> it.copy(status = SyncStageStatus.Skipped, message = "Not detected")
+              else -> it.copy(status = SyncStageStatus.Done, message = "${r.eventsPushed} events synced", sentRecords = r.eventsPushed)
+            }
           }
+        } catch (e: Exception) {
+          Log.w("ActivityWatch", "AW sync failed in syncNow: ${e.message}", e)
+          awSyncResult = ActivityWatchSyncResult(error = e.message)
+          reporter.updateStage(SyncStage.ActivityWatch) {
+            it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+          }
+        }
       }
     } catch (e: Exception) {
-      Log.w("OutboundSync", "Outbound sync failed in syncNow: ${e.message}", e)
-      statusMessage = "Outbound sync error: ${e.message}"
-    }
-    // ActivityWatch sync (if enabled)
-    if (awSyncEnabled) {
-      try {
-        awSyncResult =
-          processActivityWatchSync(
-            apiUrl = apiUrl,
-            authToken = authToken,
-            httpClient = ktorHttpClient,
-            context = currentContext,
-          )
-      } catch (e: Exception) {
-        Log.w("ActivityWatch", "AW sync failed in syncNow: ${e.message}", e)
-        awSyncResult = ActivityWatchSyncResult(error = e.message)
-      }
+      fatal = e.message
+      Log.e("SyncNow", "syncNow fatal: ${e.message}", e)
+    } finally {
+      reporter.end(fatal)
     }
   }
 
@@ -665,25 +710,31 @@ fun HealthConnectScreen(
       LifecycleEventObserver { _, event ->
         if (event == Lifecycle.Event.ON_RESUME) {
           Log.d("HealthConnectScreen", "App resumed. HasAny: $hasAnyPermissions, IsProcessing: $isProcessing")
-          if (hasAnyPermissions && !isProcessing) {
+          if (hasAnyPermissions && !reporter.state.value.isRunning) {
             scope.launch {
-              // Re-check permissions in case user changed them in system settings
               refreshPermissions()
-              // Incremental sync: fetch and send page by page
-              syncHealthData(context)
-              // Process outbound sync: write backend changes to Health Connect
+              if (reporter.state.value.isRunning) return@launch
+              reporter.begin()
               try {
-                processOutboundSync(
-                  apiUrl = apiUrl,
-                  authToken = authToken,
-                  httpClient = ktorHttpClient,
-                  healthConnectClient = healthConnectClient,
-                  grantedPermissions = grantedPermissions,
-                )
-              } catch (e: Exception) {
-                Log.w("OutboundSync", "Outbound sync failed on resume: ${e.message}")
+                syncHealthData(context)
+                try {
+                  processOutboundSync(
+                    apiUrl = apiUrl,
+                    authToken = authToken,
+                    httpClient = ktorHttpClient,
+                    healthConnectClient = healthConnectClient,
+                    grantedPermissions = grantedPermissions,
+                    reporter = reporter,
+                  )
+                } catch (e: Exception) {
+                  Log.w("OutboundSync", "Outbound sync failed on resume: ${e.message}")
+                  reporter.updateStage(SyncStage.Outbound) {
+                    it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+                  }
+                }
+              } finally {
+                reporter.end()
               }
-              // Refresh widget with latest data
               net.aurboda.widget.HrZoneWidgetProvider
                 .triggerUpdate(context)
             }
@@ -702,7 +753,7 @@ fun HealthConnectScreen(
       Log.d("HealthConnectScreen", "Starting periodic sync loop (60s interval)")
       while (true) {
         delay(60_000L)
-        if (!isProcessing) {
+        if (!reporter.state.value.isRunning) {
           Log.d("HealthConnectScreen", "Periodic sync: fetching and sending data")
           syncNow(context)
         }
@@ -743,10 +794,10 @@ fun HealthConnectScreen(
             }
           }
 
-          Text(
-            statusMessage,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          SyncProgressView(
+            state = progressState,
+            permissionStatusMessage = permissionStatusMessage,
+            activityWatchEnabled = awSyncEnabled,
           )
 
           Text(

--- a/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
+++ b/apps/android/app/src/main/java/net/aurboda/OutboundSync.kt
@@ -569,6 +569,7 @@ suspend fun processOutboundSync(
   httpClient: HttpClient,
   healthConnectClient: HealthConnectClient,
   grantedPermissions: Set<String>,
+  reporter: SyncProgressReporter = NoOpSyncProgressReporter,
 ): OutboundSyncResult {
   var totalFetched = 0
   var totalWritten = 0
@@ -580,6 +581,10 @@ suspend fun processOutboundSync(
   var pagesProcessed = 0
   var rateLimited = false
 
+  reporter.updateStage(SyncStage.Outbound) {
+    it.copy(status = SyncStageStatus.Active, message = "Checking pending write-back…")
+  }
+
   for (page in 1..MAX_OUTBOUND_SYNC_PAGES) {
     val fetchResult = fetchOutboundSyncEntries(apiUrl, authToken, httpClient)
     val entries = fetchResult.entries
@@ -587,7 +592,17 @@ suspend fun processOutboundSync(
 
     pagesProcessed++
     totalFetched += entries.size
+    val pageSizeNonZero = entries.size.coerceAtLeast(1)
+    val totalPagesEstimate = (fetchResult.totalPending + pageSizeNonZero - 1) / pageSizeNonZero
     Log.d(TAG, "🔄 Processing page $page: ${entries.size} entries (${fetchResult.totalPending} total pending)")
+    reporter.updateStage(SyncStage.Outbound) {
+      it.copy(
+        currentPage = page,
+        totalPages = totalPagesEstimate.coerceAtLeast(page),
+        message = "Page $page of ~${totalPagesEstimate.coerceAtLeast(page)} (${fetchResult.totalPending} pending)",
+      )
+    }
+    entries.oldestCreatedAt()?.let(reporter::reportDataInstant)
 
     val ackItems = mutableListOf<OutboundSyncAckItemApi>()
     val failItems = mutableListOf<OutboundSyncFailItemApi>()
@@ -635,6 +650,12 @@ suspend fun processOutboundSync(
     totalWritten += ackItems.size - pageSkipped
     totalSkipped += pageSkipped
     totalTransientFailures += pageTransientFailures
+    reporter.updateStage(SyncStage.Outbound) {
+      it.copy(
+        sentRecords = totalWritten,
+        message = "Page $page: $totalWritten written, $totalSkipped skipped, $totalTransientFailures transient",
+      )
+    }
 
     if (ackItems.isNotEmpty()) {
       val ackSuccess = acknowledgeOutboundSync(ackItems, apiUrl, authToken, httpClient)
@@ -666,6 +687,16 @@ suspend fun processOutboundSync(
 
   if (pagesProcessed > 0) {
     Log.d(TAG, "✅ Outbound sync finished: $totalWritten written, $totalSkipped skipped, $totalTransientFailures transient failures across $pagesProcessed pages")
+    reporter.updateStage(SyncStage.Outbound) {
+      it.copy(
+        status = if (allAcknowledged && !rateLimited) SyncStageStatus.Done else SyncStageStatus.Failed,
+        message = "$totalWritten written, $totalSkipped skipped, $totalTransientFailures transient ($pagesProcessed pages)",
+      )
+    }
+  } else {
+    reporter.updateStage(SyncStage.Outbound) {
+      it.copy(status = SyncStageStatus.Done, message = "Nothing to write back")
+    }
   }
 
   return OutboundSyncResult(
@@ -734,3 +765,9 @@ private fun JsonObject.getInstant(key: String): Instant? =
       null
     }
   }
+
+/** Earliest created_at across a list of pending entries; null when none parses. */
+internal fun List<OutboundSyncEntryApi>.oldestCreatedAt(): Instant? =
+  mapNotNull {
+    runCatching { Instant.parse(it.created_at) }.getOrNull()
+  }.minOrNull()

--- a/apps/android/app/src/main/java/net/aurboda/SyncProgress.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncProgress.kt
@@ -1,0 +1,242 @@
+package net.aurboda
+
+import android.content.Context
+import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
+import androidx.health.connect.client.records.BasalBodyTemperatureRecord
+import androidx.health.connect.client.records.BasalMetabolicRateRecord
+import androidx.health.connect.client.records.BloodGlucoseRecord
+import androidx.health.connect.client.records.BloodPressureRecord
+import androidx.health.connect.client.records.BodyFatRecord
+import androidx.health.connect.client.records.BodyTemperatureRecord
+import androidx.health.connect.client.records.BodyWaterMassRecord
+import androidx.health.connect.client.records.BoneMassRecord
+import androidx.health.connect.client.records.CervicalMucusRecord
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
+import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.ElevationGainedRecord
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.FloorsClimbedRecord
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
+import androidx.health.connect.client.records.HeightRecord
+import androidx.health.connect.client.records.HydrationRecord
+import androidx.health.connect.client.records.IntermenstrualBleedingRecord
+import androidx.health.connect.client.records.LeanBodyMassRecord
+import androidx.health.connect.client.records.MenstruationFlowRecord
+import androidx.health.connect.client.records.MenstruationPeriodRecord
+import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.OvulationTestRecord
+import androidx.health.connect.client.records.OxygenSaturationRecord
+import androidx.health.connect.client.records.PowerRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.RespiratoryRateRecord
+import androidx.health.connect.client.records.RestingHeartRateRecord
+import androidx.health.connect.client.records.SexualActivityRecord
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.SpeedRecord
+import androidx.health.connect.client.records.StepsCadenceRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.records.Vo2MaxRecord
+import androidx.health.connect.client.records.WeightRecord
+import androidx.health.connect.client.records.WheelchairPushesRecord
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.time.Instant
+
+enum class SyncStageStatus { Idle, Active, Done, Failed, Skipped }
+
+/** High-level sync stages, displayed as one row each in the UI. */
+enum class SyncStage(
+  val title: String,
+) {
+  PendingData("Pending uploads"),
+  DailyAggregates("Daily aggregates"),
+  HealthConnect("Health Connect data"),
+  Outbound("Write back to Health Connect"),
+  ActivityWatch("ActivityWatch"),
+}
+
+data class SyncStageInfo(
+  val stage: SyncStage,
+  val status: SyncStageStatus = SyncStageStatus.Idle,
+  val message: String? = null,
+  val sentRecords: Int = 0,
+  val sentDeletions: Int = 0,
+  val currentPage: Int? = null,
+  val totalPages: Int? = null,
+  val errorMessage: String? = null,
+)
+
+/** Per-record-type progress nested under [SyncStage.HealthConnect]. */
+data class SyncRecordTypeInfo(
+  val recordType: String,
+  val status: SyncStageStatus = SyncStageStatus.Idle,
+  val sentRecords: Int = 0,
+  val currentChunk: Int? = null,
+  val totalChunks: Int? = null,
+  val errorMessage: String? = null,
+)
+
+data class SyncProgressState(
+  val isRunning: Boolean = false,
+  val startedAt: Instant? = null,
+  val finishedAt: Instant? = null,
+  val stages: Map<SyncStage, SyncStageInfo> = emptyMap(),
+  val recordTypes: Map<String, SyncRecordTypeInfo> = emptyMap(),
+  /** Timestamp of the data currently in flight; powers the "Syncing data from N days ago" hint. */
+  val currentDataInstant: Instant? = null,
+  val lastError: String? = null,
+)
+
+/**
+ * Sync workers and UI talk to this single state object. Default and no-op implementations
+ * are provided; production code uses [DefaultSyncProgressReporter] held on the Application.
+ */
+interface SyncProgressReporter {
+  val state: StateFlow<SyncProgressState>
+
+  fun begin()
+
+  fun end(error: String? = null)
+
+  fun updateStage(
+    stage: SyncStage,
+    transform: (SyncStageInfo) -> SyncStageInfo,
+  )
+
+  fun updateRecordType(
+    recordType: String,
+    transform: (SyncRecordTypeInfo) -> SyncRecordTypeInfo,
+  )
+
+  /** Report the timestamp of the data currently being processed (drives "from N days ago"). */
+  fun reportDataInstant(time: Instant?)
+}
+
+class DefaultSyncProgressReporter : SyncProgressReporter {
+  private val mutableState = MutableStateFlow(SyncProgressState())
+  override val state: StateFlow<SyncProgressState> = mutableState.asStateFlow()
+
+  override fun begin() {
+    mutableState.update {
+      SyncProgressState(
+        isRunning = true,
+        startedAt = Instant.now(),
+      )
+    }
+  }
+
+  override fun end(error: String?) {
+    mutableState.update {
+      it.copy(
+        isRunning = false,
+        finishedAt = Instant.now(),
+        lastError = error ?: it.lastError,
+      )
+    }
+  }
+
+  override fun updateStage(
+    stage: SyncStage,
+    transform: (SyncStageInfo) -> SyncStageInfo,
+  ) {
+    mutableState.update { current ->
+      val existing = current.stages[stage] ?: SyncStageInfo(stage)
+      current.copy(stages = current.stages + (stage to transform(existing)))
+    }
+  }
+
+  override fun updateRecordType(
+    recordType: String,
+    transform: (SyncRecordTypeInfo) -> SyncRecordTypeInfo,
+  ) {
+    mutableState.update { current ->
+      val existing = current.recordTypes[recordType] ?: SyncRecordTypeInfo(recordType)
+      current.copy(recordTypes = current.recordTypes + (recordType to transform(existing)))
+    }
+  }
+
+  override fun reportDataInstant(time: Instant?) {
+    if (time == null) return
+    mutableState.update { it.copy(currentDataInstant = time) }
+  }
+}
+
+/** No-op for tests and code paths where progress reporting is irrelevant. */
+object NoOpSyncProgressReporter : SyncProgressReporter {
+  override val state: StateFlow<SyncProgressState> = MutableStateFlow(SyncProgressState()).asStateFlow()
+
+  override fun begin() {}
+
+  override fun end(error: String?) {}
+
+  override fun updateStage(
+    stage: SyncStage,
+    transform: (SyncStageInfo) -> SyncStageInfo,
+  ) {}
+
+  override fun updateRecordType(
+    recordType: String,
+    transform: (SyncRecordTypeInfo) -> SyncRecordTypeInfo,
+  ) {}
+
+  override fun reportDataInstant(time: Instant?) {}
+}
+
+/** Fetch the process-wide [SyncProgressReporter] held on the Application instance. */
+fun Context.syncProgressReporter(): SyncProgressReporter =
+  (applicationContext as? AurbodaApplication)?.syncProgress ?: NoOpSyncProgressReporter
+
+/**
+ * Extract a representative timestamp from a Health Connect record.
+ * The HC base interfaces (IntervalRecord/InstantaneousRecord) are internal in 1.2.0-alpha01,
+ * so we dispatch on the concrete classes we actually serialize.
+ */
+fun Record.eventInstant(): Instant? =
+  when (this) {
+    is ActiveCaloriesBurnedRecord -> startTime
+    is BasalBodyTemperatureRecord -> time
+    is BasalMetabolicRateRecord -> time
+    is BloodGlucoseRecord -> time
+    is BloodPressureRecord -> time
+    is BodyFatRecord -> time
+    is BodyTemperatureRecord -> time
+    is BodyWaterMassRecord -> time
+    is BoneMassRecord -> time
+    is CervicalMucusRecord -> time
+    is CyclingPedalingCadenceRecord -> startTime
+    is DistanceRecord -> startTime
+    is ElevationGainedRecord -> startTime
+    is ExerciseSessionRecord -> startTime
+    is FloorsClimbedRecord -> startTime
+    is HeartRateRecord -> startTime
+    is HeartRateVariabilityRmssdRecord -> time
+    is HeightRecord -> time
+    is HydrationRecord -> startTime
+    is IntermenstrualBleedingRecord -> time
+    is LeanBodyMassRecord -> time
+    is MenstruationFlowRecord -> time
+    is MenstruationPeriodRecord -> startTime
+    is NutritionRecord -> startTime
+    is OvulationTestRecord -> time
+    is OxygenSaturationRecord -> time
+    is PowerRecord -> startTime
+    is RespiratoryRateRecord -> time
+    is RestingHeartRateRecord -> time
+    is SexualActivityRecord -> time
+    is SleepSessionRecord -> startTime
+    is SpeedRecord -> startTime
+    is StepsCadenceRecord -> startTime
+    is StepsRecord -> startTime
+    is TotalCaloriesBurnedRecord -> startTime
+    is Vo2MaxRecord -> time
+    is WeightRecord -> time
+    is WheelchairPushesRecord -> startTime
+    else -> null
+  }
+
+/** Earliest [eventInstant] across a record list, or null when no record exposes one. */
+fun List<Record>.oldestEventInstant(): Instant? = mapNotNull { it.eventInstant() }.minOrNull()

--- a/apps/android/app/src/main/java/net/aurboda/SyncProgressView.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncProgressView.kt
@@ -1,0 +1,206 @@
+package net.aurboda
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Renders the structured sync progress: a "Syncing data from N ago" hint, a stage list with
+ * inline status icons, and per-record-type chunk progress nested under the Health Connect stage.
+ */
+@Composable
+fun SyncProgressView(
+  state: SyncProgressState,
+  permissionStatusMessage: String,
+  activityWatchEnabled: Boolean,
+) {
+  val visibleStages =
+    SyncStage.entries.filter { stage ->
+      stage in state.stages || (state.isRunning && stage.alwaysShownWhileRunning(activityWatchEnabled))
+    }
+
+  Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    // "Syncing data from 20 days ago" — only while running and only when we know how far behind we are.
+    if (state.isRunning && state.currentDataInstant != null) {
+      RelativeAgoText(state.currentDataInstant)
+    } else if (!state.isRunning && state.lastError != null) {
+      Text(
+        "Last error: ${state.lastError}",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+      )
+    } else if (!state.isRunning && state.stages.isEmpty()) {
+      Text(
+        permissionStatusMessage,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+
+    if (visibleStages.isNotEmpty()) {
+      visibleStages.forEach { stage ->
+        val info = state.stages[stage] ?: SyncStageInfo(stage)
+        StageRow(info)
+        if (stage == SyncStage.HealthConnect) {
+          val activeTypes =
+            state.recordTypes.values
+              .filter { it.status != SyncStageStatus.Idle }
+              .sortedWith(compareBy({ it.status.sortKey() }, { it.recordType }))
+          activeTypes.forEach { rt ->
+            RecordTypeRow(rt)
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun StageRow(info: SyncStageInfo) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(info.status.icon(), style = MaterialTheme.typography.bodyMedium, color = info.status.iconColor())
+      Text(
+        info.stage.title,
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.SemiBold,
+      )
+      info.pageProgressLabel()?.let {
+        Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+      }
+    }
+    val sub = info.errorMessage ?: info.message
+    if (!sub.isNullOrBlank()) {
+      Text(
+        sub,
+        style = MaterialTheme.typography.bodySmall,
+        color = if (info.errorMessage != null) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 24.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun RecordTypeRow(info: SyncRecordTypeInfo) {
+  Column(modifier = Modifier.fillMaxWidth().padding(start = 24.dp)) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(info.status.icon(), style = MaterialTheme.typography.bodySmall, color = info.status.iconColor())
+      Text(info.recordType, style = MaterialTheme.typography.bodySmall)
+      info.chunkLabel()?.let {
+        Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+      }
+      if (info.sentRecords > 0 && info.status == SyncStageStatus.Done) {
+        Text(
+          "(${info.sentRecords} records)",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+    if (info.status == SyncStageStatus.Active && info.totalChunks != null && info.currentChunk != null && info.totalChunks > 1) {
+      LinearProgressIndicator(
+        progress = { (info.currentChunk.toFloat() / info.totalChunks).coerceIn(0f, 1f) },
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp, horizontal = 0.dp),
+      )
+    }
+    info.errorMessage?.let {
+      Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+    }
+  }
+}
+
+@Composable
+private fun RelativeAgoText(target: Instant) {
+  // Re-render every 30s so "5m ago" stays accurate without a tight loop.
+  var now by remember { mutableStateOf(Instant.now()) }
+  LaunchedEffect(target) {
+    while (true) {
+      now = Instant.now()
+      delay(30_000)
+    }
+  }
+  Text(
+    "Syncing data from ${formatRelative(target, now)}",
+    style = MaterialTheme.typography.bodyMedium,
+    fontWeight = FontWeight.Medium,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = Modifier.padding(PaddingValues(0.dp)),
+  )
+}
+
+private fun formatRelative(target: Instant, now: Instant): String {
+  val seconds = ChronoUnit.SECONDS.between(target, now).coerceAtLeast(0)
+  return when {
+    seconds < 60 -> "just now"
+    seconds < 3600 -> "${seconds / 60} min ago"
+    seconds < 86_400 -> "${seconds / 3600}h ago"
+    seconds < 86_400 * 2 -> "yesterday"
+    else -> "${seconds / 86_400} days ago"
+  }
+}
+
+private fun SyncStageStatus.icon(): String =
+  when (this) {
+    SyncStageStatus.Idle -> "…" // …
+    SyncStageStatus.Active -> "⟳" // ⟳
+    SyncStageStatus.Done -> "✅" // ✅
+    SyncStageStatus.Failed -> "⚠️" // ⚠️
+    SyncStageStatus.Skipped -> "➖" // ➖
+  }
+
+@Composable
+private fun SyncStageStatus.iconColor(): Color =
+  when (this) {
+    SyncStageStatus.Failed -> MaterialTheme.colorScheme.error
+    SyncStageStatus.Active -> MaterialTheme.colorScheme.primary
+    else -> MaterialTheme.colorScheme.onSurface
+  }
+
+private fun SyncStageStatus.sortKey(): Int =
+  when (this) {
+    SyncStageStatus.Active -> 0
+    SyncStageStatus.Failed -> 1
+    SyncStageStatus.Done -> 2
+    SyncStageStatus.Skipped -> 3
+    SyncStageStatus.Idle -> 4
+  }
+
+private fun SyncStageInfo.pageProgressLabel(): String? {
+  val cur = currentPage ?: return null
+  val total = totalPages
+  return if (total != null && total >= cur) "page $cur / $total" else "page $cur"
+}
+
+private fun SyncRecordTypeInfo.chunkLabel(): String? {
+  val cur = currentChunk ?: return null
+  val total = totalChunks ?: return null
+  if (total <= 1) return null
+  return "chunk $cur / $total"
+}
+
+private fun SyncStage.alwaysShownWhileRunning(activityWatchEnabled: Boolean): Boolean =
+  when (this) {
+    SyncStage.PendingData, SyncStage.DailyAggregates, SyncStage.HealthConnect, SyncStage.Outbound -> true
+    SyncStage.ActivityWatch -> activityWatchEnabled
+  }

--- a/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
@@ -10,10 +10,22 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import kotlinx.coroutines.delay
 
 const val SYNC_UTILS_TAG = "SyncUtils"
 
-/** Result of a POST operation with error details for display */
+/** Maximum retries per chunk on transient errors (network drop, 5xx, 408, 429). */
+@PublishedApi
+internal const val MAX_CHUNK_ATTEMPTS: Int = 4
+
+/**
+ * HeartRateRecord is a SeriesRecord — each record holds many samples, so the JSON payload can
+ * blow past the backend's 10MB limit if we send too many in one go. Backend body limit is 10mb;
+ * 50 records ≈ a few hundred KB in practice. Tunable from one place.
+ */
+private const val HEART_RATE_CHUNK_SIZE = 50
+
+/** Result of a POST operation with error details for display. */
 sealed class PostResult {
   data object Success : PostResult()
 
@@ -28,6 +40,15 @@ sealed class PostResult {
 
   val isSuccess: Boolean
     get() = this is Success
+
+  /** Errors that may succeed on retry (network failures and server-side hiccups). */
+  val isTransient: Boolean
+    get() =
+      when (this) {
+        is Success -> false
+        is NetworkError -> true
+        is HttpError -> statusCode >= 500 || statusCode == 408 || statusCode == 429
+      }
 
   fun errorMessage(): String? =
     when (this) {
@@ -70,17 +91,37 @@ suspend inline fun <reified T : Any> postChunk(
   }
 
 /**
+ * Post a chunk with bounded exponential-backoff retry on transient failures.
+ * 4xx (other than 408/429) bypass retry — they will not succeed on retry.
+ */
+suspend inline fun <reified T : Any> postChunkWithRetry(
+  data: PostWrapper<T>,
+  apiUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+  logTag: String = SYNC_UTILS_TAG,
+): PostResult {
+  var lastResult: PostResult = PostResult.NetworkError("not attempted")
+  for (attempt in 1..MAX_CHUNK_ATTEMPTS) {
+    val result = postChunk(data, apiUrl, authToken, httpClient, logTag)
+    if (result.isSuccess) return result
+    lastResult = result
+    if (!result.isTransient || attempt == MAX_CHUNK_ATTEMPTS) return result
+    val backoffMs = 500L * (1L shl (attempt - 1))
+    Log.w(logTag, "Transient error on attempt $attempt: ${result.errorMessage()}; retrying in ${backoffMs}ms")
+    delay(backoffMs)
+  }
+  return lastResult
+}
+
+/**
  * Post data in chunks to avoid 413 Request Entity Too Large errors.
  * HeartRateRecord can be very large (thousands of samples per record).
  *
  * @param dataList The list of records to post
- * @param apiUrl The URL to post to
- * @param authToken The auth token for the request
- * @param httpClient The HTTP client to use
- * @param chunkSize Maximum number of records per chunk (default 10)
- * @param recordTypeName Name of the record type for logging
- * @param logTag Tag for log messages
- * @return PostResult.Success if all chunks succeed, or the first error encountered
+ * @param chunkSize Maximum number of records per chunk
+ * @param recordTypeName Name of the record type for logging and progress reporting
+ * @param reporter Sync progress reporter for per-chunk UI updates
  *
  * Note: Must be inline with reified T to preserve type information for serialization.
  */
@@ -89,8 +130,9 @@ suspend inline fun <reified T : Any> postDataChunked(
   apiUrl: String,
   authToken: String,
   httpClient: HttpClient,
-  chunkSize: Int = 10,
-  recordTypeName: String = "data",
+  chunkSize: Int,
+  recordTypeName: String,
+  reporter: SyncProgressReporter = NoOpSyncProgressReporter,
   logTag: String = SYNC_UTILS_TAG,
 ): PostResult {
   if (dataList.isEmpty()) {
@@ -99,14 +141,21 @@ suspend inline fun <reified T : Any> postDataChunked(
   }
 
   val chunks = dataList.chunked(chunkSize)
-  Log.d(logTag, "Sending $recordTypeName in ${chunks.size} chunks of up to $chunkSize records each")
+  val total = chunks.size
+  Log.d(logTag, "Sending $recordTypeName in $total chunks of up to $chunkSize records each")
 
+  reporter.updateRecordType(recordTypeName) {
+    it.copy(status = SyncStageStatus.Active, totalChunks = total, currentChunk = 0)
+  }
+
+  var sent = 0
   for ((index, chunk) in chunks.withIndex()) {
     val chunkNum = index + 1
-    Log.d(logTag, "Sending $recordTypeName chunk $chunkNum/${chunks.size} with ${chunk.size} records")
+    Log.d(logTag, "Sending $recordTypeName chunk $chunkNum/$total with ${chunk.size} records")
+    reporter.updateRecordType(recordTypeName) { it.copy(currentChunk = chunkNum) }
 
     val result =
-      postChunk(
+      postChunkWithRetry(
         data = PostWrapper(chunk),
         apiUrl = apiUrl,
         authToken = authToken,
@@ -115,14 +164,23 @@ suspend inline fun <reified T : Any> postDataChunked(
       )
 
     if (!result.isSuccess) {
-      Log.e(logTag, "$recordTypeName chunk $chunkNum failed: ${result.errorMessage()}")
+      val msg = "$recordTypeName chunk $chunkNum/$total failed: ${result.errorMessage()}"
+      Log.e(logTag, msg)
+      reporter.updateRecordType(recordTypeName) {
+        it.copy(status = SyncStageStatus.Failed, errorMessage = result.errorMessage())
+      }
       return result
     }
 
+    sent += chunk.size
+    reporter.updateRecordType(recordTypeName) { it.copy(sentRecords = sent) }
     Log.d(logTag, "$recordTypeName chunk $chunkNum succeeded")
   }
 
-  Log.d(logTag, "All ${chunks.size} chunks of $recordTypeName sent successfully")
+  reporter.updateRecordType(recordTypeName) {
+    it.copy(status = SyncStageStatus.Done, currentChunk = total, sentRecords = sent)
+  }
+  Log.d(logTag, "All $total chunks of $recordTypeName sent successfully")
   return PostResult.Success
 }
 
@@ -139,9 +197,7 @@ fun List<Record>.filterNotOwnOrigin(): List<Record> =
     !(isOwnOrigin || isOutboundSync)
   }
 
-/**
- * Send deletion IDs to the backend. Shared by SyncWorker and MainActivity.
- */
+/** Send deletion IDs to the backend. Shared by SyncWorker and MainActivity. */
 suspend fun sendDeletions(
   deletionIds: List<String>,
   serverUrl: String,
@@ -151,24 +207,49 @@ suspend fun sendDeletions(
 ): PostResult {
   if (deletionIds.isEmpty()) return PostResult.Success
 
-  return try {
-    val response =
-      httpClient.post("$serverUrl/sync/deletions") {
-        contentType(ContentType.Application.Json)
-        headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-        setBody(PostWrapper(deletionIds))
-      }
-    if (response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created) {
+  return postChunkWithRetry(
+    data = PostWrapper(deletionIds),
+    apiUrl = "$serverUrl/sync/deletions",
+    authToken = authToken,
+    httpClient = httpClient,
+    logTag = logTag,
+  ).also { result ->
+    if (result.isSuccess) {
       Log.d(logTag, "Sent ${deletionIds.size} deletions successfully")
-      PostResult.Success
     } else {
-      Log.e(logTag, "Deletions failed: HTTP ${response.status.value} ${response.status.description}")
-      PostResult.HttpError(response.status.value, response.status.description)
+      Log.e(logTag, "Deletions failed: ${result.errorMessage()}")
     }
-  } catch (e: Exception) {
-    Log.e(logTag, "Error posting deletions", e)
-    PostResult.NetworkError(e.message ?: "Unknown error")
   }
+}
+
+/**
+ * Send a non-chunked record group as one POST. Reports per-record-type progress.
+ */
+private suspend inline fun <reified S : Any> sendSingleType(
+  serializables: List<S>,
+  syncUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+  recordTypeName: String,
+  reporter: SyncProgressReporter,
+  logTag: String,
+): PostResult {
+  reporter.updateRecordType(recordTypeName) {
+    it.copy(status = SyncStageStatus.Active, totalChunks = 1, currentChunk = 1)
+  }
+  val result = postChunkWithRetry(PostWrapper(serializables), syncUrl, authToken, httpClient, logTag)
+  reporter.updateRecordType(recordTypeName) {
+    when {
+      result.isSuccess ->
+        it.copy(
+          status = SyncStageStatus.Done,
+          sentRecords = serializables.size,
+          currentChunk = 1,
+        )
+      else -> it.copy(status = SyncStageStatus.Failed, errorMessage = result.errorMessage())
+    }
+  }
+  return result
 }
 
 /**
@@ -181,6 +262,7 @@ suspend fun sendRecords(
   serverUrl: String,
   authToken: String,
   httpClient: HttpClient,
+  reporter: SyncProgressReporter = NoOpSyncProgressReporter,
   logTag: String = SYNC_UTILS_TAG,
 ): PostResult {
   if (records.isEmpty()) return PostResult.Success
@@ -192,70 +274,77 @@ suspend fun sendRecords(
     val typeName = recordClass.simpleName ?: "UnknownRecordType"
     val syncUrl = "$serverUrl/sync/$typeName"
 
+    classRecords.oldestEventInstant()?.let(reporter::reportDataInstant)
+
     val result =
       when (recordClass) {
         ActiveCaloriesBurnedRecord::class ->
-          postChunk(
-            PostWrapper(ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords)),
-            syncUrl,
-            authToken,
-            httpClient,
-            logTag,
+          sendSingleType(
+            ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         BodyFatRecord::class ->
-          postChunk(PostWrapper(BodyFatRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(BodyFatRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         BodyWaterMassRecord::class ->
-          postChunk(PostWrapper(BodyWaterMassRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         BoneMassRecord::class ->
-          postChunk(PostWrapper(BoneMassRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(BoneMassRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         DistanceRecord::class ->
-          postChunk(PostWrapper(DistanceRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(DistanceRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         ExerciseSessionRecord::class ->
-          postChunk(PostWrapper(ExerciseSessionRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(
+            ExerciseSessionRecordSerializable.fromRecordsList(classRecords),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         FloorsClimbedRecord::class ->
-          postChunk(PostWrapper(FloorsClimbedRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(
+            FloorsClimbedRecordSerializable.fromRecordsList(classRecords),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         HeartRateRecord::class ->
           postDataChunked(
             HeartRateRecordSerializable.fromRecordsList(classRecords),
             syncUrl,
             authToken,
             httpClient,
-            chunkSize = 10,
+            chunkSize = HEART_RATE_CHUNK_SIZE,
             recordTypeName = typeName,
+            reporter = reporter,
             logTag = logTag,
           )
         HeartRateVariabilityRmssdRecord::class ->
-          postChunk(PostWrapper(HrvRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(HrvRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         HeightRecord::class ->
-          postChunk(PostWrapper(HeightRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(HeightRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         LeanBodyMassRecord::class ->
-          postChunk(PostWrapper(LeanBodyMassRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(LeanBodyMassRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         NutritionRecord::class ->
-          postChunk(PostWrapper(NutritionRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(NutritionRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         PowerRecord::class ->
-          postChunk(PostWrapper(PowerRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(PowerRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         RestingHeartRateRecord::class ->
-          postChunk(PostWrapper(RestingHeartRateRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(
+            RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         SleepSessionRecord::class ->
-          postChunk(PostWrapper(SleepSessionRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(SleepSessionRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         SpeedRecord::class ->
-          postChunk(PostWrapper(SpeedRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(SpeedRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         StepsRecord::class ->
-          postChunk(PostWrapper(StepsRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(StepsRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         TotalCaloriesBurnedRecord::class ->
-          postChunk(
-            PostWrapper(TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords)),
-            syncUrl,
-            authToken,
-            httpClient,
-            logTag,
+          sendSingleType(
+            TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         Vo2MaxRecord::class ->
-          postChunk(PostWrapper(Vo2MaxRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(Vo2MaxRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         WeightRecord::class ->
-          postChunk(PostWrapper(WeightRecordSerializable.fromRecordsList(classRecords)), syncUrl, authToken, httpClient, logTag)
+          sendSingleType(WeightRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
         else -> {
           Log.w(logTag, "No serializer for $typeName, skipping ${classRecords.size} records")
+          reporter.updateRecordType(typeName) { it.copy(status = SyncStageStatus.Skipped, errorMessage = "no serializer") }
           PostResult.Success
         }
       }
@@ -280,12 +369,10 @@ suspend fun sendPage(
   serverUrl: String,
   authToken: String,
   httpClient: HttpClient,
+  reporter: SyncProgressReporter = NoOpSyncProgressReporter,
   logTag: String = SYNC_UTILS_TAG,
 ): PostResult {
-  // Send deletions first
   val deletionResult = sendDeletions(deletionIds, serverUrl, authToken, httpClient, logTag)
   if (!deletionResult.isSuccess) return deletionResult
-
-  // Then send records
-  return sendRecords(records, serverUrl, authToken, httpClient, logTag)
+  return sendRecords(records, serverUrl, authToken, httpClient, reporter, logTag)
 }

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -40,6 +40,7 @@ class SyncWorker(
 
   override suspend fun doWork(): Result {
     Log.d(TAG, "Starting background sync")
+    val reporter = applicationContext.syncProgressReporter()
 
     val credentials = CredentialsManager.getCredentials(applicationContext)
     if (credentials == null) {
@@ -59,25 +60,32 @@ class SyncWorker(
     // Invalidate token if granted types changed since last sync
     invalidateTokenIfGrantedTypesChanged(grantedTypes)
 
+    reporter.begin()
     return try {
       // Step 0: Process pending local data entries (Add Data offline queue)
-      processPendingData(credentials.apiUrl, credentials.authToken)
+      processPendingData(credentials.apiUrl, credentials.authToken, reporter)
 
       // Step 1: Fetch and send daily aggregates for cumulative metrics (deduplicated)
       val aggregates = fetchDailyAggregates(healthConnectClient, grantedTypes.toSet(), days = 7)
       if (aggregates.isNotEmpty()) {
-        val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken, httpClient)
+        val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken, httpClient, reporter)
         if (!aggregateSuccess) {
           Log.w(TAG, "Failed to send daily aggregates, will retry")
+          reporter.end("Daily aggregates failed")
           return Result.retry()
         }
         Log.d(TAG, "Sent ${aggregates.size} daily aggregates")
+      } else {
+        reporter.updateStage(SyncStage.DailyAggregates) {
+          it.copy(status = SyncStageStatus.Done, message = "Nothing to send")
+        }
       }
 
       // Step 2: Fetch and send raw records incrementally (page by page)
-      val syncSuccess = fetchAndSyncHealthData(credentials.apiUrl, credentials.authToken)
+      val syncSuccess = fetchAndSyncHealthData(credentials.apiUrl, credentials.authToken, reporter)
       if (!syncSuccess) {
         Log.w(TAG, "Incremental sync failed, will retry")
+        reporter.end("Health Connect sync failed")
         return Result.retry()
       }
 
@@ -90,9 +98,13 @@ class SyncWorker(
           httpClient = httpClient,
           healthConnectClient = healthConnectClient,
           grantedPermissions = grantedPermissions,
+          reporter = reporter,
         )
       } catch (e: Exception) {
         Log.w(TAG, "Outbound sync failed: ${e.message}")
+        reporter.updateStage(SyncStage.Outbound) {
+          it.copy(status = SyncStageStatus.Failed, errorMessage = e.message)
+        }
       }
 
       // Step 4: ActivityWatch sync (if enabled).
@@ -111,9 +123,11 @@ class SyncWorker(
       }
 
       HrZoneWidgetProvider.triggerUpdate(applicationContext)
+      reporter.end()
       Result.success()
     } catch (e: Exception) {
       Log.e(TAG, "Background sync failed", e)
+      reporter.end(e.message)
       Result.retry()
     }
   }
@@ -122,10 +136,24 @@ class SyncWorker(
    * Process pending local data entries (activities and metrics queued offline).
    * Successfully sent entries are removed; failures are left for the next sync cycle.
    */
-  private suspend fun processPendingData(serverUrl: String, authToken: String) {
+  private suspend fun processPendingData(serverUrl: String, authToken: String, reporter: SyncProgressReporter) {
     val entries = getPendingEntries(applicationContext)
-    if (entries.isEmpty()) return
+    if (entries.isEmpty()) {
+      reporter.updateStage(SyncStage.PendingData) {
+        it.copy(status = SyncStageStatus.Done, message = "No queued entries")
+      }
+      return
+    }
     Log.d(TAG, "Processing ${entries.size} pending data entries")
+    reporter.updateStage(SyncStage.PendingData) {
+      it.copy(
+        status = SyncStageStatus.Active,
+        message = "Uploading ${entries.size} queued ${if (entries.size == 1) "entry" else "entries"}",
+        sentRecords = 0,
+      )
+    }
+    var sent = 0
+    var failed = 0
 
     for (entry in entries) {
       val result = when (val data = entry.data) {
@@ -153,12 +181,21 @@ class SyncWorker(
         is DataResult.Success<*> -> {
           removePendingEntry(applicationContext, entry.id)
           Log.d(TAG, "Pending entry ${entry.id} synced successfully")
+          sent++
+          reporter.updateStage(SyncStage.PendingData) { it.copy(sentRecords = sent) }
         }
         is DataResult.Error -> {
           markPendingEntryFailed(applicationContext, entry.id, result.message)
           Log.w(TAG, "Pending entry ${entry.id} failed: ${result.message}")
+          failed++
         }
       }
+    }
+    reporter.updateStage(SyncStage.PendingData) {
+      it.copy(
+        status = if (failed == 0) SyncStageStatus.Done else SyncStageStatus.Failed,
+        message = "$sent uploaded, $failed failed",
+      )
     }
   }
 
@@ -172,11 +209,19 @@ class SyncWorker(
   private suspend fun fetchAndSyncHealthData(
     serverUrl: String,
     authToken: String,
+    reporter: SyncProgressReporter,
   ): Boolean {
     val lastToken = loadChangesToken()
     if (lastToken == null) {
       Log.d(TAG, "No token found, skipping background fetch (initial fetch should be done in foreground)")
+      reporter.updateStage(SyncStage.HealthConnect) {
+        it.copy(status = SyncStageStatus.Skipped, message = "Initial fetch must run in foreground")
+      }
       return true
+    }
+
+    reporter.updateStage(SyncStage.HealthConnect) {
+      it.copy(status = SyncStageStatus.Active, message = "Fetching incremental changes…", sentRecords = 0, sentDeletions = 0)
     }
 
     var currentToken: String = lastToken
@@ -201,13 +246,26 @@ class SyncWorker(
 
       if (upsertions.isNotEmpty() || deletionIds.isNotEmpty()) {
         Log.d(TAG, "Page $pageNum: ${upsertions.size} records, ${deletionIds.size} deletions")
-        val result = sendPage(upsertions, deletionIds, serverUrl, authToken, httpClient, TAG)
+        upsertions.oldestEventInstant()?.let(reporter::reportDataInstant)
+        reporter.updateStage(SyncStage.HealthConnect) {
+          it.copy(
+            currentPage = pageNum,
+            message = "Page $pageNum (${upsertions.size} records, ${deletionIds.size} deletions)",
+          )
+        }
+        val result = sendPage(upsertions, deletionIds, serverUrl, authToken, httpClient, reporter, TAG)
         if (!result.isSuccess) {
           Log.w(TAG, "Page $pageNum failed: ${result.errorMessage()}, will retry from saved token")
+          reporter.updateStage(SyncStage.HealthConnect) {
+            it.copy(status = SyncStageStatus.Failed, errorMessage = result.errorMessage())
+          }
           return false
         }
         totalRecords += upsertions.size
         totalDeletions += deletionIds.size
+        reporter.updateStage(SyncStage.HealthConnect) {
+          it.copy(sentRecords = totalRecords, sentDeletions = totalDeletions)
+        }
       }
 
       // Save intermediate token -- this page is permanently done
@@ -218,8 +276,18 @@ class SyncWorker(
 
     if (totalRecords > 0 || totalDeletions > 0) {
       Log.d(TAG, "Incremental sync complete: $totalRecords records, $totalDeletions deletions across $pageNum pages")
+      reporter.updateStage(SyncStage.HealthConnect) {
+        it.copy(
+          status = SyncStageStatus.Done,
+          totalPages = pageNum,
+          message = "$totalRecords records, $totalDeletions deletions ($pageNum pages)",
+        )
+      }
     } else {
       Log.d(TAG, "No new inbound data to sync")
+      reporter.updateStage(SyncStage.HealthConnect) {
+        it.copy(status = SyncStageStatus.Done, message = "Up to date")
+      }
     }
     return true
   }


### PR DESCRIPTION
## Summary

The sync page on Android currently shows a single status line and a spinner, which makes long syncs (Sara reported an hour-long heart-rate catch-up) look stuck. This PR replaces that with a structured per-stage / per-record-type progress view, surfaces chunk and page numbers, and shows how far behind the sync currently is.

- New `SyncProgressReporter` (held on `AurbodaApplication`) that both `SyncWorker` and the in-screen flows write to via a `StateFlow<SyncProgressState>`.
- `SyncProgressView` Compose component renders one row per stage (Pending uploads / Daily aggregates / Health Connect / Write back / ActivityWatch) plus per-record-type rows under HC with `chunk N / M` and a linear progress bar for HeartRate.
- "Syncing data from N days ago" line tracks the oldest in-flight record/entry timestamp and ticks every 30s, so users see the catch-up move forward.
- Outbound sync now reports `page N / ~M (X total pending)` (computed from the existing `total_pending` response field) and the oldest pending `created_at`.
- Bounded exponential-backoff retry (500ms · 1s · 2s) on transient HTTP/network errors so a flaky chunk no longer aborts a whole record type.
- HeartRateRecord chunk size bumped 10 → 50 (still well under the backend's 10MB body limit, ≈5× fewer round-trips for HR).

## Test plan

- [ ] Smoke: open the app on a phone several days behind on HR; confirm "Syncing data from N days ago" appears and updates.
- [ ] Confirm HR row shows `chunk N / 50ish` and a progress bar while it's working.
- [ ] Confirm outbound sync row shows `page N / ~M`.
- [ ] Pull network for ~10s mid-chunk; sync should retry rather than fail-out the whole record type.
- [ ] Initial sync (clear app data → re-grant) still completes and stores a token.
- [ ] Background sync (15-min WorkManager schedule) still updates the same UI when the app is reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)