### PR TITLE
feat(web): mirror the activity chart's shown metrics into the share dialog (#831)

### DIFF
--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -114,6 +114,7 @@ export function ShareActivityDialog({
   const queryClient = useQueryClient()
   // Create mode mirrors the chart's shown metrics; edit mode uses the post's saved selection.
   const defaults = defaultsFromChart(chartMetrics)
+  const mirroredFromChart = !post && (chartMetrics?.length ?? 0) > 0
   const [summary, setSummary] = useState<Set<string>>(
     () => new Set(post ? post.included_metrics : defaults.summary),
   )
@@ -196,7 +197,9 @@ export function ShareActivityDialog({
           <fieldset class="share-dialog-group">
             <legend>Share full time-series</legend>
             <p class="share-dialog-note">
-              Higher resolution — more revealing than a summary. Off by default.
+              {mirroredFromChart
+                ? 'Higher resolution — more revealing than a summary. Pre-checked to match the activity chart; uncheck any you would rather not share.'
+                : 'Higher resolution — more revealing than a summary. Off by default.'}
             </p>
             <div class="share-dialog-options">
               {seriesOptions.map(({ key, label }) => (

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -15,7 +15,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { fetchBucketedMetrics, fetchRawLocations, shareActivity, updateFeedPost } from '../state/api'
-import { SERIES_METRICS, SUMMARY_METRICS } from './feed-metrics'
+import { defaultsFromChart, SERIES_METRICS, SUMMARY_METRICS } from './feed-metrics'
 import './ShareActivityDialog.css'
 
 interface Props {
@@ -24,6 +24,8 @@ interface Props {
   /** Activity window — when given, the dialog offers only metrics with data in it. */
   activityStart?: Date
   activityEnd?: Date
+  /** Metrics currently shown on the activity's chart; mirrored into the defaults. */
+  chartMetrics?: string[]
   /** When present, edit this existing post instead of sharing anew. */
   post?: FeedPost
   onClose: () => void
@@ -35,8 +37,6 @@ const VISIBILITIES: { value: FeedVisibility; label: string; hint: string }[] = [
   { hint: 'Anyone with the link; kept out of public timelines.', label: 'Unlisted', value: 'unlisted' },
   { hint: 'Only your followers.', label: 'Followers only', value: 'followers' },
 ]
-
-const DEFAULT_SUMMARY = ['duration', 'distance', 'heart_rate_avg', 'heart_rate_max', 'calories']
 
 const toggle = <T extends string>(set: Set<T>, key: T): Set<T> => {
   const next = new Set(set)
@@ -106,19 +106,27 @@ export function ShareActivityDialog({
   activityTitle,
   activityStart,
   activityEnd,
+  chartMetrics,
   post,
   onClose,
   onShared,
 }: Props) {
   const queryClient = useQueryClient()
+  // Create mode mirrors the chart's shown metrics; edit mode uses the post's saved selection.
+  const defaults = defaultsFromChart(chartMetrics)
   const [summary, setSummary] = useState<Set<string>>(
-    () => new Set(post ? post.included_metrics : DEFAULT_SUMMARY),
+    () => new Set(post ? post.included_metrics : defaults.summary),
   )
-  // Preselect from the post's shared series, intersected with the keys this
-  // dialog can represent — keeps the state typed as `Set<MetricType>` without a
-  // cast (the dialog only offers `SERIES_METRICS` anyway).
+  // Preselect from the post's shared series (edit) or the charted metrics (create),
+  // intersected with keys this dialog can represent — keeps the state typed as
+  // `Set<MetricType>` without a cast.
   const [series, setSeries] = useState<Set<MetricType>>(
-    () => new Set(SERIES_METRICS.map((m) => m.key).filter((k) => post?.series_metrics.includes(k) ?? false)),
+    () =>
+      new Set(
+        post
+          ? SERIES_METRICS.map((m) => m.key).filter((k) => post.series_metrics.includes(k))
+          : defaults.series,
+      ),
   )
   const [visibility, setVisibility] = useState<FeedVisibility>(post?.visibility ?? 'public')
   const [includeChart, setIncludeChart] = useState(post?.include_chart ?? false)

--- a/apps/web/src/components/feed-metrics.test.ts
+++ b/apps/web/src/components/feed-metrics.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_SUMMARY, defaultsFromChart, seriesLabel, summaryLabel } from './feed-metrics'
+
+describe('defaultsFromChart', () => {
+  it('falls back to DEFAULT_SUMMARY and no series when chart metrics are unknown', () => {
+    expect(defaultsFromChart()).toEqual({ series: [], summary: DEFAULT_SUMMARY })
+    expect(defaultsFromChart([])).toEqual({ series: [], summary: DEFAULT_SUMMARY })
+  })
+
+  it('maps charted metrics to their summaries (HR → avg + max + zones) and full series', () => {
+    const { summary, series } = defaultsFromChart(['heart_rate', 'distance'])
+    expect(summary).toEqual(['duration', 'distance', 'heart_rate_avg', 'heart_rate_max', 'hr_zone_minutes'])
+    expect(series).toEqual(['heart_rate'])
+  })
+
+  it('includes series for a charted metric with no scalar summary (e.g. speed)', () => {
+    const { summary, series } = defaultsFromChart(['speed'])
+    // speed has no summary source; duration is always included.
+    expect(summary).toEqual(['duration'])
+    expect(series).toEqual(['speed'])
+  })
+
+  it('ignores charted metrics the dialog cannot represent', () => {
+    const { summary, series } = defaultsFromChart(['hrv_rmssd'])
+    expect(summary).toEqual(['duration'])
+    expect(series).toEqual([])
+  })
+})
+
+describe('metric labels', () => {
+  it('resolves known labels and falls back to the raw key', () => {
+    expect(summaryLabel('heart_rate_avg')).toBe('Avg HR')
+    expect(seriesLabel('heart_rate')).toBe('Heart rate')
+    expect(summaryLabel('unknown_key')).toBe('unknown_key')
+  })
+})

--- a/apps/web/src/components/feed-metrics.ts
+++ b/apps/web/src/components/feed-metrics.ts
@@ -31,6 +31,26 @@ export const SERIES_METRICS: { key: MetricType; label: string }[] = [
   { key: 'stress_level', label: 'Stress' },
 ]
 
+/** Fallback default summary selection when the activity's chart metrics aren't known. */
+export const DEFAULT_SUMMARY = ['duration', 'distance', 'heart_rate_avg', 'heart_rate_max', 'calories']
+
+/**
+ * Seed the share dialog's initial selection from the metrics currently shown on
+ * the activity's chart: `duration` (always) plus every summary whose source
+ * metric is on the chart, and the full series for each charted metric. Falls
+ * back to {@link DEFAULT_SUMMARY} (no series) when the chart selection is unknown.
+ */
+export const defaultsFromChart = (chartMetrics?: string[]): { summary: string[]; series: MetricType[] } => {
+  if (!chartMetrics || chartMetrics.length === 0) return { series: [], summary: DEFAULT_SUMMARY }
+  return {
+    series: SERIES_METRICS.filter((m) => chartMetrics.includes(m.key)).map((m) => m.key),
+    summary: [
+      'duration',
+      ...SUMMARY_METRICS.filter((m) => m.source && chartMetrics.includes(m.source)).map((m) => m.key),
+    ],
+  }
+}
+
 /** Human label for a stored `included_metrics` key (falls back to the raw key). */
 export const summaryLabel = (key: string): string => SUMMARY_METRICS.find((m) => m.key === key)?.label ?? key
 

--- a/apps/web/src/pages/EntityDetail/ActivityChart.tsx
+++ b/apps/web/src/pages/EntityDetail/ActivityChart.tsx
@@ -594,10 +594,14 @@ export const ActivityChart = ({
   const enabledMetrics = new Set(availableMetrics.filter((m) => !disabledMetrics.has(m)))
 
   // Surface the currently-shown metrics so a parent (the share dialog) can mirror
-  // the user's chart selection. Runs on load and each toggle (deps change ref).
+  // the user's chart selection. Keyed on the enabled set's *contents* (a stable
+  // string) — NOT the `availableMetrics`/`disabledMetrics` refs: `availableMetrics`
+  // is a fresh `[]` every render while the query has no data, which would loop.
+  // Metric names never contain `|`, so the key round-trips cleanly.
+  const enabledKey = [...enabledMetrics].join('|')
   useEffect(() => {
-    onEnabledMetricsChange?.(availableMetrics.filter((m) => !disabledMetrics.has(m)))
-  }, [availableMetrics, disabledMetrics, onEnabledMetricsChange])
+    onEnabledMetricsChange?.(enabledKey ? enabledKey.split('|') : [])
+  }, [enabledKey, onEnabledMetricsChange])
 
   // Compute which metrics get axes (last MAX_RIGHT_AXES in toggleOrder that are enabled)
   const metricsWithAxes = new Set(toggleOrder.filter((m) => enabledMetrics.has(m)).slice(-MAX_RIGHT_AXES))

--- a/apps/web/src/pages/EntityDetail/ActivityChart.tsx
+++ b/apps/web/src/pages/EntityDetail/ActivityChart.tsx
@@ -23,6 +23,8 @@ interface ActivityChartProps {
   stages?: SleepStage[]
   defaultMetrics?: string[]
   onHoverTime?: (time: Date | null) => void
+  /** Notified with the metrics currently shown on the chart (for the share dialog). */
+  onEnabledMetricsChange?: (metrics: string[]) => void
 }
 
 const CHART_HEIGHT = 260
@@ -532,6 +534,7 @@ export const ActivityChart = ({
   stages,
   defaultMetrics = [],
   onHoverTime,
+  onEnabledMetricsChange,
 }: ActivityChartProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
@@ -589,6 +592,12 @@ export const ActivityChart = ({
   }, [])
 
   const enabledMetrics = new Set(availableMetrics.filter((m) => !disabledMetrics.has(m)))
+
+  // Surface the currently-shown metrics so a parent (the share dialog) can mirror
+  // the user's chart selection. Runs on load and each toggle (deps change ref).
+  useEffect(() => {
+    onEnabledMetricsChange?.(availableMetrics.filter((m) => !disabledMetrics.has(m)))
+  }, [availableMetrics, disabledMetrics, onEnabledMetricsChange])
 
   // Compute which metrics get axes (last MAX_RIGHT_AXES in toggleOrder that are enabled)
   const metricsWithAxes = new Set(toggleOrder.filter((m) => enabledMetrics.has(m)).slice(-MAX_RIGHT_AXES))

--- a/apps/web/src/pages/EntityDetail/ShareActivityButton.tsx
+++ b/apps/web/src/pages/EntityDetail/ShareActivityButton.tsx
@@ -13,11 +13,13 @@ export const ShareActivityButton = ({
   activityTitle,
   activityStart,
   activityEnd,
+  chartMetrics,
 }: {
   activityId: string
   activityTitle?: string
   activityStart?: Date
   activityEnd?: Date
+  chartMetrics?: string[]
 }) => {
   const [open, setOpen] = useState(false)
   return (
@@ -36,6 +38,7 @@ export const ShareActivityButton = ({
           activityTitle={activityTitle}
           activityStart={activityStart}
           activityEnd={activityEnd}
+          chartMetrics={chartMetrics}
           onClose={() => setOpen(false)}
         />
       )}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -212,6 +212,7 @@ const ActivityDetailContent = ({
   referencedRules,
   onRevertOverride,
   isReverting,
+  onChartMetricsChange,
 }: {
   activity: Activity
   isEditing: boolean
@@ -222,6 +223,7 @@ const ActivityDetailContent = ({
   referencedRules?: Record<string, string>
   onRevertOverride?: () => void
   isReverting?: boolean
+  onChartMetricsChange?: (metrics: string[]) => void
 }) => {
   const displayStart = activity.merged_start_time ?? activity.start_time
   const realEnd = activity.merged_end_time ?? activity.end_time
@@ -368,6 +370,7 @@ const ActivityDetailContent = ({
             stages={hasSleepStages ? stages : undefined}
             defaultMetrics={['heart_rate', 'hrv_rmssd']}
             onHoverTime={setHoverTime}
+            onEnabledMetricsChange={onChartMetricsChange}
           />
           <ActivityMap start={displayStart} end={displayEnd} hoverTime={hoverTime} />
         </div>
@@ -483,6 +486,8 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
 
   const [isEditing, setIsEditing] = useState(false)
   const [isMerging, setIsMerging] = useState(false)
+  // Metrics currently shown on the chart, mirrored into the share dialog defaults.
+  const [chartMetrics, setChartMetrics] = useState<string[]>([])
   const emptyDraft: ActivityDraft = {
     activity_type: '',
     data: {},
@@ -632,6 +637,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
           activityTitle={activity.title}
           activityStart={activity.merged_start_time ?? activity.start_time}
           activityEnd={activity.merged_end_time ?? activity.end_time}
+          chartMetrics={chartMetrics}
         />
       )}
       {isMerging && <MergePanel activityId={rawEntityId} onCancel={() => setIsMerging(false)} />}
@@ -643,6 +649,7 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
         itemIcons={itemIcons}
         typeDefinitions={typeDefinitions}
         referencedRules={referencedRules}
+        onChartMetricsChange={setChartMetrics}
         onRevertOverride={() => revertOverrideMutation.mutate()}
         isReverting={revertOverrideMutation.isPending}
       />


### PR DESCRIPTION
## What

Per your request: opening **Share** from an activity now defaults the dialog's checked metrics to **what's shown on the activity's chart**. Toggle a metric off on the chart → it's unchecked in the Share dialog; still fully alterable there.

## How

`ActivityChart` reports its enabled (toggled-on) metrics upward:

```
ActivityChart --onEnabledMetricsChange--> ActivityDetailContent --> ActivityContent
   --chartMetrics--> ShareActivityButton --> ShareActivityDialog
```

In **create** mode the dialog seeds:
- **summary** = `duration` (always) + each summary metric whose source is charted (e.g. charting `heart_rate` → Avg HR + Max HR + HR zones; `distance` → Distance),
- **series** = the full time-series for every charted metric (this deliberately turns high-res series on to match the chart, as you chose).

**Edit** mode still uses the post's saved selection.

`DEFAULT_SUMMARY` + `defaultsFromChart` moved to the shared `feed-metrics` module and unit-tested (HR → avg/max/zones; series-only metrics like speed; unrepresentable metrics ignored; empty fallback).

`pnpm --filter aurboda-web check` clean; new test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)