### PR TITLE
fix(baseline): fall back to raw hrv_rmssd for dashboard HRV (#747)

### DIFF
--- a/apps/backend/src/services/correlations/baseline.test.ts
+++ b/apps/backend/src/services/correlations/baseline.test.ts
@@ -119,6 +119,56 @@ describe('getBaseline', () => {
     expect(result.stress.avg30day).toBeNull()
   })
 
+  test('falls back to raw hrv_rmssd when no samples overlap sleep windows (#747)', async () => {
+    vi.mocked(queries.queryMetrics).mockResolvedValue(emptyHrvResult)
+
+    vi.mocked(db.getTimeSeriesStats).mockImplementation(async (_user, metrics) => {
+      if (metrics.includes('hrv_rmssd')) {
+        return [{ avg: 43, count: 8, max: 50, metric: 'hrv_rmssd', min: 38, stddev: 3, unit: 'ms' }]
+      }
+      if (metrics.includes('resting_heart_rate')) {
+        return [
+          { avg: 55.9, count: 8, max: 60, metric: 'resting_heart_rate', min: 52, stddev: 2, unit: 'bpm' },
+        ]
+      }
+      return [{ avg: 30, count: 8, max: 60, metric: 'stress_level', min: 5, stddev: 10, unit: '' }]
+    })
+
+    const result = await getBaseline('testuser')
+
+    expect(result.hrv.avg7day).toBe(43)
+    expect(result.hrv.avg30day).toBe(43)
+    expect(result.resting_hr.avg7day).toBe(55.9)
+    const hrvRmssdCalls = vi
+      .mocked(db.getTimeSeriesStats)
+      .mock.calls.filter((call) => call[1].includes('hrv_rmssd'))
+    expect(hrvRmssdCalls).toHaveLength(3) // 7-day, 30-day, prev-30
+  })
+
+  test('prefers contextual hrv_sleep over raw hrv_rmssd when both exist', async () => {
+    vi.mocked(queries.queryMetrics).mockResolvedValue({
+      count: 2,
+      data: [
+        { time: '2024-01-14T02:00:00Z', value: 50 },
+        { time: '2024-01-15T02:00:00Z', value: 60 },
+      ],
+      metric: 'hrv_sleep',
+      unit: 'ms',
+    })
+    vi.mocked(db.getTimeSeriesStats).mockResolvedValue([
+      { avg: 100, count: 8, max: 110, metric: 'resting_heart_rate', min: 90, stddev: 5, unit: 'bpm' },
+    ])
+
+    const result = await getBaseline('testuser')
+
+    expect(result.hrv.avg7day).toBe(55) // hrv_sleep avg, NOT 100 from any fallback
+    // hrv_rmssd should NOT be queried when sleep HRV exists
+    const hrvRmssdCalls = vi
+      .mocked(db.getTimeSeriesStats)
+      .mock.calls.filter((call) => call[1].includes('hrv_rmssd'))
+    expect(hrvRmssdCalls).toHaveLength(0)
+  })
+
   test('uses reference date when provided', async () => {
     vi.mocked(queries.queryMetrics).mockResolvedValue(emptyHrvResult)
     vi.mocked(db.getTimeSeriesStats).mockResolvedValue([])
@@ -134,8 +184,9 @@ describe('getBaseline', () => {
     expect(metric).toBe('hrv_sleep')
     expect(endDate.toISOString().split('T')[0]).toBe('2024-01-15')
 
-    // getTimeSeriesStats called for resting HR and stress with dates from reference date
-    expect(db.getTimeSeriesStats).toHaveBeenCalledTimes(6) // 3 for HR + 3 for stress
+    // getTimeSeriesStats called for resting HR, stress, and the hrv_rmssd fallback
+    // (3 each since hrv_sleep was empty in this test) with dates from reference date
+    expect(db.getTimeSeriesStats).toHaveBeenCalledTimes(9)
     const statsCalls = vi.mocked(db.getTimeSeriesStats).mock.calls
     const [, , , hrEndDate] = statsCalls[0]
     expect(new Date(hrEndDate).toISOString().split('T')[0]).toBe('2024-01-15')

--- a/apps/backend/src/services/correlations/baseline.ts
+++ b/apps/backend/src/services/correlations/baseline.ts
@@ -33,12 +33,18 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
   const prevEnd30day = new Date(start30day)
   prevEnd30day.setMilliseconds(-1)
 
-  // Compute average from sleep HRV data (contextual metric, not stored directly)
-  const getSleepHrvAvg = async (start: Date, end: Date): Promise<number | null> => {
-    const result = await queryMetrics(user, 'hrv_sleep', start, end)
-    if (result.count === 0) return null
-    const sum = result.data.reduce((acc, d) => acc + d.value, 0)
-    return sum / result.count
+  // Prefer the contextual sleep HRV signal; fall back to raw hrv_rmssd when no
+  // samples overlap the user's tracked sleep windows so the widget mirrors what
+  // /api/metrics/latest/hrv_rmssd surfaces (see #747).
+  const getHrvAvg = async (start: Date, end: Date): Promise<number | null> => {
+    const sleep = await queryMetrics(user, 'hrv_sleep', start, end)
+    if (sleep.count > 0) {
+      const sum = sleep.data.reduce((acc, d) => acc + d.value, 0)
+      return sum / sleep.count
+    }
+    const rawStats = await getTimeSeriesStats(user, ['hrv_rmssd'], start, end)
+    const raw = rawStats[0]
+    return raw && raw.count > 0 && raw.avg ? raw.avg : null
   }
 
   // Fetch sleep HRV, resting HR, and stress stats in parallel
@@ -53,9 +59,9 @@ export async function getBaseline(user: string, referenceDate?: Date): Promise<B
     stressStats30day,
     stressStatsPrev30day,
   ] = await Promise.all([
-    getSleepHrvAvg(start7day, end7day),
-    getSleepHrvAvg(start30day, end30day),
-    getSleepHrvAvg(prevStart30day, prevEnd30day),
+    getHrvAvg(start7day, end7day),
+    getHrvAvg(start30day, end30day),
+    getHrvAvg(prevStart30day, prevEnd30day),
     getTimeSeriesStats(user, ['resting_heart_rate'], start7day, end7day),
     getTimeSeriesStats(user, ['resting_heart_rate'], start30day, end30day),
     getTimeSeriesStats(user, ['resting_heart_rate'], prevStart30day, prevEnd30day),


### PR DESCRIPTION
Fixes #747.

## Summary
- The dashboard HRV widget reads the contextual `hrv_sleep` signal — hrv_rmssd ∩ sleep windows — which returns null when the user's samples don't land inside their tracked sleep (common with Health Connect morning samples that arrive after the session ends).
- Prefer `hrv_sleep` when it has samples; fall back to raw `hrv_rmssd` otherwise so the widget mirrors what `/api/metrics/latest/hrv_rmssd` exposes.

## Test plan
- [ ] On a fresh self-host with hrv_rmssd samples but no Oura/Garmin scoring: dashboard HRV (7-day / 30-day) should render a value.
- [ ] With proper sleep-window overlap: widget still uses the cleaner hrv_sleep signal (preserved by the unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)