### PR TITLE
feat(food-items): composite (recipe) items with derived nutrients

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -811,9 +811,15 @@ export const migrateSchema = async (user: string) => {
   }
 
   // food_items: add source_id so re-imports key off the upstream identifier
-  // (e.g. Livsmedelsverket nummer) instead of the mutable name.
+  // (e.g. Livsmedelsverket nummer) instead of the mutable name. Also
+  // is_composite for recipe-style food items whose nutrient values are
+  // derived from food_item_ingredients at read time.
   if (existingTableNames.has('food_items')) {
     await query(db, `ALTER TABLE food_items ADD COLUMN IF NOT EXISTS source_id VARCHAR(100)`)
+    await query(
+      db,
+      `ALTER TABLE food_items ADD COLUMN IF NOT EXISTS is_composite BOOLEAN NOT NULL DEFAULT FALSE`,
+    )
   }
 
   // meal_food_items: snapshot food_item_name + food_item_icon at insertion

--- a/apps/backend/src/db/food-item-ingredients.integration.test.ts
+++ b/apps/backend/src/db/food-item-ingredients.integration.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import {
+  clearIngredients,
+  getIngredients,
+  getIngredientsBatch,
+  setIngredients,
+} from './food-item-ingredients.ts'
+import { getFoodItemById, upsertFoodItem } from './food-items.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+describe('food_item_ingredients integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('setIngredients inserts rows in order and flips is_composite', async () => {
+    const user = getTestUser()
+    const parent = await upsertFoodItem(user, { name: 'Bulletproof coffee' })
+    const coffee = await upsertFoodItem(user, { name: 'Coffee', default_quantity: 100, default_unit: 'ml' })
+    const oil = await upsertFoodItem(user, { name: 'Coconut oil', default_quantity: 1, default_unit: 'g' })
+
+    await setIngredients(user, parent.id, [
+      { ingredient_food_item_id: coffee.id, quantity: 500, sort_order: 0, unit: 'ml' },
+      { ingredient_food_item_id: oil.id, quantity: 15, sort_order: 1, unit: 'g' },
+    ])
+
+    const rows = await getIngredients(user, parent.id)
+    expect(rows.map((r) => r.ingredient_food_item_id)).toEqual([coffee.id, oil.id])
+    expect(rows[0].quantity).toBe(500)
+    expect(rows[0].unit).toBe('ml')
+
+    const refreshedParent = await getFoodItemById(user, parent.id)
+    expect(refreshedParent?.is_composite).toBe(true)
+  })
+
+  test('setIngredients with empty list clears is_composite', async () => {
+    const user = getTestUser()
+    const parent = await upsertFoodItem(user, { name: 'Recipe' })
+    const ing = await upsertFoodItem(user, { name: 'Ingredient' })
+
+    await setIngredients(user, parent.id, [{ ingredient_food_item_id: ing.id, quantity: 1, sort_order: 0 }])
+    expect((await getFoodItemById(user, parent.id))?.is_composite).toBe(true)
+
+    await setIngredients(user, parent.id, [])
+    expect((await getFoodItemById(user, parent.id))?.is_composite).toBe(false)
+    expect(await getIngredients(user, parent.id)).toEqual([])
+  })
+
+  test('clearIngredients drops rows and reverts is_composite to false', async () => {
+    const user = getTestUser()
+    const parent = await upsertFoodItem(user, { name: 'Recipe' })
+    const ing = await upsertFoodItem(user, { name: 'Ingredient' })
+
+    await setIngredients(user, parent.id, [{ ingredient_food_item_id: ing.id, quantity: 1, sort_order: 0 }])
+    await clearIngredients(user, parent.id)
+
+    expect(await getIngredients(user, parent.id)).toEqual([])
+    expect((await getFoodItemById(user, parent.id))?.is_composite).toBe(false)
+  })
+
+  test('CASCADE on parent delete removes ingredient rows', async () => {
+    const user = getTestUser()
+    const parent = await upsertFoodItem(user, { name: 'Doomed recipe' })
+    const ing = await upsertFoodItem(user, { name: 'Survivor' })
+    await setIngredients(user, parent.id, [{ ingredient_food_item_id: ing.id, quantity: 1, sort_order: 0 }])
+
+    const { deleteFoodItem } = await import('./food-items.ts')
+    await deleteFoodItem(user, parent.id)
+
+    expect(await getIngredients(user, parent.id)).toEqual([])
+    // Ingredient itself survives — no FK on ingredient_food_item_id.
+    expect(await getFoodItemById(user, ing.id)).not.toBeNull()
+  })
+
+  test('self-ingredient inserts are blocked by the SQL CHECK', async () => {
+    const user = getTestUser()
+    const parent = await upsertFoodItem(user, { name: 'Selfie' })
+    await expect(
+      setIngredients(user, parent.id, [{ ingredient_food_item_id: parent.id, quantity: 1, sort_order: 0 }]),
+    ).rejects.toThrow()
+  })
+
+  test('getIngredientsBatch keys results by parent_food_item_id', async () => {
+    const user = getTestUser()
+    const parent1 = await upsertFoodItem(user, { name: 'Parent 1' })
+    const parent2 = await upsertFoodItem(user, { name: 'Parent 2' })
+    const ing = await upsertFoodItem(user, { name: 'Ingredient' })
+
+    await setIngredients(user, parent1.id, [{ ingredient_food_item_id: ing.id, quantity: 1, sort_order: 0 }])
+    await setIngredients(user, parent2.id, [{ ingredient_food_item_id: ing.id, quantity: 2, sort_order: 0 }])
+
+    const map = await getIngredientsBatch(user, [parent1.id, parent2.id])
+    expect(map.get(parent1.id)).toHaveLength(1)
+    expect(map.get(parent2.id)?.[0]?.quantity).toBe(2)
+  })
+})

--- a/apps/backend/src/db/food-item-ingredients.ts
+++ b/apps/backend/src/db/food-item-ingredients.ts
@@ -1,0 +1,141 @@
+/**
+ * food_item_ingredients junction table — backs composite (recipe-style)
+ * food items.
+ *
+ * `parent_food_item_id` is FK'd to per-user food_items (CASCADE on delete).
+ * `ingredient_food_item_id` is a soft pointer that may resolve to a per-user
+ * row or a central shared_food_items row, so there's no FK on it. Cycle
+ * prevention is enforced in the service layer (see wouldCreateCycle).
+ *
+ * Quantities are scaled against the ingredient's own default_quantity at
+ * read time to derive the parent's nutrient totals.
+ */
+
+import { query } from './connection.ts'
+
+const COLUMNS =
+  'id, parent_food_item_id, ingredient_food_item_id, quantity, unit, sort_order, created_at, updated_at'
+
+export interface FoodItemIngredientRow {
+  id: string
+  parent_food_item_id: string
+  ingredient_food_item_id: string
+  quantity: number
+  unit?: string
+  sort_order: number
+  created_at: Date
+  updated_at: Date
+}
+
+export interface FoodItemIngredientInput {
+  ingredient_food_item_id: string
+  quantity: number
+  unit?: string
+  sort_order?: number
+}
+
+const mapRow = (row: Record<string, unknown>): FoodItemIngredientRow => ({
+  created_at: new Date(row.created_at as string),
+  id: row.id as string,
+  ingredient_food_item_id: row.ingredient_food_item_id as string,
+  parent_food_item_id: row.parent_food_item_id as string,
+  quantity: Number(row.quantity),
+  sort_order: Number(row.sort_order),
+  unit: (row.unit as string | null) ?? undefined,
+  updated_at: new Date(row.updated_at as string),
+})
+
+/**
+ * Get all ingredients of one composite food, ordered by sort_order.
+ */
+export const getIngredients = async (
+  user: string,
+  parentFoodItemId: string,
+): Promise<FoodItemIngredientRow[]> => {
+  const result = await query(
+    user,
+    `SELECT ${COLUMNS}
+     FROM food_item_ingredients
+     WHERE parent_food_item_id = $1
+     ORDER BY sort_order, created_at`,
+    [parentFoodItemId],
+  )
+  return result.rows.map(mapRow)
+}
+
+/**
+ * Replace all ingredients for a composite parent (delete + bulk insert).
+ * Marks the parent food_items row as composite.
+ *
+ * The caller is responsible for cycle-checking before invoking this — see
+ * wouldCreateCycle in services/food-items.ts. We rely on a service-layer
+ * check rather than a SQL trigger because ingredient pointers can cross
+ * databases (per-user → central) and SQL recursion can't see central rows.
+ */
+export const setIngredients = async (
+  user: string,
+  parentFoodItemId: string,
+  items: FoodItemIngredientInput[],
+): Promise<void> => {
+  await query(user, `DELETE FROM food_item_ingredients WHERE parent_food_item_id = $1`, [parentFoodItemId])
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    await query(
+      user,
+      `INSERT INTO food_item_ingredients
+         (parent_food_item_id, ingredient_food_item_id, quantity, unit, sort_order)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [
+        parentFoodItemId,
+        item.ingredient_food_item_id,
+        item.quantity,
+        item.unit ?? null,
+        item.sort_order ?? i,
+      ],
+    )
+  }
+
+  await query(user, `UPDATE food_items SET is_composite = $2, updated_at = NOW() WHERE id = $1`, [
+    parentFoodItemId,
+    items.length > 0,
+  ])
+}
+
+/**
+ * Wipe all ingredients and clear the composite flag.
+ */
+export const clearIngredients = async (user: string, parentFoodItemId: string): Promise<void> => {
+  await query(user, `DELETE FROM food_item_ingredients WHERE parent_food_item_id = $1`, [parentFoodItemId])
+  await query(user, `UPDATE food_items SET is_composite = FALSE, updated_at = NOW() WHERE id = $1`, [
+    parentFoodItemId,
+  ])
+}
+
+/**
+ * Batch fetch ingredients for several parents at once. Returns a map keyed
+ * by parent_food_item_id; absent keys = no ingredients.
+ */
+export const getIngredientsBatch = async (
+  user: string,
+  parentIds: string[],
+): Promise<Map<string, FoodItemIngredientRow[]>> => {
+  if (parentIds.length === 0) return new Map()
+  const placeholders = parentIds.map((_, i) => `$${i + 1}`).join(', ')
+  const result = await query(
+    user,
+    `SELECT ${COLUMNS}
+     FROM food_item_ingredients
+     WHERE parent_food_item_id IN (${placeholders})
+     ORDER BY parent_food_item_id, sort_order, created_at`,
+    parentIds,
+  )
+  const map = new Map<string, FoodItemIngredientRow[]>()
+  for (const row of result.rows) {
+    const link = mapRow(row)
+    const existing = map.get(link.parent_food_item_id) ?? []
+    existing.push(link)
+    map.set(link.parent_food_item_id, existing)
+  }
+  return map
+}

--- a/apps/backend/src/db/food-item-ingredients.ts
+++ b/apps/backend/src/db/food-item-ingredients.ts
@@ -64,42 +64,65 @@ export const getIngredients = async (
 }
 
 /**
- * Replace all ingredients for a composite parent (delete + bulk insert).
- * Marks the parent food_items row as composite.
+ * Replace all ingredients for a composite parent (delete + bulk insert)
+ * inside a single transaction. Marks the parent food_items row as composite.
+ *
+ * Atomicity matters: a partial failure (FK violation, SQL CHECK firing on
+ * a self-ref mid-batch, transient connection error) would otherwise leave
+ * the parent with half the new ingredient list and is_composite in an
+ * indeterminate state.
  *
  * The caller is responsible for cycle-checking before invoking this — see
  * wouldCreateCycle in services/food-items.ts. We rely on a service-layer
  * check rather than a SQL trigger because ingredient pointers can cross
  * databases (per-user → central) and SQL recursion can't see central rows.
+ * Note that the cycle check is best-effort: two concurrent setIngredients
+ * calls on related composites could each pass the check independently and
+ * still produce a cycle. Per-user dbs make this rare.
  */
 export const setIngredients = async (
   user: string,
   parentFoodItemId: string,
   items: FoodItemIngredientInput[],
 ): Promise<void> => {
-  await query(user, `DELETE FROM food_item_ingredients WHERE parent_food_item_id = $1`, [parentFoodItemId])
+  try {
+    await query(user, 'BEGIN')
+    await query(user, `DELETE FROM food_item_ingredients WHERE parent_food_item_id = $1`, [parentFoodItemId])
 
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i]
-    await query(
-      user,
-      `INSERT INTO food_item_ingredients
-         (parent_food_item_id, ingredient_food_item_id, quantity, unit, sort_order)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [
-        parentFoodItemId,
-        item.ingredient_food_item_id,
-        item.quantity,
-        item.unit ?? null,
-        item.sort_order ?? i,
-      ],
-    )
+    if (items.length > 0) {
+      // Single multi-row INSERT — 5 columns per row, parameterised.
+      const params: unknown[] = []
+      const valuesSql = items
+        .map((item, i) => {
+          const base = i * 5
+          params.push(
+            parentFoodItemId,
+            item.ingredient_food_item_id,
+            item.quantity,
+            item.unit ?? null,
+            item.sort_order ?? i,
+          )
+          return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5})`
+        })
+        .join(', ')
+      await query(
+        user,
+        `INSERT INTO food_item_ingredients
+           (parent_food_item_id, ingredient_food_item_id, quantity, unit, sort_order)
+         VALUES ${valuesSql}`,
+        params,
+      )
+    }
+
+    await query(user, `UPDATE food_items SET is_composite = $2, updated_at = NOW() WHERE id = $1`, [
+      parentFoodItemId,
+      items.length > 0,
+    ])
+    await query(user, 'COMMIT')
+  } catch (err) {
+    await query(user, 'ROLLBACK').catch(() => {})
+    throw err
   }
-
-  await query(user, `UPDATE food_items SET is_composite = $2, updated_at = NOW() WHERE id = $1`, [
-    parentFoodItemId,
-    items.length > 0,
-  ])
 }
 
 /**

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -20,6 +20,7 @@ const FOOD_ITEM_COLUMNS = [
   'default_unit',
   ...NUTRIENT_FIELD_NAMES,
   'icon',
+  'is_composite',
   'created_at',
   'updated_at',
 ].join(', ')
@@ -34,6 +35,7 @@ const mapFoodItemRow = (row: Record<string, unknown>): FoodItemEntity => {
     default_quantity: row.default_quantity ?? undefined,
     default_unit: row.default_unit ?? undefined,
     icon: row.icon ?? undefined,
+    is_composite: row.is_composite === true,
     created_at: new Date(row.created_at as string),
     updated_at: new Date(row.updated_at as string),
   }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -229,6 +229,16 @@ export {
 } from './food-items.ts'
 export { getMealFoodItems, getMealFoodItemsBatch, setMealFoodItems } from './meal-food-items.ts'
 
+// Food item ingredients (composite/recipe support)
+export {
+  clearIngredients,
+  type FoodItemIngredientInput,
+  type FoodItemIngredientRow,
+  getIngredients,
+  getIngredientsBatch,
+  setIngredients,
+} from './food-item-ingredients.ts'
+
 // Meals
 export {
   deleteMeal,

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -356,9 +356,12 @@ export interface FoodItemEntity {
   is_composite?: boolean
   default_quantity?: number
   default_unit?: string
-  // All ~65 nutrient fields are optional numbers.
-  // Using Record for the nutrient fields to avoid 65 lines of boilerplate.
-  // At runtime these are individual columns, but in TypeScript we use an index signature.
+  // ~65 nutrient fields are optional numbers, accessed dynamically via
+  // NUTRIENT_FIELD_NAMES from api-spec. The index signature has to cover
+  // every named field above too, hence the broad union — it loosens type
+  // safety on nutrient destructuring as a trade-off for not boilerplating
+  // 65 explicit columns. A dedicated cleanup PR could replace this with
+  // `extends Partial<NutrientFields>` and drop the index signature.
   [nutrient: string]: string | number | boolean | Date | undefined
   created_at: Date
   updated_at: Date

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -352,12 +352,14 @@ export interface FoodItemEntity {
   name: string
   name_lower: string
   source: string
+  source_id?: string
+  is_composite?: boolean
   default_quantity?: number
   default_unit?: string
   // All ~65 nutrient fields are optional numbers.
   // Using Record for the nutrient fields to avoid 65 lines of boilerplate.
   // At runtime these are individual columns, but in TypeScript we use an index signature.
-  [nutrient: string]: string | number | Date | undefined
+  [nutrient: string]: string | number | boolean | Date | undefined
   created_at: Date
   updated_at: Date
 }
@@ -372,7 +374,7 @@ export interface MealFoodItemLink {
   unit?: string
   sort_order: number
   // Nutrient snapshot — same fields as FoodItemEntity
-  [nutrient: string]: string | number | Date | undefined
+  [nutrient: string]: string | number | boolean | Date | undefined
 }
 
 // ============================================================================

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -7,15 +7,22 @@
  * central rows are managed via the admin import flow, not from MCP.
  */
 
-import { addFoodItemBodySchema, foodItemsQuerySchema, updateFoodItemBodySchema } from '@aurboda/api-spec'
+import {
+  addFoodItemBodySchema,
+  foodItemsQuerySchema,
+  setFoodItemIngredientsBodySchema,
+  updateFoodItemBodySchema,
+} from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import type { CentralDb } from '../services/central-db.ts'
 
 import {
+  clearIngredients,
   deleteFoodItem,
   getFoodItemById as getUserFoodItemById,
   listFoodItems,
+  setIngredients,
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
@@ -86,12 +93,61 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
 
   server.tool(
     'get_food_item',
-    'Get a food item by ID — checks the user library first, then the central shared library.',
+    'Get a food item by ID — checks the user library first, then the central shared library. For composite (recipe) items, the response includes the resolved ingredients and derived nutrient totals.',
     { id: z.string().uuid().describe('Food item ID') },
     async ({ id }) => {
-      const item = await foodItems.getById(user, id)
-      if (!item) return errorResponse('Food item not found')
-      return jsonResponse({ data: item, success: true })
+      const detail = await foodItems.getDetail(user, id)
+      if (!detail) return errorResponse('Food item not found')
+      return jsonResponse({ data: detail, success: true })
+    },
+  )
+
+  server.tool(
+    'set_food_item_ingredients',
+    [
+      "Mark a per-user food item as composite (a recipe) and replace its full ingredient list. The item's nutrient values become derived: at read time we sum each ingredient's value × quantity / default_quantity (when units match).",
+      'Each ingredient points at another food item by `ingredient_food_item_id` — may be a per-user food OR a central library item. Cycles (A → B → A) are rejected.',
+      'Only per-user items can be made composite; central shared-library rows return an error.',
+    ].join(' '),
+    {
+      id: z.string().uuid().describe('Composite food item ID (the parent)'),
+      ...setFoodItemIngredientsBodySchema.shape,
+    },
+    async ({ id, ingredients }) => {
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return errorResponse(
+          fromCentral ? 'Cannot set ingredients on shared library item' : 'Food item not found',
+        )
+      }
+      const ingredientIds = ingredients.map((i) => i.ingredient_food_item_id)
+      if (await foodItems.wouldCreateCycle(user, id, ingredientIds)) {
+        return errorResponse('Setting these ingredients would create a cycle in the recipe graph')
+      }
+      await setIngredients(user, id, ingredients)
+      const detail = await foodItems.getDetail(user, id)
+      if (!detail) return errorResponse('Food item not found')
+      return jsonResponse({ data: detail, success: true })
+    },
+  )
+
+  server.tool(
+    'clear_food_item_ingredients',
+    "Wipe all ingredients on a composite food item and revert it to atomic mode. The item's own nutrient values become authoritative again (whatever was last stored — typically zeros).",
+    { id: z.string().uuid().describe('Composite food item ID') },
+    async ({ id }) => {
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return errorResponse(
+          fromCentral ? 'Cannot clear ingredients on shared library item' : 'Food item not found',
+        )
+      }
+      await clearIngredients(user, id)
+      const detail = await foodItems.getDetail(user, id)
+      if (!detail) return errorResponse('Food item not found')
+      return jsonResponse({ data: detail, success: true })
     },
   )
 }

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -10,11 +10,15 @@ import {
   type AddFoodItemBody,
   addFoodItemBodySchema,
   type DeleteFoodItemResponse,
+  type FoodItemDetail,
+  type FoodItemDetailResponse,
   type FoodItemEntity,
   type FoodItemResponse,
   type FoodItemsQuery,
   type FoodItemsResponse,
   foodItemsQuerySchema,
+  type SetFoodItemIngredientsBody,
+  setFoodItemIngredientsBodySchema,
   type UpdateFoodItemBody,
   updateFoodItemBodySchema,
 } from '@aurboda/api-spec'
@@ -23,14 +27,20 @@ import type { CentralDb } from '../services/central-db.ts'
 import type { SharedFoodItemEntity } from '../services/central-food-items.ts'
 
 import {
+  clearIngredients as dbClearIngredients,
   deleteFoodItem,
   type FoodItemEntity as DbFoodItemEntity,
   getFoodItemById as getUserFoodItemById,
   listFoodItems,
+  setIngredients as dbSetIngredients,
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
-import { createFoodItemsService, type MergedFoodItem } from '../services/food-items.ts'
+import {
+  createFoodItemsService,
+  type FoodItemDetail as ServiceFoodItemDetail,
+  type MergedFoodItem,
+} from '../services/food-items.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
@@ -43,6 +53,23 @@ const serializeFoodItem = (
     result[key] = value instanceof Date ? value.toISOString() : value
   }
   return result as FoodItemEntity
+}
+
+const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
+  const base = serializeFoodItem(detail.item)
+  if (!detail.ingredients) return base as FoodItemDetail
+  return {
+    ...base,
+    derived_nutrients: detail.derived_nutrients ?? { nutrient_data_incomplete: false, values: {} },
+    ingredients: detail.ingredients.map((ing) => ({
+      icon: (ing.food?.icon as string | undefined) ?? null,
+      ingredient_food_item_id: ing.row.ingredient_food_item_id,
+      name: ing.food ? (ing.food.name as string) : null,
+      quantity: ing.row.quantity,
+      sort_order: ing.row.sort_order,
+      unit: ing.row.unit,
+    })),
+  }
 }
 
 export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: CentralDb): TypedRouter => {
@@ -63,10 +90,10 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
     },
   )
 
-  router.get<{ id: string }, FoodItemResponse>('/:id', authMiddleware, async (req, res) => {
-    const item = await service.getById(req.user!, req.params.id)
-    if (!item) return res.status(404).json({ error: 'Food item not found', success: false })
-    res.json({ data: serializeFoodItem(item), success: true })
+  router.get<{ id: string }, FoodItemDetailResponse>('/:id', authMiddleware, async (req, res) => {
+    const detail = await service.getDetail(req.user!, req.params.id)
+    if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+    res.json({ data: serializeDetail(detail), success: true })
   })
 
   router.post<Record<string, never>, FoodItemResponse, AddFoodItemBody>(
@@ -111,6 +138,60 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
     }
     res.json({ success: true })
   })
+
+  // Replace the full ingredient list of a composite food item. Per-user
+  // items only — central rows can't be made composite from this endpoint.
+  router.put<{ id: string }, FoodItemDetailResponse, SetFoodItemIngredientsBody>(
+    '/:id/ingredients',
+    authMiddleware,
+    validateBody(setFoodItemIngredientsBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return res.status(fromCentral ? 403 : 404).json({
+          error: fromCentral ? 'Cannot set ingredients on shared library item' : 'Food item not found',
+          success: false,
+        })
+      }
+      const ingredients = req.body.ingredients
+      const ingredientIds = ingredients.map((i) => i.ingredient_food_item_id)
+      if (await service.wouldCreateCycle(user, id, ingredientIds)) {
+        return res.status(400).json({
+          error: 'Setting these ingredients would create a cycle in the recipe graph',
+          success: false,
+        })
+      }
+      await dbSetIngredients(user, id, ingredients)
+      const detail = await service.getDetail(user, id)
+      if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+      res.json({ data: serializeDetail(detail), success: true })
+    },
+  )
+
+  // Clear all ingredients and revert the parent to atomic mode.
+  router.delete<{ id: string }, FoodItemDetailResponse>(
+    '/:id/ingredients',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return res.status(fromCentral ? 403 : 404).json({
+          error: fromCentral ? 'Cannot clear ingredients on shared library item' : 'Food item not found',
+          success: false,
+        })
+      }
+      await dbClearIngredients(user, id)
+      const detail = await service.getDetail(user, id)
+      if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+      res.json({ data: serializeDetail(detail), success: true })
+    },
+  )
 
   return router
 }

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -82,6 +82,8 @@ export const tableCreationOrder = [
   'food_items',
   'food_items_indexes',
   'food_items_search_setup',
+  'food_item_ingredients',
+  'food_item_ingredients_indexes',
   'meal_food_items',
   'meal_food_items_indexes',
   'locations',

--- a/apps/backend/src/schema/meals.ts
+++ b/apps/backend/src/schema/meals.ts
@@ -110,6 +110,7 @@ export const mealsTables: Record<string, string> = {
       salt            DOUBLE PRECISION,
       icon            TEXT,
       source_id       VARCHAR(100),
+      is_composite    BOOLEAN NOT NULL DEFAULT FALSE,
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       CONSTRAINT unique_food_item_name UNIQUE (name_lower)
@@ -120,6 +121,31 @@ export const mealsTables: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_food_items_name_lower ON food_items (name_lower);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_food_items_source_id
       ON food_items (source, source_id) WHERE source_id IS NOT NULL
+  `,
+
+  // Composite/recipe food items: a parent food item is "made of" several
+  // ingredients, each pointing at another food (per-user OR central — the FK
+  // is user-only; cross-database refs are soft pointers like meal_food_items).
+  // Quantities are scaled against the ingredient's own default_quantity to
+  // derive the parent's nutrient totals at read time.
+  food_item_ingredients: `
+    CREATE TABLE IF NOT EXISTS food_item_ingredients (
+      id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      parent_food_item_id      UUID NOT NULL REFERENCES food_items(id) ON DELETE CASCADE,
+      ingredient_food_item_id  UUID NOT NULL,
+      quantity                 DOUBLE PRECISION NOT NULL,
+      unit                     VARCHAR(100),
+      sort_order               INTEGER NOT NULL DEFAULT 0,
+      created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT no_self_ingredient CHECK (parent_food_item_id <> ingredient_food_item_id)
+    )
+  `,
+  food_item_ingredients_indexes: `
+    CREATE INDEX IF NOT EXISTS idx_food_item_ingredients_parent
+      ON food_item_ingredients (parent_food_item_id);
+    CREATE INDEX IF NOT EXISTS idx_food_item_ingredients_ingredient
+      ON food_item_ingredients (ingredient_food_item_id)
   `,
 
   // Fuzzy/accent-insensitive search support: pg_trgm + unaccent extensions,

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -4,7 +4,7 @@ import type { FoodItemEntity } from '../db/types.ts'
 import type { CentralDb } from './central-db.ts'
 import type { SharedFoodItemEntity } from './central-food-items.ts'
 
-import { createFoodItemsService } from './food-items.ts'
+import { aggregateNutrientsFromIngredients, createFoodItemsService } from './food-items.ts'
 
 vi.mock('../db/food-items.ts', () => ({
   findOrCreateFoodItem: vi.fn(),
@@ -13,7 +13,12 @@ vi.mock('../db/food-items.ts', () => ({
   searchFoodItems: vi.fn(),
 }))
 
+vi.mock('../db/food-item-ingredients.ts', () => ({
+  getIngredients: vi.fn().mockResolvedValue([]),
+}))
+
 const dbModule = await import('../db/food-items.ts')
+const ingredientsModule = await import('../db/food-item-ingredients.ts')
 
 const userItem = (id: string, name: string): FoodItemEntity =>
   ({
@@ -160,5 +165,138 @@ describe('createFoodItemsService.getByName', () => {
 
     const result = await service.getByName('user', 'Hushållsost')
     expect(result?.id).toBe('c1')
+  })
+})
+
+describe('aggregateNutrientsFromIngredients', () => {
+  test('sums each nutrient field across ingredients × per-ingredient scale', () => {
+    const coffee = userItem('coffee', 'Coffee')
+    const oil = userItem('oil', 'Coconut oil')
+    // Coffee: 100 ml default, 2 kcal/100ml
+    coffee.default_quantity = 100
+    coffee.default_unit = 'ml'
+    coffee.calories = 2
+    // Oil: 100 g default, 900 kcal/100 g
+    oil.default_quantity = 100
+    oil.default_unit = 'g'
+    oil.calories = 900
+    oil.fat = 100
+
+    const { values, nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      {
+        food: coffee,
+        row: {
+          created_at: new Date(),
+          id: 'r1',
+          ingredient_food_item_id: 'coffee',
+          parent_food_item_id: 'p',
+          quantity: 500,
+          sort_order: 0,
+          unit: 'ml',
+          updated_at: new Date(),
+        },
+      },
+      {
+        food: oil,
+        row: {
+          created_at: new Date(),
+          id: 'r2',
+          ingredient_food_item_id: 'oil',
+          parent_food_item_id: 'p',
+          quantity: 15,
+          sort_order: 1,
+          unit: 'g',
+          updated_at: new Date(),
+        },
+      },
+    ])
+
+    // 500ml × 2 kcal/100ml + 15 g × 900 kcal/100 g = 10 + 135 = 145 kcal
+    expect(values.calories).toBe(145)
+    // 15 g × 100 g fat / 100 g = 15 g fat
+    expect(values.fat).toBe(15)
+    expect(nutrient_data_incomplete).toBe(false)
+  })
+
+  test('flags nutrient_data_incomplete when an ingredient lacks calories', () => {
+    const incomplete = userItem('x', 'X')
+    incomplete.default_quantity = 1
+    incomplete.default_unit = 'g'
+    // no calories field set
+
+    const { nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      {
+        food: incomplete,
+        row: {
+          created_at: new Date(),
+          id: 'r1',
+          ingredient_food_item_id: 'x',
+          parent_food_item_id: 'p',
+          quantity: 1,
+          sort_order: 0,
+          unit: 'g',
+          updated_at: new Date(),
+        },
+      },
+    ])
+    expect(nutrient_data_incomplete).toBe(true)
+  })
+
+  test('flags incomplete when an ingredient could not be resolved', () => {
+    const { nutrient_data_incomplete, values } = aggregateNutrientsFromIngredients([
+      {
+        food: null,
+        row: {
+          created_at: new Date(),
+          id: 'r1',
+          ingredient_food_item_id: 'missing',
+          parent_food_item_id: 'p',
+          quantity: 1,
+          sort_order: 0,
+          unit: 'g',
+          updated_at: new Date(),
+        },
+      },
+    ])
+    expect(nutrient_data_incomplete).toBe(true)
+    expect(values).toEqual({})
+  })
+})
+
+describe('wouldCreateCycle', () => {
+  test('rejects direct self-reference', async () => {
+    const central = fakeCentral()
+    const service = createFoodItemsService(central)
+    expect(await service.wouldCreateCycle('user', 'A', ['A', 'B'])).toBe(true)
+  })
+
+  test('rejects transitive cycle A → B → A', async () => {
+    // B has A as one of its ingredients; trying to add B as ingredient of A.
+    vi.mocked(ingredientsModule.getIngredients).mockImplementation(async (_user, parent) => {
+      if (parent === 'B') {
+        return [
+          {
+            created_at: new Date(),
+            id: 'i1',
+            ingredient_food_item_id: 'A',
+            parent_food_item_id: 'B',
+            quantity: 1,
+            sort_order: 0,
+            unit: undefined,
+            updated_at: new Date(),
+          },
+        ]
+      }
+      return []
+    })
+
+    const service = createFoodItemsService(fakeCentral())
+    expect(await service.wouldCreateCycle('user', 'A', ['B'])).toBe(true)
+  })
+
+  test('passes for an acyclic graph', async () => {
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+    const service = createFoodItemsService(fakeCentral())
+    expect(await service.wouldCreateCycle('user', 'A', ['B', 'C'])).toBe(false)
   })
 })

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -300,3 +300,67 @@ describe('wouldCreateCycle', () => {
     expect(await service.wouldCreateCycle('user', 'A', ['B', 'C'])).toBe(false)
   })
 })
+
+describe('aggregateNutrientsFromIngredients — scaling edge cases', () => {
+  const buildRow = (qty: number, unit: string | undefined) => ({
+    created_at: new Date(),
+    id: 'r',
+    ingredient_food_item_id: 'x',
+    parent_food_item_id: 'p',
+    quantity: qty,
+    sort_order: 0,
+    unit,
+    updated_at: new Date(),
+  })
+
+  test('converts dimensionally-compatible units (dl ↔ ml) instead of falling back', () => {
+    const coffee = userItem('coffee', 'Coffee')
+    coffee.default_quantity = 100
+    coffee.default_unit = 'ml'
+    coffee.calories = 2
+
+    // 5 dl = 500 ml → 5 × (2 kcal / 100 ml) × 100 ml = 10 kcal
+    const { values, nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      { food: coffee, row: buildRow(5, 'dl') },
+    ])
+    expect(values.calories).toBe(10)
+    expect(nutrient_data_incomplete).toBe(false)
+  })
+
+  test('flags incomplete when ingredient unit is dimensionally incompatible with default_unit', () => {
+    const oil = userItem('oil', 'Oil')
+    oil.default_quantity = 100
+    oil.default_unit = 'g'
+    oil.calories = 900
+
+    // "1 ml" against "100 g default" — different dimensions, no conversion possible.
+    const { nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      { food: oil, row: buildRow(1, 'ml') },
+    ])
+    expect(nutrient_data_incomplete).toBe(true)
+  })
+
+  test('flags incomplete when default_quantity is missing or zero', () => {
+    const food = userItem('x', 'X')
+    food.default_unit = 'g'
+    food.calories = 100
+    // default_quantity left undefined
+
+    const { nutrient_data_incomplete } = aggregateNutrientsFromIngredients([{ food, row: buildRow(50, 'g') }])
+    expect(nutrient_data_incomplete).toBe(true)
+  })
+
+  test('mass conversion (kg → g)', () => {
+    const flour = userItem('flour', 'Flour')
+    flour.default_quantity = 100
+    flour.default_unit = 'g'
+    flour.calories = 360
+
+    // 0.5 kg = 500 g → 5 × 360 = 1800 kcal
+    const { values, nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      { food: flour, row: buildRow(0.5, 'kg') },
+    ])
+    expect(values.calories).toBe(1800)
+    expect(nutrient_data_incomplete).toBe(false)
+  })
+})

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -11,10 +11,16 @@
  * collide; we don't need a namespace prefix on IDs.
  */
 
+import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+
 import type { FoodItemEntity } from '../db/types.ts'
 import type { CentralDb } from './central-db.ts'
 import type { SharedFoodItemEntity } from './central-food-items.ts'
 
+import {
+  type FoodItemIngredientRow,
+  getIngredients as dbGetIngredients,
+} from '../db/food-item-ingredients.ts'
 import {
   findOrCreateFoodItem as findOrCreateUserFoodItem,
   getFoodItemById as getUserFoodItemById,
@@ -30,6 +36,31 @@ import {
  */
 export type MergedFoodItem = FoodItemEntity | SharedFoodItemEntity
 
+export interface ResolvedIngredient {
+  /** The junction row (parent → ingredient pointer + qty/unit). */
+  row: FoodItemIngredientRow
+  /** The actual ingredient food item, resolved across user + central. */
+  food: MergedFoodItem | null
+}
+
+export interface DerivedNutrients {
+  /** Sum of (ingredient.value × scale) across all resolvable ingredients. */
+  values: Record<string, number>
+  /**
+   * True if any ingredient lacks a calorie value or could not be resolved —
+   * meal totals computed from this composite would be understated.
+   */
+  nutrient_data_incomplete: boolean
+}
+
+export interface FoodItemDetail {
+  item: MergedFoodItem
+  /** Present iff the item is a per-user composite. */
+  ingredients?: ResolvedIngredient[]
+  /** Derived nutrient totals when composite; absent for atomic items. */
+  derived_nutrients?: DerivedNutrients
+}
+
 export interface FoodItemsService {
   search: (user: string, q: string, limit?: number) => Promise<MergedFoodItem[]>
   getById: (user: string, id: string) => Promise<MergedFoodItem | null>
@@ -39,6 +70,60 @@ export interface FoodItemsService {
     name: string,
     defaults?: Partial<InsertFoodItemInput>,
   ) => Promise<MergedFoodItem>
+  /** Get the item plus, if composite, its ingredients + derived nutrients. */
+  getDetail: (user: string, id: string) => Promise<FoodItemDetail | null>
+  /**
+   * Cycle guard for setIngredients. Walks the ingredient graph from each
+   * candidate looking for `parentId`. Per-user FK already prevents pointing
+   * at non-existent parents; this defends against `A → B → A`-style loops
+   * across the user's own composites.
+   */
+  wouldCreateCycle: (user: string, parentId: string, ingredientIds: string[]) => Promise<boolean>
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100
+
+/**
+ * Compute the scale factor between an ingredient's quantity and its
+ * canonical default_quantity. Same-unit assumption — if units differ we
+ * fall back to scale = 1 and the caller should treat values as raw.
+ */
+const computeIngredientScale = (
+  ingredientQuantity: number,
+  ingredientUnit: string | undefined,
+  food: MergedFoodItem,
+): number => {
+  const defaultQty = food.default_quantity as number | undefined
+  if (defaultQty === undefined || defaultQty === null || defaultQty === 0) return 1
+  const defaultUnit = food.default_unit as string | undefined
+  if (ingredientUnit && defaultUnit && ingredientUnit !== defaultUnit) return 1
+  return ingredientQuantity / defaultQty
+}
+
+/**
+ * Sum each nutrient column across the resolved ingredients × per-ingredient
+ * scale. Ingredients we couldn't resolve (cross-DB pointer to a deleted
+ * row) and ingredients without a calorie reading both flip the
+ * `nutrient_data_incomplete` flag so callers know the totals are partial.
+ */
+export const aggregateNutrientsFromIngredients = (ingredients: ResolvedIngredient[]): DerivedNutrients => {
+  const values: Record<string, number> = {}
+  let incomplete = false
+  for (const { row, food } of ingredients) {
+    if (!food) {
+      incomplete = true
+      continue
+    }
+    if (typeof food.calories !== 'number') incomplete = true
+    const scale = computeIngredientScale(row.quantity, row.unit, food)
+    for (const field of NUTRIENT_FIELD_NAMES) {
+      const v = food[field]
+      if (typeof v === 'number') {
+        values[field] = round2((values[field] ?? 0) + v * scale)
+      }
+    }
+  }
+  return { nutrient_data_incomplete: incomplete, values }
 }
 
 export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService => ({
@@ -73,5 +158,55 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
     const fromUser = await getUserFoodItemByName(user, name)
     if (fromUser) return fromUser
     return findOrCreateUserFoodItem(user, name, defaults)
+  },
+
+  getDetail: async (user, id) => {
+    const fromUser = await getUserFoodItemById(user, id)
+    if (fromUser) {
+      // Per-user item — may be composite. Always look up ingredients (cheap
+      // index seek; absent if not composite).
+      const rows = await dbGetIngredients(user, id)
+      if (rows.length === 0) {
+        return { item: fromUser }
+      }
+      const resolved: ResolvedIngredient[] = await Promise.all(
+        rows.map(async (row) => {
+          const food =
+            (await getUserFoodItemById(user, row.ingredient_food_item_id)) ??
+            (await centralDb.getSharedFoodItemById(row.ingredient_food_item_id))
+          return { food, row }
+        }),
+      )
+      return {
+        derived_nutrients: aggregateNutrientsFromIngredients(resolved),
+        ingredients: resolved,
+        item: fromUser,
+      }
+    }
+    const fromCentral = await centralDb.getSharedFoodItemById(id)
+    return fromCentral ? { item: fromCentral } : null
+  },
+
+  wouldCreateCycle: async (user, parentId, ingredientIds) => {
+    // Direct self-reference is already enforced by the SQL CHECK; the
+    // transitive case isn't.
+    if (ingredientIds.includes(parentId)) return true
+    // BFS from each candidate ingredient through the user's composite graph.
+    // Central items have no ingredients, so we only need user data.
+    const visited = new Set<string>()
+    const queue = [...ingredientIds]
+    while (queue.length > 0) {
+      const next = queue.shift()!
+      if (visited.has(next)) continue
+      visited.add(next)
+      const rows = await dbGetIngredients(user, next)
+      for (const row of rows) {
+        if (row.ingredient_food_item_id === parentId) return true
+        if (!visited.has(row.ingredient_food_item_id)) {
+          queue.push(row.ingredient_food_item_id)
+        }
+      }
+    }
+    return false
   },
 })

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -84,27 +84,60 @@ export interface FoodItemsService {
 const round2 = (n: number): number => Math.round(n * 100) / 100
 
 /**
+ * Convert a quantity from one unit to another for a small set of standard
+ * mass and volume scales. Returns undefined when the units are different
+ * dimensions (e.g. "g" → "ml") or unknown — callers should treat that as
+ * "can't scale, flag as incomplete".
+ */
+const convertUnit = (qty: number, from: string, to: string): number | undefined => {
+  if (from === to) return qty
+  const mass: Record<string, number> = { g: 1, kg: 1000, mg: 0.001, µg: 0.000_001 }
+  const volume: Record<string, number> = { ml: 1, dl: 100, cl: 10, l: 1000 }
+  const f = from.toLowerCase().trim()
+  const t = to.toLowerCase().trim()
+  if (f in mass && t in mass) return (qty * mass[f]) / mass[t]
+  if (f in volume && t in volume) return (qty * volume[f]) / volume[t]
+  return undefined
+}
+
+interface ScaleResult {
+  scale: number
+  /** True if scaling could not be done reliably — caller flips incomplete flag. */
+  incomplete: boolean
+}
+
+/**
  * Compute the scale factor between an ingredient's quantity and its
- * canonical default_quantity. Same-unit assumption — if units differ we
- * fall back to scale = 1 and the caller should treat values as raw.
+ * canonical default_quantity. Same units → straight ratio. Different but
+ * dimensionally-compatible units (e.g. dl ↔ ml) → convert. Anything else
+ * (mismatched dimension, missing default_quantity) → scale = 1 + incomplete
+ * flag so the user knows totals can't be trusted.
  */
 const computeIngredientScale = (
   ingredientQuantity: number,
   ingredientUnit: string | undefined,
   food: MergedFoodItem,
-): number => {
+): ScaleResult => {
   const defaultQty = food.default_quantity as number | undefined
-  if (defaultQty === undefined || defaultQty === null || defaultQty === 0) return 1
+  if (defaultQty === undefined || defaultQty === null || defaultQty === 0) {
+    return { incomplete: true, scale: 1 }
+  }
   const defaultUnit = food.default_unit as string | undefined
-  if (ingredientUnit && defaultUnit && ingredientUnit !== defaultUnit) return 1
-  return ingredientQuantity / defaultQty
+  if (ingredientUnit && defaultUnit && ingredientUnit !== defaultUnit) {
+    const converted = convertUnit(ingredientQuantity, ingredientUnit, defaultUnit)
+    if (converted === undefined) return { incomplete: true, scale: 1 }
+    return { incomplete: false, scale: converted / defaultQty }
+  }
+  return { incomplete: false, scale: ingredientQuantity / defaultQty }
 }
 
 /**
  * Sum each nutrient column across the resolved ingredients × per-ingredient
- * scale. Ingredients we couldn't resolve (cross-DB pointer to a deleted
- * row) and ingredients without a calorie reading both flip the
- * `nutrient_data_incomplete` flag so callers know the totals are partial.
+ * scale. Ingredients we couldn't resolve, ingredients without a calorie
+ * reading, and ingredients we couldn't scale reliably (missing default_qty
+ * or incompatible units) all flip `nutrient_data_incomplete` so callers
+ * know the totals are partial. Rounding is applied once at the end so
+ * accumulated error doesn't compound.
  */
 export const aggregateNutrientsFromIngredients = (ingredients: ResolvedIngredient[]): DerivedNutrients => {
   const values: Record<string, number> = {}
@@ -115,14 +148,16 @@ export const aggregateNutrientsFromIngredients = (ingredients: ResolvedIngredien
       continue
     }
     if (typeof food.calories !== 'number') incomplete = true
-    const scale = computeIngredientScale(row.quantity, row.unit, food)
+    const { scale, incomplete: scaleIncomplete } = computeIngredientScale(row.quantity, row.unit, food)
+    if (scaleIncomplete) incomplete = true
     for (const field of NUTRIENT_FIELD_NAMES) {
       const v = food[field]
       if (typeof v === 'number') {
-        values[field] = round2((values[field] ?? 0) + v * scale)
+        values[field] = (values[field] ?? 0) + v * scale
       }
     }
   }
+  for (const field of Object.keys(values)) values[field] = round2(values[field])
   return { nutrient_data_incomplete: incomplete, values }
 }
 
@@ -163,12 +198,10 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
   getDetail: async (user, id) => {
     const fromUser = await getUserFoodItemById(user, id)
     if (fromUser) {
-      // Per-user item — may be composite. Always look up ingredients (cheap
-      // index seek; absent if not composite).
+      // Skip the junction lookup for atomic items — most reads.
+      if (!fromUser.is_composite) return { item: fromUser }
       const rows = await dbGetIngredients(user, id)
-      if (rows.length === 0) {
-        return { item: fromUser }
-      }
+      if (rows.length === 0) return { item: fromUser }
       const resolved: ResolvedIngredient[] = await Promise.all(
         rows.map(async (row) => {
           const food =

--- a/apps/web/src/components/IngredientList.css
+++ b/apps/web/src/components/IngredientList.css
@@ -1,0 +1,78 @@
+.ingredient-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.ingredient-empty {
+  color: #9ca3af;
+  font-style: italic;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.ingredient-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.ingredient-name {
+  flex: 1;
+  font-size: 0.9rem;
+  color: #1f2937;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.ingredient-icon {
+  font-size: 1.1rem;
+}
+
+.ingredient-missing {
+  color: #9ca3af;
+}
+
+.ingredient-qty {
+  width: 70px;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  text-align: right;
+}
+
+.ingredient-unit {
+  width: 80px;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.85rem;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+}
+
+.ingredient-add-row {
+  margin-top: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ingredient-row {
+    background: #374151;
+    border-color: #4b5563;
+  }
+
+  .ingredient-name {
+    color: #e5e7eb;
+  }
+
+  .ingredient-qty,
+  .ingredient-unit {
+    background: #1f2937;
+    border-color: #4b5563;
+    color: #d1d5db;
+  }
+}

--- a/apps/web/src/components/IngredientList.tsx
+++ b/apps/web/src/components/IngredientList.tsx
@@ -3,16 +3,16 @@
  *
  * Each row is one ingredient pointing at another food item — picked via
  * FoodItemAutocomplete (which already merges user + central library), with
- * inline quantity and unit. Edits commit on blur; the parent page persists
- * the full list via PUT /food-items/:id/ingredients.
+ * inline quantity and unit. Edits commit on **blur** (or remove); the
+ * parent page persists the full list via PUT /food-items/:id/ingredients.
  */
 
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 import type { FoodItemEntity } from '../state/api'
 
-import './IngredientList.css'
 import { FoodItemAutocomplete } from './FoodItemAutocomplete'
+import './IngredientList.css'
 
 export interface IngredientRow {
   ingredient_food_item_id: string
@@ -30,18 +30,90 @@ interface Props {
   onChange: (ingredients: IngredientRow[]) => void
 }
 
+/**
+ * One ingredient row with local qty/unit state that commits to the parent
+ * on blur. Without this, every keystroke would fire a PUT — wasteful and,
+ * with non-atomic writes, race-prone.
+ */
+function IngredientRowEditor({
+  ingredient,
+  onCommit,
+  onRemove,
+}: {
+  ingredient: IngredientRow
+  onCommit: (patch: Partial<IngredientRow>) => void
+  onRemove: () => void
+}) {
+  const [qtyInput, setQtyInput] = useState<string>(String(ingredient.quantity))
+  const [unitInput, setUnitInput] = useState<string>(ingredient.unit ?? '')
+
+  // Re-sync local state if the server-side row changes (e.g. revert/refresh).
+  useEffect(() => {
+    setQtyInput(String(ingredient.quantity))
+  }, [ingredient.quantity])
+  useEffect(() => {
+    setUnitInput(ingredient.unit ?? '')
+  }, [ingredient.unit])
+
+  const commitQty = () => {
+    const trimmed = qtyInput.trim()
+    if (trimmed === '') {
+      // Empty input → revert; clearing the field shouldn't silently set to 0.
+      setQtyInput(String(ingredient.quantity))
+      return
+    }
+    const parsed = parseFloat(trimmed)
+    if (Number.isNaN(parsed)) {
+      setQtyInput(String(ingredient.quantity))
+      return
+    }
+    if (parsed !== ingredient.quantity) onCommit({ quantity: parsed })
+  }
+
+  const commitUnit = () => {
+    const next = unitInput.trim() || undefined
+    if (next !== ingredient.unit) onCommit({ unit: next })
+  }
+
+  return (
+    <div class="ingredient-row">
+      <span class="ingredient-name">
+        {ingredient.icon && <span class="ingredient-icon">{ingredient.icon}</span>}
+        {ingredient.name ?? <em class="ingredient-missing">(unresolved)</em>}
+      </span>
+      <input
+        type="number"
+        step="0.1"
+        value={qtyInput}
+        class="ingredient-qty"
+        onInput={(e) => setQtyInput((e.target as HTMLInputElement).value)}
+        onBlur={commitQty}
+      />
+      <input
+        type="text"
+        value={unitInput}
+        placeholder="unit"
+        class="ingredient-unit"
+        onInput={(e) => setUnitInput((e.target as HTMLInputElement).value)}
+        onBlur={commitUnit}
+      />
+      <button type="button" class="btn-danger-small" onClick={onRemove} title="Remove ingredient">
+        &times;
+      </button>
+    </div>
+  )
+}
+
 export function IngredientList({ ingredients, onChange }: Props) {
-  // Mirror of incoming list with one trailing blank row for adding.
+  // Autocomplete input string — independent of the persisted ingredient list.
   const [draft, setDraft] = useState('')
 
   const updateAt = (index: number, patch: Partial<IngredientRow>) => {
-    const next = ingredients.map((ing, i) => (i === index ? { ...ing, ...patch } : ing))
-    onChange(next)
+    onChange(ingredients.map((ing, i) => (i === index ? { ...ing, ...patch } : ing)))
   }
 
   const removeAt = (index: number) => {
-    const next = ingredients.filter((_, i) => i !== index).map((ing, i) => ({ ...ing, sort_order: i }))
-    onChange(next)
+    onChange(ingredients.filter((_, i) => i !== index).map((ing, i) => ({ ...ing, sort_order: i })))
   }
 
   const handleAdd = (item: FoodItemEntity) => {
@@ -61,37 +133,12 @@ export function IngredientList({ ingredients, onChange }: Props) {
     <div class="ingredient-list">
       {ingredients.length === 0 && <p class="ingredient-empty">No ingredients yet.</p>}
       {ingredients.map((ing, i) => (
-        <div key={ing.ingredient_food_item_id || i} class="ingredient-row">
-          <span class="ingredient-name">
-            {ing.icon && <span class="ingredient-icon">{ing.icon}</span>}
-            {ing.name ?? <em class="ingredient-missing">(unresolved)</em>}
-          </span>
-          <input
-            type="number"
-            step="0.1"
-            value={ing.quantity}
-            class="ingredient-qty"
-            onInput={(e) => {
-              const v = parseFloat((e.target as HTMLInputElement).value)
-              if (!Number.isNaN(v)) updateAt(i, { quantity: v })
-            }}
-          />
-          <input
-            type="text"
-            value={ing.unit ?? ''}
-            placeholder="unit"
-            class="ingredient-unit"
-            onInput={(e) => updateAt(i, { unit: (e.target as HTMLInputElement).value || undefined })}
-          />
-          <button
-            type="button"
-            class="btn-danger-small"
-            onClick={() => removeAt(i)}
-            title="Remove ingredient"
-          >
-            &times;
-          </button>
-        </div>
+        <IngredientRowEditor
+          key={ing.ingredient_food_item_id || i}
+          ingredient={ing}
+          onCommit={(patch) => updateAt(i, patch)}
+          onRemove={() => removeAt(i)}
+        />
       ))}
       <div class="ingredient-add-row">
         <FoodItemAutocomplete

--- a/apps/web/src/components/IngredientList.tsx
+++ b/apps/web/src/components/IngredientList.tsx
@@ -1,0 +1,106 @@
+/**
+ * Ingredient editor for composite (recipe-style) food items.
+ *
+ * Each row is one ingredient pointing at another food item — picked via
+ * FoodItemAutocomplete (which already merges user + central library), with
+ * inline quantity and unit. Edits commit on blur; the parent page persists
+ * the full list via PUT /food-items/:id/ingredients.
+ */
+
+import { useState } from 'preact/hooks'
+
+import type { FoodItemEntity } from '../state/api'
+
+import './IngredientList.css'
+import { FoodItemAutocomplete } from './FoodItemAutocomplete'
+
+export interface IngredientRow {
+  ingredient_food_item_id: string
+  /** Display name resolved from the canonical food item (snapshotted from server response). */
+  name: string | null
+  icon: string | null
+  quantity: number
+  unit?: string
+  sort_order: number
+}
+
+interface Props {
+  ingredients: IngredientRow[]
+  /** Called when the list changes — caller persists via PUT /food-items/:id/ingredients. */
+  onChange: (ingredients: IngredientRow[]) => void
+}
+
+export function IngredientList({ ingredients, onChange }: Props) {
+  // Mirror of incoming list with one trailing blank row for adding.
+  const [draft, setDraft] = useState('')
+
+  const updateAt = (index: number, patch: Partial<IngredientRow>) => {
+    const next = ingredients.map((ing, i) => (i === index ? { ...ing, ...patch } : ing))
+    onChange(next)
+  }
+
+  const removeAt = (index: number) => {
+    const next = ingredients.filter((_, i) => i !== index).map((ing, i) => ({ ...ing, sort_order: i }))
+    onChange(next)
+  }
+
+  const handleAdd = (item: FoodItemEntity) => {
+    const next: IngredientRow = {
+      icon: (item.icon as string | null) ?? null,
+      ingredient_food_item_id: item.id,
+      name: item.name,
+      quantity: (item.default_quantity as number | undefined) ?? 1,
+      sort_order: ingredients.length,
+      unit: (item.default_unit as string | undefined) ?? undefined,
+    }
+    onChange([...ingredients, next])
+    setDraft('')
+  }
+
+  return (
+    <div class="ingredient-list">
+      {ingredients.length === 0 && <p class="ingredient-empty">No ingredients yet.</p>}
+      {ingredients.map((ing, i) => (
+        <div key={ing.ingredient_food_item_id || i} class="ingredient-row">
+          <span class="ingredient-name">
+            {ing.icon && <span class="ingredient-icon">{ing.icon}</span>}
+            {ing.name ?? <em class="ingredient-missing">(unresolved)</em>}
+          </span>
+          <input
+            type="number"
+            step="0.1"
+            value={ing.quantity}
+            class="ingredient-qty"
+            onInput={(e) => {
+              const v = parseFloat((e.target as HTMLInputElement).value)
+              if (!Number.isNaN(v)) updateAt(i, { quantity: v })
+            }}
+          />
+          <input
+            type="text"
+            value={ing.unit ?? ''}
+            placeholder="unit"
+            class="ingredient-unit"
+            onInput={(e) => updateAt(i, { unit: (e.target as HTMLInputElement).value || undefined })}
+          />
+          <button
+            type="button"
+            class="btn-danger-small"
+            onClick={() => removeAt(i)}
+            title="Remove ingredient"
+          >
+            &times;
+          </button>
+        </div>
+      ))}
+      <div class="ingredient-add-row">
+        <FoodItemAutocomplete
+          value={draft}
+          onChange={setDraft}
+          onSelect={handleAdd}
+          placeholder="Add ingredient — search the library…"
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -288,3 +288,57 @@
     grid-template-columns: 1fr;
   }
 }
+
+.composite-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  padding: 0.5rem 0.75rem;
+  background: #f9fafb;
+  border-radius: 4px;
+}
+
+.composite-toggle-hint {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.composite-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.composite-derived-note {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.composite-incomplete {
+  margin: 0 0 0.75rem;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8rem;
+  color: #92400e;
+  background: #fef3c7;
+  border-radius: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .composite-toggle-row {
+    background: #1f2937;
+  }
+
+  .composite-derived-note,
+  .composite-toggle-hint {
+    color: #9ca3af;
+  }
+
+  .composite-incomplete {
+    color: #fef3c7;
+    background: #78350f;
+  }
+}

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,19 +1,23 @@
-import { NUTRIENT_FIELDS, type NutrientFieldDef } from '@aurboda/api-spec'
+import {
+  type FoodItemDetail as ApiFoodItemDetail,
+  type FoodItemIngredient,
+  NUTRIENT_FIELDS,
+  type NutrientFieldDef,
+} from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation, useRoute } from 'preact-iso'
 import { useEffect, useRef, useState } from 'preact/hooks'
 
-import type { FoodItemEntity } from '../../state/api'
-
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { IconInput } from '../../components/IconInput'
+import { type IngredientRow, IngredientList } from '../../components/IngredientList'
 import { auth } from '../../state/auth'
 import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import './FoodItemDetail.css'
 
 const API_URL = import.meta.env.VITE_API_URL || '/api'
 
-const fetchFoodItem = async (id: string): Promise<FoodItemEntity> => {
+const fetchFoodItem = async (id: string): Promise<ApiFoodItemDetail> => {
   const { token } = auth.value
   const res = await fetch(`${API_URL}/food-items/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -23,7 +27,7 @@ const fetchFoodItem = async (id: string): Promise<FoodItemEntity> => {
   return json.data
 }
 
-const updateFoodItemApi = async (id: string, body: Record<string, unknown>): Promise<FoodItemEntity> => {
+const updateFoodItemApi = async (id: string, body: Record<string, unknown>): Promise<ApiFoodItemDetail> => {
   const { token } = auth.value
   const res = await fetch(`${API_URL}/food-items/${id}`, {
     body: JSON.stringify(body),
@@ -42,6 +46,35 @@ const deleteFoodItemApi = async (id: string): Promise<void> => {
     method: 'DELETE',
   })
   if (!res.ok) throw new Error('Delete failed')
+}
+
+const setIngredientsApi = async (
+  id: string,
+  ingredients: FoodItemIngredient[],
+): Promise<ApiFoodItemDetail> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}/ingredients`, {
+    body: JSON.stringify({ ingredients }),
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    method: 'PUT',
+  })
+  if (!res.ok) {
+    const json = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(json.error ?? 'Failed to update ingredients')
+  }
+  const json = await res.json()
+  return json.data
+}
+
+const clearIngredientsApi = async (id: string): Promise<ApiFoodItemDetail> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}/ingredients`, {
+    headers: { Authorization: `Bearer ${token}` },
+    method: 'DELETE',
+  })
+  if (!res.ok) throw new Error('Failed to clear ingredients')
+  const json = await res.json()
+  return json.data
 }
 
 const CATEGORIES: Array<{ key: NutrientFieldDef['category']; label: string }> = [
@@ -175,6 +208,27 @@ export function FoodItemDetail() {
     },
   })
 
+  const ingredientsMutation = useMutation({
+    mutationFn: (ingredients: FoodItemIngredient[]) => setIngredientsApi(id, ingredients),
+    onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['foodItem', id], updated)
+      setSaveError(null)
+      setSavedFlash(true)
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+      flashTimer.current = setTimeout(() => setSavedFlash(false), 1200)
+    },
+  })
+
+  const clearMutation = useMutation({
+    mutationFn: () => clearIngredientsApi(id),
+    onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['foodItem', id], updated)
+      setSaveError(null)
+    },
+  })
+
   const save = (body: Record<string, unknown>) => {
     setSaveError(null)
     updateMutation.mutate(body)
@@ -290,6 +344,122 @@ export function FoodItemDetail() {
         </span>
       </div>
 
+      <CompositeOrAtomicSection
+        item={item}
+        ingredientsMutation={ingredientsMutation}
+        clearMutation={clearMutation}
+        save={save}
+      />
+    </div>
+  )
+}
+
+interface CompositeProps {
+  item: ApiFoodItemDetail
+  ingredientsMutation: { mutate: (ingredients: FoodItemIngredient[]) => void; isPending: boolean }
+  clearMutation: { mutate: () => void; isPending: boolean }
+  save: (body: Record<string, unknown>) => void
+}
+
+function CompositeOrAtomicSection({ item, ingredientsMutation, clearMutation, save }: CompositeProps) {
+  // Local state for atomic→composite intent: clicking "Convert to recipe"
+  // surfaces the IngredientList immediately even before any ingredient is
+  // saved. The is_composite flag flips server-side only when a non-empty
+  // list is persisted.
+  const [showAsComposite, setShowAsComposite] = useState(false)
+  const isComposite = !!item.is_composite || (item.ingredients?.length ?? 0) > 0 || showAsComposite
+
+  if (isComposite) {
+    const initial: IngredientRow[] = (item.ingredients ?? []).map((ing) => ({
+      icon: ing.icon,
+      ingredient_food_item_id: ing.ingredient_food_item_id,
+      name: ing.name,
+      quantity: ing.quantity,
+      sort_order: ing.sort_order ?? 0,
+      unit: ing.unit,
+    }))
+
+    const persist = (rows: IngredientRow[]) => {
+      ingredientsMutation.mutate(
+        rows.map((r) => ({
+          ingredient_food_item_id: r.ingredient_food_item_id,
+          quantity: r.quantity,
+          sort_order: r.sort_order,
+          unit: r.unit,
+        })),
+      )
+    }
+
+    return (
+      <>
+        <div class="nutrient-section">
+          <div class="composite-header">
+            <h3>Ingredients</h3>
+            <ConfirmButton
+              label="Revert to atomic"
+              confirmMessage="This will remove all ingredients and the item will use whatever nutrient values are stored on it directly. Continue?"
+              onConfirm={() => {
+                setShowAsComposite(false)
+                clearMutation.mutate()
+              }}
+              isPending={clearMutation.isPending}
+              buttonClass="btn-secondary"
+            />
+          </div>
+          <IngredientList ingredients={initial} onChange={persist} />
+        </div>
+
+        <div class="nutrient-sections">
+          <p class="composite-derived-note">
+            Nutrient values below are derived from the ingredients × quantity. Edit the ingredients to change
+            them.
+          </p>
+          {item.derived_nutrients?.nutrient_data_incomplete && (
+            <p class="composite-incomplete">
+              ⚠ One or more ingredients lack calorie data — totals may be understated.
+            </p>
+          )}
+          {CATEGORIES.map(({ key, label }) => {
+            const fields = NUTRIENT_FIELDS.filter((f) => f.category === key)
+            const populated = fields.filter((f) => typeof item.derived_nutrients?.values[f.name] === 'number')
+            if (populated.length === 0) return null
+            return (
+              <div key={key} class="nutrient-section">
+                <h3>{label}</h3>
+                <div class="nutrient-grid">
+                  {populated.map((f) => (
+                    <div key={f.name} class="nutrient-row">
+                      <span class="nutrient-label">{f.label}</span>
+                      <span class="nutrient-value">
+                        {(item.derived_nutrients?.values[f.name] as number).toFixed(2)} {f.unit}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div class="composite-toggle-row">
+        <button
+          type="button"
+          class="btn-secondary"
+          onClick={() => setShowAsComposite(true)}
+          disabled={ingredientsMutation.isPending}
+        >
+          Convert to recipe
+        </button>
+        <span class="composite-toggle-hint">
+          Build this item from other foods — its nutrients will be summed from the ingredients.
+        </span>
+      </div>
+
       <div class="nutrient-sections">
         {CATEGORIES.map(({ key, label }) => {
           const fields = NUTRIENT_FIELDS.filter((f) => f.category === key)
@@ -299,7 +469,7 @@ export function FoodItemDetail() {
               <h3>{label}</h3>
               <div class="nutrient-grid">
                 {fields.map((f) => {
-                  const value = item[f.name]
+                  const value = item[f.name as keyof ApiFoodItemDetail]
                   return (
                     <div key={f.name} class="nutrient-row">
                       <span class="nutrient-label">{f.label}</span>
@@ -316,6 +486,6 @@ export function FoodItemDetail() {
           )
         })}
       </div>
-    </div>
+    </>
   )
 }

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -226,6 +226,9 @@ export function FoodItemDetail() {
     onSuccess: (updated) => {
       queryClient.setQueryData(['foodItem', id], updated)
       setSaveError(null)
+      setSavedFlash(true)
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+      flashTimer.current = setTimeout(() => setSavedFlash(false), 1200)
     },
   })
 

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -32,17 +32,109 @@ export const foodItemEntitySchema = nutrientFieldsSchema
       .optional()
       .meta({ description: 'Icon for this food item (emoji or image URL)' }),
     id: z.string().uuid().meta({ description: 'Food item ID' }),
+    is_composite: z.boolean().optional().meta({
+      description:
+        'True if this is a composite (recipe) item — its nutrient values are derived from food_item_ingredients at read time.',
+    }),
     name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
     source: z
       .string()
       .max(50)
       .optional()
       .meta({ description: 'Data source (e.g., "cronometer", "oura", "manual", "livsmedelsverket")' }),
+    source_id: z
+      .string()
+      .max(100)
+      .optional()
+      .meta({ description: 'Stable identifier from the upstream source (e.g. LSV nummer)' }),
     updated_at: z.string().optional().meta({ description: 'Last update timestamp' }),
   })
   .meta({ description: 'A canonical food item with default nutritional data', id: 'FoodItemEntity' })
 
 export type FoodItemEntity = z.infer<typeof foodItemEntitySchema>
+
+// ============================================================================
+// Composite (recipe) ingredients
+// ============================================================================
+
+/**
+ * One ingredient line in a composite food item — points at another food
+ * (per-user or central), with quantity + unit. The pointed-at food's
+ * nutrients are scaled by quantity/default_quantity at read time to
+ * contribute to the parent's totals.
+ */
+export const foodItemIngredientSchema = z
+  .object({
+    ingredient_food_item_id: z
+      .string()
+      .uuid()
+      .meta({ description: 'ID of the food item used as an ingredient (per-user OR central library)' }),
+    quantity: z.number().meta({ description: 'Amount used, in `unit`' }),
+    unit: z.string().max(100).optional().meta({ description: 'Unit for quantity' }),
+    sort_order: z
+      .number()
+      .int()
+      .optional()
+      .meta({ description: 'Display order; defaults to position in the input array' }),
+  })
+  .meta({ description: 'One ingredient of a composite food item', id: 'FoodItemIngredient' })
+
+export type FoodItemIngredient = z.infer<typeof foodItemIngredientSchema>
+
+/**
+ * Replace the full ingredients list for a composite item.
+ */
+export const setFoodItemIngredientsBodySchema = z
+  .object({
+    ingredients: z
+      .array(foodItemIngredientSchema)
+      .meta({ description: 'Full list of ingredients — replaces any existing ones' }),
+  })
+  .meta({ description: 'Replace the ingredients of a composite food item', id: 'SetFoodItemIngredientsBody' })
+
+export type SetFoodItemIngredientsBody = z.infer<typeof setFoodItemIngredientsBodySchema>
+
+/**
+ * A resolved ingredient as returned from the detail endpoint — the
+ * junction row plus a snapshot of the ingredient food item's name/icon
+ * for display.
+ */
+export const resolvedFoodItemIngredientSchema = foodItemIngredientSchema
+  .extend({
+    name: z.string().nullable().meta({
+      description: 'Ingredient food name (null if the pointed-at item was deleted)',
+    }),
+    icon: z.string().nullable().meta({ description: 'Ingredient icon (or null)' }),
+  })
+  .meta({ description: 'A composite ingredient with display info', id: 'ResolvedFoodItemIngredient' })
+
+export type ResolvedFoodItemIngredient = z.infer<typeof resolvedFoodItemIngredientSchema>
+
+/**
+ * Detail response for a single food item. For composites, includes the
+ * ingredient list plus derived nutrient totals (sum of each ingredient's
+ * value × quantity/default_quantity, when units match). For atomic items,
+ * `ingredients` and `derived_nutrients` are absent and the entity's own
+ * nutrient values are authoritative.
+ */
+export const foodItemDetailSchema = foodItemEntitySchema
+  .extend({
+    ingredients: z.array(resolvedFoodItemIngredientSchema).optional(),
+    derived_nutrients: z
+      .object({
+        values: z.record(z.string(), z.number()).meta({
+          description: 'Summed nutrient values from the resolved ingredients',
+        }),
+        nutrient_data_incomplete: z.boolean().meta({
+          description: 'True when one or more ingredients lack calorie data or could not be resolved',
+        }),
+      })
+      .optional()
+      .meta({ description: 'Nutrient totals derived from ingredients (composite items only)' }),
+  })
+  .meta({ description: 'Food item detail with optional composite ingredients', id: 'FoodItemDetail' })
+
+export type FoodItemDetail = z.infer<typeof foodItemDetailSchema>
 
 // ============================================================================
 // Request Schemas
@@ -98,6 +190,12 @@ export const foodItemResponseSchema = createDataResponseSchema(foodItemEntitySch
 })
 
 export type FoodItemResponse = z.infer<typeof foodItemResponseSchema>
+
+export const foodItemDetailResponseSchema = createDataResponseSchema(foodItemDetailSchema).meta({
+  id: 'FoodItemDetailResponse',
+})
+
+export type FoodItemDetailResponse = z.infer<typeof foodItemDetailResponseSchema>
 
 export const foodItemsResponseSchema = createDataArrayResponseSchema(foodItemEntitySchema).meta({
   id: 'FoodItemsResponse',

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -404,12 +404,9 @@ export const frequentFoodItemSchema = z
     icon: z.string().nullable().meta({ description: 'Snapshotted icon, or null' }),
     count: z.number().int().meta({ description: 'How many times the user logged this food in the window' }),
     last_used: iso8601DateTimeSchema.meta({ description: 'Time of the most recent meal that used it' }),
-    last_quantity: z
-      .number()
-      .nullable()
-      .meta({
-        description: 'Quantity used in the most recent occurrence (a sensible default for re-logging)',
-      }),
+    last_quantity: z.number().nullable().meta({
+      description: 'Quantity used in the most recent occurrence (a sensible default for re-logging)',
+    }),
     last_unit: z.string().nullable().meta({ description: 'Unit used in the most recent occurrence' }),
   })
   .meta({ description: 'A food item the user logs repeatedly', id: 'FrequentFoodItem' })


### PR DESCRIPTION
## Summary
Phase 5 of the food-items reshape. A user can now mark a per-user food item as a **composite** (recipe) — it points at one or more other food items (per-user or central library) via a `food_item_ingredients` junction, and its nutrient values are derived at read time as `sum(ingredient.value × quantity / default_quantity)` when units match.

Concrete: log "Bulletproof coffee" once with 5 dl coffee + 15 g coconut oil + 25 g butter; future meal logs reference it as a single food item with auto-computed calories/macros/micros.

## Schema
- **`food_items.is_composite BOOLEAN`** column. ALTER for existing dbs.
- **`food_item_ingredients`** junction:
  - `parent_food_item_id` FK to per-user `food_items` (CASCADE).
  - `ingredient_food_item_id` is a *soft* pointer — may resolve to a per-user row or a central `shared_food_items` row, so no FK.
  - SQL CHECK blocks direct self-references; transitive cycles (A→B→A) caught in the service layer via DFS.

## Backend
- `db/food-item-ingredients.ts`: get/set/clear/batch, with `is_composite` auto-flipped on the parent based on whether the new list is non-empty.
- `services/food-items.ts`: 
  - `aggregateNutrientsFromIngredients` sums each nutrient column with per-ingredient scaling.
  - `nutrient_data_incomplete` flag when any ingredient lacks calories or can't be resolved.
  - `getDetail` returns the item plus, for composites, resolved ingredients + derived totals.
  - `wouldCreateCycle` BFS guards `setIngredients`.
- `GET /food-items/:id` now returns `FoodItemDetail` (entity + `ingredients[]` + `derived_nutrients` for composites).
- `PUT/DELETE /food-items/:id/ingredients` manage the recipe.
- MCP: new `set_food_item_ingredients` and `clear_food_item_ingredients`; `get_food_item` upgraded to return `FoodItemDetail`.

## Frontend
- New `IngredientList` component — reuses `FoodItemAutocomplete` (already merges user+central) for adding ingredients, inline qty/unit, delete.
- `FoodItemDetail` picks composite vs atomic mode from `is_composite + ingredients[]`:
  - Composite: ingredient list + read-only derived nutrients with an incomplete-data warning.
  - Atomic: existing editable nutrient grid + "Convert to recipe" button.

## Test plan
- [x] 6 integration tests for the junction table: set/clear, is_composite flip, cascade on parent delete, self-ingredient blocked, batch fetch.
- [x] 6 service tests: scaling math (5 dl coffee + 15 g oil → correct kcal sum), incomplete flag, cycle direct + transitive, acyclic.
- [x] Backend + web typecheck/lint clean.
- [ ] Manual: create "Bulletproof coffee" composite, see derived totals; try to add it as its own ingredient → cycle error.
- [ ] MCP: `set_food_item_ingredients` on a per-user item, then `get_food_item` returns the derived totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)