### PR TITLE
fix(web): allow sharing merged activities to the feed (#831)

### DIFF
--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -621,8 +621,11 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         onSuccess={() => queryClient.invalidateQueries()}
         isEditing={isEditing}
       />
-      {activity.id && !isMergedActivity && !activity.deleted_at && !isEditing && (
-        <ShareActivityButton activityId={activity.id} activityTitle={activity.title} />
+      {!activity.deleted_at && !isEditing && (
+        // `rawEntityId` is a plain activity UUID for both raw and merged views (a
+        // `merged:<uuid>` id wraps a real anchor activity), so merged activities
+        // — the common case — are shareable; the post references that anchor.
+        <ShareActivityButton activityId={rawEntityId} activityTitle={activity.title} />
       )}
       {isMerging && <MergePanel activityId={rawEntityId} onCancel={() => setIsMerging(false)} />}
       <ActivityDetailContent


### PR DESCRIPTION
## Problem

The **Share to feed** button was hidden for merged activities (guarded by `!isMergedActivity`). Since most activities are merged — the same workout arrives from several sources and Aurboda presents a merged view — sharing was effectively unavailable for the common case.

## Fix

A `merged:<uuid>` id wraps a **real anchor activity**, and the share endpoint (`getActivityById`) takes a plain UUID. So the button now uses `rawEntityId` — the stripped UUID already used for this view's edit/delete/notes — and drops the `!isMergedActivity` guard. The feed post references the anchor activity and resolves its shared metrics from that activity's window.

Still hidden while editing or for deleted activities.

## Follow-up (noted, not in this PR)

For a merged view whose data spans several source records, the post uses the **anchor** activity's window rather than the merged span. Usually the anchor is representative; sharing the full merged window is a possible later refinement (needs the share endpoint to accept the `merged:` prefix and persist the span).

Verified with `pnpm --filter aurboda-web check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)