### PR TITLE
feat(food-items): web UI portions editor on FoodItemDetail (PR3a/4)

### DIFF
--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -524,3 +524,117 @@
     background: #374151;
   }
 }
+
+/* ── Portions section ────────────────────────────────────────────── */
+
+.fi-portions {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #f9fafb;
+}
+
+.fi-portions-header h2 {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+}
+
+.fi-portions-help {
+  margin: 0 0 0.5rem;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.fi-portions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+}
+
+.fi-portion-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.fi-portion-row:last-child {
+  border-bottom: none;
+}
+
+.fi-portion-base {
+  color: #6b7280;
+}
+
+.fi-portion-default {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.fi-portion-row input[type="number"] {
+  width: 5rem;
+}
+
+.fi-portion-row input[type="text"] {
+  width: 8rem;
+}
+
+.fi-portion-eq-sep {
+  color: #9ca3af;
+}
+
+.fi-portion-base-unit {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.fi-portion-del {
+  margin-left: auto;
+}
+
+.fi-portion-add {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed #d1d5db;
+}
+
+.fi-portion-add input[type="number"] {
+  width: 5rem;
+}
+
+.fi-portion-add input[type="text"] {
+  width: 8rem;
+}
+
+.fi-portions-error {
+  margin: 0.5rem 0 0;
+  color: #b91c1c;
+  font-size: 0.85rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .fi-portions {
+    background: #111827;
+    border-color: #374151;
+  }
+  .fi-portions-help,
+  .fi-portion-base,
+  .fi-portion-base-unit {
+    color: #9ca3af;
+  }
+  .fi-portion-row {
+    border-color: #1f2937;
+  }
+  .fi-portion-add {
+    border-color: #374151;
+  }
+  .fi-portions-error {
+    color: #fca5a5;
+  }
+}

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -1,6 +1,7 @@
 import {
   type FoodItemDetail as ApiFoodItemDetail,
   type FoodItemIngredient,
+  type FoodItemPortion,
   NUTRIENT_FIELDS,
   type NutrientFieldDef,
 } from '@aurboda/api-spec'
@@ -12,6 +13,12 @@ import { ConfirmButton } from '../../components/ConfirmButton'
 import { FoodItemAutocomplete } from '../../components/FoodItemAutocomplete'
 import { IconInput } from '../../components/IconInput'
 import { type IngredientRow, IngredientList } from '../../components/IngredientList'
+import {
+  addFoodItemPortionApi,
+  deleteFoodItemPortionApi,
+  setDefaultPortionApi,
+  updateFoodItemPortionApi,
+} from '../../state/api/meals'
 import { auth } from '../../state/auth'
 import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
 import './FoodItemDetail.css'
@@ -470,6 +477,8 @@ export function FoodItemDetail() {
         commitDefaultUnit={commitDefaultUnit}
       />
 
+      {!isShared && <PortionsSection item={item} foodItemId={id} />}
+
       <CompositeOrAtomicSection
         item={item}
         isShared={isShared}
@@ -565,6 +574,237 @@ function DefaultMetaRow({
         )}
       </span>
     </div>
+  )
+}
+
+function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodItemId: string }) {
+  const queryClient = useQueryClient()
+  const portions = item.portions ?? []
+  const baseUnit = item.default_unit ?? 'base unit'
+  const baseQty = item.default_quantity
+  const [draft, setDraft] = useState({ label_quantity: '', label_unit: '', base_equivalent: '' })
+  const [error, setError] = useState<string | null>(null)
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['foodItem', foodItemId] })
+
+  const addMutation = useMutation({
+    mutationFn: () => {
+      const lq = parseFloat(draft.label_quantity)
+      const be = parseFloat(draft.base_equivalent)
+      if (!draft.label_unit.trim() || !(lq > 0) || !(be > 0)) {
+        throw new Error('label_quantity, label_unit, and base_equivalent are all required and positive')
+      }
+      return addFoodItemPortionApi(foodItemId, {
+        label_quantity: lq,
+        label_unit: draft.label_unit.trim(),
+        base_equivalent: be,
+      })
+    },
+    onError: (err: Error) => setError(err.message),
+    onSuccess: () => {
+      setDraft({ label_quantity: '', label_unit: '', base_equivalent: '' })
+      setError(null)
+      invalidate()
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (input: { portionId: string; body: Partial<FoodItemPortion> }) =>
+      updateFoodItemPortionApi(foodItemId, input.portionId, {
+        label_quantity: input.body.label_quantity,
+        label_unit: input.body.label_unit,
+        base_equivalent: input.body.base_equivalent,
+      }),
+    onError: (err: Error) => setError(err.message),
+    onSuccess: () => {
+      setError(null)
+      invalidate()
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (portionId: string) => deleteFoodItemPortionApi(foodItemId, portionId),
+    onError: (err: Error) => setError(err.message),
+    onSuccess: () => {
+      setError(null)
+      invalidate()
+    },
+  })
+
+  const defaultMutation = useMutation({
+    mutationFn: (portionId: string | null) => setDefaultPortionApi(foodItemId, portionId),
+    onError: (err: Error) => setError(err.message),
+    onSuccess: () => {
+      setError(null)
+      invalidate()
+    },
+  })
+
+  // Effective default is exposed by the server (resolves override layer for
+  // central items); for per-user items it mirrors the row column. UI only
+  // shows the radio when the food has portions to choose from.
+  const effectiveDefault = (item as ApiFoodItemDetail & { effective_default_portion_id?: string })
+    .effective_default_portion_id
+
+  return (
+    <section class="fi-portions">
+      <header class="fi-portions-header">
+        <h2>Portions</h2>
+        <p class="fi-portions-help">
+          Extra sizings for this food. Each portion is "label quantity label unit = base equivalent" where
+          base equivalent is measured in {baseUnit}
+          {baseQty !== undefined ? ` (the nutrient values are per ${baseQty} ${baseUnit})` : ''}.
+        </p>
+      </header>
+
+      <ul class="fi-portions-list">
+        <li class="fi-portion-row fi-portion-base">
+          <label class="fi-portion-default">
+            <input
+              type="radio"
+              name="default-portion"
+              checked={!effectiveDefault}
+              onChange={() => defaultMutation.mutate(null)}
+            />
+            Base
+          </label>
+          <span class="fi-portion-label">
+            {baseQty ?? '—'} {baseUnit}
+          </span>
+          <span class="fi-portion-eq">(nutrient density baseline)</span>
+        </li>
+        {portions.map((p) => (
+          <PortionRow
+            key={p.id}
+            portion={p}
+            baseUnit={baseUnit}
+            isDefault={effectiveDefault === p.id}
+            onSetDefault={() => defaultMutation.mutate(p.id)}
+            onUpdate={(body) => updateMutation.mutate({ portionId: p.id, body })}
+            onDelete={() => deleteMutation.mutate(p.id)}
+          />
+        ))}
+      </ul>
+
+      <div class="fi-portion-add">
+        <input
+          type="number"
+          step="0.1"
+          placeholder="Qty"
+          value={draft.label_quantity}
+          onInput={(e) =>
+            setDraft({ ...draft, label_quantity: (e.target as HTMLInputElement).value })
+          }
+        />
+        <input
+          type="text"
+          placeholder="Unit (e.g. ruta)"
+          value={draft.label_unit}
+          onInput={(e) => setDraft({ ...draft, label_unit: (e.target as HTMLInputElement).value })}
+        />
+        <span class="fi-portion-eq-sep">=</span>
+        <input
+          type="number"
+          step="0.01"
+          placeholder={`Amount in ${baseUnit}`}
+          value={draft.base_equivalent}
+          onInput={(e) =>
+            setDraft({ ...draft, base_equivalent: (e.target as HTMLInputElement).value })
+          }
+        />
+        <button
+          type="button"
+          class="btn-secondary"
+          onClick={() => addMutation.mutate()}
+          disabled={addMutation.isPending}
+        >
+          Add portion
+        </button>
+      </div>
+      {error && <p class="fi-portions-error">{error}</p>}
+    </section>
+  )
+}
+
+function PortionRow({
+  portion,
+  baseUnit,
+  isDefault,
+  onSetDefault,
+  onUpdate,
+  onDelete,
+}: {
+  portion: FoodItemPortion
+  baseUnit: string
+  isDefault: boolean
+  onSetDefault: () => void
+  onUpdate: (body: Partial<FoodItemPortion>) => void
+  onDelete: () => void
+}) {
+  // Auto-save on blur — mirrors the rest of FoodItemDetail's commit pattern.
+  // Local state lets the user edit without each keystroke racing to the API.
+  const [lq, setLq] = useState(String(portion.label_quantity))
+  const [lu, setLu] = useState(portion.label_unit)
+  const [be, setBe] = useState(String(portion.base_equivalent))
+
+  useEffect(() => {
+    setLq(String(portion.label_quantity))
+    setLu(portion.label_unit)
+    setBe(String(portion.base_equivalent))
+  }, [portion.id, portion.label_quantity, portion.label_unit, portion.base_equivalent])
+
+  const commit = (field: 'label_quantity' | 'label_unit' | 'base_equivalent') => () => {
+    if (field === 'label_unit') {
+      const trimmed = lu.trim()
+      if (!trimmed) {
+        setLu(portion.label_unit)
+        return
+      }
+      if (trimmed !== portion.label_unit) onUpdate({ label_unit: trimmed })
+      return
+    }
+    const raw = field === 'label_quantity' ? lq : be
+    const parsed = parseFloat(raw)
+    if (!(parsed > 0)) {
+      // Revert; the schema rejects non-positive values.
+      if (field === 'label_quantity') setLq(String(portion.label_quantity))
+      else setBe(String(portion.base_equivalent))
+      return
+    }
+    if (parsed !== portion[field]) onUpdate({ [field]: parsed })
+  }
+
+  return (
+    <li class="fi-portion-row">
+      <label class="fi-portion-default">
+        <input type="radio" name="default-portion" checked={isDefault} onChange={onSetDefault} />
+      </label>
+      <input
+        type="number"
+        step="0.1"
+        value={lq}
+        onInput={(e) => setLq((e.target as HTMLInputElement).value)}
+        onBlur={commit('label_quantity')}
+      />
+      <input
+        type="text"
+        value={lu}
+        onInput={(e) => setLu((e.target as HTMLInputElement).value)}
+        onBlur={commit('label_unit')}
+      />
+      <span class="fi-portion-eq-sep">=</span>
+      <input
+        type="number"
+        step="0.01"
+        value={be}
+        onInput={(e) => setBe((e.target as HTMLInputElement).value)}
+        onBlur={commit('base_equivalent')}
+      />
+      <span class="fi-portion-base-unit">{baseUnit}</span>
+      <button type="button" class="btn-link fi-portion-del" onClick={onDelete}>
+        Delete
+      </button>
+    </li>
   )
 }
 

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -670,7 +670,12 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
               type="radio"
               name="default-portion"
               checked={!effectiveDefault}
-              onChange={() => defaultMutation.mutate(null)}
+              onChange={() => {
+                // Short-circuit a redundant PUT when Base is already the
+                // effective default — radio onChange still fires on click
+                // even when `checked` is already true.
+                if (effectiveDefault) defaultMutation.mutate(null)
+              }}
             />
             Base
           </label>

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -477,6 +477,9 @@ export function FoodItemDetail() {
         commitDefaultUnit={commitDefaultUnit}
       />
 
+      {/* TODO: portions section for shared/central items goes through the
+          override layer (shared_food_item_overrides.default_portion_id +
+          a future per-user portions-on-central pattern). Deferred. */}
       {!isShared && <PortionsSection item={item} foodItemId={id} />}
 
       <CompositeOrAtomicSection
@@ -583,7 +586,11 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
   const baseUnit = item.default_unit ?? 'base unit'
   const baseQty = item.default_quantity
   const [draft, setDraft] = useState({ label_quantity: '', label_unit: '', base_equivalent: '' })
-  const [error, setError] = useState<string | null>(null)
+  // Keep the add-row error separate from row-level (update/delete/default)
+  // errors so an unrelated failure doesn't clear the message a user needs
+  // to see while they fix their draft inputs.
+  const [addError, setAddError] = useState<string | null>(null)
+  const [rowError, setRowError] = useState<string | null>(null)
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ['foodItem', foodItemId] })
 
@@ -600,10 +607,10 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
         base_equivalent: be,
       })
     },
-    onError: (err: Error) => setError(err.message),
+    onError: (err: Error) => setAddError(err.message),
     onSuccess: () => {
       setDraft({ label_quantity: '', label_unit: '', base_equivalent: '' })
-      setError(null)
+      setAddError(null)
       invalidate()
     },
   })
@@ -615,27 +622,27 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
         label_unit: input.body.label_unit,
         base_equivalent: input.body.base_equivalent,
       }),
-    onError: (err: Error) => setError(err.message),
+    onError: (err: Error) => setRowError(err.message),
     onSuccess: () => {
-      setError(null)
+      setRowError(null)
       invalidate()
     },
   })
 
   const deleteMutation = useMutation({
     mutationFn: (portionId: string) => deleteFoodItemPortionApi(foodItemId, portionId),
-    onError: (err: Error) => setError(err.message),
+    onError: (err: Error) => setRowError(err.message),
     onSuccess: () => {
-      setError(null)
+      setRowError(null)
       invalidate()
     },
   })
 
   const defaultMutation = useMutation({
     mutationFn: (portionId: string | null) => setDefaultPortionApi(foodItemId, portionId),
-    onError: (err: Error) => setError(err.message),
+    onError: (err: Error) => setRowError(err.message),
     onSuccess: () => {
-      setError(null)
+      setRowError(null)
       invalidate()
     },
   })
@@ -643,8 +650,7 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
   // Effective default is exposed by the server (resolves override layer for
   // central items); for per-user items it mirrors the row column. UI only
   // shows the radio when the food has portions to choose from.
-  const effectiveDefault = (item as ApiFoodItemDetail & { effective_default_portion_id?: string })
-    .effective_default_portion_id
+  const effectiveDefault = item.effective_default_portion_id
 
   return (
     <section class="fi-portions">
@@ -721,7 +727,8 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
           Add portion
         </button>
       </div>
-      {error && <p class="fi-portions-error">{error}</p>}
+      {addError && <p class="fi-portions-error">{addError}</p>}
+      {rowError && <p class="fi-portions-error">{rowError}</p>}
     </section>
   )
 }
@@ -747,11 +754,19 @@ function PortionRow({
   const [lu, setLu] = useState(portion.label_unit)
   const [be, setBe] = useState(String(portion.base_equivalent))
 
+  // Three independent effects so a mutation/invalidate that refreshes the
+  // server-side value of one field doesn't clobber unsaved input on a
+  // sibling field (the previous combined effect dropped pending edits any
+  // time the user blurred a different field on the same row).
   useEffect(() => {
     setLq(String(portion.label_quantity))
+  }, [portion.id, portion.label_quantity])
+  useEffect(() => {
     setLu(portion.label_unit)
+  }, [portion.id, portion.label_unit])
+  useEffect(() => {
     setBe(String(portion.base_equivalent))
-  }, [portion.id, portion.label_quantity, portion.label_unit, portion.base_equivalent])
+  }, [portion.id, portion.base_equivalent])
 
   const commit = (field: 'label_quantity' | 'label_unit' | 'base_equivalent') => () => {
     if (field === 'label_unit') {
@@ -801,9 +816,12 @@ function PortionRow({
         onBlur={commit('base_equivalent')}
       />
       <span class="fi-portion-base-unit">{baseUnit}</span>
-      <button type="button" class="btn-link fi-portion-del" onClick={onDelete}>
-        Delete
-      </button>
+      <ConfirmButton
+        label="Delete"
+        confirmMessage={`Delete portion "${portion.label_quantity} ${portion.label_unit}"?`}
+        onConfirm={onDelete}
+        buttonClass="btn-link fi-portion-del"
+      />
     </li>
   )
 }

--- a/apps/web/src/state/api/meals.ts
+++ b/apps/web/src/state/api/meals.ts
@@ -1,7 +1,10 @@
 import type {
   AddFoodItemBody,
+  AddFoodItemPortionBody,
   AddMealBody,
   Meal as ApiMeal,
+  FoodItemPortion,
+  FoodItemPortionResponse,
   FrequentFoodItem,
   FrequentFoodItemsResponse,
   FrequentMeal,
@@ -14,6 +17,7 @@ import type {
   MergeFoodItemsPreviewResponse,
   MergeFoodItemsResponse,
   MergeFoodItemsResult,
+  UpdateFoodItemPortionBody,
   UpdateMealBody,
 } from '@aurboda/api-spec'
 
@@ -173,6 +177,56 @@ export const previewMergeFoodItemsApi = async (
   )
   if (!response.data.data) throw new Error(response.data.error ?? 'Preview failed')
   return response.data.data
+}
+
+// ─── Food item portions ─────────────────────────────────────────────────────
+
+export const addFoodItemPortionApi = async (
+  foodItemId: string,
+  body: AddFoodItemPortionBody,
+): Promise<FoodItemPortion> => {
+  const { token } = auth.value
+  const response = await axios.post<FoodItemPortionResponse>(
+    `${API_URL}/food-items/${foodItemId}/portions`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!response.data.data) throw new Error(response.data.error ?? 'Failed to add portion')
+  return response.data.data
+}
+
+export const updateFoodItemPortionApi = async (
+  foodItemId: string,
+  portionId: string,
+  body: UpdateFoodItemPortionBody,
+): Promise<FoodItemPortion> => {
+  const { token } = auth.value
+  const response = await axios.patch<FoodItemPortionResponse>(
+    `${API_URL}/food-items/${foodItemId}/portions/${portionId}`,
+    body,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!response.data.data) throw new Error(response.data.error ?? 'Failed to update portion')
+  return response.data.data
+}
+
+export const deleteFoodItemPortionApi = async (foodItemId: string, portionId: string): Promise<void> => {
+  const { token } = auth.value
+  await axios.delete(`${API_URL}/food-items/${foodItemId}/portions/${portionId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export const setDefaultPortionApi = async (
+  foodItemId: string,
+  portionId: string | null,
+): Promise<void> => {
+  const { token } = auth.value
+  await axios.put(
+    `${API_URL}/food-items/${foodItemId}/default-portion`,
+    { portion_id: portionId },
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
 }
 
 export const mergeFoodItemsApi = async (


### PR DESCRIPTION
## Summary

First web UI slice for the food-portions feature. After [PR1 #779](https://github.com/fiddur/aurboda/pull/779) (entity) and [PR2 #781](https://github.com/fiddur/aurboda/pull/781) (meal-logging integration), this PR lets users define and manage portions from the food-item editor.

### What's in PR3a

- New **Portions section** in `FoodItemDetail` (per-user foods only; shared/central foods get the override-layer treatment in a later PR).
- Each row: editable `label_quantity` / `label_unit` / `base_equivalent` (auto-save on blur, matching the page's existing commit pattern).
- Default-portion radio per row (calls `PUT /food-items/:id/default-portion`). "Base" radio clears (revert to base portion).
- Inline "Add portion" row.
- API hooks: `addFoodItemPortionApi`, `updateFoodItemPortionApi`, `deleteFoodItemPortionApi`, `setDefaultPortionApi` — thin axios wrappers in `state/api/meals.ts`.
- CSS with dark-mode styles.

### Not yet in PR3a (follow-ups)

- **PR3b** (next): meal-entry portion picker — after picking a food, show portions; on portion pick, replace quantity+unit with a `× count` input; preselect via `effective_default_portion_id`.
- **PR4**: drop legacy `meal_food_items.quantity`/`unit` columns once dual-writing is no longer needed.
- Override-layer default portion on central shared foods (small UI add).

Portions defined here are already usable via REST/MCP today (backend landed in PR2). The web meal entry still uses the legacy `quantity`/`unit` path until PR3b.

## Test plan

- [x] `pnpm check` clean (web)
- [x] All 405 web tests pass
- [ ] CI green
- [ ] Manual: open a food's editor, add "1 ruta = 3.4 g" on a 100 g chocolate, set as default, verify GET returns it with effective_default_portion_id