### PR TITLE
fix(chart): restrict cumulative-metric sums to trusted sources

### DIFF
--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -1,11 +1,15 @@
+import type * as TimeSeriesModule from '../db/time-series.ts'
+
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import * as db from '../db/index.ts'
 import { buildBucketExpr, getChartData } from './chart-data.ts'
 
-// Mock the db module
-vi.mock('../db', () => ({
+// Mock the db module. getSourceFilter is pulled through real (pure function) so
+// the cumulative-source rules can't drift from production.
+vi.mock('../db', async () => ({
   expandActivityTypes: vi.fn().mockImplementation((_user: string, types: string[]) => Promise.resolve(types)),
+  getSourceFilter: (await vi.importActual<typeof TimeSeriesModule>('../db/time-series.ts')).getSourceFilter,
   query: vi.fn(),
 }))
 
@@ -122,6 +126,30 @@ describe('getChartData', () => {
 
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[1]).toContain('SUM(value)')
+    // Cumulative metric (steps) must be restricted to trusted sources so it isn't
+    // multiply-counted (raw + daily-aggregate + …). Regression guard for the
+    // chart/challenge over-count.
+    expect(call[1]).toContain('source = ANY')
+    expect(call[1]).toContain('deleted_at IS NULL')
+    expect(call[2]).toContainEqual(['health_connect_aggregate', 'aurboda'])
+  })
+
+  test('non-cumulative metric sum does not restrict sources', async () => {
+    vi.mocked(db.query).mockResolvedValue({
+      rows: [{ bucket_start: new Date('2026-01-01T00:00:00Z'), value: 5 }],
+    } as never)
+
+    await getChartData('testuser', {
+      aggregation: 'sum',
+      bucket_size: '1d',
+      end: '2026-01-31T23:59:59Z',
+      pattern: 'heart_rate',
+      source_type: 'metric',
+      start: '2026-01-01T00:00:00Z',
+    })
+
+    const call = vi.mocked(db.query).mock.calls[0]
+    expect(call[1]).not.toContain('source = ANY')
   })
 
   test('returns bucketed metric data with count aggregation', async () => {

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -7,7 +7,7 @@
 
 import type { ChartDataBreakdownBucket, ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
 
-import { expandActivityTypes, query } from '../db/index.ts'
+import { expandActivityTypes, getSourceFilter, query } from '../db/index.ts'
 
 /** Map bucket_size parameter to PostgreSQL date_trunc interval name (day and above). */
 const bucketToTrunc: Record<string, string> = {
@@ -136,16 +136,32 @@ const queryMetricBuckets = async (
 ): Promise<ChartDataBucket[]> => {
   const aggFn = aggregation === 'mean' ? 'AVG(value)' : aggregation === 'sum' ? 'SUM(value)' : 'COUNT(*)'
   const bucket = buildBucketExpr(bucketSize, 'time', 1)
+  const p = bucket.params.length
+  const params: unknown[] = [...bucket.params, metric, start, end]
+
+  // Cumulative/derived metrics (steps, distance, calories, …) are stored from
+  // multiple sources (raw per-minute + deduplicated daily aggregates + …), so
+  // summing across all sources multiply-counts them. Restrict to the trusted
+  // source(s) — the same rule the metric/period-summary read paths use — so the
+  // chart (and challenges, which share this path) matches the real totals.
+  const sourceFilter = getSourceFilter(metric)
+  let sourceClause = ''
+  if (sourceFilter !== null) {
+    params.push(sourceFilter)
+    sourceClause = ` AND source = ANY($${params.length})`
+  }
+
   const result = await query(
     user,
     `SELECT ${bucket.expr} AS bucket_start,
             ${aggFn} AS value
        FROM time_series
-      WHERE metric = $${bucket.params.length + 1}
-        AND time BETWEEN $${bucket.params.length + 2} AND $${bucket.params.length + 3}
+      WHERE metric = $${p + 1}
+        AND time BETWEEN $${p + 2} AND $${p + 3}
+        AND deleted_at IS NULL${sourceClause}
       GROUP BY 1
       ORDER BY 1`,
-    [...bucket.params, metric, start, end],
+    params,
   )
   return result.rows.map((row) => ({
     bucket_start: row.bucket_start.toISOString(),


### PR DESCRIPTION
## Problem
On `/chart` (and anywhere `query_chart_data` is used), a **daily `steps` sum** showed ~44k for a day the goal/period-summary reported as ~7.3k. `queryMetricBuckets` did `SUM(value) FROM time_series WHERE metric='steps'` across **all sources**, so cumulative/derived metrics — stored simultaneously from raw per-minute readings, deduplicated daily aggregates, and device totals — were multiply-counted. It also included soft-deleted rows.

## Fix
Apply the same trusted-source filter the metric/period-summary read paths already use (`getSourceFilter` → `cumulativeSources` for steps/distance/…, `aurbodaOnlySources` for calories) in `queryMetricBuckets`, and exclude `deleted_at`. Non-cumulative metrics (heart_rate, weight, …) are unchanged (all sources).

**This also fixes challenge totals** for cumulative metrics — challenges use the same `getChartData` path, so a steps challenge would have over-counted identically.

## Tests
- `chart-data.test.ts`: assert a cumulative metric (`steps`) sum SQL includes `source = ANY(...)` with `cumulativeSources` + `deleted_at IS NULL`; a non-cumulative metric (`heart_rate`) does not filter sources. `getSourceFilter` pulled through real (pure fn) so the rule can't drift. All 26 chart-data tests pass; `pnpm check` clean.

## Not in this PR (related, separate)
- **Zone 2 / Zone 2 (Weekly) render empty charts** — `hr_zone_*_sec` are *computed* metrics (derived from heart_rate), not stored in `time_series`, so `query_chart_data` finds nothing. Needs the chart path to compute HR-zone metrics — filing/fixing separately.
- Per-day bucket alignment for a non-UTC timezone (chart buckets in UTC; the goal buckets in local time) — the window **total** is exact regardless; per-day points can shift by the tz offset. That's the documented tz-local-bucketing refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)