### PR TITLE
fix(feed): gate Fedify middleware so large /sync bodies don't hang (Health Connect sync)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -20,6 +20,7 @@ import { Client } from 'pg'
 import type { FeedDeliver } from './routes/feed-router.ts'
 
 import { registerAuthRoutes } from './api/auth-routes.ts'
+import { gateFederation } from './api/federation-gate.ts'
 import { createAdminMiddleware, createAuditLogMiddleware, createAuthMiddleware } from './api/middleware.ts'
 import { registerOAuthRoutes } from './api/oauth-routes.ts'
 import { mountRestRouters } from './api/rest-routes.ts'
@@ -378,15 +379,18 @@ const main = async () => {
   )
 
   // ActivityPub federation (actor + WebFinger). Mounted BEFORE the JSON body
-  // parser so Fedify owns the raw body of signed inbox POSTs; it passes through
-  // (next()) any request that isn't one of its own routes. `trust proxy` lets
-  // Fedify reconstruct the external https URL from nginx's X-Forwarded-* headers.
+  // parser so Fedify owns the raw body of signed inbox POSTs. `gateFederation`
+  // restricts it to federation-owned paths: `integrateFederation` otherwise
+  // wraps EVERY non-GET body with `Readable.toWeb(req)` and next()s without
+  // consuming it, hanging `express.json()` on any large non-federation POST
+  // (e.g. a Health Connect batch > ~64 KB). `trust proxy` lets Fedify
+  // reconstruct the external https URL from nginx's X-Forwarded-* headers.
   // Scope it to `loopback`: nginx proxies to the backend over loopback
   // (proxy_pass http://127.0.0.1:3000), so Express trusts X-Forwarded-* only when
   // the immediate peer is loopback — a direct remote client isn't, so it can't
   // spoof them.
   httpd.set('trust proxy', 'loopback')
-  httpd.use(integrateFederation(feedFederation, () => undefined))
+  httpd.use(gateFederation(integrateFederation(feedFederation, () => undefined)))
 
   // `410 Gone` Tombstone for dereferenced deleted objects. Mounted right after
   // the federation integration: when the object dispatcher returns null for a

--- a/apps/backend/src/api/federation-gate.test.ts
+++ b/apps/backend/src/api/federation-gate.test.ts
@@ -1,0 +1,115 @@
+import { integrateFederation } from '@fedify/express'
+import express, { json, type RequestHandler } from 'express'
+import request from 'supertest'
+import { describe, expect, test, vi } from 'vitest'
+
+import { gateFederation, isFederationRequest } from './federation-gate.ts'
+
+describe('isFederationRequest', () => {
+  test.each([
+    '/inbox',
+    '/users/alice',
+    '/users/alice/inbox',
+    '/users/alice/outbox',
+    '/users/alice/followers',
+    '/users/alice/following',
+    '/users/alice/feed/abc-123',
+    '/.well-known/webfinger',
+    '/.well-known/nodeinfo',
+    '/nodeinfo/2.1',
+  ])('owns %s', (path) => {
+    expect(isFederationRequest(path)).toBe(true)
+  })
+
+  test.each([
+    '/sync/StepsRecord',
+    '/sync/HeartRateRecord',
+    '/sync/daily-aggregates',
+    '/activities',
+    '/mcp',
+    '/login',
+    '/u/alice', // SPA profile page — must NOT be captured (federation uses /users/)
+    '/.well-known/assetlinks.json',
+    '/.well-known/aurboda',
+  ])('skips %s', (path) => {
+    expect(isFederationRequest(path)).toBe(false)
+  })
+})
+
+describe('gateFederation', () => {
+  test('runs the wrapped middleware for a federation path', () => {
+    const inner = vi.fn<RequestHandler>((_req, _res, next) => next())
+    const next = vi.fn()
+    gateFederation(inner)({ path: '/users/alice' } as never, {} as never, next)
+    expect(inner).toHaveBeenCalledOnce()
+  })
+
+  test('skips the wrapped middleware for a non-federation path', () => {
+    const inner = vi.fn<RequestHandler>((_req, _res, next) => next())
+    const next = vi.fn()
+    gateFederation(inner)({ path: '/sync/StepsRecord' } as never, {} as never, next)
+    expect(inner).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledOnce()
+  })
+})
+
+/**
+ * Regression for the Health Connect sync hang: `integrateFederation` wraps
+ * every non-GET body with `Readable.toWeb(req)`, so mounting it before
+ * `express.json()` used to stall the body parser on any large non-federation
+ * POST (>~64 KB — the socket buffer). Exercise the REAL `@fedify/express`
+ * middleware in the production order; without the gate the large POST hangs and
+ * this test times out.
+ */
+describe('federation middleware ordering (real @fedify/express)', () => {
+  // Minimal stand-in for the Federation object: `integrateFederation` calls
+  // `federation.fetch(request, { onNotFound, ... })`. Handle the inbox, treat
+  // everything else as not-found (→ next()), mirroring the real dispatch.
+  const fakeFederation = {
+    fetch: async (req: Request, { onNotFound }: { onNotFound: () => Response }) => {
+      if (new URL(req.url).pathname === '/inbox') return new Response('accepted', { status: 202 })
+      return onNotFound()
+    },
+  }
+
+  const buildApp = () => {
+    const app = express()
+    app.use(gateFederation(integrateFederation(fakeFederation as never, () => undefined)))
+    app.use(json({ limit: '10mb' }))
+    app.post('/sync/:recordType', (req, res) => {
+      res.json({ count: Array.isArray(req.body?.data) ? req.body.data.length : 0, success: true })
+    })
+    return app
+  }
+
+  const bigBatch = (n: number) => ({
+    data: Array.from({ length: n }, (_, i) => ({
+      count: i,
+      startTime: '2026-07-03T10:00:00Z',
+      endTime: '2026-07-03T10:01:00Z',
+      metadata: { id: `rec-${i}`, dataOrigin: { packageName: 'net.aurboda' } },
+    })),
+  })
+
+  test('parses a small non-federation POST body', async () => {
+    const res = await request(buildApp()).post('/sync/StepsRecord').send(bigBatch(5))
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ count: 5, success: true })
+  })
+
+  test('parses a large (>64 KB) non-federation POST body without hanging', async () => {
+    const batch = bigBatch(2000)
+    expect(JSON.stringify(batch).length).toBeGreaterThan(64 * 1024)
+    const res = await request(buildApp()).post('/sync/StepsRecord').send(batch)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ count: 2000, success: true })
+  }, 15_000)
+
+  test('still routes a federation inbox POST to Fedify (raw body preserved)', async () => {
+    const res = await request(buildApp())
+      .post('/inbox')
+      .set('content-type', 'application/activity+json')
+      .send({ type: 'Follow' })
+    expect(res.status).toBe(202)
+  })
+})

--- a/apps/backend/src/api/federation-gate.ts
+++ b/apps/backend/src/api/federation-gate.ts
@@ -1,0 +1,40 @@
+/**
+ * Gate the `@fedify/express` integration so it only runs for the routes Fedify
+ * actually owns.
+ *
+ * `integrateFederation` must be mounted BEFORE `express.json()` so Fedify sees
+ * the raw body of signed inbox POSTs. But its `fromERequest` wraps EVERY
+ * non-GET request body with `Readable.toWeb(req)` — even for routes it doesn't
+ * own — and then calls `next()` without ever consuming that stream. The result:
+ * `express.json()` waits forever for body bytes that were siphoned into an
+ * abandoned web stream, so any non-federation POST whose body exceeds the
+ * socket buffer (~64 KB) hangs with no response (e.g. a large Health Connect
+ * batch — see the size-cliff regression test).
+ *
+ * Restricting the middleware to federation-owned paths keeps raw-body access
+ * for the inbox while letting every other route reach `express.json()`
+ * untouched.
+ */
+import type { RequestHandler } from 'express'
+
+/**
+ * Whether `path` is served by the Fedify federation surface (see
+ * `services/activitypub/federation.ts`): the per-user actor and everything
+ * mounted under it (inbox, outbox, followers, following, feed objects), the
+ * shared inbox, and WebFinger / NodeInfo discovery.
+ *
+ * Must stay a superset of every dispatcher/listener path registered on the
+ * federation object — a missed path would silently stop reaching Fedify.
+ */
+export const isFederationRequest = (path: string): boolean =>
+  path === '/inbox' ||
+  path.startsWith('/users/') ||
+  path.startsWith('/.well-known/webfinger') ||
+  path.startsWith('/.well-known/nodeinfo') ||
+  path.startsWith('/nodeinfo')
+
+/** Wrap the Fedify middleware so non-federation requests skip it entirely. */
+export const gateFederation =
+  (federation: RequestHandler): RequestHandler =>
+  (req, res, next) =>
+    isFederationRequest(req.path) ? federation(req, res, next) : next()


### PR DESCRIPTION
## Symptom

Health Connect sync from the Android app stopped landing data around **2026-07-03 13:40** for multiple users (me + Sara), with **nothing in the audit log or server log**. Garmin/Oura/Strava (server-side pulls) and `POST /activities` from computers kept working.

## Root cause

`@fedify/express`'s `integrateFederation` is mounted **before** `express.json()` (required, so Fedify sees the raw body of signed inbox POSTs). But its `fromERequest` wraps **every** non-GET request body with `Readable.toWeb(req)` — even for routes it doesn't own, like `/sync/:recordType` — and then calls `next()` without consuming that stream. `express.json()` then blocks forever waiting for body bytes that were siphoned into an abandoned web stream.

- Small bodies already sit in the socket buffer → parse fine (months of small HC syncs worked).
- Bodies past ~64 KB → **hang with no response** → `res.on('finish')` never fires → **no audit entry**.

Once a device's backlog produced a page > ~64 KB (the app's screenshot showed a **749-record / 156 KB** page), every retry hung and the backlog only grew — permanently stuck.

Confirmed by a live size sweep against prod (42 KB → fast 401; 156 KB → 30 s hang) and a local repro with the real `@fedify/express` (small → 200, large → hang, `raw-body: request aborted`).

## Fix

Gate the Fedify middleware to the paths it actually owns (`/users/*`, `/inbox`, `/.well-known/webfinger`, nodeinfo — a superset of every dispatcher/listener in `services/activitypub/federation.ts`, including the object/tombstone path `/users/{id}/feed/{postId}`). The inbox keeps raw-body access; every other route reaches `express.json()` untouched. A plain reorder won't do — `json` first makes `fromERequest` throw on the consumed stream and breaks inbox signature verification.

## Tests

- `isFederationRequest` / `gateFederation` unit coverage (owns vs skips).
- Regression: POSTs a **>64 KB** body through the **real** `integrateFederation` → gate → `json` chain in the production order and asserts 200 (hangs without the gate); plus a `/inbox` POST still routing to Fedify.

After deploy, backlogged devices self-heal on their next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)