### PR TITLE
fix(activities): override reuse + drop legacy Exercise Type field

### DIFF
--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -801,6 +801,59 @@ describe('Activities Integration Tests', () => {
       expect(survivor?.override_target_ids).toEqual([stravaId])
     })
 
+    test('reuses an existing aurboda row at the same (type, start_time) instead of inserting a duplicate', async () => {
+      // Real-world case: a previous override edit created an aurboda row
+      // targeting one synced source. The user re-edits via a different
+      // synced source in the same merge group (e.g. strava instead of
+      // garmin). insertOverride should attach the new target to the
+      // existing aurboda row rather than 23505-ing on idx_activities_type_time.
+      const user = getTestUser()
+      const garminId = randomUUID()
+      const stravaId = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'meditation',
+        end_time: new Date('2026-05-10T10:30:00Z'),
+        external_id: 'garmin-reuse',
+        id: garminId,
+        source: 'garmin',
+        start_time: new Date('2026-05-10T10:00:00Z'),
+      })
+      await insertActivity(user, {
+        activity_type: 'meditation',
+        end_time: new Date('2026-05-10T10:30:00Z'),
+        external_id: 'strava-reuse',
+        id: stravaId,
+        source: 'strava',
+        start_time: new Date('2026-05-10T10:00:00Z'),
+      })
+
+      const first = await insertOverride(user, [garminId], {
+        activity_type: 'walking',
+        end_time: new Date('2026-05-10T10:30:00Z'),
+        notes: 'first',
+        start_time: new Date('2026-05-10T10:00:00Z'),
+        title: 'first title',
+      })
+
+      const second = await insertOverride(user, [stravaId], {
+        activity_type: 'walking',
+        end_time: new Date('2026-05-10T10:25:00Z'),
+        notes: 'second',
+        start_time: new Date('2026-05-10T10:00:00Z'),
+        title: 'second title',
+      })
+
+      // Same row reused.
+      expect(second?.id).toBe(first?.id)
+      // Fields updated to the latest input.
+      expect(second?.title).toBe('second title')
+      expect(second?.notes).toBe('second')
+      expect(second?.end_time).toEqual(new Date('2026-05-10T10:25:00Z'))
+      // Both target ids now linked.
+      expect(second?.override_target_ids?.sort()).toEqual([garminId, stravaId].sort())
+    })
+
     test('multi-target cascade: deleting the last target removes the override (delete_orphan_override trigger)', async () => {
       const user = getTestUser()
       const garminId = randomUUID()

--- a/apps/backend/src/db/activities/mutations.ts
+++ b/apps/backend/src/db/activities/mutations.ts
@@ -51,6 +51,14 @@ export const insertNewActivity = async (user: string, activity: Activity): Promi
  * UNIQUE constraint on `target_id` rejects an override that tries to claim
  * a target already overridden by someone else; the caller catches the
  * unique-violation and either reuses the existing override or aborts.
+ *
+ * Reuses an existing aurboda row at the same `(activity_type, start_time)`
+ * if one already exists — the legacy partial-unique index
+ * `idx_activities_type_time` would otherwise reject the INSERT, and
+ * pre-#735 single-target overrides may have left aurboda rows whose join
+ * links don't cover all of today's merge-group members. The reuse path
+ * updates the row's fields with the new input and attaches the new
+ * targets via `ON CONFLICT DO NOTHING`.
  */
 export const insertOverride = async (
   user: string,
@@ -60,41 +68,89 @@ export const insertOverride = async (
   if (targetIds.length === 0) {
     throw new Error('insertOverride requires at least one target id')
   }
-  // Two-step insert: row first (so we have the id), then bulk-insert all
-  // target links. If the link insert fails (UNIQUE violation on a target
-  // already claimed by another override), the bare aurboda row would be
-  // orphaned — wrap in a transaction so a failure rolls back both steps.
   await query(user, 'BEGIN')
   try {
-    const inserted = await query(
+    // Look for an existing aurboda row at the same (type, start_time). It
+    // may be a sibling override left over from a prior single-target edit
+    // whose join row claims a different synced source; reuse it instead of
+    // INSERTing a duplicate (which the partial unique index would reject).
+    const existing = await query(
       user,
-      `INSERT INTO activities (source, activity_type, start_time, end_time, title, notes, data)
-       VALUES ('aurboda', $1, $2, $3, $4, $5, $6)
-       RETURNING id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at, superseded_by`,
-      [
-        override.activity_type,
-        override.start_time,
-        override.end_time ?? null,
-        override.title ?? null,
-        override.notes ?? null,
-        override.data ? JSON.stringify(override.data) : null,
-      ],
+      `SELECT id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at, superseded_by
+         FROM activities
+        WHERE source = 'aurboda'
+          AND activity_type = $1
+          AND start_time = $2
+          AND deleted_at IS NULL
+        LIMIT 1`,
+      [override.activity_type, override.start_time],
     )
-    if (inserted.rows.length === 0) {
-      await query(user, 'ROLLBACK')
-      return null
+
+    let row: Record<string, unknown>
+    if (existing.rows.length > 0) {
+      // Update the existing row's fields with the new input. The aurboda
+      // row's `start_time` is part of the lookup key so doesn't change;
+      // every other field is overwritten with the user's edited value.
+      const updated = await query(
+        user,
+        `UPDATE activities SET
+           end_time = $2,
+           title = $3,
+           notes = $4,
+           data = $5
+         WHERE id = $1
+         RETURNING id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at, superseded_by`,
+        [
+          existing.rows[0].id,
+          override.end_time ?? null,
+          override.title ?? null,
+          override.notes ?? null,
+          override.data ? JSON.stringify(override.data) : null,
+        ],
+      )
+      row = updated.rows[0]
+    } else {
+      const inserted = await query(
+        user,
+        `INSERT INTO activities (source, activity_type, start_time, end_time, title, notes, data)
+         VALUES ('aurboda', $1, $2, $3, $4, $5, $6)
+         RETURNING id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at, superseded_by`,
+        [
+          override.activity_type,
+          override.start_time,
+          override.end_time ?? null,
+          override.title ?? null,
+          override.notes ?? null,
+          override.data ? JSON.stringify(override.data) : null,
+        ],
+      )
+      if (inserted.rows.length === 0) {
+        await query(user, 'ROLLBACK')
+        return null
+      }
+      row = inserted.rows[0]
     }
-    const overrideId = inserted.rows[0].id as string
+    const overrideId = row.id as string
     // Bulk insert target links via VALUES ($1, $2), ($1, $3), …
+    // ON CONFLICT DO NOTHING handles the reuse path where some of the
+    // requested targets are already linked from a prior edit.
     const valueClauses = targetIds.map((_, i) => `($1, $${i + 2})`).join(', ')
     await query(
       user,
-      `INSERT INTO activity_override_targets (override_id, target_id) VALUES ${valueClauses}`,
+      `INSERT INTO activity_override_targets (override_id, target_id) VALUES ${valueClauses}
+       ON CONFLICT DO NOTHING`,
       [overrideId, ...targetIds],
+    )
+    // Re-read targets so the returned row reflects the full link set
+    // (including any pre-existing links on the reused row).
+    const allTargets = await query<{ ids: string[] | null }>(
+      user,
+      `SELECT array_agg(target_id) AS ids FROM activity_override_targets WHERE override_id = $1`,
+      [overrideId],
     )
     await query(user, 'COMMIT')
     await materializeSuperseded(user, override.start_time)
-    return mapActivityRow({ ...inserted.rows[0], override_target_ids: targetIds })
+    return mapActivityRow({ ...row, override_target_ids: allTargets.rows[0]?.ids ?? targetIds })
   } catch (err) {
     await query(user, 'ROLLBACK').catch(() => {})
     throw err

--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -12,7 +12,6 @@ export interface ActivityDraft {
   start_time: string // yyyy-MM-ddTHH:mm for datetime-local
   end_time: string
   notes: string
-  exercise_type?: string
   data?: Record<string, unknown>
 }
 

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -5,13 +5,13 @@
  * Activity detail is data-driven: features are shown based on what data exists
  * (sleep stages, HR zones, exercise type) rather than hard-coded by display_category.
  */
-import { exerciseTypeNames, getExerciseTypeName as getExerciseTypeNameFromValue } from '@aurboda/api-spec'
+import { getExerciseTypeName as getExerciseTypeNameFromValue } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 
-import type { Activity, ActivityTypeDefinition, ExerciseTypeName, SourceRecord } from '../../state/api'
+import type { Activity, ActivityTypeDefinition, SourceRecord } from '../../state/api'
 
 import {
   fetchActivityById,
@@ -295,31 +295,6 @@ const ActivityDetailContent = ({
           durationLabel={hasSleepStages ? 'In Bed' : undefined}
         />
 
-        {/* Exercise type selector (edit mode, when exercise type data exists) */}
-        {isEditing && hasExerciseType && (
-          <div class="entity-fields" style={{ marginTop: '0.5rem' }}>
-            <div class="field-row">
-              <span class="field-label">Exercise Type</span>
-              <span class="field-value">
-                <select
-                  class="edit-datetime-input"
-                  value={draft.exercise_type ?? exerciseType ?? ''}
-                  onChange={(e) =>
-                    onDraftChange({ ...draft, exercise_type: (e.target as HTMLSelectElement).value })
-                  }
-                >
-                  <option value="">-- Select --</option>
-                  {exerciseTypeNames.map((name) => (
-                    <option key={name} value={name}>
-                      {formatExerciseTypeName(name)}
-                    </option>
-                  ))}
-                </select>
-              </span>
-            </div>
-          </div>
-        )}
-
         {/* Schema data fields — editable in edit mode, read-only otherwise */}
         {typeDef?.data_schema && (isEditing || activity.data) && (
           <SchemaDataFields
@@ -334,18 +309,6 @@ const ActivityDetailContent = ({
         {/* Read-only stats — shown based on data presence, not activity type */}
         {!isEditing && (
           <>
-            {hasExerciseType && (
-              <div class="entity-fields">
-                <div class="field-row">
-                  <span class="field-label">Exercise Type</span>
-                  <span class="field-value">
-                    <a href={badgeHref} class="entity-meta-link">
-                      {formatExerciseTypeName(exerciseType!)}
-                    </a>
-                  </span>
-                </div>
-              </div>
-            )}
             {totalCalories !== undefined && (
               <div class="entity-fields">
                 <div class="field-row">
@@ -404,12 +367,10 @@ const ActivityDetailContent = ({
 const makeDraft = (activity: Activity): ActivityDraft => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const displayEnd = activity.merged_end_time ?? activity.end_time
-  const exerciseType = resolveExerciseType(activity)
   return {
     activity_type: activity.activity_type,
     data: (activity.data as Record<string, unknown>) ?? {},
     end_time: displayEnd ? formatDateTimeLocal(displayEnd) : '',
-    exercise_type: exerciseType,
     notes: activity.notes ?? '',
     start_time: formatDateTimeLocal(displayStart),
     title: activity.title ?? '',
@@ -553,7 +514,6 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         end_time?: string | null
         title?: string
         notes?: string
-        exercise_type?: ExerciseTypeName
         data?: Record<string, unknown>
         override_target_ids?: string[]
       } = {}
@@ -567,9 +527,6 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         body.end_time = draft.end_time ? new Date(draft.end_time).toISOString() : null
       }
       if (draft.notes !== orig.notes) body.notes = draft.notes
-      if (draft.exercise_type !== orig.exercise_type && draft.exercise_type) {
-        body.exercise_type = draft.exercise_type as ExerciseTypeName
-      }
       if (draft.data && JSON.stringify(draft.data) !== JSON.stringify(orig.data)) {
         body.data = draft.data
       }


### PR DESCRIPTION
## Summary

Two production bugs spotted while editing a merged activity at `/detail/activity/merged:1778bcdc-…`:

1. **Override edit 500'd** with `duplicate key value violates unique constraint "idx_activities_type_time"`. Root cause: when a previous edit created an aurboda override targeting one synced source (e.g. garmin) and the user re-edits the same merge group via a different synced source (e.g. strava), the merge logic doesn't find the existing override via `target_id=strava_id`, falls into the "first edit" branch, and tries to INSERT a duplicate aurboda row at the same `(activity_type, start_time)`. The legacy partial unique index `idx_activities_type_time WHERE external_id IS NULL` (which predates overrides and was meant for sync dedup) rejects it.
2. **"Exercise Type" field still rendered** on the Yoga activity detail page (read + edit). After the activity-hierarchy refactor, each former sub-type is its own activity_type — the legacy picker is dead UI.

## Fix 1 — `insertOverride` reuses an existing aurboda row at `(type, start_time)`

Inside the transaction, look first for an existing `source='aurboda'` row at the same `(activity_type, start_time, deleted_at IS NULL)`. If found, UPDATE its fields with the new input and attach the new targets via `INSERT ... ON CONFLICT DO NOTHING` on the join table. The orphan/sibling override gets healed into a proper multi-target override on the user's next edit; no more 23505.

If no existing row, the original INSERT path runs — same behaviour as before for the genuine first-edit case.

## Fix 2 — drop legacy "Exercise Type" UI

`apps/web/src/pages/EntityDetail/index.tsx`: removed the read-mode "Exercise Type" field, the edit-mode `<select>` driven by `exerciseTypeNames`, the `exercise_type` field on `ActivityDraft`, and the matching PATCH-diff branch in `saveMutation`. The HC `data.exerciseType` raw value remains in `data` for provenance.

Backend's `exercise_type` body acceptance is left untouched for older clients (Android, MCP).

## Test plan

- [x] New `insertOverride` integration test: two edits via different synced sources → same aurboda row, fields updated, both targets linked
- [x] Existing override + cascade tests still pass
- [x] Backend suite 2178/2178
- [x] Web suite 379/379
- [x] `pnpm fix` + `pnpm check` clean
- [ ] Manual on prod: re-edit the merged URL that 500'd; verify it now succeeds and the orphan aurboda row is reused
- [ ] Manual: confirm "Exercise Type" no longer renders on the Yoga detail page (read or edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)