### PR TITLE
fix(meals): quick-log food items, autosave race, Other meal edit

### DIFF
--- a/apps/backend/src/db/meals.integration.test.ts
+++ b/apps/backend/src/db/meals.integration.test.ts
@@ -460,6 +460,39 @@ describe('Meals Integration Tests', () => {
       const rows = await getFrequentFoodItems(user, { limit: 3, since_days: 30 })
       expect(rows).toHaveLength(3)
     })
+
+    test('scopes to meal_type when provided so per-slot strips show different "usuals"', async () => {
+      const user = getTestUser()
+      const oats = '11111111-1111-1111-1111-aaaaaaaaaaaa'
+      const soup = '22222222-2222-2222-2222-bbbbbbbbbbbb'
+
+      const breakfast = await insertMeal(user, { meal_type: 'breakfast', time: new Date() })
+      await setMealFoodItems(user, breakfast.id, [
+        { food_item_id: oats, food_item_name: 'Oats', quantity: 50, sort_order: 0, unit: 'g' },
+      ])
+      const lunch = await insertMeal(user, { meal_type: 'lunch', time: new Date() })
+      await setMealFoodItems(user, lunch.id, [
+        { food_item_id: soup, food_item_name: 'Soup', quantity: 1, sort_order: 0, unit: 'bowl' },
+      ])
+
+      const breakfastRows = await getFrequentFoodItems(user, {
+        limit: 10,
+        meal_type: 'breakfast',
+        since_days: 30,
+      })
+      expect(breakfastRows.map((r) => r.food_item_id)).toEqual([oats])
+
+      const lunchRows = await getFrequentFoodItems(user, {
+        limit: 10,
+        meal_type: 'lunch',
+        since_days: 30,
+      })
+      expect(lunchRows.map((r) => r.food_item_id)).toEqual([soup])
+
+      // Without the filter both items are returned.
+      const all = await getFrequentFoodItems(user, { limit: 10, since_days: 30 })
+      expect(all.map((r) => r.food_item_id).sort()).toEqual([oats, soup].sort())
+    })
   })
 
   describe('JSONB storage', () => {

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -258,18 +258,30 @@ export interface FrequentFoodItemRow {
 interface FrequentFoodItemsFilter {
   limit: number
   since_days: number
+  /** Optional: scope to a single meal_type (e.g. "breakfast"). */
+  meal_type?: string
 }
 
 /**
  * Aggregate `meal_food_items` to surface the food items the user logs most
  * often. Useful for an MCP agent to suggest "your usual" without re-running
- * fuzzy search every time. Snapshotted name/icon are read directly off the
- * junction — no JOIN to food_items, so central-library items work too.
+ * fuzzy search every time, and as the data behind the per-slot quick-log
+ * chips on the meals overview. Snapshotted name/icon are read directly off
+ * the junction — no JOIN to food_items, so central-library items work too.
+ *
+ * When `meal_type` is provided, only meal_food_items linked to meals of
+ * that type are counted.
  */
 export const getFrequentFoodItems = async (
   user: string,
   filter: FrequentFoodItemsFilter,
 ): Promise<FrequentFoodItemRow[]> => {
+  const params: unknown[] = [filter.since_days, filter.limit]
+  let mealTypeClause = ''
+  if (filter.meal_type) {
+    params.push(filter.meal_type)
+    mealTypeClause = `AND m.meal_type = $${params.length}`
+  }
   const sql = `
     WITH ranked AS (
       SELECT mfi.food_item_id, mfi.food_item_name, mfi.food_item_icon,
@@ -280,6 +292,7 @@ export const getFrequentFoodItems = async (
       JOIN meals m ON m.id = mfi.meal_id
       WHERE m.time > NOW() - ($1::int || ' days')::interval
         AND mfi.food_item_id IS NOT NULL
+        ${mealTypeClause}
     )
     SELECT food_item_id, food_item_name, food_item_icon, quantity, unit,
            time AS last_used, use_count AS count
@@ -288,7 +301,7 @@ export const getFrequentFoodItems = async (
     ORDER BY use_count DESC, time DESC
     LIMIT $2
   `
-  const result = await query(user, sql, [filter.since_days, filter.limit])
+  const result = await query(user, sql, params)
   return result.rows.map((row) => ({
     count: Number(row.count),
     food_item_id: row.food_item_id as string,

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -471,10 +471,11 @@ export async function queryFrequentMeals(
  */
 export async function queryFrequentFoodItems(
   user: string,
-  filters: { limit?: number; since_days?: number },
+  filters: { limit?: number; since_days?: number; meal_type?: string },
 ): Promise<{ success: true; data: FrequentFoodItem[] }> {
   const rows = await dbGetFrequentFoodItems(user, {
     limit: filters.limit ?? 10,
+    meal_type: filters.meal_type,
     since_days: filters.since_days ?? 90,
   })
   return {

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -402,7 +402,10 @@ export function MealDetail() {
     [],
   )
 
-  // Sync local fields whenever a fresh meal arrives.
+  // Re-seed local fields only when navigating to a different meal — depending
+  // on `[meal]` would re-run on every post-save refetch and clobber any
+  // in-progress autocomplete draft (e.g. typing a new food item name when
+  // a debounced save round-trips). Same fix as on FoodItemDetail.
   useEffect(() => {
     if (!meal) return
     setName(meal.name ?? '')
@@ -418,7 +421,7 @@ export function MealDetail() {
       fat: meal.fat,
       fiber: meal.fiber,
     })
-  }, [meal])
+  }, [meal?.id])
 
   const updateMutation = useMutation({
     mutationFn: (body: UpdateMealBody) => updateMealApi(id, body),

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -1,4 +1,4 @@
-import type { FrequentMeal } from '@aurboda/api-spec'
+import type { FrequentFoodItem } from '@aurboda/api-spec'
 
 import { NUTRIENT_FIELDS } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -11,7 +11,7 @@ import { DateNav } from '../../components/DateNav'
 import {
   addMealApi,
   deleteMealApi,
-  fetchFrequentMealsApi,
+  fetchFrequentFoodItemsApi,
   fetchMeals,
   fetchUserSettings,
   type Meal,
@@ -22,6 +22,7 @@ import {
   updateUserSettings,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import './style.css'
 
 interface MealSlot {
@@ -155,38 +156,51 @@ function MealDetails({
 }
 
 /**
- * Group frequent meals by icon. Names without an icon become single-entry chips.
- * Names sharing an icon collapse to one chip that opens a name picker on tap.
+ * Group frequent food items by icon. Items without an icon become
+ * single-entry chips keyed by name. Items sharing an icon collapse to one
+ * chip that opens a name picker on tap.
  */
-const groupByIcon = (meals: FrequentMeal[]): Array<{ icon: string | null; meals: FrequentMeal[] }> => {
-  const byIcon = new Map<string, FrequentMeal[]>()
-  const noIcon: FrequentMeal[] = []
-  for (const meal of meals) {
-    if (!meal.icon) {
-      noIcon.push(meal)
+const groupFoodItemsByIcon = (
+  items: FrequentFoodItem[],
+): Array<{ icon: string | null; items: FrequentFoodItem[] }> => {
+  const byIcon = new Map<string, FrequentFoodItem[]>()
+  const noIcon: FrequentFoodItem[] = []
+  for (const item of items) {
+    if (!item.icon) {
+      noIcon.push(item)
       continue
     }
-    const list = byIcon.get(meal.icon) ?? []
-    list.push(meal)
-    byIcon.set(meal.icon, list)
+    const list = byIcon.get(item.icon) ?? []
+    list.push(item)
+    byIcon.set(item.icon, list)
   }
-  const groups: Array<{ icon: string | null; meals: FrequentMeal[] }> = []
-  for (const [icon, list] of byIcon) groups.push({ icon, meals: list })
-  for (const meal of noIcon) groups.push({ icon: null, meals: [meal] })
+  const groups: Array<{ icon: string | null; items: FrequentFoodItem[] }> = []
+  for (const [icon, list] of byIcon) groups.push({ icon, items: list })
+  for (const item of noIcon) groups.push({ icon: null, items: [item] })
   return groups
 }
 
-function FrequentMealsStrip({
+/** Render an icon string the right way: emoji inline, URL/icon-path as <img>. */
+function ChipIcon({ icon, size = 24 }: { icon: string; size?: number }) {
+  if (isUrl(icon) || isIconPath(icon)) {
+    return <img class="frequent-icon-img" src={icon} alt="" width={size} height={size} />
+  }
+  if (isEmoji(icon)) return <span class="frequent-icon">{icon}</span>
+  // Fallback: short text (initials, custom token).
+  return <span class="frequent-icon">{icon}</span>
+}
+
+function FrequentFoodItemsStrip({
   slotName,
   onQuickLog,
 }: {
   slotName: string
-  onQuickLog: (template: FrequentMeal) => void
+  onQuickLog: (foodItem: FrequentFoodItem) => void
 }) {
   const mealType = slotName.toLowerCase()
   const { data: frequent } = useQuery({
-    queryFn: () => fetchFrequentMealsApi(mealType, 6),
-    queryKey: ['frequentMeals', mealType],
+    queryFn: () => fetchFrequentFoodItemsApi({ limit: 8, meal_type: mealType }),
+    queryKey: ['frequentFoodItems', mealType],
     staleTime: 5 * 60_000,
   })
 
@@ -204,14 +218,14 @@ function FrequentMealsStrip({
 
   if (!frequent || frequent.length === 0) return null
 
-  const groups = groupByIcon(frequent)
+  const groups = groupFoodItemsByIcon(frequent)
 
   return (
     <div ref={wrapperRef} class="frequent-meals-strip">
       {groups.map((group) => {
-        const single = group.meals[0]
-        const ambiguous = group.meals.length > 1
-        const key = group.icon ?? `noicon:${single.name}`
+        const single = group.items[0]
+        const ambiguous = group.items.length > 1
+        const key = group.icon ?? `noicon:${single.food_item_id}`
 
         if (!ambiguous) {
           return (
@@ -222,14 +236,17 @@ function FrequentMealsStrip({
               title={`Log ${single.name}`}
               onClick={() => onQuickLog(single)}
             >
-              {group.icon && <span class="frequent-icon">{group.icon}</span>}
+              {group.icon ? <ChipIcon icon={group.icon} /> : null}
               <span class="frequent-name">{single.name}</span>
             </button>
           )
         }
 
+        // When several food items share the same icon, the chip shows just
+        // the icon and tapping it opens a picker — matches the user spec
+        // "click the icon to choose which one to log".
         const isOpen = openIcon === group.icon
-        const names = group.meals.map((m) => m.name).join(', ')
+        const names = group.items.map((i) => i.name).join(', ')
         return (
           <div key={key} class="frequent-chip-group">
             <button
@@ -241,22 +258,22 @@ function FrequentMealsStrip({
               aria-expanded={isOpen}
               onClick={() => setOpenIcon(isOpen ? null : group.icon)}
             >
-              <span class="frequent-icon">{group.icon}</span>
+              {group.icon && <ChipIcon icon={group.icon} />}
               <span class="frequent-multi-caret">▾</span>
             </button>
             {isOpen && (
               <div class="frequent-picker" onClick={(e) => e.stopPropagation()}>
-                {group.meals.map((m) => (
+                {group.items.map((item) => (
                   <button
-                    key={m.name}
+                    key={item.food_item_id}
                     type="button"
                     class="frequent-picker-item"
                     onClick={() => {
                       setOpenIcon(null)
-                      onQuickLog(m)
+                      onQuickLog(item)
                     }}
                   >
-                    {m.name}
+                    {item.name}
                   </button>
                 ))}
               </div>
@@ -278,7 +295,7 @@ interface MealSlotRowProps {
   onChangeTime: (meal: Meal, hour: number, minute?: number) => void
   onCreateAtTime: (slot: MealSlot, hour: number, minute: number) => void
   onCreateAndOpen: (slot: MealSlot) => void
-  onQuickLog: (slot: MealSlot, hour: number, minute: number, template: FrequentMeal) => void
+  onQuickLog: (slot: MealSlot, hour: number, minute: number, foodItem: FrequentFoodItem) => void
   onDelete: (id: string) => void
   isDeletePending: boolean
   isSaving: boolean
@@ -391,12 +408,12 @@ function MealSlotRow({
       </div>
 
       {!primaryMeal && (
-        <FrequentMealsStrip
+        <FrequentFoodItemsStrip
           slotName={slot.name}
-          onQuickLog={(template) => {
+          onQuickLog={(foodItem) => {
             const hour = Math.floor(sliderValue / 60)
             const minute = sliderValue % 60
-            onQuickLog(slot, hour, minute, template)
+            onQuickLog(slot, hour, minute, foodItem)
           }}
         />
       )}
@@ -517,14 +534,24 @@ function OtherMealRow({
           {formatMealType(meal.meal_type)}
         </a>
         <span class="meal-time">{format(meal.time, 'HH:mm')}</span>
-        <ConfirmButton
-          label="Delete"
-          confirmMessage="Delete this meal?"
-          onConfirm={() => onDelete(meal.id!)}
-          isPending={isDeletePending}
-          pendingLabel="Deleting..."
-          buttonClass="btn-danger-small"
-        />
+        <div class="slot-actions">
+          <a
+            href={`/meals/${meal.id}`}
+            class="meal-edit-link"
+            title="Edit meal details"
+            aria-label="Edit meal"
+          >
+            ✎
+          </a>
+          <ConfirmButton
+            label="Delete"
+            confirmMessage="Delete this meal?"
+            onConfirm={() => onDelete(meal.id!)}
+            isPending={isDeletePending}
+            pendingLabel="Deleting..."
+            buttonClass="btn-danger-small"
+          />
+        </div>
       </div>
       <MealDetails
         meal={meal}
@@ -743,7 +770,7 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     })
   }
 
-  const handleQuickLog = (slot: MealSlot, hour: number, minute: number, template: FrequentMeal) => {
+  const handleQuickLog = (slot: MealSlot, hour: number, minute: number, foodItem: FrequentFoodItem) => {
     const slotName = slot.name.toLowerCase()
     const id = crypto.randomUUID()
     const mealTime = new Date(dayKey)
@@ -751,8 +778,17 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     upsertMutation.mutate({
       id,
       meal_type: slotName,
-      name: template.name,
-      food_items: template.food_items ?? [],
+      // No meal name — quick-log creates a meal containing just this one
+      // food item; the user can edit/expand from the detail page.
+      food_items: [
+        {
+          food_item_id: foodItem.food_item_id,
+          icon: foodItem.icon ?? undefined,
+          name: foodItem.name,
+          quantity: foodItem.last_quantity ?? undefined,
+          unit: foodItem.last_unit ?? undefined,
+        },
+      ],
       source: 'manual',
       time: mealTime.toISOString(),
     })

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -396,6 +396,14 @@ a.meal-name:hover {
   line-height: 1;
 }
 
+.frequent-icon-img {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
 .frequent-multi-caret {
   font-size: 0.7rem;
   color: #6b7280;

--- a/apps/web/src/state/api/meals.ts
+++ b/apps/web/src/state/api/meals.ts
@@ -1,6 +1,8 @@
 import type {
   AddMealBody,
   Meal as ApiMeal,
+  FrequentFoodItem,
+  FrequentFoodItemsResponse,
   FrequentMeal,
   FrequentMealsResponse,
   MealResponse,
@@ -111,6 +113,17 @@ export const fetchFrequentMealsApi = async (
   const response = await axios.get<FrequentMealsResponse>(`${API_URL}/meals/frequent`, {
     headers: { Authorization: `Bearer ${token}` },
     params: { meal_type, limit, since_days },
+  })
+  return response.data.data ?? []
+}
+
+export const fetchFrequentFoodItemsApi = async (
+  opts: { meal_type?: string; limit?: number; since_days?: number } = {},
+): Promise<FrequentFoodItem[]> => {
+  const { token } = auth.value
+  const response = await axios.get<FrequentFoodItemsResponse>(`${API_URL}/meals/frequent-food-items`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: opts,
   })
   return response.data.data ?? []
 }

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -371,7 +371,8 @@ export type FrequentMealsResponse = z.infer<typeof frequentMealsResponseSchema>
 
 /**
  * Query parameters for surfacing the food items a user logs most often. Helps
- * an MCP agent suggest "your usual" without re-searching every time.
+ * an MCP agent suggest "your usual" without re-searching every time, and
+ * backs the per-slot quick-log chips on the meals overview.
  */
 export const frequentFoodItemsQuerySchema = z
   .object({
@@ -389,6 +390,10 @@ export const frequentFoodItemsQuerySchema = z
       .max(365)
       .default(90)
       .meta({ description: 'How many days back to consider when computing frequency' }),
+    meal_type: mealTypeSchema.optional().meta({
+      description:
+        'Optional: only count food items used in meals of this meal_type (e.g. "breakfast"). Lets the UI suggest different "your usuals" per slot.',
+    }),
   })
   .meta({ description: 'Query parameters for frequent-food-items', id: 'FrequentFoodItemsQuery' })
 


### PR DESCRIPTION
## Summary
Four bug fixes / tweaks on the meals page reported from real use:

**Bug 1: quick-log strip shows whole-meal *titles* instead of food items** — replaced \`FrequentMealsStrip\` with \`FrequentFoodItemsStrip\` powered by \`getFrequentFoodItems\` (already on the backend; this PR adds an optional \`meal_type\` filter so the per-slot strip is meaningful — oats at breakfast vs soup at lunch). Each chip shows the icon when present plus the name underneath; quick-tap creates a meal containing just that food item.

**Bug 2: uploaded-image icons render as the URL string** — chip now picks the right rendering via \`isEmoji\` / \`isUrl\` / \`isIconPath\`, emitting \`<img>\` for URL/path icons. New \`ChipIcon\` helper is also used by the multi-icon picker.

**Bug 3: adding a food item to a meal — the autocomplete clears mid-typing when autosave fires** — \`MealDetail\`'s local-state \`useEffect([meal])\` re-ran on every post-save refetch and clobbered the in-progress draft. Switched the dependency to \`[meal?.id]\` so re-fetches of the same meal don't reset state (same shape as the fix on \`FoodItemDetail\` in #695).

**Bug 4: "Other" meal types have no edit affordance** — \`OtherMealRow\` had only a delete button. Added the same \`✎\` link to \`/meals/:id\` that \`MealSlotRow\` already has.

**Plus**: when several frequent food items share the same icon, tapping the icon opens a picker — matches the requested "having a pizza icon and then selecting which of the pizzas to log" UX.

## Test plan
- [x] New integration test: \`meal_type\`-scoped \`getFrequentFoodItems\` returns different rows per slot.
- [x] \`pnpm --filter aurboda-backend check\` and \`pnpm --filter aurboda-web check\` clean; 26/26 meal integration tests pass.
- [ ] Manual: log a Hot chocolate as "Other" yesterday, navigate to \`/meals?date=…\`, click ✎, edit succeeds.
- [ ] Manual: log oats at breakfast a few times, see the chip strip on /meals show oats with proper icon; uploaded-image icons render visually.
- [ ] Manual: add a food item to an existing meal — autocomplete input stays put while autosave fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)