### PR TITLE
feat(feed): home timeline — ingest & view posts from followed actors (#884)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -35,6 +35,7 @@
     "pg": "^8.13.1",
     "pg-boss": "^12.5.4",
     "pg-format": "^1.0.4",
+    "sanitize-html": "^2.17.5",
     "satori": "0.26.0",
     "sharp": "^0.34.5",
     "zod": "^4.3.5"
@@ -49,6 +50,7 @@
     "@types/node": "^22.18.3",
     "@types/pg": "^8.11.10",
     "@types/pg-format": "^1.0.5",
+    "@types/sanitize-html": "^2.16.1",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4",
     "supertest": "^7.2.2",

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -300,6 +300,17 @@ export {
   upsertFeedFollowing,
 } from './feed-following.ts'
 
+// Home timeline (posts received from followed actors)
+export {
+  deleteTimelineEntriesByActor,
+  deleteTimelineEntryByUri,
+  listTimelineEntries,
+  type TimelineCursor,
+  type TimelineEntryInput,
+  type TimelineEntryRecord,
+  upsertTimelineEntry,
+} from './timeline.ts'
+
 // Feed posts
 export {
   countPublicFeedPosts,

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+/**
+ * Integration tests for the home-timeline store (posts received from followed
+ * actors), including keyset pagination by (published_at DESC, id DESC).
+ */
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import {
+  deleteTimelineEntriesByActor,
+  deleteTimelineEntryByUri,
+  listTimelineEntries,
+  type TimelineEntryInput,
+  upsertTimelineEntry,
+} from './timeline.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+const entry = (n: number, overrides: Partial<TimelineEntryInput> = {}): TimelineEntryInput => ({
+  actor_uri: 'https://mastodon.example/users/alice',
+  avatar_url: 'https://mastodon.example/avatars/alice.png',
+  content: `<p>post ${n}</p>`,
+  display_name: 'Alice',
+  handle: '@alice@mastodon.example',
+  object_uri: `https://mastodon.example/notes/${n}`,
+  published_at: new Date(`2026-07-01T10:0${n}:00Z`),
+  url: `https://mastodon.example/@alice/${n}`,
+  ...overrides,
+})
+
+describe('Timeline store integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('stores a received post with its sanitised content + author snapshot', async () => {
+    const user = getTestUser()
+    const rec = await upsertTimelineEntry(user, entry(1))
+    expect(rec.id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(rec.object_uri).toBe('https://mastodon.example/notes/1')
+    expect(rec.actor_uri).toBe('https://mastodon.example/users/alice')
+    expect(rec.handle).toBe('@alice@mastodon.example')
+    expect(rec.content).toBe('<p>post 1</p>')
+    expect(rec.published_at.toISOString()).toBe('2026-07-01T10:01:00.000Z')
+  })
+
+  test('re-delivering the same object upserts in place (an edit replaces content)', async () => {
+    const user = getTestUser()
+    await upsertTimelineEntry(user, entry(1))
+    const edited = await upsertTimelineEntry(user, entry(1, { content: '<p>edited</p>' }))
+    expect(edited.content).toBe('<p>edited</p>')
+    expect(await listTimelineEntries(user, 10)).toHaveLength(1)
+  })
+
+  test('lists newest-first and keyset-paginates by (published_at, id)', async () => {
+    const user = getTestUser()
+    for (const n of [1, 2, 3, 4, 5]) await upsertTimelineEntry(user, entry(n))
+
+    const page1 = await listTimelineEntries(user, 2)
+    expect(page1.map((e) => e.object_uri)).toEqual([
+      'https://mastodon.example/notes/5',
+      'https://mastodon.example/notes/4',
+    ])
+
+    const last = page1[page1.length - 1]
+    const page2 = await listTimelineEntries(user, 2, { id: last.id, published_at: last.published_at })
+    expect(page2.map((e) => e.object_uri)).toEqual([
+      'https://mastodon.example/notes/3',
+      'https://mastodon.example/notes/2',
+    ])
+
+    const last2 = page2[page2.length - 1]
+    const page3 = await listTimelineEntries(user, 2, { id: last2.id, published_at: last2.published_at })
+    expect(page3.map((e) => e.object_uri)).toEqual(['https://mastodon.example/notes/1'])
+  })
+
+  test('deletes a single entry by object uri (inbound Delete)', async () => {
+    const user = getTestUser()
+    await upsertTimelineEntry(user, entry(1))
+    await upsertTimelineEntry(user, entry(2))
+    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1')).toBe(true)
+    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1')).toBe(false)
+    expect((await listTimelineEntries(user, 10)).map((e) => e.object_uri)).toEqual([
+      'https://mastodon.example/notes/2',
+    ])
+  })
+
+  test('purges every entry from an actor (on unfollow)', async () => {
+    const user = getTestUser()
+    await upsertTimelineEntry(user, entry(1))
+    await upsertTimelineEntry(user, entry(2))
+    await upsertTimelineEntry(user, entry(3, { actor_uri: 'https://remote.example/users/bob' }))
+
+    expect(await deleteTimelineEntriesByActor(user, 'https://mastodon.example/users/alice')).toBe(2)
+    expect((await listTimelineEntries(user, 10)).map((e) => e.actor_uri)).toEqual([
+      'https://remote.example/users/bob',
+    ])
+  })
+})

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -81,14 +81,26 @@ describe('Timeline store integration', () => {
     expect(page3.map((e) => e.object_uri)).toEqual(['https://mastodon.example/notes/1'])
   })
 
-  test('deletes a single entry by object uri (inbound Delete)', async () => {
+  test('deletes a single entry by object uri + authoring actor (inbound Delete)', async () => {
     const user = getTestUser()
     await upsertTimelineEntry(user, entry(1))
     await upsertTimelineEntry(user, entry(2))
-    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1')).toBe(true)
-    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1')).toBe(false)
+    const alice = 'https://mastodon.example/users/alice'
+    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1', alice)).toBe(true)
+    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1', alice)).toBe(false)
     expect((await listTimelineEntries(user, 10)).map((e) => e.object_uri)).toEqual([
       'https://mastodon.example/notes/2',
+    ])
+  })
+
+  test('does not delete an entry when the Delete is from a different actor (spoofed Delete)', async () => {
+    const user = getTestUser()
+    await upsertTimelineEntry(user, entry(1))
+    // A signed Delete from some other actor must not evict alice's post.
+    const attacker = 'https://evil.example/users/mallory'
+    expect(await deleteTimelineEntryByUri(user, 'https://mastodon.example/notes/1', attacker)).toBe(false)
+    expect((await listTimelineEntries(user, 10)).map((e) => e.object_uri)).toEqual([
+      'https://mastodon.example/notes/1',
     ])
   })
 

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -1,0 +1,118 @@
+/**
+ * The user's home timeline: posts received from the actors they follow (inbound
+ * ActivityPub `Create`, replaced on `Update`, removed on `Delete`).
+ *
+ * Stored per-user, keyed by a local `id`, with the remote Note's id as a UNIQUE
+ * `object_uri` so a re-delivery or edit upserts rather than duplicating. `content`
+ * is the remote HTML **after** server-side sanitisation (the ingest path is
+ * responsible for cleaning untrusted fediverse HTML before it reaches here).
+ * Ordering + pagination is keyset by `(published_at DESC, id DESC)`.
+ */
+import { query } from './connection.ts'
+
+export interface TimelineEntryRecord {
+  id: string
+  object_uri: string
+  actor_uri: string
+  handle: string | null
+  display_name: string | null
+  avatar_url: string | null
+  content: string
+  url: string | null
+  published_at: Date
+  received_at: Date
+}
+
+export interface TimelineEntryInput {
+  object_uri: string
+  actor_uri: string
+  handle?: string | null
+  display_name?: string | null
+  avatar_url?: string | null
+  /** Already-sanitised HTML. */
+  content: string
+  url?: string | null
+  published_at: Date
+}
+
+/** Opaque keyset cursor: the last row's `(published_at, id)`. */
+export interface TimelineCursor {
+  published_at: Date
+  id: string
+}
+
+const TIMELINE_COLUMNS =
+  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at'
+
+/**
+ * Insert or update a received post by `object_uri`. A re-delivered or edited post
+ * (same object id) refreshes the content/presentation in place; `received_at`
+ * stays at first receipt while `published_at` tracks the remote timestamp.
+ */
+export const upsertTimelineEntry = async (
+  user: string,
+  input: TimelineEntryInput,
+): Promise<TimelineEntryRecord> => {
+  const result = await query<TimelineEntryRecord>(
+    user,
+    `INSERT INTO timeline_entry
+       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT (object_uri)
+     DO UPDATE SET actor_uri = EXCLUDED.actor_uri,
+                   handle = EXCLUDED.handle,
+                   display_name = EXCLUDED.display_name,
+                   avatar_url = EXCLUDED.avatar_url,
+                   content = EXCLUDED.content,
+                   url = EXCLUDED.url,
+                   published_at = EXCLUDED.published_at
+     RETURNING ${TIMELINE_COLUMNS}`,
+    [
+      input.object_uri,
+      input.actor_uri,
+      input.handle ?? null,
+      input.display_name ?? null,
+      input.avatar_url ?? null,
+      input.content,
+      input.url ?? null,
+      input.published_at,
+    ],
+  )
+  return result.rows[0]
+}
+
+/**
+ * A page of the home timeline, newest first. Keyset-paginated: pass the previous
+ * page's last `(published_at, id)` as `before` to get the next page. Returns up
+ * to `limit` rows.
+ */
+export const listTimelineEntries = async (
+  user: string,
+  limit: number,
+  before?: TimelineCursor,
+): Promise<TimelineEntryRecord[]> => {
+  const result = await query<TimelineEntryRecord>(
+    user,
+    `SELECT ${TIMELINE_COLUMNS} FROM timeline_entry
+     WHERE ($1::timestamptz IS NULL OR (published_at, id) < ($1::timestamptz, $2::uuid))
+     ORDER BY published_at DESC, id DESC
+     LIMIT $3`,
+    [before?.published_at ?? null, before?.id ?? null, limit],
+  )
+  return result.rows
+}
+
+/** Remove a received post by its remote object id (on an inbound `Delete`). */
+export const deleteTimelineEntryByUri = async (user: string, objectUri: string): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM timeline_entry WHERE object_uri = $1`, [objectUri])
+  return (result.rowCount ?? 0) > 0
+}
+
+/**
+ * Remove every received post authored by an actor (on `Undo{Follow}`/unfollow, so
+ * an unfollowed actor's posts leave the timeline).
+ */
+export const deleteTimelineEntriesByActor = async (user: string, actorUri: string): Promise<number> => {
+  const result = await query(user, `DELETE FROM timeline_entry WHERE actor_uri = $1`, [actorUri])
+  return result.rowCount ?? 0
+}

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -102,9 +102,21 @@ export const listTimelineEntries = async (
   return result.rows
 }
 
-/** Remove a received post by its remote object id (on an inbound `Delete`). */
-export const deleteTimelineEntryByUri = async (user: string, objectUri: string): Promise<boolean> => {
-  const result = await query(user, `DELETE FROM timeline_entry WHERE object_uri = $1`, [objectUri])
+/**
+ * Remove a received post by its remote object id (on an inbound `Delete`), scoped
+ * to the actor that authored it. The `actor_uri` guard is an authorization check:
+ * an inbound `Delete` is only signed by *some* actor, so without it any actor
+ * could evict another author's post from the timeline by its (guessable) id.
+ */
+export const deleteTimelineEntryByUri = async (
+  user: string,
+  objectUri: string,
+  actorUri: string,
+): Promise<boolean> => {
+  const result = await query(user, `DELETE FROM timeline_entry WHERE object_uri = $1 AND actor_uri = $2`, [
+    objectUri,
+    actorUri,
+  ])
   return (result.rowCount ?? 0) > 0
 }
 

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -3,7 +3,12 @@
  * resulting posts, and follow/unfollow other actors. Mirrors the REST `/feed`
  * and `/feed/following` capabilities.
  */
-import { followActorBodySchema, shareActivityBodySchema, updateFeedPostBodySchema } from '@aurboda/api-spec'
+import {
+  followActorBodySchema,
+  shareActivityBodySchema,
+  timelineQuerySchema,
+  updateFeedPostBodySchema,
+} from '@aurboda/api-spec'
 import { z } from 'zod'
 
 import type { FeedDeliver } from '../routes/feed-router.ts'
@@ -20,6 +25,7 @@ import {
 } from '../db/index.ts'
 import { serializeFeedPost } from '../services/feed.ts'
 import { serializeFollowing } from '../services/following.ts'
+import { getTimelinePage } from '../services/timeline.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
 
 export const registerFeedTools = (
@@ -100,6 +106,13 @@ export const registerFeedTools = (
       const records = await listFeedFollowing(user)
       return jsonResponse(records.map(serializeFollowing))
     },
+  )
+
+  server.tool(
+    'list_timeline',
+    'List your home timeline: posts received from the actors you follow, newest first. Pass `cursor` (from a previous call) to page.',
+    { ...timelineQuerySchema.shape },
+    async ({ cursor, limit }) => jsonResponse(await getTimelinePage(user, limit, cursor)),
   )
 
   server.tool(

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -1,5 +1,3 @@
-import type { RequestHandler } from 'express'
-
 /**
  * Feed route group (owner-facing).
  *
@@ -15,6 +13,9 @@ import {
   type FeedPostsResponse,
   type ShareActivityBody,
   shareActivityBodySchema,
+  type TimelineQuery,
+  timelineQuerySchema,
+  type TimelineResponse,
   type UpdateFeedPostBody,
   updateFeedPostBodySchema,
 } from '@aurboda/api-spec'
@@ -30,8 +31,9 @@ import {
   updateFeedPost,
 } from '../db/index.ts'
 import { serializeFeedPost } from '../services/feed.ts'
-import { type TypedRouter, typedRouter } from '../typed-router.ts'
-import { validateBody } from '../validation.ts'
+import { getTimelinePage } from '../services/timeline.ts'
+import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
+import { validateBody, validateQuery } from '../validation.ts'
 
 /**
  * Fire-and-forget federation delivery hooks for the feed-post lifecycle,
@@ -52,7 +54,7 @@ export interface FeedDeliver {
   deleted: (user: string, post: FeedPostRecord) => void
 }
 
-export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedDeliver): TypedRouter => {
+export const createFeedRouter = (authMiddleware: AnyMiddleware, deliver?: FeedDeliver): TypedRouter => {
   const router = typedRouter()
 
   router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
@@ -61,6 +63,17 @@ export const createFeedRouter = (authMiddleware: RequestHandler, deliver?: FeedD
     const posts = await Promise.all(records.map((record) => serializeFeedPost(user, record)))
     res.json({ posts, success: true })
   })
+
+  router.get<Record<string, never>, TimelineResponse, unknown, TimelineQuery>(
+    '/timeline',
+    authMiddleware,
+    validateQuery(timelineQuerySchema),
+    async (req, res) => {
+      const user = req.user!
+      const { entries, next_cursor } = await getTimelinePage(user, req.query.limit, req.query.cursor)
+      res.json({ entries, next_cursor, success: true })
+    },
+  )
 
   router.post<{ id: string }, FeedPostResponse, ShareActivityBody>(
     '/activities/:id/share',

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -147,6 +147,8 @@ export const tableCreationOrder = [
   'feed_actor',
   'feed_follower',
   'feed_following',
+  'timeline_entry',
+  'timeline_entry_indexes',
   'profile_avatar',
   'mcp_sessions',
   'mcp_sessions_indexes',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -194,6 +194,31 @@ export const socialTables: Record<string, string> = {
     )
   `,
 
+  // The user's home timeline: posts received from actors they follow (inbound
+  // `Create`/`Update`/`Delete` on the feed). Keyed by a local `id`; `object_uri`
+  // (the remote Note's id) is UNIQUE so a re-delivery / edit upserts. `content`
+  // is the remote HTML AFTER server-side sanitisation (untrusted fediverse HTML);
+  // `published_at` is the remote post's own timestamp and drives timeline order.
+  timeline_entry: `
+    CREATE TABLE IF NOT EXISTS timeline_entry (
+      id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      object_uri    TEXT NOT NULL UNIQUE,
+      actor_uri     TEXT NOT NULL,
+      handle        TEXT,
+      display_name  TEXT,
+      avatar_url    TEXT,
+      content       TEXT NOT NULL DEFAULT '',
+      url           TEXT,
+      published_at  TIMESTAMPTZ NOT NULL,
+      received_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `,
+  // Timeline ordering / keyset pagination is by (published_at DESC, id DESC).
+  timeline_entry_indexes: `
+    CREATE INDEX IF NOT EXISTS idx_timeline_entry_published
+      ON timeline_entry (published_at DESC, id DESC)
+  `,
+
   // The user's public profile avatar. One per user (the profile owner), so a
   // `singleton` PK + CHECK pins it to a single row. Surfaced on the public
   // profile, shared-page OG cards, and the ActivityPub actor `icon`.

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -97,6 +97,11 @@ const localFollowerIdentifier = async (
  * non-Notes are ignored, and a missing DB never 500s (which would invite retries).
  */
 const ingestFeedActivity = async (ctx: InboxContext<void>, activity: Create | Update): Promise<void> => {
+  // The recipient (whose timeline this is) comes from the personal inbox owner.
+  // Unlike Accept/Reject there's no inner Follow to derive it from, so this relies
+  // on personal-inbox delivery; `ctx.recipient` is null on a shared inbox. That's
+  // fine today (the actor advertises no `sharedInbox`), but shared-inbox support
+  // would need fanning a single delivery out to every local follower of the actor.
   const me = ctx.recipient
   if (me == null || !isValidUsername(me) || activity.actorId == null) return
   try {
@@ -248,11 +253,14 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
     .on(Update, (ctx, update) => ingestFeedActivity(ctx, update))
     .on(Delete, async (ctx, del) => {
       // Delete of a post we received → drop it from the timeline. `del.objectId`
-      // is the removed object's id (a Tombstone or bare id); we key on it.
+      // is the removed object's id (a Tombstone or bare id); we key on it, but
+      // scope the delete to the sender (`del.actorId`) so a signed `Delete` from
+      // some other actor can't evict a post it didn't author — mirroring how
+      // `Undo{Follow}` is scoped to its own actor.
       const me = ctx.recipient
-      if (me == null || !isValidUsername(me) || del.objectId == null) return
+      if (me == null || !isValidUsername(me) || del.objectId == null || del.actorId == null) return
       try {
-        await deleteTimelineEntryByUri(me, del.objectId.href)
+        await deleteTimelineEntryByUri(me, del.objectId.href, del.actorId.href)
       } catch (error) {
         if (isMissingDatabase(error)) return
         throw error

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -1,5 +1,16 @@
 import { createFederation, type Federation, type InboxContext, MemoryKvStore } from '@fedify/fedify'
-import { Accept, type Create, Follow, Image, Note, Person, Reject, Undo } from '@fedify/fedify/vocab'
+import {
+  Accept,
+  Create,
+  Delete,
+  Follow,
+  Image,
+  Note,
+  Person,
+  Reject,
+  Undo,
+  Update,
+} from '@fedify/fedify/vocab'
 
 /**
  * The Fedify `Federation` object for the activity feed.
@@ -13,8 +24,9 @@ import { Accept, type Create, Follow, Image, Note, Person, Reject, Undo } from '
  * - key-pairs dispatcher backed by the per-user `feed_actor` keypair,
  * - inbound inbox: `Follow` → persist follower + `Accept`; `Undo{Follow}` →
  *   drop the follower; `Accept`/`Reject` → resolve a Follow WE sent (mark the
- *   `feed_following` row accepted, or drop it). Fedify verifies the HTTP
- *   Signature first.
+ *   `feed_following` row accepted, or drop it); `Create`/`Update` of a `Note`
+ *   from an *accepted followee* → ingest into the home timeline (sanitised);
+ *   `Delete` → drop the received post. Fedify verifies the HTTP Signature first.
  * - followers + following collections (the latter lists this user's *accepted*
  *   follows), both backed by Postgres.
  *
@@ -26,6 +38,8 @@ import {
   countAcceptedFeedFollowing,
   countFeedFollowers,
   countPublicFeedPosts,
+  deleteTimelineEntryByUri,
+  getFeedFollowingByActor,
   getFeedPostById,
   getOrCreateActorKeyPair,
   isMissingDatabase,
@@ -36,12 +50,14 @@ import {
   removeFeedFollower,
   removeFeedFollowingByActor,
   upsertFeedFollower,
+  upsertTimelineEntry,
 } from '../../db/index.ts'
 import { resolveFeedActivity } from '../feed.ts'
 import { buildProfileUrl } from '../share-urls.ts'
 import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
+import { noteToTimelineInput } from './timeline-ingest.ts'
 
 /** Posts per outbox page (cursor pagination). */
 const OUTBOX_PAGE_SIZE = 20
@@ -70,6 +86,31 @@ const localFollowerIdentifier = async (
   }
   const recipient = ctx.recipient
   return recipient != null && isValidUsername(recipient) ? recipient : null
+}
+
+/**
+ * Ingest a `Create`/`Update` of a `Note` into the recipient's home timeline —
+ * but ONLY if the sender is an *accepted* followee (so the timeline can't be
+ * injected into by a stranger who delivers to our inbox). The author's
+ * presentation comes from the cached `feed_following` row; the Note's HTML is
+ * sanitised in `noteToTimelineInput`. Best-effort: unresolvable objects and
+ * non-Notes are ignored, and a missing DB never 500s (which would invite retries).
+ */
+const ingestFeedActivity = async (ctx: InboxContext<void>, activity: Create | Update): Promise<void> => {
+  const me = ctx.recipient
+  if (me == null || !isValidUsername(me) || activity.actorId == null) return
+  try {
+    const follow = await getFeedFollowingByActor(me, activity.actorId.href)
+    if (follow == null || !follow.accepted) return
+    const object = await activity.getObject({ suppressError: true })
+    if (!(object instanceof Note)) return
+    const input = noteToTimelineInput(object, follow)
+    if (input == null) return
+    await upsertTimelineEntry(me, input)
+  } catch (error) {
+    if (isMissingDatabase(error)) return
+    throw error
+  }
 }
 
 export const createFeedFederation = (origin: string, apiBaseUrl: string): Federation<void> => {
@@ -194,6 +235,24 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
       if (me == null || reject.actorId == null) return
       try {
         await removeFeedFollowingByActor(me, reject.actorId.href)
+      } catch (error) {
+        if (isMissingDatabase(error)) return
+        throw error
+      }
+    })
+    // Create / Update of a Note from an actor we follow → ingest into our home
+    // timeline. Update reuses the same upsert (keyed on the Note's object id), so
+    // an edit replaces the stored copy. Only *accepted* followees are ingested, so
+    // a stranger who somehow delivers here can't inject into the timeline.
+    .on(Create, (ctx, create) => ingestFeedActivity(ctx, create))
+    .on(Update, (ctx, update) => ingestFeedActivity(ctx, update))
+    .on(Delete, async (ctx, del) => {
+      // Delete of a post we received → drop it from the timeline. `del.objectId`
+      // is the removed object's id (a Tombstone or bare id); we key on it.
+      const me = ctx.recipient
+      if (me == null || !isValidUsername(me) || del.objectId == null) return
+      try {
+        await deleteTimelineEntryByUri(me, del.objectId.href)
       } catch (error) {
         if (isMissingDatabase(error)) return
         throw error

--- a/apps/backend/src/services/activitypub/temporal-interop.ts
+++ b/apps/backend/src/services/activitypub/temporal-interop.ts
@@ -20,3 +20,10 @@ import { Temporal as TemporalPolyfill } from '@js-temporal/polyfill'
 
 export const dateToTemporalInstant = (date: Date): Temporal.Instant =>
   TemporalPolyfill.Instant.fromEpochMilliseconds(date.getTime()) as unknown as Temporal.Instant
+
+/**
+ * The reverse: an ambient `Temporal.Instant` (e.g. a received Note's `published`)
+ * to a JS `Date`. `epochMilliseconds` is present on both the polyfill and the
+ * ambient type, so no cast is needed.
+ */
+export const temporalInstantToDate = (instant: Temporal.Instant): Date => new Date(instant.epochMilliseconds)

--- a/apps/backend/src/services/activitypub/timeline-ingest.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.test.ts
@@ -95,4 +95,35 @@ describe('noteToTimelineInput', () => {
     const noPublished = new Note({ content: 'x', id: new URL('https://mastodon.example/notes/3') })
     expect(noteToTimelineInput(noPublished, author)).toBeNull()
   })
+
+  test('rejects a Note whose id is on a different host than the sender (id-collision spoof)', () => {
+    // An accepted followee delivering a Note with an id on ANOTHER actor's host
+    // could otherwise overwrite that actor's entry via the global object_uri key.
+    const spoof = new Note({
+      content: '<p>pwned</p>',
+      id: new URL('https://good.example/notes/1'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    expect(noteToTimelineInput(spoof, author)).toBeNull()
+  })
+
+  test('rejects a Note attributed to a different actor', () => {
+    const spoof = new Note({
+      attribution: new URL('https://mastodon.example/users/mallory'),
+      content: '<p>not mine</p>',
+      id: new URL('https://mastodon.example/notes/9'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    expect(noteToTimelineInput(spoof, author)).toBeNull()
+  })
+
+  test('accepts a Note correctly attributed to the sender', () => {
+    const note = new Note({
+      attribution: new URL(author.actor_uri),
+      content: '<p>mine</p>',
+      id: new URL('https://mastodon.example/notes/10'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    expect(noteToTimelineInput(note, author)?.object_uri).toBe('https://mastodon.example/notes/10')
+  })
 })

--- a/apps/backend/src/services/activitypub/timeline-ingest.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.test.ts
@@ -126,4 +126,24 @@ describe('noteToTimelineInput', () => {
     })
     expect(noteToTimelineInput(note, author)?.object_uri).toBe('https://mastodon.example/notes/10')
   })
+
+  test('clamps a far-future published_at to now (anti-pin), leaving past timestamps intact', () => {
+    const now = new Date('2026-07-02T12:00:00Z').getTime()
+    const future = new Note({
+      content: '<p>pinned</p>',
+      id: new URL('https://mastodon.example/notes/11'),
+      published: published('3000-01-01T00:00:00Z'),
+    })
+    expect(noteToTimelineInput(future, author, now)?.published_at.toISOString()).toBe(
+      '2026-07-02T12:00:00.000Z',
+    )
+    const past = new Note({
+      content: '<p>ok</p>',
+      id: new URL('https://mastodon.example/notes/12'),
+      published: published('2026-07-01T08:00:00Z'),
+    })
+    expect(noteToTimelineInput(past, author, now)?.published_at.toISOString()).toBe(
+      '2026-07-01T08:00:00.000Z',
+    )
+  })
 })

--- a/apps/backend/src/services/activitypub/timeline-ingest.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.test.ts
@@ -1,0 +1,98 @@
+import { Note } from '@fedify/fedify/vocab'
+import { describe, expect, test } from 'vitest'
+
+import type { FeedFollowingRecord } from '../../db/index.ts'
+
+import { dateToTemporalInstant } from './temporal-interop.ts'
+import { noteToTimelineInput, sanitizeRemoteHtml } from './timeline-ingest.ts'
+
+/** Build the ambient `Temporal.Instant` a `Note` expects from an ISO string. */
+const published = (iso: string) => dateToTemporalInstant(new Date(iso))
+
+describe('sanitizeRemoteHtml', () => {
+  test('keeps benign Mastodon-style content', () => {
+    const html = '<p>Nice run! <a href="https://ex.ample/tag">#running</a></p>'
+    const out = sanitizeRemoteHtml(html)
+    expect(out).toContain('<p>')
+    expect(out).toContain('#running')
+    expect(out).toContain('href="https://ex.ample/tag"')
+  })
+
+  test('strips <script> and inline event handlers (XSS)', () => {
+    const out = sanitizeRemoteHtml('<p onclick="steal()">hi</p><script>alert(1)</script>')
+    expect(out).not.toContain('<script')
+    expect(out).not.toContain('onclick')
+    expect(out).not.toContain('alert(1)')
+    expect(out).toContain('hi')
+  })
+
+  test('drops javascript: and data: URLs on links', () => {
+    const out = sanitizeRemoteHtml('<a href="javascript:alert(1)">x</a><a href="data:text/html,x">y</a>')
+    expect(out).not.toContain('javascript:')
+    expect(out).not.toContain('data:text/html')
+  })
+
+  test('removes images, iframes, and style attributes', () => {
+    const out = sanitizeRemoteHtml(
+      '<img src="https://x/y.png"><iframe src="https://evil"></iframe><p style="color:red">z</p>',
+    )
+    expect(out).not.toContain('<img')
+    expect(out).not.toContain('<iframe')
+    expect(out).not.toContain('style=')
+    expect(out).toContain('z')
+  })
+
+  test('forces safe rel/target on surviving links', () => {
+    const out = sanitizeRemoteHtml('<a href="https://ex.ample">link</a>')
+    expect(out).toContain('rel="nofollow noopener noreferrer"')
+    expect(out).toContain('target="_blank"')
+  })
+})
+
+describe('noteToTimelineInput', () => {
+  const author: FeedFollowingRecord = {
+    accepted: true,
+    actor_uri: 'https://mastodon.example/users/alice',
+    avatar_url: 'https://mastodon.example/avatars/alice.png',
+    created_at: new Date('2026-07-01T00:00:00Z'),
+    display_name: 'Alice',
+    handle: '@alice@mastodon.example',
+    id: '11111111-1111-1111-1111-111111111111',
+    inbox_uri: 'https://mastodon.example/users/alice/inbox',
+    shared_inbox_uri: null,
+  }
+
+  test('maps a Note to a timeline input, sanitising content and using the cached author', () => {
+    const note = new Note({
+      content: '<p>Hello <script>evil()</script></p>',
+      id: new URL('https://mastodon.example/notes/1'),
+      published: published('2026-07-02T08:30:00Z'),
+      url: new URL('https://mastodon.example/@alice/1'),
+    })
+    const input = noteToTimelineInput(note, author)
+    expect(input).not.toBeNull()
+    expect(input?.object_uri).toBe('https://mastodon.example/notes/1')
+    expect(input?.actor_uri).toBe(author.actor_uri)
+    expect(input?.handle).toBe('@alice@mastodon.example')
+    expect(input?.content).toContain('Hello')
+    expect(input?.content).not.toContain('<script')
+    expect(input?.published_at.toISOString()).toBe('2026-07-02T08:30:00.000Z')
+    expect(input?.url).toBe('https://mastodon.example/@alice/1')
+  })
+
+  test('falls back to the object id when the Note has no url', () => {
+    const note = new Note({
+      content: '<p>x</p>',
+      id: new URL('https://mastodon.example/notes/2'),
+      published: published('2026-07-02T09:00:00Z'),
+    })
+    expect(noteToTimelineInput(note, author)?.url).toBe('https://mastodon.example/notes/2')
+  })
+
+  test('returns null when the Note lacks an id or published time', () => {
+    const noId = new Note({ content: 'x', published: published('2026-07-02T09:00:00Z') })
+    expect(noteToTimelineInput(noId, author)).toBeNull()
+    const noPublished = new Note({ content: 'x', id: new URL('https://mastodon.example/notes/3') })
+    expect(noteToTimelineInput(noPublished, author)).toBeNull()
+  })
+})

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -1,0 +1,87 @@
+/**
+ * Ingest a received ActivityPub `Note` (a post from an actor the user follows)
+ * into the home-timeline store.
+ *
+ * Two concerns live here, both testable in isolation:
+ *
+ * 1. `sanitizeRemoteHtml` — remote fediverse HTML is **untrusted** and is rendered
+ *    with `dangerouslySetInnerHTML` on the web, so it MUST be sanitised before it
+ *    is stored. We keep only the small tag set Mastodon-style content uses and
+ *    force safe link attributes; scripts, styles, event handlers, iframes, images,
+ *    and every other attribute are dropped.
+ * 2. `noteToTimelineInput` — map a Fedify `Note` + the (already-known) author to a
+ *    `TimelineEntryInput`, or null if it lacks the id/published we need.
+ *
+ * The inbox handler that calls these (in `federation.ts`) is thin: it checks the
+ * sender is a followed, accepted actor and upserts the result.
+ */
+import type { Note } from '@fedify/fedify/vocab'
+
+import sanitizeHtml from 'sanitize-html'
+
+import type { FeedFollowingRecord, TimelineEntryInput } from '../../db/index.ts'
+
+import { temporalInstantToDate } from './temporal-interop.ts'
+
+/**
+ * Sanitise untrusted remote HTML to the small tag set Mastodon-style post content
+ * uses. Links are forced to `rel="nofollow noopener noreferrer"` + `target`, and
+ * only `http(s)` schemes survive — so no `javascript:` URLs, inline handlers,
+ * styles, scripts, iframes, or images.
+ */
+export const sanitizeRemoteHtml = (html: string): string =>
+  sanitizeHtml(html, {
+    allowedAttributes: {
+      a: ['href', 'rel', 'target', 'class', 'translate'],
+      ol: ['start'],
+      span: ['class', 'translate'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+    allowedTags: [
+      'p',
+      'br',
+      'a',
+      'span',
+      'em',
+      'strong',
+      'b',
+      'i',
+      'del',
+      's',
+      'u',
+      'pre',
+      'code',
+      'blockquote',
+      'ul',
+      'ol',
+      'li',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+    ],
+    disallowedTagsMode: 'discard',
+    transformTags: {
+      a: sanitizeHtml.simpleTransform('a', { rel: 'nofollow noopener noreferrer', target: '_blank' }),
+    },
+  })
+
+/**
+ * Map a received `Note` + its (already-resolved, followed) author to a timeline
+ * entry, or null if the Note lacks an id or a `published` timestamp. The author's
+ * presentation (handle / name / avatar) comes from the cached `feed_following`
+ * row — no extra network — since we only ingest posts from actors we follow.
+ */
+export const noteToTimelineInput = (note: Note, author: FeedFollowingRecord): TimelineEntryInput | null => {
+  if (note.id == null || note.published == null) return null
+  return {
+    actor_uri: author.actor_uri,
+    avatar_url: author.avatar_url,
+    content: sanitizeRemoteHtml(note.content?.toString() ?? ''),
+    display_name: author.display_name,
+    handle: author.handle,
+    object_uri: note.id.href,
+    published_at: temporalInstantToDate(note.published),
+    url: note.url instanceof URL ? note.url.href : note.id.href,
+  }
+}

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -68,12 +68,24 @@ export const sanitizeRemoteHtml = (html: string): string =>
 
 /**
  * Map a received `Note` + its (already-resolved, followed) author to a timeline
- * entry, or null if the Note lacks an id or a `published` timestamp. The author's
- * presentation (handle / name / avatar) comes from the cached `feed_following`
- * row — no extra network — since we only ingest posts from actors we follow.
+ * entry, or null if the Note lacks an id or a `published` timestamp.
+ *
+ * **Authority check.** `note.id` becomes `object_uri`, the *globally-unique* upsert
+ * key. Without an origin check a malicious accepted followee could deliver a Note
+ * whose id collides with another followee's post and overwrite it (attributed to
+ * themselves). So we require the Note to originate from the sender's host and, when
+ * it declares `attributedTo`, to attribute to the sender — the symmetric guard to
+ * the sender-scoped inbound `Delete`. The author's presentation (handle / name /
+ * avatar) comes from the cached `feed_following` row (no extra network).
  */
 export const noteToTimelineInput = (note: Note, author: FeedFollowingRecord): TimelineEntryInput | null => {
   if (note.id == null || note.published == null) return null
+  // The sender (this Note's author) is `author.actor_uri` — the accepted followee
+  // the inbox handler looked up by the activity's actor id.
+  const senderHost = new URL(author.actor_uri).host
+  if (note.id.host !== senderHost) return null
+  const attributions = note.attributionIds
+  if (attributions.length > 0 && !attributions.some((uri) => uri.href === author.actor_uri)) return null
   return {
     actor_uri: author.actor_uri,
     avatar_url: author.avatar_url,

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -78,7 +78,11 @@ export const sanitizeRemoteHtml = (html: string): string =>
  * the sender-scoped inbound `Delete`. The author's presentation (handle / name /
  * avatar) comes from the cached `feed_following` row (no extra network).
  */
-export const noteToTimelineInput = (note: Note, author: FeedFollowingRecord): TimelineEntryInput | null => {
+export const noteToTimelineInput = (
+  note: Note,
+  author: FeedFollowingRecord,
+  now: number = Date.now(),
+): TimelineEntryInput | null => {
   if (note.id == null || note.published == null) return null
   // The sender (this Note's author) is `author.actor_uri` — the accepted followee
   // the inbox handler looked up by the activity's actor id.
@@ -86,6 +90,10 @@ export const noteToTimelineInput = (note: Note, author: FeedFollowingRecord): Ti
   if (note.id.host !== senderHost) return null
   const attributions = note.attributionIds
   if (attributions.length > 0 && !attributions.some((uri) => uri.href === author.actor_uri)) return null
+  // Clamp `published_at` to "not in the future": it's the timeline sort key, so a
+  // far-future timestamp would otherwise let a followed actor pin a post to the top
+  // indefinitely (and re-pin via Update). Same guard Mastodon applies on ingest.
+  const publishedAt = temporalInstantToDate(note.published)
   return {
     actor_uri: author.actor_uri,
     avatar_url: author.avatar_url,
@@ -93,7 +101,7 @@ export const noteToTimelineInput = (note: Note, author: FeedFollowingRecord): Ti
     display_name: author.display_name,
     handle: author.handle,
     object_uri: note.id.href,
-    published_at: temporalInstantToDate(note.published),
+    published_at: new Date(Math.min(publishedAt.getTime(), now)),
     url: note.url instanceof URL ? note.url.href : note.id.href,
   }
 }

--- a/apps/backend/src/services/following.ts
+++ b/apps/backend/src/services/following.ts
@@ -24,7 +24,12 @@ import { Follow, isActor, Undo } from '@fedify/fedify/vocab'
 
 import type { FeedFollowingInput, FeedFollowingRecord } from '../db/index.ts'
 
-import { getFeedFollowing, removeFeedFollowing, upsertFeedFollowing } from '../db/index.ts'
+import {
+  deleteTimelineEntriesByActor,
+  getFeedFollowing,
+  removeFeedFollowing,
+  upsertFeedFollowing,
+} from '../db/index.ts'
 
 export interface FollowDeps {
   federation: Federation<void>
@@ -184,5 +189,8 @@ export const unfollowActor = async (deps: FollowDeps, user: string, id: string):
   }
 
   await removeFeedFollowing(user, id)
+  // Their posts leave the home timeline too (no point keeping posts from someone
+  // you no longer follow).
+  await deleteTimelineEntriesByActor(user, existing.actor_uri)
   return true
 }

--- a/apps/backend/src/services/timeline.test.ts
+++ b/apps/backend/src/services/timeline.test.ts
@@ -89,4 +89,16 @@ describe('getTimelinePage', () => {
     })
     expect(received).toBeUndefined()
   })
+
+  test('rejects a structurally-valid cursor whose id is not a UUID (avoids a $::uuid 500)', async () => {
+    // `12345:not-a-uuid` base64url-decodes with a safe-integer ms but a non-UUID id;
+    // it must decode to undefined (first page) rather than reaching the uuid cast.
+    const crafted = Buffer.from('12345:not-a-uuid').toString('base64url')
+    let received: TimelineCursor | undefined = { id: 'sentinel', published_at: new Date(0) }
+    await getTimelinePage('user', 20, crafted, async (_u, _l, cursor) => {
+      received = cursor
+      return []
+    })
+    expect(received).toBeUndefined()
+  })
 })

--- a/apps/backend/src/services/timeline.test.ts
+++ b/apps/backend/src/services/timeline.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest'
+
+import type { TimelineCursor, TimelineEntryRecord } from '../db/index.ts'
+
+import { getTimelinePage, serializeTimelineEntry } from './timeline.ts'
+
+const record = (over: Partial<TimelineEntryRecord> = {}): TimelineEntryRecord => ({
+  actor_uri: 'https://remote.example/users/alice',
+  avatar_url: 'https://remote.example/avatars/alice.png',
+  content: '<p>Ran a 5k</p>',
+  display_name: 'Alice',
+  handle: '@alice@remote.example',
+  id: '00000000-0000-0000-0000-000000000001',
+  object_uri: 'https://remote.example/notes/1',
+  published_at: new Date('2026-07-01T08:00:00.000Z'),
+  received_at: new Date('2026-07-01T08:00:05.000Z'),
+  url: 'https://remote.example/@alice/1',
+  ...over,
+})
+
+describe('serializeTimelineEntry', () => {
+  test('maps a stored record to the DTO with an ISO published_at and no received_at', () => {
+    const dto = serializeTimelineEntry(record())
+    expect(dto).toEqual({
+      actor_uri: 'https://remote.example/users/alice',
+      avatar_url: 'https://remote.example/avatars/alice.png',
+      content: '<p>Ran a 5k</p>',
+      display_name: 'Alice',
+      handle: '@alice@remote.example',
+      id: '00000000-0000-0000-0000-000000000001',
+      object_uri: 'https://remote.example/notes/1',
+      published_at: '2026-07-01T08:00:00.000Z',
+      url: 'https://remote.example/@alice/1',
+    })
+    // Ingest-only bookkeeping is not exposed.
+    expect(dto).not.toHaveProperty('received_at')
+  })
+})
+
+describe('getTimelinePage', () => {
+  const rows = (n: number): TimelineEntryRecord[] =>
+    Array.from({ length: n }, (_, i) =>
+      record({
+        id: `00000000-0000-0000-0000-00000000000${i}`,
+        object_uri: `https://remote.example/notes/${i}`,
+        published_at: new Date(Date.UTC(2026, 6, 1, 8, 0, n - i)), // newest first
+      }),
+    )
+
+  test('requests limit + 1 rows and passes a decoded cursor of undefined on the first page', async () => {
+    const calls: { limit: number; cursor?: TimelineCursor }[] = []
+    await getTimelinePage('user', 20, undefined, async (_u, limit, cursor) => {
+      calls.push({ cursor, limit })
+      return []
+    })
+    expect(calls).toEqual([{ cursor: undefined, limit: 21 }])
+  })
+
+  test('returns no next_cursor when the fetch yields at most `limit` rows', async () => {
+    const page = await getTimelinePage('user', 20, undefined, async () => rows(20))
+    expect(page.entries).toHaveLength(20)
+    expect(page.next_cursor).toBeNull()
+  })
+
+  test('trims the sentinel row and emits a next_cursor when there are more', async () => {
+    const page = await getTimelinePage('user', 20, undefined, async () => rows(21))
+    expect(page.entries).toHaveLength(20)
+    expect(page.next_cursor).toEqual(expect.any(String))
+  })
+
+  test('a next_cursor round-trips back to the (published_at, id) of the last returned row', async () => {
+    const first = await getTimelinePage('user', 2, undefined, async () => rows(3))
+    const lastEntry = first.entries[first.entries.length - 1]
+
+    let received: TimelineCursor | undefined
+    await getTimelinePage('user', 2, first.next_cursor ?? undefined, async (_u, _l, cursor) => {
+      received = cursor
+      return []
+    })
+    expect(received?.id).toBe(lastEntry.id)
+    expect(received?.published_at.toISOString()).toBe(lastEntry.published_at)
+  })
+
+  test('treats a malformed cursor as the first page (undefined) rather than throwing', async () => {
+    let received: TimelineCursor | undefined = { id: 'sentinel', published_at: new Date(0) }
+    await getTimelinePage('user', 20, 'not-a-valid-cursor!!', async (_u, _l, cursor) => {
+      received = cursor
+      return []
+    })
+    expect(received).toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/timeline.ts
+++ b/apps/backend/src/services/timeline.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared home-timeline read logic, used by the REST `/feed/timeline` route and
+ * the MCP `list_timeline` tool (parity).
+ *
+ * A page is keyset-paginated on `(published_at, id)`; the opaque `next_cursor`
+ * encodes that pair. To decide whether a next page exists we fetch one extra row
+ * and drop it. `serializeTimelineEntry` maps the stored record (whose `content`
+ * is already sanitised at ingest) to the api-spec DTO.
+ */
+import type { TimelineEntry } from '@aurboda/api-spec'
+
+import type { TimelineCursor, TimelineEntryRecord } from '../db/index.ts'
+
+import { listTimelineEntries } from '../db/index.ts'
+
+/** Encode a `(published_at, id)` keyset position as an opaque base64 cursor. */
+const encodeCursor = (record: TimelineEntryRecord): string =>
+  Buffer.from(`${record.published_at.getTime()}:${record.id}`).toString('base64url')
+
+/** Decode an opaque cursor, or undefined if it's missing/malformed (→ first page). */
+const decodeCursor = (cursor: string | undefined): TimelineCursor | undefined => {
+  if (cursor == null || cursor === '') return undefined
+  const decoded = Buffer.from(cursor, 'base64url').toString('utf8')
+  const sep = decoded.indexOf(':')
+  if (sep <= 0) return undefined
+  const ms = Number(decoded.slice(0, sep))
+  const id = decoded.slice(sep + 1)
+  if (!Number.isSafeInteger(ms) || id === '') return undefined
+  return { id, published_at: new Date(ms) }
+}
+
+export const serializeTimelineEntry = (record: TimelineEntryRecord): TimelineEntry => ({
+  actor_uri: record.actor_uri,
+  avatar_url: record.avatar_url,
+  content: record.content,
+  display_name: record.display_name,
+  handle: record.handle,
+  id: record.id,
+  object_uri: record.object_uri,
+  published_at: record.published_at.toISOString(),
+  url: record.url,
+})
+
+/** Fetch a keyset page of raw timeline rows — the one DB dependency of `getTimelinePage`. */
+export type TimelineFetcher = (
+  user: string,
+  limit: number,
+  cursor?: TimelineCursor,
+) => Promise<TimelineEntryRecord[]>
+
+/**
+ * One page of the home timeline (newest first) plus the cursor for the next page
+ * (null when there are no more). Fetches `limit + 1` rows to detect a next page
+ * without a second query. The row fetcher is injected (defaulting to the real DB
+ * query) so the pagination + cursor logic is unit-testable without a database.
+ */
+export const getTimelinePage = async (
+  user: string,
+  limit: number,
+  cursor?: string,
+  fetchEntries: TimelineFetcher = listTimelineEntries,
+): Promise<{ entries: TimelineEntry[]; next_cursor: string | null }> => {
+  const rows = await fetchEntries(user, limit + 1, decodeCursor(cursor))
+  const hasMore = rows.length > limit
+  const page = hasMore ? rows.slice(0, limit) : rows
+  const last = page[page.length - 1]
+  return {
+    entries: page.map(serializeTimelineEntry),
+    next_cursor: hasMore && last ? encodeCursor(last) : null,
+  }
+}

--- a/apps/backend/src/services/timeline.ts
+++ b/apps/backend/src/services/timeline.ts
@@ -17,6 +17,9 @@ import { listTimelineEntries } from '../db/index.ts'
 const encodeCursor = (record: TimelineEntryRecord): string =>
   Buffer.from(`${record.published_at.getTime()}:${record.id}`).toString('base64url')
 
+/** A canonical UUID, to validate a decoded cursor's id before it hits the `$::uuid` cast. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 /** Decode an opaque cursor, or undefined if it's missing/malformed (→ first page). */
 const decodeCursor = (cursor: string | undefined): TimelineCursor | undefined => {
   if (cursor == null || cursor === '') return undefined
@@ -25,7 +28,9 @@ const decodeCursor = (cursor: string | undefined): TimelineCursor | undefined =>
   if (sep <= 0) return undefined
   const ms = Number(decoded.slice(0, sep))
   const id = decoded.slice(sep + 1)
-  if (!Number.isSafeInteger(ms) || id === '') return undefined
+  // Validate the id is a UUID: it's cast to `uuid` in listTimelineEntries, so a
+  // crafted `12345:not-a-uuid` cursor would otherwise 500 instead of paging.
+  if (!Number.isSafeInteger(ms) || !UUID_RE.test(id)) return undefined
   return { id, published_at: new Date(ms) }
 }
 

--- a/apps/backend/src/test/db-test-helper.ts
+++ b/apps/backend/src/test/db-test-helper.ts
@@ -102,6 +102,7 @@ export const cleanTestDb = async (): Promise<void> => {
     'feed_actor',
     'feed_follower',
     'feed_following',
+    'timeline_entry',
     'profile_avatar',
     'tags',
     'tag_definitions',

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -14,11 +14,15 @@ import { formatDistanceToNow } from 'date-fns'
 
 import { fetchTimeline } from '../../state/api'
 
-/** A fallback avatar (a neutral silhouette) for actors without an icon. */
+/**
+ * A fallback avatar (a neutral silhouette) for actors without an icon. Colours use
+ * raw `#` — `encodeURIComponent` percent-encodes them exactly once (writing `%23`
+ * here too would double-encode to `%2523` and render the fills black).
+ */
 const FALLBACK_AVATAR =
   'data:image/svg+xml;utf8,' +
   encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewBox="0 0 44 44"><rect width="44" height="44" rx="22" fill="%23cbd5e1"/><circle cx="22" cy="17" r="8" fill="%23fff"/><path d="M8 40c0-8 6-12 14-12s14 4 14 12" fill="%23fff"/></svg>',
+    '<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewBox="0 0 44 44"><rect width="44" height="44" rx="22" fill="#cbd5e1"/><circle cx="22" cy="17" r="8" fill="#fff"/><path d="M8 40c0-8 6-12 14-12s14 4 14 12" fill="#fff"/></svg>',
   )
 
 function TimelineCard({ entry }: { entry: TimelineEntry }) {

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -1,0 +1,100 @@
+/**
+ * Home timeline — posts received from the fediverse actors the user follows
+ * (#884 §3), newest-first, keyset-paginated via the opaque `next_cursor`.
+ *
+ * Each entry renders as the same Mastodon-style card as the user's own posts,
+ * but from a remote author. The `content` HTML was already sanitised server-side
+ * on ingest (see `timeline-ingest.ts`), so it's safe to render directly here.
+ */
+import type { TimelineEntry, TimelineResponse } from '@aurboda/api-spec'
+import type { InfiniteData } from '@tanstack/react-query'
+
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+
+import { fetchTimeline } from '../../state/api'
+
+/** A fallback avatar (a neutral silhouette) for actors without an icon. */
+const FALLBACK_AVATAR =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewBox="0 0 44 44"><rect width="44" height="44" rx="22" fill="%23cbd5e1"/><circle cx="22" cy="17" r="8" fill="%23fff"/><path d="M8 40c0-8 6-12 14-12s14 4 14 12" fill="%23fff"/></svg>',
+  )
+
+function TimelineCard({ entry }: { entry: TimelineEntry }) {
+  const when = formatDistanceToNow(new Date(entry.published_at), { addSuffix: true })
+  const name = entry.display_name ?? entry.handle ?? entry.actor_uri
+  return (
+    <article class="feed-post">
+      <header class="feed-post-head">
+        <img
+          class="feed-post-avatar"
+          src={entry.avatar_url ?? FALLBACK_AVATAR}
+          alt=""
+          width={44}
+          height={44}
+          loading="lazy"
+        />
+        <div class="feed-post-ident">
+          <span class="feed-post-name">{name}</span>
+          <span class="feed-post-handle">
+            {entry.handle && <>{entry.handle} · </>}
+            {entry.url ? (
+              <a href={entry.url} target="_blank" rel="noopener noreferrer nofollow">
+                <time title={new Date(entry.published_at).toLocaleString()}>{when}</time>
+              </a>
+            ) : (
+              <time title={new Date(entry.published_at).toLocaleString()}>{when}</time>
+            )}
+          </span>
+        </div>
+      </header>
+
+      {/* Sanitised server-side on ingest (timeline-ingest.ts) — safe to render. */}
+      <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: entry.content }} />
+    </article>
+  )
+}
+
+export function HomeTimeline() {
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery<
+    TimelineResponse,
+    Error,
+    InfiniteData<TimelineResponse>,
+    readonly string[],
+    string | undefined
+  >({
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) => fetchTimeline(pageParam),
+    queryKey: ['feed', 'timeline'],
+  })
+
+  const entries = data?.pages.flatMap((page) => page.entries) ?? []
+
+  return (
+    <section class="timeline-section">
+      <h2 class="feed-section-title">Home timeline</h2>
+      {isLoading && <p>Loading…</p>}
+      {error && <p class="feed-error">Couldn't load your timeline. Please try again.</p>}
+      {!isLoading && !error && entries.length === 0 && (
+        <p class="feed-empty">
+          No posts yet. Follow some fediverse accounts above and their posts will appear here.
+        </p>
+      )}
+      {entries.map((entry) => (
+        <TimelineCard key={entry.object_uri} entry={entry} />
+      ))}
+      {hasNextPage && (
+        <button
+          type="button"
+          class="btn-secondary timeline-more"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -14,6 +14,7 @@ import { avatarUrl, deleteFeedPost, fetchFeed } from '../../state/api'
 import { auth } from '../../state/auth'
 import { FeedPostCard, type PostAuthor } from './FeedPostCard'
 import { FollowingPanel } from './FollowingPanel'
+import { HomeTimeline } from './HomeTimeline'
 import './style.css'
 
 function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
@@ -89,6 +90,8 @@ export function Feed() {
       </p>
 
       <FollowingPanel />
+
+      <HomeTimeline />
 
       <h2 class="feed-section-title">Your posts</h2>
       {isLoading && <p>Loading…</p>}

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -182,6 +182,21 @@
   color: #6b7280;
 }
 
+.feed-post-handle a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.feed-post-handle a:hover {
+  text-decoration: underline;
+}
+
+/* "Load more" at the foot of the home timeline. */
+.timeline-more {
+  display: block;
+  margin: 0.25rem auto 1rem;
+}
+
 .feed-post-content {
   margin-top: 0.5rem;
   color: #1f2937;

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -6,6 +6,7 @@ import type {
   FollowingActor,
   FollowingResponse,
   ShareActivityBody,
+  TimelineResponse,
   UpdateFeedPostBody,
 } from '@aurboda/api-spec'
 
@@ -69,4 +70,17 @@ export const followActor = async (handle: string): Promise<FollowingActor> => {
 /** Unfollow an actor by its local follow id. */
 export const unfollowActor = async (id: string): Promise<void> => {
   await axios.delete(`${API_URL}/feed/following/${id}`, { headers: authHeaders() })
+}
+
+/**
+ * Fetch one page of the home timeline (posts from the actors the user follows,
+ * newest-first). Pass the previous page's `next_cursor` to page; a null cursor
+ * (in the response) means there are no more.
+ */
+export const fetchTimeline = async (cursor?: string): Promise<TimelineResponse> => {
+  const response = await axios.get<TimelineResponse>(`${API_URL}/feed/timeline`, {
+    headers: authHeaders(),
+    params: cursor ? { cursor } : {},
+  })
+  return response.data
 }

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -128,8 +128,23 @@ The actor advertises a **following collection** (`/users/<username>/following`) 
 *accepted* follows (a pending follow isn't a confirmed relationship yet). The followee's
 inbox URIs are internal delivery details and are never exposed on the owner-facing API.
 
-> Receiving those followees' posts into a **home timeline** (inbound `Create`/`Announce`
-> handling + storage) is the next slice; this slice is the follow relationship only.
+### Home timeline (inbound)
+
+Posts from followed actors arrive at the user's inbox and are stored as a **home timeline**.
+When a `Create` or `Update` for a `Note` is delivered, the inbox:
+
+1. confirms the sender is an **accepted** followee (`feed_following`) — activities from
+   anyone else are ignored, so an unsolicited `Create` can't inject into the timeline,
+2. **sanitises** the note's HTML content server-side (`sanitize-html`, a strict tag/attribute
+   allowlist) — remote content is untrusted, so this is the XSS boundary, then
+3. upserts a `timeline_entry` (keyed by the note's `object_uri`, so an `Update` or a
+   redelivery replaces in place rather than duplicating).
+
+A `Delete` removes the matching entry; unfollowing removes all of that actor's entries. The
+timeline is read back **newest-first**, keyset-paginated on `(published_at, id)` behind an
+opaque `next_cursor` — the same cursor style as the outbox — via `GET /feed/timeline` and the
+`list_timeline` MCP tool. Because the content was sanitised on ingest, the web client renders
+it directly.
 
 ### Images
 
@@ -209,6 +224,9 @@ resolving.
 - **Follow** — the Feed page's **Following** panel lets you follow a fediverse actor by
   handle (`@user@host`) and see who you follow, with a **Pending** badge until the remote
   server accepts and an **Unfollow** button.
+- **Home timeline** — below the Following panel, the Feed page shows your **Home timeline**:
+  posts from the actors you follow, newest-first, as native cards with a **Load more** button
+  to page further back.
 
 ## API
 
@@ -223,6 +241,7 @@ Owner-facing (authenticated, scoped to the caller):
 | `GET /feed/following`             | List the actors I follow (accepted + pending)      |
 | `POST /feed/following`            | Follow an actor by handle (`@user@host` or actor URL) |
 | `DELETE /feed/following/:id`      | Unfollow (sends `Undo{Follow}`)                    |
+| `GET /feed/timeline`              | My home timeline (posts from followees), newest-first, `?cursor=` to page |
 
 Public / federation (unauthenticated):
 
@@ -240,8 +259,8 @@ Public / federation (unauthenticated):
 | `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified) |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
-`update_feed_post`, `delete_feed_post`, `list_following`, `follow_actor`, and
-`unfollow_actor` — all federating identically to the REST routes.
+`update_feed_post`, `delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`,
+and `list_timeline` — all backed by the same services as the REST routes.
 
 ## Storage
 
@@ -256,6 +275,10 @@ and, in the same statement, records its id in `feed_tombstone` so the object id 
 answer `410 Gone`. Followers live in `feed_follower`; the actors this user **follows** live
 in `feed_following` (keyed by a local `id`, with the followee's cached inbox + handle /
 display name / avatar and an `accepted` flag); the actor's RSA keypair in `feed_actor`.
+Posts received from followees are stored in `timeline_entry` (keyed by the remote note's
+`object_uri` so an `Update`/redelivery replaces in place), holding the **already-sanitised**
+content plus the author's cached handle / display name / avatar, indexed on
+`(published_at DESC, id DESC)` for the keyset-paginated home timeline.
 
 ## Caveats & limitations
 

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -214,6 +214,61 @@ export const followingResponseSchema = baseResponseSchema
 export type FollowingResponse = z.infer<typeof followingResponseSchema>
 
 // =============================================================================
+// Home timeline (posts received from followed actors)
+// =============================================================================
+
+/** A post received from a followed actor, as shown in the home timeline. */
+export const timelineEntrySchema = z
+  .object({
+    actor_uri: z.string().meta({ description: "The author's ActivityPub actor URI" }),
+    avatar_url: z.string().nullable().meta({ description: "The author's avatar URL, if known" }),
+    content: z
+      .string()
+      .meta({ description: 'The post HTML (already sanitised server-side; safe to render)' }),
+    display_name: z.string().nullable().meta({ description: "The author's display name, if known" }),
+    handle: z.string().nullable().meta({ description: "The author's `@user@host` handle, if known" }),
+    id: z.string().uuid().meta({ description: 'Local id of the timeline entry' }),
+    object_uri: z.string().meta({ description: "The remote post's canonical id" }),
+    published_at: iso8601DateTimeSchema.meta({ description: 'When the post was published (ISO 8601)' }),
+    url: z.string().nullable().meta({ description: 'Link to the original post' }),
+  })
+  .meta({ id: 'TimelineEntry' })
+
+export type TimelineEntry = z.infer<typeof timelineEntrySchema>
+
+/** Query for the home-timeline endpoint (keyset pagination). */
+export const timelineQuerySchema = z
+  .object({
+    cursor: z
+      .string()
+      .optional()
+      .meta({ description: "Opaque cursor from a previous page's `next_cursor`" }),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(20)
+      .meta({ description: 'Max entries to return (1–50, default 20)' }),
+  })
+  .meta({ id: 'TimelineQuery' })
+
+export type TimelineQuery = z.infer<typeof timelineQuerySchema>
+
+/** A page of the home timeline, newest first, with an opaque cursor for the next page. */
+export const timelineResponseSchema = baseResponseSchema
+  .extend({
+    entries: z.array(timelineEntrySchema),
+    next_cursor: z
+      .string()
+      .nullable()
+      .meta({ description: 'Cursor for the next page, or null if this is the last page' }),
+  })
+  .meta({ id: 'TimelineResponse' })
+
+export type TimelineResponse = z.infer<typeof timelineResponseSchema>
+
+// =============================================================================
 // Public series endpoint (unauthenticated, data-scoped)
 // =============================================================================
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       pg-format:
         specifier: ^1.0.4
         version: 1.0.4
+      sanitize-html:
+        specifier: ^2.17.5
+        version: 2.17.5
       satori:
         specifier: 0.26.0
         version: 0.26.0
@@ -129,6 +132,9 @@ importers:
       '@types/pg-format':
         specifier: ^1.0.5
         version: 1.0.5
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
@@ -2000,6 +2006,9 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
@@ -2702,6 +2711,9 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2713,6 +2725,10 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -2823,6 +2839,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-schema@6.1.0:
     resolution: {integrity: sha512-TWtYV2jKe7bd/19kzvNGa8GRRrSwmIMarhcWBzuZYPbHtdlUdjYhnaFvxrO4+GvcwF10sEeVGzf9b/wqLIyf9A==}
 
@@ -2868,6 +2888,10 @@ packages:
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -3107,6 +3131,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cookie-agent@7.0.3:
     resolution: {integrity: sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ==}
     engines: {node: '>=20.0.0'}
@@ -3173,6 +3200,10 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3274,6 +3305,9 @@ packages:
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -3566,6 +3600,9 @@ packages:
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -3856,6 +3893,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.5:
+    resolution: {integrity: sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==}
 
   satori@0.26.0:
     resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
@@ -6131,6 +6171,10 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 22.19.7
@@ -6868,11 +6912,15 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  dayjs@1.11.21: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  deepmerge@4.3.1: {}
 
   defaults@1.0.4:
     dependencies:
@@ -6984,6 +7032,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-schema@6.1.0:
     dependencies:
       ajv: 8.17.1
@@ -7073,6 +7123,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@4.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -7336,6 +7388,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cookie-agent@7.0.3(tough-cookie@6.0.1)(undici@7.19.2):
     dependencies:
       agent-base: 7.1.4
@@ -7420,6 +7479,8 @@ snapshots:
   is-fullwidth-code-point@3.0.0: {}
 
   is-interactive@1.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7521,6 +7582,10 @@ snapshots:
   kolorist@1.8.0: {}
 
   ky@1.14.3: {}
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.21
 
   lazystream@1.0.1:
     dependencies:
@@ -7817,6 +7882,8 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       hex-rgb: 4.3.0
+
+  parse-srcset@1.0.2: {}
 
   parse5@7.3.0:
     dependencies:
@@ -8154,6 +8221,16 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.5:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   satori@0.26.0:
     dependencies:


### PR DESCRIPTION
Slice 3 of the in-app federated feed (#884): the **home timeline** — receiving posts from the actors a user follows and showing them in the app. Builds on slice 1 (feed posts) and slice 2 (following, inbound follow relationship).

## What this adds

**Ingest (inbound `Create`/`Update`/`Delete` of `Note`s):**
- Only activities from an **accepted** followee are ingested — an unsolicited `Create` can't inject into the timeline.
- Remote HTML `content` is **sanitised server-side on ingest** (`sanitize-html`, strict allowlist) — the XSS boundary. So the web client renders it directly.
- Stored in `timeline_entry`, keyed by the note's `object_uri` so an `Update`/redelivery replaces in place. `Delete` removes the entry; unfollowing removes all of that actor's entries.

**Read API (REST + MCP parity):**
- `GET /feed/timeline` and the `list_timeline` MCP tool, backed by a shared `getTimelinePage` service.
- Keyset-paginated on `(published_at, id)` behind an opaque `next_cursor` (same style as the outbox). The row fetcher is injected so the pagination + cursor logic is **unit-tested without a database**.

**Web:**
- A **Home timeline** section on `/feed` (below Following): a `useInfiniteQuery` over `/feed/timeline` with a **Load more** button, each entry as a Mastodon-style card reusing the existing `.feed-post` styles.

## Tests
- `services/timeline.test.ts` (6) — serialize + pagination/cursor round-trip via injected fetcher.
- `db/timeline.integration.test.ts` (5), `services/activitypub/timeline-ingest.test.ts` (8, incl. XSS payloads).
- Full slice-3 + OSM suite green (30 tests); both package `check`s pass (0 errors).

## Docs
`docs/features/feed.md`: new "Home timeline (inbound)" section, `/feed/timeline` + `list_timeline` surfaces, and `timeline_entry` storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)