### PR TITLE
fix(dashboard): unify empty placeholder for period-summary cards (#746)

### DIFF
--- a/apps/web/src/components/widgets/MetricCardWidget.tsx
+++ b/apps/web/src/components/widgets/MetricCardWidget.tsx
@@ -7,7 +7,13 @@ import type { MetricCardConfig } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 import { endOfDay, startOfDay, subDays } from 'date-fns'
 
-import { fetchBaseline, fetchPeriodSummary, type BaselineData, type PeriodMetricStats } from '../../state/api'
+import {
+  fetchBaseline,
+  fetchPeriodSummary,
+  periodStatsValue,
+  type BaselineData,
+  type PeriodMetricStats,
+} from '../../state/api'
 
 // Trend indicator component
 function TrendIndicator({ value, inverse = false }: { value: number | null; inverse?: boolean }) {
@@ -76,24 +82,26 @@ const extractPeriodValue = (
 
   if (!stats) return { subtitle: undefined, trend: null, value: null }
 
+  const avg = periodStatsValue(stats, 'avg')
+  const max = periodStatsValue(stats, 'max')
   switch (metric) {
     case 'steps':
       return {
-        subtitle: stats.max ? `Max: ${Math.round(stats.max).toLocaleString()}` : undefined,
+        subtitle: max !== null ? `Max: ${Math.round(max).toLocaleString()}` : undefined,
         trend: stats.change_from_previous_period_percent ?? null,
-        value: stats.avg ? Math.round(stats.avg).toLocaleString() : null,
+        value: avg !== null ? Math.round(avg).toLocaleString() : null,
       }
     case 'zone2_weekly':
       return {
         subtitle: undefined,
         trend: stats.change_from_previous_period_percent ?? null,
-        value: stats.avg ? Math.round((stats.avg * 7) / 60) : null,
+        value: avg !== null ? Math.round((avg * 7) / 60) : null,
       }
     default:
       return {
         subtitle: stats.count ? `${stats.count} days` : undefined,
         trend: stats.change_from_previous_period_percent ?? null,
-        value: stats.avg ?? null,
+        value: avg,
       }
   }
 }

--- a/apps/web/src/pages/Sleep/index.tsx
+++ b/apps/web/src/pages/Sleep/index.tsx
@@ -4,7 +4,13 @@ import * as d3 from 'd3'
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns'
 import { useEffect, useRef } from 'preact/hooks'
 
-import { fetchActivities, fetchPeriodSummary, fetchSleepScores, type Activity } from '../../state/api'
+import {
+  fetchActivities,
+  fetchPeriodSummary,
+  fetchSleepScores,
+  periodStatsValue,
+  type Activity,
+} from '../../state/api'
 import { getSleepScoreEmptyState } from './emptyState'
 import './style.css'
 
@@ -324,7 +330,7 @@ function StatCard({
             {unit && <span class="stat-unit">{unit}</span>}
           </>
         ) : (
-          <span class="no-data">--</span>
+          <span class="no-data">No data</span>
         )}
       </div>
       {trend !== null && trend !== undefined && (
@@ -380,7 +386,7 @@ export function Sleep() {
     {}
   for (const m of metricsArray) {
     metrics[m.metric] = {
-      avg: m.avg,
+      avg: periodStatsValue(m, 'avg'),
       change_from_previous_period_percent: m.change_from_previous_period_percent,
     }
   }

--- a/apps/web/src/state/api/metrics.ts
+++ b/apps/web/src/state/api/metrics.ts
@@ -75,6 +75,8 @@ export const fetchHrvSleep = async (start: Date, end: Date): Promise<[Date, numb
   return (response.data.data ?? []).map(({ time, value }) => [new Date(time), value])
 }
 
+export { periodStatsValue } from './periodSummary'
+
 // Fetch period summary for specified metrics
 export const fetchPeriodSummary = async (
   start: Date,

--- a/apps/web/src/state/api/periodSummary.test.ts
+++ b/apps/web/src/state/api/periodSummary.test.ts
@@ -1,0 +1,39 @@
+import type { PeriodMetricStats } from '@aurboda/api-spec'
+
+import { describe, expect, it } from 'vitest'
+
+import { periodStatsValue } from './periodSummary'
+
+const stats = (overrides: Partial<PeriodMetricStats> & { count: number }): PeriodMetricStats => ({
+  avg: 0,
+  change_from_previous_period_percent: null,
+  completeness_percent: 0,
+  max: 0,
+  metric: 'sleep_score',
+  min: 0,
+  stddev: 0,
+  trend_per_day: null,
+  unit: '',
+  ...overrides,
+})
+
+describe('periodStatsValue', () => {
+  it('returns null when stats is undefined', () => {
+    expect(periodStatsValue(undefined, 'avg')).toBeNull()
+  })
+
+  it('returns null when count is 0 — even if avg is zero-filled', () => {
+    expect(periodStatsValue(stats({ avg: 0, count: 0 }), 'avg')).toBeNull()
+  })
+
+  it('returns the field value when count > 0', () => {
+    expect(periodStatsValue(stats({ avg: 82.5, count: 8 }), 'avg')).toBe(82.5)
+    expect(periodStatsValue(stats({ count: 8, max: 95 }), 'max')).toBe(95)
+  })
+
+  it('returns 0 when count > 0 and the field genuinely is zero', () => {
+    // A real zero is a valid value when we have samples — only the
+    // "no samples at all" case should collapse to null.
+    expect(periodStatsValue(stats({ avg: 0, count: 5 }), 'avg')).toBe(0)
+  })
+})

--- a/apps/web/src/state/api/periodSummary.ts
+++ b/apps/web/src/state/api/periodSummary.ts
@@ -1,0 +1,15 @@
+import type { PeriodMetricStats } from '@aurboda/api-spec'
+
+/**
+ * Read a numeric field from PeriodMetricStats, returning null when there is no
+ * underlying data (count is 0). The backend emits zero-filled stats for
+ * metrics that had no samples in the period, so a naive `stats.avg ?? null`
+ * leaks `0` to the UI and renders "0.0" instead of "No data" (see #746).
+ */
+export const periodStatsValue = (
+  stats: PeriodMetricStats | undefined,
+  field: 'avg' | 'min' | 'max',
+): number | null => {
+  if (!stats || stats.count === 0) return null
+  return stats[field]
+}


### PR DESCRIPTION
Partially addresses #746 (the period-summary side — see notes below).

## Summary
- Backend `getPeriodSummary` emits zero-filled `PeriodMetricStats` for metrics that had no samples in the period. The dashboard widget did `stats.avg ?? null`, which only catches null/undefined and let `0` pass through as a real value — so users with no Oura/Garmin connected saw "Sleep Score 0.0" / "Readiness Score 0.0" instead of "No data".
- Adds `periodStatsValue(stats, field)` that gates the read on `count > 0` so zero-fill collapses to null, with unit tests.
- Uses it in the dashboard `MetricCardWidget` (default + steps + zone2 cases) and the /sleep `StatCard` overview. /sleep StatCard's empty marker switches from `--` to `No data` to match the dashboard.

## Scope notes
- This fixes the **numeric-card** half of #746. The "unify the visual treatment" half (e.g. pick `—` vs the `No data` chip across every widget) is a broader audit that should be its own PR; flagging here so the issue can stay open for it.

## Test plan
- [ ] Fresh self-host with no Oura/Garmin connected, only Health Connect data: Dashboard Sleep Score / Readiness Score should now render "No data" instead of "0.0".
- [ ] /sleep Overview cards (Sleep Score / Efficiency / Latency) likewise render "No data" rather than "0.0 %" / "0.0 min".
- [ ] With real data: cards continue to render the correct value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)