### PR TITLE
fix(metrics): truthful add_metrics_bulk for cumulative metrics (#802)

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -78,6 +78,7 @@ export {
   getDailyAggregates,
   getDistinctMetrics,
   getRawDailySum,
+  getSourceFilter,
   getLatestMetricValuesMulti,
   getTimeSeries,
   getTimeSeriesBucketed,

--- a/apps/backend/src/db/time-series.ts
+++ b/apps/backend/src/db/time-series.ts
@@ -17,8 +17,13 @@ import { query } from './connection.ts'
 import { querySplitByCumulative } from './cumulative-query.ts'
 import { parseMetricType } from './row-mappers.ts'
 
-/** Get the source filter for a single metric: aurboda-only, cumulative sources, or all sources (null). */
-const getSourceFilter = (metric: string): string[] | null => {
+/**
+ * Get the source filter for a single metric: aurboda-only, cumulative sources,
+ * or all sources (null). Reads of cumulative/derived metrics are restricted to
+ * these sources, so a write from any other source would be unqueryable — write
+ * paths reuse this to reject such writes (see #802).
+ */
+export const getSourceFilter = (metric: string): string[] | null => {
   if (aurbodaOnlyMetrics.includes(metric as MetricType)) return aurbodaOnlySources
   if (cumulativeMetrics.includes(metric as MetricType)) return cumulativeSources
   return null

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -1,3 +1,5 @@
+import type * as TimeSeriesModule from '../db/time-series.ts'
+
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import * as db from '../db/index.ts'
@@ -18,7 +20,7 @@ import {
 } from './mutations.ts'
 
 // Mock the db module
-vi.mock('../db', () => ({
+vi.mock('../db', async () => ({
   activityTypeExists: vi.fn().mockResolvedValue(true),
   checkActivityConflict: vi.fn().mockResolvedValue(false),
   getActivityTypeDefinition: vi.fn().mockResolvedValue(null),
@@ -34,13 +36,8 @@ vi.mock('../db', () => ({
   getCustomMetricByName: vi.fn(),
   getCustomMetricDefinitions: vi.fn().mockResolvedValue([]),
   getOverrideForActivity: vi.fn().mockResolvedValue(null),
-  getSourceFilter: vi.fn((metric: string) =>
-    ['calories_active', 'calories_total'].includes(metric)
-      ? ['aurboda', 'aurboda_gap_fill']
-      : ['steps', 'distance', 'floors_climbed', 'calories_active', 'calories_total'].includes(metric)
-        ? ['health_connect_aggregate', 'aurboda']
-        : null,
-  ),
+  // Pull the real source-filter rules through so the test can't drift from production.
+  getSourceFilter: (await vi.importActual<typeof TimeSeriesModule>('../db/time-series.ts')).getSourceFilter,
   getUserNotesJoined: vi.fn().mockResolvedValue(undefined),
   getUserSettings: vi.fn(),
   insertCustomMetricDefinition: vi.fn(),

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -34,6 +34,13 @@ vi.mock('../db', () => ({
   getCustomMetricByName: vi.fn(),
   getCustomMetricDefinitions: vi.fn().mockResolvedValue([]),
   getOverrideForActivity: vi.fn().mockResolvedValue(null),
+  getSourceFilter: vi.fn((metric: string) =>
+    ['calories_active', 'calories_total'].includes(metric)
+      ? ['aurboda', 'aurboda_gap_fill']
+      : ['steps', 'distance', 'floors_climbed', 'calories_active', 'calories_total'].includes(metric)
+        ? ['health_connect_aggregate', 'aurboda']
+        : null,
+  ),
   getUserNotesJoined: vi.fn().mockResolvedValue(undefined),
   getUserSettings: vi.fn(),
   insertCustomMetricDefinition: vi.fn(),
@@ -649,6 +656,41 @@ describe('bulkAddMetrics', () => {
     expect(result.inserted).toBe(0)
     expect(result.errors).toHaveLength(2)
     expect(db.insertTimeSeries).not.toHaveBeenCalled()
+  })
+
+  test('rejects cumulative metrics written from an unqueryable source (#802)', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getCustomMetricDefinitions).mockResolvedValue([])
+
+    const result = await bulkAddMetrics('testuser', [
+      // steps from an arbitrary source would never be queryable → rejected.
+      { metric: 'steps', source: 'tryout', time: new Date('2026-05-27T00:00:00Z'), value: 5000 },
+      // resting_heart_rate is unrestricted → accepted from any source.
+      { metric: 'resting_heart_rate', source: 'tryout', time: new Date('2026-05-27T00:00:00Z'), value: 55 },
+    ])
+
+    expect(result.inserted).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].index).toBe(0)
+    expect(result.errors[0].error).toContain('cumulative/derived')
+    // Only the RHR point reaches the DB.
+    expect(db.insertTimeSeries).toHaveBeenCalledWith('testuser', [
+      expect.objectContaining({ metric: 'resting_heart_rate', source: 'tryout' }),
+    ])
+  })
+
+  test('accepts cumulative metrics from an allowed source', async () => {
+    vi.mocked(db.insertTimeSeries).mockResolvedValue(undefined)
+    vi.mocked(db.getCustomMetricDefinitions).mockResolvedValue([])
+
+    const result = await bulkAddMetrics('testuser', [
+      // Default source 'aurboda' is allowed for cumulative metrics.
+      { metric: 'steps', time: new Date('2026-05-27T00:00:00Z'), value: 5000 },
+      { metric: 'steps', source: 'health_connect_aggregate', time: new Date('2026-05-28T00:00:00Z'), value: 6000 },
+    ])
+
+    expect(result.inserted).toBe(2)
+    expect(result.errors).toHaveLength(0)
   })
 
   test('calls getCustomMetricDefinitions only once for the entire batch', async () => {

--- a/apps/backend/src/services/mutations.ts
+++ b/apps/backend/src/services/mutations.ts
@@ -31,6 +31,7 @@ import {
   updateActivity as dbUpdateActivity,
   enqueueOutboundSync,
   findHcRecordId,
+  getSourceFilter,
   insertTimeSeries,
   type TimeSeriesPoint,
 } from '../db/index.ts'
@@ -271,6 +272,19 @@ export async function bulkAddMetrics(
 
     const unit = getMetricUnit(item.metric, customMetrics)
     const source: DataSource = (item.source as DataSource) ?? resolvedDefaultSource
+
+    // Cumulative/derived metrics (steps, calories, …) are only read back from a
+    // restricted set of sources. Writing one from any other source would store a
+    // row that no query path returns — reject it rather than report a phantom
+    // insert (#802).
+    const sourceFilter = getSourceFilter(item.metric)
+    if (sourceFilter !== null && !sourceFilter.includes(source)) {
+      errors.push({
+        error: `Metric "${item.metric}" is cumulative/derived and is only queryable from source(s) [${sourceFilter.join(', ')}]; got "${source}". Omit source to use the default, or use an allowed source.`,
+        index: i,
+      })
+      continue
+    }
 
     validPoints.push({
       metric: item.metric,


### PR DESCRIPTION
Fixes #802.

## Problem
`add_metrics_bulk` accepted `steps` (and other cumulative/derived metrics) from any source and returned them in `inserted` with `errors: []`, but reads of those metrics are filtered to specific sources (`cumulativeSources` = `health_connect_aggregate`/`aurboda`; `aurbodaOnlySources` for calories). So a write from e.g. `tryout_pr800` was stored in `time_series` yet **unqueryable** via `query_metrics` / `query_metrics_bucketed` / aggregates — and `inserted` over-counted. (Non-cumulative metrics from the same call round-tripped fine.)

## Fix
Reuse the query side's `getSourceFilter` (now exported) on the write path. In `bulkAddMetrics`, if a metric is cumulative/derived and the resolved source isn't one it can be read back from, the item is **rejected with a clear per-item error** and excluded from `inserted` — so the response is truthful (the issue's option 1). Allowed sources (and the default `aurboda`) insert normally; single `add_metric` was already fine (always writes `aurboda`).

Example: a bulk call of `steps` (source `tryout`) + `resting_heart_rate` (source `tryout`) now returns `inserted: 1` with one error explaining the `steps` rejection, instead of `inserted: 2` with silently-unqueryable steps.

## Testing
- New unit tests: rejects cumulative-from-unqueryable-source; accepts cumulative from `aurboda`/`health_connect_aggregate`. Full `mutations.test.ts` (79) passes; `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)