### PR TITLE
feat(daily-summary): surface activity notes and structured data

### DIFF
--- a/apps/backend/src/db/activities/merge.ts
+++ b/apps/backend/src/db/activities/merge.ts
@@ -385,13 +385,7 @@ export const mergeOverlappingActivities = (
   return absorbGenericExercises(result)
 }
 
-const GENERIC_EXERCISE_CODES = new Set([0, 2]) // UNKNOWN=0, OTHER_WORKOUT=2
-
-const isGenericExercise = (a: MergedActivity): boolean => {
-  if (a.activity_type !== 'exercise') return false
-  const code = a.data?.exerciseType
-  return typeof code !== 'number' || GENERIC_EXERCISE_CODES.has(code)
-}
+const isGenericExercise = (a: MergedActivity): boolean => a.activity_type === 'exercise'
 
 /** Check if generic's duration overlaps >50% with another activity. */
 const findAbsorbingActivity = (

--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -1199,6 +1199,19 @@ export const migrateSchema = async (user: string) => {
     )
   }
 
+  // Strip redundant exerciseType / exerciseTypeName keys from activities.data.
+  // The specific activity_type (yoga, running, ...) is the authoritative carrier;
+  // keeping both in data duplicates state and leaks into the daily-summary `data`
+  // passthrough. Raw HC payloads still hold the originals in raw_records.
+  if (existingTableNames.has('activities')) {
+    await query(
+      db,
+      `UPDATE activities
+       SET data = data - 'exerciseType' - 'exerciseTypeName'
+       WHERE data ?| ARRAY['exerciseType', 'exerciseTypeName']`,
+    )
+  }
+
   // Step 3: Align Garmin typeKey names with HC exercise type names.
   // Garmin uses modifier_noun (e.g., treadmill_running), HC uses noun_modifier (running_treadmill).
   if (existingTableNames.has('activities')) {

--- a/apps/backend/src/db/health-connect.ts
+++ b/apps/backend/src/db/health-connect.ts
@@ -27,6 +27,18 @@ const resolveExerciseActivityType = (data: Record<string, unknown>): string => {
   return getExerciseTypeName(exerciseType) ?? 'exercise'
 }
 
+/**
+ * Strip the HC exerciseType / exerciseTypeName keys before persisting to
+ * activities.data — activity_type now carries that information, so keeping
+ * them duplicates state and pollutes the daily-summary `data` passthrough.
+ * The raw HC record (preserved in raw_records) still holds the originals.
+ */
+const stripExerciseTypeFromData = (data: Record<string, unknown>): Record<string, unknown> => {
+  if (!('exerciseType' in data) && !('exerciseTypeName' in data)) return data
+  const { exerciseType: _et, exerciseTypeName: _etn, ...rest } = data
+  return rest
+}
+
 import { insertActivities, insertActivity } from './activities/index.ts'
 import { query } from './connection.ts'
 import { insertMeal } from './meals.ts'
@@ -93,7 +105,7 @@ export const processHealthConnectData = async (
       baseActivityType === 'exercise' ? resolveExerciseActivityType(data) : baseActivityType
     await insertActivity(user, {
       activity_type: activityType,
-      data,
+      data: stripExerciseTypeFromData(data),
       end_time: data.endTime ? new Date(data.endTime as string) : undefined,
       notes: data.notes as string | undefined,
       source: 'health_connect',
@@ -176,7 +188,7 @@ export const processHealthConnectBatch = async (
         baseActivityType === 'exercise' ? resolveExerciseActivityType(data) : baseActivityType
       activities.push({
         activity_type: resolvedType,
-        data,
+        data: stripExerciseTypeFromData(data),
         end_time: data.endTime ? new Date(data.endTime as string) : undefined,
         notes: data.notes as string | undefined,
         source: 'health_connect',

--- a/apps/backend/src/mcp.test.ts
+++ b/apps/backend/src/mcp.test.ts
@@ -885,12 +885,12 @@ describe('MCP Server', () => {
       }
     }
 
-    test('creates exercise activity with exercise_type name', async () => {
+    test('creates exercise activity using the specific activity_type', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
 
       vi.mocked(mutations.addActivity).mockResolvedValue({
-        activity_type: 'exercise',
+        activity_type: 'weightlifting',
         end_time: '2024-03-15T11:45:00.000Z',
         id: 'test-uuid',
         start_time: '2024-03-15T10:30:00.000Z',
@@ -899,9 +899,9 @@ describe('MCP Server', () => {
       })
 
       const response = await callTool(app, token, 'add_activity', {
-        activity_type: 'exercise',
+        activity_type: 'weightlifting',
+        data: { reps: 12 },
         end_time: '2024-03-15T11:45:00Z',
-        exercise_type: 'weightlifting',
         start_time: '2024-03-15T10:30:00Z',
         title: 'Upper body',
         tz: 'UTC',
@@ -913,11 +913,8 @@ describe('MCP Server', () => {
       expect(mutations.addActivity).toHaveBeenCalledWith(
         'testuser',
         {
-          activity_type: 'exercise',
-          data: {
-            exerciseType: 81,
-            exerciseTypeName: 'weightlifting',
-          },
+          activity_type: 'weightlifting',
+          data: { reps: 12 },
           end_time: expect.any(Date),
           notes: undefined,
           start_time: expect.any(Date),
@@ -927,7 +924,7 @@ describe('MCP Server', () => {
       )
     })
 
-    test('creates activity without exercise_type', async () => {
+    test('creates activity without data', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
 
@@ -962,34 +959,6 @@ describe('MCP Server', () => {
         },
         undefined,
       )
-    })
-
-    test('returns error for invalid exercise_type name', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            arguments: {
-              activity_type: 'exercise',
-              end_time: '2024-03-15T11:45:00Z',
-              exercise_type: 'invalid_exercise_type',
-              start_time: '2024-03-15T10:30:00Z',
-              tz: 'UTC',
-            },
-            name: 'add_activity',
-          },
-        })
-
-      expect(response.status).toBe(200)
-      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
-      expect(parsed.result.content[0].text).toContain('Invalid exercise_type')
-      expect(mutations.addActivity).not.toHaveBeenCalled()
     })
 
     test('returns error when end_time is before start_time', async () => {
@@ -1050,12 +1019,12 @@ describe('MCP Server', () => {
 
     const testActivityId = '00000000-0000-4000-a000-000000000001'
 
-    test('updates activity with exercise_type', async () => {
+    test('updates activity_type and data fields', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
 
       vi.mocked(mutations.updateActivity).mockResolvedValue({
-        activity_type: 'exercise',
+        activity_type: 'weightlifting',
         end_time: '2024-03-15T11:00:00.000Z',
         id: testActivityId,
         start_time: '2024-03-15T10:00:00.000Z',
@@ -1064,7 +1033,8 @@ describe('MCP Server', () => {
       })
 
       const response = await callTool(app, token, 'update_activity', {
-        exercise_type: 'weightlifting',
+        activity_type: 'weightlifting',
+        data: { weight: 80 },
         id: testActivityId,
         title: 'Workout',
         tz: 'UTC',
@@ -1076,10 +1046,8 @@ describe('MCP Server', () => {
         'testuser',
         testActivityId,
         {
-          data: {
-            exerciseType: 81,
-            exerciseTypeName: 'weightlifting',
-          },
+          activity_type: 'weightlifting',
+          data: { weight: 80 },
           end_time: undefined,
           notes: undefined,
           start_time: undefined,
@@ -1089,7 +1057,7 @@ describe('MCP Server', () => {
       )
     })
 
-    test('updates activity without exercise_type', async () => {
+    test('updates activity notes only', async () => {
       const app = createTestApp()
       const token = auth.createToken('testuser')
 
@@ -1114,6 +1082,7 @@ describe('MCP Server', () => {
         'testuser',
         testActivityId,
         {
+          activity_type: undefined,
           data: undefined,
           end_time: undefined,
           notes: 'Great session',
@@ -1122,32 +1091,6 @@ describe('MCP Server', () => {
         },
         undefined,
       )
-    })
-
-    test('returns error for invalid exercise_type', async () => {
-      const app = createTestApp()
-      const token = auth.createToken('testuser')
-
-      const response = await mcpPost(app)
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          id: 1,
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            arguments: {
-              exercise_type: 'not_a_real_exercise',
-              id: testActivityId,
-              tz: 'UTC',
-            },
-            name: 'update_activity',
-          },
-        })
-
-      expect(response.status).toBe(200)
-      const parsed = parseSSEResponse(response.text) as { result: { content: { text: string }[] } }
-      expect(parsed.result.content[0].text).toContain('Invalid exercise_type')
-      expect(mutations.updateActivity).not.toHaveBeenCalled()
     })
 
     test('passes time updates as Date objects', async () => {

--- a/apps/backend/src/mcp/activity-tools.ts
+++ b/apps/backend/src/mcp/activity-tools.ts
@@ -4,9 +4,6 @@
 import {
   addActivityBodySchema,
   deleteActivityParamsSchema,
-  exerciseTypeNames,
-  getExerciseTypeValue,
-  isValidExerciseType,
   tzSchema,
   updateActivityBodySchema,
 } from '@aurboda/api-spec'
@@ -31,34 +28,14 @@ export const registerActivityTools = (
   // Tool: add_activity
   server.tool(
     'add_activity',
-    'Add an activity session (exercise, meditation, nap, rest). Use this to log workouts or other activities.',
+    'Add an activity session (exercise type like yoga/running/weightlifting, meditation, nap, rest, …). Pass the specific activity_type directly; structured fields go in `data`.',
     {
       ...addActivityBodySchema.shape,
-      // Override enum with z.string() to allow handler-level validation with friendlier error message
-      exercise_type: z
-        .string()
-        .optional()
-        .describe(
-          `Exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
-        ),
       tz: tzSchema,
     },
-    async ({ activity_type, end_time, exercise_type, notes, start_time, title, tz }) => {
+    async ({ activity_type, data, end_time, notes, start_time, title, tz }) => {
       const startDate = new Date(start_time)
       const endDate = end_time ? new Date(end_time) : undefined
-
-      let data: Record<string, unknown> | undefined
-      if (exercise_type !== undefined) {
-        if (!isValidExerciseType(exercise_type)) {
-          return errorResponse(
-            `Invalid exercise_type "${exercise_type}". Valid types include: ${exerciseTypeNames.slice(0, 15).join(', ')}...`,
-          )
-        }
-        data = {
-          exerciseType: getExerciseTypeValue(exercise_type),
-          exerciseTypeName: exercise_type,
-        }
-      }
 
       const result = await addActivity(
         user,
@@ -106,33 +83,13 @@ export const registerActivityTools = (
   // Tool: update_activity
   server.tool(
     'update_activity',
-    'Update an existing activity. Can modify activity_type, start_time, end_time, title, notes, and exercise_type. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
+    'Update an existing activity. Can modify activity_type, start_time, end_time, title, notes, and data. Only provided fields will be updated. Validates that end_time is after start_time (considering both new and existing values).',
     {
       id: z.string().uuid().describe('The ID of the activity to update'),
       ...updateActivityBodySchema.shape,
-      // Override enum with z.string() to allow handler-level validation with friendlier error message
-      exercise_type: z
-        .string()
-        .optional()
-        .describe(
-          `New exercise type name (e.g., "weightlifting", "running"). Only for exercise activities. Valid types: ${exerciseTypeNames.slice(0, 10).join(', ')}...`,
-        ),
       tz: tzSchema,
     },
-    async ({ id, activity_type, start_time, end_time, title, notes, exercise_type, tz }) => {
-      let data: Record<string, unknown> | undefined
-      if (exercise_type !== undefined) {
-        if (!isValidExerciseType(exercise_type)) {
-          return errorResponse(
-            `Invalid exercise_type "${exercise_type}". Valid types include: ${exerciseTypeNames.slice(0, 15).join(', ')}...`,
-          )
-        }
-        data = {
-          exerciseType: getExerciseTypeValue(exercise_type),
-          exerciseTypeName: exercise_type,
-        }
-      }
-
+    async ({ id, activity_type, data, start_time, end_time, title, notes, tz }) => {
       const result = await updateActivity(
         user,
         id,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -207,7 +207,7 @@ export const createActivitiesRouter = (
         user,
         {
           activity_type,
-          data: bodyData as Record<string, unknown> | undefined,
+          data: bodyData,
           end_time: endDate,
           merge_span,
           notes,
@@ -413,7 +413,7 @@ export const createActivitiesRouter = (
         id,
         {
           activity_type,
-          data: bodyData as Record<string, unknown> | undefined,
+          data: bodyData,
           end_time: end_time === null ? null : end_time ? new Date(end_time) : undefined,
           notes,
           override_target_ids,

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -16,8 +16,6 @@ import {
   addActivityBodySchema,
   type AddActivityResponse,
   type DeleteActivityResponse,
-  getExerciseTypeValue,
-  isValidExerciseType,
   type MergeActivitiesBody,
   mergeActivitiesBodySchema,
   type MergeActivitiesResponse,
@@ -76,11 +74,10 @@ const buildMergedResponse = async (
     ? overlapping.map((a) => {
         const data = a.data
         const dataOrigin = data?.dataOrigin
-        const exerciseTypeName = data?.exerciseTypeName
         return {
+          activity_type: a.activity_type,
           data_origin: typeof dataOrigin === 'string' ? dataOrigin : undefined,
           end_time: a.end_time?.toISOString(),
-          exercise_type_name: typeof exerciseTypeName === 'string' ? exerciseTypeName : undefined,
           id: a.id!,
           source: a.source,
           start_time: a.start_time.toISOString(),
@@ -200,42 +197,17 @@ export const createActivitiesRouter = (
     authMiddleware,
     validateBody(addActivityBodySchema),
     async (req, res) => {
-      const {
-        activity_type,
-        start_time,
-        end_time,
-        title,
-        notes,
-        exercise_type,
-        merge_span,
-        data: bodyData,
-      } = req.body
+      const { activity_type, start_time, end_time, title, notes, merge_span, data: bodyData } = req.body
       const user = req.user!
 
       const startDate = new Date(start_time)
       const endDate = end_time ? new Date(end_time) : undefined
 
-      // Build data: merge body data with exercise_type conversion if provided
-      let data: Record<string, unknown> | undefined = bodyData as Record<string, unknown> | undefined
-      if (exercise_type !== undefined) {
-        if (!isValidExerciseType(exercise_type)) {
-          return res.status(400).json({
-            error: `Invalid exercise_type "${exercise_type}"`,
-            success: false,
-          })
-        }
-        data = {
-          ...data,
-          exerciseType: getExerciseTypeValue(exercise_type),
-          exerciseTypeName: exercise_type,
-        }
-      }
-
       const result = await addActivity(
         user,
         {
           activity_type,
-          data,
+          data: bodyData as Record<string, unknown> | undefined,
           end_time: endDate,
           merge_span,
           notes,
@@ -290,19 +262,11 @@ export const createActivitiesRouter = (
     const results: AddActivityResponse['data'][] = []
 
     for (const fitAct of fitActivities) {
-      // Map exercise type name to Health Connect value
-      const data = {
-        ...fitAct.data,
-        exerciseType: isValidExerciseType(fitAct.exercise_type)
-          ? getExerciseTypeValue(fitAct.exercise_type)
-          : undefined,
-      }
-
       const result = await addActivity(
         user,
         {
           activity_type: fitAct.activity_type,
-          data,
+          data: fitAct.data,
           end_time: fitAct.end_time,
           notes: fitAct.notes,
           start_time: fitAct.start_time,
@@ -439,34 +403,17 @@ export const createActivitiesRouter = (
         end_time,
         title,
         notes,
-        exercise_type,
         data: bodyData,
         override_target_ids,
       } = req.body
       const user = req.user!
-
-      // Merge exercise_type into data if provided
-      let data: Record<string, unknown> | undefined = bodyData as Record<string, unknown> | undefined
-      if (exercise_type !== undefined) {
-        if (!isValidExerciseType(exercise_type)) {
-          return res.status(400).json({
-            error: `Invalid exercise_type "${exercise_type}"`,
-            success: false,
-          })
-        }
-        data = {
-          ...data,
-          exerciseType: getExerciseTypeValue(exercise_type),
-          exerciseTypeName: exercise_type,
-        }
-      }
 
       const result = await updateActivity(
         user,
         id,
         {
           activity_type,
-          data,
+          data: bodyData as Record<string, unknown> | undefined,
           end_time: end_time === null ? null : end_time ? new Date(end_time) : undefined,
           notes,
           override_target_ids,

--- a/apps/backend/src/services/fit-parser.test.ts
+++ b/apps/backend/src/services/fit-parser.test.ts
@@ -12,9 +12,8 @@ describe('parseFitBuffer', () => {
     expect(activities).toHaveLength(1)
     const act = activities[0]
 
-    expect(act.activity_type).toBe('exercise')
     // QZ file has sport=running, sub_sport=virtual_activity → running_treadmill
-    expect(act.exercise_type).toBe('running_treadmill')
+    expect(act.activity_type).toBe('running_treadmill')
     expect(act.start_time).toBeInstanceOf(Date)
     expect(act.end_time).toBeInstanceOf(Date)
     expect(act.end_time.getTime()).toBeGreaterThan(act.start_time.getTime())

--- a/apps/backend/src/services/fit-parser.ts
+++ b/apps/backend/src/services/fit-parser.ts
@@ -9,8 +9,7 @@ import type { ExerciseTypeName } from '@aurboda/api-spec'
 import FitParser from 'fit-file-parser'
 
 export interface FitActivity {
-  activity_type: 'exercise'
-  exercise_type: ExerciseTypeName
+  activity_type: ExerciseTypeName | 'exercise'
   start_time: Date
   end_time: Date
   title: string
@@ -127,7 +126,6 @@ export const parseFitBuffer = async (buffer: ArrayBuffer | Buffer<ArrayBuffer>):
     const endTime = computeEndTime(session, startTime, totalElapsed, records)
 
     const summaryData: Record<string, unknown> = {
-      exerciseTypeName: exerciseType,
       source_detail: 'fit_import',
     }
     if (session.total_calories !== undefined) summaryData.calories = session.total_calories
@@ -136,11 +134,15 @@ export const parseFitBuffer = async (buffer: ArrayBuffer | Buffer<ArrayBuffer>):
     const duration = totalElapsed ?? (endTime.getTime() - startTime.getTime()) / 1000
     const title = `${prettySport(exerciseType)} ${formatDuration(duration)}`
 
+    // 'other_workout' is FIT's catch-all for unmapped sports — surface as the
+    // generic 'exercise' activity_type rather than a misleadingly specific one.
+    const activityType: ExerciseTypeName | 'exercise' =
+      exerciseType === 'other_workout' ? 'exercise' : exerciseType
+
     return {
-      activity_type: 'exercise' as const,
+      activity_type: activityType,
       data: summaryData,
       end_time: endTime,
-      exercise_type: exerciseType,
       notes: undefined,
       start_time: startTime,
       timeSeries: records?.length ? extractTimeSeries(records) : [],

--- a/apps/backend/src/services/queries/daily-summary.test.ts
+++ b/apps/backend/src/services/queries/daily-summary.test.ts
@@ -622,7 +622,7 @@ describe('getDailySummary', () => {
     expect(result.sleep_sessions[0].sleep_location).toBeUndefined()
   })
 
-  test('includes exercise_type name from numeric Health Connect code', async () => {
+  test('surfaces inline notes and structured data fields on activities', async () => {
     vi.mocked(db.getTimeSeries)
       .mockResolvedValueOnce([]) // heart rate
       .mockResolvedValueOnce([]) // steps
@@ -631,18 +631,19 @@ describe('getDailySummary', () => {
     vi.mocked(db.getSleepSessions).mockResolvedValue([])
     vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
-        activity_type: 'exercise',
-        data: { exerciseType: 83 }, // yoga
+        activity_type: 'yoga',
+        data: { reps: 12, weight: 20 },
         end_time: new Date('2024-01-15T07:00:00Z'),
-        source: 'health_connect',
+        notes: 'Focus on hip openers',
+        source: 'aurboda',
         start_time: new Date('2024-01-15T06:30:00Z'),
       },
       {
-        activity_type: 'exercise',
-        data: { exerciseType: 56 }, // running
-        end_time: new Date('2024-01-15T12:00:00Z'),
-        source: 'health_connect',
-        start_time: new Date('2024-01-15T11:30:00Z'),
+        activity_type: 'sex',
+        data: { partner: 'Sara' },
+        end_time: new Date('2024-01-15T23:30:00Z'),
+        source: 'aurboda',
+        start_time: new Date('2024-01-15T23:00:00Z'),
       },
     ])
     vi.mocked(db.getProductivity).mockResolvedValue([])
@@ -652,10 +653,36 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
-    expect(exerciseActivities).toHaveLength(2)
-    expect(exerciseActivities[0].exercise_type).toBe('yoga')
-    expect(exerciseActivities[1].exercise_type).toBe('running')
+    expect(result.activities).toHaveLength(2)
+    const yoga = result.activities.find((a) => a.activity_type === 'yoga')!
+    expect(yoga.notes).toBe('Focus on hip openers')
+    expect(yoga.data).toEqual({ reps: 12, weight: 20 })
+    const sex = result.activities.find((a) => a.activity_type === 'sex')!
+    expect(sex.notes).toBeUndefined()
+    expect(sex.data).toEqual({ partner: 'Sara' })
+  })
+
+  test('omits notes and data when activity has neither', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([])
+
+    vi.mocked(db.getSleepSessions).mockResolvedValue([])
+    vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
+      {
+        activity_type: 'coffee',
+        end_time: new Date('2024-01-15T08:30:00Z'),
+        source: 'aurboda',
+        start_time: new Date('2024-01-15T08:00:00Z'),
+      },
+    ])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locationsService.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getDailyAggregateValue).mockResolvedValue(null)
+    vi.mocked(db.getTimeSeriesMultiMetric).mockResolvedValue({} as Record<MetricType, [Date, number][]>)
+
+    const result = await getDailySummary('testuser', new Date('2024-01-15'))
+
+    expect(result.activities[0].notes).toBeUndefined()
+    expect(result.activities[0].data).toBeUndefined()
   })
 
   test('includes meals with food item names', async () => {
@@ -762,7 +789,7 @@ describe('getDailySummary', () => {
     })
   })
 
-  test('omits data blob from activities and sleep sessions', async () => {
+  test('passes activity data through but omits it from sleep sessions', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getSleepSessions).mockResolvedValue([
       {
@@ -775,8 +802,8 @@ describe('getDailySummary', () => {
     ])
     vi.mocked(db.getNonSleepActivitiesMerged).mockResolvedValue([
       {
-        activity_type: 'exercise',
-        data: { exerciseType: 83, metadata: { device: 'oura' } },
+        activity_type: 'yoga',
+        data: { metadata: { device: 'oura' }, partner: 'Sara' },
         end_time: new Date('2024-01-15T07:30:00Z'),
         source: 'health_connect',
         start_time: new Date('2024-01-15T07:00:00Z'),
@@ -789,10 +816,11 @@ describe('getDailySummary', () => {
 
     const result = await getDailySummary('testuser', new Date('2024-01-15'))
 
-    // Exercise activities should not have raw data blob
-    const exerciseActivities = result.activities.filter((a) => a.activity_type === 'exercise')
-    expect(exerciseActivities[0]).not.toHaveProperty('data')
-    // Sleep sessions should not have raw data blob
+    // Activities now include their full data blob so that structured fields
+    // like `partner` reach AI consumers without bespoke surfacing per key.
+    const yoga = result.activities.find((a) => a.activity_type === 'yoga')!
+    expect(yoga.data).toEqual({ metadata: { device: 'oura' }, partner: 'Sara' })
+    // Sleep sessions still strip the raw blob — their data is summarized via sleep_stages.
     expect(result.sleep_sessions[0]).not.toHaveProperty('data')
   })
 

--- a/apps/backend/src/services/queries/daily-summary.ts
+++ b/apps/backend/src/services/queries/daily-summary.ts
@@ -2,7 +2,7 @@
  * Daily summary query function.
  */
 
-import { builtinMetricsForDailySummary, getExerciseTypeName } from '@aurboda/api-spec'
+import { builtinMetricsForDailySummary } from '@aurboda/api-spec'
 
 import type {
   ActivitySummary,
@@ -492,10 +492,6 @@ export async function getDailySummary(
   const activities: ActivitySummary[] = allActivities
     .filter((s) => s.activity_type !== 'screentime')
     .map((s) => {
-      const exerciseTypeCode = s.data?.exerciseType
-      const exerciseType =
-        typeof exerciseTypeCode === 'number' ? getExerciseTypeName(exerciseTypeCode) : undefined
-
       const activity: ActivitySummary = {
         activity_type: s.activity_type,
         end_time: s.end_time?.toISOString(),
@@ -503,7 +499,8 @@ export async function getDailySummary(
         title: s.title,
       }
 
-      if (exerciseType) activity.exercise_type = exerciseType
+      if (s.notes) activity.notes = s.notes
+      if (s.data && Object.keys(s.data).length > 0) activity.data = s.data
 
       // Comments
       const comments = s.id ? commentsMap.get(s.id) : undefined

--- a/apps/backend/src/services/queries/types.ts
+++ b/apps/backend/src/services/queries/types.ts
@@ -2,7 +2,7 @@
  * Shared types and helpers for query services.
  */
 
-import type { ActivityComputedMetrics, DataSource, ExerciseTypeName } from '@aurboda/api-spec'
+import type { ActivityComputedMetrics, DataSource } from '@aurboda/api-spec'
 
 import type { MetricType } from '../../schema.ts'
 import type { HrZoneSecs } from '../settings.ts'
@@ -132,7 +132,6 @@ export interface SessionSummary {
   end_time?: string
   duration?: number // minutes
   title?: string
-  exercise_type?: ExerciseTypeName
   hr_zone_secs?: HrZoneSecs
 }
 
@@ -148,8 +147,9 @@ export interface ActivitySummary {
   start_time: string
   end_time?: string
   title?: string
+  notes?: string
+  data?: Record<string, unknown>
   comments?: CommentSummary[]
-  exercise_type?: ExerciseTypeName
   hr_zone_secs?: HrZoneSecs
   stress_zone_secs?: StressZoneSecs
   category_path?: string[]

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -5,7 +5,7 @@
  * Activity detail is data-driven: features are shown based on what data exists
  * (sleep stages, HR zones, exercise type) rather than hard-coded by display_category.
  */
-import { getExerciseTypeName as getExerciseTypeNameFromValue } from '@aurboda/api-spec'
+import { isExerciseActivityType } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useLocation, useRoute } from 'preact-iso'
@@ -58,7 +58,7 @@ const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
     {records.map((record) => (
       <a key={record.id} href={`/detail/activity/${record.id}`} class="source-record">
         <span class="source-record-source">
-          {record.title ?? record.exercise_type_name ?? record.data_origin ?? record.source}
+          {record.title ?? record.activity_type ?? record.data_origin ?? record.source}
         </span>
         <span class="source-record-time">
           {formatTime(new Date(record.start_time))}
@@ -74,13 +74,14 @@ const SourceRecordsSection = ({ records }: { records: SourceRecord[] }) => (
 
 const formatExerciseTypeName = (name: string): string => name.replaceAll('_', ' ')
 
-/** Resolve exercise type name from activity data (supports both string name and numeric HC value). */
+/**
+ * Return the activity's specific exercise type (e.g. 'yoga') for exercise activities,
+ * or undefined for non-exercise activities and the generic 'exercise' bucket.
+ */
 export const resolveExerciseType = (activity: Activity): string | undefined => {
-  const data = activity.data as Record<string, unknown> | undefined
-  return (
-    (data?.exerciseTypeName as string | undefined) ??
-    (typeof data?.exerciseType === 'number' ? getExerciseTypeNameFromValue(data.exerciseType) : undefined)
-  )
+  const type = activity.activity_type
+  if (!type || type === 'exercise') return undefined
+  return isExerciseActivityType(type) ? type : undefined
 }
 
 // ── HR Zone Bar ───────────────────────────────────────────────────────────────

--- a/apps/web/src/pages/Timeline/formatting.test.ts
+++ b/apps/web/src/pages/Timeline/formatting.test.ts
@@ -45,18 +45,18 @@ describe('formatExerciseType', () => {
 })
 
 describe('getExerciseTypeName', () => {
-  it('returns title when no exercise data', () => {
-    const activity = { title: 'Morning Run' } as Activity
+  it('returns title when activity_type is generic exercise', () => {
+    const activity = { activity_type: 'exercise', title: 'Morning Run' } as Activity
     expect(getExerciseTypeName(activity)).toBe('Morning Run')
   })
 
-  it('returns Workout as fallback', () => {
-    const activity = {} as Activity
+  it('returns Workout when activity_type is generic exercise and no title', () => {
+    const activity = { activity_type: 'exercise' } as Activity
     expect(getExerciseTypeName(activity)).toBe('Workout')
   })
 
-  it('uses exerciseTypeName from data', () => {
-    const activity = { data: { exerciseTypeName: 'indoor_cycling' } } as unknown as Activity
+  it('formats specific activity_type', () => {
+    const activity = { activity_type: 'indoor_cycling' } as Activity
     expect(getExerciseTypeName(activity)).toBe('indoor cycling')
   })
 })

--- a/apps/web/src/pages/Timeline/formatting.ts
+++ b/apps/web/src/pages/Timeline/formatting.ts
@@ -1,4 +1,3 @@
-import { getExerciseTypeName as getExerciseTypeNameFromValue } from '@aurboda/api-spec'
 import { format } from 'date-fns'
 
 import type { Activity } from '../../state/api'
@@ -17,13 +16,8 @@ export const formatDuration = (start: Date, end: Date): string => {
 export const formatExerciseType = (name: string): string => name.replaceAll('_', ' ')
 
 export const getExerciseTypeName = (activity: Activity): string => {
-  const data = activity.data as Record<string, unknown> | undefined
-  const typeName = data?.exerciseTypeName as string | undefined
-  if (typeName) return formatExerciseType(typeName)
-  const typeValue = data?.exerciseType as number | undefined
-  if (typeValue !== undefined) {
-    const name = getExerciseTypeNameFromValue(typeValue)
-    if (name) return formatExerciseType(name)
+  if (activity.activity_type && activity.activity_type !== 'exercise') {
+    return formatExerciseType(activity.activity_type)
   }
   return activity.title || 'Workout'
 }

--- a/apps/web/src/state/api/types.ts
+++ b/apps/web/src/state/api/types.ts
@@ -70,7 +70,7 @@ export interface SourceRecord {
   end_time?: string
   title?: string
   data_origin?: string
-  exercise_type_name?: string
+  activity_type?: string
 }
 
 export interface Activity extends Omit<ApiActivity, 'start_time' | 'end_time'> {

--- a/packages/api-spec/src/schemas/activities.ts
+++ b/packages/api-spec/src/schemas/activities.ts
@@ -241,12 +241,9 @@ export type Activity = z.infer<typeof activitySchema>
  */
 export const sourceRecordSchema = z
   .object({
+    activity_type: z.string().optional().meta({ description: 'Activity type (e.g. yoga, running)' }),
     data_origin: z.string().optional().meta({ description: 'Health Connect data origin package' }),
     end_time: iso8601DateTimeSchema.optional(),
-    exercise_type_name: z
-      .string()
-      .optional()
-      .meta({ description: 'Exercise type name (e.g. weightlifting)' }),
     id: z.string().uuid().meta({ description: 'Activity ID' }),
     source: z.string().meta({ description: 'Data source' }),
     start_time: iso8601DateTimeSchema,
@@ -323,9 +320,6 @@ export const addActivityBodySchema = z
     end_time: iso8601DateTimeSchema.optional().meta({
       description: 'End time (omit for point-in-time activities)',
     }),
-    exercise_type: exerciseTypeSchema.optional().meta({
-      description: 'Exercise type name (only for exercise activities)',
-    }),
     merge_span: z.number().int().positive().max(3600).optional().meta({
       description:
         'If provided, merge with existing activity of same type if its end_time is within this many seconds of new start_time. Max 3600.',
@@ -399,9 +393,6 @@ export const updateActivityBodySchema = z
       .nullable()
       .optional()
       .meta({ description: 'New end time of the activity (null to clear)' }),
-    exercise_type: exerciseTypeSchema.optional().meta({
-      description: 'New exercise type name (only for exercise activities)',
-    }),
     notes: z.string().optional().meta({ description: 'New activity notes' }),
     override_target_ids: z.array(z.string().uuid()).min(1).optional().meta({
       description:

--- a/packages/api-spec/src/schemas/daily-summary.ts
+++ b/packages/api-spec/src/schemas/daily-summary.ts
@@ -4,7 +4,6 @@
 
 import { z } from 'zod'
 
-import { exerciseTypeSchema } from './activities.ts'
 import {
   addressSchema,
   createDataResponseSchema,
@@ -119,13 +118,16 @@ export const activitySummarySchema = z
         'Screen time category path (e.g., ["Work & Dev", "Software Dev"]). Only present for screentime activities.',
     }),
     comments: z.array(commentSchema).optional().meta({ description: 'Comments attached to this activity' }),
-    end_time: iso8601DateTimeSchema.optional(),
-    exercise_type: exerciseTypeSchema.optional().meta({
+    data: z.record(z.string(), z.unknown()).optional().meta({
       description:
-        'Human-readable exercise type name (e.g., "yoga", "running"). Only present for exercise activities.',
+        'Structured data attached to this activity (free-form key/value pairs, e.g. "partner", "weight", "reps", source-specific fields).',
     }),
+    end_time: iso8601DateTimeSchema.optional(),
     hr_zone_secs: hrZoneSecsSchema.optional().meta({
       description: 'Time spent in each HR zone during this activity',
+    }),
+    notes: z.string().optional().meta({
+      description: 'Free-text notes typed on the activity itself (separate from attached comments).',
     }),
     start_time: iso8601DateTimeSchema,
     stress_zone_secs: stressZoneSecsSchema.optional().meta({
@@ -279,7 +281,7 @@ export const dailySummaryResultSchema = z
   .object({
     activities: z.array(activitySummarySchema).meta({
       description:
-        'Unified chronological timeline of all activities: exercises, meditations, screen time categories, custom activities, etc. Sorted by start_time. Screen time entries have category_path set. Exercise entries have exercise_type and hr_zone_secs. Activities with stress data have stress_zone_secs.',
+        'Unified chronological timeline of all activities: exercises, meditations, screen time categories, custom activities, etc. Sorted by start_time. Screen time entries have category_path set. Exercise entries (yoga, running, weightlifting, ...) carry their type directly in `activity_type`. Activities with HR or stress data have hr_zone_secs / stress_zone_secs. Free-text notes and arbitrary structured data are surfaced via `notes` and `data`.',
     }),
     date: dateOnlySchema,
     heart_rate: heartRateStatsSchema.nullable(),


### PR DESCRIPTION
## Summary

- Daily summary now passes through each activity's inline `notes` and `data` blob. The yoga note typed on an exercise activity (and structured fields like `partner: Sara`) finally reach the AI consumer.
- Retires the redundant `exerciseType` / `exerciseTypeName` keys we used to mirror inside `data`. `activity_type` already carries the specific exercise type (`yoga`, `running`, `weightlifting`, …) since the unified-activities migration, so duplicating it in `data` only polluted the new daily-summary `data` passthrough.

## What changed

**api-spec**
- `ActivitySummary` gains `notes` and `data`, loses `exercise_type`.
- `AddActivityBody` / `UpdateActivityBody` lose `exercise_type` — callers pass `activity_type` directly.
- `SourceRecord` loses `exercise_type_name`, gains `activity_type`.

**Backend**
- `getDailySummary` surfaces `notes` + `data`; drops the `data.exerciseType → exercise_type` derivation.
- REST `POST/PATCH /activities` and MCP `add_activity` / `update_activity` no longer accept `exercise_type` or write `exerciseType`/`exerciseTypeName` into `data`.
- FIT upload sets the specific `activity_type` directly (`running_treadmill` instead of generic `exercise` + side-channel).
- Health Connect ingest still resolves the HC integer to a specific `activity_type`, but strips both keys before persisting to `activities.data`. Raw HC payloads remain intact in `raw_records`.
- `mergeOverlappingActivities`' generic-exercise absorption no longer needs the HC integer fallback — `activity_type === 'exercise'` is now the source of truth.
- `buildMergedResponse` exposes `activity_type` per source record instead of the HC name.
- Startup migration strips `exerciseType` / `exerciseTypeName` from existing `activities.data` rows (idempotent JSONB `-` operator).

**Web**
- `Timeline/getExerciseTypeName` and `EntityDetail/resolveExerciseType` resolve from `activity_type` instead of the dropped `data` keys.

## Test plan

- [x] `pnpm --filter aurboda-backend check` — 0 errors
- [x] `pnpm --filter aurboda-web check` — 0 errors
- [x] `pnpm --filter @aurboda/api-spec check` — 0 errors
- [x] Backend unit tests: 1769 / 1769 passing
- [x] Backend integration tests for activities: 36 / 36 passing
- [x] Web tests: 397 / 397 passing
- [x] New tests in `daily-summary.test.ts` verify `notes` + `data` passthrough and the "no notes/data" case
- [ ] Manual smoke after deploy: open a daily summary in the UI, confirm a yoga activity surfaces its `notes` text and any `data.partner` etc.

## Follow-up (PR #2)

Migrate the `activities.notes` column into the `notes` table so activities have a single text channel (currently both `notes` column and attached `comments[]`). Tracked separately because it touches Health Connect imports and Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)