### PR TITLE
fix(food-items): cache composite derived totals + propagate to parents

### DIFF
--- a/apps/backend/src/db/food-item-ingredients.ts
+++ b/apps/backend/src/db/food-item-ingredients.ts
@@ -136,6 +136,23 @@ export const clearIngredients = async (user: string, parentFoodItemId: string): 
 }
 
 /**
+ * Find every composite parent that uses the given food item as one of its
+ * ingredients. Used by the cache-propagation flow: when an item's effective
+ * nutrient values change, every parent recipe needs its row cache refreshed.
+ */
+export const findCompositeParentsOfIngredient = async (
+  user: string,
+  ingredientFoodItemId: string,
+): Promise<string[]> => {
+  const result = await query(
+    user,
+    'SELECT DISTINCT parent_food_item_id FROM food_item_ingredients WHERE ingredient_food_item_id = $1',
+    [ingredientFoodItemId],
+  )
+  return result.rows.map((row) => row.parent_food_item_id as string)
+}
+
+/**
  * Batch fetch ingredients for several parents at once. Returns a map keyed
  * by parent_food_item_id; absent keys = no ingredients.
  */

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -240,6 +240,7 @@ export {
 // Food item ingredients (composite/recipe support)
 export {
   clearIngredients,
+  findCompositeParentsOfIngredient,
   type FoodItemIngredientInput,
   type FoodItemIngredientRow,
   getIngredients,

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -28,7 +28,12 @@ import {
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
-import { createFoodItemsMergeService, createFoodItemsService } from '../services/food-items.ts'
+import {
+  cacheCompositeNutrients,
+  clearCompositeNutrientCache,
+  createFoodItemsMergeService,
+  createFoodItemsService,
+} from '../services/food-items.ts'
 import { resnapshotMealsForFoodItem } from '../services/meals.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
 
@@ -130,6 +135,7 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
         return errorResponse('Setting these ingredients would create a cycle in the recipe graph')
       }
       await setIngredients(user, id, ingredients)
+      await cacheCompositeNutrients(user, centralDb, id)
       const detail = await foodItems.getDetail(user, id)
       if (!detail) return errorResponse('Food item not found')
       return jsonResponse({ data: detail, success: true })
@@ -149,6 +155,7 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
         )
       }
       await clearIngredients(user, id)
+      await clearCompositeNutrientCache(user, centralDb, id)
       const detail = await foodItems.getDetail(user, id)
       if (!detail) return errorResponse('Food item not found')
       return jsonResponse({ data: detail, success: true })

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -47,6 +47,8 @@ import {
   upsertFoodItem,
 } from '../db/index.ts'
 import {
+  cacheCompositeNutrients,
+  clearCompositeNutrientCache,
   createFoodItemsMergeService,
   createFoodItemsService,
   type FoodItemDetail as ServiceFoodItemDetail,
@@ -193,6 +195,10 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       await dbSetIngredients(user, id, ingredients)
+      // Refresh the cached derived nutrients on this row + every parent
+      // recipe that uses this item — keeps search results, frequent-meal
+      // cards, and outer-recipe totals in sync without lazy recomputation.
+      await cacheCompositeNutrients(user, centralDb, id)
       const detail = await service.getDetail(user, id)
       if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
       res.json({ data: serializeDetail(detail), success: true })
@@ -215,6 +221,7 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       await dbClearIngredients(user, id)
+      await clearCompositeNutrientCache(user, centralDb, id)
       const detail = await service.getDetail(user, id)
       if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
       res.json({ data: serializeDetail(detail), success: true })

--- a/apps/backend/src/services/food-items-cache.integration.test.ts
+++ b/apps/backend/src/services/food-items-cache.integration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration tests for the composite-nutrient cache.
+ *
+ * The cache writes derived totals onto a composite's `food_items` row columns
+ * so search dropdowns, frequent-meal queries, and parent recipes that read
+ * `food.calories` directly all see live values. Editing a recipe must also
+ * propagate up to every parent recipe that uses it as an ingredient.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { CentralDb } from './central-db.ts'
+
+import { setIngredients } from '../db/food-item-ingredients.ts'
+import { getFoodItemById, upsertFoodItem } from '../db/food-items.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { cacheCompositeNutrients, clearCompositeNutrientCache } from './food-items.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+// All ingredients live in the per-user DB, so the central DB is never hit.
+// A bare stub satisfies the type without needing a real connection.
+const stubCentral = (): CentralDb =>
+  ({
+    getSharedFoodItemById: async () => null,
+    getSharedFoodItemByName: async () => null,
+    listSharedFoodItems: async () => [],
+    searchSharedFoodItems: async () => [],
+    upsertSharedFoodItem: async () => undefined,
+  }) as unknown as CentralDb
+
+describe('cacheCompositeNutrients integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('writes derived totals onto the composite row + propagates to parent recipes', async () => {
+    const user = getTestUser()
+    // Atomic leaves.
+    const oil = await upsertFoodItem(user, {
+      calories: 900,
+      default_quantity: 100,
+      default_unit: 'g',
+      fat: 100,
+      vitamin_e: 17,
+      name: 'Olive oil',
+    })
+    const garlic = await upsertFoodItem(user, {
+      calories: 100,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Garlic',
+    })
+
+    // Composite A: 50 g oil → 450 kcal, 8.5 mg vitamin E.
+    const recipeA = await upsertFoodItem(user, {
+      calories: 9999, // stale leftover; the cache should overwrite this
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Garlic oil',
+    })
+    await setIngredients(user, recipeA.id, [
+      { ingredient_food_item_id: oil.id, quantity: 50, sort_order: 0, unit: 'g' },
+      { ingredient_food_item_id: garlic.id, quantity: 10, sort_order: 1, unit: 'g' },
+    ])
+
+    // Composite B contains A as an ingredient (1 recipe of A → A's totals).
+    const recipeB = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'serving',
+      name: 'Pasta with garlic oil',
+    })
+    await setIngredients(user, recipeB.id, [
+      { ingredient_food_item_id: recipeA.id, quantity: 1, sort_order: 0, unit: 'recipe' },
+    ])
+
+    // Cache for A: derived from leaves; should overwrite stale 9999 calories.
+    await cacheCompositeNutrients(user, stubCentral(), recipeA.id)
+    const cachedA = await getFoodItemById(user, recipeA.id)
+    expect(cachedA?.calories).toBe(460) // 50 g × 9 + 10 g × 1 = 450 + 10 = 460
+    expect(cachedA?.fat).toBe(50) // 50 g × 1 g/g
+    expect(cachedA?.vitamin_e).toBe(8.5) // 50 g × 17 mg / 100 g
+
+    // Edit A: drop the garlic; cache + propagate.
+    await setIngredients(user, recipeA.id, [
+      { ingredient_food_item_id: oil.id, quantity: 50, sort_order: 0, unit: 'g' },
+    ])
+    await cacheCompositeNutrients(user, stubCentral(), recipeA.id)
+
+    const cachedA2 = await getFoodItemById(user, recipeA.id)
+    expect(cachedA2?.calories).toBe(450)
+
+    // B's row cache must have been refreshed too — it reads A's now-cached
+    // calories (450) × 1 recipe × scale 1 = 450.
+    const cachedB = await getFoodItemById(user, recipeB.id)
+    expect(cachedB?.calories).toBe(450)
+    expect(cachedB?.vitamin_e).toBe(8.5)
+  })
+
+  test('clearCompositeNutrientCache nulls the cached columns and refreshes parents', async () => {
+    const user = getTestUser()
+    const oil = await upsertFoodItem(user, {
+      calories: 900,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Olive oil',
+    })
+    const recipeA = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Recipe A',
+    })
+    await setIngredients(user, recipeA.id, [
+      { ingredient_food_item_id: oil.id, quantity: 50, sort_order: 0, unit: 'g' },
+    ])
+    const recipeB = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Recipe B',
+    })
+    await setIngredients(user, recipeB.id, [
+      { ingredient_food_item_id: recipeA.id, quantity: 1, sort_order: 0, unit: 'recipe' },
+    ])
+    await cacheCompositeNutrients(user, stubCentral(), recipeA.id)
+    expect((await getFoodItemById(user, recipeA.id))?.calories).toBe(450)
+    expect((await getFoodItemById(user, recipeB.id))?.calories).toBe(450)
+
+    await clearCompositeNutrientCache(user, stubCentral(), recipeA.id)
+    // A's cache nulled.
+    expect((await getFoodItemById(user, recipeA.id))?.calories).toBeUndefined()
+    // B's cache recomputed — A no longer contributes (resolves but yields 0/null),
+    // so B drops to 0 / null too.
+    const cachedB = await getFoodItemById(user, recipeB.id)
+    expect(cachedB?.calories === undefined || cachedB.calories === 0).toBe(true)
+  })
+
+  test('non-composite items are not touched by cacheCompositeNutrients', async () => {
+    const user = getTestUser()
+    const atom = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Bread',
+    })
+    await cacheCompositeNutrients(user, stubCentral(), atom.id)
+    // Calories untouched — the user's authoritative value stays.
+    expect((await getFoodItemById(user, atom.id))?.calories).toBe(200)
+  })
+})

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -19,6 +19,7 @@ import type { SharedFoodItemEntity } from './central-food-items.ts'
 
 import { query } from '../db/connection.ts'
 import {
+  findCompositeParentsOfIngredient,
   type FoodItemIngredientRow,
   getIngredients as dbGetIngredients,
 } from '../db/food-item-ingredients.ts'
@@ -30,6 +31,7 @@ import {
   type MergeFoodItemResult,
   mergeFoodItems as dbMergeFoodItems,
   searchFoodItems as searchUserFoodItems,
+  updateFoodItem as dbUpdateFoodItem,
 } from '../db/food-items.ts'
 
 /**
@@ -380,6 +382,81 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
     return false
   },
 })
+
+// ============================================================================
+// Composite nutrient cache
+// ============================================================================
+
+/**
+ * Recompute a composite item's derived nutrient totals and write them onto
+ * its `food_items` row columns, then walk up to every parent recipe that
+ * uses this item and re-cache them too.
+ *
+ * Why cache: read paths (search dropdown, frequent-meal queries, parent
+ * recipes summing ingredient values) all read `food_items.<nutrient>`
+ * directly from the row. Without the cache, composite rows have stale or
+ * null values from before the conversion to composite, so search shows
+ * dashes and parents-of-composites silently miss their child's contribution.
+ *
+ * Why propagate: editing recipe A invalidates the cache on every recipe B
+ * that contains A. Without propagation a parent stays at the previous totals
+ * until manually re-saved. The recursion terminates because the cycle check
+ * in `wouldCreateCycle` rejects ingredient cycles, but `visited` is a
+ * defence-in-depth guard.
+ *
+ * Atomic items aren't touched — their nutrients are user-authoritative.
+ */
+export const cacheCompositeNutrients = async (
+  user: string,
+  centralDb: CentralDb,
+  foodItemId: string,
+  visited: Set<string> = new Set(),
+): Promise<void> => {
+  if (visited.has(foodItemId)) return
+  visited.add(foodItemId)
+
+  const item = await getUserFoodItemById(user, foodItemId)
+  if (!item?.is_composite) return
+
+  const service = createFoodItemsService(centralDb)
+  const detail = await service.getDetail(user, foodItemId)
+  const values = detail?.derived_nutrients?.values ?? {}
+
+  const update: Record<string, number | null> = {}
+  for (const field of NUTRIENT_FIELD_NAMES) {
+    const v = values[field]
+    update[field] = typeof v === 'number' ? v : null
+  }
+  await dbUpdateFoodItem(user, foodItemId, update)
+
+  const parents = await findCompositeParentsOfIngredient(user, foodItemId)
+  for (const parentId of parents) {
+    await cacheCompositeNutrients(user, centralDb, parentId, visited)
+  }
+}
+
+/**
+ * Mirror of `cacheCompositeNutrients` for the clear-ingredients path: null
+ * out the cached nutrient columns (the item is no longer composite, so its
+ * row should not carry stale derived totals), then refresh parents.
+ */
+export const clearCompositeNutrientCache = async (
+  user: string,
+  centralDb: CentralDb,
+  foodItemId: string,
+): Promise<void> => {
+  const update: Record<string, null> = {}
+  for (const field of NUTRIENT_FIELD_NAMES) update[field] = null
+  await dbUpdateFoodItem(user, foodItemId, update)
+
+  // Don't recurse through this id: the parents need refreshing, but we
+  // already updated this row, and the item itself is no longer composite.
+  const parents = await findCompositeParentsOfIngredient(user, foodItemId)
+  const visited = new Set([foodItemId])
+  for (const parentId of parents) {
+    await cacheCompositeNutrients(user, centralDb, parentId, visited)
+  }
+}
 
 // ============================================================================
 // Merge two food items

--- a/apps/backend/src/services/meals.test.ts
+++ b/apps/backend/src/services/meals.test.ts
@@ -52,6 +52,9 @@ vi.mock('./food-items.ts', () => ({
   }),
   // The real service exports getEffectiveNutrients used by syncFoodItemsToJunction.
   getEffectiveNutrients: vi.fn().mockReturnValue({}),
+  // No-op for unit tests — the resnapshot path calls this; the mock just
+  // returns void to satisfy the awaiter.
+  cacheCompositeNutrients: vi.fn().mockResolvedValue(undefined),
 }))
 
 const mockUpsertMeal = vi.mocked(db.upsertMeal)

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -25,7 +25,12 @@ import {
   type Micros,
 } from '../db/index.ts'
 import { getCentralDb } from './central-db.ts'
-import { createFoodItemsService, getEffectiveNutrients, type MergedFoodItem } from './food-items.ts'
+import {
+  cacheCompositeNutrients,
+  createFoodItemsService,
+  getEffectiveNutrients,
+  type MergedFoodItem,
+} from './food-items.ts'
 
 // ============================================================================
 // Types
@@ -414,7 +419,13 @@ export async function resnapshotMealsForFoodItem(
   user: string,
   foodItemId: string,
 ): Promise<ResnapshotMealsResult> {
-  const service = createFoodItemsService(getCentralDb())
+  const centralDb = getCentralDb()
+  // Refresh the row-level derived cache first so the search dropdown,
+  // frequent-meal queries, and parent recipes pick up the same values that
+  // the meal snapshots are about to be rebuilt from. No-op for atomic items.
+  await cacheCompositeNutrients(user, centralDb, foodItemId)
+
+  const service = createFoodItemsService(centralDb)
   const detail = await service.getDetail(user, foodItemId)
   if (!detail) throw new Error('Food item not found')
   const canonical = detail.item


### PR DESCRIPTION
## Summary

Three connected symptoms with one root cause:

- Search dropdown showed `-` for every nutrient on a composite recipe (Fetkaffe etc.)
- A parent recipe that contained a composite child silently dropped the child's derived contribution (vitamin E from a sub-recipe didn't roll up)
- Frequent-meal cards / other lookups for composite items hit the same stale column

All three read `food_items.<nutrient>` directly off the row, but for composites the row columns are sparse leftovers from before the conversion to composite — the live derived totals only existed inside `getDetail`'s response.

Fix: when a composite's ingredients change, compute derived totals once and write them onto its row columns. Then walk parent recipes via `findCompositeParentsOfIngredient` and refresh each. Bounded by the existing ingredient cycle check + a `visited` guard.

The existing **Re-snapshot meals** button now calls the cache refresh up-front, so clicking it on an existing recipe heals the row cache, propagates to parents, and rebuilds meal snapshots in one click — that's the user-facing migration for already-affected recipes.

## Test plan

- [x] `pnpm check` clean
- [x] New integration: cacheCompositeNutrients writes derived to row, propagates to parent recipes, leaves atomic items untouched; clearCompositeNutrientCache nulls cached columns and refreshes parents
- [x] Existing meals + food-items + route + MCP suites still pass
- [ ] Manual: open Fetkaffe, edit ingredients (no real change), save → confirm search dropdown shows `327.72 kcal`. Open the parent recipe → vitamin E sums in. Hit "Re-snapshot meals" on an old recipe → confirm meal totals match the recipe page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)