### PR TITLE
feat(feed): serve real AP outbox + individual post objects (#831)

### DIFF
--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -7,12 +7,14 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import { deleteActivity, insertActivity } from './activities/index.ts'
 import {
+  countPublicFeedPosts,
   createFeedPost,
   deleteFeedPost,
   type FeedPostInput,
   findCoveringSharedSeriesWindow,
   getFeedPostById,
   listFeedPosts,
+  listPublicFeedPosts,
   updateFeedPost,
 } from './feed.ts'
 
@@ -104,6 +106,26 @@ describe('Feed posts integration', () => {
     expect(await deleteFeedPost(user, created.id)).toBe(true)
     expect(await deleteFeedPost(user, created.id)).toBe(false)
     expect(await getFeedPostById(user, created.id)).toBeNull()
+  })
+
+  describe('public outbox listing', () => {
+    test('lists public and unlisted posts newest-first, excluding followers-only', async () => {
+      const user = getTestUser()
+      const pub = await createFeedPost(user, postInput({ visibility: 'public' }))
+      const unlisted = await createFeedPost(user, postInput({ visibility: 'unlisted' }))
+      await createFeedPost(user, postInput({ visibility: 'followers' }))
+
+      const posts = await listPublicFeedPosts(user)
+      expect(posts.map((p) => p.id)).toEqual([unlisted.id, pub.id])
+      expect(await countPublicFeedPosts(user)).toBe(2)
+    })
+
+    test('are empty when the user has only followers-only posts', async () => {
+      const user = getTestUser()
+      await createFeedPost(user, postInput({ visibility: 'followers' }))
+      expect(await listPublicFeedPosts(user)).toEqual([])
+      expect(await countPublicFeedPosts(user)).toBe(0)
+    })
   })
 
   describe('findCoveringSharedSeriesWindow', () => {

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -89,6 +89,31 @@ export const listFeedPosts = async (user: string): Promise<FeedPostRecord[]> => 
   return result.rows.map(mapFeedPost)
 }
 
+/**
+ * Posts that appear on the public outbox / actor profile: `public` and
+ * `unlisted` (both addressed to the AS2 Public collection). `followers`-only
+ * posts are never listed here. Same deterministic newest-first ordering as
+ * `listFeedPosts`.
+ */
+export const listPublicFeedPosts = async (user: string): Promise<FeedPostRecord[]> => {
+  const result = await query<FeedPostRow>(
+    user,
+    `SELECT ${FEED_POST_COLUMNS} FROM feed_posts
+      WHERE visibility IN ('public', 'unlisted')
+      ORDER BY created_at DESC, id DESC`,
+  )
+  return result.rows.map(mapFeedPost)
+}
+
+/** Total number of posts on the public outbox (see `listPublicFeedPosts`). */
+export const countPublicFeedPosts = async (user: string): Promise<number> => {
+  const result = await query<{ count: number }>(
+    user,
+    `SELECT count(*)::int AS count FROM feed_posts WHERE visibility IN ('public', 'unlisted')`,
+  )
+  return Number(result.rows[0]?.count ?? 0)
+}
+
 export const getFeedPostById = async (user: string, id: string): Promise<FeedPostRecord | null> => {
   const result = await query<FeedPostRow>(user, `SELECT ${FEED_POST_COLUMNS} FROM feed_posts WHERE id = $1`, [
     id,

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -287,6 +287,7 @@ export {
 
 // Feed posts
 export {
+  countPublicFeedPosts,
   createFeedPost,
   deleteFeedPost,
   type FeedPostInput,
@@ -295,6 +296,7 @@ export {
   findCoveringSharedSeriesWindow,
   getFeedPostById,
   listFeedPosts,
+  listPublicFeedPosts,
   updateFeedPost,
 } from './feed.ts'
 

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -1,20 +1,24 @@
 import type { FeedVisibility } from '@aurboda/api-spec'
 /**
- * Deliver a shared feed post to the user's followers over ActivityPub.
+ * Build and deliver a shared feed post over ActivityPub.
  *
- * Builds a Fedify `Create{Note}` — the Mastodon-compatible representation: an
- * HTML `content` summary + `name`/`url`, addressed per the post's visibility —
- * and fans it out via `ctx.sendActivity(..., 'followers', …)`, which Fedify
- * signs and dedupes by shared inbox. Delivery is synchronous (no message queue
- * configured), so this awaits the outbound POSTs; retry/durability via a
- * persistent queue is a later slice.
+ * The Mastodon-compatible representation is a Fedify `Create{Note}` — an HTML
+ * `content` summary + `name`/`url`, addressed per the post's visibility. The
+ * `Note`'s id is its object-dispatcher URL (`getObjectUri(Note, …)`), so the
+ * object we deliver, the one listed in the outbox, and the one served when a
+ * remote server dereferences that id are all built here and stay identical.
  *
- * The custom `aurboda:` structured extension is not carried on the pushed Note
- * (Fedify's typed vocab drops unknown properties); it's progressive enhancement
- * an Aurboda consumer fetches by dereferencing the object id — served in a
- * follow-up slice. Delivery is best-effort: callers invoke it fire-and-forget.
+ * `deliverFeedPost` fans the `Create` out via `ctx.sendActivity(..., 'followers',
+ * …)`, which Fedify signs and dedupes by shared inbox. Delivery is synchronous
+ * (no message queue configured), so it awaits the outbound POSTs; retry/
+ * durability via a persistent queue is a later slice.
+ *
+ * The custom `aurboda:` structured extension is not carried on the Fedify `Note`
+ * (its typed vocab drops unknown properties); that richer, Aurboda-native
+ * representation lives in `object.ts` for a future content-negotiated endpoint.
+ * Delivery is best-effort: callers invoke it fire-and-forget.
  */
-import type { Federation } from '@fedify/fedify'
+import type { Context, Federation } from '@fedify/fedify'
 
 import { Create, Note } from '@fedify/fedify/vocab'
 
@@ -51,6 +55,63 @@ export interface DeliverableActivity {
   title?: string
 }
 
+/**
+ * Build the Fedify `Note` for a shared post: the Mastodon-compatible object
+ * (HTML `content` + headline `name`), addressed per visibility. Its id and `url`
+ * are the object-dispatcher URL (`getObjectUri(Note, …)`), so the delivered
+ * object and the one served at that URL are guaranteed identical.
+ *
+ * `published` is intentionally omitted: Fedify's vocab types it as the ambient
+ * (esnext.temporal) `Temporal.Instant`, which the `@js-temporal` polyfill value
+ * isn't assignable to. Delivery fires right after the share, so remote servers
+ * timestamp it at receipt (≈ share time); wiring an explicit `published` is a
+ * follow-up (needs Temporal-lib interop sorted).
+ */
+export const buildFeedNote = async (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverablePost,
+  activity: DeliverableActivity,
+): Promise<Note> => {
+  const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
+  const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars)
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Note({
+    attribution: ctx.getActorUri(user),
+    ccs: cc,
+    content,
+    id: noteId,
+    name,
+    tos: to,
+    url: noteId,
+  })
+}
+
+/**
+ * Wrap the post's `Note` in the `Create` activity that is both delivered to
+ * followers and listed in the actor's outbox. The `Create` id is a `#create`
+ * fragment on the Note id, so it never collides with (nor 404s separately from)
+ * the object URL.
+ */
+export const buildFeedCreate = async (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverablePost,
+  activity: DeliverableActivity,
+): Promise<Create> => {
+  const note = await buildFeedNote(ctx, user, post, activity)
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Create({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${noteId.href}#create`),
+    object: note,
+    tos: to,
+  })
+}
+
 /** Build and send the `Create{Note}` for a freshly-shared post to its followers. */
 export const deliverFeedPost = async (
   deps: FeedDeliveryDeps,
@@ -58,30 +119,7 @@ export const deliverFeedPost = async (
   post: DeliverablePost,
   activity: DeliverableActivity,
 ): Promise<void> => {
-  const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
-  const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars)
-
   const ctx = await deps.federation.createContext(new URL(deps.origin))
-  const actorUri = ctx.getActorUri(user)
-  const followers = ctx.getFollowersUri(user)
-  const postUrl = new URL(`${actorUri.href}/feed/${post.id}`)
-  const { cc, to } = recipients(post.visibility, followers)
-
-  // `published` is intentionally omitted: Fedify's vocab types it as the ambient
-  // (esnext.temporal) Temporal.Instant, which the @js-temporal polyfill value
-  // isn't assignable to. Delivery fires right after the share, so remote servers
-  // timestamp it at receipt (≈ share time). Wiring an explicit published is a
-  // follow-up (needs Temporal-lib interop sorted).
-  const note = new Note({
-    attribution: actorUri,
-    ccs: cc,
-    content,
-    id: new URL(`${postUrl.href}/object`),
-    name,
-    tos: to,
-    url: postUrl,
-  })
-  const create = new Create({ actor: actorUri, ccs: cc, id: postUrl, object: note, tos: to })
-
+  const create = await buildFeedCreate(ctx, user, post, activity)
   await ctx.sendActivity({ identifier: user }, 'followers', create)
 }

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -4,12 +4,34 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
  * Integration tests for the Fedify actor + WebFinger surface, exercised through
  * `federation.fetch` against a real per-user database (no Express/nginx needed).
  */
+import { insertActivity } from '../../db/activities/index.ts'
 import { upsertFeedFollower } from '../../db/feed-follower.ts'
+import { createFeedPost, type FeedPostInput } from '../../db/feed.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
 import { createFeedFederation } from './federation.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 const ORIGIN = 'https://aurboda.example'
+
+const insertExercise = (user: string): Promise<string> =>
+  insertActivity(user, {
+    activity_type: 'exercise',
+    end_time: new Date('2026-07-01T07:11:00Z'),
+    source: 'garmin',
+    start_time: new Date('2026-07-01T06:30:00Z'),
+    title: 'Morning run',
+  })
+
+const sharePost = (user: string, activityId: string, overrides: Partial<FeedPostInput> = {}) =>
+  createFeedPost(user, {
+    activity_id: activityId,
+    include_chart: false,
+    include_map: false,
+    included_metrics: ['duration'],
+    series_metrics: [],
+    visibility: 'public',
+    ...overrides,
+  })
 
 const notFound = () => new Response('nope', { status: 404 })
 const fed = createFeedFederation(ORIGIN)
@@ -99,5 +121,57 @@ describe('Feed federation actor + WebFinger', () => {
     const doc = (await res.json()) as { totalItems?: number; orderedItems?: string[] }
     expect(doc.totalItems).toBe(1)
     expect(doc.orderedItems).toContain('https://mastodon.example/users/alice')
+  })
+
+  test('serves the outbox with public posts as Create activities', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId)
+
+    const res = await fetchAs2(`/users/${user}/outbox`)
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { totalItems?: number; orderedItems?: unknown[] }
+    expect(doc.totalItems).toBe(1)
+    const items = doc.orderedItems ?? []
+    expect(items).toHaveLength(1)
+    const create = items[0] as { type: string; object: string | { id: string; type: string } }
+    expect(create.type).toBe('Create')
+    const object = typeof create.object === 'string' ? { id: create.object, type: 'Note' } : create.object
+    expect(object.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
+  })
+
+  test('serves an individual public post object as a Note at its canonical id', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId)
+
+    const res = await fetchAs2(`/users/${user}/feed/${post.id}`)
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { type: string; id: string; attributedTo?: string }
+    expect(doc.type).toBe('Note')
+    expect(doc.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
+    expect(doc.attributedTo).toBe(`${ORIGIN}/users/${user}`)
+  })
+
+  test('excludes followers-only posts from the outbox and 404s their object', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId, { visibility: 'followers' })
+
+    const outbox = (await (await fetchAs2(`/users/${user}/outbox`)).json()) as {
+      totalItems?: number
+      orderedItems?: unknown[]
+    }
+    expect(outbox.totalItems).toBe(0)
+    expect(outbox.orderedItems ?? []).toHaveLength(0)
+
+    const object = await fetchAs2(`/users/${user}/feed/${post.id}`)
+    expect(object.status).toBe(404)
+  })
+
+  test('404s a post object for a non-UUID id without touching the database', async () => {
+    const user = getTestUser()
+    const res = await fetchAs2(`/users/${user}/feed/not-a-uuid`)
+    expect(res.status).toBe(404)
   })
 })

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -1,5 +1,5 @@
 import { createFederation, type Federation, MemoryKvStore } from '@fedify/fedify'
-import { Accept, Follow, Person, Undo } from '@fedify/fedify/vocab'
+import { Accept, type Create, Follow, Note, Person, Undo } from '@fedify/fedify/vocab'
 
 /**
  * The Fedify `Federation` object for the activity feed.
@@ -20,13 +20,22 @@ import { Accept, Follow, Person, Undo } from '@fedify/fedify/vocab'
 import { isValidUsername } from '../../api/auth-routes.ts'
 import {
   countFeedFollowers,
+  countPublicFeedPosts,
+  getActivityById,
+  getFeedPostById,
   getOrCreateActorKeyPair,
   isMissingDatabase,
   listFeedFollowers,
+  listPublicFeedPosts,
   removeFeedFollower,
   upsertFeedFollower,
 } from '../../db/index.ts'
+import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
+
+/** RFC 4122 canonical form — guards `getFeedPostById` from a non-UUID `postId`
+ * (Postgres would otherwise raise `invalid input syntax for type uuid`). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export const createFeedFederation = (origin: string): Federation<void> => {
   const federation = createFederation<void>({
@@ -128,8 +137,66 @@ export const createFeedFederation = (origin: string): Federation<void> => {
       }
     })
 
-  // Outbox stays empty until the delivery slice serves the user's public posts.
-  federation.setOutboxDispatcher('/users/{identifier}/outbox', (_ctx, _identifier) => ({ items: [] }))
+  // Individual post object. Serves the same `Note` that was delivered, at its
+  // canonical id, so a remote server can dereference it. Only `public`/`unlisted`
+  // objects resolve — `followers`-only posts are delivered with the object
+  // inline, so their id never needs to be fetched; refusing them keeps
+  // follower-only content off an unauthenticated fetch.
+  federation.setObjectDispatcher(
+    Note,
+    '/users/{identifier}/feed/{postId}',
+    async (ctx, { identifier, postId }) => {
+      if (!isValidUsername(identifier) || !UUID_RE.test(postId)) return null
+      let post
+      try {
+        post = await getFeedPostById(identifier, postId)
+      } catch (error) {
+        if (isMissingDatabase(error)) return null
+        throw error
+      }
+      if (post == null || post.visibility === 'followers' || post.activity_id == null) return null
+      const activity = await getActivityById(identifier, post.activity_id)
+      if (activity == null) return null
+      return buildFeedNote(ctx, identifier, post, activity)
+    },
+  )
+
+  // Outbox: the user's public + unlisted posts as `Create` activities, so a
+  // Mastodon profile shows them. Served as a single inline OrderedCollection (no
+  // cursor) — fine at feed scale; pagination is a later slice. A post whose
+  // activity was soft-deleted is skipped from the items (its Create can't be
+  // built) while `setCounter` still counts it; the divergence self-heals when
+  // the stale post is removed.
+  federation
+    .setOutboxDispatcher('/users/{identifier}/outbox', async (ctx, identifier) => {
+      if (!isValidUsername(identifier)) return null
+      let posts
+      try {
+        posts = await listPublicFeedPosts(identifier)
+      } catch (error) {
+        if (isMissingDatabase(error)) return null
+        throw error
+      }
+      const items = (
+        await Promise.all(
+          posts.map(async (post) => {
+            if (post.activity_id == null) return null
+            const activity = await getActivityById(identifier, post.activity_id)
+            return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity)
+          }),
+        )
+      ).filter((item): item is Create => item != null)
+      return { items }
+    })
+    .setCounter(async (_ctx, identifier) => {
+      if (!isValidUsername(identifier)) return 0
+      try {
+        return await countPublicFeedPosts(identifier)
+      } catch (error) {
+        if (isMissingDatabase(error)) return 0
+        throw error
+      }
+    })
 
   // Real followers, backed by feed_follower. This both serves the followers
   // collection and enumerates recipients for `sendActivity(..., 'followers', …)`.

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -32,6 +32,7 @@ import {
 } from '../../db/index.ts'
 import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
+import { isPubliclyVisible } from './object.ts'
 
 /** RFC 4122 canonical form — guards `getFeedPostById` from a non-UUID `postId`
  * (Postgres would otherwise raise `invalid input syntax for type uuid`). */
@@ -154,7 +155,7 @@ export const createFeedFederation = (origin: string): Federation<void> => {
         if (isMissingDatabase(error)) return null
         throw error
       }
-      if (post == null || post.visibility === 'followers' || post.activity_id == null) return null
+      if (post == null || post.activity_id == null || !isPubliclyVisible(post.visibility)) return null
       const activity = await getActivityById(identifier, post.activity_id)
       if (activity == null) return null
       return buildFeedNote(ctx, identifier, post, activity)

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -113,6 +113,17 @@ export const feedPostContent = (
 }
 
 /**
+ * Whether a post is visible on the unauthenticated AP surfaces — the outbox and
+ * its dereferenceable object. `public` and `unlisted` are both addressed to the
+ * AS2 Public collection; `followers`-only never is (and is delivered with its
+ * object inline, so its id never needs fetching). An allowlist, so any future
+ * non-public visibility is excluded by default; mirrors the SQL filter in
+ * `listPublicFeedPosts`.
+ */
+export const isPubliclyVisible = (visibility: FeedVisibility): boolean =>
+  visibility === 'public' || visibility === 'unlisted'
+
+/**
  * Map a post's visibility to AS2 `to`/`cc` addressing. `followers` is the
  * actor's followers collection; public objects are addressed to the AS2 Public
  * magic collection.


### PR DESCRIPTION
## Problem

A shared activity federated fine (the `Create` reaches followers), but two AP surfaces were still stubs:

- The **outbox dispatcher returned an empty collection**, so a Mastodon profile for the actor shows **"Posts 0"** even after sharing.
- **Individual post ids didn't resolve** — nothing served the `Note` when a remote server dereferenced a post's id.

## Change

- **DRY object building**: extracted `buildFeedNote` / `buildFeedCreate` out of `deliverFeedPost`. The object we *deliver*, *list in the outbox*, and *serve at the post id* are now built in one place and stay byte-identical. The `Note` id/url is its object-dispatcher URL (`getObjectUri(Note, …)` → `/users/{u}/feed/{postId}`); the `Create` id is a `#create` fragment on it.
- **Object dispatcher**: `setObjectDispatcher(Note, '/users/{identifier}/feed/{postId}')` serves the post's `Note`. Only `public`/`unlisted` resolve; `followers`-only 404 (they're delivered with the object inline, so their id never needs fetching). Invalid usernames and non-UUID ids 404 without a DB hit.
- **Real outbox**: `public` + `unlisted` posts as `Create` activities, newest-first, as a single inline `OrderedCollection` with a total-items counter. (Pagination is a later slice; fine at feed scale.)
- **DB helpers**: `listPublicFeedPosts` / `countPublicFeedPosts` centralise the outbox visibility filter so it can't drift from the `/series` authorization filter.

## Tests

`federation.integration.test.ts`: outbox lists public posts as `Create`s; object served as a `Note` at its canonical id; followers-only excluded from outbox + object 404; non-UUID id 404s without touching the DB. `feed.integration.test.ts`: `listPublicFeedPosts`/`countPublicFeedPosts` include public+unlisted, exclude followers-only. All green + `pnpm --filter aurboda-backend check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)