### PR TITLE
feat(sharing): oEmbed + share button + theme-color (#834)

### DIFF
--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -40,6 +40,7 @@ import { createMealsRouter } from '../routes/meals-router.ts'
 import { createMetricsRouter } from '../routes/metrics-router.ts'
 import { createNotesRouter } from '../routes/notes-router.ts'
 import { createNutrientRecommendationsRouter } from '../routes/nutrient-recommendations-router.ts'
+import { createOEmbedRouter } from '../routes/oembed-router.ts'
 import { createOgImageRouter } from '../routes/og-image-router.ts'
 import { createProductivityRouter } from '../routes/productivity-router.ts'
 import { createProfileRouter } from '../routes/profile-router.ts'
@@ -148,6 +149,7 @@ export const mountRestRouters = ({
   // Mounted before the share-html router so `/u/.../opengraph-image.png` and
   // `/u/:username/avatar.png` win over the generic `/u/:username/:slug` HTML route.
   httpd.use(createPublicAvatarRouter())
+  httpd.use(createOEmbedRouter({ webHost, ...createShareResolvers() }))
   httpd.use(
     createOgImageRouter({
       loadAvatarDataUri,

--- a/apps/backend/src/routes/oembed-router.test.ts
+++ b/apps/backend/src/routes/oembed-router.test.ts
@@ -1,0 +1,79 @@
+import express from 'express'
+import supertest from 'supertest'
+import { describe, expect, test } from 'vitest'
+
+import { createOEmbedRouter, type OEmbedDeps } from './oembed-router.ts'
+
+const buildApp = (overrides: Partial<OEmbedDeps> = {}) => {
+  const deps: OEmbedDeps = {
+    profileExists: async () => false,
+    resolveChallenge: async () => null,
+    resolveDashboard: async () => null,
+    webHost: 'https://aurboda.net',
+    ...overrides,
+  }
+  const app = express()
+  app.use(createOEmbedRouter(deps))
+  return app
+}
+
+const get = (app: express.Express, url: string) =>
+  supertest(app).get(`/oembed?url=${encodeURIComponent(url)}&format=json`)
+
+describe('GET /oembed', () => {
+  test('400 when url is missing', async () => {
+    expect((await supertest(buildApp()).get('/oembed')).status).toBe(400)
+  })
+
+  test('501 for a non-json format', async () => {
+    const res = await supertest(buildApp()).get(
+      `/oembed?url=${encodeURIComponent('https://aurboda.net/u/fiddur/abc')}&format=xml`,
+    )
+    expect(res.status).toBe(501)
+  })
+
+  test('404 for a non-share URL', async () => {
+    expect((await get(buildApp(), 'https://aurboda.net/dashboard')).status).toBe(404)
+  })
+
+  test('returns an oEmbed link for a public dashboard', async () => {
+    const app = buildApp({ resolveDashboard: async () => ({ is_public: true, name: 'My Training' }) })
+    const res = await get(app, 'https://aurboda.net/u/fiddur/abc')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      author_name: 'fiddur',
+      author_url: 'https://aurboda.net/u/fiddur',
+      provider_name: 'Aurboda',
+      thumbnail_url: 'https://aurboda.net/u/fiddur/abc/opengraph-image.png',
+      title: 'My Training',
+      type: 'link',
+    })
+    expect(res.headers['cache-control']).toBe('public, max-age=300')
+  })
+
+  test('falls through to a public challenge', async () => {
+    const app = buildApp({ resolveChallenge: async () => ({ is_public: true, name: 'Step count' }) })
+    const res = await get(app, 'https://aurboda.net/u/fiddur/xyz')
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('Step count')
+  })
+
+  test('404 for an unlisted (non-public) dashboard', async () => {
+    const app = buildApp({ resolveDashboard: async () => ({ is_public: false, name: 'Secret' }) })
+    const res = await get(app, 'https://aurboda.net/u/fiddur/abc')
+    expect(res.status).toBe(404)
+    expect(JSON.stringify(res.body)).not.toContain('Secret')
+  })
+
+  test('returns an oEmbed link for an existing profile', async () => {
+    const app = buildApp({ profileExists: async () => true })
+    const res = await get(app, 'https://aurboda.net/u/fiddur')
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('fiddur — Aurboda')
+    expect(res.body.thumbnail_url).toBe('https://aurboda.net/u/fiddur/opengraph-image.png')
+  })
+
+  test('404 for a missing profile', async () => {
+    expect((await get(buildApp(), 'https://aurboda.net/u/ghost')).status).toBe(404)
+  })
+})

--- a/apps/backend/src/routes/oembed-router.ts
+++ b/apps/backend/src/routes/oembed-router.ts
@@ -1,0 +1,82 @@
+/**
+ * oEmbed endpoint (UNAUTHENTICATED): `GET /oembed?url=<share url>&format=json`.
+ *
+ * Resolves a public share URL to an oEmbed `link` document (title + author +
+ * OG-image thumbnail). Only public resources resolve; anything else 404s, so
+ * nothing private is exposed. Discoverable via the `<link rel="alternate">`
+ * that the share-html router injects.
+ */
+import { Router } from 'express'
+
+import { isValidUsername } from '../api/auth-routes.ts'
+import { buildOEmbedLink, parseShareUrl } from '../services/oembed.ts'
+import { resourceOgImage } from '../services/share-meta.ts'
+import { buildProfileUrl, buildShareUrl } from '../services/share-urls.ts'
+
+interface ResolvedResource {
+  name: string
+  is_public: boolean
+}
+
+export interface OEmbedDeps {
+  webHost: string
+  resolveDashboard: (username: string, slug: string) => Promise<ResolvedResource | null>
+  resolveChallenge: (username: string, slug: string) => Promise<ResolvedResource | null>
+  profileExists: (username: string) => Promise<boolean>
+}
+
+export const createOEmbedRouter = (deps: OEmbedDeps): Router => {
+  const { profileExists, resolveChallenge, resolveDashboard, webHost } = deps
+  const router = Router()
+
+  router.get('/oembed', async (req, res) => {
+    const url = typeof req.query.url === 'string' ? req.query.url : undefined
+    const format = typeof req.query.format === 'string' ? req.query.format : 'json'
+    if (!url) {
+      res.status(400).json({ error: 'Missing url parameter' })
+      return
+    }
+    // Per the oEmbed spec, an unsupported format is a 501.
+    if (format !== 'json') {
+      res.status(501).json({ error: 'Only json format is supported' })
+      return
+    }
+
+    const parsed = parseShareUrl(url)
+    if (!parsed || !isValidUsername(parsed.username)) {
+      res.status(404).json({ error: 'Not an oEmbed-able resource' })
+      return
+    }
+    const { slug, username } = parsed
+    const authorUrl = buildProfileUrl(webHost, username)
+
+    const respond = (title: string, resourceUrl: string): void => {
+      res.setHeader('Cache-Control', 'public, max-age=300')
+      res.json(
+        buildOEmbedLink({
+          authorName: username,
+          authorUrl,
+          providerUrl: webHost,
+          thumbnailUrl: resourceOgImage(resourceUrl),
+          title,
+        }),
+      )
+    }
+
+    if (slug === undefined) {
+      if (await profileExists(username)) return respond(`${username} — Aurboda`, authorUrl)
+      res.status(404).json({ error: 'Not found' })
+      return
+    }
+
+    const shareUrl = buildShareUrl(webHost, username, slug)
+    const dashboard = await resolveDashboard(username, slug)
+    if (dashboard?.is_public) return respond(dashboard.name, shareUrl)
+    const challenge = dashboard ? null : await resolveChallenge(username, slug)
+    if (challenge?.is_public) return respond(challenge.name, shareUrl)
+
+    res.status(404).json({ error: 'Not found' })
+  })
+
+  return router
+}

--- a/apps/backend/src/routes/share-html-router.ts
+++ b/apps/backend/src/routes/share-html-router.ts
@@ -21,6 +21,7 @@ import {
   buildDefaultShareMeta,
   buildProfileShareMeta,
   injectShareMeta,
+  oembedDiscoveryUrl,
   renderShareMetaTags,
   type ShareMeta,
 } from '../services/share-meta.ts'
@@ -126,6 +127,12 @@ export const createShareHtmlRouter = (deps: ShareHtmlDeps): Router => {
   const { loadTemplate, profileExists, resolveChallenge, resolveDashboard, webHost } = deps
   const router = Router()
 
+  // Attach the oEmbed discovery link to a public resource's meta.
+  const withOembed = (meta: ShareMeta, resourceUrl: string): ShareMeta => ({
+    ...meta,
+    oembedUrl: oembedDiscoveryUrl(webHost, resourceUrl),
+  })
+
   router.get('/u/:username/:slug', async (req, res) => {
     const { slug, username } = req.params
     const url = buildShareUrl(webHost, username, slug)
@@ -137,12 +144,15 @@ export const createShareHtmlRouter = (deps: ShareHtmlDeps): Router => {
     if (dashboard?.is_public) {
       return sendHtml(
         loadTemplate,
-        buildDashboardShareMeta({
-          description: dashboard.description,
-          name: dashboard.name,
+        withOembed(
+          buildDashboardShareMeta({
+            description: dashboard.description,
+            name: dashboard.name,
+            url,
+            username,
+          }),
           url,
-          username,
-        }),
+        ),
         true,
         res,
       )
@@ -152,7 +162,7 @@ export const createShareHtmlRouter = (deps: ShareHtmlDeps): Router => {
     if (challenge?.is_public) {
       return sendHtml(
         loadTemplate,
-        buildChallengeShareMeta({ name: challenge.name, url, username }),
+        withOembed(buildChallengeShareMeta({ name: challenge.name, url, username }), url),
         true,
         res,
       )
@@ -166,7 +176,7 @@ export const createShareHtmlRouter = (deps: ShareHtmlDeps): Router => {
     const { username } = req.params
     const url = buildProfileUrl(webHost, username)
     if (isValidUsername(username) && (await profileExists(username))) {
-      return sendHtml(loadTemplate, buildProfileShareMeta({ url, username }), true, res)
+      return sendHtml(loadTemplate, withOembed(buildProfileShareMeta({ url, username }), url), true, res)
     }
     return sendHtml(loadTemplate, buildDefaultShareMeta(webHost, url), false, res)
   })

--- a/apps/backend/src/services/oembed.test.ts
+++ b/apps/backend/src/services/oembed.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildOEmbedLink, parseShareUrl } from './oembed.ts'
+
+describe('parseShareUrl', () => {
+  test('parses a dashboard/challenge share URL', () => {
+    expect(parseShareUrl('https://aurboda.net/u/fiddur/abc123')).toEqual({
+      slug: 'abc123',
+      username: 'fiddur',
+    })
+  })
+
+  test('parses a profile URL', () => {
+    expect(parseShareUrl('https://aurboda.net/u/fiddur')).toEqual({ username: 'fiddur' })
+  })
+
+  test('tolerates a sub-path-hosted base', () => {
+    expect(parseShareUrl('http://host/some/base/u/fiddur/abc')).toEqual({
+      slug: 'abc',
+      username: 'fiddur',
+    })
+  })
+
+  test('decodes percent-encoded segments', () => {
+    expect(parseShareUrl('https://aurboda.net/u/a%20b')).toEqual({ username: 'a b' })
+  })
+
+  test('returns null for non-share URLs and malformed input', () => {
+    expect(parseShareUrl('https://aurboda.net/dashboard')).toBeNull()
+    expect(parseShareUrl('https://aurboda.net/u/a/b/c')).toBeNull()
+    expect(parseShareUrl('not a url')).toBeNull()
+  })
+})
+
+describe('buildOEmbedLink', () => {
+  test('builds a spec-shaped link document', () => {
+    const doc = buildOEmbedLink({
+      authorName: 'fiddur',
+      authorUrl: 'https://aurboda.net/u/fiddur',
+      providerUrl: 'https://aurboda.net',
+      thumbnailUrl: 'https://aurboda.net/u/fiddur/abc/opengraph-image.png',
+      title: 'My dashboard',
+    })
+    expect(doc).toMatchObject({
+      author_name: 'fiddur',
+      provider_name: 'Aurboda',
+      thumbnail_height: 630,
+      thumbnail_width: 1200,
+      title: 'My dashboard',
+      type: 'link',
+      version: '1.0',
+    })
+  })
+})

--- a/apps/backend/src/services/oembed.ts
+++ b/apps/backend/src/services/oembed.ts
@@ -1,0 +1,71 @@
+/**
+ * oEmbed (https://oembed.com) response building for public share resources.
+ *
+ * We emit `type: "link"` — the widely-supported form that gives consumers
+ * (Mastodon, etc.) a title, author, provider, and a thumbnail (the resource's
+ * OG image) without an embeddable iframe.
+ */
+import { OG_HEIGHT, OG_WIDTH } from './og-image.ts'
+import { SITE_NAME } from './share-meta.ts'
+
+export interface OEmbedLink {
+  version: '1.0'
+  type: 'link'
+  title: string
+  author_name: string
+  author_url: string
+  provider_name: string
+  provider_url: string
+  thumbnail_url: string
+  thumbnail_width: number
+  thumbnail_height: number
+}
+
+export const buildOEmbedLink = (input: {
+  title: string
+  authorName: string
+  authorUrl: string
+  providerUrl: string
+  thumbnailUrl: string
+}): OEmbedLink => ({
+  author_name: input.authorName,
+  author_url: input.authorUrl,
+  provider_name: SITE_NAME,
+  provider_url: input.providerUrl,
+  thumbnail_height: OG_HEIGHT,
+  thumbnail_url: input.thumbnailUrl,
+  thumbnail_width: OG_WIDTH,
+  title: input.title,
+  type: 'link',
+  version: '1.0',
+})
+
+export interface ParsedShareUrl {
+  username: string
+  /** Present for a dashboard/challenge; absent for a profile. */
+  slug?: string
+}
+
+/**
+ * Extract the `{username, slug?}` of a share resource from a `/u/...` URL,
+ * tolerating a sub-path-hosted base. Returns null if the path isn't a share
+ * URL. Only the last two `/u/<a>/<b>` (or one `/u/<a>`) segments are used.
+ */
+export const parseShareUrl = (url: string): ParsedShareUrl | null => {
+  let pathname: string
+  try {
+    pathname = new URL(url).pathname
+  } catch {
+    return null
+  }
+  const marker = pathname.lastIndexOf('/u/')
+  if (marker === -1) return null
+  const rest = pathname
+    .slice(marker + 3)
+    .split('/')
+    .filter(Boolean)
+    .map((s) => decodeURIComponent(s))
+  if (rest.length === 1) return { username: rest[0] }
+  if (rest.length === 2) return { slug: rest[1], username: rest[0] }
+  return null
+}

--- a/apps/backend/src/services/share-meta.ts
+++ b/apps/backend/src/services/share-meta.ts
@@ -32,7 +32,13 @@ export interface ShareMeta {
   type: 'website' | 'profile'
   /** Optional schema.org JSON-LD object embedded as a <script> tag. */
   jsonLd?: Record<string, unknown>
+  /** Optional oEmbed discovery URL (adds a `<link rel="alternate">`). */
+  oembedUrl?: string
 }
+
+/** oEmbed discovery URL for a resource (consumers fetch this for a rich unfurl). */
+export const oembedDiscoveryUrl = (webHost: string, resourceUrl: string): string =>
+  `${webHost.replace(/\/+$/, '')}/oembed?url=${encodeURIComponent(resourceUrl)}&format=json`
 
 /** Absolute URL of the branded fallback preview image. */
 export const defaultOgImage = (webHost: string): string =>
@@ -76,6 +82,9 @@ export const renderShareMetaTags = (meta: ShareMeta): string => {
     `<meta name="twitter:description" content="${escapeAttr(meta.description)}">`,
     `<meta name="twitter:image" content="${escapeAttr(meta.image)}">`,
   ]
+  if (meta.oembedUrl) {
+    tags.push(`<link rel="alternate" type="application/json+oembed" href="${escapeAttr(meta.oembedUrl)}">`)
+  }
   if (meta.jsonLd) tags.push(jsonLdScript(meta.jsonLd))
   return tags.join('\n    ')
 }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,6 +8,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#673ab8" />
     <title>Aurboda</title>
   </head>
   <body>

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'preact/hooks'
+
+/**
+ * Share control for public pages: uses the native share sheet
+ * (`navigator.share`, mainly mobile) when available, otherwise copies the link
+ * to the clipboard with brief "Copied!" feedback.
+ */
+export function ShareLinkButton({ url, title }: { url: string; title?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const onClick = async () => {
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title, url })
+        return
+      } catch {
+        // User cancelled or share failed — fall through to clipboard copy.
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — nothing more we can do.
+    }
+  }
+
+  return (
+    <button type="button" class="share-link-btn" onClick={onClick} title="Share this page">
+      {copied ? 'Copied!' : 'Share'}
+    </button>
+  )
+}

--- a/apps/web/src/components/ShareLinkButton.tsx
+++ b/apps/web/src/components/ShareLinkButton.tsx
@@ -13,8 +13,10 @@ export function ShareLinkButton({ url, title }: { url: string; title?: string })
       try {
         await navigator.share({ title, url })
         return
-      } catch {
-        // User cancelled or share failed — fall through to clipboard copy.
+      } catch (err) {
+        // A deliberate cancel (AbortError) is a no-op; only a real failure
+        // falls through to the clipboard copy.
+        if (err instanceof Error && err.name === 'AbortError') return
       }
     }
     try {

--- a/apps/web/src/pages/PublicDashboard/index.tsx
+++ b/apps/web/src/pages/PublicDashboard/index.tsx
@@ -15,6 +15,7 @@ import { useRoute } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import { EditableDashboard } from '../../components/EditableDashboard'
+import { ShareLinkButton } from '../../components/ShareLinkButton'
 import { PublicWidgetRenderer } from '../../components/widgets'
 import { avatarUrl, fetchPublicResource, listSharedDashboards, updateSharedDashboard } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -125,6 +126,7 @@ function ReadOnlyDashboard({
           <img class="public-attribution__avatar" src={avatarUrl(username)} alt="" width={28} height={28} />@
           {username}
         </a>
+        <ShareLinkButton url={window.location.href} title={`${name} — Aurboda`} />
       </div>
 
       {config.description ? <p class="dashboard-intro">{config.description}</p> : null}

--- a/apps/web/src/pages/PublicDashboard/style.css
+++ b/apps/web/src/pages/PublicDashboard/style.css
@@ -49,3 +49,18 @@
     color: #9ca3af;
   }
 }
+
+.public-dashboard .share-link-btn {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid #673ab8;
+  border-radius: 6px;
+  background: transparent;
+  color: #8b5cf6;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.public-dashboard .share-link-btn:hover {
+  background: #673ab8;
+  color: #fff;
+}

--- a/apps/web/src/pages/PublicProfile/index.tsx
+++ b/apps/web/src/pages/PublicProfile/index.tsx
@@ -5,6 +5,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useRoute } from 'preact-iso'
 
+import { ShareLinkButton } from '../../components/ShareLinkButton'
 import { avatarUrl, fetchPublicProfile } from '../../state/api'
 import './style.css'
 
@@ -56,6 +57,7 @@ export function PublicProfile() {
           height={80}
         />
         <h1>@{username}</h1>
+        <ShareLinkButton url={window.location.href} title={`@${username} on Aurboda`} />
       </header>
 
       <section class="public-section">

--- a/apps/web/src/pages/PublicProfile/style.css
+++ b/apps/web/src/pages/PublicProfile/style.css
@@ -94,3 +94,22 @@
     background: #1e1b4b;
   }
 }
+
+.public-profile-header .share-link-btn {
+  margin-left: auto;
+}
+
+.share-link-btn {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid #673ab8;
+  border-radius: 6px;
+  background: transparent;
+  color: #673ab8;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.share-link-btn:hover {
+  background: #673ab8;
+  color: #fff;
+}

--- a/apps/web/src/pages/PublicProfile/style.css
+++ b/apps/web/src/pages/PublicProfile/style.css
@@ -99,7 +99,7 @@
   margin-left: auto;
 }
 
-.share-link-btn {
+.public-profile .share-link-btn {
   padding: 0.4rem 0.9rem;
   border: 1px solid #673ab8;
   border-radius: 6px;
@@ -109,7 +109,7 @@
   font-size: 0.9rem;
 }
 
-.share-link-btn:hover {
+.public-profile .share-link-btn:hover {
   background: #673ab8;
   color: #fff;
 }

--- a/docs/features/sharing.md
+++ b/docs/features/sharing.md
@@ -126,6 +126,21 @@ OG cards, and as the ActivityPub actor `icon` (so Mastodon and friends show it).
 - **Web UI**: upload/remove from **Settings → Avatar**; the avatar shows on the
   public profile page and next to the author attribution on shared dashboards.
 
+## oEmbed & sharability
+
+- **oEmbed**: public share pages advertise a `<link rel="alternate"
+  type="application/json+oembed">` pointing at `GET /oembed?url=<share url>`, which
+  returns a `type: "link"` document (title, author, provider, OG-image thumbnail).
+  Only public resources resolve — unlisted/unknown/private URLs 404, so nothing
+  private is exposed. Primarily benefits Mastodon and other oEmbed-aware consumers.
+- **Share button**: public profile and shared-dashboard pages have a Share control
+  that uses the native share sheet (`navigator.share`) where available and otherwise
+  copies the link to the clipboard.
+- **`theme-color`** and favicons/apple-touch-icon are set so tabs and mobile share
+  sheets look finished.
+
+QR codes and per-share preview overrides are possible future additions.
+
 ## API
 
 Owner-facing CRUD (authenticated, scoped to the caller):

--- a/nginx.conf
+++ b/nginx.conf
@@ -111,6 +111,16 @@ server {
         try_files $uri $uri/ /apispec/index.html;
     }
 
+    # oEmbed endpoint - proxy to backend (rich unfurls for Mastodon etc.)
+    location = /oembed {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Public share pages - proxy to backend so crawlers get server-rendered
     # <head> meta (Open Graph / Twitter). The backend returns index.html with
     # injected meta; the SPA then hydrates and loads assets from nginx.


### PR DESCRIPTION
Final part (**5**) of the #834 epic — richer unfurls and sharability polish. Completes the epic (PRs 1–4 merged).

## What
- **oEmbed**: `GET /oembed?url=<share url>&format=json` returns a `type: "link"` document (title, author, provider, OG-image thumbnail). Only **public** resources resolve — unlisted/unknown/private/invalid all 404, so nothing private leaks; a non-json `format` returns 501 per spec. Public share pages advertise it via `<link rel="alternate" type="application/json+oembed">` (injected by the share-html router). nginx proxies `/oembed` to the backend. Primarily benefits Mastodon and other oEmbed-aware consumers.
- **Share button**: public profile and shared-dashboard pages get a Share control that uses the native share sheet (`navigator.share`, mobile) where available and otherwise copies the link to the clipboard with brief "Copied!" feedback.
- **`theme-color`** meta (brand `#673ab8`) so tabs and mobile share sheets look finished (favicons/apple-touch-icon were already present).

## Design
Pure, testable `oembed.ts` (`parseShareUrl` tolerates sub-path bases; `buildOEmbedLink`) + a DI'd `oembed-router` reusing the same `createShareResolvers()`/visibility gating as the rest of the share surface.

## Tests (green; `pnpm check` clean)
oEmbed URL parsing + link building, and the router across all paths (missing url → 400, non-json → 501, non-share → 404, public dashboard/challenge/profile → 200, unlisted → 404).

## Out of scope (optional in the issue)
QR codes and per-share preview overrides — noted as future work in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)