### PR TITLE
fix(lastfm): trigger deduction rules on background and MCP scrobble syncs

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -201,7 +201,7 @@ const main = async () => {
 
   // Create sync provider for auto-syncing data before queries. onActivitySynced
   // lets background scrobble syncs trigger deduction rules (e.g. auto-tagging),
-  // matching what the REST /sync routes already do.
+  // like the REST /sync routes — here fired only when a sync ingests new data.
   const syncProvider = createSyncProvider({
     garmin,
     getLastFmApiKey: () => centralDb.getLastFmApiKey(),

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -186,16 +186,8 @@ const main = async () => {
       centralDb.upsertStravaAthleteMapping(stravaAthleteId, username),
   })
 
-  // Create sync provider for auto-syncing data before queries
-  const syncProvider = createSyncProvider({
-    garmin,
-    getLastFmApiKey: () => centralDb.getLastFmApiKey(),
-    oura,
-  })
-
-  // Initialize shared pg-boss instance and job queues (before MCP mount)
-  const boss = await createPgBoss()
-
+  // Deduction queue is assigned once pg-boss is up (below). The notifier closes
+  // over the variable, so it starts enqueuing as soon as the queue exists.
   let deductionQueue: DeductionQueue | null = null
   const activityNotifier: ActivityNotifier = (user, activityType, start, end, sourceRuleId) => {
     deductionQueue?.enqueueEvaluation({
@@ -206,6 +198,20 @@ const main = async () => {
       window_start: start.toISOString(),
     })
   }
+
+  // Create sync provider for auto-syncing data before queries. onActivitySynced
+  // lets background scrobble syncs trigger deduction rules (e.g. auto-tagging),
+  // matching what the REST /sync routes already do.
+  const syncProvider = createSyncProvider({
+    garmin,
+    getLastFmApiKey: () => centralDb.getLastFmApiKey(),
+    oura,
+    onActivitySynced: activityNotifier,
+  })
+
+  // Initialize shared pg-boss instance and job queues (before MCP mount)
+  const boss = await createPgBoss()
+
   const engineDeps = createDefaultEngineDeps(activityNotifier)
 
   if (boss) {

--- a/apps/backend/src/integrations/lastfm/sync.ts
+++ b/apps/backend/src/integrations/lastfm/sync.ts
@@ -19,7 +19,7 @@ import { getSyncState, insertActivities, insertRawRecord, upsertSyncState } from
 import { lastfmClient } from './client.ts'
 
 /** Default start date for historical sync (30 days back) */
-const DEFAULT_SYNC_HISTORY_DAYS = 30
+export const DEFAULT_SYNC_HISTORY_DAYS = 30
 
 /** Result of a sync operation */
 export interface LastFmSyncResult {

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -71,7 +71,7 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
   registerActivityTools(server, user, deps.onActivityMutated)
   registerActivityTypeTools(server, user)
   registerDeductionRuleTools(server, user, engineDeps, deps.deductionQueue)
-  registerSyncTools(server, user, deps.oura, deps.garmin, deps.stravaQueue)
+  registerSyncTools(server, user, deps.oura, deps.garmin, deps.stravaQueue, deps.onActivityMutated)
   registerSettingsTools(server, user)
   registerLocationTools(server, user)
   registerCorrelationTools(server, user, deps.sync)

--- a/apps/backend/src/mcp/sync-tools.test.ts
+++ b/apps/backend/src/mcp/sync-tools.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { McpServer } from './helpers.ts'
+
+vi.mock('../services/central-db.ts', () => ({
+  getCentralDb: () => ({ getLastFmApiKey: vi.fn().mockResolvedValue('api-key') }),
+}))
+
+vi.mock('../services/settings.ts', () => ({
+  getSettings: vi.fn().mockResolvedValue({ lastfm_username: 'bob' }),
+}))
+
+vi.mock('../integrations/lastfm/sync.ts', () => ({
+  DEFAULT_SYNC_HISTORY_DAYS: 30,
+  syncLastFmData: vi.fn(),
+}))
+
+import { syncLastFmData } from '../integrations/lastfm/sync.ts'
+import { registerSyncTools } from './sync-tools.ts'
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>
+
+const buildFakeServer = (): { server: McpServer; tools: Map<string, ToolHandler> } => {
+  const tools = new Map<string, ToolHandler>()
+  const server = {
+    tool: (name: string, _desc: string, _shape: unknown, handler: ToolHandler) => {
+      tools.set(name, handler)
+    },
+  } as unknown as McpServer
+  return { server, tools }
+}
+
+describe('MCP sync_lastfm tool', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test('triggers deduction evaluation after a successful sync with new scrobbles', async () => {
+    vi.mocked(syncLastFmData).mockResolvedValue({ scrobbles_processed: 2, status: 'success' })
+    const notifier = vi.fn()
+    const { server, tools } = buildFakeServer()
+    registerSyncTools(server, 'alice', undefined, undefined, undefined, notifier)
+
+    await tools.get('sync_lastfm')!({})
+
+    expect(notifier).toHaveBeenCalledTimes(1)
+    const [user, activityType] = notifier.mock.calls[0]
+    expect(user).toBe('alice')
+    expect(activityType).toBe('*')
+  })
+
+  test('does not trigger deduction when no new scrobbles were processed', async () => {
+    vi.mocked(syncLastFmData).mockResolvedValue({ scrobbles_processed: 0, status: 'success' })
+    const notifier = vi.fn()
+    const { server, tools } = buildFakeServer()
+    registerSyncTools(server, 'alice', undefined, undefined, undefined, notifier)
+
+    await tools.get('sync_lastfm')!({})
+
+    expect(notifier).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -201,8 +201,9 @@ export const registerSyncTools = (
           startDate: start_date ? new Date(start_date) : undefined,
         })
 
-        // Run deduction rules (e.g. scrobble-based auto-tagging) over the synced
-        // window, matching the REST /sync/lastfm route.
+        // Trigger deduction rules (e.g. scrobble-based auto-tagging) over the
+        // synced window, like the REST /sync/lastfm route does — but only when
+        // the sync actually ingested new scrobbles.
         if (result.status === 'success' && result.scrobbles_processed > 0) {
           const now = new Date()
           notifier?.(

--- a/apps/backend/src/mcp/sync-tools.ts
+++ b/apps/backend/src/mcp/sync-tools.ts
@@ -12,10 +12,12 @@ import {
   syncStravaBodySchema,
   tzSchema,
 } from '@aurboda/api-spec'
+import { subDays } from 'date-fns'
 import { z } from 'zod'
 
 import type { GarminClient } from '../integrations/garmin/client.ts'
 import type { ouraClient } from '../integrations/oura/client.ts'
+import type { ActivityNotifier } from '../services/deduction-queue.ts'
 import type { StravaQueue } from '../services/strava-queue.ts'
 
 import {
@@ -29,7 +31,7 @@ import {
 } from '../db/index.ts'
 import { type GarminDataType, syncAllGarminData } from '../integrations/garmin/sync.ts'
 import { syncAllCalendars } from '../integrations/ical/sync.ts'
-import { syncLastFmData } from '../integrations/lastfm/sync.ts'
+import { DEFAULT_SYNC_HISTORY_DAYS, syncLastFmData } from '../integrations/lastfm/sync.ts'
 import { syncAllOuraData } from '../integrations/oura/sync.ts'
 import { syncRescueTimeData } from '../integrations/rescuetime/sync.ts'
 import { syncStrava } from '../integrations/strava/sync.ts'
@@ -46,6 +48,7 @@ export const registerSyncTools = (
   oura?: OuraClient,
   garmin?: GarminClient,
   stravaQueue?: StravaQueue,
+  notifier?: ActivityNotifier,
 ) => {
   // Tool: sync_oura
   server.tool(
@@ -197,6 +200,18 @@ export const registerSyncTools = (
           fullResync: full_resync,
           startDate: start_date ? new Date(start_date) : undefined,
         })
+
+        // Run deduction rules (e.g. scrobble-based auto-tagging) over the synced
+        // window, matching the REST /sync/lastfm route.
+        if (result.status === 'success' && result.scrobbles_processed > 0) {
+          const now = new Date()
+          notifier?.(
+            user,
+            '*',
+            start_date ? new Date(start_date) : subDays(now, DEFAULT_SYNC_HISTORY_DAYS),
+            now,
+          )
+        }
 
         return jsonResponse({
           error: result.error,

--- a/apps/backend/src/services/sync-provider.test.ts
+++ b/apps/backend/src/services/sync-provider.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import * as dbIndex from '../db/index.ts'
+
+// Partial mock: keep the real exports (other sync integrations reference them
+// at module load) and override only getSyncState.
+vi.mock('../db/index.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof dbIndex>()),
+  getSyncState: vi.fn(),
+}))
+
+vi.mock('./settings.ts', () => ({
+  getSettings: vi.fn(),
+}))
+
+vi.mock('./audit-log.ts', () => ({
+  auditError: vi.fn(),
+  auditInfo: vi.fn(),
+  auditWarn: vi.fn(),
+}))
+
+vi.mock('../integrations/lastfm/sync.ts', () => ({
+  DEFAULT_SYNC_HISTORY_DAYS: 30,
+  syncLastFmData: vi.fn(),
+}))
+
+import { syncLastFmData } from '../integrations/lastfm/sync.ts'
+import { getSettings } from './settings.ts'
+import { createSyncProvider } from './sync-provider.ts'
+
+describe('createSyncProvider › syncLastFmIfNeeded', () => {
+  const lastSync = new Date('2026-06-01T00:00:00Z')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getSettings).mockResolvedValue({ lastfm_username: 'bob' } as never)
+    vi.mocked(dbIndex.getSyncState).mockResolvedValue({ last_sync_time: lastSync } as never)
+  })
+
+  const build = (onActivitySynced = vi.fn()) => ({
+    onActivitySynced,
+    provider: createSyncProvider({ getLastFmApiKey: async () => 'api-key', onActivitySynced }),
+  })
+
+  test('triggers deduction over the synced window when new scrobbles arrived', async () => {
+    vi.mocked(syncLastFmData).mockResolvedValue({ scrobbles_processed: 3, status: 'success' })
+    const { onActivitySynced, provider } = build()
+
+    await provider.syncLastFmIfNeeded('alice')
+
+    expect(syncLastFmData).toHaveBeenCalledWith('alice', 'api-key', 'bob')
+    expect(onActivitySynced).toHaveBeenCalledTimes(1)
+    const [user, activityType, start, end] = onActivitySynced.mock.calls[0]
+    expect(user).toBe('alice')
+    expect(activityType).toBe('*') // evaluate all rules
+    expect(start).toEqual(lastSync) // window starts at last_sync_time
+    expect((end as Date).getTime()).toBeGreaterThan((start as Date).getTime())
+  })
+
+  test('does not trigger deduction when no new scrobbles were processed', async () => {
+    vi.mocked(syncLastFmData).mockResolvedValue({ scrobbles_processed: 0, status: 'success' })
+    const { onActivitySynced, provider } = build()
+
+    await provider.syncLastFmIfNeeded('alice')
+
+    expect(onActivitySynced).not.toHaveBeenCalled()
+  })
+
+  test('does not trigger deduction when the sync failed', async () => {
+    vi.mocked(syncLastFmData).mockResolvedValue({
+      error: 'boom',
+      scrobbles_processed: 0,
+      status: 'error',
+    })
+    const { onActivitySynced, provider } = build()
+
+    await provider.syncLastFmIfNeeded('alice')
+
+    expect(onActivitySynced).not.toHaveBeenCalled()
+  })
+
+  test('skips syncing entirely when synced within the threshold', async () => {
+    vi.mocked(dbIndex.getSyncState).mockResolvedValue({ last_sync_time: new Date() } as never)
+    vi.mocked(syncLastFmData).mockResolvedValue({ scrobbles_processed: 5, status: 'success' })
+    const { onActivitySynced, provider } = build()
+
+    await provider.syncLastFmIfNeeded('alice')
+
+    expect(syncLastFmData).not.toHaveBeenCalled()
+    expect(onActivitySynced).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/services/sync-provider.ts
+++ b/apps/backend/src/services/sync-provider.ts
@@ -5,10 +5,11 @@
  * functions to enable automatic data refresh before queries.
  */
 
-import { isBefore, subMinutes } from 'date-fns'
+import { isBefore, subDays, subMinutes } from 'date-fns'
 
 import type { GarminClient } from '../integrations/garmin/client.ts'
 import type { ouraClient } from '../integrations/oura/client.ts'
+import type { ActivityNotifier } from './deduction-queue.ts'
 import type { SyncProvider } from './queries/index.ts'
 
 import { getSyncState } from '../db/index.ts'
@@ -19,7 +20,7 @@ import {
   syncGarminDataType,
 } from '../integrations/garmin/sync.ts'
 import { syncAllCalendars } from '../integrations/ical/sync.ts'
-import { syncLastFmData } from '../integrations/lastfm/sync.ts'
+import { DEFAULT_SYNC_HISTORY_DAYS, syncLastFmData } from '../integrations/lastfm/sync.ts'
 import {
   isRateLimited as isOuraRateLimited,
   type OuraDataType,
@@ -45,6 +46,13 @@ export interface SyncProviderConfig {
   getLastFmApiKey?: () => Promise<string | null>
   /** Oura API client (optional - if not provided, Oura sync is disabled) */
   oura?: OuraClientType
+  /**
+   * Fired after a successful auto-sync that ingested new data, so deduction
+   * rules run over the freshly-synced window. Wired to the same
+   * ActivityNotifier the REST `/sync` routes use; when omitted (e.g. in tests),
+   * auto-sync still works but does not trigger deduction evaluation.
+   */
+  onActivitySynced?: ActivityNotifier
   /** Sync threshold in minutes (default: 30) */
   syncThresholdMinutes?: number
 }
@@ -122,13 +130,21 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
         if (!apiKey) return
 
         const syncState = await getSyncState(user, 'lastfm', 'scrobbles')
-        const thresholdTime = subMinutes(new Date(), threshold)
+        const now = new Date()
+        const thresholdTime = subMinutes(now, threshold)
         if (syncState?.last_sync_time && isBefore(thresholdTime, syncState.last_sync_time)) {
           return
         }
 
         auditInfo(user, 'sync', 'Auto-syncing Last.fm scrobbles')
-        await syncLastFmData(user, apiKey, settings.lastfm_username)
+        // The sync fetches scrobbles from last_sync_time (or 30 days back on the
+        // first sync) up to now. Remember that window so deduction rules — e.g.
+        // scrobble-based auto-tagging — run over exactly the newly-ingested data.
+        const windowStart = syncState?.last_sync_time ?? subDays(now, DEFAULT_SYNC_HISTORY_DAYS)
+        const result = await syncLastFmData(user, apiKey, settings.lastfm_username)
+        if (result.status === 'success' && result.scrobbles_processed > 0) {
+          config.onActivitySynced?.(user, '*', windowStart, now)
+        }
       } catch (error) {
         auditError(user, 'sync', 'Failed to auto-sync Last.fm', { error: String(error) })
       }

--- a/docs/lastfm.md
+++ b/docs/lastfm.md
@@ -93,6 +93,8 @@ Returns track name, artist, album, and timestamp for each scrobble in the time r
 
 Last.fm scrobbles are automatically synced when querying tags or the daily summary, if the last sync was more than 30 minutes ago. This ensures scrobble data stays current without manual intervention.
 
+Every sync path — automatic background sync, the `POST /api/sync/lastfm` REST route, and the `sync_lastfm` MCP tool — triggers evaluation of [deduction rules](features/deduction-rules.md) with `scrobble` conditions over the just-synced window. This means scrobble-based rules (e.g. a "Vocal Training" rule that matches vocal-exercise tracks) are applied automatically, without a separate manual step.
+
 ### Manual Sync
 
 - **REST:** `POST /api/sync/lastfm`
@@ -106,8 +108,7 @@ Options:
 ### Sync Process
 
 1. Fetch recent scrobbles from Last.fm API (paginated, 200 per page)
-2. Store each scrobble as a raw record
-3. Apply auto-tagging rules to each scrobble
-4. Create tags (or extend existing span tags) for matching rules
+2. Store each scrobble as a raw record and as a `music_scrobble` activity
+3. Evaluate [deduction rules](features/deduction-rules.md) with `scrobble` conditions over the synced window, creating or enriching activities from matching scrobbles
 
 Currently-playing tracks are skipped (no timestamp yet).


### PR DESCRIPTION
## Problem

A scrobble-based deduction rule (the user's **Vocal Training** rule, matching vocal-exercise tracks by `Sam West` et al.) had only been applied intermittently for weeks. Qualifying scrobbles existed in the data (e.g. May 26, Jun 2, Jun 3) with no resulting `vocal_training` activity, while a dry-run of the rule over the last 90 days said **17** activities should exist vs. only ~8 actually present.

## Root cause

Deduction rules run only when something triggers an evaluation. For scrobbles the only trigger is the `onActivitySynced` notifier — and it was wired into **just one** of the three Last.fm sync paths:

| Sync path | Triggered deduction? |
|---|---|
| REST `POST /sync/lastfm` (web "sync" button) | ✅ |
| Background auto-sync (`sync-provider.ts`, fires lazily before tag/daily-summary queries) | ❌ |
| MCP `sync_lastfm` tool | ❌ |

The background auto-sync is the path that runs in normal use, so newly-scrobbled tracks landed in `raw_records`/`music_scrobble` activities **without ever being run through the rules**. Tags only appeared when an explicit web sync or a rule edit happened to force a re-evaluation. (The MCP tool even advertised "applies auto-tagging rules" but didn't.)

## Fix

Wire `onActivitySynced` into the sync-provider config and pass the notifier to the MCP sync tool, so **every** sync path evaluates deduction rules over the synced window — matching what the REST route already does.

- `sync-provider`: fire the notifier over `[last_sync_time, now]` when a sync ingests new scrobbles (tight window → less churn than a blanket 30-day re-eval on every 30-min auto-sync).
- `sync_lastfm` MCP tool: fire the notifier over the synced window, mirroring the REST route.
- Export `DEFAULT_SYNC_HISTORY_DAYS` for the first-sync fallback window.
- Hoist the `activityNotifier`/`deductionQueue` in `api.ts` so the notifier can be injected into `createSyncProvider`.
- Unit tests for both paths (fires only on success with new scrobbles; skips within the sync threshold).

Existing gap data was already backfilled separately via `evaluate_deduction_rules`.

## Notes / follow-up

- The same trigger gap likely exists for **other** auto-synced providers (Garmin/Oura/RescueTime) whose activities feed `activity`/`screentime` conditions — scoped out of this PR, worth a follow-up.
- `docs/lastfm.md` is broadly stale (predates the tags→deduction-rules/activities migration); this PR only corrects the two sync sections it touches.

## Test plan

- [x] `pnpm --filter aurboda-backend check` (tsgo + oxlint) — passes, 0 new errors
- [x] New unit tests pass (`sync-provider.test.ts`, `sync-tools.test.ts`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)