### PR TITLE
feat(chart): chart computed HR-zone metrics (Zone 0–5)

### DIFF
--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -4,13 +4,21 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import * as db from '../db/index.ts'
 import { buildBucketExpr, getChartData } from './chart-data.ts'
+import * as settings from './settings.ts'
 
 // Mock the db module. getSourceFilter is pulled through real (pure function) so
 // the cumulative-source rules can't drift from production.
 vi.mock('../db', async () => ({
   expandActivityTypes: vi.fn().mockImplementation((_user: string, types: string[]) => Promise.resolve(types)),
   getSourceFilter: (await vi.importActual<typeof TimeSeriesModule>('../db/time-series.ts')).getSourceFilter,
+  getTimeSeries: vi.fn(),
   query: vi.fn(),
+}))
+
+// Keep the real (pure) computeHrZoneSecs; only stub the DB-backed zones lookup.
+vi.mock('./settings', async () => ({
+  ...(await vi.importActual<typeof settings>('./settings.ts')),
+  getEffectiveHrZones: vi.fn(),
 }))
 
 describe('getChartData', () => {
@@ -150,6 +158,55 @@ describe('getChartData', () => {
 
     const call = vi.mocked(db.query).mock.calls[0]
     expect(call[1]).not.toContain('source = ANY')
+  })
+
+  test('charts hr_zone metrics by computing zone seconds per bucket', async () => {
+    // Two heart-rate samples 60s apart in zone 2 (hr 115, with z2 start 110).
+    vi.mocked(db.getTimeSeries).mockResolvedValue([
+      [new Date('2026-06-24T08:00:00Z'), 115],
+      [new Date('2026-06-24T08:01:00Z'), 115],
+    ])
+    vi.mocked(settings.getEffectiveHrZones).mockResolvedValue({
+      source: 'custom',
+      zones: { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 },
+    })
+
+    const result = await getChartData('testuser', {
+      aggregation: 'sum',
+      bucket_size: '1d',
+      end: '2026-06-25T00:00:00Z',
+      pattern: 'hr_zone_2_sec',
+      source_type: 'metric',
+      start: '2026-06-24T00:00:00Z',
+    })
+
+    // Reads heart_rate (not the non-existent hr_zone_2_sec rows) and buckets by day.
+    expect(vi.mocked(db.getTimeSeries).mock.calls[0][1]).toBe('heart_rate')
+    expect(result.buckets).toHaveLength(1)
+    expect(result.buckets[0].bucket_start).toBe('2026-06-24T00:00:00.000Z')
+    expect((result.buckets[0] as { value: number }).value).toBeGreaterThan(0)
+    // Plain metric query path is not used for zone metrics.
+    expect(vi.mocked(db.query)).not.toHaveBeenCalled()
+  })
+
+  test('zone2_weekly aliases to hr_zone_2_sec (computed, not queried)', async () => {
+    vi.mocked(db.getTimeSeries).mockResolvedValue([])
+    vi.mocked(settings.getEffectiveHrZones).mockResolvedValue({
+      source: 'default',
+      zones: { 1: 90, 2: 110, 3: 130, 4: 150, 5: 170 },
+    })
+
+    await getChartData('testuser', {
+      aggregation: 'sum',
+      bucket_size: '1w',
+      end: '2026-06-25T00:00:00Z',
+      pattern: 'zone2_weekly',
+      source_type: 'metric',
+      start: '2026-06-01T00:00:00Z',
+    })
+
+    expect(vi.mocked(db.getTimeSeries).mock.calls[0][1]).toBe('heart_rate')
+    expect(vi.mocked(db.query)).not.toHaveBeenCalled()
   })
 
   test('returns bucketed metric data with count aggregation', async () => {

--- a/apps/backend/src/services/chart-data.ts
+++ b/apps/backend/src/services/chart-data.ts
@@ -7,7 +7,8 @@
 
 import type { ChartDataBreakdownBucket, ChartDataBucket, ChartDataSourceType } from '@aurboda/api-spec'
 
-import { expandActivityTypes, getSourceFilter, query } from '../db/index.ts'
+import { expandActivityTypes, getSourceFilter, getTimeSeries, query } from '../db/index.ts'
+import { computeHrZoneSecs, getEffectiveHrZones } from './settings.ts'
 
 /** Map bucket_size parameter to PostgreSQL date_trunc interval name (day and above). */
 const bucketToTrunc: Record<string, string> = {
@@ -169,6 +170,75 @@ const queryMetricBuckets = async (
   }))
 }
 
+const HR_ZONE_BIN_ORIGIN = Date.UTC(2000, 0, 1)
+
+/** UTC bucket-start for a timestamp, mirroring buildBucketExpr's date_trunc/date_bin. */
+const utcBucketStart = (t: Date, bucketSize: string): Date => {
+  const bin = (intervalMs: number): Date =>
+    new Date(HR_ZONE_BIN_ORIGIN + Math.floor((t.getTime() - HR_ZONE_BIN_ORIGIN) / intervalMs) * intervalMs)
+  switch (bucketSize) {
+    case '1m':
+      return bin(60_000)
+    case '5m':
+      return bin(5 * 60_000)
+    case '15m':
+      return bin(15 * 60_000)
+    case '1h':
+      return new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth(), t.getUTCDate(), t.getUTCHours()))
+    case '1w': {
+      const d = new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth(), t.getUTCDate()))
+      d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7)) // back to Monday (date_trunc('week'))
+      return d
+    }
+    case '1M':
+      return new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth(), 1))
+    default:
+      return new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth(), t.getUTCDate()))
+  }
+}
+
+/**
+ * Bucketed seconds-in-zone for an `hr_zone_<n>_sec` metric. HR-zone metrics are
+ * not stored — they're computed from heart-rate samples + the user's effective
+ * zones (same as the period summary / HR-zones widget). We group the samples
+ * into buckets and run the zone computation per bucket.
+ */
+const queryHrZoneBuckets = async (
+  user: string,
+  metric: string,
+  start: string,
+  end: string,
+  bucketSize: string,
+): Promise<ChartDataBucket[]> => {
+  const zoneIndex = Number.parseInt(metric.replace('hr_zone_', '').replace('_sec', ''), 10) as
+    | 0
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+  const [hrData, { zones }] = await Promise.all([
+    getTimeSeries(user, 'heart_rate', new Date(start), new Date(end)),
+    getEffectiveHrZones(user),
+  ])
+  if (hrData.length === 0) return []
+
+  const groups = new Map<number, [Date, number][]>()
+  for (const point of hrData) {
+    const key = utcBucketStart(point[0], bucketSize).getTime()
+    const arr = groups.get(key)
+    if (arr) arr.push(point)
+    else groups.set(key, [point])
+  }
+
+  return [...groups.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([key, points]) => ({
+      bucket_start: new Date(key).toISOString(),
+      value: computeHrZoneSecs(points, zones)[zoneIndex],
+    }))
+}
+
 /**
  * Query bucketed productivity category hours.
  *
@@ -312,6 +382,25 @@ const queryActivityTypeBreakdown = async (
 }
 
 /**
+ * Route a metric-source query: HR-zone metrics are computed from heart-rate data,
+ * `zone2_weekly` is a dashboard alias for zone-2 seconds, everything else is a
+ * stored time-series metric.
+ */
+const queryMetricSource = async (
+  user: string,
+  pattern: string | undefined,
+  start: string,
+  end: string,
+  bucketSize: string,
+  aggregation: 'count' | 'mean' | 'sum',
+): Promise<ChartDataBucket[]> => {
+  const metric = pattern === 'zone2_weekly' ? 'hr_zone_2_sec' : pattern
+  if (!metric) return []
+  if (/^hr_zone_[0-5]_sec$/.test(metric)) return queryHrZoneBuckets(user, metric, start, end, bucketSize)
+  return queryMetricBuckets(user, metric, start, end, bucketSize, aggregation)
+}
+
+/**
  * Get bucketed chart data for the given source type and parameters.
  */
 export const getChartData = async (
@@ -365,7 +454,7 @@ export const getChartData = async (
     }
 
     case 'metric':
-      buckets = pattern ? await queryMetricBuckets(user, pattern, start, end, bucket_size, aggregation) : []
+      buckets = await queryMetricSource(user, pattern, start, end, bucket_size, aggregation)
       break
 
     case 'productivity_category':


### PR DESCRIPTION
## Problem
On `/chart`, "Zone 2" (`hr_zone_2_sec`) and "Zone 2 (Weekly)" (`zone2_weekly`) rendered **empty charts**. HR-zone metrics aren't stored in `time_series` — they're computed from heart-rate data + the user's zone thresholds (as the period summary / HR-zones widget do) — so `query_chart_data`'s metric query found no rows. `zone2_weekly` is a dashboard-card-only alias and isn't a real metric at all.

## Fix
- `queryHrZoneBuckets`: fetch `heart_rate` for the window (source-filtered via `getTimeSeries`), group samples into UTC buckets mirroring `buildBucketExpr`, and run the existing pure `computeHrZoneSecs` per bucket with `getEffectiveHrZones`. Value = seconds in that zone per bucket.
- Route `hr_zone_<0-5>_sec` metrics through it; alias `zone2_weekly` → `hr_zone_2_sec` so that picker entry charts too. Non-zone metrics unchanged.
- Extracted the metric routing into `queryMetricSource` (keeps `getChartData` under the complexity limit).

This also enables **zone-based challenges** (they share `getChartData`).

## Tests
- `chart-data.test.ts`: hr_zone metric reads `heart_rate` + buckets per day (not the empty `hr_zone_*` rows) and never hits the plain metric query; `zone2_weekly` aliases to the computed path. `computeHrZoneSecs` pulled through real. 28 tests pass; `pnpm check` clean.

## Note
The chart shows zone time in **seconds** (raw metric value); the dashboard card separately converts to weekly minutes. Follow-up if a minutes display is wanted on the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)