### PR TITLE
fix(garmin): read naps from dailySleepDTO and parse offset timestamps

### DIFF
--- a/apps/backend/src/integrations/garmin/process.test.ts
+++ b/apps/backend/src/integrations/garmin/process.test.ts
@@ -429,19 +429,32 @@ describe('processGarminData', () => {
       expect(await processGarminData(user, 'sleep', makeSleepData(), mockDeps)).toBe(1)
     })
 
-    test('creates a nap activity for each entry in dailyNapDTOS', async () => {
-      const data = makeSleepData({
-        dailyNapDTOS: [
-          {
-            calendarDate: '2025-01-15',
-            napEndTimestampGMT: '2025-01-15T12:39:46',
-            napFeedback: 'IDEAL_DURATION_LOW_NEED',
-            napSource: 0,
-            napStartTimestampGMT: '2025-01-15T12:17:46',
-            napTimeSec: 1320,
-          },
-        ],
+    const makeSleepDataWithNaps = (naps: Record<string, unknown>[] | null) =>
+      makeSleepData({
+        dailySleepDTO: {
+          awakeSleepSeconds: 1800,
+          calendarDate: '2025-01-15',
+          dailyNapDTOS: naps,
+          deepSleepSeconds: 3600,
+          lightSleepSeconds: 7200,
+          remSleepSeconds: 5400,
+          sleepEndTimestampGMT: 1736924400000,
+          sleepScores: { overall: { value: 82 } },
+          sleepStartTimestampGMT: 1736899200000,
+        },
       })
+
+    test('creates a nap activity for each entry in dailySleepDTO.dailyNapDTOS', async () => {
+      const data = makeSleepDataWithNaps([
+        {
+          calendarDate: '2025-01-15',
+          napEndTimestampGMT: '2025-01-15T12:39:46',
+          napFeedback: 'IDEAL_DURATION_LOW_NEED',
+          napSource: 0,
+          napStartTimestampGMT: '2025-01-15T12:17:46',
+          napTimeSec: 1320,
+        },
+      ])
 
       await processGarminData(user, 'sleep', data, mockDeps)
 
@@ -456,23 +469,66 @@ describe('processGarminData', () => {
       })
     })
 
-    test('inserts both the sleep activity and multiple naps', async () => {
+    test('parses nap timestamps that include a timezone offset', async () => {
+      // Real Garmin responses return "...+02:00" suffixes despite the field name.
+      const data = makeSleepDataWithNaps([
+        {
+          calendarDate: '2026-05-06',
+          napEndTimestampGMT: '2026-05-06T15:00:20+02:00',
+          napFeedback: 'IDEAL_TIMING_IDEAL_DURATION_LOW_NEED',
+          napStartTimestampGMT: '2026-05-06T14:35:32+02:00',
+          napTimeSec: 1488,
+        },
+      ])
+
+      await processGarminData(user, 'sleep', data, mockDeps)
+
+      expect(mockDeps.insertActivity).toHaveBeenCalledWith(user, {
+        activity_type: 'nap',
+        data: { nap_feedback: 'IDEAL_TIMING_IDEAL_DURATION_LOW_NEED', nap_time_seconds: 1488 },
+        end_time: new Date('2026-05-06T15:00:20+02:00'),
+        external_id: 'garmin-nap-2026-05-06T14:35:32+02:00',
+        source: 'garmin',
+        start_time: new Date('2026-05-06T14:35:32+02:00'),
+        title: 'Nap',
+      })
+    })
+
+    test('does not read dailyNapDTOS from the top level (real API nests it under dailySleepDTO)', async () => {
+      // Top-level dailyNapDTOS must be ignored; only dailySleepDTO.dailyNapDTOS counts.
       const data = makeSleepData({
         dailyNapDTOS: [
           {
             calendarDate: '2025-01-15',
-            napEndTimestampGMT: '2025-01-15T13:00:00',
-            napStartTimestampGMT: '2025-01-15T12:30:00',
-            napTimeSec: 1800,
-          },
-          {
-            calendarDate: '2025-01-15',
-            napEndTimestampGMT: '2025-01-15T16:30:00',
-            napStartTimestampGMT: '2025-01-15T16:00:00',
-            napTimeSec: 1800,
+            napEndTimestampGMT: '2025-01-15T12:39:46',
+            napStartTimestampGMT: '2025-01-15T12:17:46',
+            napTimeSec: 1320,
           },
         ],
       })
+
+      await processGarminData(user, 'sleep', data, mockDeps)
+
+      expect(mockDeps.insertActivity).toHaveBeenCalledTimes(1)
+      const activity = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activity.activity_type).toBe('sleep')
+    })
+
+    test('inserts both the sleep activity and multiple naps', async () => {
+      const data = makeSleepDataWithNaps([
+        {
+          calendarDate: '2025-01-15',
+          napEndTimestampGMT: '2025-01-15T13:00:00',
+          napStartTimestampGMT: '2025-01-15T12:30:00',
+          napTimeSec: 1800,
+        },
+        {
+          calendarDate: '2025-01-15',
+          napEndTimestampGMT: '2025-01-15T16:30:00',
+          napStartTimestampGMT: '2025-01-15T16:00:00',
+          napTimeSec: 1800,
+        },
+      ])
 
       await processGarminData(user, 'sleep', data, mockDeps)
 
@@ -485,16 +541,14 @@ describe('processGarminData', () => {
     })
 
     test('skips nap entries with missing timestamps', async () => {
-      const data = makeSleepData({
-        dailyNapDTOS: [
-          {
-            calendarDate: '2025-01-15',
-            napEndTimestampGMT: null as unknown as string,
-            napStartTimestampGMT: null as unknown as string,
-            napTimeSec: 0,
-          },
-        ],
-      })
+      const data = makeSleepDataWithNaps([
+        {
+          calendarDate: '2025-01-15',
+          napEndTimestampGMT: null,
+          napStartTimestampGMT: null,
+          napTimeSec: 0,
+        },
+      ])
 
       await processGarminData(user, 'sleep', data, mockDeps)
 
@@ -505,7 +559,7 @@ describe('processGarminData', () => {
     })
 
     test('handles null/missing dailyNapDTOS without error', async () => {
-      const withNullNaps = makeSleepData({ dailyNapDTOS: null })
+      const withNullNaps = makeSleepDataWithNaps(null)
       await expect(processGarminData(user, 'sleep', withNullNaps, mockDeps)).resolves.toBe(1)
 
       vi.clearAllMocks()

--- a/apps/backend/src/integrations/garmin/process.ts
+++ b/apps/backend/src/integrations/garmin/process.ts
@@ -267,11 +267,14 @@ const buildSleepActivity = (dto: SleepData['dailySleepDTO']): Activity | null =>
   }
 }
 
-// Garmin's nap timestamps come as "YYYY-MM-DDTHH:mm:ss" without a timezone
-// suffix. The field name says GMT, so treat them as UTC by appending "Z".
+// Garmin's nap timestamp field is named "...GMT" but in practice the API
+// returns ISO strings with an explicit zone suffix (e.g. "+02:00") for the
+// data we've observed. Parse as-is when a Z/offset suffix is present, and
+// fall back to treating bare strings as UTC.
 const parseNapGmt = (ts: string | null | undefined): Date | null => {
   if (!ts) return null
-  const d = new Date(`${ts}Z`)
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(ts)
+  const d = new Date(hasZone ? ts : `${ts}Z`)
   return Number.isNaN(d.getTime()) ? null : d
 }
 
@@ -348,7 +351,7 @@ const processSleep = async (user: string, data: SleepData, deps: GarminProcessDe
   const activity = buildSleepActivity(dto)
   if (activity) await deps.insertActivity(user, activity)
 
-  for (const nap of data.dailyNapDTOS ?? []) {
+  for (const nap of dto.dailyNapDTOS ?? []) {
     const napActivity = buildNapActivity(nap)
     if (napActivity) await deps.insertActivity(user, napActivity)
   }

--- a/apps/backend/src/integrations/garmin/types.d.ts
+++ b/apps/backend/src/integrations/garmin/types.d.ts
@@ -72,6 +72,7 @@ declare module '@flow-js/garmin-connect/dist/garmin/types/sleep' {
         overall?: { value: number }
         [key: string]: unknown
       }
+      dailyNapDTOS?: GarminNapDTO[] | null
       [key: string]: unknown
     }
     restingHeartRate: number
@@ -97,7 +98,6 @@ declare module '@flow-js/garmin-connect/dist/garmin/types/sleep' {
       startTimeGMT: number
       respirationValue: number
     }>
-    dailyNapDTOS?: GarminNapDTO[] | null
     [key: string]: unknown
   }
 }


### PR DESCRIPTION
## Summary

PR #659 added Garmin nap parsing but two assumptions did not hold against the real `/sleep-service/sleep/dailySleepData` payload, so naps never appeared in Aurboda. Verified against today's `garmin-sleep-2026-05-06` raw record.

- **`dailyNapDTOS` is nested inside `dailySleepDTO`**, not at the top level. `processSleep` was iterating over `data.dailyNapDTOS` which is always `undefined`.
- **`napStart/EndTimestampGMT` comes back with an explicit offset suffix** (e.g. `"2026-05-06T14:35:32+02:00"`), despite the field name. The previous parser appended `"Z"` to every value, producing strings like `"...+02:00Z"` that `Date` rejects as `Invalid Date`.

The unit tests in #659 didn't catch this because the mocks shaped `dailyNapDTOS` at the top level and used bare timestamps without offsets — neither matched the real Garmin response.

## Changes

- `process.ts`: read `dto.dailyNapDTOS`; rewrite `parseNapGmt` to honor an existing zone suffix (`Z` or `±HH:MM`) and only fall back to UTC for bare strings.
- `types.d.ts`: move `dailyNapDTOS` into `dailySleepDTO` so the type matches reality.
- `process.test.ts`: reshape mocks to nest `dailyNapDTOS` under `dailySleepDTO`, add a regression test using the real offset-suffix timestamps, and a guard test that top-level `dailyNapDTOS` is now ignored.

## Test plan
- [x] `pnpm exec vitest run src/integrations/garmin/process.test.ts` — 111 tests pass, including the new offset-timestamp case.
- [x] `pnpm check` — clean.
- [ ] On deploy: confirm the existing `garmin-sleep-2026-05-06` raw record produces a `nap` activity at 14:35–15:00 local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)