### PR TITLE
feat(meals): multi-window overview with 1/7/30/90d columns + date picker

### DIFF
--- a/apps/web/src/components/ReferenceRangeBar.css
+++ b/apps/web/src/components/ReferenceRangeBar.css
@@ -44,6 +44,24 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
+.ref-range-marker-label {
+  position: absolute;
+  top: -1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.6rem;
+  line-height: 1;
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.ref-range-multi {
+  /* Reserve space above the track for the tiny window labels. */
+  padding-top: 0.85rem;
+}
+
 .ref-range-labels {
   display: flex;
   justify-content: space-between;
@@ -75,5 +93,9 @@
 
   .ref-range-labels {
     color: #6b7280;
+  }
+
+  .ref-range-marker-label {
+    color: #9ca3af;
   }
 }

--- a/apps/web/src/components/ReferenceRangeBar.css
+++ b/apps/web/src/components/ReferenceRangeBar.css
@@ -57,9 +57,17 @@
   pointer-events: none;
 }
 
+/* Stagger label vertical position by index so two markers with similar
+ * values don't overlap their labels. Adjacent windows (1d vs 7d, 30d vs
+ * 90d) are most likely to land close on stable nutrients like sodium. */
+.ref-range-multi .ref-range-marker[data-marker-index='1'] .ref-range-marker-label,
+.ref-range-multi .ref-range-marker[data-marker-index='3'] .ref-range-marker-label {
+  top: -1.75rem;
+}
+
 .ref-range-multi {
-  /* Reserve space above the track for the tiny window labels. */
-  padding-top: 0.85rem;
+  /* Reserve space above the track for the staggered window labels. */
+  padding-top: 1.7rem;
 }
 
 .ref-range-labels {

--- a/apps/web/src/components/ReferenceRangeBar.tsx
+++ b/apps/web/src/components/ReferenceRangeBar.tsx
@@ -151,6 +151,7 @@ export function ReferenceRangeBar({
             <div
               key={m.label ?? i}
               class="ref-range-marker"
+              data-marker-index={i}
               style={{ backgroundColor: color, left: `${pct}%` }}
               title={m.label ? `${m.label}: ${m.value}` : `${m.value}`}
             >

--- a/apps/web/src/components/ReferenceRangeBar.tsx
+++ b/apps/web/src/components/ReferenceRangeBar.tsx
@@ -2,11 +2,22 @@ import type { ReportFlag } from '@aurboda/api-spec'
 
 import './ReferenceRangeBar.css'
 
-interface ReferenceRangeBarProps {
+export interface RangeMarker {
   value: number
+  flag?: ReportFlag
+  /** Short label shown above the marker (e.g. "1d", "7d"). */
+  label?: string
+}
+
+interface ReferenceRangeBarProps {
+  /** Single-marker shorthand. Ignored when `markers` is provided. */
+  value?: number
+  /** Flag for the single-marker shorthand. */
+  flag?: ReportFlag
+  /** Multi-marker mode — overrides `value`/`flag`. */
+  markers?: RangeMarker[]
   reference_low?: number
   reference_high?: number
-  flag?: ReportFlag
 }
 
 const FLAG_COLORS: Record<string, string> = {
@@ -28,7 +39,8 @@ interface DisplayRange {
 
 /**
  * Compute where to draw the visible track and where the normal/warning
- * zones sit on it, given a possibly one-sided reference range.
+ * zones sit on it, given a possibly one-sided reference range and one or
+ * more values.
  *
  * Two-sided: existing 30%-padding-on-each-side display, with warning zones
  * on both ends and normal in the middle. Used by report cards (HRV, body
@@ -36,23 +48,25 @@ interface DisplayRange {
  *
  * Upper-only (e.g. salt, saturated_fat, alcohol): anchor at zero, extend
  * 30% beyond the cap; normal zone is everything from 0 up to the cap, the
- * warning zone covers only the over-cap region. Without this we used to
- * synthesize a fake low bound and label "ate 2 g of salt" as too-low.
+ * warning zone covers only the over-cap region.
  *
  * Lower-only (open upper bound, e.g. potassium minimum): warning zone
  * below the floor, normal zone above; extend display until at least the
- * value or 1.5× floor.
+ * highest value or 1.5× floor.
  */
 const computeDisplayRange = (
   low: number | undefined,
   high: number | undefined,
-  value: number,
+  values: number[],
 ): DisplayRange => {
+  const maxAbs = values.reduce((m, v) => Math.max(m, Math.abs(v)), 0)
+  const maxVal = values.reduce((m, v) => Math.max(m, v), Number.NEGATIVE_INFINITY)
+  const minVal = values.reduce((m, v) => Math.min(m, v), Number.POSITIVE_INFINITY)
   if (low !== undefined && high !== undefined) {
     const span = high - low
-    const padding = Math.max(span * 0.3, Math.abs(value) * 0.05)
-    const displayMin = low - padding
-    const displayMax = high + padding
+    const padding = Math.max(span * 0.3, maxAbs * 0.05)
+    const displayMin = Math.min(low - padding, minVal - padding * 0.1)
+    const displayMax = Math.max(high + padding, maxVal + padding * 0.1)
     const displaySpan = displayMax - displayMin
     return {
       displayMin,
@@ -62,23 +76,19 @@ const computeDisplayRange = (
     }
   }
   if (high !== undefined) {
-    const displayMin = Math.min(0, value)
-    const displayMax = Math.max(high * 1.3, value * 1.1)
+    const displayMin = Math.min(0, minVal)
+    const displayMax = Math.max(high * 1.3, maxVal * 1.1)
     const displaySpan = displayMax - displayMin || 1
     return {
       displayMin,
       displayMax,
-      // Normal zone runs from displayMin (i.e. 0%) up to where `high` sits.
       normalStartPct: 0,
       normalEndPct: ((high - displayMin) / displaySpan) * 100,
     }
   }
-  // low !== undefined && high === undefined. Bind to a local so TS keeps
-  // the narrowing through the local arithmetic — without it the inferred
-  // type is `number | undefined` again on each reference.
   const lo = low as number
-  const displayMin = Math.min(lo * 0.7, value * 0.9)
-  const displayMax = Math.max(lo * 1.5, value * 1.1)
+  const displayMin = Math.min(lo * 0.7, minVal * 0.9)
+  const displayMax = Math.max(lo * 1.5, maxVal * 1.1)
   const displaySpan = displayMax - displayMin || 1
   return {
     displayMin,
@@ -91,27 +101,35 @@ const computeDisplayRange = (
 const clampPct = (p: number): number => Math.max(0, Math.min(100, p))
 
 /**
- * Horizontal bar visualizing where a value falls relative to its reference
- * range. Supports both two-sided medical ranges (lab reports) and one-sided
- * dietary recommendations (salt cap, fiber floor) — see computeDisplayRange.
+ * Horizontal bar visualizing where one or more values fall relative to a
+ * reference range. Supports two-sided medical ranges (lab reports),
+ * one-sided dietary recommendations (salt cap, fiber floor), and overlay
+ * of multiple markers (e.g. 1d/7d/30d/90d averages on the same nutrient).
  */
-export function ReferenceRangeBar({ value, reference_low, reference_high, flag }: ReferenceRangeBarProps) {
+export function ReferenceRangeBar({
+  value,
+  flag,
+  markers,
+  reference_low,
+  reference_high,
+}: ReferenceRangeBarProps) {
   if (reference_low === undefined && reference_high === undefined) return null
+
+  const resolved: RangeMarker[] =
+    markers && markers.length > 0 ? markers : value !== undefined ? [{ flag, value }] : []
+  if (resolved.length === 0) return null
 
   const { displayMin, displayMax, normalStartPct, normalEndPct } = computeDisplayRange(
     reference_low,
     reference_high,
-    value,
+    resolved.map((m) => m.value),
   )
   const displaySpan = displayMax - displayMin || 1
-  const valuePct = clampPct(((value - displayMin) / displaySpan) * 100)
-  const markerColor = flag ? (FLAG_COLORS[flag] ?? '#6b7280') : '#6b7280'
+
+  const title = `Range: ${reference_low ?? '—'}–${reference_high ?? '—'}`
 
   return (
-    <div
-      class="ref-range-bar"
-      title={`Value: ${value}, Range: ${reference_low ?? '—'}–${reference_high ?? '—'}`}
-    >
+    <div class={`ref-range-bar${resolved.length > 1 ? ' ref-range-multi' : ''}`} title={title}>
       <div class="ref-range-track">
         {reference_low !== undefined && (
           <div class="ref-range-zone ref-range-low" style={{ left: 0, width: `${normalStartPct}%` }} />
@@ -126,7 +144,20 @@ export function ReferenceRangeBar({ value, reference_low, reference_high, flag }
           class="ref-range-zone ref-range-normal"
           style={{ left: `${normalStartPct}%`, width: `${normalEndPct - normalStartPct}%` }}
         />
-        <div class="ref-range-marker" style={{ backgroundColor: markerColor, left: `${valuePct}%` }} />
+        {resolved.map((m, i) => {
+          const pct = clampPct(((m.value - displayMin) / displaySpan) * 100)
+          const color = m.flag ? (FLAG_COLORS[m.flag] ?? '#6b7280') : '#6b7280'
+          return (
+            <div
+              key={m.label ?? i}
+              class="ref-range-marker"
+              style={{ backgroundColor: color, left: `${pct}%` }}
+              title={m.label ? `${m.label}: ${m.value}` : `${m.value}`}
+            >
+              {m.label && <span class="ref-range-marker-label">{m.label}</span>}
+            </div>
+          )
+        })}
       </div>
       <div class="ref-range-labels">
         {reference_low !== undefined ? <span class="ref-range-label-low">{reference_low}</span> : <span />}

--- a/apps/web/src/pages/Meals/MealsOverview.tsx
+++ b/apps/web/src/pages/Meals/MealsOverview.tsx
@@ -2,24 +2,34 @@ import type {
   CaloriesBurnedPeriodStat,
   NutrientFieldDef,
   NutrientPeriodStat,
+  NutrientPeriodSummary,
   NutrientRecommendation,
   ReportFlag,
 } from '@aurboda/api-spec'
 
 import { NUTRIENT_FIELDS } from '@aurboda/api-spec'
-import { useQuery } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import { format, subDays } from 'date-fns'
 import { useMemo, useState } from 'preact/hooks'
 
+import type { RangeMarker } from '../../components/ReferenceRangeBar'
+
+import { DateNav } from '../../components/DateNav'
 import { ReferenceRangeBar } from '../../components/ReferenceRangeBar'
 import { fetchMealsPeriodSummary, fetchNutrientRecommendations } from '../../state/api'
 import { auth } from '../../state/auth'
 
-type WindowKey = '7' | '14' | '30' | '90'
+type WindowKey = '1' | '7' | '30' | '90'
 
-const WINDOWS: { key: WindowKey; label: string; days: number }[] = [
+interface WindowDef {
+  key: WindowKey
+  label: string
+  days: number
+}
+
+const WINDOWS: WindowDef[] = [
+  { days: 1, key: '1', label: '1d' },
   { days: 7, key: '7', label: '7d' },
-  { days: 14, key: '14', label: '14d' },
   { days: 30, key: '30', label: '30d' },
   { days: 90, key: '90', label: '90d' },
 ]
@@ -36,12 +46,6 @@ const NUTRIENT_CATEGORIES: { key: NutrientFieldDef['category']; label: string }[
 
 const ymd = (d: Date): string => format(d, 'yyyy-MM-dd')
 
-/**
- * Format a nutrient average for display. Picks decimals based on magnitude
- * so vitamins in µg/mg with sub-1 values (B12 ≈ 2 µg, vitamin K ≈ 80 µg,
- * folate ≈ 0.3 mg if mis-unit'd) stay legible — toFixed(1) would lose all
- * precision on the small end.
- */
 const formatNutrientValue = (value: number, unit: string): string => {
   if (unit === 'kcal') return value.toFixed(0)
   const abs = Math.abs(value)
@@ -53,19 +57,6 @@ const formatNutrientValue = (value: number, unit: string): string => {
   return value.toFixed(decimals)
 }
 
-/**
- * Map a value against a recommended range to the same flag enum used by
- * report cards so the existing ReferenceRangeBar marker color stays
- * consistent across the app. v1 doesn't surface "critical" thresholds —
- * that maps to a future tier on the override schema.
- *
- * Note: ReferenceRangeBar's FLAG_COLORS palette is symmetric (low and high
- * both yellow, normal green) which fits two-sided medical ranges. For
- * dietary contexts that's a v1 simplification — exceeding the salt cap
- * arguably deserves stronger framing than missing the protein floor. A
- * follow-up could either invert the palette per nutrient or introduce a
- * dedicated dietary palette.
- */
 const flagFor = (
   value: number,
   low: number | null | undefined,
@@ -76,18 +67,25 @@ const flagFor = (
   return 'normal'
 }
 
-interface NutrientRow {
-  field: NutrientFieldDef
-  stat: NutrientPeriodStat
-  recommendation?: NutrientRecommendation
-}
-
 const userTz = (): string | undefined => {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone
   } catch {
     return undefined
   }
+}
+
+const balanceClass = (balance: number | null): string => {
+  if (balance === null) return ''
+  if (balance > 0) return 'positive'
+  if (balance < 0) return 'negative'
+  return ''
+}
+
+const balanceLabel = (balance: number): string => {
+  if (balance > 0) return 'surplus'
+  if (balance < 0) return 'deficit'
+  return 'balanced'
 }
 
 function WindowSelector({ windowKey, onChange }: { windowKey: WindowKey; onChange: (k: WindowKey) => void }) {
@@ -107,75 +105,121 @@ function WindowSelector({ windowKey, onChange }: { windowKey: WindowKey; onChang
   )
 }
 
-const balanceClass = (balance: number | null): string => {
-  if (balance === null) return ''
-  if (balance > 0) return 'positive'
-  if (balance < 0) return 'negative'
-  return ''
+interface WindowData {
+  window: WindowDef
+  start: string
+  end: string
+  summary: NutrientPeriodSummary | undefined
 }
 
-const balanceLabel = (balance: number): string => {
-  if (balance > 0) return 'surplus'
-  if (balance < 0) return 'deficit'
-  return 'balanced'
-}
-
-function EnergySection({
-  eaten,
-  burned,
-  daysWithMeals,
-}: {
-  eaten?: NutrientPeriodStat
-  burned: CaloriesBurnedPeriodStat | null
-  daysWithMeals: number
-}) {
-  const eatenAvg = eaten?.avg ?? 0
-  const burnedAvg = burned?.avg ?? null
-  const balance = burnedAvg !== null ? eatenAvg - burnedAvg : null
-
+function EnergySection({ windows, activeKey }: { windows: WindowData[]; activeKey: WindowKey }) {
   return (
     <section class="overview-energy">
       <h3>Energy balance</h3>
-      <div class="energy-row">
-        <div class="energy-cell">
-          <span class="energy-label">Eaten / day</span>
-          <span class="energy-value">{eatenAvg ? `${Math.round(eatenAvg)} kcal` : '—'}</span>
-          {daysWithMeals > 0 && (
-            <span class="energy-sub">
-              over {daysWithMeals} {daysWithMeals === 1 ? 'day' : 'days'}
+      <div class="energy-grid">
+        <div class="energy-grid-header">
+          <span />
+          {windows.map((w) => (
+            <span key={w.window.key} class="energy-col-label" data-window={w.window.key}>
+              {w.window.label}
             </span>
-          )}
+          ))}
         </div>
-        <div class="energy-cell">
-          <span class="energy-label">Burned / day</span>
-          <span class="energy-value">{burnedAvg !== null ? `${Math.round(burnedAvg)} kcal` : '—'}</span>
-          {burned ? (
-            <span class="energy-sub">
-              over {burned.days_with_data} {burned.days_with_data === 1 ? 'day' : 'days'}
-            </span>
-          ) : (
-            <span class="energy-sub">
-              No <code>calories_total</code> metric in window — connect Garmin / Health Connect to see burn
-              comparison.
-            </span>
-          )}
-        </div>
-        <div class="energy-cell">
-          <span class="energy-label">Balance</span>
-          <span class={`energy-value ${balanceClass(balance)}`}>
-            {balance !== null ? `${balance > 0 ? '+' : ''}${Math.round(balance)} kcal` : '—'}
-          </span>
-          {balance !== null && <span class="energy-sub">{balanceLabel(balance)}</span>}
-        </div>
+        <EnergyRow label="Eaten / day" windows={windows} activeKey={activeKey} kind="eaten" />
+        <EnergyRow label="Burned / day" windows={windows} activeKey={activeKey} kind="burned" />
+        <EnergyRow label="Balance" windows={windows} activeKey={activeKey} kind="balance" />
       </div>
     </section>
   )
 }
 
-function NutrientRowView({ field, stat, recommendation }: NutrientRow) {
-  const flag = recommendation
-    ? flagFor(stat.avg, recommendation.recommended_low, recommendation.recommended_high)
-    : undefined
+type EnergyKind = 'eaten' | 'burned' | 'balance'
+
+const energyValueFor = (w: WindowData, kind: EnergyKind): number | null => {
+  const eaten = w.summary?.nutrients.calories?.avg ?? null
+  const burned: CaloriesBurnedPeriodStat | null = w.summary?.calories_burned ?? null
+  const burnedAvg = burned?.avg ?? null
+  if (kind === 'eaten') return eaten
+  if (kind === 'burned') return burnedAvg
+  return eaten !== null && burnedAvg !== null ? eaten - burnedAvg : null
+}
+
+function EnergyCell({ w, kind, activeKey }: { w: WindowData; kind: EnergyKind; activeKey: WindowKey }) {
+  const value = energyValueFor(w, kind)
+  const cls = kind === 'balance' ? balanceClass(value) : ''
+  return (
+    <span
+      class={`energy-grid-cell ${cls}`}
+      data-window={w.window.key}
+      data-active={w.window.key === activeKey ? 'true' : 'false'}
+    >
+      {value !== null ? (
+        <>
+          <span class="energy-num">
+            {kind === 'balance' && value > 0 ? '+' : ''}
+            {Math.round(value)} kcal
+          </span>
+          {kind === 'balance' && <span class="energy-sub">{balanceLabel(value)}</span>}
+        </>
+      ) : (
+        <span class="energy-num muted">—</span>
+      )}
+    </span>
+  )
+}
+
+function EnergyRow({
+  label,
+  windows,
+  activeKey,
+  kind,
+}: {
+  label: string
+  windows: WindowData[]
+  activeKey: WindowKey
+  kind: EnergyKind
+}) {
+  return (
+    <div class="energy-grid-row">
+      <span class="energy-row-label">{label}</span>
+      {windows.map((w) => (
+        <EnergyCell key={w.window.key} w={w} kind={kind} activeKey={activeKey} />
+      ))}
+    </div>
+  )
+}
+
+interface NutrientCellInfo {
+  windowKey: WindowKey
+  label: string
+  stat: NutrientPeriodStat | undefined
+}
+
+function NutrientRowView({
+  field,
+  cells,
+  recommendation,
+  activeKey,
+}: {
+  field: NutrientFieldDef
+  cells: NutrientCellInfo[]
+  recommendation?: NutrientRecommendation
+  activeKey: WindowKey
+}) {
+  const markers: RangeMarker[] = recommendation
+    ? cells.flatMap((c) =>
+        c.stat
+          ? [
+              {
+                flag: flagFor(c.stat.avg, recommendation.recommended_low, recommendation.recommended_high),
+                label: c.label,
+                value: c.stat.avg,
+              },
+            ]
+          : [],
+      )
+    : []
+
   return (
     <tr>
       <td>
@@ -186,16 +230,28 @@ function NutrientRowView({ field, stat, recommendation }: NutrientRow) {
           </span>
         )}
       </td>
-      <td class="num">
-        {formatNutrientValue(stat.avg, field.unit)} {field.unit}
-      </td>
+      {cells.map((c) => (
+        <td
+          key={c.windowKey}
+          class="num window-col"
+          data-window={c.windowKey}
+          data-active={c.windowKey === activeKey ? 'true' : 'false'}
+        >
+          {c.stat ? (
+            <>
+              {formatNutrientValue(c.stat.avg, field.unit)} <span class="nutrient-unit">{field.unit}</span>
+            </>
+          ) : (
+            <span class="muted">—</span>
+          )}
+        </td>
+      ))}
       <td class="range-col">
-        {recommendation && (
+        {recommendation && markers.length > 0 && (
           <ReferenceRangeBar
-            value={stat.avg}
+            markers={markers}
             reference_low={recommendation.recommended_low ?? undefined}
             reference_high={recommendation.recommended_high ?? undefined}
-            flag={flag}
           />
         )}
       </td>
@@ -203,7 +259,23 @@ function NutrientRowView({ field, stat, recommendation }: NutrientRow) {
   )
 }
 
-function CategorySection({ label, rows }: { label: string; rows: NutrientRow[] }) {
+interface CategoryRow {
+  field: NutrientFieldDef
+  cells: NutrientCellInfo[]
+  recommendation?: NutrientRecommendation
+}
+
+function CategorySection({
+  label,
+  rows,
+  windows,
+  activeKey,
+}: {
+  label: string
+  rows: CategoryRow[]
+  windows: WindowData[]
+  activeKey: WindowKey
+}) {
   return (
     <section class="overview-group">
       <h3>{label}</h3>
@@ -211,13 +283,22 @@ function CategorySection({ label, rows }: { label: string; rows: NutrientRow[] }
         <thead>
           <tr>
             <th>Nutrient</th>
-            <th class="num">Avg / day</th>
+            {windows.map((w) => (
+              <th
+                key={w.window.key}
+                class="num window-col"
+                data-window={w.window.key}
+                data-active={w.window.key === activeKey ? 'true' : 'false'}
+              >
+                {w.window.label}
+              </th>
+            ))}
             <th class="range-col">Range</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
-            <NutrientRowView key={row.field.name} {...row} />
+            <NutrientRowView key={row.field.name} {...row} activeKey={activeKey} />
           ))}
         </tbody>
       </table>
@@ -226,40 +307,54 @@ function CategorySection({ label, rows }: { label: string; rows: NutrientRow[] }
 }
 
 const groupRowsByCategory = (
-  nutrients: Record<string, NutrientPeriodStat>,
+  windows: WindowData[],
   recByName: Map<string, NutrientRecommendation>,
-): Map<NutrientFieldDef['category'], NutrientRow[]> => {
-  const out = new Map<NutrientFieldDef['category'], NutrientRow[]>()
+): Map<NutrientFieldDef['category'], CategoryRow[]> => {
+  const out = new Map<NutrientFieldDef['category'], CategoryRow[]>()
   for (const field of NUTRIENT_FIELDS) {
-    const stat = nutrients[field.name]
-    if (!stat) continue
+    const cells: NutrientCellInfo[] = windows.map((w) => ({
+      label: w.window.label,
+      stat: w.summary?.nutrients[field.name],
+      windowKey: w.window.key,
+    }))
+    if (!cells.some((c) => c.stat)) continue
     const list = out.get(field.category) ?? []
-    list.push({ field, recommendation: recByName.get(field.name), stat })
+    list.push({ cells, field, recommendation: recByName.get(field.name) })
     out.set(field.category, list)
   }
   return out
 }
 
-const daysForWindow = (key: WindowKey): number => WINDOWS.find((w) => w.key === key)?.days ?? 30
+const rangeFor = (endDate: string, days: number): { start: string; end: string } => {
+  const end = new Date(endDate)
+  return { end: endDate, start: ymd(subDays(end, days - 1)) }
+}
 
 export function MealsOverview() {
   const isLoggedIn = auth.value.token
-  const [windowKey, setWindowKey] = useState<WindowKey>('30')
-  const days = daysForWindow(windowKey)
-
-  const range = useMemo(() => {
-    const today = new Date()
-    return { end: ymd(today), start: ymd(subDays(today, days - 1)) }
-  }, [days])
-
+  const [endDate, setEndDate] = useState<string>(ymd(new Date()))
+  const [activeKey, setActiveKey] = useState<WindowKey>('30')
   const tz = userTz()
 
-  const { data: summary, isLoading: isSummaryLoading } = useQuery({
-    enabled: !!isLoggedIn,
-    queryFn: () => fetchMealsPeriodSummary({ end: range.end, start: range.start, tz }),
-    queryKey: ['mealsPeriodSummary', range.start, range.end, tz],
-    staleTime: 60_000,
+  const ranges = useMemo(() => WINDOWS.map((w) => ({ window: w, ...rangeFor(endDate, w.days) })), [endDate])
+
+  const queries = useQueries({
+    queries: ranges.map((r) => ({
+      enabled: !!isLoggedIn,
+      queryFn: () => fetchMealsPeriodSummary({ end: r.end, start: r.start, tz }),
+      queryKey: ['mealsPeriodSummary', r.start, r.end, tz],
+      staleTime: 60_000,
+    })),
   })
+
+  const isAnyLoading = queries.some((q) => q.isLoading)
+
+  const windowsData: WindowData[] = ranges.map((r, i) => ({
+    end: r.end,
+    start: r.start,
+    summary: queries[i]?.data,
+    window: r.window,
+  }))
 
   const { data: recommendations = [] } = useQuery({
     enabled: !!isLoggedIn,
@@ -273,37 +368,40 @@ export function MealsOverview() {
     [recommendations],
   )
 
-  const nutrients = summary?.nutrients ?? {}
-  const rowsByCategory = useMemo(() => groupRowsByCategory(nutrients, recByName), [nutrients, recByName])
+  const rowsByCategory = groupRowsByCategory(windowsData, recByName)
 
   if (!isLoggedIn) return <p>Please log in to use meal tracking.</p>
 
+  const anyNutrientData = windowsData.some((w) => w.summary && Object.keys(w.summary.nutrients).length > 0)
+
   return (
-    <div class="meals-overview">
+    <div class="meals-overview" data-active={activeKey}>
       <div class="overview-controls">
-        <WindowSelector windowKey={windowKey} onChange={setWindowKey} />
-        <span class="overview-range">
-          {range.start} → {range.end}
-        </span>
+        <DateNav value={endDate} onChange={setEndDate} maxToday />
+        <div class="overview-window-control">
+          <WindowSelector windowKey={activeKey} onChange={setActiveKey} />
+        </div>
       </div>
 
-      {isSummaryLoading && <p class="loading">Loading…</p>}
+      {isAnyLoading && <p class="loading">Loading…</p>}
 
-      {!isSummaryLoading && summary && (
+      {!isAnyLoading && (
         <>
-          <EnergySection
-            eaten={summary.nutrients.calories}
-            burned={summary.calories_burned ?? null}
-            daysWithMeals={summary.days_with_meals}
-          />
+          <EnergySection windows={windowsData} activeKey={activeKey} />
           {NUTRIENT_CATEGORIES.map(({ key, label }) => {
             const rows = rowsByCategory.get(key)
             if (!rows || rows.length === 0) return null
-            return <CategorySection key={key} label={label} rows={rows} />
+            return (
+              <CategorySection
+                key={key}
+                label={label}
+                rows={rows}
+                windows={windowsData}
+                activeKey={activeKey}
+              />
+            )
           })}
-          {Object.keys(nutrients).length === 0 && (
-            <p class="overview-empty">No meal nutrient data in this window.</p>
-          )}
+          {!anyNutrientData && <p class="overview-empty">No meal nutrient data in this window.</p>}
         </>
       )}
     </div>

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -943,9 +943,7 @@ function useMealMutations(mealsQueryKey: string[], meals: Meal[] | undefined) {
     const matchIdx = items.findIndex((item) => foodItemMatches(item, target))
     if (matchIdx < 0) return // already removed by another mutation
     const remaining = items.filter((_, i) => i !== matchIdx)
-    optimisticUpdate((old) =>
-      old.map((m) => (m.id === meal.id ? { ...m, food_items: remaining } : m)),
-    )
+    optimisticUpdate((old) => old.map((m) => (m.id === meal.id ? { ...m, food_items: remaining } : m)))
     if (meal.meal_type) markSlotSaving(meal.meal_type, true)
     updateMutation.mutate({ id: meal.id!, food_items: mapFoodItemsToInput(remaining) })
   }

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -958,12 +958,6 @@ a.meal-name:hover {
   color: white;
 }
 
-.overview-range {
-  font-size: 0.85rem;
-  color: #6b7280;
-  font-variant-numeric: tabular-nums;
-}
-
 .overview-energy {
   border: 1px solid #e5e7eb;
   border-radius: 8px;
@@ -978,43 +972,70 @@ a.meal-name:hover {
   color: #374151;
 }
 
-.energy-row {
+/* Energy grid: label column + one column per window. On narrow the
+   media query below collapses to 2 columns (label + active window). */
+.energy-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  row-gap: 0.5rem;
+  column-gap: 1rem;
+  align-items: baseline;
+  grid-template-columns: minmax(120px, max-content) repeat(4, minmax(0, 1fr));
 }
 
-.energy-cell {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
+.energy-grid-header,
+.energy-grid-row {
+  display: contents;
 }
 
-.energy-label {
+.energy-col-label {
   font-size: 0.75rem;
   color: #6b7280;
   text-transform: uppercase;
   letter-spacing: 0.03em;
+  text-align: right;
 }
 
-.energy-value {
-  font-size: 1.4rem;
+.energy-row-label {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.energy-grid-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 0.1rem;
+}
+
+.energy-num {
+  font-size: 1.15rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   color: #111827;
 }
 
-.energy-value.positive {
+.energy-grid-cell.positive .energy-num {
   color: #b45309;
 }
 
-.energy-value.negative {
+.energy-grid-cell.negative .energy-num {
   color: #166534;
 }
 
+.energy-num.muted {
+  color: #9ca3af;
+  font-weight: 500;
+}
+
 .energy-sub {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: #6b7280;
+}
+
+/* Window selector — shown only on narrow screens where columns don't fit. */
+.overview-window-control {
+  display: none;
 }
 
 .overview-group h3 {
@@ -1062,8 +1083,34 @@ a.meal-name:hover {
 }
 
 .overview-table .range-col {
-  width: 40%;
-  min-width: 140px;
+  min-width: 160px;
+}
+
+.overview-table .nutrient-unit {
+  color: #6b7280;
+  font-size: 0.75rem;
+}
+
+.overview-table td.num .muted {
+  color: #c4c8cf;
+}
+
+/* Narrow: hide non-active per-window cells, show selector. */
+@media (max-width: 759px) {
+  .overview-window-control {
+    display: inline-flex;
+  }
+
+  .meals-overview[data-active='1'] [data-window]:not([data-window='1']),
+  .meals-overview[data-active='7'] [data-window]:not([data-window='7']),
+  .meals-overview[data-active='30'] [data-window]:not([data-window='30']),
+  .meals-overview[data-active='90'] [data-window]:not([data-window='90']) {
+    display: none;
+  }
+
+  .energy-grid {
+    grid-template-columns: minmax(120px, max-content) minmax(0, 1fr);
+  }
 }
 
 .overview-empty {
@@ -1112,14 +1159,26 @@ a.meal-name:hover {
     color: #d1d5db;
   }
 
-  .energy-value {
+  .energy-num {
     color: #f3f4f6;
   }
 
-  .energy-label,
-  .energy-sub,
-  .overview-range {
+  .energy-num.muted {
+    color: #6b7280;
+  }
+
+  .energy-col-label,
+  .energy-row-label,
+  .energy-sub {
     color: #9ca3af;
+  }
+
+  .overview-table .nutrient-unit {
+    color: #9ca3af;
+  }
+
+  .overview-table td.num .muted {
+    color: #4b5563;
   }
 
   .overview-table th {


### PR DESCRIPTION
## Summary
- Meals overview now shows **four windows** (1d / 7d / 30d / 90d) side-by-side on wide screens.
- On narrow screens the existing window selector returns, with non-active columns hidden via CSS (data-active on the root).
- New **DateNav** above the windows controls the end-of-range date (defaults to today), letting you scroll back to yesterday etc.
- **ReferenceRangeBar** extended with a `markers` prop. The Range column shows one bar per nutrient with all four window averages overlaid (tiny "1d/7d/30d/90d" labels above each marker, colored by flag). Single-marker callers (Reports) are unchanged.
- 14d window is gone (replaced by 1d).

## Notes for review
- Frontend-only — backend `meals/period-summary` already accepts arbitrary start/end. Four parallel requests via `useQueries`.
- `ReferenceRangeBar` is backward compatible: `value` + `flag` still works.
- I did **not** manually test in the browser (no live preview available in this session). `pnpm fix`, `pnpm check`, and `pnpm --filter aurboda-web build` are all clean.

## Test plan
- [ ] Wide screen: four columns visible, range bar shows four markers, DateNav scrolls all four windows together.
- [ ] Narrow screen: window selector visible, only one column visible, range bar still shows all four markers (this is intentional — the bar always reflects every window).
- [ ] DateNav: today label when on today; arrows walk by day/month; picker click works.
- [ ] Dark mode reads cleanly.
- [ ] Reports page's ReferenceRangeBar is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)