### PR TITLE
feat(feed): harden following — self-follow guard, icon timeout, error surfacing (#884)

### DIFF
--- a/apps/backend/src/services/following.test.ts
+++ b/apps/backend/src/services/following.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import type { FeedFollowingRecord } from '../db/index.ts'
 
-import { actorToFollowingInput, serializeFollowing } from './following.ts'
+import { actorToFollowingInput, serializeFollowing, withTimeout } from './following.ts'
 
 describe('actorToFollowingInput', () => {
   test('extracts uri, inbox, shared inbox, handle, name, and avatar from a full actor', async () => {
@@ -76,5 +76,16 @@ describe('serializeFollowing', () => {
     // Internal delivery details must not leak to the owner-facing surface.
     expect(dto).not.toHaveProperty('inbox_uri')
     expect(dto).not.toHaveProperty('shared_inbox_uri')
+  })
+})
+
+describe('withTimeout', () => {
+  test('resolves with the value when the promise settles in time', async () => {
+    await expect(withTimeout(Promise.resolve('icon'), 1000)).resolves.toBe('icon')
+  })
+
+  test('rejects when the promise does not settle within the timeout', async () => {
+    // A never-settling promise (like a hung icon deref) must not hang the follow.
+    await expect(withTimeout(new Promise(() => {}), 20)).rejects.toThrow('timeout')
   })
 })

--- a/apps/backend/src/services/following.ts
+++ b/apps/backend/src/services/following.ts
@@ -64,6 +64,24 @@ const toPlainString = (value: unknown): string | null => {
   return str.length > 0 ? str : null
 }
 
+/** How long to wait for an actor's icon before giving up (avatar is non-essential). */
+const ICON_FETCH_TIMEOUT_MS = 3000
+
+/** Reject `promise` if it doesn't settle within `ms` (clearing the timer either way). Exported for testing. */
+export const withTimeout = async <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timeout')), ms)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
 /**
  * Extract the persisted fields of a followee from a resolved Fedify actor, or
  * null if it lacks the id/inbox we require to follow + later unfollow it.
@@ -71,8 +89,10 @@ const toPlainString = (value: unknown): string | null => {
  * The handle is derived from `preferredUsername` + the actor id's host rather
  * than `getActorHandle` (which may WebFinger the host): this is deterministic and
  * offline — good enough for a display handle, and it can't hang. The avatar comes
- * from the actor's embedded `icon` (Mastodon inlines it, so `getIcon()` needs no
- * fetch). Unit-tested with a constructed `Person`.
+ * from the actor's embedded `icon` — Mastodon inlines it (no fetch), but a server
+ * that only links it would make `getIcon()` dereference a URL, so it's bounded by
+ * a timeout: a slow icon host must not hang the synchronous follow. Unit-tested
+ * with a constructed `Person`.
  */
 export const actorToFollowingInput = async (actor: Actor): Promise<FeedFollowingInput | null> => {
   if (actor.id == null || actor.inboxId == null) return null
@@ -80,7 +100,7 @@ export const actorToFollowingInput = async (actor: Actor): Promise<FeedFollowing
   const handle = username == null ? null : `@${username}@${actor.id.host}`
   let avatarUrl: string | null = null
   try {
-    const icon = await actor.getIcon()
+    const icon = await withTimeout(actor.getIcon(), ICON_FETCH_TIMEOUT_MS)
     avatarUrl = icon?.url instanceof URL ? icon.url.href : null
   } catch {
     avatarUrl = null
@@ -128,6 +148,12 @@ export const followActor = async (deps: FollowDeps, user: string, handle: string
   }
   if (actor == null) {
     return { error: `Could not resolve an actor for “${handle}”.`, ok: false, status: 404 }
+  }
+
+  // Following yourself would deliver a Follow to your own inbox and clutter the
+  // timeline with your own posts — reject it before persisting a pending row.
+  if (actor.id != null && actor.id.href === ctx.getActorUri(user).href) {
+    return { error: 'You can’t follow yourself.', ok: false, status: 422 }
   }
 
   const input = await actorToFollowingInput(actor)

--- a/apps/web/src/pages/Feed/FollowingPanel.tsx
+++ b/apps/web/src/pages/Feed/FollowingPanel.tsx
@@ -83,7 +83,13 @@ export function FollowingPanel() {
           {follow.isPending ? 'Following…' : 'Follow'}
         </button>
       </form>
-      {follow.isError && <p class="following-error">Couldn't follow that handle. Check it and try again.</p>}
+      {follow.isError && (
+        <p class="following-error">
+          {follow.error instanceof Error && follow.error.message
+            ? follow.error.message
+            : "Couldn't follow that handle. Check it and try again."}
+        </p>
+      )}
 
       {isLoading && <p>Loading…</p>}
       {following && following.length === 0 && <p class="following-empty">You aren't following anyone yet.</p>}

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -57,13 +57,29 @@ export const fetchFollowing = async (): Promise<FollowingActor[]> => {
   return response.data.following
 }
 
+/** Pull the server's `{ error }` message off a failed request, or fall back to `fallback`. */
+const apiErrorMessage = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError(error)) {
+    const serverError = (error.response?.data as { error?: unknown } | undefined)?.error
+    if (typeof serverError === 'string' && serverError.trim()) return serverError
+  }
+  return fallback
+}
+
 /** Follow a fediverse actor by handle (`@user@host`, `user@host`, or actor URL). */
 export const followActor = async (handle: string): Promise<FollowingActor> => {
-  const response = await axios.post<FollowActorResponse>(
-    `${API_URL}/feed/following`,
-    { handle },
-    { headers: authHeaders() },
-  )
+  let response
+  try {
+    response = await axios.post<FollowActorResponse>(
+      `${API_URL}/feed/following`,
+      { handle },
+      { headers: authHeaders() },
+    )
+  } catch (error) {
+    // Surface the server's specific reason (e.g. "You can't follow yourself.",
+    // "Could not resolve an actor for …") instead of a generic message.
+    throw new Error(apiErrorMessage(error, 'Couldn’t follow that handle. Check it and try again.'))
+  }
   if (!response.data.actor) throw new Error('Follow failed: no actor returned')
   return response.data.actor
 }

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -118,6 +118,11 @@ The feed also runs the **inbound** direction: a user can follow other fediverse 
 2. records a **pending** follow in `feed_following`, then
 3. sends a signed `Follow` from the user's actor to the followee's inbox.
 
+Following **yourself** is rejected (it would deliver a `Follow` to your own inbox and echo your
+posts into your timeline). Resolving the actor's avatar is bounded by a short timeout, so a slow
+icon host can't hang the (synchronous) follow. When a follow fails, the web panel surfaces the
+server's specific reason (e.g. an unresolvable handle) rather than a generic message.
+
 When the followee's server answers with an `Accept`, the inbox marks the follow
 **accepted**; a `Reject` drops it. Unfollowing sends an `Undo{Follow}` to the cached inbox
 and removes the row. Local follows use the exact same path (delivered to the local inbox


### PR DESCRIPTION
First PR of slice 5 (share consolidation). Folds in the deferred **#917 non-blocking follow-ups** on the following flow — small, independent correctness/UX hardening.

## Changes
- **Reject self-follow** — following your own actor URI is rejected (422) before persisting a pending row; it would otherwise deliver a `Follow` to your own inbox and echo your posts into your own timeline.
- **Icon-fetch timeout** — `actorToFollowingInput` now bounds `actor.getIcon()` with a 3s timeout (`withTimeout`). Mastodon inlines the icon (no fetch), but a server that only *links* it would make `getIcon()` dereference a URL, which could hang the synchronous follow. The avatar is non-essential, so a timeout falls back to no avatar.
- **Specific follow errors in the UI** — the Following panel surfaces the server's `{ error }` message (e.g. "You can't follow yourself.", "Could not resolve an actor for …") instead of a generic message; the api client extracts it from the failed response.

## Deferred (with rationale)
The fourth #917 note — paginating the ActivityPub `following` collection — is **deliberately not done**: the `followers` collection is also unpaginated, both are small, and only the outbox (potentially large) is paginated. Paginating one collection but not the symmetric other would be inconsistent; this is YAGNI until counts actually grow.

## Tests
- `following.test.ts`: added `withTimeout` cases (resolves in time / rejects on hang). `followActor`'s network orchestration stays integration-territory (unchanged pattern). Both package `check`s pass (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)