### PR TITLE
feat(feed): serve a real followers collection from feed_follower (#831)

### DIFF
--- a/apps/backend/src/db/feed-follower.integration.test.ts
+++ b/apps/backend/src/db/feed-follower.integration.test.ts
@@ -4,7 +4,12 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
  * Integration tests for the remote-follower store.
  */
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
-import { listFeedFollowers, removeFeedFollower, upsertFeedFollower } from './feed-follower.ts'
+import {
+  countFeedFollowers,
+  listFeedFollowers,
+  removeFeedFollower,
+  upsertFeedFollower,
+} from './feed-follower.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 
@@ -62,6 +67,20 @@ describe('Feed followers integration', () => {
 
     const followers = await listFeedFollowers(user)
     expect(followers).toHaveLength(1)
+  })
+
+  test('counts followers without loading rows', async () => {
+    const user = getTestUser()
+    expect(await countFeedFollowers(user)).toBe(0)
+    await upsertFeedFollower(user, alice)
+    await upsertFeedFollower(user, {
+      actor_uri: 'https://remote.example/users/bob',
+      inbox_uri: 'https://remote.example/users/bob/inbox',
+    })
+    expect(await countFeedFollowers(user)).toBe(2)
+    // Re-following an existing actor does not double-count.
+    await upsertFeedFollower(user, alice)
+    expect(await countFeedFollowers(user)).toBe(2)
   })
 
   test('removes a follower (e.g. on Undo Follow)', async () => {

--- a/apps/backend/src/db/feed-follower.ts
+++ b/apps/backend/src/db/feed-follower.ts
@@ -55,6 +55,12 @@ export const listFeedFollowers = async (user: string): Promise<FeedFollowerRecor
   return result.rows
 }
 
+/** Count followers without loading their rows (for the followers-collection counter). */
+export const countFeedFollowers = async (user: string): Promise<number> => {
+  const result = await query<{ count: string }>(user, `SELECT COUNT(*)::text AS count FROM feed_follower`)
+  return Number(result.rows[0].count)
+}
+
 /** Remove a follower by actor URI (e.g. on an Undo{Follow}). */
 export const removeFeedFollower = async (user: string, actorUri: string): Promise<boolean> => {
   const result = await query(user, `DELETE FROM feed_follower WHERE actor_uri = $1`, [actorUri])

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -277,6 +277,7 @@ export { type ActorKeyPair, getOrCreateActorKeyPair } from './feed-actor.ts'
 
 // Feed followers (remote ActivityPub actors following a user)
 export {
+  countFeedFollowers,
   type FeedFollowerInput,
   type FeedFollowerRecord,
   listFeedFollowers,

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
  * Integration tests for the Fedify actor + WebFinger surface, exercised through
  * `federation.fetch` against a real per-user database (no Express/nginx needed).
  */
+import { upsertFeedFollower } from '../../db/feed-follower.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
 import { createFeedFederation } from './federation.ts'
 
@@ -84,5 +85,19 @@ describe('Feed federation actor + WebFinger', () => {
   test('404s the actor for an invalid username (never touches the database)', async () => {
     const res = await fetchAs2('/users/Invalid..Name')
     expect(res.status).toBe(404)
+  })
+
+  test('serves the followers collection from feed_follower', async () => {
+    const user = getTestUser()
+    await upsertFeedFollower(user, {
+      actor_uri: 'https://mastodon.example/users/alice',
+      inbox_uri: 'https://mastodon.example/users/alice/inbox',
+      shared_inbox_uri: 'https://mastodon.example/inbox',
+    })
+    const res = await fetchAs2(`/users/${user}/followers`)
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { totalItems?: number; orderedItems?: string[] }
+    expect(doc.totalItems).toBe(1)
+    expect(doc.orderedItems).toContain('https://mastodon.example/users/alice')
   })
 })

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -22,6 +22,7 @@ import { isValidUsername } from '../../api/auth-routes.ts'
 import {
   getOrCreateActorKeyPair,
   isMissingDatabase,
+  listFeedFollowers,
   removeFeedFollower,
   upsertFeedFollower,
 } from '../../db/index.ts'
@@ -123,12 +124,37 @@ export const createFeedFederation = (origin: string): Federation<void> => {
       }
     })
 
-  // Empty collections for now; the outbox serves the user's public posts once
-  // delivery wiring exists.
+  // Outbox stays empty until the delivery slice serves the user's public posts.
   federation.setOutboxDispatcher('/users/{identifier}/outbox', (_ctx, _identifier) => ({ items: [] }))
-  federation.setFollowersDispatcher('/users/{identifier}/followers', (_ctx, _identifier) => ({
-    items: [],
-  }))
+
+  // Real followers, backed by feed_follower. This both serves the followers
+  // collection and enumerates recipients for `sendActivity(..., 'followers', …)`.
+  federation
+    .setFollowersDispatcher('/users/{identifier}/followers', async (_ctx, identifier) => {
+      if (!isValidUsername(identifier)) return { items: [] }
+      try {
+        const followers = await listFeedFollowers(identifier)
+        return {
+          items: followers.map((f) => ({
+            endpoints: f.shared_inbox_uri ? { sharedInbox: new URL(f.shared_inbox_uri) } : null,
+            id: new URL(f.actor_uri),
+            inboxId: new URL(f.inbox_uri),
+          })),
+        }
+      } catch (error) {
+        if (isMissingDatabase(error)) return { items: [] }
+        throw error
+      }
+    })
+    .setCounter(async (_ctx, identifier) => {
+      if (!isValidUsername(identifier)) return 0
+      try {
+        return (await listFeedFollowers(identifier)).length
+      } catch (error) {
+        if (isMissingDatabase(error)) return 0
+        throw error
+      }
+    })
 
   return federation
 }

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -20,6 +20,7 @@ import { Accept, Follow, Person, Undo } from '@fedify/fedify/vocab'
  */
 import { isValidUsername } from '../../api/auth-routes.ts'
 import {
+  countFeedFollowers,
   getOrCreateActorKeyPair,
   isMissingDatabase,
   listFeedFollowers,
@@ -149,7 +150,7 @@ export const createFeedFederation = (origin: string): Federation<void> => {
     .setCounter(async (_ctx, identifier) => {
       if (!isValidUsername(identifier)) return 0
       try {
-        return (await listFeedFollowers(identifier)).length
+        return await countFeedFollowers(identifier)
       } catch (error) {
         if (isMissingDatabase(error)) return 0
         throw error


### PR DESCRIPTION
## Summary

Delivery slice **3d-b** — the actor's **followers dispatcher** now reads `feed_follower` and returns real recipients (`id` + `inboxId` + optional shared inbox), with a **counter** for `totalItems`. This does double duty:
- serves the actor's followers `OrderedCollection` (was empty), and
- enumerates recipients for the upcoming `sendActivity(…, 'followers', …)` fan-out.

Missing DB / invalid username degrade to an empty collection, matching the actor and key-pairs dispatchers.

## Testing
Integration test (via `federation.fetch`) seeds a follower and asserts the collection reports `totalItems: 1` with the follower's actor URI in `orderedItems`. 5 federation tests pass; backend `tsgo`/oxlint clean.

## Next
The outbound **push** — build the `Create` via `buildFeedPostActivity` and `ctx.sendActivity` it to followers on share (and `Update`/`Delete`) — is the next sub-slice; that's the part best verified against the live instance (follow from Mastodon, share, watch it arrive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN