### PR TITLE
feat(feed): humanize duration and format shared posts as headline + stats (#831)

### DIFF
--- a/apps/backend/src/services/activitypub/object.test.ts
+++ b/apps/backend/src/services/activitypub/object.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'vitest'
 
-import { addressingFor, AS_PUBLIC, type BuildCreateInput, buildCreateExercise } from './object.ts'
+import {
+  addressingFor,
+  AS_PUBLIC,
+  type BuildCreateInput,
+  buildCreateExercise,
+  feedPostContent,
+} from './object.ts'
 
 const base: BuildCreateInput = {
   activityType: 'running',
@@ -56,10 +62,10 @@ describe('buildCreateExercise', () => {
     ])
   })
 
-  test('content flattens exactly the shared scalars behind the title', () => {
+  test('content is a bold title headline with the shared scalars on their own line', () => {
     const c = buildCreateExercise(base)
     expect(c.object.content).toBe(
-      '<p>Morning run · Distance 8.2 km · Avg HR 148 bpm · Hr zone minutes z2 22, z3 11</p>',
+      '<p><strong>Morning run</strong></p><p>Distance 8.2 km · Avg HR 148 bpm · Hr zone minutes z2 22, z3 11</p>',
     )
   })
 
@@ -110,7 +116,7 @@ describe('buildCreateExercise', () => {
 
   test('escapes HTML in the title for the fallback content', () => {
     const c = buildCreateExercise({ ...base, scalars: [], title: 'Run <b>x</b> & "go"' })
-    expect(c.object.content).toBe('<p>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</p>')
+    expect(c.object.content).toBe('<p><strong>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</strong></p>')
   })
 
   test('uses publishedAt for the AS2 published times, keeping the workout time in aurboda:startTime', () => {
@@ -129,5 +135,31 @@ describe('buildCreateExercise', () => {
   test('falls back to a derived name when the activity has no title', () => {
     const c = buildCreateExercise({ ...base, title: undefined })
     expect(c.object.name).toBe('Running activity')
+  })
+})
+
+describe('feedPostContent', () => {
+  test('renders a bold headline with stats below and a humanized duration', () => {
+    const { content } = feedPostContent('Evening qigong', 'yoga', [
+      { key: 'duration', label: 'Duration', unit: 'seconds', value: 642 },
+      { key: 'heart_rate_avg', label: 'Avg HR', unit: 'bpm', value: 76 },
+      { key: 'calories', label: 'Calories', unit: 'kcal', value: 9 },
+    ])
+    expect(content).toBe(
+      '<p><strong>Evening qigong</strong></p><p>Duration 10m 42s · Avg HR 76 bpm · Calories 9 kcal</p>',
+    )
+  })
+
+  test('renders hours and minutes for a long duration', () => {
+    const { content } = feedPostContent('Long ride', 'cycling', [
+      { key: 'duration', label: 'Duration', unit: 'seconds', value: 3720 },
+    ])
+    expect(content).toBe('<p><strong>Long ride</strong></p><p>Duration 1h 2m</p>')
+  })
+
+  test('untitled activity gets a type-derived headline and no stats line when nothing is shared', () => {
+    const { content, name } = feedPostContent(undefined, 'yoga', [])
+    expect(content).toBe('<p><strong>Yoga activity</strong></p>')
+    expect(name).toBe('Yoga activity')
   })
 })

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -83,32 +83,52 @@ const prettifyKey = (key: string): string => {
   return spaced.charAt(0).toUpperCase() + spaced.slice(1)
 }
 
-/** Render one scalar for the human-readable fallback line. */
+/** Render a seconds count as a compact human duration: 642 → `10m 42s`, 3720 → `1h 2m`. */
+const formatDuration = (totalSeconds: number): string => {
+  const s = Math.max(0, Math.round(totalSeconds))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  const parts: string[] = []
+  if (h) parts.push(`${h}h`)
+  if (m) parts.push(`${m}m`)
+  if (sec || parts.length === 0) parts.push(`${sec}s`)
+  return parts.join(' ')
+}
+
+/** Render one scalar for the human-readable stats line. */
 const formatScalar = ({ key, value, unit, label }: ScalarMetric): string => {
   const name = label ?? prettifyKey(key)
-  const rendered =
-    typeof value === 'number'
-      ? `${value}${unit ? ` ${unit}` : ''}`
-      : Object.entries(value)
-          .map(([k, v]) => `${k} ${v}`)
-          .join(', ')
+  let rendered: string
+  if (typeof value === 'number') {
+    // A seconds value reads as a duration ("10m 42s"), not "642 seconds".
+    rendered = unit === 'seconds' ? formatDuration(value) : `${value}${unit ? ` ${unit}` : ''}`
+  } else {
+    rendered = Object.entries(value)
+      .map(([k, v]) => `${k} ${v}`)
+      .join(', ')
+  }
   return `${name} ${rendered}`
 }
 
 /**
- * The human-readable status a plain fediverse client renders: a `name` headline
- * and an HTML `content` line flattening the title + shared scalars. Shared by
- * the AS2 object model and the Fedify delivery Note so both read identically.
+ * The human-readable status a plain fediverse client (Mastodon) renders: a bold
+ * title headline with the shared scalars on their own line below, so it reads as
+ * a workout post rather than one run-on sentence. `name` carries the same
+ * headline. Shared by the AS2 object model and the Fedify delivery Note so both
+ * read identically.
  */
 export const feedPostContent = (
   title: string | undefined,
   activityType: string,
   scalars: ScalarMetric[],
 ): { name: string; content: string } => {
-  const summaryLine = [title, ...scalars.map(formatScalar)].filter((p): p is string => Boolean(p)).join(' · ')
+  const heading = title ?? `${prettifyKey(activityType)} activity`
+  const stats = scalars.map(formatScalar).join(' · ')
+  const headingHtml = `<p><strong>${escapeHtml(heading)}</strong></p>`
   return {
-    content: `<p>${escapeHtml(summaryLine)}</p>`,
-    name: title ?? `${prettifyKey(activityType)} activity`,
+    content: stats ? `${headingHtml}<p>${escapeHtml(stats)}</p>` : headingHtml,
+    name: heading,
   }
 }
 


### PR DESCRIPTION
## Why

Live feedback on the shipped feed: a shared post reads as one cramped run-on line with a raw **`Duration 642 seconds`**:

> Evening qigong and mobility · Duration 642 seconds · Avg HR 76 bpm · Max HR 97 bpm · Calories 9 kcal

## Change

`feedPostContent` now renders the `Note` as a **bold title headline** with the shared scalars on their **own line** below, and durations render as compact human strings:

> **Evening qigong and mobility**
> Duration 10m 42s · Avg HR 76 bpm · Max HR 97 bpm · Calories 9 kcal

- `642s → "10m 42s"`, `3720s → "1h 2m"` (drops zero components; always shows something).
- Only the **human** content changes; `aurboda:metrics` values stay numeric (machine-readable).
- Since delivery, outbox, and object serving all build the `Note` from this one function, the improvement shows everywhere consistently.

## Tests

Updated the `buildCreateExercise` content assertions and added focused `feedPostContent` tests (headline + stats layout, duration humanization incl. hours, untitled fallback with no stats line). `pnpm --filter aurboda-backend check` clean.

Note: the irrelevant-metric-checkbox feedback (offering Distance for a no-distance activity) is a separate frontend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)