### PR TITLE
fix(android): add HttpTimeout to sync HttpClient

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -51,10 +51,6 @@ import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.android.Android
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -177,7 +173,7 @@ fun AurbodaApp(initialTab: MainTab? = null) {
   val appState = rememberAppState(initialTab = initialTab)
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
-  val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
+  val ktorHttpClient = remember { syncHttpClient() }
 
   // Update check state
   var updateAvailable by remember { mutableStateOf<VersionInfo?>(null) }
@@ -404,7 +400,7 @@ fun HealthConnectScreen(
   val hasBackgroundReadPermission by remember(grantedPermissions) {
     derivedStateOf { HC_BACKGROUND_READ_PERMISSION in grantedPermissions }
   }
-  val ktorHttpClient = remember { HttpClient(Android) { install(ContentNegotiation) { json(appJson) } } }
+  val ktorHttpClient = remember { syncHttpClient() }
 
   /**
    * Sync Health Connect data incrementally: fetch and send page by page.

--- a/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncUtils.kt
@@ -3,6 +3,9 @@ package net.aurboda
 import android.util.Log
 import androidx.health.connect.client.records.*
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -10,6 +13,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.delay
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
@@ -19,6 +23,22 @@ const val SYNC_UTILS_TAG = "SyncUtils"
 /** Maximum retries per chunk on transient errors (network drop, 5xx, 408, 429). */
 @PublishedApi
 internal const val MAX_CHUNK_ATTEMPTS: Int = 4
+
+/**
+ * Build the HttpClient used for all sync uploads. Without HttpTimeout the Android engine waits
+ * indefinitely on stalled connections — an HR chunk POST that black-holes will hang the whole
+ * sync until WorkManager kills the worker at its 10-minute limit. The retry path in
+ * postChunkWithRetry only fires on actual errors, so timeouts are what surface a stall as one.
+ */
+fun syncHttpClient(): HttpClient =
+  HttpClient(Android) {
+    install(ContentNegotiation) { json(appJson) }
+    install(HttpTimeout) {
+      connectTimeoutMillis = 30_000
+      socketTimeoutMillis = 60_000
+      requestTimeoutMillis = 120_000
+    }
+  }
 
 /**
  * HeartRateRecord is a SeriesRecord — each record holds many samples, so the JSON payload can

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -13,10 +13,6 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.android.Android
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
 import net.aurboda.widget.HrZoneWidgetProvider
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -33,11 +29,7 @@ class SyncWorker(
   params: WorkerParameters,
 ) : CoroutineWorker(context, params) {
   private val healthConnectClient by lazy { HealthConnectClient.getOrCreate(applicationContext) }
-  private val httpClient by lazy {
-    HttpClient(Android) {
-      install(ContentNegotiation) { json(appJson) }
-    }
-  }
+  private val httpClient by lazy { syncHttpClient() }
 
   override suspend fun doWork(): Result {
     Log.d(TAG, "Starting background sync")


### PR DESCRIPTION
## Summary
- The Android sync `HttpClient` has no `HttpTimeout` plugin installed, so the Android engine waits forever on stalled connections.
- Symptom (Sara): foreground sync hangs on `HeartRateRecord chunk 2 / 19` mid-flight; background sync gets killed by WorkManager's 10-min limit and reports "Job was cancelled". Across attempts the sync still inches forward (page 1 → page 2, fewer days behind), but each attempt loses time on the hang.
- Root cause: chunk POST hangs (TCP black-hole, dropped connection on mobile) → Ktor never times out → the chunk-retry path in `postChunkWithRetry` (only fires on errors) never sees a failure to retry.
- Fix: introduce `syncHttpClient()` in `SyncUtils.kt` with connect 30s / socket 60s / request 120s, and use it in `SyncWorker` and the two `MainActivity` sync sites. Existing retry path then handles the timeout as a transient `NetworkError` and retries with backoff.

## Test plan
- [x] `./gradlew compileDebugKotlin` — passes
- [x] `./gradlew testDebugUnitTest` — passes
- [ ] Install on Sara's device, observe initial sync completes without hanging on HR chunks
- [ ] Confirm background sync no longer reports "Job was cancelled" after 10 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)