### PR TITLE
feat(feed): persist a per-user ActivityPub actor keypair (#831)

### DIFF
--- a/apps/backend/src/db/feed-actor.integration.test.ts
+++ b/apps/backend/src/db/feed-actor.integration.test.ts
@@ -1,0 +1,59 @@
+import { createPublicKey } from 'node:crypto'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+/**
+ * Integration tests for the singleton actor keypair store.
+ */
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { getOrCreateActorKeyPair } from './feed-actor.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+describe('Feed actor keypair integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('generates a valid RSA keypair on first use', async () => {
+    const user = getTestUser()
+    const kp = await getOrCreateActorKeyPair(user)
+
+    expect(kp.private_key_pem).toContain('BEGIN PRIVATE KEY')
+    expect(kp.public_key_pem).toContain('BEGIN PUBLIC KEY')
+    expect(kp.created_at).toBeInstanceOf(Date)
+
+    // The stored public key parses as an RSA key.
+    const pub = createPublicKey(kp.public_key_pem)
+    expect(pub.asymmetricKeyType).toBe('rsa')
+  })
+
+  test('is idempotent — the second call returns the same stored pair', async () => {
+    const user = getTestUser()
+    const first = await getOrCreateActorKeyPair(user)
+    const second = await getOrCreateActorKeyPair(user)
+
+    expect(second.private_key_pem).toBe(first.private_key_pem)
+    expect(second.public_key_pem).toBe(first.public_key_pem)
+    expect(second.created_at.toISOString()).toBe(first.created_at.toISOString())
+  })
+
+  test('keeps a single keypair under concurrent first-use', async () => {
+    const user = getTestUser()
+    const [a, b, c] = await Promise.all([
+      getOrCreateActorKeyPair(user),
+      getOrCreateActorKeyPair(user),
+      getOrCreateActorKeyPair(user),
+    ])
+    // All callers observe the one keypair that won the singleton insert.
+    expect(a.public_key_pem).toBe(b.public_key_pem)
+    expect(b.public_key_pem).toBe(c.public_key_pem)
+  })
+})

--- a/apps/backend/src/db/feed-actor.ts
+++ b/apps/backend/src/db/feed-actor.ts
@@ -1,0 +1,66 @@
+import { generateKeyPair } from 'node:crypto'
+import { promisify } from 'node:util'
+
+/**
+ * The user's ActivityPub actor keypair.
+ *
+ * Each per-user database hosts exactly one actor (the user themselves), so the
+ * keypair lives in the singleton `feed_actor` table. The RSA keypair signs
+ * outbound federation traffic (HTTP Signatures) and its public half is
+ * published in the actor document; PEM encoding (PKCS#8 private / SPKI public)
+ * is chosen so it converts cleanly to a WebCrypto `CryptoKey` for the federation
+ * layer.
+ */
+import { query } from './connection.ts'
+
+const generateKeyPairAsync = promisify(generateKeyPair)
+
+export interface ActorKeyPair {
+  private_key_pem: string
+  public_key_pem: string
+  created_at: Date
+}
+
+interface ActorKeyPairRow {
+  private_key_pem: string
+  public_key_pem: string
+  created_at: Date
+}
+
+const generateRsaKeyPair = async (): Promise<{ privateKeyPem: string; publicKeyPem: string }> => {
+  const { privateKey, publicKey } = await generateKeyPairAsync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { format: 'pem', type: 'pkcs8' },
+    publicKeyEncoding: { format: 'pem', type: 'spki' },
+  })
+  return { privateKeyPem: privateKey, publicKeyPem: publicKey }
+}
+
+/**
+ * Return the user's actor keypair, generating and persisting it on first use.
+ *
+ * Idempotent and race-safe: a concurrent first call may generate a second
+ * keypair, but the `ON CONFLICT (singleton) DO NOTHING` insert keeps whichever
+ * landed first, and the subsequent read returns that single stored pair.
+ */
+export const getOrCreateActorKeyPair = async (user: string): Promise<ActorKeyPair> => {
+  const existing = await query<ActorKeyPairRow>(
+    user,
+    `SELECT private_key_pem, public_key_pem, created_at FROM feed_actor WHERE singleton = true`,
+  )
+  if (existing.rows.length > 0) return existing.rows[0]
+
+  const { privateKeyPem, publicKeyPem } = await generateRsaKeyPair()
+  await query(
+    user,
+    `INSERT INTO feed_actor (singleton, private_key_pem, public_key_pem)
+     VALUES (true, $1, $2)
+     ON CONFLICT (singleton) DO NOTHING`,
+    [privateKeyPem, publicKeyPem],
+  )
+  const stored = await query<ActorKeyPairRow>(
+    user,
+    `SELECT private_key_pem, public_key_pem, created_at FROM feed_actor WHERE singleton = true`,
+  )
+  return stored.rows[0]
+}

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -272,6 +272,9 @@ export {
 // PostgreSQL error predicates
 export { isMissingDatabase } from './pg-errors.ts'
 
+// Feed actor (ActivityPub keypair)
+export { type ActorKeyPair, getOrCreateActorKeyPair } from './feed-actor.ts'
+
 // Feed posts
 export {
   createFeedPost,

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -143,6 +143,7 @@ export const tableCreationOrder = [
   'challenge_participations_indexes',
   'feed_posts',
   'feed_posts_indexes',
+  'feed_actor',
   'mcp_sessions',
   'mcp_sessions_indexes',
   'outbound_sync_queue',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -122,4 +122,18 @@ export const socialTables: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_feed_posts_created ON feed_posts (created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_feed_posts_series ON feed_posts USING GIN (series_metrics)
   `,
+
+  // The user's ActivityPub actor keypair. Each per-user database has a single
+  // actor (the user), so this is a singleton table: the `singleton` PK + CHECK
+  // pins it to one row. The RSA keypair (PKCS#8 private / SPKI public PEM) signs
+  // outbound federation traffic and is published in the actor document.
+  feed_actor: `
+    CREATE TABLE IF NOT EXISTS feed_actor (
+      singleton        BOOLEAN PRIMARY KEY DEFAULT true,
+      private_key_pem  TEXT NOT NULL,
+      public_key_pem   TEXT NOT NULL,
+      created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CHECK (singleton)
+    )
+  `,
 }

--- a/apps/backend/src/test/db-test-helper.ts
+++ b/apps/backend/src/test/db-test-helper.ts
@@ -99,6 +99,7 @@ export const cleanTestDb = async (): Promise<void> => {
     'challenges',
     'shared_dashboards',
     'feed_posts',
+    'feed_actor',
     'tags',
     'tag_definitions',
     'time_series',


### PR DESCRIPTION
## Summary

Slice 3a of the federated activity feed ([#831](https://github.com/fiddur/aurboda/issues/831)). Lands the **actor keypair** that the upcoming Fedify-based actor / WebFinger / HTTP-signature layer will consume. Builds on the merged persistence (#838) and AS2 object model (#846).

Each per-user database hosts exactly **one** actor (the user), so `feed_actor` is a **singleton** table (`BOOLEAN singleton` PK + `CHECK (singleton)`). `getOrCreateActorKeyPair`:
- generates an **RSA-2048** keypair (PKCS#8 private / SPKI public PEM) on first use,
- is **idempotent and race-safe** — `INSERT ... ON CONFLICT (singleton) DO NOTHING` then read, so a concurrent first call can't leave two keypairs.

PEM encoding is chosen so it converts cleanly to a WebCrypto `CryptoKey` for the federation layer; the public half will be published in the actor document.

## Testing
3 integration tests: valid RSA keypair on first use (parses as RSA), idempotency across calls, and a single keypair surviving concurrent first-use. Backend `tsgo`/oxlint clean.

## Context: how this fits the federation slices
The next PR wires **Fedify 2.3** (`@fedify/express`) into an actor dispatcher (reading this keypair) + WebFinger + the served `/ns/activitystreams` context document, and updates `nginx.conf` so `/.well-known/webfinger`, the actor doc, and `/ns/` reach the backend. Planned **actor identity = `https://host/u/:user`** (content-negotiated), consistent with the AS2 object model already merged and the issue's spec — flagging that routing choice here so it can be steered before the Fedify PR. Inbound inbox + signature verification and outbound delivery (Create/Update/Delete + queue) follow in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN