### PR TITLE
feat(food-items): rank search by nutrition data quality

### DIFF
--- a/apps/backend/src/db/food-items.integration.test.ts
+++ b/apps/backend/src/db/food-items.integration.test.ts
@@ -132,6 +132,29 @@ describe('Food Items Integration Tests', () => {
       expect(results[0].name).toBe('Arla, Hushållsost')
     })
 
+    test('within substring matches, items with richer nutrition rank higher', async () => {
+      const user = getTestUser()
+
+      // Three items all match "banan" by substring; differ only in nutrition data.
+      await upsertFoodItem(user, { name: 'Banan empty' })
+      await upsertFoodItem(user, { calories: 90, name: 'Banan kcal-only' })
+      await upsertFoodItem(user, { calories: 90, name: 'Banan with macros', protein: 1.1 })
+      await upsertFoodItem(user, {
+        calories: 92,
+        name: 'Banan with micros',
+        potassium: 360,
+        protein: 1.1,
+      })
+
+      const results = await searchFoodItems(user, 'banan', 10)
+      expect(results.map((r) => r.name)).toEqual([
+        'Banan with micros',
+        'Banan with macros',
+        'Banan kcal-only',
+        'Banan empty',
+      ])
+    })
+
     test('returns empty array for empty query', async () => {
       const user = getTestUser()
       await upsertFoodItem(user, { name: 'Banana' })

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -4,7 +4,7 @@
  * Canonical food item library — each unique food is a first-class entity.
  */
 
-import { foodItemQualityTierSql, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+import { FOOD_ITEM_QUALITY_TIER_SQL, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 
 import type { FoodItemEntity } from './types.ts'
 
@@ -96,7 +96,7 @@ export const searchFoodItems = async (user: string, q: string, limit = 20): Prom
         OR ($4 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) > $5)
      ORDER BY
        CASE WHEN immutable_unaccent(name_lower) ILIKE immutable_unaccent($1) ESCAPE '\\' THEN 0 ELSE 1 END,
-       ${foodItemQualityTierSql()},
+       ${FOOD_ITEM_QUALITY_TIER_SQL},
        POSITION(immutable_unaccent($2) IN immutable_unaccent(name_lower)),
        similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) DESC,
        name_lower

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -4,7 +4,7 @@
  * Canonical food item library — each unique food is a first-class entity.
  */
 
-import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+import { foodItemQualityTierSql, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 
 import type { FoodItemEntity } from './types.ts'
 
@@ -79,8 +79,9 @@ const escapeLikeWildcards = (s: string): string => s.replaceAll(/[\\%_]/g, '\\$&
  * Search food items by name. Substring + accent-folded match wins; a trigram
  * similarity pass on top picks up typos like "hushalsost" → "Hushållsost"
  * once the query is at least TRIGRAM_MIN_QUERY_LENGTH chars. Substring hits
- * always rank above fuzzy-only hits, then earliest match position, then
- * similarity score.
+ * always rank above fuzzy-only hits, then nutrition-data quality tier
+ * (rich-micronutrient items above kcal-only imports), then earliest match
+ * position, then similarity score.
  */
 export const searchFoodItems = async (user: string, q: string, limit = 20): Promise<FoodItemEntity[]> => {
   const trimmed = q.trim()
@@ -95,6 +96,7 @@ export const searchFoodItems = async (user: string, q: string, limit = 20): Prom
         OR ($4 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) > $5)
      ORDER BY
        CASE WHEN immutable_unaccent(name_lower) ILIKE immutable_unaccent($1) ESCAPE '\\' THEN 0 ELSE 1 END,
+       ${foodItemQualityTierSql()},
        POSITION(immutable_unaccent($2) IN immutable_unaccent(name_lower)),
        similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) DESC,
        name_lower

--- a/apps/backend/src/services/central-food-items.ts
+++ b/apps/backend/src/services/central-food-items.ts
@@ -12,7 +12,7 @@
 
 import type pg from 'pg'
 
-import { NUTRIENT_FIELD_NAMES, nutrientColumnsDDL } from '@aurboda/api-spec'
+import { foodItemQualityTierSql, NUTRIENT_FIELD_NAMES, nutrientColumnsDDL } from '@aurboda/api-spec'
 
 export interface SharedFoodItemEntity {
   id: string
@@ -131,6 +131,7 @@ export const createSharedFoodItemsApi = (getClient: () => Promise<pg.Client>): S
           OR ($4 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) > $5)
        ORDER BY
          CASE WHEN immutable_unaccent(name_lower) ILIKE immutable_unaccent($1) ESCAPE '\\' THEN 0 ELSE 1 END,
+         ${foodItemQualityTierSql()},
          POSITION(immutable_unaccent($2) IN immutable_unaccent(name_lower)),
          similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) DESC,
          name_lower

--- a/apps/backend/src/services/central-food-items.ts
+++ b/apps/backend/src/services/central-food-items.ts
@@ -12,7 +12,7 @@
 
 import type pg from 'pg'
 
-import { foodItemQualityTierSql, NUTRIENT_FIELD_NAMES, nutrientColumnsDDL } from '@aurboda/api-spec'
+import { FOOD_ITEM_QUALITY_TIER_SQL, NUTRIENT_FIELD_NAMES, nutrientColumnsDDL } from '@aurboda/api-spec'
 
 export interface SharedFoodItemEntity {
   id: string
@@ -131,7 +131,7 @@ export const createSharedFoodItemsApi = (getClient: () => Promise<pg.Client>): S
           OR ($4 AND similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) > $5)
        ORDER BY
          CASE WHEN immutable_unaccent(name_lower) ILIKE immutable_unaccent($1) ESCAPE '\\' THEN 0 ELSE 1 END,
-         ${foodItemQualityTierSql()},
+         ${FOOD_ITEM_QUALITY_TIER_SQL},
          POSITION(immutable_unaccent($2) IN immutable_unaccent(name_lower)),
          similarity(immutable_unaccent(name_lower), immutable_unaccent($2)) DESC,
          name_lower

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -163,6 +163,10 @@ describe('getFoodItemQualityTier', () => {
   test('NaN treated as missing', () => {
     expect(getFoodItemQualityTier({ calories: Number.NaN })).toBe(3)
   })
+  test('non-number values treated as missing (defends against null/string slipping through)', () => {
+    expect(getFoodItemQualityTier({ calories: null, protein: '5' })).toBe(3)
+    expect(getFoodItemQualityTier({ calories: 90, iron: null })).toBe(2)
+  })
 })
 
 describe('createFoodItemsService.getById', () => {

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -1,3 +1,4 @@
+import { getFoodItemQualityTier } from '@aurboda/api-spec'
 import { describe, expect, test, vi } from 'vitest'
 
 import type { FoodItemEntity } from '../db/types.ts'
@@ -85,6 +86,82 @@ describe('createFoodItemsService.search', () => {
 
     const results = await service.search('user', 'banana')
     expect(results.map((r) => r.id)).toEqual(['c1'])
+  })
+
+  test('high-quality central LSV item beats kcal-only user matches when limit would slice it off', async () => {
+    // 8 user "banan" rows with only calories — exactly what oura imports
+    // produce. The frontend asks for 8 results; without quality re-ranking
+    // the LSV entry (rich micros) gets sliced away.
+    const userBanans = Array.from({ length: 8 }, (_, i) => {
+      const item = userItem(`u${i}`, `Banan ${i}`)
+      item.calories = 90
+      return item
+    })
+    vi.mocked(dbModule.searchFoodItems).mockResolvedValue(userBanans)
+    const lsvBanan = sharedItem('lsv', 'Banan')
+    lsvBanan.calories = 92
+    lsvBanan.protein = 1.1
+    lsvBanan.potassium = 360 // micronutrient → tier 0
+    const central = fakeCentral()
+    vi.mocked(central.searchSharedFoodItems).mockResolvedValue([lsvBanan])
+    const service = createFoodItemsService(central)
+
+    const results = await service.search('user', 'banan', 8)
+    expect(results.map((r) => r.id)[0]).toBe('lsv')
+    expect(results).toHaveLength(8)
+  })
+
+  test('within the same quality tier, user items still come before central', async () => {
+    const userMicro = userItem('u1', 'Banan')
+    userMicro.calories = 90
+    userMicro.iron = 0.3 // tier 0
+    const lsvMicro = sharedItem('c1', 'Banan, LSV')
+    lsvMicro.calories = 92
+    lsvMicro.iron = 0.26 // tier 0
+    vi.mocked(dbModule.searchFoodItems).mockResolvedValue([userMicro])
+    const central = fakeCentral()
+    vi.mocked(central.searchSharedFoodItems).mockResolvedValue([lsvMicro])
+    const service = createFoodItemsService(central)
+
+    const results = await service.search('user', 'banan', 5)
+    expect(results.map((r) => r.id)).toEqual(['u1', 'c1'])
+  })
+
+  test('empty-data items sink to the bottom', async () => {
+    const empty = userItem('u-empty', 'Banan import')
+    const macroOnly = userItem('u-macro', 'Banan recipe')
+    macroOnly.calories = 90
+    macroOnly.protein = 1
+    const richCentral = sharedItem('c1', 'Banan')
+    richCentral.calories = 92
+    richCentral.potassium = 360 // tier 0
+    vi.mocked(dbModule.searchFoodItems).mockResolvedValue([empty, macroOnly])
+    const central = fakeCentral()
+    vi.mocked(central.searchSharedFoodItems).mockResolvedValue([richCentral])
+    const service = createFoodItemsService(central)
+
+    const results = await service.search('user', 'banan', 5)
+    expect(results.map((r) => r.id)).toEqual(['c1', 'u-macro', 'u-empty'])
+  })
+})
+
+describe('getFoodItemQualityTier', () => {
+  test('tier 0 — any micronutrient', () => {
+    expect(getFoodItemQualityTier({ calories: 90, iron: 0.3 })).toBe(0)
+    expect(getFoodItemQualityTier({ vitamin_c: 60 })).toBe(0)
+  })
+  test('tier 1 — macros without micros', () => {
+    expect(getFoodItemQualityTier({ calories: 90, protein: 5, fat: 1 })).toBe(1)
+    expect(getFoodItemQualityTier({ fiber: 2 })).toBe(1)
+  })
+  test('tier 2 — only calories', () => {
+    expect(getFoodItemQualityTier({ calories: 90 })).toBe(2)
+  })
+  test('tier 3 — empty', () => {
+    expect(getFoodItemQualityTier({})).toBe(3)
+  })
+  test('NaN treated as missing', () => {
+    expect(getFoodItemQualityTier({ calories: Number.NaN })).toBe(3)
   })
 })
 

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -291,24 +291,15 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       centralDb.searchSharedFoodItems(q, limit),
     ])
     // Merge by quality tier so high-quality central LSV entries surface
-    // above kcal-only oura imports. User items still win ties so the user's
-    // own well-tagged items remain on top.
-    const merged: { item: MergedFoodItem; tier: 0 | 1 | 2 | 3; userOrigin: 0 | 1; index: number }[] = [
-      ...userItems.map((item, index) => ({
-        item: item as MergedFoodItem,
-        tier: getFoodItemQualityTier(item),
-        userOrigin: 0 as const,
-        index,
-      })),
-      ...sharedItems.map((item, index) => ({
-        item: item as MergedFoodItem,
-        tier: getFoodItemQualityTier(item),
-        userOrigin: 1 as const,
-        index,
-      })),
-    ]
-    merged.sort((a, b) => a.tier - b.tier || a.userOrigin - b.userOrigin || a.index - b.index)
-    return merged.slice(0, limit).map((m) => m.item)
+    // above kcal-only oura imports. User items come first in the spread,
+    // and Array.prototype.sort is stable since ES2019 — so within a tier,
+    // user-origin items keep their lead over central ones.
+    const tiered = [...userItems, ...sharedItems].map((item) => ({
+      item,
+      tier: getFoodItemQualityTier(item),
+    }))
+    tiered.sort((a, b) => a.tier - b.tier)
+    return tiered.slice(0, limit).map((t) => t.item)
   },
 
   getById: async (user, id) => {

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -11,7 +11,7 @@
  * collide; we don't need a namespace prefix on IDs.
  */
 
-import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+import { getFoodItemQualityTier, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 
 import type { FoodItemEntity } from '../db/types.ts'
 import type { CentralDb } from './central-db.ts'
@@ -290,9 +290,25 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       searchUserFoodItems(user, q, limit),
       centralDb.searchSharedFoodItems(q, limit),
     ])
-    // User items rank first — their own custom names + the LSV reference set
-    // is the natural ordering. Limit applies to the combined list.
-    return [...userItems, ...sharedItems].slice(0, limit)
+    // Merge by quality tier so high-quality central LSV entries surface
+    // above kcal-only oura imports. User items still win ties so the user's
+    // own well-tagged items remain on top.
+    const merged: { item: MergedFoodItem; tier: 0 | 1 | 2 | 3; userOrigin: 0 | 1; index: number }[] = [
+      ...userItems.map((item, index) => ({
+        item: item as MergedFoodItem,
+        tier: getFoodItemQualityTier(item),
+        userOrigin: 0 as const,
+        index,
+      })),
+      ...sharedItems.map((item, index) => ({
+        item: item as MergedFoodItem,
+        tier: getFoodItemQualityTier(item),
+        userOrigin: 1 as const,
+        index,
+      })),
+    ]
+    merged.sort((a, b) => a.tier - b.tier || a.userOrigin - b.userOrigin || a.index - b.index)
+    return merged.slice(0, limit).map((m) => m.item)
   },
 
   getById: async (user, id) => {

--- a/packages/api-spec/src/schemas/nutrients.ts
+++ b/packages/api-spec/src/schemas/nutrients.ts
@@ -130,6 +130,57 @@ export const NUTRIENT_FIELDS = [
 /** All nutrient field names. */
 export const NUTRIENT_FIELD_NAMES = NUTRIENT_FIELDS.map((f) => f.name)
 
+/** Macro field names ('calories' plus the four core macros). */
+export const MACRO_FIELD_NAMES = NUTRIENT_FIELDS.filter((f) => f.category === 'macro').map((f) => f.name)
+
+/** Macro field names excluding 'calories' — used to detect "more than just kcal". */
+export const NON_CALORIE_MACRO_FIELD_NAMES = MACRO_FIELD_NAMES.filter((n) => n !== 'calories')
+
+/**
+ * Micronutrient field names — every nutrient field that is *not* in the
+ * 'macro' category. Used by search ranking to prioritize food items with
+ * richer nutrition data over bare kcal-only entries.
+ */
+export const MICRO_FIELD_NAMES = NUTRIENT_FIELDS.filter((f) => f.category !== 'macro').map((f) => f.name)
+
+/**
+ * Quality tier for ranking food items by how complete their nutrition data
+ * is. Lower tier = better data. Used by food-item search to surface the
+ * Livsmedelsverket reference data above bare kcal-only imports.
+ *
+ *   0 — has at least one micronutrient (vitamin/mineral/amino acid/...)
+ *   1 — has at least one non-calorie macro (protein/carbs/fat/fiber)
+ *   2 — has only calories
+ *   3 — empty (no nutrient data at all)
+ */
+export const getFoodItemQualityTier = (item: Readonly<Record<string, unknown>>): 0 | 1 | 2 | 3 => {
+  const hasValue = (n: string): boolean => {
+    const v = item[n]
+    return typeof v === 'number' && !Number.isNaN(v)
+  }
+  if (MICRO_FIELD_NAMES.some(hasValue)) return 0
+  if (NON_CALORIE_MACRO_FIELD_NAMES.some(hasValue)) return 1
+  if (hasValue('calories')) return 2
+  return 3
+}
+
+/**
+ * SQL fragment that resolves to a 0–3 integer quality tier for a row in
+ * `food_items` or `shared_food_items`. Mirrors `getFoodItemQualityTier`
+ * exactly so the JS-side merge in `FoodItemsService.search` can re-rank
+ * results from both stores against the same tier scale.
+ */
+export const foodItemQualityTierSql = (): string => {
+  const microExpr = MICRO_FIELD_NAMES.map((n) => `${n} IS NOT NULL`).join(' OR ')
+  const macroExpr = NON_CALORIE_MACRO_FIELD_NAMES.map((n) => `${n} IS NOT NULL`).join(' OR ')
+  return `CASE
+    WHEN ${microExpr} THEN 0
+    WHEN ${macroExpr} THEN 1
+    WHEN calories IS NOT NULL THEN 2
+    ELSE 3
+  END`
+}
+
 /** Generate SQL column definitions for all nutrient fields. */
 export const nutrientColumnsDDL = (): string =>
   NUTRIENT_FIELDS.map((f) => `      ${f.name.padEnd(24)} DOUBLE PRECISION`).join(',\n')

--- a/packages/api-spec/src/schemas/nutrients.ts
+++ b/packages/api-spec/src/schemas/nutrients.ts
@@ -137,28 +137,42 @@ export const MACRO_FIELD_NAMES = NUTRIENT_FIELDS.filter((f) => f.category === 'm
 export const NON_CALORIE_MACRO_FIELD_NAMES = MACRO_FIELD_NAMES.filter((n) => n !== 'calories')
 
 /**
- * Micronutrient field names — every nutrient field that is *not* in the
- * 'macro' category. Used by search ranking to prioritize food items with
- * richer nutrition data over bare kcal-only entries.
+ * Every nutrient field that is *not* in the 'macro' category — i.e. the
+ * full set of richer-than-macro fields: extended_macro (sugars, alcohol,
+ * caffeine, water, cholesterol, …), fat_breakdown (saturated/poly/mono,
+ * omegas, individual fatty acids), vitamin, mineral, amino_acid, and
+ * other (oxalate, phytate, salt, ash). Used by search ranking to surface
+ * food items with richer nutrition data over bare kcal-only entries.
+ *
+ * Note: this is intentionally broader than just true micronutrients —
+ * the goal is to detect "this row has data beyond the basic macros",
+ * which is what distinguishes an LSV reference entry from an oura
+ * import.
  */
-export const MICRO_FIELD_NAMES = NUTRIENT_FIELDS.filter((f) => f.category !== 'macro').map((f) => f.name)
+export const NON_MACRO_NUTRIENT_FIELD_NAMES = NUTRIENT_FIELDS.filter((f) => f.category !== 'macro').map(
+  (f) => f.name,
+)
 
 /**
  * Quality tier for ranking food items by how complete their nutrition data
  * is. Lower tier = better data. Used by food-item search to surface the
  * Livsmedelsverket reference data above bare kcal-only imports.
  *
- *   0 — has at least one micronutrient (vitamin/mineral/amino acid/...)
- *   1 — has at least one non-calorie macro (protein/carbs/fat/fiber)
- *   2 — has only calories
- *   3 — empty (no nutrient data at all)
+ * | tier | meaning                                                                |
+ * | ---- | ---------------------------------------------------------------------- |
+ * | 0    | has any non-macro nutrient (extended_macro, fat_breakdown, vitamin,    |
+ * |      | mineral, amino_acid, other)                                            |
+ * | 1    | has at least one non-calorie macro (protein/carbs/fat/fiber), no       |
+ * |      | non-macro nutrient                                                     |
+ * | 2    | only calories                                                          |
+ * | 3    | empty                                                                  |
  */
 export const getFoodItemQualityTier = (item: Readonly<Record<string, unknown>>): 0 | 1 | 2 | 3 => {
   const hasValue = (n: string): boolean => {
     const v = item[n]
     return typeof v === 'number' && !Number.isNaN(v)
   }
-  if (MICRO_FIELD_NAMES.some(hasValue)) return 0
+  if (NON_MACRO_NUTRIENT_FIELD_NAMES.some(hasValue)) return 0
   if (NON_CALORIE_MACRO_FIELD_NAMES.some(hasValue)) return 1
   if (hasValue('calories')) return 2
   return 3
@@ -169,17 +183,25 @@ export const getFoodItemQualityTier = (item: Readonly<Record<string, unknown>>):
  * `food_items` or `shared_food_items`. Mirrors `getFoodItemQualityTier`
  * exactly so the JS-side merge in `FoodItemsService.search` can re-rank
  * results from both stores against the same tier scale.
+ *
+ * Computed once at module load — the field lists never change at runtime.
  */
-export const foodItemQualityTierSql = (): string => {
-  const microExpr = MICRO_FIELD_NAMES.map((n) => `${n} IS NOT NULL`).join(' OR ')
-  const macroExpr = NON_CALORIE_MACRO_FIELD_NAMES.map((n) => `${n} IS NOT NULL`).join(' OR ')
+const buildFoodItemQualityTierSql = (): string => {
+  // FALSE keeps the SQL valid if either category becomes empty in the
+  // future (e.g. someone restructures NUTRIENT_FIELDS) — without it,
+  // `.join(' OR ')` produces an empty fragment and the CASE becomes a
+  // syntax error.
+  const orElseFalse = (names: readonly string[]): string =>
+    names.length === 0 ? 'FALSE' : names.map((n) => `${n} IS NOT NULL`).join(' OR ')
   return `CASE
-    WHEN ${microExpr} THEN 0
-    WHEN ${macroExpr} THEN 1
+    WHEN ${orElseFalse(NON_MACRO_NUTRIENT_FIELD_NAMES)} THEN 0
+    WHEN ${orElseFalse(NON_CALORIE_MACRO_FIELD_NAMES)} THEN 1
     WHEN calories IS NOT NULL THEN 2
     ELSE 3
   END`
 }
+
+export const FOOD_ITEM_QUALITY_TIER_SQL = buildFoodItemQualityTierSql()
 
 /** Generate SQL column definitions for all nutrient fields. */
 export const nutrientColumnsDDL = (): string =>


### PR DESCRIPTION
## Summary
- Food-item search now prioritizes entries with richer nutrition data, so the Livsmedelsverket reference set surfaces above bare kcal-only Oura imports.
- Adds a 4-tier quality score (micros > macros > kcal > empty) used in both SQL `ORDER BY` (per-user `food_items` and central `shared_food_items`) and the JS-side merge in `FoodItemsService.search`.
- Fixes the symptom reported on `/meals/2115ca9c-…`: typing "banan" into the food-item picker would fill all 8 slots with old imports and slice the LSV "Banan" off entirely.

### Ranking
Within substring matches, tier wins; user-first wins ties so the user's own well-tagged items remain on top.

| tier | meaning |
| --- | --- |
| 0 | any micronutrient (vitamin / mineral / amino acid / fat-breakdown / extended macro / other) |
| 1 | macros (protein/carbs/fat/fiber) but no micros |
| 2 | only calories |
| 3 | empty |

The micro/macro split is derived from the existing `NUTRIENT_FIELDS[].category` in `packages/api-spec/src/schemas/nutrients.ts` — no new metadata.

## Test plan
- [ ] Unit tests for `getFoodItemQualityTier` (api-spec helper) covering each tier + NaN handling.
- [ ] Unit tests for `FoodItemsService.search` covering: high-quality central beats 8 kcal-only user matches; user-first preserved within same tier; empty-data items sink to bottom.
- [ ] Integration test for `searchFoodItems` SQL ordering: 4 items same name, different nutrition completeness, expected order returned.
- [ ] Manually confirm in the UI on https://aurboda.net/meals/2115ca9c-50ab-4251-99b4-cfa97c14f97d that searching "banan" surfaces the LSV entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)