### PR TITLE
fix(meals): meal-type editor, optimistic quick-log, duplicate meals

### DIFF
--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -15,8 +15,10 @@ import {
   type FoodItemEntity,
   updateMealApi,
 } from '../../state/api'
+import { createDebouncedFlusher } from '../../utils/debouncedFlusher'
 import { LocationInfo, MEAL_LOCATION_WINDOW_MS } from '../EntityDetail/LocationInfo'
 import './MealDetail.css'
+import { DEFAULT_CUSTOM_TYPE, MEAL_TYPES, resolveMealTypeChange } from './mealTypes'
 
 // ── Sub-components ───────────────────────────────────────────────────────────
 
@@ -58,30 +60,27 @@ const scaleNutrient = (
   return Math.round(((baseValue * currentQuantity) / ref.quantity) * 10) / 10
 }
 
-const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack', 'drink']
-
-const DEFAULT_CUSTOM_TYPE = 'other'
-
-function MealTypeEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  // The dropdown shows "Other..." for any value not in MEAL_TYPES (including
-  // empty / unknown). Selecting "Other..." was previously a no-op because we
-  // tried to filter the synthetic "__custom" sentinel out of the onChange —
-  // but that left the user stranded if they actually wanted custom mode.
-  // Now picking "Other..." commits a sensible default ("other") which both
-  // saves immediately and reveals the free-text input below.
-  const isCustom = !MEAL_TYPES.includes(value)
+function MealTypeEditor({
+  value,
+  onChange,
+  onCustomCommit,
+}: {
+  value: string
+  onChange: (v: string) => void
+  /**
+   * Called on blur of the custom-type text input — gives the parent a
+   * chance to debounce keystroke saves and only persist the final value.
+   */
+  onCustomCommit?: (v: string) => void
+}) {
+  const isCustom = !(MEAL_TYPES as readonly string[]).includes(value)
   return (
     <div class="type-editor">
       <select
         value={isCustom ? '__custom' : value}
         onChange={(e) => {
-          const v = (e.target as HTMLSelectElement).value
-          if (v === '__custom') {
-            // Don't overwrite a custom value the user already had.
-            if (!isCustom) onChange(DEFAULT_CUSTOM_TYPE)
-          } else {
-            onChange(v)
-          }
+          const next = resolveMealTypeChange(value, (e.target as HTMLSelectElement).value)
+          if (next !== null) onChange(next)
         }}
       >
         {MEAL_TYPES.map((t) => (
@@ -97,6 +96,7 @@ function MealTypeEditor({ value, onChange }: { value: string; onChange: (v: stri
           value={value}
           placeholder="Custom type"
           onInput={(e) => onChange((e.target as HTMLInputElement).value)}
+          onBlur={(e) => onCustomCommit?.((e.target as HTMLInputElement).value)}
         />
       )}
     </div>
@@ -401,27 +401,32 @@ export function MealDetail() {
   const [savedFlash, setSavedFlash] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const itemsDebounce = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Holds the pending food-items body so the unmount cleanup can flush it
-  // synchronously — without this, clicking Back within FOOD_ITEM_DEBOUNCE_MS
-  // of the last edit would silently drop the change.
-  const pendingItemsRef = useRef<UpdateMealBody | null>(null)
 
-  // Invalidate the meals list when leaving this page so the day overview refreshes
-  useEffect(() => () => void queryClient.invalidateQueries({ queryKey: ['meals'] }), [queryClient])
+  // Stable ref to the latest save callback so the debounced flushers always
+  // invoke the most recent closure rather than one captured at first render.
+  const saveRef = useRef<(body: UpdateMealBody) => void>(() => {})
+  // Two flushers — food-items edits debounce 600 ms (mostly autocomplete +
+  // qty/unit typing), meal_type custom edits debounce 600 ms too. Both
+  // flush synchronously on unmount so navigating away mid-debounce doesn't
+  // drop the user's last edit (the bug behind "Back doesn't show new item").
+  const itemsFlusherRef = useRef(
+    createDebouncedFlusher<UpdateMealBody>(FOOD_ITEM_DEBOUNCE_MS, (body) => saveRef.current(body)),
+  )
+  const mealTypeFlusherRef = useRef(
+    createDebouncedFlusher<string>(FOOD_ITEM_DEBOUNCE_MS, (v) => saveRef.current({ meal_type: v })),
+  )
 
-  // Clear pending timers on unmount; flush a pending food-items save first so
-  // navigating away mid-debounce doesn't drop the user's edit.
+  // The previous unmount-time invalidate of ['meals'] was redundant — every
+  // save mutation already invalidates the list. It also caused a flicker when
+  // a flushed save and the manual invalidate raced. Removed.
+
+  // Clear pending flash timer + flush both debouncers on unmount so any
+  // mid-debounce edit is persisted before the route changes.
   useEffect(
     () => () => {
       if (flashTimer.current) clearTimeout(flashTimer.current)
-      if (itemsDebounce.current) {
-        clearTimeout(itemsDebounce.current)
-        if (pendingItemsRef.current) {
-          updateMutation.mutate(pendingItemsRef.current)
-          pendingItemsRef.current = null
-        }
-      }
+      itemsFlusherRef.current.flush()
+      mealTypeFlusherRef.current.flush()
     },
     [],
   )
@@ -476,6 +481,8 @@ export function MealDetail() {
     setSaveError(null)
     updateMutation.mutate(body)
   }
+  // Keep the debouncers' save callback up to date with the latest closure.
+  saveRef.current = save
 
   if (isLoading) {
     return (
@@ -496,13 +503,7 @@ export function MealDetail() {
 
   const commitItems = (next: FoodItemEdit[]) => {
     setItems(next)
-    const body: UpdateMealBody = { food_items: editItemsToBody(next) }
-    pendingItemsRef.current = body
-    if (itemsDebounce.current) clearTimeout(itemsDebounce.current)
-    itemsDebounce.current = setTimeout(() => {
-      pendingItemsRef.current = null
-      save(body)
-    }, FOOD_ITEM_DEBOUNCE_MS)
+    itemsFlusherRef.current.schedule({ food_items: editItemsToBody(next) })
   }
 
   const commitName = () => {
@@ -549,7 +550,24 @@ export function MealDetail() {
               value={mealType}
               onChange={(v) => {
                 setMealType(v)
-                if (v !== (meal.meal_type ?? '')) save({ meal_type: v })
+                if (v === (meal.meal_type ?? '')) return
+                if ((MEAL_TYPES as readonly string[]).includes(v)) {
+                  // Dropdown selection — commit immediately, the debounce is
+                  // only meaningful for free-text custom-type keystrokes.
+                  mealTypeFlusherRef.current.cancel()
+                  save({ meal_type: v })
+                } else {
+                  mealTypeFlusherRef.current.schedule(v)
+                }
+              }}
+              onCustomCommit={(v) => {
+                // Blur of the custom input — flush any pending debounced save
+                // so the final value is persisted without waiting out the
+                // debounce window.
+                if (v !== (meal.meal_type ?? '')) {
+                  mealTypeFlusherRef.current.cancel()
+                  save({ meal_type: v })
+                }
               }}
             />
           </div>

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -60,7 +60,15 @@ const scaleNutrient = (
 
 const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack', 'drink']
 
+const DEFAULT_CUSTOM_TYPE = 'other'
+
 function MealTypeEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  // The dropdown shows "Other..." for any value not in MEAL_TYPES (including
+  // empty / unknown). Selecting "Other..." was previously a no-op because we
+  // tried to filter the synthetic "__custom" sentinel out of the onChange —
+  // but that left the user stranded if they actually wanted custom mode.
+  // Now picking "Other..." commits a sensible default ("other") which both
+  // saves immediately and reveals the free-text input below.
   const isCustom = !MEAL_TYPES.includes(value)
   return (
     <div class="type-editor">
@@ -68,7 +76,12 @@ function MealTypeEditor({ value, onChange }: { value: string; onChange: (v: stri
         value={isCustom ? '__custom' : value}
         onChange={(e) => {
           const v = (e.target as HTMLSelectElement).value
-          if (v !== '__custom') onChange(v)
+          if (v === '__custom') {
+            // Don't overwrite a custom value the user already had.
+            if (!isCustom) onChange(DEFAULT_CUSTOM_TYPE)
+          } else {
+            onChange(v)
+          }
         }}
       >
         {MEAL_TYPES.map((t) => (
@@ -389,15 +402,26 @@ export function MealDetail() {
   const [saveError, setSaveError] = useState<string | null>(null)
   const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const itemsDebounce = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Holds the pending food-items body so the unmount cleanup can flush it
+  // synchronously — without this, clicking Back within FOOD_ITEM_DEBOUNCE_MS
+  // of the last edit would silently drop the change.
+  const pendingItemsRef = useRef<UpdateMealBody | null>(null)
 
   // Invalidate the meals list when leaving this page so the day overview refreshes
   useEffect(() => () => void queryClient.invalidateQueries({ queryKey: ['meals'] }), [queryClient])
 
-  // Clear pending timers on unmount so callbacks don't fire against an unmounted component.
+  // Clear pending timers on unmount; flush a pending food-items save first so
+  // navigating away mid-debounce doesn't drop the user's edit.
   useEffect(
     () => () => {
       if (flashTimer.current) clearTimeout(flashTimer.current)
-      if (itemsDebounce.current) clearTimeout(itemsDebounce.current)
+      if (itemsDebounce.current) {
+        clearTimeout(itemsDebounce.current)
+        if (pendingItemsRef.current) {
+          updateMutation.mutate(pendingItemsRef.current)
+          pendingItemsRef.current = null
+        }
+      }
     },
     [],
   )
@@ -411,7 +435,10 @@ export function MealDetail() {
     setName(meal.name ?? '')
     setTimeStr(format(meal.time, "yyyy-MM-dd'T'HH:mm"))
     setNotes(meal.notes ?? '')
-    setMealType(meal.meal_type ?? 'lunch')
+    // No meal_type means this was created via the ad-hoc flow — the user
+    // explicitly opted out of a slot, so treat it as a custom "other" rather
+    // than silently defaulting to lunch.
+    setMealType(meal.meal_type ?? DEFAULT_CUSTOM_TYPE)
     setItems(mealItemsToEdit(meal.food_items))
     setFlags(meal.sensitivities ?? [])
     setMacros({
@@ -469,9 +496,12 @@ export function MealDetail() {
 
   const commitItems = (next: FoodItemEdit[]) => {
     setItems(next)
+    const body: UpdateMealBody = { food_items: editItemsToBody(next) }
+    pendingItemsRef.current = body
     if (itemsDebounce.current) clearTimeout(itemsDebounce.current)
     itemsDebounce.current = setTimeout(() => {
-      save({ food_items: editItemsToBody(next) })
+      pendingItemsRef.current = null
+      save(body)
     }, FOOD_ITEM_DEBOUNCE_MS)
   }
 

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -437,13 +437,30 @@ function MealSlotRow({
         </div>
       )}
 
-      {slotMeals.map((meal) => (
+      {primaryMeal && (
         <MealDetails
+          meal={primaryMeal}
+          foodSensitivityMap={foodSensitivityMap}
+          sensitivityAreas={sensitivityAreas}
+          onToggleFoodMapping={onToggleFoodMapping}
+        />
+      )}
+
+      {/*
+       * If the slot has more than one meal (intentional split — two snacks
+       * at different times — or the rare double-tap on the quick-log strip),
+       * render each additional meal as its own row with time + edit + delete
+       * so the duplicates are obvious and individually manageable.
+       */}
+      {slotMeals.slice(1).map((meal) => (
+        <DuplicateMealRow
           key={meal.id}
           meal={meal}
           foodSensitivityMap={foodSensitivityMap}
           sensitivityAreas={sensitivityAreas}
           onToggleFoodMapping={onToggleFoodMapping}
+          onDelete={onDelete}
+          isDeletePending={isDeletePending}
         />
       ))}
     </div>
@@ -508,6 +525,59 @@ function DayNutrientSummary({ meals }: { meals: Meal[] }) {
           })}
         </>
       )}
+    </div>
+  )
+}
+
+/**
+ * A second-or-later meal in the same slot. Rendered below the primary meal
+ * with its own time, edit, and delete affordances so users can manage each
+ * one individually (intentional split, or the rare double-click duplicate).
+ */
+function DuplicateMealRow({
+  meal,
+  foodSensitivityMap,
+  sensitivityAreas,
+  onToggleFoodMapping,
+  onDelete,
+  isDeletePending,
+}: {
+  meal: Meal
+  foodSensitivityMap: Record<string, string[]>
+  sensitivityAreas: string[]
+  onToggleFoodMapping: (foodItem: string, area: string, checked: boolean) => void
+  onDelete: (id: string) => void
+  isDeletePending: boolean
+}) {
+  return (
+    <div class="duplicate-meal-row">
+      <div class="duplicate-meal-top">
+        <span class="duplicate-meal-time">{format(meal.time, 'HH:mm')}</span>
+        <div class="slot-actions">
+          <a
+            href={`/meals/${meal.id}`}
+            class="meal-edit-link"
+            title="Edit meal details"
+            aria-label="Edit meal"
+          >
+            ✎
+          </a>
+          <ConfirmButton
+            label="Delete"
+            confirmMessage="Delete this meal?"
+            onConfirm={() => onDelete(meal.id!)}
+            isPending={isDeletePending}
+            pendingLabel="Deleting..."
+            buttonClass="btn-danger-small"
+          />
+        </div>
+      </div>
+      <MealDetails
+        meal={meal}
+        foodSensitivityMap={foodSensitivityMap}
+        sensitivityAreas={sensitivityAreas}
+        onToggleFoodMapping={onToggleFoodMapping}
+      />
     </div>
   )
 }
@@ -697,6 +767,8 @@ function useMealMutations(mealsQueryKey: string[], meals: Meal[] | undefined) {
     savingSlots,
     handleToggleSensitivity,
     handleChangeTime,
+    optimisticUpdate,
+    markSlotSaving,
     upsertMutation,
     updateMutation,
     deleteMutation,
@@ -737,6 +809,8 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     savingSlots,
     handleToggleSensitivity,
     handleChangeTime,
+    optimisticUpdate,
+    markSlotSaving,
     upsertMutation,
     updateMutation,
     deleteMutation,
@@ -762,6 +836,8 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     const id = crypto.randomUUID()
     const mealTime = new Date(dayKey)
     mealTime.setHours(hour, minute, 0, 0)
+    optimisticUpdate((old) => [...old, { id, meal_type: slotName, source: 'manual', time: mealTime }])
+    markSlotSaving(slotName, true)
     upsertMutation.mutate({
       id,
       meal_type: slotName,
@@ -775,20 +851,32 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     const id = crypto.randomUUID()
     const mealTime = new Date(dayKey)
     mealTime.setHours(hour, minute, 0, 0)
+    const foodItemPayload = {
+      food_item_id: foodItem.food_item_id,
+      icon: foodItem.icon ?? undefined,
+      name: foodItem.name,
+      quantity: foodItem.last_quantity ?? undefined,
+      unit: foodItem.last_unit ?? undefined,
+    }
+    // Optimistically inject the meal into the cache so the UI flips from
+    // "show quick-log strip" to "show the new meal" immediately. Without
+    // this the user has no feedback during the network round-trip and may
+    // double-click and create duplicate meals.
+    const placeholder: Meal = {
+      food_items: [foodItemPayload],
+      id,
+      meal_type: slotName,
+      source: 'manual',
+      time: mealTime,
+    }
+    optimisticUpdate((old) => [...old, placeholder])
+    markSlotSaving(slotName, true)
     upsertMutation.mutate({
       id,
       meal_type: slotName,
       // No meal name — quick-log creates a meal containing just this one
       // food item; the user can edit/expand from the detail page.
-      food_items: [
-        {
-          food_item_id: foodItem.food_item_id,
-          icon: foodItem.icon ?? undefined,
-          name: foodItem.name,
-          quantity: foodItem.last_quantity ?? undefined,
-          unit: foodItem.last_unit ?? undefined,
-        },
-      ],
+      food_items: [foodItemPayload],
       source: 'manual',
       time: mealTime.toISOString(),
     })
@@ -799,8 +887,11 @@ function MealsContent({ dayKey }: { dayKey: string }) {
     const mealTime = new Date()
     const dayDate = new Date(dayKey)
     mealTime.setFullYear(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate())
+    // Default to a custom "other" meal_type so the editor shows custom mode
+    // instead of silently defaulting to lunch. The user can rename freely.
     await addMealApi({
       id,
+      meal_type: 'other',
       source: 'manual',
       time: mealTime.toISOString(),
     })

--- a/apps/web/src/pages/Meals/mealTypes.test.ts
+++ b/apps/web/src/pages/Meals/mealTypes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest'
+
+import { DEFAULT_CUSTOM_TYPE, resolveMealTypeChange } from './mealTypes'
+
+describe('resolveMealTypeChange', () => {
+  test('picking a known meal type returns it', () => {
+    expect(resolveMealTypeChange('lunch', 'breakfast')).toBe('breakfast')
+    expect(resolveMealTypeChange('other', 'snack')).toBe('snack')
+  })
+
+  test('picking "Other..." while on a known type commits the default custom value', () => {
+    expect(resolveMealTypeChange('lunch', '__custom')).toBe(DEFAULT_CUSTOM_TYPE)
+    expect(resolveMealTypeChange('breakfast', '__custom')).toBe(DEFAULT_CUSTOM_TYPE)
+  })
+
+  test('picking "Other..." while already in custom mode is a no-op', () => {
+    // The user already typed "midnight snack" — picking Other... again
+    // shouldn't clobber that with "other".
+    expect(resolveMealTypeChange('midnight snack', '__custom')).toBeNull()
+    expect(resolveMealTypeChange('other', '__custom')).toBeNull()
+    expect(resolveMealTypeChange('hot chocolate', '__custom')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/Meals/mealTypes.ts
+++ b/apps/web/src/pages/Meals/mealTypes.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared meal-type constants + the dropdown sentinel logic.
+ * Pulled out of MealDetail so MealDetail and the meals overview agree
+ * on the default custom value by reference, and so the dropdown logic
+ * is independently unit-testable.
+ */
+
+export const MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack', 'drink'] as const
+
+export type KnownMealType = (typeof MEAL_TYPES)[number]
+
+/**
+ * The value committed when the user selects "Other..." while not already
+ * in custom mode. It's a real string the backend will accept; the editor
+ * input below the dropdown lets the user refine it from there.
+ */
+export const DEFAULT_CUSTOM_TYPE = 'other'
+
+/** Sentinel value used by the <select> for "Other..." */
+export const CUSTOM_SENTINEL = '__custom'
+
+/**
+ * Decide what the editor's onChange should fire given the current value
+ * and the option the user just picked from the dropdown.
+ *
+ * Returns the new value to commit, or `null` when the selection is a
+ * no-op (picking "Other..." while already in custom mode — keeping the
+ * user's existing custom string instead of clobbering it).
+ */
+export const resolveMealTypeChange = (current: string, selected: string): string | null => {
+  if (selected !== CUSTOM_SENTINEL) return selected
+  // Already in custom mode — picking "Other..." again shouldn't replace
+  // a meaningful custom value (e.g. "midnight snack") with the default.
+  if (!(MEAL_TYPES as readonly string[]).includes(current)) return null
+  return DEFAULT_CUSTOM_TYPE
+}

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -781,3 +781,35 @@ a.meal-name:hover {
     color: #d1d5db;
   }
 }
+
+/* Duplicate meal in the same slot — two breakfasts, etc. */
+.duplicate-meal-row {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed #e5e7eb;
+}
+
+.duplicate-meal-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.duplicate-meal-time {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-color-scheme: dark) {
+  .duplicate-meal-row {
+    border-top-color: #374151;
+  }
+
+  .duplicate-meal-time {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/utils/debouncedFlusher.test.ts
+++ b/apps/web/src/utils/debouncedFlusher.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createDebouncedFlusher } from './debouncedFlusher'
+
+describe('createDebouncedFlusher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('schedule fires the save after the delay', () => {
+    const save = vi.fn()
+    const f = createDebouncedFlusher<string>(100, save)
+
+    f.schedule('A')
+    expect(save).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(99)
+    expect(save).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(save).toHaveBeenCalledExactlyOnceWith('A')
+  })
+
+  test('schedule again before the timer fires replaces the pending body', () => {
+    const save = vi.fn()
+    const f = createDebouncedFlusher<string>(100, save)
+
+    f.schedule('A')
+    vi.advanceTimersByTime(50)
+    f.schedule('B')
+    vi.advanceTimersByTime(99)
+    expect(save).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(save).toHaveBeenCalledExactlyOnceWith('B')
+  })
+
+  test('flush runs the pending save synchronously and clears the timer', () => {
+    const save = vi.fn()
+    const f = createDebouncedFlusher<string>(100, save)
+
+    f.schedule('A')
+    f.flush()
+    expect(save).toHaveBeenCalledExactlyOnceWith('A')
+
+    // Timer must be cleared — advancing further must not double-fire.
+    vi.advanceTimersByTime(200)
+    expect(save).toHaveBeenCalledOnce()
+  })
+
+  test('flush with nothing pending is a no-op', () => {
+    const save = vi.fn()
+    const f = createDebouncedFlusher<string>(100, save)
+    f.flush()
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  test('cancel drops the pending save without running it', () => {
+    const save = vi.fn()
+    const f = createDebouncedFlusher<string>(100, save)
+
+    f.schedule('A')
+    f.cancel()
+    vi.advanceTimersByTime(200)
+    expect(save).not.toHaveBeenCalled()
+
+    // Subsequent schedule still works.
+    f.schedule('B')
+    vi.advanceTimersByTime(100)
+    expect(save).toHaveBeenCalledExactlyOnceWith('B')
+  })
+
+  test('flush after the timer naturally fired is a no-op', () => {
+    const save = vi.fn()
+    const f = createDebouncedFlusher<string>(100, save)
+    f.schedule('A')
+    vi.advanceTimersByTime(100)
+    expect(save).toHaveBeenCalledOnce()
+    f.flush()
+    expect(save).toHaveBeenCalledOnce() // still once
+  })
+})

--- a/apps/web/src/utils/debouncedFlusher.ts
+++ b/apps/web/src/utils/debouncedFlusher.ts
@@ -1,0 +1,53 @@
+/**
+ * A debounced save scheduler that can be flushed synchronously.
+ *
+ * `schedule(body)` arms a timer; `flush()` runs the pending save
+ * immediately (used from unmount cleanup so a navigation mid-debounce
+ * doesn't drop the user's last edit); `cancel()` discards the pending
+ * save without running it.
+ */
+export interface DebouncedFlusher<T> {
+  /** Replace any pending body and (re)start the debounce timer. */
+  schedule: (body: T) => void
+  /** If a save is pending, run it now and clear the timer. */
+  flush: () => void
+  /** Discard any pending save without running it. */
+  cancel: () => void
+}
+
+export const createDebouncedFlusher = <T>(delayMs: number, save: (body: T) => void): DebouncedFlusher<T> => {
+  let pending: T | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const clearTimer = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  return {
+    schedule(body) {
+      pending = body
+      clearTimer()
+      timer = setTimeout(() => {
+        const due = pending
+        pending = null
+        timer = null
+        if (due !== null) save(due)
+      }, delayMs)
+    },
+    flush() {
+      clearTimer()
+      if (pending !== null) {
+        const body = pending
+        pending = null
+        save(body)
+      }
+    },
+    cancel() {
+      clearTimer()
+      pending = null
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Four meal-page bugs reported from real use.

**Bug 5: editing an "Other" meal shows "Lunch", and "Other..." doesn't save.** Ad-hoc meals had no \`meal_type\`, so the local state defaulted to \`'lunch'\`. The \`MealTypeEditor\`'s \`__custom\` sentinel was filtered out of \`onChange\`, so picking "Other..." was a no-op. Now: ad-hoc creation stamps \`meal_type: 'other'\`, MealDetail loads custom-mode for any meal lacking a type, and selecting "Other..." commits a sensible default that both saves and reveals the free-text input.

**Bug 6: clicking "Back" doesn't show the new food item until reload.** Adding food items goes through a 600 ms debounce. The MealDetail unmount cleanup *cancelled* the pending timer, so any edit inside that window was silently dropped — and the cache invalidate that triggers the overview refetch was for an empty change. Cleanup now flushes the pending body via the mutation before clearing the timer.

**Bug 7: quick-log gives no feedback; double-tap creates two meals.** \`handleQuickLog\` and \`handleCreateAtTime\` did fire the upsert mutation but never optimistically updated the cache or set the slot's saving flag. Both now mirror the pattern \`handleToggleSensitivity\` already uses: optimistic inject + \`markSlotSaving\`. The strip flips to the new meal immediately, so a second tap can't hit the same chip.

**Bug 8: multiple meals per slot are visually merged.** When a slot ends up with more than one meal (intentional split or the rare duplicate from #7), only the first ("primary") was managed by the slot row's edit/delete; the rest just had their food-item chips rendered with no time, no edit, no delete. Added a \`DuplicateMealRow\` so each additional meal in the slot is its own self-contained block.

## Test plan
- [x] \`pnpm --filter aurboda-backend check\` and \`pnpm --filter aurboda-web check\` clean.
- [ ] Manual: ad-hoc create a meal → edit page shows custom-mode "other" with text input visible.
- [ ] Manual: pick "Other..." on a slot meal → input appears with "other"; type "Hot chocolate"; save fires.
- [ ] Manual: add a food item, click Back within 1 s → overview shows the new item without reload.
- [ ] Manual: click a quick-log chip → meal appears immediately, strip vanishes; second click can't hit the same chip.
- [ ] Manual: deliberately create two breakfasts at different times → both rendered with separate edit/delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)