### PR TITLE
feat(sharing): edit shared boards in place + target them from charts

### DIFF
--- a/apps/web/src/components/EditableDashboard/index.tsx
+++ b/apps/web/src/components/EditableDashboard/index.tsx
@@ -1,0 +1,296 @@
+/**
+ * EditableDashboard - the section/widget grid with optional inline editing,
+ * shared by the home Dashboard and the owner's view of a shared dashboard.
+ *
+ * Controlled component: it renders `config` and calls `onChange(next)` for every
+ * edit (add/remove/move widget, add/delete section). The parent owns
+ * persistence (home dashboard vs. a shared dashboard) and the edit toggle.
+ */
+import type { DashboardConfig, DashboardSection, DashboardWidget, SectionType } from '@aurboda/api-spec'
+
+import { useState } from 'preact/hooks'
+
+import { DashboardEditor } from '../DashboardEditor'
+import { WidgetRenderer } from '../widgets'
+
+const generateSectionId = () => `section-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+
+function DashboardSectionComponent({
+  section,
+  isEditing,
+  onRemoveWidget,
+  onMoveWidget,
+  onAddWidgetClick,
+  onDeleteSection,
+}: {
+  section: DashboardSection
+  isEditing: boolean
+  onRemoveWidget?: (widgetId: string) => void
+  onMoveWidget?: (widgetId: string, direction: 'up' | 'down') => void
+  onAddWidgetClick?: () => void
+  onDeleteSection?: () => void
+}) {
+  const [collapsed, setCollapsed] = useState(section.collapsed ?? false)
+
+  const gridClass =
+    section.type === 'links' ? 'links-grid' : section.type === 'charts' ? 'charts-grid' : 'metrics-grid'
+
+  return (
+    <section class="metrics-section">
+      <div class="section-header">
+        <h2 onClick={() => setCollapsed(!collapsed)} style={{ cursor: 'pointer' }}>
+          {section.title}
+          {section.widgets.length > 0 && (
+            <span class="collapse-indicator">{collapsed ? '▶' : '▼'}</span>
+          )}
+        </h2>
+        {isEditing && (
+          <div class="section-edit-controls">
+            <button class="section-delete-btn" onClick={onDeleteSection} title="Delete section">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+      {!collapsed && (
+        <div class={gridClass}>
+          {section.widgets.map((widget, index) => (
+            <div key={widget.id} class={isEditing ? 'widget-editing-wrapper' : ''}>
+              {isEditing && (
+                <div class="widget-edit-controls">
+                  {index > 0 && (
+                    <button
+                      class="widget-move-btn"
+                      onClick={() => onMoveWidget?.(widget.id, 'up')}
+                      title="Move up"
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 19V5M5 12l7-7 7 7" />
+                      </svg>
+                    </button>
+                  )}
+                  {index < section.widgets.length - 1 && (
+                    <button
+                      class="widget-move-btn"
+                      onClick={() => onMoveWidget?.(widget.id, 'down')}
+                      title="Move down"
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 5v14M5 12l7 7 7-7" />
+                      </svg>
+                    </button>
+                  )}
+                  <button
+                    class="widget-remove-btn"
+                    onClick={() => onRemoveWidget?.(widget.id)}
+                    title="Remove widget"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M18 6L6 18M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              )}
+              <WidgetRenderer widget={widget} />
+            </div>
+          ))}
+          {isEditing && (
+            <div class="add-widget-placeholder">
+              <button class="add-widget-btn" onClick={onAddWidgetClick}>
+                + Add Widget
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function AddSectionForm({
+  onAdd,
+  onCancel,
+}: {
+  onAdd: (title: string, type: SectionType) => void
+  onCancel: () => void
+}) {
+  const [title, setTitle] = useState('')
+  const [type, setType] = useState<SectionType>('metrics')
+
+  const handleSubmit = (e: Event) => {
+    e.preventDefault()
+    if (title.trim()) onAdd(title.trim(), type)
+  }
+
+  return (
+    <div class="add-section-placeholder">
+      <form onSubmit={handleSubmit} style={{ maxWidth: '300px', width: '100%' }}>
+        <div class="form-group" style={{ marginBottom: '0.75rem' }}>
+          <input
+            type="text"
+            value={title}
+            onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+            placeholder="Section title"
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              fontSize: '0.875rem',
+              padding: '0.5rem',
+              width: '100%',
+            }}
+            autoFocus
+          />
+        </div>
+        <div class="form-group" style={{ marginBottom: '0.75rem' }}>
+          <select
+            value={type}
+            onChange={(e) => setType((e.target as HTMLSelectElement).value as SectionType)}
+            style={{
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              fontSize: '0.875rem',
+              padding: '0.5rem',
+              width: '100%',
+            }}
+          >
+            <option value="metrics">Metrics (cards)</option>
+            <option value="charts">Charts (full width)</option>
+            <option value="links">Links (navigation)</option>
+          </select>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            class="btn-secondary"
+            style={{ fontSize: '0.875rem', padding: '0.375rem 0.75rem' }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="btn-primary"
+            style={{ fontSize: '0.875rem', padding: '0.375rem 0.75rem' }}
+            disabled={!title.trim()}
+          >
+            Add Section
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+interface EditableDashboardProps {
+  config: DashboardConfig
+  isEditing: boolean
+  onChange: (next: DashboardConfig) => void
+}
+
+export function EditableDashboard({ config, isEditing, onChange }: EditableDashboardProps) {
+  const [showWidgetPicker, setShowWidgetPicker] = useState<string | null>(null) // section id or null
+  const [showAddSection, setShowAddSection] = useState(false)
+
+  const handleRemoveWidget = (sectionId: string, widgetId: string) => {
+    onChange({
+      ...config,
+      sections: config.sections.map((section) =>
+        section.id === sectionId
+          ? { ...section, widgets: section.widgets.filter((w) => w.id !== widgetId) }
+          : section,
+      ),
+    })
+  }
+
+  const handleMoveWidget = (sectionId: string, widgetId: string, direction: 'up' | 'down') => {
+    const section = config.sections.find((s) => s.id === sectionId)
+    if (!section) return
+
+    const widgetIndex = section.widgets.findIndex((w) => w.id === widgetId)
+    if (widgetIndex === -1) return
+
+    const newIndex = direction === 'up' ? widgetIndex - 1 : widgetIndex + 1
+    if (newIndex < 0 || newIndex >= section.widgets.length) return
+
+    const newWidgets = [...section.widgets]
+    const [widget] = newWidgets.splice(widgetIndex, 1)
+    newWidgets.splice(newIndex, 0, widget)
+
+    onChange({
+      ...config,
+      sections: config.sections.map((s) => (s.id === sectionId ? { ...s, widgets: newWidgets } : s)),
+    })
+  }
+
+  const handleAddWidget = (sectionId: string, widget: DashboardWidget) => {
+    onChange({
+      ...config,
+      sections: config.sections.map((section) =>
+        section.id === sectionId ? { ...section, widgets: [...section.widgets, widget] } : section,
+      ),
+    })
+    setShowWidgetPicker(null)
+  }
+
+  const handleAddSection = (title: string, type: SectionType) => {
+    const newSection: DashboardSection = { id: generateSectionId(), title, type, widgets: [] }
+    onChange({ ...config, sections: [...config.sections, newSection] })
+    setShowAddSection(false)
+  }
+
+  const handleDeleteSection = (sectionId: string) => {
+    const section = config.sections.find((s) => s.id === sectionId)
+    if (!section) return
+
+    const widgetCount = section.widgets.length
+    const message =
+      widgetCount > 0
+        ? `Delete section "${section.title}" and its ${widgetCount} widget${widgetCount > 1 ? 's' : ''}?`
+        : `Delete section "${section.title}"?`
+
+    if (confirm(message)) {
+      onChange({ ...config, sections: config.sections.filter((s) => s.id !== sectionId) })
+    }
+  }
+
+  return (
+    <div class="sections-grid">
+      {config.sections.map((section) => (
+        <DashboardSectionComponent
+          key={section.id}
+          section={section}
+          isEditing={isEditing}
+          onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
+          onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
+          onAddWidgetClick={() => setShowWidgetPicker(section.id)}
+          onDeleteSection={() => handleDeleteSection(section.id)}
+        />
+      ))}
+
+      {isEditing &&
+        (showAddSection ? (
+          <AddSectionForm onAdd={handleAddSection} onCancel={() => setShowAddSection(false)} />
+        ) : (
+          <div class="add-section-placeholder">
+            <button class="add-section-btn" onClick={() => setShowAddSection(true)}>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+              Add Section
+            </button>
+          </div>
+        ))}
+
+      {showWidgetPicker && (
+        <DashboardEditor
+          sectionId={showWidgetPicker}
+          sectionType={config.sections.find((s) => s.id === showWidgetPicker)?.type ?? 'metrics'}
+          onAddWidget={(widget) => handleAddWidget(showWidgetPicker, widget)}
+          onClose={() => setShowWidgetPicker(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -31,8 +31,10 @@ import {
   fetchTrend,
   type FetchTrendParams,
   fetchUserSettings,
+  listSharedDashboards,
   saveDashboard,
   type TrendDisplayPeriod,
+  updateSharedDashboard,
   updateUserSettings,
 } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -582,6 +584,7 @@ function buildWidgetFromState(state: ChartState, title: string): DashboardWidget
 function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: () => void }) {
   const queryClient = useQueryClient()
   const [title, setTitle] = useState('')
+  const [targetId, setTargetId] = useState('home') // 'home' or a shared dashboard id
   const [selectedSectionId, setSelectedSectionId] = useState('')
   const [newSectionTitle, setNewSectionTitle] = useState('')
   const [saved, setSaved] = useState(false)
@@ -592,23 +595,47 @@ function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: (
     staleTime: 5 * 60 * 1000,
   })
 
+  const sharedQuery = useQuery({
+    queryFn: listSharedDashboards,
+    queryKey: ['sharedDashboards'],
+    staleTime: 60 * 1000,
+  })
+
   const saveMutation = useMutation({
-    mutationFn: saveDashboard,
-    onSuccess: (data) => {
-      queryClient.setQueryData(['dashboard'], data)
+    mutationFn: async (next: { targetId: string; config: DashboardConfig }) => {
+      if (next.targetId === 'home') {
+        await saveDashboard(next.config)
+      } else {
+        await updateSharedDashboard(next.targetId, { config: next.config })
+      }
+    },
+    onError: () => alert('Failed to add the widget. Please try again.'),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      void queryClient.invalidateQueries({ queryKey: ['sharedDashboards'] })
       setSaved(true)
     },
   })
 
-  const dashboard: DashboardConfig | undefined = dashboardQuery.data
-  const chartsSections = dashboard?.sections.filter((s) => s.type === 'charts') ?? []
+  const sharedDashboards = sharedQuery.data ?? []
+  // The config of the currently selected target (home or a shared dashboard).
+  const targetConfig: DashboardConfig | undefined =
+    targetId === 'home' ? dashboardQuery.data : sharedDashboards.find((d) => d.id === targetId)?.config
+  const chartsSections = targetConfig?.sections.filter((s) => s.type === 'charts') ?? []
+
+  // Reset the section choice when the target dashboard changes.
+  const handleTargetChange = (id: string) => {
+    setTargetId(id)
+    setSelectedSectionId('')
+    setNewSectionTitle('')
+  }
 
   const handleSave = () => {
-    if (!dashboard) return
+    if (!targetConfig) return
 
     const widget = buildWidgetFromState(state, title)
 
-    let newDashboard: DashboardConfig
+    let newConfig: DashboardConfig
     if (selectedSectionId === '__new__') {
       const sectionTitle = newSectionTitle.trim() || 'Charts'
       const newSection: DashboardSection = {
@@ -617,21 +644,22 @@ function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: (
         type: 'charts' as SectionType,
         widgets: [widget],
       }
-      newDashboard = { ...dashboard, sections: [...dashboard.sections, newSection] }
+      newConfig = { ...targetConfig, sections: [...targetConfig.sections, newSection] }
     } else {
-      newDashboard = {
-        ...dashboard,
-        sections: dashboard.sections.map((section) =>
+      newConfig = {
+        ...targetConfig,
+        sections: targetConfig.sections.map((section) =>
           section.id === selectedSectionId ? { ...section, widgets: [...section.widgets, widget] } : section,
         ),
       }
     }
 
-    saveMutation.mutate(newDashboard)
+    saveMutation.mutate({ config: newConfig, targetId })
   }
 
   const canSave =
     !saveMutation.isPending &&
+    !!targetConfig &&
     (selectedSectionId === '__new__' ? newSectionTitle.trim().length > 0 : selectedSectionId.length > 0)
 
   return (
@@ -666,6 +694,18 @@ function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: (
                   onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
                   placeholder={state.pattern || 'Chart title'}
                 />
+              </div>
+
+              <div class="form-group">
+                <label>Dashboard</label>
+                <select value={targetId} onChange={(e) => handleTargetChange((e.target as HTMLSelectElement).value)}>
+                  <option value="home">My dashboard (home)</option>
+                  {sharedDashboards.map((d) => (
+                    <option key={d.id} value={d.id}>
+                      {d.name} (shared)
+                    </option>
+                  ))}
+                </select>
               </div>
 
               <div class="form-group">

--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -1,232 +1,23 @@
-import type { DashboardConfig, DashboardSection, DashboardWidget, SectionType } from '@aurboda/api-spec'
+import type { DashboardConfig } from '@aurboda/api-spec'
 
 import { defaultDashboardConfig } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
-import { DashboardEditor } from '../../components/DashboardEditor'
-import { WidgetRenderer } from '../../components/widgets'
+import { EditableDashboard } from '../../components/EditableDashboard'
 import { fetchDashboard, resetDashboard, saveDashboard } from '../../state/api'
 import './style.css'
-
-// Generate unique section ID
-const generateSectionId = () => `section-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
-
-// Section renderer - renders a section with its widgets
-function DashboardSectionComponent({
-  section,
-  isEditing,
-  onRemoveWidget,
-  onMoveWidget,
-  onAddWidgetClick,
-  onDeleteSection,
-}: {
-  section: DashboardSection
-  isEditing: boolean
-  onRemoveWidget?: (widgetId: string) => void
-  onMoveWidget?: (widgetId: string, direction: 'up' | 'down') => void
-  onAddWidgetClick?: () => void
-  onDeleteSection?: () => void
-}) {
-  const [collapsed, setCollapsed] = useState(section.collapsed ?? false)
-
-  // Determine grid class based on section type
-  const gridClass =
-    section.type === 'links' ? 'links-grid' : section.type === 'charts' ? 'charts-grid' : 'metrics-grid'
-
-  return (
-    <section class="metrics-section">
-      <div class="section-header">
-        <h2 onClick={() => setCollapsed(!collapsed)} style={{ cursor: 'pointer' }}>
-          {section.title}
-          {section.widgets.length > 0 && (
-            <span class="collapse-indicator">{collapsed ? '\u25B6' : '\u25BC'}</span>
-          )}
-        </h2>
-        {isEditing && (
-          <div class="section-edit-controls">
-            <button class="section-delete-btn" onClick={onDeleteSection} title="Delete section">
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
-              </svg>
-            </button>
-          </div>
-        )}
-      </div>
-      {!collapsed && (
-        <div class={gridClass}>
-          {section.widgets.map((widget, index) => (
-            <div key={widget.id} class={isEditing ? 'widget-editing-wrapper' : ''}>
-              {isEditing && (
-                <div class="widget-edit-controls">
-                  {index > 0 && (
-                    <button
-                      class="widget-move-btn"
-                      onClick={() => onMoveWidget?.(widget.id, 'up')}
-                      title="Move up"
-                    >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                      >
-                        <path d="M12 19V5M5 12l7-7 7 7" />
-                      </svg>
-                    </button>
-                  )}
-                  {index < section.widgets.length - 1 && (
-                    <button
-                      class="widget-move-btn"
-                      onClick={() => onMoveWidget?.(widget.id, 'down')}
-                      title="Move down"
-                    >
-                      <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                      >
-                        <path d="M12 5v14M5 12l7 7 7-7" />
-                      </svg>
-                    </button>
-                  )}
-                  <button
-                    class="widget-remove-btn"
-                    onClick={() => onRemoveWidget?.(widget.id)}
-                    title="Remove widget"
-                  >
-                    <svg
-                      width="16"
-                      height="16"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path d="M18 6L6 18M6 6l12 12" />
-                    </svg>
-                  </button>
-                </div>
-              )}
-              <WidgetRenderer widget={widget} />
-            </div>
-          ))}
-          {isEditing && (
-            <div class="add-widget-placeholder">
-              <button class="add-widget-btn" onClick={onAddWidgetClick}>
-                + Add Widget
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </section>
-  )
-}
-
-// Add Section form component
-function AddSectionForm({
-  onAdd,
-  onCancel,
-}: {
-  onAdd: (title: string, type: SectionType) => void
-  onCancel: () => void
-}) {
-  const [title, setTitle] = useState('')
-  const [type, setType] = useState<SectionType>('metrics')
-
-  const handleSubmit = (e: Event) => {
-    e.preventDefault()
-    if (title.trim()) {
-      onAdd(title.trim(), type)
-    }
-  }
-
-  return (
-    <div class="add-section-placeholder">
-      <form onSubmit={handleSubmit} style={{ maxWidth: '300px', width: '100%' }}>
-        <div class="form-group" style={{ marginBottom: '0.75rem' }}>
-          <input
-            type="text"
-            value={title}
-            onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
-            placeholder="Section title"
-            style={{
-              border: '1px solid #d1d5db',
-              borderRadius: '6px',
-              fontSize: '0.875rem',
-              padding: '0.5rem',
-              width: '100%',
-            }}
-            autoFocus
-          />
-        </div>
-        <div class="form-group" style={{ marginBottom: '0.75rem' }}>
-          <select
-            value={type}
-            onChange={(e) => setType((e.target as HTMLSelectElement).value as SectionType)}
-            style={{
-              border: '1px solid #d1d5db',
-              borderRadius: '6px',
-              fontSize: '0.875rem',
-              padding: '0.5rem',
-              width: '100%',
-            }}
-          >
-            <option value="metrics">Metrics (cards)</option>
-            <option value="charts">Charts (full width)</option>
-            <option value="links">Links (navigation)</option>
-          </select>
-        </div>
-        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
-          <button
-            type="button"
-            onClick={onCancel}
-            class="btn-secondary"
-            style={{ fontSize: '0.875rem', padding: '0.375rem 0.75rem' }}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            class="btn-primary"
-            style={{ fontSize: '0.875rem', padding: '0.375rem 0.75rem' }}
-            disabled={!title.trim()}
-          >
-            Add Section
-          </button>
-        </div>
-      </form>
-    </div>
-  )
-}
 
 export function Dashboard() {
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = useState(false)
-  const [showWidgetPicker, setShowWidgetPicker] = useState<string | null>(null) // section id or null
-  const [showAddSection, setShowAddSection] = useState(false)
 
-  // Fetch dashboard configuration
   const dashboardQuery = useQuery({
     queryFn: fetchDashboard,
     queryKey: ['dashboard'],
     staleTime: 5 * 60 * 1000,
   })
 
-  // Mutation to save dashboard
   const saveMutation = useMutation({
     mutationFn: saveDashboard,
     onSuccess: (data) => {
@@ -234,7 +25,6 @@ export function Dashboard() {
     },
   })
 
-  // Mutation to reset dashboard
   const resetMutation = useMutation({
     mutationFn: resetDashboard,
     onSuccess: (data) => {
@@ -244,85 +34,6 @@ export function Dashboard() {
 
   const dashboard: DashboardConfig = dashboardQuery.data ?? defaultDashboardConfig
   const isLoading = dashboardQuery.isLoading
-
-  // Handlers for editing
-  const handleRemoveWidget = (sectionId: string, widgetId: string) => {
-    const newDashboard: DashboardConfig = {
-      ...dashboard,
-      sections: dashboard.sections.map((section) =>
-        section.id === sectionId
-          ? { ...section, widgets: section.widgets.filter((w) => w.id !== widgetId) }
-          : section,
-      ),
-    }
-    saveMutation.mutate(newDashboard)
-  }
-
-  const handleMoveWidget = (sectionId: string, widgetId: string, direction: 'up' | 'down') => {
-    const section = dashboard.sections.find((s) => s.id === sectionId)
-    if (!section) return
-
-    const widgetIndex = section.widgets.findIndex((w) => w.id === widgetId)
-    if (widgetIndex === -1) return
-
-    const newIndex = direction === 'up' ? widgetIndex - 1 : widgetIndex + 1
-    if (newIndex < 0 || newIndex >= section.widgets.length) return
-
-    const newWidgets = [...section.widgets]
-    const [widget] = newWidgets.splice(widgetIndex, 1)
-    newWidgets.splice(newIndex, 0, widget)
-
-    const newDashboard: DashboardConfig = {
-      ...dashboard,
-      sections: dashboard.sections.map((s) => (s.id === sectionId ? { ...s, widgets: newWidgets } : s)),
-    }
-    saveMutation.mutate(newDashboard)
-  }
-
-  const handleAddWidget = (sectionId: string, widget: DashboardWidget) => {
-    const newDashboard: DashboardConfig = {
-      ...dashboard,
-      sections: dashboard.sections.map((section) =>
-        section.id === sectionId ? { ...section, widgets: [...section.widgets, widget] } : section,
-      ),
-    }
-    saveMutation.mutate(newDashboard)
-    setShowWidgetPicker(null)
-  }
-
-  const handleAddSection = (title: string, type: SectionType) => {
-    const newSection: DashboardSection = {
-      id: generateSectionId(),
-      title,
-      type,
-      widgets: [],
-    }
-    const newDashboard: DashboardConfig = {
-      ...dashboard,
-      sections: [...dashboard.sections, newSection],
-    }
-    saveMutation.mutate(newDashboard)
-    setShowAddSection(false)
-  }
-
-  const handleDeleteSection = (sectionId: string) => {
-    const section = dashboard.sections.find((s) => s.id === sectionId)
-    if (!section) return
-
-    const widgetCount = section.widgets.length
-    const message =
-      widgetCount > 0
-        ? `Delete section "${section.title}" and its ${widgetCount} widget${widgetCount > 1 ? 's' : ''}?`
-        : `Delete section "${section.title}"?`
-
-    if (confirm(message)) {
-      const newDashboard: DashboardConfig = {
-        ...dashboard,
-        sections: dashboard.sections.filter((s) => s.id !== sectionId),
-      }
-      saveMutation.mutate(newDashboard)
-    }
-  }
 
   const handleReset = () => {
     if (confirm('Reset dashboard to default configuration? Your customizations will be lost.')) {
@@ -347,14 +58,7 @@ export function Dashboard() {
             </>
           ) : (
             <button class="btn-edit" onClick={() => setIsEditing(true)} title="Edit Dashboard">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
                 <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
               </svg>
@@ -365,52 +69,11 @@ export function Dashboard() {
 
       {isLoading && <div class="loading">Loading your dashboard...</div>}
 
-      {/* All sections in responsive grid — hidden until config is loaded */}
       {!isLoading && (
-        <div class="sections-grid">
-          {dashboard.sections.map((section) => (
-            <DashboardSectionComponent
-              key={section.id}
-              section={section}
-              isEditing={isEditing}
-              onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
-              onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
-              onAddWidgetClick={() => setShowWidgetPicker(section.id)}
-              onDeleteSection={() => handleDeleteSection(section.id)}
-            />
-          ))}
-
-          {/* Add Section button/form in edit mode */}
-          {isEditing &&
-            (showAddSection ? (
-              <AddSectionForm onAdd={handleAddSection} onCancel={() => setShowAddSection(false)} />
-            ) : (
-              <div class="add-section-placeholder">
-                <button class="add-section-btn" onClick={() => setShowAddSection(true)}>
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <path d="M12 5v14M5 12h14" />
-                  </svg>
-                  Add Section
-                </button>
-              </div>
-            ))}
-        </div>
-      )}
-
-      {/* Widget picker modal */}
-      {showWidgetPicker && (
-        <DashboardEditor
-          sectionId={showWidgetPicker}
-          sectionType={dashboard.sections.find((s) => s.id === showWidgetPicker)?.type ?? 'metrics'}
-          onAddWidget={(widget) => handleAddWidget(showWidgetPicker, widget)}
-          onClose={() => setShowWidgetPicker(null)}
+        <EditableDashboard
+          config={dashboard}
+          isEditing={isEditing}
+          onChange={(next) => saveMutation.mutate(next)}
         />
       )}
     </div>

--- a/apps/web/src/pages/PublicDashboard/index.tsx
+++ b/apps/web/src/pages/PublicDashboard/index.tsx
@@ -1,27 +1,103 @@
 /**
- * PublicDashboard - read-only view of a shared dashboard at
- * /u/:username/:slug. Unauthenticated; renders each widget from the
- * server-resolved `widget_data` via PublicWidgetRenderer (no data is fetched
- * per widget). Rendered without app chrome.
+ * PublicDashboard - a shared dashboard at /u/:username/:slug.
+ *
+ * - When the logged-in user is the owner (their token is present and the
+ *   profile username matches), it renders the live, editable dashboard (same
+ *   controls as the home dashboard) and saves edits via `updateSharedDashboard`.
+ * - Otherwise it renders read-only from the server-resolved `widget_data` via
+ *   `PublicWidgetRenderer` (no per-widget fetching).
+ *
+ * Rendered without app chrome (see index.tsx).
  */
-import type { SectionType } from '@aurboda/api-spec'
+import type { DashboardConfig, SectionType } from '@aurboda/api-spec'
 
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
 import { useRoute } from 'preact-iso'
 
+import { EditableDashboard } from '../../components/EditableDashboard'
 import { PublicWidgetRenderer } from '../../components/widgets'
-import { fetchPublicSharedDashboard } from '../../state/api'
+import {
+  fetchPublicSharedDashboard,
+  listSharedDashboards,
+  updateSharedDashboard,
+} from '../../state/api'
+import { auth } from '../../state/auth'
 import '../Dashboard/style.css'
 import './style.css'
 
 const gridClass = (type: SectionType): string =>
   type === 'links' ? 'links-grid' : type === 'charts' ? 'charts-grid' : 'metrics-grid'
 
-export function PublicDashboard() {
-  const { params } = useRoute()
-  const username = params.username
-  const slug = params.slug
+/** Owner view: live, editable dashboard backed by the authed shared-dashboard API. */
+function OwnerSharedDashboard({ username, slug }: { username: string; slug: string }) {
+  const queryClient = useQueryClient()
+  const [isEditing, setIsEditing] = useState(false)
 
+  const listQuery = useQuery({
+    queryFn: listSharedDashboards,
+    queryKey: ['sharedDashboards'],
+    staleTime: 60 * 1000,
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: ({ id, config }: { id: string; config: DashboardConfig }) =>
+      updateSharedDashboard(id, { config }),
+    onError: () => alert('Failed to save the dashboard. Please try again.'),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(
+        ['sharedDashboards'],
+        (old: typeof listQuery.data) => old?.map((d) => (d.id === updated.id ? updated : d)),
+      )
+    },
+  })
+
+  if (listQuery.isLoading) {
+    return (
+      <div class="public-dashboard">
+        <div class="public-loading">Loading…</div>
+      </div>
+    )
+  }
+
+  const share = listQuery.data?.find((d) => d.slug === slug)
+  // Owner is logged in but this slug isn't one of theirs — show the public view.
+  if (!share) return <ReadOnlyPublicDashboard username={username} slug={slug} />
+
+  return (
+    <div class="dashboard public-dashboard">
+      <div class="dashboard-header">
+        <h1>{share.name}</h1>
+        <div class="dashboard-actions">
+          <a class="public-attribution" href={`/u/${encodeURIComponent(username)}`}>
+            @{username}
+          </a>
+          {isEditing ? (
+            <button class="btn-primary" onClick={() => setIsEditing(false)}>
+              Done Editing
+            </button>
+          ) : (
+            <button class="btn-edit" onClick={() => setIsEditing(true)} title="Edit dashboard">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      <EditableDashboard
+        config={share.config}
+        isEditing={isEditing}
+        onChange={(next) => saveMutation.mutate({ config: next, id: share.id })}
+      />
+    </div>
+  )
+}
+
+/** Read-only view rendered from the server-resolved widget data. */
+function ReadOnlyPublicDashboard({ username, slug }: { username: string; slug: string }) {
   const query = useQuery({
     queryFn: () => fetchPublicSharedDashboard(username, slug),
     queryKey: ['publicSharedDashboard', username, slug],
@@ -72,5 +148,19 @@ export function PublicDashboard() {
         ))}
       </div>
     </div>
+  )
+}
+
+export function PublicDashboard() {
+  const { params } = useRoute()
+  const username = params.username
+  const slug = params.slug
+
+  const isOwner = Boolean(auth.value.token) && auth.value.user === username
+
+  return isOwner ? (
+    <OwnerSharedDashboard username={username} slug={slug} />
+  ) : (
+    <ReadOnlyPublicDashboard username={username} slug={slug} />
   )
 }

--- a/docs/features/sharing.md
+++ b/docs/features/sharing.md
@@ -63,8 +63,15 @@ beyond the saved widgets.
 - **View** a shared dashboard at `/u/<username>/<slug>` and a profile at
   `/u/<username>`. These pages are public, render without the app chrome
   (header/sidebar/footer), and fetch nothing per widget — they render from the
-  server-resolved data. Per-widget editing of a shared dashboard (beyond seeding
-  from the home dashboard) is a planned follow-up.
+  server-resolved data.
+- **Edit in place**: when you are logged in and viewing your *own* shared
+  dashboard (`/u/<you>/<slug>`), an Edit toggle appears and you get the same
+  add/remove/move-widget and section controls as the home dashboard; changes
+  save to that shared dashboard. (Owners see live widget data here, not the
+  read-only snapshot.)
+- **Add a chart to a shared dashboard**: the chart page's "Add to dashboard"
+  dialog lets you pick the target dashboard (your home dashboard or any shared
+  one) and then the section.
 
 ## API
 


### PR DESCRIPTION
## Summary
Addresses two gaps reported while using the shared-dashboards feature: **you couldn't edit a created board's widgets**, and from a chart you could only add to your home dashboard.

- **Edit in place on `/u/<you>/<slug>`** — when you're logged in and viewing your *own* shared board (token present + profile username === your username), an **Edit** toggle appears with the same add/remove/move-widget + section controls as the home dashboard; changes save via `updateSharedDashboard`. Owners see **live** widget data here (their cookie is available); non-owners keep the read-only public render.
- **Chart "Add to dashboard" → dashboard selector** — pick the target dashboard (home or any shared board), then the section.
- **`EditableDashboard` extraction** — the section/widget grid + editing controls are now one reusable component used by both the home Dashboard and shared boards (no duplication). Home Dashboard behaviour is unchanged.

This makes the "Create blank" board (#818) actually useful — you can now populate it.

## Notes
- Owner detection is client-side for UX only; the backend already enforces auth on `updateSharedDashboard`, and the public read endpoint stays unchanged.
- Stacked conceptually on #818 (blank + dark-mode fixes); no file overlap. Will merge `develop` in before finalizing.

## Testing
- `pnpm check` clean in `apps/web`; full suite (452 tests) passes.
- Manual: on `/u/<you>/<slug>` toggle Edit, add/move/remove widgets + sections, confirm they persist and show on the public view; from a chart, add to a shared board via the new selector; confirm a logged-out viewer still sees read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)