### PR TITLE
feat(correlations): chart upgrades — box plot, regression overlay, RR bars (#792)

### DIFF
--- a/apps/backend/src/services/correlations/continuous.test.ts
+++ b/apps/backend/src/services/correlations/continuous.test.ts
@@ -20,7 +20,40 @@ describe('computeContinuous', () => {
 
     expect(result.n).toBe(4)
     expect(result.pearson).toBeCloseTo(1, 5)
+    expect(result.pearson_p).toBe(0) // perfect correlation
     expect(result.spearman).toBeCloseTo(1, 5)
+  })
+
+  test('reports a Pearson p-value for a noisy correlation', () => {
+    const days = Array.from(
+      { length: 20 },
+      (_, i) => new Date(Date.parse('2024-01-01T00:00:00Z') + i * 86_400_000).toISOString().split('T')[0],
+    )
+    // Weak/none relationship -> p should be a real probability in (0, 1].
+    const trigger = seriesMap(days.map((d, i) => [d, i % 5]))
+    const outcome = seriesMap(days.map((d, i) => [d, (i * 7) % 3]))
+    const result = computeContinuous({
+      triggerDaily: trigger,
+      outcomeDaily: outcome,
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+    })
+    expect(result.pearson_p).not.toBeNull()
+    expect(result.pearson_p!).toBeGreaterThan(0)
+    expect(result.pearson_p!).toBeLessThanOrEqual(1)
+  })
+
+  test('pearson_p is null with too few pairs', () => {
+    const days = ['2024-01-01', '2024-01-02']
+    const result = computeContinuous({
+      triggerDaily: seriesMap(days.map((d, i) => [d, i])),
+      outcomeDaily: seriesMap(days.map((d, i) => [d, i])),
+      triggerKnown: days,
+      outcomeKnown: days,
+      lagDays: 0,
+    })
+    expect(result.pearson_p).toBeNull()
   })
 
   test('lag shifts the outcome forward by N days', () => {

--- a/apps/backend/src/services/correlations/continuous.ts
+++ b/apps/backend/src/services/correlations/continuous.ts
@@ -4,7 +4,7 @@
  * questions like "how does carb intake affect my sleep the next day?" work.
  */
 
-import { type TwoGroupComparison, pearson, spearman, twoGroupComparison } from './stats.ts'
+import { type TwoGroupComparison, pearson, spearman, studentTTwoSidedP, twoGroupComparison } from './stats.ts'
 
 /**
  * Group comparison for a binary/presence trigger: how the continuous outcome
@@ -32,6 +32,8 @@ export interface ContinuousResult {
   lag_days: number
   /** Pearson correlation, or null when fewer than 3 pairs / no variance. */
   pearson: number | null
+  /** Two-sided p-value for the Pearson correlation, or null when not estimable. */
+  pearson_p: number | null
   /** Spearman rank correlation, or null when fewer than 3 pairs. */
   spearman: number | null
   /** Aligned series (for plotting); capped to avoid huge payloads. */
@@ -120,15 +122,29 @@ export const computeContinuous = (input: ContinuousInput): ContinuousResult => {
     if (series.length < cap) series.push({ date: day, trigger: triggerValue, outcome: outcomeValue })
   }
 
+  const pearsonR = pearson(triggerValues, outcomeValues)
   return {
     n: triggerValues.length,
     lag_days: input.lagDays,
-    pearson: pearson(triggerValues, outcomeValues),
+    pearson: pearsonR,
+    pearson_p: pearsonPValue(pearsonR, triggerValues.length),
     spearman: spearman(triggerValues, outcomeValues),
     series,
     group_comparison: computeGroupComparison(triggerValues, outcomeValues),
     n_complete: tracksCompleteness ? nComplete : null,
   }
+}
+
+/**
+ * Two-sided significance of a Pearson r via the t-transform
+ * t = r·√((n−2)/(1−r²)) on n−2 degrees of freedom. Null when fewer than 3 pairs;
+ * 0 for a perfect correlation (where the transform diverges).
+ */
+const pearsonPValue = (r: number | null, n: number): number | null => {
+  if (r === null || n < 3) return null
+  if (Math.abs(r) >= 1) return 0
+  const t = r * Math.sqrt((n - 2) / (1 - r * r))
+  return studentTTwoSidedP(t, n - 2)
 }
 
 /**

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -18,6 +18,7 @@ import {
   fetchCorrelationSelectors,
   fetchGenericCorrelation,
 } from '../../state/api'
+import { describeSelectorAxis, fiveNumberSummary, linearRegression } from './exploreCharts'
 import {
   describeCorrelationStrength,
   describeEffectSize,
@@ -249,6 +250,46 @@ function SelectorPicker({
   )
 }
 
+// --- Results: per-lag relative-risk bars with 95% CI whiskers ---
+function RrBars({ perLag }: { perLag: LagExposureResultData[] }) {
+  const items = perLag.filter((l) => l.relative_risk !== null)
+  if (items.length === 0) return null
+  const w = 340
+  const h = 200
+  const pad = { bottom: 26, left: 40, right: 12, top: 16 }
+  const maxRr = Math.max(2, ...items.map((l) => l.ci_high ?? l.relative_risk!))
+  const sy = (v: number) => h - pad.bottom - (v / maxRr) * (h - pad.top - pad.bottom)
+  const band = (w - pad.left - pad.right) / items.length
+
+  return (
+    <svg width={w} height={h} class="rr-bars">
+      <text x={pad.left} y={pad.top - 4} class="axis-label">
+        Relative risk (95% CI)
+      </text>
+      {/* RR=1 reference line — no effect / base rate */}
+      <line x1={pad.left} y1={sy(1)} x2={w - pad.right} y2={sy(1)} stroke="#999" stroke-dasharray="4 3" />
+      <text x={w - pad.right} y={sy(1) - 3} text-anchor="end" class="axis-label">
+        RR=1
+      </text>
+      {items.map((l, i) => {
+        const cx = pad.left + band * (i + 0.5)
+        const sig = l.p_value < 0.05
+        return (
+          <g>
+            {l.ci_low !== null && l.ci_high !== null && (
+              <line x1={cx} y1={sy(l.ci_low)} x2={cx} y2={sy(l.ci_high)} stroke="#555" />
+            )}
+            <circle cx={cx} cy={sy(l.relative_risk!)} r={4} fill={sig ? '#2e7d32' : '#673ab8'} />
+            <text x={cx} y={h - 10} text-anchor="middle" class="axis-label">
+              {l.lag}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
 // --- Results: event-outcome table ---
 function EventOutcomeResults({ data }: { data: GenericCorrelationData }) {
   const eo = data.event_outcome
@@ -303,6 +344,7 @@ function EventOutcomeResults({ data }: { data: GenericCorrelationData }) {
           </tbody>
         </table>
       </div>
+      <RrBars perLag={eo.per_lag} />
     </div>
   )
 }
@@ -331,21 +373,152 @@ function GroupComparisonPanel({ gc }: { gc: GroupComparison }) {
   )
 }
 
-// --- Results: continuous scatter ---
-function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
+const CHART_W = 340
+const CHART_H = 240
+const CHART_PAD = { bottom: 38, left: 46, right: 12, top: 14 }
+
+/** Rotated y-axis label + horizontal x-axis label for a chart. */
+function AxisLabels({ x, y }: { x: string; y: string }) {
+  const midX = (CHART_PAD.left + (CHART_W - CHART_PAD.right)) / 2
+  const midY = (CHART_PAD.top + (CHART_H - CHART_PAD.bottom)) / 2
+  return (
+    <>
+      <text x={midX} y={CHART_H - 4} text-anchor="middle" class="axis-label">
+        {x}
+      </text>
+      <text x={12} y={midY} text-anchor="middle" class="axis-label" transform={`rotate(-90 12 ${midY})`}>
+        {y}
+      </text>
+    </>
+  )
+}
+
+// --- Results: continuous scatter with regression line + annotation ---
+function ScatterPlot({ data }: { data: ContinuousCorrelationData }) {
   const points = data.series
   const xs = points.map((p) => p.trigger)
   const ys = points.map((p) => p.outcome)
-  const xMin = Math.min(...xs, 0)
-  const xMax = Math.max(...xs, 1)
-  const yMin = Math.min(...ys, 0)
-  const yMax = Math.max(...ys, 1)
-  const w = 320
-  const h = 220
-  const pad = 30
-  const sx = (x: number) => pad + ((x - xMin) / (xMax - xMin || 1)) * (w - 2 * pad)
-  const sy = (y: number) => h - pad - ((y - yMin) / (yMax - yMin || 1)) * (h - 2 * pad)
+  const xMin = Math.min(...xs)
+  const xMax = Math.max(...xs)
+  const yMin = Math.min(...ys)
+  const yMax = Math.max(...ys)
+  const sx = (x: number) =>
+    CHART_PAD.left + ((x - xMin) / (xMax - xMin || 1)) * (CHART_W - CHART_PAD.left - CHART_PAD.right)
+  const sy = (y: number) =>
+    CHART_H -
+    CHART_PAD.bottom -
+    ((y - yMin) / (yMax - yMin || 1)) * (CHART_H - CHART_PAD.top - CHART_PAD.bottom)
+  const reg = linearRegression(xs, ys)
 
+  return (
+    <svg width={CHART_W} height={CHART_H} class="scatter">
+      <line
+        x1={CHART_PAD.left}
+        y1={CHART_H - CHART_PAD.bottom}
+        x2={CHART_W - CHART_PAD.right}
+        y2={CHART_H - CHART_PAD.bottom}
+        stroke="#ccc"
+      />
+      <line
+        x1={CHART_PAD.left}
+        y1={CHART_PAD.top}
+        x2={CHART_PAD.left}
+        y2={CHART_H - CHART_PAD.bottom}
+        stroke="#ccc"
+      />
+      {points.map((p) => (
+        <circle cx={sx(p.trigger)} cy={sy(p.outcome)} r={3} fill="#673ab8" opacity={0.45} />
+      ))}
+      {reg && (
+        <line
+          x1={sx(xMin)}
+          y1={sy(reg.slope * xMin + reg.intercept)}
+          x2={sx(xMax)}
+          y2={sy(reg.slope * xMax + reg.intercept)}
+          stroke="#e0457b"
+          stroke-width={2}
+        />
+      )}
+      <text x={CHART_PAD.left + 6} y={CHART_PAD.top + 10} class="plot-annot">
+        r={fmt(data.pearson)} · ρ={fmt(data.spearman)} · n={data.n} · p={fmtP(data.pearson_p)}
+      </text>
+      <AxisLabels x={describeSelectorAxis(data.trigger)} y={describeSelectorAxis(data.outcome)} />
+    </svg>
+  )
+}
+
+// --- Results: present-vs-absent box plot for a binary trigger ---
+function BoxPlot({ data }: { data: ContinuousCorrelationData }) {
+  const withVals = data.series.filter((p) => p.trigger > 0).map((p) => p.outcome)
+  const withoutVals = data.series.filter((p) => p.trigger === 0).map((p) => p.outcome)
+  const absent = fiveNumberSummary(withoutVals)
+  const present = fiveNumberSummary(withVals)
+  if (!absent || !present) return null
+  const all = [...withVals, ...withoutVals]
+  const yMin = Math.min(...all)
+  const yMax = Math.max(...all)
+  const sy = (y: number) =>
+    CHART_H -
+    CHART_PAD.bottom -
+    ((y - yMin) / (yMax - yMin || 1)) * (CHART_H - CHART_PAD.top - CHART_PAD.bottom)
+  const gc = data.group_comparison
+  const boxes = [
+    {
+      color: '#9aa0a6',
+      label: `Absent (n=${gc?.n_without ?? withoutVals.length})`,
+      s: absent,
+      x: CHART_W * 0.34,
+    },
+    {
+      color: '#673ab8',
+      label: `Present (n=${gc?.n_with ?? withVals.length})`,
+      s: present,
+      x: CHART_W * 0.68,
+    },
+  ]
+  const bw = 46
+
+  return (
+    <svg width={CHART_W} height={CHART_H} class="boxplot">
+      <line
+        x1={CHART_PAD.left}
+        y1={CHART_PAD.top}
+        x2={CHART_PAD.left}
+        y2={CHART_H - CHART_PAD.bottom}
+        stroke="#ccc"
+      />
+      {boxes.map((g) => (
+        <g>
+          <line x1={g.x} y1={sy(g.s.min)} x2={g.x} y2={sy(g.s.max)} stroke={g.color} />
+          <rect
+            x={g.x - bw / 2}
+            y={sy(g.s.q3)}
+            width={bw}
+            height={Math.max(1, sy(g.s.q1) - sy(g.s.q3))}
+            fill={g.color}
+            opacity={0.25}
+            stroke={g.color}
+          />
+          <line
+            x1={g.x - bw / 2}
+            y1={sy(g.s.median)}
+            x2={g.x + bw / 2}
+            y2={sy(g.s.median)}
+            stroke={g.color}
+            stroke-width={2}
+          />
+          <text x={g.x} y={CHART_H - 22} text-anchor="middle" class="axis-label">
+            {g.label}
+          </text>
+        </g>
+      ))}
+      <AxisLabels x="trigger present?" y={describeSelectorAxis(data.outcome)} />
+    </svg>
+  )
+}
+
+// --- Results: continuous mode (scatter or box plot, with verdicts) ---
+function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
   const gc = data.group_comparison
   // A Pearson r on a binary/presence trigger is misleading, so when the trigger
   // is binary the group comparison is the headline rather than the correlation.
@@ -374,13 +547,7 @@ function ContinuousResults({ data }: { data: ContinuousCorrelationData }) {
       )}
       {/* Shown in both modes: a small-n caution matters most for a present-vs-absent split. */}
       {caution && <p class="explore-verdict explore-caution">⚠ {caution}</p>}
-      <svg width={w} height={h} class="scatter">
-        <line x1={pad} y1={h - pad} x2={w - pad} y2={h - pad} stroke="#ccc" />
-        <line x1={pad} y1={pad} x2={pad} y2={h - pad} stroke="#ccc" />
-        {points.map((p) => (
-          <circle cx={sx(p.trigger)} cy={sy(p.outcome)} r={3} fill="#673ab8" opacity={0.5} />
-        ))}
-      </svg>
+      {showGroupAsHeadline ? <BoxPlot data={data} /> : <ScatterPlot data={data} />}
     </div>
   )
 }

--- a/apps/web/src/pages/Correlations/exploreCharts.test.ts
+++ b/apps/web/src/pages/Correlations/exploreCharts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeSelectorAxis, fiveNumberSummary, linearRegression } from './exploreCharts'
+
+describe('linearRegression', () => {
+  it('fits a clean line', () => {
+    const fit = linearRegression([0, 1, 2, 3], [1, 3, 5, 7]) // y = 2x + 1
+    expect(fit!.slope).toBeCloseTo(2, 6)
+    expect(fit!.intercept).toBeCloseTo(1, 6)
+  })
+
+  it('returns null with no x-variance or too few points', () => {
+    expect(linearRegression([1, 1, 1], [1, 2, 3])).toBeNull()
+    expect(linearRegression([1], [2])).toBeNull()
+  })
+})
+
+describe('fiveNumberSummary', () => {
+  it('computes quartiles with interpolation', () => {
+    const s = fiveNumberSummary([1, 2, 3, 4, 5])
+    expect(s).toEqual({ min: 1, q1: 2, median: 3, q3: 4, max: 5 })
+  })
+
+  it('handles a single value', () => {
+    expect(fiveNumberSummary([7])).toEqual({ min: 7, q1: 7, median: 7, q3: 7, max: 7 })
+  })
+
+  it('returns null for empty input', () => {
+    expect(fiveNumberSummary([])).toBeNull()
+  })
+})
+
+describe('describeSelectorAxis', () => {
+  it('labels built-in metrics with their unit', () => {
+    expect(describeSelectorAxis({ kind: 'metric', metric: 'weight' })).toContain('weight')
+    expect(describeSelectorAxis({ kind: 'metric', metric: 'weight' })).toMatch(/\(.+\)/)
+  })
+
+  it('labels a custom metric without a unit', () => {
+    expect(describeSelectorAxis({ kind: 'metric', metric: 'back_pain' })).toBe('back_pain')
+  })
+
+  it('uses kcal for calories and g for other nutrients', () => {
+    expect(describeSelectorAxis({ kind: 'nutrition', nutrient: 'calories' })).toBe('calories (kcal)')
+    expect(describeSelectorAxis({ kind: 'nutrition', nutrient: 'carbs' })).toBe('carbs (g)')
+  })
+
+  it('labels tags by count and productivity by minutes', () => {
+    expect(describeSelectorAxis({ kind: 'tag', pattern: 'sauna' })).toBe('sauna (count)')
+    expect(describeSelectorAxis({ kind: 'productivity_app', pattern: 'vscode' })).toBe('vscode (min)')
+  })
+})

--- a/apps/web/src/pages/Correlations/exploreCharts.ts
+++ b/apps/web/src/pages/Correlations/exploreCharts.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure chart helpers for the correlation Explore visualisations — kept free of
+ * JSX so the maths (regression, quartiles, axis labelling) is unit-testable.
+ */
+
+import type { CorrelationSelector } from '@aurboda/api-spec'
+
+import { isValidMetric, metricUnits } from '@aurboda/api-spec'
+
+export interface RegressionLine {
+  slope: number
+  intercept: number
+}
+
+/** Ordinary least-squares fit y = slope·x + intercept, or null when undefined. */
+export const linearRegression = (xs: number[], ys: number[]): RegressionLine | null => {
+  const n = xs.length
+  if (n < 2 || xs.length !== ys.length) return null
+  let sx = 0
+  let sy = 0
+  let sxx = 0
+  let sxy = 0
+  for (let i = 0; i < n; i++) {
+    sx += xs[i]
+    sy += ys[i]
+    sxx += xs[i] * xs[i]
+    sxy += xs[i] * ys[i]
+  }
+  const denom = n * sxx - sx * sx
+  if (denom === 0) return null
+  const slope = (n * sxy - sx * sy) / denom
+  return { slope, intercept: (sy - slope * sx) / n }
+}
+
+export interface FiveNumberSummary {
+  min: number
+  q1: number
+  median: number
+  q3: number
+  max: number
+}
+
+/** Five-number summary (min, quartiles, max) with linear interpolation. */
+export const fiveNumberSummary = (values: number[]): FiveNumberSummary | null => {
+  if (values.length === 0) return null
+  const s = [...values].sort((a, b) => a - b)
+  const quantile = (p: number): number => {
+    if (s.length === 1) return s[0]
+    const idx = p * (s.length - 1)
+    const lo = Math.floor(idx)
+    const hi = Math.ceil(idx)
+    return s[lo] + (s[hi] - s[lo]) * (idx - lo)
+  }
+  return { min: s[0], q1: quantile(0.25), median: quantile(0.5), q3: quantile(0.75), max: s[s.length - 1] }
+}
+
+/** Short axis label for a selector, including its unit where known. */
+export const describeSelectorAxis = (selector: CorrelationSelector): string => {
+  switch (selector.kind) {
+    case 'metric': {
+      if (!isValidMetric(selector.metric)) return selector.metric || 'metric'
+      const unit = metricUnits[selector.metric]
+      return unit ? `${selector.metric} (${unit})` : selector.metric
+    }
+    case 'nutrition':
+      return `${selector.nutrient} (${selector.nutrient === 'calories' ? 'kcal' : 'g'})`
+    case 'activity':
+      return `${selector.pattern || 'activity'} (${selector.measure === 'duration_min' ? 'min' : 'count'})`
+    case 'productivity_category':
+    case 'productivity_app':
+      return `${selector.pattern || 'productivity'} (min)`
+    case 'tag':
+    default:
+      return `${selector.pattern || 'tag'} (count)`
+  }
+}

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -509,6 +509,19 @@
 .explore-caution {
   color: #9a3412;
 }
+.axis-label {
+  fill: #6b7280;
+  font-size: 0.72rem;
+}
+.plot-annot {
+  fill: #374151;
+  font-size: 0.72rem;
+}
+.boxplot,
+.rr-bars {
+  display: block;
+  margin-top: 6px;
+}
 .explore-run {
   background: #673ab8;
   color: #fff;

--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -95,8 +95,13 @@ Surfaced through `get_metric_correlation` / `POST /correlations/continuous`:
 
 It aligns the two daily series on days where **both** sides are known (a missing
 value on a known day defaults to 0, e.g. a meal-log-complete day with no carbs),
-optionally shifting the outcome forward by `lag_days`, and returns Pearson and
-Spearman coefficients plus the aligned series for plotting.
+optionally shifting the outcome forward by `lag_days`, and returns Pearson
+(`pearson`, with a two-sided `pearson_p`) and Spearman coefficients plus the
+aligned series for plotting. The web UI draws a scatter with a regression-line
+overlay, axis labels with units, and the `r / ρ / n / p` annotation; for a binary
+trigger it switches to a present-vs-absent **box plot** (a scatter would collapse
+to two vertical lines). The event-onset table is accompanied by a per-lag
+**relative-risk chart** with 95% CI whiskers and an RR=1 reference line.
 
 ### Binary/presence trigger — `group_comparison`
 
@@ -149,6 +154,9 @@ known-vs-all days for presence-only _outcomes_).
   (`I_{df/(df+t²)}(df/2, ½)` via the regularized incomplete beta); Mann–Whitney
   U uses a tie-corrected normal approximation. Both are omitted (`null`) when a
   group has fewer than two values or no variance.
+- `pearson_p` is the two-sided significance of the Pearson r via the t-transform
+  `t = r·√((n−2)/(1−r²))` on `n−2` df; null with fewer than 3 pairs, 0 for a
+  perfect correlation.
 
 ## Performance
 

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -873,6 +873,10 @@ export const continuousCorrelationDataSchema = z
     }),
     outcome: selectorSchema,
     pearson: z.number().nullable().meta({ description: 'Pearson correlation (-1..1)' }),
+    pearson_p: z
+      .number()
+      .nullable()
+      .meta({ description: 'Two-sided p-value for the Pearson correlation (null when not estimable)' }),
     period: z.object({ days: z.number().int(), end: z.string(), start: z.string() }),
     series: z.array(alignedPointSchema).meta({ description: 'Aligned daily points for plotting' }),
     spearman: z.number().nullable().meta({ description: 'Spearman rank correlation (-1..1)' }),


### PR DESCRIPTION
Fourth #792 follow-up workstream (one PR at a time). Mostly frontend SVG, plus a small supporting backend stat.

## Problem (from the #792 UX comment)
The Explore charts were misleading/illegible:
- a **binary trigger** scatter collapses to two vertical lines at x=0/x=1;
- charts had **no axis labels or units**;
- continuous scatters had **no regression line** and no on-plot stats;
- event-onset had a table but **no visual** of effect size per lag.

## Changes
- **Box plot** for binary triggers (present vs absent) with per-group n, instead of a meaningless scatter.
- **Scatter + regression line** for continuous↔continuous, annotated `r / ρ / n / p`.
- **Axis labels with units** on every chart, derived per selector kind (metric units from api-spec, kcal/g for nutrients, count/min otherwise).
- **Relative-risk chart** for event-onset: per-lag RR points with 95% CI whiskers and an RR=1 reference line; significant lags highlighted.
- Backend: the continuous response now includes **`pearson_p`** (two-sided significance of the Pearson r via the t-transform, reusing `studentTTwoSidedP`) so the scatter's `p` annotation is real. Schema + REST + MCP flow automatically.

Chart maths (regression, quartiles, axis labelling) live in a pure `exploreCharts` module with unit tests; the SVG components stay presentational.

## Testing
- web `vitest run src/pages/Correlations/` — 20 passed (9 chart helpers + 11 guidance)
- backend `vitest run src/services/correlations/` — 86 passed (incl. new `pearson_p` cases)
- `pnpm check` — 0 errors across backend / web / api-spec

## Remaining #792 workstreams (next PRs)
- HRV context: select `stress_level`/`heart_rate` instead of HRV
- Trigger selector cleanup: retire legacy "tag" kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)