### PR TITLE
feat(timeline): hierarchy-aware routing, dynamic legend, multi-level collapse, tooltip enrichment

### DIFF
--- a/apps/web/src/pages/Timeline/TimelineLegend.tsx
+++ b/apps/web/src/pages/Timeline/TimelineLegend.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent, RefObject } from 'preact'
 
-import type { LegendCategory } from './legendCategories'
+import type { LegendCategory, ScreentimeSubEntry } from './legendCategories'
 import type { Orientation } from './types'
 
 import {
@@ -24,6 +24,8 @@ interface TimelineLegendProps {
   legendCollapsed: boolean
   setLegendCollapsed: (fn: (v: boolean) => boolean) => void
   legendRef: RefObject<HTMLDivElement>
+  /** Dynamic per-top-level screentime category sub-toggles (#718). */
+  screentimeSubEntries: ScreentimeSubEntry[]
 }
 
 export const TimelineLegend: FunctionComponent<TimelineLegendProps> = ({
@@ -34,6 +36,7 @@ export const TimelineLegend: FunctionComponent<TimelineLegendProps> = ({
   legendCollapsed,
   setLegendCollapsed,
   legendRef,
+  screentimeSubEntries,
 }) => {
   const hiddenCount = hiddenCategories.size
 
@@ -84,6 +87,12 @@ export const TimelineLegend: FunctionComponent<TimelineLegendProps> = ({
               { cat: 'other' as LegendCategory, color: TAG_COLOR, label: 'Other' },
               { cat: 'calendar' as LegendCategory, color: tagSourceColors.calendar!, label: 'Calendar' },
               { cat: 'screentime' as LegendCategory, color: productivityColors[1]!, label: 'Screen Time' },
+              // Dynamic per-top-level screentime category toggles (#718). One
+              // entry per top-level activity_type linked to a screentime_category
+              // (e.g. Work, Media, Comms). The umbrella `screentime` toggle
+              // above hides all of them; these let the user toggle a single
+              // top-level category and its descendants in isolation.
+              ...screentimeSubEntries.map((e) => ({ cat: e.legendKey, color: e.color, label: e.label })),
             ].map(({ cat, color, label }) => (
               <button
                 key={cat}

--- a/apps/web/src/pages/Timeline/activityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.test.ts
@@ -4,6 +4,7 @@ import type { Activity } from '../../state/api'
 import type { ChartItem } from './types'
 
 import {
+  ancestorChain,
   buildActivityColumnItems,
   collapseToParentType,
   EXCLUDED_ACTIVITY_PREFIXES,
@@ -13,6 +14,7 @@ import {
   mergeScreentimeActivities,
   overlapMinutes,
   resolveCollapseTarget,
+  rootTypeOf,
   tryMergeActivityIntoItem,
 } from './activityMerge'
 
@@ -296,6 +298,68 @@ describe('resolveCollapseTarget', () => {
   })
 })
 
+// -- ancestorChain / rootTypeOf -----------------------------------------------
+
+describe('ancestorChain', () => {
+  const typeDefs = new Map([
+    ['running', { parent_type: 'exercise' }],
+    ['exercise', { parent_type: 'fitness' }],
+    ['fitness', {}],
+    ['solo', {}],
+  ])
+
+  it('returns child→root chain including self', () => {
+    expect(ancestorChain('running', typeDefs)).toEqual(['running', 'exercise', 'fitness'])
+  })
+
+  it('terminates on top-level type', () => {
+    expect(ancestorChain('fitness', typeDefs)).toEqual(['fitness'])
+  })
+
+  it('returns just the input for unknown type', () => {
+    expect(ancestorChain('mystery', typeDefs)).toEqual(['mystery'])
+  })
+
+  it('cycle-guards: a self-referential parent stops the walk', () => {
+    const cyclic = new Map([['loop', { parent_type: 'loop' }]])
+    expect(ancestorChain('loop', cyclic)).toEqual(['loop'])
+  })
+
+  it('cycle-guards: an A→B→A cycle stops at the first repeat', () => {
+    const cyclic = new Map([
+      ['a', { parent_type: 'b' }],
+      ['b', { parent_type: 'a' }],
+    ])
+    expect(ancestorChain('a', cyclic)).toEqual(['a', 'b'])
+  })
+
+  it('terminates when the parent reference is not in the type defs (orphan)', () => {
+    // resolveCollapseTarget returns null for missing parents, so the walk stops.
+    const orphan = new Map([['kid', { parent_type: 'ghost' }]])
+    expect(ancestorChain('kid', orphan)).toEqual(['kid'])
+  })
+})
+
+describe('rootTypeOf', () => {
+  const typeDefs = new Map([
+    ['running', { parent_type: 'exercise' }],
+    ['exercise', { parent_type: 'fitness' }],
+    ['fitness', {}],
+  ])
+
+  it('walks to the top of a multi-level chain', () => {
+    expect(rootTypeOf('running', typeDefs)).toBe('fitness')
+  })
+
+  it('returns input when already at the root', () => {
+    expect(rootTypeOf('fitness', typeDefs)).toBe('fitness')
+  })
+
+  it('returns input for unknown type', () => {
+    expect(rootTypeOf('mystery', typeDefs)).toBe('mystery')
+  })
+})
+
 // -- collapseToParentType -----------------------------------------------------
 
 describe('collapseToParentType', () => {
@@ -397,6 +461,112 @@ describe('collapseToParentType', () => {
     const result = collapseToParentType(activities, typeDefs, 30 * 60 * 1000, false)
     expect(result).toHaveLength(1)
     expect(result[0].activity_type).toBe('running')
+  })
+
+  it('records collapsed_types provenance when sub-types fold into a parent (#657)', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'strength_training', end_time: d(11, 15), id: 'b', start_time: d(10, 35) },
+      { activity_type: 'yoga', end_time: d(11, 40), id: 'c', start_time: d(11, 20) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed).toHaveLength(1)
+    expect(collapsed[0].activity_type).toBe('exercise')
+    expect(collapsed[0].collapsed_types).toEqual([
+      { type: 'running', count: 1 },
+      { type: 'strength_training', count: 1 },
+      { type: 'yoga', count: 1 },
+    ])
+  })
+
+  it('counts repeat sub-types correctly in collapsed_types', () => {
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'running', end_time: d(10, 50), id: 'b', start_time: d(10, 35) },
+      { activity_type: 'yoga', end_time: d(11, 10), id: 'c', start_time: d(10, 55) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed[0].collapsed_types).toEqual([
+      { type: 'running', count: 2 },
+      { type: 'yoga', count: 1 },
+    ])
+  })
+
+  it('keeps provenance even when only one sub-type was involved (after retype)', () => {
+    // The bar is "exercise" but only running fed into it — the tooltip can
+    // legitimately read "Merged: Running" so the user knows the
+    // collapsed bar isn't a mixed exercise session.
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'running', end_time: d(11), id: 'b', start_time: d(10, 35) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs)
+    expect(collapsed[0].activity_type).toBe('exercise')
+    expect(collapsed[0].collapsed_types).toEqual([{ type: 'running', count: 2 }])
+  })
+
+  it('drops trivial provenance when no retype happens (collapseToParent=false)', () => {
+    // Identical sub-types merge but stay typed as themselves; the survivor's
+    // provenance would be [{ running, 2 }] which is the same as activity_type
+    // — drop so tooltip doesn't render a redundant "Merged: Running" line.
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+      { activity_type: 'running', end_time: d(11), id: 'b', start_time: d(10, 35) },
+    ]
+    const collapsed = collapseToParentType(activities, typeDefs, undefined, false)
+    expect(collapsed[0].activity_type).toBe('running')
+    expect(collapsed[0].collapsed_types).toBeUndefined()
+  })
+
+  it('collapses one hop at depth=1 (parity with prior behaviour)', () => {
+    const deepDefs = new Map([
+      ['running', { parent_type: 'exercise' }],
+      ['exercise', { parent_type: 'fitness' }],
+      ['fitness', {}],
+    ])
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+    ]
+    const result = collapseToParentType(activities, deepDefs, undefined, true, 1)
+    expect(result[0].activity_type).toBe('exercise')
+  })
+
+  it('walks two hops at depth=2', () => {
+    const deepDefs = new Map([
+      ['running', { parent_type: 'exercise' }],
+      ['exercise', { parent_type: 'fitness' }],
+      ['fitness', {}],
+    ])
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+    ]
+    const result = collapseToParentType(activities, deepDefs, undefined, true, 2)
+    expect(result[0].activity_type).toBe('fitness')
+  })
+
+  it('walks to root at depth=Infinity', () => {
+    const deepDefs = new Map([
+      ['running', { parent_type: 'exercise' }],
+      ['exercise', { parent_type: 'fitness' }],
+      ['fitness', {}],
+    ])
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+    ]
+    const result = collapseToParentType(activities, deepDefs, undefined, true, Number.POSITIVE_INFINITY)
+    expect(result[0].activity_type).toBe('fitness')
+  })
+
+  it('depth larger than chain stops at the root, not undefined', () => {
+    const deepDefs = new Map([
+      ['running', { parent_type: 'exercise' }],
+      ['exercise', {}],
+    ])
+    const activities: Activity[] = [
+      { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
+    ]
+    const result = collapseToParentType(activities, deepDefs, undefined, true, 99)
+    expect(result[0].activity_type).toBe('exercise')
   })
 })
 

--- a/apps/web/src/pages/Timeline/activityMerge.test.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.test.ts
@@ -439,26 +439,24 @@ describe('collapseToParentType', () => {
     expect(collapseToParentType(activities, typeDefs, 10 * 60 * 1000)).toHaveLength(2)
   })
 
-  it('keeps sibling sub-types distinct when collapseToParent=false', () => {
-    // Max-zoom case: warmup_run + strength_training should stay clickable as
-    // separate items even when adjacent.
+  it('keeps sibling sub-types distinct at depth=0 (max zoom)', () => {
+    // warmup_run + strength_training stay clickable as separate items.
     const activities: Activity[] = [
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
       { activity_type: 'strength_training', end_time: d(11), id: 'b', start_time: d(10, 35) },
     ]
-    const result = collapseToParentType(activities, typeDefs, 30 * 60 * 1000, false)
+    const result = collapseToParentType(activities, typeDefs, 30 * 60 * 1000, 0)
     expect(result).toHaveLength(2)
     expect(result.map((a) => a.activity_type)).toEqual(['running', 'strength_training'])
   })
 
-  it('still merges identical sub-types when collapseToParent=false', () => {
-    // Two adjacent running spans should still fold into one even at max zoom —
-    // the user reported a comb of identical slivers and wants those merged.
+  it('still merges identical sub-types at depth=0', () => {
+    // A comb of consecutive running slivers folds to one even at max zoom.
     const activities: Activity[] = [
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
       { activity_type: 'running', end_time: d(11), id: 'b', start_time: d(10, 35) },
     ]
-    const result = collapseToParentType(activities, typeDefs, 30 * 60 * 1000, false)
+    const result = collapseToParentType(activities, typeDefs, 30 * 60 * 1000, 0)
     expect(result).toHaveLength(1)
     expect(result[0].activity_type).toBe('running')
   })
@@ -505,7 +503,7 @@ describe('collapseToParentType', () => {
     expect(collapsed[0].collapsed_types).toEqual([{ type: 'running', count: 2 }])
   })
 
-  it('drops trivial provenance when no retype happens (collapseToParent=false)', () => {
+  it('drops trivial provenance when no retype happens (depth=0)', () => {
     // Identical sub-types merge but stay typed as themselves; the survivor's
     // provenance would be [{ running, 2 }] which is the same as activity_type
     // — drop so tooltip doesn't render a redundant "Merged: Running" line.
@@ -513,7 +511,7 @@ describe('collapseToParentType', () => {
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
       { activity_type: 'running', end_time: d(11), id: 'b', start_time: d(10, 35) },
     ]
-    const collapsed = collapseToParentType(activities, typeDefs, undefined, false)
+    const collapsed = collapseToParentType(activities, typeDefs, undefined, 0)
     expect(collapsed[0].activity_type).toBe('running')
     expect(collapsed[0].collapsed_types).toBeUndefined()
   })
@@ -527,7 +525,7 @@ describe('collapseToParentType', () => {
     const activities: Activity[] = [
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
     ]
-    const result = collapseToParentType(activities, deepDefs, undefined, true, 1)
+    const result = collapseToParentType(activities, deepDefs, undefined, 1)
     expect(result[0].activity_type).toBe('exercise')
   })
 
@@ -540,7 +538,7 @@ describe('collapseToParentType', () => {
     const activities: Activity[] = [
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
     ]
-    const result = collapseToParentType(activities, deepDefs, undefined, true, 2)
+    const result = collapseToParentType(activities, deepDefs, undefined, 2)
     expect(result[0].activity_type).toBe('fitness')
   })
 
@@ -553,7 +551,7 @@ describe('collapseToParentType', () => {
     const activities: Activity[] = [
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
     ]
-    const result = collapseToParentType(activities, deepDefs, undefined, true, Number.POSITIVE_INFINITY)
+    const result = collapseToParentType(activities, deepDefs, undefined, Number.POSITIVE_INFINITY)
     expect(result[0].activity_type).toBe('fitness')
   })
 
@@ -565,7 +563,7 @@ describe('collapseToParentType', () => {
     const activities: Activity[] = [
       { activity_type: 'running', end_time: d(10, 30), id: 'a', start_time: d(10) },
     ]
-    const result = collapseToParentType(activities, deepDefs, undefined, true, 99)
+    const result = collapseToParentType(activities, deepDefs, undefined, 99)
     expect(result[0].activity_type).toBe('exercise')
   })
 })

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -240,13 +240,8 @@ const buildActivityDetails = (
 
   // Hierarchy-collapsed bars (#657): surface the constituent sub-types so
   // a single "exercise" bar reveals it was actually running + strength + yoga.
-  if (a.collapsed_types && a.collapsed_types.length > 0) {
-    const labels = a.collapsed_types.map((e) => {
-      const display = toDisplayName(e.type)
-      return e.count > 1 ? `${display} ×${e.count}` : display
-    })
-    details.push(`Merged: ${labels.join(', ')}`)
-  }
+  const mergedLine = formatCollapsedTypesLine(a.collapsed_types)
+  if (mergedLine) details.push(mergedLine)
 
   return details
 }
@@ -278,6 +273,24 @@ const getActivityIconKey = (a: Activity, getExerciseTypeName: (a: Activity) => s
 
 /** Default gap below which two adjacent same-parent activities merge. */
 export const COLLAPSE_MERGE_GAP_MS = 30 * 60 * 1000 // 30 minutes
+
+/**
+ * Format a `collapsed_types` provenance list as a tooltip line. Used by both
+ * the Activity-lane (`buildActivityDetails`) and Screen-Time-lane
+ * (`categorizeScreentimeActivities`) tooltip builders. Returns undefined when
+ * there's nothing to show — a single-entry provenance is still informative
+ * (the parent bar is one sub-type only) so we keep that case.
+ */
+export const formatCollapsedTypesLine = (
+  collapsedTypes: { type: string; count: number }[] | undefined,
+): string | undefined => {
+  if (!collapsedTypes || collapsedTypes.length < 1) return undefined
+  const labels = collapsedTypes.map((e) => {
+    const display = toDisplayName(e.type)
+    return e.count > 1 ? `${display} ×${e.count}` : display
+  })
+  return `Merged: ${labels.join(', ')}`
+}
 
 /**
  * Look up the immediate parent_type of a type — the "collapse target" we
@@ -367,8 +380,11 @@ export const mergeAdjacentByKey = (
 
 /**
  * Walk the ancestor chain capped at `depth` hops. depth=1 returns the
- * immediate parent (current behaviour); depth=Infinity walks to the root.
+ * immediate parent (the common case); depth=Infinity walks to the root.
  * Returns the input type when no walk can happen.
+ *
+ * The depth=1 fast path uses `resolveCollapseTarget` directly to avoid
+ * building a full ancestor chain we'd immediately discard.
  */
 const collapseTargetAtDepth = (
   typeName: string,
@@ -376,48 +392,49 @@ const collapseTargetAtDepth = (
   depth: number,
 ): string => {
   if (depth <= 0) return typeName
+  if (depth === 1) return resolveCollapseTarget(typeName, typeDefsByName) ?? typeName
   const chain = ancestorChain(typeName, typeDefsByName)
   // chain[0] is typeName itself; ancestors at indices 1..chain.length-1.
   const targetIndex = Math.min(depth, chain.length - 1)
   return chain[targetIndex]
 }
 
+/**
+ * Pure: returns a new list with `type` accounted for. Either bumps the
+ * existing entry's count or appends a fresh `{ type, count: 1 }`. Never
+ * mutates the input — important because `Activity.collapsed_types` may end
+ * up shared across memoized references in a future iteration.
+ */
 const recordCollapsedType = (
   list: { type: string; count: number }[],
   type: string,
 ): { type: string; count: number }[] => {
-  const existing = list.find((e) => e.type === type)
-  if (existing) {
-    existing.count += 1
-    return list
-  }
-  return [...list, { type, count: 1 }]
+  const idx = list.findIndex((e) => e.type === type)
+  if (idx === -1) return [...list, { type, count: 1 }]
+  return list.map((e, i) => (i === idx ? { ...e, count: e.count + 1 } : e))
 }
 
 /**
  * Collapse adjacent activities up to `depth` levels of parent_type into a
  * single bar.
  *
- *   1. If `collapseToParent` is true, re-type each activity to its ancestor at
- *      the requested depth. depth=1 collapses one hop (warmup_run →
- *      exercise); depth=Infinity walks to the root (yoga → exercise → root).
+ *   1. Re-type each activity to its ancestor at the requested depth.
+ *      depth=0: no walk (max-zoom; sibling sub-types stay distinct and
+ *      individually clickable). depth=1: one hop (warmup_run → exercise).
+ *      depth=Infinity: walk to root.
  *   2. Merge adjacent activities with the same effective type whose gap is
- *      within `mergeGapMs`.
+ *      within `mergeGapMs`. Identical sub-types still merge at depth=0 (a
+ *      comb of consecutive `running` slivers folds to one).
  *
  * The synthetic survivor of a multi-child collapse carries `collapsed_types`
  * with the original child types and counts (deduped, ordered by first
  * appearance) — used by the tooltip enrichment in #657.
- *
- * At max zoom the caller passes `collapseToParent=false` so sibling sub-types
- * stay distinct (and individually clickable). Identical sub-types still merge
- * across small gaps (a comb of consecutive `running` slivers folds to one).
  */
 // eslint-disable-next-line complexity -- single-pass merge with provenance accumulation; splitting hurts readability
 export const collapseToParentType = (
   activities: Activity[],
   typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
   mergeGapMs: number = COLLAPSE_MERGE_GAP_MS,
-  collapseToParent = true,
   depth = 1,
 ): Activity[] => {
   if (activities.length === 0) return activities
@@ -425,9 +442,8 @@ export const collapseToParentType = (
   // Retype each activity to its target effective type, remembering the
   // original sub-type for provenance.
   const retyped = activities.map((a) => {
-    const effective = collapseToParent
-      ? collapseTargetAtDepth(a.activity_type, typeDefsByName, depth)
-      : a.activity_type
+    const effective =
+      depth > 0 ? collapseTargetAtDepth(a.activity_type, typeDefsByName, depth) : a.activity_type
     if (effective === a.activity_type) {
       return { ...a }
     }

--- a/apps/web/src/pages/Timeline/activityMerge.ts
+++ b/apps/web/src/pages/Timeline/activityMerge.ts
@@ -238,6 +238,16 @@ const buildActivityDetails = (
     if (music.length > 0) details.push(`♪ ${music.slice(0, 3).join(', ')}`)
   }
 
+  // Hierarchy-collapsed bars (#657): surface the constituent sub-types so
+  // a single "exercise" bar reveals it was actually running + strength + yoga.
+  if (a.collapsed_types && a.collapsed_types.length > 0) {
+    const labels = a.collapsed_types.map((e) => {
+      const display = toDisplayName(e.type)
+      return e.count > 1 ? `${display} ×${e.count}` : display
+    })
+    details.push(`Merged: ${labels.join(', ')}`)
+  }
+
   return details
 }
 
@@ -287,6 +297,40 @@ export const resolveCollapseTarget = (
 }
 
 /**
+ * Return the chain of ancestors for a type, ordered child→root, including the
+ * input type itself. Cycle-guarded; an unknown ancestor terminates the walk.
+ *
+ *   running → exercise → activity   ⇒  ['running', 'exercise', 'activity']
+ *   meditation                       ⇒  ['meditation']
+ *   unknown                          ⇒  ['unknown']
+ */
+export const ancestorChain = (
+  typeName: string,
+  typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
+): string[] => {
+  const chain: string[] = [typeName]
+  const visited = new Set<string>([typeName])
+  let current: string | null = typeName
+  while (current) {
+    const next = resolveCollapseTarget(current, typeDefsByName)
+    if (!next || visited.has(next)) break
+    chain.push(next)
+    visited.add(next)
+    current = next
+  }
+  return chain
+}
+
+/** Return the top-level ancestor (root of parent_type chain). Falls back to the input on cycle/missing. */
+export const rootTypeOf = (
+  typeName: string,
+  typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
+): string => {
+  const chain = ancestorChain(typeName, typeDefsByName)
+  return chain[chain.length - 1]
+}
+
+/**
  * Merge adjacent activities sharing a key (computed by `keyFn`) when their
  * start-to-previous-end gap is ≤ `mergeGapMs`. Different keys never merge,
  * so we can never collapse two distinct activity types into one bar — the
@@ -322,34 +366,111 @@ export const mergeAdjacentByKey = (
 }
 
 /**
- * Collapse adjacent activities of the same (optionally parent-resolved) type
- * into a single bar.
+ * Walk the ancestor chain capped at `depth` hops. depth=1 returns the
+ * immediate parent (current behaviour); depth=Infinity walks to the root.
+ * Returns the input type when no walk can happen.
+ */
+const collapseTargetAtDepth = (
+  typeName: string,
+  typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
+  depth: number,
+): string => {
+  if (depth <= 0) return typeName
+  const chain = ancestorChain(typeName, typeDefsByName)
+  // chain[0] is typeName itself; ancestors at indices 1..chain.length-1.
+  const targetIndex = Math.min(depth, chain.length - 1)
+  return chain[targetIndex]
+}
+
+const recordCollapsedType = (
+  list: { type: string; count: number }[],
+  type: string,
+): { type: string; count: number }[] => {
+  const existing = list.find((e) => e.type === type)
+  if (existing) {
+    existing.count += 1
+    return list
+  }
+  return [...list, { type, count: 1 }]
+}
+
+/**
+ * Collapse adjacent activities up to `depth` levels of parent_type into a
+ * single bar.
  *
- *   1. If `collapseToParent` is true, re-type each activity to its parent_type
- *      where one exists. This is what lets a warmup_run + strength_training
- *      pair render as a single "exercise" block when zoomed out.
+ *   1. If `collapseToParent` is true, re-type each activity to its ancestor at
+ *      the requested depth. depth=1 collapses one hop (warmup_run →
+ *      exercise); depth=Infinity walks to the root (yoga → exercise → root).
  *   2. Merge adjacent activities with the same effective type whose gap is
  *      within `mergeGapMs`.
  *
+ * The synthetic survivor of a multi-child collapse carries `collapsed_types`
+ * with the original child types and counts (deduped, ordered by first
+ * appearance) — used by the tooltip enrichment in #657.
+ *
  * At max zoom the caller passes `collapseToParent=false` so sibling sub-types
- * stay distinct (and individually clickable).
+ * stay distinct (and individually clickable). Identical sub-types still merge
+ * across small gaps (a comb of consecutive `running` slivers folds to one).
  */
+// eslint-disable-next-line complexity -- single-pass merge with provenance accumulation; splitting hurts readability
 export const collapseToParentType = (
   activities: Activity[],
   typeDefsByName: ReadonlyMap<string, { parent_type?: string }>,
   mergeGapMs: number = COLLAPSE_MERGE_GAP_MS,
   collapseToParent = true,
+  depth = 1,
 ): Activity[] => {
   if (activities.length === 0) return activities
 
-  const retyped = collapseToParent
-    ? activities.map((a) => {
-        const parent = resolveCollapseTarget(a.activity_type, typeDefsByName)
-        return parent ? { ...a, activity_type: parent } : a
-      })
-    : activities
+  // Retype each activity to its target effective type, remembering the
+  // original sub-type for provenance.
+  const retyped = activities.map((a) => {
+    const effective = collapseToParent
+      ? collapseTargetAtDepth(a.activity_type, typeDefsByName, depth)
+      : a.activity_type
+    if (effective === a.activity_type) {
+      return { ...a }
+    }
+    return { ...a, activity_type: effective, collapsed_types: [{ type: a.activity_type, count: 1 }] }
+  })
 
-  return mergeAdjacentByKey(retyped, (a) => a.activity_type, mergeGapMs)
+  // Merge adjacent same-effective-type spans, accumulating provenance from
+  // any participants that already carried one.
+  if (retyped.length === 0) return retyped
+  const sorted = [...retyped].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+  const merged: Activity[] = []
+  for (const current of sorted) {
+    const prev = merged[merged.length - 1]
+    if (
+      prev &&
+      prev.activity_type === current.activity_type &&
+      prev.end_time &&
+      current.end_time &&
+      current.start_time.getTime() - prev.end_time.getTime() <= mergeGapMs
+    ) {
+      if (current.end_time > prev.end_time) prev.end_time = current.end_time
+      const incoming = current.collapsed_types ?? [{ type: current.activity_type, count: 1 }]
+      let provenance = prev.collapsed_types ?? [{ type: prev.activity_type, count: 1 }]
+      for (const entry of incoming) {
+        for (let i = 0; i < entry.count; i++) provenance = recordCollapsedType(provenance, entry.type)
+      }
+      prev.collapsed_types = provenance
+      continue
+    }
+    merged.push({ ...current })
+  }
+  // Drop trivial provenance: a survivor whose only entry matches its own
+  // type carries no useful merge signal (single sub-type wasn't mixed).
+  for (const m of merged) {
+    if (
+      m.collapsed_types &&
+      m.collapsed_types.length === 1 &&
+      m.collapsed_types[0].type === m.activity_type
+    ) {
+      delete m.collapsed_types
+    }
+  }
+  return merged
 }
 
 /**

--- a/apps/web/src/pages/Timeline/categorize.test.ts
+++ b/apps/web/src/pages/Timeline/categorize.test.ts
@@ -164,29 +164,83 @@ describe('categorizeScreentimeActivities', () => {
     }) as ScreentimeCategory
 
   it('returns Screen Time column items routed to the activity entity', () => {
-    const items = categorizeScreentimeActivities([makeActivity()], [], {})
+    const items = categorizeScreentimeActivities([makeActivity()], [], {}, new Set(), new Map())
     expect(items).toHaveLength(1)
     expect(items[0]!.column).toBe('Screen Time')
     expect(items[0]!.entity_type).toBe('activity')
   })
 
   it('uses last category-path segment as label', () => {
-    const items = categorizeScreentimeActivities([makeActivity()], [], {})
+    const items = categorizeScreentimeActivities([makeActivity()], [], {}, new Set(), new Map())
     expect(items[0]!.label).toBe('Programming')
   })
 
   it('skips activities without an end_time', () => {
-    const items = categorizeScreentimeActivities([makeActivity({ end_time: undefined })], [], {})
+    const items = categorizeScreentimeActivities(
+      [makeActivity({ end_time: undefined })],
+      [],
+      {},
+      new Set(),
+      new Map(),
+    )
     expect(items).toEqual([])
   })
 
   it('skips activities of other types', () => {
-    const items = categorizeScreentimeActivities([makeActivity({ activity_type: 'exercise' })], [], {})
+    // `exercise` is neither the legacy umbrella nor in screentimeDerivedTypes — skip.
+    const items = categorizeScreentimeActivities(
+      [makeActivity({ activity_type: 'exercise' })],
+      [],
+      {},
+      new Set(),
+      new Map(),
+    )
     expect(items).toEqual([])
   })
 
+  it('includes derived screentime types via screentimeDerivedTypes (#718)', () => {
+    const derived = makeActivity({
+      activity_type: 'programming',
+      data: { category_path: 'Work > Programming' },
+    })
+    const items = categorizeScreentimeActivities(
+      [derived],
+      [],
+      {},
+      new Set(['programming']),
+      new Map([['programming', { color: '#22c55e', display_name: 'Programming' }]]),
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0]!.column).toBe('Screen Time')
+  })
+
+  it('includes a "Merged: ..." line when collapsed_types is present (#657)', () => {
+    const collapsed = makeActivity({
+      activity_type: 'work',
+      collapsed_types: [
+        { count: 2, type: 'programming' },
+        { count: 1, type: 'meetings' },
+      ],
+      data: { category_path: 'Work' },
+    })
+    const items = categorizeScreentimeActivities(
+      [collapsed],
+      [],
+      {},
+      new Set(['work']),
+      new Map([['work', { color: '#22c55e', display_name: 'Work' }]]),
+    )
+    expect(items[0]!.tooltip.details.some((d) => d.startsWith('Merged:'))).toBe(true)
+  })
+
   it('matches category by exact path for href and clears entity_id', () => {
-    const items = categorizeScreentimeActivities([makeActivity()], [makeCategory({ id: 'cat-prog' })], {})
+    const items = categorizeScreentimeActivities(
+      [makeActivity()],
+      [makeCategory({ id: 'cat-prog' })],
+      {},
+      new Set(),
+      new Map(),
+    )
     expect(items[0]!.href).toBe('/screentime-categories/cat-prog')
     expect(items[0]!.entity_id).toBeUndefined()
   })
@@ -196,26 +250,32 @@ describe('categorizeScreentimeActivities', () => {
       [makeActivity()],
       [makeCategory({ id: 'cat-work', name: ['Work'], color: '#abc' })],
       {},
+      new Set(),
+      new Map(),
     )
     expect(items[0]!.color).toBe('#abc')
     expect(items[0]!.href).toBe('/screentime-categories/cat-work')
   })
 
   it('keeps the activity id as entity_id when no category matches', () => {
-    const items = categorizeScreentimeActivities([makeActivity()], [], {})
+    const items = categorizeScreentimeActivities([makeActivity()], [], {}, new Set(), new Map())
     expect(items[0]!.entity_id).toBe('act-1')
     expect(items[0]!.href).toBeUndefined()
   })
 
   it('uses category icon from itemIcons', () => {
-    const items = categorizeScreentimeActivities([makeActivity()], [], {
-      'category:Work > Programming': '💻',
-    })
+    const items = categorizeScreentimeActivities(
+      [makeActivity()],
+      [],
+      { 'category:Work > Programming': '💻' },
+      new Set(),
+      new Map(),
+    )
     expect(items[0]!.icon).toBe('💻')
   })
 
   it('handles missing category_path gracefully', () => {
-    const items = categorizeScreentimeActivities([makeActivity({ data: {} })], [], {})
+    const items = categorizeScreentimeActivities([makeActivity({ data: {} })], [], {}, new Set(), new Map())
     expect(items[0]!.label).toBe('Screen time')
   })
 })

--- a/apps/web/src/pages/Timeline/categorize.ts
+++ b/apps/web/src/pages/Timeline/categorize.ts
@@ -7,6 +7,7 @@ import type { ChartItem, Column } from './types'
 
 import { toDisplayName } from '../../utils/displayName'
 import { resolveItemIcon } from '../../utils/emojiLookup'
+import { formatCollapsedTypesLine } from './activityMerge'
 import { getActivityColor, getPlaceColor, getProductivityColor, resolveCategoryIcon } from './colors'
 import { formatDuration, formatTime } from './formatting'
 
@@ -143,23 +144,9 @@ const matchCategoryByPath = (
  *    treatment.
  *
  *  • A `collapsed_types` provenance attached by `collapseToParentType` is
- *    surfaced as a "Merged: X, Y" tooltip line so the user can tell what
- *    sub-types the bar represents.
+ *    surfaced as a "Merged: X, Y" tooltip line via the shared
+ *    `formatCollapsedTypesLine` helper.
  */
-const formatCollapsedTypesLine = (
-  collapsedTypes: { type: string; count: number }[] | undefined,
-): string | undefined => {
-  if (!collapsedTypes || collapsedTypes.length < 1) return undefined
-  // A single-entry provenance is still informative ("Merged: Programming"
-  // tells the user the parent bar is one sub-type only). Two-or-more entries
-  // is the headline #657 use case.
-  const labels = collapsedTypes.map((e) => {
-    const display = toDisplayName(e.type)
-    return e.count > 1 ? `${display} ×${e.count}` : display
-  })
-  return `Merged: ${labels.join(', ')}`
-}
-
 export const categorizeScreentimeActivities = (
   activities: Activity[],
   categories: ScreentimeCategory[],

--- a/apps/web/src/pages/Timeline/categorize.ts
+++ b/apps/web/src/pages/Timeline/categorize.ts
@@ -131,29 +131,69 @@ const matchCategoryByPath = (
 }
 
 /**
- * Categorize `screentime` activities into Screen Time lane items. The
- * underlying activity rows are pre-merged spans (one per category-source
- * window), so per-app names are not available in the tooltip — the lane
- * still shows category, time range, and duration.
+ * Categorize screentime activities into Screen Time lane items. Two paths:
+ *
+ *  • Legacy umbrella `activity_type='screentime'` activities carry the path
+ *    as a string in `data.category_path`. The label is the leaf segment.
+ *  • Derived-type activities (e.g. `programming`, `slack`, post-#651) are
+ *    identified by `screentimeDerivedTypes`. They may carry `category_path`
+ *    in data (set on the backend at sync time); if not, we fall back to the
+ *    activity's display name. Hierarchy collapse may also produce synthetic
+ *    parents whose `activity_type` is the top-level slug (e.g. `work`) — same
+ *    treatment.
+ *
+ *  • A `collapsed_types` provenance attached by `collapseToParentType` is
+ *    surfaced as a "Merged: X, Y" tooltip line so the user can tell what
+ *    sub-types the bar represents.
  */
+const formatCollapsedTypesLine = (
+  collapsedTypes: { type: string; count: number }[] | undefined,
+): string | undefined => {
+  if (!collapsedTypes || collapsedTypes.length < 1) return undefined
+  // A single-entry provenance is still informative ("Merged: Programming"
+  // tells the user the parent bar is one sub-type only). Two-or-more entries
+  // is the headline #657 use case.
+  const labels = collapsedTypes.map((e) => {
+    const display = toDisplayName(e.type)
+    return e.count > 1 ? `${display} ×${e.count}` : display
+  })
+  return `Merged: ${labels.join(', ')}`
+}
+
 export const categorizeScreentimeActivities = (
   activities: Activity[],
   categories: ScreentimeCategory[],
   itemIcons: Record<string, string>,
+  screentimeDerivedTypes: ReadonlySet<string>,
+  typeDefsMap: ReadonlyMap<string, { display_name: string; color: string; icon?: string }>,
 ): ChartItem[] =>
   activities
-    .filter((a): a is Activity & { end_time: Date } =>
-      Boolean(a.activity_type === 'screentime' && a.end_time),
-    )
+    .filter((a): a is Activity & { end_time: Date } => Boolean(a.end_time))
+    .filter((a) => a.activity_type === 'screentime' || screentimeDerivedTypes.has(a.activity_type))
+    // eslint-disable-next-line complexity -- one fall-through pass over five label/color/icon sources
     .map((a) => {
       const categoryPathStr = typeof a.data?.category_path === 'string' ? a.data.category_path : ''
       const path = categoryPathStr ? categoryPathStr.split(' > ') : []
-      const label = path.at(-1) ?? 'Screen time'
       const score = typeof a.data?.score === 'number' ? a.data.score : undefined
 
       const matched = matchCategoryByPath(path, categories)
-      const color = matched?.color ?? getProductivityColor(score)
+      const def = a.activity_type !== 'screentime' ? typeDefsMap.get(a.activity_type) : undefined
+
+      // Label preference:
+      //   1. The matched category's leaf (path-based, used by both paths)
+      //   2. The type def's display_name (derived types when the path is missing)
+      //   3. Generic "Screen time" fallback
+      const label = path.at(-1) ?? def?.display_name ?? 'Screen time'
+      // Color preference: matched category > type def > productivity score gradient.
+      const color = matched?.color ?? def?.color ?? getProductivityColor(score)
       const href = matched ? `/screentime-categories/${matched.id}` : undefined
+
+      const mergedLine = formatCollapsedTypesLine(a.collapsed_types)
+      const details = [
+        categoryPathStr || def?.display_name || '',
+        formatDuration(a.start_time, a.end_time),
+        ...(mergedLine ? [mergedLine] : []),
+      ].filter(Boolean)
 
       return {
         color,
@@ -162,12 +202,12 @@ export const categorizeScreentimeActivities = (
         entity_id: matched ? undefined : a.id,
         entity_type: 'activity' as const,
         href,
-        icon: resolveCategoryIcon(path, itemIcons),
+        icon: resolveCategoryIcon(path, itemIcons) ?? def?.icon,
         isPoint: false,
         label,
         start: a.start_time,
         tooltip: {
-          details: [categoryPathStr, formatDuration(a.start_time, a.end_time)].filter(Boolean),
+          details,
           time: `${formatTime(a.start_time)} – ${formatTime(a.end_time)}`,
           title: label,
         },

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -54,7 +54,6 @@ export const Timeline = () => {
     bucketSize,
     barBucketSize,
     mergeGapMs,
-    shouldCollapseHierarchy,
     collapseDepth,
   } = nav
 
@@ -109,7 +108,6 @@ export const Timeline = () => {
     fromDateKey: fromDate.value,
     hiddenCategories,
     mergeGapMs,
-    shouldCollapseHierarchy,
     toDateKey: toDate.value,
   })
   const {

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -55,6 +55,7 @@ export const Timeline = () => {
     barBucketSize,
     mergeGapMs,
     shouldCollapseHierarchy,
+    collapseDepth,
   } = nav
 
   // ── Orientation state ──────────────────────────────────────────────────────
@@ -102,6 +103,7 @@ export const Timeline = () => {
   const data = useTimelineData({
     barBucketSize,
     bucketSize,
+    collapseDepth,
     fetchEnd,
     fetchStart,
     fromDateKey: fromDate.value,
@@ -122,6 +124,7 @@ export const Timeline = () => {
     trainingLoadQuery,
     screentimeBucketedQuery,
     screentimeCategoriesQuery,
+    screentimeSubEntries,
     isFetching,
     isInitialLoad,
     errorSources,
@@ -1036,6 +1039,7 @@ export const Timeline = () => {
         legendCollapsed={legendCollapsed}
         setLegendCollapsed={setLegendCollapsed}
         legendRef={legendRef}
+        screentimeSubEntries={screentimeSubEntries}
       />
 
       {/* Overlap warnings UI temporarily disabled — will be redesigned

--- a/apps/web/src/pages/Timeline/legendCategories.test.ts
+++ b/apps/web/src/pages/Timeline/legendCategories.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
+import type { ActivityTypeDefinition } from '../../state/api'
 import type { ChartItem } from './types'
 
 import { tagSourceColors } from './colors'
-import { CATEGORY_MATCHERS, LEGACY_CATEGORY_MAP } from './legendCategories'
+import {
+  buildCategoryMatchers,
+  buildScreentimeSubEntries,
+  isScreentimeSubKey,
+  LEGACY_CATEGORY_MAP,
+  screentimeSubKey,
+} from './legendCategories'
 
 const makeItem = (overrides: Partial<ChartItem> = {}): ChartItem => ({
   color: '#333',
@@ -16,75 +23,148 @@ const makeItem = (overrides: Partial<ChartItem> = {}): ChartItem => ({
   ...overrides,
 })
 
+const def = (overrides: Partial<ActivityTypeDefinition>): ActivityTypeDefinition =>
+  ({
+    aliases: [],
+    color: '#888',
+    display_category: 'productivity',
+    display_name: 'Test',
+    is_builtin: false,
+    name: 'test',
+    show_on_timeline: true,
+    ...overrides,
+  }) as ActivityTypeDefinition
+
+const matchers = (typeDefs: ActivityTypeDefinition[], screentimeDerivedTypes: ReadonlySet<string>) => {
+  const subEntries = buildScreentimeSubEntries(typeDefs, screentimeDerivedTypes)
+  const typeDefsMap = new Map(typeDefs.map((d) => [d.name, { parent_type: d.parent_type }]))
+  return buildCategoryMatchers(typeDefsMap, subEntries)
+}
+
 describe('LEGACY_CATEGORY_MAP', () => {
-  it('maps sleep, nap, rest to sleep_rest', () => {
+  it('maps sleep, nap, rest to sleep_rest (URL-hash backwards compat)', () => {
     expect(LEGACY_CATEGORY_MAP.sleep).toBe('sleep_rest')
     expect(LEGACY_CATEGORY_MAP.nap).toBe('sleep_rest')
     expect(LEGACY_CATEGORY_MAP.rest).toBe('sleep_rest')
   })
 })
 
-describe('CATEGORY_MATCHERS', () => {
+describe('static CATEGORY_MATCHERS (built without screentime sub-entries)', () => {
+  const m = matchers([], new Set())
+
   it('activity matches Activity and Screen Time columns', () => {
-    expect(CATEGORY_MATCHERS.activity(makeItem({ column: 'Activity' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.activity(makeItem({ column: 'Screen Time' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.activity(makeItem({ column: 'Location' }))).toBe(false)
+    expect(m.activity(makeItem({ column: 'Activity' }))).toBe(true)
+    expect(m.activity(makeItem({ column: 'Screen Time' }))).toBe(true)
+    expect(m.activity(makeItem({ column: 'Location' }))).toBe(false)
   })
 
   it('location matches Location column', () => {
-    expect(CATEGORY_MATCHERS.location(makeItem({ column: 'Location' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.location(makeItem({ column: 'Activity' }))).toBe(false)
+    expect(m.location(makeItem({ column: 'Location' }))).toBe(true)
+    expect(m.location(makeItem({ column: 'Activity' }))).toBe(false)
   })
 
   it('music matches Music column', () => {
-    expect(CATEGORY_MATCHERS.music(makeItem({ column: 'Music' }))).toBe(true)
+    expect(m.music(makeItem({ column: 'Music' }))).toBe(true)
   })
 
   it('exercise matches activity_type exercise', () => {
-    expect(CATEGORY_MATCHERS.exercise(makeItem({ activity_type: 'exercise' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.exercise(makeItem({ activity_type: 'sleep' }))).toBe(false)
+    expect(m.exercise(makeItem({ activity_type: 'exercise' }))).toBe(true)
+    expect(m.exercise(makeItem({ activity_type: 'sleep' }))).toBe(false)
   })
 
   it('sleep_rest matches sleep, nap, rest activity types', () => {
-    expect(CATEGORY_MATCHERS.sleep_rest(makeItem({ activity_type: 'sleep' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.sleep_rest(makeItem({ activity_type: 'nap' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.sleep_rest(makeItem({ activity_type: 'rest' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.sleep_rest(makeItem({ activity_type: 'exercise' }))).toBe(false)
+    expect(m.sleep_rest(makeItem({ activity_type: 'sleep' }))).toBe(true)
+    expect(m.sleep_rest(makeItem({ activity_type: 'nap' }))).toBe(true)
+    expect(m.sleep_rest(makeItem({ activity_type: 'rest' }))).toBe(true)
+    expect(m.sleep_rest(makeItem({ activity_type: 'exercise' }))).toBe(false)
   })
 
   it('meal matches entity_type meal', () => {
-    expect(CATEGORY_MATCHERS.meal(makeItem({ entity_type: 'meal' }))).toBe(true)
-    expect(CATEGORY_MATCHERS.meal(makeItem({ entity_type: 'activity' }))).toBe(false)
+    expect(m.meal(makeItem({ entity_type: 'meal' }))).toBe(true)
+    expect(m.meal(makeItem({ entity_type: 'activity' }))).toBe(false)
   })
 
   it('calendar matches Activity column with calendar color', () => {
-    expect(CATEGORY_MATCHERS.calendar(makeItem({ color: tagSourceColors.calendar }))).toBe(true)
-    expect(CATEGORY_MATCHERS.calendar(makeItem({ color: '#000' }))).toBe(false)
+    expect(m.calendar(makeItem({ color: tagSourceColors.calendar }))).toBe(true)
+    expect(m.calendar(makeItem({ color: '#000' }))).toBe(false)
   })
 
-  it('screentime matches Screen Time column', () => {
-    expect(CATEGORY_MATCHERS.screentime(makeItem({ column: 'Screen Time' }))).toBe(true)
+  it('screentime matches Screen Time column (legacy + derived after routing fix)', () => {
+    expect(m.screentime(makeItem({ column: 'Screen Time' }))).toBe(true)
+    expect(m.screentime(makeItem({ column: 'Activity' }))).toBe(false)
   })
 
   it('other matches Activity items without activity_type and not calendar', () => {
-    expect(CATEGORY_MATCHERS.other(makeItem({ entity_type: 'activity' }))).toBe(true)
-    // Calendar items are excluded
-    expect(
-      CATEGORY_MATCHERS.other(makeItem({ color: tagSourceColors.calendar, entity_type: 'activity' })),
-    ).toBe(false)
-    // Items with activity_type are excluded
-    expect(CATEGORY_MATCHERS.other(makeItem({ activity_type: 'exercise', entity_type: 'activity' }))).toBe(
-      false,
-    )
+    expect(m.other(makeItem({ entity_type: 'activity' }))).toBe(true)
+    expect(m.other(makeItem({ color: tagSourceColors.calendar, entity_type: 'activity' }))).toBe(false)
+    expect(m.other(makeItem({ activity_type: 'exercise', entity_type: 'activity' }))).toBe(false)
   })
 
   it('metrics sub-toggles return false (handled at draw level)', () => {
-    expect(CATEGORY_MATCHERS.hr(makeItem())).toBe(false)
-    expect(CATEGORY_MATCHERS.hrv(makeItem())).toBe(false)
-    expect(CATEGORY_MATCHERS.stress(makeItem())).toBe(false)
-    expect(CATEGORY_MATCHERS.steps(makeItem())).toBe(false)
-    expect(CATEGORY_MATCHERS.calories(makeItem())).toBe(false)
-    expect(CATEGORY_MATCHERS.training_load(makeItem())).toBe(false)
-    expect(CATEGORY_MATCHERS.screen_time_h(makeItem())).toBe(false)
+    expect(m.hr(makeItem())).toBe(false)
+    expect(m.hrv(makeItem())).toBe(false)
+    expect(m.stress(makeItem())).toBe(false)
+    expect(m.steps(makeItem())).toBe(false)
+    expect(m.calories(makeItem())).toBe(false)
+    expect(m.training_load(makeItem())).toBe(false)
+    expect(m.screen_time_h(makeItem())).toBe(false)
+  })
+})
+
+describe('buildScreentimeSubEntries', () => {
+  it('returns one entry per top-level screentime-derived type, sorted by label', () => {
+    const typeDefs = [
+      def({ name: 'work', display_name: 'Work' }),
+      def({ name: 'media', display_name: 'Media' }),
+      // Children — should be excluded.
+      def({ name: 'programming', display_name: 'Programming', parent_type: 'work' }),
+      // Not in screentimeDerivedTypes — excluded.
+      def({ name: 'exercise', display_name: 'Exercise' }),
+    ]
+    const entries = buildScreentimeSubEntries(typeDefs, new Set(['work', 'media', 'programming']))
+    expect(entries.map((e) => e.type)).toEqual(['media', 'work'])
+    expect(entries[0]!.legendKey).toBe('screentime:media')
+    expect(entries[1]!.legendKey).toBe('screentime:work')
+  })
+
+  it('excludes types with show_on_timeline=false', () => {
+    const typeDefs = [def({ name: 'hidden', display_name: 'Hidden', show_on_timeline: false })]
+    expect(buildScreentimeSubEntries(typeDefs, new Set(['hidden']))).toEqual([])
+  })
+
+  it('returns empty when no screentime-derived types are present', () => {
+    expect(buildScreentimeSubEntries([], new Set())).toEqual([])
+  })
+})
+
+describe('dynamic screentime sub-toggle matchers (#718)', () => {
+  it('matches an item by walking parent_type to the top-level slug', () => {
+    const typeDefs = [
+      def({ name: 'work', display_name: 'Work' }),
+      def({ name: 'programming', display_name: 'Programming', parent_type: 'work' }),
+    ]
+    const m = matchers(typeDefs, new Set(['work', 'programming']))
+    // A `programming` item in the Screen Time column should match the
+    // `screentime:work` toggle (its root-walked ancestor is `work`).
+    expect(m['screentime:work'](makeItem({ activity_type: 'programming', column: 'Screen Time' }))).toBe(true)
+    // The same item should NOT match a different top-level toggle.
+    expect(
+      m['screentime:media']?.(makeItem({ activity_type: 'programming', column: 'Screen Time' })),
+    ).toBeUndefined() // matcher doesn't exist for `media` since the type def isn't there
+  })
+
+  it('does not match items outside the Screen Time column', () => {
+    const typeDefs = [def({ name: 'work', display_name: 'Work' })]
+    const m = matchers(typeDefs, new Set(['work']))
+    expect(m['screentime:work'](makeItem({ activity_type: 'work', column: 'Activity' }))).toBe(false)
+  })
+})
+
+describe('isScreentimeSubKey / screentimeSubKey', () => {
+  it('round-trips a top-level slug', () => {
+    expect(screentimeSubKey('work')).toBe('screentime:work')
+    expect(isScreentimeSubKey('screentime:work')).toBe(true)
+    expect(isScreentimeSubKey('screentime')).toBe(false)
+    expect(isScreentimeSubKey('exercise')).toBe(false)
   })
 })

--- a/apps/web/src/pages/Timeline/legendCategories.test.ts
+++ b/apps/web/src/pages/Timeline/legendCategories.test.ts
@@ -146,7 +146,9 @@ describe('dynamic screentime sub-toggle matchers (#718)', () => {
     const m = matchers(typeDefs, new Set(['work', 'programming']))
     // A `programming` item in the Screen Time column should match the
     // `screentime:work` toggle (its root-walked ancestor is `work`).
-    expect(m['screentime:work'](makeItem({ activity_type: 'programming', column: 'Screen Time' }))).toBe(true)
+    expect(m['screentime:work']!(makeItem({ activity_type: 'programming', column: 'Screen Time' }))).toBe(
+      true,
+    )
     // The same item should NOT match a different top-level toggle.
     expect(
       m['screentime:media']?.(makeItem({ activity_type: 'programming', column: 'Screen Time' })),
@@ -156,7 +158,7 @@ describe('dynamic screentime sub-toggle matchers (#718)', () => {
   it('does not match items outside the Screen Time column', () => {
     const typeDefs = [def({ name: 'work', display_name: 'Work' })]
     const m = matchers(typeDefs, new Set(['work']))
-    expect(m['screentime:work'](makeItem({ activity_type: 'work', column: 'Activity' }))).toBe(false)
+    expect(m['screentime:work']!(makeItem({ activity_type: 'work', column: 'Activity' }))).toBe(false)
   })
 })
 

--- a/apps/web/src/pages/Timeline/legendCategories.ts
+++ b/apps/web/src/pages/Timeline/legendCategories.ts
@@ -87,11 +87,18 @@ const STATIC_CATEGORY_MATCHERS: Record<
 }
 
 /**
- * Top-level screentime categories visible in the legend, ordered as they
- * should appear. Built from the activity_type_definitions tree intersected
- * with the slugs that appear on at least one screentime_categories row, then
- * filtered to those whose `parent_type` is unset (the roots of each
- * category subtree).
+ * Top-level screentime categories visible in the legend, ordered alphabetically
+ * by label. Built from the activity_type_definitions tree intersected with the
+ * slugs that appear on at least one screentime_categories row, then filtered
+ * to those whose `parent_type` is unset (the roots of each category subtree).
+ *
+ * Assumption: every top-level screentime grouping the user wants in the legend
+ * has its own `screentime_categories` row whose `activity_type_name` resolves
+ * to a top-level (`parent_type=null`) type def. If a user only configured
+ * leaf-level categories (e.g. a `Programming` category but no parent `Work`),
+ * no per-top-level sub-toggles will appear — the umbrella `screentime` toggle
+ * still works as a single hide-everything switch. Restructure follow-up if
+ * this assumption gets in the way (#721 makes it moot anyway).
  */
 export interface ScreentimeSubEntry {
   /** The top-level activity_type slug (e.g. "work"). */
@@ -115,6 +122,14 @@ export const buildScreentimeSubEntries = (
     }))
     .sort((a, b) => a.label.localeCompare(b.label))
 
+/** Map of LegendCategory → matcher. Static keys are exhaustive; dynamic keys are present only when their corresponding sub-entry exists. */
+export type CategoryMatchers = Record<
+  Exclude<LegendCategory, `screentime:${string}`>,
+  (item: ChartItem) => boolean
+> & {
+  [K in `screentime:${string}`]?: (item: ChartItem) => boolean
+}
+
 /**
  * Build the matcher set including dynamic screentime sub-toggle entries.
  * Each `screentime:<top-level>` entry matches a Screen Time-column item whose
@@ -123,8 +138,8 @@ export const buildScreentimeSubEntries = (
 export const buildCategoryMatchers = (
   typeDefsMap: ReadonlyMap<string, { parent_type?: string }>,
   screentimeSubEntries: ScreentimeSubEntry[],
-): Record<string, (item: ChartItem) => boolean> => {
-  const matchers: Record<string, (item: ChartItem) => boolean> = { ...STATIC_CATEGORY_MATCHERS }
+): CategoryMatchers => {
+  const matchers = { ...STATIC_CATEGORY_MATCHERS } as CategoryMatchers
   for (const entry of screentimeSubEntries) {
     const topLevel = entry.type
     matchers[entry.legendKey] = (item) =>

--- a/apps/web/src/pages/Timeline/legendCategories.ts
+++ b/apps/web/src/pages/Timeline/legendCategories.ts
@@ -1,22 +1,31 @@
+import type { ActivityTypeDefinition } from '../../state/api'
 import type { ChartItem, Column } from './types'
 
+import { rootTypeOf } from './activityMerge'
 import { tagSourceColors } from './colors'
 
-// Top-level track toggles + sub-toggles, all stored in one flat Set.
+/**
+ * The Activity-side legend has a curated layer (sleep_rest / meditation /
+ * exercise / other / calendar / meal) plus a `screentime` umbrella toggle and
+ * — new in #718 — one dynamic sub-toggle per top-level screentime category
+ * (e.g. `Work`, `Media`, `Comms`). Dynamic keys use the
+ * `screentime:<top-level-slug>` namespace so they coexist with the static
+ * union below.
+ */
 export type LegendCategory =
   // Top-level track toggles
   | 'music'
   | 'activity'
   | 'metrics'
   | 'location'
-  // Activity sub-toggles
+  // Activity sub-toggles (curated)
   | 'sleep_rest' // replaces sleep+nap+rest
   | 'meditation'
   | 'exercise'
   | 'other'
   | 'calendar'
   | 'meal'
-  | 'screentime' // vertical only
+  | 'screentime' // umbrella: legacy `screentime` activities + all derived screentime types
   // Metrics sub-toggles
   | 'hr'
   | 'hrv'
@@ -25,8 +34,10 @@ export type LegendCategory =
   | 'calories' // horizontal only
   | 'training_load' // horizontal only
   | 'screen_time_h' // horizontal only — screentime stacked bar
+  // Dynamic per-top-level screentime category (e.g. "screentime:work").
+  | `screentime:${string}`
 
-// Legacy category names for URL hash backward compatibility
+// Legacy category names for URL hash backward compatibility.
 export const LEGACY_CATEGORY_MAP: Record<string, LegendCategory> = {
   nap: 'sleep_rest',
   rest: 'sleep_rest',
@@ -35,7 +46,19 @@ export const LEGACY_CATEGORY_MAP: Record<string, LegendCategory> = {
 
 export const BASE_COLUMNS: Column[] = ['Activity', 'Location', 'Screen Time']
 
-export const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => boolean> = {
+const SCREENTIME_SUB_PREFIX = 'screentime:' as const
+
+/** A dynamic screentime sub-toggle key (one per top-level screentime category). */
+export const screentimeSubKey = (topLevelSlug: string): LegendCategory =>
+  `${SCREENTIME_SUB_PREFIX}${topLevelSlug}` as LegendCategory
+
+/** True when a legend category is one of the dynamic screentime sub-toggles. */
+export const isScreentimeSubKey = (cat: string): boolean => cat.startsWith(SCREENTIME_SUB_PREFIX)
+
+const STATIC_CATEGORY_MATCHERS: Record<
+  Exclude<LegendCategory, `screentime:${string}`>,
+  (item: ChartItem) => boolean
+> = {
   activity: (item) => item.column === 'Activity' || item.column === 'Screen Time',
   calendar: (item) => item.column === 'Activity' && item.color === tagSourceColors.calendar,
   calories: () => false, // metrics sub-toggles handled at draw level
@@ -48,6 +71,8 @@ export const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => bool
   meditation: (item) => item.column === 'Activity' && item.activity_type === 'meditation',
   metrics: () => false, // metrics track controlled via sub-toggles at draw level
   music: (item) => item.column === 'Music',
+  // The Screen Time column is the source of truth post-routing fix: legacy
+  // `screentime` activities and all derived screentime types both land here.
   screentime: (item) => item.column === 'Screen Time',
   sleep_rest: (item) =>
     item.column === 'Activity' && ['sleep', 'nap', 'rest'].includes(item.activity_type ?? ''),
@@ -59,4 +84,53 @@ export const CATEGORY_MATCHERS: Record<LegendCategory, (item: ChartItem) => bool
     !item.activity_type,
   screen_time_h: () => false, // horizontal screentime bar controlled at draw level
   training_load: () => false,
+}
+
+/**
+ * Top-level screentime categories visible in the legend, ordered as they
+ * should appear. Built from the activity_type_definitions tree intersected
+ * with the slugs that appear on at least one screentime_categories row, then
+ * filtered to those whose `parent_type` is unset (the roots of each
+ * category subtree).
+ */
+export interface ScreentimeSubEntry {
+  /** The top-level activity_type slug (e.g. "work"). */
+  type: string
+  label: string
+  color: string
+  legendKey: LegendCategory
+}
+
+export const buildScreentimeSubEntries = (
+  typeDefs: ActivityTypeDefinition[],
+  screentimeDerivedTypes: ReadonlySet<string>,
+): ScreentimeSubEntry[] =>
+  typeDefs
+    .filter((d) => screentimeDerivedTypes.has(d.name) && !d.parent_type && d.show_on_timeline !== false)
+    .map((d) => ({
+      color: d.color,
+      label: d.display_name,
+      legendKey: screentimeSubKey(d.name),
+      type: d.name,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+
+/**
+ * Build the matcher set including dynamic screentime sub-toggle entries.
+ * Each `screentime:<top-level>` entry matches a Screen Time-column item whose
+ * activity_type's root (via parent_type walk) equals the top-level slug.
+ */
+export const buildCategoryMatchers = (
+  typeDefsMap: ReadonlyMap<string, { parent_type?: string }>,
+  screentimeSubEntries: ScreentimeSubEntry[],
+): Record<string, (item: ChartItem) => boolean> => {
+  const matchers: Record<string, (item: ChartItem) => boolean> = { ...STATIC_CATEGORY_MATCHERS }
+  for (const entry of screentimeSubEntries) {
+    const topLevel = entry.type
+    matchers[entry.legendKey] = (item) =>
+      item.column === 'Screen Time' &&
+      Boolean(item.activity_type) &&
+      rootTypeOf(item.activity_type!, typeDefsMap) === topLevel
+  }
+  return matchers
 }

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -37,7 +37,13 @@ import { categorizeMusic } from './categorizeMusic'
 import { activityColors, getExerciseColor } from './colors'
 import { parseBucketedData } from './drawActivitySparklines'
 import { getExerciseTypeName } from './formatting'
-import { BASE_COLUMNS, CATEGORY_MATCHERS, type LegendCategory } from './legendCategories'
+import {
+  BASE_COLUMNS,
+  buildCategoryMatchers,
+  buildScreentimeSubEntries,
+  type LegendCategory,
+  type ScreentimeSubEntry,
+} from './legendCategories'
 import { buildSleepDetails, type SleepMetricsByDate } from './tooltipBuilder'
 
 /** Metrics to exclude from the unified bucketed query (fetched via separate endpoints). */
@@ -74,6 +80,8 @@ export interface TimelineData {
   errorSources: string[]
   // Misc
   hasLastFm: boolean
+  /** Dynamic screentime sub-toggles to render in the legend. */
+  screentimeSubEntries: ScreentimeSubEntry[]
 }
 
 export interface UseTimelineDataOptions {
@@ -88,6 +96,8 @@ export interface UseTimelineDataOptions {
   mergeGapMs: number
   /** Whether sibling sub-types should collapse to their parent_type for merging. */
   shouldCollapseHierarchy: boolean
+  /** Hierarchy walk depth: 0=no walk, 1=one hop, Infinity=walk to root. */
+  collapseDepth: number
 }
 
 // eslint-disable-next-line complexity -- data hook aggregating multiple queries
@@ -101,6 +111,7 @@ export const useTimelineData = ({
   barBucketSize,
   mergeGapMs,
   shouldCollapseHierarchy,
+  collapseDepth,
 }: UseTimelineDataOptions): TimelineData => {
   // ── Data queries ───────────────────────────────────────────────────────────
 
@@ -206,6 +217,32 @@ export const useTimelineData = ({
     () => new Map(activityTypeDefs.map((t) => [t.name, t.display_category])),
     [activityTypeDefs],
   )
+
+  // Slugs of every screentime-category-derived activity type for this user.
+  // Built from screentime_categories.activity_type_name (set at first sync by
+  // ensureCategoryHasType in the backend). Used to route derived activities
+  // to the Screen Time column and to identify candidates for the dynamic
+  // legend sub-toggles.
+  const screentimeDerivedTypes = useMemo(
+    () =>
+      new Set(
+        (screentimeCategoriesQuery.data ?? [])
+          .map((c) => c.activity_type_name)
+          .filter((n): n is string => Boolean(n)),
+      ),
+    [screentimeCategoriesQuery.data],
+  )
+
+  const screentimeSubEntries = useMemo(
+    () => buildScreentimeSubEntries(activityTypeDefs, screentimeDerivedTypes),
+    [activityTypeDefs, screentimeDerivedTypes],
+  )
+
+  const categoryMatchers = useMemo(
+    () => buildCategoryMatchers(typeDefsMap, screentimeSubEntries),
+    [typeDefsMap, screentimeSubEntries],
+  )
+
   const allActivities = useMemo(
     () => (activitiesQuery.data ?? []).filter((a) => !hiddenTypes.has(a.activity_type ?? '')),
     [activitiesQuery.data, hiddenTypes],
@@ -219,12 +256,23 @@ export const useTimelineData = ({
     const filtered = allActivities.filter((a) =>
       ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other'),
     )
-    return collapseToParentType(filtered, typeDefsMap, mergeGapMs, shouldCollapseHierarchy)
-  }, [allActivities, categoryByType, shouldCollapseHierarchy, typeDefsMap, mergeGapMs])
+    return collapseToParentType(filtered, typeDefsMap, mergeGapMs, shouldCollapseHierarchy, collapseDepth)
+  }, [allActivities, categoryByType, shouldCollapseHierarchy, collapseDepth, typeDefsMap, mergeGapMs])
+  // Anything that's neither a primary Activity-lane type, nor a screentime
+  // type (legacy umbrella `screentime` + per-category derived types), nor a
+  // music_scrobble / location_visit (own columns) goes here. Excluding
+  // screentime-derived types prevents them from double-rendering as
+  // untoggleable bars in the Activity lane (regression introduced when #722
+  // started routing derived types as `display_category='productivity'`).
   const secondaryActivities = useMemo(
     () =>
-      allActivities.filter((a) => !ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other')),
-    [allActivities, categoryByType],
+      allActivities.filter(
+        (a) =>
+          !ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other') &&
+          a.activity_type !== 'screentime' &&
+          !screentimeDerivedTypes.has(a.activity_type),
+      ),
+    [allActivities, categoryByType, screentimeDerivedTypes],
   )
   // Locations come from `location_visit` activities materialized by the
   // backend (proactive on GPS sync; backstop on /locations browse). Only
@@ -239,16 +287,36 @@ export const useTimelineData = ({
       }),
     [activitiesQuery.data],
   )
-  // Screentime spans come from `screentime` activities. The backend pre-merges
-  // adjacent records at sync time keyed by (source, category_path) with a fixed
-  // 2-min gap — that doesn't bridge across sources or batch boundaries, so we
-  // do a second, zoom-graded merge here keyed only by category_path. Same
-  // category from rescuetime and activitywatch fold into one visual bar; gap
-  // grows with zoom so a long stretch reads as one block when zoomed out.
+  // Screentime spans come from two paths post-#651:
+  //   1. Legacy `screentime` umbrella activities (pre-derived-types data).
+  //   2. Per-category derived types (e.g. `programming`, `slack`) — present
+  //      whenever the user has screentime categories with linked types.
+  // Both render in the Screen Time column. Legacy spans merge by
+  // `category_path` (their activity_type is the same umbrella for every
+  // category, so without that discriminator they'd collapse into one bar).
+  // Derived types feed through `collapseToParentType` so the same hierarchy
+  // collapse used for exercise sub-types applies to screen time too.
   const screentimeActivities = useMemo<Activity[]>(() => {
-    const raw = (activitiesQuery.data ?? []).filter((a) => a.activity_type === 'screentime')
-    return mergeScreentimeActivities(raw, mergeGapMs)
-  }, [activitiesQuery.data, mergeGapMs])
+    const all = activitiesQuery.data ?? []
+    const legacyRaw = all.filter((a) => a.activity_type === 'screentime')
+    const derivedRaw = all.filter((a) => screentimeDerivedTypes.has(a.activity_type))
+    const legacyMerged = mergeScreentimeActivities(legacyRaw, mergeGapMs)
+    const derivedMerged = collapseToParentType(
+      derivedRaw,
+      typeDefsMap,
+      mergeGapMs,
+      shouldCollapseHierarchy,
+      collapseDepth,
+    )
+    return [...legacyMerged, ...derivedMerged].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
+  }, [
+    activitiesQuery.data,
+    mergeGapMs,
+    screentimeDerivedTypes,
+    typeDefsMap,
+    shouldCollapseHierarchy,
+    collapseDepth,
+  ])
   // Music scrobbles are derived from `music_scrobble` activities — they live
   // in the activities table and are already returned by the activities fetch,
   // so no separate /lastfm/scrobbles network call is needed.
@@ -355,16 +423,17 @@ export const useTimelineData = ({
 
   const isItemHidden = useCallback(
     (item: ChartItem): boolean => {
-      if (hiddenCategories.has('activity') && CATEGORY_MATCHERS.activity(item)) return true
-      if (hiddenCategories.has('location') && CATEGORY_MATCHERS.location(item)) return true
-      if (hiddenCategories.has('music') && CATEGORY_MATCHERS.music(item)) return true
+      if (hiddenCategories.has('activity') && categoryMatchers.activity(item)) return true
+      if (hiddenCategories.has('location') && categoryMatchers.location(item)) return true
+      if (hiddenCategories.has('music') && categoryMatchers.music(item)) return true
       for (const cat of hiddenCategories) {
         if (cat === 'activity' || cat === 'location' || cat === 'music' || cat === 'metrics') continue
-        if (CATEGORY_MATCHERS[cat](item)) return true
+        const matcher = categoryMatchers[cat]
+        if (matcher && matcher(item)) return true
       }
       return false
     },
-    [hiddenCategories],
+    [hiddenCategories, categoryMatchers],
   )
 
   const allChartItems = useMemo(
@@ -376,6 +445,8 @@ export const useTimelineData = ({
         screentimeActivities,
         screentimeCategoriesQuery.data ?? [],
         itemIcons,
+        screentimeDerivedTypes,
+        typeDefsMap,
       ),
       ...musicItems,
       ...mealItems,
@@ -389,6 +460,7 @@ export const useTimelineData = ({
       typeDefsMap,
       screentimeActivities,
       screentimeCategoriesQuery.data,
+      screentimeDerivedTypes,
       musicItems,
       mealItems,
     ],
@@ -437,6 +509,7 @@ export const useTimelineData = ({
     isInitialLoad,
     screentimeBucketedQuery,
     screentimeCategoriesQuery,
+    screentimeSubEntries,
     scrobbles,
     sparklineBuckets,
     trainingLoadQuery,

--- a/apps/web/src/pages/Timeline/useTimelineData.ts
+++ b/apps/web/src/pages/Timeline/useTimelineData.ts
@@ -94,8 +94,6 @@ export interface UseTimelineDataOptions {
   barBucketSize: '1h' | '1d' | '1w'
   /** Gap (ms) below which adjacent same-key activities merge in the timeline. */
   mergeGapMs: number
-  /** Whether sibling sub-types should collapse to their parent_type for merging. */
-  shouldCollapseHierarchy: boolean
   /** Hierarchy walk depth: 0=no walk, 1=one hop, Infinity=walk to root. */
   collapseDepth: number
 }
@@ -110,7 +108,6 @@ export const useTimelineData = ({
   bucketSize,
   barBucketSize,
   mergeGapMs,
-  shouldCollapseHierarchy,
   collapseDepth,
 }: UseTimelineDataOptions): TimelineData => {
   // ── Data queries ───────────────────────────────────────────────────────────
@@ -256,8 +253,8 @@ export const useTimelineData = ({
     const filtered = allActivities.filter((a) =>
       ACTIVITY_CATEGORIES.has(categoryByType.get(a.activity_type) ?? 'other'),
     )
-    return collapseToParentType(filtered, typeDefsMap, mergeGapMs, shouldCollapseHierarchy, collapseDepth)
-  }, [allActivities, categoryByType, shouldCollapseHierarchy, collapseDepth, typeDefsMap, mergeGapMs])
+    return collapseToParentType(filtered, typeDefsMap, mergeGapMs, collapseDepth)
+  }, [allActivities, categoryByType, collapseDepth, typeDefsMap, mergeGapMs])
   // Anything that's neither a primary Activity-lane type, nor a screentime
   // type (legacy umbrella `screentime` + per-category derived types), nor a
   // music_scrobble / location_visit (own columns) goes here. Excluding
@@ -296,27 +293,15 @@ export const useTimelineData = ({
   // category, so without that discriminator they'd collapse into one bar).
   // Derived types feed through `collapseToParentType` so the same hierarchy
   // collapse used for exercise sub-types applies to screen time too.
+  // Both branches consume `allActivities` (post-`hiddenTypes` filter) so a
+  // type with `show_on_timeline=false` stays hidden uniformly.
   const screentimeActivities = useMemo<Activity[]>(() => {
-    const all = activitiesQuery.data ?? []
-    const legacyRaw = all.filter((a) => a.activity_type === 'screentime')
-    const derivedRaw = all.filter((a) => screentimeDerivedTypes.has(a.activity_type))
+    const legacyRaw = allActivities.filter((a) => a.activity_type === 'screentime')
+    const derivedRaw = allActivities.filter((a) => screentimeDerivedTypes.has(a.activity_type))
     const legacyMerged = mergeScreentimeActivities(legacyRaw, mergeGapMs)
-    const derivedMerged = collapseToParentType(
-      derivedRaw,
-      typeDefsMap,
-      mergeGapMs,
-      shouldCollapseHierarchy,
-      collapseDepth,
-    )
+    const derivedMerged = collapseToParentType(derivedRaw, typeDefsMap, mergeGapMs, collapseDepth)
     return [...legacyMerged, ...derivedMerged].sort((a, b) => a.start_time.getTime() - b.start_time.getTime())
-  }, [
-    activitiesQuery.data,
-    mergeGapMs,
-    screentimeDerivedTypes,
-    typeDefsMap,
-    shouldCollapseHierarchy,
-    collapseDepth,
-  ])
+  }, [allActivities, mergeGapMs, screentimeDerivedTypes, typeDefsMap, collapseDepth])
   // Music scrobbles are derived from `music_scrobble` activities — they live
   // in the activities table and are already returned by the activities fetch,
   // so no separate /lastfm/scrobbles network call is needed.

--- a/apps/web/src/pages/Timeline/useTimelineNavigation.ts
+++ b/apps/web/src/pages/Timeline/useTimelineNavigation.ts
@@ -45,6 +45,12 @@ export interface TimelineNavigation {
   mergeGapMs: number
   /** Whether sibling sub-types should collapse to their parent_type for merging. */
   shouldCollapseHierarchy: boolean
+  /**
+   * How many parent_type hops to walk during hierarchy collapse. 0 = no
+   * walk (max-zoom). 1 = one hop (current default for moderate zoom-out).
+   * Number.POSITIVE_INFINITY = walk to root (deep zoom-out).
+   */
+  collapseDepth: number
 }
 
 export const useTimelineNavigation = (): TimelineNavigation => {
@@ -88,6 +94,16 @@ export const useTimelineNavigation = (): TimelineNavigation => {
   const shouldCollapseHierarchy = useMemo(() => {
     const days = differenceInCalendarDays(effectiveViewEnd, effectiveViewStart)
     return days > 3
+  }, [effectiveViewStart, effectiveViewEnd])
+
+  // Multi-tier collapse depth (#656): zoomed-in keeps sub-types; moderate
+  // zoom-out collapses one hop (warmup_run → exercise); deep zoom-out walks
+  // to the root so a 30-day view reads as fewer, broader bars.
+  const collapseDepth = useMemo(() => {
+    const days = differenceInCalendarDays(effectiveViewEnd, effectiveViewStart)
+    if (days > 14) return Number.POSITIVE_INFINITY
+    if (days > 3) return 1
+    return 0
   }, [effectiveViewStart, effectiveViewEnd])
 
   const handleZoom = useCallback((zoomStart: Date, zoomEnd: Date) => {
@@ -146,6 +162,7 @@ export const useTimelineNavigation = (): TimelineNavigation => {
   return {
     barBucketSize,
     bucketSize,
+    collapseDepth,
     effectiveViewEnd,
     effectiveViewStart,
     fetchEnd,

--- a/apps/web/src/pages/Timeline/useTimelineNavigation.ts
+++ b/apps/web/src/pages/Timeline/useTimelineNavigation.ts
@@ -43,11 +43,9 @@ export interface TimelineNavigation {
   barBucketSize: '1h' | '1d' | '1w'
   /** Gap (ms) below which adjacent same-key activities merge in the timeline. */
   mergeGapMs: number
-  /** Whether sibling sub-types should collapse to their parent_type for merging. */
-  shouldCollapseHierarchy: boolean
   /**
    * How many parent_type hops to walk during hierarchy collapse. 0 = no
-   * walk (max-zoom). 1 = one hop (current default for moderate zoom-out).
+   * walk (max-zoom). 1 = one hop (moderate zoom-out).
    * Number.POSITIVE_INFINITY = walk to root (deep zoom-out).
    */
   collapseDepth: number
@@ -88,17 +86,11 @@ export const useTimelineNavigation = (): TimelineNavigation => {
     return 10 * 60 * 1000
   }, [effectiveViewStart, effectiveViewEnd])
 
-  // Hierarchy collapse only kicks in when zoomed out: at max zoom the user
-  // wants to see (and click to edit) sibling sub-types like warmup_run vs
-  // strength_training distinctly, so we leave them as-is.
-  const shouldCollapseHierarchy = useMemo(() => {
-    const days = differenceInCalendarDays(effectiveViewEnd, effectiveViewStart)
-    return days > 3
-  }, [effectiveViewStart, effectiveViewEnd])
-
-  // Multi-tier collapse depth (#656): zoomed-in keeps sub-types; moderate
-  // zoom-out collapses one hop (warmup_run → exercise); deep zoom-out walks
-  // to the root so a 30-day view reads as fewer, broader bars.
+  // Multi-tier collapse depth (#656): at max zoom the user wants to see
+  // (and click to edit) sibling sub-types like warmup_run vs strength_training
+  // distinctly, so we leave them as-is. Moderate zoom-out collapses one hop
+  // (warmup_run → exercise); deep zoom-out walks to root so a 30-day view
+  // reads as fewer, broader bars.
   const collapseDepth = useMemo(() => {
     const days = differenceInCalendarDays(effectiveViewEnd, effectiveViewStart)
     if (days > 14) return Number.POSITIVE_INFINITY
@@ -172,7 +164,6 @@ export const useTimelineNavigation = (): TimelineNavigation => {
     handleResetToToday,
     handleZoom,
     mergeGapMs,
-    shouldCollapseHierarchy,
     toDate,
     viewEnd,
     viewLabel,

--- a/apps/web/src/state/api/types.ts
+++ b/apps/web/src/state/api/types.ts
@@ -79,6 +79,13 @@ export interface Activity extends Omit<ApiActivity, 'start_time' | 'end_time'> {
   source_records?: SourceRecord[]
   merged_start_time?: Date
   merged_end_time?: Date
+  /**
+   * Provenance of activities that were folded into this one by
+   * `collapseToParentType`. Set only on the synthetic survivor; never on
+   * activities returned by the API. Drives the "Merged: Running, Yoga"
+   * tooltip line for hierarchy-collapsed bars.
+   */
+  collapsed_types?: { type: string; count: number }[]
 }
 
 export interface ProductivityRecord extends Omit<ApiProductivityRecord, 'start_time' | 'end_time'> {


### PR DESCRIPTION
## Summary

Frontend catch-up after #651/#722. Derived screentime activity types now render correctly in the Screen Time column, are toggleable in the legend, participate in hierarchy collapse, and surface their sub-type provenance on collapsed bars.

Closes **#718** (legend derivation), **#657** (tooltip enrichment for collapsed bars), **#656** (multi-level parent_type collapse on deeper zoom-out).

## What was broken

After #722 the backend started producing activities like `programming` (with `parent_type='work'`, `display_category='productivity'`). The frontend's hardcoded routing put anything outside `['sleep_rest', 'exercise', 'meditation', 'wellness']` into `secondaryActivities` → those bars rendered as untoggleable, un-legend-ed entries in the Activity column. Hierarchy collapse never reached them either.

## Approach

- `screentimeDerivedTypes`: derived from `screentimeCategoriesQuery.data` (each category's `activity_type_name`). Source of truth for "is this slug screen time?"
- Routing in `useTimelineData.ts` directs both legacy `screentime` umbrella activities and derived-type activities into the Screen Time path.
- Legacy spans keep their `category_path`-keyed merge (their `activity_type` is the same umbrella for every category, so without a discriminator they'd collapse into one bar). Derived types feed through the same `collapseToParentType` used by the primary Activity bucket.
- `collapseToParentType` gets a `depth` parameter (0 / 1 / Infinity) and a `collapsed_types` provenance field on the synthetic survivor; the navigation hook picks a tier from the visible span.
- The legend is hierarchy-aware: the static curated layer is preserved; dynamic per-top-level screentime sub-toggles are added under the Activity group, matched by walking `parent_type` to root.

## Test plan

- [x] `pnpm fix` clean
- [x] `pnpm check` clean
- [x] Timeline test suite: 241/241 passing (existing 217 + 24 new in activityMerge / legendCategories / categorize)
- [ ] Manual smoke on staging once deployed: configure screentime categories, sync, verify Screen Time column populates, legend shows per-category sub-toggles, zoom-out → 3-14d collapses one hop, 14d+ walks to root, tooltip on a collapsed bar shows "Merged: …"

## Out of scope

- #652 backfill of legacy `screentime` activities into derived types (backend; orthogonal)
- #653 consumer migration off the productivity table (backend)
- #658 pixel-zoom gating (current span-based gate stays; depth tier is a strict extension)
- #721 column unification (four-column layout preserved; #721 is the natural next-after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)