### PR TITLE
fix(web): list public challenges on user profile page

### DIFF
--- a/apps/web/src/pages/PublicProfile/index.tsx
+++ b/apps/web/src/pages/PublicProfile/index.tsx
@@ -1,6 +1,6 @@
 /**
  * PublicProfile - a user's public page at /u/:username, listing their public
- * shared dashboards. Unauthenticated; rendered without app chrome.
+ * shared dashboards and challenges. Unauthenticated; rendered without app chrome.
  */
 import { useQuery } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
@@ -37,21 +37,35 @@ export function PublicProfile() {
   }
 
   const dashboards = query.data.dashboards ?? []
+  const challenges = query.data.challenges ?? []
+
+  const renderItem = (item: { name: string; slug: string }) => (
+    <li key={item.slug}>
+      <a href={`/u/${encodeURIComponent(username)}/${encodeURIComponent(item.slug)}`}>{item.name}</a>
+    </li>
+  )
 
   return (
     <div class="public-profile">
       <h1>@{username}</h1>
-      {dashboards.length === 0 ? (
-        <p class="public-muted">This user has no public dashboards.</p>
-      ) : (
-        <ul class="public-dashboard-list">
-          {dashboards.map((d) => (
-            <li key={d.slug}>
-              <a href={`/u/${encodeURIComponent(username)}/${encodeURIComponent(d.slug)}`}>{d.name}</a>
-            </li>
-          ))}
-        </ul>
-      )}
+
+      <section class="public-section">
+        <h2>Dashboards</h2>
+        {dashboards.length === 0 ? (
+          <p class="public-muted">This user has no public dashboards.</p>
+        ) : (
+          <ul class="public-item-list">{dashboards.map(renderItem)}</ul>
+        )}
+      </section>
+
+      <section class="public-section">
+        <h2>Challenges</h2>
+        {challenges.length === 0 ? (
+          <p class="public-muted">This user has no public challenges.</p>
+        ) : (
+          <ul class="public-item-list">{challenges.map(renderItem)}</ul>
+        )}
+      </section>
     </div>
   )
 }

--- a/apps/web/src/pages/PublicProfile/style.css
+++ b/apps/web/src/pages/PublicProfile/style.css
@@ -17,7 +17,16 @@
   padding: 2rem 0;
 }
 
-.public-dashboard-list {
+.public-section {
+  margin-top: 2rem;
+}
+
+.public-section h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.public-item-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -26,7 +35,7 @@
   gap: 0.5rem;
 }
 
-.public-dashboard-list a {
+.public-item-list a {
   display: block;
   padding: 0.75rem 1rem;
   border: 1px solid #e5e7eb;
@@ -35,7 +44,7 @@
   color: #111827;
 }
 
-.public-dashboard-list a:hover {
+.public-item-list a:hover {
   border-color: #8b5cf6;
   background: #faf5ff;
 }
@@ -50,13 +59,17 @@
     color: #9ca3af;
   }
 
-  .public-dashboard-list a {
+  .public-section h2 {
+    color: #f3f4f6;
+  }
+
+  .public-item-list a {
     border-color: #374151;
     background: #1f2937;
     color: #f3f4f6;
   }
 
-  .public-dashboard-list a:hover {
+  .public-item-list a:hover {
     border-color: #8b5cf6;
     background: #1e1b4b;
   }


### PR DESCRIPTION
## Problem

Fixes #835. A user's public profile page at `/u/:username` only listed their public **dashboards**. Public **challenges** (e.g. `/u/fiddur/8MsiUjYVOA`) were not shown anywhere on the profile, so they were undiscoverable.

## Fix

The backend already returns the user's public challenges in the same `{ name, share_url, slug }` shape as dashboards from `GET /public/:username/dashboards` — the frontend simply wasn't rendering them. This change adds a **Challenges** section to `PublicProfile` alongside the existing **Dashboards** section, each with its own heading and empty-state message, linking to `/u/:username/:slug`.

- `apps/web/src/pages/PublicProfile/index.tsx` — render `query.data.challenges` in a second list; extract a shared `renderItem` helper; wrap each list in a titled `<section>`.
- `apps/web/src/pages/PublicProfile/style.css` — generalize `.public-dashboard-list` → `.public-item-list` (used by both lists) and add `.public-section` heading styles, including dark-mode.

## Testing

- `pnpm check` (tsgo typecheck + oxlint): 0 errors.
- `pnpm test`: 474 tests pass.

No backend changes were needed. The repo has no component-render test harness (all existing tests cover pure logic), so no rendering test was added, consistent with the established pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYaK7FCGC6GJzqQNJ4QzVk