### PR TITLE
feat(feed): AS2 Create{Exercise} object model (#831)

### DIFF
--- a/apps/backend/src/services/activitypub/object.test.ts
+++ b/apps/backend/src/services/activitypub/object.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest'
+
+import { addressingFor, AS_PUBLIC, type BuildCreateInput, buildCreateExercise } from './object.ts'
+
+const base: BuildCreateInput = {
+  activityType: 'running',
+  actorUrl: 'https://aurboda.net/u/fredrik',
+  aurbodaNs: 'https://aurboda.net/ns/activitystreams#',
+  endTime: '2026-07-01T07:11:03Z',
+  postId: 'https://aurboda.net/u/fredrik/feed/abc',
+  scalars: [
+    { key: 'distance', label: 'Distance', unit: 'km', value: 8.2 },
+    { key: 'heart_rate_avg', label: 'Avg HR', unit: 'bpm', value: 148 },
+    { key: 'hr_zone_minutes', value: { z2: 22, z3: 11 } },
+  ],
+  seriesEndpointBase: 'https://aurboda.net/api/public/fredrik/series',
+  seriesMetrics: ['heart_rate'],
+  startTime: '2026-07-01T06:30:00Z',
+  title: 'Morning run',
+  visibility: 'public',
+}
+
+describe('addressingFor', () => {
+  const followers = 'https://aurboda.net/u/fredrik/followers'
+  test('public → Public in to, followers in cc', () => {
+    expect(addressingFor('public', followers)).toEqual({ cc: [followers], to: [AS_PUBLIC] })
+  })
+  test('unlisted → followers in to, Public in cc', () => {
+    expect(addressingFor('unlisted', followers)).toEqual({ cc: [AS_PUBLIC], to: [followers] })
+  })
+  test('followers → followers only, no Public anywhere', () => {
+    expect(addressingFor('followers', followers)).toEqual({ cc: [], to: [followers] })
+  })
+})
+
+describe('buildCreateExercise', () => {
+  test('produces a Create with a Note-first dual type and canonical ids', () => {
+    const c = buildCreateExercise(base)
+    expect(c.type).toBe('Create')
+    expect(c.id).toBe('https://aurboda.net/u/fredrik/feed/abc')
+    expect(c.actor).toBe(base.actorUrl)
+    expect(c.published).toBe(base.startTime)
+    expect(c.to).toEqual([AS_PUBLIC])
+    expect(c.cc).toEqual(['https://aurboda.net/u/fredrik/followers'])
+    expect(c.object.id).toBe('https://aurboda.net/u/fredrik/feed/abc/object')
+    expect(c.object.type).toEqual(['Note', 'aurboda:Exercise'])
+    expect(c.object.attributedTo).toBe(base.actorUrl)
+    expect(c.object.url).toBe(base.postId)
+  })
+
+  test('@context maps the aurboda namespace prefix', () => {
+    const c = buildCreateExercise(base)
+    expect(c['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      { aurboda: 'https://aurboda.net/ns/activitystreams#' },
+    ])
+  })
+
+  test('content flattens exactly the shared scalars behind the title', () => {
+    const c = buildCreateExercise(base)
+    expect(c.object.content).toBe(
+      '<p>Morning run · Distance 8.2 km · Avg HR 148 bpm · Hr zone minutes z2 22, z3 11</p>',
+    )
+  })
+
+  test('aurboda:metrics carries the machine-readable shared scalars only', () => {
+    const c = buildCreateExercise(base)
+    expect(c.object['aurboda:metrics']).toEqual([
+      { key: 'distance', unit: 'km', value: 8.2 },
+      { key: 'heart_rate_avg', unit: 'bpm', value: 148 },
+      { key: 'hr_zone_minutes', value: { z2: 22, z3: 11 } },
+    ])
+  })
+
+  test('duration is computed from the window', () => {
+    const c = buildCreateExercise(base)
+    expect(c.object['aurboda:durationSeconds']).toBe(2463)
+    expect(c.object['aurboda:endTime']).toBe(base.endTime)
+  })
+
+  test('aurboda:series links only the explicitly-shared series metrics, scoped to the window', () => {
+    const c = buildCreateExercise(base)
+    expect(c.object['aurboda:series']).toEqual([
+      {
+        href: 'https://aurboda.net/api/public/fredrik/series?bucket=5s&end=2026-07-01T07%3A11%3A03Z&metric=heart_rate&start=2026-07-01T06%3A30%3A00Z',
+        mediaType: 'application/json',
+        metric: 'heart_rate',
+      },
+    ])
+  })
+
+  test('no series links when none were shared', () => {
+    const c = buildCreateExercise({ ...base, seriesMetrics: [] })
+    expect(c.object['aurboda:series']).toBeUndefined()
+  })
+
+  test('no series links or duration for an open-ended activity (no end time)', () => {
+    const c = buildCreateExercise({ ...base, endTime: undefined })
+    expect(c.object['aurboda:series']).toBeUndefined()
+    expect(c.object['aurboda:durationSeconds']).toBeUndefined()
+    expect(c.object['aurboda:endTime']).toBeUndefined()
+  })
+
+  test('escapes HTML in the title for the fallback content', () => {
+    const c = buildCreateExercise({ ...base, scalars: [], title: 'Run <b>x</b> & "go"' })
+    expect(c.object.content).toBe('<p>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</p>')
+  })
+
+  test('falls back to a derived name when the activity has no title', () => {
+    const c = buildCreateExercise({ ...base, title: undefined })
+    expect(c.object.name).toBe('Running activity')
+  })
+})

--- a/apps/backend/src/services/activitypub/object.test.ts
+++ b/apps/backend/src/services/activitypub/object.test.ts
@@ -94,6 +94,13 @@ describe('buildCreateExercise', () => {
     expect(c.object['aurboda:series']).toBeUndefined()
   })
 
+  test('no series links for a followers-only post (public /series would 404)', () => {
+    const c = buildCreateExercise({ ...base, seriesMetrics: ['heart_rate'], visibility: 'followers' })
+    expect(c.object['aurboda:series']).toBeUndefined()
+    // The scalar summary still rides along for followers.
+    expect(c.object['aurboda:metrics']).toHaveLength(base.scalars.length)
+  })
+
   test('no series links or duration for an open-ended activity (no end time)', () => {
     const c = buildCreateExercise({ ...base, endTime: undefined })
     expect(c.object['aurboda:series']).toBeUndefined()

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -1,0 +1,182 @@
+/**
+ * AS2 object model for a shared activity.
+ *
+ * Serializes a feed post into a `Create` activity whose `object` is a dual-typed
+ * `["Note", "aurboda:Exercise"]`: `Note` first so plain fediverse clients
+ * (Mastodon) render `name`/`content`/`url` as a status, plus structured
+ * `aurboda:` extension fields that an Aurboda↔Aurboda consumer reads
+ * ("progressive enhancement").
+ *
+ * This module is a pure function of its inputs — the caller resolves the shared
+ * scalar values and passes in the absolute URLs — so it is fully unit-testable
+ * and carries no dependency on the (upcoming) Fedify actor/delivery layer. Only
+ * the metrics the user actually shared are ever emitted: unshared scalars are
+ * absent from `content` and `aurboda:metrics`, and only `seriesMetrics` produce
+ * `aurboda:series` links (which resolve against the public `/series` endpoint).
+ */
+
+import type { FeedVisibility } from '@aurboda/api-spec'
+
+/** The AS2 magic collection every public object is addressed to. */
+export const AS_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
+
+/** A resolved scalar summary for one shared metric. */
+export interface ScalarMetric {
+  /** Machine key, e.g. `heart_rate_avg`, `distance`, `hr_zone_minutes`. */
+  key: string
+  /** Scalar value, or a small keyed record (e.g. HR-zone minutes `{ z2: 22 }`). */
+  value: number | Record<string, number>
+  /** Optional unit for the scalar form (e.g. `bpm`, `km`). */
+  unit?: string
+  /** Optional human label for the fallback text; defaults to a prettified key. */
+  label?: string
+}
+
+export interface BuildCreateInput {
+  /** Canonical absolute URL of the post (the `Create` activity `id`). */
+  postId: string
+  /** Absolute actor URL (e.g. `https://host/u/fredrik`). */
+  actorUrl: string
+  /** The `aurboda:` term prefix IRI, ending in `#` (e.g. `https://host/ns/activitystreams#`). */
+  aurbodaNs: string
+  /** Base URL of the public series endpoint (e.g. `https://host/api/public/fredrik/series`). */
+  seriesEndpointBase: string
+  visibility: FeedVisibility
+  activityType: string
+  /** Activity start (ISO 8601); also the `published` time. */
+  startTime: string
+  /** Activity end (ISO 8601); required for duration and series links. */
+  endTime?: string
+  title?: string
+  /** Resolved scalar summaries for the shared `included_metrics`. */
+  scalars: ScalarMetric[]
+  /** Metric keys whose series were explicitly shared (drive `aurboda:series`). */
+  seriesMetrics: string[]
+  /** Bucket granularity for the series links (defaults to `5s`). */
+  seriesBucket?: string
+}
+
+export interface AS2Create {
+  '@context': [string, Record<string, string>]
+  id: string
+  type: 'Create'
+  actor: string
+  published: string
+  to: string[]
+  cc: string[]
+  object: Record<string, unknown>
+}
+
+const escapeHtml = (s: string): string =>
+  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+
+/** Prettify a snake_case metric key into a label (`hr_zone_minutes` → `Hr zone minutes`). */
+const prettifyKey = (key: string): string => {
+  const spaced = key.replaceAll('_', ' ')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/** Render one scalar for the human-readable fallback line. */
+const formatScalar = ({ key, value, unit, label }: ScalarMetric): string => {
+  const name = label ?? prettifyKey(key)
+  const rendered =
+    typeof value === 'number'
+      ? `${value}${unit ? ` ${unit}` : ''}`
+      : Object.entries(value)
+          .map(([k, v]) => `${k} ${v}`)
+          .join(', ')
+  return `${name} ${rendered}`
+}
+
+/**
+ * Map a post's visibility to AS2 `to`/`cc` addressing. `followers` is the
+ * actor's followers collection; public objects are addressed to the AS2 Public
+ * magic collection.
+ */
+export const addressingFor = (
+  visibility: FeedVisibility,
+  followersUrl: string,
+): { to: string[]; cc: string[] } => {
+  switch (visibility) {
+    case 'public':
+      return { cc: [followersUrl], to: [AS_PUBLIC] }
+    case 'unlisted':
+      return { cc: [AS_PUBLIC], to: [followersUrl] }
+    case 'followers':
+      return { cc: [], to: [followersUrl] }
+  }
+}
+
+/** Build the `aurboda:series` link objects for the shared series metrics. */
+const seriesLinks = (input: BuildCreateInput): Record<string, string>[] => {
+  const { endTime, seriesMetrics } = input
+  if (!endTime || seriesMetrics.length === 0) return []
+  const bucket = input.seriesBucket ?? '5s'
+  return seriesMetrics.map((metric) => {
+    const params = new URLSearchParams({
+      bucket,
+      end: endTime,
+      metric,
+      start: input.startTime,
+    })
+    return {
+      href: `${input.seriesEndpointBase}?${params.toString()}`,
+      mediaType: 'application/json',
+      metric,
+    }
+  })
+}
+
+/**
+ * Build a `Create{Exercise}` AS2 activity for a shared post. Pure and
+ * deterministic given its inputs.
+ */
+export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
+  const followersUrl = `${input.actorUrl}/followers`
+  const { to, cc } = addressingFor(input.visibility, followersUrl)
+  const objectId = `${input.postId}/object`
+
+  const summaryParts = [input.title, ...input.scalars.map(formatScalar)].filter((p): p is string =>
+    Boolean(p),
+  )
+  const summaryLine = summaryParts.join(' · ')
+  const name = input.title ?? `${prettifyKey(input.activityType)} activity`
+
+  const object: Record<string, unknown> = {
+    'aurboda:activityType': input.activityType,
+    'aurboda:metrics': input.scalars.map(({ key, unit, value }) => ({
+      key,
+      ...(unit === undefined ? {} : { unit }),
+      value,
+    })),
+    'aurboda:startTime': input.startTime,
+    attributedTo: input.actorUrl,
+    content: `<p>${escapeHtml(summaryLine)}</p>`,
+    id: objectId,
+    name,
+    published: input.startTime,
+    // Note first → Mastodon uses content/name/url; Aurboda recognises aurboda:Exercise.
+    type: ['Note', 'aurboda:Exercise'],
+    url: input.postId,
+  }
+
+  if (input.endTime) {
+    object['aurboda:endTime'] = input.endTime
+    object['aurboda:durationSeconds'] = Math.round(
+      (new Date(input.endTime).getTime() - new Date(input.startTime).getTime()) / 1000,
+    )
+  }
+  const series = seriesLinks(input)
+  if (series.length > 0) object['aurboda:series'] = series
+
+  return {
+    '@context': ['https://www.w3.org/ns/activitystreams', { aurboda: input.aurbodaNs }],
+    actor: input.actorUrl,
+    cc,
+    id: input.postId,
+    object,
+    published: input.startTime,
+    to,
+    type: 'Create',
+  }
+}

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -11,8 +11,9 @@
  * scalar values and passes in the absolute URLs — so it is fully unit-testable
  * and carries no dependency on the (upcoming) Fedify actor/delivery layer. Only
  * the metrics the user actually shared are ever emitted: unshared scalars are
- * absent from `content` and `aurboda:metrics`, and only `seriesMetrics` produce
- * `aurboda:series` links (which resolve against the public `/series` endpoint).
+ * absent from `content` and `aurboda:metrics`, and only `seriesMetrics` on a
+ * `public`/`unlisted` post produce `aurboda:series` links (matching what the
+ * public `/series` endpoint will actually resolve).
  */
 
 import type { FeedVisibility } from '@aurboda/api-spec'
@@ -107,10 +108,16 @@ export const addressingFor = (
   }
 }
 
-/** Build the `aurboda:series` link objects for the shared series metrics. */
+/**
+ * Build the `aurboda:series` link objects for the shared series metrics.
+ *
+ * Emitted only for `public`/`unlisted` posts: the public `/series` endpoint
+ * refuses `followers`-only posts, so advertising links there would just 404.
+ * Series also need a bounded activity window.
+ */
 const seriesLinks = (input: BuildCreateInput): Record<string, string>[] => {
-  const { endTime, seriesMetrics } = input
-  if (!endTime || seriesMetrics.length === 0) return []
+  const { endTime, seriesMetrics, visibility } = input
+  if (visibility === 'followers' || !endTime || seriesMetrics.length === 0) return []
   const bucket = input.seriesBucket ?? '5s'
   return seriesMetrics.map((metric) => {
     const params = new URLSearchParams({


### PR DESCRIPTION
## Summary

Slice 2 of the federated activity feed ([#831](https://github.com/fiddur/aurboda/issues/831)) — the **ActivityPub payload builder** the upcoming Fedify delivery layer will send. Builds on the merged persistence/share/series foundation (#838).

`buildCreateExercise` is a **pure, deterministic serializer**: given a post's visibility, its activity's window/type/title, the resolved shared scalar metrics, and the absolute actor/post/series URLs, it produces a `Create` activity whose object is dual-typed `["Note", "aurboda:Exercise"]` — `Note` first so Mastodon renders `name`/`content`/`url` as a status, with structured `aurboda:` extension fields (`activityType`, `startTime`/`endTime`, `durationSeconds`, `metrics`, `series`) for Aurboda↔Aurboda consumers ("progressive enhancement").

## Privacy stays consistent with slice 1
- Only the **shared scalars** appear in `content` and `aurboda:metrics`.
- Only explicitly-shared **`seriesMetrics`** produce `aurboda:series` links, scoped to the activity window and pointing at the public `/series` endpoint (whose data-driven scoping is the actual boundary).
- Visibility maps to AS2 `to`/`cc` addressing (public / unlisted / followers).

## Why pure / why now
The serializer is DI-free — actor/post/series URLs and the `aurboda:` namespace IRI are **parameters** — so it has no dependency on the (upcoming) Fedify actor/WebFinger/HTTP-signatures/delivery infrastructure, and it's fully unit-testable. It's the payload the delivery layer will emit; landing it separately keeps that next PR focused on the framework wiring.

## Testing
13 unit tests: `to`/`cc` addressing per visibility, Note-first dual type + canonical ids, `@context` prefix, scalar flattening into `content`, `aurboda:metrics` projection, series scoping (incl. none-shared and open-ended activity), duration computation, and HTML escaping. Backend `tsgo`/oxlint clean.

## Next slices (per issue)
Fedify-based **actor + WebFinger + HTTP signatures + inbox/outbox + delivery queue** (+ the served `/ns/activitystreams` context document and `FEDERATION.md`) — this is where the actor-URL/nginx routing decision lands; then map/chart image rendering, the web Share UI, and the README entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN