### PR TITLE
fix(feed): merged activity span everywhere + enrich GET /feed (#881, #891)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -28,7 +28,6 @@ import { setupOuraWebhook, setupStravaWebhook } from './api/webhooks-setup.ts'
 import { createAuth } from './auth.ts'
 import {
   deleteRuleActivities,
-  getActivityById,
   getDeductionRulesByIds,
   getDetectedLocationById,
   getEnabledDeductionRules,
@@ -70,6 +69,7 @@ import {
 } from './services/deduction-queue.ts'
 import { createDetectionTrigger, type DetectionTrigger } from './services/detection-trigger.ts'
 import { runDetectionForUser } from './services/detection-worker.ts'
+import { expandFeedActivityWindow, resolveFeedActivity } from './services/feed.ts'
 import { createGeocodeQueue } from './services/geocode-queue.ts'
 import { createInvitationAuth } from './services/invitation.ts'
 import { getPlaceVisits } from './services/locations.ts'
@@ -317,18 +317,23 @@ const main = async () => {
   const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>
     console.error(`⚠️ feed ${op} delivery failed for ${user}/${postId}:`, err)
   const feedDeliver: FeedDeliver = {
+    // Expand the already-resolved activity to its merged span so the delivered
+    // Note reports what the user shared, not just the anchor sub-activity (#881).
     created: (user, post, activity) => {
-      void deliverFeedPost(feedDeps, user, post, activity).catch(onDeliverError('create', user, post.id))
+      void (async () => {
+        const resolved = await expandFeedActivityWindow(user, activity)
+        await deliverFeedPost(feedDeps, user, post, resolved)
+      })().catch(onDeliverError('create', user, post.id))
     },
     deleted: (user, post) => {
       void deliverFeedDelete(feedDeps, user, post).catch(onDeliverError('delete', user, post.id))
     },
-    // Resolve the activity inside the fire-and-forget boundary so a lookup
-    // failure never bubbles into the (already-committed) edit's response.
+    // Resolve the (merged-span) activity inside the fire-and-forget boundary so a
+    // lookup failure never bubbles into the (already-committed) edit's response.
     updated: (user, post) => {
       void (async () => {
         if (!post.activity_id) return
-        const activity = await getActivityById(user, post.activity_id)
+        const activity = await resolveFeedActivity(user, post.activity_id)
         if (activity) await deliverFeedUpdate(feedDeps, user, post, activity)
       })().catch(onDeliverError('update', user, post.id))
     },

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -18,13 +18,7 @@ import type { SyncProvider } from '../services/queries/index.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 import type { AnyMiddleware } from '../typed-router.ts'
 
-import {
-  getActivityById,
-  getFeedPostById,
-  getLocations,
-  getTimeSeries,
-  markActivityDetailSynced,
-} from '../db/index.ts'
+import { getFeedPostById, getLocations, getTimeSeries, markActivityDetailSynced } from '../db/index.ts'
 import { processActivityDetail } from '../integrations/garmin/process.ts'
 import { createActivitiesRouter } from '../routes/activities-router.ts'
 import { createActivityTypesRouter } from '../routes/activity-types-router.ts'
@@ -66,6 +60,7 @@ import { createWebAuthnRouter } from '../routes/webauthn-router.ts'
 import { createWellKnownRouter, type WellKnownConfig } from '../routes/well-known-router.ts'
 import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
 import { loadAvatarDataUri } from '../services/avatar-resolve.ts'
+import { resolveFeedActivity } from '../services/feed.ts'
 import { createOgImageRenderer } from '../services/og-image.ts'
 import { createTemplateLoader } from '../services/web-template.ts'
 
@@ -157,7 +152,9 @@ export const mountRestRouters = ({
   // public/unlisted posts. Mounted alongside the series router (same guard).
   httpd.use(
     createFeedImageRouter({
-      getActivity: getActivityById,
+      // Merged-span window so the rendered chart/route cover what the user
+      // shared, matching the Note's duration/metrics (#881).
+      getActivity: resolveFeedActivity,
       getPost: getFeedPostById,
       getRoute: async (user, start, end) =>
         (await getLocations(user, start, end)).locations.map((l) => l.coordinates),

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -5,7 +5,6 @@
 import { shareActivityBodySchema, updateFeedPostBodySchema } from '@aurboda/api-spec'
 import { z } from 'zod'
 
-import type { FeedPostRecord } from '../db/index.ts'
 import type { FeedDeliver } from '../routes/feed-router.ts'
 
 import {
@@ -16,19 +15,8 @@ import {
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
+import { serializeFeedPost } from '../services/feed.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
-
-const serialize = (record: FeedPostRecord) => ({
-  activity_id: record.activity_id,
-  created_at: record.created_at.toISOString(),
-  id: record.id,
-  include_chart: record.include_chart,
-  include_map: record.include_map,
-  included_metrics: record.included_metrics,
-  series_metrics: record.series_metrics,
-  updated_at: record.updated_at.toISOString(),
-  visibility: record.visibility,
-})
 
 export const registerFeedTools = (server: McpServer, user: string, deliver?: FeedDeliver) => {
   server.tool(
@@ -37,7 +25,7 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
     {},
     async () => {
       const records = await listFeedPosts(user)
-      return jsonResponse(records.map(serialize))
+      return jsonResponse(await Promise.all(records.map((record) => serializeFeedPost(user, record))))
     },
   )
 
@@ -58,7 +46,7 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
       })
       // Fan out to followers (best-effort), same as the REST share route.
       deliver?.created(user, record, activity)
-      return jsonResponse(serialize(record))
+      return jsonResponse(await serializeFeedPost(user, record))
     },
   )
 
@@ -77,7 +65,7 @@ export const registerFeedTools = (server: McpServer, user: string, deliver?: Fee
       if (!record) return errorResponse('Feed post not found')
       // Federate the edit as an Update, same as the REST update route.
       deliver?.updated(user, record)
-      return jsonResponse(serialize(record))
+      return jsonResponse(await serializeFeedPost(user, record))
     },
   )
 

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -11,7 +11,6 @@ import type { RequestHandler } from 'express'
  * the public read surface lives in `feed-public-router.ts`.
  */
 import {
-  type FeedPost,
   type FeedPostResponse,
   type FeedPostsResponse,
   type ShareActivityBody,
@@ -30,6 +29,7 @@ import {
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
+import { serializeFeedPost } from '../services/feed.ts'
 import { type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
 
@@ -52,25 +52,14 @@ export interface FeedDeliver {
   deleted: (user: string, post: FeedPostRecord) => void
 }
 
-const serialize = (record: FeedPostRecord): FeedPost => ({
-  activity_id: record.activity_id,
-  created_at: record.created_at.toISOString(),
-  id: record.id,
-  include_chart: record.include_chart,
-  include_map: record.include_map,
-  included_metrics: record.included_metrics,
-  series_metrics: record.series_metrics,
-  updated_at: record.updated_at.toISOString(),
-  visibility: record.visibility,
-})
-
 export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedDeliver): TypedRouter => {
   const router = typedRouter()
 
   router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
     const user = req.user!
     const records = await listFeedPosts(user)
-    res.json({ posts: records.map(serialize), success: true })
+    const posts = await Promise.all(records.map((record) => serializeFeedPost(user, record)))
+    res.json({ posts, success: true })
   })
 
   router.post<{ id: string }, FeedPostResponse, ShareActivityBody>(
@@ -93,7 +82,7 @@ export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedD
       })
       // Fan the post out to followers (best-effort; never blocks the response).
       deliver?.created(user, record, activity)
-      res.json({ post: serialize(record), success: true })
+      res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )
 
@@ -116,7 +105,7 @@ export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedD
       // Federate the edit as an Update so followers replace the stored object.
       // Fire-and-forget: the impl resolves the activity, so it can't 500 here.
       deliver?.updated(user, record)
-      res.json({ post: serialize(record), success: true })
+      res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )
 

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -178,6 +178,31 @@ describe('Feed federation actor + WebFinger', () => {
     expect(new Date(doc.published ?? '').getTime()).toBe(post.created_at.getTime())
   })
 
+  test('serves the merged-span duration for a shared merged activity (#881)', async () => {
+    const user = getTestUser()
+    // Anchor 08:00–08:40 (40m) overlaps a second 08:20–09:00 → merged span is 1h.
+    const anchorId = await insertActivity(user, {
+      activity_type: 'exercise',
+      end_time: new Date('2026-07-01T08:40:00Z'),
+      source: 'garmin',
+      start_time: new Date('2026-07-01T08:00:00Z'),
+      title: 'Merged run',
+    })
+    await insertActivity(user, {
+      activity_type: 'exercise',
+      end_time: new Date('2026-07-01T09:00:00Z'),
+      source: 'strava',
+      start_time: new Date('2026-07-01T08:20:00Z'),
+      title: 'Second half',
+    })
+    const post = await sharePost(user, anchorId) // included_metrics: ['duration']
+
+    const doc = (await (await fetchAs2(`/users/${user}/feed/${post.id}`)).json()) as { content: string }
+    // The served Note reports the merged span the user saw, not the 40m anchor slice.
+    expect(doc.content).toContain('Duration 1h')
+    expect(doc.content).not.toContain('40m')
+  })
+
   test('excludes followers-only posts from the outbox and 404s their object', async () => {
     const user = getTestUser()
     const activityId = await insertExercise(user)

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -21,7 +21,6 @@ import { isValidUsername } from '../../api/auth-routes.ts'
 import {
   countFeedFollowers,
   countPublicFeedPosts,
-  getActivityById,
   getFeedPostById,
   getOrCreateActorKeyPair,
   isMissingDatabase,
@@ -30,6 +29,7 @@ import {
   removeFeedFollower,
   upsertFeedFollower,
 } from '../../db/index.ts'
+import { resolveFeedActivity } from '../feed.ts'
 import { buildProfileUrl } from '../share-urls.ts'
 import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
@@ -163,7 +163,9 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
         throw error
       }
       if (post == null || post.activity_id == null || !isPubliclyVisible(post.visibility)) return null
-      const activity = await getActivityById(identifier, post.activity_id)
+      // Resolve the merged-span activity so the served Note matches what the user
+      // shared (and what we delivered), not just the anchor sub-activity (#881).
+      const activity = await resolveFeedActivity(identifier, post.activity_id)
       if (activity == null) return null
       return buildFeedNote(ctx, identifier, post, activity, apiBaseUrl)
     },
@@ -194,7 +196,7 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
         await Promise.all(
           posts.map(async (post) => {
             if (post.activity_id == null) return null
-            const activity = await getActivityById(identifier, post.activity_id)
+            const activity = await resolveFeedActivity(identifier, post.activity_id)
             return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity, apiBaseUrl)
           }),
         )

--- a/apps/backend/src/services/feed.integration.test.ts
+++ b/apps/backend/src/services/feed.integration.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+/**
+ * Integration tests for the shared feed service: resolving a stored feed post's
+ * activity to its *merged span* (the window the detail view + share dialog show),
+ * and serialising an enriched feed post. Backed by a real DB so the merge
+ * (`resolveActivityWindow` → `getOverlappingActivities`) actually runs.
+ */
+import { deleteActivity, insertActivity } from '../db/activities/index.ts'
+import { createFeedPost, type FeedPostInput } from '../db/feed.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { expandFeedActivityWindow, resolveFeedActivity, serializeFeedPost } from './feed.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+// Two overlapping same-type activities merge into one 08:00–09:00 span; the
+// anchor's own window is only 08:00–08:40.
+const ANCHOR_START = new Date('2026-07-01T08:00:00Z')
+const ANCHOR_END = new Date('2026-07-01T08:40:00Z')
+const OTHER_START = new Date('2026-07-01T08:20:00Z')
+const MERGED_END = new Date('2026-07-01T09:00:00Z')
+
+const insertAnchor = (user: string): Promise<string> =>
+  insertActivity(user, {
+    activity_type: 'exercise',
+    end_time: ANCHOR_END,
+    source: 'garmin',
+    start_time: ANCHOR_START,
+    title: 'Merged run',
+  })
+
+const insertOverlap = (user: string): Promise<string> =>
+  insertActivity(user, {
+    activity_type: 'exercise',
+    end_time: MERGED_END,
+    source: 'strava',
+    start_time: OTHER_START,
+    title: 'Second half',
+  })
+
+const postInput = (activityId: string | null, overrides: Partial<FeedPostInput> = {}): FeedPostInput => ({
+  activity_id: activityId,
+  include_chart: false,
+  include_map: false,
+  included_metrics: ['duration'],
+  series_metrics: [],
+  visibility: 'public',
+  ...overrides,
+})
+
+describe('feed service', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  describe('resolveFeedActivity', () => {
+    test('expands a merged anchor to the full merged span (#881)', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      await insertOverlap(user)
+
+      const resolved = await resolveFeedActivity(user, anchorId)
+      expect(resolved?.start_time.toISOString()).toBe(ANCHOR_START.toISOString())
+      expect(resolved?.end_time?.toISOString()).toBe(MERGED_END.toISOString())
+      expect(resolved?.title).toBe('Merged run')
+      expect(resolved?.activity_type).toBe('exercise')
+    })
+
+    test('passes a lone (non-overlapping) activity through with its own window', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user) // no overlapping activity
+
+      const resolved = await resolveFeedActivity(user, anchorId)
+      expect(resolved?.start_time.toISOString()).toBe(ANCHOR_START.toISOString())
+      expect(resolved?.end_time?.toISOString()).toBe(ANCHOR_END.toISOString())
+    })
+
+    test('returns null for a missing/deleted activity', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      await deleteActivity(user, anchorId)
+      expect(await resolveFeedActivity(user, anchorId)).toBeNull()
+      expect(await resolveFeedActivity(user, '00000000-0000-0000-0000-000000000000')).toBeNull()
+    })
+  })
+
+  describe('expandFeedActivityWindow', () => {
+    test('expands an in-hand activity to its merged span', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      await insertOverlap(user)
+
+      // Simulate the share path (activity already loaded for its 404 check).
+      const anchor = {
+        activity_type: 'exercise' as const,
+        end_time: ANCHOR_END,
+        id: anchorId,
+        source: 'garmin' as const,
+        start_time: ANCHOR_START,
+        title: 'Merged run',
+      }
+      const resolved = await expandFeedActivityWindow(user, anchor)
+      expect(resolved.end_time?.toISOString()).toBe(MERGED_END.toISOString())
+    })
+  })
+
+  describe('serializeFeedPost', () => {
+    test('enriches a post with the activity title, type, and merged window (#891)', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      await insertOverlap(user)
+      const post = await createFeedPost(user, postInput(anchorId))
+
+      const dto = await serializeFeedPost(user, post)
+      expect(dto.activity_id).toBe(anchorId)
+      expect(dto.activity_title).toBe('Merged run')
+      expect(dto.activity_type).toBe('exercise')
+      expect(dto.activity_start_time).toBe(ANCHOR_START.toISOString())
+      expect(dto.activity_end_time).toBe(MERGED_END.toISOString())
+      // Base fields still present.
+      expect(dto.included_metrics).toEqual(['duration'])
+      expect(dto.visibility).toBe('public')
+    })
+
+    test('omits activity fields for a non-activity post', async () => {
+      const user = getTestUser()
+      const post = await createFeedPost(user, postInput(null))
+      const dto = await serializeFeedPost(user, post)
+      expect(dto.activity_id).toBeNull()
+      expect(dto.activity_title).toBeUndefined()
+      expect(dto.activity_start_time).toBeUndefined()
+    })
+
+    test('omits activity fields when the shared activity was deleted', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      const post = await createFeedPost(user, postInput(anchorId))
+      await deleteActivity(user, anchorId)
+
+      const dto = await serializeFeedPost(user, post)
+      expect(dto.activity_id).toBe(anchorId)
+      expect(dto.activity_title).toBeUndefined()
+      expect(dto.activity_start_time).toBeUndefined()
+    })
+  })
+})

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared feed business logic used by both the REST `/feed` router and the MCP
+ * feed tools (parity), and by the ActivityPub delivery/object/image paths.
+ *
+ * The one thing every feed surface needs from a stored post is its activity
+ * resolved to the **merged span** — the same window the activity detail view and
+ * the share dialog present. A feed post stores only `activity_id` (the plain
+ * anchor uuid), so resolving the merged window here (via `resolveActivityWindow`,
+ * the exact logic the `merged:` detail view uses) keeps three things consistent:
+ *
+ * - what the user *saw and chose to share* (the merged duration/metrics),
+ * - what we *deliver / serve / list* over ActivityPub (the Note's scalars, the
+ *   chart/route images), and
+ * - what the web feed view shows and offers when editing.
+ *
+ * Resolving at query time (rather than persisting a denormalised span on the
+ * post) means a later edit to the underlying activities stays reflected, per the
+ * repo's "reference by id, resolve at query time" principle.
+ */
+import type { FeedPost } from '@aurboda/api-spec'
+
+import type { Activity, FeedPostRecord } from '../db/index.ts'
+
+import { getActivityById } from '../db/index.ts'
+import { resolveActivityWindow } from './queries/index.ts'
+
+/**
+ * A feed post's shared activity, resolved for presentation/delivery: the title
+ * and type from the anchor row, and the **merged-span** window. Structurally a
+ * superset-compatible shape for the ActivityPub `DeliverableActivity`.
+ */
+export interface ResolvedFeedActivity {
+  activity_type: string
+  start_time: Date
+  end_time?: Date
+  title?: string
+}
+
+/**
+ * Expand an already-fetched activity to its merged span (no refetch). Used on the
+ * share path, where the handler already loaded the anchor for its 404 check.
+ * A plain (non-overlapping) activity passes through with its own window.
+ */
+export const expandFeedActivityWindow = async (
+  user: string,
+  activity: Activity,
+): Promise<ResolvedFeedActivity> => {
+  const window = await resolveActivityWindow(user, activity, true)
+  return {
+    activity_type: activity.activity_type,
+    end_time: window.end_time,
+    start_time: window.start_time,
+    title: activity.title,
+  }
+}
+
+/**
+ * Resolve a post's stored `activity_id` to its merged-span activity, or null if
+ * the activity is missing/deleted. The single source of the shared window for
+ * delivery, the object dispatcher, the outbox, and the rendered images.
+ */
+export const resolveFeedActivity = async (
+  user: string,
+  activityId: string,
+): Promise<ResolvedFeedActivity | null> => {
+  const activity = await getActivityById(user, activityId)
+  if (activity == null) return null
+  return expandFeedActivityWindow(user, activity)
+}
+
+/**
+ * Serialise a stored feed post for the owner-facing REST/MCP surface, enriching
+ * it with the shared activity's title/type and **merged-span** window resolved
+ * at query time. A client can therefore render the post and re-open the share
+ * dialog without a second per-post activity fetch (avoids the web feed's N+1).
+ */
+export const serializeFeedPost = async (user: string, record: FeedPostRecord): Promise<FeedPost> => {
+  const activity = record.activity_id ? await resolveFeedActivity(user, record.activity_id) : null
+  return {
+    activity_end_time: activity?.end_time?.toISOString(),
+    activity_id: record.activity_id,
+    activity_start_time: activity?.start_time.toISOString(),
+    activity_title: activity?.title,
+    activity_type: activity?.activity_type,
+    created_at: record.created_at.toISOString(),
+    id: record.id,
+    include_chart: record.include_chart,
+    include_map: record.include_map,
+    included_metrics: record.included_metrics,
+    series_metrics: record.series_metrics,
+    updated_at: record.updated_at.toISOString(),
+    visibility: record.visibility,
+  }
+}

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -12,7 +12,7 @@ import { useState } from 'preact/hooks'
 
 import { seriesLabel, summaryLabel } from '../../components/feed-metrics'
 import { ShareActivityDialog } from '../../components/ShareActivityDialog'
-import { deleteFeedPost, fetchActivityById, fetchFeed } from '../../state/api'
+import { deleteFeedPost, fetchFeed } from '../../state/api'
 import { toDisplayName } from '../../utils/displayName'
 import './style.css'
 
@@ -30,23 +30,18 @@ function FeedPostCard({ post }: { post: FeedPost }) {
   const [editing, setEditing] = useState(false)
   const activityId = post.activity_id
 
-  // Fetch the merged view (`merged:` prefix) so `merged_start_time/end` are
-  // populated — the same window the detail view uses when sharing, so the edit
-  // dialog offers the same metrics rather than a narrower anchor-only set.
-  const activityQuery = useQuery({
-    enabled: activityId != null,
-    queryFn: () => fetchActivityById(activityId ? `merged:${activityId}` : ''),
-    queryKey: ['activity', 'merged', activityId],
-    staleTime: 5 * 60 * 1000,
-  })
-
   const deleteMutation = useMutation({
     mutationFn: () => deleteFeedPost(post.id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 
-  const activity = activityQuery.data?.activity
-  const title = activity?.title || (activity ? toDisplayName(activity.activity_type) : 'Shared activity')
+  // The activity's title + merged-span window are resolved server-side into the
+  // feed response (no per-card fetch). The window is the same merged span the
+  // detail view shows, so the edit dialog offers the same metrics.
+  const title =
+    post.activity_title || (post.activity_type ? toDisplayName(post.activity_type) : 'Shared activity')
+  const activityStart = post.activity_start_time ? new Date(post.activity_start_time) : undefined
+  const activityEnd = post.activity_end_time ? new Date(post.activity_end_time) : undefined
 
   const onUnshare = () => {
     if (window.confirm('Unshare this post? It is removed from your feed and retracted from followers.')) {
@@ -107,9 +102,9 @@ function FeedPostCard({ post }: { post: FeedPost }) {
       {editing && activityId && (
         <ShareActivityDialog
           activityId={activityId}
-          activityTitle={activity?.title}
-          activityStart={activity?.merged_start_time ?? activity?.start_time}
-          activityEnd={activity?.merged_end_time ?? activity?.end_time}
+          activityTitle={post.activity_title}
+          activityStart={activityStart}
+          activityEnd={activityEnd}
           post={post}
           onClose={() => setEditing(false)}
         />

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -80,6 +80,14 @@ shared scalar summaries, plus a `name` headline, addressed per the post's visibi
 → followers only). The custom structured `aurboda:` extension (typed metrics + series
 links) is a separate, richer representation for Aurboda-to-Aurboda consumers.
 
+**Merged activities.** A post stores only `activity_id` (the plain anchor uuid). When that
+activity is part of a **merge group** (overlapping cross-source records, shown in the
+detail view as `merged:<anchor>`), the delivered/served/listed scalars and the rendered
+chart/route images are resolved over the **full merged span** — the same window the detail
+view and share dialog present — not the anchor sub-activity's narrower slice. The window is
+resolved at query time (via the same `resolveActivityWindow` the `merged:` detail view
+uses), so nothing denormalised is persisted on the post.
+
 ### Outbox & object serving
 
 - **Outbox** (`/users/<username>/outbox`) — a **cursor-paginated** `OrderedCollection`
@@ -168,7 +176,7 @@ Owner-facing (authenticated, scoped to the caller):
 
 | Method & path                     | Purpose                                            |
 | --------------------------------- | -------------------------------------------------- |
-| `GET /feed`                       | List my feed posts                                 |
+| `GET /feed`                       | List my feed posts (each enriched with the shared activity's title/type and merged-span window, resolved at query time) |
 | `POST /feed/activities/:id/share` | Publish an activity with a chosen metric selection |
 | `PATCH /feed/:postId`             | Edit selection / visibility / attachments          |
 | `DELETE /feed/:postId`            | Unpublish (its public series stops resolving)      |
@@ -210,6 +218,13 @@ These are known and intentional for the current implementation:
   post to `followers` federates an `Update` addressed only to followers; servers that
   showed it to non-followers keep their copy. This is an inherent ActivityPub limitation
   (Mastodon behaves the same) — there is no addressable "public" inbox to retract from.
+- **The public series endpoint uses the anchor window for merged shares.** The delivered
+  Note's scalar summary and the rendered images cover the full merged span, but
+  `GET /public/:username/series` still authorizes only the shared activity's *own* window
+  (`findCoveringSharedSeriesWindow` joins on `activity_id`). Since the delivered
+  Mastodon `Note` carries no series links, this is latent — expanding series
+  authorization across a merge group (which needs the merge algorithm at query time) is a
+  planned follow-up.
 - **Route maps have no basemap and no privacy trimming.** The route is a bare shape
   (no street tiles) and shows the full track, so a public route map reveals the
   approximate area; a street basemap and start/area masking are planned follow-ups.

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -105,6 +105,27 @@ export const feedPostSchema = z
       .uuid()
       .nullable()
       .meta({ description: 'The shared activity, or null for a non-activity post' }),
+    // Resolved from the shared activity at query time (not stored on the post, so
+    // a rename stays consistent). The window is the *merged* span — the same one
+    // the detail view and share dialog present — so a client can show the title
+    // and edit the metric selection without a second per-post activity fetch.
+    // Absent when there is no activity, or it was deleted.
+    activity_end_time: z
+      .string()
+      .optional()
+      .meta({ description: "The shared activity's merged-span end (ISO 8601)" }),
+    activity_start_time: z
+      .string()
+      .optional()
+      .meta({ description: "The shared activity's merged-span start (ISO 8601)" }),
+    activity_title: z
+      .string()
+      .optional()
+      .meta({ description: "The shared activity's title, resolved at query time" }),
+    activity_type: z
+      .string()
+      .optional()
+      .meta({ description: "The shared activity's type (e.g. `exercise`)" }),
     created_at: z.string().meta({ description: 'Creation timestamp (ISO 8601)' }),
     id: z.string().uuid().meta({ description: 'Feed post ID' }),
     include_chart: z.boolean().meta({ description: 'Whether a chart image is attached' }),


### PR DESCRIPTION
Chunk 4 of the #831 feed follow-up queue: **Feed data + merged window** — closes #881 and #891.

Both fixes reduce to one primitive: resolving a feed post's stored anchor `activity_id` to its **merged span** — the same window the `merged:` detail view and share dialog present — via `resolveActivityWindow(..., true)`, at query time (nothing denormalised is persisted, per the repo's reference-by-id principle). Centralised in a new **`services/feed.ts`** (`resolveFeedActivity` / `expandFeedActivityWindow` / `serializeFeedPost`), shared by REST + MCP (parity) and the ActivityPub paths.

## #881 — Shared merged activity reported anchor-only duration/metrics
A merged activity (e.g. a 1h run assembled from two overlapping sub-activities) was delivered/served over the **anchor sub-activity's own window** (40m), under-counting duration and metrics vs. what the user saw and the dialog offered.

Now the delivered / served / outbox-listed `Note` scalars **and** the rendered chart/route images resolve over the **merged span**. Wired through:
- the object + outbox dispatchers (`federation.ts`),
- the create/update delivery hooks (`api.ts`),
- the image router's activity resolver (`rest-routes.ts`).

A plain (non-overlapping) activity passes through with its own window unchanged.

## #891 — `GET /feed` lacked the activity title (web N+1)
The web feed view fetched `GET /activities/:id` **per card** just to show the title and drive the edit dialog's window. `GET /feed` (and share/update, and MCP `list_feed`) now enrich each post with the activity's title/type and merged-span start/end — resolved at query time — and the web card reads those and drops the per-card fetch.

api-spec `FeedPost` gains optional `activity_title`, `activity_type`, `activity_start_time`, `activity_end_time`.

## Tests
- `services/feed.integration.test.ts` (new) — `resolveFeedActivity` expands a merged anchor to the full span / passes a lone activity through / returns null for missing-deleted; `serializeFeedPost` enriches with title + merged window, omits for non-activity / deleted.
- `federation.integration.test.ts` — end-to-end: a shared **merged** activity's served Note reports the merged `Duration 1h`, not the `40m` anchor slice.

## Known follow-up (documented)
The public `GET /public/:username/series` endpoint still authorises only the anchor window for merged shares (`findCoveringSharedSeriesWindow` joins on `activity_id`). This is latent — the delivered Mastodon `Note` carries no series links — and expanding series authorisation across a merge group needs the merge algorithm at query time. Noted in `docs/features/feed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)