### PR TITLE
feat(meals): align overview columns, marker legend, completed-day filter

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -285,6 +285,7 @@ export {
   getFrequentMeals,
   getMealById,
   getMealLogCompleted,
+  getMealLogCompletedInRange,
   getMeals,
   insertMeal,
   upsertMeal,

--- a/apps/backend/src/db/meals.integration.test.ts
+++ b/apps/backend/src/db/meals.integration.test.ts
@@ -7,8 +7,10 @@ import {
   getFrequentFoodItems,
   getFrequentMeals,
   getMealById,
+  getMealLogCompletedInRange,
   getMeals,
   insertMeal,
+  setMealLogCompleted,
   updateMeal,
 } from './meals.ts'
 
@@ -483,6 +485,25 @@ describe('Meals Integration Tests', () => {
       // Without the filter both items are returned.
       const all = await getFrequentFoodItems(user, { limit: 10, since_days: 30 })
       expect(all.map((r) => r.food_item_id).sort()).toEqual([oats, soup].sort())
+    })
+  })
+
+  describe('getMealLogCompletedInRange', () => {
+    test('returns only completed dates within [start, end]', async () => {
+      const user = getTestUser()
+      await setMealLogCompleted(user, '2025-04-01')
+      await setMealLogCompleted(user, '2025-04-05')
+      await setMealLogCompleted(user, '2025-04-10')
+      await setMealLogCompleted(user, '2025-05-01')
+
+      const result = await getMealLogCompletedInRange(user, '2025-04-02', '2025-04-30')
+      expect(result.sort()).toEqual(['2025-04-05', '2025-04-10'])
+    })
+
+    test('returns empty when no dates match', async () => {
+      const user = getTestUser()
+      const result = await getMealLogCompletedInRange(user, '2025-01-01', '2025-01-31')
+      expect(result).toEqual([])
     })
   })
 

--- a/apps/backend/src/db/meals.integration.test.ts
+++ b/apps/backend/src/db/meals.integration.test.ts
@@ -7,6 +7,7 @@ import {
   getFrequentFoodItems,
   getFrequentMeals,
   getMealById,
+  getMealLogCompleted,
   getMealLogCompletedInRange,
   getMeals,
   insertMeal,
@@ -504,6 +505,17 @@ describe('Meals Integration Tests', () => {
       const user = getTestUser()
       const result = await getMealLogCompletedInRange(user, '2025-01-01', '2025-01-31')
       expect(result).toEqual([])
+    })
+  })
+
+  describe('getMealLogCompleted', () => {
+    test('returns only the input dates that are marked complete (TZ-safe)', async () => {
+      const user = getTestUser()
+      await setMealLogCompleted(user, '2025-06-01')
+      await setMealLogCompleted(user, '2025-06-15')
+
+      const result = await getMealLogCompleted(user, ['2025-06-01', '2025-06-02', '2025-06-15'])
+      expect(result.sort()).toEqual(['2025-06-01', '2025-06-15'])
     })
   })
 

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -333,17 +333,22 @@ export const deleteMeal = async (user: string, id: string): Promise<boolean> => 
 // ============================================================================
 
 /**
- * Get completed dates within a range.
+ * Get which of the given YYYY-MM-DD dates are marked log-completed.
+ *
+ * Formats the date in SQL with TO_CHAR — a DATE column comes back as a JS
+ * Date at midnight in the Node process's local tz, and toISOString then
+ * shifts to UTC, which can drop the date back a day in any env east of UTC.
  */
 export const getMealLogCompleted = async (user: string, dates: string[]): Promise<string[]> => {
   if (dates.length === 0) return []
   const placeholders = dates.map((_, i) => `$${i + 1}`).join(', ')
   const result = await query(
     user,
-    `SELECT date FROM meal_log_completed WHERE date IN (${placeholders})`,
+    `SELECT TO_CHAR(date, 'YYYY-MM-DD') AS date FROM meal_log_completed
+       WHERE date IN (${placeholders})`,
     dates,
   )
-  return result.rows.map((r) => r.date.toISOString().slice(0, 10))
+  return result.rows.map((r) => r.date as string)
 }
 
 /**

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -347,6 +347,28 @@ export const getMealLogCompleted = async (user: string, dates: string[]): Promis
 }
 
 /**
+ * Get all completed dates within an inclusive [start, end] YYYY-MM-DD range.
+ *
+ * Formats the date in SQL with TO_CHAR rather than `date.toISOString().slice(0,10)`
+ * — a DATE column comes back as a JS Date at midnight in the Node process's
+ * local tz, and toISOString then shifts to UTC, which can drop the date back
+ * a day in any env east of UTC.
+ */
+export const getMealLogCompletedInRange = async (
+  user: string,
+  start: string,
+  end: string,
+): Promise<string[]> => {
+  const result = await query(
+    user,
+    `SELECT TO_CHAR(date, 'YYYY-MM-DD') AS date FROM meal_log_completed
+       WHERE date >= $1 AND date <= $2`,
+    [start, end],
+  )
+  return result.rows.map((r) => r.date as string)
+}
+
+/**
  * Mark a date as completed.
  */
 export const setMealLogCompleted = async (user: string, date: string): Promise<void> => {

--- a/apps/backend/src/mcp/nutrient-recommendation-tools.ts
+++ b/apps/backend/src/mcp/nutrient-recommendation-tools.ts
@@ -79,8 +79,8 @@ export const registerNutrientRecommendationTools = (server: McpServer, user: str
       'For each nutrient: avg = mean across days that have any meal (so sparse logs are not dragged toward zero), days_with_data, and total. calories_burned is null when no calories_total metric exists in the window.',
     ].join(' '),
     { ...nutrientPeriodSummaryQuerySchema.shape },
-    async ({ start, end, tz }) => {
-      const data = await getMealPeriodSummary(user, { end, start, tz })
+    async ({ start, end, tz, count_only_completed }) => {
+      const data = await getMealPeriodSummary(user, { count_only_completed, end, start, tz })
       return jsonResponse({ data, success: true })
     },
   )

--- a/apps/backend/src/routes/meals-router.test.ts
+++ b/apps/backend/src/routes/meals-router.test.ts
@@ -53,6 +53,7 @@ describe('GET /meals/period-summary', () => {
       end: '2025-01-07',
       days_in_range: 7,
       days_with_meals: 7,
+      days_completed: 7,
       nutrients: { calories: { avg: 2100, total: 14_700, days_with_value: 7 } },
       calories_burned: { avg: 2400, days_with_data: 7 },
     })
@@ -73,6 +74,7 @@ describe('GET /meals/period-summary', () => {
       end: '2025-01-01',
       days_in_range: 1,
       days_with_meals: 0,
+      days_completed: 0,
       nutrients: {},
       calories_burned: null,
     })
@@ -82,6 +84,44 @@ describe('GET /meals/period-summary', () => {
     expect(periodSvc.getMealPeriodSummary).toHaveBeenCalledWith(
       'tester',
       expect.objectContaining({ tz: 'Europe/Stockholm' }),
+    )
+  })
+
+  test('passes through count_only_completed=true', async () => {
+    vi.mocked(periodSvc.getMealPeriodSummary).mockResolvedValue({
+      start: '2025-01-01',
+      end: '2025-01-07',
+      days_in_range: 7,
+      days_with_meals: 3,
+      days_completed: 3,
+      nutrients: {},
+      calories_burned: null,
+    })
+    await supertest(buildApp()).get(
+      '/meals/period-summary?start=2025-01-01&end=2025-01-07&count_only_completed=true',
+    )
+    expect(periodSvc.getMealPeriodSummary).toHaveBeenCalledWith(
+      'tester',
+      expect.objectContaining({ count_only_completed: true }),
+    )
+  })
+
+  test('count_only_completed=false stays falsy', async () => {
+    vi.mocked(periodSvc.getMealPeriodSummary).mockResolvedValue({
+      start: '2025-01-01',
+      end: '2025-01-07',
+      days_in_range: 7,
+      days_with_meals: 7,
+      days_completed: 0,
+      nutrients: {},
+      calories_burned: null,
+    })
+    await supertest(buildApp()).get(
+      '/meals/period-summary?start=2025-01-01&end=2025-01-07&count_only_completed=false',
+    )
+    expect(periodSvc.getMealPeriodSummary).toHaveBeenCalledWith(
+      'tester',
+      expect.objectContaining({ count_only_completed: false }),
     )
   })
 

--- a/apps/backend/src/routes/meals-router.ts
+++ b/apps/backend/src/routes/meals-router.ts
@@ -92,6 +92,7 @@ export const createMealsRouter = (authMiddleware: AnyMiddleware): TypedRouter =>
     validateQuery(nutrientPeriodSummaryQuerySchema),
     async (req, res) => {
       const data = await getMealPeriodSummary(req.user!, {
+        count_only_completed: req.query.count_only_completed,
         end: req.query.end,
         start: req.query.start,
         tz: req.query.tz,

--- a/apps/backend/src/services/queries/meal-period-summary.test.ts
+++ b/apps/backend/src/services/queries/meal-period-summary.test.ts
@@ -8,6 +8,7 @@ import { getMealPeriodSummary } from './meal-period-summary.ts'
 vi.mock('../../db', () => ({
   getMeals: vi.fn(),
   getMealFoodItemsBatch: vi.fn(),
+  getMealLogCompletedInRange: vi.fn(),
   getTimeSeriesBucketed: vi.fn(),
 }))
 
@@ -32,6 +33,7 @@ describe('getMealPeriodSummary', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(db.getTimeSeriesBucketed).mockResolvedValue([])
+    vi.mocked(db.getMealLogCompletedInRange).mockResolvedValue([])
   })
 
   test('averages over days that have data, not the full range', async () => {
@@ -143,6 +145,77 @@ describe('getMealPeriodSummary', () => {
     const result = await getMealPeriodSummary('user', { start: '2025-01-10', end: '2025-01-12' })
 
     expect(result.calories_burned).toEqual({ avg: 2500, days_with_data: 2 })
+  })
+
+  test('reports days_completed regardless of count_only_completed', async () => {
+    vi.mocked(db.getMeals).mockResolvedValue([
+      mealAt('m1', '2025-03-01T12:00:00Z'),
+      mealAt('m2', '2025-03-02T12:00:00Z'),
+      mealAt('m3', '2025-03-03T12:00:00Z'),
+    ])
+    vi.mocked(db.getMealFoodItemsBatch).mockResolvedValue(
+      new Map<string, MealFoodItemLink[]>([
+        ['m1', [link('m1', { calories: 600 })]],
+        ['m2', [link('m2', { calories: 900 })]],
+        ['m3', [link('m3', { calories: 1200 })]],
+      ]),
+    )
+    vi.mocked(db.getMealLogCompletedInRange).mockResolvedValue(['2025-03-01', '2025-03-03'])
+
+    const noFilter = await getMealPeriodSummary('user', { start: '2025-03-01', end: '2025-03-03' })
+    expect(noFilter.days_completed).toBe(2)
+    expect(noFilter.days_with_meals).toBe(3)
+    expect(noFilter.nutrients.calories.avg).toBe(900) // (600+900+1200)/3
+  })
+
+  test('count_only_completed=true averages only over completed days', async () => {
+    vi.mocked(db.getMeals).mockResolvedValue([
+      mealAt('m1', '2025-03-01T12:00:00Z'),
+      mealAt('m2', '2025-03-02T12:00:00Z'),
+      mealAt('m3', '2025-03-03T12:00:00Z'),
+    ])
+    vi.mocked(db.getMealFoodItemsBatch).mockResolvedValue(
+      new Map<string, MealFoodItemLink[]>([
+        ['m1', [link('m1', { calories: 600 })]],
+        ['m2', [link('m2', { calories: 900 })]],
+        ['m3', [link('m3', { calories: 1200 })]],
+      ]),
+    )
+    // Only the 1st and 3rd are marked complete.
+    vi.mocked(db.getMealLogCompletedInRange).mockResolvedValue(['2025-03-01', '2025-03-03'])
+
+    const result = await getMealPeriodSummary('user', {
+      start: '2025-03-01',
+      end: '2025-03-03',
+      count_only_completed: true,
+    })
+    expect(result.days_completed).toBe(2)
+    expect(result.days_with_meals).toBe(2) // March 2 dropped
+    expect(result.nutrients.calories.avg).toBe(900) // (600+1200)/2
+    expect(result.nutrients.calories.total).toBe(1800)
+  })
+
+  test('count_only_completed=true with no completed days yields empty nutrients', async () => {
+    vi.mocked(db.getMeals).mockResolvedValue([
+      mealAt('m1', '2025-03-01T12:00:00Z'),
+      mealAt('m2', '2025-03-02T12:00:00Z'),
+    ])
+    vi.mocked(db.getMealFoodItemsBatch).mockResolvedValue(
+      new Map<string, MealFoodItemLink[]>([
+        ['m1', [link('m1', { calories: 600 })]],
+        ['m2', [link('m2', { calories: 900 })]],
+      ]),
+    )
+    vi.mocked(db.getMealLogCompletedInRange).mockResolvedValue([])
+
+    const result = await getMealPeriodSummary('user', {
+      start: '2025-03-01',
+      end: '2025-03-02',
+      count_only_completed: true,
+    })
+    expect(result.days_completed).toBe(0)
+    expect(result.days_with_meals).toBe(0)
+    expect(result.nutrients).toEqual({})
   })
 
   test('returns empty nutrients map when there are no meals', async () => {

--- a/apps/backend/src/services/queries/meal-period-summary.ts
+++ b/apps/backend/src/services/queries/meal-period-summary.ts
@@ -14,6 +14,7 @@ import { NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 import {
   getMeals,
   getMealFoodItemsBatch,
+  getMealLogCompletedInRange,
   getTimeSeriesBucketed,
   type MealFoodItemLink,
 } from '../../db/index.ts'
@@ -24,6 +25,8 @@ export interface MealPeriodSummaryInput {
   end: string // YYYY-MM-DD
   /** IANA tz used to bucket meals into local days; defaults to UTC. */
   tz?: string
+  /** When true, drop days that aren't marked log-completed before averaging. */
+  count_only_completed?: boolean
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -156,13 +159,24 @@ export const getMealPeriodSummary = async (
   const { end } = dateOnlyToRange(input.end, tz)
   const daysInRange = inclusiveDayCount(input.start, input.end)
 
-  const meals = await getMeals(user, { end, start })
+  const [meals, completedDates] = await Promise.all([
+    getMeals(user, { end, start }),
+    getMealLogCompletedInRange(user, input.start, input.end),
+  ])
   const junctionMap = await getMealFoodItemsBatch(
     user,
     meals.map((m) => m.id),
   )
 
   const dayTotals = accumulateDayTotals(meals, junctionMap, tz)
+
+  if (input.count_only_completed) {
+    const completedSet = new Set(completedDates)
+    for (const dayKey of dayTotals.keys()) {
+      if (!completedSet.has(dayKey)) dayTotals.delete(dayKey)
+    }
+  }
+
   const daysWithMeals = dayTotals.size
   const nutrients = computeNutrientStats(dayTotals, daysWithMeals)
   const calories_burned = await computeCaloriesBurned(user, start, end, tz)
@@ -172,6 +186,7 @@ export const getMealPeriodSummary = async (
     end: input.end,
     days_in_range: daysInRange,
     days_with_meals: daysWithMeals,
+    days_completed: completedDates.length,
     nutrients,
     calories_burned,
   }

--- a/apps/web/src/components/ReferenceRangeBar.tsx
+++ b/apps/web/src/components/ReferenceRangeBar.tsx
@@ -7,6 +7,9 @@ export interface RangeMarker {
   flag?: ReportFlag
   /** Short label shown above the marker (e.g. "1d", "7d"). */
   label?: string
+  /** Identifier exposed as data-window on the marker so CSS can style or hide
+   * it based on the active selection. */
+  windowKey?: string
 }
 
 interface ReferenceRangeBarProps {
@@ -152,6 +155,7 @@ export function ReferenceRangeBar({
               key={m.label ?? i}
               class="ref-range-marker"
               data-marker-index={i}
+              data-window={m.windowKey}
               style={{ backgroundColor: color, left: `${pct}%` }}
               title={m.label ? `${m.label}: ${m.value}` : `${m.value}`}
             >

--- a/apps/web/src/pages/Meals/MealsOverview.tsx
+++ b/apps/web/src/pages/Meals/MealsOverview.tsx
@@ -112,23 +112,113 @@ interface WindowData {
   summary: NutrientPeriodSummary | undefined
 }
 
-function EnergySection({ windows, activeKey }: { windows: WindowData[]; activeKey: WindowKey }) {
+/**
+ * Shared <colgroup> so every <table class="overview-table"> on the page lays
+ * its columns out identically — that's what lines the 1d/7d/30d/90d numbers
+ * up across the Energy Balance section and the per-category nutrient tables.
+ * Requires `table-layout: fixed` on .overview-table.
+ */
+function OverviewColgroup() {
   return (
-    <section class="overview-energy">
+    <colgroup>
+      <col class="col-name" />
+      <col class="col-window" data-window="1" />
+      <col class="col-window" data-window="7" />
+      <col class="col-window" data-window="30" />
+      <col class="col-window" data-window="90" />
+      <col class="col-range" />
+    </colgroup>
+  )
+}
+
+function WindowHeaderCell({
+  w,
+  activeKey,
+  daysCompleted,
+  countOnlyCompleted,
+}: {
+  w: WindowData
+  activeKey: WindowKey
+  daysCompleted: number | undefined
+  countOnlyCompleted: boolean
+}) {
+  const showSub = w.window.days > 1 && daysCompleted !== undefined
+  return (
+    <th
+      class="num window-col"
+      data-window={w.window.key}
+      data-active={w.window.key === activeKey ? 'true' : 'false'}
+    >
+      <span class="window-label">{w.window.label}</span>
+      <span class="window-tick" aria-hidden="true" data-window={w.window.key} />
+      {showSub && (
+        <span class="window-sub">
+          {countOnlyCompleted ? `avg from ${daysCompleted} completed` : `${daysCompleted} completed`}
+        </span>
+      )}
+    </th>
+  )
+}
+
+function OverviewThead({
+  windows,
+  activeKey,
+  countOnlyCompleted,
+  nameLabel,
+  showRangeHeader,
+}: {
+  windows: WindowData[]
+  activeKey: WindowKey
+  countOnlyCompleted: boolean
+  nameLabel: string
+  showRangeHeader: boolean
+}) {
+  return (
+    <thead>
+      <tr>
+        <th class="col-name-header">{nameLabel}</th>
+        {windows.map((w) => (
+          <WindowHeaderCell
+            key={w.window.key}
+            w={w}
+            activeKey={activeKey}
+            daysCompleted={w.summary?.days_completed}
+            countOnlyCompleted={countOnlyCompleted}
+          />
+        ))}
+        <th class="range-col">{showRangeHeader ? 'Range' : ''}</th>
+      </tr>
+    </thead>
+  )
+}
+
+function EnergySection({
+  windows,
+  activeKey,
+  countOnlyCompleted,
+}: {
+  windows: WindowData[]
+  activeKey: WindowKey
+  countOnlyCompleted: boolean
+}) {
+  return (
+    <section class="overview-group overview-energy">
       <h3>Energy balance</h3>
-      <div class="energy-grid">
-        <div class="energy-grid-header">
-          <span />
-          {windows.map((w) => (
-            <span key={w.window.key} class="energy-col-label" data-window={w.window.key}>
-              {w.window.label}
-            </span>
-          ))}
-        </div>
-        <EnergyRow label="Eaten / day" windows={windows} activeKey={activeKey} kind="eaten" />
-        <EnergyRow label="Burned / day" windows={windows} activeKey={activeKey} kind="burned" />
-        <EnergyRow label="Balance" windows={windows} activeKey={activeKey} kind="balance" />
-      </div>
+      <table class="overview-table">
+        <OverviewColgroup />
+        <OverviewThead
+          windows={windows}
+          activeKey={activeKey}
+          countOnlyCompleted={countOnlyCompleted}
+          nameLabel=""
+          showRangeHeader={false}
+        />
+        <tbody>
+          <EnergyRow label="Eaten / day" windows={windows} activeKey={activeKey} kind="eaten" />
+          <EnergyRow label="Burned / day" windows={windows} activeKey={activeKey} kind="burned" />
+          <EnergyRow label="Balance" windows={windows} activeKey={activeKey} kind="balance" />
+        </tbody>
+      </table>
     </section>
   )
 }
@@ -148,8 +238,8 @@ function EnergyCell({ w, kind, activeKey }: { w: WindowData; kind: EnergyKind; a
   const value = energyValueFor(w, kind)
   const cls = kind === 'balance' ? balanceClass(value) : ''
   return (
-    <span
-      class={`energy-grid-cell ${cls}`}
+    <td
+      class={`num window-col energy-cell ${cls}`}
       data-window={w.window.key}
       data-active={w.window.key === activeKey ? 'true' : 'false'}
     >
@@ -164,7 +254,7 @@ function EnergyCell({ w, kind, activeKey }: { w: WindowData; kind: EnergyKind; a
       ) : (
         <span class="energy-num muted">—</span>
       )}
-    </span>
+    </td>
   )
 }
 
@@ -180,12 +270,13 @@ function EnergyRow({
   kind: EnergyKind
 }) {
   return (
-    <div class="energy-grid-row">
-      <span class="energy-row-label">{label}</span>
+    <tr>
+      <td class="energy-row-label">{label}</td>
       {windows.map((w) => (
         <EnergyCell key={w.window.key} w={w} kind={kind} activeKey={activeKey} />
       ))}
-    </div>
+      <td class="range-col" />
+    </tr>
   )
 }
 
@@ -214,6 +305,7 @@ function NutrientRowView({
                 flag: flagFor(c.stat.avg, recommendation.recommended_low, recommendation.recommended_high),
                 label: c.label,
                 value: c.stat.avg,
+                windowKey: c.windowKey,
               },
             ]
           : [],
@@ -270,32 +362,26 @@ function CategorySection({
   rows,
   windows,
   activeKey,
+  countOnlyCompleted,
 }: {
   label: string
   rows: CategoryRow[]
   windows: WindowData[]
   activeKey: WindowKey
+  countOnlyCompleted: boolean
 }) {
   return (
     <section class="overview-group">
       <h3>{label}</h3>
       <table class="overview-table">
-        <thead>
-          <tr>
-            <th>Nutrient</th>
-            {windows.map((w) => (
-              <th
-                key={w.window.key}
-                class="num window-col"
-                data-window={w.window.key}
-                data-active={w.window.key === activeKey ? 'true' : 'false'}
-              >
-                {w.window.label}
-              </th>
-            ))}
-            <th class="range-col">Range</th>
-          </tr>
-        </thead>
+        <OverviewColgroup />
+        <OverviewThead
+          windows={windows}
+          activeKey={activeKey}
+          countOnlyCompleted={countOnlyCompleted}
+          nameLabel="Nutrient"
+          showRangeHeader
+        />
         <tbody>
           {rows.map((row) => (
             <NutrientRowView key={row.field.name} {...row} activeKey={activeKey} />
@@ -334,17 +420,30 @@ export function MealsOverview() {
   const isLoggedIn = auth.value.token
   const [endDate, setEndDate] = useState<string>(ymd(new Date()))
   const [activeKey, setActiveKey] = useState<WindowKey>('30')
+  const [countOnlyCompleted, setCountOnlyCompleted] = useState<boolean>(true)
   const tz = userTz()
 
   const ranges = useMemo(() => WINDOWS.map((w) => ({ window: w, ...rangeFor(endDate, w.days) })), [endDate])
 
+  // 1D never filters by completion — a single day is either logged or not, the
+  // toggle would just blank the column. Longer windows pass the user's
+  // preference through.
   const queries = useQueries({
-    queries: ranges.map((r) => ({
-      enabled: !!isLoggedIn,
-      queryFn: () => fetchMealsPeriodSummary({ end: r.end, start: r.start, tz }),
-      queryKey: ['mealsPeriodSummary', r.start, r.end, tz],
-      staleTime: 60_000,
-    })),
+    queries: ranges.map((r) => {
+      const filterCompleted = countOnlyCompleted && r.window.days > 1
+      return {
+        enabled: !!isLoggedIn,
+        queryFn: () =>
+          fetchMealsPeriodSummary({
+            count_only_completed: filterCompleted,
+            end: r.end,
+            start: r.start,
+            tz,
+          }),
+        queryKey: ['mealsPeriodSummary', r.start, r.end, tz, filterCompleted],
+        staleTime: 60_000,
+      }
+    }),
   })
 
   const isAnyLoading = queries.some((q) => q.isLoading)
@@ -381,13 +480,25 @@ export function MealsOverview() {
         <div class="overview-window-control">
           <WindowSelector windowKey={activeKey} onChange={setActiveKey} />
         </div>
+        <label class="overview-completed-toggle" data-hide-when-active="1">
+          <input
+            type="checkbox"
+            checked={countOnlyCompleted}
+            onChange={(e) => setCountOnlyCompleted((e.target as HTMLInputElement).checked)}
+          />
+          <span>Only include completed days</span>
+        </label>
       </div>
 
       {isAnyLoading && <p class="loading">Loading…</p>}
 
       {!isAnyLoading && (
         <>
-          <EnergySection windows={windowsData} activeKey={activeKey} />
+          <EnergySection
+            windows={windowsData}
+            activeKey={activeKey}
+            countOnlyCompleted={countOnlyCompleted}
+          />
           {NUTRIENT_CATEGORIES.map(({ key, label }) => {
             const rows = rowsByCategory.get(key)
             if (!rows || rows.length === 0) return null
@@ -398,6 +509,7 @@ export function MealsOverview() {
                 rows={rows}
                 windows={windowsData}
                 activeKey={activeKey}
+                countOnlyCompleted={countOnlyCompleted}
               />
             )
           })}

--- a/apps/web/src/pages/Meals/MealsOverview.tsx
+++ b/apps/web/src/pages/Meals/MealsOverview.tsx
@@ -134,15 +134,20 @@ function OverviewColgroup() {
 function WindowHeaderCell({
   w,
   activeKey,
-  daysCompleted,
   countOnlyCompleted,
 }: {
   w: WindowData
   activeKey: WindowKey
-  daysCompleted: number | undefined
   countOnlyCompleted: boolean
 }) {
-  const showSub = w.window.days > 1 && daysCompleted !== undefined
+  // The actual avg denominator is `days_with_meals` (after the optional
+  // completed-day filter), not `days_completed` — a day marked complete with
+  // no meal logged doesn't contribute to the average, so showing the bare
+  // completed count would overstate it. `days_completed` is still useful as
+  // the "marked complete" hint when the filter is off.
+  const showSub = w.window.days > 1 && w.summary !== undefined
+  const denominator = w.summary?.days_with_meals
+  const completed = w.summary?.days_completed
   return (
     <th
       class="num window-col"
@@ -153,7 +158,9 @@ function WindowHeaderCell({
       <span class="window-tick" aria-hidden="true" data-window={w.window.key} />
       {showSub && (
         <span class="window-sub">
-          {countOnlyCompleted ? `avg from ${daysCompleted} completed` : `${daysCompleted} completed`}
+          {countOnlyCompleted
+            ? `avg from ${denominator} completed`
+            : `${completed} of ${denominator} completed`}
         </span>
       )}
     </th>
@@ -182,7 +189,6 @@ function OverviewThead({
             key={w.window.key}
             w={w}
             activeKey={activeKey}
-            daysCompleted={w.summary?.days_completed}
             countOnlyCompleted={countOnlyCompleted}
           />
         ))}

--- a/apps/web/src/pages/Meals/style.css
+++ b/apps/web/src/pages/Meals/style.css
@@ -972,40 +972,13 @@ a.meal-name:hover {
   color: #374151;
 }
 
-/* Energy grid: label column + one column per window. On narrow the
-   media query below collapses to 2 columns (label + active window). */
-.energy-grid {
-  display: grid;
-  row-gap: 0.5rem;
-  column-gap: 1rem;
-  align-items: baseline;
-  grid-template-columns: minmax(120px, max-content) repeat(4, minmax(0, 1fr));
-}
-
-.energy-grid-header,
-.energy-grid-row {
-  display: contents;
-}
-
-.energy-col-label {
-  font-size: 0.75rem;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  text-align: right;
-}
-
 .energy-row-label {
   font-size: 0.8rem;
   color: #6b7280;
 }
 
-.energy-grid-cell {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  text-align: right;
-  gap: 0.1rem;
+.overview-table .energy-cell {
+  vertical-align: baseline;
 }
 
 .energy-num {
@@ -1015,11 +988,11 @@ a.meal-name:hover {
   color: #111827;
 }
 
-.energy-grid-cell.positive .energy-num {
+.energy-cell.positive .energy-num {
   color: #b45309;
 }
 
-.energy-grid-cell.negative .energy-num {
+.energy-cell.negative .energy-num {
   color: #166534;
 }
 
@@ -1029,6 +1002,7 @@ a.meal-name:hover {
 }
 
 .energy-sub {
+  display: block;
   font-size: 0.7rem;
   color: #6b7280;
 }
@@ -1038,6 +1012,23 @@ a.meal-name:hover {
   display: none;
 }
 
+.overview-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+}
+
+.overview-completed-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+  cursor: pointer;
+  user-select: none;
+}
+
 .overview-group h3 {
   margin: 0 0 0.5rem;
   font-size: 0.9rem;
@@ -1045,10 +1036,21 @@ a.meal-name:hover {
   color: #374151;
 }
 
+/* Shared layout so Energy, Macros, Extended, etc. share the same column
+   widths and the per-window numbers line up vertically across the page. */
 .overview-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   font-size: 0.9rem;
+}
+
+.overview-table col.col-window {
+  width: 13%;
+}
+
+.overview-table col.col-range {
+  width: 22%;
 }
 
 .overview-table th {
@@ -1059,6 +1061,7 @@ a.meal-name:hover {
   text-transform: uppercase;
   padding: 0.25rem 0.5rem;
   border-bottom: 1px solid #e5e7eb;
+  vertical-align: bottom;
 }
 
 .overview-table th.num,
@@ -1083,7 +1086,7 @@ a.meal-name:hover {
 }
 
 .overview-table .range-col {
-  min-width: 160px;
+  /* width comes from <col class="col-range"> */
 }
 
 .overview-table .nutrient-unit {
@@ -1095,7 +1098,76 @@ a.meal-name:hover {
   color: #c4c8cf;
 }
 
-/* Narrow: hide non-active per-window cells, show selector. */
+/* Header tick legend — thin line for 1d, progressively thicker for 7d/30d/90d.
+   Mirrors the marker thickness on the range bars so the user can match
+   markers to windows. The marker bars themselves also vary in width below. */
+.overview-table th.window-col {
+  position: relative;
+}
+
+.window-label {
+  display: inline-block;
+}
+
+.window-tick {
+  display: block;
+  margin: 0.15rem 0 0 auto;
+  height: 8px;
+  background: #6b7280;
+  border-radius: 1px;
+}
+
+.window-tick[data-window='1'] {
+  width: 2px;
+}
+
+.window-tick[data-window='7'] {
+  width: 3px;
+}
+
+.window-tick[data-window='30'] {
+  width: 4px;
+}
+
+.window-tick[data-window='90'] {
+  width: 5px;
+}
+
+.window-sub {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.65rem;
+  color: #9ca3af;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  white-space: normal;
+  line-height: 1.1;
+}
+
+/* Vary range-bar marker thickness so each window has a recognisable weight. */
+.ref-range-marker[data-window='1'] {
+  width: 2px;
+  transform: translateX(-1px);
+}
+
+.ref-range-marker[data-window='7'] {
+  width: 3px;
+  transform: translateX(-1.5px);
+}
+
+.ref-range-marker[data-window='30'] {
+  width: 4px;
+  transform: translateX(-2px);
+}
+
+.ref-range-marker[data-window='90'] {
+  width: 5px;
+  transform: translateX(-2.5px);
+}
+
+/* Narrow: hide non-active per-window cells, show selector, hide
+   non-active markers on the range bars too. */
 @media (max-width: 759px) {
   .overview-window-control {
     display: inline-flex;
@@ -1108,8 +1180,34 @@ a.meal-name:hover {
     display: none;
   }
 
-  .energy-grid {
-    grid-template-columns: minmax(120px, max-content) minmax(0, 1fr);
+  /* Toggle is meaningless on a 1-day window. */
+  .meals-overview[data-active='1'] .overview-completed-toggle[data-hide-when-active='1'] {
+    display: none;
+  }
+
+  .overview-table {
+    /* With only one window column visible, give it more room. */
+    table-layout: auto;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .overview-energy {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .overview-energy h3,
+  .overview-group h3 {
+    color: #e5e7eb;
+  }
+
+  .energy-num {
+    color: #f3f4f6;
+  }
+
+  .window-tick {
+    background: #9ca3af;
   }
 }
 

--- a/docs/features/meals.md
+++ b/docs/features/meals.md
@@ -91,7 +91,7 @@ Auth is read from `~/.config/aurboda/config`.
 - `DELETE /meals/:id` -- delete a meal
 - `PUT /meals/log-completed/:date` -- mark day as logging-complete
 - `DELETE /meals/log-completed/:date` -- unmark
-- `GET /meals/period-summary?start=&end=&tz=` -- daily-averaged nutrient intake + averaged calories_total burn
+- `GET /meals/period-summary?start=&end=&tz=&count_only_completed=` -- daily-averaged nutrient intake + averaged calories_total burn. When `count_only_completed=true`, only days marked as log-completed contribute to averages; the response always reports `days_completed` so the UI can show "avg from N completed".
 - `GET /nutrient-recommendations` -- effective merged list (NNR2023 + user overrides)
 - `PUT /nutrient-recommendations/:nutrient_name` -- upsert a user override (pass null on a bound to suppress the central default)
 - `DELETE /nutrient-recommendations/:nutrient_name` -- revert to central default

--- a/packages/api-spec/src/schemas/nutrient-recommendations.ts
+++ b/packages/api-spec/src/schemas/nutrient-recommendations.ts
@@ -173,6 +173,14 @@ export const nutrientPeriodSummaryQuerySchema = z
       .refine(isValidTimezone, { message: 'tz must be a valid IANA timezone' })
       .optional()
       .meta({ description: 'IANA timezone (e.g. "Europe/Stockholm") for bucketing meals into local days' }),
+    count_only_completed: z
+      .union([z.boolean(), z.enum(['true', 'false'])])
+      .transform((v) => v === true || v === 'true')
+      .optional()
+      .meta({
+        description:
+          'When true, only days marked as log-completed contribute to averages. Affects days_with_meals and per-nutrient avg denominators. Defaults to false.',
+      }),
   })
   .refine((q) => q.start <= q.end, { message: 'start must be on or before end', path: ['start'] })
   .refine((q) => dayCount(q.start, q.end) <= NUTRIENT_PERIOD_SUMMARY_MAX_DAYS, {
@@ -217,7 +225,11 @@ export const nutrientPeriodSummarySchema = z
     days_in_range: z.number().int().meta({ description: 'Total days from start to end inclusive' }),
     days_with_meals: z.number().int().meta({
       description:
-        'Number of days in the range that had at least one meal logged. Used as the denominator for every per-nutrient avg so a sparse log isn’t pulled toward zero by missing days.',
+        'Number of days in the range that had at least one meal logged (and were log-completed, when count_only_completed=true). Used as the denominator for every per-nutrient avg so a sparse log isn’t pulled toward zero by missing days.',
+    }),
+    days_completed: z.number().int().meta({
+      description:
+        'Number of days in the range that the user marked as log-completed. Reported regardless of count_only_completed so the UI can show "avg from N completed".',
     }),
     nutrients: z.record(z.string(), nutrientPeriodStatSchema).meta({
       description: 'Per-nutrient stats keyed by nutrient field name',


### PR DESCRIPTION
## Summary
- **Column alignment**: convert Energy Balance to a `<table class=\"overview-table\">` matching the per-category tables, with a shared `<colgroup>` + `table-layout: fixed`, so 1d/7d/30d/90d numbers line up across the whole page.
- **Marker legend on wide view**: a small tick under each window header (thin→thick for 1d→90d) plus matching marker thickness on the range bars makes it obvious which marker belongs to which window.
- **Marker filter on narrow view**: only the active window's marker shows on the range bar.
- **Completed-day filter** (backend + frontend): new `count_only_completed` query param on `GET /meals/period-summary` (and `query_meals_period_summary` MCP tool). When set, only days marked as log-completed contribute to averages. The response always reports `days_completed`. Frontend checkbox \"Only include completed days\" defaults on; it's never sent for the 1D window, and the checkbox is hidden on narrow when 1D is the active window.
- **Subtitle**: each multi-day window header shows \"avg from N completed\".

## Test plan
- [x] `pnpm fix` clean
- [x] `pnpm check` clean (0 errors)
- [x] Backend unit + integration tests pass (2202 tests)
- [x] `pnpm --filter aurboda-web build` succeeds
- [ ] Verify in browser: columns align, header ticks visible on wide, single marker on narrow, checkbox toggles avg
- [ ] Verify on mobile width: checkbox hides when 1D selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)