### PR TITLE
fix(sync): background HC permission + defer HR calorie compute

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,14 @@
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 
+    <!--
+        Background access lets WorkManager periodic sync read Health Connect
+        data when Aurboda is not in the foreground. The user has to grant the
+        relevant foreground read permissions first; Health Connect then offers
+        a separate "all the time" / "while in use" choice for this permission.
+    -->
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
+
     <!-- Alphabetically Sorted Health Permissions -->
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED"/>
     <uses-permission android:name="android.permission.health.READ_BASAL_BODY_TEMPERATURE" />

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectPermissions.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectPermissions.kt
@@ -10,8 +10,8 @@ import kotlin.reflect.KClass
  * least one foreground read permission. Without it, [SyncWorker]'s periodic
  * job throws HealthConnectException when reading.
  */
-const val HC_BACKGROUND_READ_PERMISSION: String =
-    "android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"
+val HC_BACKGROUND_READ_PERMISSION: String =
+    HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND
 
 /**
  * A user-friendly grouping of Health Connect record types into categories.

--- a/apps/android/app/src/main/java/net/aurboda/HealthConnectPermissions.kt
+++ b/apps/android/app/src/main/java/net/aurboda/HealthConnectPermissions.kt
@@ -5,6 +5,15 @@ import androidx.health.connect.client.records.*
 import kotlin.reflect.KClass
 
 /**
+ * Permission required to read Health Connect data while Aurboda is not in the
+ * foreground. Health Connect only grants this after the user has granted at
+ * least one foreground read permission. Without it, [SyncWorker]'s periodic
+ * job throws HealthConnectException when reading.
+ */
+const val HC_BACKGROUND_READ_PERMISSION: String =
+    "android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"
+
+/**
  * A user-friendly grouping of Health Connect record types into categories.
  */
 data class HealthDataCategory(

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -394,8 +394,11 @@ fun HealthConnectScreen(
     remember(allRecordTypes) {
       val readPerms = allRecordTypes.map { HealthPermission.getReadPermission(it) }
       val writePerms = writableRecordTypes.map { HealthPermission.getWritePermission(it) }
-      (readPerms + writePerms).toSet()
+      (readPerms + writePerms + HC_BACKGROUND_READ_PERMISSION).toSet()
     }
+  val hasBackgroundReadPermission by remember(grantedPermissions) {
+    derivedStateOf { HC_BACKGROUND_READ_PERMISSION in grantedPermissions }
+  }
   val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
 
   /**
@@ -820,6 +823,44 @@ fun HealthConnectScreen(
                 }
               },
             )
+          }
+
+          // Background read permission is granted separately from foreground reads:
+          // Health Connect requires the user to grant at least one foreground read first,
+          // then offers a separate "all the time" / "while in use" prompt for this one.
+          if (hasAnyPermissions && !hasBackgroundReadPermission) {
+            androidx.compose.material3.Surface(
+              shape = MaterialTheme.shapes.small,
+              color = MaterialTheme.colorScheme.surfaceVariant,
+              modifier = Modifier.fillMaxWidth(),
+            ) {
+              Column(modifier = Modifier.padding(12.dp)) {
+                Text(
+                  "Background access not granted",
+                  style = MaterialTheme.typography.bodyMedium,
+                  fontWeight = FontWeight.Bold,
+                )
+                androidx.compose.foundation.layout
+                  .Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                  "Periodic background sync needs Health Connect to allow reads " +
+                    "while Aurboda is closed. Without it, the every-15-minute job " +
+                    "fails until you open the app.",
+                  style = MaterialTheme.typography.bodySmall,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                androidx.compose.foundation.layout
+                  .Spacer(modifier = Modifier.height(8.dp))
+                androidx.compose.material3.OutlinedButton(
+                  onClick = {
+                    requestPermissionLauncher.launch(arrayOf(HC_BACKGROUND_READ_PERMISSION))
+                  },
+                  modifier = Modifier.fillMaxWidth(),
+                ) {
+                  Text("Allow Background Access")
+                }
+              }
+            }
           }
 
           Button(

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -74,25 +74,30 @@ class SyncWorker(
       // Step 0: Process pending local data entries (Add Data offline queue)
       processPendingData(credentials.apiUrl, credentials.authToken, reporter)
 
-      // Step 1: Fetch and send daily aggregates for cumulative metrics (deduplicated)
-      val aggregates = fetchDailyAggregates(healthConnectClient, grantedTypes.toSet(), days = 7)
-      if (aggregates.isNotEmpty()) {
-        val aggregateSuccess = sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken, httpClient, reporter)
-        if (!aggregateSuccess) {
-          Log.w(TAG, "Failed to send daily aggregates, will retry")
-          reporter.end("Daily aggregates failed")
-          return Result.retry()
-        }
-        Log.d(TAG, "Sent ${aggregates.size} daily aggregates")
-      } else {
-        reporter.updateStage(SyncStage.DailyAggregates) {
-          it.copy(status = SyncStageStatus.Done, message = "Nothing to send")
-        }
-      }
-
-      // Step 2: Fetch and send raw records incrementally (page by page).
-      // Skip if the background read permission isn't granted -- foreground will catch up.
+      // Steps 1 & 2 both read from Health Connect (aggregate / getChanges) and
+      // both fail with HealthConnectException without the background read
+      // permission. Skip both as a unit; the foreground app will catch up on
+      // the next open. Outbound sync (Step 3) only writes to HC, so it runs
+      // either way.
       if (hasBackgroundRead) {
+        // Step 1: Fetch and send daily aggregates for cumulative metrics (deduplicated)
+        val aggregates = fetchDailyAggregates(healthConnectClient, grantedTypes.toSet(), days = 7)
+        if (aggregates.isNotEmpty()) {
+          val aggregateSuccess =
+            sendDailyAggregates(aggregates, credentials.apiUrl, credentials.authToken, httpClient, reporter)
+          if (!aggregateSuccess) {
+            Log.w(TAG, "Failed to send daily aggregates, will retry")
+            reporter.end("Daily aggregates failed")
+            return Result.retry()
+          }
+          Log.d(TAG, "Sent ${aggregates.size} daily aggregates")
+        } else {
+          reporter.updateStage(SyncStage.DailyAggregates) {
+            it.copy(status = SyncStageStatus.Done, message = "Nothing to send")
+          }
+        }
+
+        // Step 2: Fetch and send raw records incrementally (page by page).
         val syncSuccess = fetchAndSyncHealthData(credentials.apiUrl, credentials.authToken, reporter)
         if (!syncSuccess) {
           Log.w(TAG, "Incremental sync failed, will retry")
@@ -100,11 +105,11 @@ class SyncWorker(
           return Result.retry()
         }
       } else {
+        reporter.updateStage(SyncStage.DailyAggregates) {
+          it.copy(status = SyncStageStatus.Skipped, message = "Background read permission required")
+        }
         reporter.updateStage(SyncStage.HealthConnect) {
-          it.copy(
-            status = SyncStageStatus.Skipped,
-            message = "Background read permission required",
-          )
+          it.copy(status = SyncStageStatus.Skipped, message = "Background read permission required")
         }
       }
 

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -57,6 +57,15 @@ class SyncWorker(
     }
     Log.d(TAG, "Granted ${grantedTypes.size}/${allRecordTypes.size} record types")
 
+    // Without the background read permission, every Health Connect read here
+    // throws SecurityException/HealthConnectException. Skip HC reads cleanly
+    // (the foreground app will sync when it next opens). Outbound sync, the
+    // pending-data flush and ActivityWatch don't need HC reads, so still run.
+    val hasBackgroundRead = HC_BACKGROUND_READ_PERMISSION in grantedPermissions
+    if (!hasBackgroundRead) {
+      Log.w(TAG, "Background HC read permission not granted; skipping HC fetch")
+    }
+
     // Invalidate token if granted types changed since last sync
     invalidateTokenIfGrantedTypesChanged(grantedTypes)
 
@@ -81,12 +90,22 @@ class SyncWorker(
         }
       }
 
-      // Step 2: Fetch and send raw records incrementally (page by page)
-      val syncSuccess = fetchAndSyncHealthData(credentials.apiUrl, credentials.authToken, reporter)
-      if (!syncSuccess) {
-        Log.w(TAG, "Incremental sync failed, will retry")
-        reporter.end("Health Connect sync failed")
-        return Result.retry()
+      // Step 2: Fetch and send raw records incrementally (page by page).
+      // Skip if the background read permission isn't granted -- foreground will catch up.
+      if (hasBackgroundRead) {
+        val syncSuccess = fetchAndSyncHealthData(credentials.apiUrl, credentials.authToken, reporter)
+        if (!syncSuccess) {
+          Log.w(TAG, "Incremental sync failed, will retry")
+          reporter.end("Health Connect sync failed")
+          return Result.retry()
+        }
+      } else {
+        reporter.updateStage(SyncStage.HealthConnect) {
+          it.copy(
+            status = SyncStageStatus.Skipped,
+            message = "Background read permission required",
+          )
+        }
       }
 
       // Step 3: Process outbound sync (backend -> Health Connect).

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -50,6 +50,8 @@ import { stravaClient } from './integrations/strava/client.ts'
 import { createMcpRouter } from './mcp.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
 import { auditError } from './services/audit-log.ts'
+import { triggerCalorieComputation } from './services/calorie-computation.ts'
+import { createCalorieQueue, type CalorieQueue } from './services/calorie-queue.ts'
 import { getCentralDb, initializeCentralDb } from './services/central-db.ts'
 import { createDefaultEngineDeps } from './services/deduction-deps.ts'
 import { buildFullWindow, evaluateAllRules } from './services/deduction-engine.ts'
@@ -219,6 +221,21 @@ const main = async () => {
     console.warn('⚠️ Deduction auto-evaluation disabled - rules will only run on manual trigger')
   }
 
+  // Initialize calorie computation queue (uses shared boss).
+  // Without this, HR ingestion falls back to fire-and-forget which still
+  // returns the response fast but loses the cross-instance batching.
+  let calorieQueue: CalorieQueue | null = null
+  if (boss) {
+    try {
+      calorieQueue = await createCalorieQueue(boss, { triggerCalorieComputation })
+    } catch (error) {
+      console.error('Failed to initialize calorie queue:', error)
+    }
+  }
+  if (!calorieQueue) {
+    console.warn('⚠️ Calorie queue disabled - HR ingestion will fire-and-forget computation')
+  }
+
   // Initialize Strava queue (uses shared boss + strava client)
   let stravaQueue: StravaQueue | null = null
   if (boss) {
@@ -305,6 +322,7 @@ const main = async () => {
     oura,
     garmin,
     stravaQueue,
+    calorieQueue,
     activityNotifier,
   })
 

--- a/apps/backend/src/api/sync-setup.ts
+++ b/apps/backend/src/api/sync-setup.ts
@@ -8,6 +8,7 @@ import type { Express } from 'express'
 
 import type { GarminClient } from '../integrations/garmin/client.ts'
 import type { ouraClient } from '../integrations/oura/client.ts'
+import type { CalorieQueue } from '../services/calorie-queue.ts'
 import type { CentralDb } from '../services/central-db.ts'
 import type { ActivityNotifier } from '../services/deduction-queue.ts'
 import type { StravaQueue } from '../services/strava-queue.ts'
@@ -47,6 +48,7 @@ interface SyncSetupDeps {
   oura: OuraClient
   garmin: GarminClient
   stravaQueue: StravaQueue | null
+  calorieQueue: CalorieQueue | null
   activityNotifier: ActivityNotifier
 }
 
@@ -57,6 +59,7 @@ export const mountSyncRouter = ({
   oura,
   garmin,
   stravaQueue,
+  calorieQueue,
   activityNotifier,
 }: SyncSetupDeps): void => {
   // Transform SyncState to ProviderSyncStatus format (undefined -> null)
@@ -150,6 +153,7 @@ export const mountSyncRouter = ({
         syncRescueTime: transformRescueTimeSyncResult,
         triggerCalorieComputation: (user: string, start: Date, end: Date) =>
           triggerCalorieComputation(user, start, end),
+        enqueueCalorieComputation: calorieQueue?.enqueueComputation,
         upsertUserSettings: (user: string, settings: Record<string, unknown>) =>
           upsertUserSettings(user, settings),
         onActivitySynced: activityNotifier,

--- a/apps/backend/src/services/calorie-queue.test.ts
+++ b/apps/backend/src/services/calorie-queue.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+
+import { groupCalorieJobs } from './calorie-queue.ts'
+
+describe('groupCalorieJobs', () => {
+  const makeJob = (user: string, start: string, end: string) =>
+    ({
+      data: { end, start, user },
+    }) as never
+
+  test('groups jobs by user and merges windows', () => {
+    const jobs = [
+      makeJob('alice', '2024-01-01T10:00:00Z', '2024-01-01T10:05:00Z'),
+      makeJob('alice', '2024-01-01T10:03:00Z', '2024-01-01T10:10:00Z'),
+      makeJob('alice', '2024-01-01T09:55:00Z', '2024-01-01T10:08:00Z'),
+      makeJob('bob', '2024-01-01T12:00:00Z', '2024-01-01T12:30:00Z'),
+    ]
+
+    const result = groupCalorieJobs(jobs)
+
+    expect(result.size).toBe(2)
+    const alice = result.get('alice')!
+    expect(alice.start).toEqual(new Date('2024-01-01T09:55:00Z'))
+    expect(alice.end).toEqual(new Date('2024-01-01T10:10:00Z'))
+
+    const bob = result.get('bob')!
+    expect(bob.start).toEqual(new Date('2024-01-01T12:00:00Z'))
+    expect(bob.end).toEqual(new Date('2024-01-01T12:30:00Z'))
+  })
+
+  test('handles empty jobs list', () => {
+    expect(groupCalorieJobs([]).size).toBe(0)
+  })
+
+  test('single job returns the same window', () => {
+    const jobs = [makeJob('alice', '2024-01-01T10:00:00Z', '2024-01-01T10:05:00Z')]
+    const result = groupCalorieJobs(jobs)
+    const alice = result.get('alice')!
+    expect(alice.start).toEqual(new Date('2024-01-01T10:00:00Z'))
+    expect(alice.end).toEqual(new Date('2024-01-01T10:05:00Z'))
+  })
+})

--- a/apps/backend/src/services/calorie-queue.test.ts
+++ b/apps/backend/src/services/calorie-queue.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'vitest'
 
+import type { CalorieJobData } from './calorie-queue.ts'
+import type { Job } from './pg-boss.ts'
+
 import { groupCalorieJobs } from './calorie-queue.ts'
 
 describe('groupCalorieJobs', () => {
-  const makeJob = (user: string, start: string, end: string) =>
+  const makeJob = (user: string, start: string, end: string): Job<CalorieJobData> =>
     ({
       data: { end, start, user },
-    }) as never
+    }) as Job<CalorieJobData>
 
   test('groups jobs by user and merges windows', () => {
     const jobs = [

--- a/apps/backend/src/services/calorie-queue.ts
+++ b/apps/backend/src/services/calorie-queue.ts
@@ -106,7 +106,13 @@ export const createCalorieQueue = async (boss: PgBoss, deps: CalorieQueueDeps): 
           { retryLimit: 2 },
         )
       } catch (err) {
-        auditError(user, 'data', 'Failed to enqueue calorie computation', { error: String(err) })
+        // pg-boss send failed (transient pg connectivity, etc.). Fall back
+        // to fire-and-forget so the computation isn't silently dropped.
+        // Mirrors the no-queue fallback in sync-router.ts.
+        auditError(user, 'data', 'Failed to enqueue calorie computation; firing inline', {
+          error: String(err),
+        })
+        void deps.triggerCalorieComputation(user, start, end)
       }
     },
   }

--- a/apps/backend/src/services/calorie-queue.ts
+++ b/apps/backend/src/services/calorie-queue.ts
@@ -1,0 +1,114 @@
+/**
+ * Calorie computation job queue using pg-boss.
+ *
+ * Heart-rate ingestion (`POST /sync/HeartRateRecord`) used to call
+ * `triggerCalorieComputation` synchronously inside the request handler.
+ * For an initial Android sync that uploads weeks of HR data in 50-sample
+ * chunks, that meant dozens of full computations (HR fetch, weight/VO2
+ * lookup, per-minute formula, per-point outbound-sync enqueue, gap-fill
+ * across days) blocking the response.
+ *
+ * This queue moves that work off the request path: ingestion enqueues a
+ * job describing the affected window, the worker batches incoming jobs
+ * by user with merged windows, and runs the computation once per merged
+ * window. Pattern matches `deduction-queue.ts` and `geocode-queue.ts`.
+ */
+
+import type { Job, PgBoss } from './pg-boss.ts'
+
+import { auditError } from './audit-log.ts'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CalorieJobData {
+  user: string
+  /** ISO timestamp of the earliest HR sample in the trigger batch. */
+  start: string
+  /** ISO timestamp of the latest HR sample in the trigger batch. */
+  end: string
+}
+
+export interface CalorieQueueDeps {
+  triggerCalorieComputation: (user: string, start: Date, end: Date) => Promise<void>
+}
+
+export interface CalorieQueue {
+  enqueueComputation: (user: string, start: Date, end: Date) => Promise<void>
+}
+
+interface MergedWindow {
+  start: Date
+  end: Date
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const QUEUE_NAME = 'calorie-compute'
+
+// ============================================================================
+// Batch helper (exported for unit testing)
+// ============================================================================
+
+/**
+ * Group jobs by user and merge their time windows. When 20 HR-batch requests
+ * arrive in a 5-second polling interval, the worker runs `triggerCalorieComputation`
+ * once per user across the union window instead of 20 separate times.
+ */
+export const groupCalorieJobs = (jobs: Job<CalorieJobData>[]): Map<string, MergedWindow> => {
+  const byUser = new Map<string, MergedWindow>()
+  for (const job of jobs) {
+    const start = new Date(job.data.start)
+    const end = new Date(job.data.end)
+    const existing = byUser.get(job.data.user)
+    if (existing) {
+      if (start < existing.start) existing.start = start
+      if (end > existing.end) existing.end = end
+    } else {
+      byUser.set(job.data.user, { end, start })
+    }
+  }
+  return byUser
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/* v8 ignore start -- requires real pg-boss instance */
+export const createCalorieQueue = async (boss: PgBoss, deps: CalorieQueueDeps): Promise<CalorieQueue> => {
+  await boss.createQueue(QUEUE_NAME)
+
+  await boss.work<CalorieJobData>(QUEUE_NAME, { batchSize: 50, pollingIntervalSeconds: 5 }, async (jobs) => {
+    const grouped = groupCalorieJobs(jobs)
+    for (const [user, window] of grouped) {
+      try {
+        await deps.triggerCalorieComputation(user, window.start, window.end)
+      } catch (err) {
+        // triggerCalorieComputation already swallows errors internally,
+        // but defend against future refactors that might let one escape.
+        auditError(user, 'data', 'Calorie computation job failed', { error: String(err) })
+      }
+    }
+  })
+
+  console.info('🔥 Calorie computation queue ready')
+
+  return {
+    enqueueComputation: async (user: string, start: Date, end: Date): Promise<void> => {
+      try {
+        await boss.send(
+          QUEUE_NAME,
+          { end: end.toISOString(), start: start.toISOString(), user },
+          { retryLimit: 2 },
+        )
+      } catch (err) {
+        auditError(user, 'data', 'Failed to enqueue calorie computation', { error: String(err) })
+      }
+    },
+  }
+}
+/* v8 ignore stop */

--- a/apps/backend/src/sync-router.test.ts
+++ b/apps/backend/src/sync-router.test.ts
@@ -272,6 +272,93 @@ describe('sync router', () => {
     })
   })
 
+  describe('HR ingestion calorie computation', () => {
+    test('uses enqueueCalorieComputation when provided (off request path)', async () => {
+      const enqueue = vi.fn().mockResolvedValue(undefined)
+      const trigger = vi.fn().mockResolvedValue(undefined)
+      const app = express()
+      app.use(express.json())
+      app.use(
+        '/sync',
+        createSyncRouter(
+          { ...mockDeps, enqueueCalorieComputation: enqueue, triggerCalorieComputation: trigger },
+          testAuthMiddleware,
+        ),
+      )
+
+      const response = await request(app)
+        .post('/sync/HeartRateRecord')
+        .send({
+          data: [
+            {
+              metadata: { id: 'hr-1' },
+              samples: [
+                { beatsPerMinute: 70, time: '2024-01-15T10:00:00Z' },
+                { beatsPerMinute: 72, time: '2024-01-15T10:05:00Z' },
+              ],
+            },
+          ],
+        })
+
+      expect(response.status).toBe(200)
+      expect(enqueue).toHaveBeenCalledWith(
+        'testuser',
+        new Date('2024-01-15T10:00:00Z'),
+        new Date('2024-01-15T10:05:00Z'),
+      )
+      expect(trigger).not.toHaveBeenCalled()
+    })
+
+    test('falls back to triggerCalorieComputation (fire-and-forget) when no queue configured', async () => {
+      // Slow trigger to assert the request doesn't await it.
+      let triggerResolve: () => void = () => {}
+      const trigger = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            triggerResolve = resolve
+          }),
+      )
+      const app = express()
+      app.use(express.json())
+      app.use(
+        '/sync',
+        createSyncRouter({ ...mockDeps, triggerCalorieComputation: trigger }, testAuthMiddleware),
+      )
+
+      const response = await request(app)
+        .post('/sync/HeartRateRecord')
+        .send({
+          data: [{ metadata: { id: 'hr-2' }, startTime: '2024-01-15T10:00:00Z' }],
+        })
+
+      // Response returns even though trigger hasn't resolved
+      expect(response.status).toBe(200)
+      expect(trigger).toHaveBeenCalledTimes(1)
+      triggerResolve()
+    })
+
+    test('does not enqueue or trigger for non-HR record types', async () => {
+      const enqueue = vi.fn().mockResolvedValue(undefined)
+      const trigger = vi.fn().mockResolvedValue(undefined)
+      const app = express()
+      app.use(express.json())
+      app.use(
+        '/sync',
+        createSyncRouter(
+          { ...mockDeps, enqueueCalorieComputation: enqueue, triggerCalorieComputation: trigger },
+          testAuthMiddleware,
+        ),
+      )
+
+      await request(app)
+        .post('/sync/WeightRecord')
+        .send({ data: [{ metadata: { id: 'w' }, time: '2024-01-15T08:00:00Z' }] })
+
+      expect(enqueue).not.toHaveBeenCalled()
+      expect(trigger).not.toHaveBeenCalled()
+    })
+  })
+
   describe('activitywatch endpoint', () => {
     test('POST /sync/activitywatch passes events and device_name', async () => {
       const app = createTestApp()

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -770,12 +770,17 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       // formula, per-point outbound-sync enqueue, gap-fill) inline here
       // turns each chunk into a multi-second request.
       if (recordType === 'HeartRateRecord' && records.length > 0) {
-        const timestamps = records.flatMap((r) => {
-          const samples = r.samples as Array<{ time: string }> | undefined
-          if (samples) return samples.map((s) => new Date(s.time).getTime())
-          const t = r.startTime || r.time
-          return t ? [new Date(t as string).getTime()] : []
-        })
+        // Drop NaN here — a malformed timestamp string would propagate to
+        // Math.min/max and then to new Date(NaN).toISOString(), throwing
+        // RangeError out of the request handler.
+        const timestamps = records
+          .flatMap((r) => {
+            const samples = r.samples as Array<{ time: string }> | undefined
+            if (samples) return samples.map((s) => new Date(s.time).getTime())
+            const t = r.startTime || r.time
+            return t ? [new Date(t as string).getTime()] : []
+          })
+          .filter((t) => !Number.isNaN(t))
         if (timestamps.length > 0) {
           const start = new Date(Math.min(...timestamps))
           const end = new Date(Math.max(...timestamps))

--- a/apps/backend/src/sync-router.ts
+++ b/apps/backend/src/sync-router.ts
@@ -101,6 +101,14 @@ export interface SyncRouterDeps {
   ) => Promise<void>
   processHealthConnectData: (user: string, recordType: string, data: HealthConnectRecord) => Promise<void>
   triggerCalorieComputation: (user: string, start: Date, end: Date) => Promise<void>
+  /**
+   * Optional pg-boss-backed enqueue. When present, HR ingestion enqueues a
+   * job and returns immediately. When absent (boss failed to init), falls
+   * back to fire-and-forget `triggerCalorieComputation` so dev/test still
+   * get the side effect. Either way, the response is not blocked on the
+   * full HR-fetch + per-minute compute + per-point outbound-sync loop.
+   */
+  enqueueCalorieComputation?: (user: string, start: Date, end: Date) => Promise<void>
   syncOura: (user: string, options: { fullResync?: boolean; startDate?: Date }) => Promise<OuraSyncResult[]>
   getOuraSyncStates: (user: string) => Promise<ProviderSyncStatus[]>
   resetOuraSyncState: (user: string, dataType?: string) => Promise<void>
@@ -756,7 +764,11 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
       // Notify deduction queue
       deps.onActivitySynced?.(user, '*', new Date(Date.now() - 86400000), new Date())
 
-      // Trigger calorie computation when HR data is ingested
+      // HR ingestion: defer calorie computation off the request path.
+      // Initial Android sync uploads weeks of HR data in 50-sample chunks;
+      // running the full compute (HR fetch, weight/VO2 lookup, per-minute
+      // formula, per-point outbound-sync enqueue, gap-fill) inline here
+      // turns each chunk into a multi-second request.
       if (recordType === 'HeartRateRecord' && records.length > 0) {
         const timestamps = records.flatMap((r) => {
           const samples = r.samples as Array<{ time: string }> | undefined
@@ -767,7 +779,13 @@ export const createSyncRouter = (deps: SyncRouterDeps, authMiddleware: RequestHa
         if (timestamps.length > 0) {
           const start = new Date(Math.min(...timestamps))
           const end = new Date(Math.max(...timestamps))
-          await deps.triggerCalorieComputation(user, start, end)
+          if (deps.enqueueCalorieComputation) {
+            await deps.enqueueCalorieComputation(user, start, end)
+          } else {
+            // No queue (e.g., pg-boss disabled in dev/test). Fire-and-forget
+            // so the response isn't blocked. triggerCalorieComputation never throws.
+            void deps.triggerCalorieComputation(user, start, end)
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Two-part fix for the symptoms you saw:

### 1. Background sync failing on `READ_HEALTH_DATA_IN_BACKGROUND`

Health Connect requires a separate permission (`android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND`, Android 14+) for any read that happens while the app is not in the foreground. We never declared or requested it, so `SyncWorker`'s 15-min periodic job throws `HealthConnectException` once the UI is gone — exactly the error you reported when returning to the app.

- Declared in `AndroidManifest.xml` alongside the existing 51 health permissions.
- Added to `allPermissions` so the bulk request includes it.
- Added a separate UI card "Allow Background Access" that fires the launcher with just that one permission, shown once the user has granted at least one foreground read (HC won't grant the background one before then).
- `SyncWorker` now checks for the permission up front: if missing it skips HC fetch with a `Skipped` stage status (instead of throwing → `Result.retry()` → retry storm), and still runs outbound sync, pending-data flush and ActivityWatch which don't require HC reads.

### 2. HR ingestion API "doing more than just inserting"

Confirmed: `POST /sync/HeartRateRecord` ran `triggerCalorieComputation` inline — HR fetch, weight/VO2 lookup, per-minute calorie formula, **per-point** outbound-sync enqueue, and per-day gap-fill — all blocking the response. For an initial Android sync that posts weeks of HR data in 50-sample chunks, every chunk paid this cost.

- New pg-boss queue `calorie-compute` (`apps/backend/src/services/calorie-queue.ts`), patterned on `deduction-queue.ts` / `geocode-queue.ts`.
- Worker batches incoming jobs by user with a merged window, so 20 chunks in a 5-second polling interval = 1 computation per user, not 20.
- Wired through `api.ts` → `sync-setup.ts` → `sync-router.ts`. When the queue isn't available (boss disabled in dev/tests), the handler falls back to a fire-and-forget `triggerCalorieComputation` call so the response still doesn't block.
- Oura sync's call to `triggerCalorieComputation` is unchanged — it's already off the user request path (server cron / webhook).

### Tests

- `calorie-queue.test.ts` covers the user/window grouping helper.
- New cases in `sync-router.test.ts` verify (a) HR ingestion uses `enqueueCalorieComputation` when configured, (b) without a queue it returns the response without awaiting `triggerCalorieComputation`, (c) non-HR record types still don't trigger calorie compute.
- All 1674 existing backend non-integration tests still pass.
- `compileDebugKotlin` succeeds on the Android module.

## Test plan

- [ ] On a fresh Android install: grant foreground read perms, see "Allow Background Access" card appear, tap it → HC prompt offers "all the time" → granted → card disappears.
- [ ] Disable foreground reads, leave background granted: card should not appear (no point), background sync should skip HC fetch with a clear status message rather than retry-loop.
- [ ] Initial sync of a wearable user: `/sync/HeartRateRecord` requests should return in roughly the time it takes to insert rows; calorie computation arrives some seconds later via the queue worker (check audit log for "Computed N calorie points" audits).
- [ ] Verify `🔥 Calorie computation queue ready` appears in backend startup log; if pg-boss fails the warning fallback message appears and HR ingestion still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)