### PR TITLE
feat(feed): assemble the Create{Exercise} for a stored feed post (#831)

### DIFF
--- a/apps/backend/src/services/activitypub/feed-activity.test.ts
+++ b/apps/backend/src/services/activitypub/feed-activity.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'vitest'
+
+import type { QueryMetricsBucketedResult } from '../queries/types.ts'
+
+import {
+  buildFeedPostActivity,
+  type FeedActivityContext,
+  type FeedActivityInput,
+  windowMetricStat,
+} from './feed-activity.ts'
+
+const ctx: FeedActivityContext = {
+  apiBaseUrl: 'https://aurboda.net/api/',
+  origin: 'https://aurboda.net/',
+  username: 'fiddur',
+}
+
+const input: FeedActivityInput = {
+  activityType: 'running',
+  endTime: new Date('2026-07-01T07:11:03Z'),
+  includedMetrics: ['duration', 'heart_rate_avg'],
+  postId: 'abc123',
+  publishedAt: new Date('2026-07-01T20:00:00Z'),
+  seriesMetrics: ['heart_rate'],
+  startTime: new Date('2026-07-01T06:30:00Z'),
+  title: 'Morning run',
+  visibility: 'public',
+}
+
+describe('buildFeedPostActivity', () => {
+  test('builds canonical /users/ URLs, series href, and resolves scalars', () => {
+    const c = buildFeedPostActivity(ctx, input, (metric, stat) =>
+      metric === 'heart_rate' && stat === 'avg' ? 148 : undefined,
+    )
+    // Trailing slashes on origin/apiBaseUrl are trimmed.
+    expect(c.actor).toBe('https://aurboda.net/users/fiddur')
+    expect(c.id).toBe('https://aurboda.net/users/fiddur/feed/abc123')
+    expect(c.object.id).toBe('https://aurboda.net/users/fiddur/feed/abc123/object')
+    expect(c['@context'][1]).toEqual({ aurboda: 'https://aurboda.net/ns/activitystreams#' })
+    // publishedAt drives the Create's published, workout time stays in aurboda:startTime.
+    expect(c.published).toBe('2026-07-01T20:00:00.000Z')
+    expect(c.object['aurboda:startTime']).toBe('2026-07-01T06:30:00.000Z')
+    // Shared scalars resolved (duration from window + injected HR avg).
+    expect(c.object['aurboda:metrics']).toEqual([
+      { key: 'duration', unit: 'seconds', value: 2463 },
+      { key: 'heart_rate_avg', unit: 'bpm', value: 148 },
+    ])
+    // Series href points at the public endpoint under the API base.
+    const series = c.object['aurboda:series'] as { href: string }[]
+    expect(series[0].href).toContain('https://aurboda.net/api/public/fiddur/series?')
+    expect(series[0].href).toContain('metric=heart_rate')
+  })
+})
+
+const bucketed = (buckets: QueryMetricsBucketedResult['buckets']): QueryMetricsBucketedResult => ({
+  bucket: '1h',
+  buckets,
+  end: '',
+  start: '',
+})
+
+describe('windowMetricStat', () => {
+  test('merges buckets: sum adds, max takes the extreme, avg re-weights by count', () => {
+    const stat = windowMetricStat(
+      bucketed([
+        {
+          end: 'b',
+          metrics: {
+            distance: { avg: 0, count: 1, first_time: '', last_time: '', max: 0, min: 0, sum: 3000 },
+            heart_rate: { avg: 140, count: 10, first_time: '', last_time: '', max: 150, min: 130 },
+          },
+          start: 'a',
+        },
+        {
+          end: 'd',
+          metrics: {
+            distance: { avg: 0, count: 1, first_time: '', last_time: '', max: 0, min: 0, sum: 5200 },
+            heart_rate: { avg: 160, count: 30, first_time: '', last_time: '', max: 175, min: 140 },
+          },
+          start: 'c',
+        },
+      ]),
+    )
+    // Weighted avg = (140*10 + 160*30) / 40 = 155
+    expect(stat('heart_rate', 'avg')).toBe(155)
+    expect(stat('heart_rate', 'max')).toBe(175)
+    expect(stat('distance', 'sum')).toBe(8200)
+  })
+
+  test('returns undefined for a metric with no data', () => {
+    const stat = windowMetricStat(bucketed([]))
+    expect(stat('heart_rate', 'avg')).toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/activitypub/feed-activity.ts
+++ b/apps/backend/src/services/activitypub/feed-activity.ts
@@ -46,7 +46,7 @@ const trimSlashes = (s: string): string => s.replace(/\/+$/, '')
 /**
  * Merge a bucketed-metrics result into a `MetricStat` over the whole window.
  * Buckets are combined so date-bin splitting never skews the aggregate: sums
- * add, max/min take the extreme, and avg is re-weighted by sample count.
+ * add, max takes the extreme, and avg is re-weighted by sample count.
  */
 export const windowMetricStat = (result: QueryMetricsBucketedResult): MetricStat => {
   const merged = new Map<string, { sum: number; max: number; count: number; weighted: number }>()

--- a/apps/backend/src/services/activitypub/feed-activity.ts
+++ b/apps/backend/src/services/activitypub/feed-activity.ts
@@ -49,14 +49,13 @@ const trimSlashes = (s: string): string => s.replace(/\/+$/, '')
  * add, max/min take the extreme, and avg is re-weighted by sample count.
  */
 export const windowMetricStat = (result: QueryMetricsBucketedResult): MetricStat => {
-  const merged = new Map<string, { sum: number; max: number; min: number; count: number; weighted: number }>()
+  const merged = new Map<string, { sum: number; max: number; count: number; weighted: number }>()
   for (const bucket of result.buckets) {
     for (const [metric, stats] of Object.entries(bucket.metrics)) {
       if (!stats) continue
-      const m = merged.get(metric) ?? { count: 0, max: -Infinity, min: Infinity, sum: 0, weighted: 0 }
+      const m = merged.get(metric) ?? { count: 0, max: -Infinity, sum: 0, weighted: 0 }
       m.sum += stats.sum ?? 0
       m.max = Math.max(m.max, stats.max)
-      m.min = Math.min(m.min, stats.min)
       m.count += stats.count
       m.weighted += stats.avg * stats.count
       merged.set(metric, m)

--- a/apps/backend/src/services/activitypub/feed-activity.ts
+++ b/apps/backend/src/services/activitypub/feed-activity.ts
@@ -1,0 +1,101 @@
+/**
+ * Assemble the AS2 `Create{Exercise}` for a stored feed post.
+ *
+ * Bridges the persistence layer (`feed_posts` + `activities`) to the pure AS2
+ * serializer: resolves the shared scalar values over the activity window and
+ * builds the canonical federation URLs, then hands off to `buildCreateExercise`.
+ *
+ * The metric aggregation is dependency-injected (`MetricStat`) so this is
+ * unit-testable without a database; `windowMetricStat` adapts a
+ * `queryMetricsBucketed` result into that shape for the delivery path.
+ */
+import type { FeedVisibility } from '@aurboda/api-spec'
+
+import type { MetricType } from '../../schema.ts'
+import type { QueryMetricsBucketedResult } from '../queries/types.ts'
+import type { AS2Create } from './object.ts'
+import type { MetricStat, ScalarStat } from './scalars.ts'
+
+import { buildCreateExercise } from './object.ts'
+import { resolveSharedScalars } from './scalars.ts'
+
+/** Canonical federation URLs for a user, derived from the deploy's public hosts. */
+export interface FeedActivityContext {
+  username: string
+  /** Canonical web origin, e.g. `https://aurboda.net` (actor, post id, aurboda: ns). */
+  origin: string
+  /** Public API base, e.g. `https://aurboda.net/api` (the public series endpoint). */
+  apiBaseUrl: string
+}
+
+export interface FeedActivityInput {
+  postId: string
+  includedMetrics: string[]
+  seriesMetrics: string[]
+  visibility: FeedVisibility
+  activityType: string
+  startTime: Date
+  endTime?: Date
+  title?: string
+  /** When the post was created (drives AS2 `published`). */
+  publishedAt: Date
+}
+
+const trimSlashes = (s: string): string => s.replace(/\/+$/, '')
+
+/**
+ * Merge a bucketed-metrics result into a `MetricStat` over the whole window.
+ * Buckets are combined so date-bin splitting never skews the aggregate: sums
+ * add, max/min take the extreme, and avg is re-weighted by sample count.
+ */
+export const windowMetricStat = (result: QueryMetricsBucketedResult): MetricStat => {
+  const merged = new Map<string, { sum: number; max: number; min: number; count: number; weighted: number }>()
+  for (const bucket of result.buckets) {
+    for (const [metric, stats] of Object.entries(bucket.metrics)) {
+      if (!stats) continue
+      const m = merged.get(metric) ?? { count: 0, max: -Infinity, min: Infinity, sum: 0, weighted: 0 }
+      m.sum += stats.sum ?? 0
+      m.max = Math.max(m.max, stats.max)
+      m.min = Math.min(m.min, stats.min)
+      m.count += stats.count
+      m.weighted += stats.avg * stats.count
+      merged.set(metric, m)
+    }
+  }
+  return (metric: MetricType, stat: ScalarStat): number | undefined => {
+    const m = merged.get(metric)
+    if (m === undefined) return undefined
+    if (stat === 'sum') return m.sum
+    if (stat === 'max') return m.max
+    return m.count > 0 ? m.weighted / m.count : undefined
+  }
+}
+
+/** Build the `Create{Exercise}` activity for a feed post. */
+export const buildFeedPostActivity = (
+  ctx: FeedActivityContext,
+  input: FeedActivityInput,
+  metricStat: MetricStat,
+): AS2Create => {
+  const origin = trimSlashes(ctx.origin)
+  const actorUrl = `${origin}/users/${ctx.username}`
+  const scalars = resolveSharedScalars(
+    { endTime: input.endTime, startTime: input.startTime },
+    input.includedMetrics,
+    metricStat,
+  )
+  return buildCreateExercise({
+    activityType: input.activityType,
+    actorUrl,
+    aurbodaNs: `${origin}/ns/activitystreams#`,
+    endTime: input.endTime?.toISOString(),
+    postId: `${actorUrl}/feed/${input.postId}`,
+    publishedAt: input.publishedAt.toISOString(),
+    scalars,
+    seriesEndpointBase: `${trimSlashes(ctx.apiBaseUrl)}/public/${ctx.username}/series`,
+    seriesMetrics: input.seriesMetrics,
+    startTime: input.startTime.toISOString(),
+    title: input.title,
+    visibility: input.visibility,
+  })
+}


### PR DESCRIPTION
## Summary

Delivery slice **3d-a** — the piece that turns a stored `feed_post` into the AS2 `Create{Exercise}` the send path will deliver. Builds on the scalar producer (#860) and AS2 model (#846).

- **`buildFeedPostActivity(ctx, input, metricStat)`** bridges `feed_post` + its `activity` to the pure serializer: resolves the shared scalars over the activity window (via an injected `MetricStat`) and constructs the canonical federation URLs — `<origin>/users/<user>` actor, the post id, the `aurboda:` namespace, and the public `<apiBase>/public/<user>/series` href — then calls `buildCreateExercise` using the post's `created_at` as `publishedAt`.
- **`windowMetricStat(result)`** adapts a `queryMetricsBucketed` result into a `MetricStat`, **merging buckets** so date-bin splitting never skews the aggregate (sums add, max/min take the extreme, avg re-weights by count). This is what binds `metricStat` to real data in the send path.

## Testing
Both are pure/DI and unit-tested: URL construction (incl. trailing-slash trimming), scalar wiring, series href, `published` vs `aurboda:startTime`, and the bucket-merge math (weighted avg / summed / max). Backend `tsgo`/oxlint clean.

## Next (delivery sub-slices)
Wire share → `buildFeedPostActivity` → sign + `ctx.sendActivity` to followers (`Update`/`Delete` too); real outbox `OrderedCollection`; serve `/ns/activitystreams` (+ nginx `/ns/`); nginx `/inbox` + `endpoints.sharedInbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN