### PR TITLE
docs: clarify watchtower, admin user, and Android passkey/password auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ This starts:
 
 - **aurboda** (web + API) on port 8080
 - **PostgreSQL** with PostGIS
-- **Watchtower** for automatic updates
+- **Watchtower** -- polls Docker Hub once a day and automatically pulls/restarts the `aurboda` container when a new image is published. Convenient, but if you'd rather control your own update cadence, remove the `watchtower` service from `docker-compose.yml` before starting.
 
 ### Creating Your User
 
-Navigate to http://localhost:8080 and create your account through the web interface.
+Navigate to http://localhost:8080 and create your account through the web interface. **The first account created on a fresh instance is automatically granted admin rights** -- it's the account you'll use to invite others, configure shared integrations (Oura, Strava, etc.), and manage signup mode.
 
-After creating your user, you can set `ALLOW_SIGNUP=false` in docker-compose.yml to disallow other signups.
+After creating your user, switch signup to `invite_only` or `closed` from the in-app admin settings (or set `ALLOW_SIGNUP=false` in docker-compose.yml as a legacy fallback) to disallow other signups.
 
 ### Environment Variables
 

--- a/docs/health-connect.md
+++ b/docs/health-connect.md
@@ -61,13 +61,12 @@ Build from source or install from releases. The app requires Android with Health
 
 ### 2. Log In
 
-On first launch, enter:
+On first launch, enter the **Server URL** (e.g., `https://aurboda.net`) and authenticate with either:
 
-- **Server URL** (e.g., `https://aurboda.net`)
-- **Username**
-- **Auth token** (from the web interface)
+- **Username + password** -- the same credentials you use on the web, or
+- **Passkey** -- via Android's Credential Manager (works with Google Password Manager, 1Password, etc.; requires a passkey previously registered for your account on the web).
 
-Credentials are stored encrypted on-device using Android EncryptedSharedPreferences.
+The resulting auth token is stored encrypted on-device using Android EncryptedSharedPreferences.
 
 ### 3. Grant Permissions
 


### PR DESCRIPTION
## Summary

Three small README/docs clarifications surfaced by walking the Quick Start as a brand-new self-hoster:

- **Watchtower** — the default `docker-compose.yml` quietly installs Watchtower with `WATCHTOWER_CLEANUP=true` and a 24h poll interval. The README only said "for automatic updates"; now it explains what Watchtower actually does and how to opt out by removing the service.
- **First user is admin** — not obvious from the README. Called out explicitly in Quick Start, with a note that the followup `ALLOW_SIGNUP=false` step is the legacy fallback for what's now in admin settings.
- **Android auth** — `docs/health-connect.md` step 2 listed only "Username + auth token (from the web interface)", which made it sound like the only login path is a web-issued token. The app's `AuthApi.kt` supports username+password directly and `PasskeyApi.kt` supports WebAuthn via Credential Manager — doc now reflects both.

## Test plan

- [ ] CI green
- [ ] Re-read the Quick Start section as a new user — the "what is Watchtower / am I the admin / how do I close signup" questions are now answered without leaving the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)