### PR TITLE
perf(feed): cursor-paginate the ActivityPub outbox (#890)

### DIFF
--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -15,6 +15,7 @@ import {
   getFeedPostById,
   listFeedPosts,
   listPublicFeedPosts,
+  listPublicFeedPostsPage,
   updateFeedPost,
 } from './feed.ts'
 
@@ -125,6 +126,17 @@ describe('Feed posts integration', () => {
       await createFeedPost(user, postInput({ visibility: 'followers' }))
       expect(await listPublicFeedPosts(user)).toEqual([])
       expect(await countPublicFeedPosts(user)).toBe(0)
+    })
+
+    test('listPublicFeedPostsPage returns newest-first pages by limit/offset', async () => {
+      const user = getTestUser()
+      const a = await createFeedPost(user, postInput())
+      const b = await createFeedPost(user, postInput())
+      const c = await createFeedPost(user, postInput())
+      // Newest-first: c, b, a
+      expect((await listPublicFeedPostsPage(user, 2, 0)).map((p) => p.id)).toEqual([c.id, b.id])
+      expect((await listPublicFeedPostsPage(user, 2, 2)).map((p) => p.id)).toEqual([a.id])
+      expect(await listPublicFeedPostsPage(user, 2, 4)).toEqual([])
     })
   })
 

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -105,6 +105,26 @@ export const listPublicFeedPosts = async (user: string): Promise<FeedPostRecord[
   return result.rows.map(mapFeedPost)
 }
 
+/**
+ * One page of public outbox posts, newest-first, for the cursor-paginated
+ * ActivityPub outbox. `limit`/`offset` are clamped by the caller.
+ */
+export const listPublicFeedPostsPage = async (
+  user: string,
+  limit: number,
+  offset: number,
+): Promise<FeedPostRecord[]> => {
+  const result = await query<FeedPostRow>(
+    user,
+    `SELECT ${FEED_POST_COLUMNS} FROM feed_posts
+      WHERE visibility IN ('public', 'unlisted')
+      ORDER BY created_at DESC, id DESC
+      LIMIT $1 OFFSET $2`,
+    [limit, offset],
+  )
+  return result.rows.map(mapFeedPost)
+}
+
 /** Total number of posts on the public outbox (see `listPublicFeedPosts`). */
 export const countPublicFeedPosts = async (user: string): Promise<number> => {
   const result = await query<{ count: number }>(

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -297,6 +297,7 @@ export {
   getFeedPostById,
   listFeedPosts,
   listPublicFeedPosts,
+  listPublicFeedPostsPage,
   updateFeedPost,
 } from './feed.ts'
 

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -201,6 +201,12 @@ describe('Feed federation actor + WebFinger', () => {
     expect(page2.next).toBeUndefined()
   })
 
+  test('404s an outbox page with an out-of-range cursor (no DB error)', async () => {
+    const user = getTestUser()
+    const res = await fetchAs2(`/users/${user}/outbox?cursor=99999999999999999999`)
+    expect(res.status).toBe(404)
+  })
+
   test('404s a post object for a non-UUID id without touching the database', async () => {
     const user = getTestUser()
     const res = await fetchAs2(`/users/${user}/feed/not-a-uuid`)

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -125,16 +125,26 @@ describe('Feed federation actor + WebFinger', () => {
     expect(doc.orderedItems).toContain('https://mastodon.example/users/alice')
   })
 
-  test('serves the outbox with public posts as Create activities', async () => {
+  test('serves a paginated outbox: root has totalItems + first page link, page has the Create', async () => {
     const user = getTestUser()
     const activityId = await insertExercise(user)
     const post = await sharePost(user, activityId)
 
-    const res = await fetchAs2(`/users/${user}/outbox`)
-    expect(res.status).toBe(200)
-    const doc = (await res.json()) as { totalItems?: number; orderedItems?: unknown[] }
-    expect(doc.totalItems).toBe(1)
-    const items = doc.orderedItems ?? []
+    // Root collection: totalItems + a `first` page link (items live on the page).
+    const root = (await (await fetchAs2(`/users/${user}/outbox`)).json()) as {
+      totalItems?: number
+      first?: string
+      orderedItems?: unknown[]
+    }
+    expect(root.totalItems).toBe(1)
+    expect(root.first).toBe(`${ORIGIN}/users/${user}/outbox?cursor=0`)
+    expect(root.orderedItems).toBeUndefined()
+
+    // First page: the Create for the shared post.
+    const page = (await (await fetchAs2(`/users/${user}/outbox?cursor=0`)).json()) as {
+      orderedItems?: unknown[]
+    }
+    const items = page.orderedItems ?? []
     expect(items).toHaveLength(1)
     const create = items[0] as { type: string; object: string | { id: string; type: string } }
     expect(create.type).toBe('Create')
@@ -160,15 +170,35 @@ describe('Feed federation actor + WebFinger', () => {
     const activityId = await insertExercise(user)
     const post = await sharePost(user, activityId, { visibility: 'followers' })
 
-    const outbox = (await (await fetchAs2(`/users/${user}/outbox`)).json()) as {
-      totalItems?: number
+    const outbox = (await (await fetchAs2(`/users/${user}/outbox`)).json()) as { totalItems?: number }
+    expect(outbox.totalItems).toBe(0)
+    const page = (await (await fetchAs2(`/users/${user}/outbox?cursor=0`)).json()) as {
       orderedItems?: unknown[]
     }
-    expect(outbox.totalItems).toBe(0)
-    expect(outbox.orderedItems ?? []).toHaveLength(0)
+    expect(page.orderedItems ?? []).toHaveLength(0)
 
     const object = await fetchAs2(`/users/${user}/feed/${post.id}`)
     expect(object.status).toBe(404)
+  })
+
+  test('paginates the outbox past the page size', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    for (let i = 0; i < 21; i++) await sharePost(user, activityId)
+
+    const page1 = (await (await fetchAs2(`/users/${user}/outbox?cursor=0`)).json()) as {
+      orderedItems?: unknown[]
+      next?: string
+    }
+    expect((page1.orderedItems ?? []).length).toBe(20)
+    expect(page1.next).toBe(`${ORIGIN}/users/${user}/outbox?cursor=20`)
+
+    const page2 = (await (await fetchAs2(`/users/${user}/outbox?cursor=20`)).json()) as {
+      orderedItems?: unknown[]
+      next?: string
+    }
+    expect((page2.orderedItems ?? []).length).toBe(1)
+    expect(page2.next).toBeUndefined()
   })
 
   test('404s a post object for a non-UUID id without touching the database', async () => {

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -26,7 +26,7 @@ import {
   getOrCreateActorKeyPair,
   isMissingDatabase,
   listFeedFollowers,
-  listPublicFeedPosts,
+  listPublicFeedPostsPage,
   removeFeedFollower,
   upsertFeedFollower,
 } from '../../db/index.ts'
@@ -34,6 +34,9 @@ import { buildProfileUrl } from '../share-urls.ts'
 import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
+
+/** Posts per outbox page (cursor pagination). */
+const OUTBOX_PAGE_SIZE = 20
 
 /** RFC 4122 canonical form — guards `getFeedPostById` from a non-UUID `postId`
  * (Postgres would otherwise raise `invalid input syntax for type uuid`). */
@@ -167,17 +170,20 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
   )
 
   // Outbox: the user's public + unlisted posts as `Create` activities, so a
-  // Mastodon profile shows them. Served as a single inline OrderedCollection (no
-  // cursor) — fine at feed scale; pagination is a later slice. A post whose
-  // activity was soft-deleted is skipped from the items (its Create can't be
-  // built) while `setCounter` still counts it; the divergence self-heals when
-  // the stale post is removed.
+  // Mastodon profile shows them. Cursor-paginated (`OUTBOX_PAGE_SIZE` per page)
+  // so an unauthenticated fetch never resolves every post's scalars at once; the
+  // cursor is a simple offset (a concurrent share can shift a page boundary —
+  // acceptable for an occasionally-crawled outbox). A post whose activity was
+  // soft-deleted is skipped from the items while `setCounter` still counts it;
+  // the divergence self-heals when the stale post is removed.
   federation
-    .setOutboxDispatcher('/users/{identifier}/outbox', async (ctx, identifier) => {
+    .setOutboxDispatcher('/users/{identifier}/outbox', async (ctx, identifier, cursor) => {
       if (!isValidUsername(identifier)) return null
+      const offset = cursor == null ? 0 : Number.parseInt(cursor, 10)
+      if (!Number.isInteger(offset) || offset < 0) return null
       let posts
       try {
-        posts = await listPublicFeedPosts(identifier)
+        posts = await listPublicFeedPostsPage(identifier, OUTBOX_PAGE_SIZE, offset)
       } catch (error) {
         if (isMissingDatabase(error)) return null
         throw error
@@ -191,7 +197,8 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
           }),
         )
       ).filter((item): item is Create => item != null)
-      return { items }
+      const nextCursor = posts.length === OUTBOX_PAGE_SIZE ? String(offset + OUTBOX_PAGE_SIZE) : null
+      return { items, nextCursor }
     })
     .setCounter(async (_ctx, identifier) => {
       if (!isValidUsername(identifier)) return 0
@@ -199,6 +206,20 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
         return await countPublicFeedPosts(identifier)
       } catch (error) {
         if (isMissingDatabase(error)) return 0
+        throw error
+      }
+    })
+    .setFirstCursor((_ctx, identifier) => (isValidUsername(identifier) ? '0' : null))
+    .setLastCursor(async (_ctx, identifier) => {
+      if (!isValidUsername(identifier)) return null
+      try {
+        const count = await countPublicFeedPosts(identifier)
+        // Offset of the last page; '0' for an empty or single-page outbox.
+        return count <= OUTBOX_PAGE_SIZE
+          ? '0'
+          : String(Math.floor((count - 1) / OUTBOX_PAGE_SIZE) * OUTBOX_PAGE_SIZE)
+      } catch (error) {
+        if (isMissingDatabase(error)) return null
         throw error
       }
     })

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -180,7 +180,9 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
     .setOutboxDispatcher('/users/{identifier}/outbox', async (ctx, identifier, cursor) => {
       if (!isValidUsername(identifier)) return null
       const offset = cursor == null ? 0 : Number.parseInt(cursor, 10)
-      if (!Number.isInteger(offset) || offset < 0) return null
+      // `isSafeInteger` also rejects absurd offsets (e.g. a crafted `1e20`) that
+      // would overflow Postgres `bigint` in `OFFSET` and 500 the request.
+      if (!Number.isSafeInteger(offset) || offset < 0) return null
       let posts
       try {
         posts = await listPublicFeedPostsPage(identifier, OUTBOX_PAGE_SIZE, offset)

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -82,9 +82,11 @@ links) is a separate, richer representation for Aurboda-to-Aurboda consumers.
 
 ### Outbox & object serving
 
-- **Outbox** (`/users/<username>/outbox`) — an `OrderedCollection` of the user's
-  `public` + `unlisted` posts as `Create` activities, newest-first, so the actor's
-  profile shows their posts. `followers`-only posts are never listed.
+- **Outbox** (`/users/<username>/outbox`) — a **cursor-paginated** `OrderedCollection`
+  of the user's `public` + `unlisted` posts as `Create` activities, newest-first, so the
+  actor's profile shows their posts. The root returns `totalItems` + `first`/`last` page
+  links; each page (`?cursor=<offset>`) serves up to a fixed page size with a `next` link.
+  `followers`-only posts are never listed.
 - **Object** (`/users/<username>/feed/<postId>`) — the post's `Note`, served at its
   canonical id so a remote server can dereference it. Only `public`/`unlisted` resolve;
   `followers`-only and unknown ids return 404.
@@ -204,8 +206,6 @@ These are known and intentional for the current implementation:
   from followers' timelines.
 - **`published` is omitted** on the delivered `Note` (a Fedify/Temporal type-interop
   detail), so remote servers timestamp posts at receipt (≈ share time).
-- **The outbox is not paginated** — it serves all public posts inline. Fine at feed
-  scale; cursor pagination is a follow-up.
 - **Route maps have no basemap and no privacy trimming.** The route is a bare shape
   (no street tiles) and shows the full track, so a public route map reveals the
   approximate area; a street basemap and start/area masking are planned follow-ups.


### PR DESCRIPTION
Chunk 2 of the feed follow-up queue.

## Problem (#890)
The outbox dispatcher listed **every** public post and built each `Create` inline — `getActivityById` + `resolveActivityScalars` (a bucketed metrics-aggregation query per post). An unauthenticated `/users/:u/outbox` fetch therefore scaled O(posts × queries), unbounded.

## Fix
Serve the outbox as a **cursor-paginated** `OrderedCollection` (`OUTBOX_PAGE_SIZE = 20`):
- root `/outbox` → `totalItems` + `first`/`last` page links (no inline items),
- `/outbox?cursor=<offset>` → one page of `Create`s + a `next` link.

So a fetch resolves at most one page of posts. The cursor is a simple offset (a concurrent share can shift a page boundary — fine for an occasionally-crawled outbox; noted in a comment). New `listPublicFeedPostsPage` DB helper.

## Tests
Integration: root/page split (root has `first` link, page has the `Create`), page boundary past 20 with `next` cursor, followers-only exclusion still 0. DB: `listPublicFeedPostsPage` newest-first limit/offset. `pnpm --filter aurboda-backend check` + tests green.

Closes #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)