### PR TITLE
feat(meals): meal-entry portion picker (PR4/4)

### DIFF
--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -349,6 +349,33 @@
   width: 70px;
 }
 
+.food-portion-picker {
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #fff;
+  color: #374151;
+  max-width: 8rem;
+}
+
+.food-portion-unit {
+  color: #6b7280;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  .food-portion-picker {
+    background: #1f2937;
+    border-color: #374151;
+    color: #e5e7eb;
+  }
+  .food-portion-unit {
+    color: #9ca3af;
+  }
+}
+
 .food-item-edit-row input {
   padding: 0.25rem 0.375rem;
   font-size: 0.8rem;

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -657,16 +657,22 @@ export function MealDetail() {
 
   const commitItems = (next: FoodItemEdit[]) => {
     setItems(next)
-    // Filter rows that are mid-edit on a portion (pinned to a portion but
-    // the count input is currently empty/zero). Without this, such a row
-    // would fall through editItemsToBody's portion fork and briefly get
-    // re-saved as a legacy-quantity row, then re-pinned when the count
-    // refills. We skip the offending row only (not the whole save), so
-    // edits to other rows still flush.
-    const saveable = next.filter(
-      (fi) => !(fi.food_item_portion_id && !(typeof fi.portion_count === 'number' && fi.portion_count > 0)),
-    )
-    const body = { food_items: editItemsToBody(saveable) }
+    // Skip the entire save when any row is in a transient portion-editing
+    // state (pinned to a portion but the count input is currently
+    // empty/zero). Filtering the offending row out of the body would let
+    // updateMealById's wholesale replace semantic silently delete the row
+    // server-side until the count refills — and `flush()` on unmount would
+    // commit the row-less body, losing the row entirely. Skipping the
+    // schedule means other-row edits wait for the offending row to be
+    // completed; preferable to silent server-side data loss.
+    if (
+      next.some(
+        (fi) => fi.food_item_portion_id && !(typeof fi.portion_count === 'number' && fi.portion_count > 0),
+      )
+    ) {
+      return
+    }
+    const body = { food_items: editItemsToBody(next) }
     // De-dupe consecutive identical bodies — useAutoDefaultPortion's
     // backfill on load propagates through here with the same
     // food_item_portion_id + portion_count the server already has, and

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -249,6 +249,14 @@ const portionToSnapshot = (p: FoodItemPortion) => ({
   base_equivalent: p.base_equivalent,
 })
 
+const MACRO_LABELS: Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', (v: number) => string> = {
+  calories: (v) => `${v} kcal`,
+  protein: (v) => `P ${v}g`,
+  carbs: (v) => `C ${v}g`,
+  fat: (v) => `F ${v}g`,
+  fiber: (v) => `Fib ${v}g`,
+}
+
 function FoodItemRow({
   item,
   index,
@@ -277,6 +285,25 @@ function FoodItemRow({
       food_item_portion_id: p.id,
       portion_count: keepCount ? (item.portion_count ?? 1) : 1,
       portion: portionToSnapshot(p),
+      // For existing portion-pinned rows loaded via mealItemsToEdit, `ref`
+      // holds the per-entry snapshot (ref.calories = already-scaled, ref.quantity
+      // = portion_count × label_quantity), not the canonical (per default_quantity)
+      // values that scaleNutrient's portion-path formula requires. Refresh ref
+      // from the food's detail so the formula
+      //   nutrient × count × base_equivalent / ref.quantity
+      // evaluates correctly. (For freshly-picked foods, ref is already canonical
+      // from FoodItemEntity, and keepCount=false, so this branch is harmless.)
+      ref:
+        keepCount && detail
+          ? {
+              calories: detail.calories as number | undefined,
+              carbs: detail.carbs as number | undefined,
+              fat: detail.fat as number | undefined,
+              fiber: detail.fiber as number | undefined,
+              protein: detail.protein as number | undefined,
+              quantity: detail.default_quantity,
+            }
+          : item.ref,
     }),
   )
 
@@ -285,13 +312,6 @@ function FoodItemRow({
       ? { count: item.portion_count, base_equivalent: item.portion.base_equivalent }
       : undefined
 
-  const MACRO_LABELS: Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', (v: number) => string> = {
-    calories: (v) => `${v} kcal`,
-    protein: (v) => `P ${v}g`,
-    carbs: (v) => `C ${v}g`,
-    fat: (v) => `F ${v}g`,
-    fiber: (v) => `Fib ${v}g`,
-  }
   const macros = (['calories', 'protein', 'carbs', 'fat', 'fiber'] as const).map((f) => ({
     field: f,
     value: scaleNutrient(item.ref, f, item.quantity, portionScale),

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -541,6 +541,9 @@ export function MealDetail() {
   const itemsFlusherRef = useRef(
     createDebouncedFlusher<UpdateMealBody>(FOOD_ITEM_DEBOUNCE_MS, (body) => saveRef.current(body)),
   )
+  // Serialized last-saved food_items body — used by commitItems to de-dupe
+  // identical-payload schedules so on-load backfills don't trigger writes.
+  const lastItemsBodyRef = useRef<string | null>(null)
   const mealTypeFlusherRef = useRef(
     createDebouncedFlusher<string>(FOOD_ITEM_DEBOUNCE_MS, (v) => saveRef.current({ meal_type: v })),
   )
@@ -573,7 +576,11 @@ export function MealDetail() {
     // explicitly opted out of a slot, so treat it as a custom "other" rather
     // than silently defaulting to lunch.
     setMealType(meal.meal_type ?? DEFAULT_CUSTOM_TYPE)
-    setItems(mealItemsToEdit(meal.food_items))
+    const initialItems = mealItemsToEdit(meal.food_items)
+    setItems(initialItems)
+    // Seed the de-dupe ref so the first commitItems call (typically from
+    // useAutoDefaultPortion's backfill) doesn't fire a no-op write.
+    lastItemsBodyRef.current = JSON.stringify({ food_items: editItemsToBody(initialItems) })
     setFlags(meal.sensitivities ?? [])
     setMacros({
       calories: meal.calories,
@@ -632,7 +639,23 @@ export function MealDetail() {
 
   const commitItems = (next: FoodItemEdit[]) => {
     setItems(next)
-    itemsFlusherRef.current.schedule({ food_items: editItemsToBody(next) })
+    // Skip the save when any row is in a transient portion-editing state
+    // (pinned to a portion but the count input is currently empty). Without
+    // this guard the row would fall through editItemsToBody's portion fork
+    // and briefly get re-saved as a legacy-quantity row, then re-pinned
+    // once the user finishes typing the new count.
+    if (next.some((fi) => fi.food_item_portion_id && !(typeof fi.portion_count === 'number' && fi.portion_count > 0))) {
+      return
+    }
+    const body = { food_items: editItemsToBody(next) }
+    // De-dupe consecutive identical bodies — useAutoDefaultPortion's
+    // backfill on load propagates through here with the same
+    // food_item_portion_id + portion_count the server already has, and
+    // there's no reason to round-trip a no-op write per detail-page open.
+    const serialized = JSON.stringify(body)
+    if (serialized === lastItemsBodyRef.current) return
+    lastItemsBodyRef.current = serialized
+    itemsFlusherRef.current.schedule(body)
   }
 
   const commitName = () => {

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -1,4 +1,4 @@
-import type { UpdateMealBody } from '@aurboda/api-spec'
+import type { FoodItemDetail as ApiFoodItemDetail, FoodItemPortion, UpdateMealBody } from '@aurboda/api-spec'
 
 import { NUTRIENT_FIELDS } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -11,6 +11,7 @@ import { FoodItemAutocomplete } from '../../components/FoodItemAutocomplete'
 import {
   addFoodItemApi,
   deleteMealApi,
+  fetchFoodItemDetailApi,
   fetchMeal,
   fetchSensitivityFlags,
   type FoodItemEntity,
@@ -127,6 +128,110 @@ function MealFlagsEditor({
   )
 }
 
+const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
+
+/**
+ * After a food is picked, auto-select its effective default portion exactly
+ * once per food id change. Skips when the row is already pinned (e.g.
+ * editing an existing meal where the portion was already chosen).
+ */
+const useAutoDefaultPortion = (
+  item: FoodItemEdit,
+  detail: ApiFoodItemDetail | undefined,
+  applyPortion: (p: FoodItemPortion) => void,
+): void => {
+  const lastAppliedFoodId = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    if (!detail || !item.food_item_id) return
+    if (lastAppliedFoodId.current === item.food_item_id) return
+    lastAppliedFoodId.current = item.food_item_id
+    if (item.food_item_portion_id) return
+    const def = detail.effective_default_portion_id
+    if (!def) return
+    const p = detail.portions?.find((pp) => pp.id === def)
+    if (p) applyPortion(p)
+  }, [detail?.id, item.food_item_id])
+}
+
+function PortionPicker({
+  selectedId,
+  portions,
+  baseLabel,
+  onPick,
+}: {
+  selectedId: string | undefined
+  portions: FoodItemPortion[]
+  baseLabel: string
+  onPick: (portionId: string) => void
+}) {
+  if (portions.length === 0) return null
+  return (
+    <select
+      class="food-portion-picker"
+      value={selectedId ?? ''}
+      onChange={(e) => onPick((e.target as HTMLSelectElement).value)}
+    >
+      <option value="">Base ({baseLabel})</option>
+      {portions.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.label_quantity} {p.label_unit}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function QuantityInputs({
+  item,
+  onUpdate,
+}: {
+  item: FoodItemEdit
+  onUpdate: (patch: Partial<FoodItemEdit>) => void
+}) {
+  if (item.food_item_portion_id && item.portion) {
+    return (
+      <>
+        <input
+          type="number"
+          step="0.1"
+          value={item.portion_count ?? ''}
+          placeholder="Count"
+          class="food-num-input"
+          onInput={(e) => onUpdate({ portion_count: parseNum((e.target as HTMLInputElement).value) })}
+        />
+        <span class="food-portion-unit">
+          × {item.portion.label_quantity} {item.portion.label_unit}
+        </span>
+      </>
+    )
+  }
+  return (
+    <>
+      <input
+        type="number"
+        step="0.1"
+        value={item.quantity ?? ''}
+        placeholder="Qty"
+        class="food-num-input"
+        onInput={(e) => onUpdate({ quantity: parseNum((e.target as HTMLInputElement).value) })}
+      />
+      <input
+        type="text"
+        value={item.unit ?? ''}
+        placeholder="Unit"
+        class="food-unit-input"
+        onInput={(e) => onUpdate({ unit: (e.target as HTMLInputElement).value })}
+      />
+    </>
+  )
+}
+
+const portionToSnapshot = (p: FoodItemPortion) => ({
+  label_quantity: p.label_quantity,
+  label_unit: p.label_unit,
+  base_equivalent: p.base_equivalent,
+})
+
 function FoodItemRow({
   item,
   index,
@@ -140,15 +245,75 @@ function FoodItemRow({
   onRemove: (index: number) => void
   autoFocus?: boolean
 }) {
-  const update = (field: keyof FoodItemEdit, value: unknown) => onChange(index, { ...item, [field]: value })
-  const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
+  const update = (patch: Partial<FoodItemEdit>) => onChange(index, { ...item, ...patch })
 
-  const kcal = scaleNutrient(item.ref, 'calories', item.quantity)
-  const prot = scaleNutrient(item.ref, 'protein', item.quantity)
-  const carbs = scaleNutrient(item.ref, 'carbs', item.quantity)
-  const fat = scaleNutrient(item.ref, 'fat', item.quantity)
-  const fiber = scaleNutrient(item.ref, 'fiber', item.quantity)
-  const hasMacros = [kcal, prot, carbs, fat, fiber].some((v) => typeof v === 'number')
+  // Detail (incl. portions + effective_default_portion_id) is cached by
+  // react-query keyed on food_item_id; re-renders don't re-fetch.
+  const { data: detail } = useQuery({
+    enabled: !!item.food_item_id,
+    queryFn: () => fetchFoodItemDetailApi(item.food_item_id!),
+    queryKey: ['foodItem', item.food_item_id],
+  })
+
+  useAutoDefaultPortion(item, detail, (p) =>
+    update({ food_item_portion_id: p.id, portion_count: 1, portion: portionToSnapshot(p) }),
+  )
+
+  const portionScale =
+    item.food_item_portion_id && item.portion && typeof item.portion_count === 'number'
+      ? { count: item.portion_count, base_equivalent: item.portion.base_equivalent }
+      : undefined
+
+  const macros = (['calories', 'protein', 'carbs', 'fat', 'fiber'] as const).map((f) => ({
+    field: f,
+    value: scaleNutrient(item.ref, f, item.quantity, portionScale),
+  }))
+  const hasMacros = macros.some((m) => typeof m.value === 'number')
+
+  const handleFoodPick = (fi: FoodItemEntity) =>
+    onChange(index, {
+      ...item,
+      food_item_id: fi.id,
+      // Reset portion state — previous food's portions don't apply; the
+      // useAutoDefaultPortion effect re-applies the default for the new food.
+      food_item_portion_id: undefined,
+      portion_count: undefined,
+      portion: undefined,
+      name: fi.name,
+      quantity: fi.default_quantity ?? 1,
+      unit: fi.default_unit ?? item.unit,
+      ref: {
+        calories: fi.calories,
+        carbs: fi.carbs,
+        fat: fi.fat,
+        fiber: fi.fiber,
+        protein: fi.protein,
+        quantity: fi.default_quantity,
+      },
+    })
+
+  const handlePortionPick = (portionId: string) => {
+    if (!portionId) {
+      update({
+        food_item_portion_id: undefined,
+        portion_count: undefined,
+        portion: undefined,
+        quantity: detail?.default_quantity ?? item.quantity,
+        unit: detail?.default_unit ?? item.unit,
+      })
+      return
+    }
+    const p = detail?.portions?.find((pp) => pp.id === portionId)
+    if (!p) return
+    update({
+      food_item_portion_id: p.id,
+      portion_count:
+        item.portion_count && item.food_item_portion_id ? item.portion_count : 1,
+      portion: portionToSnapshot(p),
+    })
+  }
+
+  const baseLabel = `${detail?.default_quantity ?? '?'} ${detail?.default_unit ?? ''}`.trim()
 
   return (
     <div class="food-item-edit-row">
@@ -156,52 +321,38 @@ function FoodItemRow({
         <FoodItemAutocomplete
           value={item.name}
           autoFocus={autoFocus}
-          onChange={(name) => update('name', name)}
-          onSelect={(fi: FoodItemEntity) => {
-            onChange(index, {
-              ...item,
-              food_item_id: fi.id,
-              name: fi.name,
-              quantity: fi.default_quantity ?? 1,
-              unit: fi.default_unit ?? item.unit,
-              ref: {
-                calories: fi.calories,
-                carbs: fi.carbs,
-                fat: fi.fat,
-                fiber: fi.fiber,
-                protein: fi.protein,
-                quantity: fi.default_quantity,
-              },
-            })
-          }}
+          onChange={(name) => update({ name })}
+          onSelect={handleFoodPick}
           onCreate={(name) => addFoodItemApi({ name })}
         />
-        <input
-          type="number"
-          step="0.1"
-          value={item.quantity ?? ''}
-          placeholder="Qty"
-          class="food-num-input"
-          onInput={(e) => update('quantity', parseNum((e.target as HTMLInputElement).value))}
+        <PortionPicker
+          selectedId={item.food_item_portion_id}
+          portions={detail?.portions ?? []}
+          baseLabel={baseLabel}
+          onPick={handlePortionPick}
         />
-        <input
-          type="text"
-          value={item.unit ?? ''}
-          placeholder="Unit"
-          class="food-unit-input"
-          onInput={(e) => update('unit', (e.target as HTMLInputElement).value)}
-        />
+        <QuantityInputs item={item} onUpdate={update} />
         <button type="button" class="btn-danger-small" onClick={() => onRemove(index)}>
           &times;
         </button>
       </div>
       {hasMacros && (
         <div class="food-row-macros-display">
-          {typeof kcal === 'number' && <span>{kcal} kcal</span>}
-          {typeof prot === 'number' && <span>P {prot}g</span>}
-          {typeof carbs === 'number' && <span>C {carbs}g</span>}
-          {typeof fat === 'number' && <span>F {fat}g</span>}
-          {typeof fiber === 'number' && <span>Fib {fiber}g</span>}
+          {macros.map((m) =>
+            typeof m.value === 'number' ? (
+              <span key={m.field}>
+                {m.field === 'calories'
+                  ? `${m.value} kcal`
+                  : m.field === 'protein'
+                    ? `P ${m.value}g`
+                    : m.field === 'carbs'
+                      ? `C ${m.value}g`
+                      : m.field === 'fat'
+                        ? `F ${m.value}g`
+                        : `Fib ${m.value}g`}
+              </span>
+            ) : null,
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -131,25 +131,42 @@ function MealFlagsEditor({
 const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
 
 /**
- * After a food is picked, auto-select its effective default portion exactly
- * once per food id change. Skips when the row is already pinned (e.g.
- * editing an existing meal where the portion was already chosen).
+ * Once the food's detail arrives, do two things (each at most once per food
+ * id):
+ *
+ *   1. If the row is already pinned to a portion (e.g. editing an existing
+ *      meal that was logged with `food_item_portion_id`), backfill the
+ *      `portion` snapshot from detail.portions — the meal response doesn't
+ *      include label_quantity/label_unit/base_equivalent, so without this
+ *      backfill the row would render via the legacy quantity+unit path even
+ *      though saves still go through the portion path.
+ *   2. Otherwise (fresh row, no portion yet) apply the food's effective
+ *      default portion if one is set.
  */
 const useAutoDefaultPortion = (
   item: FoodItemEdit,
   detail: ApiFoodItemDetail | undefined,
-  applyPortion: (p: FoodItemPortion) => void,
+  applyPortion: (p: FoodItemPortion, keepCount: boolean) => void,
 ): void => {
   const lastAppliedFoodId = useRef<string | undefined>(undefined)
   useEffect(() => {
     if (!detail || !item.food_item_id) return
     if (lastAppliedFoodId.current === item.food_item_id) return
     lastAppliedFoodId.current = item.food_item_id
-    if (item.food_item_portion_id) return
+    if (item.food_item_portion_id) {
+      // Already pinned. Backfill the snapshot if we're missing it (loading
+      // an existing meal). If the portion id no longer resolves (deleted
+      // since logging), leave the row alone — the user will see legacy
+      // qty/unit and can re-pick.
+      if (item.portion) return
+      const p = detail.portions?.find((pp) => pp.id === item.food_item_portion_id)
+      if (p) applyPortion(p, /* keepCount */ true)
+      return
+    }
     const def = detail.effective_default_portion_id
     if (!def) return
     const p = detail.portions?.find((pp) => pp.id === def)
-    if (p) applyPortion(p)
+    if (p) applyPortion(p, /* keepCount */ false)
   }, [detail?.id, item.food_item_id])
 }
 
@@ -255,8 +272,12 @@ function FoodItemRow({
     queryKey: ['foodItem', item.food_item_id],
   })
 
-  useAutoDefaultPortion(item, detail, (p) =>
-    update({ food_item_portion_id: p.id, portion_count: 1, portion: portionToSnapshot(p) }),
+  useAutoDefaultPortion(item, detail, (p, keepCount) =>
+    update({
+      food_item_portion_id: p.id,
+      portion_count: keepCount ? (item.portion_count ?? 1) : 1,
+      portion: portionToSnapshot(p),
+    }),
   )
 
   const portionScale =
@@ -264,6 +285,13 @@ function FoodItemRow({
       ? { count: item.portion_count, base_equivalent: item.portion.base_equivalent }
       : undefined
 
+  const MACRO_LABELS: Record<'calories' | 'protein' | 'carbs' | 'fat' | 'fiber', (v: number) => string> = {
+    calories: (v) => `${v} kcal`,
+    protein: (v) => `P ${v}g`,
+    carbs: (v) => `C ${v}g`,
+    fat: (v) => `F ${v}g`,
+    fiber: (v) => `Fib ${v}g`,
+  }
   const macros = (['calories', 'protein', 'carbs', 'fat', 'fiber'] as const).map((f) => ({
     field: f,
     value: scaleNutrient(item.ref, f, item.quantity, portionScale),
@@ -339,19 +367,7 @@ function FoodItemRow({
       {hasMacros && (
         <div class="food-row-macros-display">
           {macros.map((m) =>
-            typeof m.value === 'number' ? (
-              <span key={m.field}>
-                {m.field === 'calories'
-                  ? `${m.value} kcal`
-                  : m.field === 'protein'
-                    ? `P ${m.value}g`
-                    : m.field === 'carbs'
-                      ? `C ${m.value}g`
-                      : m.field === 'fat'
-                        ? `F ${m.value}g`
-                        : `Fib ${m.value}g`}
-              </span>
-            ) : null,
+            typeof m.value === 'number' ? <span key={m.field}>{MACRO_LABELS[m.field](m.value)}</span> : null,
           )}
         </div>
       )}

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -296,11 +296,11 @@ function FoodItemRow({
       ref:
         keepCount && detail
           ? {
-              calories: detail.calories as number | undefined,
-              carbs: detail.carbs as number | undefined,
-              fat: detail.fat as number | undefined,
-              fiber: detail.fiber as number | undefined,
-              protein: detail.protein as number | undefined,
+              calories: detail.calories,
+              carbs: detail.carbs,
+              fat: detail.fat,
+              fiber: detail.fiber,
+              protein: detail.protein,
               quantity: detail.default_quantity,
             }
           : item.ref,

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -163,6 +163,11 @@ const useAutoDefaultPortion = (
       if (p) applyPortion(p, /* keepCount */ true)
       return
     }
+    // Auto-default-portion only applies to rows added THIS session (`_isNew`).
+    // Without this gate we'd silently re-encode legacy server-loaded rows
+    // (e.g. "50 g chocolate") as `1 × default portion` on meal open,
+    // overwriting the user's recorded quantity.
+    if (!item._isNew) return
     const def = detail.effective_default_portion_id
     if (!def) return
     const p = detail.portions?.find((pp) => pp.id === def)
@@ -285,6 +290,10 @@ function FoodItemRow({
       food_item_portion_id: p.id,
       portion_count: keepCount ? (item.portion_count ?? 1) : 1,
       portion: portionToSnapshot(p),
+      // Clear the freshness flag — once applied, the row is no longer "new
+      // pending auto-default" and shouldn't re-trigger if anything else
+      // upstream resets the effect's gate.
+      _isNew: false,
       // For existing portion-pinned rows loaded via mealItemsToEdit, `ref`
       // holds the per-entry snapshot (ref.calories = already-scaled, ref.quantity
       // = portion_count × label_quantity), not the canonical (per default_quantity)
@@ -327,6 +336,11 @@ function FoodItemRow({
       food_item_portion_id: undefined,
       portion_count: undefined,
       portion: undefined,
+      // Re-flag as fresh-w.r.t.-this-food so the auto-default branch can
+      // adopt the new food's effective default portion. (handleFoodPick
+      // already resets the quantity to fi.default_quantity, so there's no
+      // user data to preserve here — distinct from the load-time case.)
+      _isNew: true,
       name: fi.name,
       quantity: fi.default_quantity ?? 1,
       unit: fi.default_unit ?? item.unit,
@@ -412,7 +426,11 @@ function FoodItemsEditor({
   const handleRemove = (index: number) => onChange(items.filter((_, i) => i !== index))
   const handleAdd = () => {
     setAutoFocusIndex(items.length)
-    onChange([...items, { name: '' }])
+    // _isNew flags this row as added this session so useAutoDefaultPortion
+    // can adopt the food's effective default portion on pick. Rows loaded
+    // from the server via mealItemsToEdit don't carry the flag and are
+    // never silently re-encoded by the auto-default branch.
+    onChange([...items, { name: '', _isNew: true }])
   }
 
   return (
@@ -639,15 +657,16 @@ export function MealDetail() {
 
   const commitItems = (next: FoodItemEdit[]) => {
     setItems(next)
-    // Skip the save when any row is in a transient portion-editing state
-    // (pinned to a portion but the count input is currently empty). Without
-    // this guard the row would fall through editItemsToBody's portion fork
-    // and briefly get re-saved as a legacy-quantity row, then re-pinned
-    // once the user finishes typing the new count.
-    if (next.some((fi) => fi.food_item_portion_id && !(typeof fi.portion_count === 'number' && fi.portion_count > 0))) {
-      return
-    }
-    const body = { food_items: editItemsToBody(next) }
+    // Filter rows that are mid-edit on a portion (pinned to a portion but
+    // the count input is currently empty/zero). Without this, such a row
+    // would fall through editItemsToBody's portion fork and briefly get
+    // re-saved as a legacy-quantity row, then re-pinned when the count
+    // refills. We skip the offending row only (not the whole save), so
+    // edits to other rows still flush.
+    const saveable = next.filter(
+      (fi) => !(fi.food_item_portion_id && !(typeof fi.portion_count === 'number' && fi.portion_count > 0)),
+    )
+    const body = { food_items: editItemsToBody(saveable) }
     // De-dupe consecutive identical bodies — useAutoDefaultPortion's
     // backfill on load propagates through here with the same
     // food_item_portion_id + portion_count the server already has, and

--- a/apps/web/src/pages/Meals/mealItems.test.ts
+++ b/apps/web/src/pages/Meals/mealItems.test.ts
@@ -60,4 +60,66 @@ describe('scaleNutrient', () => {
     expect(scaleNutrient(undefined, 'calories', 50)).toBeUndefined()
     expect(scaleNutrient({ quantity: 100 }, 'calories', 50)).toBeUndefined()
   })
+
+  test('portion path: scales by count × base_equivalent / canonical default_quantity', () => {
+    // 100 g chocolate base, 500 kcal/100 g. "3 ruta" where ruta = 3.4 g →
+    // 500 × 3 × 3.4 / 100 = 51 kcal.
+    const canonicalRef = { calories: 500, quantity: 100 }
+    expect(
+      scaleNutrient(canonicalRef, 'calories', undefined, { count: 3, base_equivalent: 3.4 }),
+    ).toBeCloseTo(51, 2)
+  })
+
+  test('portion path ignores currentQuantity in favor of portion math', () => {
+    // currentQuantity should be irrelevant when portionScale is supplied —
+    // the bug this guards: pre-fix the formula used the row's `quantity`
+    // (which for portion-pinned rows is portion_count × label_quantity,
+    // not canonical default_quantity), causing wrong-scale display on load.
+    const canonicalRef = { calories: 500, quantity: 100 }
+    const withQty = scaleNutrient(canonicalRef, 'calories', 9999, { count: 1, base_equivalent: 10 })
+    const withoutQty = scaleNutrient(canonicalRef, 'calories', undefined, { count: 1, base_equivalent: 10 })
+    expect(withQty).toBe(withoutQty)
+    expect(withQty).toBe(50) // 500 × 1 × 10 / 100
+  })
+})
+
+describe('mealItemsToEdit + editItemsToBody portion round-trip', () => {
+  test('portion-pinned input survives the load → save cycle', () => {
+    // The meal response carries food_item_portion_id + portion_count for
+    // portion-pinned rows. mealItemsToEdit must preserve both so that
+    // editItemsToBody emits the portion-path payload on save.
+    const [row] = mealItemsToEdit([
+      {
+        food_item_id: 'food-a',
+        food_item_portion_id: 'portion-a',
+        portion_count: 3,
+        name: 'Choklad',
+        quantity: 3, // server stored count × label_quantity
+        unit: 'ruta',
+        calories: 51,
+      },
+    ])
+    expect(row.food_item_portion_id).toBe('portion-a')
+    expect(row.portion_count).toBe(3)
+
+    const body = editItemsToBody([row])
+    expect(body).toHaveLength(1)
+    expect(body![0]).toEqual({
+      food_item_id: 'food-a',
+      food_item_portion_id: 'portion-a',
+      portion_count: 3,
+      name: 'Choklad',
+    })
+  })
+
+  test('legacy row (no portion fields) round-trips through the legacy payload', () => {
+    const [row] = mealItemsToEdit([
+      { food_item_id: 'food-b', name: 'B', quantity: 200, unit: 'g', calories: 80 },
+    ])
+    expect(row.food_item_portion_id).toBeUndefined()
+    expect(row.portion_count).toBeUndefined()
+
+    const body = editItemsToBody([row])
+    expect(body![0]).toEqual({ food_item_id: 'food-b', name: 'B', quantity: 200, unit: 'g' })
+  })
 })

--- a/apps/web/src/pages/Meals/mealItems.ts
+++ b/apps/web/src/pages/Meals/mealItems.ts
@@ -1,6 +1,10 @@
 import type { UpdateMealBody } from '@aurboda/api-spec'
 
 export interface FoodItemRef {
+  /**
+   * Canonical default quantity — the denominator for legacy-path scaling
+   * (`nutrient × currentQuantity / quantity`).
+   */
   quantity?: number
   calories?: number
   protein?: number
@@ -12,8 +16,23 @@ export interface FoodItemRef {
 export interface FoodItemEdit {
   food_item_id?: string
   name: string
+  /** Free-form quantity (legacy path) — ignored when food_item_portion_id is set. */
   quantity?: number
   unit?: string
+  /**
+   * When set, the row is logged via the portion path: nutrients scale by
+   * `portion_count × portion.base_equivalent / canonical.default_quantity`.
+   */
+  food_item_portion_id?: string
+  /** Count of `food_item_portion_id` portions logged. Required when portion_id is set. */
+  portion_count?: number
+  /**
+   * Snapshot of the chosen portion's label_quantity × label_unit and
+   * base_equivalent, kept on the edit row so display + live scaling don't
+   * have to re-look-up the food. Cleared when the user reverts to the
+   * base/free-form path.
+   */
+  portion?: { label_quantity: number; label_unit: string; base_equivalent: number }
   /**
    * Reference values for live display scaling. Captured at row creation
    * (autocomplete pick: canonical default_quantity + canonical nutrients;
@@ -28,6 +47,8 @@ export const mealItemsToEdit = (
   items?: {
     name: string
     food_item_id?: string
+    food_item_portion_id?: string
+    portion_count?: number
     quantity?: number
     unit?: string
     calories?: number
@@ -39,6 +60,8 @@ export const mealItemsToEdit = (
 ): FoodItemEdit[] =>
   (items ?? []).map((fi) => ({
     food_item_id: fi.food_item_id,
+    food_item_portion_id: fi.food_item_portion_id,
+    portion_count: fi.portion_count,
     name: fi.name,
     quantity: fi.quantity,
     ref: {
@@ -66,23 +89,49 @@ export const mealItemsToEdit = (
 export const editItemsToBody = (items: FoodItemEdit[]): UpdateMealBody['food_items'] =>
   items
     .filter((fi) => fi.food_item_id && fi.name.trim())
-    .map((fi) => ({
-      food_item_id: fi.food_item_id,
-      name: fi.name,
-      quantity: fi.quantity,
-      unit: fi.unit,
-    }))
+    .map((fi) =>
+      fi.food_item_portion_id && typeof fi.portion_count === 'number'
+        ? {
+            food_item_id: fi.food_item_id,
+            food_item_portion_id: fi.food_item_portion_id,
+            portion_count: fi.portion_count,
+            name: fi.name,
+          }
+        : {
+            food_item_id: fi.food_item_id,
+            name: fi.name,
+            quantity: fi.quantity,
+            unit: fi.unit,
+          },
+    )
 
-/** Linearly scale a reference nutrient value to the current quantity. */
+/**
+ * Linearly scale a reference nutrient value to the current quantity.
+ *
+ * Two paths, mirroring the backend:
+ *   - Portion path (preferred when `portion` + `portion_count` are present):
+ *     `nutrient × portion_count × portion.base_equivalent / ref.quantity`
+ *     (ref.quantity is the canonical default_quantity — the denominator
+ *     the canonical nutrient values are reported against.)
+ *   - Legacy path: `nutrient × currentQuantity / ref.quantity` (same-unit
+ *     assumption; the backend skips scaling if units don't match — the UI
+ *     mirrors the simple ratio for display).
+ */
 export const scaleNutrient = (
   ref: FoodItemRef | undefined,
   field: keyof Omit<FoodItemRef, 'quantity'>,
   currentQuantity: number | undefined,
+  portionScale?: { count: number; base_equivalent: number },
 ): number | undefined => {
   if (!ref) return undefined
   const baseValue = ref[field]
   if (typeof baseValue !== 'number') return undefined
   if (ref.quantity === undefined || ref.quantity === 0) return baseValue
+  if (portionScale) {
+    return (
+      Math.round(((baseValue * portionScale.count * portionScale.base_equivalent) / ref.quantity) * 10) / 10
+    )
+  }
   if (currentQuantity === undefined) return baseValue
   return Math.round(((baseValue * currentQuantity) / ref.quantity) * 10) / 10
 }

--- a/apps/web/src/pages/Meals/mealItems.ts
+++ b/apps/web/src/pages/Meals/mealItems.ts
@@ -34,6 +34,16 @@ export interface FoodItemEdit {
    */
   portion?: { label_quantity: number; label_unit: string; base_equivalent: number }
   /**
+   * True for rows added this session via the "+" button (or autocomplete
+   * pick from scratch). Lets the auto-default-portion effect distinguish
+   * fresh rows — which should adopt the food's effective default portion —
+   * from existing meal rows loaded via mealItemsToEdit, where silently
+   * re-encoding a legacy `50 g` row as `1 × default portion` would
+   * silently change the meal's nutrients on open. Non-persisted; never
+   * sent to the backend.
+   */
+  _isNew?: boolean
+  /**
    * Reference values for live display scaling. Captured at row creation
    * (autocomplete pick: canonical default_quantity + canonical nutrients;
    * existing item edit: server snapshot quantity + snapshot nutrients).

--- a/apps/web/src/state/api/meals.ts
+++ b/apps/web/src/state/api/meals.ts
@@ -2,7 +2,9 @@ import type {
   AddFoodItemBody,
   AddFoodItemPortionBody,
   AddMealBody,
+  FoodItemDetail as ApiFoodItemDetail,
   Meal as ApiMeal,
+  FoodItemDetailResponse,
   FoodItemPortion,
   FoodItemPortionResponse,
   FrequentFoodItem,
@@ -176,6 +178,15 @@ export const previewMergeFoodItemsApi = async (
     },
   )
   if (!response.data.data) throw new Error(response.data.error ?? 'Preview failed')
+  return response.data.data
+}
+
+export const fetchFoodItemDetailApi = async (id: string): Promise<ApiFoodItemDetail> => {
+  const { token } = auth.value
+  const response = await axios.get<FoodItemDetailResponse>(`${API_URL}/food-items/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!response.data.data) throw new Error(response.data.error ?? 'Food item not found')
   return response.data.data
 }
 


### PR DESCRIPTION
## Summary

Final web-UI slice of the food-portions feature. PR3 ([#782](https://github.com/fiddur/aurboda/pull/782)) added the portions editor on `FoodItemDetail`; this PR wires the meal-entry row to use those portions when logging.

### What's in PR4

- **Portion picker** in `MealDetail`'s food row: after picking a food, a `<select>` shows "Base + each defined portion". Hidden when the food has no portions (legacy quantity/unit path stays).
- **Quantity input switching**: when a portion is selected, the row swaps to a single "Count × {portion label}" input. When Base, the existing quantity + unit pair is shown.
- **Auto-pin to effective default**: once the food's detail arrives, the row auto-selects `effective_default_portion_id` once per food id change. Existing meals being edited keep their pinned portion (the effect skips when already pinned).
- **Live nutrient display** uses the same portion formula as the backend: `nutrient × count × base_equivalent / canonical.default_quantity`.
- **Save payload** sends `{ food_item_portion_id, portion_count }` for pinned rows and the legacy `{ quantity, unit }` for base rows.

### Plumbing

- New `fetchFoodItemDetailApi` in `state/api/meals.ts`, cached by react-query (keyed on `food_item_id` — same key the FoodItemDetail page uses, so the cache is shared).
- `mealItems.ts`:
  - `FoodItemEdit` gains `food_item_portion_id`, `portion_count`, and a `portion` snapshot.
  - `editItemsToBody` switches payload shape based on whether the row is pinned.
  - `mealItemsToEdit` round-trips the new fields.
  - `scaleNutrient` accepts an optional `portionScale` argument.
- `FoodItemRow` extracted into `PortionPicker`, `QuantityInputs`, and a `useAutoDefaultPortion` hook to stay under the project's cyclomatic-complexity limit.
- CSS for the picker + portion-unit label, dark-mode styles.

### Backwards compat

- Foods without portions: UI unchanged (no picker shown).
- Existing meals logged via the legacy path: render with the quantity+unit inputs they already had.
- Save payload is one of two shapes per row; the backend (from PR2) accepts both.

## Test plan

- [x] `pnpm check` clean (web)
- [x] All 405 web tests pass
- [ ] CI green
- [ ] Manual: log a meal of "3 ruta" of a chocolate that defines a "ruta" portion; verify count input + live kcal scaling; verify on reload the row stays pinned to the portion.