### PR TITLE
fix(web): meals day total honors meal-level macros over food-item aggregate

### DIFF
--- a/apps/web/src/pages/Meals/dayNutrients.test.ts
+++ b/apps/web/src/pages/Meals/dayNutrients.test.ts
@@ -62,8 +62,16 @@ describe('aggregateDayNutrients', () => {
     expect(aggregateDayNutrients(meals).calories).toBe(122.82)
   })
 
-  test('skips meals without nutrients', () => {
+  test('includes meals with a meal-level macro but no nutrients object', () => {
+    // A manually logged meal with no itemized food items has no `nutrients`
+    // (the backend only attaches it when junction links exist), but its
+    // calories show on the card and must count toward the day total.
     const meals = [makeMeal({ calories: 100 }), makeMeal({ calories: 50, nutrients: { calories: 50 } })]
+    expect(aggregateDayNutrients(meals).calories).toBe(150)
+  })
+
+  test('contributes nothing for a meal with neither nutrients nor meal-level macros', () => {
+    const meals = [makeMeal({}), makeMeal({ calories: 50, nutrients: { calories: 50 } })]
     expect(aggregateDayNutrients(meals).calories).toBe(50)
   })
 

--- a/apps/web/src/pages/Meals/dayNutrients.test.ts
+++ b/apps/web/src/pages/Meals/dayNutrients.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest'
+
+import type { Meal } from '../../state/api'
+
+import { aggregateDayNutrients } from './dayNutrients'
+
+const makeMeal = (partial: Partial<Meal>): Meal => ({ time: new Date(0), ...partial })
+
+describe('aggregateDayNutrients', () => {
+  test('sums macros across meals when meal-level and aggregate agree', () => {
+    const meals = [
+      makeMeal({ calories: 300, protein: 10, nutrients: { calories: 300, protein: 10 } }),
+      makeMeal({ calories: 200, protein: 5, nutrients: { calories: 200, protein: 5 } }),
+    ]
+    const totals = aggregateDayNutrients(meals)
+    expect(totals.calories).toBe(500)
+    expect(totals.protein).toBe(15)
+  })
+
+  test('uses the meal-level macro when a food item lacks per-item nutrition (override > aggregate)', () => {
+    // Dinner: curry food item has no per-item calories, so nutrients only
+    // captures the rice (122.82). The meal-level estimate (760) is the truth.
+    const meals = [
+      makeMeal({
+        calories: 760,
+        nutrient_data_incomplete: true,
+        nutrients: { calories: 122.82 },
+      }),
+    ]
+    expect(aggregateDayNutrients(meals).calories).toBe(760)
+  })
+
+  test('reproduces the real day: card-level total, not the understated aggregate', () => {
+    const meals = [
+      makeMeal({ calories: 327.72, nutrients: { calories: 327.72 } }), // breakfast
+      makeMeal({ calories: 721.08, nutrients: { calories: 721.08 } }), // lunch
+      makeMeal({ calories: 22, nutrients: { calories: 22 } }), // supplements
+      makeMeal({ calories: 760, nutrient_data_incomplete: true, nutrients: { calories: 122.82 } }), // dinner
+      makeMeal({ calories: 266, nutrients: { calories: 266 } }), // snack
+      makeMeal({ calories: 193.8, nutrients: { calories: 193.8 } }), // snack
+    ]
+    // Old behaviour summed nutrients → 1653.42. Cards (meal.calories) sum to 2290.6.
+    expect(aggregateDayNutrients(meals).calories).toBe(2290.6)
+  })
+
+  test('micronutrients (no meal-level override) stay summed from the aggregate', () => {
+    const meals = [
+      makeMeal({
+        calories: 760,
+        nutrient_data_incomplete: true,
+        nutrients: { calories: 122.82, sodium: 234.96 },
+      }),
+      makeMeal({ calories: 266, nutrients: { calories: 266, sodium: 56 } }),
+    ]
+    const totals = aggregateDayNutrients(meals)
+    expect(totals.calories).toBe(1026)
+    expect(totals.sodium).toBe(290.96)
+  })
+
+  test('falls back to the aggregate when no meal-level macro is set', () => {
+    const meals = [makeMeal({ nutrients: { calories: 122.82 } })]
+    expect(aggregateDayNutrients(meals).calories).toBe(122.82)
+  })
+
+  test('skips meals without nutrients', () => {
+    const meals = [makeMeal({ calories: 100 }), makeMeal({ calories: 50, nutrients: { calories: 50 } })]
+    expect(aggregateDayNutrients(meals).calories).toBe(50)
+  })
+
+  test('honours a meal-level override that is lower than the aggregate', () => {
+    const meals = [makeMeal({ calories: 80, nutrients: { calories: 120 } })]
+    expect(aggregateDayNutrients(meals).calories).toBe(80)
+  })
+})

--- a/apps/web/src/pages/Meals/dayNutrients.ts
+++ b/apps/web/src/pages/Meals/dayNutrients.ts
@@ -24,15 +24,20 @@ const MEAL_MACRO_FIELDS = ['calories', 'protein', 'carbs', 'fat', 'fiber'] as co
 export const aggregateDayNutrients = (meals: Meal[]): Record<string, number> => {
   const totals: Record<string, number> = {}
   for (const meal of meals) {
-    if (!meal.nutrients) continue
-    for (const [key, val] of Object.entries(meal.nutrients)) {
-      if (typeof val === 'number' && val > 0) totals[key] = (totals[key] ?? 0) + val
+    const { nutrients } = meal
+    if (nutrients) {
+      for (const [key, val] of Object.entries(nutrients)) {
+        if (typeof val === 'number' && val > 0) totals[key] = (totals[key] ?? 0) + val
+      }
     }
-    // Swap in the meal-level macro where it differs from the aggregate.
+    // Swap in the meal-level macro where it differs from the aggregate — or
+    // add it outright when the meal has no `nutrients` object at all (a
+    // manually logged meal with no itemized food items still shows its
+    // calories on the card, so it must count toward the day total too).
     for (const key of MEAL_MACRO_FIELDS) {
       const mealVal = meal[key]
       if (typeof mealVal !== 'number') continue
-      const nutrientVal = meal.nutrients[key]
+      const nutrientVal = nutrients?.[key]
       if (mealVal === nutrientVal) continue
       totals[key] = (totals[key] ?? 0) - (typeof nutrientVal === 'number' ? nutrientVal : 0) + mealVal
     }

--- a/apps/web/src/pages/Meals/dayNutrients.ts
+++ b/apps/web/src/pages/Meals/dayNutrients.ts
@@ -1,0 +1,42 @@
+import type { Meal } from '../../state/api'
+
+/**
+ * Macro fields that live both on the meal row (manual-override-aware, shown
+ * on each meal card via `meal.calories` etc.) and inside `meal.nutrients`
+ * (aggregated from per-food-item data). When a food item lacks per-item
+ * nutrition, `meal.nutrients` understates the meal, but the meal-level field
+ * still reflects the manual override entered for the meal as a whole.
+ */
+const MEAL_MACRO_FIELDS = ['calories', 'protein', 'carbs', 'fat', 'fiber'] as const
+
+/**
+ * Aggregate nutrients across all meals for the day.
+ *
+ * For the macro fields the meal-level value wins over the per-food-item
+ * aggregate, so the day total stays consistent with each meal card. This
+ * matters when a meal is flagged `nutrient_data_incomplete`: a food item with
+ * no nutrition data contributes 0 to `meal.nutrients`, but the user's
+ * meal-level override (e.g. an estimated 760 kcal for a home-cooked dish)
+ * should still count toward the day total. Micronutrients have no meal-level
+ * override and remain summed from `meal.nutrients` (still understated, which
+ * the "totals may be understated" notice covers).
+ */
+export const aggregateDayNutrients = (meals: Meal[]): Record<string, number> => {
+  const totals: Record<string, number> = {}
+  for (const meal of meals) {
+    if (!meal.nutrients) continue
+    for (const [key, val] of Object.entries(meal.nutrients)) {
+      if (typeof val === 'number' && val > 0) totals[key] = (totals[key] ?? 0) + val
+    }
+    // Swap in the meal-level macro where it differs from the aggregate.
+    for (const key of MEAL_MACRO_FIELDS) {
+      const mealVal = meal[key]
+      if (typeof mealVal !== 'number') continue
+      const nutrientVal = meal.nutrients[key]
+      if (mealVal === nutrientVal) continue
+      totals[key] = (totals[key] ?? 0) - (typeof nutrientVal === 'number' ? nutrientVal : 0) + mealVal
+    }
+  }
+  for (const key of Object.keys(totals)) totals[key] = Math.round(totals[key] * 100) / 100
+  return totals
+}

--- a/apps/web/src/pages/Meals/index.tsx
+++ b/apps/web/src/pages/Meals/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../state/api'
 import { auth } from '../../state/auth'
 import { isEmoji, isIconPath, isUrl } from '../../utils/emojiLookup'
+import { aggregateDayNutrients } from './dayNutrients'
 import { MealsOverview } from './MealsOverview'
 import './style.css'
 
@@ -625,19 +626,6 @@ const NUTRIENT_CATEGORIES = [
   { key: 'mineral', label: 'Minerals' },
   { key: 'amino_acid', label: 'Amino Acids' },
 ] as const
-
-/** Aggregate nutrients from all meals for the day. */
-const aggregateDayNutrients = (meals: Meal[]): Record<string, number> => {
-  const totals: Record<string, number> = {}
-  for (const meal of meals) {
-    if (!meal.nutrients) continue
-    for (const [key, val] of Object.entries(meal.nutrients)) {
-      if (typeof val === 'number' && val > 0) totals[key] = (totals[key] ?? 0) + val
-    }
-  }
-  for (const key of Object.keys(totals)) totals[key] = Math.round(totals[key] * 100) / 100
-  return totals
-}
 
 function DayNutrientSummary({ meals }: { meals: Meal[] }) {
   const nutrients = aggregateDayNutrients(meals)


### PR DESCRIPTION
## Problem

On `/meals`, the **Day Totals** calorie sum disagreed with the sum of the visible meal cards. For one real day the header showed **1653 kcal** while the cards summed to **2290 kcal**.

Root cause: `aggregateDayNutrients` summed each meal's `meal.nutrients`, which is aggregated **from per-food-item data**. When a meal has a food item with no per-item nutrition (`nutrient_data_incomplete: true` — e.g. a home-cooked dish logged with a manual meal-level estimate but no per-ingredient breakdown), that item contributes 0 to `meal.nutrients`. But each meal card shows the meal-level `meal.calories` (the manual estimate), so the two views diverged.

Concretely, the dinner that day had `meal.calories = 760` (estimate) but `meal.nutrients.calories = 122.82` (only the rice had per-item data). `760 − 122.82 = 637.18`, exactly the gap between 2290.6 and 1653.42.

## Fix

- Extract `aggregateDayNutrients` into `apps/web/src/pages/Meals/dayNutrients.ts` (pure, testable).
- For the macro fields (`calories`, `protein`, `carbs`, `fat`, `fiber`), prefer the meal-level value over the per-food-item aggregate when they differ — so the day total matches the cards.
- Micronutrients have no meal-level override and stay summed from the aggregate. The existing "totals may be understated" notice still covers those.

## Tests

New `dayNutrients.test.ts` (7 cases), including a reproduction of the real day (asserts 2290.6, not 1653.42), micronutrient fallback, lower-than-aggregate override, and no-nutrients skip.

`pnpm check` passes (0 errors); all Meals tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)