### PR TITLE
feat(food-items): fuzzy/accent search, always-edit detail, search-first list

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -102,8 +102,9 @@ export const makeNewUserDb = async (adminClient: Client, user: string, password:
   await newDbClient.connect()
   await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS postgis')
   // Search extensions used for fuzzy/accent-insensitive food-item lookup.
-  // Trusted in PG13+, but we create them here while we still have the
-  // superuser connection so existing-user migrateSchema doesn't depend on it.
+  // Belt-and-braces: also created idempotently from food_items_search_setup
+  // (trusted in PG13+, db owner can install). Doing it here too keeps new
+  // users working even if the trusted-extension policy changes.
   await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS pg_trgm')
   await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS unaccent')
   await newDbClient.end()

--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -101,6 +101,11 @@ export const makeNewUserDb = async (adminClient: Client, user: string, password:
   const newDbClient = new Client({ database })
   await newDbClient.connect()
   await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS postgis')
+  // Search extensions used for fuzzy/accent-insensitive food-item lookup.
+  // Trusted in PG13+, but we create them here while we still have the
+  // superuser connection so existing-user migrateSchema doesn't depend on it.
+  await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS pg_trgm')
+  await query(newDbClient, 'CREATE EXTENSION IF NOT EXISTS unaccent')
   await newDbClient.end()
 
   const client = new Client({ database, password, user })

--- a/apps/backend/src/db/food-items.integration.test.ts
+++ b/apps/backend/src/db/food-items.integration.test.ts
@@ -85,6 +85,59 @@ describe('Food Items Integration Tests', () => {
       expect(results).toHaveLength(1)
       expect(results[0].name).toBe('Fat Coffee')
     })
+
+    test('matches mid-word substrings (brand-prefixed names)', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: 'Arla, Hushallsost' })
+      await upsertFoodItem(user, { name: 'Banana' })
+
+      const results = await searchFoodItems(user, 'hushallsost', 10)
+      expect(results.map((r) => r.name)).toContain('Arla, Hushallsost')
+    })
+
+    test('folds diacritics (å/ä/ö → a/a/o)', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: 'Arla, Hushållsost' })
+      await upsertFoodItem(user, { name: 'Mjölk' })
+
+      const cheeseHits = await searchFoodItems(user, 'hushallsost', 10)
+      expect(cheeseHits.map((r) => r.name)).toContain('Arla, Hushållsost')
+
+      const milkHits = await searchFoodItems(user, 'mjolk', 10)
+      expect(milkHits.map((r) => r.name)).toContain('Mjölk')
+    })
+
+    test('tolerates typos via trigram similarity', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: 'Arla, Hushållsost' })
+      await upsertFoodItem(user, { name: 'Banana' })
+
+      // "hushalsost" — missing one 'l' compared to "hushållsost"
+      const results = await searchFoodItems(user, 'hushalsost', 10)
+      expect(results.map((r) => r.name)).toContain('Arla, Hushållsost')
+    })
+
+    test('ranks substring hits above fuzzy-only hits', async () => {
+      const user = getTestUser()
+
+      // "hushallsost" is a substring of the first; only fuzzy-similar to the second.
+      await upsertFoodItem(user, { name: 'Arla, Hushållsost' })
+      await upsertFoodItem(user, { name: 'Hushållsosk' })
+
+      const results = await searchFoodItems(user, 'hushallsost', 10)
+      expect(results[0].name).toBe('Arla, Hushållsost')
+    })
+
+    test('returns empty array for empty query', async () => {
+      const user = getTestUser()
+      await upsertFoodItem(user, { name: 'Banana' })
+
+      expect(await searchFoodItems(user, '', 10)).toEqual([])
+      expect(await searchFoodItems(user, '   ', 10)).toEqual([])
+    })
   })
 
   describe('getFoodItemByName', () => {

--- a/apps/backend/src/db/food-items.integration.test.ts
+++ b/apps/backend/src/db/food-items.integration.test.ts
@@ -138,6 +138,39 @@ describe('Food Items Integration Tests', () => {
       expect(await searchFoodItems(user, '', 10)).toEqual([])
       expect(await searchFoodItems(user, '   ', 10)).toEqual([])
     })
+
+    test('treats LIKE wildcards in user input as literals', async () => {
+      const user = getTestUser()
+
+      await upsertFoodItem(user, { name: '500g pasta' })
+      await upsertFoodItem(user, { name: '50% off-cut bacon' })
+
+      // Plain "50%" must only match the literal "50%" string, not "500g..."
+      const percentHits = await searchFoodItems(user, '50%', 10)
+      expect(percentHits.map((r) => r.name)).toEqual(['50% off-cut bacon'])
+
+      // Plain "_" must be a literal (it shouldn't match the underscore wildcard).
+      await upsertFoodItem(user, { name: 'a_b widget' })
+      const underscoreHits = await searchFoodItems(user, 'a_b', 10)
+      expect(underscoreHits.map((r) => r.name)).toEqual(['a_b widget'])
+    })
+
+    test('does not run trigram fuzzy matching for queries shorter than 3 chars', async () => {
+      const user = getTestUser()
+
+      // "hu" is a fuzzy-similar substring of "Hushållsost" — the trigram path
+      // would surface it, but we want short queries restricted to substring.
+      await upsertFoodItem(user, { name: 'Hushållsost' })
+      await upsertFoodItem(user, { name: 'Cucumber' })
+
+      // 'cu' is a literal substring of 'Cucumber' (substring path)
+      const subHits = await searchFoodItems(user, 'cu', 10)
+      expect(subHits.map((r) => r.name)).toEqual(['Cucumber'])
+
+      // 'xz' has no substring match anywhere; without trigram it returns nothing.
+      const noHits = await searchFoodItems(user, 'xz', 10)
+      expect(noHits).toEqual([])
+    })
   })
 
   describe('getFoodItemByName', () => {

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -55,30 +55,38 @@ export interface InsertFoodItemInput {
 
 // ── CRUD ─────────────────────────────────────────────────────────────────────
 
+const TRIGRAM_SIMILARITY_THRESHOLD = 0.2
+const TRIGRAM_MIN_QUERY_LENGTH = 3
+
+// Escape user-provided LIKE wildcards so a search for "50%" doesn't match
+// anything-starting-with-50. The ESCAPE clause in the SQL pairs with this.
+const escapeLikeWildcards = (s: string): string => s.replaceAll(/[\\%_]/g, '\\$&')
+
 /**
  * Search food items by name. Substring + accent-folded match wins; a trigram
  * similarity pass on top picks up typos like "hushalsost" → "Hushållsost"
- * once the query is at least 3 chars. Substring hits always rank above
- * fuzzy-only hits, then earliest match position, then similarity score.
+ * once the query is at least TRIGRAM_MIN_QUERY_LENGTH chars. Substring hits
+ * always rank above fuzzy-only hits, then earliest match position, then
+ * similarity score.
  */
 export const searchFoodItems = async (user: string, q: string, limit = 20): Promise<FoodItemEntity[]> => {
   const trimmed = q.trim()
   if (!trimmed) return []
-  const lower = trimmed.toLowerCase()
-  const enableTrigram = lower.length >= 3
+  const enableTrigram = trimmed.length >= TRIGRAM_MIN_QUERY_LENGTH
+  const likePattern = `%${escapeLikeWildcards(trimmed)}%`
   const result = await query(
     user,
     `SELECT ${FOOD_ITEM_COLUMNS}
      FROM food_items
-     WHERE immutable_unaccent(name_lower) ILIKE '%' || immutable_unaccent($1) || '%'
-        OR ($3 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($1)) > 0.2)
+     WHERE immutable_unaccent(name_lower) ILIKE immutable_unaccent($1) ESCAPE '\\'
+        OR ($4 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) > $5)
      ORDER BY
-       CASE WHEN immutable_unaccent(name_lower) ILIKE '%' || immutable_unaccent($1) || '%' THEN 0 ELSE 1 END,
-       POSITION(immutable_unaccent($1) IN immutable_unaccent(name_lower)),
-       similarity(immutable_unaccent(name_lower), immutable_unaccent($1)) DESC,
+       CASE WHEN immutable_unaccent(name_lower) ILIKE immutable_unaccent($1) ESCAPE '\\' THEN 0 ELSE 1 END,
+       POSITION(immutable_unaccent($2) IN immutable_unaccent(name_lower)),
+       similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) DESC,
        name_lower
-     LIMIT $2`,
-    [lower, limit, enableTrigram],
+     LIMIT $3`,
+    [likePattern, trimmed, limit, enableTrigram, TRIGRAM_SIMILARITY_THRESHOLD],
   )
   return result.rows.map(mapFoodItemRow)
 }

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -56,13 +56,29 @@ export interface InsertFoodItemInput {
 // ── CRUD ─────────────────────────────────────────────────────────────────────
 
 /**
- * Search food items by name prefix (case-insensitive).
+ * Search food items by name. Substring + accent-folded match wins; a trigram
+ * similarity pass on top picks up typos like "hushalsost" → "Hushållsost"
+ * once the query is at least 3 chars. Substring hits always rank above
+ * fuzzy-only hits, then earliest match position, then similarity score.
  */
 export const searchFoodItems = async (user: string, q: string, limit = 20): Promise<FoodItemEntity[]> => {
+  const trimmed = q.trim()
+  if (!trimmed) return []
+  const lower = trimmed.toLowerCase()
+  const enableTrigram = lower.length >= 3
   const result = await query(
     user,
-    `SELECT ${FOOD_ITEM_COLUMNS} FROM food_items WHERE name_lower LIKE $1 ORDER BY name_lower LIMIT $2`,
-    [`${q.toLowerCase().trim()}%`, limit],
+    `SELECT ${FOOD_ITEM_COLUMNS}
+     FROM food_items
+     WHERE immutable_unaccent(name_lower) ILIKE '%' || immutable_unaccent($1) || '%'
+        OR ($3 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($1)) > 0.2)
+     ORDER BY
+       CASE WHEN immutable_unaccent(name_lower) ILIKE '%' || immutable_unaccent($1) || '%' THEN 0 ELSE 1 END,
+       POSITION(immutable_unaccent($1) IN immutable_unaccent(name_lower)),
+       similarity(immutable_unaccent(name_lower), immutable_unaccent($1)) DESC,
+       name_lower
+     LIMIT $2`,
+    [lower, limit, enableTrigram],
   )
   return result.rows.map(mapFoodItemRow)
 }

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -81,6 +81,7 @@ export const tableCreationOrder = [
   'meal_log_completed',
   'food_items',
   'food_items_indexes',
+  'food_items_search_setup',
   'meal_food_items',
   'meal_food_items_indexes',
   'locations',

--- a/apps/backend/src/schema/meals.ts
+++ b/apps/backend/src/schema/meals.ts
@@ -119,6 +119,20 @@ export const mealsTables: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_food_items_name_lower ON food_items (name_lower)
   `,
 
+  // Fuzzy/accent-insensitive search support: pg_trgm + unaccent extensions,
+  // an IMMUTABLE wrapper around unaccent so it can index, and a GIN trigram
+  // index over the unaccented name. Both extensions are "trusted" in PG13+,
+  // so the database owner can install them.
+  food_items_search_setup: `
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    CREATE EXTENSION IF NOT EXISTS unaccent;
+    CREATE OR REPLACE FUNCTION immutable_unaccent(text) RETURNS text AS $$
+      SELECT public.unaccent('public.unaccent', $1)
+    $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
+    CREATE INDEX IF NOT EXISTS idx_food_items_name_unaccent_trgm
+      ON food_items USING gin (immutable_unaccent(name_lower) gin_trgm_ops)
+  `,
+
   // Junction: meals <-> food items (snapshot of nutrients at insertion time)
   meal_food_items: `
     CREATE TABLE IF NOT EXISTS meal_food_items (

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -17,6 +17,26 @@
   align-items: center;
 }
 
+.save-status {
+  font-size: 0.85rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+}
+
+.save-pending {
+  color: #6b7280;
+}
+
+.save-ok {
+  color: #166534;
+  background: #dcfce7;
+}
+
+.save-error {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
 .food-item-detail-page h1 {
   font-size: 1.5rem;
   font-weight: 600;

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -44,6 +44,13 @@
   color: #1f2937;
 }
 
+.fi-name-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+}
+
 .fi-name-input {
   font-size: 1.25rem;
   font-weight: 600;
@@ -52,8 +59,7 @@
   border-radius: 4px;
   color: #374151;
   background: #fff;
-  width: 100%;
-  margin-bottom: 1rem;
+  flex: 1;
 }
 
 .fi-default-edit {

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,14 +1,13 @@
 import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation, useRoute } from 'preact-iso'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 
 import type { FoodItemEntity } from '../../state/api'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { IconInput } from '../../components/IconInput'
 import { auth } from '../../state/auth'
-import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import './FoodItemDetail.css'
 
 const API_URL = import.meta.env.VITE_API_URL || '/api'
@@ -54,62 +53,65 @@ const CATEGORIES: Array<{ key: NutrientFieldDef['category']; label: string }> = 
   { key: 'other', label: 'Other' },
 ]
 
-function NutrientSection({
-  item,
-  category,
-  label,
-  editing,
-  onEdit,
+function SaveIndicator({
+  isPending,
+  showSaved,
+  error,
 }: {
-  item: FoodItemEntity
-  category: string
-  label: string
-  editing: Record<string, unknown> | null
-  onEdit?: (field: string, value: number | undefined) => void
+  isPending: boolean
+  showSaved: boolean
+  error: string | null
 }) {
-  const fields = NUTRIENT_FIELDS.filter((f) => f.category === category)
-  const isEditing = editing !== null
-  const populated = isEditing
-    ? fields
-    : fields.filter((f) => item[f.name] !== undefined && item[f.name] !== null)
-  if (populated.length === 0) return null
+  if (error) return <span class="save-status save-error">⚠ {error}</span>
+  if (isPending) return <span class="save-status save-pending">Saving…</span>
+  if (showSaved) return <span class="save-status save-ok">Saved ✓</span>
+  return null
+}
+
+function NutrientInput({
+  field,
+  initial,
+  onCommit,
+}: {
+  field: NutrientFieldDef
+  initial: number | undefined
+  onCommit: (value: number | null) => void
+}) {
+  const [local, setLocal] = useState<string>(initial !== undefined ? String(initial) : '')
+
+  useEffect(() => {
+    setLocal(initial !== undefined ? String(initial) : '')
+  }, [initial])
+
+  const handleBlur = () => {
+    const trimmed = local.trim()
+    if (trimmed === '') {
+      if (initial !== undefined) onCommit(null)
+      return
+    }
+    const parsed = parseFloat(trimmed)
+    if (Number.isNaN(parsed)) {
+      // Revert to last good value rather than blanking the saved nutrient.
+      setLocal(initial !== undefined ? String(initial) : '')
+      return
+    }
+    if (parsed !== initial) onCommit(parsed)
+  }
 
   return (
-    <div class="nutrient-section">
-      <h3>{label}</h3>
-      <div class="nutrient-grid">
-        {populated.map((f) => {
-          const val = editing?.[f.name] !== undefined ? editing[f.name] : item[f.name]
-          return (
-            <div key={f.name} class="nutrient-row">
-              <span class="nutrient-label">{f.label}</span>
-              {isEditing ? (
-                <span class="nutrient-edit">
-                  <input
-                    type="number"
-                    step="0.01"
-                    value={typeof val === 'number' ? val : ''}
-                    onInput={(e) => {
-                      const v = (e.target as HTMLInputElement).value
-                      onEdit?.(f.name, v === '' ? undefined : parseFloat(v))
-                    }}
-                  />
-                  <span class="nutrient-unit">{f.unit}</span>
-                </span>
-              ) : (
-                <span class="nutrient-value">
-                  {typeof val === 'number' ? val.toFixed(2) : val} {f.unit}
-                </span>
-              )}
-            </div>
-          )
-        })}
-      </div>
-    </div>
+    <span class="nutrient-edit">
+      <input
+        type="number"
+        step="0.01"
+        value={local}
+        onInput={(e) => setLocal((e.target as HTMLInputElement).value)}
+        onBlur={handleBlur}
+      />
+      <span class="nutrient-unit">{field.unit}</span>
+    </span>
   )
 }
 
-// eslint-disable-next-line complexity -- detail page with edit mode
 export function FoodItemDetail() {
   const { params } = useRoute()
   const { route } = useLocation()
@@ -121,17 +123,39 @@ export function FoodItemDetail() {
     queryKey: ['foodItem', id],
   })
 
-  const [editing, setEditing] = useState<Record<string, unknown> | null>(null)
+  const [name, setName] = useState('')
+  const [defaultQuantity, setDefaultQuantity] = useState<string>('')
+  const [defaultUnit, setDefaultUnit] = useState<string>('')
 
-  // Invalidate parent list when leaving so it shows fresh data
+  const [savedFlash, setSavedFlash] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => () => void queryClient.invalidateQueries({ queryKey: ['foodItems'] }), [queryClient])
+  useEffect(
+    () => () => {
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!item) return
+    setName(item.name)
+    setDefaultQuantity(item.default_quantity !== undefined ? String(item.default_quantity) : '')
+    setDefaultUnit(item.default_unit ?? '')
+  }, [item])
 
   const updateMutation = useMutation({
     mutationFn: (body: Record<string, unknown>) => updateFoodItemApi(id, body),
+    onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['foodItem', id] })
       queryClient.invalidateQueries({ queryKey: ['foodItems'] })
-      setEditing(null)
+      setSaveError(null)
+      setSavedFlash(true)
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+      flashTimer.current = setTimeout(() => setSavedFlash(false), 1200)
     },
   })
 
@@ -142,6 +166,11 @@ export function FoodItemDetail() {
       route('/food-items')
     },
   })
+
+  const save = (body: Record<string, unknown>) => {
+    setSaveError(null)
+    updateMutation.mutate(body)
+  }
 
   if (isLoading) {
     return (
@@ -158,15 +187,34 @@ export function FoodItemDetail() {
     )
   }
 
-  const isEditing = editing !== null
-  const editName = (editing?.name as string) ?? item.name
-  const editIcon = (editing?.icon as string) ?? item.icon ?? ''
-  const editQty = (editing?.default_quantity as number) ?? item.default_quantity
-  const editUnit = (editing?.default_unit as string) ?? item.default_unit
+  const commitName = () => {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setName(item.name)
+      return
+    }
+    if (trimmed !== item.name) save({ name: trimmed })
+  }
 
-  const handleSave = () => {
-    if (!editing) return
-    updateMutation.mutate(editing)
+  const commitDefaultQuantity = () => {
+    const trimmed = defaultQuantity.trim()
+    if (trimmed === '') {
+      if (item.default_quantity !== undefined) save({ default_quantity: null })
+      return
+    }
+    const parsed = parseFloat(trimmed)
+    if (Number.isNaN(parsed)) {
+      setDefaultQuantity(item.default_quantity !== undefined ? String(item.default_quantity) : '')
+      return
+    }
+    if (parsed !== item.default_quantity) save({ default_quantity: parsed })
+  }
+
+  const commitDefaultUnit = () => {
+    const trimmed = defaultUnit.trim()
+    const current = item.default_unit ?? ''
+    if (trimmed === current) return
+    save({ default_unit: trimmed || null })
   }
 
   return (
@@ -176,25 +224,7 @@ export function FoodItemDetail() {
           &larr; Food Items
         </a>
         <div class="fi-detail-actions">
-          {isEditing ? (
-            <>
-              <button
-                type="button"
-                class="btn-primary"
-                onClick={handleSave}
-                disabled={updateMutation.isPending}
-              >
-                {updateMutation.isPending ? 'Saving...' : 'Save'}
-              </button>
-              <button type="button" class="btn-secondary" onClick={() => setEditing(null)}>
-                Cancel
-              </button>
-            </>
-          ) : (
-            <button type="button" class="btn-secondary" onClick={() => setEditing({})}>
-              Edit
-            </button>
-          )}
+          <SaveIndicator isPending={updateMutation.isPending} showSaved={savedFlash} error={saveError} />
           <ConfirmButton
             label="Delete"
             confirmMessage={`Delete ${item.name}?`}
@@ -204,72 +234,66 @@ export function FoodItemDetail() {
         </div>
       </div>
 
-      {isEditing ? (
-        <input
-          type="text"
-          class="fi-name-input"
-          value={editName}
-          onInput={(e) => setEditing({ ...editing, name: (e.target as HTMLInputElement).value })}
-        />
-      ) : (
-        <h1>
-          {item.icon && isEmoji(item.icon) && <span class="fi-icon-display">{item.icon} </span>}
-          {item.icon && (isUrl(item.icon) || isIconPath(item.icon)) && (
-            <img src={item.icon} alt="icon" width={24} height={24} class="fi-icon-display-img" />
-          )}
-          {item.name}
-        </h1>
-      )}
+      <input
+        type="text"
+        class="fi-name-input"
+        value={name}
+        onInput={(e) => setName((e.target as HTMLInputElement).value)}
+        onBlur={commitName}
+      />
 
-      {isEditing && (
-        <div class="fi-icon-row">
-          <label class="fi-icon-label">Icon</label>
-          <IconInput value={editIcon} onChange={(v) => setEditing({ ...editing, icon: v || null })} />
-        </div>
-      )}
+      <div class="fi-icon-row">
+        <label class="fi-icon-label">Icon</label>
+        <IconInput value={item.icon ?? ''} onChange={(v) => save({ icon: v || null })} />
+      </div>
 
       <div class="fi-meta">
         {item.source && <span class="fi-source">Source: {item.source}</span>}
-        {isEditing ? (
-          <span class="fi-default-edit">
-            Default:
-            <input
-              type="number"
-              step="0.1"
-              value={editQty ?? ''}
-              placeholder="Qty"
-              onInput={(e) =>
-                setEditing({
-                  ...editing,
-                  default_quantity: parseFloat((e.target as HTMLInputElement).value) || undefined,
-                })
-              }
-            />
-            <input
-              type="text"
-              value={editUnit ?? ''}
-              placeholder="Unit"
-              onInput={(e) => setEditing({ ...editing, default_unit: (e.target as HTMLInputElement).value })}
-            />
-          </span>
-        ) : item.default_quantity ? (
-          <span class="fi-default">
-            Default: {item.default_quantity} {item.default_unit ?? 'serving'}
-          </span>
-        ) : null}
+        <span class="fi-default-edit">
+          Default:
+          <input
+            type="number"
+            step="0.1"
+            value={defaultQuantity}
+            placeholder="Qty"
+            onInput={(e) => setDefaultQuantity((e.target as HTMLInputElement).value)}
+            onBlur={commitDefaultQuantity}
+          />
+          <input
+            type="text"
+            value={defaultUnit}
+            placeholder="Unit"
+            onInput={(e) => setDefaultUnit((e.target as HTMLInputElement).value)}
+            onBlur={commitDefaultUnit}
+          />
+        </span>
       </div>
 
       <div class="nutrient-sections">
-        {CATEGORIES.map(({ key, label }) => (
-          <NutrientSection
-            key={key}
-            item={item}
-            category={key}
-            label={label}
-            editing={editing}
-            onEdit={(field, value) => setEditing({ ...editing, [field]: value })}
-          />
-        ))}
+        {CATEGORIES.map(({ key, label }) => {
+          const fields = NUTRIENT_FIELDS.filter((f) => f.category === key)
+          if (fields.length === 0) return null
+          return (
+            <div key={key} class="nutrient-section">
+              <h3>{label}</h3>
+              <div class="nutrient-grid">
+                {fields.map((f) => {
+                  const value = item[f.name]
+                  return (
+                    <div key={f.name} class="nutrient-row">
+                      <span class="nutrient-label">{f.label}</span>
+                      <NutrientInput
+                        field={f}
+                        initial={typeof value === 'number' ? value : undefined}
+                        onCommit={(v) => save({ [f.name]: v })}
+                      />
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -8,6 +8,7 @@ import type { FoodItemEntity } from '../../state/api'
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { IconInput } from '../../components/IconInput'
 import { auth } from '../../state/auth'
+import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import './FoodItemDetail.css'
 
 const API_URL = import.meta.env.VITE_API_URL || '/api'
@@ -126,6 +127,7 @@ export function FoodItemDetail() {
   const [name, setName] = useState('')
   const [defaultQuantity, setDefaultQuantity] = useState<string>('')
   const [defaultUnit, setDefaultUnit] = useState<string>('')
+  const [icon, setIcon] = useState<string>('')
 
   const [savedFlash, setSavedFlash] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -139,18 +141,24 @@ export function FoodItemDetail() {
     [],
   )
 
+  // Re-seed local state only when we navigate to a different food item.
+  // On post-save refetches, item.id is stable so this skips — keeping any
+  // field the user is mid-edit from being clobbered by the new server data.
   useEffect(() => {
     if (!item) return
     setName(item.name)
     setDefaultQuantity(item.default_quantity !== undefined ? String(item.default_quantity) : '')
     setDefaultUnit(item.default_unit ?? '')
-  }, [item])
+    setIcon(item.icon ?? '')
+  }, [item?.id])
 
   const updateMutation = useMutation({
     mutationFn: (body: Record<string, unknown>) => updateFoodItemApi(id, body),
     onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['foodItem', id] })
+    onSuccess: (updated) => {
+      // Seed the cache directly instead of invalidating, so we don't trigger
+      // a refetch that could race with another in-flight blur/edit.
+      queryClient.setQueryData(['foodItem', id], updated)
       queryClient.invalidateQueries({ queryKey: ['foodItems'] })
       setSaveError(null)
       setSavedFlash(true)
@@ -217,6 +225,13 @@ export function FoodItemDetail() {
     save({ default_unit: trimmed || null })
   }
 
+  const commitIcon = () => {
+    const next = icon.trim() || null
+    const current = item.icon ?? null
+    if (next === current) return
+    save({ icon: next })
+  }
+
   return (
     <div class="food-item-detail-page">
       <div class="fi-detail-header">
@@ -234,17 +249,23 @@ export function FoodItemDetail() {
         </div>
       </div>
 
-      <input
-        type="text"
-        class="fi-name-input"
-        value={name}
-        onInput={(e) => setName((e.target as HTMLInputElement).value)}
-        onBlur={commitName}
-      />
+      <h1 class="fi-name-heading">
+        {item.icon && isEmoji(item.icon) && <span class="fi-icon-display">{item.icon}</span>}
+        {item.icon && (isUrl(item.icon) || isIconPath(item.icon)) && (
+          <img src={item.icon} alt="" width={24} height={24} class="fi-icon-display-img" />
+        )}
+        <input
+          type="text"
+          class="fi-name-input"
+          value={name}
+          onInput={(e) => setName((e.target as HTMLInputElement).value)}
+          onBlur={commitName}
+        />
+      </h1>
 
       <div class="fi-icon-row">
         <label class="fi-icon-label">Icon</label>
-        <IconInput value={item.icon ?? ''} onChange={(v) => save({ icon: v || null })} />
+        <IconInput value={icon} onChange={setIcon} onBlur={commitIcon} />
       </div>
 
       <div class="fi-meta">

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { searchFoodItemsApi } from '../../state/api'
@@ -24,10 +24,17 @@ export function FoodItems() {
   const trimmed = search.trim()
   const hasQuery = trimmed.length > 0
 
+  // Debounce so a fast typist doesn't fire one request per keystroke.
+  const [debouncedQuery, setDebouncedQuery] = useState(trimmed)
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(trimmed), 200)
+    return () => clearTimeout(id)
+  }, [trimmed])
+
   const { data: items, isLoading } = useQuery({
-    enabled: !!isLoggedIn && hasQuery,
-    queryFn: () => searchFoodItemsApi(trimmed, 100),
-    queryKey: ['foodItems', trimmed],
+    enabled: !!isLoggedIn && debouncedQuery.length > 0,
+    queryFn: () => searchFoodItemsApi(debouncedQuery, 100),
+    queryKey: ['foodItems', debouncedQuery],
     staleTime: 30_000,
   })
 

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -21,11 +21,13 @@ export function FoodItems() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()
   const [search, setSearch] = useState('')
+  const trimmed = search.trim()
+  const hasQuery = trimmed.length > 0
 
   const { data: items, isLoading } = useQuery({
-    enabled: !!isLoggedIn,
-    queryFn: () => searchFoodItemsApi(search || '', 100),
-    queryKey: ['foodItems', search],
+    enabled: !!isLoggedIn && hasQuery,
+    queryFn: () => searchFoodItemsApi(trimmed, 100),
+    queryKey: ['foodItems', trimmed],
     staleTime: 30_000,
   })
 
@@ -53,13 +55,15 @@ export function FoodItems() {
           value={search}
           onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
         />
-        <span class="fi-count">{items?.length ?? 0} items</span>
+        {hasQuery && <span class="fi-count">{items?.length ?? 0} items</span>}
       </div>
 
-      {isLoading ? (
+      {!hasQuery ? (
+        <p class="fi-help">Type to search the food library.</p>
+      ) : isLoading ? (
         <p class="loading">Loading...</p>
       ) : !items || items.length === 0 ? (
-        <p class="no-data">No food items found.</p>
+        <p class="no-data">No food items match &ldquo;{trimmed}&rdquo;.</p>
       ) : (
         <table class="fi-table">
           <thead>
@@ -76,8 +80,10 @@ export function FoodItems() {
           </thead>
           <tbody>
             {items.map((item) => (
-              <tr key={item.id}>
-                <td class="fi-name">{item.name}</td>
+              <tr key={item.id} class="fi-row">
+                <td class="fi-name">
+                  <a href={`/food-items/${item.id}`}>{item.name}</a>
+                </td>
                 <td class="fi-num">{item.calories ?? '—'}</td>
                 <td class="fi-num">{item.protein ?? '—'}</td>
                 <td class="fi-num">{item.carbs ?? '—'}</td>

--- a/apps/web/src/pages/FoodItems/style.css
+++ b/apps/web/src/pages/FoodItems/style.css
@@ -71,10 +71,21 @@
   font-size: 0.75rem;
 }
 
-.no-data {
+.no-data,
+.fi-help {
   text-align: center;
   padding: 2rem;
   color: #9ca3af;
+}
+
+.fi-name a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.fi-name a:hover {
+  color: #673ab8;
+  text-decoration: underline;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
First three phases of the [food-items enrichment plan](../../../.claude/plans/the-food-items-page-https-aurboda-net-fo-misty-moth.md). Each was scoped small enough to land together.

- **Fuzzy + accent-insensitive search.** Adds `unaccent` and `pg_trgm` extensions, an `immutable_unaccent` SQL wrapper, and a GIN trigram index over `immutable_unaccent(name_lower)`. `searchFoodItems` now does substring matching on the unaccented name, plus a trigram-similarity fallback (threshold 0.2, requires query length ≥ 3). Substring hits always rank above fuzzy-only hits, then by match position, then by similarity.
- **Always-edit detail page.** `/food-items/:id` is now a live form: every field saves on blur, with a `SaveIndicator` for pending/saved/error. Mirrors the recent meals edit-on-blur pattern (#693). All nutrient fields render as inputs (no more read-only mode).
- **Search-first list page.** Empty results until the user types — large imports later won't dump thousands of rows on page load. Rows link to the detail page.

The first PR towards this and the larger food-items reshape (Livsmedelsverket import, composite recipes, reference enrichment) is tracked in the plan file.

## Test plan
- [x] `food-items.integration.test.ts` covers: substring matching mid-name (brand prefix), å/ä/ö folding, typo tolerance, ranking, empty-query short-circuit.
- [x] `meals.integration.test.ts` still passes (snapshot path unaffected).
- [x] `pnpm --filter aurboda-backend check` and `pnpm --filter aurboda-web check` clean.
- [ ] Manual: hit `/api/food-items?q=hushallsost` against a DB containing "Arla, Hushållsost" — expect a hit.
- [ ] Manual: navigate to `/food-items`, type a query, click a row, edit a nutrient and tab out — expect "Saved ✓" flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)