### PR TITLE
feat(food-items): portion unit-model — quantity-in-unit, drop label_quantity

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -1085,6 +1085,43 @@ export const migrateSchema = async (user: string) => {
     for (const field of NUTRIENT_FIELD_NAMES) {
       await query(db, `ALTER TABLE food_items ADD COLUMN IF NOT EXISTS ${field} DOUBLE PRECISION`)
     }
+    // default_log_quantity: the default *amount* to prefill when logging, in
+    // the unit named by default_portion_id (or the base unit). Pairs with
+    // default_portion_id (portion unit-model).
+    await query(db, `ALTER TABLE food_items ADD COLUMN IF NOT EXISTS default_log_quantity DOUBLE PRECISION`)
+
+    // Portion unit-model reframe: a portion is now just a named unit + its
+    // per-unit conversion to the base unit (no more label_quantity). The old
+    // model stored `label_quantity label_unit = base_equivalent base_units`;
+    // the new one stores `1 label_unit = base_equivalent base_units`. So when
+    // dropping label_quantity we normalise base_equivalent to a per-unit value
+    // (base_equivalent / label_quantity). Guarded by a column-existence check
+    // so it's a no-op on databases created fresh from the new schema.
+    await query(
+      db,
+      `DO $$
+       BEGIN
+         IF EXISTS (
+           SELECT 1 FROM information_schema.columns
+           WHERE table_name = 'food_item_portions' AND column_name = 'label_quantity'
+         ) THEN
+           UPDATE food_item_portions
+             SET base_equivalent = base_equivalent / label_quantity
+             WHERE label_quantity IS NOT NULL AND label_quantity <> 0 AND label_quantity <> 1;
+           ALTER TABLE food_item_portions DROP COLUMN label_quantity;
+         END IF;
+       END $$`,
+    )
+
+    // Backfill a base unit for every per-user food that lacks one, so all
+    // foods have at least one (base) unit to log in. Independent per field:
+    // a missing quantity has no signal → 1; a missing unit has no signal →
+    // 'portion'. (Central shared_food_items get 100 g — see schema/system.ts.)
+    await query(db, `UPDATE food_items SET default_quantity = 1 WHERE default_quantity IS NULL`)
+    await query(
+      db,
+      `UPDATE food_items SET default_unit = 'portion' WHERE default_unit IS NULL OR default_unit = ''`,
+    )
   }
 
   // meal_food_items: drop the FK on food_item_id since the canonical row
@@ -1124,10 +1161,7 @@ export const migrateSchema = async (user: string) => {
   // shared food item. NULL means "use the central row's default_portion_id"
   // (which is itself usually NULL → use the base portion).
   if (existingTableNames.has('shared_food_item_overrides')) {
-    await query(
-      db,
-      `ALTER TABLE shared_food_item_overrides ADD COLUMN IF NOT EXISTS default_portion_id UUID`,
-    )
+    await query(db, `ALTER TABLE shared_food_item_overrides ADD COLUMN IF NOT EXISTS default_portion_id UUID`)
     // icon_overridden distinguishes "user explicitly chose icon" from "user
     // never touched it" — required now that other override fields exist
     // (a default_portion_id-only update would otherwise leave icon at the
@@ -1142,6 +1176,12 @@ export const migrateSchema = async (user: string) => {
     await query(
       db,
       `UPDATE shared_food_item_overrides SET icon_overridden = TRUE WHERE icon_overridden = FALSE`,
+    )
+    // Per-user override of the central food's default logging quantity, paired
+    // with default_portion_id (portion unit-model).
+    await query(
+      db,
+      `ALTER TABLE shared_food_item_overrides ADD COLUMN IF NOT EXISTS default_log_quantity DOUBLE PRECISION`,
     )
   }
 

--- a/apps/backend/src/db/food-item-portions.integration.test.ts
+++ b/apps/backend/src/db/food-item-portions.integration.test.ts
@@ -33,14 +33,12 @@ describe('food_item_portions integration', () => {
 
     const rad = await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 1,
       label_unit: 'rad',
       base_equivalent: 13.6,
       sort_order: 1,
     })
     const ruta = await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 1,
       label_unit: 'ruta',
       base_equivalent: 3.4,
       sort_order: 0,
@@ -57,7 +55,6 @@ describe('food_item_portions integration', () => {
     const food = await upsertFoodItem(user, { name: 'Lantmjölk', default_quantity: 100, default_unit: 'g' })
     const inserted = await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 1,
       label_unit: 'glas',
       base_equivalent: 200,
     })
@@ -65,7 +62,6 @@ describe('food_item_portions integration', () => {
     const updated = await updateFoodItemPortion(user, inserted.id, { base_equivalent: 515 })
     expect(updated?.base_equivalent).toBe(515)
     expect(updated?.label_unit).toBe('glas')
-    expect(updated?.label_quantity).toBe(1)
     expect(updated?.updated_at.getTime()).toBeGreaterThanOrEqual(inserted.updated_at.getTime())
   })
 
@@ -74,7 +70,6 @@ describe('food_item_portions integration', () => {
     const food = await upsertFoodItem(user, { name: 'Wraps', default_quantity: 1, default_unit: 'wrap' })
     const portion = await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 2,
       label_unit: 'wrap',
       base_equivalent: 2,
     })
@@ -97,19 +92,16 @@ describe('food_item_portions integration', () => {
     const c = await upsertFoodItem(user, { name: 'C-no-portions' })
     await insertFoodItemPortion(user, {
       food_item_id: a.id,
-      label_quantity: 1,
       label_unit: 'x',
       base_equivalent: 1,
     })
     await insertFoodItemPortion(user, {
       food_item_id: b.id,
-      label_quantity: 1,
       label_unit: 'y',
       base_equivalent: 1,
     })
     await insertFoodItemPortion(user, {
       food_item_id: b.id,
-      label_quantity: 2,
       label_unit: 'y',
       base_equivalent: 2,
     })
@@ -125,7 +117,6 @@ describe('food_item_portions integration', () => {
     const food = await upsertFoodItem(user, { name: 'Doomed', default_quantity: 1, default_unit: 'unit' })
     await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 1,
       label_unit: 'big',
       base_equivalent: 2,
     })
@@ -141,13 +132,11 @@ describe('food_item_portions integration', () => {
     const food = await upsertFoodItem(user, { name: 'Bulk' })
     await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 1,
       label_unit: 'a',
       base_equivalent: 1,
     })
     await insertFoodItemPortion(user, {
       food_item_id: food.id,
-      label_quantity: 1,
       label_unit: 'b',
       base_equivalent: 2,
     })

--- a/apps/backend/src/db/food-item-portions.ts
+++ b/apps/backend/src/db/food-item-portions.ts
@@ -12,7 +12,6 @@ import { query } from './connection.ts'
 export interface FoodItemPortionRow {
   id: string
   food_item_id: string
-  label_quantity: number
   label_unit: string
   base_equivalent: number
   sort_order: number
@@ -22,26 +21,22 @@ export interface FoodItemPortionRow {
 
 export interface InsertFoodItemPortionInput {
   food_item_id: string
-  label_quantity: number
   label_unit: string
   base_equivalent: number
   sort_order?: number
 }
 
 export interface UpdateFoodItemPortionInput {
-  label_quantity?: number
   label_unit?: string
   base_equivalent?: number
   sort_order?: number
 }
 
-const COLUMNS =
-  'id, food_item_id, label_quantity, label_unit, base_equivalent, sort_order, created_at, updated_at'
+const COLUMNS = 'id, food_item_id, label_unit, base_equivalent, sort_order, created_at, updated_at'
 
 const mapRow = (row: Record<string, unknown>): FoodItemPortionRow => ({
   id: row.id as string,
   food_item_id: row.food_item_id as string,
-  label_quantity: row.label_quantity as number,
   label_unit: row.label_unit as string,
   base_equivalent: row.base_equivalent as number,
   sort_order: row.sort_order as number,
@@ -56,16 +51,10 @@ export const insertFoodItemPortion = async (
   const result = await query(
     user,
     `INSERT INTO food_item_portions
-       (food_item_id, label_quantity, label_unit, base_equivalent, sort_order)
-     VALUES ($1, $2, $3, $4, $5)
+       (food_item_id, label_unit, base_equivalent, sort_order)
+     VALUES ($1, $2, $3, $4)
      RETURNING ${COLUMNS}`,
-    [
-      input.food_item_id,
-      input.label_quantity,
-      input.label_unit,
-      input.base_equivalent,
-      input.sort_order ?? 0,
-    ],
+    [input.food_item_id, input.label_unit, input.base_equivalent, input.sort_order ?? 0],
   )
   return mapRow(result.rows[0])
 }
@@ -78,10 +67,6 @@ export const updateFoodItemPortion = async (
   const setClauses: string[] = []
   const params: unknown[] = []
   let idx = 1
-  if (input.label_quantity !== undefined) {
-    setClauses.push(`label_quantity = $${idx++}`)
-    params.push(input.label_quantity)
-  }
   if (input.label_unit !== undefined) {
     setClauses.push(`label_unit = $${idx++}`)
     params.push(input.label_unit)

--- a/apps/backend/src/db/food-items.ts
+++ b/apps/backend/src/db/food-items.ts
@@ -19,6 +19,7 @@ const FOOD_ITEM_COLUMNS = [
   'default_quantity',
   'default_unit',
   'default_portion_id',
+  'default_log_quantity',
   ...NUTRIENT_FIELD_NAMES,
   'icon',
   'is_composite',
@@ -37,6 +38,7 @@ const mapFoodItemRow = (row: Record<string, unknown>): FoodItemEntity => {
     default_quantity: row.default_quantity ?? undefined,
     default_unit: row.default_unit ?? undefined,
     default_portion_id: (row.default_portion_id as string | null) ?? undefined,
+    default_log_quantity: (row.default_log_quantity as number | null) ?? undefined,
     icon: row.icon ?? undefined,
     is_composite: row.is_composite === true,
     reference_food_item_id: (row.reference_food_item_id as string | null) ?? undefined,
@@ -241,6 +243,10 @@ export const updateFoodItem = async (
   if (input.default_portion_id !== undefined) {
     setClauses.push(`default_portion_id = $${idx++}`)
     params.push(input.default_portion_id)
+  }
+  if (input.default_log_quantity !== undefined) {
+    setClauses.push(`default_log_quantity = $${idx++}`)
+    params.push(input.default_log_quantity)
   }
   if (input.icon !== undefined) {
     setClauses.push(`icon = $${idx++}`)

--- a/apps/backend/src/db/shared-food-item-overrides.integration.test.ts
+++ b/apps/backend/src/db/shared-food-item-overrides.integration.test.ts
@@ -137,6 +137,19 @@ describe('shared_food_item_overrides integration', () => {
     expect(cleared.default_portion_id).toBeNull()
   })
 
+  test('default_log_quantity override round-trips and clears via null', async () => {
+    const user = getTestUser()
+    const set = await setSharedFoodItemOverride(user, sharedId1, { default_log_quantity: 2 })
+    expect(set.default_log_quantity).toBe(2)
+    expect(set.icon_overridden).toBe(false)
+
+    const got = await getSharedFoodItemOverride(user, sharedId1)
+    expect(got?.default_log_quantity).toBe(2)
+
+    const cleared = await setSharedFoodItemOverride(user, sharedId1, { default_log_quantity: null })
+    expect(cleared.default_log_quantity).toBeNull()
+  })
+
   test('icon_overridden tracks whether the user supplied an icon value', async () => {
     const user = getTestUser()
     const portionId = '33333333-3333-3333-3333-333333333333'

--- a/apps/backend/src/db/shared-food-item-overrides.ts
+++ b/apps/backend/src/db/shared-food-item-overrides.ts
@@ -44,11 +44,17 @@ export interface SharedFoodItemOverride {
    */
   icon_overridden: boolean
   /**
-   * User-preselected portion id for the central item. NULL means "no
+   * User-preselected portion id (unit) for the central item. NULL means "no
    * override" — fall back to the central row's own default_portion_id (which
    * is itself usually NULL → use the base portion).
    */
   default_portion_id: string | null
+  /**
+   * User-preselected default quantity for the central item, in the unit named
+   * by default_portion_id (or the base unit). NULL means "no override" — fall
+   * back to the base default_quantity.
+   */
+  default_log_quantity: number | null
   created_at: Date
   updated_at: Date
 }
@@ -61,26 +67,32 @@ export interface SharedFoodItemOverrideInput {
    */
   icon?: string | null
   /**
-   * `string` sets the preselected portion id, `null` clears the override
-   * (revert to whatever the central row says — usually the base portion).
-   * `undefined` leaves the column unchanged.
+   * `string` sets the preselected portion id (unit), `null` clears the
+   * override (revert to whatever the central row says — usually the base
+   * portion). `undefined` leaves the column unchanged.
    */
   default_portion_id?: string | null
+  /**
+   * `number` sets the default quantity, `null` clears the override (revert to
+   * the base quantity). `undefined` leaves the column unchanged.
+   */
+  default_log_quantity?: number | null
 }
 
 const COLUMNS =
-  'shared_food_item_id, icon, icon_overridden, default_portion_id, created_at, updated_at'
+  'shared_food_item_id, icon, icon_overridden, default_portion_id, default_log_quantity, created_at, updated_at'
 
 const mapRow = (row: Record<string, unknown>): SharedFoodItemOverride => ({
   shared_food_item_id: row.shared_food_item_id as string,
   icon: row.icon as string | null,
   icon_overridden: row.icon_overridden === true,
   default_portion_id: (row.default_portion_id as string | null) ?? null,
+  default_log_quantity: (row.default_log_quantity as number | null) ?? null,
   created_at: row.created_at as Date,
   updated_at: row.updated_at as Date,
 })
 
-const OVERRIDE_FIELDS = ['icon', 'default_portion_id'] as const
+const OVERRIDE_FIELDS = ['icon', 'default_portion_id', 'default_log_quantity'] as const
 
 export const getSharedFoodItemOverride = async (
   user: string,

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -385,6 +385,8 @@ export interface FoodItemEntity {
   default_unit?: string
   /** Soft pointer to the preselected portion (food_item_portions.id) when logging. */
   default_portion_id?: string
+  /** Default quantity to prefill when logging, in the unit named by default_portion_id (or base). */
+  default_log_quantity?: number
   // ~65 nutrient fields are optional numbers, accessed dynamically via
   // NUTRIENT_FIELD_NAMES from api-spec. The index signature has to cover
   // every named field above too, hence the broad union — it loosens type

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -401,11 +401,12 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
         .number()
         .positive()
         .nullable()
-        .describe('Default quantity to prefill, or null for the base quantity'),
+        .optional()
+        .describe('Default quantity to prefill, or null/omitted for the base quantity'),
     },
     async ({ food_item_id, portion_id, quantity }) => {
       try {
-        await setDefaultPortion(user, food_item_id, portion_id, quantity)
+        await setDefaultPortion(user, food_item_id, portion_id, quantity ?? null)
       } catch (err) {
         return errorResponse(err instanceof Error ? err.message : 'Failed to set default portion')
       }

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -273,7 +273,11 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
     async ({ id, ...input }) => {
       // The .refine on the body schema doesn't survive .shape destructuring,
       // so re-check the at-least-one-field invariant here.
-      if (input.icon === undefined && input.default_portion_id === undefined) {
+      if (
+        input.icon === undefined &&
+        input.default_portion_id === undefined &&
+        input.default_log_quantity === undefined
+      ) {
         return errorResponse(
           'At least one override field must be supplied; use clear_shared_food_item_override to revert',
         )
@@ -322,10 +326,10 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
   )
 
   // ────────────────────────────────────────────────────────────────────────
-  // Portion sizings — additional (label_quantity, label_unit) entries per
-  // food item; each portion stores `base_equivalent` which is how much of
-  // the food's base unit the whole entry equals. Works for per-user OR
-  // central food items via the soft pointer on food_item_id.
+  // Portion sizings — extra units a food can be logged in, beyond its base
+  // unit. Each portion is a named unit (`label_unit`) plus `base_equivalent`:
+  // how many of the food's base unit ONE of this unit equals. Works for
+  // per-user OR central food items via the soft pointer on food_item_id.
   // ────────────────────────────────────────────────────────────────────────
 
   server.tool(
@@ -344,8 +348,8 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
   server.tool(
     'add_food_item_portion',
     [
-      'Add a portion sizing to a food item. The portion expresses an equivalence "label_quantity label_unit = base_equivalent of the food\'s base unit".',
-      'Example: for a 100 g chocolate base, "1 ruta = 3.4 g" stores label_quantity=1, label_unit="ruta", base_equivalent=3.4.',
+      'Add a unit a food item can be logged in. A portion expresses an equivalence "1 label_unit = base_equivalent of the food\'s base unit".',
+      'Example: for a 100 g chocolate base, "1 ruta = 3.4 g" stores label_unit="ruta", base_equivalent=3.4.',
       'Targets per-user OR central food items (soft pointer).',
     ].join(' '),
     {
@@ -389,14 +393,19 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
 
   server.tool(
     'set_default_food_item_portion',
-    "Set or clear the preselected portion for a per-user food item. Pass `portion_id: null` to revert to the food's base portion. The chosen portion must belong to the food item. Central foods aren't editable here — use the override layer (coming).",
+    'Set or clear the default logging amount for a per-user food item: which unit to preselect (`portion_id`, null = the base unit) and how much (`quantity`, null = the base quantity). The chosen portion must belong to the food item. Central foods use the override layer (set_shared_food_item_override) instead.',
     {
       food_item_id: z.string().uuid().describe('Per-user food item id'),
-      portion_id: z.string().uuid().nullable().describe('Portion id, or null to clear'),
+      portion_id: z.string().uuid().nullable().describe('Portion (unit) id, or null for the base unit'),
+      quantity: z
+        .number()
+        .positive()
+        .nullable()
+        .describe('Default quantity to prefill, or null for the base quantity'),
     },
-    async ({ food_item_id, portion_id }) => {
+    async ({ food_item_id, portion_id, quantity }) => {
       try {
-        await setDefaultPortion(user, food_item_id, portion_id)
+        await setDefaultPortion(user, food_item_id, portion_id, quantity)
       } catch (err) {
         return errorResponse(err instanceof Error ? err.message : 'Failed to set default portion')
       }

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -432,7 +432,6 @@ describe('PATCH /food-items/:id/portions/:portionId ownership guard', () => {
     vi.mocked(dbBarrel.getFoodItemPortionById).mockResolvedValue({
       id: PORTION_ID,
       food_item_id: OTHER_FOOD_ID,
-      label_quantity: 1,
       label_unit: 'g',
       base_equivalent: 1,
       sort_order: 0,
@@ -441,7 +440,7 @@ describe('PATCH /food-items/:id/portions/:portionId ownership guard', () => {
     })
     const res = await supertest(buildApp(fakeCentral()))
       .patch(`/food-items/${FOOD_ID}/portions/${PORTION_ID}`)
-      .send({ label_quantity: 999 })
+      .send({ base_equivalent: 999 })
     expect(res.status).toBe(404)
     expect(dbBarrel.updateFoodItemPortion).not.toHaveBeenCalled()
   })
@@ -450,7 +449,7 @@ describe('PATCH /food-items/:id/portions/:portionId ownership guard', () => {
     vi.mocked(dbBarrel.getFoodItemPortionById).mockResolvedValue(null)
     const res = await supertest(buildApp(fakeCentral()))
       .patch(`/food-items/${FOOD_ID}/portions/${PORTION_ID}`)
-      .send({ label_quantity: 2 })
+      .send({ base_equivalent: 2 })
     expect(res.status).toBe(404)
     expect(dbBarrel.updateFoodItemPortion).not.toHaveBeenCalled()
   })
@@ -468,7 +467,6 @@ describe('DELETE /food-items/:id/portions/:portionId ownership guard', () => {
     vi.mocked(dbBarrel.getFoodItemPortionById).mockResolvedValue({
       id: PORTION_ID,
       food_item_id: OTHER_FOOD_ID,
-      label_quantity: 1,
       label_unit: 'g',
       base_equivalent: 1,
       sort_order: 0,
@@ -498,7 +496,6 @@ describe('PUT /food-items/:id/override default_portion_id ownership guard', () =
     vi.mocked(dbBarrel.getFoodItemPortionById).mockResolvedValue({
       id: PORTION_ID,
       food_item_id: OTHER_FOOD_ID,
-      label_quantity: 1,
       label_unit: 'g',
       base_equivalent: 1,
       sort_order: 0,
@@ -522,6 +519,7 @@ describe('PUT /food-items/:id/override default_portion_id ownership guard', () =
       icon: null,
       icon_overridden: false,
       default_portion_id: null,
+      default_log_quantity: null,
       created_at: new Date(),
       updated_at: new Date(),
     })

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -6,7 +6,7 @@ import type { FoodItemEntity } from '../db/types.ts'
 import type { CentralDb } from '../services/central-db.ts'
 import type { SharedFoodItemEntity } from '../services/central-food-items.ts'
 
-import { createFoodItemsRouter } from './food-items-router.ts'
+import { createFoodItemsRouter, resolveEffectiveDefaultQuantity } from './food-items-router.ts'
 
 // The route imports from the barrel `../db/index.ts`; the food-items service
 // imports directly from `../db/food-items.ts`. Both have to be mocked, and the
@@ -549,5 +549,26 @@ describe('PATCH /food-items/:id default_portion_id is stripped from generic upda
     const callArg = vi.mocked(dbBarrel.updateFoodItem).mock.calls[0][2] as Record<string, unknown>
     expect(callArg.default_portion_id).toBeUndefined()
     expect(callArg.name).toBe('Renamed')
+  })
+})
+
+describe('resolveEffectiveDefaultQuantity', () => {
+  test('uses default_log_quantity when set (regardless of unit)', () => {
+    expect(resolveEffectiveDefaultQuantity('portion-1', 2, 100)).toBe(2)
+    expect(resolveEffectiveDefaultQuantity(undefined, 58, 100)).toBe(58)
+  })
+
+  test('base unit (no default portion) falls back to the base default_quantity', () => {
+    expect(resolveEffectiveDefaultQuantity(undefined, undefined, 100)).toBe(100)
+  })
+
+  test('non-base default unit with no default_log_quantity defaults to 1 of that unit, not the base quantity', () => {
+    // Regression: previously fell back to default_quantity (100), prefilling
+    // e.g. "100 glas" instead of "1 glas" for a 100 g base with a glas default.
+    expect(resolveEffectiveDefaultQuantity('portion-glas', undefined, 100)).toBe(1)
+  })
+
+  test('absent everywhere → undefined (no prefill hint)', () => {
+    expect(resolveEffectiveDefaultQuantity(undefined, undefined, undefined)).toBeUndefined()
   })
 })

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -101,6 +101,19 @@ const serializeFoodItem = (
   return result as FoodItemEntity
 }
 
+/**
+ * Resolve the default logging quantity, expressed in the unit named by the
+ * effective default portion. Prefer an explicit `default_log_quantity`;
+ * otherwise fall back to the base `default_quantity` only for the base unit
+ * (no default portion) — for a non-base default unit fall back to 1 of that
+ * unit, never the base quantity (which would be a number in the wrong unit).
+ */
+export const resolveEffectiveDefaultQuantity = (
+  effectiveDefaultPortionId: string | undefined,
+  defaultLogQuantity: number | undefined,
+  baseQuantity: number | undefined,
+): number | undefined => defaultLogQuantity ?? (effectiveDefaultPortionId ? 1 : baseQuantity)
+
 const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   const base = serializeFoodItem(detail.item)
   const sensitivities = detail.sensitivities ?? []
@@ -110,12 +123,11 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   // for central items applySharedOverrides decorated it from the user's
   // shared_food_item_overrides row (when the user picked a portion).
   const effective_default_portion_id = (detail.item.default_portion_id as string | undefined) ?? undefined
-  // Resolved default *quantity*: the per-user / override default_log_quantity
-  // when set, else the base default_quantity. applySharedOverrides decorates
-  // central items' default_log_quantity from the user's override row.
-  const effective_default_quantity =
-    (detail.item.default_log_quantity as number | undefined) ??
-    (detail.item.default_quantity as number | undefined)
+  const effective_default_quantity = resolveEffectiveDefaultQuantity(
+    effective_default_portion_id,
+    detail.item.default_log_quantity as number | undefined,
+    detail.item.default_quantity as number | undefined,
+  )
   // Composite branch: ingredient list + derived totals.
   if (detail.ingredients) {
     return {
@@ -645,7 +657,7 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       try {
-        await setDefaultPortion(user, id, req.body.portion_id, req.body.quantity)
+        await setDefaultPortion(user, id, req.body.portion_id, req.body.quantity ?? null)
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to set default portion'
         return res.status(/not found|does not belong/i.test(message) ? 400 : 500).json({

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -110,6 +110,12 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   // for central items applySharedOverrides decorated it from the user's
   // shared_food_item_overrides row (when the user picked a portion).
   const effective_default_portion_id = (detail.item.default_portion_id as string | undefined) ?? undefined
+  // Resolved default *quantity*: the per-user / override default_log_quantity
+  // when set, else the base default_quantity. applySharedOverrides decorates
+  // central items' default_log_quantity from the user's override row.
+  const effective_default_quantity =
+    (detail.item.default_log_quantity as number | undefined) ??
+    (detail.item.default_quantity as number | undefined)
   // Composite branch: ingredient list + derived totals.
   if (detail.ingredients) {
     return {
@@ -126,6 +132,7 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
       is_shared,
       portions,
       effective_default_portion_id,
+      effective_default_quantity,
       sensitivities,
     }
   }
@@ -137,6 +144,7 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
       is_shared,
       portions,
       effective_default_portion_id,
+      effective_default_quantity,
       reference: {
         food: serializeFoodItem(detail.reference.food),
         unit_mismatch: detail.reference.unit_mismatch,
@@ -150,6 +158,7 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
     is_shared,
     portions,
     effective_default_portion_id,
+    effective_default_quantity,
     sensitivities,
   } as FoodItemDetail
 }
@@ -157,7 +166,6 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
 const serializePortion = (row: FoodItemPortionRow): FoodItemPortion => ({
   id: row.id,
   food_item_id: row.food_item_id,
-  label_quantity: row.label_quantity,
   label_unit: row.label_unit,
   base_equivalent: row.base_equivalent,
   sort_order: row.sort_order,
@@ -170,6 +178,7 @@ const serializeOverride = (override: DbSharedFoodItemOverride): ApiSharedFoodIte
   icon: override.icon,
   icon_overridden: override.icon_overridden,
   default_portion_id: override.default_portion_id,
+  default_log_quantity: override.default_log_quantity,
   created_at: override.created_at.toISOString(),
   updated_at: override.updated_at.toISOString(),
 })
@@ -546,7 +555,7 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
   )
 
   // ────────────────────────────────────────────────────────────────────────
-  // Portion sizings — additional (label_quantity, label_unit) tuples per
+  // Portion sizings — extra named units (label_unit + base_equivalent) per
   // food item with a base_equivalent that resolves the entry into the food's
   // base unit. food_item_portions.food_item_id is a soft pointer (per-user
   // OR central), so these endpoints accept either kind of id.
@@ -636,7 +645,7 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
         })
       }
       try {
-        await setDefaultPortion(user, id, req.body.portion_id)
+        await setDefaultPortion(user, id, req.body.portion_id, req.body.quantity)
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to set default portion'
         return res.status(/not found|does not belong/i.test(message) ? 400 : 500).json({

--- a/apps/backend/src/schema/meals.ts
+++ b/apps/backend/src/schema/meals.ts
@@ -129,6 +129,7 @@ export const mealsTables: Record<string, string> = {
       is_composite    BOOLEAN NOT NULL DEFAULT FALSE,
       reference_food_item_id UUID,
       default_portion_id UUID,
+      default_log_quantity DOUBLE PRECISION,
       created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       CONSTRAINT unique_food_item_name UNIQUE (name_lower)
@@ -166,23 +167,23 @@ export const mealsTables: Record<string, string> = {
       ON food_item_ingredients (ingredient_food_item_id)
   `,
 
-  // Additional portion sizings for a food item. The food item's own
-  // (default_quantity, default_unit) is the "base portion" the nutrient
-  // columns are measured per; these rows are extra (label_quantity label_unit)
-  // tuples the user can pick when logging — e.g. "1 wrap = 1 base wrap" plus
-  // "2 wrap = 2 base wrap", or "1 glas = 515 g" for a 100 g base.
+  // Additional units a food item can be logged in, beyond its "base" unit.
+  // The food item's own (default_quantity, default_unit) is the base the
+  // nutrient columns are measured per; each portion row is a named unit plus
+  // its conversion to that base — e.g. "1 glas = 515 g" for a 100 g base, or
+  // "1 ruta = 3.4 g". When logging, the user enters a quantity in the chosen
+  // unit; nutrients scale by `quantity × base_equivalent / default_quantity`.
   //
   // `food_item_id` is a soft pointer (no FK) so portions can target the
   // per-user `food_items` table or a central `shared_food_items` row. Cascade
   // on per-user food deletion is handled in app code (deleteFoodItem).
   //
-  // `base_equivalent` is "this whole entry equals X units of the food's base
-  // unit" — direct conversion only, no chaining via other portions.
+  // `base_equivalent` is "how many base units ONE of this unit equals" —
+  // direct conversion only, no chaining via other portions.
   food_item_portions: `
     CREATE TABLE IF NOT EXISTS food_item_portions (
       id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       food_item_id      UUID NOT NULL,
-      label_quantity    DOUBLE PRECISION NOT NULL,
       label_unit        VARCHAR(100) NOT NULL,
       base_equivalent   DOUBLE PRECISION NOT NULL,
       sort_order        INTEGER NOT NULL DEFAULT 0,
@@ -389,6 +390,7 @@ export const mealsTables: Record<string, string> = {
       -- path would silently hide the central icon.
       icon_overridden      BOOLEAN NOT NULL DEFAULT FALSE,
       default_portion_id   UUID,
+      default_log_quantity DOUBLE PRECISION,
       created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )

--- a/apps/backend/src/services/central-db.ts
+++ b/apps/backend/src/services/central-db.ts
@@ -441,6 +441,19 @@ export const createCentralDb = (deps: CentralDbDeps): CentralDb => {
       for (const field of NUTRIENT_FIELD_NAMES) {
         await client.query(`ALTER TABLE shared_food_items ADD COLUMN IF NOT EXISTS ${field} DOUBLE PRECISION`)
       }
+      // Backfill a base unit for every shared food that lacks one, so all
+      // foods have at least one (base) unit to log in. Central rows are
+      // reference data measured per 100 g (e.g. Livsmedelsverket) — use 100 g
+      // where there's no other signal. (Per-user foods get 1 portion — see
+      // db/connection.ts.)
+      await client.query(
+        `ALTER TABLE shared_food_items ADD COLUMN IF NOT EXISTS default_quantity DOUBLE PRECISION`,
+      )
+      await client.query(`ALTER TABLE shared_food_items ADD COLUMN IF NOT EXISTS default_unit VARCHAR(100)`)
+      await client.query(`UPDATE shared_food_items SET default_quantity = 100 WHERE default_quantity IS NULL`)
+      await client.query(
+        `UPDATE shared_food_items SET default_unit = 'g' WHERE default_unit IS NULL OR default_unit = ''`,
+      )
       for (const stmt of CREATE_SHARED_FOOD_ITEMS_INDEXES) await client.query(stmt)
       await client.query(CREATE_IMPORT_JOBS_TABLE)
       for (const stmt of CREATE_IMPORT_JOBS_INDEXES) await client.query(stmt)

--- a/apps/backend/src/services/food-item-portions.integration.test.ts
+++ b/apps/backend/src/services/food-item-portions.integration.test.ts
@@ -49,7 +49,7 @@ describe('food-item-portions service integration', () => {
     const portion = await addPortion(
       user,
       food.id,
-      { label_quantity: 1, label_unit: 'ruta', base_equivalent: 3.4 },
+      { label_unit: 'ruta', base_equivalent: 3.4 },
       stubCentral(),
     )
     expect(portion.food_item_id).toBe(food.id)
@@ -65,7 +65,7 @@ describe('food-item-portions service integration', () => {
     const portion = await addPortion(
       user,
       central.id,
-      { label_quantity: 1, label_unit: 'cup', base_equivalent: 240 },
+      { label_unit: 'cup', base_equivalent: 240 },
       stubCentral({ [central.id]: central }),
     )
     expect(portion.food_item_id).toBe(central.id)
@@ -75,22 +75,16 @@ describe('food-item-portions service integration', () => {
     const user = getTestUser()
     const ghostId = '99999999-0000-0000-0000-000000000000'
     await expect(
-      addPortion(user, ghostId, { label_quantity: 1, label_unit: 'x', base_equivalent: 1 }, stubCentral()),
+      addPortion(user, ghostId, { label_unit: 'x', base_equivalent: 1 }, stubCentral()),
     ).rejects.toThrow(/not found/i)
   })
 
   test('updatePortion / deletePortion work end-to-end', async () => {
     const user = getTestUser()
     const food = await upsertFoodItem(user, { name: 'Wraps', default_quantity: 1, default_unit: 'wrap' })
-    const portion = await addPortion(
-      user,
-      food.id,
-      { label_quantity: 2, label_unit: 'wrap', base_equivalent: 2 },
-      stubCentral(),
-    )
+    const portion = await addPortion(user, food.id, { label_unit: 'wrap', base_equivalent: 2 }, stubCentral())
 
-    const updated = await updatePortion(user, portion.id, { label_quantity: 3, base_equivalent: 3 })
-    expect(updated.label_quantity).toBe(3)
+    const updated = await updatePortion(user, portion.id, { base_equivalent: 3 })
     expect(updated.base_equivalent).toBe(3)
 
     expect(await deletePortion(user, portion.id)).toBe(true)
@@ -104,7 +98,7 @@ describe('food-item-portions service integration', () => {
     const portionA = await addPortion(
       user,
       foodA.id,
-      { label_quantity: 1, label_unit: 'piece', base_equivalent: 50 },
+      { label_unit: 'piece', base_equivalent: 50 },
       stubCentral(),
     )
     await expect(setDefaultPortion(user, foodB.id, portionA.id)).rejects.toThrow(/does not belong/i)
@@ -116,7 +110,7 @@ describe('food-item-portions service integration', () => {
     const portion = await addPortion(
       user,
       food.id,
-      { label_quantity: 1, label_unit: 'rad', base_equivalent: 13.6 },
+      { label_unit: 'rad', base_equivalent: 13.6 },
       stubCentral(),
     )
 
@@ -127,13 +121,31 @@ describe('food-item-portions service integration', () => {
     expect((await getFoodItemById(user, food.id))?.default_portion_id).toBeUndefined()
   })
 
+  test('setDefaultPortion: persists the default quantity alongside the unit', async () => {
+    const user = getTestUser()
+    const food = await upsertFoodItem(user, { name: 'Wraps', default_quantity: 2, default_unit: 'wrap' })
+    const portion = await addPortion(user, food.id, { label_unit: 'wrap', base_equivalent: 1 }, stubCentral())
+
+    // Default to "1 wrap" even though the base is "2 wrap".
+    await setDefaultPortion(user, food.id, portion.id, 1)
+    const set = await getFoodItemById(user, food.id)
+    expect(set?.default_portion_id).toBe(portion.id)
+    expect(set?.default_log_quantity).toBe(1)
+
+    // Clearing the quantity (null) falls back to the base quantity.
+    await setDefaultPortion(user, food.id, null, null)
+    const cleared = await getFoodItemById(user, food.id)
+    expect(cleared?.default_portion_id).toBeUndefined()
+    expect(cleared?.default_log_quantity).toBeUndefined()
+  })
+
   test('setDefaultPortion: central food id is rejected as not-editable', async () => {
     const user = getTestUser()
     const central = { id: '22222222-3333-4444-5555-666666666666', name: 'LSV Choklad' }
     const portion = await addPortion(
       user,
       central.id,
-      { label_quantity: 1, label_unit: 'ruta', base_equivalent: 3.4 },
+      { label_unit: 'ruta', base_equivalent: 3.4 },
       stubCentral({ [central.id]: central }),
     )
     // updateFoodItem only touches the per-user table, so the central id won't

--- a/apps/backend/src/services/food-item-portions.ts
+++ b/apps/backend/src/services/food-item-portions.ts
@@ -27,7 +27,6 @@ import {
 import { createFoodItemsService } from './food-items.ts'
 
 export interface PortionInput {
-  label_quantity: number
   label_unit: string
   base_equivalent: number
   sort_order?: number
@@ -73,16 +72,19 @@ export const deletePortion = async (user: string, portionId: string): Promise<bo
 }
 
 /**
- * Set or clear a per-user food's preselected portion. The chosen portion must
- * belong to the food (defence-in-depth: a stale portion id from a different
- * food would otherwise silently render the default as "missing portion").
- * Central foods aren't editable here — their preselected portion is per-user
- * and goes on the override table (later PR).
+ * Set or clear a per-user food's default logging amount — which unit to
+ * preselect (`portionId`, null = the base unit) and how much (`quantity`,
+ * null = fall back to the base quantity). The chosen portion must belong to
+ * the food (defence-in-depth: a stale portion id from a different food would
+ * otherwise silently render the default as "missing portion"). Central foods
+ * aren't editable here — their default amount is per-user and goes on the
+ * override table.
  */
 export const setDefaultPortion = async (
   user: string,
   foodItemId: string,
   portionId: string | null,
+  quantity: number | null = null,
 ): Promise<void> => {
   if (portionId !== null) {
     const portion = await getFoodItemPortionById(user, portionId)
@@ -91,7 +93,10 @@ export const setDefaultPortion = async (
       throw new Error(`Portion ${portionId} does not belong to food item ${foodItemId}`)
     }
   }
-  const updated = await dbUpdateFoodItem(user, foodItemId, { default_portion_id: portionId })
+  const updated = await dbUpdateFoodItem(user, foodItemId, {
+    default_portion_id: portionId,
+    default_log_quantity: quantity,
+  })
   if (!updated) {
     throw new Error(`Food item not found or not editable: ${foodItemId}`)
   }

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -666,6 +666,7 @@ describe('createFoodItemsService — shared item overrides', () => {
             icon: '🥕',
             created_at: new Date(),
             icon_overridden: true,
+            default_log_quantity: null,
             default_portion_id: null,
             updated_at: new Date(),
           },
@@ -698,6 +699,7 @@ describe('createFoodItemsService — shared item overrides', () => {
             shared_food_item_id: 'c1',
             icon: null, // column default — NOT user-supplied
             icon_overridden: false, // user only touched default_portion_id
+            default_log_quantity: null,
             default_portion_id: '11111111-1111-1111-1111-111111111111',
             created_at: new Date(),
             updated_at: new Date(),
@@ -726,6 +728,7 @@ describe('createFoodItemsService — shared item overrides', () => {
             icon: null,
             created_at: new Date(),
             icon_overridden: true,
+            default_log_quantity: null,
             default_portion_id: null,
             updated_at: new Date(),
           },
@@ -767,6 +770,7 @@ describe('createFoodItemsService — shared item overrides', () => {
             icon: '🚫',
             created_at: new Date(),
             icon_overridden: true,
+            default_log_quantity: null,
             default_portion_id: null,
             updated_at: new Date(),
           },
@@ -886,6 +890,7 @@ describe('resolveFoodItemDisplay', () => {
           {
             created_at: new Date(),
             icon_overridden: true,
+            default_log_quantity: null,
             default_portion_id: null,
             icon: '🍯',
             shared_food_item_id: 'c1',
@@ -913,6 +918,7 @@ describe('resolveFoodItemDisplay', () => {
           {
             created_at: new Date(),
             icon_overridden: true,
+            default_log_quantity: null,
             default_portion_id: null,
             icon: null,
             shared_food_item_id: 'c1',

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -328,6 +328,9 @@ const applySharedOverrides = async (
       ...item,
       ...(override.icon_overridden ? { icon: override.icon ?? undefined } : {}),
       ...(override.default_portion_id ? { default_portion_id: override.default_portion_id } : {}),
+      ...(override.default_log_quantity != null
+        ? { default_log_quantity: override.default_log_quantity }
+        : {}),
     }
   })
 }

--- a/apps/backend/src/services/meals.integration.test.ts
+++ b/apps/backend/src/services/meals.integration.test.ts
@@ -467,7 +467,6 @@ describe('Meals service integration tests', () => {
       })
       const ruta = await insertFoodItemPortion(user, {
         food_item_id: choklad.id,
-        label_quantity: 1,
         label_unit: 'ruta',
         base_equivalent: 3.4,
       })
@@ -490,7 +489,7 @@ describe('Meals service integration tests', () => {
       // 3 × 3.4 / 100 = 0.102 scale; 500 kcal × 0.102 = 51 kcal; 30 fat × 0.102 = 3.06
       expect(links[0].calories).toBeCloseTo(51, 2)
       expect(links[0].fat).toBeCloseTo(3.06, 2)
-      // Display fallback: quantity is portion_count × label_quantity; unit is label_unit
+      // Display fallback: quantity is the entered portion_count; unit is label_unit
       expect(links[0].quantity).toBe(3)
       expect(links[0].unit).toBe('ruta')
       expect(links[0].food_item_portion_id).toBe(ruta.id)
@@ -504,7 +503,6 @@ describe('Meals service integration tests', () => {
       const foodB = await upsertFoodItem(user, { name: 'B', default_quantity: 100, default_unit: 'g' })
       const portionA = await insertFoodItemPortion(user, {
         food_item_id: foodA.id,
-        label_quantity: 1,
         label_unit: 'x',
         base_equivalent: 1,
       })
@@ -537,7 +535,6 @@ describe('Meals service integration tests', () => {
       const food = await upsertFoodItem(user, { name: 'F', default_quantity: 100, default_unit: 'g' })
       const portion = await insertFoodItemPortion(user, {
         food_item_id: food.id,
-        label_quantity: 1,
         label_unit: 'x',
         base_equivalent: 1,
       })
@@ -564,7 +561,6 @@ describe('Meals service integration tests', () => {
       const foodB = await upsertFoodItem(user, { name: 'B', default_quantity: 100, default_unit: 'g' })
       const portionA = await insertFoodItemPortion(user, {
         food_item_id: foodA.id,
-        label_quantity: 1,
         label_unit: 'x',
         base_equivalent: 1,
       })
@@ -598,7 +594,6 @@ describe('Meals service integration tests', () => {
       })
       const ruta = await insertFoodItemPortion(user, {
         food_item_id: food.id,
-        label_quantity: 1,
         label_unit: 'ruta',
         base_equivalent: 3.4,
       })
@@ -634,7 +629,6 @@ describe('Meals service integration tests', () => {
       })
       const ruta = await insertFoodItemPortion(user, {
         food_item_id: food.id,
-        label_quantity: 1,
         label_unit: 'ruta',
         base_equivalent: 5,
       })

--- a/apps/backend/src/services/meals.ts
+++ b/apps/backend/src/services/meals.ts
@@ -340,10 +340,11 @@ const round2 = (n: number): number => Math.round(n * 100) / 100
  * enriched atomic items inherit micronutrients.
  *
  * When a `portion` is provided AND the input carries `portion_count`, the
- * row is logged via the portion path: nutrients scale by
- * `count × base_equivalent / default_quantity`, and the legacy `quantity` /
- * `unit` columns are populated from the portion's label so display fallback
- * keeps working even if the portion is later deleted.
+ * row is logged via the portion path: `portion_count` is the quantity in the
+ * portion's unit, nutrients scale by `portion_count × base_equivalent /
+ * default_quantity`, and the legacy `quantity` / `unit` columns store
+ * `portion_count` + the portion's `label_unit` so display fallback keeps
+ * working even if the portion is later deleted.
  */
 export const buildScaledJunctionItem = (
   fi: FoodItemInput,
@@ -356,7 +357,7 @@ export const buildScaledJunctionItem = (
   const usingPortion = isUsingPortion(fi, portion)
   const junctionItem: Record<string, unknown> = {
     food_item_id: canonical.id,
-    quantity: usingPortion ? fi.portion_count! * portion.label_quantity : fi.quantity,
+    quantity: usingPortion ? fi.portion_count! : fi.quantity,
     sort_order: sortOrder,
     unit: usingPortion ? portion.label_unit : fi.unit,
     food_item_portion_id: usingPortion ? portion.id : undefined,
@@ -428,9 +429,7 @@ const resolvePortionForInput = async (
     throw new Error(`Portion not found: ${fi.food_item_portion_id}`)
   }
   if (portion.food_item_id !== canonical.id) {
-    throw new Error(
-      `Portion ${fi.food_item_portion_id} does not belong to food item ${canonical.id}`,
-    )
+    throw new Error(`Portion ${fi.food_item_portion_id} does not belong to food item ${canonical.id}`)
   }
   if (typeof fi.portion_count !== 'number' || fi.portion_count <= 0) {
     throw new Error('portion_count must be a positive number when food_item_portion_id is set')
@@ -657,9 +656,7 @@ export async function resnapshotMealsForFoodItem(
   // round-trip per refreshed link. A link whose food_item_portion_id is
   // present but absent from this map points at a portion that has since
   // been deleted — handled below by preserving the existing snapshot.
-  const portionsById = new Map(
-    (await listPortionsForFoodItem(user, foodItemId)).map((p) => [p.id, p]),
-  )
+  const portionsById = new Map((await listPortionsForFoodItem(user, foodItemId)).map((p) => [p.id, p]))
 
   // Pass-through serialization used both for unrelated rows and for rows
   // whose portion has been deleted (where rescaling would corrupt the
@@ -691,9 +688,9 @@ export async function resnapshotMealsForFoodItem(
         return passThroughLink(link)
       }
       // Portion was logged but has since been deleted: don't rescale. The
-      // recorded `quantity` is `count × portion.label_quantity` and `unit`
-      // is the portion's label (e.g. 'ruta'), which doesn't match the
-      // canonical default_unit (e.g. 'g') — running it through computeScale
+      // recorded `quantity` is the entered count and `unit` is the portion's
+      // label (e.g. 'ruta'), which doesn't match the canonical default_unit
+      // (e.g. 'g') — running it through computeScale
       // would fall back to scale=1 and overwrite the row with the full
       // per-default-quantity nutrients, making it more wrong than before.
       // Preserve the frozen snapshot instead.
@@ -701,9 +698,7 @@ export async function resnapshotMealsForFoodItem(
         return passThroughLink(link)
       }
       rowsUpdated++
-      const portion = link.food_item_portion_id
-        ? (portionsById.get(link.food_item_portion_id) ?? null)
-        : null
+      const portion = link.food_item_portion_id ? (portionsById.get(link.food_item_portion_id) ?? null) : null
       const fi: FoodItemInput = {
         food_item_id: foodItemId,
         food_item_portion_id: portion ? portion.id : undefined,

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.css
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.css
@@ -574,11 +574,11 @@
   gap: 0.25rem;
 }
 
-.fi-portion-row input[type="number"] {
+.fi-portion-row input[type='number'] {
   width: 5rem;
 }
 
-.fi-portion-row input[type="text"] {
+.fi-portion-row input[type='text'] {
   width: 8rem;
 }
 
@@ -595,6 +595,26 @@
   margin-left: auto;
 }
 
+.fi-default-amount {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.fi-default-amount input {
+  width: 5rem;
+}
+
+.fi-default-amount-hint {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.fi-portion-add-prefix {
+  color: #6b7280;
+}
+
 .fi-portion-add {
   display: flex;
   align-items: center;
@@ -604,11 +624,11 @@
   border-top: 1px dashed #d1d5db;
 }
 
-.fi-portion-add input[type="number"] {
+.fi-portion-add input[type='number'] {
   width: 5rem;
 }
 
-.fi-portion-add input[type="text"] {
+.fi-portion-add input[type='text'] {
   width: 8rem;
 }
 

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -580,12 +580,54 @@ function DefaultMetaRow({
   )
 }
 
+function DefaultAmount({
+  effectiveQty,
+  baseQty,
+  onCommit,
+}: {
+  effectiveQty: number | undefined
+  baseQty: number | undefined
+  onCommit: (q: number | null) => void
+}) {
+  const [v, setV] = useState(effectiveQty !== undefined ? String(effectiveQty) : '')
+  useEffect(() => {
+    setV(effectiveQty !== undefined ? String(effectiveQty) : '')
+  }, [effectiveQty])
+  const commit = () => {
+    const t = v.trim()
+    if (t === '') {
+      if (effectiveQty !== undefined) onCommit(null)
+      return
+    }
+    const n = parseFloat(t)
+    if (!(n > 0)) {
+      setV(effectiveQty !== undefined ? String(effectiveQty) : '')
+      return
+    }
+    if (n !== effectiveQty) onCommit(n)
+  }
+  return (
+    <div class="fi-default-amount">
+      <label>Default amount</label>
+      <input
+        type="number"
+        step="0.1"
+        value={v}
+        placeholder={baseQty !== undefined ? String(baseQty) : 'Qty'}
+        onInput={(e) => setV((e.target as HTMLInputElement).value)}
+        onBlur={commit}
+      />
+      <span class="fi-default-amount-hint">in the selected default unit, prefilled when logging</span>
+    </div>
+  )
+}
+
 function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodItemId: string }) {
   const queryClient = useQueryClient()
   const portions = item.portions ?? []
   const baseUnit = item.default_unit ?? 'base unit'
   const baseQty = item.default_quantity
-  const [draft, setDraft] = useState({ label_quantity: '', label_unit: '', base_equivalent: '' })
+  const [draft, setDraft] = useState({ label_unit: '', base_equivalent: '' })
   // Keep the add-row error separate from row-level (update/delete/default)
   // errors so an unrelated failure doesn't clear the message a user needs
   // to see while they fix their draft inputs.
@@ -596,20 +638,18 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
 
   const addMutation = useMutation({
     mutationFn: () => {
-      const lq = parseFloat(draft.label_quantity)
       const be = parseFloat(draft.base_equivalent)
-      if (!draft.label_unit.trim() || !(lq > 0) || !(be > 0)) {
-        throw new Error('label_quantity, label_unit, and base_equivalent are all required and positive')
+      if (!draft.label_unit.trim() || !(be > 0)) {
+        throw new Error('Unit and base-equivalent are required, and base-equivalent must be positive')
       }
       return addFoodItemPortionApi(foodItemId, {
-        label_quantity: lq,
         label_unit: draft.label_unit.trim(),
         base_equivalent: be,
       })
     },
     onError: (err: Error) => setAddError(err.message),
     onSuccess: () => {
-      setDraft({ label_quantity: '', label_unit: '', base_equivalent: '' })
+      setDraft({ label_unit: '', base_equivalent: '' })
       setAddError(null)
       invalidate()
     },
@@ -618,7 +658,6 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
   const updateMutation = useMutation({
     mutationFn: (input: { portionId: string; body: Partial<FoodItemPortion> }) =>
       updateFoodItemPortionApi(foodItemId, input.portionId, {
-        label_quantity: input.body.label_quantity,
         label_unit: input.body.label_unit,
         base_equivalent: input.body.base_equivalent,
       }),
@@ -638,8 +677,11 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
     },
   })
 
+  // Default logging amount: which unit (portion id, or null = base) and how
+  // much (quantity). The quantity carries across unit switches.
   const defaultMutation = useMutation({
-    mutationFn: (portionId: string | null) => setDefaultPortionApi(foodItemId, portionId),
+    mutationFn: (input: { portionId: string | null; quantity: number | null }) =>
+      setDefaultPortionApi(foodItemId, input.portionId, input.quantity),
     onError: (err: Error) => setRowError(err.message),
     onSuccess: () => {
       setRowError(null)
@@ -648,20 +690,26 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
   })
 
   // Effective default is exposed by the server (resolves override layer for
-  // central items); for per-user items it mirrors the row column. UI only
-  // shows the radio when the food has portions to choose from.
+  // central items); for per-user items it mirrors the row column.
   const effectiveDefault = item.effective_default_portion_id
+  const effectiveQty = item.effective_default_quantity
 
   return (
     <section class="fi-portions">
       <header class="fi-portions-header">
-        <h2>Portions</h2>
+        <h2>Units</h2>
         <p class="fi-portions-help">
-          Extra sizings for this food. Each portion is "label quantity label unit = base equivalent" where
-          base equivalent is measured in {baseUnit}
-          {baseQty !== undefined ? ` (the nutrient values are per ${baseQty} ${baseUnit})` : ''}.
+          Extra units this food can be logged in. Each is "1 unit = amount in {baseUnit}"
+          {baseQty !== undefined ? ` (nutrient values are per ${baseQty} ${baseUnit})` : ''}. Pick the
+          default unit and amount to prefill when logging.
         </p>
       </header>
+
+      <DefaultAmount
+        effectiveQty={effectiveQty}
+        baseQty={baseQty}
+        onCommit={(q) => defaultMutation.mutate({ portionId: effectiveDefault ?? null, quantity: q })}
+      />
 
       <ul class="fi-portions-list">
         <li class="fi-portion-row fi-portion-base">
@@ -674,15 +722,15 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
                 // Short-circuit a redundant PUT when Base is already the
                 // effective default — radio onChange still fires on click
                 // even when `checked` is already true.
-                if (effectiveDefault) defaultMutation.mutate(null)
+                if (effectiveDefault) defaultMutation.mutate({ portionId: null, quantity: effectiveQty ?? null })
               }}
             />
             Base
           </label>
-          <span class="fi-portion-label">
-            {baseQty ?? '—'} {baseUnit}
+          <span class="fi-portion-label">1 {baseUnit}</span>
+          <span class="fi-portion-eq">
+            (nutrient density baseline{baseQty !== undefined ? `: per ${baseQty} ${baseUnit}` : ''})
           </span>
-          <span class="fi-portion-eq">(nutrient density baseline)</span>
         </li>
         {portions.map((p) => (
           <PortionRow
@@ -690,7 +738,7 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
             portion={p}
             baseUnit={baseUnit}
             isDefault={effectiveDefault === p.id}
-            onSetDefault={() => defaultMutation.mutate(p.id)}
+            onSetDefault={() => defaultMutation.mutate({ portionId: p.id, quantity: effectiveQty ?? null })}
             onUpdate={(body) => updateMutation.mutate({ portionId: p.id, body })}
             onDelete={() => deleteMutation.mutate(p.id)}
           />
@@ -698,15 +746,7 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
       </ul>
 
       <div class="fi-portion-add">
-        <input
-          type="number"
-          step="0.1"
-          placeholder="Qty"
-          value={draft.label_quantity}
-          onInput={(e) =>
-            setDraft({ ...draft, label_quantity: (e.target as HTMLInputElement).value })
-          }
-        />
+        <span class="fi-portion-add-prefix">1</span>
         <input
           type="text"
           placeholder="Unit (e.g. ruta)"
@@ -719,17 +759,16 @@ function PortionsSection({ item, foodItemId }: { item: ApiFoodItemDetail; foodIt
           step="0.01"
           placeholder={`Amount in ${baseUnit}`}
           value={draft.base_equivalent}
-          onInput={(e) =>
-            setDraft({ ...draft, base_equivalent: (e.target as HTMLInputElement).value })
-          }
+          onInput={(e) => setDraft({ ...draft, base_equivalent: (e.target as HTMLInputElement).value })}
         />
+        <span class="fi-portion-base-unit">{baseUnit}</span>
         <button
           type="button"
           class="btn-secondary"
           onClick={() => addMutation.mutate()}
           disabled={addMutation.isPending}
         >
-          Add portion
+          Add unit
         </button>
       </div>
       {addError && <p class="fi-portions-error">{addError}</p>}
@@ -755,17 +794,13 @@ function PortionRow({
 }) {
   // Auto-save on blur — mirrors the rest of FoodItemDetail's commit pattern.
   // Local state lets the user edit without each keystroke racing to the API.
-  const [lq, setLq] = useState(String(portion.label_quantity))
   const [lu, setLu] = useState(portion.label_unit)
   const [be, setBe] = useState(String(portion.base_equivalent))
 
-  // Three independent effects so a mutation/invalidate that refreshes the
+  // Independent effects so a mutation/invalidate that refreshes the
   // server-side value of one field doesn't clobber unsaved input on a
   // sibling field (the previous combined effect dropped pending edits any
   // time the user blurred a different field on the same row).
-  useEffect(() => {
-    setLq(String(portion.label_quantity))
-  }, [portion.id, portion.label_quantity])
   useEffect(() => {
     setLu(portion.label_unit)
   }, [portion.id, portion.label_unit])
@@ -773,25 +808,22 @@ function PortionRow({
     setBe(String(portion.base_equivalent))
   }, [portion.id, portion.base_equivalent])
 
-  const commit = (field: 'label_quantity' | 'label_unit' | 'base_equivalent') => () => {
-    if (field === 'label_unit') {
-      const trimmed = lu.trim()
-      if (!trimmed) {
-        setLu(portion.label_unit)
-        return
-      }
-      if (trimmed !== portion.label_unit) onUpdate({ label_unit: trimmed })
+  const commitUnit = () => {
+    const trimmed = lu.trim()
+    if (!trimmed) {
+      setLu(portion.label_unit)
       return
     }
-    const raw = field === 'label_quantity' ? lq : be
-    const parsed = parseFloat(raw)
+    if (trimmed !== portion.label_unit) onUpdate({ label_unit: trimmed })
+  }
+  const commitBase = () => {
+    const parsed = parseFloat(be)
     if (!(parsed > 0)) {
       // Revert; the schema rejects non-positive values.
-      if (field === 'label_quantity') setLq(String(portion.label_quantity))
-      else setBe(String(portion.base_equivalent))
+      setBe(String(portion.base_equivalent))
       return
     }
-    if (parsed !== portion[field]) onUpdate({ [field]: parsed })
+    if (parsed !== portion.base_equivalent) onUpdate({ base_equivalent: parsed })
   }
 
   return (
@@ -799,18 +831,12 @@ function PortionRow({
       <label class="fi-portion-default">
         <input type="radio" name="default-portion" checked={isDefault} onChange={onSetDefault} />
       </label>
-      <input
-        type="number"
-        step="0.1"
-        value={lq}
-        onInput={(e) => setLq((e.target as HTMLInputElement).value)}
-        onBlur={commit('label_quantity')}
-      />
+      <span class="fi-portion-add-prefix">1</span>
       <input
         type="text"
         value={lu}
         onInput={(e) => setLu((e.target as HTMLInputElement).value)}
-        onBlur={commit('label_unit')}
+        onBlur={commitUnit}
       />
       <span class="fi-portion-eq-sep">=</span>
       <input
@@ -818,12 +844,12 @@ function PortionRow({
         step="0.01"
         value={be}
         onInput={(e) => setBe((e.target as HTMLInputElement).value)}
-        onBlur={commit('base_equivalent')}
+        onBlur={commitBase}
       />
       <span class="fi-portion-base-unit">{baseUnit}</span>
       <ConfirmButton
         label="Delete"
-        confirmMessage={`Delete portion "${portion.label_quantity} ${portion.label_unit}"?`}
+        confirmMessage={`Delete unit "${portion.label_unit}"?`}
         onConfirm={onDelete}
         buttonClass="btn-link fi-portion-del"
       />

--- a/apps/web/src/pages/Meals/MealDetail.css
+++ b/apps/web/src/pages/Meals/MealDetail.css
@@ -315,6 +315,16 @@
   white-space: nowrap;
 }
 
+.food-row-item-link {
+  white-space: nowrap;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.food-row-item-link:hover {
+  text-decoration: underline;
+}
+
 .food-row-macros label {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/pages/Meals/MealDetail.tsx
+++ b/apps/web/src/pages/Meals/MealDetail.tsx
@@ -137,16 +137,19 @@ const parseNum = (v: string) => (v === '' ? undefined : parseFloat(v))
  *   1. If the row is already pinned to a portion (e.g. editing an existing
  *      meal that was logged with `food_item_portion_id`), backfill the
  *      `portion` snapshot from detail.portions — the meal response doesn't
- *      include label_quantity/label_unit/base_equivalent, so without this
- *      backfill the row would render via the legacy quantity+unit path even
- *      though saves still go through the portion path.
- *   2. Otherwise (fresh row, no portion yet) apply the food's effective
- *      default portion if one is set.
+ *      include label_unit/base_equivalent, so without this backfill the row
+ *      would render via the legacy quantity+unit path even though saves still
+ *      go through the portion path.
+ *   2. Otherwise (fresh row) apply the food's effective default amount: the
+ *      default unit (portion or base) prefilled to the default quantity.
+ *
+ * `apply(p, count, isBackfill)` — `p` is the portion/unit (null = base unit),
+ * `count` the quantity to prefill, `isBackfill` true only for case 1.
  */
 const useAutoDefaultPortion = (
   item: FoodItemEdit,
   detail: ApiFoodItemDetail | undefined,
-  applyPortion: (p: FoodItemPortion, keepCount: boolean) => void,
+  apply: (p: FoodItemPortion | null, count: number, isBackfill: boolean) => void,
 ): void => {
   const lastAppliedFoodId = useRef<string | undefined>(undefined)
   useEffect(() => {
@@ -160,96 +163,83 @@ const useAutoDefaultPortion = (
       // qty/unit and can re-pick.
       if (item.portion) return
       const p = detail.portions?.find((pp) => pp.id === item.food_item_portion_id)
-      if (p) applyPortion(p, /* keepCount */ true)
+      if (p) apply(p, item.portion_count ?? 1, /* isBackfill */ true)
       return
     }
-    // Auto-default-portion only applies to rows added THIS session (`_isNew`).
+    // Auto-default only applies to rows added THIS session (`_isNew`).
     // Without this gate we'd silently re-encode legacy server-loaded rows
-    // (e.g. "50 g chocolate") as `1 × default portion` on meal open,
-    // overwriting the user's recorded quantity.
+    // (e.g. "50 g chocolate") on meal open, overwriting the recorded amount.
     if (!item._isNew) return
+    const count = detail.effective_default_quantity
     const def = detail.effective_default_portion_id
-    if (!def) return
-    const p = detail.portions?.find((pp) => pp.id === def)
-    if (p) applyPortion(p, /* keepCount */ false)
+    if (def) {
+      const p = detail.portions?.find((pp) => pp.id === def)
+      if (p) apply(p, count ?? 1, /* isBackfill */ false)
+      return
+    }
+    // Base unit is the default — prefill the quantity if the food carries one.
+    if (count !== undefined) apply(null, count, /* isBackfill */ false)
   }, [detail?.id, item.food_item_id])
 }
 
-function PortionPicker({
-  selectedId,
-  portions,
-  baseLabel,
-  onPick,
-}: {
-  selectedId: string | undefined
-  portions: FoodItemPortion[]
-  baseLabel: string
-  onPick: (portionId: string) => void
-}) {
-  if (portions.length === 0) return null
-  return (
-    <select
-      class="food-portion-picker"
-      value={selectedId ?? ''}
-      onChange={(e) => onPick((e.target as HTMLSelectElement).value)}
-    >
-      <option value="">Base ({baseLabel})</option>
-      {portions.map((p) => (
-        <option key={p.id} value={p.id}>
-          {p.label_quantity} {p.label_unit}
-        </option>
-      ))}
-    </select>
-  )
-}
-
-function QuantityInputs({
+// The number the user enters is the quantity in the selected unit. When a
+// portion (unit) is selected it's `portion_count`; on the base unit it's the
+// legacy `quantity`. Either way it's the same input — the unit dropdown picks
+// what the number is counted in.
+function QuantityInput({
   item,
   onUpdate,
 }: {
   item: FoodItemEdit
   onUpdate: (patch: Partial<FoodItemEdit>) => void
 }) {
-  if (item.food_item_portion_id && item.portion) {
-    return (
-      <>
-        <input
-          type="number"
-          step="0.1"
-          value={item.portion_count ?? ''}
-          placeholder="Count"
-          class="food-num-input"
-          onInput={(e) => onUpdate({ portion_count: parseNum((e.target as HTMLInputElement).value) })}
-        />
-        <span class="food-portion-unit">
-          × {item.portion.label_quantity} {item.portion.label_unit}
-        </span>
-      </>
-    )
-  }
+  const isPortion = !!item.food_item_portion_id
+  const value = isPortion ? item.portion_count : item.quantity
   return (
-    <>
-      <input
-        type="number"
-        step="0.1"
-        value={item.quantity ?? ''}
-        placeholder="Qty"
-        class="food-num-input"
-        onInput={(e) => onUpdate({ quantity: parseNum((e.target as HTMLInputElement).value) })}
-      />
-      <input
-        type="text"
-        value={item.unit ?? ''}
-        placeholder="Unit"
-        class="food-unit-input"
-        onInput={(e) => onUpdate({ unit: (e.target as HTMLInputElement).value })}
-      />
-    </>
+    <input
+      type="number"
+      step="0.1"
+      value={value ?? ''}
+      placeholder="Qty"
+      class="food-num-input"
+      onInput={(e) => {
+        const n = parseNum((e.target as HTMLInputElement).value)
+        onUpdate(isPortion ? { portion_count: n } : { quantity: n })
+      }}
+    />
+  )
+}
+
+// Unit dropdown. The base unit is itself an option (value ""); each portion
+// is a bare named unit (no leading number — the count lives in QuantityInput).
+function UnitPicker({
+  selectedId,
+  portions,
+  baseUnitLabel,
+  onPick,
+}: {
+  selectedId: string | undefined
+  portions: FoodItemPortion[]
+  baseUnitLabel: string
+  onPick: (portionId: string) => void
+}) {
+  return (
+    <select
+      class="food-portion-picker"
+      value={selectedId ?? ''}
+      onChange={(e) => onPick((e.target as HTMLSelectElement).value)}
+    >
+      <option value="">{baseUnitLabel}</option>
+      {portions.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.label_unit}
+        </option>
+      ))}
+    </select>
   )
 }
 
 const portionToSnapshot = (p: FoodItemPortion) => ({
-  label_quantity: p.label_quantity,
   label_unit: p.label_unit,
   base_equivalent: p.base_equivalent,
 })
@@ -285,10 +275,15 @@ function FoodItemRow({
     queryKey: ['foodItem', item.food_item_id],
   })
 
-  useAutoDefaultPortion(item, detail, (p, keepCount) =>
+  useAutoDefaultPortion(item, detail, (p, count, isBackfill) => {
+    if (!p) {
+      // Base unit is the default — just prefill the quantity.
+      update({ quantity: count, _isNew: false })
+      return
+    }
     update({
       food_item_portion_id: p.id,
-      portion_count: keepCount ? (item.portion_count ?? 1) : 1,
+      portion_count: count,
       portion: portionToSnapshot(p),
       // Clear the freshness flag — once applied, the row is no longer "new
       // pending auto-default" and shouldn't re-trigger if anything else
@@ -296,14 +291,14 @@ function FoodItemRow({
       _isNew: false,
       // For existing portion-pinned rows loaded via mealItemsToEdit, `ref`
       // holds the per-entry snapshot (ref.calories = already-scaled, ref.quantity
-      // = portion_count × label_quantity), not the canonical (per default_quantity)
-      // values that scaleNutrient's portion-path formula requires. Refresh ref
-      // from the food's detail so the formula
+      // = the entered count), not the canonical (per default_quantity) values
+      // that scaleNutrient's portion-path formula requires. Refresh ref from
+      // the food's detail so the formula
       //   nutrient × count × base_equivalent / ref.quantity
       // evaluates correctly. (For freshly-picked foods, ref is already canonical
-      // from FoodItemEntity, and keepCount=false, so this branch is harmless.)
+      // from FoodItemEntity and isBackfill=false, so this branch is harmless.)
       ref:
-        keepCount && detail
+        isBackfill && detail
           ? {
               calories: detail.calories,
               carbs: detail.carbs,
@@ -313,8 +308,8 @@ function FoodItemRow({
               quantity: detail.default_quantity,
             }
           : item.ref,
-    }),
-  )
+    })
+  })
 
   const portionScale =
     item.food_item_portion_id && item.portion && typeof item.portion_count === 'number'
@@ -355,12 +350,16 @@ function FoodItemRow({
     })
 
   const handlePortionPick = (portionId: string) => {
+    // The number the user already typed should follow them across unit
+    // switches — base→portion carries `quantity`, portion→portion carries
+    // `portion_count`.
+    const carried = item.portion_count ?? item.quantity
     if (!portionId) {
       update({
         food_item_portion_id: undefined,
         portion_count: undefined,
         portion: undefined,
-        quantity: detail?.default_quantity ?? item.quantity,
+        quantity: carried ?? detail?.default_quantity,
         unit: detail?.default_unit ?? item.unit,
       })
       return
@@ -369,13 +368,12 @@ function FoodItemRow({
     if (!p) return
     update({
       food_item_portion_id: p.id,
-      portion_count:
-        item.portion_count && item.food_item_portion_id ? item.portion_count : 1,
+      portion_count: carried ?? 1,
       portion: portionToSnapshot(p),
     })
   }
 
-  const baseLabel = `${detail?.default_quantity ?? '?'} ${detail?.default_unit ?? ''}`.trim()
+  const baseUnitLabel = detail?.default_unit || 'unit'
 
   return (
     <div class="food-item-edit-row">
@@ -387,21 +385,26 @@ function FoodItemRow({
           onSelect={handleFoodPick}
           onCreate={(name) => addFoodItemApi({ name })}
         />
-        <PortionPicker
+        <QuantityInput item={item} onUpdate={update} />
+        <UnitPicker
           selectedId={item.food_item_portion_id}
           portions={detail?.portions ?? []}
-          baseLabel={baseLabel}
+          baseUnitLabel={baseUnitLabel}
           onPick={handlePortionPick}
         />
-        <QuantityInputs item={item} onUpdate={update} />
         <button type="button" class="btn-danger-small" onClick={() => onRemove(index)}>
           &times;
         </button>
       </div>
-      {hasMacros && (
+      {(hasMacros || item.food_item_id) && (
         <div class="food-row-macros-display">
           {macros.map((m) =>
             typeof m.value === 'number' ? <span key={m.field}>{MACRO_LABELS[m.field](m.value)}</span> : null,
+          )}
+          {item.food_item_id && (
+            <a class="food-row-item-link" href={`/food-items/${item.food_item_id}`}>
+              item details
+            </a>
           )}
         </div>
       )}

--- a/apps/web/src/pages/Meals/mealItems.test.ts
+++ b/apps/web/src/pages/Meals/mealItems.test.ts
@@ -73,8 +73,8 @@ describe('scaleNutrient', () => {
   test('portion path ignores currentQuantity in favor of portion math', () => {
     // currentQuantity should be irrelevant when portionScale is supplied —
     // the bug this guards: pre-fix the formula used the row's `quantity`
-    // (which for portion-pinned rows is portion_count × label_quantity,
-    // not canonical default_quantity), causing wrong-scale display on load.
+    // (which for portion-pinned rows is the entered portion_count, not the
+    // canonical default_quantity), causing wrong-scale display on load.
     const canonicalRef = { calories: 500, quantity: 100 }
     const withQty = scaleNutrient(canonicalRef, 'calories', 9999, { count: 1, base_equivalent: 10 })
     const withoutQty = scaleNutrient(canonicalRef, 'calories', undefined, { count: 1, base_equivalent: 10 })
@@ -94,7 +94,7 @@ describe('mealItemsToEdit + editItemsToBody portion round-trip', () => {
         food_item_portion_id: 'portion-a',
         portion_count: 3,
         name: 'Choklad',
-        quantity: 3, // server stored count × label_quantity
+        quantity: 3, // server stored the entered count
         unit: 'ruta',
         calories: 51,
       },

--- a/apps/web/src/pages/Meals/mealItems.ts
+++ b/apps/web/src/pages/Meals/mealItems.ts
@@ -27,12 +27,12 @@ export interface FoodItemEdit {
   /** Count of `food_item_portion_id` portions logged. Required when portion_id is set. */
   portion_count?: number
   /**
-   * Snapshot of the chosen portion's label_quantity × label_unit and
-   * base_equivalent, kept on the edit row so display + live scaling don't
-   * have to re-look-up the food. Cleared when the user reverts to the
-   * base/free-form path.
+   * Snapshot of the chosen unit's label and its base_equivalent (how many
+   * base units one of this unit equals), kept on the edit row so display +
+   * live scaling don't have to re-look-up the food. Cleared when the user
+   * reverts to the base unit / free-form path.
    */
-  portion?: { label_quantity: number; label_unit: string; base_equivalent: number }
+  portion?: { label_unit: string; base_equivalent: number }
   /**
    * True for rows added this session via the "+" button (or autocomplete
    * pick from scratch). Lets the auto-default-portion effect distinguish

--- a/apps/web/src/state/api/meals.ts
+++ b/apps/web/src/state/api/meals.ts
@@ -231,11 +231,12 @@ export const deleteFoodItemPortionApi = async (foodItemId: string, portionId: st
 export const setDefaultPortionApi = async (
   foodItemId: string,
   portionId: string | null,
+  quantity: number | null = null,
 ): Promise<void> => {
   const { token } = auth.value
   await axios.put(
     `${API_URL}/food-items/${foodItemId}/default-portion`,
-    { portion_id: portionId },
+    { portion_id: portionId, quantity },
     { headers: { Authorization: `Bearer ${token}` } },
   )
 }

--- a/docs/features/meals.md
+++ b/docs/features/meals.md
@@ -64,52 +64,56 @@ A food item may be:
 
 Food items live in the per-user `food_items` table or the central, read-only `shared_food_items` library (see [Livsmedelsverket docs](../livsmedelsverket.md)). `food_item_id` is a soft pointer across both stores.
 
-### Base portion
+### Base unit
 
-Every food item has a **base portion** -- its `default_quantity` + `default_unit` (e.g. `100 g`, `1 wrap`). This is the amount the nutrient columns are measured *per*. It is the implicit "1×" sizing.
+Every food item has a **base unit** -- its `default_quantity` + `default_unit` (e.g. `100 g`, `2 wrap`). This is the amount the nutrient columns are measured _per_. All foods have at least this one unit (a backfill ensures it: per-user foods missing one default to `1 portion`, central shared foods to `100 g`).
 
-### Additional portions
+### Additional units (portions)
 
-A food item can define extra **portions** in the `food_item_portions` table -- alternative sizings the user can pick when logging. Each portion encodes an equivalence:
+A food item can define extra **units** in the `food_item_portions` table -- alternative units the user can pick when logging. Each is a named unit plus its conversion to the base unit:
 
-> `label_quantity` `label_unit` = `base_equivalent` of the food's base unit
+> `1` `label_unit` = `base_equivalent` base units
+
+`label_unit` is shown bare -- it never contains a number. The number lives in the quantity the user enters when logging.
 
 Examples (per food):
 
-| Food | Base | Portions (`label_quantity label_unit` → `base_equivalent`) |
-| --- | --- | --- |
-| Fylld tortilla | `1 wrap` | `2 wrap` → `2` (set as default) |
-| Lantmjölk | `100 g` | `515 g` → `515`; `1 glas` → `515` |
-| Choklad | `100 g` | `1 ruta` → `3.4`; `1 rad` → `13.6` |
+| Food           | Base unit | Units (`1 label_unit` → `base_equivalent` base units) |
+| -------------- | --------- | ----------------------------------------------------- |
+| Fylld tortilla | `2 wrap`  | `1 wrap` → `1` (enter `1 wrap` ⇒ ×0.5)                |
+| Lantmjölk      | `100 g`   | `1 glas` → `515`                                       |
+| Choklad        | `100 g`   | `1 ruta` → `3.4`; `1 rad` → `13.6`                    |
 
-`base_equivalent` is a **count of base units, not a fraction of `default_quantity`**. To scale a nutrient when logging `N` of a portion:
+When logging, the user enters a **quantity in the chosen unit**. To scale a nutrient for quantity `Q` of a unit:
 
 ```
-nutrient_value × N × base_equivalent / default_quantity
+nutrient_value × Q × base_equivalent / default_quantity
 ```
 
-So 3 `ruta` of a 100 g chocolate base at 500 kcal/100 g = `500 × 3 × 3.4 / 100` = 51 kcal.
+So `3 ruta` of a 100 g chocolate base at 500 kcal/100 g = `500 × 3 × 3.4 / 100` = 51 kcal. The base unit itself is just the unit with `base_equivalent = 1` (entering `58 g` on a 100 g base ⇒ ×0.58; entering `1 wrap` on a `2 wrap` base ⇒ ×0.5).
 
-Conversions are **direct-to-base only** -- a portion never references another portion (no chaining).
+Conversions are **direct-to-base only** -- a unit never references another unit (no chaining).
 
-`food_item_portions.food_item_id` is a soft pointer, so portions can target a per-user food OR a central shared food. Deleting a per-user food cascades its portions (app-level); deleting a portion clears any `default_portion_id` that pointed at it.
+`food_item_portions.food_item_id` is a soft pointer, so units can target a per-user food OR a central shared food. Deleting a per-user food cascades its units (app-level); deleting a unit clears any `default_portion_id` that pointed at it.
 
-### Default portion
+### Default logging amount
 
-A food's preselected portion when logging is resolved as **`effective_default_portion_id`** on the food-item detail response:
+A food's preselected logging amount is a **unit + quantity** pair, resolved on the food-item detail response as `effective_default_portion_id` (the unit) and `effective_default_quantity` (the amount):
 
-- **Per-user food** -- `food_items.default_portion_id` (NULL ⇒ base portion is the default).
-- **Central shared food** -- the user's `shared_food_item_overrides.default_portion_id` (NULL ⇒ fall through to the central row's own default, which is currently always the base portion). This lets a user pin e.g. "1 cup" as their default on a read-only LSV milk row without forking it.
+- **Per-user food** -- `food_items.default_portion_id` + `food_items.default_log_quantity`. A NULL unit means the base unit; a NULL quantity falls back to `default_quantity` (the base quantity).
+- **Central shared food** -- the user's `shared_food_item_overrides.default_portion_id` + `default_log_quantity` (NULL ⇒ fall through to the central row's own default / base). This lets a user pin e.g. "2 dl" as their default on a read-only LSV milk row without forking it.
 
-### Logging with a portion
+The default amount can differ from the base sizing -- e.g. a base of `1 wrap` but a default of `2 wrap`.
 
-When a meal item is logged with `food_item_portion_id` + `portion_count`:
+### Logging with a unit
 
-- Nutrients are snapshotted using the portion formula above.
-- The junction's legacy `quantity` / `unit` are populated from the portion's label (`portion_count × label_quantity` and `label_unit`) so a meal still renders "3 ruta" even if the portion is later deleted.
-- Re-snapshotting (`resnapshot_meals_for_food_item`) refetches the portion and rescales; if the portion was deleted since logging, the frozen snapshot is preserved rather than recomputed against a mismatched unit.
+When a meal item is logged with `food_item_portion_id` + `portion_count` (the entered quantity in that unit):
 
-Logging without a portion uses the legacy free-form `quantity` + `unit` path, unchanged.
+- Nutrients are snapshotted using the formula above.
+- The junction's legacy `quantity` / `unit` are populated from the entered count + the unit's `label_unit` so a meal still renders "3 ruta" even if the unit is later deleted.
+- Re-snapshotting (`resnapshot_meals_for_food_item`) refetches the unit and rescales; if it was deleted since logging, the frozen snapshot is preserved rather than recomputed against a mismatched unit.
+
+Logging on the base unit uses the legacy free-form `quantity` + `unit` path, unchanged.
 
 ### Food-item REST endpoints
 
@@ -122,8 +126,8 @@ Logging without a portion uses the legacy free-form `quantity` + `unit` path, un
 - `POST /food-items/:id/portions` -- add a portion
 - `PATCH /food-items/:id/portions/:portionId` -- update a portion (404 if it doesn't belong to `:id`)
 - `DELETE /food-items/:id/portions/:portionId` -- delete a portion (404 if it doesn't belong to `:id`)
-- `PUT /food-items/:id/default-portion` -- set/clear the preselected portion; body `{ "portion_id": "<uuid>" | null }`
-- `PUT /food-items/:id/override` -- per-user override on a central item; accepts `icon` and/or `default_portion_id`
+- `PUT /food-items/:id/default-portion` -- set/clear the default logging amount; body `{ "portion_id": "<uuid>" | null, "quantity": <number> | null }` (`portion_id` null = base unit, `quantity` null = base quantity)
+- `PUT /food-items/:id/override` -- per-user override on a central item; accepts `icon`, `default_portion_id`, and/or `default_log_quantity`
 - Composite/reference helpers: `PUT|DELETE /food-items/:id/ingredients`, `PUT|DELETE /food-items/:id/reference`, `POST /food-items/:id/resnapshot-meals`, merge endpoints
 
 ## Data Sources
@@ -187,8 +191,8 @@ Food items & portions:
 - `add_food_item` / `update_food_item` / `delete_food_item` -- per-user food item CRUD
 - `list_food_item_portions` -- list a food's portions
 - `add_food_item_portion` / `update_food_item_portion` / `delete_food_item_portion` -- portion CRUD (per-user OR central food, soft pointer)
-- `set_default_food_item_portion` -- set/clear a per-user food's preselected portion (`portion_id: null` reverts to base)
-- `set_shared_food_item_override` / `clear_shared_food_item_override` -- per-user overrides on a central item (`icon`, `default_portion_id`)
+- `set_default_food_item_portion` -- set/clear a per-user food's default logging amount (`portion_id` + `quantity`; `portion_id: null` = base unit, `quantity: null` = base quantity)
+- `set_shared_food_item_override` / `clear_shared_food_item_override` -- per-user overrides on a central item (`icon`, `default_portion_id`, `default_log_quantity`)
 - `set_food_item_ingredients` / `clear_food_item_ingredients` -- composite recipes; `set_food_item_reference` -- reference enrichment; `resnapshot_meals_for_food_item` -- refresh historical meal snapshots; `merge_food_items` / `preview_food_item_merge`
 
 Nutrient recommendations:

--- a/packages/api-spec/src/schemas/food-item-portions.ts
+++ b/packages/api-spec/src/schemas/food-item-portions.ts
@@ -92,7 +92,11 @@ export const setDefaultFoodItemPortionBodySchema = z
       .number()
       .positive()
       .nullable()
-      .meta({ description: 'Default quantity to prefill, or null to fall back to the base quantity' }),
+      .optional()
+      .meta({
+        description:
+          'Default quantity to prefill, or null to fall back to the base quantity. Omitting it is treated as null (back-compat for callers that send only portion_id).',
+      }),
   })
   .meta({
     description: 'Set or clear the default logging amount (unit + quantity) for a food item',

--- a/packages/api-spec/src/schemas/food-item-portions.ts
+++ b/packages/api-spec/src/schemas/food-item-portions.ts
@@ -1,8 +1,11 @@
 /**
- * Food item portion schemas — additional sizings for a food item beyond its
- * "base" (default_quantity/default_unit). Each portion expresses an
- * equivalence "label_quantity label_unit = base_equivalent base_units" so the
- * meal logger can scale nutrients without unit-conversion guesswork.
+ * Food item portion schemas — alternate *units* for a food item beyond its
+ * "base" (default_quantity/default_unit). A portion is a named unit plus its
+ * conversion to the base unit: "1 label_unit = base_equivalent base_units".
+ *
+ * When logging, the user enters a quantity in the chosen unit; nutrients
+ * scale as `entered_quantity × base_equivalent / default_quantity`. (For the
+ * base unit itself, base_equivalent is implicitly 1.)
  */
 
 import { z } from 'zod'
@@ -16,15 +19,12 @@ export const foodItemPortionSchema = z
       description:
         'Food item this portion belongs to. Soft pointer — may target a per-user or a central shared food item.',
     }),
-    label_quantity: z.number().positive().meta({
-      description: 'Display quantity for the portion (e.g. 2 in "2 wrap", 1 in "1 glas").',
-    }),
     label_unit: z.string().min(1).max(100).meta({
-      description: 'Display unit for the portion (e.g. "wrap", "glas", "ruta").',
+      description: 'Unit name (e.g. "wrap", "glas", "ruta"). Shown bare — never prefixed with a number.',
     }),
     base_equivalent: z.number().positive().meta({
       description:
-        'How much of the food item\'s base unit this whole portion entry equals — a count of base units, NOT a fraction of default_quantity. Example: a 100 g base with a "1 ruta = 3.4 g" portion stores 3.4 here. To scale nutrients when logging N of this portion: nutrient_value * N * base_equivalent / default_quantity.',
+        'How many of the food\'s base unit ONE of this unit equals. Example: a 100 g base with "1 ruta = 3.4 g" stores 3.4. To scale nutrients when logging Q of this unit: nutrient_value × Q × base_equivalent / default_quantity.',
     }),
     // sort_order, created_at, updated_at are always populated by the DB and
     // emitted by the response serializer — clients can rely on them.
@@ -32,24 +32,22 @@ export const foodItemPortionSchema = z
     created_at: z.string().meta({ description: 'Creation timestamp' }),
     updated_at: z.string().meta({ description: 'Last update timestamp' }),
   })
-  .meta({ description: 'A named portion sizing for a food item', id: 'FoodItemPortion' })
+  .meta({ description: 'A named unit (with base-unit conversion) for a food item', id: 'FoodItemPortion' })
 
 export type FoodItemPortion = z.infer<typeof foodItemPortionSchema>
 
 export const addFoodItemPortionBodySchema = z
   .object({
-    label_quantity: z.number().positive(),
     label_unit: z.string().min(1).max(100),
     base_equivalent: z.number().positive(),
     sort_order: z.number().int().optional(),
   })
-  .meta({ description: 'Create a portion on a food item', id: 'AddFoodItemPortionBody' })
+  .meta({ description: 'Create a portion (unit) on a food item', id: 'AddFoodItemPortionBody' })
 
 export type AddFoodItemPortionBody = z.infer<typeof addFoodItemPortionBodySchema>
 
 export const updateFoodItemPortionBodySchema = z
   .object({
-    label_quantity: z.number().positive().optional(),
     label_unit: z.string().min(1).max(100).optional(),
     base_equivalent: z.number().positive().optional(),
     sort_order: z.number().int().optional(),
@@ -77,8 +75,11 @@ export const deleteFoodItemPortionResponseSchema = baseResponseSchema.meta({
 export type DeleteFoodItemPortionResponse = z.infer<typeof deleteFoodItemPortionResponseSchema>
 
 /**
- * Body for `PUT /food-items/:id/default-portion` — set or clear the
- * preselected portion. `portion_id: null` reverts to the food's base portion.
+ * Body for `PUT /food-items/:id/default-portion` — set or clear the default
+ * logging amount: which unit to preselect (`portion_id`, null = the base
+ * unit) and how much (`quantity`). E.g. base 1 wrap but default "2 wrap":
+ * `{ portion_id: null, quantity: 2 }`. `{ portion_id: null, quantity: null }`
+ * clears the override (prefill falls back to the base quantity).
  */
 export const setDefaultFoodItemPortionBodySchema = z
   .object({
@@ -86,10 +87,15 @@ export const setDefaultFoodItemPortionBodySchema = z
       .string()
       .uuid()
       .nullable()
-      .meta({ description: 'Portion id to preselect, or null to revert to the base portion' }),
+      .meta({ description: 'Portion (unit) id to preselect, or null for the base unit' }),
+    quantity: z
+      .number()
+      .positive()
+      .nullable()
+      .meta({ description: 'Default quantity to prefill, or null to fall back to the base quantity' }),
   })
   .meta({
-    description: 'Set or clear the default portion for a food item',
+    description: 'Set or clear the default logging amount (unit + quantity) for a food item',
     id: 'SetDefaultFoodItemPortionBody',
   })
 

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -43,7 +43,11 @@ export const foodItemEntitySchema = nutrientFieldsSchema
     }),
     default_portion_id: z.string().uuid().optional().meta({
       description:
-        'Portion (from food_item_portions) to preselect when this food is logged. NULL/absent means the base portion (default_quantity/default_unit) is preselected.',
+        'Default *unit* to preselect when logging this food (a food_item_portions id). NULL/absent means the base unit (default_unit). Pairs with default_log_quantity to form the prefill.',
+    }),
+    default_log_quantity: z.number().positive().optional().meta({
+      description:
+        'Default *quantity* to prefill when logging this food, in the unit named by default_portion_id (or the base unit when that is null). NULL/absent falls back to default_quantity (the base quantity).',
     }),
     name: z.string().min(1).max(255).meta({ description: 'Food item name' }),
     source: z
@@ -172,7 +176,11 @@ export const foodItemDetailSchema = foodItemEntitySchema
     }),
     effective_default_portion_id: z.string().uuid().optional().meta({
       description:
-        'Resolved default portion id to preselect when logging this food. For per-user items this mirrors `default_portion_id` on the food row. For central items it falls back through `shared_food_item_overrides.default_portion_id` first, then the central row\'s own (currently absent) default. Absent when there is no default — the UI should preselect the implicit base portion.',
+        'Resolved default *unit* to preselect when logging this food. For per-user items this mirrors `default_portion_id`; for central items it resolves through `shared_food_item_overrides.default_portion_id`. Absent ⇒ preselect the base unit.',
+    }),
+    effective_default_quantity: z.number().positive().optional().meta({
+      description:
+        'Resolved default *quantity* to prefill, in the unit named by effective_default_portion_id (or the base unit). Resolves the per-user / override default_log_quantity, falling back to the base default_quantity. Absent ⇒ no prefill hint.',
     }),
     ingredients: z.array(resolvedFoodItemIngredientSchema).optional(),
     derived_nutrients: z
@@ -243,7 +251,11 @@ export const sharedFoodItemOverrideSchema = z
     }),
     default_portion_id: z.string().uuid().nullable().meta({
       description:
-        'User-preselected portion id for the central item; null means no override (fall through to the central row\'s own default_portion_id).',
+        "User-preselected portion id (unit) for the central item; null means no override (fall through to the central row's own default_portion_id).",
+    }),
+    default_log_quantity: z.number().positive().nullable().meta({
+      description:
+        'User-preselected default quantity for the central item, in the unit named by default_portion_id (or the base unit). Null means no override (fall through to the base default_quantity).',
     }),
     created_at: z.string().meta({ description: 'Override creation timestamp' }),
     updated_at: z.string().meta({ description: 'Override last-update timestamp' }),
@@ -274,12 +286,22 @@ export const setSharedFoodItemOverrideBodySchema = z
     }),
     default_portion_id: z.string().uuid().nullable().optional().meta({
       description:
-        'Override preselected portion id. String sets the override, null clears any prior override (falls through to the central default), omitted leaves the column unchanged.',
+        'Override preselected portion id (unit). String sets the override, null clears any prior override (falls through to the central default), omitted leaves the column unchanged.',
+    }),
+    default_log_quantity: z.number().positive().nullable().optional().meta({
+      description:
+        'Override default quantity, in the unit named by default_portion_id. Number sets the override, null clears it (falls through to the base quantity), omitted leaves the column unchanged.',
     }),
   })
-  .refine((body) => body.icon !== undefined || body.default_portion_id !== undefined, {
-    message: 'At least one override field must be supplied; clear via DELETE to revert to central',
-  })
+  .refine(
+    (body) =>
+      body.icon !== undefined ||
+      body.default_portion_id !== undefined ||
+      body.default_log_quantity !== undefined,
+    {
+      message: 'At least one override field must be supplied; clear via DELETE to revert to central',
+    },
+  )
   .meta({
     description: 'Upsert per-user override columns for a central shared food item',
     id: 'SetSharedFoodItemOverrideBody',


### PR DESCRIPTION
## Summary

Reframes food-item portions as **named units with a per-unit conversion to the base unit**, replacing the old "count × label_quantity" model. The number a user enters when logging is now simply the **quantity in the selected unit**.

Backend + web ship together because removing `label_quantity` from the shared `@aurboda/api-spec` type is a breaking change for the web build.

### Model change
- A portion is now `1 label_unit = base_equivalent base_units`; the unit label never contains a number. `label_quantity` is dropped everywhere (schema, api-spec, db, service, routes, MCP, tests). Existing rows are normalised on migrate via `base_equivalent /= label_quantity`.
- The base unit is itself a pickable unit (`base_equivalent = 1`). Scaling stays `entered_qty × base_equivalent / default_quantity` — e.g. `58 g` on a 100 g base ⇒ ×0.58; `1 wrap` on a `2 wrap` base ⇒ ×0.5; `1 glas (=515 g)` ⇒ ×5.15.
- Separate **default logging amount**: new `default_log_quantity` on `food_items` and `shared_food_item_overrides`; `effective_default_quantity` surfaced on the detail response; the default-portion endpoint + MCP tool now take `{ portion_id, quantity }`.
- **Backfill** a base unit for every food so all foods have at least one unit to log in: per-user → `1 portion`, central shared → `100 g` (only where missing).

### Web UI
- Meal-entry row reordered to **`[food] [number] [unit ▾] [×]`**, the redundant `× 1 unit` span removed, unit labels shown bare, the number prefilled from the food's default amount, and an **"item details"** link added after the per-row macros.
- Food-item portions editor drops the `label_quantity` input (`1 [unit] = [amount] [base unit]`) and gains a **default-amount** field.

### Docs
- `docs/features/meals.md` updated for the unit model.

## Verification
- `pnpm check` (backend + web + api-spec): **0 type errors, 0 lint errors**.
- Backend tests: **2253 passed**. Web tests: **409 passed**.
- api-spec rebuilt + `pnpm generate` run (OpenAPI + Kotlin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)