### PR TITLE
feat(android): serializers for all readable Health Connect types

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthDataModels.kt
@@ -708,6 +708,366 @@ data class Vo2MaxRecordSerializable(
   }
 }
 
+// --- Basal Body Temperature Record ---
+@Serializable
+data class BasalBodyTemperatureRecordSerializable(
+  val time: String,
+  val temperatureInCelsius: Double,
+  val measurementLocation: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BasalBodyTemperatureRecordSerializable> =
+      classRecords.filterIsInstance<BasalBodyTemperatureRecord>().map { record ->
+        BasalBodyTemperatureRecordSerializable(
+          time = record.time.toIsoString(),
+          temperatureInCelsius = record.temperature.inCelsius,
+          measurementLocation = record.measurementLocation,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Basal Metabolic Rate Record ---
+@Serializable
+data class BasalMetabolicRateRecordSerializable(
+  val time: String,
+  val basalMetabolicRateInKcalPerDay: Double,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BasalMetabolicRateRecordSerializable> =
+      classRecords.filterIsInstance<BasalMetabolicRateRecord>().map { record ->
+        BasalMetabolicRateRecordSerializable(
+          time = record.time.toIsoString(),
+          basalMetabolicRateInKcalPerDay = record.basalMetabolicRate.inKilocaloriesPerDay,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Blood Glucose Record ---
+@Serializable
+data class BloodGlucoseRecordSerializable(
+  val time: String,
+  val levelInMmolPerL: Double,
+  val specimenSource: Int,
+  val mealType: Int,
+  val relationToMeal: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BloodGlucoseRecordSerializable> =
+      classRecords.filterIsInstance<BloodGlucoseRecord>().map { record ->
+        BloodGlucoseRecordSerializable(
+          time = record.time.toIsoString(),
+          levelInMmolPerL = record.level.inMillimolesPerLiter,
+          specimenSource = record.specimenSource,
+          mealType = record.mealType,
+          relationToMeal = record.relationToMeal,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Blood Pressure Record ---
+@Serializable
+data class BloodPressureRecordSerializable(
+  val time: String,
+  val systolicInMmHg: Double,
+  val diastolicInMmHg: Double,
+  val bodyPosition: Int,
+  val measurementLocation: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BloodPressureRecordSerializable> =
+      classRecords.filterIsInstance<BloodPressureRecord>().map { record ->
+        BloodPressureRecordSerializable(
+          time = record.time.toIsoString(),
+          systolicInMmHg = record.systolic.inMillimetersOfMercury,
+          diastolicInMmHg = record.diastolic.inMillimetersOfMercury,
+          bodyPosition = record.bodyPosition,
+          measurementLocation = record.measurementLocation,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Body Temperature Record ---
+@Serializable
+data class BodyTemperatureRecordSerializable(
+  val time: String,
+  val temperatureInCelsius: Double,
+  val measurementLocation: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<BodyTemperatureRecordSerializable> =
+      classRecords.filterIsInstance<BodyTemperatureRecord>().map { record ->
+        BodyTemperatureRecordSerializable(
+          time = record.time.toIsoString(),
+          temperatureInCelsius = record.temperature.inCelsius,
+          measurementLocation = record.measurementLocation,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Cervical Mucus Record ---
+@Serializable
+data class CervicalMucusRecordSerializable(
+  val time: String,
+  val appearance: Int,
+  val sensation: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<CervicalMucusRecordSerializable> =
+      classRecords.filterIsInstance<CervicalMucusRecord>().map { record ->
+        CervicalMucusRecordSerializable(
+          time = record.time.toIsoString(),
+          appearance = record.appearance,
+          sensation = record.sensation,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Cycling Pedaling Cadence Record Helpers ---
+@Serializable
+data class CyclingCadenceSampleSerializable(
+  val time: String,
+  val revolutionsPerMinute: Double,
+)
+
+// --- Cycling Pedaling Cadence Record ---
+@Serializable
+data class CyclingPedalingCadenceRecordSerializable(
+  val startTime: String,
+  val endTime: String,
+  val samples: List<CyclingCadenceSampleSerializable>,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<CyclingPedalingCadenceRecordSerializable> =
+      classRecords.filterIsInstance<CyclingPedalingCadenceRecord>().map { record ->
+        CyclingPedalingCadenceRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          samples =
+            record.samples.map {
+              CyclingCadenceSampleSerializable(
+                time = it.time.toIsoString(),
+                revolutionsPerMinute = it.revolutionsPerMinute,
+              )
+            },
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Elevation Gained Record ---
+@Serializable
+data class ElevationGainedRecordSerializable(
+  val startTime: String,
+  val endTime: String,
+  val elevationInMeters: Double,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<ElevationGainedRecordSerializable> =
+      classRecords.filterIsInstance<ElevationGainedRecord>().map { record ->
+        ElevationGainedRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          elevationInMeters = record.elevation.inMeters,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Hydration Record ---
+@Serializable
+data class HydrationRecordSerializable(
+  val startTime: String,
+  val endTime: String,
+  val volumeInLiters: Double,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<HydrationRecordSerializable> =
+      classRecords.filterIsInstance<HydrationRecord>().map { record ->
+        HydrationRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          volumeInLiters = record.volume.inLiters,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Intermenstrual Bleeding Record ---
+@Serializable
+data class IntermenstrualBleedingRecordSerializable(
+  val time: String,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<IntermenstrualBleedingRecordSerializable> =
+      classRecords.filterIsInstance<IntermenstrualBleedingRecord>().map { record ->
+        IntermenstrualBleedingRecordSerializable(
+          time = record.time.toIsoString(),
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Menstruation Flow Record ---
+@Serializable
+data class MenstruationFlowRecordSerializable(
+  val time: String,
+  val flow: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<MenstruationFlowRecordSerializable> =
+      classRecords.filterIsInstance<MenstruationFlowRecord>().map { record ->
+        MenstruationFlowRecordSerializable(
+          time = record.time.toIsoString(),
+          flow = record.flow,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Menstruation Period Record ---
+@Serializable
+data class MenstruationPeriodRecordSerializable(
+  val startTime: String,
+  val endTime: String,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<MenstruationPeriodRecordSerializable> =
+      classRecords.filterIsInstance<MenstruationPeriodRecord>().map { record ->
+        MenstruationPeriodRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Ovulation Test Record ---
+@Serializable
+data class OvulationTestRecordSerializable(
+  val time: String,
+  val result: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<OvulationTestRecordSerializable> =
+      classRecords.filterIsInstance<OvulationTestRecord>().map { record ->
+        OvulationTestRecordSerializable(
+          time = record.time.toIsoString(),
+          result = record.result,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Oxygen Saturation Record ---
+@Serializable
+data class OxygenSaturationRecordSerializable(
+  val time: String,
+  val percentage: Double,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<OxygenSaturationRecordSerializable> =
+      classRecords.filterIsInstance<OxygenSaturationRecord>().map { record ->
+        OxygenSaturationRecordSerializable(
+          time = record.time.toIsoString(),
+          percentage = record.percentage.value,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Respiratory Rate Record ---
+@Serializable
+data class RespiratoryRateRecordSerializable(
+  val time: String,
+  val rate: Double,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<RespiratoryRateRecordSerializable> =
+      classRecords.filterIsInstance<RespiratoryRateRecord>().map { record ->
+        RespiratoryRateRecordSerializable(
+          time = record.time.toIsoString(),
+          rate = record.rate,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Sexual Activity Record ---
+@Serializable
+data class SexualActivityRecordSerializable(
+  val time: String,
+  val protectionUsed: Int,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<SexualActivityRecordSerializable> =
+      classRecords.filterIsInstance<SexualActivityRecord>().map { record ->
+        SexualActivityRecordSerializable(
+          time = record.time.toIsoString(),
+          protectionUsed = record.protectionUsed,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
+// --- Wheelchair Pushes Record ---
+@Serializable
+data class WheelchairPushesRecordSerializable(
+  val startTime: String,
+  val endTime: String,
+  val count: Long,
+  val metadata: HealthConnectRecordMetadata,
+) {
+  companion object {
+    fun fromRecordsList(classRecords: List<Record>): List<WheelchairPushesRecordSerializable> =
+      classRecords.filterIsInstance<WheelchairPushesRecord>().map { record ->
+        WheelchairPushesRecordSerializable(
+          startTime = record.startTime.toIsoString(),
+          endTime = record.endTime.toIsoString(),
+          count = record.count,
+          metadata = record.metadata.toSerializable(),
+        )
+      }
+  }
+}
+
 // Helper to format Instant to ISO 8601 String
 fun Instant.toIsoString(): String = this.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 

--- a/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
@@ -11,6 +11,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.delay
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
 
 const val SYNC_UTILS_TAG = "SyncUtils"
 
@@ -59,13 +61,11 @@ sealed class PostResult {
 }
 
 /**
- * Post a single chunk of data to the server.
- * This is the core posting logic used by both regular and chunked posting.
- *
- * Note: Must be inline with reified T to preserve type information for serialization.
+ * Post a single pre-serialized JSON body to the server.
+ * Non-inline to keep dispatch sites compact (avoids JVM "method too large" with many record types).
  */
-suspend inline fun <reified T : Any> postChunk(
-  data: PostWrapper<T>,
+suspend fun postChunkRaw(
+  jsonBody: String,
   apiUrl: String,
   authToken: String,
   httpClient: HttpClient,
@@ -76,7 +76,7 @@ suspend inline fun <reified T : Any> postChunk(
       httpClient.post(apiUrl) {
         contentType(ContentType.Application.Json)
         headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-        setBody(data)
+        setBody(jsonBody)
       }
     if (response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created) {
       Log.d(logTag, "POST successful: ${response.status}")
@@ -91,19 +91,36 @@ suspend inline fun <reified T : Any> postChunk(
   }
 
 /**
- * Post a chunk with bounded exponential-backoff retry on transient failures.
- * 4xx (other than 408/429) bypass retry — they will not succeed on retry.
+ * Encode a PostWrapper<T> using the supplied item serializer and POST it.
  */
-suspend inline fun <reified T : Any> postChunkWithRetry(
+suspend fun <T : Any> postChunk(
   data: PostWrapper<T>,
+  itemSerializer: KSerializer<T>,
   apiUrl: String,
   authToken: String,
   httpClient: HttpClient,
   logTag: String = SYNC_UTILS_TAG,
 ): PostResult {
+  val jsonBody = appJson.encodeToString(PostWrapper.serializer(itemSerializer), data)
+  return postChunkRaw(jsonBody, apiUrl, authToken, httpClient, logTag)
+}
+
+/**
+ * Post a chunk with bounded exponential-backoff retry on transient failures.
+ * 4xx (other than 408/429) bypass retry — they will not succeed on retry.
+ */
+suspend fun <T : Any> postChunkWithRetry(
+  data: PostWrapper<T>,
+  itemSerializer: KSerializer<T>,
+  apiUrl: String,
+  authToken: String,
+  httpClient: HttpClient,
+  logTag: String = SYNC_UTILS_TAG,
+): PostResult {
+  val jsonBody = appJson.encodeToString(PostWrapper.serializer(itemSerializer), data)
   var lastResult: PostResult = PostResult.NetworkError("not attempted")
   for (attempt in 1..MAX_CHUNK_ATTEMPTS) {
-    val result = postChunk(data, apiUrl, authToken, httpClient, logTag)
+    val result = postChunkRaw(jsonBody, apiUrl, authToken, httpClient, logTag)
     if (result.isSuccess) return result
     lastResult = result
     if (!result.isTransient || attempt == MAX_CHUNK_ATTEMPTS) return result
@@ -119,14 +136,14 @@ suspend inline fun <reified T : Any> postChunkWithRetry(
  * HeartRateRecord can be very large (thousands of samples per record).
  *
  * @param dataList The list of records to post
+ * @param itemSerializer kotlinx.serialization serializer for the item type
  * @param chunkSize Maximum number of records per chunk
  * @param recordTypeName Name of the record type for logging and progress reporting
  * @param reporter Sync progress reporter for per-chunk UI updates
- *
- * Note: Must be inline with reified T to preserve type information for serialization.
  */
-suspend inline fun <reified T : Any> postDataChunked(
+suspend fun <T : Any> postDataChunked(
   dataList: List<T>,
+  itemSerializer: KSerializer<T>,
   apiUrl: String,
   authToken: String,
   httpClient: HttpClient,
@@ -157,6 +174,7 @@ suspend inline fun <reified T : Any> postDataChunked(
     val result =
       postChunkWithRetry(
         data = PostWrapper(chunk),
+        itemSerializer = itemSerializer,
         apiUrl = apiUrl,
         authToken = authToken,
         httpClient = httpClient,
@@ -209,6 +227,7 @@ suspend fun sendDeletions(
 
   return postChunkWithRetry(
     data = PostWrapper(deletionIds),
+    itemSerializer = String.serializer(),
     apiUrl = "$serverUrl/sync/deletions",
     authToken = authToken,
     httpClient = httpClient,
@@ -225,8 +244,9 @@ suspend fun sendDeletions(
 /**
  * Send a non-chunked record group as one POST. Reports per-record-type progress.
  */
-private suspend inline fun <reified S : Any> sendSingleType(
+private suspend fun <S : Any> sendSingleType(
   serializables: List<S>,
+  itemSerializer: KSerializer<S>,
   syncUrl: String,
   authToken: String,
   httpClient: HttpClient,
@@ -237,7 +257,8 @@ private suspend inline fun <reified S : Any> sendSingleType(
   reporter.updateRecordType(recordTypeName) {
     it.copy(status = SyncStageStatus.Active, totalChunks = 1, currentChunk = 1)
   }
-  val result = postChunkWithRetry(PostWrapper(serializables), syncUrl, authToken, httpClient, logTag)
+  val result =
+    postChunkWithRetry(PostWrapper(serializables), itemSerializer, syncUrl, authToken, httpClient, logTag)
   reporter.updateRecordType(recordTypeName) {
     when {
       result.isSuccess ->
@@ -281,29 +302,97 @@ suspend fun sendRecords(
         ActiveCaloriesBurnedRecord::class ->
           sendSingleType(
             ActiveCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+            ActiveCaloriesBurnedRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        BasalBodyTemperatureRecord::class ->
+          sendSingleType(
+            BasalBodyTemperatureRecordSerializable.fromRecordsList(classRecords),
+            BasalBodyTemperatureRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        BasalMetabolicRateRecord::class ->
+          sendSingleType(
+            BasalMetabolicRateRecordSerializable.fromRecordsList(classRecords),
+            BasalMetabolicRateRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        BloodGlucoseRecord::class ->
+          sendSingleType(
+            BloodGlucoseRecordSerializable.fromRecordsList(classRecords),
+            BloodGlucoseRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        BloodPressureRecord::class ->
+          sendSingleType(
+            BloodPressureRecordSerializable.fromRecordsList(classRecords),
+            BloodPressureRecordSerializable.serializer(),
             syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         BodyFatRecord::class ->
-          sendSingleType(BodyFatRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            BodyFatRecordSerializable.fromRecordsList(classRecords),
+            BodyFatRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        BodyTemperatureRecord::class ->
+          sendSingleType(
+            BodyTemperatureRecordSerializable.fromRecordsList(classRecords),
+            BodyTemperatureRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         BodyWaterMassRecord::class ->
-          sendSingleType(BodyWaterMassRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            BodyWaterMassRecordSerializable.fromRecordsList(classRecords),
+            BodyWaterMassRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         BoneMassRecord::class ->
-          sendSingleType(BoneMassRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            BoneMassRecordSerializable.fromRecordsList(classRecords),
+            BoneMassRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        CervicalMucusRecord::class ->
+          sendSingleType(
+            CervicalMucusRecordSerializable.fromRecordsList(classRecords),
+            CervicalMucusRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        CyclingPedalingCadenceRecord::class ->
+          sendSingleType(
+            CyclingPedalingCadenceRecordSerializable.fromRecordsList(classRecords),
+            CyclingPedalingCadenceRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         DistanceRecord::class ->
-          sendSingleType(DistanceRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            DistanceRecordSerializable.fromRecordsList(classRecords),
+            DistanceRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        ElevationGainedRecord::class ->
+          sendSingleType(
+            ElevationGainedRecordSerializable.fromRecordsList(classRecords),
+            ElevationGainedRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         ExerciseSessionRecord::class ->
           sendSingleType(
             ExerciseSessionRecordSerializable.fromRecordsList(classRecords),
+            ExerciseSessionRecordSerializable.serializer(),
             syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         FloorsClimbedRecord::class ->
           sendSingleType(
             FloorsClimbedRecordSerializable.fromRecordsList(classRecords),
+            FloorsClimbedRecordSerializable.serializer(),
             syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         HeartRateRecord::class ->
           postDataChunked(
             HeartRateRecordSerializable.fromRecordsList(classRecords),
+            HeartRateRecordSerializable.serializer(),
             syncUrl,
             authToken,
             httpClient,
@@ -313,35 +402,131 @@ suspend fun sendRecords(
             logTag = logTag,
           )
         HeartRateVariabilityRmssdRecord::class ->
-          sendSingleType(HrvRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            HrvRecordSerializable.fromRecordsList(classRecords),
+            HrvRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         HeightRecord::class ->
-          sendSingleType(HeightRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            HeightRecordSerializable.fromRecordsList(classRecords),
+            HeightRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        HydrationRecord::class ->
+          sendSingleType(
+            HydrationRecordSerializable.fromRecordsList(classRecords),
+            HydrationRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        IntermenstrualBleedingRecord::class ->
+          sendSingleType(
+            IntermenstrualBleedingRecordSerializable.fromRecordsList(classRecords),
+            IntermenstrualBleedingRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         LeanBodyMassRecord::class ->
-          sendSingleType(LeanBodyMassRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            LeanBodyMassRecordSerializable.fromRecordsList(classRecords),
+            LeanBodyMassRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        MenstruationFlowRecord::class ->
+          sendSingleType(
+            MenstruationFlowRecordSerializable.fromRecordsList(classRecords),
+            MenstruationFlowRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        MenstruationPeriodRecord::class ->
+          sendSingleType(
+            MenstruationPeriodRecordSerializable.fromRecordsList(classRecords),
+            MenstruationPeriodRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         NutritionRecord::class ->
-          sendSingleType(NutritionRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            NutritionRecordSerializable.fromRecordsList(classRecords),
+            NutritionRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        OvulationTestRecord::class ->
+          sendSingleType(
+            OvulationTestRecordSerializable.fromRecordsList(classRecords),
+            OvulationTestRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        OxygenSaturationRecord::class ->
+          sendSingleType(
+            OxygenSaturationRecordSerializable.fromRecordsList(classRecords),
+            OxygenSaturationRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         PowerRecord::class ->
-          sendSingleType(PowerRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            PowerRecordSerializable.fromRecordsList(classRecords),
+            PowerRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        RespiratoryRateRecord::class ->
+          sendSingleType(
+            RespiratoryRateRecordSerializable.fromRecordsList(classRecords),
+            RespiratoryRateRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         RestingHeartRateRecord::class ->
           sendSingleType(
             RestingHeartRateRecordSerializable.fromRecordsList(classRecords),
+            RestingHeartRateRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        SexualActivityRecord::class ->
+          sendSingleType(
+            SexualActivityRecordSerializable.fromRecordsList(classRecords),
+            SexualActivityRecordSerializable.serializer(),
             syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         SleepSessionRecord::class ->
-          sendSingleType(SleepSessionRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            SleepSessionRecordSerializable.fromRecordsList(classRecords),
+            SleepSessionRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         SpeedRecord::class ->
-          sendSingleType(SpeedRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            SpeedRecordSerializable.fromRecordsList(classRecords),
+            SpeedRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         StepsRecord::class ->
-          sendSingleType(StepsRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            StepsRecordSerializable.fromRecordsList(classRecords),
+            StepsRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         TotalCaloriesBurnedRecord::class ->
           sendSingleType(
             TotalCaloriesBurnedRecordSerializable.fromRecordsList(classRecords),
+            TotalCaloriesBurnedRecordSerializable.serializer(),
             syncUrl, authToken, httpClient, typeName, reporter, logTag,
           )
         Vo2MaxRecord::class ->
-          sendSingleType(Vo2MaxRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            Vo2MaxRecordSerializable.fromRecordsList(classRecords),
+            Vo2MaxRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         WeightRecord::class ->
-          sendSingleType(WeightRecordSerializable.fromRecordsList(classRecords), syncUrl, authToken, httpClient, typeName, reporter, logTag)
+          sendSingleType(
+            WeightRecordSerializable.fromRecordsList(classRecords),
+            WeightRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
+        WheelchairPushesRecord::class ->
+          sendSingleType(
+            WheelchairPushesRecordSerializable.fromRecordsList(classRecords),
+            WheelchairPushesRecordSerializable.serializer(),
+            syncUrl, authToken, httpClient, typeName, reporter, logTag,
+          )
         else -> {
           Log.w(logTag, "No serializer for $typeName, skipping ${classRecords.size} records")
           reporter.updateRecordType(typeName) { it.copy(status = SyncStageStatus.Skipped, errorMessage = "no serializer") }

--- a/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
@@ -9,7 +9,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
+import io.ktor.http.content.TextContent
 import kotlinx.coroutines.delay
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
@@ -74,9 +74,10 @@ suspend fun postChunkRaw(
   try {
     val response =
       httpClient.post(apiUrl) {
-        contentType(ContentType.Application.Json)
         headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
-        setBody(jsonBody)
+        // Bypass Ktor ContentNegotiation: we already serialized — TextContent is sent as-is,
+        // avoiding the JSON converter wrapping the String into "..." again.
+        setBody(TextContent(jsonBody, ContentType.Application.Json))
       }
     if (response.status == HttpStatusCode.OK || response.status == HttpStatusCode.Created) {
       Log.d(logTag, "POST successful: ${response.status}")

--- a/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
@@ -236,6 +236,37 @@ class HealthDataModelsTest {
   }
 
   @Test
+  fun `CyclingPedalingCadenceRecordSerializable round-trips nested samples`() {
+    val metadata =
+      HealthConnectRecordMetadata(
+        id = "cad-1",
+        dataOrigin = "com.example",
+        lastModifiedTime = "2024-01-15T10:30:00Z",
+        clientRecordId = null,
+        clientRecordVersion = 0L,
+        device = null,
+        recordingMethod = 1,
+      )
+    val record =
+      CyclingPedalingCadenceRecordSerializable(
+        startTime = "2024-01-15T08:00:00Z",
+        endTime = "2024-01-15T08:05:00Z",
+        samples =
+          listOf(
+            CyclingCadenceSampleSerializable(time = "2024-01-15T08:00:30Z", revolutionsPerMinute = 85.0),
+            CyclingCadenceSampleSerializable(time = "2024-01-15T08:01:30Z", revolutionsPerMinute = 92.5),
+          ),
+        metadata = metadata,
+      )
+    val json = appJson.encodeToString(CyclingPedalingCadenceRecordSerializable.serializer(), record)
+    val decoded = appJson.decodeFromString<CyclingPedalingCadenceRecordSerializable>(json)
+    assertEquals(2, decoded.samples.size)
+    assertEquals(85.0, decoded.samples[0].revolutionsPerMinute, 0.0)
+    assertEquals("2024-01-15T08:01:30Z", decoded.samples[1].time)
+    assertEquals(92.5, decoded.samples[1].revolutionsPerMinute, 0.0)
+  }
+
+  @Test
   fun `every readable record type in allRecordTypes is dispatched in sendRecords`() {
     // Source-of-truth test: keep this in sync with the when-block in SyncUtils.sendRecords.
     // If you add a record class to allRecordTypes, you must also add a serializer + dispatch case.

--- a/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/HealthDataModelsTest.kt
@@ -184,6 +184,107 @@ class HealthDataModelsTest {
   }
 
   @Test
+  fun `BloodPressureRecordSerializable holds systolic and diastolic`() {
+    val metadata =
+      HealthConnectRecordMetadata(
+        id = "bp-1",
+        dataOrigin = "com.example",
+        lastModifiedTime = "2024-01-15T10:30:00Z",
+        clientRecordId = null,
+        clientRecordVersion = 0L,
+        device = null,
+        recordingMethod = 1,
+      )
+    val record =
+      BloodPressureRecordSerializable(
+        time = "2024-01-15T10:30:00Z",
+        systolicInMmHg = 120.0,
+        diastolicInMmHg = 80.0,
+        bodyPosition = 1,
+        measurementLocation = 1,
+        metadata = metadata,
+      )
+    val json = appJson.encodeToString(BloodPressureRecordSerializable.serializer(), record)
+    assertTrue(json.contains("\"systolicInMmHg\""))
+    assertTrue(json.contains("\"diastolicInMmHg\""))
+    assertTrue(json.contains("120"))
+  }
+
+  @Test
+  fun `ElevationGainedRecordSerializable round-trips through JSON`() {
+    val metadata =
+      HealthConnectRecordMetadata(
+        id = "elev-1",
+        dataOrigin = "com.example",
+        lastModifiedTime = "2024-01-15T10:30:00Z",
+        clientRecordId = null,
+        clientRecordVersion = 0L,
+        device = null,
+        recordingMethod = 1,
+      )
+    val record =
+      ElevationGainedRecordSerializable(
+        startTime = "2024-01-15T08:00:00Z",
+        endTime = "2024-01-15T09:00:00Z",
+        elevationInMeters = 42.5,
+        metadata = metadata,
+      )
+    val json = appJson.encodeToString(ElevationGainedRecordSerializable.serializer(), record)
+    val decoded = appJson.decodeFromString<ElevationGainedRecordSerializable>(json)
+    assertEquals(42.5, decoded.elevationInMeters, 0.0)
+    assertEquals("2024-01-15T08:00:00Z", decoded.startTime)
+  }
+
+  @Test
+  fun `every readable record type in allRecordTypes is dispatched in sendRecords`() {
+    // Source-of-truth test: keep this in sync with the when-block in SyncUtils.sendRecords.
+    // If you add a record class to allRecordTypes, you must also add a serializer + dispatch case.
+    val coveredByDispatch =
+      setOf(
+        "ActiveCaloriesBurnedRecord",
+        "BasalBodyTemperatureRecord",
+        "BasalMetabolicRateRecord",
+        "BloodGlucoseRecord",
+        "BloodPressureRecord",
+        "BodyFatRecord",
+        "BodyTemperatureRecord",
+        "BodyWaterMassRecord",
+        "BoneMassRecord",
+        "CervicalMucusRecord",
+        "CyclingPedalingCadenceRecord",
+        "DistanceRecord",
+        "ElevationGainedRecord",
+        "ExerciseSessionRecord",
+        "FloorsClimbedRecord",
+        "HeartRateRecord",
+        "HeartRateVariabilityRmssdRecord",
+        "HeightRecord",
+        "HydrationRecord",
+        "IntermenstrualBleedingRecord",
+        "LeanBodyMassRecord",
+        "MenstruationFlowRecord",
+        "MenstruationPeriodRecord",
+        "NutritionRecord",
+        "OvulationTestRecord",
+        "OxygenSaturationRecord",
+        "PowerRecord",
+        "RespiratoryRateRecord",
+        "RestingHeartRateRecord",
+        "SexualActivityRecord",
+        "SleepSessionRecord",
+        "SpeedRecord",
+        "StepsRecord",
+        "TotalCaloriesBurnedRecord",
+        "Vo2MaxRecord",
+        "WeightRecord",
+        "WheelchairPushesRecord",
+      )
+    val readable = allRecordTypes.map { it.simpleName }.toSet()
+    val missing = readable - coveredByDispatch
+    assertTrue("Record types without sendRecords dispatch: $missing", missing.isEmpty())
+  }
+
+  @Test
   fun `writableRecordTypes matches outbound sync record types`() {
     // These are the record types handled in OutboundSync.kt writeUpsertRecord()
     val expectedTypes =


### PR DESCRIPTION
## Summary
- Added serializers for the 17 readable Health Connect record types that previously fell through to the "no serializer" branch in `sendRecords`, so they now sync to the backend instead of being skipped.
- Added a unit test (`every readable record type in allRecordTypes is dispatched in sendRecords`) that locks the dispatch table to `allRecordTypes`, so adding a new permission/type without a serializer fails CI.
- Refactored `postChunk` / `postChunkWithRetry` / `postDataChunked` / `sendSingleType` from `inline reified` to non-inline taking an explicit `KSerializer<T>`. With this many record types, the inlined `when`-block in `sendRecords` overran the JVM 64KB method-size limit. Each call site now passes `Foo.serializer()`.

Newly serialized types: BasalBodyTemperature, BasalMetabolicRate, BloodGlucose, BloodPressure, BodyTemperature, CervicalMucus, CyclingPedalingCadence, ElevationGained, Hydration, IntermenstrualBleeding, MenstruationFlow, MenstruationPeriod, OvulationTest, OxygenSaturation, RespiratoryRate, SexualActivity, WheelchairPushes.

Field naming follows the conventions the backend already expects in `apps/backend/src/db/health-connect.ts` (`temperatureInCelsius`, `basalMetabolicRateInKcalPerDay`, `levelInMmolPerL`, `systolicInMmHg` / `diastolicInMmHg`, etc.).

## Test plan
- [x] `./gradlew compileDebugKotlin` — passes
- [x] `./gradlew compileReleaseKotlin` — passes
- [x] `./gradlew testDebugUnitTest` — passes (incl. new dispatch-coverage test)
- [ ] Manual: run the sync on a device and confirm the per-type rows for the previously-skipped types reach `Done` with sentRecords > 0 (where data is present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)