### PR TITLE
feat(correlations): in-UI guidance & guardrails for Explore (#792)

### DIFF
--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -95,6 +95,8 @@ const applyEventPreset = (pattern: string) => {
   eventOutcomeValue.value = 'back_pain'
   lagWindowsInput.value = '24h,48h,72h,7d'
   collapseGapDays.value = 3
+  // Scope to the behavioural regime the #792 worked example uses (the date the
+  // relevant protocol/era began); a leak is rare and meaningful only from here.
   periodStart.value = '2019-09-28'
   periodEnd.value = ''
 }

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -17,6 +17,7 @@ import {
   fetchCorrelationSelectors,
   fetchGenericCorrelation,
 } from '../../state/api'
+import { eventOutcomeLooksContinuous, MODE_HELP, TOOLTIPS } from './exploreGuidance'
 
 type Mode = 'event' | 'continuous'
 
@@ -81,6 +82,40 @@ const fmt = (value: number | null | undefined, digits = 2): string =>
 
 const fmtPct = (value: number | null | undefined): string =>
   value === null || value === undefined ? '—' : `${(value * 100).toFixed(0)}%`
+
+/** Whether the current event-mode form would misuse a continuous outcome. */
+const outcomeLooksContinuous = (): boolean =>
+  eventOutcomeLooksContinuous(mode.value, eventOutcomeSource.value, eventOutcomeValue.value)
+
+/** Apply a back-pain-onset event preset for the given trigger tag. */
+const applyEventPreset = (pattern: string) => {
+  setMode('event')
+  triggerSelector.value = { kind: 'tag', pattern }
+  setEventOutcomeSource('metric')
+  eventOutcomeValue.value = 'back_pain'
+  lagWindowsInput.value = '24h,48h,72h,7d'
+  collapseGapDays.value = 3
+  periodStart.value = '2019-09-28'
+  periodEnd.value = ''
+}
+
+/** Worked examples that teach the modes by populating the whole form. */
+const PRESETS: { label: string; apply: () => void }[] = [
+  {
+    apply: () => {
+      setMode('continuous')
+      triggerSelector.value = { kind: 'nutrition', nutrient: 'carbs' }
+      outcomeSelector.value = { kind: 'metric', metric: 'sleep_score' }
+      lagDaysInput.value = 1
+      periodStart.value = ''
+      periodEnd.value = ''
+      periodDays.value = 365
+    },
+    label: 'Carbs → sleep (Continuous)',
+  },
+  { apply: () => applyEventPreset('ejaculation'), label: 'Ejaculation → back-pain onset (Event)' },
+  { apply: () => applyEventPreset('sauna'), label: 'Sauna → back-pain onset (Event)' },
+]
 
 /** Build the request body for whichever mode is active. */
 const buildRequest = () => {
@@ -348,19 +383,28 @@ export function ExploreTab() {
 
       <div class="explore-form">
         <div class="explore-row">
+          <label>Presets</label>
+          <div class="explore-presets">
+            {PRESETS.map((preset) => (
+              <button class="explore-preset" onClick={preset.apply}>
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div class="explore-row">
           <label>Mode</label>
           <div class="explore-toggle">
             <button class={mode.value === 'event' ? 'active' : ''} onClick={() => setMode('event')}>
               Event onset
             </button>
-            <button
-              class={mode.value === 'continuous' ? 'active' : ''}
-              onClick={() => setMode('continuous')}
-            >
+            <button class={mode.value === 'continuous' ? 'active' : ''} onClick={() => setMode('continuous')}>
               Continuous
             </button>
           </div>
         </div>
+        <p class="explore-help">{MODE_HELP}</p>
 
         <div class="explore-row">
           <label>Trigger</label>
@@ -407,18 +451,26 @@ export function ExploreTab() {
           )}
         </div>
 
+        {outcomeLooksContinuous() && (
+          <p class="explore-warning">
+            ⚠ This outcome looks continuous (it has a value most days). Event-onset may not be meaningful here
+            — consider <strong>Continuous</strong> mode.
+          </p>
+        )}
+
         {mode.value === 'event' ? (
           <>
             <div class="explore-row">
-              <label>Lag windows</label>
+              <label title={TOOLTIPS.lagWindows}>Lag windows</label>
               <input
                 value={lagWindowsInput.value}
                 onInput={(e) => (lagWindowsInput.value = (e.target as HTMLInputElement).value)}
                 placeholder="24h,48h,7d"
+                title={TOOLTIPS.lagWindows}
               />
             </div>
             <div class="explore-row">
-              <label>Collapse gap (days)</label>
+              <label title={TOOLTIPS.collapseGap}>Collapse gap (days)</label>
               <input
                 type="number"
                 value={collapseGapDays.value}
@@ -428,7 +480,7 @@ export function ExploreTab() {
               />
             </div>
             <div class="explore-row">
-              <label>Denominator</label>
+              <label title={TOOLTIPS.denominator}>Denominator</label>
               <div class="explore-toggle">
                 <button
                   class={denominator.value === 'known' ? 'active' : ''}
@@ -444,8 +496,8 @@ export function ExploreTab() {
                 </button>
               </div>
               <span class="regime-hint">
-                Use <strong>All days</strong> for presence-only metrics (e.g. back_pain) that only log on
-                bad days; <strong>Known days</strong> for metrics that log explicit zeros.
+                Use <strong>All days</strong> for presence-only metrics (e.g. back_pain) that only log on bad
+                days; <strong>Known days</strong> for metrics that log explicit zeros.
               </span>
             </div>
           </>
@@ -461,7 +513,7 @@ export function ExploreTab() {
         )}
 
         <div class="explore-row">
-          <label>Regime</label>
+          <label title={TOOLTIPS.regime}>Regime</label>
           <div class="explore-regime">
             <input
               type="date"

--- a/apps/web/src/pages/Correlations/exploreGuidance.test.ts
+++ b/apps/web/src/pages/Correlations/exploreGuidance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { eventOutcomeLooksContinuous } from './exploreGuidance'
+
+describe('eventOutcomeLooksContinuous', () => {
+  it('flags a built-in (continuous) metric chosen as an event outcome', () => {
+    expect(eventOutcomeLooksContinuous('event', 'metric', 'sleep_score')).toBe(true)
+    expect(eventOutcomeLooksContinuous('event', 'metric', 'hrv_rmssd')).toBe(true)
+    expect(eventOutcomeLooksContinuous('event', 'metric', 'weight')).toBe(true)
+  })
+
+  it('does not flag presence-only custom metrics (the ones event mode is for)', () => {
+    expect(eventOutcomeLooksContinuous('event', 'metric', 'back_pain')).toBe(false)
+    expect(eventOutcomeLooksContinuous('event', 'metric', 'fissure_pain')).toBe(false)
+  })
+
+  it('ignores surrounding whitespace on the metric name', () => {
+    expect(eventOutcomeLooksContinuous('event', 'metric', '  sleep_score ')).toBe(true)
+  })
+
+  it('never flags in continuous mode', () => {
+    expect(eventOutcomeLooksContinuous('continuous', 'metric', 'sleep_score')).toBe(false)
+  })
+
+  it('never flags a tag outcome (tags are inherently event-like)', () => {
+    expect(eventOutcomeLooksContinuous('event', 'tag', 'sleep_score')).toBe(false)
+  })
+
+  it('does not flag an empty outcome', () => {
+    expect(eventOutcomeLooksContinuous('event', 'metric', '')).toBe(false)
+  })
+})

--- a/apps/web/src/pages/Correlations/exploreGuidance.ts
+++ b/apps/web/src/pages/Correlations/exploreGuidance.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure guidance helpers and copy for the correlation Explore form. Kept free of
+ * signals/JSX so the mismatch heuristic is unit-testable in isolation.
+ */
+
+import { isValidMetric } from '@aurboda/api-spec'
+
+export type ExploreMode = 'event' | 'continuous'
+
+/**
+ * Event-onset mode is for presence-only outcomes (logged only on "bad" days).
+ * Picking a value-every-day metric there collapses every day into ~1 onset and
+ * returns nonsense. Built-in device/biometric metrics (sleep_score, hrv_rmssd,
+ * weight, …) are continuous; presence-only symptom metrics (back_pain,
+ * fissure_pain) are custom and therefore NOT built-in — so a built-in metric in
+ * event mode is almost certainly a mode mismatch worth warning about. Custom
+ * metrics (the ones that genuinely belong in event mode) are left un-warned.
+ */
+export const eventOutcomeLooksContinuous = (
+  mode: ExploreMode,
+  outcomeSource: 'metric' | 'tag',
+  metricValue: string,
+): boolean => mode === 'event' && outcomeSource === 'metric' && isValidMetric(metricValue.trim())
+
+export const MODE_HELP =
+  'Pick mode by your OUTCOME. Presence-only metrics that are logged only on bad ' +
+  'days (back_pain, fissure_pain) → Event onset. Value-every-day metrics ' +
+  '(sleep_score, hrv_rmssd, weight) → Continuous.'
+
+/** Tooltip copy for the controls users most often misread. */
+export const TOOLTIPS = {
+  collapseGap: 'Consecutive bad-days within this gap count as ONE onset (a 6-day flare = 1 event).',
+  denominator:
+    'All days = for presence-only metrics that only log bad days. Known days = for metrics that log explicit zeros.',
+  lagWindows: 'How far back before an onset to look for the trigger (e.g. 24h, 48h).',
+  regime: 'Limit the analysis to a behavioural era (e.g. since you started a protocol).',
+} as const

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -458,6 +458,37 @@
 .period-days-input {
   width: 70px;
 }
+.explore-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.explore-preset {
+  background: #f3f0fa;
+  color: #5a32a3;
+  border: 1px solid #d6ccec;
+  border-radius: 999px;
+  padding: 5px 12px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.explore-preset:hover {
+  background: #e9e2f7;
+}
+.explore-help {
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin: -4px 0 4px;
+}
+.explore-warning {
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  color: #9a3412;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 0.88rem;
+  margin: 0 0 4px;
+}
 .explore-run {
   background: #673ab8;
   color: #fff;


### PR DESCRIPTION
First of the #792 follow-up UI workstreams (implementing them one PR at a time). Frontend-only, additive guidance to make the Explore form hard to misuse.

## Problem
The biggest footgun: picking **Event-onset** mode with a **continuous** outcome (e.g. `sleep_score`) collapses every day into ~1 onset and returns nonsense. There was no in-UI explanation of when to use which mode, and the controls (collapse gap, denominator, …) are easy to misread.

## Changes
- **Mode help text** — "pick mode by your OUTCOME" (presence-only → Event onset; value-every-day → Continuous).
- **Mismatch warning** — shown when Event-onset is chosen with an outcome that looks continuous.
  - Heuristic (frontend-only, no backend change): built-in device/biometric metrics (`sleep_score`, `hrv_rmssd`, `weight`) are dense; presence-only symptom metrics (`back_pain`, `fissure_pain`) are **custom** and therefore not in the built-in `MetricType` enum. So a built-in metric in event mode is almost certainly a mode mismatch — and the custom metrics that genuinely belong in event mode are correctly left un-warned. Uses `isValidMetric` from api-spec.
- **Tooltips** on lag windows, collapse gap, denominator, regime (exact copy from the issue).
- **Preset examples** that populate the whole form to teach by doing: *Carbs → sleep (Continuous)*, *Ejaculation → back-pain onset (Event)*, *Sauna → back-pain onset (Event)*.

The heuristic + copy are extracted to a pure `exploreGuidance` module (no signals/JSX) with **unit tests** (6 cases: built-in flagged, custom not flagged, whitespace, continuous mode, tag outcome, empty).

## Testing
- `pnpm --filter aurboda-web check` — 0 errors
- `vitest run exploreGuidance.test.ts` — 6 passed

## Remaining #792 workstreams (next PRs, one at a time)
- Binary→continuous inference (group means, Welch t / Mann–Whitney, effect size, plain-language verdict)
- Nutrition completeness filter (`n_complete` vs `n_aligned`)
- Visualization upgrades (box/violin for binary, axis labels, regression overlay, RR-CI bars)
- HRV context: select `stress_level`/`heart_rate` instead of HRV
- Trigger selector cleanup: retire the legacy "tag" kind (tags merged into activities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)