### PR TITLE
feat(feed): live home-timeline updates — SSE + polling (#884)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -28,6 +28,7 @@ import { setupOuraWebhook, setupStravaWebhook } from './api/webhooks-setup.ts'
 import { createAuth } from './auth.ts'
 import {
   deleteRuleActivities,
+  emitTimelineNotify,
   getDeductionRulesByIds,
   getDetectedLocationById,
   getEnabledDeductionRules,
@@ -41,6 +42,7 @@ import {
   insertRawRecord,
   insertTimeSeries,
   loginToUserDb,
+  openTimelineChannel,
   resolveOrCreateActivityType,
   softDeleteLocationRange,
   updateDetectedLocation,
@@ -78,6 +80,7 @@ import { createPgBoss } from './services/pg-boss.ts'
 import { initSentry, Sentry } from './services/sentry.ts'
 import { createStravaQueue, type StravaQueue } from './services/strava-queue.ts'
 import { createSyncProvider } from './services/sync-provider.ts'
+import { createTimelineHub } from './services/timeline-hub.ts'
 import { createWebAuthnService } from './services/webauthn.ts'
 
 declare global {
@@ -309,11 +312,19 @@ const main = async () => {
   // Mount OAuth endpoints BEFORE body-parser (uses its own parsers)
   httpd.use(createOAuthRouter({ centralDb, loginToUserDb, webHost }))
 
+  // Live home-timeline updates: one in-process hub fans Postgres NOTIFY pings out
+  // to a user's open SSE streams. Injected into the feed router (SSE endpoint) and
+  // the federation ingest (which pings it when a new post is received).
+  const timelineHub = createTimelineHub({ emit: emitTimelineNotify, openChannel: openTimelineChannel })
+  const onNewTimelineEntry = (user: string) => {
+    void timelineHub.notify(user).catch((err) => console.error(`⚠️ timeline notify failed for ${user}:`, err))
+  }
+
   // ActivityPub federation object (one instance, shared by the actor mount, the
   // MCP feed tools, and the REST feed router). `feedDeliver` fans a shared post
   // out to followers, fire-and-forget, so it's identical whether a post is
   // created via MCP or REST.
-  const feedFederation = createFeedFederation(webHost, apiBaseUrl)
+  const feedFederation = createFeedFederation(webHost, apiBaseUrl, onNewTimelineEntry)
   const feedDeps = { apiBaseUrl, federation: feedFederation, origin: webHost }
   const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>
     console.error(`⚠️ feed ${op} delivery failed for ${user}/${postId}:`, err)
@@ -497,6 +508,7 @@ const main = async () => {
     invitationAuth,
     ouraWebhookManager,
     syncProvider,
+    timelineHub,
     userDb,
     webAuthn,
     webHost,

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -16,6 +16,7 @@ import type { FollowActions } from '../services/following.ts'
 import type { InvitationAuth } from '../services/invitation.ts'
 import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
 import type { SyncProvider } from '../services/queries/index.ts'
+import type { TimelineHub } from '../services/timeline-hub.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 import type { AnyMiddleware } from '../typed-router.ts'
 
@@ -88,6 +89,7 @@ interface RestRoutesDeps {
   userDb: Client
   feedDeliver: FeedDeliver
   followActions: FollowActions
+  timelineHub: TimelineHub
 }
 
 export const mountRestRouters = ({
@@ -106,6 +108,7 @@ export const mountRestRouters = ({
   deductionQueue,
   feedDeliver,
   followActions,
+  timelineHub,
   ouraWebhookManager,
   auth,
   webAuthn,
@@ -150,7 +153,7 @@ export const mountRestRouters = ({
   // Mount the following router before `/feed` so `/feed/following/*` (two path
   // segments) resolves here and never touches the feed router's `/:postId`.
   httpd.use('/feed/following', createFeedFollowingRouter(authMiddleware, followActions))
-  httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver))
+  httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver, timelineHub))
   httpd.use('/challenges', createChallengesRouter(authMiddleware, webHost, apiBaseUrl))
   httpd.use(createChallengeDataRouter())
   // Public feed series must be mounted before the generic /public/:username/:slug

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -310,6 +310,7 @@ export {
   type TimelineEntryRecord,
   upsertTimelineEntry,
 } from './timeline.ts'
+export { emitTimelineNotify, openTimelineChannel } from './timeline-notify.ts'
 
 // Feed posts
 export {

--- a/apps/backend/src/db/timeline-notify.integration.test.ts
+++ b/apps/backend/src/db/timeline-notify.integration.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+/**
+ * Integration tests for the home-timeline LISTEN/NOTIFY transport against a real
+ * Postgres. The user's single per-user connection both LISTENs and NOTIFYs, so it
+ * receives its own ping (exactly how ingest → open SSE stream works in one process).
+ */
+import { getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { emitTimelineNotify, openTimelineChannel } from './timeline-notify.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+/** Resolve on the next ping (or reject after `ms`), so async NOTIFY delivery is awaitable. */
+const nextPing = (ms: number): { promise: Promise<void>; onNotify: () => void } => {
+  let resolve!: () => void
+  let reject!: (e: Error) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  const timer = setTimeout(() => reject(new Error('no ping within timeout')), ms)
+  return {
+    onNotify: () => {
+      clearTimeout(timer)
+      resolve()
+    },
+    promise,
+  }
+}
+
+describe('Timeline LISTEN/NOTIFY integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  test('a subscriber receives a ping emitted on the same user DB', async () => {
+    const user = getTestUser()
+    const ping = nextPing(5000)
+    const close = await openTimelineChannel(user, ping.onNotify)
+    try {
+      await emitTimelineNotify(user)
+      await expect(ping.promise).resolves.toBeUndefined()
+    } finally {
+      await close()
+    }
+  })
+
+  test('after teardown, further pings are not delivered', async () => {
+    const user = getTestUser()
+    let count = 0
+    const close = await openTimelineChannel(user, () => {
+      count++
+    })
+    await emitTimelineNotify(user)
+    // Give the first notification time to arrive, then tear down.
+    await new Promise((r) => setTimeout(r, 200))
+    expect(count).toBe(1)
+
+    await close()
+    await emitTimelineNotify(user)
+    await new Promise((r) => setTimeout(r, 200))
+    expect(count).toBe(1)
+  })
+})

--- a/apps/backend/src/db/timeline-notify.ts
+++ b/apps/backend/src/db/timeline-notify.ts
@@ -1,0 +1,48 @@
+/**
+ * Postgres `LISTEN/NOTIFY` for the home timeline — the low-level transport behind
+ * live updates. Each user has one long-lived per-user DB connection (see
+ * `getDbForUser`); the ingest path emits a ping on it when a new post arrives, and
+ * an open SSE stream listens on that same connection and receives its own ping.
+ *
+ * The payload is intentionally empty: a ping means "your timeline changed, refetch
+ * the newest page". Keeping it empty sidesteps NOTIFY's 8 kB payload limit and
+ * avoids leaking post content through the notification channel.
+ *
+ * The per-user channel refcounting (open on the first subscriber, close on the
+ * last) lives in the in-process `TimelineHub`; this module is the thin PG glue.
+ */
+import type { Client, Notification } from 'pg'
+
+import { getDbForUser } from './connection.ts'
+
+/** A fixed identifier (no interpolation of user input) — safe to inline in LISTEN/UNLISTEN. */
+const CHANNEL = 'timeline_updates'
+
+/** Emit a home-timeline "changed" ping on the user's DB. */
+export const emitTimelineNotify = async (user: string): Promise<void> => {
+  const client = await getDbForUser(user)
+  await client.query('SELECT pg_notify($1, $2)', [CHANNEL, ''])
+}
+
+/**
+ * Start listening for home-timeline pings on the user's DB connection, invoking
+ * `onNotify` for each. Returns a teardown that detaches the listener and issues
+ * `UNLISTEN`. The caller opens exactly one channel per user (and tears it down when
+ * the last subscriber leaves), so this doesn't refcount.
+ */
+export const openTimelineChannel = async (
+  user: string,
+  onNotify: () => void,
+): Promise<() => Promise<void>> => {
+  const client: Client = await getDbForUser(user)
+  const handler = (msg: Notification) => {
+    if (msg.channel === CHANNEL) onNotify()
+  }
+  client.on('notification', handler)
+  await client.query(`LISTEN ${CHANNEL}`)
+  return async () => {
+    client.removeListener('notification', handler)
+    // Best-effort: the connection may already be gone on shutdown.
+    await client.query(`UNLISTEN ${CHANNEL}`).catch(() => {})
+  }
+}

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -53,8 +53,12 @@ describe('Timeline store integration', () => {
 
   test('re-delivering the same object upserts in place (an edit replaces content)', async () => {
     const user = getTestUser()
-    await upsertTimelineEntry(user, entry(1))
+    // `inserted` drives "ping live subscribers only for a genuinely new post": true
+    // on the first insert, false on the re-delivery (the ON CONFLICT update path).
+    const first = await upsertTimelineEntry(user, entry(1))
+    expect(first.inserted).toBe(true)
     const edited = await upsertTimelineEntry(user, entry(1, { content: '<p>edited</p>' }))
+    expect(edited.inserted).toBe(false)
     expect(edited.content).toBe('<p>edited</p>')
     expect(await listTimelineEntries(user, 10)).toHaveLength(1)
   })

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -48,12 +48,17 @@ const TIMELINE_COLUMNS =
  * Insert or update a received post by `object_uri`. A re-delivered or edited post
  * (same object id) refreshes the content/presentation in place; `received_at`
  * stays at first receipt while `published_at` tracks the remote timestamp.
+ *
+ * `inserted` distinguishes a brand-new post from an in-place refresh via the
+ * `xmax = 0` trick (freshly-inserted tuples have xmax 0; the ON CONFLICT update
+ * path locks the existing row, so its xmax is non-zero). The ingest path uses it
+ * to notify live subscribers only about genuinely new posts, not edits.
  */
 export const upsertTimelineEntry = async (
   user: string,
   input: TimelineEntryInput,
-): Promise<TimelineEntryRecord> => {
-  const result = await query<TimelineEntryRecord>(
+): Promise<TimelineEntryRecord & { inserted: boolean }> => {
+  const result = await query<TimelineEntryRecord & { inserted: boolean }>(
     user,
     `INSERT INTO timeline_entry
        (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at)
@@ -66,7 +71,7 @@ export const upsertTimelineEntry = async (
                    content = EXCLUDED.content,
                    url = EXCLUDED.url,
                    published_at = EXCLUDED.published_at
-     RETURNING ${TIMELINE_COLUMNS}`,
+     RETURNING ${TIMELINE_COLUMNS}, (xmax = 0) AS inserted`,
     [
       input.object_uri,
       input.actor_uri,

--- a/apps/backend/src/routes/feed-router.test.ts
+++ b/apps/backend/src/routes/feed-router.test.ts
@@ -1,0 +1,101 @@
+import type { RequestHandler } from 'express'
+import type { AddressInfo } from 'node:net'
+
+import express from 'express'
+import supertest from 'supertest'
+import { describe, expect, test } from 'vitest'
+
+import type { TimelineHub } from '../services/timeline-hub.ts'
+
+import { createFeedRouter } from './feed-router.ts'
+
+/** Stand-in auth that just sets the acting user, like the real middleware does. */
+const auth: RequestHandler = (req, _res, next) => {
+  req.user = 'tester'
+  next()
+}
+
+/** A fake hub that captures the SSE listener so the test can fire pings, and records teardown. */
+const fakeHub = () => {
+  let fire: (() => void) | null = null
+  let unsubscribed = false
+  const hub: TimelineHub = {
+    notify: async () => {},
+    subscribe: async (_user, onEvent) => {
+      fire = onEvent
+      return async () => {
+        unsubscribed = true
+      }
+    },
+  }
+  return { fire: () => fire?.(), hub, wasUnsubscribed: () => unsubscribed }
+}
+
+const startApp = (hub?: TimelineHub) => {
+  const app = express()
+  app.use('/feed', createFeedRouter(auth, undefined, hub))
+  const server = app.listen(0)
+  const port = (server.address() as AddressInfo).port
+  const close = () =>
+    new Promise<void>((resolve) => {
+      server.closeAllConnections()
+      server.close(() => resolve())
+    })
+  return { close, url: `http://127.0.0.1:${port}` }
+}
+
+describe('GET /feed/timeline/stream', () => {
+  test('returns 503 when live updates are unavailable (no hub wired)', async () => {
+    const app = express()
+    app.use('/feed', createFeedRouter(auth, undefined, undefined))
+    const res = await supertest(app).get('/feed/timeline/stream')
+    expect(res.status).toBe(503)
+    expect(res.body).toEqual({ error: 'Live updates unavailable', success: false })
+  })
+
+  test('opens an SSE stream and forwards a hub ping as `event: new`', async () => {
+    const { hub, fire } = fakeHub()
+    const { url, close } = startApp(hub)
+    const ctrl = new AbortController()
+    try {
+      const res = await fetch(`${url}/feed/timeline/stream`, { signal: ctrl.signal })
+      expect(res.headers.get('content-type')).toContain('text/event-stream')
+      expect(res.headers.get('x-accel-buffering')).toBe('no')
+
+      const reader = res.body?.getReader()
+      if (!reader) throw new Error('no response body')
+      const decoder = new TextDecoder()
+
+      const connected = await reader.read()
+      expect(decoder.decode(connected.value)).toContain(': connected')
+
+      fire()
+      const event = await reader.read()
+      expect(decoder.decode(event.value)).toContain('event: new')
+
+      ctrl.abort()
+      await reader.cancel().catch(() => {})
+    } finally {
+      await close()
+    }
+  })
+
+  test('unsubscribes from the hub when the client disconnects', async () => {
+    const { hub, wasUnsubscribed } = fakeHub()
+    const { url, close } = startApp(hub)
+    const ctrl = new AbortController()
+    try {
+      const res = await fetch(`${url}/feed/timeline/stream`, { signal: ctrl.signal })
+      const reader = res.body?.getReader()
+      if (!reader) throw new Error('no response body')
+      await reader.read() // wait until the stream is live (subscribed)
+      ctrl.abort()
+      await reader.cancel().catch(() => {})
+      // The server-side 'close' → cleanup is async; poll briefly for the teardown.
+      for (let i = 0; i < 50 && !wasUnsubscribed(); i++) await new Promise((r) => setTimeout(r, 20))
+      expect(wasUnsubscribed()).toBe(true)
+    } finally {
+      await close()
+    }
+  })
+})

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -21,6 +21,7 @@ import {
 } from '@aurboda/api-spec'
 
 import type { Activity, FeedPostRecord } from '../db/index.ts'
+import type { TimelineHub } from '../services/timeline-hub.ts'
 
 import {
   createFeedPost,
@@ -54,7 +55,11 @@ export interface FeedDeliver {
   deleted: (user: string, post: FeedPostRecord) => void
 }
 
-export const createFeedRouter = (authMiddleware: AnyMiddleware, deliver?: FeedDeliver): TypedRouter => {
+export const createFeedRouter = (
+  authMiddleware: AnyMiddleware,
+  deliver?: FeedDeliver,
+  hub?: TimelineHub,
+): TypedRouter => {
   const router = typedRouter()
 
   router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
@@ -63,6 +68,59 @@ export const createFeedRouter = (authMiddleware: AnyMiddleware, deliver?: FeedDe
     const posts = await Promise.all(records.map((record) => serializeFeedPost(user, record)))
     res.json({ posts, success: true })
   })
+
+  // Live home-timeline updates over Server-Sent Events. Each ping (`event: new`)
+  // means "a new post arrived — refetch the newest page"; the payload is empty so
+  // no post content crosses the wire. The client falls back to polling if this
+  // stream can't be opened or drops. Registered before `/:postId`-style routes.
+  router.get<Record<string, never>, { success: false; error: string }>(
+    '/timeline/stream',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      if (!hub) return res.status(503).json({ error: 'Live updates unavailable', success: false })
+
+      // `X-Accel-Buffering: no` tells nginx not to buffer the stream (SSE needs
+      // each event flushed immediately, not held back for a full response body).
+      res.writeHead(200, {
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream',
+        'X-Accel-Buffering': 'no',
+      })
+      const write = (chunk: string) => {
+        if (res.writableEnded) return
+        try {
+          res.write(chunk)
+        } catch {
+          /* client vanished mid-write */
+        }
+      }
+      write(': connected\n\n')
+
+      // Comment heartbeats keep the connection from being reaped as idle.
+      const heartbeat = setInterval(() => write(': ping\n\n'), 25_000)
+      let unsubscribe: (() => Promise<void>) | null = null
+      let closed = false
+      const cleanup = async () => {
+        if (closed) return
+        closed = true
+        clearInterval(heartbeat)
+        if (unsubscribe) await unsubscribe().catch(() => {})
+      }
+      req.on('close', () => void cleanup())
+
+      try {
+        unsubscribe = await hub.subscribe(user, () => write('event: new\ndata: {}\n\n'))
+        // The client may have disconnected while the channel was opening.
+        if (closed) await unsubscribe().catch(() => {})
+      } catch {
+        // Couldn't open the live channel — end the stream so the client polls instead.
+        await cleanup()
+        if (!res.writableEnded) res.end()
+      }
+    },
+  )
 
   router.get<Record<string, never>, TimelineResponse, unknown, TimelineQuery>(
     '/timeline',

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -9,6 +9,7 @@
  * the public read surface lives in `feed-public-router.ts`.
  */
 import {
+  type BaseResponse,
   type FeedPostResponse,
   type FeedPostsResponse,
   type ShareActivityBody,
@@ -73,54 +74,50 @@ export const createFeedRouter = (
   // means "a new post arrived — refetch the newest page"; the payload is empty so
   // no post content crosses the wire. The client falls back to polling if this
   // stream can't be opened or drops. Registered before `/:postId`-style routes.
-  router.get<Record<string, never>, { success: false; error: string }>(
-    '/timeline/stream',
-    authMiddleware,
-    async (req, res) => {
-      const user = req.user!
-      if (!hub) return res.status(503).json({ error: 'Live updates unavailable', success: false })
+  router.get<Record<string, never>, BaseResponse>('/timeline/stream', authMiddleware, async (req, res) => {
+    const user = req.user!
+    if (!hub) return res.status(503).json({ error: 'Live updates unavailable', success: false })
 
-      // `X-Accel-Buffering: no` tells nginx not to buffer the stream (SSE needs
-      // each event flushed immediately, not held back for a full response body).
-      res.writeHead(200, {
-        'Cache-Control': 'no-cache, no-transform',
-        Connection: 'keep-alive',
-        'Content-Type': 'text/event-stream',
-        'X-Accel-Buffering': 'no',
-      })
-      const write = (chunk: string) => {
-        if (res.writableEnded) return
-        try {
-          res.write(chunk)
-        } catch {
-          /* client vanished mid-write */
-        }
-      }
-      write(': connected\n\n')
-
-      // Comment heartbeats keep the connection from being reaped as idle.
-      const heartbeat = setInterval(() => write(': ping\n\n'), 25_000)
-      let unsubscribe: (() => Promise<void>) | null = null
-      let closed = false
-      const cleanup = async () => {
-        if (closed) return
-        closed = true
-        clearInterval(heartbeat)
-        if (unsubscribe) await unsubscribe().catch(() => {})
-      }
-      req.on('close', () => void cleanup())
-
+    // `X-Accel-Buffering: no` tells nginx not to buffer the stream (SSE needs
+    // each event flushed immediately, not held back for a full response body).
+    res.writeHead(200, {
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'Content-Type': 'text/event-stream',
+      'X-Accel-Buffering': 'no',
+    })
+    const write = (chunk: string) => {
+      if (res.writableEnded) return
       try {
-        unsubscribe = await hub.subscribe(user, () => write('event: new\ndata: {}\n\n'))
-        // The client may have disconnected while the channel was opening.
-        if (closed) await unsubscribe().catch(() => {})
+        res.write(chunk)
       } catch {
-        // Couldn't open the live channel — end the stream so the client polls instead.
-        await cleanup()
-        if (!res.writableEnded) res.end()
+        /* client vanished mid-write */
       }
-    },
-  )
+    }
+    write(': connected\n\n')
+
+    // Comment heartbeats keep the connection from being reaped as idle.
+    const heartbeat = setInterval(() => write(': ping\n\n'), 25_000)
+    let unsubscribe: (() => Promise<void>) | null = null
+    let closed = false
+    const cleanup = async () => {
+      if (closed) return
+      closed = true
+      clearInterval(heartbeat)
+      if (unsubscribe) await unsubscribe().catch(() => {})
+    }
+    req.on('close', () => void cleanup())
+
+    try {
+      unsubscribe = await hub.subscribe(user, () => write('event: new\ndata: {}\n\n'))
+      // The client may have disconnected while the channel was opening.
+      if (closed) await unsubscribe().catch(() => {})
+    } catch {
+      // Couldn't open the live channel — end the stream so the client polls instead.
+      await cleanup()
+      if (!res.writableEnded) res.end()
+    }
+  })
 
   router.get<Record<string, never>, TimelineResponse, unknown, TimelineQuery>(
     '/timeline',

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -96,7 +96,11 @@ const localFollowerIdentifier = async (
  * sanitised in `noteToTimelineInput`. Best-effort: unresolvable objects and
  * non-Notes are ignored, and a missing DB never 500s (which would invite retries).
  */
-const ingestFeedActivity = async (ctx: InboxContext<void>, activity: Create | Update): Promise<void> => {
+const ingestFeedActivity = async (
+  ctx: InboxContext<void>,
+  activity: Create | Update,
+  onNewEntry?: (user: string) => void,
+): Promise<void> => {
   // The recipient (whose timeline this is) comes from the personal inbox owner.
   // Unlike Accept/Reject there's no inner Follow to derive it from, so this relies
   // on personal-inbox delivery; `ctx.recipient` is null on a shared inbox. That's
@@ -111,14 +115,21 @@ const ingestFeedActivity = async (ctx: InboxContext<void>, activity: Create | Up
     if (!(object instanceof Note)) return
     const input = noteToTimelineInput(object, follow)
     if (input == null) return
-    await upsertTimelineEntry(me, input)
+    const { inserted } = await upsertTimelineEntry(me, input)
+    // Ping live subscribers only for a genuinely new post (not an edit/redelivery).
+    if (inserted) onNewEntry?.(me)
   } catch (error) {
     if (isMissingDatabase(error)) return
     throw error
   }
 }
 
-export const createFeedFederation = (origin: string, apiBaseUrl: string): Federation<void> => {
+export const createFeedFederation = (
+  origin: string,
+  apiBaseUrl: string,
+  /** Fire-and-forget: called with the recipient when a genuinely new post is ingested. */
+  onNewTimelineEntry?: (user: string) => void,
+): Federation<void> => {
   const federation = createFederation<void>({
     kv: new MemoryKvStore(),
     // Pin the canonical origin (the public base URL) so actor ids, WebFinger
@@ -249,8 +260,8 @@ export const createFeedFederation = (origin: string, apiBaseUrl: string): Federa
     // timeline. Update reuses the same upsert (keyed on the Note's object id), so
     // an edit replaces the stored copy. Only *accepted* followees are ingested, so
     // a stranger who somehow delivers here can't inject into the timeline.
-    .on(Create, (ctx, create) => ingestFeedActivity(ctx, create))
-    .on(Update, (ctx, update) => ingestFeedActivity(ctx, update))
+    .on(Create, (ctx, create) => ingestFeedActivity(ctx, create, onNewTimelineEntry))
+    .on(Update, (ctx, update) => ingestFeedActivity(ctx, update, onNewTimelineEntry))
     .on(Delete, async (ctx, del) => {
       // Delete of a post we received → drop it from the timeline. `del.objectId`
       // is the removed object's id (a Tombstone or bare id); we key on it, but

--- a/apps/backend/src/services/timeline-hub.test.ts
+++ b/apps/backend/src/services/timeline-hub.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { createTimelineHub, type TimelineHubDeps } from './timeline-hub.ts'
+
+/**
+ * A fake PG-notify layer: records opens/emits and lets the test fire a ping by
+ * invoking the stored `onNotify`, so the hub's fan-out + per-user refcounting can
+ * be exercised without a database.
+ */
+const fakeDeps = () => {
+  const opened: { user: string; onNotify: () => void; teardown: ReturnType<typeof vi.fn> }[] = []
+  const emits: string[] = []
+  const deps: TimelineHubDeps = {
+    emit: async (user) => {
+      emits.push(user)
+    },
+    openChannel: async (user, onNotify) => {
+      const teardown = vi.fn(async () => {})
+      opened.push({ onNotify, teardown, user })
+      return teardown
+    },
+  }
+  return { deps, emits, opened }
+}
+
+describe('createTimelineHub', () => {
+  test('opens one channel per user and fans a ping out to all its listeners', async () => {
+    const { deps, opened } = fakeDeps()
+    const hub = createTimelineHub(deps)
+    const a = vi.fn()
+    const b = vi.fn()
+
+    await hub.subscribe('alice', a)
+    await hub.subscribe('alice', b)
+
+    // One shared channel for the two listeners.
+    expect(opened).toHaveLength(1)
+    expect(opened[0].user).toBe('alice')
+
+    opened[0].onNotify()
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+  })
+
+  test('isolates users — a ping for one does not reach another', async () => {
+    const { deps, opened } = fakeDeps()
+    const hub = createTimelineHub(deps)
+    const alice = vi.fn()
+    const bob = vi.fn()
+
+    await hub.subscribe('alice', alice)
+    await hub.subscribe('bob', bob)
+    expect(opened).toHaveLength(2)
+    expect(opened[0].user).toBe('alice')
+
+    opened[0].onNotify()
+    expect(alice).toHaveBeenCalledTimes(1)
+    expect(bob).not.toHaveBeenCalled()
+  })
+
+  test('tears the channel down only when the last listener unsubscribes', async () => {
+    const { deps, opened } = fakeDeps()
+    const hub = createTimelineHub(deps)
+    const a = vi.fn()
+    const b = vi.fn()
+
+    const offA = await hub.subscribe('alice', a)
+    const offB = await hub.subscribe('alice', b)
+    const teardown = opened[0].teardown
+
+    await offA()
+    expect(teardown).not.toHaveBeenCalled()
+    // A remaining listener still receives pings.
+    opened[0].onNotify()
+    expect(b).toHaveBeenCalledTimes(1)
+
+    await offB()
+    expect(teardown).toHaveBeenCalledTimes(1)
+  })
+
+  test('re-opens a fresh channel after all listeners have left', async () => {
+    const { deps, opened } = fakeDeps()
+    const hub = createTimelineHub(deps)
+
+    const off = await hub.subscribe('alice', vi.fn())
+    await off()
+    await hub.subscribe('alice', vi.fn())
+
+    expect(opened).toHaveLength(2)
+  })
+
+  test('notify emits a ping for the user', async () => {
+    const { deps, emits } = fakeDeps()
+    const hub = createTimelineHub(deps)
+    await hub.notify('alice')
+    expect(emits).toEqual(['alice'])
+  })
+
+  test('a failed channel open surfaces to the subscriber and frees the slot for retry', async () => {
+    const opened: string[] = []
+    let failNext = true
+    const deps: TimelineHubDeps = {
+      emit: async () => {},
+      openChannel: async (user) => {
+        opened.push(user)
+        if (failNext) {
+          failNext = false
+          throw new Error('LISTEN failed')
+        }
+        return async () => {}
+      },
+    }
+    const hub = createTimelineHub(deps)
+
+    await expect(hub.subscribe('alice', vi.fn())).rejects.toThrow('LISTEN failed')
+    // The slot was freed, so a retry opens a fresh channel instead of reusing the broken one.
+    await expect(hub.subscribe('alice', vi.fn())).resolves.toBeTypeOf('function')
+    expect(opened).toEqual(['alice', 'alice'])
+  })
+})

--- a/apps/backend/src/services/timeline-hub.ts
+++ b/apps/backend/src/services/timeline-hub.ts
@@ -1,0 +1,77 @@
+/**
+ * In-process fan-out hub for live home-timeline updates.
+ *
+ * An open SSE stream `subscribe`s a listener; the ingest path `notify`s when a new
+ * post arrives. The hub keeps at most **one** Postgres `LISTEN` channel open per
+ * user (via the injected `openChannel`) no matter how many browser tabs that user
+ * has streaming, and closes it when the last one disconnects. The PG glue is
+ * injected so this refcounting + fan-out logic is unit-testable without a database.
+ *
+ * Notifications are pings (no payload): a listener firing means "refetch the newest
+ * page". `notify` always emits via PG (rather than fanning out in-process directly)
+ * so a future multi-process deployment keeps working — every process LISTENing on
+ * the user's DB receives it.
+ */
+export interface TimelineHub {
+  /**
+   * Register a listener for a user's live updates. Resolves once the channel is
+   * live (so an open failure surfaces to the caller, which can fall back to
+   * polling) and returns an unsubscribe.
+   */
+  subscribe: (user: string, onEvent: () => void) => Promise<() => Promise<void>>
+  /** Signal that a user's timeline gained a new post. */
+  notify: (user: string) => Promise<void>
+}
+
+export interface TimelineHubDeps {
+  /** Open the PG notify channel for a user, invoking `onNotify` per ping; resolves to a teardown. */
+  openChannel: (user: string, onNotify: () => void) => Promise<() => Promise<void>>
+  /** Emit a PG notify ping for a user. */
+  emit: (user: string) => Promise<void>
+}
+
+interface UserChannel {
+  listeners: Set<() => void>
+  /** Resolves to the channel teardown; rejects if opening failed. */
+  ready: Promise<() => Promise<void>>
+}
+
+export const createTimelineHub = (deps: TimelineHubDeps): TimelineHub => {
+  const channels = new Map<string, UserChannel>()
+
+  const subscribe = async (user: string, onEvent: () => void): Promise<() => Promise<void>> => {
+    let channel = channels.get(user)
+    if (!channel) {
+      // Reserve the slot synchronously (before any await) so concurrent subscribes
+      // for the same user share a single channel rather than racing to open two.
+      const listeners = new Set<() => void>()
+      const ready = deps.openChannel(user, () => {
+        for (const listener of listeners) listener()
+      })
+      const reserved: UserChannel = { listeners, ready }
+      channels.set(user, reserved)
+      // If opening fails, drop the slot so a later subscribe can retry cleanly.
+      ready.catch(() => {
+        if (channels.get(user) === reserved) channels.delete(user)
+      })
+      channel = reserved
+    }
+    channel.listeners.add(onEvent)
+    await channel.ready
+
+    return async () => {
+      const current = channels.get(user)
+      if (!current) return
+      current.listeners.delete(onEvent)
+      if (current.listeners.size === 0) {
+        channels.delete(user)
+        const teardown = await current.ready.catch(() => null)
+        if (teardown) await teardown().catch(() => {})
+      }
+    }
+  }
+
+  const notify = (user: string): Promise<void> => deps.emit(user)
+
+  return { notify, subscribe }
+}

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -11,8 +11,23 @@ import type { InfiniteData } from '@tanstack/react-query'
 
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
+import { useState } from 'preact/hooks'
 
 import { fetchTimeline } from '../../state/api'
+import { useTimelineLive } from './useTimelineLive'
+
+/** De-duplicate entries by `object_uri`, keeping the first (newest) occurrence. */
+const dedupByUri = (list: TimelineEntry[]): TimelineEntry[] => {
+  const seen = new Set<string>()
+  const out: TimelineEntry[] = []
+  for (const entry of list) {
+    if (!seen.has(entry.object_uri)) {
+      seen.add(entry.object_uri)
+      out.push(entry)
+    }
+  }
+  return out
+}
 
 /**
  * A fallback avatar (a neutral silhouette) for actors without an icon. Colours use
@@ -76,17 +91,50 @@ export function HomeTimeline() {
 
   const entries = data?.pages.flatMap((page) => page.entries) ?? []
 
+  // Posts that arrived live (or via the polling fallback) since the page loaded:
+  // buffered in `pending` (shown as a pill) until the user reveals them, then
+  // prepended via `revealed`. Both are de-duped against the query data on render.
+  const [pending, setPending] = useState<TimelineEntry[]>([])
+  const [revealed, setRevealed] = useState<TimelineEntry[]>([])
+
+  // On a live ping (or poll tick), refetch the newest page and buffer anything we
+  // aren't already showing. Cheap: one page, and only when the server says so.
+  const checkForNew = async () => {
+    try {
+      const { entries: latest } = await fetchTimeline()
+      const known = new Set([...revealed, ...pending, ...entries].map((entry) => entry.object_uri))
+      const fresh = latest.filter((entry) => !known.has(entry.object_uri))
+      if (fresh.length > 0) setPending((prev) => dedupByUri([...fresh, ...prev]))
+    } catch {
+      // A transient refetch failure just means the pill doesn't update this tick.
+    }
+  }
+  useTimelineLive(() => void checkForNew())
+
+  const reveal = () => {
+    setRevealed((prev) => dedupByUri([...pending, ...prev]))
+    setPending([])
+    window.scrollTo({ behavior: 'smooth', top: 0 })
+  }
+
+  const displayed = dedupByUri([...revealed, ...entries])
+
   return (
     <section class="timeline-section">
       <h2 class="feed-section-title">Home timeline</h2>
+      {pending.length > 0 && (
+        <button type="button" class="timeline-new-pill" onClick={reveal}>
+          {pending.length} new post{pending.length === 1 ? '' : 's'}
+        </button>
+      )}
       {isLoading && <p>Loading…</p>}
       {error && <p class="feed-error">Couldn't load your timeline. Please try again.</p>}
-      {!isLoading && !error && entries.length === 0 && (
+      {!isLoading && !error && displayed.length === 0 && (
         <p class="feed-empty">
           No posts yet. Follow some fediverse accounts above and their posts will appear here.
         </p>
       )}
-      {entries.map((entry) => (
+      {displayed.map((entry) => (
         <TimelineCard key={entry.object_uri} entry={entry} />
       ))}
       {hasNextPage && (

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -197,6 +197,25 @@
   margin: 0.25rem auto 1rem;
 }
 
+/* "N new posts" pill — appears above the list when live updates arrive. */
+.timeline-new-pill {
+  display: block;
+  margin: 0 auto 0.75rem;
+  padding: 0.4rem 1rem;
+  border: none;
+  border-radius: 999px;
+  background: #673ab8;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(103, 58, 184, 0.3);
+}
+
+.timeline-new-pill:hover {
+  background: #5a2fa0;
+}
+
 .feed-post-content {
   margin-top: 0.5rem;
   color: #1f2937;

--- a/apps/web/src/pages/Feed/useTimelineLive.ts
+++ b/apps/web/src/pages/Feed/useTimelineLive.ts
@@ -1,0 +1,38 @@
+/**
+ * Subscribe to live home-timeline updates: opens the SSE stream and calls `onPing`
+ * whenever the server signals new posts. If the stream can't be opened or drops
+ * (proxy buffering, network blip), it falls back to polling on an interval — so the
+ * "N new posts" pill still works without a live connection.
+ */
+import { useEffect, useRef } from 'preact/hooks'
+
+import { openTimelineStream } from '../../state/api'
+
+const POLL_MS = 30_000
+
+export const useTimelineLive = (onPing: () => void): void => {
+  // Keep the latest callback in a ref so re-renders don't re-open the stream.
+  const cb = useRef(onPing)
+  cb.current = onPing
+
+  useEffect(() => {
+    let stopped = false
+    let poll: ReturnType<typeof setInterval> | null = null
+
+    const startPolling = () => {
+      if (stopped || poll) return
+      poll = setInterval(() => cb.current(), POLL_MS)
+    }
+
+    const close = openTimelineStream(
+      () => cb.current(),
+      () => startPolling(),
+    )
+
+    return () => {
+      stopped = true
+      close()
+      if (poll) clearInterval(poll)
+    }
+  }, [])
+}

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -14,6 +14,7 @@ import axios from 'axios'
 
 import { API_URL } from '../../config'
 import { auth } from '../auth'
+import { parseTimelineEvents } from './timeline-sse'
 
 const authHeaders = () => ({ Authorization: `Bearer ${auth.value.token}` })
 
@@ -83,4 +84,41 @@ export const fetchTimeline = async (cursor?: string): Promise<TimelineResponse> 
     params: cursor ? { cursor } : {},
   })
   return response.data
+}
+
+/**
+ * Open the live home-timeline SSE stream, invoking `onPing` for each "new posts"
+ * event. Uses `fetch` (not `EventSource`) so the bearer token rides in the
+ * `Authorization` header rather than the URL. Calls `onClose` when the stream ends
+ * or errors (so the caller can fall back to polling). Returns a teardown.
+ */
+export const openTimelineStream = (onPing: () => void, onClose: () => void): (() => void) => {
+  const controller = new AbortController()
+  void (async () => {
+    try {
+      const response = await fetch(`${API_URL}/feed/timeline/stream`, {
+        headers: authHeaders(),
+        signal: controller.signal,
+      })
+      if (!response.ok || !response.body) {
+        onClose()
+        return
+      }
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const { pings, rest } = parseTimelineEvents(buffer)
+        buffer = rest
+        for (let i = 0; i < pings; i++) onPing()
+      }
+      onClose()
+    } catch {
+      if (!controller.signal.aborted) onClose()
+    }
+  })()
+  return () => controller.abort()
 }

--- a/apps/web/src/state/api/timeline-sse.test.ts
+++ b/apps/web/src/state/api/timeline-sse.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+
+import { parseTimelineEvents } from './timeline-sse'
+
+describe('parseTimelineEvents', () => {
+  test('counts complete `event: new` blocks and carries the partial tail', () => {
+    const { pings, rest } = parseTimelineEvents('event: new\ndata: {}\n\nevent: new\ndata: {}\n\nevent: ne')
+    expect(pings).toBe(2)
+    expect(rest).toBe('event: ne')
+  })
+
+  test('ignores comment heartbeats (`: connected` / `: ping`)', () => {
+    const { pings, rest } = parseTimelineEvents(': connected\n\n: ping\n\n')
+    expect(pings).toBe(0)
+    expect(rest).toBe('')
+  })
+
+  test('does not count a partial event still buffering', () => {
+    const { pings, rest } = parseTimelineEvents('event: new\ndata: {}')
+    expect(pings).toBe(0)
+    expect(rest).toBe('event: new\ndata: {}')
+  })
+
+  test('reassembles an event split across two chunks', () => {
+    const first = parseTimelineEvents('event: ne')
+    expect(first.pings).toBe(0)
+    const second = parseTimelineEvents(first.rest + 'w\ndata: {}\n\n')
+    expect(second.pings).toBe(1)
+    expect(second.rest).toBe('')
+  })
+})

--- a/apps/web/src/state/api/timeline-sse.ts
+++ b/apps/web/src/state/api/timeline-sse.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure SSE parsing for the live home-timeline stream — kept free of the API
+ * config (no `window`) so it's unit-testable in a plain Node environment.
+ */
+
+/**
+ * Parse an accumulated SSE text buffer: count the complete `event: new` blocks
+ * (server pings) and return the unparsed tail. Events are `\n\n`-separated; the
+ * trailing partial block is carried over to the next chunk.
+ */
+export const parseTimelineEvents = (buffer: string): { pings: number; rest: string } => {
+  const blocks = buffer.split('\n\n')
+  const rest = blocks.pop() ?? ''
+  let pings = 0
+  for (const block of blocks) {
+    if (block.split('\n').some((line) => line.trim() === 'event: new')) pings++
+  }
+  return { pings, rest }
+}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -146,6 +146,28 @@ opaque `next_cursor` — the same cursor style as the outbox — via `GET /feed/
 `list_timeline` MCP tool. Because the content was sanitised on ingest, the web client renders
 it directly.
 
+Two ingest guards keep the timeline honest given `object_uri` is a **globally-unique** upsert
+key: the note's id must be on the **sender's host** and, when it declares `attributedTo`, must
+attribute to the sender (so an accepted followee can't overwrite another actor's post by
+colliding its id); and `published_at` is **clamped to "not in the future"** on ingest (it's the
+sort key, so a far-future timestamp would otherwise pin a post to the top).
+
+### Live updates
+
+New posts appear **without a refresh**. When a genuinely new `timeline_entry` is inserted, the
+ingest path emits a Postgres `NOTIFY` ping on the user's DB (each user has one long-lived
+connection, so the ping is received in-process). The web client holds an **SSE** stream open at
+`GET /feed/timeline/stream`; each ping is forwarded as an empty `event: new` (no post content on
+the wire — just "your timeline changed"). The client then refetches the newest page and shows a
+**"N new posts"** pill; clicking it prepends the new posts.
+
+The stream uses `fetch` (not `EventSource`) so the bearer token rides in the `Authorization`
+header rather than the URL, and sends `X-Accel-Buffering: no` so nginx flushes each event
+immediately. If the stream can't be opened or drops, the client **falls back to polling** the
+same newest page every 30s — so the pill still works without a live connection. In-process
+fan-out is handled by a single `TimelineHub` that keeps one `LISTEN` channel open per user
+regardless of how many tabs are streaming.
+
 ### Images
 
 A post can carry a rendered **heart-rate chart** (`include_chart`) and/or a **GPS
@@ -226,7 +248,8 @@ resolving.
   server accepts and an **Unfollow** button.
 - **Home timeline** — below the Following panel, the Feed page shows your **Home timeline**:
   posts from the actors you follow, newest-first, as native cards with a **Load more** button
-  to page further back.
+  to page further back. New posts arrive **live** (or via polling fallback) as a **"N new
+  posts"** pill at the top; click it to reveal them.
 
 ## API
 
@@ -242,6 +265,7 @@ Owner-facing (authenticated, scoped to the caller):
 | `POST /feed/following`            | Follow an actor by handle (`@user@host` or actor URL) |
 | `DELETE /feed/following/:id`      | Unfollow (sends `Undo{Follow}`)                    |
 | `GET /feed/timeline`              | My home timeline (posts from followees), newest-first, `?cursor=` to page |
+| `GET /feed/timeline/stream`       | Server-Sent Events stream of live "new posts" pings (falls back to polling) |
 
 Public / federation (unauthenticated):
 


### PR DESCRIPTION
Slice 4 of the in-app federated feed (#884): **live updates** — new posts from followed actors appear on the Feed page without a refresh. Builds on slice 3 (the home timeline #920).

## How it works

**Transport — Postgres `LISTEN/NOTIFY` → SSE.** Each user has one long-lived per-user DB connection, so ingest and an open stream share it: when a genuinely new `timeline_entry` is inserted, ingest emits an **empty `NOTIFY` ping**; the browser's SSE stream on the same connection receives it. Payload is empty (sidesteps NOTIFY's 8 kB cap; no post content on the wire).

**Backend:**
- `db/timeline-notify.ts` — thin `LISTEN/NOTIFY` glue (integration-tested against real PG).
- `services/timeline-hub.ts` — an injected in-process fan-out hub that keeps **one** `LISTEN` channel per user regardless of tab count, closing it when the last subscriber leaves. PG glue is injected, so refcounting/fan-out is unit-tested without a DB.
- `GET /feed/timeline/stream` — authenticated SSE endpoint; forwards each ping as `event: new`, heartbeats, sets `X-Accel-Buffering: no` (nginx), cleans up on disconnect, and `503`s if no hub is wired (client then polls).
- `upsertTimelineEntry` reports `inserted` (`xmax = 0`) so ingest pings **only on new posts**, not edits.

**Frontend:**
- `openTimelineStream` — a **`fetch`-based** SSE reader (bearer token in the `Authorization` header, not the URL, unlike `EventSource`); pure SSE parsing is unit-tested.
- `useTimelineLive` — subscribes and **falls back to 30 s polling** if the stream can't open or drops.
- On a ping/poll, `HomeTimeline` refetches the newest page and buffers anything new as a **"N new posts" pill**; clicking prepends them. Entries are de-duped by `object_uri`.

## Tests
- `timeline-hub.test.ts` (6, fan-out + refcount + open-failure), `timeline-notify.integration.test.ts` (2, real LISTEN/NOTIFY round-trip), `feed-router.test.ts` (3, SSE headers + event forward + disconnect cleanup), `timeline-sse.test.ts` (4, stream parsing). Affected suites all green (52 backend tests across the slice); both package `check`s pass (0 errors).

## No new schema
No api-spec/schema changes (SSE has no body); the transport is app-level NOTIFY on the existing per-user connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)