### PR TITLE
feat(meals): derive missing nutrients from precursors at aggregation

### DIFF
--- a/apps/backend/src/services/derived-nutrients.test.ts
+++ b/apps/backend/src/services/derived-nutrients.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest'
+
+import { withDerivedNutrients } from './derived-nutrients.ts'
+
+describe('withDerivedNutrients', () => {
+  test('passes through a row with no derivable inputs', () => {
+    expect(withDerivedNutrients({ calories: 100, protein: 10 })).toEqual({
+      calories: 100,
+      protein: 10,
+    })
+  })
+
+  test('derives vitamin_a (RAE) from retinol + beta_carotene/12 when vitamin_a is null', () => {
+    // 580 µg retinol + 6720 µg β-carotene → 580 + 560 = 1140 µg RAE
+    const out = withDerivedNutrients({ retinol: 580, beta_carotene: 6720 })
+    expect(out.vitamin_a).toBeCloseTo(1140)
+    expect(out.retinol).toBe(580)
+    expect(out.beta_carotene).toBe(6720)
+  })
+
+  test('vitamin_a explicit value wins (no double-counting against precursors)', () => {
+    const out = withDerivedNutrients({ vitamin_a: 50, retinol: 580, beta_carotene: 6720 })
+    expect(out.vitamin_a).toBe(50)
+  })
+
+  test('vitamin_a derives from a single precursor when the other is missing', () => {
+    expect(withDerivedNutrients({ retinol: 200 }).vitamin_a).toBe(200)
+    expect(withDerivedNutrients({ beta_carotene: 1200 }).vitamin_a).toBe(100)
+  })
+
+  test('derives niacin_equivalents from b3_niacin (mg) + tryptophan (g)/60', () => {
+    // 8 mg niacin + 0.6 g tryptophan → 8 + (600/60) = 18 mg NE
+    const out = withDerivedNutrients({ b3_niacin: 8, tryptophan: 0.6 })
+    expect(out.niacin_equivalents).toBeCloseTo(18)
+  })
+
+  test('niacin_equivalents explicit value wins', () => {
+    const out = withDerivedNutrients({ niacin_equivalents: 14, b3_niacin: 8, tryptophan: 0.6 })
+    expect(out.niacin_equivalents).toBe(14)
+  })
+
+  test('cross-fills sodium from salt when sodium is missing', () => {
+    // 5 g salt → 2000 mg sodium
+    expect(withDerivedNutrients({ salt: 5 }).sodium).toBeCloseTo(2000)
+  })
+
+  test('cross-fills salt from sodium when salt is missing', () => {
+    // 2000 mg sodium → 5 g salt
+    expect(withDerivedNutrients({ sodium: 2000 }).salt).toBeCloseTo(5)
+  })
+
+  test('keeps both salt and sodium when both are explicit', () => {
+    const out = withDerivedNutrients({ sodium: 2000, salt: 5 })
+    expect(out.sodium).toBe(2000)
+    expect(out.salt).toBe(5)
+  })
+
+  test('uses vitamin_d_25oh as vitamin_d when vitamin_d is missing', () => {
+    // LSV's VITD_x is the combined value already including 25-OH-D3 contribution.
+    expect(withDerivedNutrients({ vitamin_d_25oh: 8 }).vitamin_d).toBe(8)
+  })
+
+  test('vitamin_d explicit value wins over vitamin_d_25oh', () => {
+    expect(withDerivedNutrients({ vitamin_d: 5, vitamin_d_25oh: 8 }).vitamin_d).toBe(5)
+  })
+
+  test('derives omega_3 from ala + epa + dha + dpa', () => {
+    const out = withDerivedNutrients({ ala: 1.2, epa: 0.3, dha: 0.5, dpa: 0.1 })
+    expect(out.omega_3).toBeCloseTo(2.1)
+  })
+
+  test('omega_3 explicit value wins', () => {
+    expect(withDerivedNutrients({ omega_3: 5, ala: 1.2, epa: 0.3 }).omega_3).toBe(5)
+  })
+
+  test('derives omega_6 from la + aa', () => {
+    expect(withDerivedNutrients({ la: 3, aa: 0.1 }).omega_6).toBeCloseTo(3.1)
+  })
+
+  test('derives net_carbs from carbs - fiber (clamped at zero)', () => {
+    expect(withDerivedNutrients({ carbs: 40, fiber: 5 }).net_carbs).toBe(35)
+    expect(withDerivedNutrients({ carbs: 5, fiber: 10 }).net_carbs).toBe(0)
+  })
+
+  test('net_carbs requires carbs to be set', () => {
+    // No carbs → cannot derive (fiber alone tells us nothing)
+    expect(withDerivedNutrients({ fiber: 5 }).net_carbs).toBeUndefined()
+  })
+
+  test('derives sugars from monosaccharides + disaccharides', () => {
+    expect(withDerivedNutrients({ monosaccharides: 8, disaccharides: 12 }).sugars).toBe(20)
+  })
+
+  test('preserves zero values as explicit (does not override with derivation)', () => {
+    // vitamin_a explicitly 0 should stay 0 — user/data source said zero.
+    const out = withDerivedNutrients({ vitamin_a: 0, retinol: 100, beta_carotene: 1200 })
+    expect(out.vitamin_a).toBe(0)
+  })
+
+  test('ignores undefined/null source fields without throwing', () => {
+    const out = withDerivedNutrients({
+      retinol: 100,
+      beta_carotene: null as unknown as number,
+    })
+    expect(out.vitamin_a).toBe(100)
+  })
+
+  test('chained derivation: salt fills sodium then is not double-derived', () => {
+    // Make sure we don't loop: salt set, sodium null → derive sodium, then leave salt alone.
+    const out = withDerivedNutrients({ salt: 5 })
+    expect(out.salt).toBe(5)
+    expect(out.sodium).toBeCloseTo(2000)
+  })
+
+  test('numeric strings or non-numbers in row are ignored', () => {
+    const out = withDerivedNutrients({
+      retinol: 'bad' as unknown as number,
+      beta_carotene: 1200,
+    })
+    expect(out.vitamin_a).toBe(100)
+  })
+})

--- a/apps/backend/src/services/derived-nutrients.ts
+++ b/apps/backend/src/services/derived-nutrients.ts
@@ -1,0 +1,122 @@
+/**
+ * Compute derived nutrient values from precursor fields when the explicit
+ * field is missing. Applied at meal-totals aggregation so the derivation
+ * cascades into daily/weekly/90d/baseline & dashboard widgets without
+ * touching canonical food-item rows.
+ *
+ * Each rule fills a *single* nutrient from components if (and only if) the
+ * explicit field is null/undefined — a value of 0 is treated as an explicit
+ * "this food has none of this", not as missing.
+ */
+
+type NutrientRow = Record<string, number | null | undefined | unknown>
+
+const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
+
+/** True only when the field is genuinely absent — null/undefined/non-number. A literal 0 is explicit. */
+const isMissing = (v: unknown): boolean => num(v) === undefined
+
+/**
+ * Sum of finite contributors; returns undefined when *none* of them are
+ * present (so we don't fabricate a derived "0" from a row with no relevant
+ * data — that would let derived nutrients show up everywhere, polluting
+ * days_with_value diagnostics in the period summary).
+ */
+const sumPresent = (...values: unknown[]): number | undefined => {
+  let total = 0
+  let any = false
+  for (const v of values) {
+    const n = num(v)
+    if (n === undefined) continue
+    total += n
+    any = true
+  }
+  return any ? total : undefined
+}
+
+// Vitamin A (RAE, µg) = retinol + β-carotene/12. LSV ships precursors but
+// typically leaves the combined column null.
+const deriveVitaminA = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.vitamin_a)) return
+  const retinol = num(out.retinol)
+  const bc = num(out.beta_carotene)
+  if (retinol === undefined && bc === undefined) return
+  out.vitamin_a = (retinol ?? 0) + (bc ?? 0) / 12
+}
+
+// Niacin equivalents (mg NE) = b3_niacin (mg) + tryptophan (g) / 60.
+// Tryptophan column is grams; 1 mg NE ≡ 60 mg tryptophan ⇒ g × 1000 / 60.
+const deriveNiacinEquivalents = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.niacin_equivalents)) return
+  const niacin = num(out.b3_niacin)
+  const trp = num(out.tryptophan)
+  if (niacin === undefined && trp === undefined) return
+  out.niacin_equivalents = (niacin ?? 0) + ((trp ?? 0) * 1000) / 60
+}
+
+// Salt ↔ sodium cross-fill. salt is g, sodium is mg; 1 g salt ≈ 400 mg
+// sodium. Fill only one direction per call so an all-explicit row keeps
+// both values intact.
+const deriveSaltSodium = (out: Record<string, unknown>): void => {
+  const saltExplicit = !isMissing(out.salt)
+  const sodiumExplicit = !isMissing(out.sodium)
+  if (!sodiumExplicit && saltExplicit) {
+    out.sodium = (num(out.salt) ?? 0) * 400
+  } else if (!saltExplicit && sodiumExplicit) {
+    out.salt = (num(out.sodium) ?? 0) / 400
+  }
+}
+
+// Vitamin D (µg): LSV's VITD_x (vitamin_d_25oh) is already the combined value
+// including 25-OH-D3 contribution with their potency factor, so when the bare
+// D3 column is null we adopt the inclusive value directly.
+const deriveVitaminD = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.vitamin_d) || isMissing(out.vitamin_d_25oh)) return
+  out.vitamin_d = num(out.vitamin_d_25oh)
+}
+
+const deriveOmega3 = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.omega_3)) return
+  const s = sumPresent(out.ala, out.epa, out.dha, out.dpa)
+  if (s !== undefined) out.omega_3 = s
+}
+
+const deriveOmega6 = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.omega_6)) return
+  const s = sumPresent(out.la, out.aa)
+  if (s !== undefined) out.omega_6 = s
+}
+
+// Net carbs (g) = carbs − fiber, clamped at 0. Requires carbs to be set —
+// fiber alone doesn't tell us net carbs.
+const deriveNetCarbs = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.net_carbs)) return
+  const carbs = num(out.carbs)
+  if (carbs === undefined) return
+  const fiber = num(out.fiber) ?? 0
+  out.net_carbs = Math.max(0, carbs - fiber)
+}
+
+const deriveSugars = (out: Record<string, unknown>): void => {
+  if (!isMissing(out.sugars)) return
+  const s = sumPresent(out.monosaccharides, out.disaccharides)
+  if (s !== undefined) out.sugars = s
+}
+
+/**
+ * Return a shallow copy of `row` with derived nutrient fields filled in when
+ * the explicit column is missing. Non-nutrient fields on the row are passed
+ * through untouched so callers can hand in a raw junction-row record.
+ */
+export const withDerivedNutrients = (row: NutrientRow): Record<string, unknown> => {
+  const out: Record<string, unknown> = { ...row }
+  deriveVitaminA(out)
+  deriveNiacinEquivalents(out)
+  deriveSaltSodium(out)
+  deriveVitaminD(out)
+  deriveOmega3(out)
+  deriveOmega6(out)
+  deriveNetCarbs(out)
+  deriveSugars(out)
+  return out
+}

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -26,6 +26,7 @@ import {
   type Micros,
 } from '../db/index.ts'
 import { getCentralDb } from './central-db.ts'
+import { withDerivedNutrients } from './derived-nutrients.ts'
 import {
   cacheCompositeNutrients,
   createFoodItemsService,
@@ -192,12 +193,18 @@ const linksToFoodItems = (
     }
   })
 
-/** Aggregate all nutrient columns from junction links into a flat record. */
+/**
+ * Aggregate all nutrient columns from junction links into a flat record.
+ * Each link is run through `withDerivedNutrients` first so totals include
+ * vitamin A (RAE), niacin equivalents, salt/sodium cross-fill, etc. when
+ * the food item only carries the precursor fields.
+ */
 const aggregateNutrients = (links: MealFoodItemLink[]): Record<string, number> => {
   const totals: Record<string, number> = {}
   for (const link of links) {
+    const derived = withDerivedNutrients(link as Record<string, unknown>)
     for (const field of NUTRIENT_FIELD_NAMES) {
-      const val = link[field]
+      const val = derived[field]
       if (typeof val === 'number' && val > 0) {
         totals[field] = (totals[field] ?? 0) + val
       }

--- a/apps/backend/src/services/queries/meal-period-summary.test.ts
+++ b/apps/backend/src/services/queries/meal-period-summary.test.ts
@@ -218,6 +218,40 @@ describe('getMealPeriodSummary', () => {
     expect(result.nutrients).toEqual({})
   })
 
+  test('derives vitamin_a, niacin_equivalents and salt from precursors across a period', async () => {
+    // One day, two food items: an LSV-style row carrying only precursors
+    // (vitamin_a/niacin_equivalents/sodium null) and an explicit row.
+    vi.mocked(db.getMeals).mockResolvedValue([mealAt('m1', '2025-04-10T12:00:00Z')])
+    vi.mocked(db.getMealFoodItemsBatch).mockResolvedValue(
+      new Map<string, MealFoodItemLink[]>([
+        [
+          'm1',
+          [
+            link('m1', {
+              calories: 200,
+              b3_niacin: 4,
+              beta_carotene: 6720,
+              retinol: 580,
+              salt: 5,
+              tryptophan: 0.3,
+            }),
+            link('m1', { calories: 100, vitamin_a: 50 }),
+          ],
+        ],
+      ]),
+    )
+
+    const result = await getMealPeriodSummary('user', { start: '2025-04-10', end: '2025-04-10' })
+
+    // 580 + 6720/12 = 1140 from precursors + 50 explicit = 1190 µg RAE
+    expect(result.nutrients.vitamin_a.total).toBeCloseTo(1190)
+    // 4 mg niacin + 0.3 g tryptophan × 1000 / 60 = 4 + 5 = 9 mg NE
+    expect(result.nutrients.niacin_equivalents.total).toBeCloseTo(9)
+    // 5 g salt → 2000 mg sodium
+    expect(result.nutrients.sodium.total).toBeCloseTo(2000)
+    expect(result.nutrients.salt.total).toBeCloseTo(5)
+  })
+
   test('returns empty nutrients map when there are no meals', async () => {
     vi.mocked(db.getMeals).mockResolvedValue([])
     vi.mocked(db.getMealFoodItemsBatch).mockResolvedValue(new Map())

--- a/apps/backend/src/services/queries/meal-period-summary.test.ts
+++ b/apps/backend/src/services/queries/meal-period-summary.test.ts
@@ -218,6 +218,30 @@ describe('getMealPeriodSummary', () => {
     expect(result.nutrients).toEqual({})
   })
 
+  test('vitamin_a derivation is per-row: explicit row keeps its value, precursor-only row contributes derived', async () => {
+    // Row 1 has explicit vitamin_a=100 AND retinol=500 — the explicit value
+    // already represents that food's RAE, so retinol must NOT be re-added.
+    // Row 2 has only retinol=300 → contributes 300 µg RAE.
+    // Expected vitamin_a total: 100 + 300 = 400 (NOT 100 + 500 + 300 = 900).
+    vi.mocked(db.getMeals).mockResolvedValue([mealAt('m1', '2025-04-20T12:00:00Z')])
+    vi.mocked(db.getMealFoodItemsBatch).mockResolvedValue(
+      new Map<string, MealFoodItemLink[]>([
+        [
+          'm1',
+          [
+            link('m1', { calories: 100, retinol: 500, vitamin_a: 100 }),
+            link('m1', { calories: 100, retinol: 300 }),
+          ],
+        ],
+      ]),
+    )
+
+    const result = await getMealPeriodSummary('user', { start: '2025-04-20', end: '2025-04-20' })
+
+    expect(result.nutrients.vitamin_a.total).toBe(400)
+    expect(result.nutrients.retinol.total).toBe(800)
+  })
+
   test('derives vitamin_a, niacin_equivalents and salt from precursors across a period', async () => {
     // One day, two food items: an LSV-style row carrying only precursors
     // (vitamin_a/niacin_equivalents/sodium null) and an explicit row.

--- a/apps/backend/src/services/queries/meal-period-summary.ts
+++ b/apps/backend/src/services/queries/meal-period-summary.ts
@@ -19,6 +19,7 @@ import {
   type MealFoodItemLink,
 } from '../../db/index.ts'
 import { dateOnlyToRange } from '../../mcp/tz-utils.ts'
+import { withDerivedNutrients } from '../derived-nutrients.ts'
 
 export interface MealPeriodSummaryInput {
   start: string // YYYY-MM-DD
@@ -70,8 +71,9 @@ const localDateKey = (d: Date, tz: string): string => getDateKeyFormatter(tz).fo
 const aggregateNutrientsFromLinks = (links: MealFoodItemLink[]): Map<string, number> => {
   const totals = new Map<string, number>()
   for (const link of links) {
+    const derived = withDerivedNutrients(link as Record<string, unknown>)
     for (const field of NUTRIENT_FIELD_NAMES) {
-      const v = link[field]
+      const v = derived[field]
       if (typeof v === 'number' && v > 0) {
         totals.set(field, (totals.get(field) ?? 0) + v)
       }


### PR DESCRIPTION
## Summary

Closes #773.

Livsmedelsverket-sourced food items carry precursor fields (`retinol` + `beta_carotene`, `b3_niacin` + `tryptophan`, `salt` or `sodium` alone, `vitamin_d_25oh`, fatty-acid breakdown) but typically leave the combined columns null. As a result, daily/weekly/90d totals understated Vitamin A by 20-40× (e.g. 54 µg avg vs ~640 µg real intake) and missed niacin equivalents, sodium↔salt and 25-OH-D3-only vitamin D entirely.

## Approach

New `apps/backend/src/services/derived-nutrients.ts` exports `withDerivedNutrients(row)`, which fills in a nutrient only when the explicit column is **missing** (null/undefined — a literal `0` stays explicit, so user/data-source "this food has none of this" is preserved).

Derivations:

| Nutrient | Formula (only when explicit field is null) |
|---|---|
| `vitamin_a` (µg RAE) | `retinol + beta_carotene / 12` |
| `niacin_equivalents` (mg NE) | `b3_niacin + tryptophan_g × 1000 / 60` |
| `sodium` ↔ `salt` | cross-fill: `sodium = salt × 400` or `salt = sodium / 400` |
| `vitamin_d` (µg) | adopt `vitamin_d_25oh` (LSV's `VITD_x` is already the combined value) |
| `omega_3` (g) | `ala + epa + dha + dpa` |
| `omega_6` (g) | `la + aa` |
| `net_carbs` (g) | `max(0, carbs − fiber)` |
| `sugars` (g) | `monosaccharides + disaccharides` |

Applied per junction row in both aggregators (`aggregateNutrients` in `meals.ts`, `aggregateNutrientsFromLinks` in `meal-period-summary.ts`) so the fix cascades into daily/weekly/90d/baseline & every dashboard widget without touching canonical food-item rows.

## Test plan

- [x] 21 unit tests covering each derivation, explicit-wins, zero-vs-null, and edge cases (`derived-nutrients.test.ts`)
- [x] Period-summary test exercising mixed explicit + derived rows on a real meal
- [x] `pnpm check` clean
- [x] Full backend test suite (2230 tests) passing
- [ ] After deploy: confirm fiddur's 90d Vitamin A lands in 600-1500 µg/day range

🤖 Generated with [Claude Code](https://claude.com/claude-code)