### PR TITLE
feat(feed): chart + route-map images on shared posts (#831)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -310,8 +310,8 @@ const main = async () => {
   // MCP feed tools, and the REST feed router). `feedDeliver` fans a shared post
   // out to followers, fire-and-forget, so it's identical whether a post is
   // created via MCP or REST.
-  const feedFederation = createFeedFederation(webHost)
-  const feedDeps = { federation: feedFederation, origin: webHost }
+  const feedFederation = createFeedFederation(webHost, apiBaseUrl)
+  const feedDeps = { apiBaseUrl, federation: feedFederation, origin: webHost }
   const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>
     console.error(`⚠️ feed ${op} delivery failed for ${user}/${postId}:`, err)
   const feedDeliver: FeedDeliver = {

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -18,7 +18,13 @@ import type { SyncProvider } from '../services/queries/index.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 import type { AnyMiddleware } from '../typed-router.ts'
 
-import { markActivityDetailSynced } from '../db/index.ts'
+import {
+  getActivityById,
+  getFeedPostById,
+  getLocations,
+  getTimeSeries,
+  markActivityDetailSynced,
+} from '../db/index.ts'
 import { processActivityDetail } from '../integrations/garmin/process.ts'
 import { createActivitiesRouter } from '../routes/activities-router.ts'
 import { createActivityTypesRouter } from '../routes/activity-types-router.ts'
@@ -30,6 +36,7 @@ import { createChartDataRouter } from '../routes/chart-data-router.ts'
 import { createCorrelationsRouter } from '../routes/correlations-router.ts'
 import { createDashboardRouter } from '../routes/dashboard-router.ts'
 import { createDeductionRulesRouter } from '../routes/deduction-rules-router.ts'
+import { createFeedImageRouter } from '../routes/feed-image-router.ts'
 import { createFeedPublicRouter } from '../routes/feed-public-router.ts'
 import { createFeedRouter, type FeedDeliver } from '../routes/feed-router.ts'
 import { createFoodItemsRouter } from '../routes/food-items-router.ts'
@@ -144,6 +151,17 @@ export const mountRestRouters = ({
   // Public feed series must be mounted before the generic /public/:username/:slug
   // resolver so `series` is not matched as a share slug.
   httpd.use(createFeedPublicRouter())
+  // Public feed-post images (chart / route map), rendered on demand for opted-in
+  // public/unlisted posts. Mounted alongside the series router (same guard).
+  httpd.use(
+    createFeedImageRouter({
+      getActivity: getActivityById,
+      getPost: getFeedPostById,
+      getRoute: async (user, start, end) =>
+        (await getLocations(user, start, end)).locations.map((l) => l.coordinates),
+      getSeries: getTimeSeries,
+    }),
+  )
   httpd.use(createPublicSharesRouter(webHost))
   // Mounted before the share-html router so `/u/.../opengraph-image.png` and
   // `/u/:username/avatar.png` win over the generic `/u/:username/:slug` HTML route.

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+
+import type { FeedPostRecord } from '../db/index.ts'
+
+import { type ImageActivity, resolveImageWindow } from './feed-image-router.ts'
+
+const POST_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ACTIVITY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+const activity: ImageActivity = {
+  end_time: new Date('2026-07-01T07:11:00Z'),
+  start_time: new Date('2026-07-01T06:30:00Z'),
+}
+
+const makePost = (overrides: Partial<FeedPostRecord> = {}): FeedPostRecord => ({
+  activity_id: ACTIVITY_ID,
+  created_at: new Date('2026-07-01T08:00:00Z'),
+  id: POST_ID,
+  include_chart: true,
+  include_map: true,
+  included_metrics: [],
+  series_metrics: [],
+  updated_at: new Date('2026-07-01T08:00:00Z'),
+  visibility: 'public',
+  ...overrides,
+})
+
+const deps = (post: FeedPostRecord | null, act: ImageActivity | null = activity) => ({
+  getActivity: async () => act,
+  getPost: async () => post,
+})
+
+describe('resolveImageWindow', () => {
+  test('resolves the activity window for an eligible public opted-in post', async () => {
+    expect(await resolveImageWindow(deps(makePost()), 'fiddur', POST_ID, 'include_chart')).toEqual(activity)
+  })
+
+  test('null for an invalid username or non-UUID post id (no DB hit)', async () => {
+    expect(await resolveImageWindow(deps(makePost()), 'Bad..Name', POST_ID, 'include_chart')).toBeNull()
+    expect(await resolveImageWindow(deps(makePost()), 'fiddur', 'not-a-uuid', 'include_chart')).toBeNull()
+  })
+
+  test('null when the post is missing', async () => {
+    expect(await resolveImageWindow(deps(null), 'fiddur', POST_ID, 'include_chart')).toBeNull()
+  })
+
+  test('null for a followers-only post', async () => {
+    const post = makePost({ visibility: 'followers' })
+    expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_chart')).toBeNull()
+  })
+
+  test('null when the requested attachment was not opted into', async () => {
+    const post = makePost({ include_chart: false })
+    expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_chart')).toBeNull()
+    // ...but the map flag is still on for the same post.
+    expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_map')).toEqual(activity)
+  })
+
+  test('null when the post has no linked activity', async () => {
+    expect(
+      await resolveImageWindow(deps(makePost({ activity_id: null })), 'fiddur', POST_ID, 'include_chart'),
+    ).toBeNull()
+  })
+
+  test('null for an open-ended activity (no bounded window)', async () => {
+    const openEnded = { start_time: activity.start_time }
+    expect(await resolveImageWindow(deps(makePost(), openEnded), 'fiddur', POST_ID, 'include_map')).toBeNull()
+  })
+})

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -1,0 +1,97 @@
+/**
+ * Public feed-post image endpoints (UNAUTHENTICATED).
+ *
+ * Handles: GET /public/:username/feed/:postId/chart.png
+ *          GET /public/:username/feed/:postId/route.png
+ *
+ * Rendered on demand from the shared activity's data. Like the public `/series`
+ * endpoint there is no auth token, so the gating below is the whole privacy
+ * boundary: an image is served only for a `public`/`unlisted` post that opted
+ * into that attachment (`include_chart` / `include_map`). `no-store` keeps the
+ * images revocable (unshare / flip to followers / clear the flag takes effect
+ * immediately). Mounted before the generic `/public/:username/:slug` resolver.
+ */
+import { type Response, Router } from 'express'
+
+import type { FeedPostRecord } from '../db/index.ts'
+
+import { isValidUsername } from '../api/auth-routes.ts'
+import { isMissingDatabase } from '../db/index.ts'
+import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
+import { isPubliclyVisible } from '../services/activitypub/object.ts'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** The window an image renders over. */
+export interface ImageActivity {
+  start_time: Date
+  end_time?: Date
+}
+
+export interface FeedImageDeps {
+  getPost: (user: string, postId: string) => Promise<FeedPostRecord | null>
+  getActivity: (user: string, activityId: string) => Promise<ImageActivity | null>
+  getSeries: (user: string, metric: string, start: Date, end: Date) => Promise<[Date, number][]>
+  getRoute: (user: string, start: Date, end: Date) => Promise<[number, number][]>
+}
+
+/**
+ * Resolve the activity window an image may render over, or `null` if the request
+ * isn't eligible: invalid username / non-UUID id, missing DB, missing or
+ * non-public post, the attachment flag not opted in, no linked activity, or an
+ * open-ended activity (no bounded window). Pure of Express — unit-testable.
+ */
+export const resolveImageWindow = async (
+  deps: Pick<FeedImageDeps, 'getPost' | 'getActivity'>,
+  username: string,
+  postId: string,
+  flag: 'include_chart' | 'include_map',
+): Promise<ImageActivity | null> => {
+  if (!isValidUsername(username) || !UUID_RE.test(postId)) return null
+  let post: FeedPostRecord | null
+  try {
+    post = await deps.getPost(username, postId)
+  } catch (error) {
+    if (isMissingDatabase(error)) return null
+    throw error
+  }
+  if (post == null || !isPubliclyVisible(post.visibility) || !post[flag] || post.activity_id == null) {
+    return null
+  }
+  const activity = await deps.getActivity(username, post.activity_id)
+  if (activity?.end_time == null) return null
+  return activity
+}
+
+const notFound = (res: Response) => res.status(404).json({ error: 'Not found', success: false })
+
+const sendPng = (res: Response, png: Buffer) => {
+  // Revocable like the /series endpoint: never let a shared cache serve an image
+  // for a post that was just un-shared.
+  res.setHeader('Cache-Control', 'no-store')
+  res.type('png').send(png)
+}
+
+export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
+  const router = Router()
+
+  router.get('/public/:username/feed/:postId/chart.png', async (req, res) => {
+    const { postId, username } = req.params
+    const activity = await resolveImageWindow(deps, username, postId, 'include_chart')
+    if (!activity?.end_time) return notFound(res)
+    const series = await deps.getSeries(username, 'heart_rate', activity.start_time, activity.end_time)
+    if (series.length === 0) return notFound(res)
+    sendPng(res, await renderChartPng(series))
+  })
+
+  router.get('/public/:username/feed/:postId/route.png', async (req, res) => {
+    const { postId, username } = req.params
+    const activity = await resolveImageWindow(deps, username, postId, 'include_map')
+    if (!activity?.end_time) return notFound(res)
+    const coords = await deps.getRoute(username, activity.start_time, activity.end_time)
+    if (coords.length === 0) return notFound(res)
+    sendPng(res, await renderRoutePng(coords))
+  })
+
+  return router
+}

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -34,6 +34,8 @@ describe('buildFeedDelete', () => {
   const deliverablePost = (visibility: DeliverablePost['visibility']): DeliverablePost => ({
     created_at: new Date('2026-07-01T00:00:00Z'),
     id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    include_chart: false,
+    include_map: false,
     included_metrics: [],
     updated_at: new Date('2026-07-01T00:00:00Z'),
     visibility,

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -1,7 +1,7 @@
 import { Tombstone } from '@fedify/fedify/vocab'
 import { describe, expect, test } from 'vitest'
 
-import { buildFeedDelete, type DeliverablePost, recipients } from './deliver.ts'
+import { buildFeedDelete, type DeliverablePost, imageAttachments, recipients } from './deliver.ts'
 import { createFeedFederation } from './federation.ts'
 
 const PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
@@ -67,5 +67,42 @@ describe('buildFeedDelete', () => {
     const del = buildFeedDelete(ctx, 'fiddur', deliverablePost('followers'))
     expect(hrefs([...del.toIds])).toEqual([`${ORIGIN}/users/fiddur/followers`])
     expect([...del.ccIds]).toEqual([])
+  })
+})
+
+describe('imageAttachments', () => {
+  const actorUri = new URL('https://aurboda.example/users/fiddur')
+  const POST_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  const base = `https://aurboda.example/api/public/fiddur/feed/${POST_ID}`
+  const post = (overrides: Partial<DeliverablePost>): DeliverablePost => ({
+    created_at: new Date('2026-07-01T00:00:00Z'),
+    id: POST_ID,
+    include_chart: false,
+    include_map: false,
+    included_metrics: [],
+    updated_at: new Date('2026-07-01T00:00:00Z'),
+    visibility: 'public',
+    ...overrides,
+  })
+
+  test('attaches only the opted-in images, at the public endpoints', () => {
+    const chartOnly = imageAttachments(actorUri, 'fiddur', post({ include_chart: true }))
+    expect(chartOnly.map((a) => a.url?.href)).toEqual([`${base}/chart.png`])
+
+    const both = imageAttachments(actorUri, 'fiddur', post({ include_chart: true, include_map: true }))
+    expect(both.map((a) => a.url?.href)).toEqual([`${base}/chart.png`, `${base}/route.png`])
+  })
+
+  test('attaches nothing for a followers-only post (image endpoint is unauthenticated)', () => {
+    const atts = imageAttachments(
+      actorUri,
+      'fiddur',
+      post({ include_chart: true, include_map: true, visibility: 'followers' }),
+    )
+    expect(atts).toEqual([])
+  })
+
+  test('attaches nothing when neither flag is set', () => {
+    expect(imageAttachments(actorUri, 'fiddur', post({}))).toEqual([])
   })
 })

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -43,7 +43,7 @@ describe('buildFeedDelete', () => {
 
   // No DB: builds a Fedify context off the federation's registered dispatchers
   // (URL builders only), so the Delete/Tombstone shape is unit-testable.
-  const contextFor = () => createFeedFederation(ORIGIN).createContext(new URL(ORIGIN))
+  const contextFor = () => createFeedFederation(ORIGIN, `${ORIGIN}/api`).createContext(new URL(ORIGIN))
 
   test('wraps a Tombstone at the post object id, addressed by visibility', async () => {
     const ctx = await contextFor()
@@ -71,7 +71,7 @@ describe('buildFeedDelete', () => {
 })
 
 describe('imageAttachments', () => {
-  const actorUri = new URL('https://aurboda.example/users/fiddur')
+  const apiBaseUrl = 'https://aurboda.example/api'
   const POST_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
   const base = `https://aurboda.example/api/public/fiddur/feed/${POST_ID}`
   const post = (overrides: Partial<DeliverablePost>): DeliverablePost => ({
@@ -86,16 +86,16 @@ describe('imageAttachments', () => {
   })
 
   test('attaches only the opted-in images, at the public endpoints', () => {
-    const chartOnly = imageAttachments(actorUri, 'fiddur', post({ include_chart: true }))
+    const chartOnly = imageAttachments(apiBaseUrl, 'fiddur', post({ include_chart: true }))
     expect(chartOnly.map((a) => a.url?.href)).toEqual([`${base}/chart.png`])
 
-    const both = imageAttachments(actorUri, 'fiddur', post({ include_chart: true, include_map: true }))
+    const both = imageAttachments(apiBaseUrl, 'fiddur', post({ include_chart: true, include_map: true }))
     expect(both.map((a) => a.url?.href)).toEqual([`${base}/chart.png`, `${base}/route.png`])
   })
 
   test('attaches nothing for a followers-only post (image endpoint is unauthenticated)', () => {
     const atts = imageAttachments(
-      actorUri,
+      apiBaseUrl,
       'fiddur',
       post({ include_chart: true, include_map: true, visibility: 'followers' }),
     )
@@ -103,6 +103,6 @@ describe('imageAttachments', () => {
   })
 
   test('attaches nothing when neither flag is set', () => {
-    expect(imageAttachments(actorUri, 'fiddur', post({}))).toEqual([])
+    expect(imageAttachments(apiBaseUrl, 'fiddur', post({}))).toEqual([])
   })
 })

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -20,7 +20,7 @@ import type { FeedVisibility } from '@aurboda/api-spec'
  */
 import type { Context, Federation } from '@fedify/fedify'
 
-import { Create, Delete, Note, Tombstone, Update } from '@fedify/fedify/vocab'
+import { Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/vocab'
 
 import { resolveActivityScalars } from './feed-activity.ts'
 import { addressingFor, feedPostContent } from './object.ts'
@@ -48,6 +48,44 @@ export interface DeliverablePost {
   created_at: Date
   /** Last-edited time; makes each `Update` activity id unique (see `buildFeedUpdate`). */
   updated_at: Date
+  /** Attach a rendered heart-rate chart image. */
+  include_chart: boolean
+  /** Attach a rendered GPS route-map image. */
+  include_map: boolean
+}
+
+/**
+ * Image attachments for a post's opted-in chart/route. Each points at the public
+ * on-demand image endpoint (`/api/public/<user>/feed/<id>/{chart,route}.png`),
+ * built against the actor's origin so it matches the deployed API base. Fedify's
+ * `Image` carries `url` + `mediaType` + intrinsic size so Mastodon lays it out.
+ */
+const imageAttachments = (actorUri: URL, user: string, post: DeliverablePost): Image[] => {
+  const base = new URL(`/api/public/${encodeURIComponent(user)}/feed/${post.id}`, actorUri)
+  const images: Image[] = []
+  if (post.include_chart) {
+    images.push(
+      new Image({
+        height: 420,
+        mediaType: 'image/png',
+        name: 'Heart rate',
+        url: new URL(`${base.href}/chart.png`),
+        width: 1000,
+      }),
+    )
+  }
+  if (post.include_map) {
+    images.push(
+      new Image({
+        height: 700,
+        mediaType: 'image/png',
+        name: 'Route',
+        url: new URL(`${base.href}/route.png`),
+        width: 700,
+      }),
+    )
+  }
+  return images
 }
 
 export interface DeliverableActivity {
@@ -77,10 +115,12 @@ export const buildFeedNote = async (
 ): Promise<Note> => {
   const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
   const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars)
+  const actorUri = ctx.getActorUri(user)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
   return new Note({
-    attribution: ctx.getActorUri(user),
+    attachments: imageAttachments(actorUri, user, post),
+    attribution: actorUri,
     ccs: cc,
     content,
     id: noteId,

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -39,6 +39,8 @@ export interface FeedDeliveryDeps {
   federation: Federation<void>
   /** Canonical web origin, e.g. `https://aurboda.net`. */
   origin: string
+  /** Public API base, e.g. `https://aurboda.net/api` — image attachment URLs hang off this. */
+  apiBaseUrl: string
 }
 
 export interface DeliverablePost {
@@ -65,9 +67,11 @@ export interface DeliverablePost {
  * posts, so attaching a URL that would 404 for a follower is worse than omitting
  * it. (Authenticated per-follower image delivery is a possible later slice.)
  */
-export const imageAttachments = (actorUri: URL, user: string, post: DeliverablePost): Image[] => {
+export const imageAttachments = (apiBaseUrl: string, user: string, post: DeliverablePost): Image[] => {
   if (!isPubliclyVisible(post.visibility)) return []
-  const base = new URL(`/api/public/${encodeURIComponent(user)}/feed/${post.id}`, actorUri)
+  // Same base as the series links (feed-activity.ts) — the configured API base,
+  // NOT a hardcoded `<origin>/api`, so it stays correct if the two ever diverge.
+  const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${post.id}`
   const images: Image[] = []
   if (post.include_chart) {
     images.push(
@@ -75,7 +79,7 @@ export const imageAttachments = (actorUri: URL, user: string, post: DeliverableP
         height: 420,
         mediaType: 'image/png',
         name: 'Heart rate',
-        url: new URL(`${base.href}/chart.png`),
+        url: new URL(`${base}/chart.png`),
         width: 1000,
       }),
     )
@@ -86,7 +90,7 @@ export const imageAttachments = (actorUri: URL, user: string, post: DeliverableP
         height: 700,
         mediaType: 'image/png',
         name: 'Route',
-        url: new URL(`${base.href}/route.png`),
+        url: new URL(`${base}/route.png`),
         width: 700,
       }),
     )
@@ -118,6 +122,7 @@ export const buildFeedNote = async (
   user: string,
   post: DeliverablePost,
   activity: DeliverableActivity,
+  apiBaseUrl: string,
 ): Promise<Note> => {
   const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
   const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars)
@@ -125,7 +130,7 @@ export const buildFeedNote = async (
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
   return new Note({
-    attachments: imageAttachments(actorUri, user, post),
+    attachments: imageAttachments(apiBaseUrl, user, post),
     attribution: actorUri,
     ccs: cc,
     content,
@@ -147,8 +152,9 @@ export const buildFeedCreate = async (
   user: string,
   post: DeliverablePost,
   activity: DeliverableActivity,
+  apiBaseUrl: string,
 ): Promise<Create> => {
-  const note = await buildFeedNote(ctx, user, post, activity)
+  const note = await buildFeedNote(ctx, user, post, activity, apiBaseUrl)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
   return new Create({
@@ -173,8 +179,9 @@ export const buildFeedUpdate = async (
   user: string,
   post: DeliverablePost,
   activity: DeliverableActivity,
+  apiBaseUrl: string,
 ): Promise<Update> => {
-  const note = await buildFeedNote(ctx, user, post, activity)
+  const note = await buildFeedNote(ctx, user, post, activity, apiBaseUrl)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
   return new Update({
@@ -212,7 +219,7 @@ export const deliverFeedPost = async (
   activity: DeliverableActivity,
 ): Promise<void> => {
   const ctx = await deps.federation.createContext(new URL(deps.origin))
-  const create = await buildFeedCreate(ctx, user, post, activity)
+  const create = await buildFeedCreate(ctx, user, post, activity, deps.apiBaseUrl)
   await ctx.sendActivity({ identifier: user }, 'followers', create)
 }
 
@@ -224,7 +231,7 @@ export const deliverFeedUpdate = async (
   activity: DeliverableActivity,
 ): Promise<void> => {
   const ctx = await deps.federation.createContext(new URL(deps.origin))
-  const update = await buildFeedUpdate(ctx, user, post, activity)
+  const update = await buildFeedUpdate(ctx, user, post, activity, deps.apiBaseUrl)
   await ctx.sendActivity({ identifier: user }, 'followers', update)
 }
 

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -23,7 +23,7 @@ import type { Context, Federation } from '@fedify/fedify'
 import { Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/vocab'
 
 import { resolveActivityScalars } from './feed-activity.ts'
-import { addressingFor, feedPostContent } from './object.ts'
+import { addressingFor, feedPostContent, isPubliclyVisible } from './object.ts'
 
 /**
  * AS2 `to`/`cc` addressing (as URLs) for a post's visibility — the same table
@@ -59,8 +59,14 @@ export interface DeliverablePost {
  * on-demand image endpoint (`/api/public/<user>/feed/<id>/{chart,route}.png`),
  * built against the actor's origin so it matches the deployed API base. Fedify's
  * `Image` carries `url` + `mediaType` + intrinsic size so Mastodon lays it out.
+ *
+ * Only `public`/`unlisted` posts get attachments: the image endpoint is
+ * unauthenticated and (like the object/series endpoints) refuses `followers`-only
+ * posts, so attaching a URL that would 404 for a follower is worse than omitting
+ * it. (Authenticated per-follower image delivery is a possible later slice.)
  */
-const imageAttachments = (actorUri: URL, user: string, post: DeliverablePost): Image[] => {
+export const imageAttachments = (actorUri: URL, user: string, post: DeliverablePost): Image[] => {
+  if (!isPubliclyVisible(post.visibility)) return []
   const base = new URL(`/api/public/${encodeURIComponent(user)}/feed/${post.id}`, actorUri)
   const images: Image[] = []
   if (post.include_chart) {

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -36,7 +36,7 @@ const sharePost = (user: string, activityId: string, overrides: Partial<FeedPost
   })
 
 const notFound = () => new Response('nope', { status: 404 })
-const fed = createFeedFederation(ORIGIN)
+const fed = createFeedFederation(ORIGIN, `${ORIGIN}/api`)
 
 const fetchAs2 = (path: string) =>
   fed.fetch(new Request(`${ORIGIN}${path}`, { headers: { Accept: 'application/activity+json' } }), {
@@ -183,12 +183,18 @@ describe('Feed federation actor + WebFinger', () => {
     const post = await sharePost(user, activityId)
 
     const ctx = await fed.createContext(new URL(ORIGIN))
-    const update = await buildFeedUpdate(ctx, user, post, {
-      activity_type: 'exercise',
-      end_time: new Date('2026-07-01T07:11:00Z'),
-      start_time: new Date('2026-07-01T06:30:00Z'),
-      title: 'Morning run',
-    })
+    const update = await buildFeedUpdate(
+      ctx,
+      user,
+      post,
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2026-07-01T07:11:00Z'),
+        start_time: new Date('2026-07-01T06:30:00Z'),
+        title: 'Morning run',
+      },
+      `${ORIGIN}/api`,
+    )
 
     const noteId = `${ORIGIN}/users/${user}/feed/${post.id}`
     expect(update.id?.href).toBe(`${noteId}#update-${post.updated_at.getTime()}`)

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -39,7 +39,7 @@ import { isPubliclyVisible } from './object.ts'
  * (Postgres would otherwise raise `invalid input syntax for type uuid`). */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-export const createFeedFederation = (origin: string): Federation<void> => {
+export const createFeedFederation = (origin: string, apiBaseUrl: string): Federation<void> => {
   const federation = createFederation<void>({
     kv: new MemoryKvStore(),
     // Pin the canonical origin (the public base URL) so actor ids, WebFinger
@@ -162,7 +162,7 @@ export const createFeedFederation = (origin: string): Federation<void> => {
       if (post == null || post.activity_id == null || !isPubliclyVisible(post.visibility)) return null
       const activity = await getActivityById(identifier, post.activity_id)
       if (activity == null) return null
-      return buildFeedNote(ctx, identifier, post, activity)
+      return buildFeedNote(ctx, identifier, post, activity, apiBaseUrl)
     },
   )
 
@@ -187,7 +187,7 @@ export const createFeedFederation = (origin: string): Federation<void> => {
           posts.map(async (post) => {
             if (post.activity_id == null) return null
             const activity = await getActivityById(identifier, post.activity_id)
-            return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity)
+            return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity, apiBaseUrl)
           }),
         )
       ).filter((item): item is Create => item != null)

--- a/apps/backend/src/services/activitypub/feed-images.test.ts
+++ b/apps/backend/src/services/activitypub/feed-images.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+
+import { renderChartPng, renderRoutePng } from './feed-images.ts'
+
+/** PNG files start with this 8-byte signature. */
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+const isPng = (buf: Buffer) => buf.subarray(0, 8).equals(PNG_MAGIC)
+
+describe('renderChartPng', () => {
+  const series: [Date, number][] = [
+    [new Date('2026-07-01T06:30:00Z'), 70],
+    [new Date('2026-07-01T06:35:00Z'), 95],
+    [new Date('2026-07-01T06:40:00Z'), 88],
+    [new Date('2026-07-01T06:45:00Z'), 60],
+  ]
+
+  test('renders a non-empty PNG for a series', async () => {
+    const png = await renderChartPng(series)
+    expect(isPng(png)).toBe(true)
+    expect(png.length).toBeGreaterThan(100)
+  })
+
+  test('tolerates a single point and non-finite values without throwing', async () => {
+    const png = await renderChartPng([
+      [new Date('2026-07-01T06:30:00Z'), 70],
+      [new Date('2026-07-01T06:35:00Z'), Number.NaN],
+    ])
+    expect(isPng(png)).toBe(true)
+  })
+})
+
+describe('renderRoutePng', () => {
+  // A small loop near Gothenburg, GeoJSON [lon, lat] order.
+  const coords: [number, number][] = [
+    [11.97, 57.7],
+    [11.975, 57.702],
+    [11.98, 57.701],
+    [11.976, 57.699],
+    [11.97, 57.7],
+  ]
+
+  test('renders a non-empty PNG for a route', async () => {
+    const png = await renderRoutePng(coords)
+    expect(isPng(png)).toBe(true)
+    expect(png.length).toBeGreaterThan(100)
+  })
+
+  test('tolerates a degenerate single-point route without throwing', async () => {
+    const png = await renderRoutePng([[11.97, 57.7]])
+    expect(isPng(png)).toBe(true)
+  })
+})

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -1,0 +1,100 @@
+/**
+ * Render feed-post attachment images (a metric line chart and a GPS route map)
+ * as PNGs, from raw series / coordinate data.
+ *
+ * Both are pure functions of their inputs: they build a self-contained SVG and
+ * rasterize it with `sharp` (no fonts, no external tiles). The route is drawn as
+ * a bare polyline shape — a street basemap would need an external tile provider
+ * and is a later enhancement. No privacy trimming is applied (area masking is a
+ * planned follow-up), so callers must only render for public/unlisted posts that
+ * opted in.
+ */
+import sharp from 'sharp'
+
+const CHART_W = 1000
+const CHART_H = 420
+const ROUTE_W = 700
+const ROUTE_H = 700
+const PAD = 40
+
+const svgToPng = (svg: string): Promise<Buffer> => sharp(Buffer.from(svg)).png().toBuffer()
+
+/** Scale a value from `[min, max]` into `[lo, hi]`; collapses to the midpoint when the range is empty. */
+const scale = (v: number, min: number, max: number, lo: number, hi: number): number =>
+  max === min ? (lo + hi) / 2 : lo + ((v - min) / (max - min)) * (hi - lo)
+
+/**
+ * A metric line chart (e.g. heart rate). `series` is `[time, value]` pairs,
+ * assumed time-ordered; non-finite values are dropped. Renders a bg, a smooth
+ * polyline, and min/max value labels.
+ */
+export const renderChartPng = async (
+  series: [Date, number][],
+  opts: { color?: string; label?: string } = {},
+): Promise<Buffer> => {
+  const color = opts.color ?? '#ef4444'
+  const pts = series.filter(([, v]) => Number.isFinite(v))
+  const times = pts.map(([t]) => t.getTime())
+  const vals = pts.map(([, v]) => v)
+  const tMin = Math.min(...times)
+  const tMax = Math.max(...times)
+  const vMin = Math.min(...vals)
+  const vMax = Math.max(...vals)
+
+  const x = (t: number) => scale(t, tMin, tMax, PAD, CHART_W - PAD)
+  const y = (v: number) => scale(v, vMin, vMax, CHART_H - PAD, PAD)
+  const polyline = pts.map(([t, v]) => `${x(t.getTime()).toFixed(1)},${y(v).toFixed(1)}`).join(' ')
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${CHART_W}" height="${CHART_H}" viewBox="0 0 ${CHART_W} ${CHART_H}">
+  <rect width="${CHART_W}" height="${CHART_H}" fill="#0b0f19" rx="16"/>
+  ${pts.length >= 2 ? `<polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="4" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
+  <text x="${PAD}" y="${PAD - 12}" fill="#e5e7eb" font-family="sans-serif" font-size="26" font-weight="700">${escapeXml(opts.label ?? 'Heart rate')}</text>
+  <text x="${CHART_W - PAD}" y="${PAD}" fill="#9ca3af" font-family="sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMax) ? Math.round(vMax) : ''}</text>
+  <text x="${CHART_W - PAD}" y="${CHART_H - PAD}" fill="#9ca3af" font-family="sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMin) ? Math.round(vMin) : ''}</text>
+</svg>`
+  return svgToPng(svg)
+}
+
+/** Escape text for safe inclusion in SVG. */
+const escapeXml = (s: string): string =>
+  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+
+/**
+ * A GPS route map. `coords` is GeoJSON `[lon, lat]` pairs (as `getLocations`
+ * returns). Longitudes are compressed by `cos(lat)` so the shape keeps its true
+ * aspect, the route is fit to the box preserving that aspect, and start (green)
+ * / end (red) points are marked. North is up.
+ */
+export const renderRoutePng = async (coords: [number, number][]): Promise<Buffer> => {
+  const pts = coords.filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat))
+  const lons = pts.map(([lon]) => lon)
+  const lats = pts.map(([, lat]) => lat)
+  const minLon = Math.min(...lons)
+  const maxLon = Math.max(...lons)
+  const minLat = Math.min(...lats)
+  const maxLat = Math.max(...lats)
+  const midLatRad = (((minLat + maxLat) / 2) * Math.PI) / 180
+
+  // Aspect-correct spans in a common unit; guard against a zero span (a point).
+  const lonSpan = Math.max((maxLon - minLon) * Math.cos(midLatRad), 1e-9)
+  const latSpan = Math.max(maxLat - minLat, 1e-9)
+  const boxW = ROUTE_W - 2 * PAD
+  const boxH = ROUTE_H - 2 * PAD
+  const unit = Math.min(boxW / lonSpan, boxH / latSpan)
+  const offX = PAD + (boxW - lonSpan * unit) / 2
+  const offY = PAD + (boxH - latSpan * unit) / 2
+
+  const x = (lon: number) => offX + (lon - minLon) * Math.cos(midLatRad) * unit
+  const y = (lat: number) => offY + (maxLat - lat) * unit // invert so north is up
+  const polyline = pts.map(([lon, lat]) => `${x(lon).toFixed(1)},${y(lat).toFixed(1)}`).join(' ')
+  const first = pts[0]
+  const last = pts[pts.length - 1]
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${ROUTE_W}" height="${ROUTE_H}" viewBox="0 0 ${ROUTE_W} ${ROUTE_H}">
+  <rect width="${ROUTE_W}" height="${ROUTE_H}" fill="#0b0f19" rx="16"/>
+  ${pts.length >= 2 ? `<polyline points="${polyline}" fill="none" stroke="#673ab8" stroke-width="5" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
+  ${first ? `<circle cx="${x(first[0]).toFixed(1)}" cy="${y(first[1]).toFixed(1)}" r="9" fill="#22c55e"/>` : ''}
+  ${last ? `<circle cx="${x(last[0]).toFixed(1)}" cy="${y(last[1]).toFixed(1)}" r="9" fill="#ef4444"/>` : ''}
+</svg>`
+  return svgToPng(svg)
+}

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -14,7 +14,7 @@ import type { FeedPost, FeedVisibility, MetricType } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
-import { fetchBucketedMetrics, shareActivity, updateFeedPost } from '../state/api'
+import { fetchBucketedMetrics, fetchRawLocations, shareActivity, updateFeedPost } from '../state/api'
 import { SERIES_METRICS, SUMMARY_METRICS } from './feed-metrics'
 import './ShareActivityDialog.css'
 
@@ -70,15 +70,25 @@ const useShareableMetricOptions = (
     queryKey: ['share-activity-metrics', activityStart?.toISOString(), activityEnd?.toISOString()],
     staleTime: 5 * 60 * 1000,
   })
+  // The route map is rendered from actual GPS points, so gate its toggle on real
+  // location data — not a distance/speed proxy (a treadmill run has those but no
+  // GPS, and would otherwise attach a route.png that 404s).
+  const locationsQuery = useQuery({
+    enabled: activityStart != null && activityEnd != null,
+    queryFn: () => fetchRawLocations(activityStart ?? new Date(), activityEnd ?? new Date()),
+    queryKey: ['share-activity-locations', activityStart?.toISOString(), activityEnd?.toISOString()],
+    staleTime: 5 * 60 * 1000,
+  })
+  const hasGps = (locationsQuery.data?.length ?? 0) > 0
+
   const present = availabilityQuery.data?.buckets
     ? new Set(availabilityQuery.data.buckets.flatMap((b) => Object.keys(b.metrics)))
     : undefined
   return {
-    // The chart renders heart rate; the route map needs a GPS signal (distance /
-    // speed). While availability is unknown, offer both. `keepChart`/`keepMap`
-    // keep an already-attached image toggleable when editing.
+    // The chart renders heart rate (a time-series metric, so presence is exact).
+    // `keepChart`/`keepMap` keep an already-attached image toggleable when editing.
     canChart: present ? present.has('heart_rate') || keepChart : true,
-    canMap: present ? present.has('distance') || present.has('speed') || keepMap : true,
+    canMap: hasGps || keepMap,
     seriesOptions: present
       ? SERIES_METRICS.filter((m) => present.has(m.key) || keepSeries.includes(m.key))
       : SERIES_METRICS,

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -53,11 +53,14 @@ const toggle = <T extends string>(set: Set<T>, key: T): Set<T> => {
  * One coarse bucketed fetch; while it loads (or without a window) every option
  * is offered.
  */
+// eslint-disable-next-line complexity -- availability gating across summary/series/chart/map
 const useShareableMetricOptions = (
   activityStart?: Date,
   activityEnd?: Date,
   keepSummary: string[] = [],
   keepSeries: string[] = [],
+  keepChart = false,
+  keepMap = false,
 ) => {
   const availabilityQuery = useQuery({
     // The `??` fallbacks never run — `enabled` gates the fetch on both being set.
@@ -71,6 +74,11 @@ const useShareableMetricOptions = (
     ? new Set(availabilityQuery.data.buckets.flatMap((b) => Object.keys(b.metrics)))
     : undefined
   return {
+    // The chart renders heart rate; the route map needs a GPS signal (distance /
+    // speed). While availability is unknown, offer both. `keepChart`/`keepMap`
+    // keep an already-attached image toggleable when editing.
+    canChart: present ? present.has('heart_rate') || keepChart : true,
+    canMap: present ? present.has('distance') || present.has('speed') || keepMap : true,
     seriesOptions: present
       ? SERIES_METRICS.filter((m) => present.has(m.key) || keepSeries.includes(m.key))
       : SERIES_METRICS,
@@ -82,6 +90,7 @@ const useShareableMetricOptions = (
   }
 }
 
+// eslint-disable-next-line complexity -- composite share/edit form (metrics, series, images, visibility)
 export function ShareActivityDialog({
   activityId,
   activityTitle,
@@ -102,30 +111,30 @@ export function ShareActivityDialog({
     () => new Set(SERIES_METRICS.map((m) => m.key).filter((k) => post?.series_metrics.includes(k) ?? false)),
   )
   const [visibility, setVisibility] = useState<FeedVisibility>(post?.visibility ?? 'public')
-  const { summaryOptions, seriesOptions } = useShareableMetricOptions(
+  const [includeChart, setIncludeChart] = useState(post?.include_chart ?? false)
+  const [includeMap, setIncludeMap] = useState(post?.include_map ?? false)
+  const { summaryOptions, seriesOptions, canChart, canMap } = useShareableMetricOptions(
     activityStart,
     activityEnd,
     post?.included_metrics,
     post?.series_metrics,
+    post?.include_chart,
+    post?.include_map,
   )
 
   const mutation = useMutation({
     mutationFn: () => {
       // Only send metrics the dialog actually offered (drops defaults hidden as
-      // irrelevant); the backend still ignores any with no data.
-      const included_metrics = summaryOptions.map((m) => m.key).filter((k) => summary.has(k))
-      const series_metrics = seriesOptions.map((m) => m.key).filter((k) => series.has(k))
-      // Edit mode leaves include_chart/include_map untouched (both optional on
-      // UpdateFeedPostBody); only the create path sets their defaults.
-      return post
-        ? updateFeedPost(post.id, { included_metrics, series_metrics, visibility })
-        : shareActivity(activityId, {
-            include_chart: false,
-            include_map: false,
-            included_metrics,
-            series_metrics,
-            visibility,
-          })
+      // irrelevant); the backend still ignores any with no data. Attachments are
+      // only requested when their toggle is offered (chart needs HR, map needs GPS).
+      const body = {
+        include_chart: canChart && includeChart,
+        include_map: canMap && includeMap,
+        included_metrics: summaryOptions.map((m) => m.key).filter((k) => summary.has(k)),
+        series_metrics: seriesOptions.map((m) => m.key).filter((k) => series.has(k)),
+        visibility,
+      }
+      return post ? updateFeedPost(post.id, body) : shareActivity(activityId, body)
     },
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['feed'] })
@@ -182,6 +191,34 @@ export function ShareActivityDialog({
                   {label}
                 </label>
               ))}
+            </div>
+          </fieldset>
+        )}
+
+        {(canChart || canMap) && (
+          <fieldset class="share-dialog-group">
+            <legend>Images</legend>
+            <div class="share-dialog-options">
+              {canChart && (
+                <label class="share-dialog-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={includeChart}
+                    onChange={(e) => setIncludeChart((e.target as HTMLInputElement).checked)}
+                  />
+                  Heart-rate chart
+                </label>
+              )}
+              {canMap && (
+                <label class="share-dialog-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={includeMap}
+                    onChange={(e) => setIncludeMap((e.target as HTMLInputElement).checked)}
+                  />
+                  Route map
+                </label>
+              )}
             </div>
           </fieldset>
         )}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -68,11 +68,11 @@ Sharing, editing, or unsharing a post federates the matching activity to the use
 followers (best-effort, fire-and-forget; delivery is synchronous — a durable retry queue
 is a later slice):
 
-| Action        | Federated activity   | Effect on followers                          |
-| ------------- | -------------------- | -------------------------------------------- |
-| Share         | `Create{Note}`       | The post appears in their timeline           |
-| Edit          | `Update{Note}`       | Their stored copy is replaced                |
-| Unshare       | `Delete{Tombstone}`  | The post is retracted from their timeline    |
+| Action  | Federated activity  | Effect on followers                       |
+| ------- | ------------------- | ----------------------------------------- |
+| Share   | `Create{Note}`      | The post appears in their timeline        |
+| Edit    | `Update{Note}`      | Their stored copy is replaced             |
+| Unshare | `Delete{Tombstone}` | The post is retracted from their timeline |
 
 The `Note` is Mastodon-compatible: an HTML `content` summary flattening the title and the
 shared scalar summaries, plus a `name` headline, addressed per the post's visibility
@@ -106,7 +106,10 @@ GET /api/public/:username/feed/:postId/route.png
 
 The gating mirrors the object endpoint (public/unlisted only, and only when the
 matching flag was opted into) and responses are `no-store` so an unshare/visibility
-change takes effect immediately. The route is drawn as a bare, aspect-correct shape —
+change takes effect immediately. A `followers`-only post therefore carries **no** image
+attachments — the endpoint is unauthenticated and can't safely serve them, so attaching
+a URL that would 404 for a follower is omitted (authenticated per-follower delivery is a
+possible later slice). The route is drawn as a bare, aspect-correct shape —
 no street basemap (a later enhancement) and **no privacy trimming** (area masking is a
 planned follow-up), so a public route map reveals the approximate area. The share
 dialog only offers the chart toggle when the activity has heart-rate data and the map
@@ -122,7 +125,7 @@ GET /public/:username/series?metric=<key>&start=<iso>&end=<iso>&bucket=<5s|60s|�
 ```
 
 Like a shared-dashboard slug, it takes **no auth token** — so the scoping below is the
-*entire* privacy boundary, and it is **data-driven, not obscurity-based**. A request
+_entire_ privacy boundary, and it is **data-driven, not obscurity-based**. A request
 resolves only when **all** of these hold:
 
 1. some feed post shared **that exact metric as a series** (`series_metrics`) — sharing
@@ -163,17 +166,17 @@ Owner-facing (authenticated, scoped to the caller):
 
 Public / federation (unauthenticated):
 
-| Method & path                              | Purpose                                                    |
-| ------------------------------------------ | ---------------------------------------------------------- |
-| `GET /public/:username/series`             | Bucketed samples for a **shared** series within its window |
-| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post                 |
-| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post            |
-| `GET /.well-known/webfinger`               | Resolve `acct:<username>@<host>` → the actor               |
-| `GET /users/:username`                     | The actor document (`Person`)                              |
-| `GET /users/:username/outbox`              | Public + unlisted posts as `Create` activities             |
-| `GET /users/:username/followers`           | The actor's followers collection                           |
-| `GET /users/:username/feed/:postId`        | A single post's `Note`                                     |
-| `POST /users/:username/inbox` (+ `/inbox`) | Inbound `Follow` / `Undo{Follow}` (HTTP-Signature verified) |
+| Method & path                                  | Purpose                                                     |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| `GET /public/:username/series`                 | Bucketed samples for a **shared** series within its window  |
+| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post                      |
+| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post                 |
+| `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                |
+| `GET /users/:username`                         | The actor document (`Person`)                               |
+| `GET /users/:username/outbox`                  | Public + unlisted posts as `Create` activities              |
+| `GET /users/:username/followers`               | The actor's followers collection                            |
+| `GET /users/:username/feed/:postId`            | A single post's `Note`                                      |
+| `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` (HTTP-Signature verified) |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
 `update_feed_post`, and `delete_feed_post` — sharing/editing/deleting over MCP federates

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -28,7 +28,8 @@ selection that bounds what is shared:
   revealing than an average, so series are **off unless deliberately chosen**, even for
   a metric whose scalar summary is shared.
 - **`visibility`** — `public`, `unlisted`, or `followers`.
-- **`include_map` / `include_chart`** — flags for the (deferred) image attachments.
+- **`include_chart` / `include_map`** — attach a rendered heart-rate chart and/or
+  GPS route-map image to the post (see [Images](#images)).
 
 Defaults are privacy-conservative: sharing an activity with no explicit selection
 shares no scalars and, crucially, **no series**.
@@ -91,6 +92,26 @@ links) is a separate, richer representation for Aurboda-to-Aurboda consumers.
 The object we deliver, list in the outbox, and serve at that id are all built from one
 place, so they can't drift.
 
+### Images
+
+A post can carry a rendered **heart-rate chart** (`include_chart`) and/or a **GPS
+route map** (`include_map`) as AS2 `Image` attachments, so Mastodon shows them inline.
+Both are rendered on demand (SVG → PNG) from the activity's data at public,
+unauthenticated endpoints:
+
+```
+GET /api/public/:username/feed/:postId/chart.png
+GET /api/public/:username/feed/:postId/route.png
+```
+
+The gating mirrors the object endpoint (public/unlisted only, and only when the
+matching flag was opted into) and responses are `no-store` so an unshare/visibility
+change takes effect immediately. The route is drawn as a bare, aspect-correct shape —
+no street basemap (a later enhancement) and **no privacy trimming** (area masking is a
+planned follow-up), so a public route map reveals the approximate area. The share
+dialog only offers the chart toggle when the activity has heart-rate data and the map
+toggle when it has a GPS signal.
+
 ## Public series endpoint (the privacy boundary)
 
 High-resolution series are **never** embedded in a post. Instead each shared series is
@@ -145,6 +166,8 @@ Public / federation (unauthenticated):
 | Method & path                              | Purpose                                                    |
 | ------------------------------------------ | ---------------------------------------------------------- |
 | `GET /public/:username/series`             | Bucketed samples for a **shared** series within its window |
+| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post                 |
+| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post            |
 | `GET /.well-known/webfinger`               | Resolve `acct:<username>@<host>` → the actor               |
 | `GET /users/:username`                     | The actor document (`Person`)                              |
 | `GET /users/:username/outbox`              | Public + unlisted posts as `Create` activities             |
@@ -180,6 +203,9 @@ These are known and intentional for the current implementation:
   detail), so remote servers timestamp posts at receipt (≈ share time).
 - **The outbox is not paginated** — it serves all public posts inline. Fine at feed
   scale; cursor pagination is a follow-up.
+- **Route maps have no basemap and no privacy trimming.** The route is a bare shape
+  (no street tiles) and shows the full track, so a public route map reveals the
+  approximate area; a street basemap and start/area masking are planned follow-ups.
 
 ## Related
 

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -113,7 +113,7 @@ possible later slice). The route is drawn as a bare, aspect-correct shape —
 no street basemap (a later enhancement) and **no privacy trimming** (area masking is a
 planned follow-up), so a public route map reveals the approximate area. The share
 dialog only offers the chart toggle when the activity has heart-rate data and the map
-toggle when it has a GPS signal.
+toggle when it has an actual GPS track.
 
 ## Public series endpoint (the privacy boundary)
 


### PR DESCRIPTION
Implements the feed-post images you asked for: a **heart-rate chart** and a **full GPS route map**, each with a checkbox in the share dialog. (No privacy trimming — area masking is a tracked follow-up.)

## Backend
- **Renderers** (`services/activitypub/feed-images.ts`): pure SVG→PNG (via `sharp`, no fonts/tiles). `renderChartPng` (line chart from `[time,value]`), `renderRoutePng` (aspect-correct route shape from GeoJSON `[lon,lat]`, north-up, start/end marked). Unit-tested for valid PNG output incl. degenerate inputs.
- **Serving** (`feed-image-router.ts`): `GET /public/:username/feed/:postId/{chart,route}.png`, rendered on demand. Gating (`resolveImageWindow`, unit-tested) mirrors the object endpoint — public/unlisted only, only when the matching flag was opted in, non-UUID/invalid/missing → 404. `no-store` so unshare/visibility change takes effect immediately.
- **Attachment**: `buildFeedNote` attaches AS2 `Image`(s) (url + mediaType + intrinsic size) for `include_chart`/`include_map`, so Mastodon renders them inline. Since delivery/outbox/object all build the Note here, attachments show consistently.

## Web
- Share dialog exposes **Heart-rate chart** / **Route map** toggles, offered only when the activity has the data (HR for the chart; a GPS signal — distance/speed — for the map), wired through create **and** edit.

## Docs
- `feed.md`: Images section, endpoint table rows, and a caveat that route maps have no basemap and no privacy trimming.

## Notes / follow-ups (tracked)
- Route map is a bare **shape** (no street basemap — needs a tile provider) and shows the **full** track (area masking later).
- The chart currently renders **heart rate** (the canonical workout series).

`pnpm --filter aurboda-backend check` and `pnpm --filter aurboda-web check` clean; renderer + eligibility + deliver tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)