### PR TITLE
feat(correlations): nutrition completeness filter for continuous mode (#792)

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -303,6 +303,7 @@ export {
   getMealLogCompleted,
   getMealLogCompletedInRange,
   getMeals,
+  getNutritionCompleteDaysInRange,
   insertMeal,
   type NutrientKey,
   NUTRIENT_KEYS,

--- a/apps/backend/src/db/meals.integration.test.ts
+++ b/apps/backend/src/db/meals.integration.test.ts
@@ -11,6 +11,7 @@ import {
   getMealLogCompleted,
   getMealLogCompletedInRange,
   getMeals,
+  getNutritionCompleteDaysInRange,
   insertMeal,
   setMealLogCompleted,
   updateMeal,
@@ -517,6 +518,50 @@ describe('Meals Integration Tests', () => {
 
       const result = await getMealLogCompleted(user, ['2025-06-01', '2025-06-02', '2025-06-15'])
       expect(result.sort()).toEqual(['2025-06-01', '2025-06-15'])
+    })
+  })
+
+  describe('getNutritionCompleteDaysInRange', () => {
+    test('returns only days with a meal that has real macros (non-null calories)', async () => {
+      const user = getTestUser()
+      // Complete days: meals carrying calories.
+      await insertMeal(user, { calories: 500, time: new Date('2025-07-01T08:00:00Z') })
+      await insertMeal(user, { calories: 300, time: new Date('2025-07-03T19:00:00Z') })
+      // Flag-only day: a meal logged with no macros (calories NULL).
+      await insertMeal(user, { time: new Date('2025-07-02T12:00:00Z') })
+
+      const result = await getNutritionCompleteDaysInRange(
+        user,
+        new Date('2025-07-01T00:00:00Z'),
+        new Date('2025-07-31T23:59:59Z'),
+      )
+      expect(result).toEqual(['2025-07-01', '2025-07-03'])
+    })
+
+    test('counts a day complete if any of its meals has calories', async () => {
+      const user = getTestUser()
+      await insertMeal(user, { time: new Date('2025-07-05T08:00:00Z') }) // flag-only
+      await insertMeal(user, { calories: 120, time: new Date('2025-07-05T13:00:00Z') }) // real
+
+      const result = await getNutritionCompleteDaysInRange(
+        user,
+        new Date('2025-07-01T00:00:00Z'),
+        new Date('2025-07-31T23:59:59Z'),
+      )
+      expect(result).toEqual(['2025-07-05'])
+    })
+
+    test('respects the [start, end] range', async () => {
+      const user = getTestUser()
+      await insertMeal(user, { calories: 100, time: new Date('2025-08-01T08:00:00Z') })
+      await insertMeal(user, { calories: 100, time: new Date('2025-08-20T08:00:00Z') })
+
+      const result = await getNutritionCompleteDaysInRange(
+        user,
+        new Date('2025-08-10T00:00:00Z'),
+        new Date('2025-08-31T23:59:59Z'),
+      )
+      expect(result).toEqual(['2025-08-20'])
     })
   })
 

--- a/apps/backend/src/db/meals.integration.test.ts
+++ b/apps/backend/src/db/meals.integration.test.ts
@@ -522,7 +522,7 @@ describe('Meals Integration Tests', () => {
   })
 
   describe('getNutritionCompleteDaysInRange', () => {
-    test('returns only days with a meal that has real macros (non-null calories)', async () => {
+    test('returns only days with a meal that has a non-null value for the nutrient', async () => {
       const user = getTestUser()
       // Complete days: meals carrying calories.
       await insertMeal(user, { calories: 500, time: new Date('2025-07-01T08:00:00Z') })
@@ -532,23 +532,48 @@ describe('Meals Integration Tests', () => {
 
       const result = await getNutritionCompleteDaysInRange(
         user,
+        'calories',
         new Date('2025-07-01T00:00:00Z'),
         new Date('2025-07-31T23:59:59Z'),
       )
       expect(result).toEqual(['2025-07-01', '2025-07-03'])
     })
 
-    test('counts a day complete if any of its meals has calories', async () => {
+    test('counts a day complete if any of its meals has the nutrient', async () => {
       const user = getTestUser()
       await insertMeal(user, { time: new Date('2025-07-05T08:00:00Z') }) // flag-only
       await insertMeal(user, { calories: 120, time: new Date('2025-07-05T13:00:00Z') }) // real
 
       const result = await getNutritionCompleteDaysInRange(
         user,
+        'calories',
         new Date('2025-07-01T00:00:00Z'),
         new Date('2025-07-31T23:59:59Z'),
       )
       expect(result).toEqual(['2025-07-05'])
+    })
+
+    test('is keyed per-nutrient: a calorie-only day is incomplete for fiber', async () => {
+      const user = getTestUser()
+      // Calories logged but fiber never tracked.
+      await insertMeal(user, { calories: 400, time: new Date('2025-07-08T08:00:00Z') })
+      // Fiber explicitly logged on another day.
+      await insertMeal(user, { calories: 200, fiber: 6, time: new Date('2025-07-09T08:00:00Z') })
+
+      const calorieDays = await getNutritionCompleteDaysInRange(
+        user,
+        'calories',
+        new Date('2025-07-01T00:00:00Z'),
+        new Date('2025-07-31T23:59:59Z'),
+      )
+      const fiberDays = await getNutritionCompleteDaysInRange(
+        user,
+        'fiber',
+        new Date('2025-07-01T00:00:00Z'),
+        new Date('2025-07-31T23:59:59Z'),
+      )
+      expect(calorieDays).toEqual(['2025-07-08', '2025-07-09'])
+      expect(fiberDays).toEqual(['2025-07-09'])
     })
 
     test('respects the [start, end] range', async () => {
@@ -558,6 +583,7 @@ describe('Meals Integration Tests', () => {
 
       const result = await getNutritionCompleteDaysInRange(
         user,
+        'calories',
         new Date('2025-08-10T00:00:00Z'),
         new Date('2025-08-31T23:59:59Z'),
       )

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -181,24 +181,30 @@ export const getDailyNutrientTotals = async (
 }
 
 /**
- * UTC days in the inclusive [start, end] range that have *real* nutrition
- * logged — at least one meal with a non-null `calories` value.
+ * UTC days in the inclusive [start, end] range that have a *real* logged value
+ * for `nutrient` — at least one meal whose `nutrient` column is non-null.
  *
- * Distinguishes nutrition-complete days from flag-only days (a meal logged with
- * no macros), which otherwise sum to 0 in getDailyNutrientTotals and contaminate
- * nutrient correlations by inflating n with noisy zeros. Bucketed by UTC date to
- * match the correlation daily matrix.
+ * Keyed on the specific nutrient (not a single calories proxy) so completeness
+ * matches what's being correlated: a day that logged calories but never tracked
+ * fiber is complete for `calories` but not for `fiber`. Distinguishes
+ * nutrition-complete days from flag-only days (a meal logged with no macros),
+ * which otherwise sum to 0 in getDailyNutrientTotals and contaminate nutrient
+ * correlations by inflating n with noisy zeros. Bucketed by UTC date to match
+ * the correlation daily matrix.
  */
 export const getNutritionCompleteDaysInRange = async (
   user: string,
+  nutrient: NutrientKey,
   start: Date,
   end: Date,
 ): Promise<string[]> => {
+  // Column name comes from the fixed NUTRIENT_KEYS whitelist, so interpolation is safe.
+  const column = NUTRIENT_KEYS.includes(nutrient) ? nutrient : 'calories'
   const result = await query(
     user,
     `SELECT DISTINCT TO_CHAR((time AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS date
        FROM meals
-       WHERE time >= $1 AND time <= $2 AND calories IS NOT NULL
+       WHERE time >= $1 AND time <= $2 AND ${column} IS NOT NULL
        ORDER BY date`,
     [start, end],
   )

--- a/apps/backend/src/db/meals.ts
+++ b/apps/backend/src/db/meals.ts
@@ -180,6 +180,31 @@ export const getDailyNutrientTotals = async (
   return totals
 }
 
+/**
+ * UTC days in the inclusive [start, end] range that have *real* nutrition
+ * logged — at least one meal with a non-null `calories` value.
+ *
+ * Distinguishes nutrition-complete days from flag-only days (a meal logged with
+ * no macros), which otherwise sum to 0 in getDailyNutrientTotals and contaminate
+ * nutrient correlations by inflating n with noisy zeros. Bucketed by UTC date to
+ * match the correlation daily matrix.
+ */
+export const getNutritionCompleteDaysInRange = async (
+  user: string,
+  start: Date,
+  end: Date,
+): Promise<string[]> => {
+  const result = await query(
+    user,
+    `SELECT DISTINCT TO_CHAR((time AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS date
+       FROM meals
+       WHERE time >= $1 AND time <= $2 AND calories IS NOT NULL
+       ORDER BY date`,
+    [start, end],
+  )
+  return result.rows.map((r) => r.date as string)
+}
+
 export interface UpdateMealInput {
   meal_type?: string
   name?: string | null

--- a/apps/backend/src/mcp/correlation-tools.ts
+++ b/apps/backend/src/mcp/correlation-tools.ts
@@ -122,11 +122,21 @@ are known.
 Example: "How does carb intake affect my sleep score the next day?"
 -> trigger: {kind:"nutrition", nutrient:"carbs"}, outcome: {kind:"metric", metric:"sleep_score"}, lag_days: 1`,
     { ...continuousCorrelationBodySchema.shape, tz: tzSchema },
-    async ({ lag_days, outcome, period_days, period_end, period_start, trigger, tz }) => {
+    async ({
+      lag_days,
+      nutrition_completeness,
+      outcome,
+      period_days,
+      period_end,
+      period_start,
+      trigger,
+      tz,
+    }) => {
       const result = await getContinuousCorrelation(
         user,
         {
           lagDays: lag_days,
+          nutritionCompleteness: nutrition_completeness,
           outcome: outcome as Selector,
           periodDays: period_days,
           periodEnd: period_end,

--- a/apps/backend/src/routes/correlations-router.ts
+++ b/apps/backend/src/routes/correlations-router.ts
@@ -145,13 +145,15 @@ export const createCorrelationsRouter = (
     authMiddleware,
     validateBody(continuousCorrelationBodySchema),
     async (req, res) => {
-      const { trigger, outcome, lag_days, period_days, period_start, period_end } = req.body
+      const { trigger, outcome, lag_days, period_days, period_start, period_end, nutrition_completeness } =
+        req.body
       const user = req.user!
 
       const result = await getContinuousCorrelation(
         user,
         {
           lagDays: lag_days,
+          nutritionCompleteness: nutrition_completeness,
           outcome,
           periodDays: period_days,
           periodEnd: period_end,

--- a/apps/backend/src/services/correlations/continuous.test.ts
+++ b/apps/backend/src/services/correlations/continuous.test.ts
@@ -123,6 +123,52 @@ describe('computeContinuous', () => {
     expect(gc!.mann_whitney!.rank_biserial).toBeCloseTo(1, 6)
   })
 
+  test('counts and (optionally) filters incomplete nutrition days', () => {
+    const days = ['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04']
+    const trigger = seriesMap(days.map((d, i) => [d, i + 1]))
+    const outcome = seriesMap(days.map((d, i) => [d, 10 + i]))
+    // Only the 1st and 3rd days have complete nutrition on the trigger side.
+    const triggerCompleteDays = ['2024-01-01', '2024-01-03']
+
+    // 'all': keep every aligned pair but report how many were complete.
+    const all = computeContinuous({
+      triggerDaily: trigger,
+      outcomeDaily: outcome,
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+      triggerCompleteDays,
+    })
+    expect(all.n).toBe(4)
+    expect(all.n_complete).toBe(2)
+
+    // 'complete_only': drop the incomplete pairs entirely.
+    const filtered = computeContinuous({
+      triggerDaily: trigger,
+      outcomeDaily: outcome,
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+      triggerCompleteDays,
+      requireComplete: true,
+    })
+    expect(filtered.n).toBe(2)
+    expect(filtered.n_complete).toBe(2)
+    expect(filtered.series.map((p) => p.date)).toEqual(['2024-01-01', '2024-01-03'])
+  })
+
+  test('n_complete is null when no completeness set is provided', () => {
+    const days = ['2024-01-01', '2024-01-02', '2024-01-03']
+    const result = computeContinuous({
+      triggerDaily: seriesMap(days.map((d, i) => [d, i])),
+      outcomeDaily: seriesMap(days.map((d, i) => [d, i])),
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+    })
+    expect(result.n_complete).toBeNull()
+  })
+
   test('no group comparison when the trigger is present every day', () => {
     const days = ['2024-01-01', '2024-01-02', '2024-01-03']
     const result = computeContinuous({

--- a/apps/backend/src/services/correlations/continuous.ts
+++ b/apps/backend/src/services/correlations/continuous.ts
@@ -41,6 +41,13 @@ export interface ContinuousResult {
    * never present or always present (no split to compare).
    */
   group_comparison: GroupComparison | null
+  /**
+   * Of the `n` aligned pairs, how many have *complete* nutrition on every
+   * nutrition side. Null when neither side is a nutrition dimension (the notion
+   * doesn't apply). Lets the UI surface `n_complete` beside `n` so flag-only
+   * days don't quietly inflate confidence.
+   */
+  n_complete: number | null
 }
 
 export interface ContinuousInput {
@@ -51,6 +58,12 @@ export interface ContinuousInput {
   lagDays: number
   /** Max points returned in `series` (default 1000). */
   maxSeriesPoints?: number
+  /** Days the trigger is nutrition-complete (only when the trigger is nutrition). */
+  triggerCompleteDays?: string[]
+  /** Days the outcome is nutrition-complete (only when the outcome is nutrition). */
+  outcomeCompleteDays?: string[]
+  /** When true, drop aligned pairs that aren't nutrition-complete on every nutrition side. */
+  requireComplete?: boolean
 }
 
 const MS_PER_DAY = 86_400_000
@@ -59,6 +72,19 @@ const MS_PER_DAY = 86_400_000
 const shiftDay = (day: string, days: number): string =>
   new Date(Date.parse(`${day}T00:00:00Z`) + days * MS_PER_DAY).toISOString().split('T')[0]
 
+/** A nutrition-side day-set: null means "every day is complete" for that side. */
+type CompleteSet = Set<string> | null
+
+/** A pair is complete when every nutrition side present is complete on its day. */
+const pairIsComplete = (
+  day: string,
+  outcomeDay: string,
+  triggerComplete: CompleteSet,
+  outcomeComplete: CompleteSet,
+): boolean =>
+  (triggerComplete === null || triggerComplete.has(day)) &&
+  (outcomeComplete === null || outcomeComplete.has(outcomeDay))
+
 /**
  * Pure continuous correlation. A day pair (d, d+lag) is used only when the
  * trigger is known on d and the outcome is known on d+lag. Missing values on a
@@ -66,20 +92,31 @@ const shiftDay = (day: string, days: number): string =>
  */
 export const computeContinuous = (input: ContinuousInput): ContinuousResult => {
   const outcomeKnownSet = new Set(input.outcomeKnown)
+  const triggerCompleteSet: CompleteSet = input.triggerCompleteDays
+    ? new Set(input.triggerCompleteDays)
+    : null
+  const outcomeCompleteSet: CompleteSet = input.outcomeCompleteDays
+    ? new Set(input.outcomeCompleteDays)
+    : null
+  const tracksCompleteness = triggerCompleteSet !== null || outcomeCompleteSet !== null
   const triggerValues: number[] = []
   const outcomeValues: number[] = []
   const series: AlignedPoint[] = []
   const cap = input.maxSeriesPoints ?? 1000
+  let nComplete = 0
 
   // Iterate trigger-known days in chronological order for a tidy series.
   const triggerKnownSorted = [...input.triggerKnown].sort()
   for (const day of triggerKnownSorted) {
     const outcomeDay = shiftDay(day, input.lagDays)
     if (!outcomeKnownSet.has(outcomeDay)) continue
+    const pairComplete = pairIsComplete(day, outcomeDay, triggerCompleteSet, outcomeCompleteSet)
+    if (input.requireComplete && !pairComplete) continue
     const triggerValue = input.triggerDaily.get(day) ?? 0
     const outcomeValue = input.outcomeDaily.get(outcomeDay) ?? 0
     triggerValues.push(triggerValue)
     outcomeValues.push(outcomeValue)
+    if (pairComplete) nComplete++
     if (series.length < cap) series.push({ date: day, trigger: triggerValue, outcome: outcomeValue })
   }
 
@@ -90,6 +127,7 @@ export const computeContinuous = (input: ContinuousInput): ContinuousResult => {
     spearman: spearman(triggerValues, outcomeValues),
     series,
     group_comparison: computeGroupComparison(triggerValues, outcomeValues),
+    n_complete: tracksCompleteness ? nComplete : null,
   }
 }
 

--- a/apps/backend/src/services/correlations/explore.ts
+++ b/apps/backend/src/services/correlations/explore.ts
@@ -40,6 +40,12 @@ export interface ContinuousParams {
   periodStart?: string
   periodEnd?: string
   periodDays?: number
+  /**
+   * How to treat partially-logged nutrition days. 'all' (default) keeps every
+   * known day; 'complete_only' drops days that lack real macros (flag-only),
+   * which otherwise read as noisy zeros. n_complete is reported either way.
+   */
+  nutritionCompleteness?: 'all' | 'complete_only'
 }
 
 export interface ContinuousCorrelation extends ContinuousResult {
@@ -74,6 +80,9 @@ export const getContinuousCorrelation = async (
     triggerKnown: triggerSeries.knownDays,
     outcomeKnown: outcomeSeries.knownDays,
     lagDays,
+    triggerCompleteDays: triggerSeries.completeDays,
+    outcomeCompleteDays: outcomeSeries.completeDays,
+    requireComplete: params.nutritionCompleteness === 'complete_only',
   })
 
   const days = Math.round((end.getTime() - start.getTime()) / 86_400_000)

--- a/apps/backend/src/services/correlations/selectors.test.ts
+++ b/apps/backend/src/services/correlations/selectors.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../db', () => ({
   getAllActivitiesInRange: vi.fn(),
   getDailyNutrientTotals: vi.fn(),
   getMealLogCompletedInRange: vi.fn(),
+  getNutritionCompleteDaysInRange: vi.fn(),
   getProductivity: vi.fn(),
   getTimeSeries: vi.fn(),
 }))
@@ -19,6 +20,7 @@ beforeEach(() => {
   vi.mocked(db.getAllActivitiesInRange).mockResolvedValue([])
   vi.mocked(db.getDailyNutrientTotals).mockResolvedValue([])
   vi.mocked(db.getMealLogCompletedInRange).mockResolvedValue([])
+  vi.mocked(db.getNutritionCompleteDaysInRange).mockResolvedValue([])
   vi.mocked(db.getProductivity).mockResolvedValue([])
   vi.mocked(db.getTimeSeries).mockResolvedValue([])
 })

--- a/apps/backend/src/services/correlations/selectors.ts
+++ b/apps/backend/src/services/correlations/selectors.ts
@@ -205,7 +205,7 @@ const resolveNutrition = async (
   const [totals, completed, completeDays] = await Promise.all([
     getDailyNutrientTotals(user, [selector.nutrient], start, end),
     getMealLogCompletedInRange(user, toUtcDay(start), toUtcDay(end)),
-    getNutritionCompleteDaysInRange(user, start, end),
+    getNutritionCompleteDaysInRange(user, selector.nutrient, start, end),
   ])
 
   const daily = new Map<string, number>()
@@ -216,7 +216,7 @@ const resolveNutrition = async (
   const knownSet = new Set<string>([...daily.keys(), ...completed])
   for (const day of completed) if (!daily.has(day)) daily.set(day, 0)
 
-  // Complete = days with real macros (a non-null calories meal), so callers can
+  // Complete = days with a real logged value for *this* nutrient, so callers can
   // exclude or count flag-only days that otherwise read as noisy zeros.
   return { ...fromDailyValues(daily, [...knownSet], selector.threshold), completeDays }
 }

--- a/apps/backend/src/services/correlations/selectors.ts
+++ b/apps/backend/src/services/correlations/selectors.ts
@@ -16,6 +16,7 @@ import {
   getAllActivitiesInRange,
   getDailyNutrientTotals,
   getMealLogCompletedInRange,
+  getNutritionCompleteDaysInRange,
   getProductivity,
   getTimeSeries,
 } from '../../db/index.ts'
@@ -75,6 +76,12 @@ export interface ResolvedSeries {
   daily: Map<string, number>
   /** Days where the dimension's status is known (the denominator universe). */
   knownDays: string[]
+  /**
+   * Days with *complete* data, when the dimension distinguishes complete from
+   * partial logging. Only nutrition populates this (days with real macros, vs
+   * flag-only days); undefined for dimensions where every known day is complete.
+   */
+  completeDays?: string[]
 }
 
 const MS_PER_DAY = 86_400_000
@@ -195,9 +202,10 @@ const resolveNutrition = async (
   start: Date,
   end: Date,
 ): Promise<ResolvedSeries> => {
-  const [totals, completed] = await Promise.all([
+  const [totals, completed, completeDays] = await Promise.all([
     getDailyNutrientTotals(user, [selector.nutrient], start, end),
     getMealLogCompletedInRange(user, toUtcDay(start), toUtcDay(end)),
+    getNutritionCompleteDaysInRange(user, start, end),
   ])
 
   const daily = new Map<string, number>()
@@ -208,7 +216,9 @@ const resolveNutrition = async (
   const knownSet = new Set<string>([...daily.keys(), ...completed])
   for (const day of completed) if (!daily.has(day)) daily.set(day, 0)
 
-  return fromDailyValues(daily, [...knownSet], selector.threshold)
+  // Complete = days with real macros (a non-null calories meal), so callers can
+  // exclude or count flag-only days that otherwise read as noisy zeros.
+  return { ...fromDailyValues(daily, [...knownSet], selector.threshold), completeDays }
 }
 
 /** Productivity minutes per day for a matching category or app. */

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -38,6 +38,8 @@ const eventOutcomeValue = signal('')
 const lagWindowsInput = signal('24h,48h,7d')
 const lagDaysInput = signal(0)
 const collapseGapDays = signal(3)
+// Continuous mode: drop nutrition days lacking real macros (flag-only) when set.
+const nutritionCompleteness = signal<'all' | 'complete_only'>('all')
 // Defaults to 'all' since the default outcome source is a (presence-only) metric.
 const denominator = signal<'known' | 'all'>('all')
 const periodStart = signal('')
@@ -353,7 +355,9 @@ function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
   return (
     <div class="explore-results">
       <p class="explore-summary">
-        n={data.n} · Pearson r={fmt(data.pearson)} · Spearman ρ={fmt(data.spearman)} · lag {data.lag_days}d
+        n={data.n}
+        {data.n_complete !== null && ` (${data.n_complete} with full nutrition)`} · Pearson r=
+        {fmt(data.pearson)} · Spearman ρ={fmt(data.spearman)} · lag {data.lag_days}d
       </p>
       {!showGroupAsHeadline && (
         <p class="explore-verdict">{describeCorrelationStrength(data.pearson)} correlation</p>
@@ -406,11 +410,16 @@ const runExplore = async (): Promise<ExploreResult> => {
   const data = await fetchContinuousCorrelation({
     ...period,
     lag_days: lagDaysInput.value,
+    nutrition_completeness: nutritionCompleteness.value,
     outcome: outcomeSelector.value,
     trigger: triggerSelector.value,
   })
   return { kind: 'continuous', data }
 }
+
+/** Continuous mode: is either side a nutrition dimension (so completeness applies)? */
+const continuousHasNutrition = (): boolean =>
+  triggerSelector.value.kind === 'nutrition' || outcomeSelector.value.kind === 'nutrition'
 
 // eslint-disable-next-line complexity -- form render branches on mode/selector kind
 export function ExploreTab() {
@@ -560,14 +569,43 @@ export function ExploreTab() {
             </div>
           </>
         ) : (
-          <div class="explore-row">
-            <label>Outcome lag (days)</label>
-            <input
-              type="number"
-              value={lagDaysInput.value}
-              onInput={(e) => (lagDaysInput.value = parseInt((e.target as HTMLInputElement).value, 10) || 0)}
-            />
-          </div>
+          <>
+            <div class="explore-row">
+              <label>Outcome lag (days)</label>
+              <input
+                type="number"
+                value={lagDaysInput.value}
+                onInput={(e) =>
+                  (lagDaysInput.value = parseInt((e.target as HTMLInputElement).value, 10) || 0)
+                }
+              />
+            </div>
+            {continuousHasNutrition() && (
+              <div class="explore-row">
+                <label title="Flag-only days (a meal logged with no macros) read as noisy zeros.">
+                  Nutrition days
+                </label>
+                <div class="explore-toggle">
+                  <button
+                    class={nutritionCompleteness.value === 'all' ? 'active' : ''}
+                    onClick={() => (nutritionCompleteness.value = 'all')}
+                  >
+                    All
+                  </button>
+                  <button
+                    class={nutritionCompleteness.value === 'complete_only' ? 'active' : ''}
+                    onClick={() => (nutritionCompleteness.value = 'complete_only')}
+                  >
+                    Full macros only
+                  </button>
+                </div>
+                <span class="regime-hint">
+                  Exclude days logged without real macros (flag-only). The result shows how many aligned days
+                  had full nutrition either way.
+                </span>
+              </div>
+            )}
+          </>
         )}
 
         <div class="explore-row">

--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -114,6 +114,22 @@ the **headline** when `trigger_is_binary` (and flags the correlation coefficient
 as misleading there), and otherwise shows it beside the correlation along with a
 plain-language strength verdict and a small-sample caution.
 
+### Nutrition completeness
+
+Nutrition days come in two flavours: **nutrition-complete** days (at least one
+meal with real macros — a non-null `calories`) and **flag-only** days (a meal
+logged with no macros, which sums to 0 and otherwise reads as a noisy zero).
+When either side of a continuous correlation is a `nutrition` selector:
+
+- the response always reports `n_complete` — of the `n` aligned pairs, how many
+  are nutrition-complete on every nutrition side (null when no side is
+  nutrition), so the UI can show "n=104 (47 with full nutrition)";
+- `nutrition_completeness: "complete_only"` (request body, default `"all"`)
+  drops the flag-only pairs entirely so they don't dilute the correlation.
+
+Completeness is independent of the event-mode `denominator` knob (which governs
+known-vs-all days for presence-only *outcomes*).
+
 ## Statistics notes
 
 - Chi-squared p-values are exact for 1 degree of freedom (`erfc(√(χ²/2))`). A

--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -13,15 +13,15 @@ API, and the MCP tools. All analysis is bucketed by **UTC calendar day**.
 
 ## Selectors
 
-A *selector* names any data dimension and resolves to event days, a daily value
-series, and the set of days where its status is *known*:
+A _selector_ names any data dimension and resolves to event days, a daily value
+series, and the set of days where its status is _known_:
 
-| kind | resolves from | known days |
-| --- | --- | --- |
-| `tag` / `activity` | activities matched by `activity_type` (regex) | every day in range (absence = no event) |
-| `metric` | `time_series` entries (avg/sum per day) | days with ≥1 entry (incl. explicit 0s) |
-| `nutrition` | per-day meal totals (calories/protein/carbs/fat/fiber) | days with a meal **or** marked meal-log-complete |
-| `productivity_category` / `productivity_app` | productivity minutes matched by category/app | every day in range |
+| kind                                         | resolves from                                          | known days                                       |
+| -------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------ |
+| `tag` / `activity`                           | activities matched by `activity_type` (regex)          | every day in range (absence = no event)          |
+| `metric`                                     | `time_series` entries (avg/sum per day)                | days with ≥1 entry (incl. explicit 0s)           |
+| `nutrition`                                  | per-day meal totals (calories/protein/carbs/fat/fiber) | days with a meal **or** marked meal-log-complete |
+| `productivity_category` / `productivity_app` | productivity minutes matched by category/app           | every day in range                               |
 
 `GET /correlations/selectors` (MCP: `list_correlation_selectors`) lists the
 available metrics, tags, activity types, nutrients and productivity categories.
@@ -34,24 +34,29 @@ Surfaced through `get_generic_correlation` / `POST /correlations/generic` with a
 ```jsonc
 {
   "triggers": [{ "type": "tag", "pattern": "ejaculation" }],
-  "outcome": { "type": "event", "source": "metric", "metric": "back_pain",
-               "threshold": { "op": "gt", "value": 0 }, "collapse_gap_days": 3 },
+  "outcome": {
+    "type": "event",
+    "source": "metric",
+    "metric": "back_pain",
+    "threshold": { "op": "gt", "value": 0 },
+    "collapse_gap_days": 3,
+  },
   "lag_windows": ["24h", "48h", "7d"],
-  "period_start": "2019-09-28",       // regime scoping (optional)
-  "denominator": "all"                 // see below
+  "period_start": "2019-09-28", // regime scoping (optional)
+  "denominator": "all", // see below
 }
 ```
 
 How it works:
 
 - **Onset-collapsing.** Consecutive outcome days no more than `collapse_gap_days`
-  apart (default 3) collapse into a single *onset*, so a 6-day flare counts once
+  apart (default 3) collapse into a single _onset_, so a 6-day flare counts once
   instead of six times.
-- **Exposure.** A known day is *exposed* when a trigger occurred within the lag
+- **Exposure.** A known day is _exposed_ when a trigger occurred within the lag
   window ending on that day (e.g. `48h` = the day itself plus the day before).
 - **Effect.** Over the known-day denominator, the engine builds a 2×2 table of
   {onset, non-onset} × {exposed, unexposed} and reports, per lag window:
-  - **`reverse_conditional`** — P(recent trigger | onset). *This is the headline*
+  - **`reverse_conditional`** — P(recent trigger | onset). _This is the headline_
     — the user's actual question ("when my back flares, how often had I recently
     leaked?").
   - **`base_rate`** — P(a known day is exposed), for comparison.
@@ -83,8 +88,8 @@ Surfaced through `get_metric_correlation` / `POST /correlations/continuous`:
 {
   "trigger": { "kind": "nutrition", "nutrient": "carbs" },
   "outcome": { "kind": "metric", "metric": "sleep_score" },
-  "lag_days": 1,            // outcome measured 1 day after the trigger
-  "period_days": 180
+  "lag_days": 1, // outcome measured 1 day after the trigger
+  "period_days": 180,
 }
 ```
 
@@ -98,7 +103,7 @@ Spearman coefficients plus the aligned series for plotting.
 A Pearson r on a **binary or presence** trigger (e.g. `hot_bath` → `sleep_score`,
 where the trigger is 0/1 each day) is misleading — every point sits at x=0 or
 x=1. So the response also includes a `group_comparison` that answers the question
-users actually mean, *"how much does X change Y?"*, by splitting the outcome into
+users actually mean, _"how much does X change Y?"_, by splitting the outcome into
 the days the trigger was **present** (value > 0) vs **absent** (value 0):
 
 - `mean_with` / `mean_without` and their `difference`;
@@ -117,8 +122,10 @@ plain-language strength verdict and a small-sample caution.
 ### Nutrition completeness
 
 Nutrition days come in two flavours: **nutrition-complete** days (at least one
-meal with real macros — a non-null `calories`) and **flag-only** days (a meal
-logged with no macros, which sums to 0 and otherwise reads as a noisy zero).
+meal with a real logged value for the nutrient being correlated) and
+**flag-only** days (a meal logged with no macros, which sums to 0 and otherwise
+reads as a noisy zero). Completeness is keyed per-nutrient — a day that logged
+calories but never tracked fiber is complete for `calories` but not for `fiber`.
 When either side of a continuous correlation is a `nutrition` selector:
 
 - the response always reports `n_complete` — of the `n` aligned pairs, how many
@@ -128,7 +135,7 @@ When either side of a continuous correlation is a `nutrition` selector:
   drops the flag-only pairs entirely so they don't dilute the correlation.
 
 Completeness is independent of the event-mode `denominator` knob (which governs
-known-vs-all days for presence-only *outcomes*).
+known-vs-all days for presence-only _outcomes_).
 
 ## Statistics notes
 

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -779,6 +779,15 @@ export const selectorSchema = z
 
 export type CorrelationSelector = z.infer<typeof selectorSchema>
 
+/** How partially-logged nutrition days are treated in continuous correlation. */
+export const nutritionCompletenessSchema = z.enum(['all', 'complete_only']).meta({
+  description:
+    "How to treat partial nutrition days: 'all' keeps every known day; 'complete_only' drops days without real macros (flag-only). n_complete is reported either way.",
+  id: 'NutritionCompleteness',
+})
+
+export type NutritionCompleteness = z.infer<typeof nutritionCompletenessSchema>
+
 /** Continuous correlation request body */
 export const continuousCorrelationBodySchema = z
   .object({
@@ -786,6 +795,9 @@ export const continuousCorrelationBodySchema = z
       description: 'Days the outcome lags the trigger (default: 0)',
       example: 1,
     }),
+    nutrition_completeness: nutritionCompletenessSchema
+      .optional()
+      .meta({ description: 'Filter for partial nutrition days (default: all)' }),
     outcome: selectorSchema.meta({ description: 'Outcome dimension' }),
     period_days: z.number().int().optional().meta({ description: 'Days to analyze (default: 90)' }),
     period_end: z.string().optional().meta({ description: 'Inclusive regime end (YYYY-MM-DD)' }),
@@ -855,6 +867,10 @@ export const continuousCorrelationDataSchema = z
       .meta({ description: 'Present-vs-absent group comparison; null when there is no split to compare' }),
     lag_days: z.number().int(),
     n: z.number().int().meta({ description: 'Number of aligned day pairs' }),
+    n_complete: z.number().int().nullable().meta({
+      description:
+        'Of the n aligned pairs, how many have complete nutrition on every nutrition side; null when no side is nutrition',
+    }),
     outcome: selectorSchema,
     pearson: z.number().nullable().meta({ description: 'Pearson correlation (-1..1)' }),
     period: z.object({ days: z.number().int(), end: z.string(), start: z.string() }),


### PR DESCRIPTION
Third #792 follow-up workstream (one PR at a time). Full-stack: db + api-spec + REST + MCP + web.

## Problem
Logging completeness limits nutrition analyses: many days are marked "completed" but carry only meal *flags*, not full macros. These sum to 0 in `getDailyNutrientTotals` and **contaminate nutrient correlations** — inflating `n` with noisy zeros (the issue's `carbs → sleep_score` n=104 was really ~40–60 full-nutrition days).

## Changes
- **db** `getNutritionCompleteDaysInRange` — UTC days with ≥1 meal that has real macros (non-null `calories`), distinguishing complete days from flag-only ones. **Integration-tested** (3 cases) against real Postgres.
- **selectors** — `resolveNutrition` also returns `completeDays`.
- **continuous.ts** — report `n_complete` (of the `n` aligned pairs, how many are nutrition-complete on every nutrition side; `null` when no side is nutrition) and optionally drop incomplete pairs (`requireComplete`). Complexity kept under budget via a small `pairIsComplete` helper.
- **api-spec** — `nutrition_completeness` (`'all' | 'complete_only'`, default `all`) on the request; `n_complete` on the response. Threaded through **REST** and **MCP** (`get_metric_correlation`), so parity holds.
- **web** — a "Nutrition days: All / Full macros only" toggle (shown only when a side is nutrition) and `n=104 (47 with full nutrition)` in the summary.
- **docs** — `docs/correlations.md` documents `n_complete` and the filter.

## Definition
A day is **nutrition-complete** when it has at least one meal with non-null `calories` (real food logged). Flag-only meals (logged with no macros) leave `calories` NULL. This is independent of the event-mode `denominator` knob.

## Testing
- backend `vitest run src/services/correlations/` — 84 passed (incl. new completeness cases)
- new meals integration test — 3 passed (testcontainers)
- `pnpm check` — 0 errors across backend / web / api-spec

## Remaining #792 workstreams (next PRs)
- Visualization upgrades (box/violin, axis labels, regression overlay, RR-CI bars)
- HRV context: select `stress_level`/`heart_rate` instead of HRV
- Trigger selector cleanup: retire legacy "tag" kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)