### PR TITLE
fix(activities): refresh structured data fields when type changes in edit

### DIFF
--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -197,7 +197,8 @@ const ActivityDetailContent = ({
 
   // Resolve type info
   const exerciseType = resolveExerciseType(activity)
-  const typeDef = typeDefinitions?.find((d) => d.name === activity.activity_type)
+  const currentActivityType = isEditing ? draft.activity_type : activity.activity_type
+  const typeDef = typeDefinitions?.find((d) => d.name === currentActivityType)
   const typeDisplayName = exerciseType
     ? formatExerciseTypeName(exerciseType)
     : (typeDef?.display_name ?? toDisplayName(activity.activity_type))


### PR DESCRIPTION
## Summary
- When editing an activity and changing its type (e.g. Yoga → Sex), the schema-driven structured data fields for the new type now appear immediately, instead of only after saving and reopening.
- Derive `typeDef` from `draft.activity_type` while editing, otherwise from the saved `activity.activity_type`.

## Test plan
- [ ] Open an existing Yoga activity, click edit, change activity type to Sex → "Partner" field appears without saving.
- [ ] Switching back to a type without extra schema fields hides them again.
- [ ] Read-only view still shows fields based on the saved activity type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)