### PR TITLE
feat(meals): autofocus food name input when adding a food item

### DIFF
--- a/apps/web/src/components/FoodItemAutocomplete.tsx
+++ b/apps/web/src/components/FoodItemAutocomplete.tsx
@@ -9,6 +9,7 @@ interface FoodItemAutocompleteProps {
   onSelect: (item: FoodItemEntity) => void
   placeholder?: string
   class?: string
+  autoFocus?: boolean
 }
 
 export function FoodItemAutocomplete({
@@ -16,6 +17,7 @@ export function FoodItemAutocomplete({
   onChange,
   onSelect,
   placeholder,
+  autoFocus,
   ...rest
 }: FoodItemAutocompleteProps) {
   const [suggestions, setSuggestions] = useState<FoodItemEntity[]>([])
@@ -27,7 +29,13 @@ export function FoodItemAutocomplete({
   // = N dropdowns opening simultaneously on page load.
   const [hasFocus, setHasFocus] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Debounced search — only when the input is focused. Re-runs when
   // hasFocus flips true so re-focusing a populated field also re-fetches.
@@ -86,6 +94,7 @@ export function FoodItemAutocomplete({
   return (
     <div ref={ref} class={`food-autocomplete ${rest.class ?? ''}`}>
       <input
+        ref={inputRef}
         type="text"
         value={value}
         placeholder={placeholder ?? 'Food name'}

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -168,11 +168,13 @@ function FoodItemRow({
   index,
   onChange,
   onRemove,
+  autoFocus,
 }: {
   item: FoodItemEdit
   index: number
   onChange: (index: number, item: FoodItemEdit) => void
   onRemove: (index: number) => void
+  autoFocus?: boolean
 }) {
   const update = (field: keyof FoodItemEdit, value: unknown) => onChange(index, { ...item, [field]: value })
   const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
@@ -189,6 +191,7 @@ function FoodItemRow({
       <div class="food-row-top">
         <FoodItemAutocomplete
           value={item.name}
+          autoFocus={autoFocus}
           onChange={(name) => update('name', name)}
           onSelect={(fi: FoodItemEntity) => {
             onChange(index, {
@@ -247,18 +250,30 @@ function FoodItemsEditor({
   items: FoodItemEdit[]
   onChange: (items: FoodItemEdit[]) => void
 }) {
+  const [autoFocusIndex, setAutoFocusIndex] = useState<number | null>(null)
+
   const handleChange = (index: number, item: FoodItemEdit) => {
     const next = [...items]
     next[index] = item
     onChange(next)
   }
   const handleRemove = (index: number) => onChange(items.filter((_, i) => i !== index))
-  const handleAdd = () => onChange([...items, { name: '' }])
+  const handleAdd = () => {
+    setAutoFocusIndex(items.length)
+    onChange([...items, { name: '' }])
+  }
 
   return (
     <div class="food-items-editor">
       {items.map((item, i) => (
-        <FoodItemRow key={i} item={item} index={i} onChange={handleChange} onRemove={handleRemove} />
+        <FoodItemRow
+          key={i}
+          item={item}
+          index={i}
+          onChange={handleChange}
+          onRemove={handleRemove}
+          autoFocus={i === autoFocusIndex}
+        />
       ))}
       <button type="button" class="btn-secondary btn-add-item" onClick={handleAdd}>
         + Add food item


### PR DESCRIPTION
## Summary
- When clicking "+ Add food item" in a meal, the new row's food name input now receives keyboard focus automatically, so the user can immediately start typing.

## Implementation
- `FoodItemAutocomplete` gained an optional `autoFocus` prop that focuses its internal input on mount via a ref + `useEffect`.
- `FoodItemsEditor` tracks an `autoFocusIndex` set when the user clicks Add, and passes `autoFocus` to the matching row. The effect only runs on mount, so existing rows are not re-focused on later renders.

## Test plan
- [ ] Open a meal, click "+ Add food item" — the name input gains focus.
- [ ] Existing rows on initial meal load do not auto-open their autocomplete dropdowns.
- [ ] Clicking Add a second time focuses the newly added row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)