### PR TITLE
fix(challenges): correct public view end date + show joiners immediately (#828, #827)

### DIFF
--- a/apps/web/src/pages/Challenges/PublicChallenge.test.ts
+++ b/apps/web/src/pages/Challenges/PublicChallenge.test.ts
@@ -2,7 +2,7 @@ import type { ChallengeStanding } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
-import { bucketEnd, toCumulativeSeries } from './race-series'
+import { bucketEnd, formatDateInZone, toCumulativeSeries } from './race-series'
 
 const standing = (buckets: { bucket_start: string; value: number }[]): ChallengeStanding => ({
   buckets,
@@ -12,6 +12,24 @@ const standing = (buckets: { bucket_start: string; value: number }[]): Challenge
   stale: false,
   status: 'active',
   total: buckets.reduce((s, b) => s + b.value, 0),
+})
+
+describe('formatDateInZone', () => {
+  test('formats the instant in the given IANA timezone', () => {
+    // 2026-06-30T22:00Z is 2026-07-01 in Europe/Stockholm (UTC+2) but 2026-06-30 in UTC,
+    // so honoring the zone must yield a different calendar day than UTC.
+    const iso = '2026-06-30T22:00:00.000Z'
+    expect(formatDateInZone(iso, 'Europe/Stockholm')).toBe(
+      new Date(iso).toLocaleDateString(undefined, { timeZone: 'Europe/Stockholm' }),
+    )
+    expect(formatDateInZone(iso, 'Europe/Stockholm')).not.toBe(formatDateInZone(iso, 'UTC'))
+  })
+
+  test('falls back to the viewer locale (does not throw) on an invalid timezone', () => {
+    const iso = '2026-07-01T12:00:00.000Z'
+    expect(() => formatDateInZone(iso, 'Not/AZone')).not.toThrow()
+    expect(formatDateInZone(iso, 'Not/AZone')).toBe(new Date(iso).toLocaleDateString())
+  })
 })
 
 describe('bucketEnd', () => {

--- a/apps/web/src/pages/Challenges/PublicChallenge.test.ts
+++ b/apps/web/src/pages/Challenges/PublicChallenge.test.ts
@@ -1,0 +1,53 @@
+import type { ChallengeStanding } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import { bucketEnd, toCumulativeSeries } from './race-series'
+
+const standing = (buckets: { bucket_start: string; value: number }[]): ChallengeStanding => ({
+  buckets,
+  display_name: 'fiddur',
+  identity_base_url: 'https://aurboda.net/u/fiddur',
+  last_updated: null,
+  stale: false,
+  status: 'active',
+  total: buckets.reduce((s, b) => s + b.value, 0),
+})
+
+describe('bucketEnd', () => {
+  test('advances by one day / week / month', () => {
+    expect(bucketEnd('2026-07-01T00:00:00.000Z', '1d')).toBe('2026-07-02T00:00:00.000Z')
+    expect(bucketEnd('2026-07-01T00:00:00.000Z', '1w')).toBe('2026-07-08T00:00:00.000Z')
+    expect(bucketEnd('2026-07-01T00:00:00.000Z', '1M')).toBe('2026-08-01T00:00:00.000Z')
+  })
+})
+
+describe('toCumulativeSeries', () => {
+  test('seeds a zero start-line point so a single bucket still yields a drawable line', () => {
+    const series = toCumulativeSeries(
+      standing([{ bucket_start: '2026-07-01T00:00:00.000Z', value: 4486 }]),
+      '#8b5cf6',
+      '2026-06-30T22:00:00.000Z',
+      '1d',
+    )
+    // start line (0) + the bucket's running total plotted at the bucket end.
+    expect(series.data).toEqual([
+      { date: '2026-06-30T22:00:00.000Z', value: 0 },
+      { date: '2026-07-02T00:00:00.000Z', value: 4486 },
+    ])
+    expect(series.data.length).toBeGreaterThan(1)
+  })
+
+  test('accumulates running totals across ordered buckets', () => {
+    const series = toCumulativeSeries(
+      standing([
+        { bucket_start: '2026-07-02T00:00:00.000Z', value: 3000 },
+        { bucket_start: '2026-07-01T00:00:00.000Z', value: 5000 },
+      ]),
+      '#8b5cf6',
+      '2026-07-01T00:00:00.000Z',
+      '1d',
+    )
+    expect(series.data.map((d) => d.value)).toEqual([0, 5000, 8000])
+  })
+})

--- a/apps/web/src/pages/Challenges/PublicChallenge.tsx
+++ b/apps/web/src/pages/Challenges/PublicChallenge.tsx
@@ -81,10 +81,14 @@ export function PublicChallenge({
 
       <p class="challenge-view-meta">
         {challenge.spec.pattern} · {challenge.spec.aggregation} ({challenge.spec.unit}) ·{' '}
-        {new Date(challenge.start_ts).toLocaleDateString()} –{' '}
+        {/* Render both dates in the timezone the range was chosen in, so they read
+            exactly as entered regardless of the viewer's browser locale/timezone. */}
+        {new Date(challenge.start_ts).toLocaleDateString(undefined, { timeZone: challenge.timezone })} –{' '}
         {/* end_ts is the exclusive window end (midnight after the last day); step back
             one ms to render the inclusive last competing day. */}
-        {new Date(new Date(challenge.end_ts).getTime() - 1).toLocaleDateString()}
+        {new Date(new Date(challenge.end_ts).getTime() - 1).toLocaleDateString(undefined, {
+          timeZone: challenge.timezone,
+        })}
       </p>
 
       <div class="challenge-view-actions">

--- a/apps/web/src/pages/Challenges/PublicChallenge.tsx
+++ b/apps/web/src/pages/Challenges/PublicChallenge.tsx
@@ -3,31 +3,18 @@
  * resolves to a challenge. Shows a cumulative "race" chart (one line per member)
  * and a leaderboard, plus join actions. Rendered without app chrome.
  */
-import type { ChallengeStanding, PublicChallenge as PublicChallengeData } from '@aurboda/api-spec'
+import type { PublicChallenge as PublicChallengeData } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
-import { type LineSeriesData, TrendLineChart } from '../../components/charts/TrendLineChart'
+import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { fetchPublicChallengeStandings, joinChallengeByUrl } from '../../state/api'
 import { auth } from '../../state/auth'
+import { toCumulativeSeries } from './race-series'
 import './style.css'
 
 const COLORS = ['#8b5cf6', '#10b981', '#3b82f6', '#f59e0b', '#ef4444', '#ec4899', '#14b8a6', '#a855f7']
-
-/** Build a cumulative (running-total) series from a member's per-bucket values. */
-const toCumulativeSeries = (standing: ChallengeStanding, color: string): LineSeriesData => {
-  const sorted = [...standing.buckets].sort((a, b) => a.bucket_start.localeCompare(b.bucket_start))
-  let running = 0
-  return {
-    color,
-    data: sorted.map((b) => {
-      running += b.value
-      return { date: b.bucket_start, value: running }
-    }),
-    name: standing.display_name,
-  }
-}
 
 const shortHost = (identityBaseUrl: string): string => {
   try {
@@ -79,8 +66,9 @@ export function PublicChallenge({
 
   const standings = (standingsQuery.data ?? []).filter((s) => s.status === 'active')
   const series = standings
-    .map((s, i) => toCumulativeSeries(s, COLORS[i % COLORS.length]))
-    .filter((s) => s.data.length > 0)
+    .map((s, i) => toCumulativeSeries(s, COLORS[i % COLORS.length], challenge.start_ts, challenge.spec.bucket_size))
+    // Keep members with at least one real bucket (the start-line point alone is length 1).
+    .filter((s) => s.data.length > 1)
 
   return (
     <div class="dashboard public-dashboard public-challenge">

--- a/apps/web/src/pages/Challenges/PublicChallenge.tsx
+++ b/apps/web/src/pages/Challenges/PublicChallenge.tsx
@@ -11,7 +11,7 @@ import { useState } from 'preact/hooks'
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { fetchPublicChallengeStandings, joinChallengeByUrl } from '../../state/api'
 import { auth } from '../../state/auth'
-import { toCumulativeSeries } from './race-series'
+import { formatDateInZone, toCumulativeSeries } from './race-series'
 import './style.css'
 
 const COLORS = ['#8b5cf6', '#10b981', '#3b82f6', '#f59e0b', '#ef4444', '#ec4899', '#14b8a6', '#a855f7']
@@ -83,12 +83,10 @@ export function PublicChallenge({
         {challenge.spec.pattern} · {challenge.spec.aggregation} ({challenge.spec.unit}) ·{' '}
         {/* Render both dates in the timezone the range was chosen in, so they read
             exactly as entered regardless of the viewer's browser locale/timezone. */}
-        {new Date(challenge.start_ts).toLocaleDateString(undefined, { timeZone: challenge.timezone })} –{' '}
+        {formatDateInZone(challenge.start_ts, challenge.timezone)} –{' '}
         {/* end_ts is the exclusive window end (midnight after the last day); step back
             one ms to render the inclusive last competing day. */}
-        {new Date(new Date(challenge.end_ts).getTime() - 1).toLocaleDateString(undefined, {
-          timeZone: challenge.timezone,
-        })}
+        {formatDateInZone(new Date(new Date(challenge.end_ts).getTime() - 1).toISOString(), challenge.timezone)}
       </p>
 
       <div class="challenge-view-actions">

--- a/apps/web/src/pages/Challenges/PublicChallenge.tsx
+++ b/apps/web/src/pages/Challenges/PublicChallenge.tsx
@@ -6,6 +6,7 @@
 import type { ChallengeStanding, PublicChallenge as PublicChallengeData } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
 
 import { type LineSeriesData, TrendLineChart } from '../../components/charts/TrendLineChart'
 import { fetchPublicChallengeStandings, joinChallengeByUrl } from '../../state/api'
@@ -48,6 +49,7 @@ export function PublicChallenge({
   const queryClient = useQueryClient()
   const isLoggedIn = Boolean(auth.value.token)
   const isOwner = isLoggedIn && auth.value.user === username
+  const [joined, setJoined] = useState(false)
 
   const standingsQuery = useQuery({
     queryFn: () => fetchPublicChallengeStandings(username, slug),
@@ -58,9 +60,13 @@ export function PublicChallenge({
   const joinMutation = useMutation({
     mutationFn: () => joinChallengeByUrl(challenge.share_url),
     onError: (e) => alert(e instanceof Error ? e.message : 'Failed to join.'),
-    onSuccess: () => {
-      alert('Joined!')
-      queryClient.invalidateQueries({ queryKey: ['challengeStandings', username, slug] })
+    onSuccess: async () => {
+      setJoined(true)
+      // Refetch with the cache buster so the just-joined member shows up immediately
+      // (a plain refetch can be served the pre-join list from the endpoint's 60s HTTP
+      // cache), and seed the query cache with the fresh result so no stale refetch races.
+      const fresh = await fetchPublicChallengeStandings(username, slug, { bustCache: true })
+      queryClient.setQueryData(['challengeStandings', username, slug], fresh)
     },
   })
 
@@ -87,15 +93,19 @@ export function PublicChallenge({
 
       <p class="challenge-view-meta">
         {challenge.spec.pattern} · {challenge.spec.aggregation} ({challenge.spec.unit}) ·{' '}
-        {new Date(challenge.start_ts).toLocaleDateString()} – {new Date(challenge.end_ts).toLocaleDateString()}
+        {new Date(challenge.start_ts).toLocaleDateString()} –{' '}
+        {/* end_ts is the exclusive window end (midnight after the last day); step back
+            one ms to render the inclusive last competing day. */}
+        {new Date(new Date(challenge.end_ts).getTime() - 1).toLocaleDateString()}
       </p>
 
       <div class="challenge-view-actions">
-        {isLoggedIn && !isOwner && (
+        {isLoggedIn && !isOwner && !joined && (
           <button class="btn-primary" disabled={joinMutation.isPending} onClick={() => joinMutation.mutate()}>
             Join
           </button>
         )}
+        {joined && <span class="challenge-joined">✓ Joined</span>}
         <button class="btn-secondary" onClick={joinFromOtherHost}>
           Join from another instance
         </button>

--- a/apps/web/src/pages/Challenges/race-series.ts
+++ b/apps/web/src/pages/Challenges/race-series.ts
@@ -1,0 +1,37 @@
+import type { ChallengeSpec, ChallengeStanding } from '@aurboda/api-spec'
+
+import type { LineSeriesData } from '../../components/charts/TrendLineChart'
+
+type BucketSize = ChallengeSpec['bucket_size']
+
+/** Advance an ISO instant by one bucket, returning that bucket's exclusive end. */
+export const bucketEnd = (bucketStartIso: string, bucketSize: BucketSize): string => {
+  const d = new Date(bucketStartIso)
+  if (bucketSize === '1M') d.setUTCMonth(d.getUTCMonth() + 1)
+  else if (bucketSize === '1w') d.setUTCDate(d.getUTCDate() + 7)
+  else d.setUTCDate(d.getUTCDate() + 1)
+  return d.toISOString()
+}
+
+/**
+ * Build a cumulative (running-total) "race" series from a member's per-bucket values.
+ * Every racer starts at 0 on the start line, and each cumulative total is plotted at
+ * its bucket's end (the total reached by then). Seeding the start-line point means the
+ * chart draws a proper rising line as soon as there is a single bucket — so it renders
+ * even a few hours into the challenge with only one member.
+ */
+export const toCumulativeSeries = (
+  standing: ChallengeStanding,
+  color: string,
+  startTs: string,
+  bucketSize: BucketSize,
+): LineSeriesData => {
+  const sorted = [...standing.buckets].sort((a, b) => a.bucket_start.localeCompare(b.bucket_start))
+  const data = [{ date: startTs, value: 0 }]
+  let running = 0
+  for (const b of sorted) {
+    running += b.value
+    data.push({ date: bucketEnd(b.bucket_start, bucketSize), value: running })
+  }
+  return { color, data, name: standing.display_name }
+}

--- a/apps/web/src/pages/Challenges/race-series.ts
+++ b/apps/web/src/pages/Challenges/race-series.ts
@@ -4,6 +4,20 @@ import type { LineSeriesData } from '../../components/charts/TrendLineChart'
 
 type BucketSize = ChallengeSpec['bucket_size']
 
+/**
+ * Format an ISO instant as a date in the given IANA timezone, falling back to the
+ * viewer's locale timezone if it is invalid. The backend only validates `timezone` as
+ * a non-empty string, so a crafted challenge could carry garbage — without this guard
+ * `toLocaleDateString` throws `RangeError` and takes down the whole public render.
+ */
+export const formatDateInZone = (iso: string, timeZone: string): string => {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { timeZone })
+  } catch {
+    return new Date(iso).toLocaleDateString()
+  }
+}
+
 /** Advance an ISO instant by one bucket, returning that bucket's exclusive end. */
 export const bucketEnd = (bucketStartIso: string, bucketSize: BucketSize): string => {
   const d = new Date(bucketStartIso)

--- a/apps/web/src/pages/Challenges/style.css
+++ b/apps/web/src/pages/Challenges/style.css
@@ -150,8 +150,14 @@
 /* Public challenge view */
 .public-challenge .challenge-view-actions {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.challenge-joined {
+  color: var(--color-success, #10b981);
+  font-weight: 600;
 }
 
 .challenge-race-chart {

--- a/apps/web/src/state/api/challenges.ts
+++ b/apps/web/src/state/api/challenges.ts
@@ -77,9 +77,15 @@ export const fetchPublicResource = async (
 export const fetchPublicChallengeStandings = async (
   username: string,
   slug: string,
+  options: { bustCache?: boolean } = {},
 ): Promise<ChallengeStanding[]> => {
   const res = await axios.get<ChallengeStandingsResponse>(
     `${API_URL}/public/${encodeURIComponent(username)}/${encodeURIComponent(slug)}/standings`,
+    // The endpoint sends `Cache-Control: public, max-age=60`, so a plain refetch right
+    // after joining can be served a pre-join member list from an HTTP/proxy cache. A
+    // unique query param forces a never-before-seen URL past those caches. The backend
+    // ignores unknown params (and never honors `refresh` here — see public-shares-router).
+    { params: options.bustCache ? { _: Date.now() } : undefined },
   )
   return res.data.members ?? []
 }


### PR DESCRIPTION
Followups to #825 on the public challenge view (`/u/:username/:slug`).

## #828 — end date off-by-one
The meta line rendered the exclusive `end_ts` (local midnight *after* the last day) as the inclusive last day, so a challenge entered as **6/22 – 6/29** displayed **6/22 – 6/30**, contradicting both the create form and the race chart's x-axis. Now renders `end_ts − 1ms` — the actual last competing day.

## #827 — joiner invisible until cache expires
After **Join**, the standings refetch hit the same `/standings` URL, which sends `Cache-Control: public, max-age=60`, so an HTTP/proxy cache could serve the **pre-join member list**. The public endpoint deliberately ignores `?refresh` (unauthenticated — would allow outbound-fetch amplification, see #820), so instead `fetchPublicChallengeStandings` takes a `bustCache` option that appends a unique `_` query param (never-before-seen URL slips past HTTP/proxy caches; backend ignores the unknown param and computes the member list fresh). The post-join refetch uses it and seeds the query cache via `setQueryData`, so no stale refetch races. The **Join** button also flips to **✓ Joined**.

## Also — race chart renders from a single bucket / single member
The chart showed "Insufficient data for chart" a few hours into a challenge with only one member: a daily-bucketed window yields one point on day one, and `TrendLineChart` needs ≥2 points to draw a line. The cumulative series is now modelled as a proper race — every member starts at **0 on the start line**, and each running total is plotted at its bucket's **end** — so a drawable rising line appears as soon as there is one bucket, for any member count. Pure `toCumulativeSeries`/`bucketEnd` helpers extracted to `race-series.ts` with unit tests.

## Testing
- `pnpm check` — green (0 errors).
- `pnpm vitest run src/pages/Challenges` — 8 passing (incl. new race-series tests).

Closes #828
Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)