### PR TITLE
feat(food-items): duplicate a food item into an editable copy

### DIFF
--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -45,6 +45,7 @@ import {
   clearCompositeNutrientCache,
   createFoodItemsMergeService,
   createFoodItemsService,
+  duplicateFoodItem,
 } from '../services/food-items.ts'
 import { resnapshotMealsForFoodItem } from '../services/meals.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
@@ -114,6 +115,17 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
         return errorResponse(fromCentral ? 'Cannot delete shared library item' : 'Food item not found')
       }
       return jsonResponse({ success: true })
+    },
+  )
+
+  server.tool(
+    'duplicate_food_item',
+    'Duplicate a food item into a fresh per-user copy named "<name> (copy)" and return the new copy\'s detail. Copies nutrients, default quantity/unit/icon, composite ingredients, portions, reference pointer, and sensitivity flags. The source may be one of the user\'s own items OR a central shared-library item — duplicating a shared item yields an editable per-user fork. Use this to base a new recipe on an existing one and then change a single ingredient.',
+    { id: z.string().uuid().describe('ID of the food item to duplicate (per-user or central)') },
+    async ({ id }) => {
+      const detail = await duplicateFoodItem(user, centralDb, id)
+      if (!detail) return errorResponse('Food item not found')
+      return jsonResponse({ data: detail, success: true })
     },
   )
 

--- a/apps/backend/src/routes/activities-router.test.ts
+++ b/apps/backend/src/routes/activities-router.test.ts
@@ -65,9 +65,9 @@ describe('GET /activities/:id', () => {
 
   test('includes the user notes as comments (#794)', async () => {
     vi.mocked(queries.getCommentsMap).mockResolvedValue(
-      new Map([
-        [ACTIVITY_ID, [{ content: 'Tempo run — felt strong', id: 'note-1' }]],
-      ]) as Awaited<ReturnType<typeof queries.getCommentsMap>>,
+      new Map([[ACTIVITY_ID, [{ content: 'Tempo run — felt strong', id: 'note-1' }]]]) as Awaited<
+        ReturnType<typeof queries.getCommentsMap>
+      >,
     )
 
     const res = await supertest(buildApp()).get(`/activities/${ACTIVITY_ID}`)

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -60,6 +60,9 @@ vi.mock('../db/food-items.ts', () => ({
   getFoodItemByName: vi.fn(),
   mergeFoodItems: vi.fn(),
   searchFoodItems: vi.fn(),
+  setFoodItemReference: vi.fn(),
+  updateFoodItem: vi.fn(),
+  upsertFoodItem: vi.fn(),
 }))
 
 vi.mock('../services/meals.ts', () => ({
@@ -570,5 +573,59 @@ describe('resolveEffectiveDefaultQuantity', () => {
 
   test('absent everywhere → undefined (no prefill hint)', () => {
     expect(resolveEffectiveDefaultQuantity(undefined, undefined, undefined)).toBeUndefined()
+  })
+})
+
+describe('POST /food-items/:id/duplicate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('404 when the source resolves nowhere', async () => {
+    setUserFoodItem(async () => null)
+    const central = fakeCentral()
+    vi.mocked(central.getSharedFoodItemById).mockResolvedValue(null)
+    const res = await supertest(buildApp(central)).post(
+      '/food-items/11111111-1111-4111-8111-111111111111/duplicate',
+    )
+    expect(res.status).toBe(404)
+    expect(res.body.error).toMatch(/not found/i)
+  })
+
+  test('200 creates a "(copy)" manual item and returns its detail', async () => {
+    const sourceId = '11111111-1111-4111-8111-111111111111'
+    const copyId = '22222222-2222-4222-8222-222222222222'
+    const source = userItem(sourceId, {
+      calories: 52,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Apple',
+    })
+    const copy = userItem(copyId, {
+      calories: 52,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Apple (copy)',
+      source: 'manual',
+    })
+    setUserFoodItem(async (_u, fid) => {
+      if (fid === sourceId) return source
+      if (fid === copyId) return copy
+      return null
+    })
+    // Name is available; the upsert returns the freshly created copy row.
+    vi.mocked(dbFoodItems.getFoodItemByName).mockResolvedValue(null)
+    vi.mocked(dbFoodItems.upsertFoodItem).mockResolvedValue(copy)
+
+    const res = await supertest(buildApp(fakeCentral())).post(`/food-items/${sourceId}/duplicate`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.name).toBe('Apple (copy)')
+    expect(res.body.data.source).toBe('manual')
+    expect(dbFoodItems.upsertFoodItem).toHaveBeenCalledWith(
+      'tester',
+      expect.objectContaining({ calories: 52, name: 'Apple (copy)', source: 'manual' }),
+    )
   })
 })

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -83,6 +83,7 @@ import {
   clearCompositeNutrientCache,
   createFoodItemsMergeService,
   createFoodItemsService,
+  duplicateFoodItem,
   type FoodItemDetail as ServiceFoodItemDetail,
   type MergedFoodItem,
 } from '../services/food-items.ts'
@@ -266,6 +267,15 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
       })
     }
     res.json({ success: true })
+  })
+
+  // Duplicate a food item into a fresh per-user copy ("<name> (copy)") and
+  // return the new copy's detail. The source may be per-user OR central — a
+  // copy of a central item becomes an editable per-user fork.
+  router.post<{ id: string }, FoodItemDetailResponse>('/:id/duplicate', authMiddleware, async (req, res) => {
+    const detail = await duplicateFoodItem(req.user!, centralDb, req.params.id)
+    if (!detail) return res.status(404).json({ error: 'Food item not found', success: false })
+    res.json({ data: serializeDetail(detail), success: true })
   })
 
   // Replace the full ingredient list of a composite food item. Per-user

--- a/apps/backend/src/services/calorie-computation.ts
+++ b/apps/backend/src/services/calorie-computation.ts
@@ -182,11 +182,7 @@ const resolveBmr = async (
  * post-hoc fallback if the resolved zones look unusable for this user
  * (e.g. zone-1 start at or below resting HR).
  */
-const resolveZoneMetsContext = (
-  settings: UserSettings,
-  age: number,
-  restingHr: number,
-): ZoneMetsContext => {
+const resolveZoneMetsContext = (settings: UserSettings, age: number, restingHr: number): ZoneMetsContext => {
   const observedMax = settings.training_load?.observed_hr_max ?? 220 - age
   // Mirror getEffectiveHrZones' priority without going back to the DB:
   // custom (settings.hr_zone_start) → age-based (from birth_date) → default.
@@ -402,10 +398,7 @@ export const computeAndStoreCaloriesAll = async (
     // Snap to next local midnight; +26h buffer handles spring-forward (23h
     // days). getLocalDayStart truncates back to the local midnight, so a
     // 23h or 25h day is handled correctly.
-    const nextChunkStart = getLocalDayStart(
-      new Date(chunkStart.getTime() + 26 * 60 * 60 * 1000),
-      timezone,
-    )
+    const nextChunkStart = getLocalDayStart(new Date(chunkStart.getTime() + 26 * 60 * 60 * 1000), timezone)
     const result = await computeAndStoreCalories(user, chunkStart, nextChunkStart, {
       skipSync: true,
     })

--- a/apps/backend/src/services/food-items-duplicate.integration.test.ts
+++ b/apps/backend/src/services/food-items-duplicate.integration.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Integration tests for duplicateFoodItem.
+ *
+ * Duplicating copies a food item into a fresh per-user "manual" item: its
+ * nutrients, defaults, composite ingredients, portions, reference pointer, and
+ * sensitivity flags. The copy must be fully independent of the source (editing
+ * one must not touch the other) and must never overwrite an existing item via
+ * the name_lower upsert conflict.
+ *
+ * Note: duplicateFoodItem returns the *service* FoodItemDetail shape — the row
+ * fields live under `.item`, while ingredients/portions/sensitivities/reference
+ * are top-level. (The flattened "name at top level" shape is the REST
+ * serializer's job, covered by the router test.)
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { CentralDb } from './central-db.ts'
+import type { SharedFoodItemEntity } from './central-food-items.ts'
+
+import { setIngredients } from '../db/food-item-ingredients.ts'
+import { insertFoodItemPortion, listPortionsForFoodItem } from '../db/food-item-portions.ts'
+import { getFoodItemById, setFoodItemReference, updateFoodItem, upsertFoodItem } from '../db/food-items.ts'
+import { insertSensitivityFlag, setFoodItemSensitivities } from '../db/sensitivities.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { createFoodItemsService, duplicateFoodItem, type FoodItemDetail } from './food-items.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+/** Narrow a duplicate result to non-null so the assertions can read `.item`. */
+function assertDetail(detail: FoodItemDetail | null): asserts detail is FoodItemDetail {
+  if (detail === null) throw new Error('expected a food item detail, got null')
+}
+
+// Most paths keep everything in the per-user DB, so a bare stub satisfies the
+// type. The central-source test overrides getSharedFoodItemById.
+const stubCentral = (item: SharedFoodItemEntity | null = null): CentralDb =>
+  ({
+    getSharedFoodItemById: async (id: string) => (item && item.id === id ? item : null),
+    getSharedFoodItemByName: async () => null,
+    getSharedFoodItemsByIds: async () => new Map(),
+    listSharedFoodItems: async () => [],
+    searchSharedFoodItems: async () => [],
+    upsertSharedFoodItem: async () => undefined,
+  }) as unknown as CentralDb
+
+describe('duplicateFoodItem integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('copies an atomic item with a "(copy)" name and manual source', async () => {
+    const user = getTestUser()
+    const source = await upsertFoodItem(user, {
+      calories: 52,
+      carbs: 14,
+      default_quantity: 100,
+      default_unit: 'g',
+      fiber: 2.4,
+      icon: '🍎',
+      name: 'Apple',
+      source: 'livsmedelsverket',
+    })
+
+    const copy = await duplicateFoodItem(user, stubCentral(), source.id)
+    assertDetail(copy)
+
+    expect(copy.item.name).toBe('Apple (copy)')
+    expect(copy.item.id).not.toBe(source.id)
+    expect(copy.item.source).toBe('manual')
+    expect(copy.item.calories).toBe(52)
+    expect(copy.item.carbs).toBe(14)
+    expect(copy.item.fiber).toBe(2.4)
+    expect(copy.item.default_quantity).toBe(100)
+    expect(copy.item.default_unit).toBe('g')
+    expect(copy.item.icon).toBe('🍎')
+
+    // Editing the copy must not touch the original.
+    await updateFoodItem(user, copy.item.id, { calories: 99 })
+    expect((await getFoodItemById(user, source.id))?.calories).toBe(52)
+  })
+
+  test('copies a composite recipe with its ingredients and derived nutrients, independently', async () => {
+    const user = getTestUser()
+    const oil = await upsertFoodItem(user, {
+      calories: 900,
+      default_quantity: 100,
+      default_unit: 'g',
+      fat: 100,
+      name: 'Olive oil',
+    })
+    const garlic = await upsertFoodItem(user, {
+      calories: 100,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Garlic',
+    })
+    const recipe = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Garlic oil',
+    })
+    await setIngredients(user, recipe.id, [
+      { ingredient_food_item_id: oil.id, quantity: 50, sort_order: 0, unit: 'g' },
+      { ingredient_food_item_id: garlic.id, quantity: 10, sort_order: 1, unit: 'g' },
+    ])
+
+    const copy = await duplicateFoodItem(user, stubCentral(), recipe.id)
+    assertDetail(copy)
+
+    expect(copy.item.name).toBe('Garlic oil (copy)')
+    expect(copy.item.is_composite).toBe(true)
+    expect(copy.ingredients ?? []).toHaveLength(2)
+    expect((copy.ingredients ?? []).map((i) => i.row.ingredient_food_item_id).sort()).toEqual(
+      [oil.id, garlic.id].sort(),
+    )
+    // 50 g oil × 9 + 10 g garlic × 1 = 450 + 10 = 460 kcal, cached on the row.
+    expect(copy.derived_nutrients?.values.calories).toBe(460)
+    expect((await getFoodItemById(user, copy.item.id))?.calories).toBe(460)
+
+    // The copy's ingredient list is its own — shrinking it leaves the source intact.
+    await setIngredients(user, copy.item.id, [
+      { ingredient_food_item_id: oil.id, quantity: 50, sort_order: 0, unit: 'g' },
+    ])
+    const service = createFoodItemsService(stubCentral())
+    const sourceDetail = await service.getDetail(user, recipe.id)
+    assertDetail(sourceDetail)
+    expect(sourceDetail.ingredients ?? []).toHaveLength(2)
+  })
+
+  test('recreates portions with fresh ids and remaps the default portion', async () => {
+    const user = getTestUser()
+    const source = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Bread',
+    })
+    const portion = await insertFoodItemPortion(user, {
+      base_equivalent: 35,
+      food_item_id: source.id,
+      label_unit: 'slice',
+      sort_order: 0,
+    })
+    await updateFoodItem(user, source.id, { default_log_quantity: 2, default_portion_id: portion.id })
+
+    const copy = await duplicateFoodItem(user, stubCentral(), source.id)
+    assertDetail(copy)
+
+    const copyPortions = await listPortionsForFoodItem(user, copy.item.id)
+    expect(copyPortions).toHaveLength(1)
+    expect(copyPortions[0].label_unit).toBe('slice')
+    expect(copyPortions[0].base_equivalent).toBe(35)
+    // Fresh id — not the source's portion id.
+    expect(copyPortions[0].id).not.toBe(portion.id)
+    // Default portion points at the copy's own portion, with the log quantity.
+    expect(copy.item.default_portion_id).toBe(copyPortions[0].id)
+    expect(copy.item.default_log_quantity).toBe(2)
+  })
+
+  test('copies sensitivity flag assignments', async () => {
+    const user = getTestUser()
+    const dairy = await insertSensitivityFlag(user, { name: 'Dairy' })
+    const gluten = await insertSensitivityFlag(user, { name: 'Gluten' })
+    const source = await upsertFoodItem(user, {
+      calories: 300,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Cheese bread',
+    })
+    await setFoodItemSensitivities(user, source.id, [dairy.id, gluten.id])
+
+    const copy = await duplicateFoodItem(user, stubCentral(), source.id)
+    assertDetail(copy)
+
+    expect((copy.sensitivities ?? []).map((s) => s.id).sort()).toEqual([dairy.id, gluten.id].sort())
+  })
+
+  test('copies the reference pointer for atomic items', async () => {
+    const user = getTestUser()
+    const reference = await upsertFoodItem(user, {
+      calories: 250,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Canonical cheese',
+      vitamin_c: 12,
+    })
+    const source = await upsertFoodItem(user, {
+      calories: 260,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'My cheese',
+    })
+    await setFoodItemReference(user, source.id, reference.id)
+
+    const copy = await duplicateFoodItem(user, stubCentral(), source.id)
+    assertDetail(copy)
+
+    expect(copy.reference?.food.id).toBe(reference.id)
+    expect(copy.item.reference_food_item_id).toBe(reference.id)
+  })
+
+  test('dedupes the copy name so it never overwrites an existing item', async () => {
+    const user = getTestUser()
+    const source = await upsertFoodItem(user, {
+      calories: 10,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Sauce',
+    })
+
+    const first = await duplicateFoodItem(user, stubCentral(), source.id)
+    const second = await duplicateFoodItem(user, stubCentral(), source.id)
+    assertDetail(first)
+    assertDetail(second)
+
+    expect(first.item.name).toBe('Sauce (copy)')
+    expect(second.item.name).toBe('Sauce (copy 2)')
+    expect(second.item.id).not.toBe(first.item.id)
+    // Three distinct rows now exist (source + two copies).
+    expect(new Set([source.id, first.item.id, second.item.id]).size).toBe(3)
+  })
+
+  test('forks a central shared-library item into an editable per-user copy', async () => {
+    const user = getTestUser()
+    const central: SharedFoodItemEntity = {
+      calories: 89,
+      carbs: 23,
+      created_at: new Date(),
+      default_quantity: 100,
+      default_unit: 'g',
+      id: '99999999-9999-4999-8999-999999999999',
+      name: 'Banana',
+      name_lower: 'banana',
+      source: 'livsmedelsverket',
+      source_id: '123',
+      updated_at: new Date(),
+    } as unknown as SharedFoodItemEntity
+
+    const copy = await duplicateFoodItem(user, stubCentral(central), central.id)
+    assertDetail(copy)
+
+    expect(copy.item.name).toBe('Banana (copy)')
+    expect(copy.is_shared).toBe(false)
+    expect(copy.item.source).toBe('manual')
+    expect(copy.item.calories).toBe(89)
+    expect(copy.item.carbs).toBe(23)
+    // The fork is a real per-user row, editable directly.
+    expect(await getFoodItemById(user, copy.item.id)).not.toBeNull()
+  })
+
+  test('returns null for an unknown source id', async () => {
+    const user = getTestUser()
+    const result = await duplicateFoodItem(user, stubCentral(), '00000000-0000-4000-8000-000000000000')
+    expect(result).toBeNull()
+  })
+})

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -640,6 +640,13 @@ export const clearCompositeNutrientCache = async (
  * with — and thus silently overwrites via the name_lower upsert conflict — an
  * existing item. Only the per-user library is checked; central names live in
  * a separate database and never conflict with per-user inserts.
+ *
+ * The check is best-effort against concurrency: two duplicate calls racing on
+ * the same source could each see the same name free, and the second's upsert
+ * (ON CONFLICT (name_lower) DO UPDATE) would then overwrite the first's row
+ * rather than insert a new one. Per-user, single-actor DBs make this vanishingly
+ * rare — same as the concurrent-setIngredients note above — so we don't pay for
+ * a fail-and-retry insert path here.
  */
 const findAvailableCopyName = async (user: string, baseName: string): Promise<string> => {
   const first = `${baseName} (copy)`

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -22,8 +22,13 @@ import {
   findCompositeParentsOfIngredient,
   type FoodItemIngredientRow,
   getIngredients as dbGetIngredients,
+  setIngredients as dbSetIngredients,
 } from '../db/food-item-ingredients.ts'
-import { type FoodItemPortionRow, listPortionsForFoodItem } from '../db/food-item-portions.ts'
+import {
+  type FoodItemPortionRow,
+  insertFoodItemPortion,
+  listPortionsForFoodItem,
+} from '../db/food-item-portions.ts'
 import {
   findOrCreateFoodItem as findOrCreateUserFoodItem,
   getFoodItemById as getUserFoodItemById,
@@ -33,9 +38,14 @@ import {
   type MergeFoodItemResult,
   mergeFoodItems as dbMergeFoodItems,
   searchFoodItems as searchUserFoodItems,
+  setFoodItemReference as dbSetFoodItemReference,
   updateFoodItem as dbUpdateFoodItem,
+  upsertFoodItem,
 } from '../db/food-items.ts'
-import { getFoodItemSensitivities } from '../db/sensitivities.ts'
+import {
+  getFoodItemSensitivities,
+  setFoodItemSensitivities as dbSetFoodItemSensitivities,
+} from '../db/sensitivities.ts'
 import { getSharedFoodItemOverridesByIds } from '../db/shared-food-item-overrides.ts'
 
 /**
@@ -618,6 +628,158 @@ export const clearCompositeNutrientCache = async (
   for (const parentId of parents) {
     await cacheCompositeNutrients(user, centralDb, parentId, visited)
   }
+}
+
+// ============================================================================
+// Duplicate a food item
+// ============================================================================
+
+/**
+ * Find a free per-user name for a copy of `baseName`. Tries "<name> (copy)"
+ * first, then "<name> (copy 2)", "(copy 3)", … so duplicating never collides
+ * with — and thus silently overwrites via the name_lower upsert conflict — an
+ * existing item. Only the per-user library is checked; central names live in
+ * a separate database and never conflict with per-user inserts.
+ */
+const findAvailableCopyName = async (user: string, baseName: string): Promise<string> => {
+  const first = `${baseName} (copy)`
+  if (!(await getUserFoodItemByName(user, first))) return first
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${baseName} (copy ${n})`
+    if (!(await getUserFoodItemByName(user, candidate))) return candidate
+  }
+  // Practically unreachable — 1000 copies of the same recipe. Fall back to a
+  // timestamp suffix rather than throwing so the user still gets their copy.
+  return `${baseName} (copy ${Date.now()})`
+}
+
+/**
+ * Build the insert input for a copy: name + source/default_* + every numeric
+ * nutrient column. For composites these nutrient values are the cached derived
+ * totals; cacheCompositeNutrients recomputes them identically afterwards, so
+ * copying them here is harmless and keeps the atomic path correct in one place.
+ */
+const buildFoodItemCopyInput = (source: MergedFoodItem, name: string): InsertFoodItemInput => {
+  const input: InsertFoodItemInput = {
+    name,
+    source: 'manual',
+    default_quantity: source.default_quantity as number | undefined,
+    default_unit: source.default_unit as string | undefined,
+    icon: source.icon as string | undefined,
+  }
+  for (const field of NUTRIENT_FIELD_NAMES) {
+    const v = source[field]
+    if (typeof v === 'number') input[field] = v
+  }
+  return input
+}
+
+/**
+ * Recreate each source portion on the new food with a fresh id, returning the
+ * old→new id map so a copied default_portion_id can be remapped onto the
+ * copy's own portion rather than the source's.
+ */
+const copyPortionsToFood = async (
+  user: string,
+  portions: FoodItemPortionRow[],
+  newId: string,
+): Promise<Map<string, string>> => {
+  const portionIdMap = new Map<string, string>()
+  for (const portion of portions) {
+    const inserted = await insertFoodItemPortion(user, {
+      food_item_id: newId,
+      label_unit: portion.label_unit,
+      base_equivalent: portion.base_equivalent,
+      sort_order: portion.sort_order,
+    })
+    portionIdMap.set(portion.id, inserted.id)
+  }
+  return portionIdMap
+}
+
+/**
+ * Build the partial update carrying the copy's default-portion preselection.
+ * `source.default_portion_id` is the per-user column or (for a central source)
+ * the override-decorated value; it's remapped through `portionIdMap` to the
+ * copy's own portion id.
+ */
+const buildDefaultPortionUpdate = (
+  source: MergedFoodItem,
+  portionIdMap: Map<string, string>,
+): Record<string, unknown> => {
+  const update: Record<string, unknown> = {}
+  const sourceDefaultPortionId = source.default_portion_id as string | undefined
+  const remapped = sourceDefaultPortionId ? portionIdMap.get(sourceDefaultPortionId) : undefined
+  if (remapped) update.default_portion_id = remapped
+  const logQuantity = source.default_log_quantity as number | undefined
+  if (logQuantity !== undefined) update.default_log_quantity = logQuantity
+  return update
+}
+
+/**
+ * Duplicate a food item into a fresh per-user "manual" copy and return its
+ * detail. Works for both per-user and central (shared library) sources — a
+ * copy of a central LSV entry becomes an editable per-user fork, which is the
+ * point of the feature: base a custom recipe on a canonical item, then tweak
+ * one ingredient.
+ *
+ * What is copied:
+ * - name → "<name> (copy)" (deduped, see findAvailableCopyName)
+ * - nutrient columns + default_quantity/default_unit/icon
+ * - composite ingredient list (then derived nutrients are re-cached)
+ * - extra portions (new ids), with default_portion_id / default_log_quantity
+ *   remapped onto the freshly-created portion rows
+ * - reference_food_item_id (atomic items inheriting micronutrients)
+ * - sensitivity flag assignments
+ *
+ * What is deliberately not copied: `source`/`source_id` provenance — the copy
+ * is a user-authored fork, so it is plain `source: 'manual'` with no upstream
+ * id. Returns null when the source id resolves nowhere.
+ */
+export const duplicateFoodItem = async (
+  user: string,
+  centralDb: CentralDb,
+  sourceId: string,
+): Promise<FoodItemDetail | null> => {
+  const service = createFoodItemsService(centralDb)
+  const detail = await service.getDetail(user, sourceId)
+  if (!detail) return null
+  const source = detail.item
+
+  const name = await findAvailableCopyName(user, source.name as string)
+  const created = await upsertFoodItem(user, buildFoodItemCopyInput(source, name))
+  const newId = created.id
+
+  // Composite ingredients — replace the (empty) list on the new row, then
+  // refresh its cached derived nutrient columns.
+  const ingredients = detail.ingredients ?? []
+  if (ingredients.length > 0) {
+    await dbSetIngredients(
+      user,
+      newId,
+      ingredients.map((ing) => ({
+        ingredient_food_item_id: ing.row.ingredient_food_item_id,
+        quantity: ing.row.quantity,
+        unit: ing.row.unit,
+        sort_order: ing.row.sort_order,
+      })),
+    )
+    await cacheCompositeNutrients(user, centralDb, newId)
+  }
+
+  const portionIdMap = await copyPortionsToFood(user, detail.portions ?? [], newId)
+  const defaultsUpdate = buildDefaultPortionUpdate(source, portionIdMap)
+  if (Object.keys(defaultsUpdate).length > 0) await dbUpdateFoodItem(user, newId, defaultsUpdate)
+
+  // Reference pointer (atomic items only — composites can't have one).
+  const referenceId = source.reference_food_item_id as string | undefined
+  if (referenceId && ingredients.length === 0) await dbSetFoodItemReference(user, newId, referenceId)
+
+  // Sensitivity flag assignments.
+  const flagIds = (detail.sensitivities ?? []).map((s) => s.id)
+  if (flagIds.length > 0) await dbSetFoodItemSensitivities(user, newId, flagIds)
+
+  return service.getDetail(user, newId)
 }
 
 // ============================================================================

--- a/apps/web/src/pages/EntityDetail/activityStats.ts
+++ b/apps/web/src/pages/EntityDetail/activityStats.ts
@@ -46,16 +46,20 @@ export const buildActivityStatRows = ({
       : formatDateTime(displayStart),
   })
   if (displayEnd) rows.push({ label: durationLabel, value: formatDuration(displayStart, displayEnd) })
-  if (activity.distance !== undefined)
-    {rows.push({ label: 'Distance', value: formatDistance(activity.distance) })}
+  if (activity.distance !== undefined) {
+    rows.push({ label: 'Distance', value: formatDistance(activity.distance) })
+  }
   const pace = formatPace(activity.avg_pace, activity.avg_speed)
   if (pace !== undefined) rows.push({ label: 'Avg Pace', value: pace })
-  if (activity.avg_cadence !== undefined)
-    {rows.push({ label: 'Avg Cadence', value: formatCadence(activity.avg_cadence) })}
-  if (activity.avg_hr !== undefined)
-    {rows.push({ label: 'Avg HR', value: `${Math.round(activity.avg_hr)} bpm` })}
-  if (activity.max_hr !== undefined)
-    {rows.push({ label: 'Max HR', value: `${Math.round(activity.max_hr)} bpm` })}
+  if (activity.avg_cadence !== undefined) {
+    rows.push({ label: 'Avg Cadence', value: formatCadence(activity.avg_cadence) })
+  }
+  if (activity.avg_hr !== undefined) {
+    rows.push({ label: 'Avg HR', value: `${Math.round(activity.avg_hr)} bpm` })
+  }
+  if (activity.max_hr !== undefined) {
+    rows.push({ label: 'Max HR', value: `${Math.round(activity.max_hr)} bpm` })
+  }
   if (totalCalories !== undefined) rows.push({ label: 'Active Calories', value: `${totalCalories} kcal` })
   if (sleepMinutes !== undefined) rows.push({ label: 'Asleep', value: formatMinutesAsHM(sleepMinutes) })
   if (activity.avg_hrv !== undefined) rows.push({ label: 'Avg HRV', value: `${activity.avg_hrv} ms` })

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -16,6 +16,7 @@ import { type IngredientRow, IngredientList } from '../../components/IngredientL
 import {
   addFoodItemPortionApi,
   deleteFoodItemPortionApi,
+  duplicateFoodItemApi,
   setDefaultPortionApi,
   updateFoodItemPortionApi,
 } from '../../state/api/meals'
@@ -296,6 +297,19 @@ export function FoodItemDetail() {
     },
   })
 
+  const duplicateMutation = useMutation({
+    mutationFn: () => duplicateFoodItemApi(id),
+    onError: (err: Error) => setSaveError(err.message ?? 'Duplicate failed'),
+    onSuccess: (copy) => {
+      // Seed the new copy's detail so its page renders without a refetch, then
+      // navigate there so the user can immediately tweak the one ingredient
+      // they wanted to change.
+      queryClient.setQueryData(['foodItem', copy.id], copy)
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      route(`/food-items/${copy.id}`)
+    },
+  })
+
   const [resnapshotResult, setResnapshotResult] = useState<{
     meals_updated: number
     rows_updated: number
@@ -431,6 +445,19 @@ export function FoodItemDetail() {
             isPending={resnapshotMutation.isPending}
             buttonClass="btn-secondary"
           />
+          <button
+            type="button"
+            class="btn-secondary"
+            onClick={() => duplicateMutation.mutate()}
+            disabled={duplicateMutation.isPending}
+            title={
+              isShared
+                ? `Create an editable personal copy of ${item.name}`
+                : `Create a copy of ${item.name} to edit`
+            }
+          >
+            {duplicateMutation.isPending ? 'Duplicating…' : 'Duplicate'}
+          </button>
           {!isShared && (
             <ConfirmButton
               label="Delete"

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -46,9 +46,15 @@ export function FoodItems() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['foodItems'] }),
   })
 
+  // Surfaces a failed row-action (duplicate) — the list page navigates away on
+  // success, so without this a network/500 error would silently do nothing.
+  const [actionError, setActionError] = useState<string | null>(null)
+
   const duplicateMutation = useMutation({
     mutationFn: (sourceId: string) => duplicateFoodItemApi(sourceId),
+    onError: (err: Error) => setActionError(err.message || 'Duplicate failed'),
     onSuccess: (copy) => {
+      setActionError(null)
       queryClient.invalidateQueries({ queryKey: ['foodItems'] })
       // Land on the new copy so the user can immediately edit it.
       route(`/food-items/${copy.id}`)
@@ -107,6 +113,15 @@ export function FoodItems() {
           {createMutation.isPending ? 'Creating…' : '+ New'}
         </button>
       </div>
+
+      {actionError && (
+        <p class="fi-error" role="alert">
+          {actionError}
+          <button type="button" class="btn-link" onClick={() => setActionError(null)}>
+            Dismiss
+          </button>
+        </p>
+      )}
 
       {!hasQuery ? (
         <p class="fi-help">Type to search the food library.</p>

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'preact/hooks'
 
 import { ConfirmButton } from '../../components/ConfirmButton'
 import { MergeFoodItemDialog } from '../../components/MergeFoodItemDialog'
-import { addFoodItemApi, searchFoodItemsApi } from '../../state/api'
+import { addFoodItemApi, duplicateFoodItemApi, searchFoodItemsApi } from '../../state/api'
 import { auth } from '../../state/auth'
 import './style.css'
 
@@ -44,6 +44,15 @@ export function FoodItems() {
   const deleteMutation = useMutation({
     mutationFn: deleteFoodItemApi,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['foodItems'] }),
+  })
+
+  const duplicateMutation = useMutation({
+    mutationFn: (sourceId: string) => duplicateFoodItemApi(sourceId),
+    onSuccess: (copy) => {
+      queryClient.invalidateQueries({ queryKey: ['foodItems'] })
+      // Land on the new copy so the user can immediately edit it.
+      route(`/food-items/${copy.id}`)
+    },
   })
 
   const createMutation = useMutation({
@@ -132,6 +141,15 @@ export function FoodItems() {
                 <td class="fi-num">{item.fiber ?? '—'}</td>
                 <td class="fi-source">{item.source ?? '—'}</td>
                 <td class="fi-row-actions">
+                  <button
+                    type="button"
+                    class="btn-secondary"
+                    onClick={() => duplicateMutation.mutate(item.id)}
+                    disabled={duplicateMutation.isPending}
+                    title={`Duplicate ${item.name} into an editable copy`}
+                  >
+                    Duplicate
+                  </button>
                   <button
                     type="button"
                     class="btn-secondary fi-merge-btn"

--- a/apps/web/src/pages/FoodItems/index.tsx
+++ b/apps/web/src/pages/FoodItems/index.tsx
@@ -160,7 +160,9 @@ export function FoodItems() {
                     type="button"
                     class="btn-secondary"
                     onClick={() => duplicateMutation.mutate(item.id)}
-                    disabled={duplicateMutation.isPending}
+                    // Disable only the row being duplicated, not every row, by
+                    // matching the in-flight mutation's source id.
+                    disabled={duplicateMutation.isPending && duplicateMutation.variables === item.id}
                     title={`Duplicate ${item.name} into an editable copy`}
                   >
                     Duplicate

--- a/apps/web/src/pages/FoodItems/style.css
+++ b/apps/web/src/pages/FoodItems/style.css
@@ -78,6 +78,30 @@
   color: #9ca3af;
 }
 
+.fi-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+  padding: 0.6rem 0.9rem;
+  border-radius: 6px;
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.fi-error .btn-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #b91c1c;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
 .fi-name a {
   color: inherit;
   text-decoration: none;

--- a/apps/web/src/state/api/meals.ts
+++ b/apps/web/src/state/api/meals.ts
@@ -190,6 +190,15 @@ export const fetchFoodItemDetailApi = async (id: string): Promise<ApiFoodItemDet
   return response.data.data
 }
 
+export const duplicateFoodItemApi = async (id: string): Promise<ApiFoodItemDetail> => {
+  const { token } = auth.value
+  const response = await axios.post<FoodItemDetailResponse>(`${API_URL}/food-items/${id}/duplicate`, null, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!response.data.data) throw new Error(response.data.error ?? 'Duplicate failed')
+  return response.data.data
+}
+
 // ─── Food item portions ─────────────────────────────────────────────────────
 
 export const addFoodItemPortionApi = async (

--- a/docs/features/calories.md
+++ b/docs/features/calories.md
@@ -37,15 +37,15 @@ If neither is available, computation is skipped with `skipped_reason: 'no BMR an
 
 ## Other Required Inputs
 
-| Input               | Source                                                                  | Lookback             |
-| ------------------- | ----------------------------------------------------------------------- | -------------------- |
-| Sex                 | `sex` user setting                                                      | required             |
-| Birth date          | `birth_date` user setting                                               | required (for age)   |
-| Weight              | `weight` metric                                                         | 90 days              |
-| Height              | `height` metric (for BMR fallback only)                                 | 10 years             |
-| Resting HR          | `resting_heart_rate` metric (else 60 bpm)                               | 90 days              |
-| HR zone boundaries  | `hr_zone_start` setting (else age-based, then HRR-derived fallback)     | live                 |
-| Observed HR max     | `settings.training_load.observed_hr_max` (else `220 − age`)             | live                 |
+| Input              | Source                                                              | Lookback           |
+| ------------------ | ------------------------------------------------------------------- | ------------------ |
+| Sex                | `sex` user setting                                                  | required           |
+| Birth date         | `birth_date` user setting                                           | required (for age) |
+| Weight             | `weight` metric                                                     | 90 days            |
+| Height             | `height` metric (for BMR fallback only)                             | 10 years           |
+| Resting HR         | `resting_heart_rate` metric (else 60 bpm)                           | 90 days            |
+| HR zone boundaries | `hr_zone_start` setting (else age-based, then HRR-derived fallback) | live               |
+| Observed HR max    | `settings.training_load.observed_hr_max` (else `220 − age`)         | live               |
 
 If the resolved zone-1 start lands at or below the resting HR (user has not set zones and the age-based default is too low for them), zones are re-derived from HRR percentages (50/60/70/80/90 % of `observed_hr_max − resting_hr` above resting).
 
@@ -72,11 +72,11 @@ Both metrics are stored in `time_series` with `source = 'aurboda'`. The `aurboda
 
 Calorie computation runs in three places:
 
-| Trigger                                                      | Range passed by caller     | Effective range after day-expansion |
-| ------------------------------------------------------------ | -------------------------- | ----------------------------------- |
-| Health Connect HR sync (`POST /sync/health-connect/...`)     | HR-batch window (≈ minutes) | The whole local day(s) it overlaps |
-| Oura sync (sleep / session HR samples)                       | Sample range               | Whole local day(s)                  |
-| Manual recompute (`recalculate_calories` MCP tool or REST)   | User-provided, or full     | Whole local day(s)                  |
+| Trigger                                                    | Range passed by caller      | Effective range after day-expansion |
+| ---------------------------------------------------------- | --------------------------- | ----------------------------------- |
+| Health Connect HR sync (`POST /sync/health-connect/...`)   | HR-batch window (≈ minutes) | The whole local day(s) it overlaps  |
+| Oura sync (sleep / session HR samples)                     | Sample range                | Whole local day(s)                  |
+| Manual recompute (`recalculate_calories` MCP tool or REST) | User-provided, or full      | Whole local day(s)                  |
 
 Each call is authoritative for the day(s) it touches: it deletes any prior aurboda rows in the expanded range and re-writes from scratch. There is no incremental "skip already-computed minutes" optimisation any more — the operation is fast enough at one day at a time and avoids the partial-day inconsistency the prior incremental path could create.
 
@@ -90,10 +90,10 @@ After deploy, run a full recompute via the MCP tool `recalculate_calories` (or `
 
 ## Key Files
 
-| File                                                  | Purpose                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------------- |
-| `apps/backend/src/services/calories.ts`               | Zone-METs formula, BMR estimator, MAX_HOLD_MINUTES, types     |
-| `apps/backend/src/services/calorie-computation.ts`    | Orchestration: BMR/zones resolution, day-aligned recompute    |
-| `apps/backend/src/db/time-series.ts`                  | DB read/write, source filtering for aurbodaOnly metrics       |
-| `apps/backend/src/db/cumulative-query.ts`             | Routes cumulative metrics to the aurbodaOnly source filter    |
-| `packages/api-spec/src/schemas/common.ts`             | `aurbodaOnlyMetrics`, `aurbodaOnlySources`, `cumulativeMetrics` |
+| File                                               | Purpose                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------- |
+| `apps/backend/src/services/calories.ts`            | Zone-METs formula, BMR estimator, MAX_HOLD_MINUTES, types       |
+| `apps/backend/src/services/calorie-computation.ts` | Orchestration: BMR/zones resolution, day-aligned recompute      |
+| `apps/backend/src/db/time-series.ts`               | DB read/write, source filtering for aurbodaOnly metrics         |
+| `apps/backend/src/db/cumulative-query.ts`          | Routes cumulative metrics to the aurbodaOnly source filter      |
+| `packages/api-spec/src/schemas/common.ts`          | `aurbodaOnlyMetrics`, `aurbodaOnlySources`, `cumulativeMetrics` |

--- a/docs/features/meals.md
+++ b/docs/features/meals.md
@@ -81,7 +81,7 @@ Examples (per food):
 | Food           | Base unit | Units (`1 label_unit` → `base_equivalent` base units) |
 | -------------- | --------- | ----------------------------------------------------- |
 | Fylld tortilla | `2 wrap`  | `1 wrap` → `1` (enter `1 wrap` ⇒ ×0.5)                |
-| Lantmjölk      | `100 g`   | `1 glas` → `515`                                       |
+| Lantmjölk      | `100 g`   | `1 glas` → `515`                                      |
 | Choklad        | `100 g`   | `1 ruta` → `3.4`; `1 rad` → `13.6`                    |
 
 When logging, the user enters a **quantity in the chosen unit**. To scale a nutrient for quantity `Q` of a unit:
@@ -122,6 +122,7 @@ Logging on the base unit uses the legacy free-form `quantity` + `unit` path, unc
 - `POST /food-items` -- create a per-user food item
 - `PATCH /food-items/:id` -- update a per-user food item (does **not** accept `default_portion_id` -- use the dedicated endpoint below)
 - `DELETE /food-items/:id` -- delete a per-user food item
+- `POST /food-items/:id/duplicate` -- duplicate into a fresh per-user copy named `"<name> (copy)"` (deduped); copies nutrients, defaults, composite ingredients, portions, reference, and sensitivities. Works on per-user **and** central items (a central copy becomes an editable per-user fork). Returns the new copy's detail.
 - `GET /food-items/:id/portions` -- list portions
 - `POST /food-items/:id/portions` -- add a portion
 - `PATCH /food-items/:id/portions/:portionId` -- update a portion (404 if it doesn't belong to `:id`)
@@ -189,6 +190,7 @@ Food items & portions:
 
 - `search_food_items` / `get_food_item` -- search / fetch the merged library (detail includes `portions[]` + `effective_default_portion_id`)
 - `add_food_item` / `update_food_item` / `delete_food_item` -- per-user food item CRUD
+- `duplicate_food_item` -- copy a food item (per-user or central) into a fresh editable per-user `"<name> (copy)"`, including ingredients, portions, reference, and sensitivities
 - `list_food_item_portions` -- list a food's portions
 - `add_food_item_portion` / `update_food_item_portion` / `delete_food_item_portion` -- portion CRUD (per-user OR central food, soft pointer)
 - `set_default_food_item_portion` -- set/clear a per-user food's default logging amount (`portion_id` + `quantity`; `portion_id: null` = base unit, `quantity: null` = base quantity)

--- a/docs/sentry.md
+++ b/docs/sentry.md
@@ -17,7 +17,7 @@ handler is a no-op — no data leaves the server.
 
 `Sentry.init` runs inside `main()` after all module imports. `@sentry/node` v8+
 auto-instrumentation (OpenTelemetry HTTP/express/db tracing, automatic
-breadcrumbs) needs init *before* those modules are imported to patch them, so
+breadcrumbs) needs init _before_ those modules are imported to patch them, so
 that side of the SDK is effectively inert here. Only the explicit
 `setupExpressErrorHandler` path captures errors.
 

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -192,15 +192,10 @@ export const updateAdminSettingsBodySchema = z
       .boolean()
       .optional()
       .meta({ description: 'Enable or disable Oura webhook push sync' }),
-    sentry_dsn: z
-      .string()
-      .url()
-      .nullable()
-      .optional()
-      .meta({
-        description:
-          'Sentry DSN for backend error reporting (set to null to clear). Takes effect after the next backend restart.',
-      }),
+    sentry_dsn: z.string().url().nullable().optional().meta({
+      description:
+        'Sentry DSN for backend error reporting (set to null to clear). Takes effect after the next backend restart.',
+    }),
     signup_mode: signupModeSchema.optional().meta({ description: 'New signup mode' }),
     strava_client_id: z
       .string()

--- a/packages/api-spec/src/schemas/food-item-portions.ts
+++ b/packages/api-spec/src/schemas/food-item-portions.ts
@@ -88,15 +88,10 @@ export const setDefaultFoodItemPortionBodySchema = z
       .uuid()
       .nullable()
       .meta({ description: 'Portion (unit) id to preselect, or null for the base unit' }),
-    quantity: z
-      .number()
-      .positive()
-      .nullable()
-      .optional()
-      .meta({
-        description:
-          'Default quantity to prefill, or null to fall back to the base quantity. Omitting it is treated as null (back-compat for callers that send only portion_id).',
-      }),
+    quantity: z.number().positive().nullable().optional().meta({
+      description:
+        'Default quantity to prefill, or null to fall back to the base quantity. Omitting it is treated as null (back-compat for callers that send only portion_id).',
+    }),
   })
   .meta({
     description: 'Set or clear the default logging amount (unit + quantity) for a food item',

--- a/packages/api-spec/src/schemas/meals.ts
+++ b/packages/api-spec/src/schemas/meals.ts
@@ -127,7 +127,7 @@ export const foodItemInputSchema = z
     }),
     food_item_portion_id: z.string().uuid().optional().meta({
       description:
-        'Optional portion id (from food_item_portions). When set, nutrients are scaled by `portion_count × portion.base_equivalent / food.default_quantity` and the row\'s display label is derived from the portion. When omitted, falls back to the legacy `quantity` + `unit` scaling.',
+        "Optional portion id (from food_item_portions). When set, nutrients are scaled by `portion_count × portion.base_equivalent / food.default_quantity` and the row's display label is derived from the portion. When omitted, falls back to the legacy `quantity` + `unit` scaling.",
     }),
     portion_count: z.number().positive().optional().meta({
       description:
@@ -151,13 +151,10 @@ export const foodItemInputSchema = z
         'Unit for `quantity` (e.g., "g", "ml", "large slice", "full recipe"). Ignored when `food_item_portion_id` is provided.',
     }),
   })
-  .refine(
-    (body) => body.food_item_portion_id === undefined || typeof body.portion_count === 'number',
-    {
-      message: 'portion_count is required when food_item_portion_id is set',
-      path: ['portion_count'],
-    },
-  )
+  .refine((body) => body.food_item_portion_id === undefined || typeof body.portion_count === 'number', {
+    message: 'portion_count is required when food_item_portion_id is set',
+    path: ['portion_count'],
+  })
   .meta({ description: 'Input shape for a food item in a meal request body', id: 'FoodItemInput' })
 
 export type FoodItemInput = z.infer<typeof foodItemInputSchema>


### PR DESCRIPTION
## What

Adds a **duplicate food item** function and UI so you can copy a recipe and then tweak it — e.g. swap a single ingredient — without re-entering everything.

## How it works

`duplicateFoodItem` (`services/food-items.ts`) creates a fresh per-user `manual` copy named `"<name> (copy)"`, deduped to `"(copy 2)"`, `"(copy 3)"`, … so it never silently overwrites an existing item via the `name_lower` upsert conflict. It copies:

- nutrient columns + `default_quantity` / `default_unit` / `icon`
- composite **ingredients** (then re-caches derived nutrients)
- **portions** (fresh ids), with `default_portion_id` / `default_log_quantity` remapped onto the new portion rows
- the **reference** pointer (atomic items)
- **sensitivity** flag assignments

`source` / `source_id` provenance is deliberately dropped — the copy is a user-authored fork (`source: 'manual'`).

Works on **per-user and central** sources: duplicating a central (e.g. Livsmedelsverket) item gives you an **editable per-user fork** — a clean way to base a custom recipe on a canonical entry.

## Surface (API/MCP parity)

- **REST:** `POST /food-items/:id/duplicate` → the new copy's detail
- **MCP:** `duplicate_food_item` tool
- **Web:** a `Duplicate` button on the food item detail header (next to Re-snapshot/Delete, shown for shared items too) and a `Duplicate` action on each Food Items list row. Both navigate to the new copy for editing.

## Tests

- Integration (`food-items-duplicate.integration.test.ts`, testcontainers): atomic copy, composite ingredients + independence, portions + default-portion remap, sensitivities, reference, name dedup, central fork, unknown id → null
- Router endpoint tests: 404 + 200 happy path
- `pnpm check` green (0 errors); 94 food-item tests pass

## Docs

- `docs/features/meals.md`: added the duplicate REST endpoint + MCP tool to the food-items lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)