### PR TITLE
fix(dashboard): count exercise subtypes as workouts (#748)

### DIFF
--- a/apps/web/src/components/widgets/ActivitySummaryWidget.test.ts
+++ b/apps/web/src/components/widgets/ActivitySummaryWidget.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Activity } from '../../state/api/types'
+
+import { summarizeActivities } from './activitySummary'
+
+const makeActivity = (overrides: Partial<Activity> & Pick<Activity, 'activity_type'>): Activity =>
+  ({
+    end_time: new Date('2026-01-01T08:30:00Z'),
+    id: 'a1',
+    start_time: new Date('2026-01-01T08:00:00Z'),
+    ...overrides,
+  }) as unknown as Activity
+
+describe('summarizeActivities', () => {
+  it('counts generic exercise and HC exercise subtypes as workouts', () => {
+    const activities: Activity[] = [
+      makeActivity({ activity_type: 'exercise' }),
+      makeActivity({ activity_type: 'running' }),
+      makeActivity({ activity_type: 'biking' }),
+      makeActivity({ activity_type: 'weightlifting' }),
+    ]
+    const summary = summarizeActivities(activities)
+    expect(summary.exerciseCount).toBe(4)
+    expect(summary.totalExerciseMinutes).toBe(120) // 4 × 30 min
+  })
+
+  it('does not count sleep or meditation as workouts', () => {
+    const activities: Activity[] = [
+      makeActivity({ activity_type: 'sleep' }),
+      makeActivity({ activity_type: 'meditation' }),
+      makeActivity({ activity_type: 'running' }),
+    ]
+    const summary = summarizeActivities(activities)
+    expect(summary.exerciseCount).toBe(1)
+    expect(summary.sleepCount).toBe(1)
+    expect(summary.meditationCount).toBe(1)
+  })
+
+  it('averages sleep duration across sleep sessions', () => {
+    const activities: Activity[] = [
+      makeActivity({
+        activity_type: 'sleep',
+        end_time: new Date('2026-01-01T08:00:00Z'),
+        start_time: new Date('2026-01-01T00:00:00Z'), // 8h
+      }),
+      makeActivity({
+        activity_type: 'sleep',
+        end_time: new Date('2026-01-02T06:00:00Z'),
+        start_time: new Date('2026-01-02T00:00:00Z'), // 6h
+      }),
+    ]
+    const summary = summarizeActivities(activities)
+    expect(summary.avgSleepHours).toBe(7)
+  })
+
+  it('returns null avgSleepHours when there are no sleep sessions', () => {
+    expect(summarizeActivities([]).avgSleepHours).toBeNull()
+  })
+
+  it('skips activities without an end_time when summing duration', () => {
+    const activities: Activity[] = [
+      makeActivity({ activity_type: 'running' }),
+      makeActivity({ activity_type: 'exercise', end_time: undefined }),
+    ]
+    const summary = summarizeActivities(activities)
+    expect(summary.exerciseCount).toBe(2)
+    expect(summary.totalExerciseMinutes).toBe(30)
+  })
+})

--- a/apps/web/src/components/widgets/ActivitySummaryWidget.tsx
+++ b/apps/web/src/components/widgets/ActivitySummaryWidget.tsx
@@ -7,7 +7,8 @@ import type { ActivitySummaryConfig } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 
-import { fetchActivities, type Activity } from '../../state/api'
+import { fetchActivities } from '../../state/api'
+import { summarizeActivities } from './activitySummary'
 
 interface ActivitySummaryWidgetProps {
   config: ActivitySummaryConfig
@@ -27,27 +28,14 @@ export function ActivitySummaryWidget({ config }: ActivitySummaryWidgetProps) {
 
   const activities = activitiesQuery.data ?? []
 
-  const exerciseSessions = activities.filter((a: Activity) => a.activity_type === 'exercise')
-  const sleepSessions = activities.filter((a: Activity) => a.activity_type === 'sleep')
-  const meditationSessions = activities.filter((a: Activity) => a.activity_type === 'meditation')
-
-  const totalExerciseMinutes = exerciseSessions.reduce((sum: number, a: Activity) => {
-    if (!a.end_time) return sum
-    return sum + (a.end_time.getTime() - a.start_time.getTime()) / 60000
-  }, 0)
-
-  const avgSleepHours =
-    sleepSessions.length > 0
-      ? sleepSessions.reduce((sum: number, a: Activity) => {
-          if (!a.end_time) return sum
-          return sum + (a.end_time.getTime() - a.start_time.getTime()) / 3600000
-        }, 0) / sleepSessions.length
-      : null
-
-  const totalMeditationMinutes = meditationSessions.reduce((sum: number, a: Activity) => {
-    if (!a.end_time) return sum
-    return sum + (a.end_time.getTime() - a.start_time.getTime()) / 60000
-  }, 0)
+  const {
+    avgSleepHours,
+    exerciseCount,
+    meditationCount,
+    sleepCount,
+    totalExerciseMinutes,
+    totalMeditationMinutes,
+  } = summarizeActivities(activities)
 
   if (activitiesQuery.isLoading) {
     return (
@@ -80,7 +68,7 @@ export function ActivitySummaryWidget({ config }: ActivitySummaryWidgetProps) {
               </svg>
             </span>
             <div class="activity-details">
-              <span class="activity-value">{exerciseSessions.length}</span>
+              <span class="activity-value">{exerciseCount}</span>
               <span class="activity-label">Workouts</span>
             </div>
             <div class="activity-sub">{Math.round(totalExerciseMinutes)} min total</div>
@@ -105,7 +93,7 @@ export function ActivitySummaryWidget({ config }: ActivitySummaryWidgetProps) {
               <span class="activity-value">{avgSleepHours !== null ? avgSleepHours.toFixed(1) : '--'}</span>
               <span class="activity-label">Avg Sleep (hrs)</span>
             </div>
-            <div class="activity-sub">{sleepSessions.length} nights tracked</div>
+            <div class="activity-sub">{sleepCount} nights tracked</div>
           </div>
         )}
 
@@ -125,7 +113,7 @@ export function ActivitySummaryWidget({ config }: ActivitySummaryWidgetProps) {
               </svg>
             </span>
             <div class="activity-details">
-              <span class="activity-value">{meditationSessions.length}</span>
+              <span class="activity-value">{meditationCount}</span>
               <span class="activity-label">Meditations</span>
             </div>
             <div class="activity-sub">{Math.round(totalMeditationMinutes)} min total</div>

--- a/apps/web/src/components/widgets/activitySummary.ts
+++ b/apps/web/src/components/widgets/activitySummary.ts
@@ -1,0 +1,31 @@
+import { isExerciseActivityType } from '@aurboda/api-spec'
+
+import type { Activity } from '../../state/api/types'
+
+const durationMinutes = (a: Activity): number =>
+  a.end_time ? (a.end_time.getTime() - a.start_time.getTime()) / 60000 : 0
+
+const durationHours = (a: Activity): number => durationMinutes(a) / 60
+
+/**
+ * Summarize activities by category for the ActivitySummaryWidget cards.
+ * Exercise counts include every Health Connect exercise subtype (running,
+ * cycling, …) plus the generic `'exercise'` bucket — see #748.
+ */
+export const summarizeActivities = (activities: readonly Activity[]) => {
+  const exerciseSessions = activities.filter((a) => isExerciseActivityType(a.activity_type))
+  const sleepSessions = activities.filter((a) => a.activity_type === 'sleep')
+  const meditationSessions = activities.filter((a) => a.activity_type === 'meditation')
+
+  return {
+    avgSleepHours:
+      sleepSessions.length > 0
+        ? sleepSessions.reduce((sum, a) => sum + durationHours(a), 0) / sleepSessions.length
+        : null,
+    exerciseCount: exerciseSessions.length,
+    meditationCount: meditationSessions.length,
+    sleepCount: sleepSessions.length,
+    totalExerciseMinutes: exerciseSessions.reduce((sum, a) => sum + durationMinutes(a), 0),
+    totalMeditationMinutes: meditationSessions.reduce((sum, a) => sum + durationMinutes(a), 0),
+  }
+}

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -124,6 +124,14 @@ export const exerciseTypeSchema = z
 
 export const isValidExerciseType = (name: string): name is ExerciseTypeName => name in exerciseTypes
 
+/**
+ * True when an activity_type counts as a workout/exercise — either the generic
+ * `'exercise'` bucket or one of the Health Connect exercise subtypes (running,
+ * cycling, …). Used by widgets and summaries that count "workouts".
+ */
+export const isExerciseActivityType = (activityType: string): boolean =>
+  activityType === 'exercise' || activityType in exerciseTypes
+
 /** Reverse lookup: Health Connect exercise type integer → exercise type name. */
 const exerciseTypesByValue = Object.fromEntries(
   Object.entries(exerciseTypes).map(([name, value]) => [value, name]),


### PR DESCRIPTION
Fixes #748.

## Summary
- Health Connect exercise records are stored with `activity_type` set to the specific subtype (e.g. `running`, `weightlifting`). The "Last 7 Days" widget filtered on the literal `'exercise'`, so a week of 8 runs read as 0 workouts while Correlations reported them correctly.
- Adds `isExerciseActivityType()` to `@aurboda/api-spec` (true for `'exercise'` or any HC exercise subtype name).
- Extracts a `summarizeActivities()` helper in the widget folder so the filter is unit-tested. The widget now consumes the helper.

## Test plan
- [ ] Seed Health Connect exercise sessions with `exerciseType=56` (running). Verify the dashboard "Last 7 Days" widget reports the correct workout count and minutes.
- [ ] Confirm sleep / meditation counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)