### PR TITLE
feat(food-items): portion units for recipe ingredients

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -1124,6 +1124,18 @@ export const migrateSchema = async (user: string) => {
     )
   }
 
+  // food_item_ingredients: per-ingredient portion selection, mirroring
+  // meal_food_items. Both nullable so legacy ingredients (logged with free-form
+  // quantity + unit before portions existed) keep working — the scaling falls
+  // back to (quantity, unit) when food_item_portion_id is NULL.
+  if (existingTableNames.has('food_item_ingredients')) {
+    await query(db, `ALTER TABLE food_item_ingredients ADD COLUMN IF NOT EXISTS food_item_portion_id UUID`)
+    await query(
+      db,
+      `ALTER TABLE food_item_ingredients ADD COLUMN IF NOT EXISTS portion_count DOUBLE PRECISION`,
+    )
+  }
+
   // meal_food_items: drop the FK on food_item_id since the canonical row
   // may now live in the central shared_food_items table (different
   // database). The food_item_name + food_item_icon columns existed in

--- a/apps/backend/src/db/food-item-ingredients.ts
+++ b/apps/backend/src/db/food-item-ingredients.ts
@@ -14,7 +14,7 @@
 import { query } from './connection.ts'
 
 const COLUMNS =
-  'id, parent_food_item_id, ingredient_food_item_id, quantity, unit, sort_order, created_at, updated_at'
+  'id, parent_food_item_id, ingredient_food_item_id, quantity, unit, food_item_portion_id, portion_count, sort_order, created_at, updated_at'
 
 export interface FoodItemIngredientRow {
   id: string
@@ -22,6 +22,10 @@ export interface FoodItemIngredientRow {
   ingredient_food_item_id: string
   quantity: number
   unit?: string
+  /** When set, the ingredient is measured in this portion (unit); scaling uses portion_count × base_equivalent. */
+  food_item_portion_id?: string
+  /** The count entered in the portion's unit (paired with food_item_portion_id). */
+  portion_count?: number
   sort_order: number
   created_at: Date
   updated_at: Date
@@ -31,6 +35,8 @@ export interface FoodItemIngredientInput {
   ingredient_food_item_id: string
   quantity: number
   unit?: string
+  food_item_portion_id?: string
+  portion_count?: number
   sort_order?: number
 }
 
@@ -40,6 +46,8 @@ const mapRow = (row: Record<string, unknown>): FoodItemIngredientRow => ({
   ingredient_food_item_id: row.ingredient_food_item_id as string,
   parent_food_item_id: row.parent_food_item_id as string,
   quantity: Number(row.quantity),
+  food_item_portion_id: (row.food_item_portion_id as string | null) ?? undefined,
+  portion_count: row.portion_count == null ? undefined : Number(row.portion_count),
   sort_order: Number(row.sort_order),
   unit: (row.unit as string | null) ?? undefined,
   updated_at: new Date(row.updated_at as string),
@@ -90,25 +98,27 @@ export const setIngredients = async (
     await query(user, `DELETE FROM food_item_ingredients WHERE parent_food_item_id = $1`, [parentFoodItemId])
 
     if (items.length > 0) {
-      // Single multi-row INSERT — 5 columns per row, parameterised.
+      // Single multi-row INSERT — 7 columns per row, parameterised.
       const params: unknown[] = []
       const valuesSql = items
         .map((item, i) => {
-          const base = i * 5
+          const base = i * 7
           params.push(
             parentFoodItemId,
             item.ingredient_food_item_id,
             item.quantity,
             item.unit ?? null,
+            item.food_item_portion_id ?? null,
+            item.portion_count ?? null,
             item.sort_order ?? i,
           )
-          return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5})`
+          return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7})`
         })
         .join(', ')
       await query(
         user,
         `INSERT INTO food_item_ingredients
-           (parent_food_item_id, ingredient_food_item_id, quantity, unit, sort_order)
+           (parent_food_item_id, ingredient_food_item_id, quantity, unit, food_item_portion_id, portion_count, sort_order)
          VALUES ${valuesSql}`,
         params,
       )

--- a/apps/backend/src/mcp/food-item-tools.ts
+++ b/apps/backend/src/mcp/food-item-tools.ts
@@ -46,6 +46,7 @@ import {
   createFoodItemsMergeService,
   createFoodItemsService,
   duplicateFoodItem,
+  prepareIngredientInputs,
 } from '../services/food-items.ts'
 import { resnapshotMealsForFoodItem } from '../services/meals.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
@@ -143,8 +144,8 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
   server.tool(
     'set_food_item_ingredients',
     [
-      "Mark a per-user food item as composite (a recipe) and replace its full ingredient list. The item's nutrient values become derived: at read time we sum each ingredient's value × quantity / default_quantity (when units match).",
-      'Each ingredient points at another food item by `ingredient_food_item_id` — may be a per-user food OR a central library item. Cycles (A → B → A) are rejected.',
+      "Mark a per-user food item as composite (a recipe) and replace its full ingredient list. The item's nutrient values become derived: at read time we sum each ingredient's contribution, scaled by quantity / default_quantity (legacy) or, when a `food_item_portion_id` is given, by portion_count × portion.base_equivalent / default_quantity.",
+      'Each ingredient points at another food item by `ingredient_food_item_id` — may be a per-user food OR a central library item. Provide either `quantity` (+ optional `unit`) or a `food_item_portion_id` of that food plus `portion_count` (e.g. "2 brödkaka"). Cycles (A → B → A) are rejected.',
       'Only per-user items can be made composite; central shared-library rows return an error.',
     ].join(' '),
     {
@@ -163,7 +164,13 @@ export const registerFoodItemTools = (server: McpServer, user: string, centralDb
       if (await foodItems.wouldCreateCycle(user, id, ingredientIds)) {
         return errorResponse('Setting these ingredients would create a cycle in the recipe graph')
       }
-      await setIngredients(user, id, ingredients)
+      let prepared
+      try {
+        prepared = await prepareIngredientInputs(user, ingredients)
+      } catch (err) {
+        return errorResponse(err instanceof Error ? err.message : 'Invalid ingredient portion')
+      }
+      await setIngredients(user, id, prepared)
       await cacheCompositeNutrients(user, centralDb, id)
       const detail = await foodItems.getDetail(user, id)
       if (!detail) return errorResponse('Food item not found')

--- a/apps/backend/src/routes/food-items-router.test.ts
+++ b/apps/backend/src/routes/food-items-router.test.ts
@@ -78,6 +78,8 @@ vi.mock('../db/shared-food-item-overrides.ts', () => ({
 
 const dbBarrel = await import('../db/index.ts')
 const dbFoodItems = await import('../db/food-items.ts')
+const dbIngredients = await import('../db/food-item-ingredients.ts')
+const dbPortions = await import('../db/food-item-portions.ts')
 
 /** Set the mock return for both barrel and direct getFoodItemById lookups. */
 const setUserFoodItem = (impl: (user: string, id: string) => Promise<FoodItemEntity | null>) => {
@@ -627,5 +629,66 @@ describe('POST /food-items/:id/duplicate', () => {
       'tester',
       expect.objectContaining({ calories: 52, name: 'Apple (copy)', source: 'manual' }),
     )
+  })
+})
+
+describe('PUT /food-items/:id/ingredients — portions', () => {
+  const PARENT = '11111111-1111-4111-8111-111111111111'
+  const INGREDIENT = '22222222-2222-4222-8222-222222222222'
+  const PORTION = '33333333-3333-4333-8333-333333333333'
+
+  const portionRow = (foodItemId: string) => ({
+    base_equivalent: 35,
+    created_at: new Date(),
+    food_item_id: foodItemId,
+    id: PORTION,
+    label_unit: 'brödkaka',
+    sort_order: 0,
+    updated_at: new Date(),
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // wouldCreateCycle walks the ingredient graph — no existing ingredients.
+    vi.mocked(dbIngredients.getIngredients).mockResolvedValue([])
+    setUserFoodItem(async (_u, id) => (id === PARENT ? userItem(PARENT, { is_composite: true }) : null))
+  })
+
+  test('400 when the portion does not belong to the ingredient food', async () => {
+    // Portion belongs to some OTHER food, not INGREDIENT.
+    vi.mocked(dbPortions.getFoodItemPortionById).mockResolvedValue(
+      portionRow('99999999-9999-4999-8999-999999999999'),
+    )
+    const res = await supertest(buildApp(fakeCentral()))
+      .put(`/food-items/${PARENT}/ingredients`)
+      .send({
+        ingredients: [
+          { ingredient_food_item_id: INGREDIENT, food_item_portion_id: PORTION, portion_count: 2 },
+        ],
+      })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/does not belong/i)
+    expect(dbBarrel.setIngredients).not.toHaveBeenCalled()
+  })
+
+  test('200 persists the portion ingredient with display columns filled from the portion', async () => {
+    vi.mocked(dbPortions.getFoodItemPortionById).mockResolvedValue(portionRow(INGREDIENT))
+    const res = await supertest(buildApp(fakeCentral()))
+      .put(`/food-items/${PARENT}/ingredients`)
+      .send({
+        ingredients: [
+          { ingredient_food_item_id: INGREDIENT, food_item_portion_id: PORTION, portion_count: 2 },
+        ],
+      })
+    expect(res.status).toBe(200)
+    expect(dbBarrel.setIngredients).toHaveBeenCalledWith('tester', PARENT, [
+      expect.objectContaining({
+        food_item_portion_id: PORTION,
+        ingredient_food_item_id: INGREDIENT,
+        portion_count: 2,
+        quantity: 2,
+        unit: 'brödkaka',
+      }),
+    ])
   })
 })

--- a/apps/backend/src/routes/food-items-router.ts
+++ b/apps/backend/src/routes/food-items-router.ts
@@ -86,6 +86,7 @@ import {
   duplicateFoodItem,
   type FoodItemDetail as ServiceFoodItemDetail,
   type MergedFoodItem,
+  prepareIngredientInputs,
 } from '../services/food-items.ts'
 import { resnapshotMealsForFoodItem } from '../services/meals.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
@@ -136,9 +137,11 @@ const serializeDetail = (detail: ServiceFoodItemDetail): FoodItemDetail => {
       ...base,
       derived_nutrients: detail.derived_nutrients ?? { nutrient_data_incomplete: false, values: {} },
       ingredients: detail.ingredients.map((ing) => ({
+        food_item_portion_id: ing.row.food_item_portion_id,
         icon: (ing.food?.icon as string | undefined) ?? null,
         ingredient_food_item_id: ing.row.ingredient_food_item_id,
         name: ing.food ? (ing.food.name as string) : null,
+        portion_count: ing.row.portion_count,
         quantity: ing.row.quantity,
         sort_order: ing.row.sort_order,
         unit: ing.row.unit,
@@ -303,7 +306,18 @@ export const createFoodItemsRouter = (authMiddleware: AnyMiddleware, centralDb: 
           success: false,
         })
       }
-      await dbSetIngredients(user, id, ingredients)
+      // Validate + normalise portions (must belong to the ingredient food) and
+      // fill display columns before persisting.
+      let prepared
+      try {
+        prepared = await prepareIngredientInputs(user, ingredients)
+      } catch (err) {
+        return res.status(400).json({
+          error: err instanceof Error ? err.message : 'Invalid ingredient portion',
+          success: false,
+        })
+      }
+      await dbSetIngredients(user, id, prepared)
       // Refresh the cached derived nutrients on this row + every parent
       // recipe that uses this item — keeps search results, frequent-meal
       // cards, and outer-recipe totals in sync without lazy recomputation.

--- a/apps/backend/src/schema/meals.ts
+++ b/apps/backend/src/schema/meals.ts
@@ -154,6 +154,8 @@ export const mealsTables: Record<string, string> = {
       ingredient_food_item_id  UUID NOT NULL,
       quantity                 DOUBLE PRECISION NOT NULL,
       unit                     VARCHAR(100),
+      food_item_portion_id     UUID,
+      portion_count            DOUBLE PRECISION,
       sort_order               INTEGER NOT NULL DEFAULT 0,
       created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/apps/backend/src/services/food-item-ingredient-portions.integration.test.ts
+++ b/apps/backend/src/services/food-item-ingredient-portions.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration tests for portion-based recipe ingredients.
+ *
+ * Recipes can measure an ingredient in one of the ingredient food's portions
+ * (e.g. "2 brödkaka") instead of a free-form quantity/unit, mirroring meals.
+ * The ingredient's nutrient contribution then scales by
+ * `portion_count × portion.base_equivalent / ingredient.default_quantity`.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { CentralDb } from './central-db.ts'
+
+import { getIngredients, setIngredients } from '../db/food-item-ingredients.ts'
+import { insertFoodItemPortion } from '../db/food-item-portions.ts'
+import { getFoodItemById, upsertFoodItem } from '../db/food-items.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { createFoodItemsService, prepareIngredientInputs } from './food-items.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+const stubCentral = (): CentralDb =>
+  ({
+    getSharedFoodItemById: async () => null,
+    getSharedFoodItemByName: async () => null,
+    getSharedFoodItemsByIds: async () => new Map(),
+    searchSharedFoodItems: async () => [],
+  }) as unknown as CentralDb
+
+describe('recipe ingredient portions integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('prepareIngredientInputs fills quantity/unit from the portion and round-trips', async () => {
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Bread',
+    })
+    const portion = await insertFoodItemPortion(user, {
+      base_equivalent: 35,
+      food_item_id: bread.id,
+      label_unit: 'brödkaka',
+      sort_order: 0,
+    })
+    const recipe = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Bananmacka',
+    })
+
+    const prepared = await prepareIngredientInputs(user, [
+      {
+        food_item_portion_id: portion.id,
+        ingredient_food_item_id: bread.id,
+        portion_count: 2,
+        sort_order: 0,
+      },
+    ])
+    // The portion path fills the display columns from the portion.
+    expect(prepared[0]).toMatchObject({
+      food_item_portion_id: portion.id,
+      portion_count: 2,
+      quantity: 2,
+      unit: 'brödkaka',
+    })
+
+    await setIngredients(user, recipe.id, prepared)
+
+    const rows = await getIngredients(user, recipe.id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].food_item_portion_id).toBe(portion.id)
+    expect(rows[0].portion_count).toBe(2)
+    expect(rows[0].unit).toBe('brödkaka')
+  })
+
+  test('derived nutrients scale by portion_count × base_equivalent / default_quantity', async () => {
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      protein: 8,
+      name: 'Bread',
+    })
+    const portion = await insertFoodItemPortion(user, {
+      base_equivalent: 35, // 1 brödkaka = 35 g
+      food_item_id: bread.id,
+      label_unit: 'brödkaka',
+      sort_order: 0,
+    })
+    const recipe = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Bananmacka',
+    })
+    const prepared = await prepareIngredientInputs(user, [
+      {
+        food_item_portion_id: portion.id,
+        ingredient_food_item_id: bread.id,
+        portion_count: 2,
+        sort_order: 0,
+      },
+    ])
+    await setIngredients(user, recipe.id, prepared)
+
+    const service = createFoodItemsService(stubCentral())
+    const detail = await service.getDetail(user, recipe.id)
+    // 2 brödkaka = 70 g; scale = 70/100 = 0.7 → calories 200×0.7 = 140, protein 8×0.7 = 5.6.
+    expect(detail?.derived_nutrients?.values.calories).toBe(140)
+    expect(detail?.derived_nutrients?.values.protein).toBe(5.6)
+    expect(detail?.derived_nutrients?.nutrient_data_incomplete).toBe(false)
+  })
+
+  test('legacy quantity-based ingredients still scale (no portion)', async () => {
+    const user = getTestUser()
+    const milk = await upsertFoodItem(user, {
+      calories: 60,
+      default_quantity: 100,
+      default_unit: 'ml',
+      name: 'Milk',
+    })
+    const recipe = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Latte',
+    })
+    const prepared = await prepareIngredientInputs(user, [
+      { ingredient_food_item_id: milk.id, quantity: 250, sort_order: 0, unit: 'ml' },
+    ])
+    await setIngredients(user, recipe.id, prepared)
+
+    const service = createFoodItemsService(stubCentral())
+    const detail = await service.getDetail(user, recipe.id)
+    expect(detail?.derived_nutrients?.values.calories).toBe(150) // 60 × 250/100
+  })
+
+  test('rejects a portion that does not belong to the ingredient food', async () => {
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Bread',
+    })
+    const other = await upsertFoodItem(user, {
+      calories: 50,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Cheese',
+    })
+    // Portion belongs to `other`, not `bread`.
+    const portion = await insertFoodItemPortion(user, {
+      base_equivalent: 20,
+      food_item_id: other.id,
+      label_unit: 'slice',
+      sort_order: 0,
+    })
+
+    await expect(
+      prepareIngredientInputs(user, [
+        {
+          food_item_portion_id: portion.id,
+          ingredient_food_item_id: bread.id,
+          portion_count: 1,
+          sort_order: 0,
+        },
+      ]),
+    ).rejects.toThrow(/does not belong/)
+  })
+
+  test('cached row columns reflect portion scaling after setIngredients via the route path', async () => {
+    // Mirrors what the PUT route does: prepare → setIngredients → cache.
+    const user = getTestUser()
+    const bread = await upsertFoodItem(user, {
+      calories: 200,
+      default_quantity: 100,
+      default_unit: 'g',
+      name: 'Bread',
+    })
+    const portion = await insertFoodItemPortion(user, {
+      base_equivalent: 50,
+      food_item_id: bread.id,
+      label_unit: 'big slice',
+      sort_order: 0,
+    })
+    const recipe = await upsertFoodItem(user, {
+      default_quantity: 1,
+      default_unit: 'recipe',
+      name: 'Toast',
+    })
+    const { cacheCompositeNutrients } = await import('./food-items.ts')
+    const prepared = await prepareIngredientInputs(user, [
+      {
+        food_item_portion_id: portion.id,
+        ingredient_food_item_id: bread.id,
+        portion_count: 3,
+        sort_order: 0,
+      },
+    ])
+    await setIngredients(user, recipe.id, prepared)
+    await cacheCompositeNutrients(user, stubCentral(), recipe.id)
+
+    // 3 big slice = 150 g; scale 1.5 → calories 300 cached on the row.
+    expect((await getFoodItemById(user, recipe.id))?.calories).toBe(300)
+  })
+})

--- a/apps/backend/src/services/food-items.test.ts
+++ b/apps/backend/src/services/food-items.test.ts
@@ -31,6 +31,7 @@ vi.mock('../db/sensitivities.ts', () => ({
 }))
 
 vi.mock('../db/food-item-portions.ts', () => ({
+  getFoodItemPortionById: vi.fn().mockResolvedValue(null),
   listPortionsForFoodItem: vi.fn().mockResolvedValue([]),
 }))
 
@@ -476,6 +477,55 @@ describe('aggregateNutrientsFromIngredients — scaling edge cases', () => {
     ])
     expect(values.calories).toBe(1800)
     expect(nutrient_data_incomplete).toBe(false)
+  })
+
+  const buildPortionRow = (portionId: string, count: number) => ({
+    created_at: new Date(),
+    food_item_portion_id: portionId,
+    id: 'r',
+    ingredient_food_item_id: 'x',
+    parent_food_item_id: 'p',
+    portion_count: count,
+    quantity: count,
+    sort_order: 0,
+    unit: 'brödkaka',
+    updated_at: new Date(),
+  })
+
+  const portion = (id: string, base_equivalent: number) => ({
+    base_equivalent,
+    created_at: new Date(),
+    food_item_id: 'bread',
+    id,
+    label_unit: 'brödkaka',
+    sort_order: 0,
+    updated_at: new Date(),
+  })
+
+  test('portion path scales by portion_count × base_equivalent / default_quantity', () => {
+    const bread = userItem('bread', 'Bread')
+    bread.default_quantity = 100
+    bread.default_unit = 'g'
+    bread.calories = 200
+
+    // 2 brödkaka × 35 g = 70 g; scale 0.7 → 200 × 0.7 = 140 kcal
+    const { values, nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      { food: bread, row: buildPortionRow('por-1', 2), portion: portion('por-1', 35) },
+    ])
+    expect(values.calories).toBe(140)
+    expect(nutrient_data_incomplete).toBe(false)
+  })
+
+  test('flags incomplete when a portion-based row has no resolved portion (deleted unit)', () => {
+    const bread = userItem('bread', 'Bread')
+    bread.default_quantity = 100
+    bread.default_unit = 'g'
+    bread.calories = 200
+
+    const { nutrient_data_incomplete } = aggregateNutrientsFromIngredients([
+      { food: bread, row: buildPortionRow('por-gone', 2), portion: null },
+    ])
+    expect(nutrient_data_incomplete).toBe(true)
   })
 })
 

--- a/apps/backend/src/services/food-items.ts
+++ b/apps/backend/src/services/food-items.ts
@@ -11,7 +11,7 @@
  * collide; we don't need a namespace prefix on IDs.
  */
 
-import { getFoodItemQualityTier, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
+import { type FoodItemIngredient, getFoodItemQualityTier, NUTRIENT_FIELD_NAMES } from '@aurboda/api-spec'
 
 import type { FoodItemEntity } from '../db/types.ts'
 import type { CentralDb } from './central-db.ts'
@@ -20,12 +20,14 @@ import type { SharedFoodItemEntity } from './central-food-items.ts'
 import { query } from '../db/connection.ts'
 import {
   findCompositeParentsOfIngredient,
+  type FoodItemIngredientInput,
   type FoodItemIngredientRow,
   getIngredients as dbGetIngredients,
   setIngredients as dbSetIngredients,
 } from '../db/food-item-ingredients.ts'
 import {
   type FoodItemPortionRow,
+  getFoodItemPortionById,
   insertFoodItemPortion,
   listPortionsForFoodItem,
 } from '../db/food-item-portions.ts'
@@ -60,6 +62,12 @@ export interface ResolvedIngredient {
   row: FoodItemIngredientRow
   /** The actual ingredient food item, resolved across user + central. */
   food: MergedFoodItem | null
+  /**
+   * The portion (unit) the ingredient is measured in, when `row.food_item_portion_id`
+   * is set and resolves. Null/absent on the legacy quantity/unit path or when the
+   * portion was deleted (scaling then falls back / flags incomplete).
+   */
+  portion?: FoodItemPortionRow | null
 }
 
 export interface DerivedNutrients {
@@ -188,28 +196,37 @@ interface ScaleResult {
 }
 
 /**
- * Compute the scale factor between an ingredient's quantity and its
- * canonical default_quantity. Same units → straight ratio. Different but
- * dimensionally-compatible units (e.g. dl ↔ ml) → convert. Anything else
- * (mismatched dimension, missing default_quantity) → scale = 1 + incomplete
- * flag so the user knows totals can't be trusted.
+ * Compute the scale factor for one resolved ingredient against its canonical
+ * default_quantity.
+ *
+ * - Portion path (row.food_item_portion_id set + portion resolved): the count
+ *   is in the portion's unit, so scale = `portion_count × base_equivalent /
+ *   default_quantity` — mirrors the meal portion formula. A portion id that no
+ *   longer resolves flips `incomplete` (the unit it referenced is gone).
+ * - Legacy path: same units → straight ratio; dimensionally-compatible units
+ *   (e.g. dl ↔ ml) → convert; anything else (mismatched dimension, missing
+ *   default_quantity) → scale = 1 + incomplete flag.
  */
-const computeIngredientScale = (
-  ingredientQuantity: number,
-  ingredientUnit: string | undefined,
-  food: MergedFoodItem,
-): ScaleResult => {
+const computeIngredientScale = (ingredient: ResolvedIngredient): ScaleResult => {
+  const { row, food, portion } = ingredient
+  if (!food) return { incomplete: true, scale: 1 }
   const defaultQty = food.default_quantity as number | undefined
   if (defaultQty === undefined || defaultQty === null || defaultQty === 0) {
     return { incomplete: true, scale: 1 }
   }
+  // Portion path.
+  if (row.food_item_portion_id) {
+    if (!portion || typeof row.portion_count !== 'number') return { incomplete: true, scale: 1 }
+    return { incomplete: false, scale: (row.portion_count * portion.base_equivalent) / defaultQty }
+  }
+  // Legacy quantity/unit path.
   const defaultUnit = food.default_unit as string | undefined
-  if (ingredientUnit && defaultUnit && ingredientUnit !== defaultUnit) {
-    const converted = convertUnit(ingredientQuantity, ingredientUnit, defaultUnit)
+  if (row.unit && defaultUnit && row.unit !== defaultUnit) {
+    const converted = convertUnit(row.quantity, row.unit, defaultUnit)
     if (converted === undefined) return { incomplete: true, scale: 1 }
     return { incomplete: false, scale: converted / defaultQty }
   }
-  return { incomplete: false, scale: ingredientQuantity / defaultQty }
+  return { incomplete: false, scale: row.quantity / defaultQty }
 }
 
 /**
@@ -285,13 +302,14 @@ const enrichWithReference = (self: MergedFoodItem, ref: MergedFoodItem): FoodIte
 export const aggregateNutrientsFromIngredients = (ingredients: ResolvedIngredient[]): DerivedNutrients => {
   const values: Record<string, number> = {}
   let incomplete = false
-  for (const { row, food } of ingredients) {
+  for (const ingredient of ingredients) {
+    const { food } = ingredient
     if (!food) {
       incomplete = true
       continue
     }
     if (typeof food.calories !== 'number') incomplete = true
-    const { scale, incomplete: scaleIncomplete } = computeIngredientScale(row.quantity, row.unit, food)
+    const { scale, incomplete: scaleIncomplete } = computeIngredientScale(ingredient)
     if (scaleIncomplete) incomplete = true
     for (const field of NUTRIENT_FIELD_NAMES) {
       const v = food[field]
@@ -496,8 +514,20 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
           .filter((f): f is SharedFoodItemEntity => f !== null)
         const decoratedCentral = await applySharedOverrides(user, centralFoods)
         const decoratedById = new Map(decoratedCentral.map((f) => [f.id, f]))
+        // Resolve the portion (unit) for ingredients logged via a portion, so
+        // scaling can use its base_equivalent. Batch the distinct ids.
+        const portionIds = Array.from(
+          new Set(rows.map((r) => r.food_item_portion_id).filter((p): p is string => !!p)),
+        )
+        const portionEntries = await Promise.all(
+          portionIds.map(async (pid) => [pid, await getFoodItemPortionById(user, pid)] as const),
+        )
+        const portionById = new Map(
+          portionEntries.filter((e): e is [string, FoodItemPortionRow] => e[1] !== null),
+        )
         const resolved: ResolvedIngredient[] = resolutions.map(({ row, userFood, centralFood }) => ({
           food: userFood ?? (centralFood ? (decoratedById.get(centralFood.id) ?? null) : null),
+          portion: row.food_item_portion_id ? (portionById.get(row.food_item_portion_id) ?? null) : null,
           row,
         }))
         return {
@@ -554,6 +584,59 @@ export const createFoodItemsService = (centralDb: CentralDb): FoodItemsService =
     return false
   },
 })
+
+/**
+ * Validate + normalise ingredient inputs before persisting, mirroring the meal
+ * portion path (resolvePortionForInput + buildScaledJunctionItem):
+ *
+ * - For a portion-based ingredient, the portion must exist AND belong to the
+ *   ingredient food item, and portion_count must be positive. The display
+ *   columns are filled from the portion (`quantity = portion_count`,
+ *   `unit = portion.label_unit`) so the row renders "2 brödkaka" even without
+ *   re-fetching the portion, while scaling re-derives live from the portion id.
+ * - For a legacy ingredient, quantity is required (the schema enforces this;
+ *   we guard anyway).
+ *
+ * Throws on invalid portion references — callers surface it as a 400.
+ */
+export const prepareIngredientInputs = async (
+  user: string,
+  ingredients: FoodItemIngredient[],
+): Promise<FoodItemIngredientInput[]> =>
+  Promise.all(
+    ingredients.map(async (ing, i): Promise<FoodItemIngredientInput> => {
+      const sort_order = ing.sort_order ?? i
+      if (ing.food_item_portion_id) {
+        const portion = await getFoodItemPortionById(user, ing.food_item_portion_id)
+        if (!portion) throw new Error(`Portion not found: ${ing.food_item_portion_id}`)
+        if (portion.food_item_id !== ing.ingredient_food_item_id) {
+          throw new Error(
+            `Portion ${ing.food_item_portion_id} does not belong to food item ${ing.ingredient_food_item_id}`,
+          )
+        }
+        if (typeof ing.portion_count !== 'number' || ing.portion_count <= 0) {
+          throw new Error('portion_count must be a positive number when food_item_portion_id is set')
+        }
+        return {
+          food_item_portion_id: ing.food_item_portion_id,
+          ingredient_food_item_id: ing.ingredient_food_item_id,
+          portion_count: ing.portion_count,
+          quantity: ing.portion_count,
+          sort_order,
+          unit: portion.label_unit,
+        }
+      }
+      if (typeof ing.quantity !== 'number') {
+        throw new Error('quantity is required when no food_item_portion_id is set')
+      }
+      return {
+        ingredient_food_item_id: ing.ingredient_food_item_id,
+        quantity: ing.quantity,
+        sort_order,
+        unit: ing.unit,
+      }
+    }),
+  )
 
 // ============================================================================
 // Composite nutrient cache
@@ -765,10 +848,12 @@ export const duplicateFoodItem = async (
       user,
       newId,
       ingredients.map((ing) => ({
+        food_item_portion_id: ing.row.food_item_portion_id,
         ingredient_food_item_id: ing.row.ingredient_food_item_id,
+        portion_count: ing.row.portion_count,
         quantity: ing.row.quantity,
-        unit: ing.row.unit,
         sort_order: ing.row.sort_order,
+        unit: ing.row.unit,
       })),
     )
     await cacheCompositeNutrients(user, centralDb, newId)

--- a/apps/web/src/components/IngredientList.css
+++ b/apps/web/src/components/IngredientList.css
@@ -47,12 +47,14 @@
   text-align: right;
 }
 
-.ingredient-unit {
-  width: 80px;
+.ingredient-portion-picker {
+  max-width: 7rem;
   padding: 0.25rem 0.375rem;
   font-size: 0.85rem;
   border: 1px solid #d1d5db;
   border-radius: 3px;
+  background: #fff;
+  color: #374151;
 }
 
 .ingredient-add-row {
@@ -70,7 +72,7 @@
   }
 
   .ingredient-qty,
-  .ingredient-unit {
+  .ingredient-portion-picker {
     background: #1f2937;
     border-color: #4b5563;
     color: #d1d5db;

--- a/apps/web/src/components/IngredientList.tsx
+++ b/apps/web/src/components/IngredientList.tsx
@@ -2,15 +2,21 @@
  * Ingredient editor for composite (recipe-style) food items.
  *
  * Each row is one ingredient pointing at another food item — picked via
- * FoodItemAutocomplete (which already merges user + central library), with
- * inline quantity and unit. Edits commit on **blur** (or remove); the
- * parent page persists the full list via PUT /food-items/:id/ingredients.
+ * FoodItemAutocomplete (which already merges user + central library), with an
+ * inline quantity and a unit picker. The unit picker offers the ingredient
+ * food's base unit plus any portions it defines (e.g. "brödkaka"), mirroring
+ * the meal logging UI: when a portion is selected the number is `portion_count`
+ * and the recipe scales by `portion_count × base_equivalent / default_quantity`.
+ * Edits commit on **blur** (or pick/remove); the parent page persists the full
+ * list via PUT /food-items/:id/ingredients.
  */
 
+import type { FoodItemPortion } from '@aurboda/api-spec'
+
+import { useQuery } from '@tanstack/react-query'
 import { useEffect, useState } from 'preact/hooks'
 
-import type { FoodItemEntity } from '../state/api'
-
+import { type FoodItemEntity, fetchFoodItemDetailApi } from '../state/api'
 import { FoodItemAutocomplete } from './FoodItemAutocomplete'
 import './IngredientList.css'
 
@@ -21,6 +27,10 @@ export interface IngredientRow {
   icon: string | null
   quantity: number
   unit?: string
+  /** When set, the ingredient is measured in this portion (unit) of the ingredient food. */
+  food_item_portion_id?: string
+  /** The count entered in the portion's unit (paired with food_item_portion_id). */
+  portion_count?: number
   sort_order: number
 }
 
@@ -30,10 +40,39 @@ interface Props {
   onChange: (ingredients: IngredientRow[]) => void
 }
 
+// Unit dropdown for an ingredient: the base unit is value "", each portion of
+// the ingredient food is a bare named unit (the count lives in the qty input).
+function UnitPicker({
+  selectedId,
+  portions,
+  baseUnitLabel,
+  onPick,
+}: {
+  selectedId: string | undefined
+  portions: FoodItemPortion[]
+  baseUnitLabel: string
+  onPick: (portionId: string) => void
+}) {
+  return (
+    <select
+      class="ingredient-portion-picker"
+      value={selectedId ?? ''}
+      onChange={(e) => onPick((e.target as HTMLSelectElement).value)}
+    >
+      <option value="">{baseUnitLabel}</option>
+      {portions.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.label_unit}
+        </option>
+      ))}
+    </select>
+  )
+}
+
 /**
- * One ingredient row with local qty/unit state that commits to the parent
- * on blur. Without this, every keystroke would fire a PUT — wasteful and,
- * with non-atomic writes, race-prone.
+ * One ingredient row with local qty state that commits to the parent on blur.
+ * Without this, every keystroke would fire a PUT — wasteful and, with
+ * non-atomic writes, race-prone. The unit picker commits immediately on change.
  */
 function IngredientRowEditor({
   ingredient,
@@ -44,35 +83,62 @@ function IngredientRowEditor({
   onCommit: (patch: Partial<IngredientRow>) => void
   onRemove: () => void
 }) {
-  const [qtyInput, setQtyInput] = useState<string>(String(ingredient.quantity))
-  const [unitInput, setUnitInput] = useState<string>(ingredient.unit ?? '')
+  const isPortion = !!ingredient.food_item_portion_id
+  const effectiveQty = isPortion ? ingredient.portion_count : ingredient.quantity
+  const [qtyInput, setQtyInput] = useState<string>(effectiveQty === undefined ? '' : String(effectiveQty))
 
-  // Re-sync local state if the server-side row changes (e.g. revert/refresh).
+  // Re-sync local state when the row's effective quantity changes (e.g. unit
+  // switch carries the number, or a server refresh/revert).
   useEffect(() => {
-    setQtyInput(String(ingredient.quantity))
-  }, [ingredient.quantity])
-  useEffect(() => {
-    setUnitInput(ingredient.unit ?? '')
-  }, [ingredient.unit])
+    setQtyInput(effectiveQty === undefined ? '' : String(effectiveQty))
+  }, [effectiveQty])
+
+  // Fetch the ingredient food's detail for its available portions + base unit.
+  // Cached by react-query keyed on the id, so re-renders don't re-fetch.
+  const { data: detail } = useQuery({
+    enabled: !!ingredient.ingredient_food_item_id,
+    queryFn: () => fetchFoodItemDetailApi(ingredient.ingredient_food_item_id),
+    queryKey: ['foodItem', ingredient.ingredient_food_item_id],
+  })
+  const portions = detail?.portions ?? []
+  const baseUnitLabel = detail?.default_unit || 'unit'
 
   const commitQty = () => {
     const trimmed = qtyInput.trim()
     if (trimmed === '') {
       // Empty input → revert; clearing the field shouldn't silently set to 0.
-      setQtyInput(String(ingredient.quantity))
+      setQtyInput(effectiveQty === undefined ? '' : String(effectiveQty))
       return
     }
     const parsed = parseFloat(trimmed)
     if (Number.isNaN(parsed)) {
-      setQtyInput(String(ingredient.quantity))
+      setQtyInput(effectiveQty === undefined ? '' : String(effectiveQty))
       return
     }
-    if (parsed !== ingredient.quantity) onCommit({ quantity: parsed })
+    if (parsed === effectiveQty) return
+    onCommit(isPortion ? { portion_count: parsed } : { quantity: parsed })
   }
 
-  const commitUnit = () => {
-    const next = unitInput.trim() || undefined
-    if (next !== ingredient.unit) onCommit({ unit: next })
+  // Switching unit carries the number the user already typed: base→portion
+  // carries `quantity`, portion→portion carries `portion_count`.
+  const handlePortionPick = (portionId: string) => {
+    const carried = ingredient.portion_count ?? ingredient.quantity
+    if (!portionId) {
+      onCommit({
+        food_item_portion_id: undefined,
+        portion_count: undefined,
+        quantity: carried ?? detail?.default_quantity ?? 1,
+        unit: detail?.default_unit ?? ingredient.unit,
+      })
+      return
+    }
+    const p = portions.find((pp) => pp.id === portionId)
+    if (!p) return
+    onCommit({
+      food_item_portion_id: p.id,
+      portion_count: carried ?? 1,
+      unit: p.label_unit,
+    })
   }
 
   return (
@@ -89,13 +155,11 @@ function IngredientRowEditor({
         onInput={(e) => setQtyInput((e.target as HTMLInputElement).value)}
         onBlur={commitQty}
       />
-      <input
-        type="text"
-        value={unitInput}
-        placeholder="unit"
-        class="ingredient-unit"
-        onInput={(e) => setUnitInput((e.target as HTMLInputElement).value)}
-        onBlur={commitUnit}
+      <UnitPicker
+        selectedId={ingredient.food_item_portion_id}
+        portions={portions}
+        baseUnitLabel={baseUnitLabel}
+        onPick={handlePortionPick}
       />
       <button type="button" class="btn-danger-small" onClick={onRemove} title="Remove ingredient">
         &times;

--- a/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
+++ b/apps/web/src/pages/FoodItems/FoodItemDetail.tsx
@@ -924,22 +924,34 @@ function CompositeOrAtomicSection({
 
   if (isComposite) {
     const initial: IngredientRow[] = (item.ingredients ?? []).map((ing) => ({
+      food_item_portion_id: ing.food_item_portion_id,
       icon: ing.icon,
       ingredient_food_item_id: ing.ingredient_food_item_id,
       name: ing.name,
-      quantity: ing.quantity,
+      portion_count: ing.portion_count,
+      quantity: ing.quantity ?? 0,
       sort_order: ing.sort_order ?? 0,
       unit: ing.unit,
     }))
 
     const persist = (rows: IngredientRow[]) => {
       ingredientsMutation.mutate(
-        rows.map((r) => ({
-          ingredient_food_item_id: r.ingredient_food_item_id,
-          quantity: r.quantity,
-          sort_order: r.sort_order,
-          unit: r.unit,
-        })),
+        rows.map((r) =>
+          // Portion path: send the portion + count. Legacy path: quantity + unit.
+          r.food_item_portion_id && typeof r.portion_count === 'number'
+            ? {
+                food_item_portion_id: r.food_item_portion_id,
+                ingredient_food_item_id: r.ingredient_food_item_id,
+                portion_count: r.portion_count,
+                sort_order: r.sort_order,
+              }
+            : {
+                ingredient_food_item_id: r.ingredient_food_item_id,
+                quantity: r.quantity,
+                sort_order: r.sort_order,
+                unit: r.unit,
+              },
+        ),
       )
     }
 

--- a/docs/features/meals.md
+++ b/docs/features/meals.md
@@ -59,7 +59,7 @@ Meals reference a **canonical food item** by `food_item_id` rather than embeddin
 A food item may be:
 
 - **Atomic** -- its own nutrient columns are authoritative.
-- **Composite (recipe)** -- nutrients are derived at read time by summing its ingredients (`food_item_ingredients`), each scaled by `quantity / default_quantity`.
+- **Composite (recipe)** -- nutrients are derived at read time by summing its ingredients (`food_item_ingredients`), each scaled by `quantity / default_quantity`. Like meal items, an ingredient can be measured in a **portion** of the ingredient food instead of a free-form quantity/unit: set `food_item_portion_id` (a portion of that food) + `portion_count` and it scales by `portion_count × portion.base_equivalent / default_quantity` -- e.g. "2 brödkaka". The portion must belong to the ingredient food; the request stores `portion_count` + the portion's `label_unit` in the legacy `quantity`/`unit` columns for display fallback.
 - **Reference-enriched** -- an atomic item with `reference_food_item_id` pointing at a richer canonical item (e.g. a Livsmedelsverket row) to inherit empty micronutrient fields, scaled by serving.
 
 Food items live in the per-user `food_items` table or the central, read-only `shared_food_items` library (see [Livsmedelsverket docs](../livsmedelsverket.md)). `food_item_id` is a soft pointer across both stores.
@@ -195,7 +195,7 @@ Food items & portions:
 - `add_food_item_portion` / `update_food_item_portion` / `delete_food_item_portion` -- portion CRUD (per-user OR central food, soft pointer)
 - `set_default_food_item_portion` -- set/clear a per-user food's default logging amount (`portion_id` + `quantity`; `portion_id: null` = base unit, `quantity: null` = base quantity)
 - `set_shared_food_item_override` / `clear_shared_food_item_override` -- per-user overrides on a central item (`icon`, `default_portion_id`, `default_log_quantity`)
-- `set_food_item_ingredients` / `clear_food_item_ingredients` -- composite recipes; `set_food_item_reference` -- reference enrichment; `resnapshot_meals_for_food_item` -- refresh historical meal snapshots; `merge_food_items` / `preview_food_item_merge`
+- `set_food_item_ingredients` / `clear_food_item_ingredients` -- composite recipes (ingredients accept `quantity`+`unit` **or** `food_item_portion_id`+`portion_count`, like meal items); `set_food_item_reference` -- reference enrichment; `resnapshot_meals_for_food_item` -- refresh historical meal snapshots; `merge_food_items` / `preview_food_item_merge`
 
 Nutrient recommendations:
 

--- a/packages/api-spec/src/schemas/food-items.ts
+++ b/packages/api-spec/src/schemas/food-items.ts
@@ -72,23 +72,48 @@ export type FoodItemEntity = z.infer<typeof foodItemEntitySchema>
 
 /**
  * One ingredient line in a composite food item — points at another food
- * (per-user or central), with quantity + unit. The pointed-at food's
- * nutrients are scaled by quantity/default_quantity at read time to
- * contribute to the parent's totals.
+ * (per-user or central). The pointed-at food's nutrients are scaled by
+ * quantity/default_quantity (legacy) or, when a `food_item_portion_id` is set,
+ * by portion_count × portion.base_equivalent / default_quantity, to contribute
+ * to the parent's totals.
+ *
+ * Base fields are kept as a bare object so both `.refine()` (for the request
+ * schema's cross-field rules) and `.extend()` (for the resolved response
+ * schema with name/icon) are available.
  */
+const foodItemIngredientFields = {
+  ingredient_food_item_id: z
+    .string()
+    .uuid()
+    .meta({ description: 'ID of the food item used as an ingredient (per-user OR central library)' }),
+  quantity: z.number().optional().meta({
+    description:
+      'Amount used, in `unit` — legacy path. Ignored when `food_item_portion_id` is set (the backend stores `portion_count` here for display). Either `quantity` or (`food_item_portion_id` + `portion_count`) must be provided.',
+  }),
+  unit: z.string().max(100).optional().meta({ description: 'Unit for quantity (legacy free-form path)' }),
+  food_item_portion_id: z.string().uuid().optional().meta({
+    description:
+      'Optional portion id (a food_item_portions row belonging to the ingredient food). When set, the ingredient\'s contribution is scaled by `portion_count × portion.base_equivalent / ingredient.default_quantity`, mirroring meals. Lets a recipe say e.g. "2 brödkaka".',
+  }),
+  portion_count: z.number().positive().optional().meta({
+    description: 'Required when `food_item_portion_id` is set: how many of that portion the recipe uses.',
+  }),
+  sort_order: z
+    .number()
+    .int()
+    .optional()
+    .meta({ description: 'Display order; defaults to position in the input array' }),
+}
+
 export const foodItemIngredientSchema = z
-  .object({
-    ingredient_food_item_id: z
-      .string()
-      .uuid()
-      .meta({ description: 'ID of the food item used as an ingredient (per-user OR central library)' }),
-    quantity: z.number().meta({ description: 'Amount used, in `unit`' }),
-    unit: z.string().max(100).optional().meta({ description: 'Unit for quantity' }),
-    sort_order: z
-      .number()
-      .int()
-      .optional()
-      .meta({ description: 'Display order; defaults to position in the input array' }),
+  .object(foodItemIngredientFields)
+  .refine((body) => body.food_item_portion_id === undefined || typeof body.portion_count === 'number', {
+    message: 'portion_count is required when food_item_portion_id is set',
+    path: ['portion_count'],
+  })
+  .refine((body) => body.food_item_portion_id !== undefined || typeof body.quantity === 'number', {
+    message: 'quantity is required when no food_item_portion_id is set',
+    path: ['quantity'],
   })
   .meta({ description: 'One ingredient of a composite food item', id: 'FoodItemIngredient' })
 
@@ -112,8 +137,9 @@ export type SetFoodItemIngredientsBody = z.infer<typeof setFoodItemIngredientsBo
  * junction row plus a snapshot of the ingredient food item's name/icon
  * for display.
  */
-export const resolvedFoodItemIngredientSchema = foodItemIngredientSchema
-  .extend({
+export const resolvedFoodItemIngredientSchema = z
+  .object({
+    ...foodItemIngredientFields,
     name: z.string().nullable().meta({
       description: 'Ingredient food name (null if the pointed-at item was deleted)',
     }),


### PR DESCRIPTION
## What

Recipe **ingredients** could only use a free-text unit — you couldn't pick a defined portion the way meal items can. So in a copied recipe you couldn't say "2 brödkaka". This adds portion/unit selection to recipe ingredients, mirroring how meals already work.

## How

An ingredient can now carry `food_item_portion_id` + `portion_count` (a portion of the *ingredient* food). When set, its nutrient contribution scales by:

```
portion_count × portion.base_equivalent / ingredient.default_quantity
```

— the same formula meal items use. The legacy `quantity` + `unit` path still works; for the portion path both columns are filled from the portion (`portion_count` + `label_unit`) as a display fallback, while scaling re-derives live from the portion id. The portion must belong to the ingredient food — validated in a shared `prepareIngredientInputs` used by **both** the REST route and the MCP tool.

## Changes

- **DB**: nullable `food_item_portion_id` + `portion_count` on `food_item_ingredients` (table def + idempotent `ALTER … ADD COLUMN IF NOT EXISTS` migration), round-tripped through `set`/`getIngredients`.
- **api-spec**: `foodItemIngredientSchema` gains the portion fields + two refines (portion_count required with a portion id; quantity required without one). Resolved schema returns them.
- **service**: `computeIngredientScale` / `aggregateNutrientsFromIngredients` use the resolved portion; `getDetail` resolves each ingredient's portion; `duplicateFoodItem` carries the portion fields.
- **web**: the ingredient editor swaps the free-text unit input for a portion **picker** (base unit + the ingredient food's portions) and carries the typed number across unit switches — reusing the meal `UnitPicker`/`QuantityInput` pattern.
- **docs**: `meals.md` composite + MCP sections.

## Tests

- Integration (testcontainers): DB round-trip of portion columns, portion scaling end-to-end (`2 brödkaka` → 140 kcal), legacy still scales, portion-ownership rejection, cached row columns.
- Unit: `aggregateNutrientsFromIngredients` portion scaling + deleted-portion incomplete flag; route tests for portion validation (400 not-belonging / 200 persists with filled display columns).
- `pnpm check` green (0 errors).

## Note

`food_item_portion_id` is a soft pointer (no FK), consistent with `meal_food_items` and `food_item_portions` — portions can target per-user or central foods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)