### PR TITLE
feat(activity-detail): show distance, pace, cadence, HR averages

### DIFF
--- a/apps/web/src/pages/EntityDetail/format-utils.test.ts
+++ b/apps/web/src/pages/EntityDetail/format-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatCadence, formatDistance, formatPace } from './format-utils'
+
+describe('formatDistance', () => {
+  test('formats meters under 1km without decimals', () => {
+    expect(formatDistance(850)).toBe('850 m')
+    expect(formatDistance(0)).toBe('0 m')
+    expect(formatDistance(999)).toBe('999 m')
+  })
+
+  test('formats km with two decimals at and above 1000m', () => {
+    expect(formatDistance(1000)).toBe('1.00 km')
+    expect(formatDistance(3420)).toBe('3.42 km')
+    expect(formatDistance(12345)).toBe('12.35 km')
+  })
+})
+
+describe('formatPace', () => {
+  test('returns undefined when no pace and no speed', () => {
+    expect(formatPace(undefined)).toBeUndefined()
+    expect(formatPace(0)).toBeUndefined()
+    expect(formatPace(undefined, 0)).toBeUndefined()
+  })
+
+  test('formats seconds-per-km as M:SS /km', () => {
+    expect(formatPace(330)).toBe('5:30 /km')
+    expect(formatPace(360)).toBe('6:00 /km')
+    expect(formatPace(65)).toBe('1:05 /km')
+  })
+
+  test('pads seconds with leading zero', () => {
+    expect(formatPace(305)).toBe('5:05 /km')
+  })
+
+  test('derives pace from speed (m/s) when pace missing', () => {
+    // 2.5 m/s => 400 s/km => 6:40 /km
+    expect(formatPace(undefined, 2.5)).toBe('6:40 /km')
+  })
+
+  test('prefers explicit pace over speed', () => {
+    expect(formatPace(330, 2.5)).toBe('5:30 /km')
+  })
+})
+
+describe('formatCadence', () => {
+  test('rounds and appends spm', () => {
+    expect(formatCadence(172)).toBe('172 spm')
+    expect(formatCadence(171.7)).toBe('172 spm')
+  })
+})

--- a/apps/web/src/pages/EntityDetail/format-utils.ts
+++ b/apps/web/src/pages/EntityDetail/format-utils.ts
@@ -15,3 +15,26 @@ export const formatDuration = (start: Date, end: Date): string => {
   const m = totalMin % 60
   return m > 0 ? `${h}h ${m}m` : `${h}h`
 }
+
+/** Format a distance (in meters) as `"X.XX km"` for >= 1 km, else `"N m"`. */
+export const formatDistance = (meters: number): string => {
+  if (meters >= 1000) return `${(meters / 1000).toFixed(2)} km`
+  return `${Math.round(meters)} m`
+}
+
+/**
+ * Format a pace (in seconds per kilometer) as `"M:SS /km"`.
+ * If `paceSecPerKm` is missing/zero but `speedMps` is provided, derive it.
+ */
+export const formatPace = (paceSecPerKm: number | undefined, speedMps?: number): string | undefined => {
+  const pace =
+    paceSecPerKm && paceSecPerKm > 0 ? paceSecPerKm : speedMps && speedMps > 0 ? 1000 / speedMps : undefined
+  if (pace === undefined) return undefined
+  const totalSec = Math.round(pace)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${s.toString().padStart(2, '0')} /km`
+}
+
+/** Format cadence (steps per minute). */
+export const formatCadence = (spm: number): string => `${Math.round(spm)} spm`

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -31,7 +31,7 @@ import { ActivityChart } from './ActivityChart'
 import { ActivityMap } from './ActivityMap'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { EntityActions, type EntityType } from './EntityActions'
-import { formatDateTimeLocal, formatTime } from './format-utils'
+import { formatCadence, formatDateTimeLocal, formatDistance, formatPace, formatTime } from './format-utils'
 import { LocationInfo } from './LocationInfo'
 import { forceMergedSpanForOverride, mergedEditAction } from './mergedEdit'
 import { MergePanel } from './MergePanel'
@@ -181,6 +181,53 @@ const SleepMetricsCards = ({ metrics }: { metrics: Partial<Record<SleepMetricKey
   </div>
 )
 
+type ActivityStatRow = { label: string; value: string }
+
+const buildActivityStatRows = (
+  activity: Activity,
+  totalCalories: number | undefined,
+  sleepMinutes: number | undefined,
+): ActivityStatRow[] => {
+  const rows: ActivityStatRow[] = []
+  if (activity.distance !== undefined)
+    {rows.push({ label: 'Distance', value: formatDistance(activity.distance) })}
+  const pace = formatPace(activity.avg_pace, activity.avg_speed)
+  if (pace !== undefined) rows.push({ label: 'Avg Pace', value: pace })
+  if (activity.avg_cadence !== undefined)
+    {rows.push({ label: 'Avg Cadence', value: formatCadence(activity.avg_cadence) })}
+  if (activity.avg_hr !== undefined)
+    {rows.push({ label: 'Avg HR', value: `${Math.round(activity.avg_hr)} bpm` })}
+  if (activity.max_hr !== undefined)
+    {rows.push({ label: 'Max HR', value: `${Math.round(activity.max_hr)} bpm` })}
+  if (totalCalories !== undefined) rows.push({ label: 'Active Calories', value: `${totalCalories} kcal` })
+  if (sleepMinutes !== undefined) rows.push({ label: 'Asleep', value: formatMinutesAsHM(sleepMinutes) })
+  if (activity.avg_hrv !== undefined) rows.push({ label: 'Avg HRV', value: `${activity.avg_hrv} ms` })
+  return rows
+}
+
+const ActivityStats = ({
+  activity,
+  totalCalories,
+  sleepMinutes,
+}: {
+  activity: Activity
+  totalCalories: number | undefined
+  sleepMinutes: number | undefined
+}) => {
+  const rows = buildActivityStatRows(activity, totalCalories, sleepMinutes)
+  if (rows.length === 0) return null
+  return (
+    <div class="entity-fields">
+      {rows.map((row) => (
+        <div class="field-row" key={row.label}>
+          <span class="field-label">{row.label}</span>
+          <span class="field-value">{row.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 // ── Unified Activity Detail ──────────────────────────────────────────────────
 
 /** Data-driven activity detail: shows features based on what data exists, not display_category. */
@@ -328,30 +375,7 @@ const ActivityDetailContent = ({
         {/* Read-only stats — shown based on data presence, not activity type */}
         {!isEditing && (
           <>
-            {totalCalories !== undefined && (
-              <div class="entity-fields">
-                <div class="field-row">
-                  <span class="field-label">Active Calories</span>
-                  <span class="field-value">{totalCalories} kcal</span>
-                </div>
-              </div>
-            )}
-            {sleepMinutes !== undefined && (
-              <div class="entity-fields">
-                <div class="field-row">
-                  <span class="field-label">Asleep</span>
-                  <span class="field-value">{formatMinutesAsHM(sleepMinutes)}</span>
-                </div>
-              </div>
-            )}
-            {activity.avg_hrv !== undefined && (
-              <div class="entity-fields">
-                <div class="field-row">
-                  <span class="field-label">Avg HRV</span>
-                  <span class="field-value">{activity.avg_hrv} ms</span>
-                </div>
-              </div>
-            )}
+            <ActivityStats activity={activity} totalCalories={totalCalories} sleepMinutes={sleepMinutes} />
             {hasHrZones && <HrZoneBar zones={hrZoneSecs!} />}
           </>
         )}


### PR DESCRIPTION
## Summary
- Activity detail summary previously only showed Active Calories — add Distance, Avg Pace, Avg Cadence, Avg HR, and Max HR.
- Fields are rendered only when present on the activity (already returned by the detail endpoint via `ActivityComputedMetrics`).
- Avg Pace uses `avg_pace` when set; otherwise derives it from `avg_speed`.

## Test plan
- [x] `pnpm check` (web + backend + api-spec) — passes
- [x] `vitest run src/pages/EntityDetail/` — 44 tests pass (8 new format-utils tests)
- [ ] Verify on a Running activity (e.g. `/detail/activity/merged:6742de9d-...`): Distance, Avg Pace, Avg Cadence appear
- [ ] Verify on an activity without these fields (e.g. a sleep entry) that the rows are omitted cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)