### PR TITLE
feat(dashboard): editable section titles + update board charts from chart page (#822)

### DIFF
--- a/apps/web/src/components/EditableDashboard/index.tsx
+++ b/apps/web/src/components/EditableDashboard/index.tsx
@@ -18,36 +18,94 @@ const generateSectionId = () => `section-${Date.now()}-${Math.random().toString(
 function DashboardSectionComponent({
   section,
   isEditing,
+  boardId,
   onRemoveWidget,
   onMoveWidget,
   onAddWidgetClick,
   onDeleteSection,
+  onRenameSection,
 }: {
   section: DashboardSection
   isEditing: boolean
+  boardId?: string
   onRemoveWidget?: (widgetId: string) => void
   onMoveWidget?: (widgetId: string, direction: 'up' | 'down') => void
   onAddWidgetClick?: () => void
   onDeleteSection?: () => void
+  onRenameSection?: (title: string) => void
 }) {
   const [collapsed, setCollapsed] = useState(section.collapsed ?? false)
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(section.title)
 
   const gridClass =
     section.type === 'links' ? 'links-grid' : section.type === 'charts' ? 'charts-grid' : 'metrics-grid'
 
+  const commitTitle = () => {
+    const next = titleDraft.trim()
+    if (next && next !== section.title) onRenameSection?.(next)
+    else setTitleDraft(section.title)
+    setEditingTitle(false)
+  }
+
+  const cancelTitle = () => {
+    setTitleDraft(section.title)
+    setEditingTitle(false)
+  }
+
   return (
     <section class="metrics-section">
       <div class="section-header">
-        <h2 onClick={() => setCollapsed(!collapsed)} style={{ cursor: 'pointer' }}>
-          {section.title}
-          {section.widgets.length > 0 && (
-            <span class="collapse-indicator">{collapsed ? '▶' : '▼'}</span>
-          )}
-        </h2>
-        {isEditing && (
+        {editingTitle ? (
+          <input
+            class="section-title-input"
+            type="text"
+            value={titleDraft}
+            onInput={(e) => setTitleDraft((e.target as HTMLInputElement).value)}
+            onBlur={commitTitle}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitTitle()
+              else if (e.key === 'Escape') cancelTitle()
+            }}
+            autoFocus
+          />
+        ) : (
+          <h2 onClick={() => setCollapsed(!collapsed)} style={{ cursor: 'pointer' }}>
+            {section.title}
+            {section.widgets.length > 0 && <span class="collapse-indicator">{collapsed ? '▶' : '▼'}</span>}
+          </h2>
+        )}
+        {isEditing && !editingTitle && (
           <div class="section-edit-controls">
+            <button
+              class="section-rename-btn"
+              onClick={() => {
+                setTitleDraft(section.title)
+                setEditingTitle(true)
+              }}
+              title="Rename section"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+            </button>
             <button class="section-delete-btn" onClick={onDeleteSection} title="Delete section">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
                 <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
               </svg>
             </button>
@@ -66,7 +124,14 @@ function DashboardSectionComponent({
                       onClick={() => onMoveWidget?.(widget.id, 'up')}
                       title="Move up"
                     >
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
                         <path d="M12 19V5M5 12l7-7 7 7" />
                       </svg>
                     </button>
@@ -77,7 +142,14 @@ function DashboardSectionComponent({
                       onClick={() => onMoveWidget?.(widget.id, 'down')}
                       title="Move down"
                     >
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
                         <path d="M12 5v14M5 12l7 7 7-7" />
                       </svg>
                     </button>
@@ -87,13 +159,20 @@ function DashboardSectionComponent({
                     onClick={() => onRemoveWidget?.(widget.id)}
                     title="Remove widget"
                   >
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
                       <path d="M18 6L6 18M6 6l12 12" />
                     </svg>
                   </button>
                 </div>
               )}
-              <WidgetRenderer widget={widget} />
+              <WidgetRenderer widget={widget} boardId={boardId} sectionId={section.id} />
             </div>
           ))}
           {isEditing && (
@@ -187,9 +266,11 @@ interface EditableDashboardProps {
   config: DashboardConfig
   isEditing: boolean
   onChange: (next: DashboardConfig) => void
+  /** Identifies this board ('home' or a shared-dashboard id) so chart widgets can link back for update-in-place. */
+  boardId: string
 }
 
-export function EditableDashboard({ config, isEditing, onChange }: EditableDashboardProps) {
+export function EditableDashboard({ config, isEditing, onChange, boardId }: EditableDashboardProps) {
   const [showWidgetPicker, setShowWidgetPicker] = useState<string | null>(null) // section id or null
   const [showAddSection, setShowAddSection] = useState(false)
 
@@ -240,6 +321,15 @@ export function EditableDashboard({ config, isEditing, onChange }: EditableDashb
     setShowAddSection(false)
   }
 
+  const handleRenameSection = (sectionId: string, title: string) => {
+    onChange({
+      ...config,
+      sections: config.sections.map((section) =>
+        section.id === sectionId ? { ...section, title } : section,
+      ),
+    })
+  }
+
   const handleDeleteSection = (sectionId: string) => {
     const section = config.sections.find((s) => s.id === sectionId)
     if (!section) return
@@ -262,10 +352,12 @@ export function EditableDashboard({ config, isEditing, onChange }: EditableDashb
           key={section.id}
           section={section}
           isEditing={isEditing}
+          boardId={boardId}
           onRemoveWidget={(widgetId) => handleRemoveWidget(section.id, widgetId)}
           onMoveWidget={(widgetId, direction) => handleMoveWidget(section.id, widgetId, direction)}
           onAddWidgetClick={() => setShowWidgetPicker(section.id)}
           onDeleteSection={() => handleDeleteSection(section.id)}
+          onRenameSection={(title) => handleRenameSection(section.id, title)}
         />
       ))}
 
@@ -275,7 +367,14 @@ export function EditableDashboard({ config, isEditing, onChange }: EditableDashb
         ) : (
           <div class="add-section-placeholder">
             <button class="add-section-btn" onClick={() => setShowAddSection(true)}>
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
                 <path d="M12 5v14M5 12h14" />
               </svg>
               Add Section

--- a/apps/web/src/components/widgets/BarChartWidget.tsx
+++ b/apps/web/src/components/widgets/BarChartWidget.tsx
@@ -10,7 +10,7 @@ import type { BarChartConfig, BarChartData } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
 import { fetchChartData } from '../../state/api'
-import { buildChartUrl } from '../../utils/chart-url'
+import { buildChartUrl, type ChartOrigin } from '../../utils/chart-url'
 import { BarChart } from '../charts/BarChart'
 
 /** Compute start/end ISO strings from lookback_days. */
@@ -50,9 +50,11 @@ export function BarChartView({ config, data, href }: BarChartViewProps) {
 
 interface BarChartWidgetProps {
   config: BarChartConfig
+  /** When rendered inside a board, links back to /chart carrying this widget's origin. */
+  origin?: ChartOrigin
 }
 
-export function BarChartWidget({ config }: BarChartWidgetProps) {
+export function BarChartWidget({ config, origin }: BarChartWidgetProps) {
   const {
     source_type,
     pattern,
@@ -90,6 +92,7 @@ export function BarChartWidget({ config }: BarChartWidgetProps) {
     pattern: pattern ?? undefined,
     source_type,
     activity_type_id,
+    origin,
   })
 
   if (chartQuery.isLoading) {

--- a/apps/web/src/components/widgets/TrendChartWidget.tsx
+++ b/apps/web/src/components/widgets/TrendChartWidget.tsx
@@ -11,7 +11,7 @@ import type { TrendChartConfig, TrendChartData } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
 import { fetchTrend } from '../../state/api'
-import { buildChartUrl } from '../../utils/chart-url'
+import { buildChartUrl, type ChartOrigin } from '../../utils/chart-url'
 import { TrendLineChart } from '../charts/TrendLineChart'
 
 interface TrendChartViewProps {
@@ -50,9 +50,11 @@ export function TrendChartView({ config, data, href }: TrendChartViewProps) {
 
 interface TrendChartWidgetProps {
   config: TrendChartConfig
+  /** When rendered inside a board, links back to /chart carrying this widget's origin. */
+  origin?: ChartOrigin
 }
 
-export function TrendChartWidget({ config }: TrendChartWidgetProps) {
+export function TrendChartWidget({ config, origin }: TrendChartWidgetProps) {
   const {
     source_type,
     pattern,
@@ -87,6 +89,7 @@ export function TrendChartWidget({ config }: TrendChartWidgetProps) {
     pattern,
     source_type,
     activity_type_id: config.tag_definition_id,
+    origin,
   })
 
   if (trendQuery.isLoading) {

--- a/apps/web/src/components/widgets/WidgetRenderer.tsx
+++ b/apps/web/src/components/widgets/WidgetRenderer.tsx
@@ -18,9 +18,16 @@ interface WidgetRendererProps {
   widget: DashboardWidget
   isEditing?: boolean
   onRemove?: () => void
+  /** Board this widget belongs to ('home' or a shared-dashboard id) — enables update-in-place from the chart page. */
+  boardId?: string
+  /** Section this widget belongs to. */
+  sectionId?: string
 }
 
-export function WidgetRenderer({ widget, isEditing, onRemove }: WidgetRendererProps) {
+export function WidgetRenderer({ widget, isEditing, onRemove, boardId, sectionId }: WidgetRendererProps) {
+  const origin =
+    boardId && sectionId ? { board_id: boardId, section_id: sectionId, widget_id: widget.id } : undefined
+
   const renderWidget = () => {
     switch (widget.type) {
       case 'metric_card':
@@ -28,9 +35,9 @@ export function WidgetRenderer({ widget, isEditing, onRemove }: WidgetRendererPr
       case 'sparkline_card':
         return <SparklineCardWidget config={widget.config} />
       case 'trend_chart':
-        return <TrendChartWidget config={widget.config} />
+        return <TrendChartWidget config={widget.config} origin={origin} />
       case 'bar_chart':
-        return <BarChartWidget config={widget.config} />
+        return <BarChartWidget config={widget.config} origin={origin} />
       case 'correlation':
         return <CorrelationWidget config={widget.config} />
       case 'activity_summary':

--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -18,6 +18,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLocation } from 'preact-iso'
 import { useCallback, useMemo, useState } from 'preact/hooks'
 
+import type { ChartOrigin } from '../../utils/chart-url'
+
 import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { BarChart, type BarClickInfo } from '../../components/charts/BarChart'
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
@@ -38,6 +40,7 @@ import {
   updateUserSettings,
 } from '../../state/api'
 import { auth } from '../../state/auth'
+import { chartWidgetTitle, parseChartOrigin, replaceWidgetInConfig } from './updateWidget'
 import './style.css'
 
 type SourceType = 'metric' | 'productivity_category' | 'activity_type'
@@ -100,8 +103,8 @@ function parseQuery(query: Record<string, string>): ChartState {
   }
 }
 
-/** Sync current state to URL query params. */
-function syncUrl(state: ChartState) {
+/** Sync current state to URL query params, preserving any board-chart origin. */
+function syncUrl(state: ChartState, origin: ChartOrigin | null) {
   const params = new URLSearchParams()
   params.set('source_type', state.source_type)
   if (state.pattern) params.set('pattern', state.pattern)
@@ -122,6 +125,11 @@ function syncUrl(state: ChartState) {
   }
   if (state.breakdown_fields.length > 0) {
     params.set('breakdown_fields', state.breakdown_fields.join(','))
+  }
+  if (origin) {
+    params.set('board_id', origin.board_id)
+    params.set('section_id', origin.section_id)
+    params.set('widget_id', origin.widget_id)
   }
   history.replaceState(null, '', `${window.location.pathname}?${params}`)
 }
@@ -543,8 +551,15 @@ function BarDisplay({ params }: { params: FetchChartDataParams }) {
 /** Generate unique ID for widgets and sections. */
 const generateId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 
-/** Build a dashboard widget config from the current chart state. */
-function buildWidgetFromState(state: ChartState, title: string): DashboardWidget {
+/**
+ * Build a dashboard widget config from the current chart state. Pass `id` to
+ * update an existing widget in place; omit it to create a new one.
+ */
+function buildWidgetFromState(
+  state: ChartState,
+  title: string,
+  id: string = generateId('widget'),
+): DashboardWidget {
   if (state.chart_type === 'bar') {
     return {
       config: {
@@ -556,7 +571,7 @@ function buildWidgetFromState(state: ChartState, title: string): DashboardWidget
         ...(state.activity_type_id ? { tag_definition_id: state.activity_type_id } : {}),
         ...(title ? { title } : {}),
       },
-      id: generateId('widget'),
+      id,
       type: 'bar_chart',
     } as DashboardWidget
   }
@@ -575,7 +590,7 @@ function buildWidgetFromState(state: ChartState, title: string): DashboardWidget
       ...(state.activity_type_id ? { tag_definition_id: state.activity_type_id } : {}),
       ...(title ? { title } : {}),
     },
-    id: generateId('widget'),
+    id,
     type: 'trend_chart',
   } as DashboardWidget
 }
@@ -698,7 +713,10 @@ function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: (
 
               <div class="form-group">
                 <label>Dashboard</label>
-                <select value={targetId} onChange={(e) => handleTargetChange((e.target as HTMLSelectElement).value)}>
+                <select
+                  value={targetId}
+                  onChange={(e) => handleTargetChange((e.target as HTMLSelectElement).value)}
+                >
                   <option value="home">My dashboard (home)</option>
                   {sharedDashboards.map((d) => (
                     <option key={d.id} value={d.id}>
@@ -760,12 +778,134 @@ function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: (
   )
 }
 
+/**
+ * Bottom-of-page control shown when the user navigated here from a board chart.
+ * Lets them replace that widget in place with the current chart configuration,
+ * optionally under a new title.
+ */
+function UpdateChartOnBoard({ state, origin }: { state: ChartState; origin: ChartOrigin }) {
+  const queryClient = useQueryClient()
+  const isHome = origin.board_id === 'home'
+  const [expanded, setExpanded] = useState(false)
+  const [title, setTitle] = useState('')
+  const [saved, setSaved] = useState(false)
+
+  const dashboardQuery = useQuery({
+    enabled: isHome,
+    queryFn: fetchDashboard,
+    queryKey: ['dashboard'],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const sharedQuery = useQuery({
+    enabled: !isHome,
+    queryFn: listSharedDashboards,
+    queryKey: ['sharedDashboards'],
+    staleTime: 60 * 1000,
+  })
+
+  const shared = isHome ? undefined : sharedQuery.data?.find((d) => d.id === origin.board_id)
+  const targetConfig: DashboardConfig | undefined = isHome ? dashboardQuery.data : shared?.config
+  const boardName = isHome ? 'home dashboard' : shared?.name
+  const section = targetConfig?.sections.find((s) => s.id === origin.section_id)
+  const existingWidget = section?.widgets.find((w) => w.id === origin.widget_id)
+
+  const updateMutation = useMutation({
+    mutationFn: async () => {
+      if (!targetConfig) return
+      const widget = buildWidgetFromState(state, title.trim(), origin.widget_id)
+      const nextConfig = replaceWidgetInConfig(targetConfig, origin.section_id, origin.widget_id, widget)
+      if (isHome) await saveDashboard(nextConfig)
+      else await updateSharedDashboard(origin.board_id, { config: nextConfig })
+    },
+    onError: () => alert('Failed to update the chart. Please try again.'),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      void queryClient.invalidateQueries({ queryKey: ['sharedDashboards'] })
+      setSaved(true)
+    },
+  })
+
+  // The origin no longer resolves to a real widget (widget/section/board removed).
+  if (!section || !existingWidget) return null
+
+  const label = `Update Chart in ${boardName} / ${section.title}`
+
+  if (!expanded) {
+    return (
+      <div class="add-to-dashboard-row">
+        <button
+          class="btn-add-to-dashboard"
+          onClick={() => {
+            setTitle(chartWidgetTitle(existingWidget) ?? '')
+            setSaved(false)
+            setExpanded(true)
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+          {label}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div class="chart-goal-form">
+      <h3>{label}</h3>
+      {saved ? (
+        <>
+          <div class="add-to-dash-success">Chart updated!</div>
+          <div class="goal-form-actions">
+            <button class="btn-save" onClick={() => setExpanded(false)}>
+              Done
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p class="goal-form-description">
+            Replace this chart on <strong>{boardName}</strong> with the current configuration.
+          </p>
+          <div class="goal-form-fields">
+            <label style={{ flex: 1 }}>
+              Title (optional)
+              <input
+                class="chart-update-title"
+                type="text"
+                value={title}
+                onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+                placeholder={state.pattern || 'Chart title'}
+              />
+            </label>
+          </div>
+          <div class="goal-form-actions">
+            <button class="btn-cancel" onClick={() => setExpanded(false)}>
+              Cancel
+            </button>
+            <button
+              class="btn-save"
+              disabled={updateMutation.isPending}
+              onClick={() => updateMutation.mutate()}
+            >
+              {updateMutation.isPending ? 'Updating...' : 'Update Chart'}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 // eslint-disable-next-line complexity -- chart page with multiple feature sections
 export function Chart() {
   const isLoggedIn = auth.value.token
   const queryClient = useQueryClient()
   const { query } = useLocation()
   const [state, setState] = useState(() => parseQuery(query))
+  const [origin] = useState(() => parseChartOrigin(query))
   const [showAddToDashboard, setShowAddToDashboard] = useState(false)
   const [showSetGoal, setShowSetGoal] = useState(false)
   const [goalMax, setGoalMax] = useState('')
@@ -776,9 +916,9 @@ export function Chart() {
     (patch: Partial<ChartState>) => {
       const next = { ...state, ...patch }
       setState(next)
-      syncUrl(next)
+      syncUrl(next, origin)
     },
-    [state],
+    [state, origin],
   )
 
   if (!isLoggedIn) {
@@ -866,6 +1006,8 @@ export function Chart() {
           )}
         </div>
       )}
+
+      {origin && <UpdateChartOnBoard state={state} origin={origin} />}
 
       {showSetGoal && (
         <div class="chart-goal-form">

--- a/apps/web/src/pages/Chart/style.css
+++ b/apps/web/src/pages/Chart/style.css
@@ -384,6 +384,10 @@
   width: 8rem;
 }
 
+.goal-form-fields .chart-update-title {
+  width: 100%;
+}
+
 .goal-form-error {
   color: #e53e3e;
   font-size: 0.8rem;

--- a/apps/web/src/pages/Chart/updateWidget.test.ts
+++ b/apps/web/src/pages/Chart/updateWidget.test.ts
@@ -1,0 +1,79 @@
+import type { DashboardConfig, DashboardWidget } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import { chartWidgetTitle, parseChartOrigin, replaceWidgetInConfig } from './updateWidget'
+
+const trendWidget = (id: string, title?: string): DashboardWidget => ({
+  config: { pattern: 'coffee', source_type: 'activity_type', ...(title ? { title } : {}) },
+  id,
+  type: 'trend_chart',
+})
+
+const config: DashboardConfig = {
+  sections: [
+    { id: 'sec-1', title: 'Charts', type: 'charts', widgets: [trendWidget('w-1'), trendWidget('w-2')] },
+    { id: 'sec-2', title: 'More', type: 'charts', widgets: [trendWidget('w-3')] },
+  ],
+  version: 1,
+}
+
+describe('parseChartOrigin', () => {
+  test('returns null when any origin param is missing', () => {
+    expect(parseChartOrigin({})).toBeNull()
+    expect(parseChartOrigin({ board_id: 'home', section_id: 'sec-1' })).toBeNull()
+    expect(parseChartOrigin({ board_id: 'home', widget_id: 'w-1' })).toBeNull()
+    expect(parseChartOrigin({ section_id: 'sec-1', widget_id: 'w-1' })).toBeNull()
+  })
+
+  test('parses a full origin', () => {
+    expect(parseChartOrigin({ board_id: 'home', section_id: 'sec-1', widget_id: 'w-1' })).toEqual({
+      board_id: 'home',
+      section_id: 'sec-1',
+      widget_id: 'w-1',
+    })
+  })
+})
+
+describe('chartWidgetTitle', () => {
+  test('returns the title of a chart widget', () => {
+    expect(chartWidgetTitle(trendWidget('w-1', 'Morning coffee'))).toBe('Morning coffee')
+  })
+
+  test('returns undefined when the chart widget has no title', () => {
+    expect(chartWidgetTitle(trendWidget('w-1'))).toBeUndefined()
+  })
+
+  test('returns undefined for non-chart widgets', () => {
+    const link: DashboardWidget = { config: { href: '/x', label: 'X' }, id: 'l-1', type: 'quick_link' }
+    expect(chartWidgetTitle(link)).toBeUndefined()
+  })
+})
+
+describe('replaceWidgetInConfig', () => {
+  test('replaces only the matching widget in the matching section', () => {
+    const replacement = trendWidget('w-1', 'Updated')
+    const next = replaceWidgetInConfig(config, 'sec-1', 'w-1', replacement)
+
+    expect(next.sections[0].widgets[0]).toBe(replacement)
+    expect(next.sections[0].widgets[1].id).toBe('w-2')
+    expect(next.sections[1].widgets[0].id).toBe('w-3')
+  })
+
+  test('does not mutate the original config', () => {
+    const before = structuredClone(config)
+    replaceWidgetInConfig(config, 'sec-1', 'w-1', trendWidget('w-1', 'Updated'))
+    expect(config).toEqual(before)
+  })
+
+  test('leaves the config unchanged when the section id is unknown', () => {
+    const next = replaceWidgetInConfig(config, 'missing', 'w-1', trendWidget('w-1', 'Updated'))
+    expect(next.sections[0].widgets[0].id).toBe('w-1')
+    expect(chartWidgetTitle(next.sections[0].widgets[0])).toBeUndefined()
+  })
+
+  test('leaves the config unchanged when the widget id is unknown', () => {
+    const next = replaceWidgetInConfig(config, 'sec-1', 'missing', trendWidget('missing', 'Updated'))
+    expect(next.sections[0].widgets.map((w) => w.id)).toEqual(['w-1', 'w-2'])
+  })
+})

--- a/apps/web/src/pages/Chart/updateWidget.ts
+++ b/apps/web/src/pages/Chart/updateWidget.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure helpers for updating an existing board chart widget in place from the
+ * chart page. Kept separate from the component so they can be unit-tested.
+ */
+import type { DashboardConfig, DashboardWidget } from '@aurboda/api-spec'
+
+import type { ChartOrigin } from '../../utils/chart-url'
+
+/** Read the origin of a board chart from the chart page's query params. */
+export function parseChartOrigin(query: Record<string, string>): ChartOrigin | null {
+  const { board_id, section_id, widget_id } = query
+  if (!board_id || !section_id || !widget_id) return null
+  return { board_id, section_id, widget_id }
+}
+
+/** Existing display title of a chart widget, if any (used to pre-fill the update form). */
+export function chartWidgetTitle(widget: DashboardWidget): string | undefined {
+  if (widget.type === 'trend_chart' || widget.type === 'bar_chart') return widget.config.title
+  return undefined
+}
+
+/**
+ * Return a new config with the widget matching `widgetId` in section `sectionId`
+ * replaced by `widget`. Other sections and widgets are left untouched.
+ */
+export function replaceWidgetInConfig(
+  config: DashboardConfig,
+  sectionId: string,
+  widgetId: string,
+  widget: DashboardWidget,
+): DashboardConfig {
+  return {
+    ...config,
+    sections: config.sections.map((section) =>
+      section.id === sectionId
+        ? { ...section, widgets: section.widgets.map((w) => (w.id === widgetId ? widget : w)) }
+        : section,
+    ),
+  }
+}

--- a/apps/web/src/pages/Dashboard/index.tsx
+++ b/apps/web/src/pages/Dashboard/index.tsx
@@ -58,7 +58,14 @@ export function Dashboard() {
             </>
           ) : (
             <button class="btn-edit" onClick={() => setIsEditing(true)} title="Edit Dashboard">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
                 <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
                 <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
               </svg>
@@ -73,6 +80,7 @@ export function Dashboard() {
         <EditableDashboard
           config={dashboard}
           isEditing={isEditing}
+          boardId="home"
           onChange={(next) => saveMutation.mutate(next)}
         />
       )}

--- a/apps/web/src/pages/Dashboard/style.css
+++ b/apps/web/src/pages/Dashboard/style.css
@@ -770,6 +770,35 @@
   background: #fee2e2;
 }
 
+.dashboard .section-rename-btn {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.dashboard .section-rename-btn:hover {
+  color: #673ab8;
+  background: #faf5ff;
+}
+
+/* Inline section-title editor */
+.dashboard .section-title-input {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #555;
+  border: none;
+  border-bottom: 2px solid #673ab8;
+  background: transparent;
+  padding: 0 0 0.5rem 0;
+  margin: 0 0 1rem 0;
+  width: 100%;
+  outline: none;
+}
+
 /* Dark mode additions for editing */
 @media (prefers-color-scheme: dark) {
   .dashboard .btn-edit {
@@ -887,5 +916,14 @@
   .dashboard .section-delete-btn:hover {
     color: #f87171;
     background: #7f1d1d;
+  }
+
+  .dashboard .section-rename-btn:hover {
+    color: #a855f7;
+    background: #1e1b4b;
+  }
+
+  .dashboard .section-title-input {
+    color: #e5e7eb;
   }
 }

--- a/apps/web/src/pages/PublicDashboard/index.tsx
+++ b/apps/web/src/pages/PublicDashboard/index.tsx
@@ -12,16 +12,12 @@
 import type { DashboardConfig, SectionType } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'preact/hooks'
 import { useRoute } from 'preact-iso'
+import { useState } from 'preact/hooks'
 
 import { EditableDashboard } from '../../components/EditableDashboard'
 import { PublicWidgetRenderer } from '../../components/widgets'
-import {
-  fetchPublicSharedDashboard,
-  listSharedDashboards,
-  updateSharedDashboard,
-} from '../../state/api'
+import { fetchPublicSharedDashboard, listSharedDashboards, updateSharedDashboard } from '../../state/api'
 import { auth } from '../../state/auth'
 import '../Dashboard/style.css'
 import './style.css'
@@ -45,9 +41,8 @@ function OwnerSharedDashboard({ username, slug }: { username: string; slug: stri
       updateSharedDashboard(id, { config }),
     onError: () => alert('Failed to save the dashboard. Please try again.'),
     onSuccess: (updated) => {
-      queryClient.setQueryData(
-        ['sharedDashboards'],
-        (old: typeof listQuery.data) => old?.map((d) => (d.id === updated.id ? updated : d)),
+      queryClient.setQueryData(['sharedDashboards'], (old: typeof listQuery.data) =>
+        old?.map((d) => (d.id === updated.id ? updated : d)),
       )
     },
   })
@@ -78,7 +73,14 @@ function OwnerSharedDashboard({ username, slug }: { username: string; slug: stri
             </button>
           ) : (
             <button class="btn-edit" onClick={() => setIsEditing(true)} title="Edit dashboard">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
                 <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
                 <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
               </svg>
@@ -90,6 +92,7 @@ function OwnerSharedDashboard({ username, slug }: { username: string; slug: stri
       <EditableDashboard
         config={share.config}
         isEditing={isEditing}
+        boardId={share.id}
         onChange={(next) => saveMutation.mutate({ config: next, id: share.id })}
       />
     </div>

--- a/apps/web/src/utils/chart-url.test.ts
+++ b/apps/web/src/utils/chart-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildChartUrl } from './chart-url'
+
+const params = (url: string) => new URLSearchParams(url.split('?')[1])
+
+describe('buildChartUrl', () => {
+  test('serializes core trend params', () => {
+    const p = params(
+      buildChartUrl({
+        chart_type: 'trend',
+        display_period: 'monthly',
+        half_life_days: 30,
+        lookback_days: 90,
+        pattern: 'coffee',
+        source_type: 'activity_type',
+      }),
+    )
+    expect(p.get('source_type')).toBe('activity_type')
+    expect(p.get('pattern')).toBe('coffee')
+    expect(p.get('chart_type')).toBe('trend')
+    expect(p.get('display_period')).toBe('monthly')
+    expect(p.get('half_life_days')).toBe('30')
+  })
+
+  test('omits origin params when no origin is given', () => {
+    const p = params(buildChartUrl({ chart_type: 'trend', pattern: 'coffee', source_type: 'activity_type' }))
+    expect(p.has('board_id')).toBe(false)
+    expect(p.has('section_id')).toBe(false)
+    expect(p.has('widget_id')).toBe(false)
+  })
+
+  test('carries the board-chart origin when provided', () => {
+    const p = params(
+      buildChartUrl({
+        chart_type: 'trend',
+        origin: { board_id: 'home', section_id: 'sec-1', widget_id: 'w-1' },
+        pattern: 'coffee',
+        source_type: 'activity_type',
+      }),
+    )
+    expect(p.get('board_id')).toBe('home')
+    expect(p.get('section_id')).toBe('sec-1')
+    expect(p.get('widget_id')).toBe('w-1')
+  })
+})

--- a/apps/web/src/utils/chart-url.ts
+++ b/apps/web/src/utils/chart-url.ts
@@ -1,3 +1,14 @@
+/**
+ * Origin of a chart the user navigated from: identifies the exact board widget
+ * so the chart page can offer to update it in place. `board_id` is 'home' for
+ * the private dashboard or a shared-dashboard id.
+ */
+export interface ChartOrigin {
+  board_id: string
+  section_id: string
+  widget_id: string
+}
+
 /** Build a /chart URL from widget config parameters. */
 export function buildChartUrl(params: {
   aggregation?: string
@@ -9,6 +20,7 @@ export function buildChartUrl(params: {
   pattern?: string
   source_type: string
   activity_type_id?: string
+  origin?: ChartOrigin
 }): string {
   const qs = new URLSearchParams()
   qs.set('source_type', params.source_type)
@@ -26,6 +38,12 @@ export function buildChartUrl(params: {
 
   if (params.aggregation && params.aggregation !== 'count') {
     qs.set('aggregation', params.aggregation)
+  }
+
+  if (params.origin) {
+    qs.set('board_id', params.origin.board_id)
+    qs.set('section_id', params.origin.section_id)
+    qs.set('widget_id', params.origin.widget_id)
   }
 
   return `/chart?${qs}`

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -84,10 +84,20 @@ Click the pencil icon next to the "Dashboard" title to enter edit mode.
 - **Remove a widget**: Click the X button on any widget.
 - **Reorder widgets**: Use the up/down arrows on each widget to move it within its section.
 - **Add a section**: Click "Add Section" at the bottom. Give it a title and choose a type (Metrics, Charts, or Links).
+- **Rename a section**: Click the pencil icon next to a section title, edit the title inline, and press Enter (or click away) to save. Press Escape to cancel.
 - **Delete a section**: Click the trash icon next to a section title. Confirms before deleting the section and all its widgets.
 - **Reset to defaults**: Click "Reset to Default" to restore the original 4-section layout. Your customizations will be lost.
 
 Every change saves immediately -- there is no separate "Save" button. Click "Done Editing" to exit edit mode.
+
+### Updating a chart from the chart explorer
+
+Every chart widget links to the [Chart Explorer](./trends.md) (`/chart`), carrying an
+identifier for the exact board widget it came from. On the chart page you can tweak the
+source, lookback, aggregation, or chart type, then click **"Update Chart in _&lt;board&gt;_ /
+_&lt;section&gt;_"** at the bottom to replace that widget in place with the new configuration
+(and optionally give it a new title). This works for both your home dashboard and any
+shared dashboard you own.
 
 ### Metric Picker
 

--- a/docs/features/sharing.md
+++ b/docs/features/sharing.md
@@ -66,12 +66,15 @@ beyond the saved widgets.
   server-resolved data.
 - **Edit in place**: when you are logged in and viewing your *own* shared
   dashboard (`/u/<you>/<slug>`), an Edit toggle appears and you get the same
-  add/remove/move-widget and section controls as the home dashboard; changes
-  save to that shared dashboard. (Owners see live widget data here, not the
-  read-only snapshot.)
+  add/remove/move-widget and section controls as the home dashboard (including
+  renaming sections inline); changes save to that shared dashboard. (Owners see
+  live widget data here, not the read-only snapshot.)
 - **Add a chart to a shared dashboard**: the chart page's "Add to dashboard"
   dialog lets you pick the target dashboard (your home dashboard or any shared
   one) and then the section.
+- **Update a chart on a shared dashboard**: clicking a chart on a shared
+  dashboard you own opens the chart page carrying that widget's origin; tweak it
+  and use "Update Chart in _&lt;board&gt;_ / _&lt;section&gt;_" to replace it in place.
 
 ## API
 


### PR DESCRIPTION
Closes #822.

## What & why

Issue #822 asked for two dashboard-editing capabilities:

1. **Editable section titles.**
2. When you click a chart on a board and land on the chart explorer, the URL should carry which board chart you came from, and the chart page should offer an **"Update Chart in _&lt;dashboard&gt;_ / _&lt;section&gt;_"** button (with an option to set a new title).

Both are delivered here, for the home dashboard and for shared dashboards the user owns. No backend/api-spec changes — everything persists through the existing `saveDashboard` / `updateSharedDashboard` endpoints.

## Changes

**Section rename (part 1)**
- In edit mode, each section header gains a pencil button that swaps the title for an inline input. Enter or blur commits (via a new `handleRenameSection` → `onChange`); Escape cancels; empty/unchanged titles are ignored.

**Update-a-chart-in-place (part 2)**
- `buildChartUrl` gains an optional `origin` (`board_id` / `section_id` / `widget_id`); `'home'` denotes the private dashboard, otherwise a shared-dashboard id.
- `EditableDashboard` now takes a `boardId` and threads `{ board_id, section_id, widget_id }` down through `WidgetRenderer` into the trend/bar chart widgets, so their link back to `/chart` carries the origin.
- The chart page parses the origin, preserves it in the URL as controls change, and renders `UpdateChartOnBoard`: an "Update Chart in _&lt;board&gt;_ / _&lt;section&gt;_" button that replaces the originating widget in place (preserving its id) with the current config and an optional new title. Board/section names are resolved from the live config (IDs in the URL, names at render time). The control hides itself if the origin no longer resolves to a real widget.

**Docs**
- Updated `docs/features/dashboard.md` and `docs/features/sharing.md`.

## Testing

- New unit tests for the pure helpers: `parseChartOrigin`, `chartWidgetTitle`, `replaceWidgetInConfig` (`updateWidget.test.ts`) and `buildChartUrl` origin params (`chart-url.test.ts`).
- `pnpm check` clean (0 errors; new code adds 0 lint warnings).
- Full `apps/web` suite green (464 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)