### PR TITLE
fix+feat(food-items): action alignment, create button, focus-gated autocomplete

### DIFF
--- a/apps/web/src/components/FoodItemAutocomplete.tsx
+++ b/apps/web/src/components/FoodItemAutocomplete.tsx
@@ -21,16 +21,23 @@ export function FoodItemAutocomplete({
   const [suggestions, setSuggestions] = useState<FoodItemEntity[]>([])
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
+  // Whether the input is currently focused. Without this gate, every
+  // FoodItemAutocomplete on a freshly-loaded meal would auto-fire a search
+  // for its pre-filled value and pop its dropdown — N food items in a meal
+  // = N dropdowns opening simultaneously on page load.
+  const [hasFocus, setHasFocus] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>()
 
-  // Debounced search
+  // Debounced search — only when the input is focused. Re-runs when
+  // hasFocus flips true so re-focusing a populated field also re-fetches.
   useEffect(() => {
     if (value.length < 2) {
       setSuggestions([])
       setOpen(false)
       return
     }
+    if (!hasFocus) return
 
     clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(async () => {
@@ -41,7 +48,7 @@ export function FoodItemAutocomplete({
     }, 300)
 
     return () => clearTimeout(debounceRef.current)
-  }, [value])
+  }, [value, hasFocus])
 
   // Close on click outside
   useEffect(() => {
@@ -85,7 +92,17 @@ export function FoodItemAutocomplete({
         onInput={(e) => onChange((e.target as HTMLInputElement).value)}
         onKeyDown={handleKeyDown}
         onFocus={() => {
+          setHasFocus(true)
+          // Re-show pre-cached suggestions immediately. The effect will
+          // re-fire to refresh them in the background.
           if (suggestions.length > 0) setOpen(true)
+        }}
+        onBlur={() => {
+          // Don't close on blur — clicking a suggestion blurs the input
+          // before its onClick fires, and the existing click-outside
+          // handler already closes the dropdown when the user actually
+          // clicks away. Just stop firing fresh searches.
+          setHasFocus(false)
         }}
       />
       {open && (

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLocation } from 'preact-iso'
 import { useEffect, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
@@ -17,9 +18,22 @@ const deleteFoodItemApi = async (id: string): Promise<void> => {
   if (!res.ok) throw new Error('Delete failed')
 }
 
+const createFoodItemApi = async (name: string): Promise<{ id: string }> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items`, {
+    body: JSON.stringify({ name }),
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    method: 'POST',
+  })
+  if (!res.ok) throw new Error('Failed to create food item')
+  const json = (await res.json()) as { data: { id: string } }
+  return json.data
+}
+
 export function FoodItems() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()
+  const { route } = useLocation()
   const [search, setSearch] = useState('')
   const trimmed = search.trim()
   const hasQuery = trimmed.length > 0
@@ -43,6 +57,22 @@ export function FoodItems() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['foodItems'] }),
   })
 
+  const createMutation = useMutation({
+    mutationFn: createFoodItemApi,
+    onSuccess: ({ id }) => {
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      // Land on the detail page so the user can rename, set an icon, click
+      // "Convert to recipe" — the easiest path to creating a composite item.
+      route(`/food-items/${id}`)
+    },
+  })
+
+  const handleCreate = () => {
+    // Seed with the current search text when present so the user doesn't
+    // have to retype what they were looking for.
+    createMutation.mutate(trimmed || 'New food item')
+  }
+
   if (!isLoggedIn) {
     return (
       <div class="food-items-page">
@@ -63,6 +93,19 @@ export function FoodItems() {
           onInput={(e) => setSearch((e.target as HTMLInputElement).value)}
         />
         {hasQuery && <span class="fi-count">{items?.length ?? 0} items</span>}
+        <button
+          type="button"
+          class="btn-primary fi-create"
+          onClick={handleCreate}
+          disabled={createMutation.isPending}
+          title={
+            trimmed
+              ? `Create "${trimmed}" as a new food item`
+              : 'Create a new food item — useful as the parent of a composite recipe'
+          }
+        >
+          {createMutation.isPending ? 'Creating…' : '+ New'}
+        </button>
       </div>
 
       {!hasQuery ? (

--- a/apps/web/src/pages/FoodItems/style.css
+++ b/apps/web/src/pages/FoodItems/style.css
@@ -128,3 +128,31 @@
     padding: 0.375rem 0.25rem;
   }
 }
+
+.fi-create {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* btn-primary mirrored here so the "+ New" button is styled even when the
+   user lands on /food-items without first visiting a detail page (whose
+   stylesheet otherwise contributes the rules). */
+.btn-primary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+  background: #673ab8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background: #5e35b1;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -343,6 +343,12 @@ a.meal-name:hover {
   align-items: center;
   gap: 0.5rem;
   flex-shrink: 0;
+  /* Push actions to the right of the slot row. In MealSlotRow the slider
+     wrapper already has flex:1 so this is redundant; in OtherMealRow there's
+     no flex sibling between title+time and the actions, and without this the
+     edit pen and delete button cling to the time. Auto-margin is the
+     cheapest right-align that works in both cases. */
+  margin-left: auto;
 }
 
 .meal-edit-link {


### PR DESCRIPTION
## Summary
Three small UI tweaks bundled to share a single deploy.

### Bug: Other-meal row action alignment
\`OtherMealRow\` had its edit pen and delete button immediately after the timestamp instead of right-aligned. Added \`margin-left: auto\` to \`.slot-actions\` — also fixes \`DuplicateMealRow\`.

### Feat: \"+ New\" button on /food-items
Composite (recipe) items had no clean entry point — food items only got created as a side effect of meal logging. The new button POSTs a per-user food item (seeded with the current search text or \"New food item\") and routes to its detail page where the user can rename, set the icon, and click \"Convert to recipe\" in one flow.

### Bug: every food-item autocomplete opens on meal load
Loading an existing meal rendered one \`FoodItemAutocomplete\` per food row, each pre-filled with the food name. The debounce-on-value effect treated that as user typing and auto-opened every dropdown. Gated the search and auto-open on a \`hasFocus\` state — only the actively-focused input fetches and opens.

## Test plan
- [ ] Other-meal row: pen + delete flush right.
- [ ] \`/food-items\` → \"+ New\" → detail page → \"Convert to recipe\" works end-to-end.
- [ ] Open an existing meal with multiple food items: no dropdowns appear until you focus a row.
- [ ] Click into a row → dropdown opens with suggestions; click outside → closes; click a suggestion → it selects (the blur-then-click race doesn't drop the click).

## Follow-up
The user mentioned the activity-type selector has the same auto-open issue. Worth a separate small PR — likely the same fix shape on whichever component backs it.