### PR TITLE
fix(food-items): expose is_shared so UI uses override endpoint for icon

### DIFF
--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -289,6 +289,30 @@ describe('POST /food-items/:id/resnapshot-meals', () => {
   })
 })
 
+describe('GET /food-items/:id — is_shared flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('per-user item → is_shared: false', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    setUserFoodItem(async (_u, fid) => (fid === id ? userItem(id) : null))
+    const res = await supertest(buildApp(fakeCentral())).get(`/food-items/${id}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.is_shared).toBe(false)
+  })
+
+  test('central library item → is_shared: true (so the UI knows to use the override endpoint)', async () => {
+    const id = '11111111-1111-4111-8111-111111111111'
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(sharedItem(id))
+    const res = await supertest(buildApp(central)).get(`/food-items/${id}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.is_shared).toBe(true)
+  })
+})
+
 describe('PATCH /food-items/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -85,6 +85,7 @@ const serializeFoodItem = (
 const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   const base = serializeFoodItem(detail.item)
   const sensitivities = detail.sensitivities ?? []
+  const is_shared = detail.is_shared
   // Composite branch: ingredient list + derived totals.
   if (detail.ingredients) {
     return {
@@ -98,6 +99,7 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
         sort_order: ing.row.sort_order,
         unit: ing.row.unit,
       })),
+      is_shared,
       sensitivities,
     }
   }
@@ -106,6 +108,7 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   if (detail.reference) {
     return {
       ...base,
+      is_shared,
       reference: {
         food: serializeFoodItem(detail.reference.food),
         unit_mismatch: detail.reference.unit_mismatch,
@@ -114,7 +117,7 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
       sensitivities,
     }
   }
-  return { ...base, sensitivities } as FoodItemDetail
+  return { ...base, is_shared, sensitivities } as FoodItemDetail
 }
 
 const serializeOverride = (override: DbSharedFoodItemOverride): ApiSharedFoodItemOverride => ({

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -471,8 +471,22 @@ describe('createFoodItemsService.getDetail — reference enrichment', () => {
 
     const detail = await service.getDetail('user', 'u1')
     expect(detail?.item.id).toBe('u1')
+    expect(detail?.is_shared).toBe(false)
     expect(detail?.reference).toBeUndefined()
     expect(detail?.reference_enriched).toBeUndefined()
+  })
+
+  test('flags is_shared on details that fall through to the central library', async () => {
+    // Per-user lookup misses; central does match. UI uses this flag to switch
+    // the icon save from PATCH to the override endpoint.
+    vi.mocked(dbModule.getFoodItemById).mockResolvedValue(null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(sharedItem('c1', 'Banana'))
+    vi.mocked(ingredientsModule.getIngredients).mockResolvedValue([])
+
+    const detail = await createFoodItemsService(central).getDetail('user', 'c1')
+    expect(detail?.item.id).toBe('c1')
+    expect(detail?.is_shared).toBe(true)
   })
 
   test('emits per-field origin info: self wins, reference fills empty (scaled by serving)', async () => {
@@ -596,6 +610,7 @@ describe('getEffectiveNutrients', () => {
     const detail: FoodItemDetail = {
       derived_nutrients: { nutrient_data_incomplete: false, values: { calories: 320, fiber: 0, protein: 1 } },
       ingredients: [],
+      is_shared: false,
       item,
     }
     expect(getEffectiveNutrients(detail)).toEqual({ calories: 320, fiber: 0, protein: 1 })
@@ -604,6 +619,7 @@ describe('getEffectiveNutrients', () => {
   test('reference-enriched — returns the per-field origin values', () => {
     const item = userItem('p', 'Atomic')
     const detail: FoodItemDetail = {
+      is_shared: false,
       item,
       reference: { food: item, unit_mismatch: false },
       reference_enriched: {
@@ -620,7 +636,7 @@ describe('getEffectiveNutrients', () => {
     const item = userItem('p', 'Plain')
     item.calories = 100
     item.fiber = 3
-    const detail: FoodItemDetail = { item }
+    const detail: FoodItemDetail = { is_shared: false, item }
     const eff = getEffectiveNutrients(detail)
     expect(eff.calories).toBe(100)
     expect(eff.fiber).toBe(3)

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -84,6 +84,8 @@ export interface ReferenceEnrichedFields {
 
 export interface FoodItemDetail {
   item: MergedFoodItem
+  /** True when the item came from the central shared library — read-only, customizable only via the override endpoints. */
+  is_shared: boolean
   /** Present iff the item is a per-user composite. */
   ingredients?: ResolvedIngredient[]
   /** Derived nutrient totals when composite; absent for atomic items. */
@@ -248,8 +250,11 @@ const enrichWithReference = (self: MergedFoodItem, ref: MergedFoodItem): FoodIte
       fields[field] = { origin: 'reference', value: round2(refVal * scale) }
     }
   }
+  // Only per-user atomic items reach reference enrichment — central rows
+  // never carry a reference_food_item_id, so is_shared is always false here.
   return {
     item: self,
+    is_shared: false,
     reference: { food: ref, unit_mismatch },
     reference_enriched: { fields },
   }
@@ -377,7 +382,7 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       // a reference would be ignored anyway.
       if (fromUser.is_composite) {
         const rows = await dbGetIngredients(user, id)
-        if (rows.length === 0) return { item: fromUser, sensitivities }
+        if (rows.length === 0) return { item: fromUser, is_shared: false, sensitivities }
         // Resolve each ingredient: prefer the per-user row, fall back to the
         // central library. Once we know which ingredients came from central,
         // batch the override lookup so a 10-ingredient recipe makes one
@@ -402,6 +407,7 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
         return {
           derived_nutrients: aggregateNutrientsFromIngredients(resolved),
           ingredients: resolved,
+          is_shared: false,
           item: fromUser,
           sensitivities,
         }
@@ -422,10 +428,10 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
           return { ...enrichWithReference(fromUser, refFood), sensitivities }
         }
       }
-      return { item: fromUser, sensitivities }
+      return { item: fromUser, is_shared: false, sensitivities }
     }
     const fromCentral = await applySharedOverride(user, await centralDb.getSharedFoodItemById(id))
-    return fromCentral ? { item: fromCentral, sensitivities } : null
+    return fromCentral ? { item: fromCentral, is_shared: true, sensitivities } : null
   },
 
   wouldCreateCycle: async (user, parentId, ingredientIds) => {

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -190,6 +190,38 @@
   color: #6b7280;
 }
 
+.fi-shared-banner {
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 6px;
+  color: #075985;
+  font-size: 0.85rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0 0 1rem;
+}
+
+.fi-name-readonly {
+  color: inherit;
+  font-weight: inherit;
+}
+
+.fi-default-readonly {
+  color: #374151;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-color-scheme: dark) {
+  .fi-shared-banner {
+    background: #082f49;
+    border-color: #155e75;
+    color: #bae6fd;
+  }
+
+  .fi-default-readonly {
+    color: #d1d5db;
+  }
+}
+
 .nutrient-sections {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -92,6 +92,26 @@ const resnapshotMealsApi = async (id: string): Promise<{ meals_updated: number; 
   return json.data
 }
 
+const setSharedIconOverrideApi = async (id: string, icon: string | null): Promise<void> => {
+  const { token } = auth.value
+  // Clearing the icon → DELETE the whole override row (matches the
+  // "revert to central" semantic the user expects from blanking the field).
+  // Setting an icon → PUT with `{ icon }`. We never call PATCH on a shared row.
+  const init: RequestInit =
+    icon === null
+      ? { headers: { Authorization: `Bearer ${token}` }, method: 'DELETE' }
+      : {
+          body: JSON.stringify({ icon }),
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          method: 'PUT',
+        }
+  const res = await fetch(`${API_URL}/food-items/${id}/override`, init)
+  if (!res.ok) {
+    const json = (await res.json().catch(() => ({}))) as { error?: string }
+    throw new Error(json.error ?? 'Failed to update icon override')
+  }
+}
+
 const setReferenceApi = async (id: string, referenceId: string | null): Promise<ApiFoodItemDetail> => {
   const { token } = auth.value
   const init: RequestInit =
@@ -245,6 +265,22 @@ export function FoodItemDetail() {
     },
   })
 
+  const sharedIconMutation = useMutation({
+    mutationFn: (next: string | null) => setSharedIconOverrideApi(id, next),
+    onError: (err: Error) => setSaveError(err.message ?? 'Save failed'),
+    onSuccess: () => {
+      // The override endpoints don't echo back the merged detail, so refetch
+      // to pick up the new effective icon (and any other override fields
+      // surfaced later).
+      queryClient.invalidateQueries({ queryKey: ['foodItem', id] })
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      setSaveError(null)
+      setSavedFlash(true)
+      if (flashTimer.current) clearTimeout(flashTimer.current)
+      flashTimer.current = setTimeout(() => setSavedFlash(false), 1200)
+    },
+  })
+
   const deleteMutation = useMutation({
     mutationFn: () => deleteFoodItemApi(id),
     onSuccess: () => {
@@ -360,8 +396,18 @@ export function FoodItemDetail() {
     const next = icon.trim() || null
     const current = item.icon ?? null
     if (next === current) return
+    // Central library rows can't be PATCHed — icon edits go through the
+    // per-user override layer. Other fields (name, default_*, nutrients) are
+    // hidden in the UI for shared rows since they have no override slot yet.
+    if (item.is_shared) {
+      sharedIconMutation.mutate(next)
+      return
+    }
     save({ icon: next })
   }
+
+  const isShared = !!item.is_shared
+  const savePending = updateMutation.isPending || sharedIconMutation.isPending
 
   return (
     <div class="food-item-detail-page">
@@ -370,7 +416,7 @@ export function FoodItemDetail() {
           &larr; Food Items
         </a>
         <div class="fi-detail-actions">
-          <SaveIndicator isPending={updateMutation.isPending} showSaved={savedFlash} error={saveError} />
+          <SaveIndicator isPending={savePending} showSaved={savedFlash} error={saveError} />
           <ConfirmButton
             label={resnapshotMutation.isPending ? 'Re-snapshotting…' : 'Re-snapshot meals'}
             confirmMessage={`Refresh every past meal containing "${item.name}" with the current nutrient values? Other items in those meals are not changed.`}
@@ -378,12 +424,14 @@ export function FoodItemDetail() {
             isPending={resnapshotMutation.isPending}
             buttonClass="btn-secondary"
           />
-          <ConfirmButton
-            label="Delete"
-            confirmMessage={`Delete ${item.name}?`}
-            onConfirm={() => deleteMutation.mutate()}
-            isPending={deleteMutation.isPending}
-          />
+          {!isShared && (
+            <ConfirmButton
+              label="Delete"
+              confirmMessage={`Delete ${item.name}?`}
+              onConfirm={() => deleteMutation.mutate()}
+              isPending={deleteMutation.isPending}
+            />
+          )}
         </div>
       </div>
 
@@ -398,49 +446,33 @@ export function FoodItemDetail() {
         </div>
       )}
 
-      <h1 class="fi-name-heading">
-        {item.icon && isEmoji(item.icon) && <span class="fi-icon-display">{item.icon}</span>}
-        {item.icon && (isUrl(item.icon) || isIconPath(item.icon)) && (
-          <img src={item.icon} alt="" width={24} height={24} class="fi-icon-display-img" />
-        )}
-        <input
-          type="text"
-          class="fi-name-input"
-          value={name}
-          onInput={(e) => setName((e.target as HTMLInputElement).value)}
-          onBlur={commitName}
-        />
-      </h1>
+      {isShared && (
+        <p class="fi-shared-banner" role="note">
+          Shared library item — only the icon can be customized for your account. Other fields are read-only.
+        </p>
+      )}
+
+      <NameHeading item={item} isShared={isShared} name={name} setName={setName} commitName={commitName} />
 
       <div class="fi-icon-row">
         <label class="fi-icon-label">Icon</label>
         <IconInput value={icon} onChange={setIcon} onBlur={commitIcon} />
       </div>
 
-      <div class="fi-meta">
-        {item.source && <span class="fi-source">Source: {item.source}</span>}
-        <span class="fi-default-edit">
-          Default:
-          <input
-            type="number"
-            step="0.1"
-            value={defaultQuantity}
-            placeholder="Qty"
-            onInput={(e) => setDefaultQuantity((e.target as HTMLInputElement).value)}
-            onBlur={commitDefaultQuantity}
-          />
-          <input
-            type="text"
-            value={defaultUnit}
-            placeholder="Unit"
-            onInput={(e) => setDefaultUnit((e.target as HTMLInputElement).value)}
-            onBlur={commitDefaultUnit}
-          />
-        </span>
-      </div>
+      <DefaultMetaRow
+        item={item}
+        isShared={isShared}
+        defaultQuantity={defaultQuantity}
+        defaultUnit={defaultUnit}
+        setDefaultQuantity={setDefaultQuantity}
+        setDefaultUnit={setDefaultUnit}
+        commitDefaultQuantity={commitDefaultQuantity}
+        commitDefaultUnit={commitDefaultUnit}
+      />
 
       <CompositeOrAtomicSection
         item={item}
+        isShared={isShared}
         ingredientsMutation={ingredientsMutation}
         clearMutation={clearMutation}
         referenceMutation={referenceMutation}
@@ -450,8 +482,95 @@ export function FoodItemDetail() {
   )
 }
 
+function NameHeading({
+  item,
+  isShared,
+  name,
+  setName,
+  commitName,
+}: {
+  item: ApiFoodItemDetail
+  isShared: boolean
+  name: string
+  setName: (v: string) => void
+  commitName: () => void
+}) {
+  return (
+    <h1 class="fi-name-heading">
+      {item.icon && isEmoji(item.icon) && <span class="fi-icon-display">{item.icon}</span>}
+      {item.icon && (isUrl(item.icon) || isIconPath(item.icon)) && (
+        <img src={item.icon} alt="" width={24} height={24} class="fi-icon-display-img" />
+      )}
+      {isShared ? (
+        <span class="fi-name-readonly">{item.name}</span>
+      ) : (
+        <input
+          type="text"
+          class="fi-name-input"
+          value={name}
+          onInput={(e) => setName((e.target as HTMLInputElement).value)}
+          onBlur={commitName}
+        />
+      )}
+    </h1>
+  )
+}
+
+function DefaultMetaRow({
+  item,
+  isShared,
+  defaultQuantity,
+  defaultUnit,
+  setDefaultQuantity,
+  setDefaultUnit,
+  commitDefaultQuantity,
+  commitDefaultUnit,
+}: {
+  item: ApiFoodItemDetail
+  isShared: boolean
+  defaultQuantity: string
+  defaultUnit: string
+  setDefaultQuantity: (v: string) => void
+  setDefaultUnit: (v: string) => void
+  commitDefaultQuantity: () => void
+  commitDefaultUnit: () => void
+}) {
+  return (
+    <div class="fi-meta">
+      {item.source && <span class="fi-source">Source: {item.source}</span>}
+      <span class="fi-default-edit">
+        Default:
+        {isShared ? (
+          <span class="fi-default-readonly">
+            {item.default_quantity ?? '—'} {item.default_unit ?? ''}
+          </span>
+        ) : (
+          <>
+            <input
+              type="number"
+              step="0.1"
+              value={defaultQuantity}
+              placeholder="Qty"
+              onInput={(e) => setDefaultQuantity((e.target as HTMLInputElement).value)}
+              onBlur={commitDefaultQuantity}
+            />
+            <input
+              type="text"
+              value={defaultUnit}
+              placeholder="Unit"
+              onInput={(e) => setDefaultUnit((e.target as HTMLInputElement).value)}
+              onBlur={commitDefaultUnit}
+            />
+          </>
+        )}
+      </span>
+    </div>
+  )
+}
+
 interface CompositeProps {
   item: ApiFoodItemDetail
+  isShared: boolean
   ingredientsMutation: { mutate: (ingredients: FoodItemIngredient[]) => void; isPending: boolean }
   clearMutation: { mutate: () => void; isPending: boolean }
   referenceMutation: { mutate: (referenceId: string | null) => void; isPending: boolean }
@@ -460,6 +579,7 @@ interface CompositeProps {
 
 function CompositeOrAtomicSection({
   item,
+  isShared,
   ingredientsMutation,
   clearMutation,
   referenceMutation,
@@ -551,26 +671,54 @@ function CompositeOrAtomicSection({
 
   return (
     <>
-      <div class="composite-toggle-row">
-        <button
-          type="button"
-          class="btn-secondary"
-          onClick={() => setShowAsComposite(true)}
-          disabled={ingredientsMutation.isPending}
-        >
-          Convert to recipe
-        </button>
-        <span class="composite-toggle-hint">
-          Build this item from other foods — its nutrients will be summed from the ingredients.
-        </span>
-      </div>
+      {!isShared && (
+        <>
+          <div class="composite-toggle-row">
+            <button
+              type="button"
+              class="btn-secondary"
+              onClick={() => setShowAsComposite(true)}
+              disabled={ingredientsMutation.isPending}
+            >
+              Convert to recipe
+            </button>
+            <span class="composite-toggle-hint">
+              Build this item from other foods — its nutrients will be summed from the ingredients.
+            </span>
+          </div>
 
-      <ReferencePicker item={item} referenceMutation={referenceMutation} />
+          <ReferencePicker item={item} referenceMutation={referenceMutation} />
+        </>
+      )}
 
       <div class="nutrient-sections">
         {CATEGORIES.map(({ key, label }) => {
           const fields = NUTRIENT_FIELDS.filter((f) => f.category === key)
           if (fields.length === 0) return null
+          // For shared rows, only show categories that have at least one
+          // populated value — central LSV entries have most fields blank,
+          // and rendering empty grids is just noise.
+          if (isShared) {
+            const populated = fields.filter(
+              (f) => typeof item[f.name as keyof ApiFoodItemDetail] === 'number',
+            )
+            if (populated.length === 0) return null
+            return (
+              <div key={key} class="nutrient-section">
+                <h3>{label}</h3>
+                <div class="nutrient-grid">
+                  {populated.map((f) => (
+                    <div key={f.name} class="nutrient-row">
+                      <span class="nutrient-label">{f.label}</span>
+                      <span class="nutrient-value">
+                        {(item[f.name as keyof ApiFoodItemDetail] as number).toFixed(2)} {f.unit}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          }
           return (
             <div key={key} class="nutrient-section">
               <h3>{label}</h3>

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -158,6 +158,10 @@ export type ReferenceEnrichedFields = z.infer<typeof referenceEnrichedFieldsSche
 
 export const foodItemDetailSchema = foodItemEntitySchema
   .extend({
+    is_shared: z.boolean().optional().meta({
+      description:
+        'True when this row lives in the central shared library (e.g. Livsmedelsverket). Such rows are read-only — clients must use the `/food-items/:id/override` endpoints (or `set_shared_food_item_override` MCP tool) to customize fields like icon, and PATCH/DELETE on the row itself will 403.',
+    }),
     ingredients: z.array(resolvedFoodItemIngredientSchema).optional(),
     derived_nutrients: z
       .object({


### PR DESCRIPTION
## Summary

Fixes a 403 \"Cannot edit shared library item\" when setting an icon on a central food item in the web UI.

PR #719 added `PUT/DELETE /food-items/:id/override` for per-user customization of central rows, but didn't tell clients which rows are central. The web `FoodItemDetail` page kept calling `PATCH /food-items/:id` for icon edits — which 403s for shared rows.

This PR:

- Adds `is_shared: boolean` to `foodItemDetailSchema` (api-spec). Set in `services/food-items.ts:getDetail` whenever the lookup falls through to the central library.
- Web: when `item.is_shared`, icon saves go through the override endpoint (`PUT` to set, `DELETE` to clear an empty value). Other fields (name, default_quantity, default_unit, nutrients) become read-only since there's no override slot for them yet, and Delete / Convert-to-recipe / ReferencePicker are hidden. A small \"shared library item\" banner explains the limitation.
- Tests: route-level tests asserting `is_shared` flips correctly for user vs central, and a service-level test for the central fall-through path.

The MCP layer already returns the same `FoodItemDetail` shape from `get_food_item`, so MCP callers automatically pick up the new flag — no separate tool description churn.

When more override fields land (`default_quantity`, etc.), the same flag gates the UI; the `commitDefault*` handlers will need a similar override branch.

## Test plan

- [x] `pnpm check` clean across all three packages
- [x] Service + router + MCP unit tests (`pnpm test --run src/services/food-items.test.ts src/routes/food-items-router.test.ts src/mcp/food-item-tools.test.ts`) — 76 passing
- [x] Adjacent suites (`food-items-merge.test.ts`, `meals.test.ts`) — 101 total passing
- [ ] Manual: open a central LSV item in the web UI, set/clear an icon — expect the override row to be created/cleared and the displayed icon to update on refetch
- [ ] Manual: confirm name + default_quantity/unit + nutrient inputs are read-only on a shared row, and the Delete / Convert-to-recipe controls are gone
- [ ] Manual: per-user food items still let you edit everything as before