### PR TITLE
fix(food-items): FoodItemDetail.portions is always [] when empty (#780)

### DIFF
--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -117,7 +117,8 @@ export const resolveEffectiveDefaultQuantity = (
 const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
   const base = serializeFoodItem(detail.item)
   const sensitivities = detail.sensitivities ?? []
-  const portions = detail.portions?.map(serializePortion)
+  // Always an array so the response is `portions: []`, never null/absent (#780).
+  const portions = (detail.portions ?? []).map(serializePortion)
   const is_shared = detail.is_shared
   // For per-user items default_portion_id is the column on the food row;
   // for central items applySharedOverrides decorated it from the user's

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -212,6 +212,17 @@ describe('createFoodItemsService.getById', () => {
   })
 })
 
+describe('createFoodItemsService.getDetail portions', () => {
+  test('returns [] (not null/undefined) when the item has no portions', async () => {
+    vi.mocked(dbModule.getFoodItemById).mockResolvedValue(userItem('u1', 'Apple'))
+    // listPortionsForFoodItem is mocked to [] by default.
+    const service = createFoodItemsService(fakeCentral())
+
+    const detail = await service.getDetail('user', 'u1')
+    expect(detail?.portions).toEqual([])
+  })
+})
+
 describe('createFoodItemsService.findOrCreate', () => {
   test('prefers central canonical entry over creating a per-user duplicate', async () => {
     const central = fakeCentral()

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -456,7 +456,10 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
       listPortionsForFoodItem(user, id),
     ])
     const sensitivities = sensitivityFlags.map((f) => ({ id: f.id, name: f.name, color: f.color ?? null }))
-    const portions = portionRows.length > 0 ? portionRows : undefined
+    // Always an array (empty when the item has no portions) so the detail
+    // contract is `portions: FoodItemPortion[]` on every path — consumers can
+    // rely on `.map`/`.length` without a null check (#780).
+    const portions = portionRows
 
     const fromUser = await getUserFoodItemById(user, id)
     if (fromUser) {


### PR DESCRIPTION
Closes #780.

## Problem
`GET /api/food-items/:id` returned `"portions": null` (not `[]`) when a food item had zero portions — a shape-contract violation. `getDetail` set `portions = portionRows.length > 0 ? portionRows : undefined`, and the router's `detail.portions?.map(...)` then yielded null/absent. Any consumer doing `detail.portions.map(...)` / `.length` throws.

## Fix
Always return the array (empty when none):
- service `getDetail`: `const portions = portionRows`
- router `serializeDetail`: `(detail.portions ?? []).map(serializePortion)` (defensive boundary)

So the detail contract is `portions: FoodItemPortion[]` on every path. The dedicated `GET /:id/portions` endpoint already returned `[]`; this aligns the detail payload.

## Test
`getDetail` unit test asserting `portions` is `[]` for an item with no portions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)