### PR TITLE
fix(feed): render chart text (bundle fonts) + cache feed image renders (#887, #892)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN pnpm --filter @aurboda/api-spec generate:openapi && pnpm --filter @aurboda/a
 # Production stage
 FROM node:25-alpine
 
-# Install nginx
-RUN apk add --no-cache nginx
+# Install nginx + fontconfig (librsvg, via sharp, needs a registered font to
+# rasterize SVG <text> in server-rendered images — the base image ships none).
+RUN apk add --no-cache nginx fontconfig
 
 # Install pnpm
 RUN npm install -g pnpm@10
@@ -46,6 +47,12 @@ COPY --from=builder /app/packages/api-spec/dist ./packages/api-spec/dist
 # Copy backend source (Node 25 runs TypeScript directly via built-in type stripping)
 COPY tsconfig.json ./
 COPY apps/backend/src ./apps/backend/src
+
+# Register the bundled Liberation fonts so librsvg/sharp can render SVG text
+# (feed chart images) instead of tofu boxes — the base image has no fonts.
+RUN mkdir -p /usr/share/fonts/liberation \
+ && cp apps/backend/src/assets/fonts/*.ttf /usr/share/fonts/liberation/ \
+ && fc-cache -f
 
 # Copy built web frontend
 COPY --from=builder /app/apps/web/dist /usr/share/nginx/html

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -64,6 +64,7 @@ import { createTrainingLoadRouter } from '../routes/training-load-router.ts'
 import { createTrendsRouter } from '../routes/trends-router.ts'
 import { createWebAuthnRouter } from '../routes/webauthn-router.ts'
 import { createWellKnownRouter, type WellKnownConfig } from '../routes/well-known-router.ts'
+import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
 import { loadAvatarDataUri } from '../services/avatar-resolve.ts'
 import { createOgImageRenderer } from '../services/og-image.ts'
 import { createTemplateLoader } from '../services/web-template.ts'
@@ -161,6 +162,8 @@ export const mountRestRouters = ({
       getRoute: async (user, start, end) =>
         (await getLocations(user, start, end)).locations.map((l) => l.coordinates),
       getSeries: getTimeSeries,
+      renderChart: renderChartPng,
+      renderRoute: renderRoutePng,
     }),
   )
   httpd.use(createPublicSharesRouter(webHost))

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import type { FeedPostRecord } from '../db/index.ts'
 
-import { type ImageActivity, resolveImageWindow } from './feed-image-router.ts'
+import { createRenderCache, type ImageActivity, resolveImageWindow } from './feed-image-router.ts'
 
 const POST_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const ACTIVITY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -65,5 +65,51 @@ describe('resolveImageWindow', () => {
   test('null for an open-ended activity (no bounded window)', async () => {
     const openEnded = { start_time: activity.start_time }
     expect(await resolveImageWindow(deps(makePost(), openEnded), 'fiddur', POST_ID, 'include_map')).toBeNull()
+  })
+})
+
+describe('createRenderCache', () => {
+  const png = (s: string) => Buffer.from(s)
+
+  test('renders once per key, then serves the cached buffer', async () => {
+    const cached = createRenderCache()
+    const produce = vi.fn(async () => png('a'))
+    expect(await cached('k', produce)).toEqual(png('a'))
+    expect(await cached('k', produce)).toEqual(png('a'))
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
+  test('de-duplicates concurrent misses into a single render', async () => {
+    const cached = createRenderCache()
+    const produce = vi.fn(async () => png('b'))
+    const [a, b] = await Promise.all([cached('k', produce), cached('k', produce)])
+    expect(a).toEqual(png('b'))
+    expect(b).toEqual(png('b'))
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders separately per key', async () => {
+    const cached = createRenderCache()
+    const produce = vi.fn(async (): Promise<Buffer | null> => png('x'))
+    await cached('k1', produce)
+    await cached('k2', produce)
+    expect(produce).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not cache a null (no-data) result', async () => {
+    const cached = createRenderCache()
+    const produce = vi.fn(async (): Promise<Buffer | null> => null)
+    expect(await cached('k', produce)).toBeNull()
+    expect(await cached('k', produce)).toBeNull()
+    expect(produce).toHaveBeenCalledTimes(2)
+  })
+
+  test('evicts the oldest entry past the bound', async () => {
+    const cached = createRenderCache(1)
+    const produce = vi.fn(async (): Promise<Buffer | null> => png('v'))
+    await cached('k1', produce) // cached
+    await cached('k2', produce) // evicts k1
+    await cached('k1', produce) // re-renders (was evicted)
+    expect(produce).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -17,7 +17,6 @@ import type { FeedPostRecord } from '../db/index.ts'
 
 import { isValidUsername } from '../api/auth-routes.ts'
 import { isMissingDatabase } from '../db/index.ts'
-import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -33,6 +32,43 @@ export interface FeedImageDeps {
   getActivity: (user: string, activityId: string) => Promise<ImageActivity | null>
   getSeries: (user: string, metric: string, start: Date, end: Date) => Promise<[Date, number][]>
   getRoute: (user: string, start: Date, end: Date) => Promise<[number, number][]>
+  renderChart: (series: [Date, number][]) => Promise<Buffer>
+  renderRoute: (coords: [number, number][]) => Promise<Buffer>
+}
+
+/**
+ * A tiny memoising render cache with in-flight de-duplication (mirrors
+ * og-image-router): repeated fetches for the same image serve a cached buffer,
+ * and concurrent misses collapse to a single render. Rendering is CPU-heavy and
+ * the source data (a past activity's series/GPS) is effectively immutable, so a
+ * bounded LRU + process-restart eviction is enough. `produce` returning `null`
+ * (no data) is NOT cached. The caller checks eligibility BEFORE consulting this,
+ * so an unshared/visibility-changed post 404s and never reaches the cache.
+ */
+export const createRenderCache = (maxEntries = 200) => {
+  const cache = new Map<string, Buffer>()
+  const inFlight = new Map<string, Promise<Buffer | null>>()
+  return async (key: string, produce: () => Promise<Buffer | null>): Promise<Buffer | null> => {
+    const cached = cache.get(key)
+    if (cached) return cached
+    const pending = inFlight.get(key)
+    if (pending) return pending
+    const promise = produce()
+    inFlight.set(key, promise)
+    try {
+      const png = await promise
+      if (png) {
+        if (cache.size >= maxEntries) {
+          const oldest = cache.keys().next().value
+          if (oldest !== undefined) cache.delete(oldest)
+        }
+        cache.set(key, png)
+      }
+      return png
+    } finally {
+      inFlight.delete(key)
+    }
+  }
 }
 
 /**
@@ -74,23 +110,32 @@ const sendPng = (res: Response, png: Buffer) => {
 
 export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
   const router = Router()
+  const cached = createRenderCache()
 
   router.get('/public/:username/feed/:postId/chart.png', async (req, res) => {
     const { postId, username } = req.params
     const activity = await resolveImageWindow(deps, username, postId, 'include_chart')
     if (!activity?.end_time) return notFound(res)
-    const series = await deps.getSeries(username, 'heart_rate', activity.start_time, activity.end_time)
-    if (series.length === 0) return notFound(res)
-    sendPng(res, await renderChartPng(series))
+    const { end_time, start_time } = activity
+    const png = await cached(`chart:${username}:${postId}`, async () => {
+      const series = await deps.getSeries(username, 'heart_rate', start_time, end_time)
+      return series.length === 0 ? null : deps.renderChart(series)
+    })
+    if (!png) return notFound(res)
+    sendPng(res, png)
   })
 
   router.get('/public/:username/feed/:postId/route.png', async (req, res) => {
     const { postId, username } = req.params
     const activity = await resolveImageWindow(deps, username, postId, 'include_map')
     if (!activity?.end_time) return notFound(res)
-    const coords = await deps.getRoute(username, activity.start_time, activity.end_time)
-    if (coords.length === 0) return notFound(res)
-    sendPng(res, await renderRoutePng(coords))
+    const { end_time, start_time } = activity
+    const png = await cached(`route:${username}:${postId}`, async () => {
+      const coords = await deps.getRoute(username, start_time, end_time)
+      return coords.length === 0 ? null : deps.renderRoute(coords)
+    })
+    if (!png) return notFound(res)
+    sendPng(res, png)
   })
 
   return router

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -48,9 +48,9 @@ export const renderChartPng = async (
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${CHART_W}" height="${CHART_H}" viewBox="0 0 ${CHART_W} ${CHART_H}">
   <rect width="${CHART_W}" height="${CHART_H}" fill="#0b0f19" rx="16"/>
   ${pts.length >= 2 ? `<polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="4" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
-  <text x="${PAD}" y="${PAD - 12}" fill="#e5e7eb" font-family="sans-serif" font-size="26" font-weight="700">${escapeXml(opts.label ?? 'Heart rate')}</text>
-  <text x="${CHART_W - PAD}" y="${PAD}" fill="#9ca3af" font-family="sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMax) ? Math.round(vMax) : ''}</text>
-  <text x="${CHART_W - PAD}" y="${CHART_H - PAD}" fill="#9ca3af" font-family="sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMin) ? Math.round(vMin) : ''}</text>
+  <text x="${PAD}" y="${PAD - 12}" fill="#e5e7eb" font-family="Liberation Sans, sans-serif" font-size="26" font-weight="700">${escapeXml(opts.label ?? 'Heart rate')}</text>
+  <text x="${CHART_W - PAD}" y="${PAD}" fill="#9ca3af" font-family="Liberation Sans, sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMax) ? Math.round(vMax) : ''}</text>
+  <text x="${CHART_W - PAD}" y="${CHART_H - PAD}" fill="#9ca3af" font-family="Liberation Sans, sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMin) ? Math.round(vMin) : ''}</text>
 </svg>`
   return svgToPng(svg)
 }


### PR DESCRIPTION
Chunk 1 of the feed follow-up queue (batched).

## #887 — chart text renders as tofu boxes
The runtime image (`node:25-alpine`) ships **no fonts** (`fc-list` → 0), so the chart PNG's `<text>` (title + min/max labels) rendered as missing-glyph boxes; the route map (no text) was fine.

**Fix:** install `fontconfig` and register the already-bundled Liberation TTFs (`apps/backend/src/assets/fonts`) via `fc-cache` in the Docker runtime stage, and reference `Liberation Sans` explicitly in the chart SVG so librsvg/sharp resolves it. (Reuses the fonts already shipped for the OG-image renderer.)

## #892 — image endpoints render per request
`/public/:username/feed/:postId/{chart,route}.png` re-fetched raw series/GPS and rasterized SVG→PNG on every request.

**Fix:** a bounded `createRenderCache` (LRU + in-flight dedup, mirroring `og-image-router`), keyed per post. Past-activity data is effectively immutable so a bounded cache + restart eviction suffices, and the **eligibility gate runs first** so an unshared/visibility-changed post still 404s without touching the cache. Renderers are injected (`FeedImageDeps.renderChart/renderRoute`), so the cache behaviour is unit-tested: render-once, concurrent-dedup, per-key, null-not-cached, eviction.

Closes #887, #892. `pnpm --filter aurboda-backend check` + tests green.

Note: the font fix is a Docker runtime change (not exercised by Node CI); verified against the documented `fc-list`/`fc-match` failure and the standard fontconfig setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)