### PR TITLE
feat(correlations): retire the legacy "tag" selector in the Explore picker (#792)

### DIFF
--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -673,7 +673,7 @@ export function ExploreTab() {
                 <option value="tag">activity / tag</option>
               </select>
               <input
-                list="metric-options"
+                list={eventOutcomeSource.value === 'metric' ? 'metric-options' : 'activity-type-options'}
                 placeholder={
                   eventOutcomeSource.value === 'metric' ? 'metric (e.g. back_pain)' : 'activity_type regex'
                 }
@@ -683,6 +683,11 @@ export function ExploreTab() {
               <datalist id="metric-options">
                 {selectors?.metrics.map((m) => (
                   <option value={m.value}>{m.label}</option>
+                ))}
+              </datalist>
+              <datalist id="activity-type-options">
+                {selectors?.activity_types.map((a) => (
+                  <option value={a.value}>{a.label}</option>
                 ))}
               </datalist>
             </div>

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -32,7 +32,7 @@ type Mode = 'event' | 'continuous'
 
 // --- Form state (module signals, mirroring the rest of this page) ---
 const mode = signal<Mode>('event')
-const triggerSelector = signal<CorrelationSelector>({ kind: 'tag', pattern: '' })
+const triggerSelector = signal<CorrelationSelector>({ kind: 'activity', pattern: '' })
 const outcomeSelector = signal<CorrelationSelector>({ kind: 'metric', metric: '' })
 const eventOutcomeSource = signal<'metric' | 'tag'>('metric')
 const eventOutcomeValue = signal('')
@@ -51,9 +51,11 @@ const runToken = signal(0)
 
 const NUTRIENTS: NutrientKey[] = ['calories', 'protein', 'carbs', 'fat', 'fiber']
 
-// Trigger kinds allowed per mode (event mode has no metric trigger).
+// Trigger kinds offered in the picker (event mode has no metric trigger). The
+// legacy 'tag' kind is intentionally omitted — tags were merged into activities,
+// so 'activity' already matches them (and its picker autocompletes every
+// activity_type). The backend still accepts 'tag' for older callers.
 const EVENT_TRIGGER_KINDS: CorrelationSelector['kind'][] = [
-  'tag',
   'activity',
   'nutrition',
   'productivity_category',
@@ -63,11 +65,18 @@ const EVENT_TRIGGER_KINDS: CorrelationSelector['kind'][] = [
 // Every selector kind (continuous mode allows a metric on either side).
 const ALL_SELECTOR_KINDS: CorrelationSelector['kind'][] = ['metric', ...EVENT_TRIGGER_KINDS]
 
+/** Human labels for selector kinds (the raw kind is opaque in a dropdown). */
+const KIND_LABELS: Partial<Record<CorrelationSelector['kind'], string>> = {
+  activity: 'activity / tag',
+  productivity_app: 'productivity app',
+  productivity_category: 'productivity category',
+}
+
 /** Switch mode, clamping the trigger to a kind valid in the new mode. */
 const setMode = (next: Mode) => {
   mode.value = next
   if (next === 'event' && !EVENT_TRIGGER_KINDS.includes(triggerSelector.value.kind)) {
-    triggerSelector.value = { kind: 'tag', pattern: '' }
+    triggerSelector.value = { kind: 'activity', pattern: '' }
   }
 }
 
@@ -101,10 +110,10 @@ const fmtP = (value: number | null | undefined): string =>
 const outcomeLooksContinuous = (): boolean =>
   eventOutcomeLooksContinuous(mode.value, eventOutcomeSource.value, eventOutcomeValue.value)
 
-/** Apply a back-pain-onset event preset for the given trigger tag. */
+/** Apply a back-pain-onset event preset for the given trigger activity/tag. */
 const applyEventPreset = (pattern: string) => {
   setMode('event')
-  triggerSelector.value = { kind: 'tag', pattern }
+  triggerSelector.value = { kind: 'activity', pattern }
   setEventOutcomeSource('metric')
   eventOutcomeValue.value = 'back_pain'
   lagWindowsInput.value = '24h,48h,72h,7d'
@@ -141,7 +150,7 @@ const buildRequest = () => {
       trigger.kind === 'nutrition'
         ? { nutrient: trigger.nutrient, type: 'nutrition' }
         : trigger.kind === 'metric'
-          ? { pattern: '', type: 'tag' } // metric not valid as a trigger; fall back to empty tag
+          ? { pattern: '', type: 'activity' } // metric not valid as a trigger; fall back to empty activity
           : {
               pattern: 'pattern' in trigger ? trigger.pattern : '',
               type: trigger.kind === 'activity' ? 'activity' : (trigger.kind as TriggerCondition['type']),
@@ -179,7 +188,7 @@ function SelectorPicker({
       case 'productivity_app':
         return onChange({ kind, pattern: '' })
       default:
-        return onChange({ kind: 'tag', pattern: '' })
+        return onChange({ kind: 'activity', pattern: '' })
     }
   }
 
@@ -190,7 +199,7 @@ function SelectorPicker({
         onChange={(e) => setKind((e.target as HTMLSelectElement).value as CorrelationSelector['kind'])}
       >
         {allowedKinds.map((k) => (
-          <option value={k}>{k}</option>
+          <option value={k}>{KIND_LABELS[k] ?? k}</option>
         ))}
       </select>
 
@@ -661,11 +670,13 @@ export function ExploreTab() {
                 }
               >
                 <option value="metric">metric</option>
-                <option value="tag">tag</option>
+                <option value="tag">activity / tag</option>
               </select>
               <input
                 list="metric-options"
-                placeholder={eventOutcomeSource.value === 'metric' ? 'metric (e.g. back_pain)' : 'tag regex'}
+                placeholder={
+                  eventOutcomeSource.value === 'metric' ? 'metric (e.g. back_pain)' : 'activity_type regex'
+                }
                 value={eventOutcomeValue.value}
                 onInput={(e) => (eventOutcomeValue.value = (e.target as HTMLInputElement).value)}
               />

--- a/docs/correlations.md
+++ b/docs/correlations.md
@@ -26,6 +26,12 @@ series, and the set of days where its status is _known_:
 `GET /correlations/selectors` (MCP: `list_correlation_selectors`) lists the
 available metrics, tags, activity types, nutrients and productivity categories.
 
+`tag` and `activity` both match `activity_type` by regex and behave identically —
+tags were long ago merged into activities. The API still accepts both for
+backward compatibility, but the web picker only offers **activity / tag** (one
+option) to avoid the confusing duplicate; it autocompletes from every
+`activity_type`, including former tags.
+
 ## Event-outcome mode
 
 Surfaced through `get_generic_correlation` / `POST /correlations/generic` with an


### PR DESCRIPTION
Final #792 follow-up workstream, addressing your note: *"the selector for trigger included 'tag' and other things that were long since merged into Activity. I don't even know what that selection would do."*

## Problem
The trigger/outcome picker offered both **tag** and **activity**. Tags were long ago merged into activities, and both kinds resolve identically (match `activity_type` by regex), so the duplicate was pure confusion.

## Changes (UI + docs only)
- Drop **tag** from the picker's selectable kinds; default to **activity**, relabelled **"activity / tag"** so it's clear it covers former tags. Its autocomplete already lists every `activity_type`.
- The event-outcome source's **tag** option is relabelled **"activity / tag"** (placeholder → `activity_type regex`).
- Presets and the form default now use the `activity` kind.
- The backend schema still accepts the `tag` kind/source for older REST + MCP callers — nothing breaking, this is a UI cleanup. Documented in `docs/correlations.md`.

## Testing
- web `vitest run src/pages/Correlations/` — 20 passed
- `pnpm --filter aurboda-web check` — 0 errors

## This completes the #792 follow-up series
All six workstreams from the issue's UX comments are now done (guidance/guardrails, binary→continuous inference, nutrition completeness, visualizations, HRV context metric, and this tag-selector cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)