### PR TITLE
docs(correlations): explain fire-and-forget sync in Performance section (#792)

### DIFF
--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -106,3 +106,11 @@ Spearman coefficients plus the aligned series for plotting.
 
 Analysis is day-level with linear exposure sweeps, so multi-year regimes
 (2000+ days) run without timing out.
+
+External data syncs (Oura, RescueTime, calendars) are triggered
+**fire-and-forget** before the analysis rather than awaited — a first or stale
+sync makes live HTTP calls that can take many seconds, long enough to blow the
+request timeout regardless of how small the analysis window is. The triggering
+request therefore reads from data already in the database (so it may miss the
+most recent few minutes); the sync warms the data for the next request. This is
+the same pattern the rest of the query layer uses.


### PR DESCRIPTION
## What

Small docs follow-up to #800. The correlation timeout that #800 fixed was caused by the analysis **awaiting** four live external syncs (Oura, RescueTime, calendars) before reading the DB. The `docs/correlations.md` Performance section said multi-year regimes "run without timing out" but didn't explain why they used to — or the now-background sync behaviour and its tradeoff.

This adds a paragraph documenting:
- syncs are fire-and-forget (not awaited),
- the triggering request reads already-stored data (may miss the most recent few minutes),
- the sync warms data for the next request — matching the rest of the query layer.

## Context

While closing out #792 I verified the full event-outcome mode end-to-end against live data (no timeout, reproduces the expected ejaculation↔back_pain signal and the sauna↔back_pain null). Details in the #792 issue thread. This PR is just the doc accuracy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)