### PR TITLE
fix(food-items): PATCH returns full detail so rename keeps ingredients

### DIFF
--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -82,7 +82,12 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
       }
       const item = await updateFoodItem(user, id, params)
       if (!item) return errorResponse('Food item not found')
-      return jsonResponse({ data: item, success: true })
+      // Mirror the REST PATCH: return the full detail so callers see the
+      // current ingredients / derived nutrients / reference enrichment, not
+      // just the row columns.
+      const detail = await foodItems.getDetail(user, id)
+      if (!detail) return errorResponse('Food item not found')
+      return jsonResponse({ data: detail, success: true })
     },
   )
 

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -267,3 +267,43 @@ describe('POST /food-items/:id/resnapshot-meals', () => {
     expect(res.status).toBe(500)
   })
 })
+
+describe('PATCH /food-items/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns the full detail (not just the entity) so the UI cache keeps ingredients on rename', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    const updated = userItem(id, { is_composite: true, name: 'Renamed Recipe' })
+    setUserFoodItem(async (_u, fid) => (fid === id ? updated : null))
+    vi.mocked(dbBarrel.updateFoodItem).mockResolvedValue(updated)
+    // The composite branch of getDetail loads ingredients via getIngredients,
+    // which we mock to return one row.
+    const ingredientsModule = await import('../db/food-item-ingredients.ts')
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([
+      {
+        created_at: new Date(),
+        id: 'i1',
+        ingredient_food_item_id: '22222222-2222-4222-8222-222222222222',
+        parent_food_item_id: id,
+        quantity: 50,
+        sort_order: 0,
+        unit: 'g',
+        updated_at: new Date(),
+      },
+    ])
+
+    const res = await supertest(buildApp(fakeCentral()))
+      .patch(`/food-items/${id}`)
+      .send({ name: 'Renamed Recipe' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.name).toBe('Renamed Recipe')
+    // Crucially: ingredients + derived_nutrients are present so the frontend
+    // cache update doesn't strip them.
+    expect(Array.isArray(res.body.data.ingredients)).toBe(true)
+    expect(res.body.data.ingredients).toHaveLength(1)
+    expect(res.body.data.derived_nutrients).toBeDefined()
+  })
+})

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -136,7 +136,7 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
     },
   )
 
-  router.patch<{ id: string }, FoodItemResponse, UpdateFoodItemBody>(
+  router.patch<{ id: string }, FoodItemDetailResponse, UpdateFoodItemBody>(
     '/:id',
     authMiddleware,
     validateBody(updateFoodItemBodySchema),
@@ -151,9 +151,13 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
           success: false,
         })
       }
-      const item = await updateFoodItem(req.user!, req.params.id, req.body)
-      if (!item) return res.status(404).json({ error: 'Food item not found', success: false })
-      res.json({ data: serializeFoodItem(item), success: true })
+      const updated = await updateFoodItem(req.user!, req.params.id, req.body)
+      if (!updated) return res.status(404).json({ error: 'Food item not found', success: false })
+      // Return the full detail (ingredients + derived + reference) so the UI
+      // doesn't replace its cached detail with a stripped entity on rename.
+      const detail = await service.getDetail(req.user!, req.params.id)
+      if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+      res.json({ data: serializeDetail(detail), success: true })
     },
   )
 


### PR DESCRIPTION
## Summary

User reported renaming a recipe seemed to delete all its ingredients. The DB is fine — the bug is in the round trip:

- PATCH `/food-items/:id` was typed to return `FoodItemResponse` (the row only).
- Frontend called `queryClient.setQueryData(['foodItem', id], updated)` with that stripped response.
- The cached `FoodItemDetail` (with `ingredients`, `derived_nutrients`, `reference`) was replaced by the bare entity → UI re-renders empty.

A hard refresh would re-fetch via GET (which returns the full detail) and the ingredients reappeared. So no data was lost; just a cache-shape mismatch.

Fix: make PATCH (and the MCP `update_food_item` tool) return `FoodItemDetailResponse` like GET does.

## Test plan

- [x] `pnpm check` clean
- [x] New route test: PATCH on a composite returns `ingredients` + `derived_nutrients` in the response body
- [ ] Manual: rename a composite recipe — confirm ingredients stay visible without a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)