### PR TITLE
fix(timeline): clamp activity/location label to chart bounds (#750)

### DIFF
--- a/apps/web/src/pages/Timeline/drawItems.test.ts
+++ b/apps/web/src/pages/Timeline/drawItems.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ChartItem } from './types'
 
-import { getDetailUrl } from './drawItems'
+import { clampLabelLayout, getDetailUrl, truncateLabel } from './drawItems'
 
 const baseItem: ChartItem = {
   color: '#000',
@@ -37,5 +37,30 @@ describe('getDetailUrl', () => {
   it('returns undefined when entity_type is missing', () => {
     const item: ChartItem = { ...baseItem, entity_id: 'x' }
     expect(getDetailUrl(item)).toBeUndefined()
+  })
+})
+
+describe('clampLabelLayout', () => {
+  it('uses bar start when the bar is fully visible', () => {
+    expect(clampLabelLayout(100, 200, 4)).toEqual({ x: 104, width: 192 })
+  })
+
+  it('clamps to chart left edge when the bar starts before the chart', () => {
+    // Bar from -200 to 200 (width 400), chart starts at 0. Label clamped to 4.
+    expect(clampLabelLayout(-200, 400, 4)).toEqual({ x: 4, width: 192 })
+  })
+
+  it('respects a non-zero chart left x', () => {
+    expect(clampLabelLayout(-50, 200, 4, 10)).toEqual({ x: 14, width: 132 })
+  })
+
+  it('returns zero width when the bar ends before the chart', () => {
+    expect(clampLabelLayout(-500, 200, 4).width).toBe(0)
+  })
+
+  it('produces a width that yields the visible portion of the label', () => {
+    // Bar -100..300, chart 0..400. Visible 0..300. Label at x=4, width = 300-4-4 = 292.
+    const { width } = clampLabelLayout(-100, 400, 4)
+    expect(truncateLabel('sleep', width)).toBe('sleep')
   })
 })

--- a/apps/web/src/pages/Timeline/drawItems.ts
+++ b/apps/web/src/pages/Timeline/drawItems.ts
@@ -98,3 +98,21 @@ export const truncateLabel = (label: string, widthPx: number, charWidth = 6): st
   if (label.length <= maxChars) return label
   return label.slice(0, Math.max(maxChars - 1, 0)) + '…'
 }
+
+/**
+ * Position a label inside a horizontal bar so it stays inside the visible chart
+ * region even when the bar starts before the chart's left edge (e.g. an activity
+ * spanning midnight). Returns the clamped x and the remaining width available
+ * for truncation.
+ */
+export const clampLabelLayout = (
+  barStartX: number,
+  barWidth: number,
+  padding: number,
+  chartLeftX = 0,
+): { x: number; width: number } => {
+  const barEndX = barStartX + barWidth
+  const x = Math.max(barStartX + padding, chartLeftX + padding)
+  const width = Math.max(0, barEndX - x - padding)
+  return { x, width }
+}

--- a/apps/web/src/pages/Timeline/index.tsx
+++ b/apps/web/src/pages/Timeline/index.tsx
@@ -10,7 +10,7 @@ import { aggregateBucketsAligned } from '../../utils/chart'
 import { packLanes } from '../../utils/lanePacking'
 import { computeBarLayout, type BarSlot } from './barLayout'
 import { drawActivitySparklines } from './drawActivitySparklines'
-import { attachHoverHandlers, drawItemIcon, getDetailUrl, truncateLabel } from './drawItems'
+import { attachHoverHandlers, clampLabelLayout, drawItemIcon, getDetailUrl, truncateLabel } from './drawItems'
 import { computeYScales, drawMetricsTrack, HR_COLOR, HRV_COLOR } from './drawMetricsTrack'
 import {
   buildMusicTooltipHtml,
@@ -861,14 +861,15 @@ export const Timeline = () => {
 
           const blockIconSize = Math.max(ICON_SIZE, Math.min(laneH, rw))
           if (!drawItemIcon(parent, item.icon, rx + rw / 2, laneY + laneH / 2, blockIconSize) && rw > 40) {
+            const { x: labelX, width: labelWidth } = clampLabelLayout(rx, rw, 4)
             parent
               .append('text')
-              .attr('x', rx + 4)
+              .attr('x', labelX)
               .attr('y', laneY + Math.min(laneH * 0.6, 14))
               .attr('fill', 'white')
               .attr('font-size', '0.65rem')
               .attr('pointer-events', 'none')
-              .text(truncateLabel(item.label, rw))
+              .text(truncateLabel(item.label, labelWidth))
           }
         }
 
@@ -897,15 +898,16 @@ export const Timeline = () => {
           attachHoverHandlers(placeRect, place, showTooltip, hideTooltip)
 
           if (pw > 30) {
+            const { x: labelX, width: labelWidth } = clampLabelLayout(px, pw, 4)
             parent
               .append('text')
-              .attr('x', px + 4)
+              .attr('x', labelX)
               .attr('y', trackPlaces + LOCATION_TRACK_HEIGHT / 2)
               .attr('dy', '0.35em')
               .attr('fill', 'white')
               .attr('font-size', '0.6rem')
               .attr('pointer-events', 'none')
-              .text(truncateLabel(place.label, pw))
+              .text(truncateLabel(place.label, labelWidth))
           }
         }
 


### PR DESCRIPTION
Fixes #750.

## Summary
- When a bar starts before the visible chart area (e.g. a sleep block crossing midnight), the SVG label was placed at the bar's negative startX. The chart clip then revealed only the right-most fragment, so "sleep" rendered as "ep".
- Introduces `clampLabelLayout()` that anchors the label inside the visible chart region and recomputes the width for truncation.
- Applies the helper to activity-track block labels and location-track block labels in the horizontal-mode draw loop.

## Test plan
- [ ] Visit `/timeline` with a sleep activity spanning midnight; verify the label reads "sleep" (or truncated form) instead of "ep".
- [ ] Verify activity/location bars that start inside the viewport still render labels in the same position as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)