### PR TITLE
fix(federation): route /.well-known/aurboda to the backend

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -61,6 +61,16 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Aurboda cross-instance federation discovery (challenges / shared dashboards)
+    location = /.well-known/aurboda {
+        proxy_pass http://127.0.0.1:3000/.well-known/aurboda;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ActivityPub WebFinger discovery (acct:<user>@<host> -> actor)
     location = /.well-known/webfinger {
         proxy_pass http://127.0.0.1:3000/.well-known/webfinger;


### PR DESCRIPTION
## Summary

`https://aurboda.net/.well-known/aurboda` returned the SPA `index.html` instead of the cross-instance discovery JSON, because nginx had explicit `location =` blocks for the other `/.well-known/*` endpoints (oauth, assetlinks, webfinger) but **none for `/.well-known/aurboda`** — so it fell through to the SPA catch-all. (Reported: a 404/HTML there.)

Add an exact-match proxy to the backend (`well-known-router` already serves `/.well-known/aurboda` with `{ product, version, federation, api_base }`), matching the pattern of the sibling well-known routes.

This is the **challenge / shared-dashboard** federation discovery doc — separate from the ActivityPub feed work, but the same class of well-known-routing gap. No code change, nginx only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN