### PR TITLE
fix(feed): compact Share button + token-gated followers-only images (#872, #893)

### DIFF
--- a/apps/backend/src/db/connection.ts
+++ b/apps/backend/src/db/connection.ts
@@ -666,6 +666,14 @@ export const migrateSchema = async (user: string) => {
     await query(db, `ALTER TABLE tags ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
     await query(db, `ALTER TABLE tags ADD COLUMN IF NOT EXISTS tag_definition_id UUID`)
   }
+  if (existingTableNames.has('feed_posts')) {
+    // Capability token for followers-only image URLs (#893). Existing rows get a
+    // token via the DEFAULT applied on ADD COLUMN.
+    await query(
+      db,
+      `ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS image_token TEXT NOT NULL DEFAULT gen_random_uuid()::text`,
+    )
+  }
   if (existingTableNames.has('activities')) {
     await query(db, `ALTER TABLE activities ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ`)
     await query(db, `ALTER TABLE activities ADD COLUMN IF NOT EXISTS external_id VARCHAR(255)`)

--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -76,6 +76,17 @@ describe('Feed posts integration', () => {
     expect(await getFeedPostById(user, '00000000-0000-0000-0000-000000000000')).toBeNull()
   })
 
+  test('assigns an unguessable image_token that round-trips (#893)', async () => {
+    const user = getTestUser()
+    const created = await createFeedPost(user, postInput())
+    // Non-empty and unguessable (a UUID by default).
+    expect(created.image_token).toMatch(/^[0-9a-f-]{36}$/)
+    // Distinct per post, and stable on re-read.
+    const other = await createFeedPost(user, postInput())
+    expect(other.image_token).not.toBe(created.image_token)
+    expect((await getFeedPostById(user, created.id))?.image_token).toBe(created.image_token)
+  })
+
   test('lists posts newest-first', async () => {
     const user = getTestUser()
     const first = await createFeedPost(user, postInput())

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -22,6 +22,8 @@ export interface FeedPostRecord {
   visibility: FeedVisibility
   include_map: boolean
   include_chart: boolean
+  /** Unguessable capability token for `followers`-only image URLs (see schema). */
+  image_token: string
   created_at: Date
   updated_at: Date
 }
@@ -44,7 +46,7 @@ export interface FeedPostPatch {
 }
 
 const FEED_POST_COLUMNS =
-  'id, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, created_at, updated_at'
+  'id, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, image_token, created_at, updated_at'
 
 interface FeedPostRow {
   id: string
@@ -54,6 +56,7 @@ interface FeedPostRow {
   visibility: FeedVisibility
   include_map: boolean
   include_chart: boolean
+  image_token: string
   created_at: Date
   updated_at: Date
 }

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -16,6 +16,7 @@ const makePost = (overrides: Partial<FeedPostRecord> = {}): FeedPostRecord => ({
   activity_id: ACTIVITY_ID,
   created_at: new Date('2026-07-01T08:00:00Z'),
   id: POST_ID,
+  image_token: 'secret-token',
   include_chart: true,
   include_map: true,
   included_metrics: [],
@@ -44,9 +45,29 @@ describe('resolveImageWindow', () => {
     expect(await resolveImageWindow(deps(null), 'fiddur', POST_ID, 'include_chart')).toBeNull()
   })
 
-  test('null for a followers-only post', async () => {
-    const post = makePost({ visibility: 'followers' })
+  test('null for a followers-only post without a token', async () => {
+    const post = makePost({ image_token: 'secret-token', visibility: 'followers' })
     expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_chart')).toBeNull()
+  })
+
+  test('null for a followers-only post with the wrong token', async () => {
+    const post = makePost({ image_token: 'secret-token', visibility: 'followers' })
+    expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_chart', 'wrong')).toBeNull()
+    // A prefix of the real token must not pass (length-checked constant-time compare).
+    expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_chart', 'secret')).toBeNull()
+  })
+
+  test('resolves a followers-only post when the capability token matches (#893)', async () => {
+    const post = makePost({ image_token: 'secret-token', visibility: 'followers' })
+    expect(await resolveImageWindow(deps(post), 'fiddur', POST_ID, 'include_chart', 'secret-token')).toEqual(
+      activity,
+    )
+  })
+
+  test('a token is ignored for a public post (already unauthenticated)', async () => {
+    expect(
+      await resolveImageWindow(deps(makePost()), 'fiddur', POST_ID, 'include_chart', 'anything'),
+    ).toEqual(activity)
   })
 
   test('null when the requested attachment was not opted into', async () => {

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -1,17 +1,21 @@
+import { type Response, Router } from 'express'
 /**
  * Public feed-post image endpoints (UNAUTHENTICATED).
  *
  * Handles: GET /public/:username/feed/:postId/chart.png
  *          GET /public/:username/feed/:postId/route.png
  *
- * Rendered on demand from the shared activity's data. Like the public `/series`
- * endpoint there is no auth token, so the gating below is the whole privacy
- * boundary: an image is served only for a `public`/`unlisted` post that opted
- * into that attachment (`include_chart` / `include_map`). `no-store` keeps the
- * images revocable (unshare / flip to followers / clear the flag takes effect
- * immediately). Mounted before the generic `/public/:username/:slug` resolver.
+ * Rendered on demand from the shared activity's data. An image is served for a
+ * `public`/`unlisted` post that opted into that attachment (`include_chart` /
+ * `include_map`); a `followers`-only post is served only when the request carries
+ * the post's unguessable capability `?token=` (embedded solely in the Note
+ * delivered to followers — #893), since the fediverse fetches media unsigned and
+ * a signed-request gate wouldn't be exercised. `no-store` keeps the images
+ * revocable (unshare / clear the flag / flip a public post to followers all take
+ * effect immediately — the untoken'd public URL then 404s). Mounted before the
+ * generic `/public/:username/:slug` resolver.
  */
-import { type Response, Router } from 'express'
+import { timingSafeEqual } from 'node:crypto'
 
 import type { FeedPostRecord } from '../db/index.ts'
 
@@ -20,6 +24,22 @@ import { isMissingDatabase } from '../db/index.ts'
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Constant-time string compare (avoids leaking the token via response timing). */
+const tokenMatches = (provided: string, expected: string): boolean => {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+/**
+ * Whether an image request may see this post: `public`/`unlisted` are always
+ * served; a `followers`-only post is served only when the request carries the
+ * post's unguessable capability token (`?token=…`), which is embedded only in
+ * the Note delivered to followers (#893).
+ */
+const isImageAuthorized = (post: FeedPostRecord, token: string | undefined): boolean =>
+  isPubliclyVisible(post.visibility) || (token != null && tokenMatches(token, post.image_token))
 
 /** The window an image renders over. */
 export interface ImageActivity {
@@ -73,15 +93,17 @@ export const createRenderCache = (maxEntries = 200) => {
 
 /**
  * Resolve the activity window an image may render over, or `null` if the request
- * isn't eligible: invalid username / non-UUID id, missing DB, missing or
- * non-public post, the attachment flag not opted in, no linked activity, or an
- * open-ended activity (no bounded window). Pure of Express — unit-testable.
+ * isn't eligible: invalid username / non-UUID id, missing DB, missing post, a
+ * `followers`-only post without a matching capability `token`, the attachment
+ * flag not opted in, no linked activity, or an open-ended activity (no bounded
+ * window). Pure of Express — unit-testable.
  */
 export const resolveImageWindow = async (
   deps: Pick<FeedImageDeps, 'getPost' | 'getActivity'>,
   username: string,
   postId: string,
   flag: 'include_chart' | 'include_map',
+  token?: string,
 ): Promise<ImageActivity | null> => {
   if (!isValidUsername(username) || !UUID_RE.test(postId)) return null
   let post: FeedPostRecord | null
@@ -91,7 +113,7 @@ export const resolveImageWindow = async (
     if (isMissingDatabase(error)) return null
     throw error
   }
-  if (post == null || !isPubliclyVisible(post.visibility) || !post[flag] || post.activity_id == null) {
+  if (post == null || !isImageAuthorized(post, token) || !post[flag] || post.activity_id == null) {
     return null
   }
   const activity = await deps.getActivity(username, post.activity_id)
@@ -114,7 +136,8 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
 
   router.get('/public/:username/feed/:postId/chart.png', async (req, res) => {
     const { postId, username } = req.params
-    const activity = await resolveImageWindow(deps, username, postId, 'include_chart')
+    const token = typeof req.query.token === 'string' ? req.query.token : undefined
+    const activity = await resolveImageWindow(deps, username, postId, 'include_chart', token)
     if (!activity?.end_time) return notFound(res)
     const { end_time, start_time } = activity
     const png = await cached(`chart:${username}:${postId}`, async () => {
@@ -127,7 +150,8 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
 
   router.get('/public/:username/feed/:postId/route.png', async (req, res) => {
     const { postId, username } = req.params
-    const activity = await resolveImageWindow(deps, username, postId, 'include_map')
+    const token = typeof req.query.token === 'string' ? req.query.token : undefined
+    const activity = await resolveImageWindow(deps, username, postId, 'include_map', token)
     if (!activity?.end_time) return notFound(res)
     const { end_time, start_time } = activity
     const png = await cached(`route:${username}:${postId}`, async () => {

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -103,6 +103,11 @@ export const socialTables: Record<string, string> = {
   // endpoint. `activity_id` is a soft reference (no FK): activities are
   // soft-deleted, and the series endpoint re-checks `deleted_at` at query time,
   // so a removed activity simply stops resolving.
+  // `image_token` is an unguessable per-post capability token. A `followers`-only
+  // post's rendered chart/route image URLs carry it (`?token=…`), so a follower's
+  // server can fetch them even though the endpoint is otherwise unauthenticated —
+  // the fediverse fetches media without HTTP signatures, so a signed-request gate
+  // wouldn't be exercised. `public`/`unlisted` images need no token.
   feed_posts: `
     CREATE TABLE IF NOT EXISTS feed_posts (
       id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -112,6 +117,7 @@ export const socialTables: Record<string, string> = {
       visibility        VARCHAR(12) NOT NULL DEFAULT 'public',
       include_map       BOOLEAN NOT NULL DEFAULT false,
       include_chart     BOOLEAN NOT NULL DEFAULT false,
+      image_token       TEXT NOT NULL DEFAULT gen_random_uuid()::text,
       created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -34,6 +34,7 @@ describe('buildFeedDelete', () => {
   const deliverablePost = (visibility: DeliverablePost['visibility']): DeliverablePost => ({
     created_at: new Date('2026-07-01T00:00:00Z'),
     id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    image_token: 'secret-token',
     include_chart: false,
     include_map: false,
     included_metrics: [],
@@ -77,6 +78,7 @@ describe('imageAttachments', () => {
   const post = (overrides: Partial<DeliverablePost>): DeliverablePost => ({
     created_at: new Date('2026-07-01T00:00:00Z'),
     id: POST_ID,
+    image_token: 'secret-token',
     include_chart: false,
     include_map: false,
     included_metrics: [],
@@ -85,7 +87,7 @@ describe('imageAttachments', () => {
     ...overrides,
   })
 
-  test('attaches only the opted-in images, at the public endpoints', () => {
+  test('attaches only the opted-in images, at the public endpoints (no token for public)', () => {
     const chartOnly = imageAttachments(apiBaseUrl, 'fiddur', post({ include_chart: true }))
     expect(chartOnly.map((a) => a.url?.href)).toEqual([`${base}/chart.png`])
 
@@ -93,13 +95,21 @@ describe('imageAttachments', () => {
     expect(both.map((a) => a.url?.href)).toEqual([`${base}/chart.png`, `${base}/route.png`])
   })
 
-  test('attaches nothing for a followers-only post (image endpoint is unauthenticated)', () => {
+  test('attaches unlisted images without a token', () => {
+    const atts = imageAttachments(apiBaseUrl, 'fiddur', post({ include_chart: true, visibility: 'unlisted' }))
+    expect(atts.map((a) => a.url?.href)).toEqual([`${base}/chart.png`])
+  })
+
+  test('attaches followers-only images carrying the capability token (#893)', () => {
     const atts = imageAttachments(
       apiBaseUrl,
       'fiddur',
       post({ include_chart: true, include_map: true, visibility: 'followers' }),
     )
-    expect(atts).toEqual([])
+    expect(atts.map((a) => a.url?.href)).toEqual([
+      `${base}/chart.png?token=secret-token`,
+      `${base}/route.png?token=secret-token`,
+    ])
   })
 
   test('attaches nothing when neither flag is set', () => {

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -55,6 +55,8 @@ export interface DeliverablePost {
   include_chart: boolean
   /** Attach a rendered GPS route-map image. */
   include_map: boolean
+  /** Capability token appended to `followers`-only image URLs (see `imageAttachments`). */
+  image_token: string
 }
 
 /**
@@ -63,16 +65,18 @@ export interface DeliverablePost {
  * built against the actor's origin so it matches the deployed API base. Fedify's
  * `Image` carries `url` + `mediaType` + intrinsic size so Mastodon lays it out.
  *
- * Only `public`/`unlisted` posts get attachments: the image endpoint is
- * unauthenticated and (like the object/series endpoints) refuses `followers`-only
- * posts, so attaching a URL that would 404 for a follower is worse than omitting
- * it. (Authenticated per-follower image delivery is a possible later slice.)
+ * `public`/`unlisted` images are served unauthenticated. A `followers`-only
+ * post's URLs instead carry the post's unguessable **capability token**
+ * (`?token=…`): the fediverse fetches media without HTTP signatures, so the
+ * endpoint can't verify a signed request — the token is what lets a follower's
+ * server fetch the image while an untoken'd guess 404s. The token is only ever
+ * embedded in the Note delivered to followers, never in the public object/outbox.
  */
 export const imageAttachments = (apiBaseUrl: string, user: string, post: DeliverablePost): Image[] => {
-  if (!isPubliclyVisible(post.visibility)) return []
   // Same base as the series links (feed-activity.ts) — the configured API base,
   // NOT a hardcoded `<origin>/api`, so it stays correct if the two ever diverge.
   const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${post.id}`
+  const query = isPubliclyVisible(post.visibility) ? '' : `?token=${encodeURIComponent(post.image_token)}`
   const images: Image[] = []
   if (post.include_chart) {
     images.push(
@@ -80,7 +84,7 @@ export const imageAttachments = (apiBaseUrl: string, user: string, post: Deliver
         height: 420,
         mediaType: 'image/png',
         name: 'Heart rate',
-        url: new URL(`${base}/chart.png`),
+        url: new URL(`${base}/chart.png${query}`),
         width: 1000,
       }),
     )
@@ -91,7 +95,7 @@ export const imageAttachments = (apiBaseUrl: string, user: string, post: Deliver
         height: 700,
         mediaType: 'image/png',
         name: 'Route',
-        url: new URL(`${base}/route.png`),
+        url: new URL(`${base}/route.png${query}`),
         width: 700,
       }),
     )

--- a/apps/web/src/pages/EntityDetail/ShareActivityButton.tsx
+++ b/apps/web/src/pages/EntityDetail/ShareActivityButton.tsx
@@ -24,14 +24,19 @@ export const ShareActivityButton = ({
   const [open, setOpen] = useState(false)
   return (
     <>
-      <button
-        type="button"
-        class="btn-secondary"
-        onClick={() => setOpen(true)}
-        title="Share this activity to your federated feed"
-      >
-        Share to feed
-      </button>
+      {/* Wrap in `.entity-actions` (like ResyncDetailButton) so the button sits
+          compactly in an action row instead of stretching full-width as a bare
+          flex child of the detail page column (#872). */}
+      <div class="entity-actions">
+        <button
+          type="button"
+          class="btn-secondary"
+          onClick={() => setOpen(true)}
+          title="Share this activity to your federated feed"
+        >
+          Share to feed
+        </button>
+      </div>
       {open && (
         <ShareActivityDialog
           activityId={activityId}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -121,16 +121,22 @@ GET /api/public/:username/feed/:postId/chart.png
 GET /api/public/:username/feed/:postId/route.png
 ```
 
-The gating mirrors the object endpoint (public/unlisted only, and only when the
-matching flag was opted into) and responses are `no-store` so an unshare/visibility
-change takes effect immediately. A `followers`-only post therefore carries **no** image
-attachments — the endpoint is unauthenticated and can't safely serve them, so attaching
-a URL that would 404 for a follower is omitted (authenticated per-follower delivery is a
-possible later slice). The route is drawn as a bare, aspect-correct shape —
-no street basemap (a later enhancement) and **no privacy trimming** (area masking is a
-planned follow-up), so a public route map reveals the approximate area. The share
-dialog only offers the chart toggle when the activity has heart-rate data and the map
-toggle when it has an actual GPS track.
+An image is served when the matching flag was opted into. `public`/`unlisted` posts
+serve their images unauthenticated. A `followers`-only post's image URLs instead carry
+the post's **unguessable capability token** (`?token=<image_token>`), which is embedded
+only in the `Note` delivered to followers; a request without a matching token 404s. This
+is a deliberate capability-URL model (like the shared-dashboard slugs), chosen because
+the fediverse fetches media **without** HTTP signatures — Mastodon's "authorized fetch"
+signs ActivityPub object/actor requests, not media downloads — so a signed-request gate
+wouldn't be exercised and followers would just see a broken image. The tradeoff is that a
+leaked image URL grants access to that one rendered image (a chart or a bare route shape,
+not the underlying high-resolution series, which stays `followers`-excluded entirely).
+Responses are `no-store`, so an unshare / cleared flag / a public→followers flip takes
+effect immediately (the now-untoken'd public URL 404s). The route is drawn as a bare,
+aspect-correct shape — no street basemap (a later enhancement) and **no privacy trimming**
+(area masking is a planned follow-up), so a route map reveals the approximate area. The
+share dialog only offers the chart toggle when the activity has heart-rate data and the
+map toggle when it has an actual GPS track.
 
 ## Public series endpoint (the privacy boundary)
 
@@ -186,8 +192,8 @@ Public / federation (unauthenticated):
 | Method & path                                  | Purpose                                                     |
 | ---------------------------------------------- | ----------------------------------------------------------- |
 | `GET /public/:username/series`                 | Bucketed samples for a **shared** series within its window  |
-| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post                      |
-| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post                 |
+| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post (`?token=` for followers-only) |
+| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post (`?token=` for followers-only) |
 | `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                |
 | `GET /users/:username`                         | The actor document (`Person`)                               |
 | `GET /users/:username/outbox`                  | Public + unlisted posts as `Create` activities              |
@@ -205,7 +211,9 @@ Feed posts live in the user's own database in the `feed_posts` table. `activity_
 **soft reference** (no foreign key): activities are soft-deleted and the series lookup
 re-checks `deleted_at` at query time, so a removed activity simply stops resolving rather
 than cascading a delete. A GIN index over `series_metrics` backs the public series
-endpoint's authorization check. Deleting a `public`/`unlisted` post hard-deletes its row
+endpoint's authorization check. Each post also holds an unguessable `image_token`
+(defaulted at insert) that gates its `followers`-only image URLs. Deleting a
+`public`/`unlisted` post hard-deletes its row
 and, in the same statement, records its id in `feed_tombstone` so the object id can still
 answer `410 Gone`. Followers live in `feed_follower`; the actor's RSA keypair in
 `feed_actor`.


### PR DESCRIPTION
Final chunk of the #831 feed follow-up queue — closes #872 and #893.

## #872 — Share-to-feed button rendered full-width, detached
The `ShareActivityButton` was a bare flex child of the detail-page column, so it stretched to full content width instead of sitting in the action row. Wrapped in `.entity-actions` (matching `ResyncDetailButton`) so it's compact.

## #893 — Followers-only posts now carry images (token-gated)
**Context / decision:** The naive fix (verify the fetching server's HTTP Signature) doesn't work — the fediverse fetches **media without HTTP signatures** (Mastodon's authorized-fetch signs ActivityPub object/actor requests, not media downloads), so a signed-request gate would reject the media fetcher and followers would see a broken image. Per the maintainer's call, this uses the **capability-URL** model already established in this codebase (shared-dashboard slugs, challenge join tokens):

- Each post gets an unguessable `image_token` (`feed_posts.image_token`, `DEFAULT gen_random_uuid()::text`).
- A `followers`-only post's image URLs carry `?token=<image_token>`, embedded **only** in the `Note` delivered to followers.
- The image endpoint serves a `followers`-only image only on a **timing-safe** token match (`crypto.timingSafeEqual`, length-checked); `public`/`unlisted` images stay unauthenticated (no token).
- Tradeoff (documented): a leaked image URL grants access to that one rendered image — a chart or a bare route shape, **not** the underlying high-resolution series, which stays `followers`-excluded entirely.

`image_token` is **never** exposed in any owner-facing/public response (not in `FeedPost`, `serializeFeedPost`, the object/outbox) — only embedded in delivered followers-only image URLs and checked on inbound image requests. Existing DBs get the column via `ADD COLUMN IF NOT EXISTS` + the on-schema-error migration (`42703` → migrate → retry).

## Tests
- `deliver.test.ts` — `imageAttachments`: public/unlisted → no token; **followers-only → chart/route URLs carry `?token=…`**.
- `feed-image-router.test.ts` — `resolveImageWindow`: followers-only rejected without a token / with a wrong token / with a token **prefix** (length-checked); **served on exact match**; token ignored for public.
- `feed.integration.test.ts` — `createFeedPost` assigns a persistent, per-post unguessable `image_token`.

docs/features/feed.md updated (Images section, API table, storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)