### PR TITLE
fix(meals): require explicit confirmation before creating food items from meal search

### DIFF
--- a/apps/web/src/components/FoodItemAutocomplete.css
+++ b/apps/web/src/components/FoodItemAutocomplete.css
@@ -56,6 +56,15 @@
   font-size: 0.7rem;
 }
 
+.autocomplete-create {
+  border-top: 1px solid #e5e7eb;
+}
+
+.autocomplete-create .ac-name {
+  color: #2563eb;
+  font-weight: 500;
+}
+
 @media (prefers-color-scheme: dark) {
   .food-autocomplete input {
     background: #374151;
@@ -79,5 +88,13 @@
 
   .ac-cal {
     color: #9ca3af;
+  }
+
+  .autocomplete-create {
+    border-top-color: #4b5563;
+  }
+
+  .autocomplete-create .ac-name {
+    color: #60a5fa;
   }
 }

--- a/apps/web/src/components/FoodItemAutocomplete.tsx
+++ b/apps/web/src/components/FoodItemAutocomplete.tsx
@@ -7,6 +7,14 @@ interface FoodItemAutocompleteProps {
   value: string
   onChange: (name: string) => void
   onSelect: (item: FoodItemEntity) => void
+  /**
+   * Optional explicit-create hook. When provided, a "+ Create '<value>'" row
+   * is appended to the dropdown so the user can opt into creating a new
+   * canonical food item from the typed name. Without this, the autocomplete
+   * is search-only — preventing the backend's findOrCreate path from being
+   * triggered implicitly by autosave keystrokes.
+   */
+  onCreate?: (name: string) => Promise<FoodItemEntity>
   placeholder?: string
   class?: string
   autoFocus?: boolean
@@ -16,6 +24,7 @@ export function FoodItemAutocomplete({
   value,
   onChange,
   onSelect,
+  onCreate,
   placeholder,
   autoFocus,
   ...rest
@@ -23,6 +32,7 @@ export function FoodItemAutocomplete({
   const [suggestions, setSuggestions] = useState<FoodItemEntity[]>([])
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
+  const [creating, setCreating] = useState(false)
   // Whether the input is currently focused. Without this gate, every
   // FoodItemAutocomplete on a freshly-loaded meal would auto-fire a search
   // for its pre-filled value and pop its dropdown — N food items in a meal
@@ -36,6 +46,12 @@ export function FoodItemAutocomplete({
     if (autoFocus) inputRef.current?.focus()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const trimmed = value.trim()
+  const canCreate = !!onCreate && trimmed.length >= 2
+  const exactMatch = suggestions.some((s) => s.name.toLowerCase() === trimmed.toLowerCase())
+  const showCreate = canCreate && !exactMatch
+  const createIndex = showCreate ? suggestions.length : -1
 
   // Debounced search — only when the input is focused. Re-runs when
   // hasFocus flips true so re-focusing a populated field also re-fetches.
@@ -51,12 +67,15 @@ export function FoodItemAutocomplete({
     debounceRef.current = setTimeout(async () => {
       const results = await searchFoodItemsApi(value, 8)
       setSuggestions(results)
-      setOpen(results.length > 0)
+      // Open the dropdown whenever there's either a suggestion or a
+      // "+ Create" row to show. With explicit-create enabled, zero matches
+      // still means there's a row to pick.
+      setOpen(results.length > 0 || !!onCreate)
       setActiveIndex(-1)
     }, 300)
 
     return () => clearTimeout(debounceRef.current)
-  }, [value, hasFocus])
+  }, [value, hasFocus, onCreate])
 
   // Close on click outside
   useEffect(() => {
@@ -74,18 +93,35 @@ export function FoodItemAutocomplete({
     setOpen(false)
   }
 
+  const handleCreate = async () => {
+    if (!onCreate || creating) return
+    setCreating(true)
+    try {
+      const created = await onCreate(trimmed)
+      handleSelect(created)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const optionCount = suggestions.length + (showCreate ? 1 : 0)
+
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (!open || suggestions.length === 0) return
+    if (!open || optionCount === 0) return
 
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1))
+      setActiveIndex((i) => Math.min(i + 1, optionCount - 1))
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
       setActiveIndex((i) => Math.max(i - 1, 0))
     } else if (e.key === 'Enter' && activeIndex >= 0) {
       e.preventDefault()
-      handleSelect(suggestions[activeIndex])
+      if (activeIndex === createIndex) {
+        void handleCreate()
+      } else {
+        handleSelect(suggestions[activeIndex])
+      }
     } else if (e.key === 'Escape') {
       setOpen(false)
     }
@@ -104,7 +140,7 @@ export function FoodItemAutocomplete({
           setHasFocus(true)
           // Re-show pre-cached suggestions immediately. The effect will
           // re-fire to refresh them in the background.
-          if (suggestions.length > 0) setOpen(true)
+          if (suggestions.length > 0 || (canCreate && !exactMatch)) setOpen(true)
         }}
         onBlur={() => {
           // Don't close on blur — clicking a suggestion blurs the input
@@ -114,7 +150,7 @@ export function FoodItemAutocomplete({
           setHasFocus(false)
         }}
       />
-      {open && (
+      {open && optionCount > 0 && (
         <ul class="autocomplete-dropdown">
           {suggestions.map((item, i) => (
             <li
@@ -129,6 +165,16 @@ export function FoodItemAutocomplete({
               </span>
             </li>
           ))}
+          {showCreate && (
+            <li
+              key="__create"
+              class={`autocomplete-option autocomplete-create ${createIndex === activeIndex ? 'active' : ''}`}
+              onMouseEnter={() => setActiveIndex(createIndex)}
+              onClick={() => void handleCreate()}
+            >
+              <span class="ac-name">{creating ? 'Creating…' : <>+ Create &ldquo;{trimmed}&rdquo;</>}</span>
+            </li>
+          )}
         </ul>
       )}
     </div>

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { MergeFoodItemDialog } from '../../components/MergeFoodItemDialog'
-import { searchFoodItemsApi } from '../../state/api'
+import { addFoodItemApi, searchFoodItemsApi } from '../../state/api'
 import { auth } from '../../state/auth'
 import './style.css'
 
@@ -17,18 +17,6 @@ const deleteFoodItemApi = async (id: string): Promise<void> => {
     method: 'DELETE',
   })
   if (!res.ok) throw new Error('Delete failed')
-}
-
-const createFoodItemApi = async (name: string): Promise<{ id: string }> => {
-  const { token } = auth.value
-  const res = await fetch(`${API_URL}/food-items`, {
-    body: JSON.stringify({ name }),
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    method: 'POST',
-  })
-  if (!res.ok) throw new Error('Failed to create food item')
-  const json = (await res.json()) as { data: { id: string } }
-  return json.data
 }
 
 export function FoodItems() {
@@ -59,7 +47,7 @@ export function FoodItems() {
   })
 
   const createMutation = useMutation({
-    mutationFn: createFoodItemApi,
+    mutationFn: (name: string) => addFoodItemApi({ name }),
     onSuccess: ({ id }) => {
       queryClient.invalidateQueries({ queryKey: ['foodItems'] })
       // Land on the detail page so the user can rename, set an icon, click

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { FoodItemAutocomplete } from '../../components/FoodItemAutocomplete'
 import {
+  addFoodItemApi,
   deleteMealApi,
   fetchMeal,
   fetchSensitivityFlags,
@@ -18,47 +19,10 @@ import {
 import { createDebouncedFlusher } from '../../utils/debouncedFlusher'
 import { LocationInfo, MEAL_LOCATION_WINDOW_MS } from '../EntityDetail/LocationInfo'
 import './MealDetail.css'
+import { editItemsToBody, type FoodItemEdit, mealItemsToEdit, scaleNutrient } from './mealItems'
 import { DEFAULT_CUSTOM_TYPE, MEAL_TYPES, resolveMealTypeChange } from './mealTypes'
 
 // ── Sub-components ───────────────────────────────────────────────────────────
-
-interface FoodItemRef {
-  quantity?: number
-  calories?: number
-  protein?: number
-  carbs?: number
-  fat?: number
-  fiber?: number
-}
-
-interface FoodItemEdit {
-  food_item_id?: string
-  name: string
-  quantity?: number
-  unit?: string
-  /**
-   * Reference values for live display scaling. Captured at row creation
-   * (autocomplete pick: canonical default_quantity + canonical nutrients;
-   * existing item edit: server snapshot quantity + snapshot nutrients).
-   * Stripped before save — the backend re-derives the snapshot from the
-   * canonical food item × quantity.
-   */
-  ref?: FoodItemRef
-}
-
-/** Linearly scale a reference nutrient value to the current quantity. */
-const scaleNutrient = (
-  ref: FoodItemRef | undefined,
-  field: keyof Omit<FoodItemRef, 'quantity'>,
-  currentQuantity: number | undefined,
-): number | undefined => {
-  if (!ref) return undefined
-  const baseValue = ref[field]
-  if (typeof baseValue !== 'number') return undefined
-  if (ref.quantity === undefined || ref.quantity === 0) return baseValue
-  if (currentQuantity === undefined) return baseValue
-  return Math.round(((baseValue * currentQuantity) / ref.quantity) * 10) / 10
-}
 
 function MealTypeEditor({
   value,
@@ -210,6 +174,7 @@ function FoodItemRow({
               },
             })
           }}
+          onCreate={(name) => addFoodItemApi({ name })}
         />
         <input
           type="number"
@@ -348,44 +313,6 @@ function SaveIndicator({
 // ── Main component ───────────────────────────────────────────────────────────
 
 const FOOD_ITEM_DEBOUNCE_MS = 600
-
-const mealItemsToEdit = (
-  items?: {
-    name: string
-    food_item_id?: string
-    quantity?: number
-    unit?: string
-    calories?: number
-    protein?: number
-    carbs?: number
-    fat?: number
-    fiber?: number
-  }[],
-): FoodItemEdit[] =>
-  (items ?? []).map((fi) => ({
-    food_item_id: fi.food_item_id,
-    name: fi.name,
-    quantity: fi.quantity,
-    ref: {
-      calories: fi.calories,
-      carbs: fi.carbs,
-      fat: fi.fat,
-      fiber: fi.fiber,
-      protein: fi.protein,
-      quantity: fi.quantity,
-    },
-    unit: fi.unit,
-  }))
-
-const editItemsToBody = (items: FoodItemEdit[]): UpdateMealBody['food_items'] =>
-  items
-    .filter((fi) => fi.name.trim())
-    .map((fi) => ({
-      food_item_id: fi.food_item_id,
-      name: fi.name,
-      quantity: fi.quantity,
-      unit: fi.unit,
-    }))
 
 // eslint-disable-next-line complexity -- detail page with many independently auto-saved fields
 export function MealDetail() {

--- a/apps/web/src/pages/Meals/mealItems.test.ts
+++ b/apps/web/src/pages/Meals/mealItems.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+
+import { editItemsToBody, mealItemsToEdit, scaleNutrient } from './mealItems'
+
+describe('editItemsToBody', () => {
+  test('drops draft rows without food_item_id so autosave never implicitly creates items', () => {
+    // The bug this guards against: every autosave keystroke without a
+    // food_item_id was hitting backend findOrCreate and minting a new
+    // canonical food item per partial name ("A", "As", "Ask"…).
+    const body = editItemsToBody([
+      { food_item_id: 'abc-123', name: 'Banana', quantity: 1, unit: 'piece' },
+      { name: 'Asko' }, // user mid-type, no canonical pick yet
+      { name: 'Askorbi' },
+    ])
+    expect(body).toEqual([{ food_item_id: 'abc-123', name: 'Banana', quantity: 1, unit: 'piece' }])
+  })
+
+  test('drops rows with food_item_id but empty/whitespace name', () => {
+    expect(editItemsToBody([{ food_item_id: 'abc', name: '   ' }])).toEqual([])
+  })
+
+  test('keeps all rows that have both an id and a name', () => {
+    const body = editItemsToBody([
+      { food_item_id: 'a', name: 'A', quantity: 1 },
+      { food_item_id: 'b', name: 'B', quantity: 2, unit: 'g' },
+    ])
+    expect(body).toHaveLength(2)
+  })
+})
+
+describe('mealItemsToEdit', () => {
+  test('handles undefined input as empty list', () => {
+    expect(mealItemsToEdit(undefined)).toEqual([])
+  })
+
+  test('snapshots nutrient ref values for live scaling', () => {
+    const [row] = mealItemsToEdit([{ calories: 100, food_item_id: 'a', name: 'Apple', quantity: 50 }])
+    expect(row.ref).toEqual({
+      calories: 100,
+      carbs: undefined,
+      fat: undefined,
+      fiber: undefined,
+      protein: undefined,
+      quantity: 50,
+    })
+  })
+})
+
+describe('scaleNutrient', () => {
+  test('scales linearly to current quantity', () => {
+    expect(scaleNutrient({ calories: 100, quantity: 100 }, 'calories', 250)).toBe(250)
+  })
+
+  test('returns base value when reference quantity is 0 or missing', () => {
+    expect(scaleNutrient({ calories: 100, quantity: 0 }, 'calories', 50)).toBe(100)
+    expect(scaleNutrient({ calories: 100 }, 'calories', 50)).toBe(100)
+  })
+
+  test('returns undefined when ref or field is missing', () => {
+    expect(scaleNutrient(undefined, 'calories', 50)).toBeUndefined()
+    expect(scaleNutrient({ quantity: 100 }, 'calories', 50)).toBeUndefined()
+  })
+})

--- a/apps/web/src/pages/Meals/mealItems.ts
+++ b/apps/web/src/pages/Meals/mealItems.ts
@@ -1,0 +1,88 @@
+import type { UpdateMealBody } from '@aurboda/api-spec'
+
+export interface FoodItemRef {
+  quantity?: number
+  calories?: number
+  protein?: number
+  carbs?: number
+  fat?: number
+  fiber?: number
+}
+
+export interface FoodItemEdit {
+  food_item_id?: string
+  name: string
+  quantity?: number
+  unit?: string
+  /**
+   * Reference values for live display scaling. Captured at row creation
+   * (autocomplete pick: canonical default_quantity + canonical nutrients;
+   * existing item edit: server snapshot quantity + snapshot nutrients).
+   * Stripped before save — the backend re-derives the snapshot from the
+   * canonical food item × quantity.
+   */
+  ref?: FoodItemRef
+}
+
+export const mealItemsToEdit = (
+  items?: {
+    name: string
+    food_item_id?: string
+    quantity?: number
+    unit?: string
+    calories?: number
+    protein?: number
+    carbs?: number
+    fat?: number
+    fiber?: number
+  }[],
+): FoodItemEdit[] =>
+  (items ?? []).map((fi) => ({
+    food_item_id: fi.food_item_id,
+    name: fi.name,
+    quantity: fi.quantity,
+    ref: {
+      calories: fi.calories,
+      carbs: fi.carbs,
+      fat: fi.fat,
+      fiber: fi.fiber,
+      protein: fi.protein,
+      quantity: fi.quantity,
+    },
+    unit: fi.unit,
+  }))
+
+/**
+ * Build the food_items payload for an UpdateMeal request.
+ *
+ * Rows without `food_item_id` are treated as in-progress drafts (the user
+ * is still typing in the autocomplete and hasn't picked or created a
+ * canonical food item) and are excluded. This prevents the backend's
+ * findOrCreate path from being triggered implicitly by autosaved keystrokes
+ * — each partial name would otherwise become a new canonical food item
+ * (e.g. "A", "As", "Ask", "Asko"…). Creation must go through the explicit
+ * "+ Create" path in the autocomplete dropdown.
+ */
+export const editItemsToBody = (items: FoodItemEdit[]): UpdateMealBody['food_items'] =>
+  items
+    .filter((fi) => fi.food_item_id && fi.name.trim())
+    .map((fi) => ({
+      food_item_id: fi.food_item_id,
+      name: fi.name,
+      quantity: fi.quantity,
+      unit: fi.unit,
+    }))
+
+/** Linearly scale a reference nutrient value to the current quantity. */
+export const scaleNutrient = (
+  ref: FoodItemRef | undefined,
+  field: keyof Omit<FoodItemRef, 'quantity'>,
+  currentQuantity: number | undefined,
+): number | undefined => {
+  if (!ref) return undefined
+  const baseValue = ref[field]
+  if (typeof baseValue !== 'number') return undefined
+  if (ref.quantity === undefined || ref.quantity === 0) return baseValue
+  if (currentQuantity === undefined) return baseValue
+  return Math.round(((baseValue * currentQuantity) / ref.quantity) * 10) / 10
+}

--- a/apps/web/src/state/api/meals.ts
+++ b/apps/web/src/state/api/meals.ts
@@ -1,4 +1,5 @@
 import type {
+  AddFoodItemBody,
   AddMealBody,
   Meal as ApiMeal,
   FrequentFoodItem,
@@ -131,6 +132,20 @@ export const fetchFrequentFoodItemsApi = async (
     params: opts,
   })
   return response.data.data ?? []
+}
+
+export const addFoodItemApi = async (body: AddFoodItemBody): Promise<FoodItemEntity> => {
+  const { token } = auth.value
+  // Use the local FoodItemEntity shape on the response (matches the pattern
+  // in searchFoodItemsApi) — the api-spec FoodItemResponse has a boolean
+  // `is_composite` field that doesn't fit the local entity's index signature.
+  const response = await axios.post<{ data?: FoodItemEntity; error?: string; success: boolean }>(
+    `${API_URL}/food-items`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!response.data.data) throw new Error(response.data.error ?? 'Failed to create food item')
+  return response.data.data
 }
 
 export const searchFoodItemsApi = async (q: string, limit = 10): Promise<FoodItemEntity[]> => {


### PR DESCRIPTION
## Summary

- Typing in the meal food-item search was creating canonical food items on every autosave (one per partial name — `A`, `As`, `Ask`, `Asko`…), because the autosave posted `food_items` rows with the typed name but no `food_item_id`, and the backend's `resolveCanonical` falls through to `findOrCreate`.
- Autosave now drops draft rows without `food_item_id`; quantity/unit edits on resolved rows still flow through.
- `FoodItemAutocomplete` gains an optional `onCreate` hook — when provided, a `+ Create "<typed name>"` row is always appended as the last dropdown option (Linear/Notion style). Click or Enter creates the canonical item via `POST /food-items` and selects it. Wired up in meal logging; merge dialog and ingredient picker stay search-only.
- `editItemsToBody` / `mealItemsToEdit` extracted to `mealItems.ts` with unit tests covering the draft-filter behavior.

## Test plan

- [x] `pnpm --filter aurboda-web check` — typecheck + lint clean
- [x] `vitest run mealItems.test.ts` — 8/8 pass
- [ ] Manually: open a meal, type a non-existent name slowly, confirm no Food Item is created; click `+ Create "X"` and verify the row resolves with the new id and a `Food Items` page entry appears.
- [ ] Manually: existing meal items still autosave quantity/unit edits.
- [ ] Manually: merge dialog and recipe ingredient picker show no `+ Create` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)