### PR TITLE
feat(correlations): selectable HRV-context metric (HR / stress, not just HRV) (#792)

### DIFF
--- a/apps/backend/src/mcp/correlation-tools.ts
+++ b/apps/backend/src/mcp/correlation-tools.ts
@@ -46,11 +46,11 @@ export const registerCorrelationTools = (server: McpServer, user: string, sync?:
   // Tool: get_hrv_activities_correlation
   server.tool(
     'get_hrv_activities_correlation',
-    'Get HRV correlations with various activities. Returns Pearson correlation coefficients between HRV and productivity, locations, and activity types.',
+    'Get autonomic-context correlations with activities, locations and productivity. Returns mean HRV, heart rate and stress per item (with baseline deltas). The productivity correlation is computed against context_metric — hrv_rmssd (default), heart_rate, or stress_level — so it stays meaningful when continuous HRV is sparse.',
     { ...hrvCorrelationInputSchema.shape, tz: tzSchema },
-    async ({ period_days, tz }) => {
+    async ({ context_metric, period_days, tz }) => {
       const periodDays = period_days ?? 30
-      const correlations = await getHrvActivitiesCorrelation(user, periodDays, sync)
+      const correlations = await getHrvActivitiesCorrelation(user, periodDays, sync, context_metric)
       return tzJsonResponse({ data: correlations, success: true }, tz)
     },
   )

--- a/apps/backend/src/routes/correlations-router.ts
+++ b/apps/backend/src/routes/correlations-router.ts
@@ -66,11 +66,11 @@ export const createCorrelationsRouter = (
     authMiddleware,
     validateQuery(hrvActivitiesQuerySchema),
     async (req, res) => {
-      const { period_days } = req.query
+      const { period_days, context_metric } = req.query
       const user = req.user!
 
       const periodDays = period_days ? parseInt(period_days, 10) : 30
-      const correlations = await getHrvActivitiesCorrelation(user, periodDays, syncProvider)
+      const correlations = await getHrvActivitiesCorrelation(user, periodDays, syncProvider, context_metric)
       res.json({ data: correlations, success: true })
     },
   )

--- a/apps/backend/src/services/correlations/hrv-activities.test.ts
+++ b/apps/backend/src/services/correlations/hrv-activities.test.ts
@@ -91,37 +91,67 @@ describe('getHrvActivitiesCorrelation', () => {
     expect(hr.context_metric).toBe('heart_rate')
   })
 
-  test('correlates productivity against the chosen context metric', async () => {
+  test('derives the productivity correlation from the chosen context series', async () => {
     const t = (minsAgo: number) => new Date(Date.now() - minsAgo * 60_000)
-    // One productivity window; productivity score is constant so r is null, but
-    // the point is that the *chosen* metric's series feeds the correlation.
+    // Two windows in the same category with different productivity scores, so the
+    // correlation is computable and its sign depends on which series is used.
     vi.mocked(db.getProductivity).mockResolvedValue([
       {
         activity: 'vscode',
         category: 'Dev',
-        duration_sec: 3600,
-        end_time: t(0),
-        productivity: 2,
+        duration_sec: 1800,
+        end_time: t(90),
+        productivity: 1,
+        start_time: t(120),
+      },
+      {
+        activity: 'vscode',
+        category: 'Dev',
+        duration_sec: 1800,
+        end_time: t(30),
+        productivity: 3,
         start_time: t(60),
       },
     ])
     vi.mocked(locations.getPlaceVisits).mockResolvedValue([])
     vi.mocked(db.getAllActivitiesInRange).mockResolvedValue([])
-    // Distinct series per metric so we can tell which one was used for the means.
+    // HRV rises with the score (positive r); HR falls with it (negative r).
     vi.mocked(db.getTimeSeries).mockImplementation(async (_u: string, metric: string) => {
-      const at = [t(50), t(40), t(30)]
-      if (metric === 'heart_rate') return at.map((d) => [d, 62] as [Date, number])
-      if (metric === 'stress_level') return at.map((d) => [d, 20] as [Date, number])
-      return at.map((d) => [d, 45] as [Date, number]) // hrv_rmssd
+      const pts: [Date, number][] =
+        metric === 'heart_rate'
+          ? [
+              [t(115), 70],
+              [t(105), 72],
+              [t(55), 50],
+              [t(45), 52],
+            ]
+          : metric === 'stress_level'
+            ? [
+                [t(115), 20],
+                [t(105), 20],
+                [t(55), 20],
+                [t(45), 20],
+              ]
+            : [
+                [t(115), 40],
+                [t(105), 42],
+                [t(55), 60],
+                [t(45), 62],
+              ] // hrv_rmssd
+      return pts
     })
 
-    const result = await getHrvActivitiesCorrelation('testuser', 7, undefined, 'heart_rate')
-    expect(result.context_metric).toBe('heart_rate')
-    // All three metric means are still populated for the table.
-    const dev = result.correlations.productivity.find((p) => p.category === 'Dev')
-    expect(dev?.mean_hr).toBe(62)
-    expect(dev?.mean_hrv).toBe(45)
-    expect(dev?.mean_stress).toBe(20)
+    const hrv = await getHrvActivitiesCorrelation('testuser', 7, undefined, 'hrv_rmssd')
+    const hr = await getHrvActivitiesCorrelation('testuser', 7, undefined, 'heart_rate')
+    const hrvDev = hrv.correlations.productivity.find((p) => p.category === 'Dev')
+    const hrDev = hr.correlations.productivity.find((p) => p.category === 'Dev')
+
+    // The coefficient flips sign with the context metric, proving it uses the
+    // selected series. Means stay populated for all three either way.
+    expect(hrvDev?.correlation_coefficient).toBeGreaterThan(0.9)
+    expect(hrDev?.correlation_coefficient).toBeLessThan(-0.9)
+    expect(hrvDev?.mean_hr).toBe(61)
+    expect(hrvDev?.mean_hrv).toBe(51)
   })
 
   test('calls sync provider when provided', async () => {

--- a/apps/backend/src/services/correlations/hrv-activities.test.ts
+++ b/apps/backend/src/services/correlations/hrv-activities.test.ts
@@ -78,6 +78,52 @@ describe('getHrvActivitiesCorrelation', () => {
     expect(result.correlations.activities).toBeInstanceOf(Array)
   })
 
+  test('echoes the context metric (defaults to hrv_rmssd)', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(db.getProductivity).mockResolvedValue([])
+    vi.mocked(locations.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getAllActivitiesInRange).mockResolvedValue([])
+
+    const def = await getHrvActivitiesCorrelation('testuser', 7)
+    expect(def.context_metric).toBe('hrv_rmssd')
+
+    const hr = await getHrvActivitiesCorrelation('testuser', 7, undefined, 'heart_rate')
+    expect(hr.context_metric).toBe('heart_rate')
+  })
+
+  test('correlates productivity against the chosen context metric', async () => {
+    const t = (minsAgo: number) => new Date(Date.now() - minsAgo * 60_000)
+    // One productivity window; productivity score is constant so r is null, but
+    // the point is that the *chosen* metric's series feeds the correlation.
+    vi.mocked(db.getProductivity).mockResolvedValue([
+      {
+        activity: 'vscode',
+        category: 'Dev',
+        duration_sec: 3600,
+        end_time: t(0),
+        productivity: 2,
+        start_time: t(60),
+      },
+    ])
+    vi.mocked(locations.getPlaceVisits).mockResolvedValue([])
+    vi.mocked(db.getAllActivitiesInRange).mockResolvedValue([])
+    // Distinct series per metric so we can tell which one was used for the means.
+    vi.mocked(db.getTimeSeries).mockImplementation(async (_u: string, metric: string) => {
+      const at = [t(50), t(40), t(30)]
+      if (metric === 'heart_rate') return at.map((d) => [d, 62] as [Date, number])
+      if (metric === 'stress_level') return at.map((d) => [d, 20] as [Date, number])
+      return at.map((d) => [d, 45] as [Date, number]) // hrv_rmssd
+    })
+
+    const result = await getHrvActivitiesCorrelation('testuser', 7, undefined, 'heart_rate')
+    expect(result.context_metric).toBe('heart_rate')
+    // All three metric means are still populated for the table.
+    const dev = result.correlations.productivity.find((p) => p.category === 'Dev')
+    expect(dev?.mean_hr).toBe(62)
+    expect(dev?.mean_hrv).toBe(45)
+    expect(dev?.mean_stress).toBe(20)
+  })
+
   test('calls sync provider when provided', async () => {
     vi.mocked(db.getTimeSeries).mockResolvedValue([])
     vi.mocked(db.getProductivity).mockResolvedValue([])

--- a/apps/backend/src/services/correlations/hrv-activities.ts
+++ b/apps/backend/src/services/correlations/hrv-activities.ts
@@ -2,6 +2,8 @@
  * HRV-activities correlation analysis.
  */
 
+import type { HrvContextMetric } from '@aurboda/api-spec'
+
 import type { SyncProvider } from '../queries/index.ts'
 import type {
   ActivityCorrelation,
@@ -22,6 +24,7 @@ export async function getHrvActivitiesCorrelation(
   user: string,
   periodDays: number = 30,
   sync?: SyncProvider,
+  contextMetric: HrvContextMetric = 'hrv_rmssd',
 ): Promise<HrvActivitiesResult> {
   const end = new Date()
   end.setHours(23, 59, 59, 999)
@@ -49,6 +52,11 @@ export async function getHrvActivitiesCorrelation(
     getAllActivitiesInRange(user, start, end),
   ])
 
+  // The series the productivity correlation is computed against. HRV is the
+  // default, but heart rate / stress are denser when continuous HRV is sparse.
+  const contextData =
+    contextMetric === 'heart_rate' ? hrData : contextMetric === 'stress_level' ? stressData : hrvData
+
   // Calculate baseline stats
   const baselineHrvValues = hrvData.map(([, v]) => v)
   const baselineHrValues = hrData.map(([, v]) => v)
@@ -59,13 +67,21 @@ export async function getHrvActivitiesCorrelation(
   // === Productivity correlations by category ===
   const productivityByCategory = new Map<
     string,
-    { hrvValues: number[]; hrValues: number[]; stressValues: number[]; minutes: number; scores: number[] }
+    {
+      hrvValues: number[]
+      hrValues: number[]
+      stressValues: number[]
+      contextValues: number[]
+      minutes: number
+      scores: number[]
+    }
   >()
 
   for (const record of productivity) {
     const category = record.resolved_category?.join(' > ') || record.category || 'Uncategorized'
     if (!productivityByCategory.has(category)) {
       productivityByCategory.set(category, {
+        contextValues: [],
         hrValues: [],
         hrvValues: [],
         minutes: 0,
@@ -76,17 +92,19 @@ export async function getHrvActivitiesCorrelation(
     const cat = productivityByCategory.get(category)!
     cat.minutes += record.duration_sec / 60
 
-    // Get HRV/HR during this productivity window
+    // Get HRV/HR/stress during this productivity window (all shown in the table).
     const hrvInWindow = getDataInRange(hrvData, record.start_time, record.end_time)
     const hrInWindow = getDataInRange(hrData, record.start_time, record.end_time)
     const stressInWindow = getDataInRange(stressData, record.start_time, record.end_time)
+    const contextInWindow = getDataInRange(contextData, record.start_time, record.end_time)
     cat.hrvValues.push(...hrvInWindow)
     cat.hrValues.push(...hrInWindow)
     cat.stressValues.push(...stressInWindow)
+    cat.contextValues.push(...contextInWindow)
 
     if (record.productivity !== undefined && record.productivity !== null) {
-      // Add productivity score for correlation calculation - one score per HRV value
-      cat.scores.push(...hrvInWindow.map(() => record.productivity!))
+      // One productivity score per context-metric value, for the correlation.
+      cat.scores.push(...contextInWindow.map(() => record.productivity!))
     }
   }
 
@@ -97,10 +115,10 @@ export async function getHrvActivitiesCorrelation(
     const stats = calculateHrvStats(data.hrvValues, data.hrValues, data.minutes, data.stressValues)
     const statsWithDelta = addBaselineDelta(stats, baseline)
 
-    // Calculate correlation between productivity score and HRV
+    // Correlation between productivity score and the chosen context metric.
     const correlation =
-      data.scores.length >= 3 && data.hrvValues.length === data.scores.length
-        ? pearsonCorrelation(data.scores, data.hrvValues)
+      data.scores.length >= 3 && data.contextValues.length === data.scores.length
+        ? pearsonCorrelation(data.scores, data.contextValues)
         : null
 
     productivityCorrelations.push({
@@ -226,6 +244,7 @@ export async function getHrvActivitiesCorrelation(
 
   return {
     baseline,
+    context_metric: contextMetric,
     correlations: {
       activities: activityCorrelations,
       locations: locationCorrelations,

--- a/apps/backend/src/services/correlations/types.ts
+++ b/apps/backend/src/services/correlations/types.ts
@@ -2,6 +2,8 @@
  * Type definitions for correlation analysis services.
  */
 
+import type { HrvContextMetric } from '@aurboda/api-spec'
+
 import type { LagExposureResult } from './event-outcome.ts'
 
 /** HRV statistics for a context/activity */
@@ -78,6 +80,8 @@ export interface HrvActivitiesResult {
     end: string
     days: number
   }
+  /** The autonomic metric the productivity correlation_coefficient is computed against. */
+  context_metric: HrvContextMetric
   baseline: HrvStats
   correlations: {
     productivity: ProductivityCorrelation[]

--- a/apps/web/src/pages/Correlations/index.tsx
+++ b/apps/web/src/pages/Correlations/index.tsx
@@ -11,6 +11,7 @@ import {
   type ActivityImpactData,
   type ActivityImpactType,
   type BaselineData,
+  type HrvContextMetric,
   type HrvStatsWithDelta,
   type LocationCorrelation,
   type ProductivityCorrelation,
@@ -20,6 +21,16 @@ import './style.css'
 
 // Period signal
 const periodDays = signal(30)
+
+// Which autonomic metric drives the productivity correlation. Not everyone has
+// continuous HRV, so heart rate / stress can be a denser context.
+const contextMetric = signal<HrvContextMetric>('hrv_rmssd')
+
+const CONTEXT_METRIC_LABELS: Record<HrvContextMetric, string> = {
+  heart_rate: 'Heart rate',
+  hrv_rmssd: 'HRV',
+  stress_level: 'Stress',
+}
 
 // Active tab
 const activeTab = signal<'hrv' | 'explore'>('hrv')
@@ -317,8 +328,8 @@ export function Correlations() {
 
   // Fetch HRV-activities correlations
   const correlationsQuery = useQuery({
-    queryFn: () => fetchHrvActivitiesCorrelation(periodDays.value),
-    queryKey: ['hrvActivitiesCorrelation', periodDays.value],
+    queryFn: () => fetchHrvActivitiesCorrelation(periodDays.value, contextMetric.value),
+    queryKey: ['hrvActivitiesCorrelation', periodDays.value, contextMetric.value],
     staleTime: 5 * 60 * 1000,
   })
 
@@ -356,12 +367,26 @@ export function Correlations() {
       <div class="correlations-header">
         <h1>Analyze</h1>
         {activeTab.value === 'hrv' && (
-          <select value={periodDays.value} onChange={handlePeriodChange} class="period-select">
-            <option value={14}>Last 14 days</option>
-            <option value={30}>Last 30 days</option>
-            <option value={60}>Last 60 days</option>
-            <option value={90}>Last 90 days</option>
-          </select>
+          <div class="hrv-controls">
+            <select
+              value={contextMetric.value}
+              onChange={(e) =>
+                (contextMetric.value = (e.target as HTMLSelectElement).value as HrvContextMetric)
+              }
+              class="period-select"
+              title="Which autonomic metric the productivity correlation is computed against"
+            >
+              <option value="hrv_rmssd">Context: HRV</option>
+              <option value="heart_rate">Context: Heart rate</option>
+              <option value="stress_level">Context: Stress</option>
+            </select>
+            <select value={periodDays.value} onChange={handlePeriodChange} class="period-select">
+              <option value={14}>Last 14 days</option>
+              <option value={30}>Last 30 days</option>
+              <option value={60}>Last 60 days</option>
+              <option value={90}>Last 90 days</option>
+            </select>
+          </div>
         )}
       </div>
 
@@ -580,7 +605,9 @@ export function Correlations() {
               </li>
               <li>
                 <strong>Correlation coefficient (r):</strong> For productivity, this shows how the
-                productivity score correlates with HRV (-1 to 1).
+                productivity score correlates with{' '}
+                {CONTEXT_METRIC_LABELS[correlations?.context_metric ?? contextMetric.value]} (-1 to 1). Pick a
+                different <em>context</em> metric above if you don't have continuous HRV.
               </li>
             </ul>
           </section>

--- a/apps/web/src/pages/Correlations/index.tsx
+++ b/apps/web/src/pages/Correlations/index.tsx
@@ -607,7 +607,10 @@ export function Correlations() {
                 <strong>Correlation coefficient (r):</strong> For productivity, this shows how the
                 productivity score correlates with{' '}
                 {CONTEXT_METRIC_LABELS[correlations?.context_metric ?? contextMetric.value]} (-1 to 1). Pick a
-                different <em>context</em> metric above if you don't have continuous HRV.
+                different <em>context</em> metric above if you don't have continuous HRV. The HRV / HR /
+                Stress columns are each metric's own mean (— when that metric wasn't recorded), independent of
+                the chosen context — so a row can show a blank HRV yet still have an r from the context
+                metric.
               </li>
             </ul>
           </section>

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -51,6 +51,12 @@
   border-color: #673ab8;
 }
 
+.correlations-page .hrv-controls {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .correlations-page .loading {
   text-align: center;
   padding: 2rem;

--- a/apps/web/src/state/api/correlations.ts
+++ b/apps/web/src/state/api/correlations.ts
@@ -15,6 +15,7 @@ import type {
   GenericCorrelationResponse,
   HrvActivitiesData,
   HrvActivitiesResponse,
+  HrvContextMetric,
 } from '@aurboda/api-spec'
 
 import axios from 'axios'
@@ -35,9 +36,14 @@ export const fetchBaseline = async (referenceDate?: string): Promise<BaselineDat
 }
 
 // Fetch HRV-activities correlations
-export const fetchHrvActivitiesCorrelation = async (periodDays?: number): Promise<HrvActivitiesData> => {
+export const fetchHrvActivitiesCorrelation = async (
+  periodDays?: number,
+  contextMetric?: HrvContextMetric,
+): Promise<HrvActivitiesData> => {
   const { token } = auth.value
-  const params = periodDays ? { period_days: String(periodDays) } : {}
+  const params: Record<string, string> = {}
+  if (periodDays) params.period_days = String(periodDays)
+  if (contextMetric) params.context_metric = contextMetric
   const response = await axios.get<HrvActivitiesResponse>(`${API_URL}/correlations/hrv-activities`, {
     headers: { Authorization: `Bearer ${token}` },
     params,

--- a/apps/web/src/state/api/types.ts
+++ b/apps/web/src/state/api/types.ts
@@ -151,6 +151,7 @@ export type {
   Goal,
   GoalProgress,
   HrvActivitiesData,
+  HrvContextMetric,
   HrvStats,
   HrvStatsWithDelta,
   HrZoneThresholds,

--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -142,6 +142,20 @@ When either side of a continuous correlation is a `nutrition` selector:
 Completeness is independent of the event-mode `denominator` knob (which governs
 known-vs-all days for presence-only _outcomes_).
 
+## HRV context
+
+`get_hrv_activities_correlation` / `GET /correlations/hrv-activities` summarises
+the autonomic context (mean HRV, heart rate and stress, with baseline deltas)
+around each activity, location and productivity category, and correlates the
+productivity score against an autonomic metric.
+
+That metric is selectable via `context_metric` — `hrv_rmssd` (default),
+`heart_rate` or `stress_level`. Not everyone records continuous HRV throughout
+the day, so heart rate or stress (which are denser) keep the productivity
+`correlation_coefficient` meaningful. The chosen metric is echoed back as
+`context_metric`; all three means stay in the response regardless. The web
+"HRV context" tab exposes this as a **Context** dropdown.
+
 ## Statistics notes
 
 - Chi-squared p-values are exact for 1 degree of freedom (`erfc(√(χ²/2))`). A

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -94,9 +94,23 @@ export type BaselineResponse = z.infer<typeof baselineResponseSchema>
 // HRV-Activities endpoint
 // ============================================================================
 
+/**
+ * The autonomic metric the HRV-context analysis correlates against. HRV is the
+ * default, but not everyone has continuous HRV — heart rate and stress are
+ * denser and let the analysis still produce a meaningful productivity
+ * correlation.
+ */
+export const hrvContextMetricSchema = z.enum(['hrv_rmssd', 'heart_rate', 'stress_level']).meta({
+  description: 'Autonomic metric to correlate against (default: hrv_rmssd)',
+  id: 'HrvContextMetric',
+})
+
+export type HrvContextMetric = z.infer<typeof hrvContextMetricSchema>
+
 /** HRV-Activities query parameters */
 export const hrvActivitiesQuerySchema = z
   .object({
+    context_metric: hrvContextMetricSchema.optional().meta({ description: 'Metric to correlate against' }),
     period_days: z
       .string()
       .optional()
@@ -144,6 +158,9 @@ export type ActivityCorrelation = z.infer<typeof activityCorrelationSchema>
 export const hrvActivitiesDataSchema = z
   .object({
     baseline: hrvStatsSchema,
+    context_metric: hrvContextMetricSchema.meta({
+      description: 'The metric the correlation_coefficient was computed against',
+    }),
     correlations: z.object({
       activities: z.array(activityCorrelationSchema),
       locations: z.array(locationCorrelationSchema),
@@ -730,6 +747,9 @@ export type EventProbabilityInput = z.infer<typeof eventProbabilityInputSchema>
 /** HRV correlation MCP input schema */
 export const hrvCorrelationInputSchema = z
   .object({
+    context_metric: hrvContextMetricSchema
+      .optional()
+      .meta({ description: 'Autonomic metric to correlate against (default: hrv_rmssd)' }),
     period_days: z
       .number()
       .int()


### PR DESCRIPTION
Fifth #792 follow-up workstream (one PR at a time), addressing your request: *"I would like to be able to select e.g. stress_level or even heart rate instead of HRV. I (and other users) may not have continuous HRV throughout the day."*

## Problem
The "HRV context" analysis computed its productivity `correlation_coefficient` against HRV only. Without continuous HRV that correlation is null/sparse — even though the table already shows HR and stress.

## Changes
- **`context_metric`** parameter (`hrv_rmssd` default, `heart_rate`, `stress_level`) selects which denser autonomic metric drives the productivity correlation. All three means (HRV/HR/stress + baseline deltas) remain in the response/table; only the correlation follows the choice. The chosen metric is **echoed** as `context_metric`.
- **api-spec**: `HrvContextMetric` enum on the query + MCP input schemas, echoed on `HrvActivitiesData`.
- **service**: correlate productivity scores against the chosen metric's in-window values.
- **REST + MCP**: threaded through; the MCP tool description now explains the option.
- **web**: a **Context** dropdown in the HRV tab and a metric-aware explanation of `r`.
- **docs + tests**.

## Testing
- backend `vitest run src/services/correlations/` — 88 passed (incl. new `context_metric` cases)
- web `vitest run src/pages/Correlations/` — 20 passed
- `pnpm check` — 0 errors across backend / web / api-spec

## Remaining #792 workstream (last PR)
- Trigger selector cleanup: retire the legacy "tag" kind (tags merged into activities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)