### PR TITLE
fix(sleep): explain missing scoring source on /sleep score trend (#749)

### DIFF
--- a/apps/web/src/pages/Sleep/emptyState.test.ts
+++ b/apps/web/src/pages/Sleep/emptyState.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSleepScoreEmptyState } from './emptyState'
+
+describe('getSleepScoreEmptyState', () => {
+  it('returns null when there are enough scores', () => {
+    expect(getSleepScoreEmptyState(2, true)).toBeNull()
+    expect(getSleepScoreEmptyState(10, false)).toBeNull()
+  })
+
+  it('points to the data-sources page when sleep sessions exist but no scores', () => {
+    const state = getSleepScoreEmptyState(0, true)
+    expect(state).not.toBeNull()
+    expect(state!.message).toMatch(/scoring source/i)
+    expect(state!.linkHref).toBe('/data-sources')
+    expect(state!.linkLabel).toBeTruthy()
+  })
+
+  it('uses the generic message when there is no sleep activity at all', () => {
+    const state = getSleepScoreEmptyState(0, false)
+    expect(state).not.toBeNull()
+    expect(state!.message).toMatch(/not enough sleep data/i)
+    expect(state!.linkHref).toBeUndefined()
+  })
+
+  it('treats a single score as not enough even with sessions', () => {
+    const state = getSleepScoreEmptyState(1, true)
+    expect(state).not.toBeNull()
+    expect(state!.linkHref).toBe('/data-sources')
+  })
+})

--- a/apps/web/src/pages/Sleep/emptyState.ts
+++ b/apps/web/src/pages/Sleep/emptyState.ts
@@ -1,0 +1,31 @@
+/**
+ * Empty-state copy for the Sleep Score Trend chart.
+ *
+ * The chart has two distinct empty conditions:
+ * 1. No sleep activity at all → user hasn't recorded any sleep yet.
+ * 2. Sleep activity exists but no score data → no sleep-scoring source
+ *    (Oura, Garmin, …) is connected. Tell the user that specifically so
+ *    they don't read "not enough data" as "the chart is broken" (#749).
+ */
+export interface SleepScoreEmptyState {
+  message: string
+  /** Path to link the user to (when relevant). */
+  linkHref?: string
+  /** Label for the link. */
+  linkLabel?: string
+}
+
+export const getSleepScoreEmptyState = (
+  scoreCount: number,
+  hasSleepSessions: boolean,
+): SleepScoreEmptyState | null => {
+  if (scoreCount >= 2) return null
+  if (hasSleepSessions) {
+    return {
+      linkHref: '/data-sources',
+      linkLabel: 'Connect a sleep scoring source',
+      message: 'Sleep Score Trend requires a scoring source (e.g. Oura or Garmin).',
+    }
+  }
+  return { message: 'Not enough sleep data to display chart.' }
+}

--- a/apps/web/src/pages/Sleep/index.tsx
+++ b/apps/web/src/pages/Sleep/index.tsx
@@ -5,13 +5,22 @@ import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 import { useEffect, useRef } from 'preact/hooks'
 
 import { fetchActivities, fetchPeriodSummary, fetchSleepScores, type Activity } from '../../state/api'
+import { getSleepScoreEmptyState } from './emptyState'
 import './style.css'
 
 // Date range signal (default 30 days)
 const daysBack = signal(30)
 
 // Sleep score line chart component
-function SleepScoreChart({ data, height = 200 }: { data: [Date, number][]; height?: number }) {
+function SleepScoreChart({
+  data,
+  hasSleepSessions,
+  height = 200,
+}: {
+  data: [Date, number][]
+  hasSleepSessions: boolean
+  height?: number
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
 
@@ -137,8 +146,19 @@ function SleepScoreChart({ data, height = 200 }: { data: [Date, number][]; heigh
       .text('Sleep Score')
   }, [data, height])
 
-  if (data.length < 2) {
-    return <div class="chart-placeholder">Not enough sleep data to display chart</div>
+  const emptyState = getSleepScoreEmptyState(data.length, hasSleepSessions)
+  if (emptyState) {
+    return (
+      <div class="chart-placeholder">
+        {emptyState.message}
+        {emptyState.linkHref && (
+          <>
+            {' '}
+            <a href={emptyState.linkHref}>{emptyState.linkLabel}</a>.
+          </>
+        )}
+      </div>
+    )
   }
 
   return (
@@ -428,7 +448,7 @@ export function Sleep() {
       {/* Sleep score chart */}
       <section class="chart-section">
         <h2>Sleep Score Trend</h2>
-        <SleepScoreChart data={sleepScores} />
+        <SleepScoreChart data={sleepScores} hasSleepSessions={sleepSessions.length > 0} />
       </section>
 
       {/* Sleep duration chart */}


### PR DESCRIPTION
Fixes #749.

## Summary
- The Sleep Score Trend chart said "Not enough sleep data to display chart" whenever fewer than 2 score points were present, even when the user had a full week of sleep activity but no scoring source connected.
- Branches the empty message: when sleep sessions exist but no scores, point the user to `/data-sources`. Original wording preserved for the no-data-at-all case.
- Extracts `getSleepScoreEmptyState()` with unit tests.

## Test plan
- [ ] On a fresh account with sleep sessions but no Oura/Garmin: visit `/sleep` — the Score Trend should explain that a scoring source is needed and link to `/data-sources`.
- [ ] With ≥ 2 sleep scores: chart renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)