### PR TITLE
feat(feed): deliver shared activities to followers over ActivityPub (#831)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -17,6 +17,8 @@ import cors from 'cors'
 import express, { json, type NextFunction, type Request, type Response } from 'express'
 import { Client } from 'pg'
 
+import type { FeedDeliver } from './routes/feed-router.ts'
+
 import { registerAuthRoutes } from './api/auth-routes.ts'
 import { createAdminMiddleware, createAuditLogMiddleware, createAuthMiddleware } from './api/middleware.ts'
 import { registerOAuthRoutes } from './api/oauth-routes.ts'
@@ -50,6 +52,7 @@ import { createOwnTracksRouter } from './integrations/owntracks/router.ts'
 import { stravaClient } from './integrations/strava/client.ts'
 import { createMcpRouter } from './mcp.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
+import { deliverFeedPost } from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
 import { auditError } from './services/audit-log.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
@@ -329,7 +332,15 @@ const main = async () => {
   // the immediate peer is loopback — a direct remote client isn't, so it can't
   // spoof them.
   httpd.set('trust proxy', 'loopback')
-  httpd.use(integrateFederation(createFeedFederation(webHost), () => undefined))
+  const feedFederation = createFeedFederation(webHost)
+  httpd.use(integrateFederation(feedFederation, () => undefined))
+
+  // Fire-and-forget federation delivery for shared feed posts.
+  const feedDeliver: FeedDeliver = (user, post, activity) => {
+    void deliverFeedPost({ federation: feedFederation, origin: webHost }, user, post, activity).catch((err) =>
+      console.error(`⚠️ feed delivery failed for ${user}/${post.id}:`, err),
+    )
+  }
 
   httpd.use(json({ limit: '10mb' }))
 
@@ -439,6 +450,7 @@ const main = async () => {
     centralDb,
     deductionQueue,
     engineDeps,
+    feedDeliver,
     garmin,
     httpd,
     invitationAuth,

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -31,7 +31,7 @@ import { createCorrelationsRouter } from '../routes/correlations-router.ts'
 import { createDashboardRouter } from '../routes/dashboard-router.ts'
 import { createDeductionRulesRouter } from '../routes/deduction-rules-router.ts'
 import { createFeedPublicRouter } from '../routes/feed-public-router.ts'
-import { createFeedRouter } from '../routes/feed-router.ts'
+import { createFeedRouter, type FeedDeliver } from '../routes/feed-router.ts'
 import { createFoodItemsRouter } from '../routes/food-items-router.ts'
 import { createIconsRouter } from '../routes/icons-router.ts'
 import { createImportsRouter } from '../routes/imports-router.ts'
@@ -76,6 +76,7 @@ interface RestRoutesDeps {
   webAuthn: WebAuthnService
   wellKnown: WellKnownConfig
   userDb: Client
+  feedDeliver: FeedDeliver
 }
 
 export const mountRestRouters = ({
@@ -92,6 +93,7 @@ export const mountRestRouters = ({
   activityNotifier,
   engineDeps,
   deductionQueue,
+  feedDeliver,
   ouraWebhookManager,
   auth,
   webAuthn,
@@ -132,7 +134,7 @@ export const mountRestRouters = ({
   httpd.use(createRawRecordsRouter(authMiddleware))
   httpd.use('/dashboard', createDashboardRouter(authMiddleware))
   httpd.use('/shared-dashboards', createSharedDashboardsRouter(authMiddleware, webHost))
-  httpd.use('/feed', createFeedRouter(authMiddleware))
+  httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver))
   httpd.use('/challenges', createChallengesRouter(authMiddleware, webHost, apiBaseUrl))
   httpd.use(createChallengeDataRouter())
   // Public feed series must be mounted before the generic /public/:username/:slug

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -20,7 +20,7 @@ import {
   updateFeedPostBodySchema,
 } from '@aurboda/api-spec'
 
-import type { FeedPostRecord } from '../db/index.ts'
+import type { Activity, FeedPostRecord } from '../db/index.ts'
 
 import {
   createFeedPost,
@@ -31,6 +31,13 @@ import {
 } from '../db/index.ts'
 import { type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
+
+/**
+ * Fire-and-forget federation delivery for a freshly-shared post. Injected so the
+ * router stays decoupled from the ActivityPub layer (and testable without it);
+ * the implementation signs + fans the Create out to the user's followers.
+ */
+export type FeedDeliver = (user: string, post: FeedPostRecord, activity: Activity) => void
 
 const serialize = (record: FeedPostRecord): FeedPost => ({
   activity_id: record.activity_id,
@@ -44,7 +51,7 @@ const serialize = (record: FeedPostRecord): FeedPost => ({
   visibility: record.visibility,
 })
 
-export const createFeedRouter = (authMiddleware: RequestHandler): TypedRouter => {
+export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedDeliver): TypedRouter => {
   const router = typedRouter()
 
   router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
@@ -71,6 +78,8 @@ export const createFeedRouter = (authMiddleware: RequestHandler): TypedRouter =>
         series_metrics: req.body.series_metrics,
         visibility: req.body.visibility,
       })
+      // Fan the post out to followers (best-effort; never blocks the response).
+      deliver?.(user, record, activity)
       res.json({ post: serialize(record), success: true })
     },
   )

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest'
+
+import { recipients } from './deliver.ts'
+
+const PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
+const followers = new URL('https://aurboda.net/users/fiddur/followers')
+
+const hrefs = (urls: URL[]) => urls.map((u) => u.href)
+
+describe('recipients', () => {
+  test('public → Public in to, followers in cc', () => {
+    const { to, cc } = recipients('public', followers)
+    expect(hrefs(to)).toEqual([PUBLIC])
+    expect(hrefs(cc)).toEqual([followers.href])
+  })
+
+  test('unlisted → followers in to, Public in cc', () => {
+    const { to, cc } = recipients('unlisted', followers)
+    expect(hrefs(to)).toEqual([followers.href])
+    expect(hrefs(cc)).toEqual([PUBLIC])
+  })
+
+  test('followers → followers only, never Public', () => {
+    const { to, cc } = recipients('followers', followers)
+    expect(hrefs(to)).toEqual([followers.href])
+    expect(cc).toEqual([])
+  })
+})

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -1,0 +1,89 @@
+import type { FeedVisibility } from '@aurboda/api-spec'
+/**
+ * Deliver a shared feed post to the user's followers over ActivityPub.
+ *
+ * Builds a Fedify `Create{Note}` — the Mastodon-compatible representation: an
+ * HTML `content` summary + `name`/`url`, addressed per the post's visibility —
+ * and fans it out via `ctx.sendActivity(..., 'followers', …)`, which Fedify
+ * signs, dedupes by shared inbox, and queues with retries.
+ *
+ * The custom `aurboda:` structured extension is not carried on the pushed Note
+ * (Fedify's typed vocab drops unknown properties); it's progressive enhancement
+ * an Aurboda consumer fetches by dereferencing the object id — served in a
+ * follow-up slice. Delivery is best-effort: callers invoke it fire-and-forget.
+ */
+import type { Federation } from '@fedify/fedify'
+
+import { Create, Note } from '@fedify/fedify/vocab'
+
+import { resolveActivityScalars } from './feed-activity.ts'
+import { feedPostContent } from './object.ts'
+
+const PUBLIC_URI = new URL('https://www.w3.org/ns/activitystreams#Public')
+
+/** AS2 `to`/`cc` addressing (as URLs) for a post's visibility. */
+export const recipients = (visibility: FeedVisibility, followers: URL): { to: URL[]; cc: URL[] } => {
+  switch (visibility) {
+    case 'public':
+      return { cc: [followers], to: [PUBLIC_URI] }
+    case 'unlisted':
+      return { cc: [PUBLIC_URI], to: [followers] }
+    case 'followers':
+      return { cc: [], to: [followers] }
+  }
+}
+
+export interface FeedDeliveryDeps {
+  federation: Federation<void>
+  /** Canonical web origin, e.g. `https://aurboda.net`. */
+  origin: string
+}
+
+export interface DeliverablePost {
+  id: string
+  included_metrics: string[]
+  visibility: FeedVisibility
+  created_at: Date
+}
+
+export interface DeliverableActivity {
+  activity_type: string
+  start_time: Date
+  end_time?: Date
+  title?: string
+}
+
+/** Build and send the `Create{Note}` for a freshly-shared post to its followers. */
+export const deliverFeedPost = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverablePost,
+  activity: DeliverableActivity,
+): Promise<void> => {
+  const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
+  const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars)
+
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  const actorUri = ctx.getActorUri(user)
+  const followers = ctx.getFollowersUri(user)
+  const postUrl = new URL(`${actorUri.href}/feed/${post.id}`)
+  const { cc, to } = recipients(post.visibility, followers)
+
+  // `published` is intentionally omitted: Fedify's vocab types it as the ambient
+  // (esnext.temporal) Temporal.Instant, which the @js-temporal polyfill value
+  // isn't assignable to. Delivery fires right after the share, so remote servers
+  // timestamp it at receipt (≈ share time). Wiring an explicit published is a
+  // follow-up (needs Temporal-lib interop sorted).
+  const note = new Note({
+    attribution: actorUri,
+    ccs: cc,
+    content,
+    id: new URL(`${postUrl.href}/object`),
+    name,
+    tos: to,
+    url: postUrl,
+  })
+  const create = new Create({ actor: actorUri, ccs: cc, id: postUrl, object: note, tos: to })
+
+  await ctx.sendActivity({ identifier: user }, 'followers', create)
+}

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -17,20 +17,16 @@ import type { Federation } from '@fedify/fedify'
 import { Create, Note } from '@fedify/fedify/vocab'
 
 import { resolveActivityScalars } from './feed-activity.ts'
-import { feedPostContent } from './object.ts'
+import { addressingFor, feedPostContent } from './object.ts'
 
-const PUBLIC_URI = new URL('https://www.w3.org/ns/activitystreams#Public')
-
-/** AS2 `to`/`cc` addressing (as URLs) for a post's visibility. */
+/**
+ * AS2 `to`/`cc` addressing (as URLs) for a post's visibility — the same table
+ * `addressingFor` uses for the JSON object model, mapped through `URL` so the
+ * two can't drift.
+ */
 export const recipients = (visibility: FeedVisibility, followers: URL): { to: URL[]; cc: URL[] } => {
-  switch (visibility) {
-    case 'public':
-      return { cc: [followers], to: [PUBLIC_URI] }
-    case 'unlisted':
-      return { cc: [PUBLIC_URI], to: [followers] }
-    case 'followers':
-      return { cc: [], to: [followers] }
-  }
+  const { cc, to } = addressingFor(visibility, followers.href)
+  return { cc: cc.map((u) => new URL(u)), to: to.map((u) => new URL(u)) }
 }
 
 export interface FeedDeliveryDeps {

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -96,6 +96,23 @@ const formatScalar = ({ key, value, unit, label }: ScalarMetric): string => {
 }
 
 /**
+ * The human-readable status a plain fediverse client renders: a `name` headline
+ * and an HTML `content` line flattening the title + shared scalars. Shared by
+ * the AS2 object model and the Fedify delivery Note so both read identically.
+ */
+export const feedPostContent = (
+  title: string | undefined,
+  activityType: string,
+  scalars: ScalarMetric[],
+): { name: string; content: string } => {
+  const summaryLine = [title, ...scalars.map(formatScalar)].filter((p): p is string => Boolean(p)).join(' · ')
+  return {
+    content: `<p>${escapeHtml(summaryLine)}</p>`,
+    name: title ?? `${prettifyKey(activityType)} activity`,
+  }
+}
+
+/**
  * Map a post's visibility to AS2 `to`/`cc` addressing. `followers` is the
  * actor's followers collection; public objects are addressed to the AS2 Public
  * magic collection.
@@ -149,11 +166,7 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
   const { to, cc } = addressingFor(input.visibility, followersUrl)
   const objectId = `${input.postId}/object`
 
-  const summaryParts = [input.title, ...input.scalars.map(formatScalar)].filter((p): p is string =>
-    Boolean(p),
-  )
-  const summaryLine = summaryParts.join(' · ')
-  const name = input.title ?? `${prettifyKey(input.activityType)} activity`
+  const { content, name } = feedPostContent(input.title, input.activityType, input.scalars)
   // `published` is the share time (timeline ordering); the workout time lives in
   // `aurboda:startTime`.
   const published = input.publishedAt ?? input.startTime
@@ -167,7 +180,7 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
     })),
     'aurboda:startTime': input.startTime,
     attributedTo: input.actorUrl,
-    content: `<p>${escapeHtml(summaryLine)}</p>`,
+    content,
     id: objectId,
     name,
     published,


### PR DESCRIPTION
## Summary

Delivery slice **3d-c** — **sharing an activity now fans a `Create{Note}` out to the user's followers.** This is the step that puts a shared activity into a follower's Mastodon timeline.

- **`services/activitypub/deliver.ts` — `deliverFeedPost`**: resolves the shared scalars over the activity window, builds a Mastodon-compatible Fedify `Create{Note}` (HTML `content` summary + `name` + `url`, addressed per visibility via a pure `recipients` helper), and sends it with `ctx.sendActivity(…, 'followers', …)` — Fedify signs, dedupes shared inboxes, and queues with retries. Extracted a shared `feedPostContent` helper so the pushed Note and the AS2 object model read identically.
- **Wiring**: the feed router takes an injected fire-and-forget `FeedDeliver`; `api.ts` builds the Fedify federation **once** (shared with the actor mount) and delivers on share, catching/logging failures so it never blocks the HTTP response.

## Testing
Unit-tested the `recipients` addressing (public / unlisted / followers). The send path is **type-checked against Fedify's vocab** but **needs live verification** — constructing signed federation delivery can't be unit-tested. **To verify:** follow `@<user>@<host>` from Mastodon, share an activity (MCP `share_activity` or `POST /feed/activities/:id/share`), and watch it appear in the follower's timeline.

## Deferred / notes
- **`published`** is omitted on the pushed Note: Fedify types it as the ambient `esnext.temporal` `Temporal.Instant`, which the `@js-temporal/polyfill` value isn't assignable to. Delivery fires right after the share, so remote servers timestamp at receipt (≈ share time). Wiring an explicit `published` is a follow-up once the Temporal-lib interop is sorted.
- The `aurboda:` **structured extension** isn't carried on the pushed Note (Fedify's typed vocab drops unknown properties) — progressive enhancement via dereferencing the object id is a follow-up.
- **`Update`/`Delete`** propagation and the **real outbox** are follow-ups (3d-d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN