### PR TITLE
feat(feed): shared-scalar producer + post-publish timestamp (#831)

### DIFF
--- a/apps/backend/src/services/activitypub/object.test.ts
+++ b/apps/backend/src/services/activitypub/object.test.ts
@@ -113,6 +113,19 @@ describe('buildCreateExercise', () => {
     expect(c.object.content).toBe('<p>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</p>')
   })
 
+  test('uses publishedAt for the AS2 published times, keeping the workout time in aurboda:startTime', () => {
+    const c = buildCreateExercise({ ...base, publishedAt: '2026-07-01T20:00:00Z' })
+    expect(c.published).toBe('2026-07-01T20:00:00Z')
+    expect(c.object.published).toBe('2026-07-01T20:00:00Z')
+    expect(c.object['aurboda:startTime']).toBe(base.startTime)
+  })
+
+  test('published defaults to startTime when publishedAt is omitted', () => {
+    const c = buildCreateExercise(base)
+    expect(c.published).toBe(base.startTime)
+    expect(c.object.published).toBe(base.startTime)
+  })
+
   test('falls back to a derived name when the activity has no title', () => {
     const c = buildCreateExercise({ ...base, title: undefined })
     expect(c.object.name).toBe('Running activity')

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -44,10 +44,16 @@ export interface BuildCreateInput {
   seriesEndpointBase: string
   visibility: FeedVisibility
   activityType: string
-  /** Activity start (ISO 8601); also the `published` time. */
+  /** Activity start (ISO 8601); the workout time, kept in `aurboda:startTime`. */
   startTime: string
   /** Activity end (ISO 8601); required for duration and series links. */
   endTime?: string
+  /**
+   * When the post was created (ISO 8601), used for the AS2 `published` of the
+   * Create and its object so remote timelines order it by share time, not the
+   * (possibly much earlier) workout time. Defaults to `startTime`.
+   */
+  publishedAt?: string
   title?: string
   /** Resolved scalar summaries for the shared `included_metrics`. */
   scalars: ScalarMetric[]
@@ -148,6 +154,9 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
   )
   const summaryLine = summaryParts.join(' · ')
   const name = input.title ?? `${prettifyKey(input.activityType)} activity`
+  // `published` is the share time (timeline ordering); the workout time lives in
+  // `aurboda:startTime`.
+  const published = input.publishedAt ?? input.startTime
 
   const object: Record<string, unknown> = {
     'aurboda:activityType': input.activityType,
@@ -161,7 +170,7 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
     content: `<p>${escapeHtml(summaryLine)}</p>`,
     id: objectId,
     name,
-    published: input.startTime,
+    published,
     // Note first → Mastodon uses content/name/url; Aurboda recognises aurboda:Exercise.
     type: ['Note', 'aurboda:Exercise'],
     url: input.postId,
@@ -182,7 +191,7 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
     cc,
     id: input.postId,
     object,
-    published: input.startTime,
+    published,
     to,
     type: 'Create',
   }

--- a/apps/backend/src/services/activitypub/scalars.test.ts
+++ b/apps/backend/src/services/activitypub/scalars.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { type MetricStat, resolveSharedScalars } from './scalars.ts'
+
+const window = {
+  endTime: new Date('2026-07-01T07:11:03Z'),
+  startTime: new Date('2026-07-01T06:30:00Z'),
+}
+
+// A metricStat backed by a fixed table of window aggregates.
+const statFrom =
+  (table: Record<string, Partial<Record<'avg' | 'max' | 'sum', number>>>): MetricStat =>
+  (metric, stat) =>
+    table[metric]?.[stat]
+
+describe('resolveSharedScalars', () => {
+  test('resolves duration from the activity window', () => {
+    const out = resolveSharedScalars(window, ['duration'], statFrom({}))
+    expect(out).toEqual([{ key: 'duration', label: 'Duration', unit: 'seconds', value: 2463 }])
+  })
+
+  test('omits duration for an open-ended activity', () => {
+    const out = resolveSharedScalars({ startTime: window.startTime }, ['duration'], statFrom({}))
+    expect(out).toEqual([])
+  })
+
+  test('resolves and rounds metric-backed scalars with units', () => {
+    const stat = statFrom({
+      calories_active: { sum: 431.7 },
+      distance: { sum: 8231 },
+      heart_rate: { avg: 148.6, max: 172 },
+      stress_level: { avg: 33.4 },
+    })
+    const out = resolveSharedScalars(
+      window,
+      ['heart_rate_avg', 'heart_rate_max', 'stress_avg', 'distance', 'calories'],
+      stat,
+    )
+    expect(out).toEqual([
+      { key: 'heart_rate_avg', label: 'Avg HR', unit: 'bpm', value: 149 },
+      { key: 'heart_rate_max', label: 'Max HR', unit: 'bpm', value: 172 },
+      { key: 'stress_avg', label: 'Avg stress', unit: 'score', value: 33 },
+      { key: 'distance', label: 'Distance', unit: 'km', value: 8.23 }, // meters → km, 2dp
+      { key: 'calories', label: 'Calories', unit: 'kcal', value: 432 },
+    ])
+  })
+
+  test('builds hr_zone_minutes from zone-second sums, skipping empty zones', () => {
+    const stat = statFrom({
+      hr_zone_1_sec: { sum: 180 }, // 3 min
+      hr_zone_2_sec: { sum: 1320 }, // 22 min
+      hr_zone_3_sec: { sum: 650 }, // ~11 min
+      hr_zone_5_sec: { sum: 0 }, // skipped (no time)
+    })
+    const out = resolveSharedScalars(window, ['hr_zone_minutes'], stat)
+    expect(out).toEqual([
+      { key: 'hr_zone_minutes', label: 'HR zone minutes', value: { z1: 3, z2: 22, z3: 11 } },
+    ])
+  })
+
+  test('skips unsupported keys and metrics with no data', () => {
+    const stat = statFrom({ heart_rate: { avg: 150 } })
+    const out = resolveSharedScalars(window, ['made_up_key', 'stress_avg', 'heart_rate_avg'], stat)
+    // made_up_key unsupported; stress_avg has no data; only heart_rate_avg resolves.
+    expect(out).toEqual([{ key: 'heart_rate_avg', label: 'Avg HR', unit: 'bpm', value: 150 }])
+  })
+
+  test('preserves the requested order and only asks for what was requested', () => {
+    const metricStat = vi.fn<MetricStat>((_m, _s) => 100)
+    const out = resolveSharedScalars(window, ['calories', 'heart_rate_avg'], metricStat)
+    expect(out.map((s) => s.key)).toEqual(['calories', 'heart_rate_avg'])
+    // Never queried unrelated metrics (e.g. distance/stress).
+    const queried = metricStat.mock.calls.map(([m]) => m)
+    expect(queried).toEqual(['calories_active', 'heart_rate'])
+  })
+})

--- a/apps/backend/src/services/activitypub/scalars.ts
+++ b/apps/backend/src/services/activitypub/scalars.ts
@@ -1,0 +1,113 @@
+/**
+ * Resolve the shared scalar-summary values for a feed post.
+ *
+ * Turns the user's chosen `included_metrics` keys into the `ScalarMetric[]` that
+ * `buildCreateExercise` renders into `content` and `aurboda:metrics`. Pure and
+ * dependency-injected: the caller supplies `metricStat`, an aggregate of a
+ * metric over the shared activity's window (backed by `queryMetricsBucketed`
+ * with a single window-sized bucket when wired to delivery). Only the requested
+ * keys that are supported AND have data are emitted; everything else is skipped,
+ * so a post never advertises a summary it can't back.
+ */
+import type { MetricType } from '../../schema.ts'
+import type { ScalarMetric } from './object.ts'
+
+export type ScalarStat = 'avg' | 'max' | 'sum'
+
+/** Aggregate a metric over the activity window; `undefined` when there's no data. */
+export type MetricStat = (metric: MetricType, stat: ScalarStat) => number | undefined
+
+export interface ActivityWindow {
+  startTime: Date
+  endTime?: Date
+}
+
+const roundTo = (n: number, decimals = 0): number => {
+  const f = 10 ** decimals
+  return Math.round(n * f) / f
+}
+
+/** Scalar keys resolved from a single metric aggregate. */
+const METRIC_SCALARS: Record<
+  string,
+  { metric: MetricType; stat: ScalarStat; unit?: string; label: string; transform?: (raw: number) => number }
+> = {
+  calories: {
+    label: 'Calories',
+    metric: 'calories_active',
+    stat: 'sum',
+    transform: (v) => roundTo(v),
+    unit: 'kcal',
+  },
+  distance: {
+    label: 'Distance',
+    metric: 'distance',
+    stat: 'sum',
+    transform: (v) => roundTo(v / 1000, 2),
+    unit: 'km',
+  },
+  heart_rate_avg: {
+    label: 'Avg HR',
+    metric: 'heart_rate',
+    stat: 'avg',
+    transform: (v) => roundTo(v),
+    unit: 'bpm',
+  },
+  heart_rate_max: {
+    label: 'Max HR',
+    metric: 'heart_rate',
+    stat: 'max',
+    transform: (v) => roundTo(v),
+    unit: 'bpm',
+  },
+  stress_avg: {
+    label: 'Avg stress',
+    metric: 'stress_level',
+    stat: 'avg',
+    transform: (v) => roundTo(v),
+    unit: 'score',
+  },
+}
+
+/** Build the `hr_zone_minutes` record (minutes per zone with data) from zone-second sums. */
+const hrZoneMinutes = (metricStat: MetricStat): Record<string, number> => {
+  const zones: Record<string, number> = {}
+  for (let i = 0; i <= 5; i++) {
+    const seconds = metricStat(`hr_zone_${i}_sec` as MetricType, 'sum')
+    if (seconds !== undefined && seconds > 0) zones[`z${i}`] = Math.round(seconds / 60)
+  }
+  return zones
+}
+
+/**
+ * Resolve the requested scalar keys into `ScalarMetric[]`, in the order given.
+ * Supported keys: `duration`, `hr_zone_minutes`, plus the `METRIC_SCALARS` set
+ * (`heart_rate_avg`/`heart_rate_max`, `stress_avg`, `distance`, `calories`).
+ */
+export const resolveSharedScalars = (
+  window: ActivityWindow,
+  includedMetrics: string[],
+  metricStat: MetricStat,
+): ScalarMetric[] => {
+  const out: ScalarMetric[] = []
+  for (const key of includedMetrics) {
+    if (key === 'duration') {
+      if (window.endTime) {
+        const seconds = Math.round((window.endTime.getTime() - window.startTime.getTime()) / 1000)
+        out.push({ key, label: 'Duration', unit: 'seconds', value: seconds })
+      }
+      continue
+    }
+    if (key === 'hr_zone_minutes') {
+      const zones = hrZoneMinutes(metricStat)
+      if (Object.keys(zones).length > 0) out.push({ key, label: 'HR zone minutes', value: zones })
+      continue
+    }
+    const cfg = METRIC_SCALARS[key]
+    if (cfg === undefined) continue
+    const raw = metricStat(cfg.metric, cfg.stat)
+    if (raw === undefined) continue
+    out.push({ key, label: cfg.label, unit: cfg.unit, value: cfg.transform ? cfg.transform(raw) : raw })
+  }
+  return out
+}

--- a/apps/backend/src/services/activitypub/scalars.ts
+++ b/apps/backend/src/services/activitypub/scalars.ts
@@ -9,6 +9,8 @@
  * keys that are supported AND have data are emitted; everything else is skipped,
  * so a post never advertises a summary it can't back.
  */
+import { hrZoneMetrics } from '@aurboda/api-spec'
+
 import type { MetricType } from '../../schema.ts'
 import type { ScalarMetric } from './object.ts'
 
@@ -72,8 +74,8 @@ const METRIC_SCALARS: Record<
 /** Build the `hr_zone_minutes` record (minutes per zone with data) from zone-second sums. */
 const hrZoneMinutes = (metricStat: MetricStat): Record<string, number> => {
   const zones: Record<string, number> = {}
-  for (let i = 0; i <= 5; i++) {
-    const seconds = metricStat(`hr_zone_${i}_sec` as MetricType, 'sum')
+  for (const [i, metric] of hrZoneMetrics.entries()) {
+    const seconds = metricStat(metric, 'sum')
     if (seconds !== undefined && seconds > 0) zones[`z${i}`] = Math.round(seconds / 60)
   }
   return zones


### PR DESCRIPTION
## Summary

Delivery-prep for the federated feed ([#831](https://github.com/fiddur/aurboda/issues/831)) — two pure, tested building blocks the outbound-delivery slice will use.

- **`services/activitypub/scalars.ts` — `resolveSharedScalars`**: turns the user's chosen `included_metrics` keys into the `ScalarMetric[]` that `buildCreateExercise` renders into `content` and `aurboda:metrics`. Pure + dependency-injected: the caller supplies `metricStat(metric, stat)` (a metric aggregate over the activity window, backed by `queryMetricsBucketed` when wired to delivery). Supported keys: `duration` (from the window), `hr_zone_minutes` (per-zone minutes from `hr_zone_*_sec` sums), and `heart_rate_avg`/`heart_rate_max`, `stress_avg`, `distance` (m→km), `calories`. **Only requested keys that are supported AND have data are emitted**, so a post never advertises a summary it can't back.
- **`buildCreateExercise` `publishedAt`**: the deferred #846 nit — a post-creation timestamp drives the AS2 `published` of the Create + object (so remote timelines order by *share* time), while the workout time stays in `aurboda:startTime`. Defaults to `startTime`.

## Testing
6 scalar-producer unit tests (duration, rounding + units, m→km, hr-zone-minutes skipping empty zones, unsupported/no-data skipping, request-order + minimal querying) + 2 new `publishedAt` tests. 22 tests in the two files; backend `tsgo`/oxlint clean.

## Scope
Both are pure/DI, so no runtime wiring yet. The **delivery slice** binds `metricStat` to real window aggregates and wires share → `buildCreateExercise` → sign + deliver `Create` to followers (plus `/ns/activitystreams`, shared inbox, real outbox). The initial scalar-key vocabulary is intentionally small and extensible when the Share UI lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN