### PR TITLE
fix(health-connect): dedupe insertRawRecords batch to avoid 21000 (#772)

### DIFF
--- a/apps/backend/src/db/dedupe.test.ts
+++ b/apps/backend/src/db/dedupe.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+
+import { dedupeLastWins } from './dedupe.ts'
+
+describe('dedupeLastWins', () => {
+  test('keeps the last item per key, preserving first-seen order', () => {
+    const items = [
+      { k: 'a', v: 1 },
+      { k: 'b', v: 2 },
+      { k: 'a', v: 3 },
+      { k: 'c', v: 4 },
+      { k: 'b', v: 5 },
+    ]
+    const result = dedupeLastWins(items, (i) => i.k)
+    expect(result).toEqual([
+      { k: 'a', v: 3 },
+      { k: 'b', v: 5 },
+      { k: 'c', v: 4 },
+    ])
+  })
+
+  test('never dedupes items whose key is null', () => {
+    const items = [
+      { k: null, v: 1 },
+      { k: null, v: 2 },
+      { k: 'x', v: 3 },
+      { k: 'x', v: 4 },
+    ]
+    const result = dedupeLastWins(items, (i) => i.k)
+    expect(result).toEqual([
+      { k: null, v: 1 },
+      { k: null, v: 2 },
+      { k: 'x', v: 4 },
+    ])
+  })
+
+  test('empty input', () => {
+    expect(dedupeLastWins([], () => 'k')).toEqual([])
+  })
+
+  test('no duplicates passes through unchanged', () => {
+    const items = [{ k: 'a' }, { k: 'b' }, { k: 'c' }]
+    expect(dedupeLastWins(items, (i) => i.k)).toEqual(items)
+  })
+})

--- a/apps/backend/src/db/dedupe.ts
+++ b/apps/backend/src/db/dedupe.ts
@@ -1,0 +1,34 @@
+/**
+ * Intra-batch dedupe for upserts.
+ *
+ * Postgres' `ON CONFLICT DO UPDATE` can only touch each existing row once per
+ * command, so a batch that contains two rows hitting the same conflict key
+ * raises `21000: ON CONFLICT DO UPDATE command cannot affect row a second time`.
+ * This collapses such batches to one row per key (last write wins, matching
+ * upsert semantics) before they reach the DB.
+ */
+
+/**
+ * Keep the last item per key, preserving first-seen order. Items whose `keyFn`
+ * returns `null` are never deduped — use this for rows that don't collide in the
+ * unique index (e.g. a NULL `external_id`, which Postgres treats as distinct).
+ */
+export const dedupeLastWins = <T>(items: T[], keyFn: (item: T) => string | null): T[] => {
+  const out: T[] = []
+  const indexByKey = new Map<string, number>()
+  for (const item of items) {
+    const key = keyFn(item)
+    if (key === null) {
+      out.push(item)
+      continue
+    }
+    const existing = indexByKey.get(key)
+    if (existing === undefined) {
+      indexByKey.set(key, out.length)
+      out.push(item)
+    } else {
+      out[existing] = item
+    }
+  }
+  return out
+}

--- a/apps/backend/src/db/raw-records.integration.test.ts
+++ b/apps/backend/src/db/raw-records.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
-import { getScrobbles, insertRawRecord, queryRawRecords } from './raw-records.ts'
+import { getScrobbles, insertRawRecord, insertRawRecords, queryRawRecords } from './raw-records.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 
@@ -214,6 +214,65 @@ describe('Raw Records Integration Tests', () => {
         start: new Date('2026-02-17T12:00:00Z'),
       })
       expect(rows).toEqual([])
+    })
+  })
+
+  describe('insertRawRecords', () => {
+    test('dedupes a batch sharing (source, record_type, external_id) — no 21000', async () => {
+      const user = getTestUser()
+
+      // Two copies of the same ExerciseSessionRecord (same external_id) in one
+      // batch — the un-deduped upsert would raise 21000. Last write wins.
+      await expect(
+        insertRawRecords(user, [
+          {
+            data: { title: 'First' },
+            external_id: 'dup-1',
+            record_type: 'ExerciseSessionRecord',
+            recorded_at: new Date('2026-04-01T10:00:00Z'),
+            source: 'health_connect',
+          },
+          {
+            data: { title: 'Second' },
+            external_id: 'dup-1',
+            record_type: 'ExerciseSessionRecord',
+            recorded_at: new Date('2026-04-01T10:00:00Z'),
+            source: 'health_connect',
+          },
+        ]),
+      ).resolves.not.toThrow()
+
+      const { rows, total } = await queryRawRecords(user, {
+        record_type: 'ExerciseSessionRecord',
+        source: 'health_connect',
+      })
+      expect(total).toBe(1)
+      expect(rows[0].data).toEqual({ title: 'Second' })
+    })
+
+    test('keeps multiple rows with NULL external_id (they do not collide)', async () => {
+      const user = getTestUser()
+
+      await insertRawRecords(user, [
+        {
+          data: { n: 1 },
+          record_type: 'StepsRecord',
+          recorded_at: new Date('2026-04-02T10:00:00Z'),
+          source: 'health_connect',
+        },
+        {
+          data: { n: 2 },
+          record_type: 'StepsRecord',
+          recorded_at: new Date('2026-04-02T10:05:00Z'),
+          source: 'health_connect',
+        },
+      ])
+
+      const { total } = await queryRawRecords(user, {
+        record_type: 'StepsRecord',
+        source: 'health_connect',
+      })
+      expect(total).toBe(2)
     })
   })
 })

--- a/apps/backend/src/db/raw-records.ts
+++ b/apps/backend/src/db/raw-records.ts
@@ -6,6 +6,7 @@ import format from 'pg-format'
 import type { RawRecord } from './types.ts'
 
 import { query } from './connection.ts'
+import { dedupeLastWins } from './dedupe.ts'
 
 export const insertRawRecord = async (user: string, record: RawRecord) => {
   await query(
@@ -22,7 +23,15 @@ export const insertRawRecord = async (user: string, record: RawRecord) => {
 export const insertRawRecords = async (user: string, records: RawRecord[]) => {
   if (records.length === 0) return
 
-  const values = records.map((r) => [r.source, r.record_type, r.external_id, r.recorded_at, r.data])
+  // Collapse duplicate (source, record_type, external_id) within the batch so the
+  // upsert never tries to touch the same row twice (21000). Rows with a NULL
+  // external_id are distinct in the unique index, so they never collide — keep
+  // them all. Mirrors the dedupe insertActivities does (#770).
+  const deduped = dedupeLastWins(records, (r) =>
+    r.external_id == null ? null : `${r.source}|${r.record_type}|${r.external_id}`,
+  )
+
+  const values = deduped.map((r) => [r.source, r.record_type, r.external_id, r.recorded_at, r.data])
 
   await query(
     user,


### PR DESCRIPTION
Closes #772.

## Problem
A Health Connect re-sync chunk can include the same `ExerciseSessionRecord` twice (same `metadata.id`). `insertRawRecords` fed the whole batch into one `ON CONFLICT (source, record_type, external_id) DO UPDATE`, so two rows hitting the same key raised `21000: ON CONFLICT DO UPDATE command cannot affect row a second time` — aborting the batch and blocking sync (Sara's case). #770 fixed this for `insertActivities` but the HC path runs `insertRawRecords` first.

## Fix
- Add a small shared `dedupeLastWins(items, keyFn)` helper (the pattern #770 inlined into `insertActivities`; the issue suggested extracting it).
- `insertRawRecords` now dedupes the batch by `(source, record_type, external_id)` (last write wins), keeping rows with a NULL `external_id` as-is since they're distinct in the unique index.

## Tests
- Unit test for `dedupeLastWins` (last-wins, null keys never deduped, order preserved).
- Integration tests: a batch with two records sharing `external_id` no longer throws and collapses to one row (second wins); two NULL-`external_id` rows are both kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)