### PR TITLE
feat(web): feed/outbox view of shared activities (#831)

### DIFF
--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { shareActivity, updateFeedPost } from '../state/api'
+import { SERIES_METRICS, SUMMARY_METRICS } from './feed-metrics'
 import './ShareActivityDialog.css'
 
 interface Props {
@@ -25,27 +26,6 @@ interface Props {
   onClose: () => void
   onShared?: (post: FeedPost) => void
 }
-
-/** Scalar summaries the backend knows how to resolve (see services/activitypub/scalars.ts). */
-const SUMMARY_METRICS: { key: string; label: string }[] = [
-  { key: 'duration', label: 'Duration' },
-  { key: 'distance', label: 'Distance' },
-  { key: 'heart_rate_avg', label: 'Avg HR' },
-  { key: 'heart_rate_max', label: 'Max HR' },
-  { key: 'hr_zone_minutes', label: 'HR zones' },
-  { key: 'calories', label: 'Calories' },
-  { key: 'stress_avg', label: 'Avg stress' },
-]
-
-/** High-resolution series a user can explicitly opt into sharing. */
-const SERIES_METRICS: { key: MetricType; label: string }[] = [
-  { key: 'heart_rate', label: 'Heart rate' },
-  { key: 'speed', label: 'Speed' },
-  { key: 'power', label: 'Power' },
-  { key: 'elevation', label: 'Elevation' },
-  { key: 'run_cadence', label: 'Cadence' },
-  { key: 'stress_level', label: 'Stress' },
-]
 
 const VISIBILITIES: { value: FeedVisibility; label: string; hint: string }[] = [
   { hint: 'Anyone can see it; appears in public timelines.', label: 'Public', value: 'public' },

--- a/apps/web/src/components/feed-metrics.ts
+++ b/apps/web/src/components/feed-metrics.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared metric-option lists for the federated feed UI (share dialog + feed
+ * view), so the labels a post is created with match the labels it's displayed
+ * with.
+ */
+import type { MetricType } from '@aurboda/api-spec'
+
+/** Scalar summaries the backend knows how to resolve (see services/activitypub/scalars.ts). */
+export const SUMMARY_METRICS: { key: string; label: string }[] = [
+  { key: 'duration', label: 'Duration' },
+  { key: 'distance', label: 'Distance' },
+  { key: 'heart_rate_avg', label: 'Avg HR' },
+  { key: 'heart_rate_max', label: 'Max HR' },
+  { key: 'hr_zone_minutes', label: 'HR zones' },
+  { key: 'calories', label: 'Calories' },
+  { key: 'stress_avg', label: 'Avg stress' },
+]
+
+/** High-resolution series a user can explicitly opt into sharing. */
+export const SERIES_METRICS: { key: MetricType; label: string }[] = [
+  { key: 'heart_rate', label: 'Heart rate' },
+  { key: 'speed', label: 'Speed' },
+  { key: 'power', label: 'Power' },
+  { key: 'elevation', label: 'Elevation' },
+  { key: 'run_cadence', label: 'Cadence' },
+  { key: 'stress_level', label: 'Stress' },
+]
+
+/** Human label for a stored `included_metrics` key (falls back to the raw key). */
+export const summaryLabel = (key: string): string => SUMMARY_METRICS.find((m) => m.key === key)?.label ?? key
+
+/** Human label for a stored `series_metrics` key (falls back to the raw key). */
+export const seriesLabel = (key: string): string => SERIES_METRICS.find((m) => m.key === key)?.label ?? key

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -8,6 +8,7 @@ export const NAV_LINKS = [
   { href: '/add', label: '+ Add', icon: '➕' },
   { href: '/chart', label: 'Chart', icon: '📈' },
   { href: '/shared-dashboards', label: 'Share', icon: '🔆' },
+  { href: '/feed', label: 'Feed', icon: '📣' },
   { href: '/challenges', label: 'Challenges', icon: '🏆' },
   { href: '/correlations', label: 'Analyze', icon: '🔬' },
   { href: '/places', label: 'Places', icon: '📍' },

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -32,6 +32,7 @@ import { StravaSource } from './pages/DataSources/StravaSource.jsx'
 import { DeductionRules } from './pages/DeductionRules/index.jsx'
 import { DeductionRuleDetail } from './pages/DeductionRules/RuleDetail.jsx'
 import { EntityDetail } from './pages/EntityDetail/index.jsx'
+import { Feed } from './pages/Feed/index.jsx'
 import { FoodItemDetail } from './pages/FoodItems/FoodItemDetail.jsx'
 import { FoodItems } from './pages/FoodItems/index.jsx'
 import { Goals } from './pages/Goals/index.jsx'
@@ -98,6 +99,7 @@ function AppShell() {
             <Route path="/reports/:id" component={ReportDetail} />
             <Route path="/reports" component={Reports} />
             <Route path="/detail/:type/:id" component={EntityDetail} />
+            <Route path="/feed" component={Feed} />
             <Route path="/activity-type/:name" component={ActivityTypeMeta} />
             <Route path="/metric/:metricName" component={MetricMeta} />
             <Route path="/sleep" component={Sleep} />

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -1,0 +1,138 @@
+/**
+ * Feed / outbox view — the activities the user has published to their federated
+ * (ActivityPub) feed. Lists each shared post with its audience and the metrics
+ * it exposes, and lets the user edit the selection (reusing the share dialog in
+ * edit mode) or unshare (which retracts a Delete to followers).
+ */
+import type { FeedPost, FeedVisibility } from '@aurboda/api-spec'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { useState } from 'preact/hooks'
+
+import { seriesLabel, summaryLabel } from '../../components/feed-metrics'
+import { ShareActivityDialog } from '../../components/ShareActivityDialog'
+import { deleteFeedPost, fetchActivityById, fetchFeed } from '../../state/api'
+import { toDisplayName } from '../../utils/displayName'
+import './style.css'
+
+const VISIBILITY_LABEL: Record<FeedVisibility, string> = {
+  followers: 'Followers only',
+  public: 'Public',
+  unlisted: 'Unlisted',
+}
+
+const formatWhen = (iso: string): string => format(new Date(iso), 'PP')
+
+function FeedPostCard({ post }: { post: FeedPost }) {
+  const queryClient = useQueryClient()
+  const [editing, setEditing] = useState(false)
+  const activityId = post.activity_id
+
+  const activityQuery = useQuery({
+    enabled: activityId != null,
+    queryFn: () => fetchActivityById(activityId ?? ''),
+    queryKey: ['activity', activityId],
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteFeedPost(post.id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
+  })
+
+  const activity = activityQuery.data?.activity
+  const title = activity?.title || (activity ? toDisplayName(activity.activity_type) : 'Shared activity')
+
+  const onUnshare = () => {
+    if (window.confirm('Unshare this post? It is removed from your feed and retracted from followers.')) {
+      deleteMutation.mutate()
+    }
+  }
+
+  return (
+    <div class="feed-card">
+      <div class="feed-card-head">
+        {activityId ? (
+          <a class="feed-card-title" href={`/detail/activity/${activityId}`}>
+            {title}
+          </a>
+        ) : (
+          <span class="feed-card-title">{title}</span>
+        )}
+        <span class={`feed-badge feed-badge-${post.visibility}`}>{VISIBILITY_LABEL[post.visibility]}</span>
+      </div>
+
+      <div class="feed-card-meta">
+        Shared {formatWhen(post.created_at)}
+        {post.updated_at !== post.created_at ? ` · edited ${formatWhen(post.updated_at)}` : ''}
+      </div>
+
+      {post.included_metrics.length > 0 && (
+        <div class="feed-chips">
+          {post.included_metrics.map((k) => (
+            <span key={k} class="feed-chip">
+              {summaryLabel(k)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {post.series_metrics.length > 0 && (
+        <div class="feed-chips">
+          <span class="feed-chips-label">Series</span>
+          {post.series_metrics.map((k) => (
+            <span key={k} class="feed-chip feed-chip-series">
+              {seriesLabel(k)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div class="feed-card-actions">
+        {activityId && (
+          <button type="button" class="btn-secondary" onClick={() => setEditing(true)}>
+            Edit
+          </button>
+        )}
+        <button type="button" class="btn-danger" onClick={onUnshare} disabled={deleteMutation.isPending}>
+          {deleteMutation.isPending ? 'Unsharing…' : 'Unshare'}
+        </button>
+      </div>
+
+      {editing && activityId && (
+        <ShareActivityDialog
+          activityId={activityId}
+          activityTitle={activity?.title}
+          post={post}
+          onClose={() => setEditing(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+export function Feed() {
+  const { data: posts, isLoading, error } = useQuery({ queryFn: fetchFeed, queryKey: ['feed'] })
+
+  return (
+    <div class="feed-page">
+      <h1>Feed</h1>
+      <p class="feed-intro">
+        Activities you've published to your federated feed. People can follow your{' '}
+        <code>@handle@aurboda.net</code> from Mastodon and the wider fediverse to see these posts.
+      </p>
+
+      {isLoading && <p>Loading…</p>}
+      {error && <p class="feed-error">Couldn't load your feed. Please try again.</p>}
+      {posts && posts.length === 0 && (
+        <p class="feed-empty">
+          You haven't shared anything yet. Open an activity and choose <strong>Share to feed</strong>.
+        </p>
+      )}
+      {posts?.map((post) => (
+        <FeedPostCard key={post.id} post={post} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -1,0 +1,159 @@
+.feed-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.feed-page h1 {
+  margin: 0 0 0.25rem;
+}
+
+.feed-intro {
+  margin: 0 0 1.25rem;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.feed-intro code {
+  background: rgba(103, 58, 184, 0.1);
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+}
+
+.feed-empty,
+.feed-error {
+  padding: 1rem;
+  border-radius: 8px;
+  background: #f9fafb;
+  color: #374151;
+}
+
+.feed-error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.feed-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.feed-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.feed-card-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #1f2937;
+  text-decoration: none;
+}
+
+.feed-card-title[href]:hover {
+  text-decoration: underline;
+}
+
+.feed-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.feed-badge-public {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.feed-badge-unlisted {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
+.feed-badge-followers {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.feed-card-meta {
+  font-size: 0.78rem;
+  color: #6b7280;
+  margin-top: 0.15rem;
+}
+
+.feed-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.6rem;
+}
+
+.feed-chips-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.feed-chip {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.feed-chip-series {
+  background: rgba(103, 58, 184, 0.12);
+  color: #4c1d95;
+}
+
+.feed-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .feed-card {
+    border-color: #374151;
+  }
+
+  .feed-card-title {
+    color: #e5e7eb;
+  }
+
+  .feed-empty {
+    background: #1f2937;
+    color: #d1d5db;
+  }
+
+  .feed-chip {
+    background: #374151;
+    color: #d1d5db;
+  }
+
+  .feed-badge-public {
+    background: #14532d;
+    color: #bbf7d0;
+  }
+
+  .feed-badge-unlisted {
+    background: #312e81;
+    color: #c7d2fe;
+  }
+
+  .feed-badge-followers {
+    background: #374151;
+    color: #d1d5db;
+  }
+}


### PR DESCRIPTION
## What

A **Feed** page (sidebar link + `/feed` route) — the "see the outbox feed" ask — listing everything the user has published to their federated feed, newest-first.

Each post card shows:
- the **activity** (linked to its detail page), with its title resolved via the cached activities query,
- an **audience badge** (public / unlisted / followers-only),
- the shared **summary-metric** chips and any opted-in **series** chips,
- when it was shared (and edited, if different).

Actions:
- **Edit** — reuses `ShareActivityDialog` in edit mode (`PATCH` → federated `Update`).
- **Unshare** — deletes the post (`DELETE` → federated `Delete{Tombstone}`) behind a `window.confirm`.

## How

- New `pages/Feed` (+ CSS), registered at `/feed` with a `📣 Feed` nav entry.
- Extracted the metric-option lists into a shared `components/feed-metrics` module so the share dialog and this view label metrics identically (DRY) — the dialog now imports from it.
- Uses the `feed.ts` client (`fetchFeed`/`deleteFeedPost`/`updateFeedPost`) landed in #870.

## Notes

- Per-card activity-title lookups use react-query caching; feeds are small so this is cheap. Enriching `GET /feed` with the activity title server-side is a possible future optimization.
- `pnpm --filter aurboda-web check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)