### PR TITLE
refactor(activity-detail): unified summary table

### DIFF
--- a/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
+++ b/apps/web/src/pages/EntityDetail/EditableActivityFields.tsx
@@ -4,7 +4,7 @@
  */
 import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { IconPreview } from '../../components/IconPreview'
-import { formatDateTime, formatDuration, formatTime } from './format-utils'
+import { formatDuration } from './format-utils'
 
 export interface ActivityDraft {
   activity_type: string
@@ -17,13 +17,10 @@ export interface ActivityDraft {
 
 interface EditableActivityFieldsProps {
   title: string
-  displayStart: Date
-  displayEnd?: Date
-  notes?: string
   isEditing: boolean
   draft: ActivityDraft
   onDraftChange: (draft: ActivityDraft) => void
-  /** Label for the duration row (e.g. "In Bed" for sleep). Defaults to "Duration". */
+  /** Label for the duration row in edit mode (e.g. "In Bed" for sleep). Defaults to "Duration". */
   durationLabel?: string
   /** Icon (emoji or URL) to display next to the title. */
   icon?: string
@@ -33,9 +30,6 @@ interface EditableActivityFieldsProps {
 
 export const EditableActivityFields = ({
   title,
-  displayStart,
-  displayEnd,
-  notes,
   isEditing,
   draft,
   onDraftChange,
@@ -152,35 +146,12 @@ export const EditableActivityFields = ({
     title
   )
 
+  // Read-only mode: render only the title. Parent renders the unified stats
+  // table (Time, Duration, Distance, etc.) and any Notes block.
   return (
-    <>
-      <h2 class="entity-title-with-icon">
-        {icon && <IconPreview icon={icon} size={28} />}
-        {titleContent}
-      </h2>
-
-      <div class="entity-fields">
-        <div class="field-row">
-          <span class="field-label">Time</span>
-          <span class="field-value">
-            {displayEnd
-              ? `${formatDateTime(displayStart)} – ${formatTime(displayEnd)}`
-              : formatDateTime(displayStart)}
-          </span>
-        </div>
-        {displayEnd && (
-          <div class="field-row">
-            <span class="field-label">{durationLabel}</span>
-            <span class="field-value">{formatDuration(displayStart, displayEnd)}</span>
-          </div>
-        )}
-        {notes && (
-          <div class="field-row">
-            <span class="field-label">Notes</span>
-            <span class="field-value">{notes}</span>
-          </div>
-        )}
-      </div>
-    </>
+    <h2 class="entity-title-with-icon">
+      {icon && <IconPreview icon={icon} size={28} />}
+      {titleContent}
+    </h2>
   )
 }

--- a/apps/web/src/pages/EntityDetail/activityStats.test.ts
+++ b/apps/web/src/pages/EntityDetail/activityStats.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest'
+
+import type { Activity } from '../../state/api'
+
+import { buildActivityStatRows } from './activityStats'
+
+const baseActivity = (overrides: Partial<Activity> = {}): Activity =>
+  ({
+    id: 'a1',
+    activity_type: 'running',
+    start_time: new Date('2026-06-01T09:57:00Z'),
+    ...overrides,
+  }) as Activity
+
+const input = (overrides: Partial<Parameters<typeof buildActivityStatRows>[0]> = {}) => ({
+  activity: baseActivity(),
+  displayStart: new Date('2026-06-01T09:57:00Z'),
+  displayEnd: new Date('2026-06-01T10:28:00Z'),
+  durationLabel: 'Duration',
+  totalCalories: undefined,
+  sleepMinutes: undefined,
+  notes: '',
+  ...overrides,
+})
+
+describe('buildActivityStatRows', () => {
+  test('always emits a Time row', () => {
+    const rows = buildActivityStatRows(input({ displayEnd: undefined }))
+    expect(rows[0]?.label).toBe('Time')
+    expect(rows.find((r) => r.label === 'Duration')).toBeUndefined()
+  })
+
+  test('emits Duration row only when displayEnd is present', () => {
+    const rows = buildActivityStatRows(input())
+    expect(rows.find((r) => r.label === 'Duration')?.value).toBe('31m')
+  })
+
+  test('uses custom duration label (e.g. "In Bed" for sleep)', () => {
+    const rows = buildActivityStatRows(input({ durationLabel: 'In Bed' }))
+    expect(rows.find((r) => r.label === 'In Bed')).toBeDefined()
+    expect(rows.find((r) => r.label === 'Duration')).toBeUndefined()
+  })
+
+  test('emits all populated metric rows in order', () => {
+    const rows = buildActivityStatRows(
+      input({
+        activity: baseActivity({
+          distance: 2770,
+          avg_pace: 651,
+          avg_cadence: 153,
+          avg_hr: 122,
+          max_hr: 136,
+          avg_hrv: 45,
+        }),
+        totalCalories: 193,
+      }),
+    )
+    expect(rows.map((r) => r.label)).toEqual([
+      'Time',
+      'Duration',
+      'Distance',
+      'Avg Pace',
+      'Avg Cadence',
+      'Avg HR',
+      'Max HR',
+      'Active Calories',
+      'Avg HRV',
+    ])
+    expect(rows.find((r) => r.label === 'Distance')?.value).toBe('2.77 km')
+    expect(rows.find((r) => r.label === 'Avg Cadence')?.value).toBe('153 spm')
+    expect(rows.find((r) => r.label === 'Avg HR')?.value).toBe('122 bpm')
+    expect(rows.find((r) => r.label === 'Max HR')?.value).toBe('136 bpm')
+    expect(rows.find((r) => r.label === 'Active Calories')?.value).toBe('193 kcal')
+  })
+
+  test('omits rows whose underlying data is missing', () => {
+    const rows = buildActivityStatRows(input())
+    expect(rows.find((r) => r.label === 'Distance')).toBeUndefined()
+    expect(rows.find((r) => r.label === 'Avg Pace')).toBeUndefined()
+    expect(rows.find((r) => r.label === 'Avg Cadence')).toBeUndefined()
+    expect(rows.find((r) => r.label === 'Active Calories')).toBeUndefined()
+    expect(rows.find((r) => r.label === 'Notes')).toBeUndefined()
+  })
+
+  test('emits Asleep row when sleepMinutes provided', () => {
+    const rows = buildActivityStatRows(input({ sleepMinutes: 425 }))
+    expect(rows.find((r) => r.label === 'Asleep')?.value).toBe('7h 5m')
+  })
+
+  test('emits Notes row when notes are non-empty', () => {
+    const rows = buildActivityStatRows(input({ notes: 'Felt great' }))
+    expect(rows.at(-1)).toEqual({ label: 'Notes', value: 'Felt great' })
+  })
+})

--- a/apps/web/src/pages/EntityDetail/activityStats.ts
+++ b/apps/web/src/pages/EntityDetail/activityStats.ts
@@ -1,0 +1,64 @@
+import type { Activity } from '../../state/api'
+
+import {
+  formatCadence,
+  formatDateTime,
+  formatDistance,
+  formatDuration,
+  formatPace,
+  formatTime,
+} from './format-utils'
+import { formatMinutesAsHM } from './sleep-utils'
+
+export interface ActivityStatRow {
+  label: string
+  value: string
+}
+
+export interface BuildActivityStatRowsInput {
+  activity: Activity
+  displayStart: Date
+  displayEnd: Date | undefined
+  durationLabel: string
+  totalCalories: number | undefined
+  sleepMinutes: number | undefined
+  notes: string
+}
+
+/**
+ * Build the rows shown in the read-only activity summary table.
+ * Returns Time, Duration, and any populated metric/note rows in display order.
+ */
+export const buildActivityStatRows = ({
+  activity,
+  displayStart,
+  displayEnd,
+  durationLabel,
+  totalCalories,
+  sleepMinutes,
+  notes,
+}: BuildActivityStatRowsInput): ActivityStatRow[] => {
+  const rows: ActivityStatRow[] = []
+  rows.push({
+    label: 'Time',
+    value: displayEnd
+      ? `${formatDateTime(displayStart)} – ${formatTime(displayEnd)}`
+      : formatDateTime(displayStart),
+  })
+  if (displayEnd) rows.push({ label: durationLabel, value: formatDuration(displayStart, displayEnd) })
+  if (activity.distance !== undefined)
+    {rows.push({ label: 'Distance', value: formatDistance(activity.distance) })}
+  const pace = formatPace(activity.avg_pace, activity.avg_speed)
+  if (pace !== undefined) rows.push({ label: 'Avg Pace', value: pace })
+  if (activity.avg_cadence !== undefined)
+    {rows.push({ label: 'Avg Cadence', value: formatCadence(activity.avg_cadence) })}
+  if (activity.avg_hr !== undefined)
+    {rows.push({ label: 'Avg HR', value: `${Math.round(activity.avg_hr)} bpm` })}
+  if (activity.max_hr !== undefined)
+    {rows.push({ label: 'Max HR', value: `${Math.round(activity.max_hr)} bpm` })}
+  if (totalCalories !== undefined) rows.push({ label: 'Active Calories', value: `${totalCalories} kcal` })
+  if (sleepMinutes !== undefined) rows.push({ label: 'Asleep', value: formatMinutesAsHM(sleepMinutes) })
+  if (activity.avg_hrv !== undefined) rows.push({ label: 'Avg HRV', value: `${activity.avg_hrv} ms` })
+  if (notes) rows.push({ label: 'Notes', value: notes })
+  return rows
+}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -29,9 +29,10 @@ import { toDisplayName } from '../../utils/displayName'
 import { resolveItemIcon } from '../../utils/emojiLookup'
 import { ActivityChart } from './ActivityChart'
 import { ActivityMap } from './ActivityMap'
+import { type BuildActivityStatRowsInput, buildActivityStatRows } from './activityStats'
 import { type ActivityDraft, EditableActivityFields } from './EditableActivityFields'
 import { EntityActions, type EntityType } from './EntityActions'
-import { formatCadence, formatDateTimeLocal, formatDistance, formatPace, formatTime } from './format-utils'
+import { formatDateTimeLocal, formatTime } from './format-utils'
 import { LocationInfo } from './LocationInfo'
 import { forceMergedSpanForOverride, mergedEditAction } from './mergedEdit'
 import { MergePanel } from './MergePanel'
@@ -43,7 +44,6 @@ import { activityRouteAfterSave } from './saveNavigation'
 import { SchemaDataFields } from './SchemaDataFields'
 import {
   computeSleepMinutesFromStages,
-  formatMinutesAsHM,
   SLEEP_METRIC_LABELS,
   SLEEP_METRIC_UNITS,
   SLEEP_METRICS,
@@ -181,50 +181,19 @@ const SleepMetricsCards = ({ metrics }: { metrics: Partial<Record<SleepMetricKey
   </div>
 )
 
-type ActivityStatRow = { label: string; value: string }
-
-const buildActivityStatRows = (
-  activity: Activity,
-  totalCalories: number | undefined,
-  sleepMinutes: number | undefined,
-): ActivityStatRow[] => {
-  const rows: ActivityStatRow[] = []
-  if (activity.distance !== undefined)
-    {rows.push({ label: 'Distance', value: formatDistance(activity.distance) })}
-  const pace = formatPace(activity.avg_pace, activity.avg_speed)
-  if (pace !== undefined) rows.push({ label: 'Avg Pace', value: pace })
-  if (activity.avg_cadence !== undefined)
-    {rows.push({ label: 'Avg Cadence', value: formatCadence(activity.avg_cadence) })}
-  if (activity.avg_hr !== undefined)
-    {rows.push({ label: 'Avg HR', value: `${Math.round(activity.avg_hr)} bpm` })}
-  if (activity.max_hr !== undefined)
-    {rows.push({ label: 'Max HR', value: `${Math.round(activity.max_hr)} bpm` })}
-  if (totalCalories !== undefined) rows.push({ label: 'Active Calories', value: `${totalCalories} kcal` })
-  if (sleepMinutes !== undefined) rows.push({ label: 'Asleep', value: formatMinutesAsHM(sleepMinutes) })
-  if (activity.avg_hrv !== undefined) rows.push({ label: 'Avg HRV', value: `${activity.avg_hrv} ms` })
-  return rows
-}
-
-const ActivityStats = ({
-  activity,
-  totalCalories,
-  sleepMinutes,
-}: {
-  activity: Activity
-  totalCalories: number | undefined
-  sleepMinutes: number | undefined
-}) => {
-  const rows = buildActivityStatRows(activity, totalCalories, sleepMinutes)
-  if (rows.length === 0) return null
+const ActivityStatsTable = (props: BuildActivityStatRowsInput) => {
+  const rows = buildActivityStatRows(props)
   return (
-    <div class="entity-fields">
-      {rows.map((row) => (
-        <div class="field-row" key={row.label}>
-          <span class="field-label">{row.label}</span>
-          <span class="field-value">{row.value}</span>
-        </div>
-      ))}
-    </div>
+    <table class="activity-stats-table">
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.label}>
+            <th scope="row">{row.label}</th>
+            <td>{row.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   )
 }
 
@@ -351,9 +320,6 @@ const ActivityDetailContent = ({
 
         <EditableActivityFields
           title={activity.title || exerciseDisplayName || typeDisplayName}
-          displayStart={displayStart}
-          displayEnd={realEnd}
-          notes={getUserNotesContent(activity)}
           isEditing={isEditing}
           draft={draft}
           onDraftChange={onDraftChange}
@@ -375,7 +341,15 @@ const ActivityDetailContent = ({
         {/* Read-only stats — shown based on data presence, not activity type */}
         {!isEditing && (
           <>
-            <ActivityStats activity={activity} totalCalories={totalCalories} sleepMinutes={sleepMinutes} />
+            <ActivityStatsTable
+              activity={activity}
+              displayStart={displayStart}
+              displayEnd={realEnd}
+              durationLabel={hasSleepStages ? 'In Bed' : 'Duration'}
+              totalCalories={totalCalories}
+              sleepMinutes={sleepMinutes}
+              notes={getUserNotesContent(activity)}
+            />
             {hasHrZones && <HrZoneBar zones={hrZoneSecs!} />}
           </>
         )}

--- a/apps/web/src/pages/EntityDetail/style.css
+++ b/apps/web/src/pages/EntityDetail/style.css
@@ -138,6 +138,28 @@ a.entity-type-badge:hover {
   gap: 0.5rem;
 }
 
+.activity-stats-table {
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.activity-stats-table th {
+  text-align: left;
+  font-weight: 500;
+  color: #6b7280;
+  padding: 0.25rem 1rem 0.25rem 0;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.activity-stats-table td {
+  color: #374151;
+  padding: 0.25rem 0;
+  vertical-align: top;
+  white-space: pre-wrap;
+}
+
 .field-row {
   display: flex;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- Activity detail read-only summary previously stacked separate \`.entity-fields\` blocks, producing uneven row spacing and misaligned value columns (e.g. Time/Duration tight, then a visible step before Avg Pace/Cadence).
- Render all rows (Time, Duration, Distance, Avg Pace, Avg Cadence, Avg HR, Max HR, Active Calories, Asleep, Avg HRV, Notes) as a single \`<table class="activity-stats-table">\` — semantically correct for tabular data, with naturally aligned label/value columns and uniform row padding.
- Row builder extracted to \`activityStats.ts\` with focused unit tests (inclusion logic, custom \`durationLabel\` for sleep, notes row). \`EditableActivityFields\` in read mode now renders only the title h2; edit mode is unchanged.

## Test plan
- [x] \`pnpm check\` — 0 errors across backend / web / api-spec
- [x] \`vitest run src/pages/EntityDetail/\` — 51 tests pass (7 new)
- [ ] Visual check on a Running activity: rows have consistent spacing and values column-align
- [ ] Visual check on a Sleep activity: \"In Bed\" label appears in the table; \"Asleep\" row shows
- [ ] Edit mode still works (inputs render, save flow intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)