### PR TITLE
feat(food-items): reference enrichment for atomic items

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -820,6 +820,11 @@ export const migrateSchema = async (user: string) => {
       db,
       `ALTER TABLE food_items ADD COLUMN IF NOT EXISTS is_composite BOOLEAN NOT NULL DEFAULT FALSE`,
     )
+    // Reference enrichment: a per-user item can point at a richer canonical
+    // food (typically a central LSV row) to inherit micronutrients while
+    // keeping its own label-derived macros. Soft pointer (no FK — target
+    // may live in central DB).
+    await query(db, `ALTER TABLE food_items ADD COLUMN IF NOT EXISTS reference_food_item_id UUID`)
   }
 
   // meal_food_items: snapshot food_item_name + food_item_icon at insertion

--- a/apps/backend/src/db/food-items.integration.test.ts
+++ b/apps/backend/src/db/food-items.integration.test.ts
@@ -7,6 +7,7 @@ import {
   getFoodItemById,
   getFoodItemByName,
   searchFoodItems,
+  setFoodItemReference,
   updateFoodItem,
   upsertFoodItem,
 } from './food-items.ts'
@@ -233,6 +234,26 @@ describe('Food Items Integration Tests', () => {
 
       const found = await getFoodItemById(user, item.id)
       expect(found).toBeNull()
+    })
+  })
+
+  describe('setFoodItemReference', () => {
+    test('sets and clears the reference_food_item_id pointer', async () => {
+      const user = getTestUser()
+      const target = await upsertFoodItem(user, { name: 'Hushållsost' })
+      const product = await upsertFoodItem(user, { name: 'Arla Hushållsost' })
+
+      const set = await setFoodItemReference(user, product.id, target.id)
+      expect(set?.reference_food_item_id).toBe(target.id)
+
+      const cleared = await setFoodItemReference(user, product.id, null)
+      expect(cleared?.reference_food_item_id).toBeUndefined()
+    })
+
+    test('returns null for missing food item', async () => {
+      const user = getTestUser()
+      const result = await setFoodItemReference(user, '00000000-0000-0000-0000-000000000000', null)
+      expect(result).toBeNull()
     })
   })
 

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -21,6 +21,7 @@ const FOOD_ITEM_COLUMNS = [
   ...NUTRIENT_FIELD_NAMES,
   'icon',
   'is_composite',
+  'reference_food_item_id',
   'created_at',
   'updated_at',
 ].join(', ')
@@ -36,6 +37,7 @@ const mapFoodItemRow = (row: Record<string, unknown>): FoodItemEntity => {
     default_unit: row.default_unit ?? undefined,
     icon: row.icon ?? undefined,
     is_composite: row.is_composite === true,
+    reference_food_item_id: (row.reference_food_item_id as string | null) ?? undefined,
     created_at: new Date(row.created_at as string),
     updated_at: new Date(row.updated_at as string),
   }
@@ -239,6 +241,26 @@ export const updateFoodItem = async (
 export const deleteFoodItem = async (user: string, id: string): Promise<boolean> => {
   const result = await query(user, 'DELETE FROM food_items WHERE id = $1', [id])
   return (result.rowCount ?? 0) > 0
+}
+
+/**
+ * Set or clear the reference_food_item_id soft pointer. Pass null to clear.
+ * Caller is responsible for validating the reference target exists in the
+ * merged user+central library.
+ */
+export const setFoodItemReference = async (
+  user: string,
+  id: string,
+  referenceId: string | null,
+): Promise<FoodItemEntity | null> => {
+  const result = await query(
+    user,
+    `UPDATE food_items SET reference_food_item_id = $2, updated_at = NOW()
+     WHERE id = $1
+     RETURNING ${FOOD_ITEM_COLUMNS}`,
+    [id, referenceId],
+  )
+  return result.rows.length > 0 ? mapFoodItemRow(result.rows[0]) : null
 }
 
 /**

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -246,17 +246,21 @@ export const deleteFoodItem = async (user: string, id: string): Promise<boolean>
 /**
  * Set or clear the reference_food_item_id soft pointer. Pass null to clear.
  * Caller is responsible for validating the reference target exists in the
- * merged user+central library.
+ * merged user+central library. Refuses to set a reference on composite rows
+ * as defence-in-depth — the route + MCP layers also check.
  */
 export const setFoodItemReference = async (
   user: string,
   id: string,
   referenceId: string | null,
 ): Promise<FoodItemEntity | null> => {
+  // Allow clearing (referenceId === null) on any row; only block setting on a
+  // composite parent.
+  const whereClause = referenceId === null ? 'WHERE id = $1' : 'WHERE id = $1 AND is_composite = FALSE'
   const result = await query(
     user,
     `UPDATE food_items SET reference_food_item_id = $2, updated_at = NOW()
-     WHERE id = $1
+     ${whereClause}
      RETURNING ${FOOD_ITEM_COLUMNS}`,
     [id, referenceId],
   )

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -226,6 +226,7 @@ export {
   type MergeFoodItemResult,
   mergeFoodItems,
   searchFoodItems,
+  setFoodItemReference,
   updateFoodItem,
   upsertFoodItem,
 } from './food-items.ts'

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -354,6 +354,8 @@ export interface FoodItemEntity {
   source: string
   source_id?: string
   is_composite?: boolean
+  /** Soft pointer to a richer canonical food item (per-user OR central) used to inherit empty micronutrient fields. */
+  reference_food_item_id?: string
   default_quantity?: number
   default_unit?: string
   // ~65 nutrient fields are optional numbers, accessed dynamically via

--- a/apps/backend/src/mcp/food-item-tools.test.ts
+++ b/apps/backend/src/mcp/food-item-tools.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { FoodItemEntity } from '../db/types.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { SharedFoodItemEntity } from '../services/central-food-items.ts'
+import type { McpServer } from './helpers.ts'
+
+import { registerFoodItemTools } from './food-item-tools.ts'
+
+vi.mock('../db/index.ts', () => ({
+  clearIngredients: vi.fn(),
+  deleteFoodItem: vi.fn(),
+  getFoodItemById: vi.fn(),
+  listFoodItems: vi.fn(),
+  setFoodItemReference: vi.fn(),
+  setIngredients: vi.fn(),
+  updateFoodItem: vi.fn(),
+  upsertFoodItem: vi.fn(),
+}))
+
+vi.mock('../db/food-items.ts', () => ({
+  findOrCreateFoodItem: vi.fn(),
+  getFoodItemById: vi.fn(),
+  getFoodItemByName: vi.fn(),
+  mergeFoodItems: vi.fn(),
+  searchFoodItems: vi.fn(),
+}))
+
+vi.mock('../db/food-item-ingredients.ts', () => ({
+  getIngredients: vi.fn().mockResolvedValue([]),
+}))
+
+const dbBarrel = await import('../db/index.ts')
+const dbFoodItems = await import('../db/food-items.ts')
+
+const setUserFoodItem = (impl: (user: string, id: string) => Promise<FoodItemEntity | null>) => {
+  vi.mocked(dbBarrel.getFoodItemById).mockImplementation(impl)
+  vi.mocked(dbFoodItems.getFoodItemById).mockImplementation(impl)
+}
+
+const userItem = (id: string, overrides: Partial<FoodItemEntity> = {}): FoodItemEntity =>
+  ({
+    created_at: new Date(),
+    id,
+    name: id,
+    name_lower: id.toLowerCase(),
+    source: 'manual',
+    updated_at: new Date(),
+    ...overrides,
+  }) as unknown as FoodItemEntity
+
+const sharedItem = (id: string, overrides: Partial<SharedFoodItemEntity> = {}): SharedFoodItemEntity =>
+  ({
+    created_at: new Date(),
+    id,
+    name: id,
+    name_lower: id.toLowerCase(),
+    source: 'livsmedelsverket',
+    source_id: '1',
+    updated_at: new Date(),
+    ...overrides,
+  }) as unknown as SharedFoodItemEntity
+
+const fakeCentral = (): CentralDb =>
+  ({
+    getSharedFoodItemById: vi.fn().mockResolvedValue(null),
+    getSharedFoodItemByName: vi.fn().mockResolvedValue(null),
+    listSharedFoodItems: vi.fn().mockResolvedValue([]),
+    searchSharedFoodItems: vi.fn().mockResolvedValue([]),
+    upsertSharedFoodItem: vi.fn(),
+  }) as unknown as CentralDb
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>
+
+/** Build a fake MCP server that captures registered tools by name so tests can invoke them directly. */
+const buildFakeServer = (): { server: McpServer; tools: Map<string, ToolHandler> } => {
+  const tools = new Map<string, ToolHandler>()
+  const server = {
+    tool: (name: string, _desc: string, _shape: unknown, handler: ToolHandler) => {
+      tools.set(name, handler)
+    },
+  } as unknown as McpServer
+  return { server, tools }
+}
+
+const callTool = async (handler: ToolHandler, params: Record<string, unknown>) => {
+  const result = await handler(params)
+  return result.content[0].text
+}
+
+describe('MCP set_food_item_reference', () => {
+  const id = '11111111-1111-4111-8111-111111111111'
+  const refId = '22222222-2222-4222-8222-222222222222'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('rejects when self item is not found', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(null)
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', central)
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: refId,
+    })
+    expect(text).toMatch(/not found/i)
+  })
+
+  test('rejects when self resolves to a central shared library row', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(sharedItem('shared'))
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', central)
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: refId,
+    })
+    expect(text).toMatch(/shared library/i)
+  })
+
+  test('rejects self-reference', async () => {
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id) : null))
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', fakeCentral())
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: id,
+    })
+    expect(text).toMatch(/cannot reference itself/i)
+  })
+
+  test('rejects when self is composite', async () => {
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id, { is_composite: true }) : null))
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', fakeCentral())
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: refId,
+    })
+    expect(text).toMatch(/composite/i)
+  })
+
+  test('rejects when reference target does not exist', async () => {
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id) : null))
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(null)
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', central)
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: refId,
+    })
+    expect(text).toMatch(/reference food item not found/i)
+  })
+
+  test('rejects when reference target is itself a composite', async () => {
+    setUserFoodItem(async (_u, fid) => {
+      if (fid === id) return userItem(id)
+      if (fid === refId) return userItem(refId, { is_composite: true })
+      return null
+    })
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', fakeCentral())
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: refId,
+    })
+    expect(text).toMatch(/composite recipe/i)
+  })
+
+  test('sets reference on success and returns enriched detail', async () => {
+    const self = userItem(id, { reference_food_item_id: refId })
+    const ref = sharedItem(refId, { name: 'Ref' })
+    setUserFoodItem(async (_u, fid) => (fid === id ? self : null))
+    vi.mocked(dbBarrel.setFoodItemReference).mockResolvedValue(self)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(ref)
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', central)
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: refId,
+    })
+    const json = JSON.parse(text) as { success: boolean; data?: { reference?: { food: { id: string } } } }
+    expect(json.success).toBe(true)
+    expect(json.data?.reference?.food.id).toBe(refId)
+    expect(dbBarrel.setFoodItemReference).toHaveBeenCalledWith('tester', id, refId)
+  })
+
+  test('clears reference when reference_food_item_id is null', async () => {
+    const self = userItem(id)
+    setUserFoodItem(async (_u, fid) => (fid === id ? self : null))
+    vi.mocked(dbBarrel.setFoodItemReference).mockResolvedValue(self)
+    const { server, tools } = buildFakeServer()
+    registerFoodItemTools(server, 'tester', fakeCentral())
+
+    const text = await callTool(tools.get('set_food_item_reference')!, {
+      id,
+      reference_food_item_id: null,
+    })
+    const json = JSON.parse(text) as { success: boolean }
+    expect(json.success).toBe(true)
+    expect(dbBarrel.setFoodItemReference).toHaveBeenCalledWith('tester', id, null)
+  })
+})

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -183,6 +183,11 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
           (await getUserFoodItemById(user, reference_food_item_id)) ??
           (await centralDb.getSharedFoodItemById(reference_food_item_id))
         if (!ref) return errorResponse('Reference food item not found')
+        if (ref.is_composite) {
+          return errorResponse(
+            'Reference target cannot be a composite recipe — its nutrient columns are derived, not authoritative',
+          )
+        }
       }
       await setFoodItemReference(user, id, reference_food_item_id)
       const detail = await foodItems.getDetail(user, id)

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -11,6 +11,7 @@ import {
   addFoodItemBodySchema,
   foodItemsQuerySchema,
   setFoodItemIngredientsBodySchema,
+  setFoodItemReferenceBodySchema,
   updateFoodItemBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -22,6 +23,7 @@ import {
   deleteFoodItem,
   getFoodItemById as getUserFoodItemById,
   listFoodItems,
+  setFoodItemReference,
   setIngredients,
   updateFoodItem,
   upsertFoodItem,
@@ -146,6 +148,43 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
         )
       }
       await clearIngredients(user, id)
+      const detail = await foodItems.getDetail(user, id)
+      if (!detail) return errorResponse('Food item not found')
+      return jsonResponse({ data: detail, success: true })
+    },
+  )
+
+  server.tool(
+    'set_food_item_reference',
+    [
+      "Point a per-user atomic food item at a reference food (per-user or central). The target inherits the reference's micronutrients on read, scaled by `self.default_quantity / reference.default_quantity` when units match. Self-set values always win; the reference only fills empty fields.",
+      'Pass `reference_food_item_id: null` to clear the pointer. Composite items cannot have a reference (their nutrients are derived from ingredients).',
+    ].join(' '),
+    {
+      id: z.string().uuid().describe('Food item ID (must be per-user)'),
+      ...setFoodItemReferenceBodySchema.shape,
+    },
+    async ({ id, reference_food_item_id }) => {
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return errorResponse(
+          fromCentral ? 'Cannot set reference on shared library item' : 'Food item not found',
+        )
+      }
+      if (reference_food_item_id !== null) {
+        if (reference_food_item_id === id) return errorResponse('A food item cannot reference itself')
+        if (userItem.is_composite) {
+          return errorResponse(
+            'Composite items cannot have a reference — nutrients are derived from ingredients',
+          )
+        }
+        const ref =
+          (await getUserFoodItemById(user, reference_food_item_id)) ??
+          (await centralDb.getSharedFoodItemById(reference_food_item_id))
+        if (!ref) return errorResponse('Reference food item not found')
+      }
+      await setFoodItemReference(user, id, reference_food_item_id)
       const detail = await foodItems.getDetail(user, id)
       if (!detail) return errorResponse('Food item not found')
       return jsonResponse({ data: detail, success: true })

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -1,0 +1,227 @@
+import express from 'express'
+import supertest from 'supertest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { FoodItemEntity } from '../db/types.ts'
+import type { CentralDb } from '../services/central-db.ts'
+import type { SharedFoodItemEntity } from '../services/central-food-items.ts'
+
+import { createFoodItemsRouter } from './food-items-router.ts'
+
+// The route imports from the barrel `../db/index.ts`; the food-items service
+// imports directly from `../db/food-items.ts`. Both have to be mocked, and the
+// `getFoodItemById` mocks in both paths must be kept in sync (the test helper
+// `setSelf()` does that).
+vi.mock('../db/index.ts', () => ({
+  clearIngredients: vi.fn(),
+  deleteFoodItem: vi.fn(),
+  getFoodItemById: vi.fn(),
+  listFoodItems: vi.fn(),
+  setFoodItemReference: vi.fn(),
+  setIngredients: vi.fn(),
+  updateFoodItem: vi.fn(),
+  upsertFoodItem: vi.fn(),
+}))
+
+vi.mock('../db/food-item-ingredients.ts', () => ({
+  getIngredients: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../db/food-items.ts', () => ({
+  findOrCreateFoodItem: vi.fn(),
+  getFoodItemById: vi.fn(),
+  getFoodItemByName: vi.fn(),
+  mergeFoodItems: vi.fn(),
+  searchFoodItems: vi.fn(),
+}))
+
+const dbBarrel = await import('../db/index.ts')
+const dbFoodItems = await import('../db/food-items.ts')
+
+/** Set the mock return for both barrel and direct getFoodItemById lookups. */
+const setUserFoodItem = (impl: (user: string, id: string) => Promise<FoodItemEntity | null>) => {
+  vi.mocked(dbBarrel.getFoodItemById).mockImplementation(impl)
+  vi.mocked(dbFoodItems.getFoodItemById).mockImplementation(impl)
+}
+
+const userItem = (id: string, overrides: Partial<FoodItemEntity> = {}): FoodItemEntity =>
+  ({
+    created_at: new Date(),
+    id,
+    name: id,
+    name_lower: id.toLowerCase(),
+    source: 'manual',
+    updated_at: new Date(),
+    ...overrides,
+  }) as unknown as FoodItemEntity
+
+const sharedItem = (id: string, overrides: Partial<SharedFoodItemEntity> = {}): SharedFoodItemEntity =>
+  ({
+    created_at: new Date(),
+    id,
+    name: id,
+    name_lower: id.toLowerCase(),
+    source: 'livsmedelsverket',
+    source_id: '1',
+    updated_at: new Date(),
+    ...overrides,
+  }) as unknown as SharedFoodItemEntity
+
+const fakeCentral = (): CentralDb =>
+  ({
+    getSharedFoodItemById: vi.fn().mockResolvedValue(null),
+    getSharedFoodItemByName: vi.fn().mockResolvedValue(null),
+    listSharedFoodItems: vi.fn().mockResolvedValue([]),
+    searchSharedFoodItems: vi.fn().mockResolvedValue([]),
+    upsertSharedFoodItem: vi.fn(),
+  }) as unknown as CentralDb
+
+const buildApp = (centralDb: CentralDb) => {
+  const app = express()
+  app.use(express.json())
+  // Stub auth middleware: always authenticate as 'tester'.
+  const auth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = 'tester'
+    next()
+  }
+  app.use('/food-items', createFoodItemsRouter(auth, centralDb) as unknown as express.RequestHandler)
+  return app
+}
+
+describe('PUT /food-items/:id/reference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('404 when self item is not found in user or central DB', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(null)
+    const res = await supertest(buildApp(central))
+      .put('/food-items/11111111-1111-4111-8111-111111111111/reference')
+      .send({ reference_food_item_id: '22222222-2222-4222-8222-222222222222' })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toMatch(/not found/i)
+  })
+
+  test('403 when self resolves to a central shared library row', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(sharedItem('shared-1'))
+    const res = await supertest(buildApp(central))
+      .put('/food-items/11111111-1111-4111-8111-111111111111/reference')
+      .send({ reference_food_item_id: '22222222-2222-4222-8222-222222222222' })
+    expect(res.status).toBe(403)
+    expect(res.body.error).toMatch(/shared library/i)
+  })
+
+  test('400 on self-reference', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id) : null))
+    const res = await supertest(buildApp(fakeCentral()))
+      .put(`/food-items/${id}/reference`)
+      .send({ reference_food_item_id: id })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/cannot reference itself/i)
+  })
+
+  test('400 when self item is composite', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id, { is_composite: true }) : null))
+    const res = await supertest(buildApp(fakeCentral()))
+      .put(`/food-items/${id}/reference`)
+      .send({ reference_food_item_id: '22222222-2222-4222-8222-222222222222' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/composite/i)
+  })
+
+  test('400 when reference target does not exist', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    const refId = '22222222-2222-4222-8222-222222222222'
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id) : null))
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(null)
+    const res = await supertest(buildApp(central))
+      .put(`/food-items/${id}/reference`)
+      .send({ reference_food_item_id: refId })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/reference food item not found/i)
+  })
+
+  test('400 when reference target is itself a composite', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    const refId = '22222222-2222-4222-8222-222222222222'
+    setUserFoodItem(async (_u, fid) => {
+      if (fid === id) return userItem(id)
+      if (fid === refId) return userItem(refId, { is_composite: true })
+      return null
+    })
+    const res = await supertest(buildApp(fakeCentral()))
+      .put(`/food-items/${id}/reference`)
+      .send({ reference_food_item_id: refId })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/composite recipe/i)
+  })
+
+  test('200 sets reference and returns enriched detail', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    const refId = '22222222-2222-4222-8222-222222222222'
+    const self = userItem(id, { reference_food_item_id: refId })
+    const ref = sharedItem(refId, { name: 'Ref' })
+    setUserFoodItem(async (_u, fid) => (fid === id ? self : null))
+    vi.mocked(dbBarrel.setFoodItemReference).mockResolvedValue(self)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(ref)
+
+    const res = await supertest(buildApp(central))
+      .put(`/food-items/${id}/reference`)
+      .send({ reference_food_item_id: refId })
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.reference?.food.id).toBe(refId)
+    expect(dbBarrel.setFoodItemReference).toHaveBeenCalledWith('tester', id, refId)
+  })
+
+  test('400 on validation: malformed body (non-uuid)', async () => {
+    const res = await supertest(buildApp(fakeCentral()))
+      .put('/food-items/11111111-1111-4111-8111-111111111111/reference')
+      .send({ reference_food_item_id: 'not-a-uuid' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('DELETE /food-items/:id/reference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('404 when self item is not found', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(null)
+    const res = await supertest(buildApp(central)).delete(
+      '/food-items/11111111-1111-4111-8111-111111111111/reference',
+    )
+    expect(res.status).toBe(404)
+  })
+
+  test('403 when self is a shared library item', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(sharedItem('s1'))
+    const res = await supertest(buildApp(central)).delete(
+      '/food-items/11111111-1111-4111-8111-111111111111/reference',
+    )
+    expect(res.status).toBe(403)
+  })
+
+  test('200 clears the pointer', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    const self = userItem(id)
+    setUserFoodItem(async (_u, fid) => (fid === id ? self : null))
+    vi.mocked(dbBarrel.setFoodItemReference).mockResolvedValue(self)
+    const res = await supertest(buildApp(fakeCentral())).delete(`/food-items/${id}/reference`)
+    expect(res.status).toBe(200)
+    expect(dbBarrel.setFoodItemReference).toHaveBeenCalledWith('tester', id, null)
+  })
+})

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -83,14 +83,15 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
     }
   }
   // Reference branch: emit the resolved reference + per-field origin map.
-  if (detail.reference && detail.reference_enriched) {
+  // The service guarantees these two are set together.
+  if (detail.reference) {
     return {
       ...base,
       reference: {
         food: serializeFoodItem(detail.reference.food),
         unit_mismatch: detail.reference.unit_mismatch,
       },
-      reference_enriched: detail.reference_enriched,
+      reference_enriched: detail.reference_enriched ?? { fields: {} },
     }
   }
   return base as FoodItemDetail
@@ -250,6 +251,13 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         const ref = (await getUserFoodItemById(user, refId)) ?? (await centralDb.getSharedFoodItemById(refId))
         if (!ref) {
           return res.status(400).json({ error: 'Reference food item not found', success: false })
+        }
+        if (ref.is_composite) {
+          return res.status(400).json({
+            error:
+              'Reference target cannot be a composite recipe — its nutrient columns are derived, not authoritative',
+            success: false,
+          })
         }
       }
       await dbSetFoodItemReference(user, id, refId)

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -25,6 +25,8 @@ import {
   type MergeFoodItemsResponse,
   type SetFoodItemIngredientsBody,
   setFoodItemIngredientsBodySchema,
+  type SetFoodItemReferenceBody,
+  setFoodItemReferenceBodySchema,
   type UpdateFoodItemBody,
   updateFoodItemBodySchema,
 } from '@aurboda/api-spec'
@@ -38,6 +40,7 @@ import {
   type FoodItemEntity as DbFoodItemEntity,
   getFoodItemById as getUserFoodItemById,
   listFoodItems,
+  setFoodItemReference as dbSetFoodItemReference,
   setIngredients as dbSetIngredients,
   updateFoodItem,
   upsertFoodItem,
@@ -64,19 +67,33 @@ const serializeFoodItem = (
 
 const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   const base = serializeFoodItem(detail.item)
-  if (!detail.ingredients) return base as FoodItemDetail
-  return {
-    ...base,
-    derived_nutrients: detail.derived_nutrients ?? { nutrient_data_incomplete: false, values: {} },
-    ingredients: detail.ingredients.map((ing) => ({
-      icon: (ing.food?.icon as string | undefined) ?? null,
-      ingredient_food_item_id: ing.row.ingredient_food_item_id,
-      name: ing.food ? (ing.food.name as string) : null,
-      quantity: ing.row.quantity,
-      sort_order: ing.row.sort_order,
-      unit: ing.row.unit,
-    })),
+  // Composite branch: ingredient list + derived totals.
+  if (detail.ingredients) {
+    return {
+      ...base,
+      derived_nutrients: detail.derived_nutrients ?? { nutrient_data_incomplete: false, values: {} },
+      ingredients: detail.ingredients.map((ing) => ({
+        icon: (ing.food?.icon as string | undefined) ?? null,
+        ingredient_food_item_id: ing.row.ingredient_food_item_id,
+        name: ing.food ? (ing.food.name as string) : null,
+        quantity: ing.row.quantity,
+        sort_order: ing.row.sort_order,
+        unit: ing.row.unit,
+      })),
+    }
   }
+  // Reference branch: emit the resolved reference + per-field origin map.
+  if (detail.reference && detail.reference_enriched) {
+    return {
+      ...base,
+      reference: {
+        food: serializeFoodItem(detail.reference.food),
+        unit_mismatch: detail.reference.unit_mismatch,
+      },
+      reference_enriched: detail.reference_enriched,
+    }
+  }
+  return base as FoodItemDetail
 }
 
 export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: CentralDb): TypedRouter => {
@@ -195,6 +212,69 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       await dbClearIngredients(user, id)
+      const detail = await service.getDetail(user, id)
+      if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+      res.json({ data: serializeDetail(detail), success: true })
+    },
+  )
+
+  // Set the reference_food_item_id pointer on a per-user atomic item. The
+  // target may be per-user or central. Composite items can't have a reference
+  // (their nutrients are derived from ingredients).
+  router.put<{ id: string }, FoodItemDetailResponse, SetFoodItemReferenceBody>(
+    '/:id/reference',
+    authMiddleware,
+    validateBody(setFoodItemReferenceBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      const refId = req.body.reference_food_item_id
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return res.status(fromCentral ? 403 : 404).json({
+          error: fromCentral ? 'Cannot set reference on shared library item' : 'Food item not found',
+          success: false,
+        })
+      }
+      if (refId !== null) {
+        if (refId === id) {
+          return res.status(400).json({ error: 'A food item cannot reference itself', success: false })
+        }
+        if (userItem.is_composite) {
+          return res.status(400).json({
+            error: 'Composite items cannot have a reference — nutrients are derived from ingredients',
+            success: false,
+          })
+        }
+        const ref = (await getUserFoodItemById(user, refId)) ?? (await centralDb.getSharedFoodItemById(refId))
+        if (!ref) {
+          return res.status(400).json({ error: 'Reference food item not found', success: false })
+        }
+      }
+      await dbSetFoodItemReference(user, id, refId)
+      const detail = await service.getDetail(user, id)
+      if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+      res.json({ data: serializeDetail(detail), success: true })
+    },
+  )
+
+  // Clear the reference pointer.
+  router.delete<{ id: string }, FoodItemDetailResponse>(
+    '/:id/reference',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      const userItem = await getUserFoodItemById(user, id)
+      if (!userItem) {
+        const fromCentral = await centralDb.getSharedFoodItemById(id)
+        return res.status(fromCentral ? 403 : 404).json({
+          error: fromCentral ? 'Cannot clear reference on shared library item' : 'Food item not found',
+          success: false,
+        })
+      }
+      await dbSetFoodItemReference(user, id, null)
       const detail = await service.getDetail(user, id)
       if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
       res.json({ data: serializeDetail(detail), success: true })

--- a/apps/backend/src/schema/meals.ts
+++ b/apps/backend/src/schema/meals.ts
@@ -111,6 +111,7 @@ export const mealsTables: Record<string, string> = {
       icon            TEXT,
       source_id       VARCHAR(100),
       is_composite    BOOLEAN NOT NULL DEFAULT FALSE,
+      reference_food_item_id UUID,
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       CONSTRAINT unique_food_item_name UNIQUE (name_lower)

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -417,10 +417,11 @@ describe('createFoodItemsService.getDetail — reference enrichment', () => {
     expect(fields.vitamin_c).toEqual({ origin: 'reference', value: 0.45 })
   })
 
-  test('flags unit_mismatch and emits unscaled values when units differ dimensionally', async () => {
+  test('flags unit_mismatch and drops inherited values when units differ dimensionally', async () => {
     const self = userItem('u1', 'Slice')
     self.default_quantity = 1
     self.default_unit = 'slice' // not in conversion table
+    self.protein = 5 // self value should still be emitted
     const reference = sharedItem('c1', 'Bread')
     reference.default_quantity = 100
     reference.default_unit = 'g'
@@ -434,11 +435,34 @@ describe('createFoodItemsService.getDetail — reference enrichment', () => {
 
     const detail = await createFoodItemsService(central).getDetail('user', 'u1')
     expect(detail?.reference?.unit_mismatch).toBe(true)
-    // Unscaled: 250 stays 250 (× 1).
-    expect(detail?.reference_enriched?.fields.calories).toEqual({ origin: 'reference', value: 250 })
+    // Self value still surfaces.
+    expect(detail?.reference_enriched?.fields.protein).toEqual({ origin: 'self', value: 5 })
+    // Reference value dropped — emitting "250 cal per slice" with a warning is more confusing than no value.
+    expect(detail?.reference_enriched?.fields.calories).toBeUndefined()
   })
 
-  test('composite items take precedence over reference enrichment', async () => {
+  test('scales nutrient values across compatible units (kg ↔ g)', async () => {
+    const self = userItem('u1', 'Bag of flour')
+    self.default_quantity = 1
+    self.default_unit = 'kg'
+    const reference = sharedItem('c1', 'Flour')
+    reference.default_quantity = 100
+    reference.default_unit = 'g'
+    reference.calories = 360 // per 100 g
+    self.reference_food_item_id = 'c1'
+
+    vi.mocked(dbModule.getFoodItemById).mockImplementation(async (_user, id) => (id === 'u1' ? self : null))
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(reference)
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+
+    const detail = await createFoodItemsService(central).getDetail('user', 'u1')
+    expect(detail?.reference?.unit_mismatch).toBe(false)
+    // 1 kg = 1000 g → 1000 / 100 × 360 = 3600 kcal per bag.
+    expect(detail?.reference_enriched?.fields.calories).toEqual({ origin: 'reference', value: 3600 })
+  })
+
+  test('composite self items take precedence over reference enrichment', async () => {
     const self = userItem('u1', 'Recipe')
     self.is_composite = true
     self.reference_food_item_id = 'c1'
@@ -448,5 +472,23 @@ describe('createFoodItemsService.getDetail — reference enrichment', () => {
     const detail = await createFoodItemsService(fakeCentral()).getDetail('user', 'u1')
     expect(detail?.reference).toBeUndefined()
     expect(detail?.reference_enriched).toBeUndefined()
+  })
+
+  test('skips enrichment when the resolved reference target is itself a composite', async () => {
+    const self = userItem('u1', 'Atomic')
+    self.reference_food_item_id = 'c1'
+    const compositeRef = sharedItem('c1', 'Recipe target')
+    ;(compositeRef as unknown as { is_composite: boolean }).is_composite = true
+    compositeRef.calories = 0 // sparse — would be misleading to inherit
+
+    vi.mocked(dbModule.getFoodItemById).mockImplementation(async (_user, id) => (id === 'u1' ? self : null))
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(compositeRef)
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+
+    const detail = await createFoodItemsService(central).getDetail('user', 'u1')
+    expect(detail?.reference).toBeUndefined()
+    expect(detail?.reference_enriched).toBeUndefined()
+    expect(detail?.item.id).toBe('u1')
   })
 })

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -364,3 +364,89 @@ describe('aggregateNutrientsFromIngredients — scaling edge cases', () => {
     expect(nutrient_data_incomplete).toBe(false)
   })
 })
+
+describe('createFoodItemsService.getDetail — reference enrichment', () => {
+  test('returns plain detail when no reference is set', async () => {
+    const item = userItem('u1', 'Plain')
+    item.calories = 50
+    vi.mocked(dbModule.getFoodItemById).mockResolvedValue(item)
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+    const service = createFoodItemsService(fakeCentral())
+
+    const detail = await service.getDetail('user', 'u1')
+    expect(detail?.item.id).toBe('u1')
+    expect(detail?.reference).toBeUndefined()
+    expect(detail?.reference_enriched).toBeUndefined()
+  })
+
+  test('emits per-field origin info: self wins, reference fills empty (scaled by serving)', async () => {
+    // Self: 30 g serving, has its own calories + protein, missing iron + vitamin_c.
+    const self = userItem('u1', 'Arla Hushållsost')
+    self.default_quantity = 30
+    self.default_unit = 'g'
+    self.calories = 90
+    self.protein = 8
+    // Reference (LSV): 100 g serving, full micros.
+    const reference = sharedItem('c1', 'Hushållsost')
+    reference.default_quantity = 100
+    reference.default_unit = 'g'
+    reference.calories = 350
+    reference.iron = 0.4 // mg/100 g
+    reference.vitamin_c = 1.5
+    self.reference_food_item_id = 'c1'
+
+    vi.mocked(dbModule.getFoodItemById).mockImplementation(async (_user, id) => {
+      if (id === 'u1') return self
+      return null
+    })
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockImplementation(async (id) => {
+      return id === 'c1' ? reference : null
+    })
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+
+    const detail = await createFoodItemsService(central).getDetail('user', 'u1')
+    expect(detail?.reference?.food.id).toBe('c1')
+    expect(detail?.reference?.unit_mismatch).toBe(false)
+    const fields = detail?.reference_enriched?.fields ?? {}
+    // Self values stay self.
+    expect(fields.calories).toEqual({ origin: 'self', value: 90 })
+    expect(fields.protein).toEqual({ origin: 'self', value: 8 })
+    // Empty self fields filled from reference, scaled by 30/100 = 0.3.
+    expect(fields.iron).toEqual({ origin: 'reference', value: 0.12 })
+    expect(fields.vitamin_c).toEqual({ origin: 'reference', value: 0.45 })
+  })
+
+  test('flags unit_mismatch and emits unscaled values when units differ dimensionally', async () => {
+    const self = userItem('u1', 'Slice')
+    self.default_quantity = 1
+    self.default_unit = 'slice' // not in conversion table
+    const reference = sharedItem('c1', 'Bread')
+    reference.default_quantity = 100
+    reference.default_unit = 'g'
+    reference.calories = 250
+    self.reference_food_item_id = 'c1'
+
+    vi.mocked(dbModule.getFoodItemById).mockImplementation(async (_user, id) => (id === 'u1' ? self : null))
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(reference)
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+
+    const detail = await createFoodItemsService(central).getDetail('user', 'u1')
+    expect(detail?.reference?.unit_mismatch).toBe(true)
+    // Unscaled: 250 stays 250 (× 1).
+    expect(detail?.reference_enriched?.fields.calories).toEqual({ origin: 'reference', value: 250 })
+  })
+
+  test('composite items take precedence over reference enrichment', async () => {
+    const self = userItem('u1', 'Recipe')
+    self.is_composite = true
+    self.reference_food_item_id = 'c1'
+    vi.mocked(dbModule.getFoodItemById).mockResolvedValue(self)
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+
+    const detail = await createFoodItemsService(fakeCentral()).getDetail('user', 'u1')
+    expect(detail?.reference).toBeUndefined()
+    expect(detail?.reference_enriched).toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -191,6 +191,11 @@ const computeReferenceScale = (
  * Build a `FoodItemDetail` with reference-origin nutrients merged in.
  * Self values always win; reference values fill empty fields, scaled by
  * `self.default_quantity / ref.default_quantity` when units match.
+ *
+ * When units can't be reliably converted (`unit_mismatch=true`), self values
+ * are still emitted but reference values are dropped — surfacing a
+ * wrong-magnitude number with a warning is more confusing than no value.
+ * The UI shows a banner pointing the user at the unit settings instead.
  */
 const enrichWithReference = (self: MergedFoodItem, ref: MergedFoodItem): FoodItemDetail => {
   const { scale, unit_mismatch } = computeReferenceScale(self, ref)
@@ -201,22 +206,10 @@ const enrichWithReference = (self: MergedFoodItem, ref: MergedFoodItem): FoodIte
       fields[field] = { origin: 'self', value: selfVal }
       continue
     }
+    if (unit_mismatch) continue
     const refVal = ref[field]
     if (typeof refVal === 'number') {
       fields[field] = { origin: 'reference', value: round2(refVal * scale) }
-    }
-  }
-  // Icon and default_* are also inheritable for display purposes — the
-  // detail page can render the reference's icon when self has none.
-  for (const field of ['icon', 'default_unit'] as const) {
-    const selfVal = self[field]
-    if (typeof selfVal === 'string' && selfVal.length > 0) {
-      fields[field] = { origin: 'self', value: selfVal }
-    } else {
-      const refVal = ref[field]
-      if (typeof refVal === 'string' && refVal.length > 0) {
-        fields[field] = { origin: 'reference', value: refVal }
-      }
     }
   }
   return {
@@ -315,12 +308,16 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       }
 
       // Atomic per-user item — resolve the reference (if any) and emit
-      // per-field origin info.
+      // per-field origin info. Defence in depth: skip enrichment when the
+      // resolved target is itself a composite. Composite columns are sparse
+      // (real values live in derived_nutrients), so reading them as
+      // inheritable nutrients would surface stale/empty numbers. The route +
+      // MCP layers also reject composite targets up-front.
       const refId = fromUser.reference_food_item_id as string | undefined
       if (refId) {
         const refFood =
           (await getUserFoodItemById(user, refId)) ?? (await centralDb.getSharedFoodItemById(refId))
-        if (refFood) {
+        if (refFood && !refFood.is_composite) {
           return enrichWithReference(fromUser, refFood)
         }
       }

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -56,12 +56,38 @@ export interface DerivedNutrients {
   nutrient_data_incomplete: boolean
 }
 
+export interface ReferencedFood {
+  /** The reference food item resolved across user + central. */
+  food: MergedFoodItem
+  /** True when self.default_quantity / reference.default_quantity isn't possible (missing default_quantity, or units that can't convert). Inherited values are still emitted at scale=1 but flagged so the UI can warn. */
+  unit_mismatch: boolean
+}
+
+/**
+ * Per-field origin info for an atomic item with an optional reference.
+ * Each entry says where the value came from — the item itself, an inherited
+ * reference, or both (with the self winning).
+ */
+export interface FieldOrigin {
+  origin: 'self' | 'reference'
+  value: number | string
+}
+
+export interface ReferenceEnrichedFields {
+  /** Map of NUTRIENT_FIELD_NAME → { origin, value }. Only entries that have a value (self or inherited) appear. */
+  fields: Record<string, FieldOrigin>
+}
+
 export interface FoodItemDetail {
   item: MergedFoodItem
   /** Present iff the item is a per-user composite. */
   ingredients?: ResolvedIngredient[]
   /** Derived nutrient totals when composite; absent for atomic items. */
   derived_nutrients?: DerivedNutrients
+  /** Set when the atomic item has a reference_food_item_id set. Provides the resolved reference + per-field origin info. */
+  reference?: ReferencedFood
+  /** Per-field origin map — set together with `reference`. */
+  reference_enriched?: ReferenceEnrichedFields
 }
 
 export interface FoodItemsService {
@@ -135,6 +161,72 @@ const computeIngredientScale = (
 }
 
 /**
+ * Compute the scale factor between a self food item and its reference.
+ * Reference values are stored "per default_quantity"; if the self item also
+ * specifies default_quantity (and units match or convert), we scale by
+ * `self.default_quantity / ref.default_quantity`. When units don't match
+ * and don't convert, return scale=1 + unit_mismatch=true so the caller can
+ * surface a warning instead of silently producing wrong-magnitude values.
+ */
+const computeReferenceScale = (
+  self: MergedFoodItem,
+  ref: MergedFoodItem,
+): { scale: number; unit_mismatch: boolean } => {
+  const selfQty = self.default_quantity as number | undefined
+  const refQty = ref.default_quantity as number | undefined
+  if (selfQty === undefined || refQty === undefined || refQty === 0) {
+    return { scale: 1, unit_mismatch: true }
+  }
+  const selfUnit = self.default_unit as string | undefined
+  const refUnit = ref.default_unit as string | undefined
+  if (selfUnit && refUnit && selfUnit !== refUnit) {
+    const converted = convertUnit(selfQty, selfUnit, refUnit)
+    if (converted === undefined) return { scale: 1, unit_mismatch: true }
+    return { scale: converted / refQty, unit_mismatch: false }
+  }
+  return { scale: selfQty / refQty, unit_mismatch: false }
+}
+
+/**
+ * Build a `FoodItemDetail` with reference-origin nutrients merged in.
+ * Self values always win; reference values fill empty fields, scaled by
+ * `self.default_quantity / ref.default_quantity` when units match.
+ */
+const enrichWithReference = (self: MergedFoodItem, ref: MergedFoodItem): FoodItemDetail => {
+  const { scale, unit_mismatch } = computeReferenceScale(self, ref)
+  const fields: Record<string, FieldOrigin> = {}
+  for (const field of NUTRIENT_FIELD_NAMES) {
+    const selfVal = self[field]
+    if (typeof selfVal === 'number') {
+      fields[field] = { origin: 'self', value: selfVal }
+      continue
+    }
+    const refVal = ref[field]
+    if (typeof refVal === 'number') {
+      fields[field] = { origin: 'reference', value: round2(refVal * scale) }
+    }
+  }
+  // Icon and default_* are also inheritable for display purposes — the
+  // detail page can render the reference's icon when self has none.
+  for (const field of ['icon', 'default_unit'] as const) {
+    const selfVal = self[field]
+    if (typeof selfVal === 'string' && selfVal.length > 0) {
+      fields[field] = { origin: 'self', value: selfVal }
+    } else {
+      const refVal = ref[field]
+      if (typeof refVal === 'string' && refVal.length > 0) {
+        fields[field] = { origin: 'reference', value: refVal }
+      }
+    }
+  }
+  return {
+    item: self,
+    reference: { food: ref, unit_mismatch },
+    reference_enriched: { fields },
+  }
+}
+
+/**
  * Sum each nutrient column across the resolved ingredients × per-ingredient
  * scale. Ingredients we couldn't resolve, ingredients without a calorie
  * reading, and ingredients we couldn't scale reliably (missing default_qty
@@ -201,23 +293,38 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
   getDetail: async (user, id) => {
     const fromUser = await getUserFoodItemById(user, id)
     if (fromUser) {
-      // Skip the junction lookup for atomic items — most reads.
-      if (!fromUser.is_composite) return { item: fromUser }
-      const rows = await dbGetIngredients(user, id)
-      if (rows.length === 0) return { item: fromUser }
-      const resolved: ResolvedIngredient[] = await Promise.all(
-        rows.map(async (row) => {
-          const food =
-            (await getUserFoodItemById(user, row.ingredient_food_item_id)) ??
-            (await centralDb.getSharedFoodItemById(row.ingredient_food_item_id))
-          return { food, row }
-        }),
-      )
-      return {
-        derived_nutrients: aggregateNutrientsFromIngredients(resolved),
-        ingredients: resolved,
-        item: fromUser,
+      // Composite path takes precedence over reference enrichment — a
+      // recipe's nutrients are entirely derived from its ingredients, so
+      // a reference would be ignored anyway.
+      if (fromUser.is_composite) {
+        const rows = await dbGetIngredients(user, id)
+        if (rows.length === 0) return { item: fromUser }
+        const resolved: ResolvedIngredient[] = await Promise.all(
+          rows.map(async (row) => {
+            const food =
+              (await getUserFoodItemById(user, row.ingredient_food_item_id)) ??
+              (await centralDb.getSharedFoodItemById(row.ingredient_food_item_id))
+            return { food, row }
+          }),
+        )
+        return {
+          derived_nutrients: aggregateNutrientsFromIngredients(resolved),
+          ingredients: resolved,
+          item: fromUser,
+        }
       }
+
+      // Atomic per-user item — resolve the reference (if any) and emit
+      // per-field origin info.
+      const refId = fromUser.reference_food_item_id as string | undefined
+      if (refId) {
+        const refFood =
+          (await getUserFoodItemById(user, refId)) ?? (await centralDb.getSharedFoodItemById(refId))
+        if (refFood) {
+          return enrichWithReference(fromUser, refFood)
+        }
+      }
+      return { item: fromUser }
     }
     const fromCentral = await centralDb.getSharedFoodItemById(id)
     return fromCentral ? { item: fromCentral } : null

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -342,3 +342,134 @@
     background: #78350f;
   }
 }
+
+.fi-reference-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+  padding: 0.5rem 0.75rem;
+  background: #f9fafb;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.fi-reference-label {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.fi-reference-current {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.fi-reference-name {
+  color: #374151;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.fi-reference-name:hover {
+  text-decoration: underline;
+}
+
+.fi-icon-display-inline {
+  margin-right: 0.25rem;
+}
+
+.fi-reference-picker {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 200px;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: #673ab8;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.125rem 0.25rem;
+}
+
+.btn-link:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.btn-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-link-danger {
+  color: #b91c1c;
+}
+
+.fi-reference-warning {
+  width: 100%;
+  margin: 0.25rem 0 0;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8rem;
+  color: #92400e;
+  background: #fef3c7;
+  border-radius: 4px;
+}
+
+.nutrient-edit-inherited input {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.nutrient-edit-inherited input::placeholder {
+  color: #9ca3af;
+  font-style: italic;
+  opacity: 1;
+}
+
+.nutrient-origin-badge {
+  font-size: 0.6rem;
+  color: #6b7280;
+  background: #e5e7eb;
+  padding: 0.05rem 0.25rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+@media (prefers-color-scheme: dark) {
+  .fi-reference-row {
+    background: #1f2937;
+  }
+
+  .fi-reference-label {
+    color: #9ca3af;
+  }
+
+  .fi-reference-name {
+    color: #d1d5db;
+  }
+
+  .btn-link {
+    color: #c4b5fd;
+  }
+
+  .btn-link-danger {
+    color: #fca5a5;
+  }
+
+  .fi-reference-warning {
+    color: #fef3c7;
+    background: #78350f;
+  }
+
+  .nutrient-origin-badge {
+    color: #9ca3af;
+    background: #374151;
+  }
+}

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -80,11 +80,15 @@ const clearIngredientsApi = async (id: string): Promise<ApiFoodItemDetail> => {
 
 const setReferenceApi = async (id: string, referenceId: string | null): Promise<ApiFoodItemDetail> => {
   const { token } = auth.value
-  const res = await fetch(`${API_URL}/food-items/${id}/reference`, {
-    body: JSON.stringify({ reference_food_item_id: referenceId }),
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    method: referenceId === null ? 'DELETE' : 'PUT',
-  })
+  const init: RequestInit =
+    referenceId === null
+      ? { headers: { Authorization: `Bearer ${token}` }, method: 'DELETE' }
+      : {
+          body: JSON.stringify({ reference_food_item_id: referenceId }),
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          method: 'PUT',
+        }
+  const res = await fetch(`${API_URL}/food-items/${id}/reference`, init)
   if (!res.ok) {
     const json = (await res.json().catch(() => ({}))) as { error?: string }
     throw new Error(json.error ?? 'Failed to set reference')

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -9,6 +9,7 @@ import { useLocation, useRoute } from 'preact-iso'
 import { useEffect, useRef, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
+import { FoodItemAutocomplete } from '../../components/FoodItemAutocomplete'
 import { IconInput } from '../../components/IconInput'
 import { type IngredientRow, IngredientList } from '../../components/IngredientList'
 import { auth } from '../../state/auth'
@@ -77,6 +78,21 @@ const clearIngredientsApi = async (id: string): Promise<ApiFoodItemDetail> => {
   return json.data
 }
 
+const setReferenceApi = async (id: string, referenceId: string | null): Promise<ApiFoodItemDetail> => {
+  const { token } = auth.value
+  const res = await fetch(`${API_URL}/food-items/${id}/reference`, {
+    body: JSON.stringify({ reference_food_item_id: referenceId }),
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    method: referenceId === null ? 'DELETE' : 'PUT',
+  })
+  if (!res.ok) {
+    const json = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(json.error ?? 'Failed to set reference')
+  }
+  const json = await res.json()
+  return json.data
+}
+
 const CATEGORIES: Array<{ key: NutrientFieldDef['category']; label: string }> = [
   { key: 'macro', label: 'Macros' },
   { key: 'extended_macro', label: 'Extended Macros' },
@@ -105,10 +121,13 @@ function SaveIndicator({
 function NutrientInput({
   field,
   initial,
+  inheritedValue,
   onCommit,
 }: {
   field: NutrientFieldDef
   initial: number | undefined
+  /** If set, the value comes from the reference. Shown as placeholder; user typing turns it into a self value. */
+  inheritedValue?: number
   onCommit: (value: number | null) => void
 }) {
   const [local, setLocal] = useState<string>(initial !== undefined ? String(initial) : '')
@@ -125,23 +144,31 @@ function NutrientInput({
     }
     const parsed = parseFloat(trimmed)
     if (Number.isNaN(parsed)) {
-      // Revert to last good value rather than blanking the saved nutrient.
       setLocal(initial !== undefined ? String(initial) : '')
       return
     }
     if (parsed !== initial) onCommit(parsed)
   }
 
+  const isInherited = initial === undefined && inheritedValue !== undefined
+  const placeholder = inheritedValue !== undefined ? String(inheritedValue) : undefined
+
   return (
-    <span class="nutrient-edit">
+    <span class={`nutrient-edit${isInherited ? ' nutrient-edit-inherited' : ''}`}>
       <input
         type="number"
         step="0.01"
         value={local}
+        placeholder={placeholder}
         onInput={(e) => setLocal((e.target as HTMLInputElement).value)}
         onBlur={handleBlur}
       />
       <span class="nutrient-unit">{field.unit}</span>
+      {isInherited && (
+        <span class="nutrient-origin-badge" title="Value inherited from reference food">
+          ref
+        </span>
+      )}
     </span>
   )
 }
@@ -222,6 +249,18 @@ export function FoodItemDetail() {
 
   const clearMutation = useMutation({
     mutationFn: () => clearIngredientsApi(id),
+    onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['foodItem', id], updated)
+      setSaveError(null)
+      setSavedFlash(true)
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+      flashTimer.current = setTimeout(() => setSavedFlash(false), 1200)
+    },
+  })
+
+  const referenceMutation = useMutation({
+    mutationFn: (referenceId: string | null) => setReferenceApi(id, referenceId),
     onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
     onSuccess: (updated) => {
       queryClient.setQueryData(['foodItem', id], updated)
@@ -351,6 +390,7 @@ export function FoodItemDetail() {
         item={item}
         ingredientsMutation={ingredientsMutation}
         clearMutation={clearMutation}
+        referenceMutation={referenceMutation}
         save={save}
       />
     </div>
@@ -361,10 +401,17 @@ interface CompositeProps {
   item: ApiFoodItemDetail
   ingredientsMutation: { mutate: (ingredients: FoodItemIngredient[]) => void; isPending: boolean }
   clearMutation: { mutate: () => void; isPending: boolean }
+  referenceMutation: { mutate: (referenceId: string | null) => void; isPending: boolean }
   save: (body: Record<string, unknown>) => void
 }
 
-function CompositeOrAtomicSection({ item, ingredientsMutation, clearMutation, save }: CompositeProps) {
+function CompositeOrAtomicSection({
+  item,
+  ingredientsMutation,
+  clearMutation,
+  referenceMutation,
+  save,
+}: CompositeProps) {
   // Local state for atomic→composite intent: clicking "Convert to recipe"
   // surfaces the IngredientList immediately even before any ingredient is
   // saved. The is_composite flag flips server-side only when a non-empty
@@ -447,6 +494,8 @@ function CompositeOrAtomicSection({ item, ingredientsMutation, clearMutation, sa
     )
   }
 
+  const enrichedFields = item.reference_enriched?.fields ?? {}
+
   return (
     <>
       <div class="composite-toggle-row">
@@ -463,6 +512,8 @@ function CompositeOrAtomicSection({ item, ingredientsMutation, clearMutation, sa
         </span>
       </div>
 
+      <ReferencePicker item={item} referenceMutation={referenceMutation} />
+
       <div class="nutrient-sections">
         {CATEGORIES.map(({ key, label }) => {
           const fields = NUTRIENT_FIELDS.filter((f) => f.category === key)
@@ -473,12 +524,21 @@ function CompositeOrAtomicSection({ item, ingredientsMutation, clearMutation, sa
               <div class="nutrient-grid">
                 {fields.map((f) => {
                   const value = item[f.name as keyof ApiFoodItemDetail]
+                  const selfValue = typeof value === 'number' ? value : undefined
+                  const enriched = enrichedFields[f.name]
+                  const inheritedValue =
+                    selfValue === undefined &&
+                    enriched?.origin === 'reference' &&
+                    typeof enriched.value === 'number'
+                      ? enriched.value
+                      : undefined
                   return (
                     <div key={f.name} class="nutrient-row">
                       <span class="nutrient-label">{f.label}</span>
                       <NutrientInput
                         field={f}
-                        initial={typeof value === 'number' ? value : undefined}
+                        initial={selfValue}
+                        inheritedValue={inheritedValue}
                         onCommit={(v) => save({ [f.name]: v })}
                       />
                     </div>
@@ -490,5 +550,84 @@ function CompositeOrAtomicSection({ item, ingredientsMutation, clearMutation, sa
         })}
       </div>
     </>
+  )
+}
+
+function ReferencePicker({
+  item,
+  referenceMutation,
+}: {
+  item: ApiFoodItemDetail
+  referenceMutation: { mutate: (referenceId: string | null) => void; isPending: boolean }
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [draftName, setDraftName] = useState('')
+  const ref = item.reference?.food
+  const unitMismatch = item.reference?.unit_mismatch ?? false
+
+  return (
+    <div class="fi-reference-row">
+      <label class="fi-reference-label">Reference food</label>
+      {ref && !pickerOpen && (
+        <span class="fi-reference-current">
+          <a href={`/food-items/${ref.id}`} class="fi-reference-name">
+            {ref.icon && isEmoji(ref.icon) && <span class="fi-icon-display-inline">{ref.icon}</span>}
+            {ref.name}
+          </a>
+          <button
+            type="button"
+            class="btn-link"
+            onClick={() => {
+              setDraftName(ref.name)
+              setPickerOpen(true)
+            }}
+            disabled={referenceMutation.isPending}
+          >
+            Change
+          </button>
+          <button
+            type="button"
+            class="btn-link btn-link-danger"
+            onClick={() => referenceMutation.mutate(null)}
+            disabled={referenceMutation.isPending}
+          >
+            Clear
+          </button>
+        </span>
+      )}
+      {(!ref || pickerOpen) && (
+        <span class="fi-reference-picker">
+          <FoodItemAutocomplete
+            value={draftName}
+            onChange={setDraftName}
+            onSelect={(picked) => {
+              if (picked.id === item.id) return
+              referenceMutation.mutate(picked.id)
+              setPickerOpen(false)
+              setDraftName('')
+            }}
+            placeholder="Search for a reference food…"
+          />
+          {pickerOpen && (
+            <button
+              type="button"
+              class="btn-link"
+              onClick={() => {
+                setPickerOpen(false)
+                setDraftName('')
+              }}
+            >
+              Cancel
+            </button>
+          )}
+        </span>
+      )}
+      {ref && unitMismatch && (
+        <p class="fi-reference-warning">
+          ⚠ Unit mismatch — this item's default unit ({item.default_unit ?? '?'}) can't be converted to the
+          reference's ({ref.default_unit ?? '?'}). Inherited values are shown unscaled.
+        </p>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -55,11 +55,13 @@ const findMealsForSlot = (meals: Meal[], slotName: string): Meal[] =>
 /** A clickable food item chip with popover for sensitivity mapping. */
 function FoodItemChip({
   name,
+  foodItemId,
   mappedSensitivities,
   sensitivityAreas,
   onToggle,
 }: {
   name: string
+  foodItemId?: string
   mappedSensitivities: string[]
   sensitivityAreas: string[]
   onToggle: (foodItem: string, area: string, checked: boolean) => void
@@ -85,7 +87,16 @@ function FoodItemChip({
       {hasMappings && <span class="mapping-dot" />}
       {open && sensitivityAreas.length > 0 && (
         <div class="food-map-popover" onClick={(e) => e.stopPropagation()}>
-          <div class="popover-title">Flags for "{name}"</div>
+          <div class="popover-title">
+            Flags for{' '}
+            {foodItemId ? (
+              <a href={`/food-items/${foodItemId}`} class="popover-title-link">
+                "{name}"
+              </a>
+            ) : (
+              `"${name}"`
+            )}
+          </div>
           {sensitivityAreas.map((area) => (
             <label key={area} class="popover-option">
               <input
@@ -132,6 +143,7 @@ function MealDetails({
             <FoodItemChip
               key={i}
               name={item.name}
+              foodItemId={item.food_item_id}
               mappedSensitivities={foodSensitivityMap[item.name] ?? []}
               sensitivityAreas={sensitivityAreas}
               onToggle={onToggleFoodMapping}

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -513,6 +513,15 @@ a.meal-name:hover {
   white-space: nowrap;
 }
 
+.popover-title-link {
+  color: #673ab8;
+  text-decoration: none;
+}
+
+.popover-title-link:hover {
+  text-decoration: underline;
+}
+
 .popover-option {
   display: flex;
   align-items: center;

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -36,6 +36,10 @@ export const foodItemEntitySchema = nutrientFieldsSchema
       description:
         'True if this is a composite (recipe) item — its nutrient values are derived from food_item_ingredients at read time.',
     }),
+    reference_food_item_id: z.string().uuid().optional().meta({
+      description:
+        'Optional pointer to a richer canonical food item (typically a central library row, e.g. an LSV item) used to inherit empty micronutrient fields. Per-user atomic items only.',
+    }),
     name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
     source: z
       .string()
@@ -117,6 +121,41 @@ export type ResolvedFoodItemIngredient = z.infer<typeof resolvedFoodItemIngredie
  * `ingredients` and `derived_nutrients` are absent and the entity's own
  * nutrient values are authoritative.
  */
+export const fieldOriginSchema = z
+  .object({
+    origin: z.enum(['self', 'reference']).meta({
+      description:
+        '"self" if the value comes from this food item directly; "reference" if inherited from the referenced canonical item (scaled to this serving).',
+    }),
+    value: z.union([z.number(), z.string()]),
+  })
+  .meta({ description: 'Per-field origin info for a reference-enriched food item', id: 'FieldOrigin' })
+
+export type FieldOrigin = z.infer<typeof fieldOriginSchema>
+
+export const referencedFoodSchema = z
+  .object({
+    food: foodItemEntitySchema,
+    unit_mismatch: z.boolean().meta({
+      description:
+        'True when the self item and reference have units that cannot be converted (e.g. "1 slice" vs "100 g") — inherited values are emitted at scale=1 with this flag so the UI can warn.',
+    }),
+  })
+  .meta({ description: 'Resolved reference for an enriched food item', id: 'ReferencedFood' })
+
+export type ReferencedFood = z.infer<typeof referencedFoodSchema>
+
+export const referenceEnrichedFieldsSchema = z
+  .object({
+    fields: z.record(z.string(), fieldOriginSchema).meta({
+      description:
+        'Per-field origin map. Self values always win when set; reference values fill empty fields, scaled to the self serving.',
+    }),
+  })
+  .meta({ id: 'ReferenceEnrichedFields' })
+
+export type ReferenceEnrichedFields = z.infer<typeof referenceEnrichedFieldsSchema>
+
 export const foodItemDetailSchema = foodItemEntitySchema
   .extend({
     ingredients: z.array(resolvedFoodItemIngredientSchema).optional(),
@@ -131,10 +170,27 @@ export const foodItemDetailSchema = foodItemEntitySchema
       })
       .optional()
       .meta({ description: 'Nutrient totals derived from ingredients (composite items only)' }),
+    reference: referencedFoodSchema.optional().meta({
+      description: 'The referenced canonical food item (atomic items only).',
+    }),
+    reference_enriched: referenceEnrichedFieldsSchema.optional().meta({
+      description: 'Per-field origin info when a reference is set.',
+    }),
   })
   .meta({ description: 'Food item detail with optional composite ingredients', id: 'FoodItemDetail' })
 
 export type FoodItemDetail = z.infer<typeof foodItemDetailSchema>
+
+export const setFoodItemReferenceBodySchema = z
+  .object({
+    reference_food_item_id: z.string().uuid().nullable().meta({
+      description:
+        'ID of the food item to reference (per-user OR central). Pass null to clear the reference.',
+    }),
+  })
+  .meta({ description: 'Set or clear the reference_food_item_id pointer', id: 'SetFoodItemReferenceBody' })
+
+export type SetFoodItemReferenceBody = z.infer<typeof setFoodItemReferenceBodySchema>
 
 // ============================================================================
 // Request Schemas


### PR DESCRIPTION
## Summary

Phase 6 of the food-items overhaul: a per-user atomic item can now point at a richer canonical food (typically central LSV) via `reference_food_item_id`, inheriting micronutrients while keeping its own label-derived macros.

- Storage stays sparse — only fields the user/label populated are non-null on self.
- On read, the service fills empty fields from the reference, scaled by `self.default_quantity / reference.default_quantity` (with g↔kg, ml↔dl conversion). Mismatched dimensions surface a `unit_mismatch` flag instead of silently producing wrong-magnitude numbers.
- Composite items take precedence — their nutrients derive from ingredients, references on composites are ignored.
- REST + MCP parity: PUT/DELETE `/food-items/:id/reference` and `set_food_item_reference` MCP tool.
- Detail page shows the reference picker for atomic items, an italic/grey "ref" badge on inherited cells, and a unit-mismatch warning when applicable.

## Test plan

- [x] `pnpm check` passes
- [x] Service unit tests: self-wins / scaling / unit-mismatch / composite precedence (24 tests)
- [x] Integration test: setFoodItemReference round-trip
- [ ] Manual: create "Hushållsost (Arla)" with macros only, point at LSV "Hushållsost", verify italic/grey micros render and override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)