### PR TITLE
fix(feed): deliver activities synchronously (drop the undrained queue) (#831)

### DIFF
--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -5,7 +5,9 @@ import type { FeedVisibility } from '@aurboda/api-spec'
  * Builds a Fedify `Create{Note}` — the Mastodon-compatible representation: an
  * HTML `content` summary + `name`/`url`, addressed per the post's visibility —
  * and fans it out via `ctx.sendActivity(..., 'followers', …)`, which Fedify
- * signs, dedupes by shared inbox, and queues with retries.
+ * signs and dedupes by shared inbox. Delivery is synchronous (no message queue
+ * configured), so this awaits the outbound POSTs; retry/durability via a
+ * persistent queue is a later slice.
  *
  * The custom `aurboda:` structured extension is not carried on the pushed Note
  * (Fedify's typed vocab drops unknown properties); it's progressive enhancement

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -1,4 +1,4 @@
-import { createFederation, type Federation, InProcessMessageQueue, MemoryKvStore } from '@fedify/fedify'
+import { createFederation, type Federation, MemoryKvStore } from '@fedify/fedify'
 import { Accept, Follow, Person, Undo } from '@fedify/fedify/vocab'
 
 /**
@@ -14,9 +14,8 @@ import { Accept, Follow, Person, Undo } from '@fedify/fedify/vocab'
  * - inbound inbox: `Follow` → persist follower + `Accept`; `Undo{Follow}` →
  *   drop the follower (Fedify verifies the HTTP Signature first).
  *
- * Outbound delivery of the user's own posts is a later slice. The in-memory
- * KV/queue are fine here (Accept is sent inline); a persistent (Postgres)
- * backing lands with reliable delivery.
+ * Delivery is synchronous (no message queue — see `createFeedFederation`); a
+ * persistent Postgres queue for retried, durable delivery is a later slice.
  */
 import { isValidUsername } from '../../api/auth-routes.ts'
 import {
@@ -37,7 +36,11 @@ export const createFeedFederation = (origin: string): Federation<void> => {
     // scheme + host — Mastodon requires https, and reconstructing the scheme
     // from the request yields http behind the TLS-terminating proxy.
     origin,
-    queue: new InProcessMessageQueue(),
+    // No message queue: `sendActivity` then delivers synchronously (awaits the
+    // POST). An in-process queue would need `federation.startQueue()` to drain —
+    // which the Express integration doesn't run — so queued activities (e.g. the
+    // Create on share) would never send. A persistent Postgres queue + worker is
+    // a later reliability slice; synchronous delivery is correct for now.
   })
 
   federation


### PR DESCRIPTION
## Summary

**Live-verification bug fix.** Sharing an activity created the post + exposed the public series, and the `Follow`→`Accept` completed — but the shared `Create` never reached the follower's timeline.

**Cause:** `createFederation` was given an `InProcessMessageQueue`, but nothing calls `federation.startQueue()` (the `@fedify/express` integration doesn't run a queue worker). So `ctx.sendActivity(…, 'followers', …)` **enqueued** the `Create` and it was never drained/sent. The inbound `Accept` worked only because it fires *inside* Fedify's inbox-request lifecycle.

**Fix:** drop the `queue` option so `sendActivity` delivers **synchronously** (awaits the outbound POST) — the documented alternative. Share delivery is already fire-and-forget in the router, so this doesn't block the HTTP response. Actor / WebFinger / followers still work (tests green).

Durable, **retried** delivery via a persistent Postgres queue + worker is a deliberate later reliability slice.

## Verification
After this deploys, re-sharing an activity should land the status in a follower's Mastodon home timeline. (The bug was invisible to unit tests — federation delivery only fails end-to-end, which is why this needed the live check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iiGPmb6LMa9nvNQ1tSFqN