### PR TITLE
feat(feed): Note published + 410 Tombstone on deleted objects (#894, #895)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -32,6 +32,7 @@ import {
   getDeductionRulesByIds,
   getDetectedLocationById,
   getEnabledDeductionRules,
+  getFeedTombstone,
   getNamedLocations,
   insertActivities,
   insertActivity,
@@ -52,6 +53,7 @@ import { ouraClient } from './integrations/oura/client.ts'
 import { createOwnTracksRouter } from './integrations/owntracks/router.ts'
 import { stravaClient } from './integrations/strava/client.ts'
 import { createMcpRouter } from './mcp.ts'
+import { createFeedTombstoneRouter } from './routes/feed-tombstone-router.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
 import { deliverFeedDelete, deliverFeedPost, deliverFeedUpdate } from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
@@ -361,6 +363,11 @@ const main = async () => {
   // spoof them.
   httpd.set('trust proxy', 'loopback')
   httpd.use(integrateFederation(feedFederation, () => undefined))
+
+  // `410 Gone` Tombstone for dereferenced deleted objects. Mounted right after
+  // the federation integration: when the object dispatcher returns null for a
+  // since-deleted post, `@fedify/express` calls next(), and this catches it.
+  httpd.use(createFeedTombstoneRouter({ getTombstone: getFeedTombstone, origin: webHost }))
 
   httpd.use(json({ limit: '10mb' }))
 

--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -13,6 +13,7 @@ import {
   type FeedPostInput,
   findCoveringSharedSeriesWindow,
   getFeedPostById,
+  getFeedTombstone,
   listFeedPosts,
   listPublicFeedPosts,
   listPublicFeedPostsPage,
@@ -107,6 +108,39 @@ describe('Feed posts integration', () => {
     expect(await deleteFeedPost(user, created.id)).toBe(true)
     expect(await deleteFeedPost(user, created.id)).toBe(false)
     expect(await getFeedPostById(user, created.id)).toBeNull()
+  })
+
+  describe('tombstones on delete', () => {
+    test('records a tombstone for a deleted public post', async () => {
+      const user = getTestUser()
+      const created = await createFeedPost(user, postInput({ visibility: 'public' }))
+      expect(await getFeedTombstone(user, created.id)).toBeNull()
+
+      await deleteFeedPost(user, created.id)
+      const tomb = await getFeedTombstone(user, created.id)
+      expect(tomb).not.toBeNull()
+      expect(tomb?.deleted_at).toBeInstanceOf(Date)
+    })
+
+    test('records a tombstone for a deleted unlisted post', async () => {
+      const user = getTestUser()
+      const created = await createFeedPost(user, postInput({ visibility: 'unlisted' }))
+      await deleteFeedPost(user, created.id)
+      expect(await getFeedTombstone(user, created.id)).not.toBeNull()
+    })
+
+    test('does NOT tombstone a deleted followers-only post (its id never resolved publicly)', async () => {
+      const user = getTestUser()
+      const created = await createFeedPost(user, postInput({ visibility: 'followers' }))
+      await deleteFeedPost(user, created.id)
+      expect(await getFeedTombstone(user, created.id)).toBeNull()
+    })
+
+    test('has no tombstone for a live (never-deleted) post', async () => {
+      const user = getTestUser()
+      const created = await createFeedPost(user, postInput({ visibility: 'public' }))
+      expect(await getFeedTombstone(user, created.id)).toBeNull()
+    })
   })
 
   describe('public outbox listing', () => {

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -172,9 +172,45 @@ export const updateFeedPost = async (
   return result.rows.length ? mapFeedPost(result.rows[0]) : null
 }
 
+/**
+ * Delete a feed post and, if it was `public`/`unlisted` (so its object id was
+ * publicly dereferenceable), record a tombstone in the same statement so a later
+ * GET of that id can return `410 Gone` instead of `404`. Atomic: the delete and
+ * the tombstone insert commit together. `followers`-only posts leave no tombstone
+ * — their id never resolved publicly, so a 410 would leak that a post existed.
+ * Idempotent via `ON CONFLICT` (re-deleting a since-recreated id is a no-op).
+ */
 export const deleteFeedPost = async (user: string, id: string): Promise<boolean> => {
-  const result = await query(user, `DELETE FROM feed_posts WHERE id = $1`, [id])
-  return (result.rowCount ?? 0) > 0
+  const result = await query<{ id: string }>(
+    user,
+    `WITH deleted AS (
+       DELETE FROM feed_posts WHERE id = $1
+       RETURNING id, visibility
+     ), tomb AS (
+       INSERT INTO feed_tombstone (post_id)
+       SELECT id FROM deleted WHERE visibility IN ('public', 'unlisted')
+       ON CONFLICT (post_id) DO NOTHING
+     )
+     SELECT id FROM deleted`,
+    [id],
+  )
+  return result.rows.length > 0
+}
+
+/**
+ * The tombstone for a deleted public/unlisted post, or null if the id was never
+ * publicly shared (or is still live). Backs the `410 Gone` object dereference.
+ */
+export const getFeedTombstone = async (
+  user: string,
+  postId: string,
+): Promise<{ deleted_at: Date } | null> => {
+  const result = await query<{ deleted_at: Date }>(
+    user,
+    `SELECT deleted_at FROM feed_tombstone WHERE post_id = $1`,
+    [postId],
+  )
+  return result.rows.length ? result.rows[0] : null
 }
 
 /**

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -295,6 +295,7 @@ export {
   type FeedPostRecord,
   findCoveringSharedSeriesWindow,
   getFeedPostById,
+  getFeedTombstone,
   listFeedPosts,
   listPublicFeedPosts,
   listPublicFeedPostsPage,

--- a/apps/backend/src/routes/feed-tombstone-router.test.ts
+++ b/apps/backend/src/routes/feed-tombstone-router.test.ts
@@ -1,0 +1,95 @@
+import express from 'express'
+import supertest from 'supertest'
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildTombstoneJsonLd,
+  createFeedTombstoneRouter,
+  type FeedTombstoneDeps,
+} from './feed-tombstone-router.ts'
+
+const POST_ID = '11111111-1111-4111-8111-111111111111'
+const DELETED_AT = new Date('2026-07-02T09:00:00.000Z')
+
+/** Mounts the router with a fallback 404 so `next()` fall-through is observable. */
+const buildApp = (overrides: Partial<FeedTombstoneDeps> = {}) => {
+  const deps: FeedTombstoneDeps = {
+    getTombstone: async () => ({ deleted_at: DELETED_AT }),
+    origin: 'https://aurboda.net',
+    ...overrides,
+  }
+  const app = express()
+  app.use(createFeedTombstoneRouter(deps))
+  app.use((_req, res) => res.status(404).json({ fellThrough: true }))
+  return app
+}
+
+describe('buildTombstoneJsonLd', () => {
+  test('is a canonical AS2 Tombstone with the note id and deleted time', () => {
+    const id = 'https://aurboda.net/users/fiddur/feed/' + POST_ID
+    expect(buildTombstoneJsonLd(id, DELETED_AT)).toEqual({
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      deleted: '2026-07-02T09:00:00.000Z',
+      formerType: 'Note',
+      id,
+      type: 'Tombstone',
+    })
+  })
+})
+
+describe('GET /users/:username/feed/:postId (tombstone)', () => {
+  test('serves 410 Gone with an AS2 Tombstone for a tombstoned post', async () => {
+    const res = await supertest(buildApp()).get(`/users/fiddur/feed/${POST_ID}`)
+    expect(res.status).toBe(410)
+    expect(res.type).toBe('application/activity+json')
+    expect(res.headers['cache-control']).toBe('no-store')
+    expect(res.body).toEqual({
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      deleted: DELETED_AT.toISOString(),
+      formerType: 'Note',
+      id: `https://aurboda.net/users/fiddur/feed/${POST_ID}`,
+      type: 'Tombstone',
+    })
+  })
+
+  test('normalises a trailing slash on the origin so the id has no double slash', async () => {
+    const res = await supertest(buildApp({ origin: 'https://aurboda.net/' })).get(
+      `/users/fiddur/feed/${POST_ID}`,
+    )
+    expect(res.body.id).toBe(`https://aurboda.net/users/fiddur/feed/${POST_ID}`)
+  })
+
+  test('falls through (404) when there is no tombstone', async () => {
+    const res = await supertest(buildApp({ getTombstone: async () => null })).get(
+      `/users/fiddur/feed/${POST_ID}`,
+    )
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ fellThrough: true })
+  })
+
+  test('falls through for an invalid username without consulting the store', async () => {
+    let consulted = false
+    const app = buildApp({
+      getTombstone: async () => {
+        consulted = true
+        return { deleted_at: DELETED_AT }
+      },
+    })
+    const res = await supertest(app).get(`/users/Invalid..Name/feed/${POST_ID}`)
+    expect(res.status).toBe(404)
+    expect(consulted).toBe(false)
+  })
+
+  test('falls through for a non-UUID post id without consulting the store', async () => {
+    let consulted = false
+    const app = buildApp({
+      getTombstone: async () => {
+        consulted = true
+        return { deleted_at: DELETED_AT }
+      },
+    })
+    const res = await supertest(app).get('/users/fiddur/feed/not-a-uuid')
+    expect(res.status).toBe(404)
+    expect(consulted).toBe(false)
+  })
+})

--- a/apps/backend/src/routes/feed-tombstone-router.ts
+++ b/apps/backend/src/routes/feed-tombstone-router.ts
@@ -1,0 +1,78 @@
+/**
+ * `410 Gone` Tombstone for deleted feed-post objects (UNAUTHENTICATED).
+ *
+ * Handles: GET /users/:username/feed/:postId
+ *
+ * A shared post's object row is hard-deleted on unshare, so Fedify's object
+ * dispatcher returns `null` and `@fedify/express` falls through (`next()`). This
+ * router — mounted right AFTER `integrateFederation` — catches that fall-through:
+ * if the id is a recorded tombstone (a since-deleted `public`/`unlisted` post) it
+ * answers `410 Gone` with an AS2 `Tombstone`, which tells a remote server the
+ * object is *permanently* gone (vs a `404`, which reads as transient/unknown).
+ * Anything without a tombstone — a live post (served by Fedify, never reaches
+ * here), a `followers`-only id, or one that never existed — falls through to the
+ * normal 404.
+ *
+ * Fedify's `handleObject` serialises a returned `Tombstone` as `200`, so the 410
+ * can't come from the dispatcher; the Express layer is the only place to set it.
+ */
+import { type Response, Router } from 'express'
+
+import { isValidUsername } from '../api/auth-routes.ts'
+import { isMissingDatabase } from '../db/index.ts'
+
+/** RFC 4122 canonical form — mirrors the object dispatcher's guard. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export interface FeedTombstoneDeps {
+  /** Canonical web origin, e.g. `https://aurboda.net` — the Tombstone `id` base. */
+  origin: string
+  getTombstone: (user: string, postId: string) => Promise<{ deleted_at: Date } | null>
+}
+
+/**
+ * The AS2 `Tombstone` JSON-LD served at a deleted object's id. `id` mirrors the
+ * object dispatcher's canonical note id (`<origin>/users/<user>/feed/<postId>`);
+ * `formerType`/`deleted` are the standard Tombstone descriptors.
+ */
+export const buildTombstoneJsonLd = (id: string, deletedAt: Date) => ({
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  deleted: deletedAt.toISOString(),
+  formerType: 'Note',
+  id,
+  type: 'Tombstone',
+})
+
+const sendTombstone = (res: Response, id: string, deletedAt: Date) => {
+  // Match the object endpoint: no caching, so a re-share at a new id (or any
+  // future change) is never served stale.
+  res.setHeader('Cache-Control', 'no-store')
+  res
+    .status(410)
+    .type('application/activity+json')
+    .send(JSON.stringify(buildTombstoneJsonLd(id, deletedAt)))
+}
+
+export const createFeedTombstoneRouter = (deps: FeedTombstoneDeps): Router => {
+  const base = deps.origin.replace(/\/+$/, '')
+  const router = Router()
+
+  router.get('/users/:username/feed/:postId', async (req, res, next) => {
+    const { postId, username } = req.params
+    if (!isValidUsername(username) || !UUID_RE.test(postId)) return next()
+    let tombstone: { deleted_at: Date } | null
+    try {
+      tombstone = await deps.getTombstone(username, postId)
+    } catch (error) {
+      // A syntactically-valid username with no database is not a tombstone.
+      if (isMissingDatabase(error)) return next()
+      throw error
+    }
+    if (tombstone == null) return next()
+    // isValidUsername guarantees URL-safe chars, so no encoding needed to match
+    // the dispatcher's `getObjectUri(Note, …)` output exactly.
+    sendTombstone(res, `${base}/users/${username}/feed/${postId}`, tombstone.deleted_at)
+  })
+
+  return router
+}

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -143,6 +143,7 @@ export const tableCreationOrder = [
   'challenge_participations_indexes',
   'feed_posts',
   'feed_posts_indexes',
+  'feed_tombstone',
   'feed_actor',
   'feed_follower',
   'profile_avatar',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -123,6 +123,20 @@ export const socialTables: Record<string, string> = {
     CREATE INDEX IF NOT EXISTS idx_feed_posts_series ON feed_posts USING GIN (series_metrics)
   `,
 
+  // Tombstones for deleted public/unlisted feed posts. A post row is hard-deleted
+  // on unshare, but a remote server may still dereference its object id; AS2 wants
+  // a `410 Gone` Tombstone there (a `404` reads as transient/unknown). We record
+  // only `public`/`unlisted` deletions — a `followers`-only object id never
+  // resolved publicly, so tombstoning it would leak that a post once existed. The
+  // pushed `Delete{Tombstone}` still handles timeline retraction; this backs only
+  // the direct dereference of an already-known id.
+  feed_tombstone: `
+    CREATE TABLE IF NOT EXISTS feed_tombstone (
+      post_id     UUID PRIMARY KEY,
+      deleted_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
+
   // The user's ActivityPub actor keypair. Each per-user database has a single
   // actor (the user), so this is a singleton table: the `singleton` PK + CHECK
   // pins it to one row. The RSA keypair (PKCS#8 private / SPKI public PEM) signs

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -24,6 +24,7 @@ import { Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/v
 
 import { resolveActivityScalars } from './feed-activity.ts'
 import { addressingFor, feedPostContent, isPubliclyVisible } from './object.ts'
+import { dateToTemporalInstant } from './temporal-interop.ts'
 
 /**
  * AS2 `to`/`cc` addressing (as URLs) for a post's visibility — the same table
@@ -111,11 +112,10 @@ export interface DeliverableActivity {
  * are the object-dispatcher URL (`getObjectUri(Note, …)`), so the delivered
  * object and the one served at that URL are guaranteed identical.
  *
- * `published` is intentionally omitted: Fedify's vocab types it as the ambient
- * (esnext.temporal) `Temporal.Instant`, which the `@js-temporal` polyfill value
- * isn't assignable to. Delivery fires right after the share, so remote servers
- * timestamp it at receipt (≈ share time); wiring an explicit `published` is a
- * follow-up (needs Temporal-lib interop sorted).
+ * `published` is the post's `created_at` (its share time), so remote servers
+ * order and timestamp it correctly instead of stamping it at receipt. Fedify
+ * types `published` as the ambient `Temporal.Instant`; `dateToTemporalInstant`
+ * bridges our `@js-temporal/polyfill` value to it.
  */
 export const buildFeedNote = async (
   ctx: Context<void>,
@@ -136,6 +136,7 @@ export const buildFeedNote = async (
     content,
     id: noteId,
     name,
+    published: dateToTemporalInstant(post.created_at),
     tos: to,
     url: noteId,
   })
@@ -162,6 +163,7 @@ export const buildFeedCreate = async (
     ccs: cc,
     id: new URL(`${noteId.href}#create`),
     object: note,
+    published: dateToTemporalInstant(post.created_at),
     tos: to,
   })
 }

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -2,12 +2,16 @@
  * Integration tests for the Fedify actor + WebFinger surface, exercised through
  * `federation.fetch` against a real per-user database (no Express/nginx needed).
  */
+import { integrateFederation } from '@fedify/express'
 import { Note } from '@fedify/fedify/vocab'
+import express from 'express'
+import supertest from 'supertest'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { insertActivity } from '../../db/activities/index.ts'
 import { upsertFeedFollower } from '../../db/feed-follower.ts'
-import { createFeedPost, type FeedPostInput } from '../../db/feed.ts'
+import { createFeedPost, deleteFeedPost, type FeedPostInput, getFeedTombstone } from '../../db/feed.ts'
+import { createFeedTombstoneRouter } from '../../routes/feed-tombstone-router.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
 import { buildFeedUpdate } from './deliver.ts'
 import { createFeedFederation } from './federation.ts'
@@ -159,10 +163,19 @@ describe('Feed federation actor + WebFinger', () => {
 
     const res = await fetchAs2(`/users/${user}/feed/${post.id}`)
     expect(res.status).toBe(200)
-    const doc = (await res.json()) as { type: string; id: string; attributedTo?: string }
+    const doc = (await res.json()) as {
+      type: string
+      id: string
+      attributedTo?: string
+      published?: string
+    }
     expect(doc.type).toBe('Note')
     expect(doc.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
     expect(doc.attributedTo).toBe(`${ORIGIN}/users/${user}`)
+    // `published` is the post's share time (created_at), not the fetch time, so
+    // remote servers order it correctly.
+    expect(doc.published).toBeDefined()
+    expect(new Date(doc.published ?? '').getTime()).toBe(post.created_at.getTime())
   })
 
   test('excludes followers-only posts from the outbox and 404s their object', async () => {
@@ -210,6 +223,51 @@ describe('Feed federation actor + WebFinger', () => {
   test('404s a post object for a non-UUID id without touching the database', async () => {
     const user = getTestUser()
     const res = await fetchAs2(`/users/${user}/feed/not-a-uuid`)
+    expect(res.status).toBe(404)
+  })
+
+  // The 410-Tombstone slice lives in an Express router mounted after the Fedify
+  // integration; exercise the two together so the "dispatcher returns null →
+  // @fedify/express next() → tombstone router" fall-through is covered.
+  const buildFederatedApp = () => {
+    const app = express()
+    app.set('trust proxy', 'loopback')
+    app.use(integrateFederation(fed, () => undefined))
+    app.use(createFeedTombstoneRouter({ getTombstone: getFeedTombstone, origin: ORIGIN }))
+    return app
+  }
+
+  const getObject = (app: express.Express, path: string) =>
+    supertest(app).get(path).set('Accept', 'application/activity+json')
+
+  test('serves a 410 Tombstone after a public post is deleted (Fedify falls through)', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId)
+    const app = buildFederatedApp()
+
+    // Live: the object dispatcher serves the Note (200).
+    const live = await getObject(app, `/users/${user}/feed/${post.id}`)
+    expect(live.status).toBe(200)
+
+    // Unshare, then the same id returns 410 Gone with a Tombstone at the same id.
+    await deleteFeedPost(user, post.id)
+    const gone = await getObject(app, `/users/${user}/feed/${post.id}`)
+    expect(gone.status).toBe(410)
+    expect(gone.type).toBe('application/activity+json')
+    expect(gone.body.type).toBe('Tombstone')
+    expect(gone.body.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
+  })
+
+  test('a deleted followers-only object stays 404 (no public tombstone)', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId, { visibility: 'followers' })
+    const app = buildFederatedApp()
+
+    await deleteFeedPost(user, post.id)
+    expect(await getFeedTombstone(user, post.id)).toBeNull()
+    const res = await getObject(app, `/users/${user}/feed/${post.id}`)
     expect(res.status).toBe(404)
   })
 

--- a/apps/backend/src/services/activitypub/temporal-interop.test.ts
+++ b/apps/backend/src/services/activitypub/temporal-interop.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+
+import { dateToTemporalInstant } from './temporal-interop.ts'
+
+describe('dateToTemporalInstant', () => {
+  test('preserves the exact epoch milliseconds', () => {
+    const date = new Date('2026-07-01T06:30:00.000Z')
+    const instant = dateToTemporalInstant(date)
+    expect(instant.epochMilliseconds).toBe(date.getTime())
+  })
+
+  test('round-trips back to the same ISO instant', () => {
+    const date = new Date('2026-07-01T06:30:00.123Z')
+    expect(new Date(dateToTemporalInstant(date).toString()).getTime()).toBe(date.getTime())
+  })
+
+  test('handles the unix epoch', () => {
+    expect(dateToTemporalInstant(new Date(0)).epochMilliseconds).toBe(0)
+  })
+})

--- a/apps/backend/src/services/activitypub/temporal-interop.ts
+++ b/apps/backend/src/services/activitypub/temporal-interop.ts
@@ -1,0 +1,22 @@
+/// <reference lib="esnext.temporal" />
+/**
+ * Bridge a JS `Date` to the ambient `Temporal.Instant` that Fedify's vocab
+ * expects for timestamp fields (`published`, `deleted`, …).
+ *
+ * Fedify types those fields as the ambient (esnext.temporal) `Temporal.Instant`,
+ * but neither Fedify's runtime nor ours has a native `Temporal` (Node has none
+ * yet) — both construct instants with `@js-temporal/polyfill`. The polyfill's
+ * `Instant` is the *same class at runtime* (Fedify imports the same polyfill), so
+ * passing one is correct; the two `Instant` types are only nominally different at
+ * compile time (their method signatures differ slightly), which no type guard can
+ * reconcile. This one boundary cast, confined here, keeps every call site
+ * cast-free.
+ *
+ * The return type is the ambient global `Temporal.Instant` (from the triple-slash
+ * lib reference above); the polyfill is imported under an alias so it doesn't
+ * shadow that global type.
+ */
+import { Temporal as TemporalPolyfill } from '@js-temporal/polyfill'
+
+export const dateToTemporalInstant = (date: Date): Temporal.Instant =>
+  TemporalPolyfill.Instant.fromEpochMilliseconds(date.getTime()) as unknown as Temporal.Instant

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -89,7 +89,14 @@ links) is a separate, richer representation for Aurboda-to-Aurboda consumers.
   `followers`-only posts are never listed.
 - **Object** (`/users/<username>/feed/<postId>`) — the post's `Note`, served at its
   canonical id so a remote server can dereference it. Only `public`/`unlisted` resolve;
-  `followers`-only and unknown ids return 404.
+  `followers`-only and unknown ids return 404. Once a `public`/`unlisted` post is
+  **deleted**, that id returns **`410 Gone` with an AS2 `Tombstone`** (recorded in
+  `feed_tombstone`) so a dereferencing server learns the object is *permanently* gone
+  rather than transiently missing. A `followers`-only id is never tombstoned — it never
+  resolved publicly, so a 410 would leak that a post once existed.
+
+The `Note` carries `published` = the post's share time (its `created_at`), so remote
+servers order and timestamp it correctly instead of stamping it at receipt.
 
 The object we deliver, list in the outbox, and serve at that id are all built from one
 place, so they can't drift.
@@ -177,7 +184,7 @@ Public / federation (unauthenticated):
 | `GET /users/:username`                         | The actor document (`Person`)                               |
 | `GET /users/:username/outbox`                  | Public + unlisted posts as `Create` activities              |
 | `GET /users/:username/followers`               | The actor's followers collection                            |
-| `GET /users/:username/feed/:postId`            | A single post's `Note`                                      |
+| `GET /users/:username/feed/:postId`            | A single post's `Note` (or `410` Tombstone once deleted)    |
 | `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` (HTTP-Signature verified) |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
@@ -190,8 +197,10 @@ Feed posts live in the user's own database in the `feed_posts` table. `activity_
 **soft reference** (no foreign key): activities are soft-deleted and the series lookup
 re-checks `deleted_at` at query time, so a removed activity simply stops resolving rather
 than cascading a delete. A GIN index over `series_metrics` backs the public series
-endpoint's authorization check. Followers live in `feed_follower`; the actor's RSA
-keypair in `feed_actor`.
+endpoint's authorization check. Deleting a `public`/`unlisted` post hard-deletes its row
+and, in the same statement, records its id in `feed_tombstone` so the object id can still
+answer `410 Gone`. Followers live in `feed_follower`; the actor's RSA keypair in
+`feed_actor`.
 
 ## Caveats & limitations
 
@@ -201,11 +210,6 @@ These are known and intentional for the current implementation:
   post to `followers` federates an `Update` addressed only to followers; servers that
   showed it to non-followers keep their copy. This is an inherent ActivityPub limitation
   (Mastodon behaves the same) — there is no addressable "public" inbox to retract from.
-- **No `410 Tombstone` on GET of a deleted object.** A deleted post's object id returns
-  `404` (the row is hard-deleted). The pushed `Delete{Tombstone}` is what retracts it
-  from followers' timelines.
-- **`published` is omitted** on the delivered `Note` (a Fedify/Temporal type-interop
-  detail), so remote servers timestamp posts at receipt (≈ share time).
 - **Route maps have no basemap and no privacy trimming.** The route is a bare shape
   (no street tiles) and shows the full track, so a public route map reveals the
   approximate area; a street basemap and start/area masking are planned follow-ups.


### PR DESCRIPTION
Chunk 3 of the #831 feed follow-up queue: **Delivery lifecycle** — closes #894 and #895.

## #894 — Delivered Note carries a `published` timestamp
The `Note` (and outbox `Create`) now set `published` = the post's share time (`created_at`), so remote servers order and timestamp posts correctly instead of stamping them at receipt.

Fedify types `published` as the ambient (`esnext.temporal`) `Temporal.Instant`, which our `@js-temporal/polyfill` value isn't *nominally* assignable to (their method signatures differ) — but the values are the **identical class at runtime** (Fedify imports the same polyfill). A dedicated `temporal-interop.ts` helper bridges the two with a single documented boundary cast, confined to that one spot, so every call site stays cast-free.

## #895 — Deleted object returns `410 Gone` Tombstone (not `404`)
After unshare, a `public`/`unlisted` post's object id now answers **`410 Gone` with an AS2 `Tombstone`**, so a dereferencing server learns the object is *permanently* gone rather than transiently missing.

- Deleting a post records its id in a new **`feed_tombstone`** table, atomically in the same `DELETE` statement (a CTE).
- `followers`-only posts are **never** tombstoned — their id never resolved publicly, so a 410 would leak that a post once existed.
- Fedify's `handleObject` serialises a returned `Tombstone` as **200**, so the 410 can't come from the object dispatcher. Instead a small router mounted right after the Fedify integration catches the dispatcher's `null` → `@fedify/express` `next()` fall-through and serves the 410.

## Tests
- `temporal-interop.test.ts` — epoch-ms preservation / round-trip.
- `feed-tombstone-router.test.ts` — 410 body/headers, origin trailing-slash, fall-through on no-tombstone / invalid username / non-UUID.
- `feed.integration.test.ts` — tombstone recorded for public/unlisted deletes, **not** for followers-only, none for live posts.
- `federation.integration.test.ts` — end-to-end: live object → 200 Note (now with `published`), delete → 410 Tombstone through the real Fedify + Express wiring; deleted followers-only stays 404.

Docs (`feed.md`) updated: the two former caveats ("`published` omitted", "no 410 Tombstone") are removed and the object-serving / storage sections describe the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)