### PR TITLE
chore(deps): harden pnpm against supply-chain attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "engines": {
     "node": "~25"
   },
-  "packageManager": "pnpm@10.15.1"
+  "packageManager": "pnpm@10.33.4"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,16 @@
 packages:
   - apps/*
   - packages/*
+
+# Supply-chain hardening.
+# Refuse to install package versions younger than this many minutes. Buys time
+# for the npm/community to detect and yank malicious publishes before they land
+# on a dev box or in CI. 4320 = 72h.
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@aurboda/*'
+
+# Refuse transitive deps that use non-registry protocols (github:, git:, file:,
+# URL tarballs). Direct deps in our own package.json are unaffected. Default is
+# true in pnpm 10.26+; pinned here to make the policy explicit.
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: 4320` (72h) and `minimumReleaseAgeExclude: ['@aurboda/*']` to `pnpm-workspace.yaml` — refuses to install third-party versions younger than 3 days, buying time for malicious publishes to be detected and yanked before they reach our dev boxes or CI.
- Add `blockExoticSubdeps: true` — refuses transitive deps using non-registry protocols (`github:`, `git:`, `file:`, URL tarballs). This is the default in pnpm 10.26+; pinning it makes the policy explicit. Our one direct `github:` dep (`@flow-js/garmin-connect` fork) is unaffected since the setting only blocks *sub*deps.
- Bump `packageManager` from `pnpm@10.15.1` → `pnpm@10.33.4` (latest 10.x LTS). `minimumReleaseAge` needs ≥10.16, `blockExoticSubdeps` needs ≥10.26.

## Motivation

Today's TanStack npm compromise: 42 `@tanstack/*` packages had malicious versions published, with the payload delivered via an exotic subdep entry (`"@tanstack/setup": "github:tanstack/router#79ac49ee…"` in `optionalDependencies`) that exfiltrated AWS/GCP/K8s/Vault credentials, GitHub tokens, `.npmrc` contents, and SSH keys.

Our lockfile was 2+ weeks old when the malicious versions were published, so we were not affected. But neither of the two settings that would have categorically blocked this class of attack were configured.

## Test plan

- [x] `pnpm install` succeeds with new settings (lockfile already up to date — no re-resolution needed)
- [x] `pnpm check` passes (after rebuilding `@aurboda/api-spec`)
- [ ] CI green on develop merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)