### PR TITLE
fix(activities): dedupe insertActivities batch by SQL conflict key

### DIFF
--- a/apps/backend/src/db/activities.integration.test.ts
+++ b/apps/backend/src/db/activities.integration.test.ts
@@ -11,6 +11,7 @@ import {
   getOverlappingActivities,
   getOverrideForActivity,
   getSleepSessions,
+  insertActivities,
   insertActivity,
   insertOverride,
   markActivityDetailSynced,
@@ -130,6 +131,74 @@ describe('Activities Integration Tests', () => {
       // Should NOT need detail re-sync
       const needingDetail = await getActivitiesNeedingDetail(user)
       expect(needingDetail).toHaveLength(0)
+    })
+  })
+
+  describe('insertActivities batch dedupe', () => {
+    test('dedupes duplicate (source, external_id) within a single batch (last write wins)', async () => {
+      const user = getTestUser()
+
+      await insertActivities(user, [
+        {
+          activity_type: 'exercise',
+          data: { calories: 100 },
+          end_time: new Date('2026-05-05T10:30:00Z'),
+          external_id: 'hc-dup-1',
+          source: 'health_connect',
+          start_time: new Date('2026-05-05T10:00:00Z'),
+          title: 'First',
+        },
+        {
+          activity_type: 'exercise',
+          data: { calories: 200 },
+          end_time: new Date('2026-05-05T10:45:00Z'),
+          external_id: 'hc-dup-1',
+          source: 'health_connect',
+          start_time: new Date('2026-05-05T10:00:00Z'),
+          title: 'Second',
+        },
+      ])
+
+      const activities = await getActivities(
+        user,
+        'exercise',
+        new Date('2026-05-05T00:00:00Z'),
+        new Date('2026-05-05T23:59:59Z'),
+      )
+      expect(activities).toHaveLength(1)
+      expect(activities[0].title).toBe('Second')
+      expect(activities[0].data).toEqual({ calories: 200 })
+    })
+
+    test('dedupes duplicate (source, type, start_time) without external_id', async () => {
+      const user = getTestUser()
+
+      await insertActivities(user, [
+        {
+          activity_type: 'sleep',
+          end_time: new Date('2026-05-06T07:00:00Z'),
+          source: 'health_connect',
+          start_time: new Date('2026-05-05T23:00:00Z'),
+          title: 'A',
+        },
+        {
+          activity_type: 'sleep',
+          end_time: new Date('2026-05-06T07:30:00Z'),
+          source: 'health_connect',
+          start_time: new Date('2026-05-05T23:00:00Z'),
+          title: 'B',
+        },
+      ])
+
+      const activities = await getActivities(
+        user,
+        'sleep',
+        new Date('2026-05-05T00:00:00Z'),
+        new Date('2026-05-06T23:59:59Z'),
+      )
+      expect(activities).toHaveLength(1)
+      expect(activities[0].title).toBe('B')
+      expect(activities[0].end_time).toEqual(new Date('2026-05-06T07:30:00Z'))
     })
   })
 

--- a/apps/backend/src/db/activities/mutations.ts
+++ b/apps/backend/src/db/activities/mutations.ts
@@ -231,8 +231,24 @@ export const insertActivities = async (
   if (activities.length === 0) return []
 
   // Split into external_id and non-external_id batches for different conflict targets
-  const withExtId = activities.filter((a) => a.external_id)
-  const withoutExtId = activities.filter((a) => !a.external_id)
+  const withExtIdAll = activities.filter((a) => a.external_id)
+  const withoutExtIdAll = activities.filter((a) => !a.external_id)
+
+  // Dedupe within each batch by the SQL conflict key. Postgres' ON CONFLICT
+  // DO UPDATE can only touch each existing row once per command, so a batch
+  // containing two rows that hit the same key (e.g. an HC sync that re-sends
+  // the same ExerciseSessionRecord, or two records sharing
+  // (source, activity_type, start_time)) raises 21000. Last write wins,
+  // matching the upsert semantics callers already rely on.
+  const withExtIdMap = new Map<string, Activity>()
+  for (const a of withExtIdAll) withExtIdMap.set(`${a.source}|${a.external_id}`, a)
+  const withExtId = Array.from(withExtIdMap.values())
+
+  const withoutExtIdMap = new Map<string, Activity>()
+  for (const a of withoutExtIdAll) {
+    withoutExtIdMap.set(`${a.source}|${a.activity_type}|${a.start_time.getTime()}`, a)
+  }
+  const withoutExtId = Array.from(withoutExtIdMap.values())
 
   const inserted: InsertedActivityKey[] = []
 


### PR DESCRIPTION
## Summary
- A batch containing two rows that resolve to the same upsert conflict key triggers Postgres 21000 (`ON CONFLICT DO UPDATE command cannot affect row a second time`), aborting the whole batch.
- Health Connect sync surfaced this: a re-sync chunk could include two copies of the same `ExerciseSessionRecord`, or two records lacking `metadata.id` sharing a `start_time`, blocking initial sync indefinitely (Sara's case).
- Dedupe inside `insertActivities` by the SQL conflict key (last write wins, matching the upsert semantics callers already rely on) so every caller — HC, screentime, lastfm, rescuetime, activitywatch, location-visit — is protected.

## Test plan
- [x] New integration test: duplicate `(source, external_id)` in one batch — second row wins.
- [x] New integration test: duplicate `(source, activity_type, start_time)` without `external_id` — second row wins.
- [x] Existing 36 activities integration tests still pass.
- [ ] Sara retries Health Connect initial sync once deployed and it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)