### PR TITLE
fix(activities): include comments in GET /activities/:id so Notes render (#794)

### DIFF
--- a/apps/backend/src/routes/activities-router.test.ts
+++ b/apps/backend/src/routes/activities-router.test.ts
@@ -1,0 +1,89 @@
+import express from 'express'
+import supertest from 'supertest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createActivitiesRouter } from './activities-router.ts'
+
+// Mock the DB barrel and the queries barrel the router pulls from. Only the
+// functions the GET /activities/:id plain path calls need real behaviour.
+vi.mock('../db/index.ts', () => ({
+  getActivityById: vi.fn(),
+  getDeductionRule: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('../services/queries/index.ts', () => ({
+  computeActivityDetailMetrics: vi.fn().mockResolvedValue({}),
+  getActivityFullDetail: vi.fn(),
+  getCommentsMap: vi.fn(),
+  parseActivityId: vi.fn(),
+  parseMetricsParam: vi.fn(),
+  queryActivities: vi.fn(),
+  resolveActivityWindow: vi.fn(),
+}))
+
+vi.mock('../services/mutations.ts', () => ({
+  addActivity: vi.fn(),
+  deleteActivity: vi.fn(),
+  mergeActivities: vi.fn(),
+  restoreActivity: vi.fn(),
+  updateActivity: vi.fn(),
+}))
+
+vi.mock('../services/fit-parser.ts', () => ({ parseFitBuffer: vi.fn() }))
+
+const db = await import('../db/index.ts')
+const queries = await import('../services/queries/index.ts')
+
+const ACTIVITY_ID = '9d0124e7-d161-4855-a54f-fa8bdb45c4f2'
+
+const buildApp = () => {
+  const app = express()
+  app.use(express.json())
+  const auth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = 'tester'
+    next()
+  }
+  app.use(createActivitiesRouter(auth) as unknown as express.RequestHandler)
+  return app
+}
+
+describe('GET /activities/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(queries.computeActivityDetailMetrics).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof queries.computeActivityDetailMetrics>>,
+    )
+    vi.mocked(db.getActivityById).mockResolvedValue({
+      activity_type: 'running',
+      data: {},
+      id: ACTIVITY_ID,
+      source: 'garmin',
+      start_time: new Date('2026-06-08T10:00:00Z'),
+    } as unknown as Awaited<ReturnType<typeof db.getActivityById>>)
+  })
+
+  test('includes the user notes as comments (#794)', async () => {
+    vi.mocked(queries.getCommentsMap).mockResolvedValue(
+      new Map([
+        [ACTIVITY_ID, [{ content: 'Tempo run — felt strong', id: 'note-1' }]],
+      ]) as Awaited<ReturnType<typeof queries.getCommentsMap>>,
+    )
+
+    const res = await supertest(buildApp()).get(`/activities/${ACTIVITY_ID}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.comments).toEqual([{ content: 'Tempo run — felt strong', id: 'note-1' }])
+    expect(vi.mocked(queries.getCommentsMap)).toHaveBeenCalledWith('tester', 'activity', [ACTIVITY_ID])
+  })
+
+  test('returns an empty comments array when the activity has no notes', async () => {
+    vi.mocked(queries.getCommentsMap).mockResolvedValue(
+      new Map() as Awaited<ReturnType<typeof queries.getCommentsMap>>,
+    )
+
+    const res = await supertest(buildApp()).get(`/activities/${ACTIVITY_ID}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.comments).toEqual([])
+  })
+})

--- a/apps/backend/src/routes/activities-router.test.ts
+++ b/apps/backend/src/routes/activities-router.test.ts
@@ -13,6 +13,7 @@ vi.mock('../db/index.ts', () => ({
 
 vi.mock('../services/queries/index.ts', () => ({
   computeActivityDetailMetrics: vi.fn().mockResolvedValue({}),
+  dedupeCommentsForIds: vi.fn(),
   getActivityFullDetail: vi.fn(),
   getCommentsMap: vi.fn(),
   parseActivityId: vi.fn(),

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -50,6 +50,7 @@ import {
 import {
   computeActivityDetailMetrics,
   getActivityFullDetail,
+  getCommentsMap,
   parseActivityId,
   parseMetricsParam,
   queryActivities,
@@ -111,9 +112,21 @@ const buildMergedResponse = async (
     })
   }
 
+  // Collect user notes/comments across every merged source (deduped by id) so
+  // the detail page's Notes row reflects the real note (#794).
+  const commentLookupIds = overlapping.map((a) => a.id).filter((id): id is string => Boolean(id))
+  const commentsMap = await getCommentsMap(user, 'activity', commentLookupIds)
+  type CommentEntry = NonNullable<ReturnType<typeof commentsMap.get>>[number]
+  const seenComments = new Map<string, CommentEntry>()
+  for (const id of commentLookupIds) {
+    for (const c of commentsMap.get(id) ?? []) seenComments.set(c.id, c)
+  }
+  const comments = [...seenComments.values()]
+
   return {
     ...metrics,
     activity_type: activity.activity_type,
+    comments,
     data: Object.keys(mergedData).length > 0 ? mergedData : activity.data,
     end_time: activity.end_time?.toISOString(),
     id: activity.id,
@@ -468,11 +481,16 @@ export const createActivitiesRouter = (
       }
     }
 
+    // Attach user notes/comments so the detail page's Notes row and edit-mode
+    // notes textarea reflect the real note (#794).
+    const commentsMap = await getCommentsMap(user, 'activity', [realId])
+
     // Plain UUID: return raw single activity (no overlap lookup)
     res.json({
       data: {
         ...activityMetrics,
         activity_type: activity.activity_type,
+        comments: commentsMap.get(realId) ?? [],
         data: activity.data,
         deleted_at: activity.deleted_at?.toISOString(),
         end_time: activity.end_time?.toISOString(),

--- a/apps/backend/src/routes/activities-router.ts
+++ b/apps/backend/src/routes/activities-router.ts
@@ -49,6 +49,7 @@ import {
 } from '../services/mutations.ts'
 import {
   computeActivityDetailMetrics,
+  dedupeCommentsForIds,
   getActivityFullDetail,
   getCommentsMap,
   parseActivityId,
@@ -116,12 +117,7 @@ const buildMergedResponse = async (
   // the detail page's Notes row reflects the real note (#794).
   const commentLookupIds = overlapping.map((a) => a.id).filter((id): id is string => Boolean(id))
   const commentsMap = await getCommentsMap(user, 'activity', commentLookupIds)
-  type CommentEntry = NonNullable<ReturnType<typeof commentsMap.get>>[number]
-  const seenComments = new Map<string, CommentEntry>()
-  for (const id of commentLookupIds) {
-    for (const c of commentsMap.get(id) ?? []) seenComments.set(c.id, c)
-  }
-  const comments = [...seenComments.values()]
+  const comments = dedupeCommentsForIds(commentsMap, commentLookupIds)
 
   return {
     ...metrics,

--- a/apps/backend/src/services/queries/activities.ts
+++ b/apps/backend/src/services/queries/activities.ts
@@ -18,7 +18,7 @@ import {
   SUMMARY_METRICS,
   type SummaryMetricSeries,
 } from './activity-summary-metrics.ts'
-import { buildCategoryMap, getCommentsMap } from './types.ts'
+import { buildCategoryMap, dedupeCommentsForIds, getCommentsMap } from './types.ts'
 
 type TimeSeriesPoint = [Date, number]
 
@@ -85,13 +85,9 @@ function enrichActivity(
   // For merged rows, collect comments anchored to the winner and to any
   // sibling source row that was folded in, deduping by note id.
   const commentLookupIds = a.id ? [a.id, ...(a.source_ids ?? [])] : []
-  const seen = new Map<string, CommentSummary>()
-  for (const lid of commentLookupIds) {
-    for (const c of ctx.commentsMap.get(lid) ?? []) seen.set(c.id, c)
-  }
   const result: ActivityResult = {
     activity_type: a.activity_type,
-    comments: [...seen.values()],
+    comments: dedupeCommentsForIds(ctx.commentsMap, commentLookupIds),
     data: a.data,
     duration: a.end_time
       ? Math.round((a.end_time.getTime() - a.start_time.getTime()) / 1000 / 60)

--- a/apps/backend/src/services/queries/index.ts
+++ b/apps/backend/src/services/queries/index.ts
@@ -13,6 +13,7 @@ export {
   type CategoryInfo,
   type CommentSummary,
   type DailySummaryResult,
+  dedupeCommentsForIds,
   getCommentsMap,
   type HeartRateStats,
   type MealSummary,

--- a/apps/backend/src/services/queries/index.ts
+++ b/apps/backend/src/services/queries/index.ts
@@ -13,6 +13,7 @@ export {
   type CategoryInfo,
   type CommentSummary,
   type DailySummaryResult,
+  getCommentsMap,
   type HeartRateStats,
   type MealSummary,
   type MetricBucket,

--- a/apps/backend/src/services/queries/types.ts
+++ b/apps/backend/src/services/queries/types.ts
@@ -53,6 +53,24 @@ export const getCommentsMap = async (
   return result
 }
 
+/**
+ * Collect comments for the given entity ids, deduped by note id. Merged
+ * activities anchor the same note to multiple source rows, so the winner plus
+ * its siblings can surface duplicates — this keeps one entry per note. Shared by
+ * the activity list path and the merged activity-detail response so they can't
+ * drift.
+ */
+export const dedupeCommentsForIds = (
+  commentsMap: Map<string, CommentSummary[]>,
+  ids: string[],
+): CommentSummary[] => {
+  const seen = new Map<string, CommentSummary>()
+  for (const id of ids) {
+    for (const c of commentsMap.get(id) ?? []) seen.set(c.id, c)
+  }
+  return [...seen.values()]
+}
+
 // ============================================================================
 // Types
 // ============================================================================


### PR DESCRIPTION
Closes #794.

## Problem
The activity-detail page loads via `fetchActivityById` → `GET /activities/:id`, but that response omitted `comments`. So `getUserNotesContent(activity)` returned `''`, the unified stats table's **Notes row never rendered**, and edit mode showed an **empty Notes textarea** even when the activity had a user note. (Notes still showed via the separate NotesSection, so impact was limited, but the table row + edit field were dead — and #789's unit test passed in isolation while the integration path was broken.)

## Fix (chose "populate comments" — fixes both symptoms)
Attach `comments` to the activity-detail response on both paths:
- **plain UUID**: `getCommentsMap(user, 'activity', [realId])`
- **merged**: collect + dedupe comments across all merged sources (mirrors the list path)

The response schema already permits `comments` and the web layer already reads `activity.comments`, so no schema or frontend change is needed — the Notes row and the edit-mode textarea now reflect the real note.

## Tests
New `activities-router.test.ts` (supertest): `GET /activities/:id` carries the user note as `comments`, and returns `[]` when there are none. The comment-attaching logic itself is already covered by `queries/activities.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)