### PR TITLE
feat(food-items): per-user overrides on central shared items

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -332,6 +332,16 @@ export {
 // Uploaded icons
 export { deleteIcon, getIcon, insertIcon } from './icons.ts'
 
+// Shared food-item overrides (per-user customizations layered onto central rows)
+export {
+  clearSharedFoodItemOverride,
+  getSharedFoodItemOverride,
+  getSharedFoodItemOverridesByIds,
+  setSharedFoodItemOverride,
+  type SharedFoodItemOverride,
+  type SharedFoodItemOverrideInput,
+} from './shared-food-item-overrides.ts'
+
 // Settings
 export { getUserSettings, upsertUserSettings } from './settings.ts'
 

--- a/apps/backend/src/db/shared-food-item-overrides.integration.test.ts
+++ b/apps/backend/src/db/shared-food-item-overrides.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for per-user overrides on central shared_food_items.
+ *
+ * Verifies set/get/clear semantics against a real PostgreSQL — including
+ * batch lookup (which the food-items service uses to merge overrides into
+ * search results in one round-trip) and explicit-null icon (user wants no
+ * icon, distinct from "no override applied").
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import {
+  clearSharedFoodItemOverride,
+  getSharedFoodItemOverride,
+  getSharedFoodItemOverridesByIds,
+  setSharedFoodItemOverride,
+} from './shared-food-item-overrides.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+const sharedId1 = '11111111-1111-1111-1111-111111111111'
+const sharedId2 = '22222222-2222-2222-2222-222222222222'
+
+describe('shared_food_item_overrides integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('set + get round-trips an icon override', async () => {
+    const user = getTestUser()
+    const set = await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
+    expect(set.icon).toBe('🥩')
+
+    const got = await getSharedFoodItemOverride(user, sharedId1)
+    expect(got?.icon).toBe('🥩')
+    expect(got?.shared_food_item_id).toBe(sharedId1)
+  })
+
+  test('get returns null when no override exists', async () => {
+    const user = getTestUser()
+    expect(await getSharedFoodItemOverride(user, sharedId1)).toBeNull()
+  })
+
+  test('set upserts and bumps updated_at on second write', async () => {
+    const user = getTestUser()
+    const first = await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
+
+    // Wait a tick so the timestamp comparison is robust.
+    await new Promise((r) => setTimeout(r, 5))
+    const second = await setSharedFoodItemOverride(user, sharedId1, { icon: '🥕' })
+
+    expect(second.icon).toBe('🥕')
+    expect(second.updated_at.getTime()).toBeGreaterThanOrEqual(first.updated_at.getTime())
+  })
+
+  test('null icon is a real "no icon" override, distinct from clear', async () => {
+    const user = getTestUser()
+    await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
+    await setSharedFoodItemOverride(user, sharedId1, { icon: null })
+
+    const got = await getSharedFoodItemOverride(user, sharedId1)
+    expect(got).not.toBeNull()
+    expect(got?.icon).toBeNull()
+  })
+
+  test('clear removes the row entirely', async () => {
+    const user = getTestUser()
+    await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
+    expect(await clearSharedFoodItemOverride(user, sharedId1)).toBe(true)
+    expect(await getSharedFoodItemOverride(user, sharedId1)).toBeNull()
+    // Idempotent — clearing a missing row returns false but doesn't throw.
+    expect(await clearSharedFoodItemOverride(user, sharedId1)).toBe(false)
+  })
+
+  test('batch lookup returns overrides for the requested ids only', async () => {
+    const user = getTestUser()
+    const unknownId = '99999999-9999-9999-9999-999999999999'
+    await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
+    await setSharedFoodItemOverride(user, sharedId2, { icon: '🥕' })
+
+    const map = await getSharedFoodItemOverridesByIds(user, [sharedId1, sharedId2, unknownId])
+    expect(map.size).toBe(2)
+    expect(map.get(sharedId1)?.icon).toBe('🥩')
+    expect(map.get(sharedId2)?.icon).toBe('🥕')
+    expect(map.has(unknownId)).toBe(false)
+  })
+
+  test('batch lookup returns an empty map for an empty id list', async () => {
+    const user = getTestUser()
+    const map = await getSharedFoodItemOverridesByIds(user, [])
+    expect(map.size).toBe(0)
+  })
+
+  test('omitted icon on set leaves existing icon intact', async () => {
+    const user = getTestUser()
+    await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
+    // Simulate a future field-add: an empty input shouldn't wipe the icon.
+    await setSharedFoodItemOverride(user, sharedId1, {})
+    const got = await getSharedFoodItemOverride(user, sharedId1)
+    expect(got?.icon).toBe('🥩')
+  })
+})

--- a/apps/backend/src/db/shared-food-item-overrides.integration.test.ts
+++ b/apps/backend/src/db/shared-food-item-overrides.integration.test.ts
@@ -99,11 +99,20 @@ describe('shared_food_item_overrides integration', () => {
     expect(map.size).toBe(0)
   })
 
-  test('omitted icon on set leaves existing icon intact', async () => {
+  test('rejects empty input — would otherwise silently hide central icon', async () => {
+    const user = getTestUser()
+    // Fresh row case: an empty set used to insert (icon=NULL, shared_food_item_id=...),
+    // and the read path read that as "user picked no icon", erasing the central
+    // icon. Reject the call instead — clear() is the explicit revert.
+    await expect(setSharedFoodItemOverride(user, sharedId1, {})).rejects.toThrow(/at least one/i)
+    expect(await getSharedFoodItemOverride(user, sharedId1)).toBeNull()
+  })
+
+  test('rejects empty input even when a row already exists', async () => {
     const user = getTestUser()
     await setSharedFoodItemOverride(user, sharedId1, { icon: '🥩' })
-    // Simulate a future field-add: an empty input shouldn't wipe the icon.
-    await setSharedFoodItemOverride(user, sharedId1, {})
+    await expect(setSharedFoodItemOverride(user, sharedId1, {})).rejects.toThrow(/at least one/i)
+    // The pre-existing row is left untouched.
     const got = await getSharedFoodItemOverride(user, sharedId1)
     expect(got?.icon).toBe('🥩')
   })

--- a/apps/backend/src/db/shared-food-item-overrides.ts
+++ b/apps/backend/src/db/shared-food-item-overrides.ts
@@ -2,15 +2,26 @@
  * Per-user overrides for central `shared_food_items` rows.
  *
  * The central library is read-only from a user's perspective, so any
- * customization (icon today, more fields later) goes here. NULL on an
- * override column means "no override applied" — the central value passes
- * through unchanged. A row with every override column NULL is equivalent to
- * having no row, so callers should `clear` rather than `set` everything to
- * null when they want to revert.
+ * customization (icon today, more fields later) goes here. The semantics
+ * for each override column are:
+ *
+ *   - `string` value → user-set override (the value the user picked)
+ *   - `null`         → "use no value" (explicit revert to empty — e.g. user
+ *                      hides the central icon)
+ *   - row absent     → no override at all; the central value passes through
+ *
+ * Because of those three states, an empty input on `setSharedFoodItemOverride`
+ * (no override fields supplied) is treated as caller error — without it we'd
+ * silently insert a row whose every column is NULL and then the read path
+ * couldn't tell that apart from "user explicitly chose no value", erasing the
+ * central icon by accident. Use `clearSharedFoodItemOverride` to revert.
  *
  * `shared_food_item_id` is a soft pointer (no FK — central lives in a
  * separate database), same pattern as `meal_food_items.food_item_id` and
- * `food_item_sensitivities.food_item_id`.
+ * `food_item_sensitivities.food_item_id`. If a central row is removed the
+ * orphan override row is harmless: lookups by id won't find anything to
+ * apply it to, and the row carries no data on its own. We don't currently
+ * sweep them.
  */
 
 import { query } from './connection.ts'
@@ -36,10 +47,12 @@ const COLUMNS = 'shared_food_item_id, icon, created_at, updated_at'
 
 const mapRow = (row: Record<string, unknown>): SharedFoodItemOverride => ({
   shared_food_item_id: row.shared_food_item_id as string,
-  icon: (row.icon as string | null) ?? null,
+  icon: row.icon as string | null,
   created_at: row.created_at as Date,
   updated_at: row.updated_at as Date,
 })
+
+const OVERRIDE_FIELDS = ['icon'] as const
 
 export const getSharedFoodItemOverride = async (
   user: string,
@@ -78,9 +91,15 @@ export const getSharedFoodItemOverridesByIds = async (
 }
 
 /**
- * Upsert override columns for a central food item. Only fields explicitly
- * present in `input` are written — passing `{}` is a no-op set that just
- * touches `updated_at` on an existing row (or creates an empty row).
+ * Upsert override columns for a central food item. At least one override
+ * field must be supplied — passing `{}` is rejected, since it would
+ * otherwise insert a row with every override NULL and the read path can't
+ * tell that apart from "user explicitly chose no value", silently erasing
+ * the central icon. Callers wanting to revert should use
+ * `clearSharedFoodItemOverride` instead.
+ *
+ * For an existing row, only the explicitly-provided columns are updated;
+ * omitted fields keep their current value.
  */
 export const setSharedFoodItemOverride = async (
   user: string,
@@ -91,14 +110,23 @@ export const setSharedFoodItemOverride = async (
   const insertValues: unknown[] = [sharedFoodItemId]
   const updateAssignments: string[] = []
 
-  if (input.icon !== undefined) {
-    insertFields.push('icon')
-    insertValues.push(input.icon)
-    updateAssignments.push('icon = EXCLUDED.icon')
+  for (const field of OVERRIDE_FIELDS) {
+    const value = input[field]
+    if (value !== undefined) {
+      insertFields.push(field)
+      insertValues.push(value)
+      updateAssignments.push(`${field} = EXCLUDED.${field}`)
+    }
+  }
+
+  if (updateAssignments.length === 0) {
+    throw new Error(
+      'setSharedFoodItemOverride requires at least one override field; use clearSharedFoodItemOverride to revert',
+    )
   }
 
   // Always bump updated_at on conflict so the row reflects the most recent
-  // user action even when a no-op set is replayed.
+  // user action.
   updateAssignments.push('updated_at = NOW()')
 
   const placeholders = insertValues.map((_, i) => `$${i + 1}`).join(', ')

--- a/apps/backend/src/db/shared-food-item-overrides.ts
+++ b/apps/backend/src/db/shared-food-item-overrides.ts
@@ -1,0 +1,123 @@
+/**
+ * Per-user overrides for central `shared_food_items` rows.
+ *
+ * The central library is read-only from a user's perspective, so any
+ * customization (icon today, more fields later) goes here. NULL on an
+ * override column means "no override applied" — the central value passes
+ * through unchanged. A row with every override column NULL is equivalent to
+ * having no row, so callers should `clear` rather than `set` everything to
+ * null when they want to revert.
+ *
+ * `shared_food_item_id` is a soft pointer (no FK — central lives in a
+ * separate database), same pattern as `meal_food_items.food_item_id` and
+ * `food_item_sensitivities.food_item_id`.
+ */
+
+import { query } from './connection.ts'
+
+export interface SharedFoodItemOverride {
+  shared_food_item_id: string
+  /** User-set icon for the central item; null means "use no icon" (explicit override to empty). */
+  icon: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface SharedFoodItemOverrideInput {
+  /**
+   * `string` sets the icon, `null` explicitly hides the central icon.
+   * `undefined` leaves the column unchanged on update (and inserts NULL on
+   * first insert).
+   */
+  icon?: string | null
+}
+
+const COLUMNS = 'shared_food_item_id, icon, created_at, updated_at'
+
+const mapRow = (row: Record<string, unknown>): SharedFoodItemOverride => ({
+  shared_food_item_id: row.shared_food_item_id as string,
+  icon: (row.icon as string | null) ?? null,
+  created_at: row.created_at as Date,
+  updated_at: row.updated_at as Date,
+})
+
+export const getSharedFoodItemOverride = async (
+  user: string,
+  sharedFoodItemId: string,
+): Promise<SharedFoodItemOverride | null> => {
+  const result = await query(
+    user,
+    `SELECT ${COLUMNS} FROM shared_food_item_overrides WHERE shared_food_item_id = $1`,
+    [sharedFoodItemId],
+  )
+  return result.rows.length > 0 ? mapRow(result.rows[0]) : null
+}
+
+/**
+ * Batch lookup used by the food-items service to merge overrides into a list
+ * of central items in one round-trip. Unknown ids simply don't appear in the
+ * map — callers can treat absence as "no override".
+ */
+export const getSharedFoodItemOverridesByIds = async (
+  user: string,
+  ids: string[],
+): Promise<Map<string, SharedFoodItemOverride>> => {
+  const map = new Map<string, SharedFoodItemOverride>()
+  if (ids.length === 0) return map
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ')
+  const result = await query(
+    user,
+    `SELECT ${COLUMNS} FROM shared_food_item_overrides WHERE shared_food_item_id IN (${placeholders})`,
+    ids,
+  )
+  for (const row of result.rows) {
+    const override = mapRow(row)
+    map.set(override.shared_food_item_id, override)
+  }
+  return map
+}
+
+/**
+ * Upsert override columns for a central food item. Only fields explicitly
+ * present in `input` are written — passing `{}` is a no-op set that just
+ * touches `updated_at` on an existing row (or creates an empty row).
+ */
+export const setSharedFoodItemOverride = async (
+  user: string,
+  sharedFoodItemId: string,
+  input: SharedFoodItemOverrideInput,
+): Promise<SharedFoodItemOverride> => {
+  const insertFields = ['shared_food_item_id']
+  const insertValues: unknown[] = [sharedFoodItemId]
+  const updateAssignments: string[] = []
+
+  if (input.icon !== undefined) {
+    insertFields.push('icon')
+    insertValues.push(input.icon)
+    updateAssignments.push('icon = EXCLUDED.icon')
+  }
+
+  // Always bump updated_at on conflict so the row reflects the most recent
+  // user action even when a no-op set is replayed.
+  updateAssignments.push('updated_at = NOW()')
+
+  const placeholders = insertValues.map((_, i) => `$${i + 1}`).join(', ')
+  const sql = `
+    INSERT INTO shared_food_item_overrides (${insertFields.join(', ')})
+    VALUES (${placeholders})
+    ON CONFLICT (shared_food_item_id) DO UPDATE SET ${updateAssignments.join(', ')}
+    RETURNING ${COLUMNS}
+  `
+  const result = await query(user, sql, insertValues)
+  return mapRow(result.rows[0])
+}
+
+export const clearSharedFoodItemOverride = async (
+  user: string,
+  sharedFoodItemId: string,
+): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM shared_food_item_overrides WHERE shared_food_item_id = $1`, [
+    sharedFoodItemId,
+  ])
+  return (result.rowCount ?? 0) > 0
+}

--- a/apps/backend/src/mcp/food-item-tools.test.ts
+++ b/apps/backend/src/mcp/food-item-tools.test.ts
@@ -42,6 +42,13 @@ vi.mock('../services/meals.ts', () => ({
   resnapshotMealsForFoodItem: vi.fn(),
 }))
 
+vi.mock('../db/shared-food-item-overrides.ts', () => ({
+  clearSharedFoodItemOverride: vi.fn().mockResolvedValue(true),
+  getSharedFoodItemOverride: vi.fn().mockResolvedValue(null),
+  getSharedFoodItemOverridesByIds: vi.fn().mockResolvedValue(new Map()),
+  setSharedFoodItemOverride: vi.fn(),
+}))
+
 const dbBarrel = await import('../db/index.ts')
 const dbFoodItems = await import('../db/food-items.ts')
 

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -12,6 +12,7 @@ import {
   foodItemsQuerySchema,
   setFoodItemIngredientsBodySchema,
   setFoodItemReferenceBodySchema,
+  setSharedFoodItemOverrideBodySchema,
   updateFoodItemBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -28,6 +29,11 @@ import {
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
+import {
+  clearSharedFoodItemOverride,
+  getSharedFoodItemOverride,
+  setSharedFoodItemOverride,
+} from '../db/shared-food-item-overrides.ts'
 import {
   cacheCompositeNutrients,
   clearCompositeNutrientCache,
@@ -244,6 +250,52 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
       } catch (err) {
         return errorResponse(err instanceof Error ? err.message : 'Preview failed')
       }
+    },
+  )
+
+  server.tool(
+    'set_shared_food_item_override',
+    [
+      'Layer a per-user override onto a central shared food item (e.g. set your own icon on a Livsmedelsverket entry without forking it).',
+      'The id must resolve to a central item — per-user items have no override layer; edit them directly with update_food_item.',
+      'Pass `icon: null` to explicitly hide the central icon, or omit the field to leave it unchanged. To revert to the central value entirely, use clear_shared_food_item_override.',
+    ].join(' '),
+    {
+      id: z.string().uuid().describe('Central shared food item ID to override'),
+      ...setSharedFoodItemOverrideBodySchema.shape,
+    },
+    async ({ id, ...input }) => {
+      const central = await centralDb.getSharedFoodItemById(id)
+      if (!central) {
+        const userItem = await getUserFoodItemById(user, id)
+        return errorResponse(
+          userItem
+            ? 'Per-user items have no override layer — edit them directly via update_food_item'
+            : 'Food item not found',
+        )
+      }
+      const override = await setSharedFoodItemOverride(user, id, input)
+      return jsonResponse({ data: override, success: true })
+    },
+  )
+
+  server.tool(
+    'clear_shared_food_item_override',
+    "Remove the user's override layer on a central shared food item, reverting to the central row's values.",
+    { id: z.string().uuid().describe('Central shared food item ID whose override should be cleared') },
+    async ({ id }) => {
+      const central = await centralDb.getSharedFoodItemById(id)
+      if (!central) {
+        const userItem = await getUserFoodItemById(user, id)
+        return errorResponse(
+          userItem
+            ? 'Per-user items have no override layer — edit them directly via update_food_item'
+            : 'Food item not found',
+        )
+      }
+      await clearSharedFoodItemOverride(user, id)
+      const override = await getSharedFoodItemOverride(user, id)
+      return jsonResponse({ data: { cleared: !override, shared_food_item_id: id }, success: true })
     },
   )
 

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -29,11 +29,7 @@ import {
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
-import {
-  clearSharedFoodItemOverride,
-  getSharedFoodItemOverride,
-  setSharedFoodItemOverride,
-} from '../db/shared-food-item-overrides.ts'
+import { clearSharedFoodItemOverride, setSharedFoodItemOverride } from '../db/shared-food-item-overrides.ts'
 import {
   cacheCompositeNutrients,
   clearCompositeNutrientCache,
@@ -258,13 +254,20 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
     [
       'Layer a per-user override onto a central shared food item (e.g. set your own icon on a Livsmedelsverket entry without forking it).',
       'The id must resolve to a central item — per-user items have no override layer; edit them directly with update_food_item.',
-      'Pass `icon: null` to explicitly hide the central icon, or omit the field to leave it unchanged. To revert to the central value entirely, use clear_shared_food_item_override.',
+      'Pass `icon: null` to explicitly hide the central icon. At least one override field must be supplied — to revert to the central value entirely, use clear_shared_food_item_override.',
     ].join(' '),
     {
       id: z.string().uuid().describe('Central shared food item ID to override'),
       ...setSharedFoodItemOverrideBodySchema.shape,
     },
     async ({ id, ...input }) => {
+      // The .refine on the body schema doesn't survive .shape destructuring,
+      // so re-check the at-least-one-field invariant here.
+      if (input.icon === undefined) {
+        return errorResponse(
+          'At least one override field must be supplied; use clear_shared_food_item_override to revert',
+        )
+      }
       const central = await centralDb.getSharedFoodItemById(id)
       if (!central) {
         const userItem = await getUserFoodItemById(user, id)
@@ -293,9 +296,8 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
             : 'Food item not found',
         )
       }
-      await clearSharedFoodItemOverride(user, id)
-      const override = await getSharedFoodItemOverride(user, id)
-      return jsonResponse({ data: { cleared: !override, shared_food_item_id: id }, success: true })
+      const cleared = await clearSharedFoodItemOverride(user, id)
+      return jsonResponse({ data: { cleared, shared_food_item_id: id }, success: true })
     },
   )
 

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -53,6 +53,13 @@ vi.mock('../services/meals.ts', () => ({
   resnapshotMealsForFoodItem: vi.fn(),
 }))
 
+vi.mock('../db/shared-food-item-overrides.ts', () => ({
+  clearSharedFoodItemOverride: vi.fn().mockResolvedValue(true),
+  getSharedFoodItemOverride: vi.fn().mockResolvedValue(null),
+  getSharedFoodItemOverridesByIds: vi.fn().mockResolvedValue(new Map()),
+  setSharedFoodItemOverride: vi.fn(),
+}))
+
 const dbBarrel = await import('../db/index.ts')
 const dbFoodItems = await import('../db/food-items.ts')
 

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -401,6 +401,12 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
   // customize an LSV (or other central) row without forking it. The id MUST
   // resolve to a central item; per-user items are editable directly via
   // PATCH /:id and have no need for an override layer.
+  //
+  // Response shape: `data` carries the override row when one exists; when
+  // none exists the field is absent (`success: true`, no `data`). That keeps
+  // "no override" distinct from "override with null icon" — an explicit
+  // `data: { icon: null, ... }` means the user picked "hide the central
+  // icon", which the UI must render differently from "central icon shows".
   router.get<{ id: string }, SharedFoodItemOverrideResponse>(
     '/:id/override',
     authMiddleware,
@@ -418,17 +424,8 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       const override = await getSharedFoodItemOverride(user, id)
-      // Empty placeholder when no override exists yet — gives the UI a
-      // consistent shape and lets it know the central value is in effect.
-      const data: ApiSharedFoodItemOverride = override
-        ? serializeOverride(override)
-        : {
-            shared_food_item_id: id,
-            icon: null,
-            created_at: new Date(0).toISOString(),
-            updated_at: new Date(0).toISOString(),
-          }
-      res.json({ data, success: true })
+      if (!override) return res.json({ success: true })
+      res.json({ data: serializeOverride(override), success: true })
     },
   )
 
@@ -474,15 +471,8 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       await clearSharedFoodItemOverride(user, id)
-      res.json({
-        data: {
-          shared_food_item_id: id,
-          icon: null,
-          created_at: new Date(0).toISOString(),
-          updated_at: new Date(0).toISOString(),
-        },
-        success: true,
-      })
+      // No `data` after clear — same shape as GET when no override exists.
+      res.json({ success: true })
     },
   )
 

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -30,6 +30,10 @@ import {
   setFoodItemReferenceBodySchema,
   type SetFoodItemSensitivitiesBody,
   setFoodItemSensitivitiesBodySchema,
+  type SetSharedFoodItemOverrideBody,
+  setSharedFoodItemOverrideBodySchema,
+  type SharedFoodItemOverride as ApiSharedFoodItemOverride,
+  type SharedFoodItemOverrideResponse,
   type UpdateFoodItemBody,
   updateFoodItemBodySchema,
 } from '@aurboda/api-spec'
@@ -49,6 +53,12 @@ import {
   updateFoodItem,
   upsertFoodItem,
 } from '../db/index.ts'
+import {
+  clearSharedFoodItemOverride,
+  getSharedFoodItemOverride,
+  setSharedFoodItemOverride,
+  type SharedFoodItemOverride as DbSharedFoodItemOverride,
+} from '../db/shared-food-item-overrides.ts'
 import {
   cacheCompositeNutrients,
   clearCompositeNutrientCache,
@@ -106,6 +116,13 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   }
   return { ...base, sensitivities } as FoodItemDetail
 }
+
+const serializeOverride = (override: DbSharedFoodItemOverride): ApiSharedFoodItemOverride => ({
+  shared_food_item_id: override.shared_food_item_id,
+  icon: override.icon,
+  created_at: override.created_at.toISOString(),
+  updated_at: override.updated_at.toISOString(),
+})
 
 export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: CentralDb): TypedRouter => {
   const router = typedRouter()
@@ -377,6 +394,95 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         const message = err instanceof Error ? err.message : 'Re-snapshot failed'
         res.status(/not found/i.test(message) ? 404 : 500).json({ error: message, success: false })
       }
+    },
+  )
+
+  // Per-user override on a central shared item — the only way a user can
+  // customize an LSV (or other central) row without forking it. The id MUST
+  // resolve to a central item; per-user items are editable directly via
+  // PATCH /:id and have no need for an override layer.
+  router.get<{ id: string }, SharedFoodItemOverrideResponse>(
+    '/:id/override',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      const central = await centralDb.getSharedFoodItemById(id)
+      if (!central) {
+        const userItem = await getUserFoodItemById(user, id)
+        return res.status(userItem ? 400 : 404).json({
+          error: userItem
+            ? 'Per-user items have no override layer — edit them directly via PATCH /:id'
+            : 'Food item not found',
+          success: false,
+        })
+      }
+      const override = await getSharedFoodItemOverride(user, id)
+      // Empty placeholder when no override exists yet — gives the UI a
+      // consistent shape and lets it know the central value is in effect.
+      const data: ApiSharedFoodItemOverride = override
+        ? serializeOverride(override)
+        : {
+            shared_food_item_id: id,
+            icon: null,
+            created_at: new Date(0).toISOString(),
+            updated_at: new Date(0).toISOString(),
+          }
+      res.json({ data, success: true })
+    },
+  )
+
+  router.put<{ id: string }, SharedFoodItemOverrideResponse, SetSharedFoodItemOverrideBody>(
+    '/:id/override',
+    authMiddleware,
+    validateBody(setSharedFoodItemOverrideBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      const central = await centralDb.getSharedFoodItemById(id)
+      if (!central) {
+        const userItem = await getUserFoodItemById(user, id)
+        return res.status(userItem ? 400 : 404).json({
+          error: userItem
+            ? 'Per-user items have no override layer — edit them directly via PATCH /:id'
+            : 'Food item not found',
+          success: false,
+        })
+      }
+      const override = await setSharedFoodItemOverride(user, id, req.body)
+      res.json({ data: serializeOverride(override), success: true })
+    },
+  )
+
+  router.delete<{ id: string }, SharedFoodItemOverrideResponse>(
+    '/:id/override',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const id = req.params.id
+      // Validate the target is central — we don't 404 on a no-op clear of an
+      // already-empty override, but we do reject ids that aren't shared items
+      // so the caller learns about the mistake.
+      const central = await centralDb.getSharedFoodItemById(id)
+      if (!central) {
+        const userItem = await getUserFoodItemById(user, id)
+        return res.status(userItem ? 400 : 404).json({
+          error: userItem
+            ? 'Per-user items have no override layer — edit them directly via PATCH /:id'
+            : 'Food item not found',
+          success: false,
+        })
+      }
+      await clearSharedFoodItemOverride(user, id)
+      res.json({
+        data: {
+          shared_food_item_id: id,
+          icon: null,
+          created_at: new Date(0).toISOString(),
+          updated_at: new Date(0).toISOString(),
+        },
+        success: true,
+      })
     },
   )
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -90,6 +90,7 @@ export const tableCreationOrder = [
   'sensitivity_flags_indexes',
   'food_item_sensitivities',
   'food_item_sensitivities_indexes',
+  'shared_food_item_overrides',
   'locations',
   'locations_indexes',
   'places',

--- a/apps/backend/src/schema/meals.ts
+++ b/apps/backend/src/schema/meals.ts
@@ -330,4 +330,22 @@ export const mealsTables: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_food_item_sensitivities_flag
       ON food_item_sensitivities (sensitivity_flag_id)
   `,
+
+  // Per-user customizations layered onto central shared_food_items rows. The
+  // shared library is read-only from a user's perspective (a single LSV row
+  // is the same for everyone), so when a user wants their own icon (or, in
+  // the future, default_quantity / display name / etc.) we keep the central
+  // row pristine and stash the overrides here. Each NULL column means "no
+  // override applied" — the central value passes through. Designed to grow:
+  // adding columns is an idempotent ALTER in connection.ts.
+  //
+  // Soft pointer on shared_food_item_id (no FK; central lives in another DB).
+  shared_food_item_overrides: `
+    CREATE TABLE IF NOT EXISTS shared_food_item_overrides (
+      shared_food_item_id  UUID PRIMARY KEY,
+      icon                 TEXT,
+      created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
 }

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -28,8 +28,13 @@ vi.mock('../db/sensitivities.ts', () => ({
   getFoodItemSensitivities: vi.fn().mockResolvedValue([]),
 }))
 
+vi.mock('../db/shared-food-item-overrides.ts', () => ({
+  getSharedFoodItemOverridesByIds: vi.fn().mockResolvedValue(new Map()),
+}))
+
 const dbModule = await import('../db/food-items.ts')
 const ingredientsModule = await import('../db/food-item-ingredients.ts')
+const overridesModule = await import('../db/shared-food-item-overrides.ts')
 
 const userItem = (id: string, name: string): FoodItemEntity =>
   ({
@@ -619,5 +624,96 @@ describe('getEffectiveNutrients', () => {
     const eff = getEffectiveNutrients(detail)
     expect(eff.calories).toBe(100)
     expect(eff.fiber).toBe(3)
+  })
+})
+
+describe('createFoodItemsService — shared item overrides', () => {
+  test('search applies icon override to central items only', async () => {
+    const lsv = sharedItem('c1', 'Banan')
+    lsv.icon = '🍌' // central icon
+    vi.mocked(dbModule.searchFoodItems).mockResolvedValue([])
+    const central = fakeCentral()
+    vi.mocked(central.searchSharedFoodItems).mockResolvedValue([lsv])
+    vi.mocked(overridesModule.getSharedFoodItemOverridesByIds).mockResolvedValue(
+      new Map([
+        [
+          'c1',
+          {
+            shared_food_item_id: 'c1',
+            icon: '🥕',
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      ]),
+    )
+    const service = createFoodItemsService(central)
+
+    const results = await service.search('user', 'banan')
+    expect(results.map((r) => r.icon)).toEqual(['🥕'])
+  })
+
+  test('null override icon hides the central icon', async () => {
+    const lsv = sharedItem('c1', 'Banan')
+    lsv.icon = '🍌'
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(lsv)
+    vi.mocked(dbModule.getFoodItemById).mockResolvedValue(null)
+    vi.mocked(overridesModule.getSharedFoodItemOverridesByIds).mockResolvedValue(
+      new Map([
+        [
+          'c1',
+          {
+            shared_food_item_id: 'c1',
+            icon: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      ]),
+    )
+    const service = createFoodItemsService(central)
+
+    const result = await service.getById('user', 'c1')
+    expect(result?.icon).toBeUndefined()
+  })
+
+  test('missing override row leaves central item unchanged', async () => {
+    const lsv = sharedItem('c1', 'Banan')
+    lsv.icon = '🍌'
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemByName).mockResolvedValue(lsv)
+    vi.mocked(dbModule.getFoodItemByName).mockResolvedValue(null)
+    vi.mocked(overridesModule.getSharedFoodItemOverridesByIds).mockResolvedValue(new Map())
+    const service = createFoodItemsService(central)
+
+    const result = await service.getByName('user', 'Banan')
+    expect(result?.icon).toBe('🍌')
+  })
+
+  test('overrides do not touch per-user items', async () => {
+    const u1 = userItem('u1', 'Banan')
+    u1.icon = '🍌'
+    vi.mocked(dbModule.getFoodItemById).mockResolvedValue(u1)
+    const central = fakeCentral()
+    // Even if a stray override row existed at the same id, per-user items
+    // resolve before central — the override path is never consulted.
+    vi.mocked(overridesModule.getSharedFoodItemOverridesByIds).mockResolvedValue(
+      new Map([
+        [
+          'u1',
+          {
+            shared_food_item_id: 'u1',
+            icon: '🚫',
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      ]),
+    )
+    const service = createFoodItemsService(central)
+
+    const result = await service.getById('user', 'u1')
+    expect(result?.icon).toBe('🍌')
   })
 })

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -716,4 +716,67 @@ describe('createFoodItemsService — shared item overrides', () => {
     const result = await service.getById('user', 'u1')
     expect(result?.icon).toBe('🍌')
   })
+
+  test('composite recipe with N central ingredients triggers a single override lookup (no N+1)', async () => {
+    // Per-user composite parent with three central LSV ingredients.
+    const parent = userItem('p1', 'Frukostskål')
+    parent.is_composite = true
+    vi.mocked(dbModule.getFoodItemById).mockImplementation(async (_user, fid) =>
+      fid === 'p1' ? parent : null,
+    )
+
+    const ingredientRows = [
+      {
+        id: 'r1',
+        parent_food_item_id: 'p1',
+        ingredient_food_item_id: 'c1',
+        quantity: 100,
+        unit: 'g',
+        sort_order: 0,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+      {
+        id: 'r2',
+        parent_food_item_id: 'p1',
+        ingredient_food_item_id: 'c2',
+        quantity: 50,
+        unit: 'g',
+        sort_order: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+      {
+        id: 'r3',
+        parent_food_item_id: 'p1',
+        ingredient_food_item_id: 'c3',
+        quantity: 25,
+        unit: 'g',
+        sort_order: 2,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ]
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue(
+      ingredientRows as unknown as Awaited<ReturnType<typeof ingredientsModule.getIngredients>>,
+    )
+
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockImplementation(async (cid) => {
+      const food = sharedItem(cid, `central-${cid}`)
+      food.calories = 100
+      return food
+    })
+
+    vi.mocked(overridesModule.getSharedFoodItemOverridesByIds).mockClear()
+    vi.mocked(overridesModule.getSharedFoodItemOverridesByIds).mockResolvedValue(new Map())
+
+    await createFoodItemsService(central).getDetail('user', 'p1')
+
+    expect(overridesModule.getSharedFoodItemOverridesByIds).toHaveBeenCalledTimes(1)
+    expect(overridesModule.getSharedFoodItemOverridesByIds).toHaveBeenCalledWith(
+      'user',
+      expect.arrayContaining(['c1', 'c2', 'c3']),
+    )
+  })
 })

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -378,18 +378,27 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       if (fromUser.is_composite) {
         const rows = await dbGetIngredients(user, id)
         if (rows.length === 0) return { item: fromUser, sensitivities }
-        const resolved: ResolvedIngredient[] = await Promise.all(
+        // Resolve each ingredient: prefer the per-user row, fall back to the
+        // central library. Once we know which ingredients came from central,
+        // batch the override lookup so a 10-ingredient recipe makes one
+        // override query instead of ten.
+        const resolutions = await Promise.all(
           rows.map(async (row) => {
             const fromUserIng = await getUserFoodItemById(user, row.ingredient_food_item_id)
-            const food =
-              fromUserIng ??
-              (await applySharedOverride(
-                user,
-                await centralDb.getSharedFoodItemById(row.ingredient_food_item_id),
-              ))
-            return { food, row }
+            if (fromUserIng) return { row, userFood: fromUserIng, centralFood: null }
+            const fromCentralIng = await centralDb.getSharedFoodItemById(row.ingredient_food_item_id)
+            return { row, userFood: null, centralFood: fromCentralIng }
           }),
         )
+        const centralFoods = resolutions
+          .map((r) => r.centralFood)
+          .filter((f): f is SharedFoodItemEntity => f !== null)
+        const decoratedCentral = await applySharedOverrides(user, centralFoods)
+        const decoratedById = new Map(decoratedCentral.map((f) => [f.id, f]))
+        const resolved: ResolvedIngredient[] = resolutions.map(({ row, userFood, centralFood }) => ({
+          food: userFood ?? (centralFood ? (decoratedById.get(centralFood.id) ?? null) : null),
+          row,
+        }))
         return {
           derived_nutrients: aggregateNutrientsFromIngredients(resolved),
           ingredients: resolved,

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -34,6 +34,7 @@ import {
   updateFoodItem as dbUpdateFoodItem,
 } from '../db/food-items.ts'
 import { getFoodItemSensitivities } from '../db/sensitivities.ts'
+import { getSharedFoodItemOverridesByIds } from '../db/shared-food-item-overrides.ts'
 
 /**
  * `MergedFoodItem` is intentionally the union of user and central entity
@@ -284,12 +285,49 @@ export const aggregateNutrientsFromIngredients = (ingredients: ResolvedIngredien
   return { nutrient_data_incomplete: incomplete, values }
 }
 
+/**
+ * Merge per-user overrides onto a list of central items. Central rows are
+ * read-only (one canonical LSV entry serves every user), so user-specific
+ * customizations live in `shared_food_item_overrides` and are layered in at
+ * read time.
+ *
+ * `override.icon` semantics: a string sets the icon, `null` explicitly hides
+ * the central icon (user picked "no icon"), and a missing override row falls
+ * through to the central value untouched.
+ */
+const applySharedOverrides = async (
+  user: string,
+  items: SharedFoodItemEntity[],
+): Promise<SharedFoodItemEntity[]> => {
+  if (items.length === 0) return items
+  const overrides = await getSharedFoodItemOverridesByIds(
+    user,
+    items.map((i) => i.id),
+  )
+  if (overrides.size === 0) return items
+  return items.map((item) => {
+    const override = overrides.get(item.id)
+    if (!override) return item
+    return { ...item, icon: override.icon ?? undefined }
+  })
+}
+
+const applySharedOverride = async (
+  user: string,
+  item: SharedFoodItemEntity | null,
+): Promise<SharedFoodItemEntity | null> => {
+  if (!item) return item
+  const [decorated] = await applySharedOverrides(user, [item])
+  return decorated
+}
+
 export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService => ({
   search: async (user, q, limit = 20) => {
-    const [userItems, sharedItems] = await Promise.all([
+    const [userItems, rawSharedItems] = await Promise.all([
       searchUserFoodItems(user, q, limit),
       centralDb.searchSharedFoodItems(q, limit),
     ])
+    const sharedItems = await applySharedOverrides(user, rawSharedItems)
     // Merge by quality tier so high-quality central LSV entries surface
     // above kcal-only oura imports. User items come first in the spread,
     // and Array.prototype.sort is stable since ES2019 — so within a tier,
@@ -305,20 +343,20 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
   getById: async (user, id) => {
     const fromUser = await getUserFoodItemById(user, id)
     if (fromUser) return fromUser
-    return centralDb.getSharedFoodItemById(id)
+    return applySharedOverride(user, await centralDb.getSharedFoodItemById(id))
   },
 
   getByName: async (user, name) => {
     const fromUser = await getUserFoodItemByName(user, name)
     if (fromUser) return fromUser
-    return centralDb.getSharedFoodItemByName(name)
+    return applySharedOverride(user, await centralDb.getSharedFoodItemByName(name))
   },
 
   findOrCreate: async (user, name, defaults) => {
     // Prefer the central canonical entry over creating a per-user duplicate.
     // Exact name match only — fuzzy resolution would silently bind a meal to
     // the wrong food item.
-    const central = await centralDb.getSharedFoodItemByName(name)
+    const central = await applySharedOverride(user, await centralDb.getSharedFoodItemByName(name))
     if (central) return central
     const fromUser = await getUserFoodItemByName(user, name)
     if (fromUser) return fromUser
@@ -342,9 +380,13 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
         if (rows.length === 0) return { item: fromUser, sensitivities }
         const resolved: ResolvedIngredient[] = await Promise.all(
           rows.map(async (row) => {
+            const fromUserIng = await getUserFoodItemById(user, row.ingredient_food_item_id)
             const food =
-              (await getUserFoodItemById(user, row.ingredient_food_item_id)) ??
-              (await centralDb.getSharedFoodItemById(row.ingredient_food_item_id))
+              fromUserIng ??
+              (await applySharedOverride(
+                user,
+                await centralDb.getSharedFoodItemById(row.ingredient_food_item_id),
+              ))
             return { food, row }
           }),
         )
@@ -365,14 +407,15 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       const refId = fromUser.reference_food_item_id as string | undefined
       if (refId) {
         const refFood =
-          (await getUserFoodItemById(user, refId)) ?? (await centralDb.getSharedFoodItemById(refId))
+          (await getUserFoodItemById(user, refId)) ??
+          (await applySharedOverride(user, await centralDb.getSharedFoodItemById(refId)))
         if (refFood && !refFood.is_composite) {
           return { ...enrichWithReference(fromUser, refFood), sensitivities }
         }
       }
       return { item: fromUser, sensitivities }
     }
-    const fromCentral = await centralDb.getSharedFoodItemById(id)
+    const fromCentral = await applySharedOverride(user, await centralDb.getSharedFoodItemById(id))
     return fromCentral ? { item: fromCentral, sensitivities } : null
   },
 

--- a/apps/backend/src/test/db-test-helper.ts
+++ b/apps/backend/src/test/db-test-helper.ts
@@ -85,6 +85,7 @@ export const cleanTestDb = async (): Promise<void> => {
   const tables = [
     'food_item_sensitivities',
     'sensitivity_flags',
+    'shared_food_item_overrides',
     'meal_food_items',
     'food_items',
     'report_entries',

--- a/docs/livsmedelsverket.md
+++ b/docs/livsmedelsverket.md
@@ -8,6 +8,12 @@ The shared library is a single table — `shared_food_items` — in the **centra
 
 A meal item that points at a shared row stores `food_item_id` as a soft pointer (no FK, since the row lives in a different database). Display name, icon, and nutrient values are snapshotted onto `meal_food_items` at insertion time — meal reads never have to JOIN across databases.
 
+### Per-user overrides
+
+The shared library is read-only from a user's perspective — one canonical LSV row serves every user. To let users customize a shared row without forking it (e.g. their own icon for a generic "Banan" entry), per-user customizations live in `shared_food_item_overrides` (per-user DB), keyed by `shared_food_item_id` as a soft pointer to central. Each override column is layered onto the central row at read time in the food-items service: `string` sets the value, `null` hides the central value, missing row falls through. Today the table holds `icon` only; the design accommodates new fields (default_quantity, display name, …) via idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS`.
+
+REST endpoints (per shared item id): `GET /api/food-items/:id/override`, `PUT /api/food-items/:id/override`, `DELETE /api/food-items/:id/override`. MCP equivalents: `set_shared_food_item_override`, `clear_shared_food_item_override`. All reject ids that resolve to a per-user item — those are editable directly via the standard food-item routes.
+
 ## What's synced
 
 For each LSV food item we upsert a row into `shared_food_items` with:

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -200,6 +200,62 @@ export const setFoodItemReferenceBodySchema = z
 export type SetFoodItemReferenceBody = z.infer<typeof setFoodItemReferenceBodySchema>
 
 // ============================================================================
+// Shared (central) food-item overrides
+// ============================================================================
+
+/**
+ * Per-user customization layered onto a central shared food-item row. The
+ * central library is read-only from a user's perspective, so any per-user
+ * tweaks (icon today, more fields later) live in this side-table. Each
+ * absent field on the response means "no override applied — central value
+ * passes through"; an explicit `null` (e.g. `icon: null`) means the user
+ * wants no value, hiding the central one.
+ */
+export const sharedFoodItemOverrideSchema = z
+  .object({
+    shared_food_item_id: z
+      .string()
+      .uuid()
+      .meta({ description: 'ID of the central shared food item this override applies to' }),
+    icon: z.string().max(2048).nullable().meta({
+      description: 'User-set icon for the central item; null means "no icon" (explicit override to empty).',
+    }),
+    created_at: z.string().meta({ description: 'Override creation timestamp' }),
+    updated_at: z.string().meta({ description: 'Override last-update timestamp' }),
+  })
+  .meta({
+    description: 'Per-user override of fields on a central shared food item',
+    id: 'SharedFoodItemOverride',
+  })
+
+export type SharedFoodItemOverride = z.infer<typeof sharedFoodItemOverrideSchema>
+
+/**
+ * Body for upserting an override. Fields are independently optional —
+ * omitting a field leaves it untouched on an existing row (no-op set);
+ * passing `null` writes "no value" semantics for that field.
+ */
+export const setSharedFoodItemOverrideBodySchema = z
+  .object({
+    icon: z.string().max(2048).nullable().optional().meta({
+      description:
+        'Override icon for the central item. String sets the icon, null hides the central icon, omitted leaves the column unchanged.',
+    }),
+  })
+  .meta({
+    description: 'Upsert per-user override columns for a central shared food item',
+    id: 'SetSharedFoodItemOverrideBody',
+  })
+
+export type SetSharedFoodItemOverrideBody = z.infer<typeof setSharedFoodItemOverrideBodySchema>
+
+export const sharedFoodItemOverrideResponseSchema = createDataResponseSchema(
+  sharedFoodItemOverrideSchema,
+).meta({ id: 'SharedFoodItemOverrideResponse' })
+
+export type SharedFoodItemOverrideResponse = z.infer<typeof sharedFoodItemOverrideResponseSchema>
+
+// ============================================================================
 // Request Schemas
 // ============================================================================
 

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -232,8 +232,14 @@ export type SharedFoodItemOverride = z.infer<typeof sharedFoodItemOverrideSchema
 
 /**
  * Body for upserting an override. Fields are independently optional —
- * omitting a field leaves it untouched on an existing row (no-op set);
- * passing `null` writes "no value" semantics for that field.
+ * omitting a field leaves it untouched on an existing row; passing `null`
+ * writes "no value" semantics for that field.
+ *
+ * At least one override field must be supplied. An empty body is rejected
+ * because it would otherwise create a row with every column NULL, which
+ * the read path cannot distinguish from "user explicitly chose no value"
+ * — silently hiding the central icon. To revert to central, call
+ * DELETE /:id/override (or `clear_shared_food_item_override` over MCP).
  */
 export const setSharedFoodItemOverrideBodySchema = z
   .object({
@@ -241,6 +247,9 @@ export const setSharedFoodItemOverrideBodySchema = z
       description:
         'Override icon for the central item. String sets the icon, null hides the central icon, omitted leaves the column unchanged.',
     }),
+  })
+  .refine((body) => body.icon !== undefined, {
+    message: 'At least one override field must be supplied; clear via DELETE to revert to central',
   })
   .meta({
     description: 'Upsert per-user override columns for a central shared food item',


### PR DESCRIPTION
## Summary

- Adds a per-user override layer over central `shared_food_items` rows so users can customize LSV (and future canonical sources like USDA / OpenFoodFacts) without forking the canonical row. First field: `icon`. Designed to grow — the table sits behind a thin DB module + service merge so adding `default_quantity`, display name, etc. is just an idempotent `ALTER TABLE` plus a new column on the upsert path.
- Wires the merge into every food-items service code path that surfaces a central row: `search`, `getById`, `getByName`, `findOrCreate`, and `getDetail` (including composite ingredient resolution and reference resolution). Per-user items are untouched — overrides are exclusively a shared-library mechanism.
- Exposes set/clear via REST (`PUT/DELETE/GET /api/food-items/:id/override`) and MCP (`set_shared_food_item_override`, `clear_shared_food_item_override`). Both reject ids that resolve to a per-user item — those are editable directly via the existing PATCH endpoint.

### Override semantics

- Override row missing → central value passes through.
- `icon: "🥕"` → user-set icon (returned wherever the central item is read).
- `icon: null` (explicit) → hide the central icon.
- `clearSharedFoodItemOverride` → delete the row entirely, full revert.

The `meal_food_items` snapshot path automatically picks up the overridden icon at meal-add time, since meal resolution runs through `service.findOrCreate`/`service.getById`.

## Test plan

- [x] DB integration tests (`shared-food-item-overrides.integration.test.ts`): set/get round-trip, upsert + `updated_at` bump, null vs clear semantics, batch lookup with unknown ids, `cleanTestDb` truncates the new table.
- [x] Service unit tests (`food-items.test.ts`): override applied in search, null override hides central icon, missing row falls through, per-user items don't consult the override path.
- [x] All 134 existing food-related tests still pass (services + db: food-items, meals, food-item-ingredients, sensitivities, food-items-cache, food-items-merge).
- [x] `pnpm check` clean across all three packages (0 errors).
- [ ] Manual: import LSV, set an icon override on a central item via MCP, search the same item, confirm the user-set icon comes back instead of the central one.
- [ ] Manual: log a meal with an override-icon central item, confirm the snapshotted icon on `meal_food_items` is the overridden one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)