### PR TITLE
fix(locations): stop a stale GPS fix from swallowing travel + destination (#811)

### DIFF
--- a/apps/backend/src/services/locations-place-visits.integration.test.ts
+++ b/apps/backend/src/services/locations-place-visits.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Integration test for getPlaceVisits — issue #811.
+ *
+ * A stale GPS fix on the way to an un-named destination used to be merged with
+ * every later "unknown" fix (by the shared "Somewhere" name), producing one
+ * long stay anchored at the first (travel) fix that swallowed the drive and the
+ * real destination. getPlaceVisits must instead break unknown visits on
+ * movement / long gaps, so the destination surfaces as its own stay at its own
+ * coordinates (promotable to a named place).
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { Location } from '../db/types.ts'
+
+import { insertLocations, insertNamedLocation } from '../db/locations.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { getPlaceVisits } from './locations.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+const HOME = { lat: 57.66, lon: 12.6 } // "Hökås", named
+const HOSPITAL = { lat: 57.72, lon: 12.92 } // un-named destination, ~25 km east
+
+const at = (hour: number, minute: number, lat: number, lon: number): Location => ({
+  lat,
+  lon,
+  regions: [],
+  source: 'owntracks',
+  time: new Date(Date.UTC(2026, 5, 14, hour, minute, 0)),
+})
+
+const haversine = (a: { lat: number; lon: number }, b: { lat: number; lon: number }): number => {
+  const R = 6371000
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180
+  const dLon = ((b.lon - a.lon) * Math.PI) / 180
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLon / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h))
+}
+
+describe('getPlaceVisits — unknown stay segmentation (issue #811)', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('a stale travel fix does not swallow the drive + real destination', async () => {
+    const user = getTestUser()
+    await insertNamedLocation(user, { lat: HOME.lat, lon: HOME.lon, name: 'Hökås', radius: 200 })
+
+    await insertLocations(user, [
+      // Morning at home.
+      at(8, 0, HOME.lat, HOME.lon),
+      at(9, 0, HOME.lat + 0.0002, HOME.lon),
+      at(10, 0, HOME.lat, HOME.lon + 0.0002),
+      at(11, 12, HOME.lat, HOME.lon),
+      // Stale travel waypoint, then the drive east — each fix far from the last.
+      at(14, 50, 57.665, 12.64),
+      at(15, 0, 57.68, 12.72),
+      at(15, 15, 57.7, 12.82),
+      // ~7h dwell at the hospital — clustered, fixes < the 90-min gap cap apart.
+      at(15, 30, HOSPITAL.lat, HOSPITAL.lon),
+      at(16, 30, HOSPITAL.lat + 0.0003, HOSPITAL.lon - 0.0002),
+      at(17, 30, HOSPITAL.lat - 0.0002, HOSPITAL.lon + 0.0003),
+      at(18, 45, HOSPITAL.lat + 0.0001, HOSPITAL.lon),
+      at(20, 0, HOSPITAL.lat, HOSPITAL.lon + 0.0001),
+      at(21, 15, HOSPITAL.lat - 0.0001, HOSPITAL.lon),
+      at(22, 30, HOSPITAL.lat + 0.0002, HOSPITAL.lon - 0.0001),
+      // Drive back, then home in the evening.
+      at(22, 45, 57.7, 12.82),
+      at(23, 0, 57.68, 12.72),
+      at(23, 46, HOME.lat, HOME.lon),
+      at(23, 55, HOME.lat + 0.0001, HOME.lon),
+    ])
+
+    const visits = await getPlaceVisits(
+      user,
+      new Date(Date.UTC(2026, 5, 14, 0, 0, 0)),
+      new Date(Date.UTC(2026, 5, 14, 23, 59, 59)),
+    )
+
+    const unknown = visits.filter((v) => v.source === 'unknown')
+    // Exactly one substantial unknown stay — the hospital, not the waypoint.
+    expect(unknown).toHaveLength(1)
+    const hospital = unknown[0]
+    expect(haversine(hospital, HOSPITAL)).toBeLessThan(200)
+    // It is the destination cluster, not the stale 14:50 waypoint.
+    expect(hospital.start_time.getTime()).toBeGreaterThanOrEqual(Date.UTC(2026, 5, 14, 15, 0, 0))
+    // ~7h dwell, NOT the full 14:50 → 22:54 block.
+    expect(hospital.duration_minutes).toBeGreaterThan(360)
+    expect(hospital.duration_minutes).toBeLessThan(440)
+
+    // No unknown stay sits at the travel waypoint longitude (~12.64).
+    expect(unknown.some((v) => Math.abs(v.lon - 12.64) < 0.01)).toBe(false)
+
+    // The morning home stay is not stretched across the drive — it ends ~11:12.
+    const morningHome = visits.find((v) => v.name === 'Hökås')
+    expect(morningHome).toBeDefined()
+    expect(morningHome!.end_time.getTime()).toBeLessThanOrEqual(Date.UTC(2026, 5, 14, 11, 30, 0))
+  })
+})

--- a/apps/backend/src/services/locations.test.ts
+++ b/apps/backend/src/services/locations.test.ts
@@ -284,4 +284,59 @@ describe('mergeShortUnknownVisits', () => {
     expect(result[0].name).toBe('Home')
     expect(result[0].duration_minutes).toBe(68) // extended
   })
+
+  // Space/time gating (issue #811): a short unknown must be genuinely
+  // contiguous with a neighbour to be absorbed, otherwise it is dropped —
+  // so travel fragments can't keep extending a real stay.
+  const makeVisitAt = (
+    name: string,
+    source: PlaceVisit['source'],
+    startMinutes: number,
+    durationMinutes: number,
+    lat: number,
+    lon: number,
+  ): PlaceVisit => {
+    const startTime = new Date(Date.UTC(2024, 0, 15, 10, startMinutes, 0))
+    return {
+      duration_minutes: durationMinutes,
+      end_time: new Date(startTime.getTime() + durationMinutes * 60 * 1000),
+      lat,
+      lon,
+      name,
+      source,
+      start_time: startTime,
+    }
+  }
+
+  test('drops a short unknown that is spatially far from both neighbours (travel)', () => {
+    // ~30 km east of the stays — a travel fix, not a glitch at the stay.
+    const visits = [
+      makeVisitAt('Home', 'named', 0, 60, 57.66, 12.6),
+      makeVisitAt('Somewhere', 'unknown', 60, 2, 57.72, 12.92),
+      makeVisitAt('Home', 'named', 62, 60, 57.66, 12.6),
+    ]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    // The travel fragment is dropped; neither Home is stretched over it.
+    expect(result).toHaveLength(2)
+    expect(result[0].duration_minutes).toBe(60)
+    expect(result[1].duration_minutes).toBe(60)
+  })
+
+  test('does not bridge a stay across a long time gap', () => {
+    // Same coordinate, but the unknown blip is ~3h after the stay ended.
+    const visits = [
+      makeVisitAt('Home', 'named', 0, 60, 57.66, 12.6),
+      makeVisitAt('Somewhere', 'unknown', 240, 2, 57.66, 12.6),
+      makeVisitAt('Office', 'named', 300, 60, 59.33, 18.07),
+    ]
+
+    const result = mergeShortUnknownVisits(visits)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Home')
+    expect(result[0].duration_minutes).toBe(60) // NOT stretched to 242
+    expect(result[1].name).toBe('Office')
+  })
 })

--- a/apps/backend/src/services/locations.ts
+++ b/apps/backend/src/services/locations.ts
@@ -54,6 +54,22 @@ export interface Stay {
 const DEFAULT_CLUSTER_RADIUS_METERS = 200
 const DEFAULT_MIN_STAY_MINUTES = 60
 
+// Unknown ("Somewhere") visits have no named/detected place identity to bound
+// them, so merging consecutive unknown fixes by name alone lets a single stale
+// GPS fix be stretched into one long stay that swallows travel *and* the real
+// destination (issue #811). Break such a visit when a fix moves beyond this
+// radius from the visit's running centroid (real movement), or after a gap with
+// no fixes longer than the cap below (no evidence of continuous presence).
+const UNKNOWN_VISIT_BREAK_RADIUS_METERS = DEFAULT_CLUSTER_RADIUS_METERS
+const MAX_UNKNOWN_VISIT_GAP_MINUTES = 90
+
+// When collapsing short unknown visits, only absorb one into an adjacent visit
+// if it is genuinely contiguous — close in both space and time. This keeps a
+// brief GPS glitch stitched into the stay it interrupted while refusing to
+// bridge a stay across travel or a long data gap.
+const MERGE_BRIDGE_RADIUS_METERS = DEFAULT_CLUSTER_RADIUS_METERS
+const MERGE_BRIDGE_GAP_MINUTES = 30
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -388,6 +404,107 @@ export const getRawLocationPoints = async (
   }))
 }
 
+interface FixClassification {
+  placeName: string
+  source: 'named' | 'detected' | 'owntracks' | 'unknown'
+  address?: string
+  detectedLocationId?: string
+  namedLocationId?: string
+}
+
+/**
+ * Classify a single fix to a place: a named location wins, then a detected
+ * location, then an OwnTracks region, else "Somewhere" (unknown).
+ */
+const classifyFix = (
+  lat: number,
+  lon: number,
+  regions: string[],
+  namedLocations: NamedLocation[],
+  detectedLocations: StoredDetectedLocation[],
+): FixClassification => {
+  const namedMatch = matchLocationToNamed(lat, lon, namedLocations)
+  if (namedMatch) return { namedLocationId: namedMatch.id, placeName: namedMatch.name, source: 'named' }
+
+  const detectedMatch = matchLocationToDetected(lat, lon, detectedLocations)
+  if (detectedMatch) {
+    return {
+      address: detectedMatch.address || undefined,
+      detectedLocationId: detectedMatch.id,
+      placeName: detectedMatch.address || 'Detected location',
+      source: 'detected',
+    }
+  }
+
+  if (regions.length > 0) return { placeName: regions[0], source: 'owntracks' }
+  return { placeName: 'Somewhere', source: 'unknown' }
+}
+
+/**
+ * Mutable accumulator for a visit being built. `point_count` tracks how many
+ * fixes have been folded into the running centroid of an unknown visit (lat/lon
+ * hold that centroid); `duration_minutes` is computed when the visit is
+ * finalized.
+ */
+interface VisitAccumulator {
+  name: string
+  lat: number
+  lon: number
+  start_time: Date
+  end_time: Date
+  source: 'named' | 'detected' | 'owntracks' | 'unknown'
+  address?: string
+  detected_location_id?: string
+  named_location_id?: string
+  point_count: number
+}
+
+/**
+ * Decide whether `loc` continues `current`. Beyond matching the place identity,
+ * an unknown ("Somewhere") visit also breaks on real movement away from its
+ * running centroid or after a long data gap — otherwise a single stale fix
+ * would swallow travel and the real destination (issue #811).
+ */
+const continuesVisit = (current: VisitAccumulator, cls: FixClassification, loc: LocationPoint): boolean => {
+  if (
+    current.named_location_id !== cls.namedLocationId ||
+    current.name !== cls.placeName ||
+    current.detected_location_id !== cls.detectedLocationId
+  ) {
+    return false
+  }
+  if (cls.source !== 'unknown') return true
+  const movedAway =
+    haversineDistance(current.lat, current.lon, loc.lat, loc.lon) > UNKNOWN_VISIT_BREAK_RADIUS_METERS
+  const gapMinutes = (loc.time.getTime() - current.end_time.getTime()) / (1000 * 60)
+  return !movedAway && gapMinutes <= MAX_UNKNOWN_VISIT_GAP_MINUTES
+}
+
+/** Extend `current` to include `loc`, folding unknown fixes into a running centroid. */
+const extendVisit = (current: VisitAccumulator, loc: LocationPoint): void => {
+  current.end_time = loc.time
+  if (current.source === 'unknown') {
+    const n = current.point_count
+    current.lat = (current.lat * n + loc.lat) / (n + 1)
+    current.lon = (current.lon * n + loc.lon) / (n + 1)
+    current.point_count = n + 1
+  }
+}
+
+/** Convert a visit accumulator into a PlaceVisit (computes duration, drops bookkeeping). */
+const finalizeVisit = (v: VisitAccumulator): PlaceVisit => ({
+  address: v.address,
+  detected_location_id: v.detected_location_id,
+  duration_minutes: Math.round((v.end_time.getTime() - v.start_time.getTime()) / (1000 * 60)),
+  end_time: v.end_time,
+  lat: v.lat,
+  lon: v.lon,
+  name: v.name,
+  named_location_id: v.named_location_id,
+  source: v.source,
+  start_time: v.start_time,
+})
+
 /**
  * Get place visits for a time range, using named locations when available.
  * Falls back to detected locations, then OwnTracks regions.
@@ -421,96 +538,38 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
     time: new Date(row.time),
   }))
 
-  // Group consecutive locations at the same place
+  // Group consecutive locations at the same place. named_location_id is part
+  // of the identity key (see continuesVisit) so two named locations with the
+  // same display name correctly split into separate visits.
   const visits: PlaceVisit[] = []
-  let currentVisit: {
-    name: string
-    lat: number
-    lon: number
-    start_time: Date
-    end_time: Date
-    source: 'named' | 'detected' | 'owntracks' | 'unknown'
-    address?: string
-    detected_location_id?: string
-    named_location_id?: string
-  } | null = null
+  let currentVisit: VisitAccumulator | null = null
 
   for (const loc of locations) {
-    // Try to match against named locations first
-    const namedMatch = matchLocationToNamed(loc.lat, loc.lon, namedLocations)
+    const cls = classifyFix(loc.lat, loc.lon, loc.regions, namedLocations, detectedLocations)
 
-    let placeName: string
-    let source: 'named' | 'detected' | 'owntracks' | 'unknown'
-    let address: string | undefined
-    let detectedLocationId: string | undefined
-    let namedLocationId: string | undefined
-
-    if (namedMatch) {
-      placeName = namedMatch.name
-      source = 'named'
-      namedLocationId = namedMatch.id
-    } else {
-      // Try to match against detected locations
-      const detectedMatch = matchLocationToDetected(loc.lat, loc.lon, detectedLocations)
-      if (detectedMatch) {
-        placeName = detectedMatch.address || 'Detected location'
-        source = 'detected'
-        address = detectedMatch.address || undefined
-        detectedLocationId = detectedMatch.id
-      } else if (loc.regions.length > 0) {
-        placeName = loc.regions[0]
-        source = 'owntracks'
-      } else {
-        placeName = 'Somewhere'
-        source = 'unknown'
-      }
+    if (currentVisit && continuesVisit(currentVisit, cls, loc)) {
+      extendVisit(currentVisit, loc)
+      continue
     }
 
-    // Check if this is a continuation of the same visit.
-    // named_location_id is part of the key so two named locations with the
-    // same name (e.g. different "Home" entries) correctly split into
-    // separate visits rather than being merged by display name alone.
-    const samePlace =
-      currentVisit &&
-      currentVisit.named_location_id === namedLocationId &&
-      currentVisit.name === placeName &&
-      currentVisit.detected_location_id === detectedLocationId
-
-    if (samePlace) {
-      // Extend current visit
-      currentVisit!.end_time = loc.time
-    } else {
-      // Finalize previous visit if exists
-      if (currentVisit) {
-        const duration = (currentVisit.end_time.getTime() - currentVisit.start_time.getTime()) / (1000 * 60)
-        visits.push({
-          ...currentVisit,
-          duration_minutes: Math.round(duration),
-        })
-      }
-
-      // Start new visit
-      currentVisit = {
-        address,
-        detected_location_id: detectedLocationId,
-        end_time: loc.time,
-        lat: loc.lat,
-        lon: loc.lon,
-        name: placeName,
-        named_location_id: namedLocationId,
-        source,
-        start_time: loc.time,
-      }
+    if (currentVisit) visits.push(finalizeVisit(currentVisit))
+    currentVisit = {
+      address: cls.address,
+      detected_location_id: cls.detectedLocationId,
+      end_time: loc.time,
+      lat: loc.lat,
+      lon: loc.lon,
+      name: cls.placeName,
+      named_location_id: cls.namedLocationId,
+      point_count: 1,
+      source: cls.source,
+      start_time: loc.time,
     }
   }
 
   // Don't forget the last visit
   if (currentVisit) {
-    const duration = (currentVisit.end_time.getTime() - currentVisit.start_time.getTime()) / (1000 * 60)
-    visits.push({
-      ...currentVisit,
-      duration_minutes: Math.round(duration),
-    })
+    visits.push(finalizeVisit(currentVisit))
   }
 
   // Filter out short "unknown" visits (GPS jumps) and merge into adjacent visits
@@ -518,40 +577,53 @@ export const getPlaceVisits = async (user: string, start: Date, end: Date): Prom
 }
 
 /**
- * Merge short "unknown" (Somewhere) visits into adjacent visits.
- * Short visits (<5 min) at unknown locations are typically GPS jumps.
- * They are removed and the previous/next visit is extended to cover the gap.
+ * Collapse short "unknown" (Somewhere) visits — typically brief GPS glitches.
+ *
+ * A short unknown visit is absorbed into an adjacent visit only when it is
+ * genuinely *contiguous* with it: close in both space (within
+ * `MERGE_BRIDGE_RADIUS_METERS`) and time (gap ≤ `MERGE_BRIDGE_GAP_MINUTES`).
+ * That stitches a momentary glitch back into the stay it interrupted, but it
+ * refuses to bridge a stay across travel or a long data gap — without this, a
+ * chain of brief travel fixes would keep extending a neighbouring stay and
+ * re-create the issue #811 swallowing. A short unknown that fits neither
+ * neighbour is dropped (it was movement, not a stay).
  */
 export const mergeShortUnknownVisits = (visits: PlaceVisit[], minDurationMinutes = 5): PlaceVisit[] => {
   if (visits.length === 0) return visits
 
   const result: PlaceVisit[] = []
 
+  const contiguous = (a: PlaceVisit, b: PlaceVisit): boolean => {
+    // `a` precedes `b` in time; measure the gap between them and the distance.
+    const gapMinutes = (b.start_time.getTime() - a.end_time.getTime()) / (1000 * 60)
+    return (
+      gapMinutes <= MERGE_BRIDGE_GAP_MINUTES &&
+      haversineDistance(a.lat, a.lon, b.lat, b.lon) <= MERGE_BRIDGE_RADIUS_METERS
+    )
+  }
+
   for (let i = 0; i < visits.length; i++) {
     const visit = visits[i]
 
-    // Keep non-unknown visits and unknown visits >= minDuration
+    // Keep non-unknown visits and unknown visits >= minDuration.
     if (visit.source !== 'unknown' || visit.duration_minutes >= minDurationMinutes) {
       result.push(visit)
-    } else {
-      // Short unknown visit - merge into adjacent visits
-      if (result.length > 0) {
-        // Extend previous visit to cover this gap
-        const prev = result[result.length - 1]
-        prev.end_time = visit.end_time
-        prev.duration_minutes = Math.round(
-          (prev.end_time.getTime() - prev.start_time.getTime()) / (1000 * 60),
-        )
-      } else if (i + 1 < visits.length) {
-        // No previous visit, extend next visit backwards
-        const next = visits[i + 1]
-        next.start_time = visit.start_time
-        next.duration_minutes = Math.round(
-          (next.end_time.getTime() - next.start_time.getTime()) / (1000 * 60),
-        )
-      }
-      // If it's the only visit and it's short unknown, we drop it entirely
+      continue
     }
+
+    const prev = result.length > 0 ? result[result.length - 1] : null
+    const next = i + 1 < visits.length ? visits[i + 1] : null
+
+    if (prev && contiguous(prev, visit)) {
+      // Extend the previous visit to cover this brief glitch.
+      prev.end_time = visit.end_time
+      prev.duration_minutes = Math.round((prev.end_time.getTime() - prev.start_time.getTime()) / (1000 * 60))
+    } else if (next && contiguous(visit, next)) {
+      // No usable previous visit — fold backwards into the next one.
+      next.start_time = visit.start_time
+      next.duration_minutes = Math.round((next.end_time.getTime() - next.start_time.getTime()) / (1000 * 60))
+    }
+    // Otherwise drop it: a transient fix not contiguous with either neighbour.
   }
 
   return result


### PR DESCRIPTION
Fixes #811.

## The bug

An unknown (`"Somewhere"`) place visit was built by merging *every* consecutive unmatched fix purely by name, anchored at the first fix and reported at its coordinates. So a single stale GPS breadcrumb on the way to an un-named destination collapsed the entire intervening block — **travel time and the real destination** — into one long stay sitting at the **wrong (travel-waypoint) coordinates**. That's why the ER trip showed one `Somewhere` 14:50→22:54 at a point near Lönnåsen instead of the hospital, and why the hospital couldn't be attached.

## The fix (`apps/backend/src/services/locations.ts`)

**`getPlaceVisits`** — an unknown visit now breaks when a fix:
- moves **beyond the cluster radius (200 m) from the visit's running centroid** (real movement), or
- arrives after a **> 90-min gap with no fixes** (no evidence of continuous presence).

It also reports the unknown visit at its **running centroid**, not the first (possibly stale) fix. So the dwell at the destination surfaces as **its own stay at its own coordinates** — promotable/renameable.

**`mergeShortUnknownVisits`** — a short unknown blip is absorbed into a neighbour only when **genuinely contiguous** (close in *both* space and time). A brief GPS glitch still stitches back into the stay it interrupted, but a chain of travel fragments can no longer keep extending a neighbouring stay (which would otherwise re-create the swallowing).

Also refactored the visit loop into small helpers (`classifyFix` / `continuesVisit` / `extendVisit` / `finalizeVisit`).

## Behaviour after the fix (the reported day)

- Morning `Hökås` ends ~11:12 (no longer stretched across the drive).
- The hospital dwell is its own `Somewhere` stay at the hospital coordinates (~7 h) — attachable as a named place.
- The travel waypoint and drive fixes no longer form a stay.

## Tests

- Unit: new space/time gating in `mergeShortUnknownVisits` (drops a far travel fragment; refuses to bridge a long time gap) — existing glitch-merge tests still pass.
- Integration: `getPlaceVisits` reproduction of the #811 ER-trip scenario (stale waypoint → ~7 h hospital dwell → home), asserting the hospital is its own stay at its coordinates, sized to the dwell (not the full block), and the morning home stay isn't extended.
- `pnpm check` green (0 errors).

## Note / possible follow-up

This fixes the user-facing `places`/visit segmentation (the reported symptom). The lower-level `detectStays` clustering already breaks on distance but does not break on long *time* gaps; hardening that (so a multi-hour no-data gap doesn't inflate a detected-location's stay duration) could be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)