### PR TITLE
feat(dashboard): redirect to the board after updating a chart from the chart page

### DIFF
--- a/apps/web/src/pages/Chart/index.tsx
+++ b/apps/web/src/pages/Chart/index.tsx
@@ -40,7 +40,7 @@ import {
   updateUserSettings,
 } from '../../state/api'
 import { auth } from '../../state/auth'
-import { chartWidgetTitle, parseChartOrigin, replaceWidgetInConfig } from './updateWidget'
+import { boardReturnPath, chartWidgetTitle, parseChartOrigin, replaceWidgetInConfig } from './updateWidget'
 import './style.css'
 
 type SourceType = 'metric' | 'productivity_category' | 'activity_type'
@@ -785,10 +785,10 @@ function AddToDashboardModal({ state, onClose }: { state: ChartState; onClose: (
  */
 function UpdateChartOnBoard({ state, origin }: { state: ChartState; origin: ChartOrigin }) {
   const queryClient = useQueryClient()
+  const { route } = useLocation()
   const isHome = origin.board_id === 'home'
   const [expanded, setExpanded] = useState(false)
   const [title, setTitle] = useState('')
-  const [saved, setSaved] = useState(false)
 
   const dashboardQuery = useQuery({
     enabled: isHome,
@@ -810,6 +810,9 @@ function UpdateChartOnBoard({ state, origin }: { state: ChartState; origin: Char
   const section = targetConfig?.sections.find((s) => s.id === origin.section_id)
   const existingWidget = section?.widgets.find((w) => w.id === origin.widget_id)
 
+  // Where to send the user after a successful update: the board they came from.
+  const destination = boardReturnPath(origin, auth.value.user, shared?.slug)
+
   const updateMutation = useMutation({
     mutationFn: async () => {
       if (!targetConfig) return
@@ -822,7 +825,7 @@ function UpdateChartOnBoard({ state, origin }: { state: ChartState; origin: Char
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['dashboard'] })
       void queryClient.invalidateQueries({ queryKey: ['sharedDashboards'] })
-      setSaved(true)
+      route(destination)
     },
   })
 
@@ -838,7 +841,6 @@ function UpdateChartOnBoard({ state, origin }: { state: ChartState; origin: Char
           class="btn-add-to-dashboard"
           onClick={() => {
             setTitle(chartWidgetTitle(existingWidget) ?? '')
-            setSaved(false)
             setExpanded(true)
           }}
         >
@@ -855,46 +857,30 @@ function UpdateChartOnBoard({ state, origin }: { state: ChartState; origin: Char
   return (
     <div class="chart-goal-form">
       <h3>{label}</h3>
-      {saved ? (
-        <>
-          <div class="add-to-dash-success">Chart updated!</div>
-          <div class="goal-form-actions">
-            <button class="btn-save" onClick={() => setExpanded(false)}>
-              Done
-            </button>
-          </div>
-        </>
-      ) : (
-        <>
-          <p class="goal-form-description">
-            Replace this chart on <strong>{boardName}</strong> with the current configuration.
-          </p>
-          <div class="goal-form-fields">
-            <label style={{ flex: 1 }}>
-              Title (optional)
-              <input
-                class="chart-update-title"
-                type="text"
-                value={title}
-                onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
-                placeholder={state.pattern || 'Chart title'}
-              />
-            </label>
-          </div>
-          <div class="goal-form-actions">
-            <button class="btn-cancel" onClick={() => setExpanded(false)}>
-              Cancel
-            </button>
-            <button
-              class="btn-save"
-              disabled={updateMutation.isPending}
-              onClick={() => updateMutation.mutate()}
-            >
-              {updateMutation.isPending ? 'Updating...' : 'Update Chart'}
-            </button>
-          </div>
-        </>
-      )}
+      <p class="goal-form-description">
+        Replace this chart on <strong>{boardName}</strong> with the current configuration. You'll be taken
+        back to the dashboard.
+      </p>
+      <div class="goal-form-fields">
+        <label style={{ flex: 1 }}>
+          Title (optional)
+          <input
+            class="chart-update-title"
+            type="text"
+            value={title}
+            onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+            placeholder={state.pattern || 'Chart title'}
+          />
+        </label>
+      </div>
+      <div class="goal-form-actions">
+        <button class="btn-cancel" onClick={() => setExpanded(false)}>
+          Cancel
+        </button>
+        <button class="btn-save" disabled={updateMutation.isPending} onClick={() => updateMutation.mutate()}>
+          {updateMutation.isPending ? 'Updating...' : 'Update Chart'}
+        </button>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/Chart/updateWidget.test.ts
+++ b/apps/web/src/pages/Chart/updateWidget.test.ts
@@ -46,9 +46,9 @@ describe('boardReturnPath', () => {
     )
   })
 
-  test('url-encodes the username', () => {
-    expect(boardReturnPath({ board_id: 'sd-1', section_id: 's', widget_id: 'w' }, 'a b', 'abc')).toBe(
-      '/u/a%20b/abc',
+  test('url-encodes both the username and the slug', () => {
+    expect(boardReturnPath({ board_id: 'sd-1', section_id: 's', widget_id: 'w' }, 'a b', 'a/b')).toBe(
+      '/u/a%20b/a%2Fb',
     )
   })
 })

--- a/apps/web/src/pages/Chart/updateWidget.test.ts
+++ b/apps/web/src/pages/Chart/updateWidget.test.ts
@@ -2,7 +2,7 @@ import type { DashboardConfig, DashboardWidget } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
-import { chartWidgetTitle, parseChartOrigin, replaceWidgetInConfig } from './updateWidget'
+import { boardReturnPath, chartWidgetTitle, parseChartOrigin, replaceWidgetInConfig } from './updateWidget'
 
 const trendWidget = (id: string, title?: string): DashboardWidget => ({
   config: { pattern: 'coffee', source_type: 'activity_type', ...(title ? { title } : {}) },
@@ -32,6 +32,24 @@ describe('parseChartOrigin', () => {
       section_id: 'sec-1',
       widget_id: 'w-1',
     })
+  })
+})
+
+describe('boardReturnPath', () => {
+  test('returns the home dashboard path for the home board', () => {
+    expect(boardReturnPath({ board_id: 'home', section_id: 's', widget_id: 'w' }, 'fiddur', 'abc')).toBe('/')
+  })
+
+  test('returns the owner shared-dashboard path for a shared board', () => {
+    expect(boardReturnPath({ board_id: 'sd-1', section_id: 's', widget_id: 'w' }, 'fiddur', 'abc')).toBe(
+      '/u/fiddur/abc',
+    )
+  })
+
+  test('url-encodes the username', () => {
+    expect(boardReturnPath({ board_id: 'sd-1', section_id: 's', widget_id: 'w' }, 'a b', 'abc')).toBe(
+      '/u/a%20b/abc',
+    )
   })
 })
 

--- a/apps/web/src/pages/Chart/updateWidget.ts
+++ b/apps/web/src/pages/Chart/updateWidget.ts
@@ -13,6 +13,19 @@ export function parseChartOrigin(query: Record<string, string>): ChartOrigin | n
   return { board_id, section_id, widget_id }
 }
 
+/**
+ * App path of the board a chart update should return to: the home dashboard at
+ * `/`, or the owner's shared dashboard at `/u/<username>/<slug>`.
+ */
+export function boardReturnPath(
+  origin: ChartOrigin,
+  username: string | undefined,
+  slug: string | undefined,
+): string {
+  if (origin.board_id === 'home') return '/'
+  return `/u/${encodeURIComponent(username ?? '')}/${slug ?? ''}`
+}
+
 /** Existing display title of a chart widget, if any (used to pre-fill the update form). */
 export function chartWidgetTitle(widget: DashboardWidget): string | undefined {
   if (widget.type === 'trend_chart' || widget.type === 'bar_chart') return widget.config.title

--- a/apps/web/src/pages/Chart/updateWidget.ts
+++ b/apps/web/src/pages/Chart/updateWidget.ts
@@ -23,7 +23,7 @@ export function boardReturnPath(
   slug: string | undefined,
 ): string {
   if (origin.board_id === 'home') return '/'
-  return `/u/${encodeURIComponent(username ?? '')}/${slug ?? ''}`
+  return `/u/${encodeURIComponent(username ?? '')}/${encodeURIComponent(slug ?? '')}`
 }
 
 /** Existing display title of a chart widget, if any (used to pre-fill the update form). */

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -96,8 +96,8 @@ Every chart widget links to the [Chart Explorer](./trends.md) (`/chart`), carryi
 identifier for the exact board widget it came from. On the chart page you can tweak the
 source, lookback, aggregation, or chart type, then click **"Update Chart in _&lt;board&gt;_ /
 _&lt;section&gt;_"** at the bottom to replace that widget in place with the new configuration
-(and optionally give it a new title). This works for both your home dashboard and any
-shared dashboard you own.
+(and optionally give it a new title). On save you are taken straight back to that
+dashboard. This works for both your home dashboard and any shared dashboard you own.
 
 ### Metric Picker
 


### PR DESCRIPTION
Follow-up to #823 (issue #822).

## What & why

After updating a board chart from the Chart Explorer, the page used to show a "Chart updated!" box with a **Done** button. Per feedback, it now **forwards the user straight back to the dashboard they came from** instead.

- Home board → `/`
- Owned shared board → `/u/<username>/<slug>`

Navigation is client-side (preact-iso `route`), and the `['dashboard']` / `['sharedDashboards']` queries are still invalidated first, so the updated widget is visible on arrival.

## Changes

- `UpdateChartOnBoard` (Chart page): dropped the `saved` state and the success/Done UI; `onSuccess` now invalidates + `route(destination)`.
- New pure helper `boardReturnPath(origin, username, slug)` in `updateWidget.ts` computes the return path. Extracting it also keeps `UpdateChartOnBoard` under the eslint `complexity` cap.
- Docs: `dashboard.md` notes the redirect.

## Testing

- New unit tests for `boardReturnPath` (home, shared, username url-encoding).
- `pnpm check` clean (0 errors, back to the 255-warning baseline).
- Full `apps/web` suite green (467 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)