### PR TITLE
feat(android): background sync observability + use HC lastModifiedTime

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
@@ -3,6 +3,7 @@ package net.aurboda
 import android.app.Application
 import android.content.Context
 import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
 
 private const val TAG = "AurbodaApplication"
 private const val PREFS_NAME = "AurbodaAppPrefs"
@@ -10,9 +11,12 @@ private const val BACKGROUND_SYNC_ENABLED_KEY = "backgroundSyncEnabled"
 
 class AurbodaApplication : Application() {
   val syncProgress: SyncProgressReporter = DefaultSyncProgressReporter()
+  val backgroundSyncStatus: MutableStateFlow<BackgroundSyncStatus> = MutableStateFlow(BackgroundSyncStatus())
 
   override fun onCreate() {
     super.onCreate()
+
+    backgroundSyncStatus.value = loadBackgroundSyncStatus(this)
 
     // Schedule background sync if it was previously enabled
     // This ensures sync continues after app restarts, device reboots, etc.

--- a/apps/android/app/src/main/java/net/aurboda/BackgroundSyncStatus.kt
+++ b/apps/android/app/src/main/java/net/aurboda/BackgroundSyncStatus.kt
@@ -1,0 +1,71 @@
+package net.aurboda
+
+import android.content.Context
+import java.time.Instant
+
+private const val PREFS_NAME = "AurbodaAppPrefs"
+private const val LAST_ATTEMPT_KEY = "bgSyncLastAttemptMs"
+private const val LAST_SUCCESS_KEY = "bgSyncLastSuccessMs"
+private const val LAST_RESULT_KEY = "bgSyncLastResult"
+private const val LAST_ERROR_KEY = "bgSyncLastError"
+private const val LAST_DURATION_KEY = "bgSyncLastDurationMs"
+
+enum class BackgroundSyncResult { Success, Retry, Skipped }
+
+data class BackgroundSyncStatus(
+  val lastAttempt: Instant? = null,
+  val lastSuccess: Instant? = null,
+  val lastResult: BackgroundSyncResult? = null,
+  val lastError: String? = null,
+  val lastDurationMs: Long? = null,
+)
+
+fun loadBackgroundSyncStatus(context: Context): BackgroundSyncStatus {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  val attemptMs = prefs.getLong(LAST_ATTEMPT_KEY, 0L).takeIf { it > 0 }
+  val successMs = prefs.getLong(LAST_SUCCESS_KEY, 0L).takeIf { it > 0 }
+  val resultName = prefs.getString(LAST_RESULT_KEY, null)
+  val durationMs = prefs.getLong(LAST_DURATION_KEY, -1L).takeIf { it >= 0 }
+  val parsedResult = resultName?.let { runCatching { BackgroundSyncResult.valueOf(it) }.getOrNull() }
+  return BackgroundSyncStatus(
+    lastAttempt = attemptMs?.let(Instant::ofEpochMilli),
+    lastSuccess = successMs?.let(Instant::ofEpochMilli),
+    lastResult = parsedResult,
+    lastError = prefs.getString(LAST_ERROR_KEY, null),
+    lastDurationMs = durationMs,
+  )
+}
+
+fun recordBackgroundSyncAttempt(context: Context, attemptAt: Instant) {
+  context
+    .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    .edit()
+    .putLong(LAST_ATTEMPT_KEY, attemptAt.toEpochMilli())
+    .apply()
+  publishStatus(context)
+}
+
+fun recordBackgroundSyncResult(
+  context: Context,
+  result: BackgroundSyncResult,
+  finishedAt: Instant,
+  durationMs: Long,
+  error: String? = null,
+) {
+  val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  val edit = prefs.edit()
+    .putString(LAST_RESULT_KEY, result.name)
+    .putLong(LAST_DURATION_KEY, durationMs)
+  when (result) {
+    BackgroundSyncResult.Success -> edit.putLong(LAST_SUCCESS_KEY, finishedAt.toEpochMilli()).remove(LAST_ERROR_KEY)
+    BackgroundSyncResult.Skipped -> edit.remove(LAST_ERROR_KEY)
+    BackgroundSyncResult.Retry -> if (error != null) edit.putString(LAST_ERROR_KEY, error) else edit.remove(LAST_ERROR_KEY)
+  }
+  edit.apply()
+  publishStatus(context)
+}
+
+private fun publishStatus(context: Context) {
+  val app = context.applicationContext as? AurbodaApplication ?: return
+  app.backgroundSyncStatus.value = loadBackgroundSyncStatus(context)
+}

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -373,6 +373,11 @@ fun HealthConnectScreen(
   var permissionStatusMessage by remember { mutableStateOf("Checking permissions...") }
   var backgroundSyncEnabled by remember { mutableStateOf(isBackgroundSyncEnabled(context)) }
   var showBatteryOptimizationDialog by remember { mutableStateOf(false) }
+  val bgSyncStatusFlow = remember(context) {
+    (context.applicationContext as? AurbodaApplication)?.backgroundSyncStatus
+      ?: kotlinx.coroutines.flow.MutableStateFlow(BackgroundSyncStatus())
+  }
+  val bgSyncStatus by bgSyncStatusFlow.collectAsState()
 
   // -- ActivityWatch state --
   var awSyncEnabled by remember { mutableStateOf(isActivityWatchSyncEnabled(context)) }
@@ -431,7 +436,6 @@ fun HealthConnectScreen(
         val sevenDaysAgo = ZonedDateTime.now().minusDays(7).toInstant()
         val now = Instant.now()
         var totalSent = 0
-        reporter.reportDataInstant(sevenDaysAgo)
 
         for (recordType: KClass<out Record> in typesToFetch) {
           try {
@@ -451,7 +455,7 @@ fun HealthConnectScreen(
 
             if (recordsOfType.isNotEmpty()) {
               Log.d("SyncData", "Fetched ${recordsOfType.size} ${recordType.simpleName} records, sending...")
-              recordsOfType.oldestEventInstant()?.let(reporter::reportDataInstant)
+              recordsOfType.oldestModifiedTime()?.let(reporter::reportDataInstant)
               val result = sendRecords(recordsOfType, apiUrl, authToken, ktorHttpClient, reporter, "SyncData")
               if (!result.isSuccess) {
                 reporter.updateStage(SyncStage.HealthConnect) {
@@ -515,7 +519,7 @@ fun HealthConnectScreen(
 
           if (upsertions.isNotEmpty() || deletionIds.isNotEmpty()) {
             Log.d("SyncData", "Page $pageNum: ${upsertions.size} records, ${deletionIds.size} deletions")
-            upsertions.oldestEventInstant()?.let(reporter::reportDataInstant)
+            upsertions.oldestModifiedTime()?.let(reporter::reportDataInstant)
             reporter.updateStage(SyncStage.HealthConnect) {
               it.copy(
                 currentPage = pageNum,
@@ -823,6 +827,10 @@ fun HealthConnectScreen(
                 }
               },
             )
+          }
+
+          if (backgroundSyncEnabled) {
+            BackgroundSyncStatusRow(bgSyncStatus)
           }
 
           // Background read permission is granted separately from foreground reads:

--- a/apps/android/app/src/main/java/net/aurboda/SyncProgress.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncProgress.kt
@@ -1,45 +1,7 @@
 package net.aurboda
 
 import android.content.Context
-import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
-import androidx.health.connect.client.records.BasalBodyTemperatureRecord
-import androidx.health.connect.client.records.BasalMetabolicRateRecord
-import androidx.health.connect.client.records.BloodGlucoseRecord
-import androidx.health.connect.client.records.BloodPressureRecord
-import androidx.health.connect.client.records.BodyFatRecord
-import androidx.health.connect.client.records.BodyTemperatureRecord
-import androidx.health.connect.client.records.BodyWaterMassRecord
-import androidx.health.connect.client.records.BoneMassRecord
-import androidx.health.connect.client.records.CervicalMucusRecord
-import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
-import androidx.health.connect.client.records.DistanceRecord
-import androidx.health.connect.client.records.ElevationGainedRecord
-import androidx.health.connect.client.records.ExerciseSessionRecord
-import androidx.health.connect.client.records.FloorsClimbedRecord
-import androidx.health.connect.client.records.HeartRateRecord
-import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
-import androidx.health.connect.client.records.HeightRecord
-import androidx.health.connect.client.records.HydrationRecord
-import androidx.health.connect.client.records.IntermenstrualBleedingRecord
-import androidx.health.connect.client.records.LeanBodyMassRecord
-import androidx.health.connect.client.records.MenstruationFlowRecord
-import androidx.health.connect.client.records.MenstruationPeriodRecord
-import androidx.health.connect.client.records.NutritionRecord
-import androidx.health.connect.client.records.OvulationTestRecord
-import androidx.health.connect.client.records.OxygenSaturationRecord
-import androidx.health.connect.client.records.PowerRecord
 import androidx.health.connect.client.records.Record
-import androidx.health.connect.client.records.RespiratoryRateRecord
-import androidx.health.connect.client.records.RestingHeartRateRecord
-import androidx.health.connect.client.records.SexualActivityRecord
-import androidx.health.connect.client.records.SleepSessionRecord
-import androidx.health.connect.client.records.SpeedRecord
-import androidx.health.connect.client.records.StepsCadenceRecord
-import androidx.health.connect.client.records.StepsRecord
-import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
-import androidx.health.connect.client.records.Vo2MaxRecord
-import androidx.health.connect.client.records.WeightRecord
-import androidx.health.connect.client.records.WheelchairPushesRecord
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,7 +48,10 @@ data class SyncProgressState(
   val finishedAt: Instant? = null,
   val stages: Map<SyncStage, SyncStageInfo> = emptyMap(),
   val recordTypes: Map<String, SyncRecordTypeInfo> = emptyMap(),
-  /** Timestamp of the data currently in flight; powers the "Syncing data from N days ago" hint. */
+  /**
+   * Oldest `lastModifiedTime` among records currently in flight; powers the
+   * "Syncing data updated N ago" hint, i.e. how stale this batch is.
+   */
   val currentDataInstant: Instant? = null,
   val lastError: String? = null,
 )
@@ -112,7 +77,7 @@ interface SyncProgressReporter {
     transform: (SyncRecordTypeInfo) -> SyncRecordTypeInfo,
   )
 
-  /** Report the timestamp of the data currently being processed (drives "from N days ago"). */
+  /** Report the oldest `lastModifiedTime` of records being processed (drives "updated N ago"). */
   fun reportDataInstant(time: Instant?)
 }
 
@@ -191,52 +156,10 @@ fun Context.syncProgressReporter(): SyncProgressReporter =
   (applicationContext as? AurbodaApplication)?.syncProgress ?: NoOpSyncProgressReporter
 
 /**
- * Extract a representative timestamp from a Health Connect record.
- * The HC base interfaces (IntervalRecord/InstantaneousRecord) are internal in 1.2.0-alpha01,
- * so we dispatch on the concrete classes we actually serialize.
+ * Earliest Health Connect `lastModifiedTime` across a record list. Drives the
+ * "Syncing data updated N ago" hint — i.e. how stale the freshest record we're
+ * about to upload looks against wall-clock now. Using lastModifiedTime instead
+ * of the record's event time means a sleep session that started 8h ago but was
+ * just written by the source app shows as "minutes ago", not "hours ago".
  */
-fun Record.eventInstant(): Instant? =
-  when (this) {
-    is ActiveCaloriesBurnedRecord -> startTime
-    is BasalBodyTemperatureRecord -> time
-    is BasalMetabolicRateRecord -> time
-    is BloodGlucoseRecord -> time
-    is BloodPressureRecord -> time
-    is BodyFatRecord -> time
-    is BodyTemperatureRecord -> time
-    is BodyWaterMassRecord -> time
-    is BoneMassRecord -> time
-    is CervicalMucusRecord -> time
-    is CyclingPedalingCadenceRecord -> startTime
-    is DistanceRecord -> startTime
-    is ElevationGainedRecord -> startTime
-    is ExerciseSessionRecord -> startTime
-    is FloorsClimbedRecord -> startTime
-    is HeartRateRecord -> startTime
-    is HeartRateVariabilityRmssdRecord -> time
-    is HeightRecord -> time
-    is HydrationRecord -> startTime
-    is IntermenstrualBleedingRecord -> time
-    is LeanBodyMassRecord -> time
-    is MenstruationFlowRecord -> time
-    is MenstruationPeriodRecord -> startTime
-    is NutritionRecord -> startTime
-    is OvulationTestRecord -> time
-    is OxygenSaturationRecord -> time
-    is PowerRecord -> startTime
-    is RespiratoryRateRecord -> time
-    is RestingHeartRateRecord -> time
-    is SexualActivityRecord -> time
-    is SleepSessionRecord -> startTime
-    is SpeedRecord -> startTime
-    is StepsCadenceRecord -> startTime
-    is StepsRecord -> startTime
-    is TotalCaloriesBurnedRecord -> startTime
-    is Vo2MaxRecord -> time
-    is WeightRecord -> time
-    is WheelchairPushesRecord -> startTime
-    else -> null
-  }
-
-/** Earliest [eventInstant] across a record list, or null when no record exposes one. */
-fun List<Record>.oldestEventInstant(): Instant? = mapNotNull { it.eventInstant() }.minOrNull()
+fun List<Record>.oldestModifiedTime(): Instant? = minOfOrNull { it.metadata.lastModifiedTime }

--- a/apps/android/app/src/main/java/net/aurboda/SyncProgressView.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncProgressView.kt
@@ -25,7 +25,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 /**
- * Renders the structured sync progress: a "Syncing data from N ago" hint, a stage list with
+ * Renders the structured sync progress: a "Syncing data updated N ago" hint, a stage list with
  * inline status icons, and per-record-type chunk progress nested under the Health Connect stage.
  */
 @Composable
@@ -40,7 +40,7 @@ fun SyncProgressView(
     }
 
   Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-    // "Syncing data from 20 days ago" — only while running and only when we know how far behind we are.
+    // "Syncing data updated 5 min ago" — only while running and only when we know the freshness of the in-flight batch.
     if (state.isRunning && state.currentDataInstant != null) {
       RelativeAgoText(state.currentDataInstant)
     } else if (!state.isRunning && state.lastError != null) {
@@ -141,7 +141,7 @@ private fun RelativeAgoText(target: Instant) {
     }
   }
   Text(
-    "Syncing data from ${formatRelative(target, now)}",
+    "Syncing data updated ${formatRelative(target, now)}",
     style = MaterialTheme.typography.bodyMedium,
     fontWeight = FontWeight.Medium,
     color = MaterialTheme.colorScheme.primary,
@@ -157,6 +157,74 @@ private fun formatRelative(target: Instant, now: Instant): String {
     seconds < 86_400 -> "${seconds / 3600}h ago"
     seconds < 86_400 * 2 -> "yesterday"
     else -> "${seconds / 86_400} days ago"
+  }
+}
+
+@Composable
+fun BackgroundSyncStatusRow(status: BackgroundSyncStatus) {
+  // 30s tick keeps "ago" labels fresh.
+  var now by remember { mutableStateOf(Instant.now()) }
+  LaunchedEffect(status.lastAttempt, status.lastSuccess) {
+    while (true) {
+      now = Instant.now()
+      delay(30_000)
+    }
+  }
+
+  val attempt = status.lastAttempt
+  if (attempt == null) {
+    Text(
+      "Background sync: not yet run",
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    return
+  }
+
+  val durationLabel = status.lastDurationMs?.let { ms ->
+    when {
+      ms < 1000 -> "${ms}ms"
+      ms < 60_000 -> "${ms / 1000}s"
+      else -> "${ms / 60_000}m ${(ms % 60_000) / 1000}s"
+    }
+  }
+
+  val outcomeLabel = when (status.lastResult) {
+    BackgroundSyncResult.Success -> "success"
+    BackgroundSyncResult.Retry -> "retry pending"
+    BackgroundSyncResult.Skipped -> "skipped"
+    null -> "running…"
+  }
+
+  val color = when (status.lastResult) {
+    BackgroundSyncResult.Retry -> MaterialTheme.colorScheme.error
+    else -> MaterialTheme.colorScheme.onSurfaceVariant
+  }
+
+  val attemptText = "Background sync: ${formatRelative(attempt, now)} ($outcomeLabel${if (durationLabel != null) ", $durationLabel" else ""})"
+
+  Column {
+    Text(
+      attemptText,
+      style = MaterialTheme.typography.bodySmall,
+      color = color,
+    )
+    val success = status.lastSuccess
+    if (success != null && status.lastResult != BackgroundSyncResult.Success) {
+      Text(
+        "Last successful run: ${formatRelative(success, now)}",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    val error = status.lastError
+    if (error != null && status.lastResult != BackgroundSyncResult.Success) {
+      Text(
+        "Last error: $error",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+      )
+    }
   }
 }
 

--- a/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
@@ -296,7 +296,7 @@ suspend fun sendRecords(
     val typeName = recordClass.simpleName ?: "UnknownRecordType"
     val syncUrl = "$serverUrl/sync/$typeName"
 
-    classRecords.oldestEventInstant()?.let(reporter::reportDataInstant)
+    classRecords.oldestModifiedTime()?.let(reporter::reportDataInstant)
 
     val result =
       when (recordClass) {

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -18,6 +18,7 @@ import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import net.aurboda.widget.HrZoneWidgetProvider
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 
@@ -40,12 +41,14 @@ class SyncWorker(
 
   override suspend fun doWork(): Result {
     Log.d(TAG, "Starting background sync")
+    val attemptAt = Instant.now()
+    recordBackgroundSyncAttempt(applicationContext, attemptAt)
     val reporter = applicationContext.syncProgressReporter()
 
     val credentials = CredentialsManager.getCredentials(applicationContext)
     if (credentials == null) {
       Log.w(TAG, "No credentials found, skipping sync")
-      return Result.success()
+      return finishAttempt(attemptAt, BackgroundSyncResult.Skipped, error = "No credentials")
     }
 
     // Check permissions -- proceed with whatever is granted (partial permissions support)
@@ -53,7 +56,7 @@ class SyncWorker(
     val grantedTypes = getGrantedRecordTypes(grantedPermissions)
     if (grantedTypes.isEmpty()) {
       Log.w(TAG, "No permissions granted, skipping sync")
-      return Result.success()
+      return finishAttempt(attemptAt, BackgroundSyncResult.Skipped, error = "No HC permissions granted")
     }
     Log.d(TAG, "Granted ${grantedTypes.size}/${allRecordTypes.size} record types")
 
@@ -88,7 +91,7 @@ class SyncWorker(
           if (!aggregateSuccess) {
             Log.w(TAG, "Failed to send daily aggregates, will retry")
             reporter.end("Daily aggregates failed")
-            return Result.retry()
+            return finishAttempt(attemptAt, BackgroundSyncResult.Retry, error = "Daily aggregates failed")
           }
           Log.d(TAG, "Sent ${aggregates.size} daily aggregates")
         } else {
@@ -102,7 +105,7 @@ class SyncWorker(
         if (!syncSuccess) {
           Log.w(TAG, "Incremental sync failed, will retry")
           reporter.end("Health Connect sync failed")
-          return Result.retry()
+          return finishAttempt(attemptAt, BackgroundSyncResult.Retry, error = "Health Connect sync failed")
         }
       } else {
         reporter.updateStage(SyncStage.DailyAggregates) {
@@ -148,11 +151,30 @@ class SyncWorker(
 
       HrZoneWidgetProvider.triggerUpdate(applicationContext)
       reporter.end()
-      Result.success()
+      finishAttempt(attemptAt, BackgroundSyncResult.Success)
     } catch (e: Exception) {
       Log.e(TAG, "Background sync failed", e)
       reporter.end(e.message)
-      Result.retry()
+      finishAttempt(attemptAt, BackgroundSyncResult.Retry, error = e.message)
+    }
+  }
+
+  private fun finishAttempt(
+    attemptAt: Instant,
+    outcome: BackgroundSyncResult,
+    error: String? = null,
+  ): Result {
+    val finishedAt = Instant.now()
+    recordBackgroundSyncResult(
+      applicationContext,
+      outcome,
+      finishedAt,
+      finishedAt.toEpochMilli() - attemptAt.toEpochMilli(),
+      error,
+    )
+    return when (outcome) {
+      BackgroundSyncResult.Success, BackgroundSyncResult.Skipped -> Result.success()
+      BackgroundSyncResult.Retry -> Result.retry()
     }
   }
 
@@ -270,7 +292,7 @@ class SyncWorker(
 
       if (upsertions.isNotEmpty() || deletionIds.isNotEmpty()) {
         Log.d(TAG, "Page $pageNum: ${upsertions.size} records, ${deletionIds.size} deletions")
-        upsertions.oldestEventInstant()?.let(reporter::reportDataInstant)
+        upsertions.oldestModifiedTime()?.let(reporter::reportDataInstant)
         reporter.updateStage(SyncStage.HealthConnect) {
           it.copy(
             currentPage = pageNum,

--- a/apps/android/app/src/test/java/net/aurboda/BackgroundSyncTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/BackgroundSyncTest.kt
@@ -217,4 +217,78 @@ class BackgroundSyncTest {
     assertEquals("AurbodaAppPrefs", prefsName)
     assertEquals("backgroundSyncEnabled", backgroundSyncEnabledKey)
   }
+
+  @Test
+  fun `loadBackgroundSyncStatus returns empty status when no run has happened`() {
+    val status = loadBackgroundSyncStatus(context)
+    assertNull(status.lastAttempt)
+    assertNull(status.lastSuccess)
+    assertNull(status.lastResult)
+    assertNull(status.lastError)
+    assertNull(status.lastDurationMs)
+  }
+
+  @Test
+  fun `recordBackgroundSyncAttempt persists attempt timestamp`() {
+    val now = java.time.Instant.parse("2026-05-06T12:00:00Z")
+    recordBackgroundSyncAttempt(context, now)
+
+    val status = loadBackgroundSyncStatus(context)
+    assertEquals(now, status.lastAttempt)
+    assertNull(status.lastSuccess)
+    assertNull(status.lastResult)
+  }
+
+  @Test
+  fun `recordBackgroundSyncResult success records success time and clears prior error`() {
+    // Previous failed run leaves an error
+    recordBackgroundSyncResult(
+      context,
+      BackgroundSyncResult.Retry,
+      java.time.Instant.parse("2026-05-06T12:00:00Z"),
+      durationMs = 1500,
+      error = "boom",
+    )
+    assertEquals("boom", loadBackgroundSyncStatus(context).lastError)
+
+    // Now a success
+    val finishedAt = java.time.Instant.parse("2026-05-06T12:15:00Z")
+    recordBackgroundSyncResult(
+      context,
+      BackgroundSyncResult.Success,
+      finishedAt,
+      durationMs = 8500,
+    )
+
+    val status = loadBackgroundSyncStatus(context)
+    assertEquals(BackgroundSyncResult.Success, status.lastResult)
+    assertEquals(finishedAt, status.lastSuccess)
+    assertEquals(8500L, status.lastDurationMs)
+    assertNull("Success clears the prior error", status.lastError)
+  }
+
+  @Test
+  fun `recordBackgroundSyncResult retry stores error but does not advance lastSuccess`() {
+    // Seed a prior success
+    recordBackgroundSyncResult(
+      context,
+      BackgroundSyncResult.Success,
+      java.time.Instant.parse("2026-05-06T11:00:00Z"),
+      durationMs = 3000,
+    )
+    val priorSuccess = loadBackgroundSyncStatus(context).lastSuccess
+
+    // A subsequent retry doesn't bump lastSuccess and stores the error
+    recordBackgroundSyncResult(
+      context,
+      BackgroundSyncResult.Retry,
+      java.time.Instant.parse("2026-05-06T11:15:00Z"),
+      durationMs = 4000,
+      error = "network",
+    )
+    val status = loadBackgroundSyncStatus(context)
+    assertEquals(BackgroundSyncResult.Retry, status.lastResult)
+    assertEquals("network", status.lastError)
+    assertEquals(priorSuccess, status.lastSuccess)
+  }
 }


### PR DESCRIPTION
## Summary

Adds the missing "is the periodic worker actually firing?" signal to the Sync card and fixes the misleading "Syncing data from N ago" hint.

- **Observability**: `SyncWorker` now persists `lastAttempt` / `lastSuccess` / `lastResult` (Success / Retry / Skipped) / `lastError` / `lastDurationMs` to SharedPreferences and an Application-scoped `MutableStateFlow<BackgroundSyncStatus>`. New `BackgroundSyncStatusRow` renders this on the sync card when Background Sync is enabled. Until now there was no way to tell from the UI whether the 15-min worker had run at all.
- **Switch to `metadata.lastModifiedTime`**: the previous `oldestEventInstant()` reported the start-time of the underlying activity, so a sleep session written *just now* but starting 8h ago surfaced as "data from 8h ago". The new `oldestModifiedTime()` uses HC's `lastModifiedTime` — when the record was written into Health Connect — which is what the label is actually trying to answer. Label updated to "Syncing data updated N ago" to match.
- **Drop the 7-days-ago placeholder** at the start of initial sync — once we report the lastModifiedTime of the actual records, a static 7d marker is just noise.

## Why

User reported that despite having background HC permissions, opening the app would show "syncing data from 37 minutes ago", suggesting the periodic worker wasn't running. The actual cause was likely a mix of two things:

1. The hint was based on event start-time, so a watch syncing an 8h sleep session would always read as old.
2. There's no observability into whether the worker is firing on schedule — so the symptom is unfalsifiable.

This PR fixes #2 first; with the new status row visible, the next steps (chained `OneTimeWorkRequest` for sub-15-min cadence, boot-completed re-schedule, etc.) can be evaluated against real data.

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` (run locally, passing)
- [ ] Install debug build, enable Background Sync, observe "Background sync: just now (success, …s)" populates after the first run
- [ ] Force a failure (toggle airplane mode mid-run) and confirm "retry pending" + "Last error: …" surfaces
- [ ] Open the app fresh and confirm "Syncing data updated …" reflects HC write time, not record start time

🤖 Generated with [Claude Code](https://claude.com/claude-code)