### PR TITLE
feat(screentime): per-category activity types with parent_type hierarchy

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -871,7 +871,15 @@ export const migrateSchema = async (user: string) => {
     )
     await query(
       db,
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_screentime_categories_activity_type_name
+      `ALTER TABLE screentime_categories ADD COLUMN IF NOT EXISTS category_owns_type BOOLEAN NOT NULL DEFAULT FALSE`,
+    )
+    // Plain (non-unique) index — multiple categories may legitimately share
+    // a slug via convergence. Drop any older unique form left from earlier
+    // dev installs so the index can be recreated as non-unique.
+    await query(db, `DROP INDEX IF EXISTS idx_screentime_categories_activity_type_name`)
+    await query(
+      db,
+      `CREATE INDEX IF NOT EXISTS idx_screentime_categories_activity_type_name
          ON screentime_categories (activity_type_name) WHERE activity_type_name IS NOT NULL`,
     )
   }

--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -865,6 +865,15 @@ export const migrateSchema = async (user: string) => {
       db,
       `ALTER TABLE screentime_categories ADD COLUMN IF NOT EXISTS exclude_from_screentime BOOLEAN DEFAULT FALSE`,
     )
+    await query(
+      db,
+      `ALTER TABLE screentime_categories ADD COLUMN IF NOT EXISTS activity_type_name VARCHAR(100)`,
+    )
+    await query(
+      db,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_screentime_categories_activity_type_name
+         ON screentime_categories (activity_type_name) WHERE activity_type_name IS NOT NULL`,
+    )
   }
 
   if (existingTableNames.has('outbound_sync_queue')) {

--- a/apps/backend/src/db/screentime-categories.ts
+++ b/apps/backend/src/db/screentime-categories.ts
@@ -6,7 +6,6 @@ import type { ScreentimeCategory, ScreentimeCategoryInput } from './types.ts'
 import { query } from './connection.ts'
 
 const mapRow = (row: Record<string, unknown>): ScreentimeCategory => ({
-  ...(row.activity_type_name ? { activity_type_name: row.activity_type_name as string } : {}),
   color: (row.color as string) || undefined,
   created_at: new Date(row.created_at as string),
   exclude_from_screentime: (row.exclude_from_screentime as boolean) || undefined,
@@ -18,12 +17,16 @@ const mapRow = (row: Record<string, unknown>): ScreentimeCategory => ({
   score: row.score != null ? (row.score as number) : undefined,
   sort_order: row.sort_order as number,
   updated_at: new Date(row.updated_at as string),
+  ...(row.activity_type_name ? { activity_type_name: row.activity_type_name as string } : {}),
+  ...(row.category_owns_type !== undefined && row.category_owns_type !== null
+    ? { category_owns_type: row.category_owns_type as boolean }
+    : {}),
 })
 
 export const getScreentimeCategories = async (user: string): Promise<ScreentimeCategory[]> => {
   const result = await query(
     user,
-    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at
+    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, category_owns_type, created_at, updated_at
      FROM screentime_categories
      ORDER BY sort_order, name`,
   )
@@ -37,7 +40,7 @@ export const getScreentimeCategoryById = async (
 ): Promise<ScreentimeCategory | null> => {
   const result = await query(
     user,
-    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at
+    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, category_owns_type, created_at, updated_at
      FROM screentime_categories
      WHERE id = $1`,
     [id],
@@ -54,7 +57,7 @@ export const insertScreentimeCategory = async (
     user,
     `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, category_owns_type, created_at, updated_at`,
     [
       input.name,
       input.rule_type,
@@ -93,7 +96,7 @@ export const upsertScreentimeCategory = async (
        exclude_from_screentime = EXCLUDED.exclude_from_screentime,
        sort_order = EXCLUDED.sort_order,
        updated_at = NOW()
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, category_owns_type, created_at, updated_at`,
     [
       id,
       input.name,
@@ -198,7 +201,7 @@ export const updateScreentimeCategory = async (
     `UPDATE screentime_categories
      SET ${fields.join(', ')}
      WHERE id = $${paramIndex}
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, category_owns_type, created_at, updated_at`,
     values,
   )
 
@@ -268,7 +271,7 @@ export const bulkInsertScreentimeCategories = async (
     user,
     `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
      VALUES ${valueClauses.join(', ')}
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, category_owns_type, created_at, updated_at`,
     params,
   )
 

--- a/apps/backend/src/db/screentime-categories.ts
+++ b/apps/backend/src/db/screentime-categories.ts
@@ -6,6 +6,7 @@ import type { ScreentimeCategory, ScreentimeCategoryInput } from './types.ts'
 import { query } from './connection.ts'
 
 const mapRow = (row: Record<string, unknown>): ScreentimeCategory => ({
+  ...(row.activity_type_name ? { activity_type_name: row.activity_type_name as string } : {}),
   color: (row.color as string) || undefined,
   created_at: new Date(row.created_at as string),
   exclude_from_screentime: (row.exclude_from_screentime as boolean) || undefined,
@@ -22,7 +23,7 @@ const mapRow = (row: Record<string, unknown>): ScreentimeCategory => ({
 export const getScreentimeCategories = async (user: string): Promise<ScreentimeCategory[]> => {
   const result = await query(
     user,
-    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at
+    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at
      FROM screentime_categories
      ORDER BY sort_order, name`,
   )
@@ -36,7 +37,7 @@ export const getScreentimeCategoryById = async (
 ): Promise<ScreentimeCategory | null> => {
   const result = await query(
     user,
-    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at
+    `SELECT id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at
      FROM screentime_categories
      WHERE id = $1`,
     [id],
@@ -53,7 +54,7 @@ export const insertScreentimeCategory = async (
     user,
     `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
     [
       input.name,
       input.rule_type,
@@ -92,7 +93,7 @@ export const upsertScreentimeCategory = async (
        exclude_from_screentime = EXCLUDED.exclude_from_screentime,
        sort_order = EXCLUDED.sort_order,
        updated_at = NOW()
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
     [
       id,
       input.name,
@@ -197,7 +198,7 @@ export const updateScreentimeCategory = async (
     `UPDATE screentime_categories
      SET ${fields.join(', ')}
      WHERE id = $${paramIndex}
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, sort_order, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
     values,
   )
 
@@ -267,7 +268,7 @@ export const bulkInsertScreentimeCategories = async (
     user,
     `INSERT INTO screentime_categories (name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order)
      VALUES ${valueClauses.join(', ')}
-     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, created_at, updated_at`,
+     RETURNING id, name, rule_type, rule_regex, ignore_case, color, score, exclude_from_screentime, sort_order, activity_type_name, created_at, updated_at`,
     params,
   )
 

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -223,6 +223,8 @@ export interface ScreentimeCategory {
   sort_order: number
   /** Slug pointing at the linked `activity_type_definitions` row. Set on first sync; never auto-changed. */
   activity_type_name?: string
+  /** True when this category created the linked activity_type; false when it converged onto a pre-existing one. */
+  category_owns_type?: boolean
   created_at: Date
   updated_at: Date
 }

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -221,6 +221,8 @@ export interface ScreentimeCategory {
   score?: number
   exclude_from_screentime?: boolean
   sort_order: number
+  /** Slug pointing at the linked `activity_type_definitions` row. Set on first sync; never auto-changed. */
+  activity_type_name?: string
   created_at: Date
   updated_at: Date
 }

--- a/apps/backend/src/integrations/activitywatch/sync.ts
+++ b/apps/backend/src/integrations/activitywatch/sync.ts
@@ -18,6 +18,7 @@ import {
 } from '../../db/index.ts'
 import { buildScreentimeActivitySpans, spansToActivities } from '../../services/screentime-activities.ts'
 import { categorizeRecords, compileRules } from '../../services/screentime-categories.ts'
+import { ensureAllCategoriesHaveTypes } from '../../services/screentime-category-sync.ts'
 
 /**
  * Process a batch of ActivityWatch events from a push agent.
@@ -65,6 +66,10 @@ export const processActivityWatchEvents = async (
     // Also create merged-span activities so screentime participates in the
     // unified activity pipeline (charts, queries, deduction rules).
     if (categories.length > 0) {
+      // Ensure each category has its derived activity_type linked. Lazy
+      // backfill: pre-link migration users hit this path on their first
+      // sync after deploy and get their types created in depth order.
+      await ensureAllCategoriesHaveTypes(user, categories)
       const spans = buildScreentimeActivitySpans(records, categories)
       if (spans.length > 0) await insertActivities(user, spansToActivities(spans))
     }

--- a/apps/backend/src/integrations/rescuetime/sync.ts
+++ b/apps/backend/src/integrations/rescuetime/sync.ts
@@ -19,6 +19,7 @@ import {
 } from '../../db/index.ts'
 import { buildScreentimeActivitySpans, spansToActivities } from '../../services/screentime-activities.ts'
 import { categorizeRecords, compileRules } from '../../services/screentime-categories.ts'
+import { ensureAllCategoriesHaveTypes } from '../../services/screentime-category-sync.ts'
 import { rescuetimeClient } from './client.ts'
 
 /** Default start date for historical sync (30 days back) */
@@ -119,6 +120,10 @@ export const syncRescueTimeData = async (
       // Also create merged-span activities so screentime participates in the
       // unified activity pipeline (charts, queries, deduction rules).
       if (categories.length > 0) {
+        // Ensure each category has its derived activity_type linked. Lazy
+        // backfill: pre-link migration users hit this path on their first
+        // sync after deploy and get their types created in depth order.
+        await ensureAllCategoriesHaveTypes(user, categories)
         const spans = buildScreentimeActivitySpans(productivityRecords, categories)
         if (spans.length > 0) await insertActivities(user, spansToActivities(spans))
       }

--- a/apps/backend/src/schema/productivity.ts
+++ b/apps/backend/src/schema/productivity.ts
@@ -28,7 +28,9 @@ export const productivityTables: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_productivity_resolved_category ON productivity (resolved_category) WHERE resolved_category IS NOT NULL
   `,
 
-  // Screentime category rules for categorizing productivity records
+  // Screentime category rules for categorizing productivity records.
+  // activity_type_name links the category to its derived activity_type_definitions row;
+  // it is set once on first sync and never auto-changed (renames/moves don't touch it).
   screentime_categories: `
     CREATE TABLE IF NOT EXISTS screentime_categories (
       id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -40,11 +42,14 @@ export const productivityTables: Record<string, string> = {
       score           SMALLINT,
       exclude_from_screentime BOOLEAN DEFAULT FALSE,
       sort_order      INTEGER DEFAULT 0,
+      activity_type_name VARCHAR(100),
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `,
   screentime_categories_indexes: `
-    CREATE INDEX IF NOT EXISTS idx_screentime_categories_name ON screentime_categories USING GIN (name)
+    CREATE INDEX IF NOT EXISTS idx_screentime_categories_name ON screentime_categories USING GIN (name);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_screentime_categories_activity_type_name
+      ON screentime_categories (activity_type_name) WHERE activity_type_name IS NOT NULL
   `,
 }

--- a/apps/backend/src/schema/productivity.ts
+++ b/apps/backend/src/schema/productivity.ts
@@ -29,8 +29,13 @@ export const productivityTables: Record<string, string> = {
   `,
 
   // Screentime category rules for categorizing productivity records.
-  // activity_type_name links the category to its derived activity_type_definitions row;
-  // it is set once on first sync and never auto-changed (renames/moves don't touch it).
+  // activity_type_name points to the linked activity_type_definitions row;
+  // it is set once on first sync and never auto-changed (renames/moves don't
+  // touch it). Multiple categories may share a single activity_type_name —
+  // either because they have the same leaf slug (Sport > Tennis and Hobby >
+  // Tennis both → `tennis`) or because they converge onto a pre-existing
+  // non-builtin type. Hence the column is intentionally NOT unique; only a
+  // plain (non-unique) index supports lookup.
   screentime_categories: `
     CREATE TABLE IF NOT EXISTS screentime_categories (
       id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -43,13 +48,17 @@ export const productivityTables: Record<string, string> = {
       exclude_from_screentime BOOLEAN DEFAULT FALSE,
       sort_order      INTEGER DEFAULT 0,
       activity_type_name VARCHAR(100),
+      -- True when this category created its activity_type_definitions row,
+      -- false when it converged onto a pre-existing one. Drives whether a
+      -- category move propagates parent_type to the shared type def.
+      category_owns_type BOOLEAN NOT NULL DEFAULT FALSE,
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `,
   screentime_categories_indexes: `
     CREATE INDEX IF NOT EXISTS idx_screentime_categories_name ON screentime_categories USING GIN (name);
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_screentime_categories_activity_type_name
+    CREATE INDEX IF NOT EXISTS idx_screentime_categories_activity_type_name
       ON screentime_categories (activity_type_name) WHERE activity_type_name IS NOT NULL
   `,
 }

--- a/apps/backend/src/services/backfill-screentime-activities.test.ts
+++ b/apps/backend/src/services/backfill-screentime-activities.test.ts
@@ -11,6 +11,12 @@ vi.mock('../db/connection', () => ({
   query: vi.fn(),
 }))
 
+vi.mock('./audit-log.ts', () => ({
+  auditError: vi.fn(),
+  auditInfo: vi.fn(),
+  auditWarn: vi.fn(),
+}))
+
 import { query } from '../db/connection.ts'
 import { getScreentimeCategories, getSyncState, insertActivities, upsertSyncState } from '../db/index.ts'
 import { backfillScreentimeActivities } from './backfill-screentime-activities.ts'
@@ -21,7 +27,8 @@ const mockedQuery = vi.mocked(query)
 const mockedInsertActivities = vi.mocked(insertActivities)
 const mockedUpsertSyncState = vi.mocked(upsertSyncState)
 
-const cat = (name: string[]) => ({
+const cat = (name: string[], activityTypeName?: string) => ({
+  ...(activityTypeName ? { activity_type_name: activityTypeName } : {}),
   created_at: new Date(),
   id: `cat-${name.join('-')}`,
   ignore_case: true,
@@ -35,7 +42,11 @@ describe('backfillScreentimeActivities', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockedGetSyncState.mockResolvedValue(null)
-    mockedGetScreentimeCategories.mockResolvedValue([cat(['Work'])])
+    // Categories enter the backfill already linked (slug set). The lazy
+    // ensure inside backfill is then a no-op — keeps the mock minimal.
+    mockedGetScreentimeCategories.mockResolvedValue([cat(['Work'], 'work')])
+    // Default: any unspecified query returns an empty result set.
+    mockedQuery.mockResolvedValue({ rows: [] } as never)
   })
 
   test('short-circuits when sync_state marks backfill as completed', async () => {
@@ -106,7 +117,7 @@ describe('backfillScreentimeActivities', () => {
       'user',
       expect.arrayContaining([
         expect.objectContaining({
-          activity_type: 'screentime',
+          activity_type: 'work',
           source: 'rescuetime',
           data: expect.objectContaining({ category_path: 'Work' }),
         }),

--- a/apps/backend/src/services/backfill-screentime-activities.ts
+++ b/apps/backend/src/services/backfill-screentime-activities.ts
@@ -20,6 +20,7 @@ import type { ProductivityRecord } from '../db/types.ts'
 import { query } from '../db/connection.ts'
 import { getScreentimeCategories, getSyncState, insertActivities, upsertSyncState } from '../db/index.ts'
 import { buildScreentimeActivitySpans, spansToActivities } from './screentime-activities.ts'
+import { ensureAllCategoriesHaveTypes } from './screentime-category-sync.ts'
 
 export interface BackfillResult {
   /** How many screentime activities were upserted. */
@@ -78,6 +79,11 @@ export const backfillScreentimeActivities = async (user: string): Promise<Backfi
     })
     return { created: 0, reason: 'no_records', skipped: true }
   }
+
+  // Ensure derived activity types exist for every category before producing
+  // spans — otherwise spansToActivities falls back to the umbrella `screentime`
+  // type and we'd lose the per-category hierarchy.
+  await ensureAllCategoriesHaveTypes(user, categories)
 
   const spans = buildScreentimeActivitySpans(records, categories)
   const activities = spansToActivities(spans)

--- a/apps/backend/src/services/screentime-activities.test.ts
+++ b/apps/backend/src/services/screentime-activities.test.ts
@@ -173,10 +173,11 @@ describe('buildScreentimeActivitySpans', () => {
 })
 
 describe('spansToActivities', () => {
-  test('maps spans to Activity records with stable external_id', () => {
+  test('uses span.activity_type and slug-keyed external_id', () => {
     const startTime = new Date('2026-04-19T10:00:00Z')
     const spans = [
       {
+        activity_type: 'work_programming',
         category_path: ['Work', 'Programming'],
         end_time: new Date('2026-04-19T10:15:00Z'),
         source: 'rescuetime',
@@ -187,10 +188,10 @@ describe('spansToActivities', () => {
     const activities = spansToActivities(spans)
     expect(activities).toEqual([
       {
-        activity_type: 'screentime',
+        activity_type: 'work_programming',
         data: { category_path: 'Work > Programming', score: 2 },
         end_time: new Date('2026-04-19T10:15:00Z'),
-        external_id: `rescuetime_${startTime.getTime()}_Work > Programming`,
+        external_id: `rescuetime_${startTime.getTime()}_work_programming`,
         source: 'rescuetime',
         start_time: startTime,
       },
@@ -200,6 +201,7 @@ describe('spansToActivities', () => {
   test('omits score when not present', () => {
     const spans = [
       {
+        activity_type: 'screentime',
         category_path: ['Work'],
         end_time: new Date('2026-04-19T10:05:00Z'),
         source: 'activitywatch',
@@ -208,5 +210,33 @@ describe('spansToActivities', () => {
     ]
     const activities = spansToActivities(spans)
     expect(activities[0].data).toEqual({ category_path: 'Work' })
+  })
+})
+
+describe('buildScreentimeActivitySpans → derived activity_type', () => {
+  test('uses category.activity_type_name when present', () => {
+    const categories = [cat({ name: ['Work', 'TV'], activity_type_name: 'tv' })]
+    const records = [
+      rec({
+        resolved_category: ['Work', 'TV'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, categories)
+    expect(spans[0].activity_type).toBe('tv')
+  })
+
+  test('falls back to umbrella `screentime` when category has no slug yet', () => {
+    const categories = [cat({ name: ['Work'] })]
+    const records = [
+      rec({
+        resolved_category: ['Work'],
+        start_time: new Date('2026-04-19T10:00:00Z'),
+        end_time: new Date('2026-04-19T10:05:00Z'),
+      }),
+    ]
+    const spans = buildScreentimeActivitySpans(records, categories)
+    expect(spans[0].activity_type).toBe('screentime')
   })
 })

--- a/apps/backend/src/services/screentime-activities.ts
+++ b/apps/backend/src/services/screentime-activities.ts
@@ -56,12 +56,6 @@ interface Span {
   score?: number
 }
 
-const findCategoryByPath = (
-  path: string[],
-  categories: ScreentimeCategory[],
-): ScreentimeCategory | undefined =>
-  categories.find((c) => c.name.length === path.length && c.name.every((seg, i) => seg === path[i]))
-
 /**
  * Group records by (source, resolved_category) and merge adjacent same-group
  * records within MERGE_GAP_MS. Records are grouped by source so rescuetime and
@@ -73,6 +67,9 @@ export const buildScreentimeActivitySpans = (
   categories: ScreentimeCategory[],
 ): Span[] => {
   const excludedPaths = categories.filter((c) => c.exclude_from_screentime).map((c) => c.name)
+  // Index categories by joined path for O(1) lookup inside the merge loop.
+  const categoryByPath = new Map<string, ScreentimeCategory>()
+  for (const c of categories) categoryByPath.set(categoryPathToString(c.name), c)
 
   const groups = new Map<string, ProductivityRecord[]>()
   for (const record of records) {
@@ -91,7 +88,7 @@ export const buildScreentimeActivitySpans = (
     const sorted = [...group].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
     const first = sorted[0]
     const score = getScoreForCategory(first.resolved_category!, categories)
-    const matchingCategory = findCategoryByPath(first.resolved_category!, categories)
+    const matchingCategory = categoryByPath.get(categoryPathToString(first.resolved_category!))
     const activityType = matchingCategory?.activity_type_name ?? UMBRELLA_TYPE
     const makeSpan = (r: ProductivityRecord): Span => ({
       activity_type: activityType,

--- a/apps/backend/src/services/screentime-activities.ts
+++ b/apps/backend/src/services/screentime-activities.ts
@@ -1,10 +1,12 @@
 /**
- * Convert categorized productivity records into `screentime` activities.
+ * Convert categorized productivity records into screentime activities.
  *
  * We mirror the frontend `productivityMerge.ts` contract: adjacent records of
  * the same resolved category within MERGE_GAP_MS collapse into a single span.
- * Each span becomes an activity with activity_type='screentime' and
- * data.category_path set to the full category path joined by ' > '.
+ * Each span becomes an activity whose `activity_type` is the category's
+ * derived type slug (one type per category, mirroring the category hierarchy
+ * via `parent_type`). Categories that haven't been linked yet — legacy data
+ * before the link migration ran — fall back to the umbrella `screentime` type.
  *
  * Uncategorized records and records under categories flagged
  * exclude_from_screentime are skipped — they remain in the productivity table
@@ -41,13 +43,24 @@ export const isCategoryExcluded = (categoryPath: string[], excludedPaths: string
       categoryPath.length >= excluded.length && excluded.every((seg, idx) => seg === categoryPath[idx]),
   )
 
+/** Fallback activity type when a category isn't linked yet (pre-migration data). */
+const UMBRELLA_TYPE = 'screentime'
+
 interface Span {
   category_path: string[]
+  /** Derived activity type slug for this span's category. Falls back to `screentime` for unlinked legacy categories. */
+  activity_type: string
   source: string
   start_time: Date
   end_time: Date
   score?: number
 }
+
+const findCategoryByPath = (
+  path: string[],
+  categories: ScreentimeCategory[],
+): ScreentimeCategory | undefined =>
+  categories.find((c) => c.name.length === path.length && c.name.every((seg, i) => seg === path[i]))
 
 /**
  * Group records by (source, resolved_category) and merge adjacent same-group
@@ -78,7 +91,10 @@ export const buildScreentimeActivitySpans = (
     const sorted = [...group].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
     const first = sorted[0]
     const score = getScoreForCategory(first.resolved_category!, categories)
+    const matchingCategory = findCategoryByPath(first.resolved_category!, categories)
+    const activityType = matchingCategory?.activity_type_name ?? UMBRELLA_TYPE
     const makeSpan = (r: ProductivityRecord): Span => ({
+      activity_type: activityType,
       category_path: r.resolved_category!,
       end_time: r.end_time,
       source: r.source!,
@@ -108,21 +124,25 @@ export const buildScreentimeActivitySpans = (
 /**
  * Convert spans to Activity records for bulk insert.
  *
- * external_id is deterministic: `${source}_${startEpoch}_${categoryPath}`.
- * Re-running sync or regenerating after category changes upserts cleanly
- * thanks to the (source, external_id) unique index.
+ * external_id is deterministic: `${source}_${startEpoch}_${activity_type}`.
+ * The activity_type slug replaced the joined category path in the v2 format
+ * because slugs are stable across category renames (a renamed category keeps
+ * its slug, so re-syncs upsert onto the same row). v1 activities written with
+ * `${source}_${startEpoch}_${categoryPath}` and `activity_type='screentime'`
+ * remain queryable but won't collide with v2 inserts — they sit in their own
+ * keyspace until #652 backfills them under the new types.
  */
 export const spansToActivities = (spans: Span[]): Activity[] =>
   spans.map((span) => {
     const categoryPath = categoryPathToString(span.category_path)
     return {
-      activity_type: 'screentime',
+      activity_type: span.activity_type,
       data: {
         category_path: categoryPath,
         ...(span.score !== undefined ? { score: span.score } : {}),
       },
       end_time: span.end_time,
-      external_id: `${span.source}_${span.start_time.getTime()}_${categoryPath}`,
+      external_id: `${span.source}_${span.start_time.getTime()}_${span.activity_type}`,
       source: span.source as Activity['source'],
       start_time: span.start_time,
     }

--- a/apps/backend/src/services/screentime-categories.ts
+++ b/apps/backend/src/services/screentime-categories.ts
@@ -27,6 +27,11 @@ import {
   upsertScreentimeCategory,
 } from '../db/index.ts'
 import { auditError } from './audit-log.ts'
+import {
+  ensureAllCategoriesHaveTypes,
+  ensureCategoryHasType,
+  recomputeCategoryParentType,
+} from './screentime-category-sync.ts'
 
 // ============================================================================
 // Category Resolution
@@ -181,6 +186,17 @@ export const listCategories = async (user: string) => getScreentimeCategories(us
 export const createCategory = async (user: string, input: ScreentimeCategoryInput) => {
   const result = await insertScreentimeCategory(user, input)
 
+  // Mirror into activity_type_definitions so screentime activities for this
+  // category will use a derived type (one type per category) instead of the
+  // generic `screentime` umbrella.
+  try {
+    const all = await getScreentimeCategories(user)
+    const slug = await ensureCategoryHasType(user, result, all)
+    result.activity_type_name = slug
+  } catch (err) {
+    auditError(user, 'data', 'Failed to mirror category to activity type', { error: String(err) })
+  }
+
   // Fire-and-forget recategorization (only if the new category has a rule)
   if (input.rule_type === 'regex' && input.rule_regex) {
     recategorizeAll(user).catch((err) => {
@@ -226,6 +242,15 @@ export const getCategoryById = async (user: string, id: string) => getScreentime
 export const upsertCategory = async (user: string, id: string, input: ScreentimeCategoryInput) => {
   const result = await upsertScreentimeCategory(user, id, input)
 
+  // Mirror into activity_type_definitions (idempotent — no-op if already linked).
+  try {
+    const all = await getScreentimeCategories(user)
+    const slug = await ensureCategoryHasType(user, result, all)
+    result.activity_type_name = slug
+  } catch (err) {
+    auditError(user, 'data', 'Failed to mirror category to activity type', { error: String(err) })
+  }
+
   // Recategorize if the category has a rule
   if (input.rule_type === 'regex' && input.rule_regex) {
     recategorizeAll(user).catch((err) => {
@@ -245,6 +270,28 @@ export const moveCategoryToParent = async (user: string, id: string, newParentId
   const result = await moveScreentimeCategory(user, id, newParentName)
 
   if (result.updated > 0) {
+    // Recompute parent_type for the moved category and any descendants whose
+    // path prefix changed. Slugs themselves are stable; only `parent_type`
+    // walks to mirror the new hierarchy.
+    try {
+      const all = await getScreentimeCategories(user)
+      const moved = all.find((c) => c.id === id)
+      if (moved) {
+        await recomputeCategoryParentType(user, moved, all)
+        const descendants = all.filter(
+          (c) =>
+            c.id !== id &&
+            c.name.length > moved.name.length &&
+            moved.name.every((seg, i) => c.name[i] === seg),
+        )
+        for (const desc of descendants) await recomputeCategoryParentType(user, desc, all)
+      }
+    } catch (err) {
+      auditError(user, 'data', 'Failed to recompute activity-type parent after move', {
+        error: String(err),
+      })
+    }
+
     recategorizeAll(user).catch((err) => {
       auditError(user, 'data', 'Recategorization after move failed', { error: String(err) })
     })
@@ -302,6 +349,15 @@ export const importFromActivityWatch = async (
       sort_order: c.sort_order,
     })),
   )
+
+  // Mirror all freshly-inserted categories into activity types in depth order.
+  try {
+    await ensureAllCategoriesHaveTypes(user, result)
+  } catch (err) {
+    auditError(user, 'data', 'Failed to mirror imported categories to activity types', {
+      error: String(err),
+    })
+  }
 
   // Fire-and-forget recategorization
   recategorizeAll(user).catch((err) => {

--- a/apps/backend/src/services/screentime-categories.ts
+++ b/apps/backend/src/services/screentime-categories.ts
@@ -194,6 +194,8 @@ export const createCategory = async (user: string, input: ScreentimeCategoryInpu
     const slug = await ensureCategoryHasType(user, result, all)
     result.activity_type_name = slug
   } catch (err) {
+    // Log to stderr too — auditError alone hides this from runtime dashboards.
+    console.error(`⚠️ Failed to mirror screentime category ${result.id} to activity type:`, err)
     auditError(user, 'data', 'Failed to mirror category to activity type', { error: String(err) })
   }
 
@@ -248,6 +250,7 @@ export const upsertCategory = async (user: string, id: string, input: Screentime
     const slug = await ensureCategoryHasType(user, result, all)
     result.activity_type_name = slug
   } catch (err) {
+    console.error(`⚠️ Failed to mirror screentime category ${result.id} to activity type:`, err)
     auditError(user, 'data', 'Failed to mirror category to activity type', { error: String(err) })
   }
 
@@ -287,6 +290,7 @@ export const moveCategoryToParent = async (user: string, id: string, newParentId
         for (const desc of descendants) await recomputeCategoryParentType(user, desc, all)
       }
     } catch (err) {
+      console.error('⚠️ Failed to recompute activity-type parent after move:', err)
       auditError(user, 'data', 'Failed to recompute activity-type parent after move', {
         error: String(err),
       })
@@ -354,6 +358,7 @@ export const importFromActivityWatch = async (
   try {
     await ensureAllCategoriesHaveTypes(user, result)
   } catch (err) {
+    console.error('⚠️ Failed to mirror imported categories to activity types:', err)
     auditError(user, 'data', 'Failed to mirror imported categories to activity types', {
       error: String(err),
     })

--- a/apps/backend/src/services/screentime-category-slug.test.ts
+++ b/apps/backend/src/services/screentime-category-slug.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+
+import { generateSlug } from './screentime-category-slug.ts'
+
+const opts = (nonBuiltin: string[] = [], builtin: string[] = []) => ({
+  existingNonBuiltin: new Set(nonBuiltin),
+  existingBuiltin: new Set(builtin),
+})
+
+describe('generateSlug', () => {
+  test('uses leaf name slugified', () => {
+    expect(generateSlug('TV', null, opts())).toEqual({ slug: 'tv', linkToExisting: false })
+  })
+
+  test('handles non-alphanumeric and trim', () => {
+    expect(generateSlug('  Hot Bath ', null, opts()).slug).toBe('hot_bath')
+    expect(generateSlug('[Work] Meetings', null, opts()).slug).toBe('work_meetings')
+  })
+
+  test('returns linkToExisting when a non-builtin type already has that slug', () => {
+    expect(generateSlug('TV', null, opts(['tv']))).toEqual({ slug: 'tv', linkToExisting: true })
+  })
+
+  test('renames when builtin collides — prefers parent-prefix', () => {
+    expect(generateSlug('Screentime', null, opts([], ['screentime']))).toEqual({
+      slug: 'screentime_2',
+      linkToExisting: false,
+    })
+    expect(generateSlug('Programming', 'work', opts([], ['programming']))).toEqual({
+      slug: 'work_programming',
+      linkToExisting: false,
+    })
+  })
+
+  test('parent-prefix form also converges if non-builtin owns it', () => {
+    expect(generateSlug('Programming', 'work', opts(['work_programming'], ['programming']))).toEqual({
+      slug: 'work_programming',
+      linkToExisting: true,
+    })
+  })
+
+  test('falls back to numeric suffix when both base and parent-prefix builtin-collide', () => {
+    expect(generateSlug('Sleep', 'rest', opts([], ['sleep', 'rest_sleep']))).toEqual({
+      slug: 'sleep_2',
+      linkToExisting: false,
+    })
+  })
+
+  test('numeric leaf gets letter prefix', () => {
+    expect(generateSlug('123 Test', null, opts()).slug).toBe('t_123_test')
+  })
+
+  test('truncates to 100 chars', () => {
+    const long = 'a'.repeat(150)
+    const result = generateSlug(long, null, opts())
+    expect(result.slug.length).toBeLessThanOrEqual(100)
+  })
+
+  test('empty slugifies to "unknown"', () => {
+    expect(generateSlug('!@#$', null, opts()).slug).toBe('unknown')
+  })
+})

--- a/apps/backend/src/services/screentime-category-slug.ts
+++ b/apps/backend/src/services/screentime-category-slug.ts
@@ -1,0 +1,89 @@
+/**
+ * Slug generation for screentime category → activity_type_definitions linking.
+ *
+ * Slugs are derived from the category leaf name (`["Work", "TV"]` → `tv`) so a
+ * category and a same-named deduction-rule activity type converge on a single
+ * type. Only when the bare leaf collides with an unrelated builtin type does
+ * the slug get prefixed with the parent slug (`work_tv`); a final numeric
+ * suffix is appended if even that is taken.
+ *
+ * Slugs are saved on the category row at first sync and never recomputed —
+ * renames and moves leave the slug stable so existing activities of that type
+ * keep their classification across category edits.
+ */
+
+const MAX_LEN = 100
+
+const slugify = (s: string): string =>
+  s
+    .replaceAll(/[[\]()]/g, '')
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '_')
+    .replaceAll(/^_|_$/g, '')
+    .replaceAll(/_+/g, '_') || 'unknown'
+
+const ensureLeadingLetter = (s: string): string => (/^[a-z]/.test(s) ? s : `t_${s}`)
+
+const truncate = (s: string): string => (s.length <= MAX_LEN ? s : s.slice(0, MAX_LEN))
+
+interface SlugOptions {
+  /** Slugs that already exist as non-builtin activity types — convergence target. */
+  existingNonBuiltin: ReadonlySet<string>
+  /** Slugs that already exist as builtin activity types — must NOT be reused. */
+  existingBuiltin: ReadonlySet<string>
+}
+
+export interface GenerateSlugResult {
+  slug: string
+  /** True when an existing non-builtin type with that slug already exists; the caller links to it instead of inserting. */
+  linkToExisting: boolean
+}
+
+/**
+ * Pick a slug for a category whose leaf is `leafName` and whose immediate
+ * parent (in the category hierarchy) has slug `parentSlug` (or null for
+ * top-level).
+ *
+ * Convergence rule: a non-builtin type with the same name is *reused*, not
+ * renamed. This is what makes a `tv` deduction rule and a `tv` category
+ * collapse into one type. Only builtin collisions (the umbrella `screentime`,
+ * `exercise`, etc.) force a rename.
+ */
+export const generateSlug = (
+  leafName: string,
+  parentSlug: string | null,
+  opts: SlugOptions,
+): GenerateSlugResult => {
+  const base = ensureLeadingLetter(slugify(leafName))
+
+  if (opts.existingNonBuiltin.has(base)) {
+    return { slug: truncate(base), linkToExisting: true }
+  }
+  if (!opts.existingBuiltin.has(base)) {
+    return { slug: truncate(base), linkToExisting: false }
+  }
+
+  // Builtin collision — try parent-prefixed form.
+  if (parentSlug) {
+    const prefixed = ensureLeadingLetter(`${parentSlug}_${base}`)
+    if (opts.existingNonBuiltin.has(prefixed)) {
+      return { slug: truncate(prefixed), linkToExisting: true }
+    }
+    if (!opts.existingBuiltin.has(prefixed)) {
+      return { slug: truncate(prefixed), linkToExisting: false }
+    }
+  }
+
+  // Final fallback: numeric suffix until free. Unlikely in practice.
+  for (let i = 2; i < 1000; i++) {
+    const candidate = ensureLeadingLetter(`${base}_${i}`)
+    if (opts.existingNonBuiltin.has(candidate)) {
+      return { slug: truncate(candidate), linkToExisting: true }
+    }
+    if (!opts.existingBuiltin.has(candidate)) {
+      return { slug: truncate(candidate), linkToExisting: false }
+    }
+  }
+  throw new Error(`Could not generate slug for "${leafName}" — exhausted suffixes`)
+}

--- a/apps/backend/src/services/screentime-category-sync.integration.test.ts
+++ b/apps/backend/src/services/screentime-category-sync.integration.test.ts
@@ -164,4 +164,80 @@ describe('screentime category → activity type sync', () => {
     const def = await getActivityTypeDefinition(user, 'solo')
     expect(def).not.toBeNull()
   })
+
+  test('two categories with the same leaf converge on one type', async () => {
+    const user = getTestUser()
+    // "Reading" is not a builtin activity_type — clean leaf, no rename.
+    await createCategory(user, { name: ['Quiet'], rule_type: 'none' })
+    await createCategory(user, { name: ['Loud'], rule_type: 'none' })
+    const a = await createCategory(user, { name: ['Quiet', 'Reading'], rule_type: 'none' })
+    const b = await createCategory(user, { name: ['Loud', 'Reading'], rule_type: 'none' })
+
+    expect(a.activity_type_name).toBe('reading')
+    expect(b.activity_type_name).toBe('reading') // converged — no unique-index error
+
+    // Both rows persisted the slug; the column is intentionally not unique.
+    const refreshed = await getScreentimeCategories(user)
+    const readingRows = refreshed.filter((c) => c.activity_type_name === 'reading')
+    expect(readingRows).toHaveLength(2)
+  })
+
+  test('moving a converged category does NOT clobber the shared type parent_type', async () => {
+    const user = getTestUser()
+    // A pre-existing user activity type — could be from a deduction rule.
+    await insertActivityTypeDefinition(user, {
+      color: '#ec4899',
+      display_category: 'other',
+      display_name: 'TV',
+      name: 'tv',
+    })
+    // Two parents, one category that converges on the existing `tv` type.
+    await createCategory(user, { name: ['Media'], rule_type: 'none' })
+    await createCategory(user, { name: ['Hobby'], rule_type: 'none' })
+    const tvCat = await createCategory(user, { name: ['Media', 'TV'], rule_type: 'none' })
+    expect(tvCat.activity_type_name).toBe('tv')
+
+    // tv was created with no parent_type by the deduction rule path.
+    expect((await getActivityTypeDefinition(user, 'tv'))!.parent_type).toBeUndefined()
+
+    // Move the category. Because the type was created independently
+    // (category linked, not created), parent_type should NOT change.
+    const hobby = (await getScreentimeCategories(user)).find((c) => c.name[0] === 'Hobby')!
+    await moveCategoryToParent(user, tvCat.id, hobby.id)
+
+    expect((await getActivityTypeDefinition(user, 'tv'))!.parent_type).toBeUndefined()
+  })
+
+  test('moving a sole-owner category DOES update its type parent_type', async () => {
+    const user = getTestUser()
+    await createCategory(user, { name: ['Quiet'], rule_type: 'none' })
+    await createCategory(user, { name: ['Loud'], rule_type: 'none' })
+    const reading = await createCategory(user, {
+      name: ['Quiet', 'Reading'],
+      rule_type: 'none',
+    })
+    expect((await getActivityTypeDefinition(user, 'reading'))!.parent_type).toBe('quiet')
+
+    const loud = (await getScreentimeCategories(user)).find((c) => c.name[0] === 'Loud')!
+    await moveCategoryToParent(user, reading.id, loud.id)
+
+    expect((await getActivityTypeDefinition(user, 'reading'))!.parent_type).toBe('loud')
+  })
+
+  test('concurrent ensureCategoryHasType calls do not error', async () => {
+    const user = getTestUser()
+    // Insert raw (no slug yet).
+    const inserted = await insertScreentimeCategory(user, { name: ['Race'], rule_type: 'none' })
+    const all = await getScreentimeCategories(user)
+
+    // Two parallel ensures for the same category — simulating concurrent
+    // RescueTime + ActivityWatch syncs hitting the lazy-link path.
+    const [s1, s2] = await Promise.all([
+      ensureCategoryHasType(user, { ...inserted }, [...all]),
+      ensureCategoryHasType(user, { ...inserted }, [...all]),
+    ])
+    expect(s1).toBe('race')
+    expect(s2).toBe('race')
+    expect(await getActivityTypeDefinition(user, 'race')).not.toBeNull()
+  })
 })

--- a/apps/backend/src/services/screentime-category-sync.integration.test.ts
+++ b/apps/backend/src/services/screentime-category-sync.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration tests for screentime category ↔ activity_type_definitions linking.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { query } from '../db/connection.ts'
+import {
+  getActivityTypeDefinition,
+  getScreentimeCategories,
+  getScreentimeCategoryById,
+  insertActivityTypeDefinition,
+  insertScreentimeCategory,
+} from '../db/index.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { createCategory, moveCategoryToParent } from './screentime-categories.ts'
+import { ensureAllCategoriesHaveTypes, ensureCategoryHasType } from './screentime-category-sync.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+describe('screentime category → activity type sync', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+    // Clear non-builtin types accumulated across tests so each test starts fresh.
+    await query(getTestUser(), `DELETE FROM activity_type_definitions WHERE is_builtin = false`)
+  })
+
+  test('createCategory mirrors a fresh category into a derived type def', async () => {
+    const user = getTestUser()
+    const cat = await createCategory(user, {
+      color: '#22c55e',
+      name: ['Work'],
+      rule_regex: 'vscode',
+      rule_type: 'regex',
+    })
+
+    expect(cat.activity_type_name).toBe('work')
+    const def = await getActivityTypeDefinition(user, 'work')
+    expect(def).not.toBeNull()
+    expect(def!.display_name).toBe('Work')
+    expect(def!.color).toBe('#22c55e')
+    expect(def!.parent_type).toBeUndefined()
+    expect(def!.is_builtin).toBe(false)
+  })
+
+  test('child category inherits parent slug as parent_type', async () => {
+    const user = getTestUser()
+    const parent = await createCategory(user, {
+      name: ['Work'],
+      rule_type: 'none',
+    })
+    expect(parent.activity_type_name).toBe('work')
+
+    const child = await createCategory(user, {
+      name: ['Work', 'Programming'],
+      rule_regex: 'vscode',
+      rule_type: 'regex',
+    })
+
+    expect(child.activity_type_name).toBe('programming')
+    const def = await getActivityTypeDefinition(user, 'programming')
+    expect(def!.parent_type).toBe('work')
+  })
+
+  test('convergence: leaf colliding with existing non-builtin type links to it', async () => {
+    const user = getTestUser()
+    // A pre-existing user activity type — could be from a deduction rule or manual create.
+    await insertActivityTypeDefinition(user, {
+      color: '#ec4899',
+      display_category: 'other',
+      display_name: 'TV',
+      name: 'tv',
+    })
+
+    const cat = await createCategory(user, {
+      color: '#999999',
+      name: ['Media', 'TV'],
+      rule_regex: 'Plex|VLC',
+      rule_type: 'regex',
+    })
+
+    // Linked to the pre-existing type, not a fresh insert.
+    expect(cat.activity_type_name).toBe('tv')
+    const def = await getActivityTypeDefinition(user, 'tv')
+    // Pre-existing metadata preserved (no clobbering).
+    expect(def!.display_name).toBe('TV')
+    expect(def!.color).toBe('#ec4899')
+  })
+
+  test('builtin collision forces parent-prefix slug', async () => {
+    const user = getTestUser()
+    // `screentime` is a builtin — a category literally named "Screentime"
+    // would collide. The slug helper falls back to parent-prefix when a parent
+    // slug is available.
+    await createCategory(user, { name: ['Test'], rule_type: 'none' })
+    const cat = await createCategory(user, {
+      name: ['Test', 'Screentime'],
+      rule_type: 'none',
+    })
+    expect(cat.activity_type_name).toBe('test_screentime')
+  })
+
+  test('moveCategoryToParent updates parent_type on the derived type def', async () => {
+    const user = getTestUser()
+    await createCategory(user, { name: ['Work'], rule_type: 'none' })
+    const hobby = await createCategory(user, { name: ['Hobby'], rule_type: 'none' })
+    const programming = await createCategory(user, {
+      name: ['Work', 'Programming'],
+      rule_type: 'none',
+    })
+    expect((await getActivityTypeDefinition(user, 'programming'))!.parent_type).toBe('work')
+
+    await moveCategoryToParent(user, programming.id, hobby.id)
+
+    expect((await getActivityTypeDefinition(user, 'programming'))!.parent_type).toBe('hobby')
+    // The category itself reflects the new path
+    const moved = await getScreentimeCategoryById(user, programming.id)
+    expect(moved!.name).toEqual(['Hobby', 'Programming'])
+    // Slug stayed stable
+    expect(moved!.activity_type_name).toBe('programming')
+    // Sanity: untouched siblings unaffected
+    expect((await getActivityTypeDefinition(user, 'work'))!.parent_type).toBeUndefined()
+    expect((await getActivityTypeDefinition(user, 'hobby'))!.parent_type).toBeUndefined()
+  })
+
+  test('ensureAllCategoriesHaveTypes processes parents before children', async () => {
+    const user = getTestUser()
+    // Insert categories raw (bypassing service layer) so they have no slugs yet.
+    await insertScreentimeCategory(user, { name: ['Top'], rule_type: 'none' })
+    await insertScreentimeCategory(user, { name: ['Top', 'Mid'], rule_type: 'none' })
+    await insertScreentimeCategory(user, { name: ['Top', 'Mid', 'Leaf'], rule_type: 'none' })
+
+    const all = await getScreentimeCategories(user)
+    await ensureAllCategoriesHaveTypes(user, all)
+
+    const refreshed = await getScreentimeCategories(user)
+    const slugByPath = new Map(refreshed.map((c) => [c.name.join('/'), c.activity_type_name]))
+    expect(slugByPath.get('Top')).toBe('top')
+    expect(slugByPath.get('Top/Mid')).toBe('mid')
+    expect(slugByPath.get('Top/Mid/Leaf')).toBe('leaf')
+
+    expect((await getActivityTypeDefinition(user, 'top'))!.parent_type).toBeUndefined()
+    expect((await getActivityTypeDefinition(user, 'mid'))!.parent_type).toBe('top')
+    expect((await getActivityTypeDefinition(user, 'leaf'))!.parent_type).toBe('mid')
+  })
+
+  test('ensureCategoryHasType is idempotent — second call is a no-op', async () => {
+    const user = getTestUser()
+    const cat = await createCategory(user, { name: ['Solo'], rule_type: 'none' })
+    expect(cat.activity_type_name).toBe('solo')
+
+    const all = await getScreentimeCategories(user)
+    const slug = await ensureCategoryHasType(user, all[0], all)
+    expect(slug).toBe('solo')
+    // Type def should still exist exactly once.
+    const def = await getActivityTypeDefinition(user, 'solo')
+    expect(def).not.toBeNull()
+  })
+})

--- a/apps/backend/src/services/screentime-category-sync.ts
+++ b/apps/backend/src/services/screentime-category-sync.ts
@@ -1,0 +1,138 @@
+/**
+ * Mirror screentime categories into `activity_type_definitions`.
+ *
+ * The category row owns a stable slug (`activity_type_name`) set once at first
+ * sync. The type-definition row carries the display metadata used by the
+ * timeline / queries / hierarchy collapse. Together they replace the v1 model
+ * where every screentime span had `activity_type='screentime'` regardless of
+ * category.
+ *
+ * Convergence: a category whose leaf name slugifies to an already-existing
+ * non-builtin type (e.g. a `tv` deduction-rule type) links to that type
+ * instead of creating a parallel one. This is the design payoff — a `tv`
+ * screentime category and a `tv` deduction-rule activity merge into a single
+ * `activity_type` automatically.
+ */
+
+import type { ScreentimeCategory } from '../db/index.ts'
+
+import { query } from '../db/connection.ts'
+import { insertActivityTypeDefinition } from '../db/index.ts'
+import { generateSlug } from './screentime-category-slug.ts'
+
+const findParentCategory = (
+  category: ScreentimeCategory,
+  all: ScreentimeCategory[],
+): ScreentimeCategory | null => {
+  if (category.name.length <= 1) return null
+  const parentPath = category.name.slice(0, -1)
+  return (
+    all.find((c) => c.name.length === parentPath.length && c.name.every((seg, i) => seg === parentPath[i])) ??
+    null
+  )
+}
+
+const loadExistingTypeNames = async (
+  user: string,
+): Promise<{ builtin: Set<string>; nonBuiltin: Set<string> }> => {
+  const result = await query<{ name: string; is_builtin: boolean }>(
+    user,
+    `SELECT name, is_builtin FROM activity_type_definitions`,
+  )
+  const builtin = new Set<string>()
+  const nonBuiltin = new Set<string>()
+  for (const row of result.rows) {
+    if (row.is_builtin) builtin.add(row.name)
+    else nonBuiltin.add(row.name)
+  }
+  return { builtin, nonBuiltin }
+}
+
+const persistSlugOnCategory = async (user: string, categoryId: string, slug: string): Promise<void> => {
+  await query(
+    user,
+    `UPDATE screentime_categories SET activity_type_name = $1, updated_at = NOW() WHERE id = $2`,
+    [slug, categoryId],
+  )
+}
+
+/**
+ * Ensure a category has a linked activity_type_definitions row.
+ *
+ * Idempotent: if the category already has `activity_type_name`, returns it.
+ * Otherwise generates a slug, inserts a new type def (or links to an existing
+ * non-builtin same-name type), and persists the slug on the category.
+ *
+ * Caller passes the full category list so the parent path can be resolved
+ * locally — depth-ordered iteration in `ensureAllCategoriesHaveTypes` mutates
+ * the list as slugs are minted, so each child can read its parent's slug.
+ */
+export const ensureCategoryHasType = async (
+  user: string,
+  category: ScreentimeCategory,
+  allCategories: ScreentimeCategory[],
+): Promise<string> => {
+  if (category.activity_type_name) return category.activity_type_name
+
+  const parent = findParentCategory(category, allCategories)
+  let parentSlug: string | null = null
+  if (parent) {
+    parentSlug = parent.activity_type_name ?? (await ensureCategoryHasType(user, parent, allCategories))
+  }
+
+  const { builtin, nonBuiltin } = await loadExistingTypeNames(user)
+  const leaf = category.name[category.name.length - 1]
+  const { slug, linkToExisting } = generateSlug(leaf, parentSlug, {
+    existingBuiltin: builtin,
+    existingNonBuiltin: nonBuiltin,
+  })
+
+  if (!linkToExisting) {
+    await insertActivityTypeDefinition(user, {
+      display_category: 'productivity',
+      display_name: leaf,
+      name: slug,
+      ...(category.color !== undefined ? { color: category.color } : {}),
+      ...(parentSlug !== null ? { parent_type: parentSlug } : {}),
+    })
+  }
+
+  await persistSlugOnCategory(user, category.id, slug)
+  category.activity_type_name = slug
+  return slug
+}
+
+/**
+ * Bulk-ensure: every category gets a slug + type def. Iterates depth-first so
+ * parents are minted before children — `ensureCategoryHasType` then sees a
+ * resolved parent slug locally without recursing.
+ */
+export const ensureAllCategoriesHaveTypes = async (
+  user: string,
+  categories: ScreentimeCategory[],
+): Promise<void> => {
+  const sorted = [...categories].sort((a, b) => a.name.length - b.name.length)
+  for (const cat of sorted) {
+    await ensureCategoryHasType(user, cat, sorted)
+  }
+}
+
+/**
+ * After a category is moved (its `name[]` prefix changed), update the linked
+ * type def's `parent_type` so the type hierarchy mirrors the category
+ * hierarchy. The slug itself is stable — only `parent_type` walks.
+ */
+export const recomputeCategoryParentType = async (
+  user: string,
+  category: ScreentimeCategory,
+  allCategories: ScreentimeCategory[],
+): Promise<void> => {
+  if (!category.activity_type_name) return // not yet linked — nothing to recompute
+  const parent = findParentCategory(category, allCategories)
+  const newParentSlug = parent?.activity_type_name ?? null
+  await query(
+    user,
+    `UPDATE activity_type_definitions SET parent_type = $1, updated_at = NOW() WHERE name = $2`,
+    [newParentSlug, category.activity_type_name],
+  )
+}

--- a/apps/backend/src/services/screentime-category-sync.ts
+++ b/apps/backend/src/services/screentime-category-sync.ts
@@ -11,13 +11,15 @@
  * non-builtin type (e.g. a `tv` deduction-rule type) links to that type
  * instead of creating a parallel one. This is the design payoff — a `tv`
  * screentime category and a `tv` deduction-rule activity merge into a single
- * `activity_type` automatically.
+ * `activity_type` automatically. Multiple categories may also share a slug
+ * (Sport > Tennis and Hobby > Tennis both → `tennis`); the
+ * `activity_type_name` column is therefore intentionally non-unique.
  */
 
 import type { ScreentimeCategory } from '../db/index.ts'
 
 import { query } from '../db/connection.ts'
-import { insertActivityTypeDefinition } from '../db/index.ts'
+import { auditInfo, auditWarn } from './audit-log.ts'
 import { generateSlug } from './screentime-category-slug.ts'
 
 const findParentCategory = (
@@ -32,9 +34,17 @@ const findParentCategory = (
   )
 }
 
-const loadExistingTypeNames = async (
-  user: string,
-): Promise<{ builtin: Set<string>; nonBuiltin: Set<string> }> => {
+/**
+ * Existing activity_type names, partitioned by builtin status. Mutable: the
+ * caller adds to `nonBuiltin` after every successful insert so subsequent
+ * categories see the just-minted slugs without a re-query.
+ */
+interface ExistingTypeNames {
+  builtin: Set<string>
+  nonBuiltin: Set<string>
+}
+
+const loadExistingTypeNames = async (user: string): Promise<ExistingTypeNames> => {
   const result = await query<{ name: string; is_builtin: boolean }>(
     user,
     `SELECT name, is_builtin FROM activity_type_definitions`,
@@ -48,12 +58,47 @@ const loadExistingTypeNames = async (
   return { builtin, nonBuiltin }
 }
 
-const persistSlugOnCategory = async (user: string, categoryId: string, slug: string): Promise<void> => {
+const persistSlugOnCategory = async (
+  user: string,
+  categoryId: string,
+  slug: string,
+  ownsType: boolean,
+): Promise<void> => {
   await query(
     user,
-    `UPDATE screentime_categories SET activity_type_name = $1, updated_at = NOW() WHERE id = $2`,
-    [slug, categoryId],
+    `UPDATE screentime_categories
+       SET activity_type_name = $1, category_owns_type = $2, updated_at = NOW()
+     WHERE id = $3`,
+    [slug, ownsType, categoryId],
   )
+}
+
+/**
+ * Insert a derived activity_type row, using ON CONFLICT to tolerate a
+ * concurrent sync that just inserted the same slug. Returns true if we
+ * inserted, false if a concurrent writer beat us to it.
+ */
+const insertDerivedType = async (
+  user: string,
+  slug: string,
+  displayName: string,
+  color: string | undefined,
+  parentSlug: string | null,
+): Promise<boolean> => {
+  // ON CONFLICT (name) DO NOTHING — the (RescueTime push, ActivityWatch push)
+  // two-syncs-at-once case computes the same slug for the same category, and
+  // without this the loser fails the whole sync.
+  const aliases = [slug.toLowerCase()]
+  const result = await query(
+    user,
+    `INSERT INTO activity_type_definitions
+       (name, display_name, display_category, color, aliases, show_on_timeline, parent_type)
+     VALUES ($1, $2, 'productivity', COALESCE($3, '#6b7280'), $4, true, $5)
+     ON CONFLICT (name) DO NOTHING
+     RETURNING name`,
+    [slug, displayName, color ?? null, aliases, parentSlug],
+  )
+  return (result.rowCount ?? 0) > 0
 }
 
 /**
@@ -63,64 +108,117 @@ const persistSlugOnCategory = async (user: string, categoryId: string, slug: str
  * Otherwise generates a slug, inserts a new type def (or links to an existing
  * non-builtin same-name type), and persists the slug on the category.
  *
- * Caller passes the full category list so the parent path can be resolved
- * locally — depth-ordered iteration in `ensureAllCategoriesHaveTypes` mutates
- * the list as slugs are minted, so each child can read its parent's slug.
+ * `existing` is mutated in place — when a fresh slug is minted, it's added to
+ * the non-builtin set so subsequent same-batch categories see it.
  */
 export const ensureCategoryHasType = async (
   user: string,
   category: ScreentimeCategory,
   allCategories: ScreentimeCategory[],
+  existing?: ExistingTypeNames,
 ): Promise<string> => {
   if (category.activity_type_name) return category.activity_type_name
 
   const parent = findParentCategory(category, allCategories)
   let parentSlug: string | null = null
   if (parent) {
-    parentSlug = parent.activity_type_name ?? (await ensureCategoryHasType(user, parent, allCategories))
+    parentSlug =
+      parent.activity_type_name ?? (await ensureCategoryHasType(user, parent, allCategories, existing))
   }
 
-  const { builtin, nonBuiltin } = await loadExistingTypeNames(user)
+  const types = existing ?? (await loadExistingTypeNames(user))
   const leaf = category.name[category.name.length - 1]
   const { slug, linkToExisting } = generateSlug(leaf, parentSlug, {
-    existingBuiltin: builtin,
-    existingNonBuiltin: nonBuiltin,
+    existingBuiltin: types.builtin,
+    existingNonBuiltin: types.nonBuiltin,
   })
 
-  if (!linkToExisting) {
-    await insertActivityTypeDefinition(user, {
-      display_category: 'productivity',
-      display_name: leaf,
-      name: slug,
-      ...(category.color !== undefined ? { color: category.color } : {}),
-      ...(parentSlug !== null ? { parent_type: parentSlug } : {}),
+  let ownsType: boolean
+  if (linkToExisting) {
+    ownsType = false
+    // Audit-log convergence so users can debug why their category color/name
+    // didn't take effect on the type def.
+    auditInfo(user, 'data', 'Screentime category linked to existing activity type', {
+      category_id: category.id,
+      category_path: category.name.join(' > '),
+      slug,
     })
+  } else {
+    const inserted = await insertDerivedType(user, slug, leaf, category.color, parentSlug)
+    if (!inserted) {
+      // Concurrent writer minted this slug first. The slug exists; we link
+      // (and disclaim ownership of parent_type since the racer owns it).
+      ownsType = false
+      auditWarn(user, 'data', 'Concurrent insert beat us; linking to type minted by sibling sync', {
+        category_id: category.id,
+        slug,
+      })
+    } else {
+      ownsType = true
+    }
+    types.nonBuiltin.add(slug)
   }
 
-  await persistSlugOnCategory(user, category.id, slug)
+  await persistSlugOnCategory(user, category.id, slug, ownsType)
   category.activity_type_name = slug
+  category.category_owns_type = ownsType
   return slug
 }
 
 /**
  * Bulk-ensure: every category gets a slug + type def. Iterates depth-first so
  * parents are minted before children — `ensureCategoryHasType` then sees a
- * resolved parent slug locally without recursing.
+ * resolved parent slug locally without recursing. The existing-types snapshot
+ * is loaded once and threaded through to avoid an N+1 lookup.
  */
 export const ensureAllCategoriesHaveTypes = async (
   user: string,
   categories: ScreentimeCategory[],
 ): Promise<void> => {
+  if (categories.length === 0) return
+  const existing = await loadExistingTypeNames(user)
   const sorted = [...categories].sort((a, b) => a.name.length - b.name.length)
   for (const cat of sorted) {
-    await ensureCategoryHasType(user, cat, sorted)
+    await ensureCategoryHasType(user, cat, sorted, existing)
   }
+}
+
+/**
+ * Returns true when this category alone owns the activity_type — it created
+ * the type def itself (`category_owns_type=true`), no other category links to
+ * the same slug, and no deduction rule outputs it. Activities of that type
+ * are by extension also "ours" because nothing else could have produced them.
+ */
+const isTypeSolelyOwnedByCategory = async (user: string, category: ScreentimeCategory): Promise<boolean> => {
+  if (!category.activity_type_name) return false
+  if (!category.category_owns_type) return false // converged onto a pre-existing type
+  const result = await query<{ cat_count: string; has_rule: boolean }>(
+    user,
+    `SELECT
+       (SELECT COUNT(*)::int FROM screentime_categories
+          WHERE activity_type_name = $1 AND id <> $2) AS cat_count,
+       EXISTS(SELECT 1 FROM deduction_rules WHERE output_activity_type = $1) AS has_rule`,
+    [category.activity_type_name, category.id],
+  )
+  if (result.rows.length === 0) return false
+  const otherCatCount = Number(result.rows[0].cat_count)
+  const hasRule = result.rows[0].has_rule
+  return otherCatCount === 0 && !hasRule
 }
 
 /**
  * After a category is moved (its `name[]` prefix changed), update the linked
  * type def's `parent_type` so the type hierarchy mirrors the category
  * hierarchy. The slug itself is stable — only `parent_type` walks.
+ *
+ * Skipped when the type is shared (this category linked rather than created,
+ * other categories link, or a deduction rule outputs it). Reorganizing a
+ * shared hierarchy on behalf of one consumer would silently change collapse
+ * behaviour for unrelated activities.
+ *
+ * The raw UPDATE bypasses validateParentTypeUpdate; cycles can't form here
+ * because the new parent_type is derived from the category tree, which is a
+ * DAG by construction.
  */
 export const recomputeCategoryParentType = async (
   user: string,
@@ -128,6 +226,14 @@ export const recomputeCategoryParentType = async (
   allCategories: ScreentimeCategory[],
 ): Promise<void> => {
   if (!category.activity_type_name) return // not yet linked — nothing to recompute
+  const owned = await isTypeSolelyOwnedByCategory(user, category)
+  if (!owned) {
+    auditInfo(user, 'data', 'Skipped parent_type update on shared activity type', {
+      category_id: category.id,
+      slug: category.activity_type_name,
+    })
+    return
+  }
   const parent = findParentCategory(category, allCategories)
   const newParentSlug = parent?.activity_type_name ?? null
   await query(

--- a/packages/api-spec/src/schemas/screentime-categories.ts
+++ b/packages/api-spec/src/schemas/screentime-categories.ts
@@ -25,6 +25,10 @@ export const screentimeRuleTypeSchema = z.enum(['regex', 'none']).meta({
  */
 export const screentimeCategorySchema = z
   .object({
+    activity_type_name: z.string().optional().meta({
+      description:
+        'Slug of the linked `activity_type_definitions` row — set on first sync and stable across category renames. Read-only.',
+    }),
     color: z
       .string()
       .optional()


### PR DESCRIPTION
## Summary

- Each screentime category now mirrors into its own `activity_type_definitions` row, with `parent_type` reflecting the category hierarchy.
- Convergence-by-default: a category whose leaf slugifies to an existing non-builtin type (e.g. a `tv` deduction-rule type) links to that type instead of creating a parallel one — so a `tv` deduction-rule activity and a `tv` screentime category collapse into one `activity_type` automatically.
- Slugs saved on the category row, frozen at first sync — renames/moves don't change them, so existing activities of that type keep their classification.

Closes #651.

## Why

Phase 5 of the unified-activities initiative (#650) collapses sibling subtypes to their `parent_type` when the timeline is zoomed out. v1 of screen-time-as-activities (#648) used a single `screentime` type for every span — so the collapse did nothing for screen time. After this PR, the category hierarchy becomes a real type hierarchy and the existing collapse mechanism handles screen time uniformly.

The convergence design is the bigger payoff: a `Media > TV` screentime category and a `tv` deduction-rule activity (auto-created from a "media computer is active" rule) used to be two different `activity_type` values. Now they're one — same type on the timeline, same type in correlations, same type in queries.

## Design decisions

- **No umbrella `screentime` parent for derived types.** Top-level categories have `parent_type=null`. Forcing `parent_type='screentime'` onto a `tv` type would lie about provenance — that type may also be produced by a deduction rule on calendar events, with no relation to RescueTime/ActivityWatch. The legacy `screentime` builtin stays as a fallback for unlinked v1 activities; #652 backfills them, then it can retire.
- **Slug = leaf name, not path-prefixed.** `Media > TV` → `tv`, not `screentime_media_tv`. Convergence requires bare leaf names. Parent disambiguation only kicks in on builtin collision (e.g. literally naming a category "Screentime") or genuine cross-tree collisions.
- **Slug stable across renames/moves.** Saved on the category row at first sync, never recomputed. Activities of that type survive category edits.
- **Only `parent_type` walks on move.** When a category is moved, we update the linked type def's `parent_type` and recurse into descendants. Slugs themselves don't change.
- **No auto-update of `display_name` / `color` on subsequent rename / color edit.** v1 keeps it simple; user can rename the type def directly. Followups can add full mirroring.

## Out of scope

- **Backfill of existing v1 `screentime` activities** under derived types — covered by #652. v1 activities stay typed `screentime`; new ones use the derived types. The `external_id` format change ensures no collisions.
- **Migration of `/productivity`, daily summary, deduction rules** to read from activities — #653.
- **Frontend legend awareness** of the new types — #718.
- **Manual relink** (changing `activity_type_name` on a category to point at a different existing type) — captured for a follow-up; the column is the schema groundwork.

## Test plan

- [x] Unit tests for `generateSlug` (collision, parent-prefix, numeric fallback, truncation, special chars).
- [x] Unit tests for `buildScreentimeActivitySpans` derived-type selection (uses `activity_type_name`, falls back to `screentime`).
- [x] Unit tests for `spansToActivities` slug-keyed external_id.
- [x] Integration tests:
  - Fresh category create → derived type def appears.
  - Child inherits parent slug as `parent_type`.
  - Convergence: leaf colliding with existing non-builtin type links to it.
  - Builtin collision forces parent-prefix slug.
  - `moveCategoryToParent` updates `parent_type` on the type def.
  - `ensureAllCategoriesHaveTypes` processes parents before children.
  - Idempotency: second `ensureCategoryHasType` is a no-op.
- [x] `pnpm fix` and `pnpm check` pass.
- [ ] Smoke-test on staging once deployed: existing categories get types lazily on next RescueTime/ActivityWatch sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)