### PR TITLE
feat(food-items): MCP agent UX — descriptions + frequent-foods

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -232,7 +232,9 @@ export { getMealFoodItems, getMealFoodItemsBatch, setMealFoodItems } from './mea
 // Meals
 export {
   deleteMeal,
+  type FrequentFoodItemRow,
   type FrequentMealRow,
+  getFrequentFoodItems,
   getFrequentMeals,
   getMealById,
   getMealLogCompleted,

--- a/apps/backend/src/db/meals.integration.test.ts
+++ b/apps/backend/src/db/meals.integration.test.ts
@@ -1,7 +1,16 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
-import { deleteMeal, getFrequentMeals, getMealById, getMeals, insertMeal, updateMeal } from './meals.ts'
+import { setMealFoodItems } from './meal-food-items.ts'
+import {
+  deleteMeal,
+  getFrequentFoodItems,
+  getFrequentMeals,
+  getMealById,
+  getMeals,
+  insertMeal,
+  updateMeal,
+} from './meals.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 
@@ -360,6 +369,96 @@ describe('Meals Integration Tests', () => {
 
       const rows = await getFrequentMeals(user, { meal_type: 'breakfast', limit: 2, since_days: 30 })
       expect(rows).toHaveLength(2)
+    })
+  })
+
+  describe('getFrequentFoodItems', () => {
+    test('aggregates by food_item_id, ranks by usage, exposes the most recent quantity/unit', async () => {
+      const user = getTestUser()
+      const now = Date.now()
+      const days = (n: number) => new Date(now - n * 86_400_000)
+
+      const breadId = '11111111-1111-1111-1111-111111111111'
+      const oatsId = '22222222-2222-2222-2222-222222222222'
+      const teaId = '33333333-3333-3333-3333-333333333333'
+
+      // Bread: used 3 times, most recent quantity = 80g
+      const breadMeals = [
+        await insertMeal(user, { meal_type: 'breakfast', time: days(10) }),
+        await insertMeal(user, { meal_type: 'breakfast', time: days(5) }),
+        await insertMeal(user, { meal_type: 'breakfast', time: days(1) }),
+      ]
+      for (let i = 0; i < breadMeals.length; i++) {
+        await setMealFoodItems(user, breadMeals[i].id, [
+          {
+            food_item_icon: '🍞',
+            food_item_id: breadId,
+            food_item_name: 'Rye bread',
+            quantity: i === breadMeals.length - 1 ? 80 : 100,
+            sort_order: 0,
+            unit: 'g',
+          },
+        ])
+      }
+
+      // Oats: used twice
+      for (const day of [7, 3]) {
+        const meal = await insertMeal(user, { meal_type: 'breakfast', time: days(day) })
+        await setMealFoodItems(user, meal.id, [
+          {
+            food_item_icon: '🥣',
+            food_item_id: oatsId,
+            food_item_name: 'Oats',
+            quantity: 50,
+            sort_order: 0,
+            unit: 'g',
+          },
+        ])
+      }
+
+      // Tea: once but outside the 30-day window — should be excluded.
+      const oldTeaMeal = await insertMeal(user, { meal_type: 'breakfast', time: days(120) })
+      await setMealFoodItems(user, oldTeaMeal.id, [
+        {
+          food_item_icon: undefined,
+          food_item_id: teaId,
+          food_item_name: 'Tea',
+          quantity: 1,
+          sort_order: 0,
+          unit: 'cup',
+        },
+      ])
+
+      const rows = await getFrequentFoodItems(user, { limit: 10, since_days: 30 })
+
+      expect(rows.map((r) => r.food_item_id)).toEqual([breadId, oatsId])
+      expect(rows[0]).toMatchObject({
+        count: 3,
+        food_item_id: breadId,
+        icon: '🍞',
+        last_quantity: 80,
+        last_unit: 'g',
+        name: 'Rye bread',
+      })
+      expect(rows[1]).toMatchObject({ count: 2, food_item_id: oatsId, name: 'Oats' })
+    })
+
+    test('respects limit', async () => {
+      const user = getTestUser()
+      for (let i = 0; i < 5; i++) {
+        const meal = await insertMeal(user, { meal_type: 'breakfast', time: new Date() })
+        await setMealFoodItems(user, meal.id, [
+          {
+            food_item_id: `00000000-0000-0000-0000-00000000000${i}`,
+            food_item_name: `Food ${i}`,
+            quantity: 1,
+            sort_order: 0,
+            unit: 'g',
+          },
+        ])
+      }
+      const rows = await getFrequentFoodItems(user, { limit: 3, since_days: 30 })
+      expect(rows).toHaveLength(3)
     })
   })
 

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -241,6 +241,65 @@ export const getFrequentMeals = async (
   }))
 }
 
+// ============================================================================
+// Frequent food items
+// ============================================================================
+
+export interface FrequentFoodItemRow {
+  food_item_id: string
+  name: string
+  icon: string | null
+  count: number
+  last_used: Date
+  last_quantity: number | null
+  last_unit: string | null
+}
+
+interface FrequentFoodItemsFilter {
+  limit: number
+  since_days: number
+}
+
+/**
+ * Aggregate `meal_food_items` to surface the food items the user logs most
+ * often. Useful for an MCP agent to suggest "your usual" without re-running
+ * fuzzy search every time. Snapshotted name/icon are read directly off the
+ * junction — no JOIN to food_items, so central-library items work too.
+ */
+export const getFrequentFoodItems = async (
+  user: string,
+  filter: FrequentFoodItemsFilter,
+): Promise<FrequentFoodItemRow[]> => {
+  const sql = `
+    WITH ranked AS (
+      SELECT mfi.food_item_id, mfi.food_item_name, mfi.food_item_icon,
+             mfi.quantity, mfi.unit, m.time,
+             COUNT(*) OVER (PARTITION BY mfi.food_item_id) AS use_count,
+             ROW_NUMBER() OVER (PARTITION BY mfi.food_item_id ORDER BY m.time DESC) AS rn
+      FROM meal_food_items mfi
+      JOIN meals m ON m.id = mfi.meal_id
+      WHERE m.time > NOW() - ($1::int || ' days')::interval
+        AND mfi.food_item_id IS NOT NULL
+    )
+    SELECT food_item_id, food_item_name, food_item_icon, quantity, unit,
+           time AS last_used, use_count AS count
+    FROM ranked
+    WHERE rn = 1
+    ORDER BY use_count DESC, time DESC
+    LIMIT $2
+  `
+  const result = await query(user, sql, [filter.since_days, filter.limit])
+  return result.rows.map((row) => ({
+    count: Number(row.count),
+    food_item_id: row.food_item_id as string,
+    icon: (row.food_item_icon as string | null) ?? null,
+    last_quantity: row.quantity === null ? null : Number(row.quantity),
+    last_unit: (row.unit as string | null) ?? null,
+    last_used: row.last_used as Date,
+    name: (row.food_item_name as string | null) ?? '',
+  }))
+}
+
 /**
  * Delete a meal by ID.
  * Returns true if the meal was found and deleted.

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -20,7 +20,13 @@ import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
 export const registerFoodItemTools = (server: McpServer, user: string) => {
   server.tool(
     'search_food_items',
-    'Search canonical food items by name. Returns matching items with their default nutritional data.',
+    [
+      "Search the merged food library: the user's private items plus any canonical reference data the admin has imported into the central shared library (national food databases, barcode-scanned products, etc. — what's available depends on which sources the admin has imported on this installation).",
+      'Search is accent-insensitive and tolerates typos (trigram fuzzy matching). Returns up to `limit` items, user-private items first.',
+      'Each result has an `id`, `name`, `source` (a string identifying where the row came from — `"manual"` means user-created; any other value indicates canonical reference data), `default_quantity`/`default_unit` (the "1 serving" basis the nutrient values are reported against), and per-serving nutrient values.',
+      "To log a meal, pass the result's `id` to add_meal as `food_item_id` — never re-pass the name, that would create a per-user duplicate of a shared item. The backend scales nutrient values linearly by `quantity / default_quantity` when the meal's `unit` matches the canonical `default_unit`.",
+      'Reference items may have non-English names. If a search misses, try synonyms in plausible source languages.',
+    ].join(' '),
     { ...foodItemsQuerySchema.shape },
     async (params) => {
       const maxResults = params.limit ? parseInt(params.limit, 10) : 20

--- a/apps/backend/src/mcp/meal-tools.ts
+++ b/apps/backend/src/mcp/meal-tools.ts
@@ -5,6 +5,7 @@
  */
 import {
   addMealBodySchema,
+  frequentFoodItemsQuerySchema,
   frequentMealsQuerySchema,
   mealsQuerySchema,
   tzSchema,
@@ -16,6 +17,7 @@ import {
   addMeal,
   deleteMealById,
   getMeal,
+  queryFrequentFoodItems,
   queryFrequentMeals,
   queryMeals,
   updateMealById,
@@ -26,7 +28,11 @@ export const registerMealTools = (server: McpServer, user: string) => {
   // Tool: add_meal
   server.tool(
     'add_meal',
-    'Add a meal record with optional nutrition details. Supports food items, macros (calories, protein, carbs, fat, fiber), and micronutrients.',
+    [
+      'Add a meal record. Each item in `food_items` should reference a canonical food via `food_item_id` (preferred — found via search_food_items) so the backend can scale nutrient values from the canonical record. Pass `quantity` in the canonical `default_unit` for accurate scaling; mismatched units skip scaling and use raw values.',
+      "If `food_item_id` is omitted, the backend matches by exact `name` first (in both the user's items and the central library) and falls back to creating a new per-user item — so always prefer `food_item_id` when you have one.",
+      'Top-level macros (calories/protein/carbs/fat/fiber) and `micros` are optional overrides for the meal as a whole. If omitted, the backend computes meal totals from the food_items snapshots.',
+    ].join(' '),
     { ...addMealBodySchema.shape, tz: tzSchema },
     async ({ tz, ...params }) => {
       const result = await addMeal(user, { ...params })
@@ -84,6 +90,20 @@ export const registerMealTools = (server: McpServer, user: string) => {
     { ...frequentMealsQuerySchema.shape, tz: tzSchema },
     async ({ tz, ...params }) => {
       const result = await queryFrequentMeals(user, params)
+      return tzJsonResponse(result, tz)
+    },
+  )
+
+  // Tool: query_frequent_food_items
+  server.tool(
+    'query_frequent_food_items',
+    [
+      'List the individual food items a user logs most often, regardless of meal type. Useful as a "your usual" shortcut so you can suggest add_meal entries without running fuzzy search every time.',
+      'Each result has the canonical `food_item_id` (pass to add_meal as-is), the snapshotted `name` and `icon`, total `count` in the window, plus `last_quantity` and `last_unit` from the most recent occurrence — sensible defaults for re-logging.',
+    ].join(' '),
+    { ...frequentFoodItemsQuerySchema.shape, tz: tzSchema },
+    async ({ tz, ...params }) => {
+      const result = await queryFrequentFoodItems(user, params)
       return tzJsonResponse(result, tz)
     },
   )

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -4,8 +4,11 @@ import {
   type AddMealBody,
   addMealBodySchema,
   type DeleteMealResponse,
+  type FrequentFoodItemsQuery,
+  type FrequentFoodItemsResponse,
   type FrequentMealsQuery,
   type FrequentMealsResponse,
+  frequentFoodItemsQuerySchema,
   frequentMealsQuerySchema,
   type MealResponse,
   type MealsQuery,
@@ -25,6 +28,7 @@ import {
   addMeal,
   deleteMealById,
   getMeal,
+  queryFrequentFoodItems,
   queryFrequentMeals,
   queryMeals,
   updateMealById,
@@ -64,6 +68,16 @@ export const createMealsRouter = (authMiddleware: AnyMiddleware): TypedRouter =>
     validateQuery(frequentMealsQuerySchema),
     async (req, res) => {
       const result = await queryFrequentMeals(req.user!, req.query)
+      res.json({ data: result.data, success: true })
+    },
+  )
+
+  router.get<Record<string, never>, FrequentFoodItemsResponse, unknown, FrequentFoodItemsQuery>(
+    '/frequent-food-items',
+    authMiddleware,
+    validateQuery(frequentFoodItemsQuerySchema),
+    async (req, res) => {
+      const result = await queryFrequentFoodItems(req.user!, req.query)
       res.json({ data: result.data, success: true })
     },
   )

--- a/apps/backend/src/services/central-food-items.integration.test.ts
+++ b/apps/backend/src/services/central-food-items.integration.test.ts
@@ -1,11 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
+import { getTestDbClient, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import {
   createSharedFoodItemsApi,
   CREATE_SHARED_FOOD_ITEMS_INDEXES,
   CREATE_SHARED_FOOD_ITEMS_TABLE,
 } from './central-food-items.ts'
-import { getTestDbClient, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 

--- a/apps/backend/src/services/central-import-jobs.integration.test.ts
+++ b/apps/backend/src/services/central-import-jobs.integration.test.ts
@@ -1,11 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
+import { getTestDbClient, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import {
   createCentralImportJobsApi,
   CREATE_IMPORT_JOBS_INDEXES,
   CREATE_IMPORT_JOBS_TABLE,
 } from './central-import-jobs.ts'
-import { getTestDbClient, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -48,7 +48,7 @@ const fakeCentral = (): CentralDb =>
 describe('createFoodItemsService.search', () => {
   test('user items rank first, then central, capped at limit', async () => {
     vi.mocked(dbModule.searchFoodItems).mockResolvedValue([
-      userItem('u1', 'Mom\'s Hushållsost'),
+      userItem('u1', "Mom's Hushållsost"),
       userItem('u2', 'Hushållsost (homemade)'),
     ])
     const central = fakeCentral()
@@ -118,10 +118,10 @@ describe('createFoodItemsService.findOrCreate', () => {
   test('falls back to existing user item when central has no match', async () => {
     const central = fakeCentral()
     vi.mocked(central.getSharedFoodItemByName).mockResolvedValue(null)
-    vi.mocked(dbModule.getFoodItemByName).mockResolvedValue(userItem('u1', 'Mom\'s pancakes'))
+    vi.mocked(dbModule.getFoodItemByName).mockResolvedValue(userItem('u1', "Mom's pancakes"))
     const service = createFoodItemsService(central)
 
-    const result = await service.findOrCreate('user', 'Mom\'s pancakes')
+    const result = await service.findOrCreate('user', "Mom's pancakes")
     expect(result.id).toBe('u1')
     expect(dbModule.findOrCreateFoodItem).not.toHaveBeenCalled()
   })

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -5,10 +5,11 @@
  * Food items are stored relationally via the food_items + meal_food_items junction table.
  */
 
-import { type FrequentMeal, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+import { type FrequentFoodItem, type FrequentMeal, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 
 import {
   deleteMeal as dbDeleteMeal,
+  getFrequentFoodItems as dbGetFrequentFoodItems,
   getFrequentMeals as dbGetFrequentMeals,
   getMealById as dbGetMealById,
   getMealFoodItemsBatch,
@@ -460,6 +461,34 @@ export async function queryFrequentMeals(
   })
 
   return { data, success: true }
+}
+
+/**
+ * Top-N food items by usage in the user's meal log over the last
+ * `since_days`. Returns the snapshotted name/icon and the most recent
+ * quantity/unit, so an MCP agent can suggest "your usual" without re-running
+ * fuzzy search every time.
+ */
+export async function queryFrequentFoodItems(
+  user: string,
+  filters: { limit?: number; since_days?: number },
+): Promise<{ success: true; data: FrequentFoodItem[] }> {
+  const rows = await dbGetFrequentFoodItems(user, {
+    limit: filters.limit ?? 10,
+    since_days: filters.since_days ?? 90,
+  })
+  return {
+    data: rows.map((row) => ({
+      count: row.count,
+      food_item_id: row.food_item_id,
+      icon: row.icon,
+      last_quantity: row.last_quantity,
+      last_unit: row.last_unit,
+      last_used: row.last_used.toISOString(),
+      name: row.name,
+    })),
+    success: true,
+  }
 }
 
 /**

--- a/docs/livsmedelsverket.md
+++ b/docs/livsmedelsverket.md
@@ -64,3 +64,17 @@ MCP:
 ## Attribution and license
 
 Data is published by [Livsmedelsverket / Swedish Food Agency](https://www.livsmedelsverket.se/) under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). The Admin Settings page renders the attribution alongside the import button.
+
+## Other sources (future)
+
+The shared library is source-agnostic — `shared_food_items` rows carry a `source` (free-form string) and a `source_id` (the upstream identifier). Adding another reference DB only needs:
+
+- A service module that fetches the catalog + per-item data and calls `centralDb.upsertSharedFoodItem({ source: <source>, source_id, ... })`.
+- A new `runners[<source>]` entry in `services/imports/runner.ts`.
+- A new `POST /admin/imports/<source>` route.
+
+Concrete candidates a Swedish/Nordic install might want next:
+
+- **[OpenFoodFacts](https://world.openfoodfacts.org/)** — community-edited global database of branded products with EAN/UPC barcodes, ingredients, NutriScore, allergens. ODbL-licensed (attribution required). The natural fit for barcode-scanning, since the canonical key is the barcode itself (use it as `source_id`). On-demand fetch by barcode is cheaper than bulk-importing 3M+ products.
+- **[USDA FoodData Central](https://fdc.nal.usda.gov/)** — US equivalent of LSV, public-domain, well-structured nutrient data.
+- Other national agencies (e.g. UK CoFID, Finnish Fineli) for installs in those countries.

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -109,19 +109,27 @@ export type FoodItem = z.infer<typeof foodItemSchema>
  */
 export const foodItemInputSchema = z
   .object({
-    food_item_id: z.string().uuid().optional().meta({ description: 'Link to canonical food item entity' }),
+    food_item_id: z.string().uuid().optional().meta({
+      description:
+        'ID of a canonical food item (use the `id` returned by search_food_items). Preferred over `name` — binding by ID avoids creating per-user duplicates of items already in the shared library.',
+    }),
     icon: z
       .string()
       .max(2048)
       .optional()
       .meta({ description: 'Icon for this food item (emoji or image URL)' }),
-    name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
-    quantity: z.number().optional().meta({ description: 'Quantity consumed' }),
-    unit: z
-      .string()
-      .max(100)
-      .optional()
-      .meta({ description: 'Unit for quantity (e.g., "g", "ml", "large slice", "full recipe")' }),
+    name: z.string().min(1).max(255).meta({
+      description:
+        'Food item name. Used as a label and, when food_item_id is omitted, as the lookup key (matches an existing item by name first, otherwise creates a new per-user item).',
+    }),
+    quantity: z.number().optional().meta({
+      description:
+        "Amount consumed, in `unit`. If unit matches the canonical food item's default_unit, the backend scales nutrients by quantity / default_quantity. If units differ, no scaling is applied (canonical values are used as-is).",
+    }),
+    unit: z.string().max(100).optional().meta({
+      description:
+        'Unit for quantity (e.g., "g", "ml", "large slice", "full recipe"). For best scaling, use the canonical food item\'s default_unit (returned by search_food_items).',
+    }),
   })
   .meta({ description: 'Input shape for a food item in a meal request body', id: 'FoodItemInput' })
 
@@ -356,3 +364,60 @@ export const frequentMealsResponseSchema = createDataArrayResponseSchema(frequen
 })
 
 export type FrequentMealsResponse = z.infer<typeof frequentMealsResponseSchema>
+
+// ============================================================================
+// Frequent food items
+// ============================================================================
+
+/**
+ * Query parameters for surfacing the food items a user logs most often. Helps
+ * an MCP agent suggest "your usual" without re-searching every time.
+ */
+export const frequentFoodItemsQuerySchema = z
+  .object({
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .meta({ description: 'Maximum number of food items to return' }),
+    since_days: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(365)
+      .default(90)
+      .meta({ description: 'How many days back to consider when computing frequency' }),
+  })
+  .meta({ description: 'Query parameters for frequent-food-items', id: 'FrequentFoodItemsQuery' })
+
+export type FrequentFoodItemsQuery = z.infer<typeof frequentFoodItemsQuerySchema>
+
+export const frequentFoodItemSchema = z
+  .object({
+    food_item_id: z.string().uuid().meta({
+      description:
+        'ID of the canonical food item — pass to add_meal as `food_item_id`. May resolve to a per-user item or a central shared-library item.',
+    }),
+    name: z.string().meta({ description: 'Snapshotted name from the most recent meal use' }),
+    icon: z.string().nullable().meta({ description: 'Snapshotted icon, or null' }),
+    count: z.number().int().meta({ description: 'How many times the user logged this food in the window' }),
+    last_used: iso8601DateTimeSchema.meta({ description: 'Time of the most recent meal that used it' }),
+    last_quantity: z
+      .number()
+      .nullable()
+      .meta({
+        description: 'Quantity used in the most recent occurrence (a sensible default for re-logging)',
+      }),
+    last_unit: z.string().nullable().meta({ description: 'Unit used in the most recent occurrence' }),
+  })
+  .meta({ description: 'A food item the user logs repeatedly', id: 'FrequentFoodItem' })
+
+export type FrequentFoodItem = z.infer<typeof frequentFoodItemSchema>
+
+export const frequentFoodItemsResponseSchema = createDataArrayResponseSchema(frequentFoodItemSchema).meta({
+  id: 'FrequentFoodItemsResponse',
+})
+
+export type FrequentFoodItemsResponse = z.infer<typeof frequentFoodItemsResponseSchema>


### PR DESCRIPTION
## Summary
Small follow-up to PR #695 that makes the food-item / meal MCP surface easier for an LLM agent to use.

- **search_food_items description** now spells out: merged user + central library, `default_quantity` / `default_unit` is the per-serving basis, pass `id` (not name) to `add_meal`, reference items may be non-English. Generic phrasing — doesn't assume any specific source is installed.
- **add_meal description** + `foodItemInputSchema` field descriptions clarify `food_item_id` is preferred over `name`, `name` is the fallback lookup key (and may auto-create per-user items), quantity is in `default_unit` and scales linearly.
- **New `query_frequent_food_items` tool** (MCP + REST `GET /meals/frequent-food-items`): aggregates `meal_food_items.food_item_id` over the last N days, returns top usage with `last_quantity` / `last_unit`. Lets an agent suggest "your usual oatmeal" without re-running fuzzy search.
- **docs/livsmedelsverket.md** gets a "Other sources (future)" section calling out OpenFoodFacts (barcode + branded products), USDA FoodData Central, and other national agencies — the import infrastructure is source-agnostic.

## Test plan
- [x] New integration test for `getFrequentFoodItems`: aggregation, last_quantity/last_unit from most recent occurrence, since_days window, limit.
- [x] `pnpm --filter aurboda-backend check` and `pnpm --filter aurboda-web check` clean.
- [ ] Manual: from MCP, `query_frequent_food_items({ limit: 5 })` returns top items; `add_meal({ food_items: [{ food_item_id, quantity }] })` works without re-passing name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)