### PR TITLE
fix(dashboard): route SparklineCardWidget through periodStatsValue (#759)

### DIFF
--- a/apps/web/src/components/widgets/SparklineCardWidget.tsx
+++ b/apps/web/src/components/widgets/SparklineCardWidget.tsx
@@ -16,6 +16,7 @@ import {
   fetchRestingHeartRate,
   fetchSleepScores,
   fetchSteps,
+  periodStatsValue,
   type PeriodMetricStats,
 } from '../../state/api'
 import { SparklineChart } from '../SparklineChart'
@@ -105,11 +106,9 @@ export function SparklineCardWidget({ config }: SparklineCardWidgetProps) {
       periodSummary[m.metric] = m
     }
     const stats = periodSummary[apiMetric]
-    if (stats) {
-      value = stats.avg ?? null
-      trend = stats.change_from_previous_period_percent ?? null
-      subtitle = stats.count ? `${stats.count} days` : undefined
-    }
+    value = periodStatsValue(stats, 'avg')
+    trend = stats?.change_from_previous_period_percent ?? null
+    subtitle = stats?.count ? `${stats.count} days` : undefined
   }
 
   const sparklineData = timeSeriesQuery.data ?? []


### PR DESCRIPTION
Fixes #759.

## Summary
- #746 routed `MetricCardWidget` + `/sleep` StatCards through `periodStatsValue()` so the backend's zero-filled empty stats collapse to null. `SparklineCardWidget` was missed — the dashboard's Sleep Score (a sparkline card) still rendered \`0.0\` while the neighbouring Readiness Score (metric card) correctly rendered "No data" on the same fresh self-host.
- Switch the sparkline's value read to `periodStatsValue(stats, 'avg')` so it matches the rest of the dashboard. Existing unit tests for `periodStatsValue` already cover the count-gate behavior.

## Test plan
- [ ] Fresh self-host with no Oura/Garmin: dashboard Sleep Score sparkline card should now render "No data" instead of "0.0".
- [ ] With real Sleep Score data: card continues to render the value and trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)