### PR TITLE
feat(dashboard): author-editable description + per-section intro text (#834)

### DIFF
--- a/apps/backend/src/routes/public-shares-router.test.ts
+++ b/apps/backend/src/routes/public-shares-router.test.ts
@@ -68,4 +68,17 @@ describe('sanitizeConfig', () => {
     // Original config is not mutated.
     expect(config.sections[0].widgets[0]).toMatchObject({ config: { href: '/secret/admin' } })
   })
+
+  test('preserves author prose (dashboard + section descriptions)', () => {
+    const config: DashboardConfig = {
+      description: 'Two years of training.',
+      sections: [
+        { description: 'Recovery metrics.', id: 's1', title: 'Baseline', type: 'metrics', widgets: [] },
+      ],
+      version: 1,
+    }
+    const sanitized = sanitizeConfig(config)
+    expect(sanitized.description).toBe('Two years of training.')
+    expect(sanitized.sections[0].description).toBe('Recovery metrics.')
+  })
 })

--- a/apps/backend/src/routes/public-shares-router.ts
+++ b/apps/backend/src/routes/public-shares-router.ts
@@ -45,6 +45,9 @@ const MAX_CHALLENGE_MEMBERS = 200
  * Quick links point into the owner's private app, so neutralize their hrefs.
  */
 export const sanitizeConfig = (config: DashboardConfig): DashboardConfig => ({
+  // Author prose is meant for public viewers — preserve it (section descriptions
+  // survive via the section spread below).
+  description: config.description,
   sections: config.sections.map((section) => ({
     ...section,
     widgets: section.widgets.map((widget) =>

--- a/apps/backend/src/routes/share-html-router.test.ts
+++ b/apps/backend/src/routes/share-html-router.test.ts
@@ -34,6 +34,20 @@ describe('GET /u/:username/:slug', () => {
     expect(res.headers['cache-control']).toBe('public, max-age=300')
   })
 
+  test("uses the dashboard's author description in the meta when present", async () => {
+    const app = buildApp({
+      resolveDashboard: async () => ({
+        description: 'Two years of training and its effect on sleep.',
+        is_public: true,
+        name: 'My Training',
+      }),
+    })
+    const res = await supertest(app).get('/u/fiddur/abc123')
+    expect(res.text).toContain(
+      'property="og:description" content="Two years of training and its effect on sleep."',
+    )
+  })
+
   test('does not leak an unlisted (non-public) dashboard name', async () => {
     const app = buildApp({
       resolveDashboard: async () => ({ is_public: false, name: 'Secret Dashboard' }),

--- a/apps/backend/src/routes/share-html-router.ts
+++ b/apps/backend/src/routes/share-html-router.ts
@@ -30,6 +30,8 @@ import { buildProfileUrl, buildShareUrl } from '../services/share-urls.ts'
 interface ResolvedResource {
   name: string
   is_public: boolean
+  /** Author-provided description (dashboards only), for the meta description. */
+  description?: string
 }
 
 export interface ShareHtmlDeps {
@@ -78,7 +80,13 @@ export const createShareResolvers = (): Pick<
   resolveDashboard: async (username, slug) => {
     try {
       const dashboard = await getSharedDashboardBySlug(username, slug)
-      return dashboard ? { is_public: dashboard.is_public, name: dashboard.name } : null
+      return dashboard
+        ? {
+            description: dashboard.config.description,
+            is_public: dashboard.is_public,
+            name: dashboard.name,
+          }
+        : null
     } catch (error) {
       if (isMissingDatabase(error)) return null
       throw error
@@ -129,7 +137,12 @@ export const createShareHtmlRouter = (deps: ShareHtmlDeps): Router => {
     if (dashboard?.is_public) {
       return sendHtml(
         loadTemplate,
-        buildDashboardShareMeta({ name: dashboard.name, url, username }),
+        buildDashboardShareMeta({
+          description: dashboard.description,
+          name: dashboard.name,
+          url,
+          username,
+        }),
         true,
         res,
       )

--- a/apps/backend/src/services/share-meta.test.ts
+++ b/apps/backend/src/services/share-meta.test.ts
@@ -89,6 +89,17 @@ describe('builders', () => {
     expect(m.description).toContain('Training')
   })
 
+  test('dashboard meta falls back when the description is empty/whitespace', () => {
+    const m = buildDashboardShareMeta({
+      description: '   ',
+      name: 'Training',
+      url: 'https://aurboda.net/u/fiddur/abc',
+      username: 'fiddur',
+    })
+    expect(m.description).toContain('Training')
+    expect(m.description.trim()).not.toBe('')
+  })
+
   test('dashboard meta prefers an author description', () => {
     const m = buildDashboardShareMeta({
       description: 'Two years of training and effect.',

--- a/apps/backend/src/services/share-meta.ts
+++ b/apps/backend/src/services/share-meta.ts
@@ -120,7 +120,8 @@ export const buildDashboardShareMeta = ({
   description,
 }: DashboardMetaInput): ShareMeta => ({
   description: clampDescription(
-    description ?? `${name} — a public dashboard shared by ${username} on ${SITE_NAME}.`,
+    // A stored empty/whitespace description (possible via the API) falls back.
+    description?.trim() ? description : `${name} — a public dashboard shared by ${username} on ${SITE_NAME}.`,
   ),
   image: resourceOgImage(url),
   imageAlt: `${SITE_NAME} dashboard: ${name}`,

--- a/apps/web/src/components/EditableDashboard/index.tsx
+++ b/apps/web/src/components/EditableDashboard/index.tsx
@@ -8,7 +8,7 @@
  */
 import type { DashboardConfig, DashboardSection, DashboardWidget, SectionType } from '@aurboda/api-spec'
 
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 import { DashboardEditor } from '../DashboardEditor'
 import { WidgetRenderer } from '../widgets'
@@ -40,6 +40,9 @@ function DashboardSectionComponent({
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState(section.title)
   const [descDraft, setDescDraft] = useState(section.description ?? '')
+  // Re-sync the draft when the underlying value changes (e.g. reset elsewhere),
+  // so a stale draft can't re-persist removed text on blur.
+  useEffect(() => setDescDraft(section.description ?? ''), [section.description])
 
   const commitDescription = () => {
     const next = descDraft.trim() || undefined
@@ -294,6 +297,10 @@ export function EditableDashboard({ config, isEditing, onChange, boardId }: Edit
   const [showWidgetPicker, setShowWidgetPicker] = useState<string | null>(null) // section id or null
   const [showAddSection, setShowAddSection] = useState(false)
   const [descDraft, setDescDraft] = useState(config.description ?? '')
+  // Re-sync when config changes under a still-mounted editor (home "Reset to
+  // Default", or navigating between shared dashboards), so the draft can't go
+  // stale and re-persist stale text on blur.
+  useEffect(() => setDescDraft(config.description ?? ''), [config.description])
 
   const commitDescription = () => {
     const next = descDraft.trim() || undefined

--- a/apps/web/src/components/EditableDashboard/index.tsx
+++ b/apps/web/src/components/EditableDashboard/index.tsx
@@ -24,6 +24,7 @@ function DashboardSectionComponent({
   onAddWidgetClick,
   onDeleteSection,
   onRenameSection,
+  onDescriptionChange,
 }: {
   section: DashboardSection
   isEditing: boolean
@@ -33,10 +34,17 @@ function DashboardSectionComponent({
   onAddWidgetClick?: () => void
   onDeleteSection?: () => void
   onRenameSection?: (title: string) => void
+  onDescriptionChange?: (description: string | undefined) => void
 }) {
   const [collapsed, setCollapsed] = useState(section.collapsed ?? false)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState(section.title)
+  const [descDraft, setDescDraft] = useState(section.description ?? '')
+
+  const commitDescription = () => {
+    const next = descDraft.trim() || undefined
+    if (next !== section.description) onDescriptionChange?.(next)
+  }
 
   const gridClass =
     section.type === 'links' ? 'links-grid' : section.type === 'charts' ? 'charts-grid' : 'metrics-grid'
@@ -112,6 +120,18 @@ function DashboardSectionComponent({
           </div>
         )}
       </div>
+      {isEditing ? (
+        <textarea
+          class="section-intro-input"
+          value={descDraft}
+          placeholder="Optional intro text shown above this section…"
+          onInput={(e) => setDescDraft((e.target as HTMLTextAreaElement).value)}
+          onBlur={commitDescription}
+          rows={2}
+        />
+      ) : section.description ? (
+        <p class="section-intro">{section.description}</p>
+      ) : null}
       {!collapsed && (
         <div class={gridClass}>
           {section.widgets.map((widget, index) => (
@@ -273,6 +293,19 @@ interface EditableDashboardProps {
 export function EditableDashboard({ config, isEditing, onChange, boardId }: EditableDashboardProps) {
   const [showWidgetPicker, setShowWidgetPicker] = useState<string | null>(null) // section id or null
   const [showAddSection, setShowAddSection] = useState(false)
+  const [descDraft, setDescDraft] = useState(config.description ?? '')
+
+  const commitDescription = () => {
+    const next = descDraft.trim() || undefined
+    if (next !== config.description) onChange({ ...config, description: next })
+  }
+
+  const handleSectionDescription = (sectionId: string, description: string | undefined) => {
+    onChange({
+      ...config,
+      sections: config.sections.map((s) => (s.id === sectionId ? { ...s, description } : s)),
+    })
+  }
 
   const handleRemoveWidget = (sectionId: string, widgetId: string) => {
     onChange({
@@ -347,6 +380,19 @@ export function EditableDashboard({ config, isEditing, onChange, boardId }: Edit
 
   return (
     <div class="sections-grid">
+      {isEditing ? (
+        <textarea
+          class="dashboard-intro-input"
+          value={descDraft}
+          placeholder="Optional dashboard description — shown on the page and in link previews…"
+          onInput={(e) => setDescDraft((e.target as HTMLTextAreaElement).value)}
+          onBlur={commitDescription}
+          rows={2}
+        />
+      ) : config.description ? (
+        <p class="dashboard-intro">{config.description}</p>
+      ) : null}
+
       {config.sections.map((section) => (
         <DashboardSectionComponent
           key={section.id}
@@ -358,6 +404,7 @@ export function EditableDashboard({ config, isEditing, onChange, boardId }: Edit
           onAddWidgetClick={() => setShowWidgetPicker(section.id)}
           onDeleteSection={() => handleDeleteSection(section.id)}
           onRenameSection={(title) => handleRenameSection(section.id, title)}
+          onDescriptionChange={(description) => handleSectionDescription(section.id, description)}
         />
       ))}
 

--- a/apps/web/src/pages/Dashboard/style.css
+++ b/apps/web/src/pages/Dashboard/style.css
@@ -799,6 +799,51 @@
   outline: none;
 }
 
+/* Author-editable prose: dashboard + section intro text */
+.dashboard .dashboard-intro,
+.dashboard .section-intro {
+  color: #555;
+  line-height: 1.5;
+  margin: 0 0 1rem 0;
+  white-space: pre-wrap;
+}
+
+.dashboard .dashboard-intro {
+  grid-column: 1 / -1;
+  font-size: 1.05rem;
+}
+
+.dashboard .section-intro {
+  font-size: 0.95rem;
+}
+
+.dashboard .dashboard-intro-input,
+.dashboard .section-intro-input {
+  width: 100%;
+  font: inherit;
+  color: #555;
+  background: transparent;
+  border: 1px solid #673ab8;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin: 0 0 1rem 0;
+  resize: vertical;
+  outline: none;
+}
+
+.dashboard .dashboard-intro-input {
+  grid-column: 1 / -1;
+}
+
+@media (prefers-color-scheme: dark) {
+  .dashboard .dashboard-intro,
+  .dashboard .section-intro,
+  .dashboard .dashboard-intro-input,
+  .dashboard .section-intro-input {
+    color: #bbb;
+  }
+}
+
 /* Dark mode additions for editing */
 @media (prefers-color-scheme: dark) {
   .dashboard .btn-edit {

--- a/apps/web/src/pages/PublicDashboard/index.tsx
+++ b/apps/web/src/pages/PublicDashboard/index.tsx
@@ -127,12 +127,15 @@ function ReadOnlyDashboard({
         </a>
       </div>
 
+      {config.description ? <p class="dashboard-intro">{config.description}</p> : null}
+
       <div class="sections-grid">
         {config.sections.map((section) => (
           <section key={section.id} class="metrics-section">
             <div class="section-header">
               <h2>{section.title}</h2>
             </div>
+            {section.description ? <p class="section-intro">{section.description}</p> : null}
             <div class={gridClass(section.type)}>
               {section.widgets.map((widget) => (
                 <PublicWidgetRenderer key={widget.id} widget={widget} data={widgetData?.[widget.id]} />

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -74,6 +74,16 @@ Widgets are organized into sections, each with a title and a layout type:
 
 Sections are collapsible -- click the section header to toggle between expanded and collapsed. On wide screens, multiple sections can appear side by side.
 
+## Descriptive text
+
+While editing a dashboard you can add optional prose (both fields are plain text
+and optional, so existing dashboards are unaffected):
+
+- A **dashboard description** shown under the title. For a [shared dashboard](./sharing.md)
+  this also feeds the link-preview / `og:description`, so a pasted link reads well.
+- A **per-section intro** rendered above that section's widgets, so the page reads
+  as a narrative rather than just a wall of charts.
+
 ## Editing the Dashboard
 
 Click the pencil icon next to the "Dashboard" title to enter edit mode.

--- a/docs/features/sharing.md
+++ b/docs/features/sharing.md
@@ -89,6 +89,9 @@ get the full SPA and hydrate normally — only the head is enriched.
 
 - **Dashboards** and **challenges** get a title (resource name), a description, and
   a canonical URL; profiles get a `profile`-typed card with `ProfilePage` JSON-LD.
+  A dashboard's description uses the author-provided text when set (see
+  [Dashboard → Descriptive text](./dashboard.md#descriptive-text)), else a generated
+  fallback.
 - Every public resource has a **dynamically rendered 1200×630 preview image** at
   `<resource-url>/opengraph-image.png`. Satori renders a branded card (title +
   DASHBOARD/CHALLENGE/PROFILE eyebrow + the owner's avatar + Aurboda wordmark) to

--- a/packages/api-spec/src/schemas/dashboard.ts
+++ b/packages/api-spec/src/schemas/dashboard.ts
@@ -105,13 +105,10 @@ export const trendChartConfigSchema = z
       .array(z.string())
       .optional()
       .meta({ description: 'Categorical data fields to break the series down by' }),
-    masked_breakdown_fields: z
-      .array(z.string())
-      .optional()
-      .meta({
-        description:
-          'Subset of breakdown_fields whose values are masked (shown as A, B, C…) to public viewers of a shared board',
-      }),
+    masked_breakdown_fields: z.array(z.string()).optional().meta({
+      description:
+        'Subset of breakdown_fields whose values are masked (shown as A, B, C…) to public viewers of a shared board',
+    }),
     display_period: z
       .enum(['daily', 'weekly', 'monthly'])
       .optional()
@@ -139,13 +136,10 @@ export const barChartConfigSchema = z
       .array(z.string())
       .optional()
       .meta({ description: 'Categorical data fields to break the series down by' }),
-    masked_breakdown_fields: z
-      .array(z.string())
-      .optional()
-      .meta({
-        description:
-          'Subset of breakdown_fields whose values are masked (shown as A, B, C…) to public viewers of a shared board',
-      }),
+    masked_breakdown_fields: z.array(z.string()).optional().meta({
+      description:
+        'Subset of breakdown_fields whose values are masked (shown as A, B, C…) to public viewers of a shared board',
+    }),
     bucket_size: z
       .enum(['1m', '5m', '15m', '1h', '1d', '1w', '1M'])
       .meta({ description: 'Time bucket size' }),
@@ -346,6 +340,10 @@ export type SectionType = z.infer<typeof sectionTypeSchema>
 export const dashboardSectionSchema = z
   .object({
     collapsed: z.boolean().optional().meta({ description: 'Whether section is collapsed' }),
+    description: z
+      .string()
+      .optional()
+      .meta({ description: 'Optional intro text rendered above the section widgets' }),
     id: z.string().min(1).meta({ description: 'Unique section ID' }),
     title: z.string().min(1).meta({ description: 'Section title' }),
     type: sectionTypeSchema.meta({ description: 'Section type for layout' }),
@@ -360,6 +358,10 @@ export type DashboardSection = z.infer<typeof dashboardSectionSchema>
  */
 export const dashboardConfigSchema = z
   .object({
+    description: z.string().optional().meta({
+      description:
+        'Optional author-provided description (plain text). Feeds the shared-page meta description / link preview.',
+    }),
     sections: z.array(dashboardSectionSchema).meta({ description: 'Dashboard sections' }),
     version: z.literal(1).meta({ description: 'Config version for future migrations' }),
   })


### PR DESCRIPTION
Part **4** of the #834 epic. Dashboards gain optional author prose that improves both the page and its link preview.

## What
- **api-spec**: optional `description` on `DashboardConfig` and a per-section `description`. Both additive/optional, so existing v1 configs stay valid — **no version bump or migration needed** (`z.literal(1)` would reject a bumped config; the point of optional fields is backward compatibility).
- **Backend**: a shared dashboard's `config.description` now feeds `og:description` / the `<meta name=description>` (falls back to the generated sentence from PR1 when unset). Covered by a new share-html-router test.
- **Web**: `EditableDashboard` edits the dashboard description and each section's intro (commit-on-blur, matching the section-rename pattern). Both render read-only on the home dashboard and public shared pages — section intros above their widgets, so the page reads as a narrative.

## Notes
- No new API endpoints — the existing shared-dashboard/home-dashboard update paths validate the config, which now accepts the optional fields.
- `pnpm check` green.

## Follow-up
5: oEmbed + sharability polish (copy-link/Web Share, theme-color, JSON-LD, QR, debugger validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)