### PR TITLE
fix(sharing): visible profile Share button + owner attribution avatar

### DIFF
--- a/apps/web/src/pages/PublicDashboard/index.tsx
+++ b/apps/web/src/pages/PublicDashboard/index.tsx
@@ -26,6 +26,17 @@ import './style.css'
 const gridClass = (type: SectionType): string =>
   type === 'links' ? 'links-grid' : type === 'charts' ? 'charts-grid' : 'metrics-grid'
 
+/** Author attribution (avatar + @handle). Shared so the owner and public views
+ *  can't drift apart (#879). */
+function AttributionLink({ username }: { username: string }) {
+  return (
+    <a class="public-attribution" href={`/u/${encodeURIComponent(username)}`}>
+      <img class="public-attribution__avatar" src={avatarUrl(username)} alt="" width={28} height={28} />@
+      {username}
+    </a>
+  )
+}
+
 /** Owner view: live, editable dashboard backed by the authed shared-dashboard API. */
 function OwnerSharedDashboard({ username, slug }: { username: string; slug: string }) {
   const queryClient = useQueryClient()
@@ -71,9 +82,7 @@ function OwnerSharedDashboard({ username, slug }: { username: string; slug: stri
       <div class="dashboard-header">
         <h1>{share.name}</h1>
         <div class="dashboard-actions">
-          <a class="public-attribution" href={`/u/${encodeURIComponent(username)}`}>
-            @{username}
-          </a>
+          <AttributionLink username={username} />
           {isEditing ? (
             <button class="btn-primary" onClick={() => setIsEditing(false)}>
               Done Editing
@@ -122,10 +131,7 @@ function ReadOnlyDashboard({
     <div class="dashboard public-dashboard">
       <div class="dashboard-header">
         <h1>{name}</h1>
-        <a class="public-attribution" href={`/u/${encodeURIComponent(username)}`}>
-          <img class="public-attribution__avatar" src={avatarUrl(username)} alt="" width={28} height={28} />@
-          {username}
-        </a>
+        <AttributionLink username={username} />
         <ShareLinkButton url={window.location.href} title={`${name} — Aurboda`} />
       </div>
 

--- a/apps/web/src/pages/PublicProfile/index.tsx
+++ b/apps/web/src/pages/PublicProfile/index.tsx
@@ -48,7 +48,9 @@ export function PublicProfile() {
 
   return (
     <div class="public-profile">
-      <header class="public-profile-header">
+      {/* A <div>, not <header>: the global `header` rule paints a #673ab8 bar
+          (mobile nav style) that made the purple Share button invisible (#883). */}
+      <div class="public-profile-header">
         <img
           class="public-avatar"
           src={avatarUrl(username)}
@@ -58,7 +60,7 @@ export function PublicProfile() {
         />
         <h1>@{username}</h1>
         <ShareLinkButton url={window.location.href} title={`@${username} on Aurboda`} />
-      </header>
+      </div>
 
       <section class="public-section">
         <h2>Dashboards</h2>


### PR DESCRIPTION
Fixes two tryout-findings from the #834 sharing work.

## #883 — Share button invisible on public profile
The `.public-profile-header` used a `<header>` element, which matches the global `header { background-color: #673ab8 }` (mobile-nav) rule, painting a purple bar. My `#673ab8` Share button was then purple-on-purple → invisible. That purple bar was itself unintended (introduced when I wrapped the profile header in PR #876). **Fix:** use a `<div>` — removes the accidental purple bar, and the button (purple on the light page) reads fine.

## #879 — Owner's own view missing the attribution avatar
The avatar was only added to `ReadOnlyDashboard`, not `OwnerSharedDashboard`, so owners saw a bare `@handle`. **Fix:** extract a shared `AttributionLink` (avatar + handle) used by **both** views, so they can't drift again (as the finding suggested).

## Verification
`pnpm check` green. Both are UI-only; the finding repro steps (avatar upload → owner vs anonymous view; profile Share button contrast) are covered by the change.

`Fixes #883`, `Fixes #879`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)