### PR TITLE
fix(db): hard-delete in deleteTimeSeriesBySource (calorie recompute is broken in prod)

### DIFF
--- a/apps/backend/src/db/time-series.integration.test.ts
+++ b/apps/backend/src/db/time-series.integration.test.ts
@@ -678,6 +678,46 @@ describe('Time Series Integration Tests', () => {
 
       expect(count).toBe(0)
     })
+
+    test('subsequent insertTimeSeries on the same (time, metric, source) is visible (no tombstone)', async () => {
+      // Regression: deleteTimeSeriesBySource used to soft-delete (set
+      // deleted_at = NOW()). The ON CONFLICT clause in insertTimeSeries has
+      // `WHERE deleted_at IS NULL`, so re-inserting the same key was
+      // silently skipped and the row stayed invisible. This broke the
+      // calorie recompute's wipe-and-rewrite pattern. Hard-delete now.
+      const user = getTestUser()
+      const t = new Date('2024-02-01T10:00:00Z')
+
+      // 1. Initial insert (e.g. previous recompute pass)
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'aurboda', time: t, value: 70 },
+      ])
+
+      // 2. Wipe via deleteTimeSeriesBySource
+      const deleted = await deleteTimeSeriesBySource(
+        user,
+        'heart_rate',
+        'aurboda',
+        new Date('2024-02-01T09:00:00Z'),
+        new Date('2024-02-01T11:00:00Z'),
+      )
+      expect(deleted).toBe(1)
+
+      // 3. Re-insert with a new value
+      await insertTimeSeries(user, [
+        { metric: 'heart_rate', source: 'aurboda', time: t, value: 99 },
+      ])
+
+      // 4. The new value must be visible
+      const rows = await getTimeSeriesWithSource(
+        user,
+        'heart_rate',
+        new Date('2024-02-01T09:00:00Z'),
+        new Date('2024-02-01T11:00:00Z'),
+      )
+      expect(rows).toHaveLength(1)
+      expect(rows[0].value).toBe(99)
+    })
   })
 
   describe('deleteTimeSeriesMetric', () => {

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -397,6 +397,20 @@ export const deleteTimeSeriesMetric = async (user: string, metric: string): Prom
   return result.rowCount ?? 0
 }
 
+/**
+ * Hard-delete time_series rows in [start, end) for a given (metric, source).
+ *
+ * Used by "wipe and rewrite" rebuild paths (e.g. calorie recompute, training-
+ * load rebuild) where the caller will immediately re-insert fresh rows. We
+ * cannot soft-delete here: `insertTimeSeries`' ON CONFLICT clause has a
+ * `WHERE deleted_at IS NULL` filter (to preserve user-initiated tombstones
+ * against background re-syncs), which means a soft-deleted row would block
+ * the re-insert from writing the new value — the row stays invisible.
+ * A real DELETE removes the row so the subsequent INSERT lands cleanly.
+ *
+ * For single-row user-initiated deletes (e.g. `deleteMetric`), keep using
+ * soft-delete: that path's intent is to preserve the tombstone.
+ */
 export const deleteTimeSeriesBySource = async (
   user: string,
   metric: string,
@@ -406,7 +420,7 @@ export const deleteTimeSeriesBySource = async (
 ): Promise<number> => {
   const result = await query(
     user,
-    `UPDATE time_series SET deleted_at = NOW() WHERE metric = $1 AND source = $2 AND time >= $3 AND time < $4 AND deleted_at IS NULL`,
+    `DELETE FROM time_series WHERE metric = $1 AND source = $2 AND time >= $3 AND time < $4`,
     [metric, source, start, end],
   )
   return result.rowCount ?? 0


### PR DESCRIPTION
## Summary

PR #775's calorie recompute is currently broken in production. The new model writes per-minute \`calories_total\` and \`calories_active\` with a wipe-and-rewrite pattern: delete prior aurboda rows for the affected local day, then re-insert under the same \`(time, metric, source)\` keys. After deploy, the meals overview shows zero burned calories for today and yesterday, and \`query_metrics calories_total\` returns 0 rows even though the audit log shows \`Computed N calorie points\` (N=4870, 4579, etc.).

Root cause: \`deleteTimeSeriesBySource\` does a **soft** delete (sets \`deleted_at = NOW()\`), and \`insertTimeSeries\`' \`ON CONFLICT (time, metric, source) DO UPDATE SET value = EXCLUDED.value WHERE time_series.deleted_at IS NULL\` skips the update when the existing row is tombstoned — leaving the row invisible. The PK constraint then prevents the new row from being inserted.

The \`WHERE deleted_at IS NULL\` filter on the conflict update exists to preserve user-initiated tombstones (so deleting a manual reading isn't auto-restored by the next background sync). That contract should stay. But the \`deleteTimeSeriesBySource\` callers (calorie recompute, training-load rebuild) want **hard**-delete semantics, not tombstones.

## Changes

- \`deleteTimeSeriesBySource\` now does \`DELETE FROM time_series\` instead of \`UPDATE … SET deleted_at = NOW()\`. The single-row user delete path (\`deleteMetric\`) still soft-deletes — its intent is to preserve the tombstone.
- Docstring expanded to explain the soft-vs-hard contract.
- Regression integration test added: delete + re-insert on the same \`(time, metric, source)\` results in the new value being visible.

## Test plan

- [x] \`pnpm check\` — 0 errors
- [x] All time-series integration tests pass (37 including the new one)
- [ ] After merge + deploy: re-run \`recalculate_calories\` and confirm the meals overview shows non-zero burn for today / yesterday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)