### PR TITLE
feat(correlations): binary-trigger group comparison & plain-language verdicts (#792)

### DIFF
--- a/apps/backend/src/services/correlations/continuous.test.ts
+++ b/apps/backend/src/services/correlations/continuous.test.ts
@@ -90,6 +90,51 @@ describe('computeContinuous', () => {
     expect(day2?.trigger).toBe(0)
   })
 
+  test('binary trigger yields a present-vs-absent group comparison', () => {
+    const days = Array.from(
+      { length: 8 },
+      (_, i) => new Date(Date.parse('2024-01-01T00:00:00Z') + i * 86_400_000).toISOString().split('T')[0],
+    )
+    // Trigger present (1) on the first four days, absent on the rest. Outcome is
+    // clearly higher on present days (with within-group variance so the t-test
+    // is estimable), and the groups don't overlap.
+    const presentOutcomes = [78, 80, 82, 80]
+    const absentOutcomes = [69, 71, 70, 70]
+    const trigger = seriesMap(days.map((d, i) => [d, i < 4 ? 1 : 0]))
+    const outcome = seriesMap(days.map((d, i) => [d, i < 4 ? presentOutcomes[i] : absentOutcomes[i - 4]]))
+
+    const result = computeContinuous({
+      triggerDaily: trigger,
+      outcomeDaily: outcome,
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+    })
+
+    const gc = result.group_comparison
+    expect(gc).not.toBeNull()
+    expect(gc!.trigger_is_binary).toBe(true)
+    expect(gc!.n_with).toBe(4)
+    expect(gc!.n_without).toBe(4)
+    expect(gc!.mean_with).toBeCloseTo(80, 6)
+    expect(gc!.mean_without).toBeCloseTo(70, 6)
+    expect(gc!.difference).toBeCloseTo(10, 6)
+    expect(gc!.welch).not.toBeNull()
+    expect(gc!.mann_whitney!.rank_biserial).toBeCloseTo(1, 6)
+  })
+
+  test('no group comparison when the trigger is present every day', () => {
+    const days = ['2024-01-01', '2024-01-02', '2024-01-03']
+    const result = computeContinuous({
+      triggerDaily: seriesMap(days.map((d) => [d, 5])),
+      outcomeDaily: seriesMap(days.map((d, i) => [d, i])),
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+    })
+    expect(result.group_comparison).toBeNull()
+  })
+
   test('caps the returned series', () => {
     const days = Array.from(
       { length: 50 },

--- a/apps/backend/src/services/correlations/continuous.ts
+++ b/apps/backend/src/services/correlations/continuous.ts
@@ -4,7 +4,17 @@
  * questions like "how does carb intake affect my sleep the next day?" work.
  */
 
-import { pearson, spearman } from './stats.ts'
+import { type TwoGroupComparison, pearson, spearman, twoGroupComparison } from './stats.ts'
+
+/**
+ * Group comparison for a binary/presence trigger: how the continuous outcome
+ * differs between days the trigger was present vs absent. A Pearson r on a 0/1
+ * trigger is misleading, so this answers "how much does X change Y?" directly.
+ */
+export interface GroupComparison extends TwoGroupComparison {
+  /** True when every aligned trigger value is exactly 0 or 1. */
+  trigger_is_binary: boolean
+}
 
 export interface AlignedPoint {
   /** Trigger day (YYYY-MM-DD). */
@@ -26,6 +36,11 @@ export interface ContinuousResult {
   spearman: number | null
   /** Aligned series (for plotting); capped to avoid huge payloads. */
   series: AlignedPoint[]
+  /**
+   * Present-vs-absent group comparison of the outcome. Null when the trigger is
+   * never present or always present (no split to compare).
+   */
+  group_comparison: GroupComparison | null
 }
 
 export interface ContinuousInput {
@@ -74,5 +89,25 @@ export const computeContinuous = (input: ContinuousInput): ContinuousResult => {
     pearson: pearson(triggerValues, outcomeValues),
     spearman: spearman(triggerValues, outcomeValues),
     series,
+    group_comparison: computeGroupComparison(triggerValues, outcomeValues),
+  }
+}
+
+/**
+ * Split the outcome by whether the trigger was present (value > 0) on the same
+ * aligned day and compare the two groups. Returns null when there is nothing to
+ * compare (the trigger is present on every day or on none).
+ */
+const computeGroupComparison = (triggerValues: number[], outcomeValues: number[]): GroupComparison | null => {
+  const withValues: number[] = []
+  const withoutValues: number[] = []
+  for (let i = 0; i < triggerValues.length; i++) {
+    if (triggerValues[i] > 0) withValues.push(outcomeValues[i])
+    else withoutValues.push(outcomeValues[i])
+  }
+  if (withValues.length === 0 || withoutValues.length === 0) return null
+  return {
+    ...twoGroupComparison(withValues, withoutValues),
+    trigger_is_binary: triggerValues.every((v) => v === 0 || v === 1),
   }
 }

--- a/apps/backend/src/services/correlations/stats.test.ts
+++ b/apps/backend/src/services/correlations/stats.test.ts
@@ -3,12 +3,18 @@ import { describe, expect, test } from 'vitest'
 import {
   chiSquared2x2,
   chiSquaredPValue1df,
+  cohensD,
   erfc,
   fisherExact2x2,
+  mannWhitneyU,
   pearson,
+  regularizedIncompleteBeta,
   riskRatio,
   significance2x2,
   spearman,
+  studentTTwoSidedP,
+  twoGroupComparison,
+  welchTTest,
 } from './stats.ts'
 
 describe('erfc', () => {
@@ -115,5 +121,103 @@ describe('spearman', () => {
     const result = spearman([1, 2, 2, 3], [1, 2, 3, 4])
     expect(result).not.toBeNull()
     expect(result!).toBeGreaterThan(0.8)
+  })
+})
+
+describe('regularizedIncompleteBeta', () => {
+  test('symmetric I_0.5(a, a) = 0.5', () => {
+    expect(regularizedIncompleteBeta(0.5, 2, 2)).toBeCloseTo(0.5, 6)
+    expect(regularizedIncompleteBeta(0.5, 1, 1)).toBeCloseTo(0.5, 6)
+  })
+
+  test('saturates at the bounds', () => {
+    expect(regularizedIncompleteBeta(0, 2, 3)).toBe(0)
+    expect(regularizedIncompleteBeta(1, 2, 3)).toBe(1)
+  })
+})
+
+describe('studentTTwoSidedP', () => {
+  test('t = 0 gives p = 1', () => {
+    expect(studentTTwoSidedP(0, 10)).toBeCloseTo(1, 6)
+  })
+
+  test('matches t-table critical values (df=10, t=2.228 -> 0.05)', () => {
+    expect(studentTTwoSidedP(2.228, 10)).toBeCloseTo(0.05, 3)
+  })
+
+  test('approaches the normal 1.96 -> 0.05 at high df', () => {
+    expect(studentTTwoSidedP(1.96, 100000)).toBeCloseTo(0.05, 3)
+  })
+})
+
+describe('welchTTest', () => {
+  test('clearly separated groups: t and df match the hand calculation', () => {
+    // A mean 3, B mean 8, both sample var 2.5, n=5 -> t=-5, df=8.
+    const result = welchTTest([1, 2, 3, 4, 5], [6, 7, 8, 9, 10])
+    expect(result).not.toBeNull()
+    expect(result!.t).toBeCloseTo(-5, 5)
+    expect(result!.df).toBeCloseTo(8, 5)
+    expect(result!.p_value).toBeLessThan(0.01)
+  })
+
+  test('identical groups give t ~= 0 and p ~= 1', () => {
+    const result = welchTTest([4, 5, 6, 7], [4, 5, 6, 7])
+    expect(result!.t).toBeCloseTo(0, 6)
+    expect(result!.p_value).toBeCloseTo(1, 6)
+  })
+
+  test('null when a group has fewer than two values', () => {
+    expect(welchTTest([1], [2, 3, 4])).toBeNull()
+  })
+})
+
+describe('mannWhitneyU', () => {
+  test('fully separated (A below B) gives U=0 and rank-biserial -1', () => {
+    const result = mannWhitneyU([1, 2, 3], [4, 5, 6])
+    expect(result!.u).toBe(0)
+    expect(result!.rank_biserial).toBeCloseTo(-1, 6)
+  })
+
+  test('fully separated (A above B) gives rank-biserial +1', () => {
+    const result = mannWhitneyU([4, 5, 6], [1, 2, 3])
+    expect(result!.u).toBe(9)
+    expect(result!.rank_biserial).toBeCloseTo(1, 6)
+  })
+
+  test('null when a group is empty', () => {
+    expect(mannWhitneyU([], [1, 2])).toBeNull()
+  })
+})
+
+describe('cohensD', () => {
+  test('matches the hand calculation', () => {
+    // means 3 vs 8, pooled var 2.5 -> d = -5/sqrt(2.5) = -3.162.
+    expect(cohensD([1, 2, 3, 4, 5], [6, 7, 8, 9, 10])).toBeCloseTo(-3.1623, 3)
+  })
+
+  test('null when not estimable', () => {
+    expect(cohensD([1], [2, 3])).toBeNull()
+  })
+})
+
+describe('twoGroupComparison', () => {
+  test('reports means, difference and effect sizes', () => {
+    const result = twoGroupComparison([10, 11, 12], [1, 2, 3])
+    expect(result.n_with).toBe(3)
+    expect(result.n_without).toBe(3)
+    expect(result.mean_with).toBeCloseTo(11, 6)
+    expect(result.mean_without).toBeCloseTo(2, 6)
+    expect(result.difference).toBeCloseTo(9, 6)
+    expect(result.cohens_d!).toBeGreaterThan(2)
+    expect(result.welch!.t).toBeGreaterThan(0)
+    expect(result.mann_whitney!.rank_biserial).toBeCloseTo(1, 6)
+  })
+
+  test('handles empty groups without throwing', () => {
+    const result = twoGroupComparison([], [1, 2, 3])
+    expect(result.mean_with).toBeNull()
+    expect(result.difference).toBeNull()
+    expect(result.welch).toBeNull()
+    expect(result.mann_whitney).toBeNull()
   })
 })

--- a/apps/backend/src/services/correlations/stats.ts
+++ b/apps/backend/src/services/correlations/stats.ts
@@ -272,3 +272,169 @@ export const spearman = (x: number[], y: number[]): number | null => {
   if (x.length !== y.length || x.length < 3) return null
   return pearson(toRanks(x), toRanks(y))
 }
+
+/** Sample variance (n-1 denominator), or null when fewer than 2 values. */
+const sampleVariance = (values: number[]): number | null => {
+  const sd = stddev(values)
+  return sd === null ? null : sd * sd
+}
+
+/** Continued fraction for the incomplete beta function (Numerical Recipes betacf). */
+const betacf = (x: number, a: number, b: number): number => {
+  const MAX_ITER = 200
+  const EPS = 3e-12
+  const FPMIN = 1e-300
+  const qab = a + b
+  const qap = a + 1
+  const qam = a - 1
+  let c = 1
+  let d = 1 - (qab * x) / qap
+  if (Math.abs(d) < FPMIN) d = FPMIN
+  d = 1 / d
+  let h = d
+  for (let m = 1; m <= MAX_ITER; m++) {
+    const m2 = 2 * m
+    let aa = (m * (b - m) * x) / ((qam + m2) * (a + m2))
+    d = 1 + aa * d
+    if (Math.abs(d) < FPMIN) d = FPMIN
+    c = 1 + aa / c
+    if (Math.abs(c) < FPMIN) c = FPMIN
+    d = 1 / d
+    h *= d * c
+    aa = (-(a + m) * (qab + m) * x) / ((a + m2) * (qap + m2))
+    d = 1 + aa * d
+    if (Math.abs(d) < FPMIN) d = FPMIN
+    c = 1 + aa / c
+    if (Math.abs(c) < FPMIN) c = FPMIN
+    d = 1 / d
+    const del = d * c
+    h *= del
+    if (Math.abs(del - 1) < EPS) break
+  }
+  return h
+}
+
+/** Regularized incomplete beta function I_x(a, b). */
+export const regularizedIncompleteBeta = (x: number, a: number, b: number): number => {
+  if (x <= 0) return 0
+  if (x >= 1) return 1
+  const logBeta = logGamma(a + b) - logGamma(a) - logGamma(b)
+  const front = Math.exp(logBeta + a * Math.log(x) + b * Math.log(1 - x))
+  return x < (a + 1) / (a + b + 2) ? (front * betacf(x, a, b)) / a : 1 - (front * betacf(1 - x, b, a)) / b
+}
+
+/**
+ * Two-sided p-value for a Student's t statistic with `df` degrees of freedom,
+ * via P(|T| > |t|) = I_{df/(df+t²)}(df/2, 1/2).
+ */
+export const studentTTwoSidedP = (t: number, df: number): number => {
+  if (df <= 0 || !Number.isFinite(t)) return 1
+  return Math.min(1, regularizedIncompleteBeta(df / (df + t * t), df / 2, 0.5))
+}
+
+/** Welch's two-sample t-test (unequal variances). */
+export interface WelchResult {
+  /** t statistic (positive when group A's mean is higher). */
+  t: number
+  /** Welch–Satterthwaite degrees of freedom. */
+  df: number
+  /** Two-sided p-value. */
+  p_value: number
+}
+
+/** Welch's t-test, or null when either group has fewer than 2 values / no variance. */
+export const welchTTest = (groupA: number[], groupB: number[]): WelchResult | null => {
+  if (groupA.length < 2 || groupB.length < 2) return null
+  const varA = sampleVariance(groupA)!
+  const varB = sampleVariance(groupB)!
+  const na = groupA.length
+  const nb = groupB.length
+  const seA = varA / na
+  const seB = varB / nb
+  const seTotal = seA + seB
+  if (seTotal === 0) return null
+  const t = (mean(groupA)! - mean(groupB)!) / Math.sqrt(seTotal)
+  const df = (seTotal * seTotal) / ((seA * seA) / (na - 1) + (seB * seB) / (nb - 1))
+  return { t, df, p_value: studentTTwoSidedP(t, df) }
+}
+
+/** Mann–Whitney U test (normal approximation with tie correction). */
+export interface MannWhitneyResult {
+  /** U statistic for group A. */
+  u: number
+  /** Two-sided p-value. */
+  p_value: number
+  /** Rank-biserial effect size in [-1, 1] (positive when A tends to exceed B). */
+  rank_biserial: number
+}
+
+/** Mann–Whitney U comparing groupA vs groupB, or null when either group is empty. */
+export const mannWhitneyU = (groupA: number[], groupB: number[]): MannWhitneyResult | null => {
+  const na = groupA.length
+  const nb = groupB.length
+  if (na === 0 || nb === 0) return null
+  const combined = [...groupA, ...groupB]
+  const ranks = toRanks(combined)
+  let rankSumA = 0
+  for (let i = 0; i < na; i++) rankSumA += ranks[i]
+  const uA = rankSumA - (na * (na + 1)) / 2
+  const rankBiserial = (2 * uA) / (na * nb) - 1
+
+  const n = na + nb
+  const mu = (na * nb) / 2
+  const counts = new Map<number, number>()
+  for (const v of combined) counts.set(v, (counts.get(v) ?? 0) + 1)
+  let tieTerm = 0
+  for (const t of counts.values()) tieTerm += t ** 3 - t
+  const sigmaSq = ((na * nb) / 12) * (n + 1 - tieTerm / (n * (n - 1)))
+  if (sigmaSq <= 0) return { u: uA, p_value: 1, rank_biserial: rankBiserial }
+  const z = (uA - mu) / Math.sqrt(sigmaSq)
+  return { u: uA, p_value: Math.min(1, erfc(Math.abs(z) / Math.SQRT2)), rank_biserial: rankBiserial }
+}
+
+/** Cohen's d (pooled standard deviation), or null when not estimable. */
+export const cohensD = (groupA: number[], groupB: number[]): number | null => {
+  if (groupA.length < 2 || groupB.length < 2) return null
+  const na = groupA.length
+  const nb = groupB.length
+  const varA = sampleVariance(groupA)!
+  const varB = sampleVariance(groupB)!
+  const pooledVar = ((na - 1) * varA + (nb - 1) * varB) / (na + nb - 2)
+  if (pooledVar <= 0) return null
+  return (mean(groupA)! - mean(groupB)!) / Math.sqrt(pooledVar)
+}
+
+/** Comparison of a continuous outcome split into two groups (e.g. by a binary trigger). */
+export interface TwoGroupComparison {
+  n_with: number
+  n_without: number
+  mean_with: number | null
+  mean_without: number | null
+  /** mean_with − mean_without. */
+  difference: number | null
+  /** Cohen's d (pooled). */
+  cohens_d: number | null
+  welch: WelchResult | null
+  mann_whitney: MannWhitneyResult | null
+}
+
+/**
+ * Compare a continuous outcome between the "trigger present" and "trigger
+ * absent" groups: group means, their difference, Cohen's d, a Welch t-test and
+ * a Mann–Whitney U test. This answers "how much does X change Y?" — the
+ * question a Pearson r on a binary trigger can't.
+ */
+export const twoGroupComparison = (withValues: number[], withoutValues: number[]): TwoGroupComparison => {
+  const meanWith = mean(withValues)
+  const meanWithout = mean(withoutValues)
+  return {
+    n_with: withValues.length,
+    n_without: withoutValues.length,
+    mean_with: meanWith,
+    mean_without: meanWithout,
+    difference: meanWith !== null && meanWithout !== null ? meanWith - meanWithout : null,
+    cohens_d: cohensD(withValues, withoutValues),
+    welch: welchTTest(withValues, withoutValues),
+    mann_whitney: mannWhitneyU(withValues, withoutValues),
+  }
+}

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -356,10 +356,7 @@ function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
         n={data.n} · Pearson r={fmt(data.pearson)} · Spearman ρ={fmt(data.spearman)} · lag {data.lag_days}d
       </p>
       {!showGroupAsHeadline && (
-        <p class="explore-verdict">
-          {describeCorrelationStrength(data.pearson)} correlation
-          {caution && <span class="explore-caution"> · {caution}</span>}
-        </p>
+        <p class="explore-verdict">{describeCorrelationStrength(data.pearson)} correlation</p>
       )}
       {gc && (
         <>
@@ -371,6 +368,8 @@ function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
           <GroupComparisonPanel gc={gc} />
         </>
       )}
+      {/* Shown in both modes: a small-n caution matters most for a present-vs-absent split. */}
+      {caution && <p class="explore-verdict explore-caution">⚠ {caution}</p>}
       <svg width={w} height={h} class="scatter">
         <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} stroke="#ccc" />
         <line x1={pad} y1={pad} x2={pad} y2={h - pad} stroke="#ccc" />

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -4,6 +4,7 @@ import type {
   CorrelationSelectorsData,
   EventOutcome,
   GenericCorrelationData,
+  GroupComparison,
   LagExposureResultData,
   NutrientKey,
   TriggerCondition,
@@ -17,7 +18,14 @@ import {
   fetchCorrelationSelectors,
   fetchGenericCorrelation,
 } from '../../state/api'
-import { eventOutcomeLooksContinuous, MODE_HELP, TOOLTIPS } from './exploreGuidance'
+import {
+  describeCorrelationStrength,
+  describeEffectSize,
+  eventOutcomeLooksContinuous,
+  MODE_HELP,
+  sampleCaution,
+  TOOLTIPS,
+} from './exploreGuidance'
 
 type Mode = 'event' | 'continuous'
 
@@ -82,6 +90,9 @@ const fmt = (value: number | null | undefined, digits = 2): string =>
 
 const fmtPct = (value: number | null | undefined): string =>
   value === null || value === undefined ? '—' : `${(value * 100).toFixed(0)}%`
+
+const fmtP = (value: number | null | undefined): string =>
+  value === null || value === undefined ? '—' : value < 0.001 ? '<0.001' : value.toFixed(3)
 
 /** Whether the current event-mode form would misuse a continuous outcome. */
 const outcomeLooksContinuous = (): boolean =>
@@ -294,6 +305,30 @@ function EventOutcomeResults({ data }: { data: GenericCorrelationData }) {
   )
 }
 
+// --- Results: present-vs-absent group comparison for a binary trigger ---
+function GroupComparisonPanel({ gc }: { gc: GroupComparison }) {
+  const better =
+    gc.difference === null ? '' : gc.difference > 0 ? 'higher when present' : 'lower when present'
+  return (
+    <div class="group-comparison">
+      <p class="explore-verdict">
+        With trigger: <strong>{fmt(gc.mean_with, 1)}</strong> (n={gc.n_with}) · Without:{' '}
+        <strong>{fmt(gc.mean_without, 1)}</strong> (n={gc.n_without}) · Difference{' '}
+        <strong>
+          {gc.difference !== null && gc.difference > 0 ? '+' : ''}
+          {fmt(gc.difference, 1)}
+        </strong>{' '}
+        {better}
+      </p>
+      <p class="explore-verdict-sub">
+        Effect size: {describeEffectSize(gc.cohens_d)} (Cohen's d {fmt(gc.cohens_d)})
+        {gc.welch && <> · Welch t-test p={fmtP(gc.welch.p_value)}</>}
+        {gc.mann_whitney && <> · Mann–Whitney p={fmtP(gc.mann_whitney.p_value)}</>}
+      </p>
+    </div>
+  )
+}
+
 // --- Results: continuous scatter ---
 function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
   const points = data.series
@@ -309,11 +344,33 @@ function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
   const sx = (x: number) => pad + ((x - xMin) / (xMax - xMin || 1)) * (w - 2 * pad)
   const sy = (y: number) => h - pad - ((y - yMin) / (yMax - yMin || 1)) * (h - 2 * pad)
 
+  const gc = data.group_comparison
+  // A Pearson r on a binary/presence trigger is misleading, so when the trigger
+  // is binary the group comparison is the headline rather than the correlation.
+  const showGroupAsHeadline = gc !== null && gc.trigger_is_binary
+  const caution = sampleCaution(data.n)
+
   return (
     <div class="explore-results">
       <p class="explore-summary">
         n={data.n} · Pearson r={fmt(data.pearson)} · Spearman ρ={fmt(data.spearman)} · lag {data.lag_days}d
       </p>
+      {!showGroupAsHeadline && (
+        <p class="explore-verdict">
+          {describeCorrelationStrength(data.pearson)} correlation
+          {caution && <span class="explore-caution"> · {caution}</span>}
+        </p>
+      )}
+      {gc && (
+        <>
+          {showGroupAsHeadline && (
+            <p class="explore-help">
+              The trigger is binary, so a correlation coefficient is misleading — compare the groups instead:
+            </p>
+          )}
+          <GroupComparisonPanel gc={gc} />
+        </>
+      )}
       <svg width={w} height={h} class="scatter">
         <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} stroke="#ccc" />
         <line x1={pad} y1={pad} x2={pad} y2={h - pad} stroke="#ccc" />

--- a/apps/web/src/pages/Correlations/exploreGuidance.test.ts
+++ b/apps/web/src/pages/Correlations/exploreGuidance.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { eventOutcomeLooksContinuous } from './exploreGuidance'
+import {
+  describeCorrelationStrength,
+  describeEffectSize,
+  eventOutcomeLooksContinuous,
+  sampleCaution,
+} from './exploreGuidance'
 
 describe('eventOutcomeLooksContinuous', () => {
   it('flags a built-in (continuous) metric chosen as an event outcome', () => {
@@ -28,5 +33,41 @@ describe('eventOutcomeLooksContinuous', () => {
 
   it('does not flag an empty outcome', () => {
     expect(eventOutcomeLooksContinuous('event', 'metric', '')).toBe(false)
+  })
+})
+
+describe('describeCorrelationStrength', () => {
+  it('labels negligible without a direction', () => {
+    expect(describeCorrelationStrength(0.05)).toBe('negligible')
+    expect(describeCorrelationStrength(-0.09)).toBe('negligible')
+  })
+
+  it('labels strength and direction for meaningful coefficients', () => {
+    expect(describeCorrelationStrength(0.2)).toBe('weak positive')
+    expect(describeCorrelationStrength(-0.4)).toBe('moderate negative')
+    expect(describeCorrelationStrength(0.6)).toBe('strong positive')
+    expect(describeCorrelationStrength(-0.9)).toBe('very strong negative')
+  })
+
+  it('handles null', () => {
+    expect(describeCorrelationStrength(null)).toBe('not enough data')
+  })
+})
+
+describe('describeEffectSize', () => {
+  it('maps Cohen d to standard buckets', () => {
+    expect(describeEffectSize(0.1)).toBe('negligible')
+    expect(describeEffectSize(0.3)).toBe('small')
+    expect(describeEffectSize(-0.6)).toBe('medium')
+    expect(describeEffectSize(1.2)).toBe('large')
+    expect(describeEffectSize(null)).toBe('not estimable')
+  })
+})
+
+describe('sampleCaution', () => {
+  it('flags very small and small samples, clears at 30+', () => {
+    expect(sampleCaution(5)).toContain('anecdotal')
+    expect(sampleCaution(20)).toContain('caution')
+    expect(sampleCaution(50)).toBeNull()
   })
 })

--- a/apps/web/src/pages/Correlations/exploreGuidance.ts
+++ b/apps/web/src/pages/Correlations/exploreGuidance.ts
@@ -27,6 +27,32 @@ export const MODE_HELP =
   'days (back_pain, fissure_pain) → Event onset. Value-every-day metrics ' +
   '(sleep_score, hrv_rmssd, weight) → Continuous.'
 
+/**
+ * Plain-language strength label for a correlation coefficient, so a small r
+ * isn't over-read. Includes direction once the magnitude is non-negligible.
+ */
+export const describeCorrelationStrength = (r: number | null): string => {
+  if (r === null) return 'not enough data'
+  const a = Math.abs(r)
+  if (a < 0.1) return 'negligible'
+  const strength = a < 0.3 ? 'weak' : a < 0.5 ? 'moderate' : a < 0.7 ? 'strong' : 'very strong'
+  return `${strength} ${r > 0 ? 'positive' : 'negative'}`
+}
+
+/** Plain-language label for a Cohen's d effect size (standard conventions). */
+export const describeEffectSize = (d: number | null): string => {
+  if (d === null) return 'not estimable'
+  const a = Math.abs(d)
+  return a < 0.2 ? 'negligible' : a < 0.5 ? 'small' : a < 0.8 ? 'medium' : 'large'
+}
+
+/** A caution string when the sample is too small to trust, otherwise null. */
+export const sampleCaution = (n: number): string | null => {
+  if (n < 10) return 'very small sample — treat as anecdotal'
+  if (n < 30) return 'small sample — interpret with caution'
+  return null
+}
+
 /** Tooltip copy for the controls users most often misread. */
 export const TOOLTIPS = {
   collapseGap: 'Consecutive bad-days within this gap count as ONE onset (a 6-day flare = 1 event).',

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -489,6 +489,26 @@
   font-size: 0.88rem;
   margin: 0 0 4px;
 }
+.group-comparison {
+  background: #f6f5fb;
+  border: 1px solid #e3def2;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 6px 0;
+}
+.explore-verdict {
+  color: #374151;
+  font-size: 0.92rem;
+  margin: 4px 0;
+}
+.explore-verdict-sub {
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin: 4px 0 0;
+}
+.explore-caution {
+  color: #9a3412;
+}
 .explore-run {
   background: #673ab8;
   color: #fff;

--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -93,6 +93,27 @@ value on a known day defaults to 0, e.g. a meal-log-complete day with no carbs),
 optionally shifting the outcome forward by `lag_days`, and returns Pearson and
 Spearman coefficients plus the aligned series for plotting.
 
+### Binary/presence trigger — `group_comparison`
+
+A Pearson r on a **binary or presence** trigger (e.g. `hot_bath` → `sleep_score`,
+where the trigger is 0/1 each day) is misleading — every point sits at x=0 or
+x=1. So the response also includes a `group_comparison` that answers the question
+users actually mean, *"how much does X change Y?"*, by splitting the outcome into
+the days the trigger was **present** (value > 0) vs **absent** (value 0):
+
+- `mean_with` / `mean_without` and their `difference`;
+- `cohens_d` (pooled effect size);
+- a `welch` two-sample t-test (`t`, `df`, `p_value`);
+- a `mann_whitney` U test (`u`, `p_value`, `rank_biserial` effect size);
+- `n_with` / `n_without`, and `trigger_is_binary` (true when every aligned
+  trigger value is exactly 0 or 1).
+
+`group_comparison` is `null` when there is no split to compare (the trigger is
+present on every aligned day or on none). The web UI makes the group comparison
+the **headline** when `trigger_is_binary` (and flags the correlation coefficient
+as misleading there), and otherwise shows it beside the correlation along with a
+plain-language strength verdict and a small-sample caution.
+
 ## Statistics notes
 
 - Chi-squared p-values are exact for 1 degree of freedom (`erfc(√(χ²/2))`). A
@@ -101,6 +122,10 @@ Spearman coefficients plus the aligned series for plotting.
   counts.
 - Relative-risk CIs use the Wald log-RR standard error; they are omitted when an
   outcome cell count is zero.
+- The Welch t-test p-value uses the two-sided Student-t distribution
+  (`I_{df/(df+t²)}(df/2, ½)` via the regularized incomplete beta); Mann–Whitney
+  U uses a tie-corrected normal approximation. Both are omitted (`null`) when a
+  group has fewer than two values or no variance.
 
 ## Performance
 

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -379,9 +379,7 @@ export const triggerConditionSchema = z
         'Minimum occurrences within the window (default: 1). In event-outcome mode (day-granular) this counts distinct days with the event, not raw occurrences.',
       example: 3,
     }),
-    nutrient: nutrientKeySchema
-      .optional()
-      .meta({ description: 'Nutrient to use when type is "nutrition"' }),
+    nutrient: nutrientKeySchema.optional().meta({ description: 'Nutrient to use when type is "nutrition"' }),
     pattern: z.string().optional().meta({
       description:
         'Pattern to match (regex for tags, exact match for activity types). Omit for nutrition triggers.',
@@ -807,9 +805,54 @@ export const alignedPointSchema = z
   })
   .meta({ id: 'AlignedPoint' })
 
+/** Welch two-sample t-test result. */
+export const welchResultSchema = z
+  .object({
+    df: z.number().meta({ description: 'Welch–Satterthwaite degrees of freedom' }),
+    p_value: z.number().meta({ description: 'Two-sided p-value' }),
+    t: z.number().meta({ description: 't statistic (positive when present-group mean is higher)' }),
+  })
+  .meta({ id: 'WelchResult' })
+
+/** Mann–Whitney U test result. */
+export const mannWhitneyResultSchema = z
+  .object({
+    p_value: z.number().meta({ description: 'Two-sided p-value (normal approximation)' }),
+    rank_biserial: z.number().meta({
+      description: 'Rank-biserial effect size in [-1, 1] (positive when present tends to exceed absent)',
+    }),
+    u: z.number().meta({ description: 'U statistic for the present group' }),
+  })
+  .meta({ id: 'MannWhitneyResult' })
+
+/**
+ * Present-vs-absent comparison of a continuous outcome for a binary/presence
+ * trigger — group means, their difference, effect size and group-difference
+ * tests. Answers "how much does X change Y?" where a Pearson r on a 0/1 trigger
+ * would mislead.
+ */
+export const groupComparisonSchema = z
+  .object({
+    cohens_d: z.number().nullable().meta({ description: "Cohen's d (pooled SD)" }),
+    difference: z.number().nullable().meta({ description: 'mean_with − mean_without' }),
+    mann_whitney: mannWhitneyResultSchema.nullable(),
+    mean_with: z.number().nullable().meta({ description: 'Mean outcome on days the trigger was present' }),
+    mean_without: z.number().nullable().meta({ description: 'Mean outcome on days the trigger was absent' }),
+    n_with: z.number().int().meta({ description: 'Days the trigger was present (value > 0)' }),
+    n_without: z.number().int().meta({ description: 'Days the trigger was absent (value 0)' }),
+    trigger_is_binary: z.boolean().meta({ description: 'True when every aligned trigger value is 0 or 1' }),
+    welch: welchResultSchema.nullable(),
+  })
+  .meta({ id: 'GroupComparison' })
+
+export type GroupComparison = z.infer<typeof groupComparisonSchema>
+
 /** Continuous correlation result data */
 export const continuousCorrelationDataSchema = z
   .object({
+    group_comparison: groupComparisonSchema
+      .nullable()
+      .meta({ description: 'Present-vs-absent group comparison; null when there is no split to compare' }),
     lag_days: z.number().int(),
     n: z.number().int().meta({ description: 'Number of aligned day pairs' }),
     outcome: selectorSchema,


### PR DESCRIPTION
Second #792 follow-up workstream (one PR at a time). Full-stack: backend stats + api-spec + web.

## Problem
For a **binary/presence trigger** (e.g. `hot_bath` → `sleep_score`) every aligned point sits at x=0 or x=1, so a Pearson r is misleading. Users actually mean *"how much does X change Y?"*. Continuous results also had no plain-language read, making a tiny-n r easy to over-interpret.

## Changes
**Backend `stats.ts`** (new, unit-tested against t-tables / hand calcs):
- `welchTTest` — Welch's two-sample t-test; Student-t two-sided p via a new `regularizedIncompleteBeta` (continued fraction) on the existing `logGamma`.
- `mannWhitneyU` — tie-corrected normal approximation + rank-biserial effect size.
- `cohensD` (pooled) and a `twoGroupComparison` builder.

**`continuous.ts`** — split the aligned outcome by trigger presence (>0) and attach `group_comparison` (means, difference, Cohen's d, Welch, Mann–Whitney, `trigger_is_binary`). Null when there's no split. Flows automatically into **both** the REST `get_metric_correlation` and MCP responses — no new endpoint, parity preserved.

**api-spec** — `GroupComparison` / `WelchResult` / `MannWhitneyResult` schemas added to `ContinuousCorrelationData`.

**Web** — when the trigger is binary the group comparison is the headline (correlation flagged as misleading); otherwise a plain-language strength verdict + small-sample caution sits beside r/ρ. Verdict helpers are pure and unit-tested.

Visualization of these (box/violin, regression overlay, RR-CI bars) is the **next** workstream (#4) — this PR is the inference layer.

## Testing
- backend `vitest run src/services/correlations/` — 82 passed (incl. 18 new stats/group-comparison cases)
- web `vitest run exploreGuidance.test.ts` — 11 passed
- `pnpm check` — 0 errors across backend / web / api-spec

## Remaining #792 workstreams (next PRs)
- Nutrition completeness filter (`n_complete` vs `n_aligned`)
- Visualization upgrades (box/violin, axis labels, regression overlay, RR-CI bars)
- HRV context: select `stress_level`/`heart_rate` instead of HRV
- Trigger selector cleanup: retire legacy "tag" kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)