### PR TITLE
refactor(nav): group feed/dashboards/challenges under a "Sharing" section (#884)

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -4,10 +4,10 @@ import { useCallback, useEffect, useState } from 'preact/hooks'
 import { auth, logout } from '../state/auth'
 import {
   DATA_SOURCE_LINKS,
+  isSharingActive,
   NAV_LINKS_PRIMARY,
   NAV_LINKS_SECONDARY,
   SHARING_LINKS,
-  SHARING_PATHS,
 } from './nav-links'
 
 // eslint-disable-next-line complexity -- navigation component with many branches
@@ -21,7 +21,7 @@ export function Header() {
   const [sharingExpandedInDrawer, setSharingExpandedInDrawer] = useState(true)
 
   const isDataSourcesActive = url.startsWith('/data-sources')
-  const isSharingActive = SHARING_PATHS.some((p) => url === p || url.startsWith(`${p}/`))
+  const sharingActive = isSharingActive(url)
 
   const handleLogout = (e: Event) => {
     e.preventDefault()
@@ -93,7 +93,7 @@ export function Header() {
             ))}
             {/* Sharing inline expand */}
             <button
-              class={`drawer-section-toggle${isSharingActive ? ' active' : ''}`}
+              class={`drawer-section-toggle${sharingActive ? ' active' : ''}`}
               onClick={() => setSharingExpandedInDrawer((v) => !v)}
               type="button"
             >

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -2,7 +2,13 @@ import { useLocation } from 'preact-iso'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 
 import { auth, logout } from '../state/auth'
-import { DATA_SOURCE_LINKS, NAV_LINKS } from './nav-links'
+import {
+  DATA_SOURCE_LINKS,
+  NAV_LINKS_PRIMARY,
+  NAV_LINKS_SECONDARY,
+  SHARING_LINKS,
+  SHARING_PATHS,
+} from './nav-links'
 
 // eslint-disable-next-line complexity -- navigation component with many branches
 export function Header() {
@@ -12,8 +18,10 @@ export function Header() {
 
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [dsExpandedInDrawer, setDsExpandedInDrawer] = useState(false)
+  const [sharingExpandedInDrawer, setSharingExpandedInDrawer] = useState(true)
 
   const isDataSourcesActive = url.startsWith('/data-sources')
+  const isSharingActive = SHARING_PATHS.some((p) => url === p || url.startsWith(`${p}/`))
 
   const handleLogout = (e: Event) => {
     e.preventDefault()
@@ -73,7 +81,36 @@ export function Header() {
             <a href="/" class={url === '/' ? 'active' : undefined} onClick={closeDrawer}>
               Home
             </a>
-            {NAV_LINKS.filter((l) => l.href !== '/').map((link) => (
+            {NAV_LINKS_PRIMARY.filter((l) => l.href !== '/').map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                class={url === link.href ? 'active' : undefined}
+                onClick={closeDrawer}
+              >
+                {link.label}
+              </a>
+            ))}
+            {/* Sharing inline expand */}
+            <button
+              class={`drawer-section-toggle${isSharingActive ? ' active' : ''}`}
+              onClick={() => setSharingExpandedInDrawer((v) => !v)}
+              type="button"
+            >
+              Sharing <span class="dropdown-arrow">{sharingExpandedInDrawer ? '▴' : '▾'}</span>
+            </button>
+            {sharingExpandedInDrawer &&
+              SHARING_LINKS.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  class={`drawer-sub-link${url === link.href ? ' active' : ''}`}
+                  onClick={closeDrawer}
+                >
+                  {link.label}
+                </a>
+              ))}
+            {NAV_LINKS_SECONDARY.map((link) => (
               <a
                 key={link.href}
                 href={link.href}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2,8 +2,16 @@ import { useLocation } from 'preact-iso'
 import { useState } from 'preact/hooks'
 
 import { auth, logout } from '../state/auth'
-import { DATA_SOURCE_LINKS, NAV_LINKS } from './nav-links'
+import {
+  DATA_SOURCE_LINKS,
+  NAV_LINKS_PRIMARY,
+  NAV_LINKS_SECONDARY,
+  SHARING_LINKS,
+  SHARING_PATHS,
+} from './nav-links'
 import './Sidebar.css'
+
+const isSharingActive = (url: string) => SHARING_PATHS.some((p) => url === p || url.startsWith(`${p}/`))
 
 const COLLAPSED_KEY = 'sidebar-collapsed'
 
@@ -15,6 +23,8 @@ export function Sidebar() {
 
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSED_KEY) === '1')
   const [dsExpanded, setDsExpanded] = useState(() => url.startsWith('/data-sources'))
+  // Sharing group is open by default so its surfaces stay one click away.
+  const [sharingExpanded, setSharingExpanded] = useState(true)
 
   const toggleCollapsed = () => {
     const next = !collapsed
@@ -30,6 +40,7 @@ export function Sidebar() {
   }
 
   const isDataSourcesActive = url.startsWith('/data-sources')
+  const sharingActive = isSharingActive(url)
 
   return (
     <aside class={`sidebar${collapsed ? ' collapsed' : ''}`}>
@@ -48,7 +59,60 @@ export function Sidebar() {
       <nav class="sidebar-nav">
         {isLoggedIn ? (
           <>
-            {NAV_LINKS.map((link) => (
+            {NAV_LINKS_PRIMARY.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                class={`sidebar-link${url === link.href ? ' active' : ''}`}
+                title={collapsed ? link.label : undefined}
+              >
+                <span class="sidebar-icon">{link.icon}</span>
+                <span class="sidebar-label">{link.label}</span>
+              </a>
+            ))}
+
+            {/* Sharing group (collapsed sidebar: the three surfaces as plain links) */}
+            {collapsed ? (
+              SHARING_LINKS.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  class={`sidebar-link${url === link.href ? ' active' : ''}`}
+                  title={link.label}
+                >
+                  <span class="sidebar-icon">{link.icon}</span>
+                  <span class="sidebar-label">{link.label}</span>
+                </a>
+              ))
+            ) : (
+              <>
+                <button
+                  class={`sidebar-section-btn${sharingActive ? ' active' : ''}`}
+                  onClick={() => setSharingExpanded((v) => !v)}
+                  type="button"
+                >
+                  <span class="sidebar-icon">🌐</span>
+                  <span class="sidebar-label">Sharing</span>
+                  <span class="sidebar-section-arrow">{sharingExpanded ? '▴' : '▾'}</span>
+                </button>
+                {sharingExpanded && (
+                  <div class="sidebar-sub-links">
+                    {SHARING_LINKS.map((link) => (
+                      <a
+                        key={link.href}
+                        href={link.href}
+                        class={`sidebar-link${url === link.href ? ' active' : ''}`}
+                      >
+                        <span class="sidebar-icon">{link.icon}</span>
+                        <span class="sidebar-label">{link.label}</span>
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+
+            {NAV_LINKS_SECONDARY.map((link) => (
               <a
                 key={link.href}
                 href={link.href}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4,14 +4,12 @@ import { useState } from 'preact/hooks'
 import { auth, logout } from '../state/auth'
 import {
   DATA_SOURCE_LINKS,
+  isSharingActive,
   NAV_LINKS_PRIMARY,
   NAV_LINKS_SECONDARY,
   SHARING_LINKS,
-  SHARING_PATHS,
 } from './nav-links'
 import './Sidebar.css'
-
-const isSharingActive = (url: string) => SHARING_PATHS.some((p) => url === p || url.startsWith(`${p}/`))
 
 const COLLAPSED_KEY = 'sidebar-collapsed'
 

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -24,6 +24,10 @@ export const SHARING_LINKS = [
 /** Routes that make the "Sharing" section count as active. */
 export const SHARING_PATHS = SHARING_LINKS.map((l) => l.href)
 
+/** Whether the current URL is within the Sharing section (a surface or a sub-route of one). */
+export const isSharingActive = (url: string): boolean =>
+  SHARING_PATHS.some((p) => url === p || url.startsWith(`${p}/`))
+
 export const NAV_LINKS_SECONDARY = [
   { href: '/correlations', label: 'Analyze', icon: '🔬' },
   { href: '/places', label: 'Places', icon: '📍' },

--- a/apps/web/src/components/nav-links.ts
+++ b/apps/web/src/components/nav-links.ts
@@ -1,4 +1,9 @@
-export const NAV_LINKS = [
+// Primary nav (top of the sidebar), the Sharing group, then the secondary nav.
+// The three sharing surfaces (feed, shared dashboards, challenges) are grouped
+// under one collapsible "Sharing" section (see Sidebar/Header) instead of being
+// three flat siblings, so "Share" stops being an ambiguous top-level label.
+
+export const NAV_LINKS_PRIMARY = [
   { href: '/', label: 'Home', icon: '🏠' },
   { href: '/goals', label: 'Goals', icon: '🎯' },
   { href: '/timeline', label: 'Timeline', icon: '📅' },
@@ -7,9 +12,19 @@ export const NAV_LINKS = [
   { href: '/reports', label: 'Reports', icon: '📝' },
   { href: '/add', label: '+ Add', icon: '➕' },
   { href: '/chart', label: 'Chart', icon: '📈' },
-  { href: '/shared-dashboards', label: 'Share', icon: '🔆' },
+]
+
+/** The three sharing surfaces, grouped under the "Sharing" section. */
+export const SHARING_LINKS = [
   { href: '/feed', label: 'Feed', icon: '📣' },
+  { href: '/shared-dashboards', label: 'Dashboards', icon: '🔆' },
   { href: '/challenges', label: 'Challenges', icon: '🏆' },
+]
+
+/** Routes that make the "Sharing" section count as active. */
+export const SHARING_PATHS = SHARING_LINKS.map((l) => l.href)
+
+export const NAV_LINKS_SECONDARY = [
   { href: '/correlations', label: 'Analyze', icon: '🔬' },
   { href: '/places', label: 'Places', icon: '📍' },
   { href: '/activity-types', label: 'Types', icon: '🏷' },

--- a/docs/features/challenges.md
+++ b/docs/features/challenges.md
@@ -42,20 +42,20 @@ base-URL federation identity, and the bucketed-data engine behind dashboards.
   as shared dashboards. The public resolver `/public/:username/:slug` returns a
   `type` (`dashboard` | `challenge`); slugs are unique across both per user.
 - Challenges + members live in the **host's** per-user DB; a joiner's
-  *participations* live in the **joiner's** DB, each backed by an unguessable
+  _participations_ live in the **joiner's** DB, each backed by an unguessable
   `data_token`. No central-DB tables.
 
 ## Federation protocol
 
 Endpoints (under each instance's API base):
 
-| Endpoint | Auth | Purpose |
-| --- | --- | --- |
-| `GET /.well-known/aurboda` | none | Discovery: `{ product, version, federation, api_base }` |
-| `GET /public/:username/:slug` | none | Resolve a slug → dashboard or challenge spec (incl. `join_token`, public member list) |
-| `POST /public/:username/:slug/members` | none | Register-back: a joining instance adds itself as a remote member |
-| `GET /public/:username/:slug/standings` | none (slug-gated) | Host-aggregated standings (`?refresh=1` busts the cache) |
-| `GET /challenge-data/:username/:token` | none (token) | A member instance serves its own series for one challenge |
+| Endpoint                                | Auth              | Purpose                                                                               |
+| --------------------------------------- | ----------------- | ------------------------------------------------------------------------------------- |
+| `GET /.well-known/aurboda`              | none              | Discovery: `{ product, version, federation, api_base }`                               |
+| `GET /public/:username/:slug`           | none              | Resolve a slug → dashboard or challenge spec (incl. `join_token`, public member list) |
+| `POST /public/:username/:slug/members`  | none              | Register-back: a joining instance adds itself as a remote member                      |
+| `GET /public/:username/:slug/standings` | none (slug-gated) | Host-aggregated standings (`?refresh=1` busts the cache)                              |
+| `GET /challenge-data/:username/:token`  | none (token)      | A member instance serves its own series for one challenge                             |
 
 **Join (canonical: "join by challenge URL on your own instance B", host = A):**
 
@@ -75,7 +75,7 @@ persisted per member; a failed fetch falls back to last-known data flagged `stal
 and computes local members in-process.
 
 Each standing carries a **`last_updated`** — the timestamp of that member's most
-recent *contributing* data point within the challenge window (`MAX(time)` of the
+recent _contributing_ data point within the challenge window (`MAX(time)` of the
 measured metric/activity, using the same source filter as the total). A member with
 no data yet reports `null` (rendered as "—"), never the request time — so members on
 0 don't all share a bogus "just now". Remote members report their own `last_updated`;
@@ -102,7 +102,7 @@ the backend directly need no extra config.
 
 ## Using it in the web app
 
-- **Manage** at `/challenges` (sidebar "Challenges"): create a challenge (name,
+- **Manage** at `/challenges` ("Challenges" under the sidebar **Sharing** section): create a challenge (name,
   metric or activity type, sum/count, unit, date range with This-week/This-month
   quick-sets, public/unlisted), copy its link, delete it; see challenges you've
   joined; and **join by URL** (paste any challenge link — local or remote).
@@ -130,7 +130,7 @@ the backend directly need no extra config.
   register-back gaps below.
 - Register-back is capped per challenge (`MAX_CHALLENGE_MEMBERS`) to bound growth,
   but within the v1 trust model a slug+`join_token` holder can still re-register an
-  existing *remote* member (overwriting its data-endpoint URL). Accepted for now.
+  existing _remote_ member (overwriting its data-endpoint URL). Accepted for now.
 - Standings has no in-flight de-duplication, so concurrent requests on a cold/expired
   cache each fan out to every remote member (thundering herd, bounded by the TTL +
   8s per-fetch timeout). A shared in-flight promise per challenge would remove it.

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -102,7 +102,7 @@ uses), so nothing denormalised is persisted on the post.
   canonical id so a remote server can dereference it. Only `public`/`unlisted` resolve;
   `followers`-only and unknown ids return 404. Once a `public`/`unlisted` post is
   **deleted**, that id returns **`410 Gone` with an AS2 `Tombstone`** (recorded in
-  `feed_tombstone`) so a dereferencing server learns the object is *permanently* gone
+  `feed_tombstone`) so a dereferencing server learns the object is _permanently_ gone
   rather than transiently missing. A `followers`-only id is never tombstoned — it never
   resolved publicly, so a 410 would leak that a post once existed.
 
@@ -115,7 +115,7 @@ place, so they can't drift.
 ### Following other actors (inbound)
 
 The feed also runs the **inbound** direction: a user can follow other fediverse actors
-(remote *or* another local Aurboda user). Following `@alice@mastodon.social`:
+(remote _or_ another local Aurboda user). Following `@alice@mastodon.social`:
 
 1. resolves the target actor (WebFinger + actor fetch) to its inbox + presentation,
 2. records a **pending** follow in `feed_following`, then
@@ -133,7 +133,7 @@ over loopback), so there is no special-casing. Delivery is best-effort/synchrono
 the rest of the feed — a failed `Follow` POST leaves the pending row so the user can retry.
 
 The actor advertises a **following collection** (`/users/<username>/following`) listing only
-*accepted* follows (a pending follow isn't a confirmed relationship yet). The followee's
+_accepted_ follows (a pending follow isn't a confirmed relationship yet). The followee's
 inbox URIs are internal delivery details and are never exposed on the owner-facing API.
 
 ### Home timeline (inbound)
@@ -247,7 +247,8 @@ resolving.
 
 - **Share** — an activity's detail page has a **Share to feed** button. It opens a dialog
   to pick the summary metrics, optionally opt into full series, and choose the audience.
-- **Manage** — the **Feed** page (`/feed`, the 📣 item in the sidebar) lists everything
+- **Manage** — the **Feed** page (`/feed`, the 📣 item under the **Sharing** section in
+  the sidebar) lists everything
   you've shared, with each post's audience and metrics. From there you can **Edit** a
   post (re-opens the dialog; saving federates an `Update`) or **Unshare** it (federates a
   `Delete`).
@@ -263,31 +264,31 @@ resolving.
 
 Owner-facing (authenticated, scoped to the caller):
 
-| Method & path                     | Purpose                                            |
-| --------------------------------- | -------------------------------------------------- |
+| Method & path                     | Purpose                                                                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `GET /feed`                       | List my feed posts (each enriched with the shared activity's title/type and merged-span window, resolved at query time) |
-| `POST /feed/activities/:id/share` | Publish an activity with a chosen metric selection |
-| `PATCH /feed/:postId`             | Edit selection / visibility / attachments          |
-| `DELETE /feed/:postId`            | Unpublish (its public series stops resolving)      |
-| `GET /feed/following`             | List the actors I follow (accepted + pending)      |
-| `POST /feed/following`            | Follow an actor by handle (`@user@host` or actor URL) |
-| `DELETE /feed/following/:id`      | Unfollow (sends `Undo{Follow}`)                    |
-| `GET /feed/timeline`              | My home timeline (posts from followees), newest-first, `?cursor=` to page |
-| `GET /feed/timeline/stream`       | Server-Sent Events stream of live "new posts" pings (falls back to polling) |
+| `POST /feed/activities/:id/share` | Publish an activity with a chosen metric selection                                                                      |
+| `PATCH /feed/:postId`             | Edit selection / visibility / attachments                                                                               |
+| `DELETE /feed/:postId`            | Unpublish (its public series stops resolving)                                                                           |
+| `GET /feed/following`             | List the actors I follow (accepted + pending)                                                                           |
+| `POST /feed/following`            | Follow an actor by handle (`@user@host` or actor URL)                                                                   |
+| `DELETE /feed/following/:id`      | Unfollow (sends `Undo{Follow}`)                                                                                         |
+| `GET /feed/timeline`              | My home timeline (posts from followees), newest-first, `?cursor=` to page                                               |
+| `GET /feed/timeline/stream`       | Server-Sent Events stream of live "new posts" pings (falls back to polling)                                             |
 
 Public / federation (unauthenticated):
 
-| Method & path                                  | Purpose                                                     |
-| ---------------------------------------------- | ----------------------------------------------------------- |
-| `GET /public/:username/series`                 | Bucketed samples for a **shared** series within its window  |
-| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post (`?token=` for followers-only) |
-| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post (`?token=` for followers-only) |
-| `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                |
-| `GET /users/:username`                         | The actor document (`Person`)                               |
-| `GET /users/:username/outbox`                  | Public + unlisted posts as `Create` activities              |
-| `GET /users/:username/followers`               | The actor's followers collection                            |
-| `GET /users/:username/following`               | The actor's following collection (accepted follows only)    |
-| `GET /users/:username/feed/:postId`            | A single post's `Note` (or `410` Tombstone once deleted)    |
+| Method & path                                  | Purpose                                                                           |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `GET /public/:username/series`                 | Bucketed samples for a **shared** series within its window                        |
+| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post (`?token=` for followers-only)             |
+| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post (`?token=` for followers-only)        |
+| `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                                      |
+| `GET /users/:username`                         | The actor document (`Person`)                                                     |
+| `GET /users/:username/outbox`                  | Public + unlisted posts as `Create` activities                                    |
+| `GET /users/:username/followers`               | The actor's followers collection                                                  |
+| `GET /users/:username/following`               | The actor's following collection (accepted follows only)                          |
+| `GET /users/:username/feed/:postId`            | A single post's `Note` (or `410` Tombstone once deleted)                          |
 | `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified) |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
@@ -322,7 +323,7 @@ These are known and intentional for the current implementation:
   (Mastodon behaves the same) — there is no addressable "public" inbox to retract from.
 - **The public series endpoint uses the anchor window for merged shares.** The delivered
   Note's scalar summary and the rendered images cover the full merged span, but
-  `GET /public/:username/series` still authorizes only the shared activity's *own* window
+  `GET /public/:username/series` still authorizes only the shared activity's _own_ window
   (`findCoveringSharedSeriesWindow` joins on `activity_id`). Since the delivered
   Mastodon `Note` carries no series links, this is latent — expanding series
   authorization across a merge group (which needs the merge algorithm at query time) is a

--- a/docs/features/sharing.md
+++ b/docs/features/sharing.md
@@ -64,9 +64,10 @@ beyond the saved widgets.
 
 ## Using it in the web app
 
-- **Manage** your shared dashboards at `/shared-dashboards` (the "Share" item in
-  the sidebar): create a copy from your current home dashboard (or a blank one),
-  rename it, toggle public/unlisted, copy its link, or delete it.
+- **Manage** your shared dashboards at `/shared-dashboards` ("Dashboards" under the
+  **Sharing** section in the sidebar, alongside Feed and Challenges): create a copy
+  from your current home dashboard (or a blank one), rename it, set its visibility,
+  copy its link, or delete it.
 - **View** a shared dashboard at `/u/<username>/<slug>` and a profile at
   `/u/<username>`. For anonymous visitors these public pages render without the
   app header/sidebar (but keep the standard site footer) — a clean, standalone
@@ -136,7 +137,7 @@ OG cards, and as the ActivityPub actor `icon` (so Mastodon and friends show it).
 ## oEmbed & sharability
 
 - **oEmbed**: public share pages advertise a `<link rel="alternate"
-  type="application/json+oembed">` pointing at `GET /oembed?url=<share url>`, which
+type="application/json+oembed">` pointing at `GET /oembed?url=<share url>`, which
   returns a `type: "link"` document (title, author, provider, OG-image thumbnail).
   Only public resources resolve — unlisted/unknown/private URLs 404, so nothing
   private is exposed. Primarily benefits Mastodon and other oEmbed-aware consumers.


### PR DESCRIPTION
## Slice 5c of #884 — nav/IA consolidation

The sidebar item literally labeled **"Share"** pointed only to `/shared-dashboards`,
while **Feed** and **Challenges** were separate flat siblings — so "Share" read as a
generic verb but meant *dashboards*, and the three sharing surfaces had no grouping.

### What changed
Group the three sharing surfaces under one collapsible **"Sharing"** section (reusing
the existing **Data Sources** expandable pattern) in both the desktop sidebar and the
mobile drawer:

- **`nav-links.ts`** — split `NAV_LINKS` into `NAV_LINKS_PRIMARY` / `NAV_LINKS_SECONDARY`
  and add `SHARING_LINKS` (Feed, Dashboards, Challenges) + `SHARING_PATHS`. The bare
  **"Share"** label is gone; the dashboards item is now clearly **"Dashboards"**.
- **Sidebar** — renders the Sharing section in its current mid-list position, **open by
  default** so the surfaces stay one click away. When the sidebar is collapsed, the three
  render as individual icon links (each is a real page).
- **Header (mobile drawer)** — the same grouped, open-by-default section.
- **Routes unchanged** (`/feed`, `/shared-dashboards`, `/challenges`) — bookmarks safe.
- **docs** — the "using it in the web app" notes in sharing/feed/challenges point at the
  new Sharing section.

### Resulting sidebar
```
🏠 Home · 🎯 Goals · 📅 Timeline · 📊 Data · 🍽 Meals · 📝 Reports · ➕ +Add · 📈 Chart
🌐 Sharing ▴
   📣 Feed          → /feed
   🔆 Dashboards    → /shared-dashboards
   🏆 Challenges    → /challenges
🔬 Analyze · 📍 Places · 🏷 Types · 🔗 Rules
📡 Data Sources ▾ · ⚙️ Admin
```

### Scope note
Frontend-only (no backend/api-spec changes). The "Share to feed" activity button and the
native-share "Share" on public pages are each contextually clear and left as-is. Per the
chosen option ("Grouped Sharing section"), this keeps all existing routes rather than
introducing a hub page.

### Checks
- web `tsgo` clean; oxlint clean; **web 499 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)