### PR TITLE
fix(sharing): blank board empty + dark-mode colors

### DIFF
--- a/apps/web/src/pages/PublicDashboard/style.css
+++ b/apps/web/src/pages/PublicDashboard/style.css
@@ -27,3 +27,14 @@
 .public-dashboard .quick-link-static {
   cursor: default;
 }
+
+@media (prefers-color-scheme: dark) {
+  .public-dashboard .public-muted,
+  .public-dashboard .public-loading {
+    color: #9ca3af;
+  }
+
+  .public-dashboard .public-attribution {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/pages/PublicProfile/style.css
+++ b/apps/web/src/pages/PublicProfile/style.css
@@ -39,3 +39,25 @@
   border-color: #8b5cf6;
   background: #faf5ff;
 }
+
+@media (prefers-color-scheme: dark) {
+  .public-profile h1 {
+    color: #f3f4f6;
+  }
+
+  .public-profile .public-muted,
+  .public-profile .public-loading {
+    color: #9ca3af;
+  }
+
+  .public-dashboard-list a {
+    border-color: #374151;
+    background: #1f2937;
+    color: #f3f4f6;
+  }
+
+  .public-dashboard-list a:hover {
+    border-color: #8b5cf6;
+    background: #1e1b4b;
+  }
+}

--- a/apps/web/src/pages/SharedDashboards/index.tsx
+++ b/apps/web/src/pages/SharedDashboards/index.tsx
@@ -6,9 +6,8 @@
  * Per-widget editing of a shared dashboard is a follow-up; today a share is
  * seeded from the home dashboard's current layout.
  */
-import type { SharedDashboard } from '@aurboda/api-spec'
+import type { DashboardConfig, SharedDashboard } from '@aurboda/api-spec'
 
-import { defaultDashboardConfig } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
@@ -110,7 +109,8 @@ export function SharedDashboards() {
 
   const createMutation = useMutation({
     mutationFn: async (seedFromHome: boolean) => {
-      const config = seedFromHome ? await fetchDashboard() : defaultDashboardConfig
+      const emptyConfig: DashboardConfig = { sections: [], version: 1 }
+      const config = seedFromHome ? await fetchDashboard() : emptyConfig
       return createSharedDashboard({ config, is_public: false, name: name.trim() || 'Shared dashboard' })
     },
     onError: () => alert('Failed to create the shared dashboard. Please try again.'),

--- a/apps/web/src/pages/SharedDashboards/style.css
+++ b/apps/web/src/pages/SharedDashboards/style.css
@@ -55,12 +55,14 @@
   font-size: 1rem;
   font-weight: 600;
   background: transparent;
+  color: #111827;
 }
 
 .shared-dashboard-name:hover,
 .shared-dashboard-name:focus {
   border-color: #d1d5db;
   background: #fff;
+  color: #111827;
 }
 
 .shared-dashboard-public {
@@ -88,4 +90,51 @@
 
 .shared-dashboard-actions .btn-danger:hover {
   background: #fee2e2;
+}
+
+@media (prefers-color-scheme: dark) {
+  .shared-dashboards h1 {
+    color: #f3f4f6;
+  }
+
+  .shared-dashboards-intro,
+  .shared-dashboards-empty {
+    color: #9ca3af;
+  }
+
+  .shared-dashboards-create input {
+    background: #111827;
+    border-color: #374151;
+    color: #f3f4f6;
+  }
+
+  .shared-dashboard-row {
+    border-color: #374151;
+    background: #1f2937;
+  }
+
+  .shared-dashboard-name {
+    color: #f3f4f6;
+  }
+
+  .shared-dashboard-name:hover,
+  .shared-dashboard-name:focus {
+    background: #111827;
+    border-color: #4b5563;
+    color: #f3f4f6;
+  }
+
+  .shared-dashboard-public {
+    color: #d1d5db;
+  }
+
+  .shared-dashboard-actions .btn-danger {
+    background: #3f1d1d;
+    border-color: #7f1d1d;
+    color: #fca5a5;
+  }
+
+  .shared-dashboard-actions .btn-danger:hover {
+    background: #4c1d1d;
+  }
 }


### PR DESCRIPTION
Polish fixes for the just-shipped shared-dashboards feature.

## 1. "Create blank" produced a populated board
`Create blank` seeded from `defaultDashboardConfig` (the populated default layout). Now it uses an empty config `{ version: 1, sections: [] }`. `Create from my dashboard` still copies the home layout.

## 2. Dark-mode colors broken on the new pages
The new pages hardcoded light colors and the board-name input had no explicit text color, so in dark mode the title was invisible (white-on-white focused, dark-on-dark blurred) and rows/links/inputs didn't adapt. Added `@media (prefers-color-scheme: dark)` blocks + explicit input colors for SharedDashboards, PublicProfile, and PublicDashboard. (PublicDashboard widget cards already inherit Dashboard's dark styles.)

## Testing
- `pnpm check` clean in `apps/web`.
- Manual (dark mode): board name readable focused + blurred on /shared-dashboards; /u/<user> profile + /u/<user>/<slug> render with correct contrast.

## Follow-up (separate PR)
Editing a shared board's widgets (and adding a chart to a shared board from the chart page) — see notes; a blank board is only useful once editing lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)