### PR TITLE
fix(activities): revive soft-deleted override on type/start_time conflict

### DIFF
--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -854,6 +854,50 @@ describe('Activities Integration Tests', () => {
       expect(second?.override_target_ids?.sort()).toEqual([garminId, stravaId].sort())
     })
 
+    test('reuses a soft-deleted aurboda row at the same (type, start_time) by reviving it', async () => {
+      // Real-world case: user edits → override created. User clicks "revert
+      // to source" → override soft-deleted (deleted_at set). User edits
+      // again to the same type → must NOT 23505 on idx_activities_type_time
+      // (which doesn't filter on deleted_at). Revive the existing row.
+      const user = getTestUser()
+      const garminId = randomUUID()
+
+      await insertActivity(user, {
+        activity_type: 'meditation',
+        end_time: new Date('2026-05-11T10:30:00Z'),
+        external_id: 'garmin-revive',
+        id: garminId,
+        source: 'garmin',
+        start_time: new Date('2026-05-11T10:00:00Z'),
+      })
+
+      const first = await insertOverride(user, [garminId], {
+        activity_type: 'walking',
+        end_time: new Date('2026-05-11T10:30:00Z'),
+        notes: 'before revert',
+        start_time: new Date('2026-05-11T10:00:00Z'),
+        title: 'before revert',
+      })
+
+      // Soft-delete the override (mimics the "revert to source" flow).
+      const { query } = await import('./connection.ts')
+      await query(user, `UPDATE activities SET deleted_at = NOW() WHERE id = $1`, [first!.id])
+
+      // New edit at the same (type, start_time) — must succeed by reviving.
+      const second = await insertOverride(user, [garminId], {
+        activity_type: 'walking',
+        end_time: new Date('2026-05-11T10:25:00Z'),
+        notes: 'after revive',
+        start_time: new Date('2026-05-11T10:00:00Z'),
+        title: 'after revive',
+      })
+
+      expect(second?.id).toBe(first?.id)
+      expect(second?.title).toBe('after revive')
+      expect(second?.notes).toBe('after revive')
+      expect(second?.deleted_at).toBeUndefined()
+    })
+
     test('multi-target cascade: deleting the last target removes the override (delete_orphan_override trigger)', async () => {
       const user = getTestUser()
       const garminId = randomUUID()

--- a/apps/backend/src/db/activities/mutations.ts
+++ b/apps/backend/src/db/activities/mutations.ts
@@ -70,10 +70,13 @@ export const insertOverride = async (
   }
   await query(user, 'BEGIN')
   try {
-    // Look for an existing aurboda row at the same (type, start_time). It
-    // may be a sibling override left over from a prior single-target edit
-    // whose join row claims a different synced source; reuse it instead of
-    // INSERTing a duplicate (which the partial unique index would reject).
+    // Look for an existing aurboda row at the same (type, start_time),
+    // including soft-deleted ones. The partial unique index
+    // `idx_activities_type_time` doesn't filter on `deleted_at`, so a
+    // soft-deleted aurboda row (e.g. from a prior "revert to source") still
+    // occupies the (source, type, start_time) slot. INSERTing a fresh row
+    // would 23505 — instead, revive the soft-deleted row by clearing
+    // `deleted_at` and overwriting its fields with the new input.
     const existing = await query(
       user,
       `SELECT id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at, superseded_by
@@ -81,23 +84,23 @@ export const insertOverride = async (
         WHERE source = 'aurboda'
           AND activity_type = $1
           AND start_time = $2
-          AND deleted_at IS NULL
         LIMIT 1`,
       [override.activity_type, override.start_time],
     )
 
     let row: Record<string, unknown>
     if (existing.rows.length > 0) {
-      // Update the existing row's fields with the new input. The aurboda
-      // row's `start_time` is part of the lookup key so doesn't change;
-      // every other field is overwritten with the user's edited value.
+      // Update the existing row's fields with the new input. `start_time`
+      // is part of the lookup key so doesn't change; every other field is
+      // overwritten. `deleted_at = NULL` revives a soft-deleted override.
       const updated = await query(
         user,
         `UPDATE activities SET
            end_time = $2,
            title = $3,
            notes = $4,
-           data = $5
+           data = $5,
+           deleted_at = NULL
          WHERE id = $1
          RETURNING id, source, external_id, activity_type, start_time, end_time, title, notes, data, deleted_at, superseded_by`,
         [


### PR DESCRIPTION
## Summary

Prod still 500'd on \`/detail/activity/merged:1778bcdc-…\` after #737 was deployed:

\`\`\`
duplicate key value violates unique constraint "idx_activities_type_time"
detail: 'Key (source, activity_type, start_time)=(aurboda, sex, 2026-05-10 09:20:09+00) already exists.'
\`\`\`

Root cause: the existing aurboda 'sex' row at that timestamp was **soft-deleted** (likely from an earlier "revert to source"). The reuse SELECT added in #737 had \`AND deleted_at IS NULL\`, missed the soft-deleted row, and fell through to the INSERT branch — but the partial unique index \`idx_activities_type_time\` doesn't filter on \`deleted_at\`, so the soft-deleted row still occupies the \`(source, type, start_time)\` slot and the INSERT 23505'd.

## Fix

Drop \`deleted_at IS NULL\` from the lookup; add \`deleted_at = NULL\` to the UPDATE so a matching soft-deleted override is revived in place — same id, fields refreshed to the new input, targets attached via \`ON CONFLICT DO NOTHING\`. Conceptually a UPSERT keyed on (source='aurboda', activity_type, start_time), implemented via SELECT-then-UPDATE-or-INSERT to keep the join-table attach inside the same transaction.

## Test plan

- [x] New integration test: insert override → soft-delete → re-edit at the same (type, start_time) → succeeds, same id revived
- [x] Existing override + cascade tests still pass
- [x] \`pnpm fix\` + \`pnpm check\` clean
- [ ] Manual on prod after deploy: re-attempt \`merged:1778bcdc-…\` yoga → sex; should succeed and revive the orphan row

🤖 Generated with [Claude Code](https://claude.com/claude-code)