### PR TITLE
feat(feed): federate Update on edit and Delete{Tombstone} on unshare (#831)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -28,6 +28,7 @@ import { setupOuraWebhook, setupStravaWebhook } from './api/webhooks-setup.ts'
 import { createAuth } from './auth.ts'
 import {
   deleteRuleActivities,
+  getActivityById,
   getDeductionRulesByIds,
   getDetectedLocationById,
   getEnabledDeductionRules,
@@ -320,8 +321,14 @@ const main = async () => {
     deleted: (user, post) => {
       void deliverFeedDelete(feedDeps, user, post).catch(onDeliverError('delete', user, post.id))
     },
-    updated: (user, post, activity) => {
-      void deliverFeedUpdate(feedDeps, user, post, activity).catch(onDeliverError('update', user, post.id))
+    // Resolve the activity inside the fire-and-forget boundary so a lookup
+    // failure never bubbles into the (already-committed) edit's response.
+    updated: (user, post) => {
+      void (async () => {
+        if (!post.activity_id) return
+        const activity = await getActivityById(user, post.activity_id)
+        if (activity) await deliverFeedUpdate(feedDeps, user, post, activity)
+      })().catch(onDeliverError('update', user, post.id))
     },
   }
 

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -52,7 +52,7 @@ import { createOwnTracksRouter } from './integrations/owntracks/router.ts'
 import { stravaClient } from './integrations/strava/client.ts'
 import { createMcpRouter } from './mcp.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
-import { deliverFeedPost } from './services/activitypub/deliver.ts'
+import { deliverFeedDelete, deliverFeedPost, deliverFeedUpdate } from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
 import { auditError } from './services/audit-log.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
@@ -310,10 +310,19 @@ const main = async () => {
   // out to followers, fire-and-forget, so it's identical whether a post is
   // created via MCP or REST.
   const feedFederation = createFeedFederation(webHost)
-  const feedDeliver: FeedDeliver = (user, post, activity) => {
-    void deliverFeedPost({ federation: feedFederation, origin: webHost }, user, post, activity).catch((err) =>
-      console.error(`⚠️ feed delivery failed for ${user}/${post.id}:`, err),
-    )
+  const feedDeps = { federation: feedFederation, origin: webHost }
+  const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>
+    console.error(`⚠️ feed ${op} delivery failed for ${user}/${postId}:`, err)
+  const feedDeliver: FeedDeliver = {
+    created: (user, post, activity) => {
+      void deliverFeedPost(feedDeps, user, post, activity).catch(onDeliverError('create', user, post.id))
+    },
+    deleted: (user, post) => {
+      void deliverFeedDelete(feedDeps, user, post).catch(onDeliverError('delete', user, post.id))
+    },
+    updated: (user, post, activity) => {
+      void deliverFeedUpdate(feedDeps, user, post, activity).catch(onDeliverError('update', user, post.id))
+    },
   }
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -57,7 +57,7 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
         visibility: body.visibility,
       })
       // Fan out to followers (best-effort), same as the REST share route.
-      deliver?.(user, record, activity)
+      deliver?.created(user, record, activity)
       return jsonResponse(serialize(record))
     },
   )
@@ -75,6 +75,11 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
         visibility: body.visibility,
       })
       if (!record) return errorResponse('Feed post not found')
+      // Federate the edit as an Update, same as the REST update route.
+      if (record.activity_id) {
+        const activity = await getActivityById(user, record.activity_id)
+        if (activity) deliver?.updated(user, record, activity)
+      }
       return jsonResponse(serialize(record))
     },
   )
@@ -87,6 +92,8 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
       const existing = await getFeedPostById(user, id)
       if (!existing) return errorResponse('Feed post not found')
       await deleteFeedPost(user, id)
+      // Retract from followers with a Delete{Tombstone}, same as the REST route.
+      deliver?.deleted(user, existing)
       return jsonResponse({ deleted: true, id })
     },
   )

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -76,10 +76,7 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
       })
       if (!record) return errorResponse('Feed post not found')
       // Federate the edit as an Update, same as the REST update route.
-      if (record.activity_id) {
-        const activity = await getActivityById(user, record.activity_id)
-        if (activity) deliver?.updated(user, record, activity)
-      }
+      deliver?.updated(user, record)
       return jsonResponse(serialize(record))
     },
   )

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -38,12 +38,17 @@ import { validateBody } from '../validation.ts'
  * injected so the router + MCP tools stay decoupled from the ActivityPub layer
  * (and testable without it). Each impl signs + fans the corresponding activity
  * out to the user's followers: `created` → `Create`, `updated` → `Update`,
- * `deleted` → `Delete{Tombstone}`. `deleted` takes only the post — no activity
- * lookup is needed to retract by object id, and the row is already gone.
+ * `deleted` → `Delete{Tombstone}`.
+ *
+ * `created` receives the activity because the share handler already resolved it
+ * (for the 404 check), so there's no double fetch. `updated`/`deleted` take only
+ * the post: their implementation resolves whatever it needs *inside* the
+ * fire-and-forget boundary, so a post-mutation lookup can never turn a
+ * successful edit/delete into a 500.
  */
 export interface FeedDeliver {
   created: (user: string, post: FeedPostRecord, activity: Activity) => void
-  updated: (user: string, post: FeedPostRecord, activity: Activity) => void
+  updated: (user: string, post: FeedPostRecord) => void
   deleted: (user: string, post: FeedPostRecord) => void
 }
 
@@ -109,10 +114,8 @@ export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedD
         return res.status(404).json({ error: 'Feed post not found', success: false })
       }
       // Federate the edit as an Update so followers replace the stored object.
-      if (record.activity_id) {
-        const activity = await getActivityById(user, record.activity_id)
-        if (activity) deliver?.updated(user, record, activity)
-      }
+      // Fire-and-forget: the impl resolves the activity, so it can't 500 here.
+      deliver?.updated(user, record)
       res.json({ post: serialize(record), success: true })
     },
   )

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -26,6 +26,7 @@ import {
   createFeedPost,
   deleteFeedPost,
   getActivityById,
+  getFeedPostById,
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
@@ -33,11 +34,18 @@ import { type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
 /**
- * Fire-and-forget federation delivery for a freshly-shared post. Injected so the
- * router stays decoupled from the ActivityPub layer (and testable without it);
- * the implementation signs + fans the Create out to the user's followers.
+ * Fire-and-forget federation delivery hooks for the feed-post lifecycle,
+ * injected so the router + MCP tools stay decoupled from the ActivityPub layer
+ * (and testable without it). Each impl signs + fans the corresponding activity
+ * out to the user's followers: `created` → `Create`, `updated` → `Update`,
+ * `deleted` → `Delete{Tombstone}`. `deleted` takes only the post — no activity
+ * lookup is needed to retract by object id, and the row is already gone.
  */
-export type FeedDeliver = (user: string, post: FeedPostRecord, activity: Activity) => void
+export interface FeedDeliver {
+  created: (user: string, post: FeedPostRecord, activity: Activity) => void
+  updated: (user: string, post: FeedPostRecord, activity: Activity) => void
+  deleted: (user: string, post: FeedPostRecord) => void
+}
 
 const serialize = (record: FeedPostRecord): FeedPost => ({
   activity_id: record.activity_id,
@@ -79,7 +87,7 @@ export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedD
         visibility: req.body.visibility,
       })
       // Fan the post out to followers (best-effort; never blocks the response).
-      deliver?.(user, record, activity)
+      deliver?.created(user, record, activity)
       res.json({ post: serialize(record), success: true })
     },
   )
@@ -100,16 +108,25 @@ export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedD
       if (!record) {
         return res.status(404).json({ error: 'Feed post not found', success: false })
       }
+      // Federate the edit as an Update so followers replace the stored object.
+      if (record.activity_id) {
+        const activity = await getActivityById(user, record.activity_id)
+        if (activity) deliver?.updated(user, record, activity)
+      }
       res.json({ post: serialize(record), success: true })
     },
   )
 
   router.delete<{ postId: string }, FeedPostResponse>('/:postId', authMiddleware, async (req, res) => {
     const user = req.user!
+    // Capture the post before deleting so its Delete can be addressed by the
+    // same visibility and reference the right object id.
+    const existing = await getFeedPostById(user, req.params.postId)
     const deleted = await deleteFeedPost(user, req.params.postId)
-    if (!deleted) {
+    if (!deleted || !existing) {
       return res.status(404).json({ error: 'Feed post not found', success: false })
     }
+    deliver?.deleted(user, existing)
     res.json({ success: true })
   })
 

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -1,6 +1,8 @@
+import { Tombstone } from '@fedify/fedify/vocab'
 import { describe, expect, test } from 'vitest'
 
-import { recipients } from './deliver.ts'
+import { buildFeedDelete, type DeliverablePost, recipients } from './deliver.ts'
+import { createFeedFederation } from './federation.ts'
 
 const PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
 const followers = new URL('https://aurboda.net/users/fiddur/followers')
@@ -24,5 +26,43 @@ describe('recipients', () => {
     const { to, cc } = recipients('followers', followers)
     expect(hrefs(to)).toEqual([followers.href])
     expect(cc).toEqual([])
+  })
+})
+
+describe('buildFeedDelete', () => {
+  const ORIGIN = 'https://aurboda.example'
+  const deliverablePost = (visibility: DeliverablePost['visibility']): DeliverablePost => ({
+    created_at: new Date('2026-07-01T00:00:00Z'),
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    included_metrics: [],
+    visibility,
+  })
+
+  // No DB: builds a Fedify context off the federation's registered dispatchers
+  // (URL builders only), so the Delete/Tombstone shape is unit-testable.
+  const contextFor = () => createFeedFederation(ORIGIN).createContext(new URL(ORIGIN))
+
+  test('wraps a Tombstone at the post object id, addressed by visibility', async () => {
+    const ctx = await contextFor()
+    const post = deliverablePost('public')
+    const del = buildFeedDelete(ctx, 'fiddur', post)
+
+    const noteId = `${ORIGIN}/users/fiddur/feed/${post.id}`
+    expect(del.actorId?.href).toBe(`${ORIGIN}/users/fiddur`)
+    expect(del.id?.href).toBe(`${noteId}#delete`)
+
+    const object = await del.getObject()
+    expect(object).toBeInstanceOf(Tombstone)
+    expect(object?.id?.href).toBe(noteId)
+
+    expect(hrefs([...del.toIds])).toContain(PUBLIC)
+    expect(hrefs([...del.ccIds])).toContain(`${ORIGIN}/users/fiddur/followers`)
+  })
+
+  test('addresses a followers-only delete to followers, never Public', async () => {
+    const ctx = await contextFor()
+    const del = buildFeedDelete(ctx, 'fiddur', deliverablePost('followers'))
+    expect(hrefs([...del.toIds])).toEqual([`${ORIGIN}/users/fiddur/followers`])
+    expect([...del.ccIds]).toEqual([])
   })
 })

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -35,6 +35,7 @@ describe('buildFeedDelete', () => {
     created_at: new Date('2026-07-01T00:00:00Z'),
     id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     included_metrics: [],
+    updated_at: new Date('2026-07-01T00:00:00Z'),
     visibility,
   })
 

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -46,6 +46,8 @@ export interface DeliverablePost {
   included_metrics: string[]
   visibility: FeedVisibility
   created_at: Date
+  /** Last-edited time; makes each `Update` activity id unique (see `buildFeedUpdate`). */
+  updated_at: Date
 }
 
 export interface DeliverableActivity {
@@ -115,8 +117,10 @@ export const buildFeedCreate = async (
 /**
  * Wrap the post's (re-resolved) `Note` in an `Update` activity. Sent when a
  * post's shared metric selection or visibility changes, so followers' servers
- * replace the stored object. The `Update` id is a `#update` fragment on the
- * Note id; Mastodon supersedes by the object being updated, not the activity id.
+ * replace the stored object. The `Update` id carries the post's `updated_at`
+ * (`#update-<epoch-ms>`) so each edit has a distinct activity id — AS2 requires
+ * unique activity ids, and servers that dedupe inbound activities by id would
+ * otherwise drop every edit after the first.
  */
 export const buildFeedUpdate = async (
   ctx: Context<void>,
@@ -130,7 +134,7 @@ export const buildFeedUpdate = async (
   return new Update({
     actor: ctx.getActorUri(user),
     ccs: cc,
-    id: new URL(`${noteId.href}#update`),
+    id: new URL(`${noteId.href}#update-${post.updated_at.getTime()}`),
     object: note,
     tos: to,
   })

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -20,7 +20,7 @@ import type { FeedVisibility } from '@aurboda/api-spec'
  */
 import type { Context, Federation } from '@fedify/fedify'
 
-import { Create, Note } from '@fedify/fedify/vocab'
+import { Create, Delete, Note, Tombstone, Update } from '@fedify/fedify/vocab'
 
 import { resolveActivityScalars } from './feed-activity.ts'
 import { addressingFor, feedPostContent } from './object.ts'
@@ -112,6 +112,48 @@ export const buildFeedCreate = async (
   })
 }
 
+/**
+ * Wrap the post's (re-resolved) `Note` in an `Update` activity. Sent when a
+ * post's shared metric selection or visibility changes, so followers' servers
+ * replace the stored object. The `Update` id is a `#update` fragment on the
+ * Note id; Mastodon supersedes by the object being updated, not the activity id.
+ */
+export const buildFeedUpdate = async (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverablePost,
+  activity: DeliverableActivity,
+): Promise<Update> => {
+  const note = await buildFeedNote(ctx, user, post, activity)
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Update({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${noteId.href}#update`),
+    object: note,
+    tos: to,
+  })
+}
+
+/**
+ * Build the `Delete{Tombstone}` for a removed post — the AS2-standard way to
+ * retract it from followers' timelines. Needs no activity/scalar resolution
+ * (just the object id + addressing), so it stays synchronous and survives the
+ * post row already being gone.
+ */
+export const buildFeedDelete = (ctx: Context<void>, user: string, post: DeliverablePost): Delete => {
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Delete({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${noteId.href}#delete`),
+    object: new Tombstone({ id: noteId }),
+    tos: to,
+  })
+}
+
 /** Build and send the `Create{Note}` for a freshly-shared post to its followers. */
 export const deliverFeedPost = async (
   deps: FeedDeliveryDeps,
@@ -122,4 +164,27 @@ export const deliverFeedPost = async (
   const ctx = await deps.federation.createContext(new URL(deps.origin))
   const create = await buildFeedCreate(ctx, user, post, activity)
   await ctx.sendActivity({ identifier: user }, 'followers', create)
+}
+
+/** Build and send the `Update{Note}` for an edited post to its followers. */
+export const deliverFeedUpdate = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverablePost,
+  activity: DeliverableActivity,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  const update = await buildFeedUpdate(ctx, user, post, activity)
+  await ctx.sendActivity({ identifier: user }, 'followers', update)
+}
+
+/** Build and send the `Delete{Tombstone}` for a removed post to its followers. */
+export const deliverFeedDelete = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverablePost,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  const del = buildFeedDelete(ctx, user, post)
+  await ctx.sendActivity({ identifier: user }, 'followers', del)
 }

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -191,7 +191,7 @@ describe('Feed federation actor + WebFinger', () => {
     })
 
     const noteId = `${ORIGIN}/users/${user}/feed/${post.id}`
-    expect(update.id?.href).toBe(`${noteId}#update`)
+    expect(update.id?.href).toBe(`${noteId}#update-${post.updated_at.getTime()}`)
     const object = await update.getObject()
     expect(object).toBeInstanceOf(Note)
     expect(object?.id?.href).toBe(noteId)

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -1,13 +1,15 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
-
 /**
  * Integration tests for the Fedify actor + WebFinger surface, exercised through
  * `federation.fetch` against a real per-user database (no Express/nginx needed).
  */
+import { Note } from '@fedify/fedify/vocab'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
 import { insertActivity } from '../../db/activities/index.ts'
 import { upsertFeedFollower } from '../../db/feed-follower.ts'
 import { createFeedPost, type FeedPostInput } from '../../db/feed.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
+import { buildFeedUpdate } from './deliver.ts'
 import { createFeedFederation } from './federation.ts'
 
 const CONTAINER_TIMEOUT = 120_000
@@ -173,5 +175,25 @@ describe('Feed federation actor + WebFinger', () => {
     const user = getTestUser()
     const res = await fetchAs2(`/users/${user}/feed/not-a-uuid`)
     expect(res.status).toBe(404)
+  })
+
+  test('buildFeedUpdate wraps the post Note in an Update at the canonical object id', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId)
+
+    const ctx = await fed.createContext(new URL(ORIGIN))
+    const update = await buildFeedUpdate(ctx, user, post, {
+      activity_type: 'exercise',
+      end_time: new Date('2026-07-01T07:11:00Z'),
+      start_time: new Date('2026-07-01T06:30:00Z'),
+      title: 'Morning run',
+    })
+
+    const noteId = `${ORIGIN}/users/${user}/feed/${post.id}`
+    expect(update.id?.href).toBe(`${noteId}#update`)
+    const object = await update.getObject()
+    expect(object).toBeInstanceOf(Note)
+    expect(object?.id?.href).toBe(noteId)
   })
 })


### PR DESCRIPTION
## Problem

Only `Create` was federated (on share). Editing a shared post's metric selection/visibility, or unsharing it, left the post stale in followers' timelines.

## Change

Propagate the full feed-post lifecycle:

- **`deliver.ts`**: `buildFeedUpdate`/`deliverFeedUpdate` (`Update{Note}`) and `buildFeedDelete`/`deliverFeedDelete` (`Delete{Tombstone}`). Both reuse the same `getObjectUri`-derived `Note` id, so an `Update` replaces exactly the object that was delivered and a `Delete` retracts it by that id. `buildFeedDelete` needs no activity/scalar resolution, so it stays synchronous and works even after the row is gone.
- **Hook shape**: generalised `FeedDeliver` from a single function to a `{ created, updated, deleted }` interface (one fire-and-forget hook per lifecycle event). Wired `updated`/`deleted` into both the REST feed router (`PATCH`/`DELETE`) and the MCP tools (`update_feed_post`/`delete_feed_post`), so a post edited/deleted via either transport federates identically. The `DELETE` route now reads the post before removing it so the `Delete` can be addressed by its original visibility.

## Tests

- Unit: `buildFeedDelete` → `Delete` wrapping a `Tombstone` at the object id, with correct visibility addressing (public → Public/followers; followers-only → followers, never Public).
- Integration: `buildFeedUpdate` wraps the post's `Note` in an `Update` at its canonical id.

All green + `pnpm --filter aurboda-backend check` clean.

## Follow-up (out of scope)

Serving a `410 Tombstone` on a GET of a deleted object needs persistence (feed_posts are hard-deleted); the pushed `Delete` is what retracts from followers' timelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)