### PR TITLE
fix(feed): deliver Create to followers when sharing via MCP (#831)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -305,6 +305,17 @@ const main = async () => {
   // Mount OAuth endpoints BEFORE body-parser (uses its own parsers)
   httpd.use(createOAuthRouter({ centralDb, loginToUserDb, webHost }))
 
+  // ActivityPub federation object (one instance, shared by the actor mount, the
+  // MCP feed tools, and the REST feed router). `feedDeliver` fans a shared post
+  // out to followers, fire-and-forget, so it's identical whether a post is
+  // created via MCP or REST.
+  const feedFederation = createFeedFederation(webHost)
+  const feedDeliver: FeedDeliver = (user, post, activity) => {
+    void deliverFeedPost({ federation: feedFederation, origin: webHost }, user, post, activity).catch((err) =>
+      console.error(`⚠️ feed delivery failed for ${user}/${post.id}:`, err),
+    )
+  }
+
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
   // Stateless mode — no session tracking needed (tools only, no subscriptions)
   httpd.use(
@@ -314,6 +325,7 @@ const main = async () => {
       centralDb,
       deductionQueue: deductionQueue ?? undefined,
       engineDeps,
+      feedDeliver,
       garmin,
       onActivityMutated: activityNotifier,
       oura,
@@ -332,15 +344,7 @@ const main = async () => {
   // the immediate peer is loopback — a direct remote client isn't, so it can't
   // spoof them.
   httpd.set('trust proxy', 'loopback')
-  const feedFederation = createFeedFederation(webHost)
   httpd.use(integrateFederation(feedFederation, () => undefined))
-
-  // Fire-and-forget federation delivery for shared feed posts.
-  const feedDeliver: FeedDeliver = (user, post, activity) => {
-    void deliverFeedPost({ federation: feedFederation, origin: webHost }, user, post, activity).catch((err) =>
-      console.error(`⚠️ feed delivery failed for ${user}/${post.id}:`, err),
-    )
-  }
 
   httpd.use(json({ limit: '10mb' }))
 

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -14,6 +14,7 @@ import { type Request, type Response, Router } from 'express'
 import type { Auth } from './auth.ts'
 import type { GarminClient } from './integrations/garmin/client.ts'
 import type { ouraClient } from './integrations/oura/client.ts'
+import type { FeedDeliver } from './routes/feed-router.ts'
 import type { CentralDb } from './services/central-db.ts'
 import type { DeductionEngineDeps } from './services/deduction-engine.ts'
 import type { ActivityNotifier, DeductionQueue } from './services/deduction-queue.ts'
@@ -55,6 +56,7 @@ interface McpDeps {
   centralDb?: CentralDb
   deductionQueue?: DeductionQueue
   engineDeps?: DeductionEngineDeps
+  feedDeliver?: FeedDeliver
   garmin?: GarminClient
   onActivityMutated?: ActivityNotifier
   oura?: OuraClientType
@@ -93,7 +95,7 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
   }
   registerReportTools(server, user)
   registerSharedDashboardTools(server, user)
-  registerFeedTools(server, user)
+  registerFeedTools(server, user, deps.feedDeliver)
   registerChallengeTools(server, user, { apiBaseUrl: deps.apiBaseUrl, webHost: deps.webHost })
   registerScreentimeCategoryTools(server, user)
   registerDebugTools(server, user)

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -6,6 +6,7 @@ import { shareActivityBodySchema, updateFeedPostBodySchema } from '@aurboda/api-
 import { z } from 'zod'
 
 import type { FeedPostRecord } from '../db/index.ts'
+import type { FeedDeliver } from '../routes/feed-router.ts'
 
 import {
   createFeedPost,
@@ -29,7 +30,7 @@ const serialize = (record: FeedPostRecord) => ({
   visibility: record.visibility,
 })
 
-export const registerFeedTools = (server: McpServer, user: string) => {
+export const registerFeedTools = (server: McpServer, user: string, deliver?: FeedDeliver) => {
   server.tool(
     'list_feed',
     'List activities you have published to your feed, with their shared metric selection, series opt-in, and visibility.',
@@ -55,6 +56,8 @@ export const registerFeedTools = (server: McpServer, user: string) => {
         series_metrics: body.series_metrics,
         visibility: body.visibility,
       })
+      // Fan out to followers (best-effort), same as the REST share route.
+      deliver?.(user, record, activity)
       return jsonResponse(serialize(record))
     },
   )


### PR DESCRIPTION
## Problem

Sharing an activity via the **MCP** `share_activity` tool created the `feed_post` row but never pushed a `Create{Note}` to followers — the ActivityPub delivery hook was only wired into the **REST** `/feed` share route (#864). Since the live share went through MCP, followers never received anything in their timelines.

This is the second of two delivery bugs found during live testing (the first, #866, dropped the never-drained in-process queue for synchronous delivery).

## Fix

Thread the same fire-and-forget `feedDeliver` hook into the MCP path so a share delivers identically regardless of transport:

- `registerFeedTools(server, user, deliver?)` calls `deliver?.(user, record, activity)` right after `createFeedPost`, mirroring the REST handler.
- `McpDeps.feedDeliver` carries the hook, passed through `createMcpServer` → `registerFeedTools`.
- `api.ts` hoists `feedFederation` + `feedDeliver` above the MCP mount so MCP and REST share **one** federation instance and the exact same delivery closure.

No new logic — pure wiring of the existing `deliverFeedPost`. Verified with `pnpm --filter aurboda-backend check` (tsgo + oxlint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)