### PR TITLE
feat(feed): OpenStreetMap basemap for GPS route maps

### DIFF
--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -59,6 +59,7 @@ import { createTrendsRouter } from '../routes/trends-router.ts'
 import { createWebAuthnRouter } from '../routes/webauthn-router.ts'
 import { createWellKnownRouter, type WellKnownConfig } from '../routes/well-known-router.ts'
 import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
+import { fetchOsmTile } from '../services/activitypub/osm-tiles.ts'
 import { loadAvatarDataUri } from '../services/avatar-resolve.ts'
 import { resolveFeedActivity } from '../services/feed.ts'
 import { createOgImageRenderer } from '../services/og-image.ts'
@@ -160,7 +161,9 @@ export const mountRestRouters = ({
         (await getLocations(user, start, end)).locations.map((l) => l.coordinates),
       getSeries: getTimeSeries,
       renderChart: renderChartPng,
-      renderRoute: renderRoutePng,
+      // Draw the route over the OSM basemap; falls back to a bare shape if tiles
+      // can't be fetched (e.g. offline).
+      renderRoute: (coords) => renderRoutePng(coords, { fetchTile: fetchOsmTile }),
     }),
   )
   httpd.use(createPublicSharesRouter(webHost))

--- a/apps/backend/src/services/activitypub/feed-images.test.ts
+++ b/apps/backend/src/services/activitypub/feed-images.test.ts
@@ -1,5 +1,5 @@
 import sharp from 'sharp'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { renderChartPng, renderRoutePng } from './feed-images.ts'
 
@@ -80,11 +80,19 @@ describe('renderRoutePng', () => {
   })
 
   test('falls back to the bare shape when every tile fails to load', async () => {
-    const png = await renderRoutePng(coords, { fetchTile: async () => null })
-    expect(isPng(png)).toBe(true)
-    // No basemap → the dark background shows through at the corner.
-    const p = await pixelAt(png, 40, 40)
-    expect(p.g).toBeLessThan(60)
+    // An OSM outage/block (every tile null) must be observable, not silent.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const png = await renderRoutePng(coords, { fetchTile: async () => null })
+      expect(isPng(png)).toBe(true)
+      // No basemap → the dark background shows through at the corner.
+      const p = await pixelAt(png, 40, 40)
+      expect(p.g).toBeLessThan(60)
+      // ...and a warning is logged so the degradation isn't invisible.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('all'))
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   test('renders a plain background for an empty route without throwing', async () => {

--- a/apps/backend/src/services/activitypub/feed-images.test.ts
+++ b/apps/backend/src/services/activitypub/feed-images.test.ts
@@ -1,3 +1,4 @@
+import sharp from 'sharp'
 import { describe, expect, test } from 'vitest'
 
 import { renderChartPng, renderRoutePng } from './feed-images.ts'
@@ -6,6 +7,19 @@ import { renderChartPng, renderRoutePng } from './feed-images.ts'
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 
 const isPng = (buf: Buffer) => buf.subarray(0, 8).equals(PNG_MAGIC)
+
+/** A solid-colour 256×256 tile, standing in for an OSM tile (no network). */
+const fakeTile = (r: number, g: number, b: number): Promise<Buffer> =>
+  sharp({ create: { background: { b, g, r }, channels: 3, height: 256, width: 256 } })
+    .png()
+    .toBuffer()
+
+/** The RGB of a single pixel in a PNG. */
+const pixelAt = async (png: Buffer, px: number, py: number) => {
+  const { data, info } = await sharp(png).ensureAlpha().raw().toBuffer({ resolveWithObject: true })
+  const i = (py * info.width + px) * info.channels
+  return { b: data[i + 2], g: data[i + 1], r: data[i] }
+}
 
 describe('renderChartPng', () => {
   const series: [Date, number][] = [
@@ -48,6 +62,33 @@ describe('renderRoutePng', () => {
 
   test('tolerates a degenerate single-point route without throwing', async () => {
     const png = await renderRoutePng([[11.97, 57.7]])
+    expect(isPng(png)).toBe(true)
+  })
+
+  test('composites the OSM basemap when tiles are supplied', async () => {
+    const tile = await fakeTile(180, 210, 170) // a distinctive light green
+    const png = await renderRoutePng(coords, { fetchTile: async () => tile })
+    expect(isPng(png)).toBe(true)
+    const meta = await sharp(png).metadata()
+    expect(meta.width).toBe(700)
+    expect(meta.height).toBe(700)
+    // A corner interior pixel should be the basemap tile colour, proving the
+    // tiles were actually composited (the bare fallback is near-black there).
+    const p = await pixelAt(png, 40, 40)
+    expect(p.g).toBeGreaterThan(150)
+    expect(p.r).toBeGreaterThan(120)
+  })
+
+  test('falls back to the bare shape when every tile fails to load', async () => {
+    const png = await renderRoutePng(coords, { fetchTile: async () => null })
+    expect(isPng(png)).toBe(true)
+    // No basemap → the dark background shows through at the corner.
+    const p = await pixelAt(png, 40, 40)
+    expect(p.g).toBeLessThan(60)
+  })
+
+  test('renders a plain background for an empty route without throwing', async () => {
+    const png = await renderRoutePng([])
     expect(isPng(png)).toBe(true)
   })
 })

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -195,7 +195,16 @@ const renderRouteWithBasemap = async (
     ty,
   }))
   const loaded = tiles.filter((t): t is { tx: number; ty: number; buf: Buffer } => t.buf != null)
-  if (loaded.length === 0) return null
+  if (loaded.length === 0) {
+    // Every covering tile failed to fetch — an OSM outage or block (e.g. 429), not
+    // an expected case like the MAX_TILES guard above. `fetchTile` swallows each
+    // failure to null, so this is the only place a real outage surfaces: log it so
+    // the silent degradation to a bare shape is observable rather than invisible.
+    console.warn(
+      `⚠️ OSM basemap: all ${coords.length} tiles failed to fetch (zoom ${zoom}); using bare route`,
+    )
+    return null
+  }
 
   // Composite tiles onto a grid canvas (all non-negative offsets), then crop the
   // 700×700 viewport out of it — avoids negative composite offsets entirely.

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -2,20 +2,29 @@
  * Render feed-post attachment images (a metric line chart and a GPS route map)
  * as PNGs, from raw series / coordinate data.
  *
- * Both are pure functions of their inputs: they build a self-contained SVG and
- * rasterize it with `sharp` (no fonts, no external tiles). The route is drawn as
- * a bare polyline shape — a street basemap would need an external tile provider
- * and is a later enhancement. No privacy trimming is applied (area masking is a
- * planned follow-up), so callers must only render for public/unlisted posts that
- * opted in.
+ * The chart is a pure, self-contained SVG rasterized with `sharp`. The route map
+ * is drawn over an **OpenStreetMap street basemap**: the track is projected into
+ * Web Mercator (the tiles' projection), the covering tiles are fetched and
+ * composited behind it, and the required "© OpenStreetMap contributors"
+ * attribution is baked in (see `osm-tiles.ts`). Tile fetching is injected
+ * (`opts.fetchTile`) so it's opt-in and testable; when it's absent, or every tile
+ * fails (e.g. offline), the route falls back to a bare polyline on a dark
+ * background. No privacy trimming is applied (area masking is a planned
+ * follow-up), so callers must only render for posts that opted in.
  */
 import sharp from 'sharp'
+
+import { chooseZoom, latToWorldY, lonToWorldX, TILE_SIZE, type TileFetcher } from './osm-tiles.ts'
 
 const CHART_W = 1000
 const CHART_H = 420
 const ROUTE_W = 700
 const ROUTE_H = 700
 const PAD = 40
+/** Dark background behind the route (and behind any missing basemap tiles). */
+const ROUTE_BG = '#0b0f19'
+/** Guard against a pathological tile grid (chooseZoom keeps the route ≤ ~3 tiles wide). */
+const MAX_TILES = 25
 
 const svgToPng = (svg: string): Promise<Buffer> => sharp(Buffer.from(svg)).png().toBuffer()
 
@@ -59,42 +68,195 @@ export const renderChartPng = async (
 const escapeXml = (s: string): string =>
   s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
 
-/**
- * A GPS route map. `coords` is GeoJSON `[lon, lat]` pairs (as `getLocations`
- * returns). Longitudes are compressed by `cos(lat)` so the shape keeps its true
- * aspect, the route is fit to the box preserving that aspect, and start (green)
- * / end (red) points are marked. North is up.
- */
-export const renderRoutePng = async (coords: [number, number][]): Promise<Buffer> => {
-  const pts = coords.filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat))
+const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v))
+
+interface Bbox {
+  minLon: number
+  minLat: number
+  maxLon: number
+  maxLat: number
+}
+
+const boundingBox = (pts: [number, number][]): Bbox => {
   const lons = pts.map(([lon]) => lon)
   const lats = pts.map(([, lat]) => lat)
-  const minLon = Math.min(...lons)
-  const maxLon = Math.max(...lons)
-  const minLat = Math.min(...lats)
-  const maxLat = Math.max(...lats)
-  const midLatRad = (((minLat + maxLat) / 2) * Math.PI) / 180
+  return {
+    maxLat: Math.max(...lats),
+    maxLon: Math.max(...lons),
+    minLat: Math.min(...lats),
+    minLon: Math.min(...lons),
+  }
+}
 
+/**
+ * The route polyline + start/end markers (+ optional attribution) as an SVG
+ * overlay, projected into the 700×700 frame by the supplied `x`/`y`. Over a
+ * basemap the line gets a white halo so it stays legible on any tile colour.
+ */
+const routeOverlaySvg = (
+  pts: [number, number][],
+  x: (lon: number) => number,
+  y: (lat: number) => number,
+  overBasemap: boolean,
+): string => {
+  const polyline = pts.map(([lon, lat]) => `${x(lon).toFixed(1)},${y(lat).toFixed(1)}`).join(' ')
+  const first = pts[0]
+  const last = pts[pts.length - 1]
+  const line =
+    pts.length >= 2
+      ? `${overBasemap ? `<polyline points="${polyline}" fill="none" stroke="#ffffff" stroke-opacity="0.7" stroke-width="9" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
+  <polyline points="${polyline}" fill="none" stroke="#673ab8" stroke-width="5" stroke-linejoin="round" stroke-linecap="round"/>`
+      : ''
+  const markerStroke = overBasemap ? ' stroke="#ffffff" stroke-width="2.5"' : ''
+  const start = first
+    ? `<circle cx="${x(first[0]).toFixed(1)}" cy="${y(first[1]).toFixed(1)}" r="9" fill="#22c55e"${markerStroke}/>`
+    : ''
+  const end = last
+    ? `<circle cx="${x(last[0]).toFixed(1)}" cy="${y(last[1]).toFixed(1)}" r="9" fill="#ef4444"${markerStroke}/>`
+    : ''
+  // Required OSM attribution, bottom-right, on a translucent chip.
+  const attribution = overBasemap
+    ? `<g font-family="Liberation Sans, sans-serif" font-size="15">
+    <rect x="${ROUTE_W - 262}" y="${ROUTE_H - 26}" width="258" height="22" fill="#ffffff" fill-opacity="0.75"/>
+    <text x="${ROUTE_W - 6}" y="${ROUTE_H - 10}" text-anchor="end" fill="#1f2937">© OpenStreetMap contributors</text>
+  </g>`
+    : ''
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${ROUTE_W}" height="${ROUTE_H}" viewBox="0 0 ${ROUTE_W} ${ROUTE_H}">
+  ${line}
+  ${start}
+  ${end}
+  ${attribution}
+</svg>`
+}
+
+/** A rounded-rect mask (used with `blend: 'dest-in'`) to round the map corners. */
+const roundedMaskSvg = (): string =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${ROUTE_W}" height="${ROUTE_H}"><rect width="${ROUTE_W}" height="${ROUTE_H}" rx="16" fill="#fff"/></svg>`
+
+/**
+ * Render the route over an OSM basemap, or `null` if the basemap can't be built
+ * (grid too large, or every covering tile failed to fetch) so the caller can fall
+ * back to the bare shape. The route is projected in Web Mercator to match the
+ * tiles, centred in the frame at a zoom that fits the whole track.
+ */
+const renderRouteWithBasemap = async (
+  pts: [number, number][],
+  bbox: Bbox,
+  fetchTile: TileFetcher,
+): Promise<Buffer | null> => {
+  const zoom = chooseZoom(bbox, ROUTE_W - 2 * PAD, ROUTE_H - 2 * PAD)
+  const worldSize = TILE_SIZE * 2 ** zoom
+  const centerX = lonToWorldX((bbox.minLon + bbox.maxLon) / 2, worldSize)
+  const centerY = latToWorldY((bbox.minLat + bbox.maxLat) / 2, worldSize)
+  const vpLeft = centerX - ROUTE_W / 2
+  const vpTop = centerY - ROUTE_H / 2
+
+  const tileMinX = Math.floor(vpLeft / TILE_SIZE)
+  const tileMaxX = Math.floor((vpLeft + ROUTE_W) / TILE_SIZE)
+  const tileMinY = Math.floor(vpTop / TILE_SIZE)
+  const tileMaxY = Math.floor((vpTop + ROUTE_H) / TILE_SIZE)
+  const cols = tileMaxX - tileMinX + 1
+  const rows = tileMaxY - tileMinY + 1
+  if (cols * rows > MAX_TILES) return null
+
+  const jobs: Promise<{ tx: number; ty: number; buf: Buffer | null }>[] = []
+  for (let tx = tileMinX; tx <= tileMaxX; tx++) {
+    for (let ty = tileMinY; ty <= tileMaxY; ty++) {
+      jobs.push(fetchTile(zoom, tx, ty).then((buf) => ({ buf, tx, ty })))
+    }
+  }
+  const tiles = await Promise.all(jobs)
+  const loaded = tiles.filter((t): t is { tx: number; ty: number; buf: Buffer } => t.buf != null)
+  if (loaded.length === 0) return null
+
+  // Composite tiles onto a grid canvas (all non-negative offsets), then crop the
+  // 700×700 viewport out of it — avoids negative composite offsets entirely.
+  const gridW = cols * TILE_SIZE
+  const gridH = rows * TILE_SIZE
+  const gridBuf = await sharp({
+    create: { background: ROUTE_BG, channels: 4, height: gridH, width: gridW },
+  })
+    .composite(
+      loaded.map((t) => ({
+        input: t.buf,
+        left: (t.tx - tileMinX) * TILE_SIZE,
+        top: (t.ty - tileMinY) * TILE_SIZE,
+      })),
+    )
+    .png()
+    .toBuffer()
+
+  const extractLeft = clamp(Math.round(vpLeft - tileMinX * TILE_SIZE), 0, gridW - ROUTE_W)
+  const extractTop = clamp(Math.round(vpTop - tileMinY * TILE_SIZE), 0, gridH - ROUTE_H)
+  const mapBuf = await sharp(gridBuf)
+    .extract({ height: ROUTE_H, left: extractLeft, top: extractTop, width: ROUTE_W })
+    .png()
+    .toBuffer()
+
+  const x = (lon: number) => lonToWorldX(lon, worldSize) - vpLeft
+  const y = (lat: number) => latToWorldY(lat, worldSize) - vpTop
+  return sharp(mapBuf)
+    .composite([
+      { input: Buffer.from(routeOverlaySvg(pts, x, y, true)), left: 0, top: 0 },
+      { blend: 'dest-in', input: Buffer.from(roundedMaskSvg()) },
+    ])
+    .png()
+    .toBuffer()
+}
+
+/**
+ * Render the route as a bare polyline on a dark background (no basemap). Used as
+ * the fallback. Longitudes are compressed by `cos(lat)` so the shape keeps its
+ * true aspect, fit to the box, with start (green) / end (red) markers. North up.
+ */
+const renderBareRoute = async (pts: [number, number][], bbox: Bbox): Promise<Buffer> => {
+  const midLatRad = (((bbox.minLat + bbox.maxLat) / 2) * Math.PI) / 180
   // Aspect-correct spans in a common unit; guard against a zero span (a point).
-  const lonSpan = Math.max((maxLon - minLon) * Math.cos(midLatRad), 1e-9)
-  const latSpan = Math.max(maxLat - minLat, 1e-9)
+  const lonSpan = Math.max((bbox.maxLon - bbox.minLon) * Math.cos(midLatRad), 1e-9)
+  const latSpan = Math.max(bbox.maxLat - bbox.minLat, 1e-9)
   const boxW = ROUTE_W - 2 * PAD
   const boxH = ROUTE_H - 2 * PAD
   const unit = Math.min(boxW / lonSpan, boxH / latSpan)
   const offX = PAD + (boxW - lonSpan * unit) / 2
   const offY = PAD + (boxH - latSpan * unit) / 2
 
-  const x = (lon: number) => offX + (lon - minLon) * Math.cos(midLatRad) * unit
-  const y = (lat: number) => offY + (maxLat - lat) * unit // invert so north is up
-  const polyline = pts.map(([lon, lat]) => `${x(lon).toFixed(1)},${y(lat).toFixed(1)}`).join(' ')
-  const first = pts[0]
-  const last = pts[pts.length - 1]
+  const x = (lon: number) => offX + (lon - bbox.minLon) * Math.cos(midLatRad) * unit
+  const y = (lat: number) => offY + (bbox.maxLat - lat) * unit // invert so north is up
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${ROUTE_W}" height="${ROUTE_H}" viewBox="0 0 ${ROUTE_W} ${ROUTE_H}">
-  <rect width="${ROUTE_W}" height="${ROUTE_H}" fill="#0b0f19" rx="16"/>
-  ${pts.length >= 2 ? `<polyline points="${polyline}" fill="none" stroke="#673ab8" stroke-width="5" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
-  ${first ? `<circle cx="${x(first[0]).toFixed(1)}" cy="${y(first[1]).toFixed(1)}" r="9" fill="#22c55e"/>` : ''}
-  ${last ? `<circle cx="${x(last[0]).toFixed(1)}" cy="${y(last[1]).toFixed(1)}" r="9" fill="#ef4444"/>` : ''}
+  <rect width="${ROUTE_W}" height="${ROUTE_H}" fill="${ROUTE_BG}" rx="16"/>
+  ${routeOverlaySvg(pts, x, y, false)
+    .replace(/^<svg[^>]*>/, '')
+    .replace(/<\/svg>$/, '')}
 </svg>`
   return svgToPng(svg)
+}
+
+/**
+ * A GPS route map. `coords` is GeoJSON `[lon, lat]` pairs (as `getLocations`
+ * returns). When `opts.fetchTile` is supplied (the production wiring passes the
+ * OSM fetcher), the track is drawn over a street basemap; otherwise, or if the
+ * basemap can't be built, it falls back to a bare polyline shape.
+ */
+export const renderRoutePng = async (
+  coords: [number, number][],
+  opts: { fetchTile?: TileFetcher } = {},
+): Promise<Buffer> => {
+  const pts = coords.filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat))
+  if (pts.length === 0) {
+    return svgToPng(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${ROUTE_W}" height="${ROUTE_H}"><rect width="${ROUTE_W}" height="${ROUTE_H}" fill="${ROUTE_BG}" rx="16"/></svg>`,
+    )
+  }
+  const bbox = boundingBox(pts)
+
+  if (opts.fetchTile) {
+    try {
+      const map = await renderRouteWithBasemap(pts, bbox, opts.fetchTile)
+      if (map) return map
+    } catch {
+      // Any compositing/fetch failure falls back to the bare shape below.
+    }
+  }
+  return renderBareRoute(pts, bbox)
 }

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -25,6 +25,29 @@ const PAD = 40
 const ROUTE_BG = '#0b0f19'
 /** Guard against a pathological tile grid (chooseZoom keeps the route ≤ ~3 tiles wide). */
 const MAX_TILES = 25
+/** Max concurrent tile fetches — OSM's tile policy asks for ≤ ~2 connections. */
+const TILE_FETCH_CONCURRENCY = 2
+
+/**
+ * Map over `items` running at most `limit` async calls at once, preserving order.
+ * A tiny fixed-pool scheduler — no big `Promise.all` burst.
+ */
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results = Array.from<R>({ length: items.length })
+  let next = 0
+  const worker = async (): Promise<void> => {
+    while (next < items.length) {
+      const i = next++
+      results[i] = await fn(items[i])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
+  return results
+}
 
 const svgToPng = (svg: string): Promise<Buffer> => sharp(Buffer.from(svg)).png().toBuffer()
 
@@ -159,13 +182,18 @@ const renderRouteWithBasemap = async (
   const rows = tileMaxY - tileMinY + 1
   if (cols * rows > MAX_TILES) return null
 
-  const jobs: Promise<{ tx: number; ty: number; buf: Buffer | null }>[] = []
+  const coords: { tx: number; ty: number }[] = []
   for (let tx = tileMinX; tx <= tileMaxX; tx++) {
-    for (let ty = tileMinY; ty <= tileMaxY; ty++) {
-      jobs.push(fetchTile(zoom, tx, ty).then((buf) => ({ buf, tx, ty })))
-    }
+    for (let ty = tileMinY; ty <= tileMaxY; ty++) coords.push({ tx, ty })
   }
-  const tiles = await Promise.all(jobs)
+  // Fetch through a small pool (not one big burst): OSM's tile policy asks for at
+  // most ~2 concurrent download connections. Renders are cached per post, so the
+  // extra latency is paid at most once per route.
+  const tiles = await mapWithConcurrency(coords, TILE_FETCH_CONCURRENCY, async ({ tx, ty }) => ({
+    buf: await fetchTile(zoom, tx, ty),
+    tx,
+    ty,
+  }))
   const loaded = tiles.filter((t): t is { tx: number; ty: number; buf: Buffer } => t.buf != null)
   if (loaded.length === 0) return null
 

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -282,8 +282,11 @@ export const renderRoutePng = async (
     try {
       const map = await renderRouteWithBasemap(pts, bbox, opts.fetchTile)
       if (map) return map
-    } catch {
-      // Any compositing/fetch failure falls back to the bare shape below.
+    } catch (error) {
+      // Fall back to the bare shape below. Log it: a bare shape is also the
+      // *offline* fallback, so a genuine basemap regression would otherwise
+      // silently degrade every route map with no signal.
+      console.warn('⚠️ route basemap render failed, using bare shape:', error)
     }
   }
   return renderBareRoute(pts, bbox)

--- a/apps/backend/src/services/activitypub/osm-tiles.test.ts
+++ b/apps/backend/src/services/activitypub/osm-tiles.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest'
+
+import { chooseZoom, fetchOsmTile, latToWorldY, lonToWorldX, TILE_SIZE } from './osm-tiles.ts'
+
+describe('Web Mercator projection', () => {
+  const worldSize = TILE_SIZE * 2 ** 4 // arbitrary zoom
+
+  test('longitude maps -180→0, 0→center, 180→worldSize', () => {
+    expect(lonToWorldX(-180, worldSize)).toBeCloseTo(0)
+    expect(lonToWorldX(0, worldSize)).toBeCloseTo(worldSize / 2)
+    expect(lonToWorldX(180, worldSize)).toBeCloseTo(worldSize)
+  })
+
+  test('latitude 0 maps to the vertical centre; north is a smaller Y than south', () => {
+    expect(latToWorldY(0, worldSize)).toBeCloseTo(worldSize / 2)
+    expect(latToWorldY(60, worldSize)).toBeLessThan(latToWorldY(0, worldSize))
+    expect(latToWorldY(-60, worldSize)).toBeGreaterThan(latToWorldY(0, worldSize))
+  })
+})
+
+describe('chooseZoom', () => {
+  test('a tiny bounding box zooms all the way in (maxZoom)', () => {
+    const z = chooseZoom({ maxLat: 57.7001, maxLon: 11.9701, minLat: 57.7, minLon: 11.97 }, 620, 620)
+    expect(z).toBe(18)
+  })
+
+  test('a world-spanning box falls to the minimum zoom', () => {
+    const z = chooseZoom({ maxLat: 80, maxLon: 179, minLat: -80, minLon: -179 }, 620, 620, 1, 18)
+    expect(z).toBe(1)
+  })
+
+  test('picks a mid zoom that fits a city-scale route within the frame', () => {
+    // ~0.05° span (a few km) should land somewhere in the teens, and must fit.
+    const bbox = { maxLat: 57.73, maxLon: 12.0, minLat: 57.7, minLon: 11.95 }
+    const z = chooseZoom(bbox, 620, 620)
+    const worldSize = TILE_SIZE * 2 ** z
+    const w = lonToWorldX(bbox.maxLon, worldSize) - lonToWorldX(bbox.minLon, worldSize)
+    const h = latToWorldY(bbox.minLat, worldSize) - latToWorldY(bbox.maxLat, worldSize)
+    expect(w).toBeLessThanOrEqual(620)
+    expect(h).toBeLessThanOrEqual(620)
+    // One zoom deeper, at least one dimension overflows — i.e. this is the
+    // tightest fit (here Mercator stretches latitude at ~57.7°, so height binds).
+    const deeper = TILE_SIZE * 2 ** (z + 1)
+    const wDeeper = lonToWorldX(bbox.maxLon, deeper) - lonToWorldX(bbox.minLon, deeper)
+    const hDeeper = latToWorldY(bbox.minLat, deeper) - latToWorldY(bbox.maxLat, deeper)
+    expect(wDeeper > 620 || hDeeper > 620).toBe(true)
+  })
+})
+
+describe('fetchOsmTile', () => {
+  test('returns null for out-of-range tile indices without touching the network', async () => {
+    // At zoom 2 there are 4×4 tiles (0..3); 5 and -1 are out of range.
+    expect(await fetchOsmTile(2, 5, 0)).toBeNull()
+    expect(await fetchOsmTile(2, 0, -1)).toBeNull()
+  })
+})

--- a/apps/backend/src/services/activitypub/osm-tiles.ts
+++ b/apps/backend/src/services/activitypub/osm-tiles.ts
@@ -1,0 +1,78 @@
+/**
+ * OpenStreetMap slippy-map tile helpers for the route basemap.
+ *
+ * Web Mercator (EPSG:3857) projection math + a tile fetcher for
+ * `tile.openstreetmap.org`. The route renderer projects the track into the same
+ * world-pixel space as the tiles so they align, fetches the covering tiles, and
+ * composites them behind the track.
+ *
+ * OSM's tile usage policy is respected: a descriptive `User-Agent`, low volume
+ * (route renders are cached per post, so tiles are fetched at most once per
+ * route until eviction), and the required "© OpenStreetMap contributors"
+ * attribution is baked into the rendered image (see `feed-images.ts`). Fetches
+ * are best-effort with a short timeout — a failure falls back to the bare shape.
+ */
+
+/** Standard slippy-map tile edge, in pixels. World size at zoom z is `TILE_SIZE * 2**z`. */
+export const TILE_SIZE = 256
+
+/** `User-Agent` identifying this app + a contact URL, per the OSM tile policy. */
+const TILE_USER_AGENT = 'Aurboda/1.0 (+https://aurboda.net; feed route maps)'
+
+/** Per-tile fetch timeout — a slow tile must not stall the (cached) image response. */
+const TILE_TIMEOUT_MS = 5000
+
+/** World pixel X for a longitude at the given world size (`TILE_SIZE * 2**zoom`). */
+export const lonToWorldX = (lon: number, worldSize: number): number => ((lon + 180) / 360) * worldSize
+
+/** World pixel Y for a latitude (Web Mercator) at the given world size. */
+export const latToWorldY = (lat: number, worldSize: number): number => {
+  const latRad = (lat * Math.PI) / 180
+  const merc = Math.log(Math.tan(latRad) + 1 / Math.cos(latRad))
+  return (0.5 - merc / (2 * Math.PI)) * worldSize
+}
+
+/**
+ * The largest zoom in `[minZoom, maxZoom]` at which the lat/lon bounding box fits
+ * inside `fitW × fitH` pixels — so the route fills the frame without spilling
+ * out. A degenerate (zero-span) box returns `maxZoom`.
+ */
+export const chooseZoom = (
+  bbox: { minLon: number; minLat: number; maxLon: number; maxLat: number },
+  fitW: number,
+  fitH: number,
+  minZoom = 1,
+  maxZoom = 18,
+): number => {
+  for (let z = maxZoom; z >= minZoom; z--) {
+    const worldSize = TILE_SIZE * 2 ** z
+    const w = lonToWorldX(bbox.maxLon, worldSize) - lonToWorldX(bbox.minLon, worldSize)
+    // minLat is the southern edge → larger world-Y, so height = y(minLat) - y(maxLat).
+    const h = latToWorldY(bbox.minLat, worldSize) - latToWorldY(bbox.maxLat, worldSize)
+    if (w <= fitW && h <= fitH) return z
+  }
+  return minZoom
+}
+
+/** A fetched tile PNG, or `null` if the tile is out of range or the fetch failed. */
+export type TileFetcher = (z: number, x: number, y: number) => Promise<Buffer | null>
+
+/**
+ * Fetch a single OSM tile PNG, or `null` on any failure (out-of-range indices,
+ * non-200, network error, or timeout). Never throws — the renderer treats a null
+ * tile as a gap to leave as background.
+ */
+export const fetchOsmTile: TileFetcher = async (z, x, y) => {
+  const n = 2 ** z
+  if (x < 0 || y < 0 || x >= n || y >= n) return null
+  try {
+    const res = await fetch(`https://tile.openstreetmap.org/${z}/${x}/${y}.png`, {
+      headers: { 'User-Agent': TILE_USER_AGENT },
+      signal: AbortSignal.timeout(TILE_TIMEOUT_MS),
+    })
+    if (!res.ok) return null
+    return Buffer.from(await res.arrayBuffer())
+  } catch {
+    return null
+  }
+}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -151,14 +151,23 @@ is a deliberate capability-URL model (like the shared-dashboard slugs), chosen b
 the fediverse fetches media **without** HTTP signatures — Mastodon's "authorized fetch"
 signs ActivityPub object/actor requests, not media downloads — so a signed-request gate
 wouldn't be exercised and followers would just see a broken image. The tradeoff is that a
-leaked image URL grants access to that one rendered image (a chart or a bare route shape,
+leaked image URL grants access to that one rendered image (a chart or a route map,
 not the underlying high-resolution series, which stays `followers`-excluded entirely).
 Responses are `no-store`, so an unshare / cleared flag / a public→followers flip takes
-effect immediately (the now-untoken'd public URL 404s). The route is drawn as a bare,
-aspect-correct shape — no street basemap (a later enhancement) and **no privacy trimming**
-(area masking is a planned follow-up), so a route map reveals the approximate area. The
-share dialog only offers the chart toggle when the activity has heart-rate data and the
-map toggle when it has an actual GPS track.
+effect immediately (the now-untoken'd public URL 404s). The route is drawn over an
+**OpenStreetMap street basemap** (see below); **no privacy trimming** is applied (area
+masking is a planned follow-up), so a route map reveals the precise area. The share dialog
+only offers the chart toggle when the activity has heart-rate data and the map toggle when
+it has an actual GPS track.
+
+**Route basemap.** The route map projects the GPS track into Web Mercator, fetches the
+covering OpenStreetMap tiles, and composites them behind the track (with a white halo for
+legibility) plus start/end markers. The required "© OpenStreetMap contributors"
+attribution is baked into the image. OSM's tile usage policy is respected: a descriptive
+`User-Agent`, and low volume — route renders are cached per post, so tiles are fetched at
+most once per route until eviction. Tile fetching is best-effort with a short timeout; if
+the tiles can't be fetched (e.g. offline) it falls back to a bare polyline on a dark
+background.
 
 ## Public series endpoint (the privacy boundary)
 
@@ -263,9 +272,10 @@ These are known and intentional for the current implementation:
   Mastodon `Note` carries no series links, this is latent — expanding series
   authorization across a merge group (which needs the merge algorithm at query time) is a
   planned follow-up.
-- **Route maps have no basemap and no privacy trimming.** The route is a bare shape
-  (no street tiles) and shows the full track, so a public route map reveals the
-  approximate area; a street basemap and start/area masking are planned follow-ups.
+- **Route maps have no privacy trimming.** The route is drawn over an OpenStreetMap
+  basemap and shows the full track, so a public route map reveals the precise area
+  (including start/end points, i.e. likely home/work); start-point and area masking are
+  planned follow-ups. Only share a route publicly when that exposure is acceptable.
 
 ## Related
 


### PR DESCRIPTION
## Summary

The shared GPS **route image** was a bare purple polyline on a dark background. It now renders over an **OpenStreetMap street basemap**, so the route reads in context.

Requested by @fiddur ("The shared GPS route image should have the openstreetmap background if allowed"). Confirmed decisions: **OSM public tiles, on by default**, applied to **all route images** (public + followers).

| Before | After |
| --- | --- |
| Bare polyline on dark navy | Track over OSM street tiles, haloed, with attribution |

## What changed

- **New `osm-tiles.ts`** — Web Mercator (EPSG:3857) projection helpers (`lonToWorldX`, `latToWorldY`, `chooseZoom`) + a best-effort tile fetcher for `tile.openstreetmap.org`.
- **`renderRoutePng` rewrite** — reprojects the track to Web Mercator (matching the tiles), picks the zoom that fits the whole route, fetches the covering tiles, composites them behind a **white-haloed** track + start/end markers, rounds the corners, and bakes in the required **"© OpenStreetMap contributors"** attribution.
- **Injected tile fetching** (`opts.fetchTile`) so it's opt-in and testable; the production wiring passes the real OSM fetcher. If tiles can't be fetched (offline, timeout, all-fail) it **falls back to the original bare shape**.

## OSM tile-policy compliance

- Descriptive `User-Agent` (`Aurboda/1.0 (+https://aurboda.net; feed route maps)`).
- **Low volume** — route renders are cached per post (#892), so a route's tiles are fetched at most once until cache eviction.
- Required **attribution baked into the image**.
- 5 s per-tile timeout + out-of-range guard; a defensive `MAX_TILES` cap.

## ⚠️ Privacy note

A real basemap makes a route's **precise location obvious** (including start/end = likely home/work), and per your choice this applies to **public/unlisted** images fetched by the whole fediverse — a genuine increase in location exposure vs. the old bare shape. The docs caveat is sharpened accordingly; start-point / area masking remains a planned follow-up. Flagging so it's a conscious call.

## Testing

- `pnpm check` — green across all packages (0 errors).
- New `osm-tiles.test.ts` (projection math, zoom-fit selection, out-of-range tiles return null without network) + extended `feed-images.test.ts` (basemap compositing — asserts a tile pixel shows through; bare-shape fallback when tiles fail; empty-route guard). Tests use injected fake tiles — **no network in CI**.

> Branch is off the latest develop (includes #884 slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)