### PR TITLE
feat(feed): render own feed posts as native cards (#884 slice 1)

### DIFF
--- a/apps/backend/src/services/feed.integration.test.ts
+++ b/apps/backend/src/services/feed.integration.test.ts
@@ -125,6 +125,8 @@ describe('feed service', () => {
       expect(dto.activity_type).toBe('exercise')
       expect(dto.activity_start_time).toBe(ANCHOR_START.toISOString())
       expect(dto.activity_end_time).toBe(MERGED_END.toISOString())
+      // Rendered `content` HTML (as federated) with the title headline (#884 §1).
+      expect(dto.content).toContain('<strong>Merged run</strong>')
       // Base fields still present.
       expect(dto.included_metrics).toEqual(['duration'])
       expect(dto.visibility).toBe('public')

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -22,6 +22,8 @@ import type { FeedPost } from '@aurboda/api-spec'
 import type { Activity, FeedPostRecord } from '../db/index.ts'
 
 import { getActivityById } from '../db/index.ts'
+import { resolveActivityScalars } from './activitypub/feed-activity.ts'
+import { feedPostContent } from './activitypub/object.ts'
 import { resolveActivityWindow } from './queries/index.ts'
 
 /**
@@ -70,18 +72,34 @@ export const resolveFeedActivity = async (
 
 /**
  * Serialise a stored feed post for the owner-facing REST/MCP surface, enriching
- * it with the shared activity's title/type and **merged-span** window resolved
- * at query time. A client can therefore render the post and re-open the share
- * dialog without a second per-post activity fetch (avoids the web feed's N+1).
+ * it with the shared activity's title/type, the **merged-span** window, and the
+ * exact `content` HTML the post federates with — all resolved at query time. A
+ * client can therefore render the post WYSIWYG (as it appears on Mastodon) and
+ * re-open the share dialog without a second per-post activity fetch.
+ *
+ * The `content` is the same server-built, HTML-escaped string the delivered Note
+ * carries (via `feedPostContent`), so the web renders it directly. (When the feed
+ * later renders *remote* actors' posts, that untrusted content will need
+ * sanitising — this owner-facing content does not.)
  */
 export const serializeFeedPost = async (user: string, record: FeedPostRecord): Promise<FeedPost> => {
   const activity = record.activity_id ? await resolveFeedActivity(user, record.activity_id) : null
+  let content: string | undefined
+  if (activity) {
+    const scalars = await resolveActivityScalars(
+      user,
+      { end_time: activity.end_time, start_time: activity.start_time },
+      record.included_metrics,
+    )
+    content = feedPostContent(activity.title, activity.activity_type, scalars).content
+  }
   return {
     activity_end_time: activity?.end_time?.toISOString(),
     activity_id: record.activity_id,
     activity_start_time: activity?.start_time.toISOString(),
     activity_title: activity?.title,
     activity_type: activity?.activity_type,
+    content,
     created_at: record.created_at.toISOString(),
     id: record.id,
     include_chart: record.include_chart,

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -1,0 +1,89 @@
+/**
+ * A single feed post rendered as it actually federates — a Mastodon-style card
+ * (author, handle, timestamp, visibility, the AS2 `content` HTML, and any
+ * chart/route image attachments) rather than a management chip list (#884 §1).
+ *
+ * Reusable for the future home timeline: the author identity is passed in, so
+ * the same card renders both the viewer's own posts and (later) remote actors'.
+ * `footer` carries per-post controls (Edit / Unshare) for the viewer's own posts.
+ */
+import type { FeedPost, FeedVisibility } from '@aurboda/api-spec'
+import type { ComponentChildren } from 'preact'
+
+import { formatDistanceToNow } from 'date-fns'
+
+import { API_URL } from '../../config'
+
+export interface PostAuthor {
+  displayName: string
+  /** `@user@host`. */
+  handle: string
+  /** Local username, used to build the post's image URLs. */
+  username: string
+  avatarUrl: string
+  profileUrl?: string
+}
+
+const VISIBILITY: Record<FeedVisibility, { icon: string; label: string }> = {
+  followers: { icon: '🔒', label: 'Followers only' },
+  public: { icon: '🌐', label: 'Public' },
+  unlisted: { icon: '🔓', label: 'Unlisted' },
+}
+
+/**
+ * A public/unlisted post's rendered image URL, or `null`. `followers`-only images
+ * are token-gated and the browser has no token (#893), so they're omitted here.
+ */
+const imageUrl = (username: string, post: FeedPost, kind: 'chart' | 'route'): string | null =>
+  post.visibility === 'followers'
+    ? null
+    : `${API_URL}/public/${encodeURIComponent(username)}/feed/${post.id}/${kind}.png`
+
+export const FeedPostCard = ({
+  post,
+  author,
+  footer,
+}: {
+  post: FeedPost
+  author: PostAuthor
+  footer?: ComponentChildren
+}) => {
+  const vis = VISIBILITY[post.visibility]
+  const when = formatDistanceToNow(new Date(post.created_at), { addSuffix: true })
+  const chart = post.include_chart ? imageUrl(author.username, post, 'chart') : null
+  const route = post.include_map ? imageUrl(author.username, post, 'route') : null
+
+  return (
+    <article class="feed-post">
+      <header class="feed-post-head">
+        <img class="feed-post-avatar" src={author.avatarUrl} alt="" width={44} height={44} />
+        <div class="feed-post-ident">
+          <span class="feed-post-name">{author.displayName}</span>
+          <span class="feed-post-handle">
+            {author.handle} · <time title={new Date(post.created_at).toLocaleString()}>{when}</time> ·{' '}
+            <span title={vis.label} aria-label={vis.label}>
+              {vis.icon}
+            </span>
+          </span>
+        </div>
+      </header>
+
+      {/* Server-generated, HTML-escaped `content` (see serializeFeedPost) — safe
+          to render directly. Remote timeline content will need sanitising. */}
+      {post.content ? (
+        <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: post.content }} />
+      ) : (
+        <div class="feed-post-content">{post.activity_title ?? 'Shared activity'}</div>
+      )}
+
+      {(chart || route) && (
+        <div class="feed-post-media">
+          {chart && <img class="feed-post-image" src={chart} alt="Heart rate chart" loading="lazy" />}
+          {route && <img class="feed-post-image" src={route} alt="Route map" loading="lazy" />}
+        </div>
+      )}
+
+      {footer && <footer class="feed-post-footer">{footer}</footer>}
+    </article>
+  )
+}

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -1,31 +1,21 @@
 /**
  * Feed / outbox view — the activities the user has published to their federated
- * (ActivityPub) feed. Lists each shared post with its audience and the metrics
- * it exposes, and lets the user edit the selection (reusing the share dialog in
- * edit mode) or unshare (which retracts a Delete to followers).
+ * (ActivityPub) feed, rendered as native Mastodon-style cards (matching how they
+ * actually appear once federated), each with an Edit / Unshare shortcut. Editing
+ * reuses the share dialog; unsharing retracts a Delete to followers.
  */
-import type { FeedPost, FeedVisibility } from '@aurboda/api-spec'
+import type { FeedPost } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { format } from 'date-fns'
 import { useState } from 'preact/hooks'
 
-import { seriesLabel, summaryLabel } from '../../components/feed-metrics'
 import { ShareActivityDialog } from '../../components/ShareActivityDialog'
-import { deleteFeedPost, fetchFeed } from '../../state/api'
-import { toDisplayName } from '../../utils/displayName'
+import { avatarUrl, deleteFeedPost, fetchFeed } from '../../state/api'
+import { auth } from '../../state/auth'
+import { FeedPostCard, type PostAuthor } from './FeedPostCard'
 import './style.css'
 
-const VISIBILITY_LABEL: Record<FeedVisibility, string> = {
-  followers: 'Followers only',
-  public: 'Public',
-  unlisted: 'Unlisted',
-}
-
-const formatWhen = (iso: string): string => format(new Date(iso), 'PP')
-
-// eslint-disable-next-line complexity -- render-heavy card: title resolution, edit/unshare actions, chips
-function FeedPostCard({ post }: { post: FeedPost }) {
+function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState(false)
   const activityId = post.activity_id
@@ -35,14 +25,6 @@ function FeedPostCard({ post }: { post: FeedPost }) {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 
-  // The activity's title + merged-span window are resolved server-side into the
-  // feed response (no per-card fetch). The window is the same merged span the
-  // detail view shows, so the edit dialog offers the same metrics.
-  const title =
-    post.activity_title || (post.activity_type ? toDisplayName(post.activity_type) : 'Shared activity')
-  const activityStart = post.activity_start_time ? new Date(post.activity_start_time) : undefined
-  const activityEnd = post.activity_end_time ? new Date(post.activity_end_time) : undefined
-
   const onUnshare = () => {
     if (window.confirm('Unshare this post? It is removed from your feed and retracted from followers.')) {
       deleteMutation.mutate()
@@ -50,78 +32,59 @@ function FeedPostCard({ post }: { post: FeedPost }) {
   }
 
   return (
-    <div class="feed-card">
-      <div class="feed-card-head">
-        {activityId ? (
-          <a class="feed-card-title" href={`/detail/activity/${activityId}`}>
-            {title}
-          </a>
-        ) : (
-          <span class="feed-card-title">{title}</span>
-        )}
-        <span class={`feed-badge feed-badge-${post.visibility}`}>{VISIBILITY_LABEL[post.visibility]}</span>
-      </div>
-
-      <div class="feed-card-meta">
-        Shared {formatWhen(post.created_at)}
-        {post.updated_at !== post.created_at ? ` · edited ${formatWhen(post.updated_at)}` : ''}
-      </div>
-
-      {post.included_metrics.length > 0 && (
-        <div class="feed-chips">
-          {post.included_metrics.map((k) => (
-            <span key={k} class="feed-chip">
-              {summaryLabel(k)}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {post.series_metrics.length > 0 && (
-        <div class="feed-chips">
-          <span class="feed-chips-label">Series</span>
-          {post.series_metrics.map((k) => (
-            <span key={k} class="feed-chip feed-chip-series">
-              {seriesLabel(k)}
-            </span>
-          ))}
-        </div>
-      )}
-
-      <div class="feed-card-actions">
-        {activityId && (
-          <button type="button" class="btn-secondary" onClick={() => setEditing(true)}>
-            Edit
-          </button>
-        )}
-        <button type="button" class="btn-danger" onClick={onUnshare} disabled={deleteMutation.isPending}>
-          {deleteMutation.isPending ? 'Unsharing…' : 'Unshare'}
-        </button>
-      </div>
+    <>
+      <FeedPostCard
+        post={post}
+        author={author}
+        footer={
+          <>
+            {activityId && (
+              <button type="button" class="btn-secondary" onClick={() => setEditing(true)}>
+                Edit
+              </button>
+            )}
+            <button type="button" class="btn-danger" onClick={onUnshare} disabled={deleteMutation.isPending}>
+              {deleteMutation.isPending ? 'Unsharing…' : 'Unshare'}
+            </button>
+          </>
+        }
+      />
 
       {editing && activityId && (
         <ShareActivityDialog
           activityId={activityId}
           activityTitle={post.activity_title}
-          activityStart={activityStart}
-          activityEnd={activityEnd}
+          activityStart={post.activity_start_time ? new Date(post.activity_start_time) : undefined}
+          activityEnd={post.activity_end_time ? new Date(post.activity_end_time) : undefined}
           post={post}
           onClose={() => setEditing(false)}
         />
       )}
-    </div>
+    </>
   )
 }
 
 export function Feed() {
   const { data: posts, isLoading, error } = useQuery({ queryFn: fetchFeed, queryKey: ['feed'] })
 
+  const username = auth.value.user ?? ''
+  // The actor handle host is the web host the user is browsing (`<user>@<host>`);
+  // the actor lives at `<host>/users/<user>` and WebFinger resolves that host.
+  const host = window.location.host
+  const author: PostAuthor = {
+    avatarUrl: avatarUrl(username),
+    displayName: username,
+    handle: `@${username}@${host}`,
+    profileUrl: `/u/${encodeURIComponent(username)}`,
+    username,
+  }
+
   return (
     <div class="feed-page">
       <h1>Feed</h1>
       <p class="feed-intro">
-        Activities you've published to your federated feed. People can follow your{' '}
-        <code>@handle@aurboda.net</code> from Mastodon and the wider fediverse to see these posts.
+        Activities you've published to your federated feed, shown the way they appear once federated. People
+        can follow your <code>{author.handle}</code> from Mastodon and the wider fediverse to see these posts.
       </p>
 
       {isLoading && <p>Loading…</p>}
@@ -132,7 +95,7 @@ export function Feed() {
         </p>
       )}
       {posts?.map((post) => (
-        <FeedPostCard key={post.id} post={post} />
+        <OwnPostCard key={post.id} post={post} author={author} />
       ))}
     </div>
   )

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -33,90 +33,74 @@
   color: #991b1b;
 }
 
-.feed-card {
+/* Native post card — mirrors how the post federates. */
+.feed-post {
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   padding: 0.875rem 1rem;
   margin-bottom: 0.75rem;
 }
 
-.feed-card-head {
+.feed-post-head {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 0.6rem;
 }
 
-.feed-card-title {
-  font-weight: 600;
-  font-size: 1rem;
-  color: #1f2937;
-  text-decoration: none;
-}
-
-.feed-card-title[href]:hover {
-  text-decoration: underline;
-}
-
-.feed-badge {
-  font-size: 0.72rem;
-  font-weight: 600;
-  padding: 0.1rem 0.5rem;
-  border-radius: 999px;
-  white-space: nowrap;
-}
-
-.feed-badge-public {
-  background: #dcfce7;
-  color: #166534;
-}
-
-.feed-badge-unlisted {
-  background: #e0e7ff;
-  color: #3730a3;
-}
-
-.feed-badge-followers {
+.feed-post-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
   background: #f3f4f6;
-  color: #374151;
+  flex-shrink: 0;
 }
 
-.feed-card-meta {
-  font-size: 0.78rem;
+.feed-post-ident {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.feed-post-name {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.feed-post-handle {
+  font-size: 0.8rem;
   color: #6b7280;
-  margin-top: 0.15rem;
 }
 
-.feed-chips {
+.feed-post-content {
+  margin-top: 0.5rem;
+  color: #1f2937;
+  overflow-wrap: anywhere;
+}
+
+.feed-post-content p {
+  margin: 0 0 0.4rem;
+}
+
+.feed-post-content p:last-child {
+  margin-bottom: 0;
+}
+
+.feed-post-media {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
   margin-top: 0.6rem;
 }
 
-.feed-chips-label {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
+.feed-post-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
 }
 
-.feed-chip {
-  font-size: 0.75rem;
-  padding: 0.1rem 0.5rem;
-  border-radius: 4px;
-  background: #f3f4f6;
-  color: #374151;
-}
-
-.feed-chip-series {
-  background: rgba(103, 58, 184, 0.12);
-  color: #4c1d95;
-}
-
-.feed-card-actions {
+.feed-post-footer {
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;
@@ -124,36 +108,23 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .feed-card {
+  .feed-post {
     border-color: #374151;
   }
 
-  .feed-card-title {
+  .feed-post-name,
+  .feed-post-content {
     color: #e5e7eb;
+  }
+
+  .feed-post-avatar,
+  .feed-post-image {
+    border-color: #374151;
+    background: #1f2937;
   }
 
   .feed-empty {
     background: #1f2937;
-    color: #d1d5db;
-  }
-
-  .feed-chip {
-    background: #374151;
-    color: #d1d5db;
-  }
-
-  .feed-badge-public {
-    background: #14532d;
-    color: #bbf7d0;
-  }
-
-  .feed-badge-unlisted {
-    background: #312e81;
-    color: #c7d2fe;
-  }
-
-  .feed-badge-followers {
-    background: #374151;
     color: #d1d5db;
   }
 }

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -126,6 +126,14 @@ export const feedPostSchema = z
       .string()
       .optional()
       .meta({ description: "The shared activity's type (e.g. `exercise`)" }),
+    // The exact HTML `content` that federates for this post (headline + shared
+    // scalar summary), so a client can render the post WYSIWYG — matching what
+    // Mastodon shows — instead of reconstructing it from the metric keys. Absent
+    // when there is no resolvable activity.
+    content: z
+      .string()
+      .optional()
+      .meta({ description: 'Rendered AS2 `content` HTML for the post (as federated)' }),
     created_at: z.string().meta({ description: 'Creation timestamp (ISO 8601)' }),
     id: z.string().uuid().meta({ description: 'Feed post ID' }),
     include_chart: z.boolean().meta({ description: 'Whether a chart image is attached' }),


### PR DESCRIPTION
## Summary

**Slice 1 of #884** (in-app federated feed). Renders the activities a user has published to their feed as **native Mastodon-style post cards** that mirror how the post actually federates — replacing the old management-chip list.

This is the first of several slices toward a full in-app feed. It deliberately touches only the *own-posts* view; following, home timeline, and live updates come in later slices.

## What changed

- **New `FeedPostCard`** (`apps/web/src/pages/Feed/FeedPostCard.tsx`) — a reusable card showing author, `@user@host` handle, timestamp, visibility, the AS2 `content` HTML, and chart/route attachments. The author identity is **injected**, so the same component will serve remote actors' posts in the home-timeline slice without change.
- **`serializeFeedPost` now returns `content`** — the *exact* server-built HTML the delivered Note carries (via `feedPostContent`), resolved at query time. The web renders it directly (WYSIWYG, matching Mastodon) instead of reconstructing a summary from metric keys. Added an optional `content` field to the api-spec `FeedPost` schema.
- **Own-post controls preserved** — `index.tsx`'s `OwnPostCard` wraps `FeedPostCard`, passing Edit / Unshare into the card's `footer` slot; editing still reuses the share dialog.
- **Followers-only images** are token-gated (#893) and the browser has no token, so they're omitted from the card; public/unlisted chart/route images render.

## Notes for review

- The owner-facing `content` is server-generated and HTML-escaped (same string that federates), so it renders via `dangerouslySetInnerHTML` without extra sanitising. A code comment flags that *remote* timeline content (a later slice) will need sanitising.
- The feed schema is not wired into OpenAPI path generation (pre-existing), so `pnpm generate` produces no diff for this change.

## Testing

- `pnpm check` — green across all packages (0 errors).
- Backend `services/feed.integration.test.ts` extended to assert the rendered `content` HTML carries the activity headline; passes against a real DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)