### PR TITLE
feat(feed): follower approval flow + manual-approval setting (#884)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -72,6 +72,12 @@ import {
 import { createDetectionTrigger, type DetectionTrigger } from './services/detection-trigger.ts'
 import { runDetectionForUser } from './services/detection-worker.ts'
 import { expandFeedActivityWindow, resolveFeedActivity } from './services/feed.ts'
+import {
+  approveFollower,
+  type FollowerActions,
+  rejectFollower,
+  serializeFollower,
+} from './services/followers.ts'
 import { type FollowActions, followActor, unfollowActor } from './services/following.ts'
 import { createGeocodeQueue } from './services/geocode-queue.ts'
 import { createInvitationAuth } from './services/invitation.ts'
@@ -356,6 +362,15 @@ const main = async () => {
     follow: (user, handle) => followActor(feedDeps, user, handle),
     unfollow: (user, id) => unfollowActor(feedDeps, user, id),
   }
+  // The follower-management operations (approve/reject a follow request), sharing
+  // the same federation + origin. Approve returns the serialised follower.
+  const followerActions: FollowerActions = {
+    approve: async (user, id) => {
+      const record = await approveFollower(feedDeps, user, id)
+      return record ? serializeFollower(record) : null
+    },
+    reject: (user, id) => rejectFollower(feedDeps, user, id),
+  }
 
   // Mount MCP server BEFORE body-parser (MCP SDK needs raw body)
   // Stateless mode — no session tracking needed (tools only, no subscriptions)
@@ -368,6 +383,7 @@ const main = async () => {
       engineDeps,
       feedDeliver,
       followActions,
+      followerActions,
       garmin,
       onActivityMutated: activityNotifier,
       oura,
@@ -503,6 +519,7 @@ const main = async () => {
     engineDeps,
     feedDeliver,
     followActions,
+    followerActions,
     garmin,
     httpd,
     invitationAuth,

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -12,6 +12,7 @@ import type { GarminClient } from '../integrations/garmin/client.ts'
 import type { CentralDb } from '../services/central-db.ts'
 import type { DeductionEngineDeps } from '../services/deduction-engine.ts'
 import type { ActivityNotifier, DeductionQueue } from '../services/deduction-queue.ts'
+import type { FollowerActions } from '../services/followers.ts'
 import type { FollowActions } from '../services/following.ts'
 import type { InvitationAuth } from '../services/invitation.ts'
 import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
@@ -32,6 +33,7 @@ import { createChartDataRouter } from '../routes/chart-data-router.ts'
 import { createCorrelationsRouter } from '../routes/correlations-router.ts'
 import { createDashboardRouter } from '../routes/dashboard-router.ts'
 import { createDeductionRulesRouter } from '../routes/deduction-rules-router.ts'
+import { createFeedFollowersRouter } from '../routes/feed-followers-router.ts'
 import { createFeedFollowingRouter } from '../routes/feed-following-router.ts'
 import { createFeedImageRouter } from '../routes/feed-image-router.ts'
 import { createFeedPublicRouter } from '../routes/feed-public-router.ts'
@@ -89,6 +91,7 @@ interface RestRoutesDeps {
   userDb: Client
   feedDeliver: FeedDeliver
   followActions: FollowActions
+  followerActions: FollowerActions
   timelineHub: TimelineHub
 }
 
@@ -108,6 +111,7 @@ export const mountRestRouters = ({
   deductionQueue,
   feedDeliver,
   followActions,
+  followerActions,
   timelineHub,
   ouraWebhookManager,
   auth,
@@ -150,9 +154,11 @@ export const mountRestRouters = ({
   httpd.use('/dashboard', createDashboardRouter(authMiddleware))
   httpd.use('/shared-dashboards', createSharedDashboardsRouter(authMiddleware, webHost))
   httpd.use('/profile', createProfileRouter(authMiddleware, webHost))
-  // Mount the following router before `/feed` so `/feed/following/*` (two path
-  // segments) resolves here and never touches the feed router's `/:postId`.
+  // Mount the following + followers routers before `/feed` so `/feed/following/*`
+  // and `/feed/followers/*` (two path segments) resolve here and never touch the
+  // feed router's `/:postId`.
   httpd.use('/feed/following', createFeedFollowingRouter(authMiddleware, followActions))
+  httpd.use('/feed/followers', createFeedFollowersRouter(authMiddleware, followerActions))
   httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver, timelineHub))
   httpd.use('/challenges', createChallengesRouter(authMiddleware, webHost, apiBaseUrl))
   httpd.use(createChallengeDataRouter())

--- a/apps/backend/src/db/feed-follower.integration.test.ts
+++ b/apps/backend/src/db/feed-follower.integration.test.ts
@@ -6,8 +6,12 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import {
   countFeedFollowers,
+  getFeedFollowerByActor,
+  getFeedFollowerById,
   listFeedFollowers,
   removeFeedFollower,
+  removeFeedFollowerById,
+  setFeedFollowerAccepted,
   upsertFeedFollower,
 } from './feed-follower.ts'
 
@@ -15,8 +19,17 @@ const CONTAINER_TIMEOUT = 120_000
 
 const alice = {
   actor_uri: 'https://mastodon.example/users/alice',
+  avatar_url: 'https://mastodon.example/avatars/alice.png',
+  display_name: 'Alice',
+  follow_activity_uri: 'https://mastodon.example/users/alice/follows/1',
+  handle: '@alice@mastodon.example',
   inbox_uri: 'https://mastodon.example/users/alice/inbox',
   shared_inbox_uri: 'https://mastodon.example/inbox',
+}
+
+const bob = {
+  actor_uri: 'https://remote.example/users/bob',
+  inbox_uri: 'https://remote.example/users/bob/inbox',
 }
 
 describe('Feed followers integration', () => {
@@ -32,58 +45,104 @@ describe('Feed followers integration', () => {
     await cleanTestDb()
   })
 
-  test('adds a follower and lists it', async () => {
+  test('adds a follower with presentation + follow id and lists it', async () => {
     const user = getTestUser()
     const rec = await upsertFeedFollower(user, { ...alice, accepted: true })
+    expect(rec.id).toMatch(/^[0-9a-f-]{36}$/)
     expect(rec.actor_uri).toBe(alice.actor_uri)
     expect(rec.inbox_uri).toBe(alice.inbox_uri)
     expect(rec.shared_inbox_uri).toBe(alice.shared_inbox_uri)
+    expect(rec.handle).toBe('@alice@mastodon.example')
+    expect(rec.display_name).toBe('Alice')
+    expect(rec.avatar_url).toBe(alice.avatar_url)
+    expect(rec.follow_activity_uri).toBe(alice.follow_activity_uri)
     expect(rec.accepted).toBe(true)
 
     const followers = await listFeedFollowers(user)
     expect(followers.map((f) => f.actor_uri)).toEqual([alice.actor_uri])
   })
 
-  test('defaults accepted to false and shared_inbox to null', async () => {
+  test('defaults accepted to false and optional fields to null', async () => {
     const user = getTestUser()
-    const rec = await upsertFeedFollower(user, {
-      actor_uri: 'https://remote.example/users/bob',
-      inbox_uri: 'https://remote.example/users/bob/inbox',
-    })
+    const rec = await upsertFeedFollower(user, bob)
     expect(rec.accepted).toBe(false)
     expect(rec.shared_inbox_uri).toBeNull()
+    expect(rec.handle).toBeNull()
+    expect(rec.display_name).toBeNull()
+    expect(rec.avatar_url).toBeNull()
+    expect(rec.follow_activity_uri).toBeNull()
   })
 
-  test('re-following the same actor updates in place (no duplicate)', async () => {
+  test('re-following updates in place, keeps the id, and keeps last-known presentation', async () => {
     const user = getTestUser()
-    await upsertFeedFollower(user, { ...alice, accepted: false })
+    const first = await upsertFeedFollower(user, { ...alice, accepted: false })
+    // A re-delivered Follow that couldn't re-extract presentation must not wipe it,
+    // but should refresh the inbox and can flip acceptance.
     const updated = await upsertFeedFollower(user, {
-      ...alice,
       accepted: true,
+      actor_uri: alice.actor_uri,
       inbox_uri: 'https://mastodon.example/users/alice/inbox2',
     })
+    expect(updated.id).toBe(first.id)
     expect(updated.accepted).toBe(true)
     expect(updated.inbox_uri).toBe('https://mastodon.example/users/alice/inbox2')
+    expect(updated.handle).toBe('@alice@mastodon.example')
+    expect(updated.display_name).toBe('Alice')
 
-    const followers = await listFeedFollowers(user)
-    expect(followers).toHaveLength(1)
+    expect(await listFeedFollowers(user)).toHaveLength(1)
   })
 
-  test('counts followers without loading rows', async () => {
+  test('lists pending vs accepted with the status filter', async () => {
+    const user = getTestUser()
+    await upsertFeedFollower(user, { ...alice, accepted: true })
+    await upsertFeedFollower(user, { ...bob, accepted: false })
+
+    expect((await listFeedFollowers(user, { accepted: true })).map((f) => f.actor_uri)).toEqual([
+      alice.actor_uri,
+    ])
+    expect((await listFeedFollowers(user, { accepted: false })).map((f) => f.actor_uri)).toEqual([
+      bob.actor_uri,
+    ])
+    expect(await listFeedFollowers(user)).toHaveLength(2)
+  })
+
+  test('counts only accepted followers', async () => {
     const user = getTestUser()
     expect(await countFeedFollowers(user)).toBe(0)
-    await upsertFeedFollower(user, alice)
-    await upsertFeedFollower(user, {
-      actor_uri: 'https://remote.example/users/bob',
-      inbox_uri: 'https://remote.example/users/bob/inbox',
-    })
-    expect(await countFeedFollowers(user)).toBe(2)
-    // Re-following an existing actor does not double-count.
-    await upsertFeedFollower(user, alice)
-    expect(await countFeedFollowers(user)).toBe(2)
+    await upsertFeedFollower(user, { ...alice, accepted: true })
+    await upsertFeedFollower(user, { ...bob, accepted: false })
+    // Only alice (accepted) is counted; bob is a pending request.
+    expect(await countFeedFollowers(user)).toBe(1)
   })
 
-  test('removes a follower (e.g. on Undo Follow)', async () => {
+  test('fetches a follower by id and by actor uri', async () => {
+    const user = getTestUser()
+    const rec = await upsertFeedFollower(user, alice)
+    expect((await getFeedFollowerById(user, rec.id))?.actor_uri).toBe(alice.actor_uri)
+    expect((await getFeedFollowerByActor(user, alice.actor_uri))?.id).toBe(rec.id)
+    expect(await getFeedFollowerById(user, '00000000-0000-0000-0000-000000000000')).toBeNull()
+    expect(await getFeedFollowerByActor(user, 'https://nope.example/x')).toBeNull()
+  })
+
+  test('approves a pending follower by id', async () => {
+    const user = getTestUser()
+    const rec = await upsertFeedFollower(user, { ...alice, accepted: false })
+    const approved = await setFeedFollowerAccepted(user, rec.id)
+    expect(approved?.accepted).toBe(true)
+    expect((await getFeedFollowerById(user, rec.id))?.accepted).toBe(true)
+    expect(await setFeedFollowerAccepted(user, '00000000-0000-0000-0000-000000000000')).toBeNull()
+  })
+
+  test('removes a follower by id, returning the removed row', async () => {
+    const user = getTestUser()
+    const rec = await upsertFeedFollower(user, alice)
+    const removed = await removeFeedFollowerById(user, rec.id)
+    expect(removed?.inbox_uri).toBe(alice.inbox_uri)
+    expect(await getFeedFollowerById(user, rec.id)).toBeNull()
+    expect(await removeFeedFollowerById(user, rec.id)).toBeNull()
+  })
+
+  test('removes a follower by actor uri (e.g. on Undo Follow)', async () => {
     const user = getTestUser()
     await upsertFeedFollower(user, alice)
     expect(await removeFeedFollower(user, alice.actor_uri)).toBe(true)

--- a/apps/backend/src/db/feed-follower.ts
+++ b/apps/backend/src/db/feed-follower.ts
@@ -3,15 +3,26 @@
  *
  * Stored per-user (in the followed user's database), keyed by the follower's
  * actor URI. We cache the follower's inbox (and optional shared inbox) so the
- * delivery slice can fan a user's public posts out to them, and record whether
- * we have accepted their Follow.
+ * delivery slice can fan a user's posts out to them, their handle / display name
+ * / avatar so a follow-request UI can show who is asking, and the id of the
+ * Follow they sent so a deferred Accept/Reject can reference the original
+ * request. `accepted` records whether we have approved them: in manual-approval
+ * mode it stays false (a pending request) until the owner approves; only
+ * accepted followers appear in the followers collection + count and receive
+ * `followers`-only posts. `id` is a stable local handle for the approve/reject
+ * API (the actor_uri is unwieldy as a path param).
  */
 import { query } from './connection.ts'
 
 export interface FeedFollowerRecord {
+  id: string
   actor_uri: string
   inbox_uri: string
   shared_inbox_uri: string | null
+  handle: string | null
+  display_name: string | null
+  avatar_url: string | null
+  follow_activity_uri: string | null
   accepted: boolean
   created_at: Date
 }
@@ -20,14 +31,22 @@ export interface FeedFollowerInput {
   actor_uri: string
   inbox_uri: string
   shared_inbox_uri?: string | null
+  handle?: string | null
+  display_name?: string | null
+  avatar_url?: string | null
+  follow_activity_uri?: string | null
   accepted?: boolean
 }
 
-const FEED_FOLLOWER_COLUMNS = 'actor_uri, inbox_uri, shared_inbox_uri, accepted, created_at'
+const FEED_FOLLOWER_COLUMNS =
+  'id, actor_uri, inbox_uri, shared_inbox_uri, handle, display_name, avatar_url, follow_activity_uri, accepted, created_at'
 
 /**
- * Insert or update a follower by actor URI. Re-following (or a re-delivered
- * Follow) updates the cached inboxes and acceptance flag without duplicating.
+ * Insert or update a follower by actor URI. A re-delivered Follow refreshes the
+ * cached inboxes, presentation, and Follow-activity id and updates the
+ * acceptance flag, without duplicating or minting a new local id. Presentation
+ * and the Follow id are COALESCEd so a re-Follow that couldn't re-extract them
+ * doesn't wipe the last-known values.
  */
 export const upsertFeedFollower = async (
   user: string,
@@ -35,29 +54,93 @@ export const upsertFeedFollower = async (
 ): Promise<FeedFollowerRecord> => {
   const result = await query<FeedFollowerRecord>(
     user,
-    `INSERT INTO feed_follower (actor_uri, inbox_uri, shared_inbox_uri, accepted)
-     VALUES ($1, $2, $3, $4)
+    `INSERT INTO feed_follower
+       (actor_uri, inbox_uri, shared_inbox_uri, handle, display_name, avatar_url, follow_activity_uri, accepted)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      ON CONFLICT (actor_uri)
      DO UPDATE SET inbox_uri = EXCLUDED.inbox_uri,
                    shared_inbox_uri = EXCLUDED.shared_inbox_uri,
+                   handle = COALESCE(EXCLUDED.handle, feed_follower.handle),
+                   display_name = COALESCE(EXCLUDED.display_name, feed_follower.display_name),
+                   avatar_url = COALESCE(EXCLUDED.avatar_url, feed_follower.avatar_url),
+                   follow_activity_uri = COALESCE(EXCLUDED.follow_activity_uri, feed_follower.follow_activity_uri),
                    accepted = EXCLUDED.accepted
      RETURNING ${FEED_FOLLOWER_COLUMNS}`,
-    [input.actor_uri, input.inbox_uri, input.shared_inbox_uri ?? null, input.accepted ?? false],
+    [
+      input.actor_uri,
+      input.inbox_uri,
+      input.shared_inbox_uri ?? null,
+      input.handle ?? null,
+      input.display_name ?? null,
+      input.avatar_url ?? null,
+      input.follow_activity_uri ?? null,
+      input.accepted ?? false,
+    ],
   )
   return result.rows[0]
 }
 
-export const listFeedFollowers = async (user: string): Promise<FeedFollowerRecord[]> => {
+/**
+ * List followers, optionally filtered by acceptance state. `{ accepted: true }`
+ * is the confirmed-followers view used by the followers collection + delivery;
+ * `{ accepted: false }` is the pending-requests view; omitting it lists all.
+ */
+export const listFeedFollowers = async (
+  user: string,
+  opts: { accepted?: boolean } = {},
+): Promise<FeedFollowerRecord[]> => {
+  const where = opts.accepted === undefined ? '' : 'WHERE accepted = $1'
+  const params = opts.accepted === undefined ? [] : [opts.accepted]
   const result = await query<FeedFollowerRecord>(
     user,
-    `SELECT ${FEED_FOLLOWER_COLUMNS} FROM feed_follower ORDER BY created_at ASC`,
+    `SELECT ${FEED_FOLLOWER_COLUMNS} FROM feed_follower ${where} ORDER BY created_at ASC`,
+    params,
   )
   return result.rows
 }
 
-/** Count followers without loading their rows (for the followers-collection counter). */
+/** Fetch a single follower by its local id, or null. */
+export const getFeedFollowerById = async (user: string, id: string): Promise<FeedFollowerRecord | null> => {
+  const result = await query<FeedFollowerRecord>(
+    user,
+    `SELECT ${FEED_FOLLOWER_COLUMNS} FROM feed_follower WHERE id = $1`,
+    [id],
+  )
+  return result.rows[0] ?? null
+}
+
+/** Fetch a single follower by their actor URI, or null. */
+export const getFeedFollowerByActor = async (
+  user: string,
+  actorUri: string,
+): Promise<FeedFollowerRecord | null> => {
+  const result = await query<FeedFollowerRecord>(
+    user,
+    `SELECT ${FEED_FOLLOWER_COLUMNS} FROM feed_follower WHERE actor_uri = $1`,
+    [actorUri],
+  )
+  return result.rows[0] ?? null
+}
+
+/** Mark a follower accepted (approving a pending request). Returns the updated row, or null if unknown. */
+export const setFeedFollowerAccepted = async (
+  user: string,
+  id: string,
+): Promise<FeedFollowerRecord | null> => {
+  const result = await query<FeedFollowerRecord>(
+    user,
+    `UPDATE feed_follower SET accepted = true WHERE id = $1 RETURNING ${FEED_FOLLOWER_COLUMNS}`,
+    [id],
+  )
+  return result.rows[0] ?? null
+}
+
+/** Count *accepted* followers without loading their rows (for the followers-collection counter). */
 export const countFeedFollowers = async (user: string): Promise<number> => {
-  const result = await query<{ count: string }>(user, `SELECT COUNT(*)::text AS count FROM feed_follower`)
+  const result = await query<{ count: string }>(
+    user,
+    `SELECT COUNT(*)::text AS count FROM feed_follower WHERE accepted = true`,
+  )
   return Number(result.rows[0].count)
 }
 
@@ -65,4 +148,21 @@ export const countFeedFollowers = async (user: string): Promise<number> => {
 export const removeFeedFollower = async (user: string, actorUri: string): Promise<boolean> => {
   const result = await query(user, `DELETE FROM feed_follower WHERE actor_uri = $1`, [actorUri])
   return (result.rowCount ?? 0) > 0
+}
+
+/**
+ * Remove a follower by its local id (rejecting a request or removing a
+ * follower), returning the removed row so the caller can send a Reject to their
+ * inbox — or null if there was no such follower.
+ */
+export const removeFeedFollowerById = async (
+  user: string,
+  id: string,
+): Promise<FeedFollowerRecord | null> => {
+  const result = await query<FeedFollowerRecord>(
+    user,
+    `DELETE FROM feed_follower WHERE id = $1 RETURNING ${FEED_FOLLOWER_COLUMNS}`,
+    [id],
+  )
+  return result.rows[0] ?? null
 }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -280,8 +280,12 @@ export {
   countFeedFollowers,
   type FeedFollowerInput,
   type FeedFollowerRecord,
+  getFeedFollowerByActor,
+  getFeedFollowerById,
   listFeedFollowers,
   removeFeedFollower,
+  removeFeedFollowerById,
+  setFeedFollowerAccepted,
   upsertFeedFollower,
 } from './feed-follower.ts'
 

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -478,6 +478,7 @@ export interface UserSettings {
   device_timezone?: string // IANA timezone from the Android device (e.g. "Europe/Stockholm")
   hr_zone_start?: { 1: number; 2: number; 3: number; 4: number; 5: number }
   lastfm_username?: string // Last.fm username for scrobble sync
+  manually_approve_followers?: boolean // Hold incoming follows for manual approval (locked account)
   rescue_time_key?: string // RescueTime API key (personal token)
   sex?: BiologicalSex // Biological sex for calorie calculation
   item_icons?: Record<string, string> // Unified icon mappings for all timeline items (tags, activities, exercise types)

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -18,6 +18,7 @@ import type { FeedDeliver } from './routes/feed-router.ts'
 import type { CentralDb } from './services/central-db.ts'
 import type { DeductionEngineDeps } from './services/deduction-engine.ts'
 import type { ActivityNotifier, DeductionQueue } from './services/deduction-queue.ts'
+import type { FollowerActions } from './services/followers.ts'
 import type { FollowActions } from './services/following.ts'
 import type { SyncProvider } from './services/queries/index.ts'
 import type { StravaQueue } from './services/strava-queue.ts'
@@ -59,6 +60,7 @@ interface McpDeps {
   engineDeps?: DeductionEngineDeps
   feedDeliver?: FeedDeliver
   followActions?: FollowActions
+  followerActions?: FollowerActions
   garmin?: GarminClient
   onActivityMutated?: ActivityNotifier
   oura?: OuraClientType
@@ -97,7 +99,7 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
   }
   registerReportTools(server, user)
   registerSharedDashboardTools(server, user)
-  registerFeedTools(server, user, deps.feedDeliver, deps.followActions)
+  registerFeedTools(server, user, deps.feedDeliver, deps.followActions, deps.followerActions)
   registerChallengeTools(server, user, { apiBaseUrl: deps.apiBaseUrl, webHost: deps.webHost })
   registerScreentimeCategoryTools(server, user)
   registerDebugTools(server, user)

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -5,6 +5,7 @@
  */
 import {
   followActorBodySchema,
+  followersQuerySchema,
   shareActivityBodySchema,
   timelineQuerySchema,
   updateFeedPostBodySchema,
@@ -12,6 +13,7 @@ import {
 import { z } from 'zod'
 
 import type { FeedDeliver } from '../routes/feed-router.ts'
+import type { FollowerActions } from '../services/followers.ts'
 import type { FollowActions } from '../services/following.ts'
 
 import {
@@ -19,20 +21,30 @@ import {
   deleteFeedPost,
   getActivityById,
   getFeedPostById,
+  listFeedFollowers,
   listFeedFollowing,
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
 import { serializeFeedPost } from '../services/feed.ts'
+import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
 import { getTimelinePage } from '../services/timeline.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
+
+/** Map the `status` filter to the follower-list DB options. */
+const followerStatusFilter = (status: 'accepted' | 'all' | 'pending'): { accepted?: boolean } => {
+  if (status === 'pending') return { accepted: false }
+  if (status === 'accepted') return { accepted: true }
+  return {}
+}
 
 export const registerFeedTools = (
   server: McpServer,
   user: string,
   deliver?: FeedDeliver,
   followActions?: FollowActions,
+  followerActions?: FollowerActions,
 ) => {
   server.tool(
     'list_feed',
@@ -136,6 +148,40 @@ export const registerFeedTools = (
       const removed = await followActions.unfollow(user, id)
       if (!removed) return errorResponse('Not following that actor')
       return jsonResponse({ id, unfollowed: true })
+    },
+  )
+
+  server.tool(
+    'list_followers',
+    'List the actors that follow you, with their handle, display name, and acceptance state. Pass `status` to see only `pending` follow requests or only `accepted` followers (default `all`). Requests are pending only when you have enabled manual follower approval.',
+    { ...followersQuerySchema.shape },
+    async ({ status }) => {
+      const records = await listFeedFollowers(user, followerStatusFilter(status))
+      return jsonResponse(records.map(serializeFollower))
+    },
+  )
+
+  server.tool(
+    'approve_follower',
+    'Approve a pending follow request by the local follower id (from `list_followers`). Marks them an accepted follower and sends the Accept.',
+    { id: z.string().uuid().describe('Local follower id (the `id` from list_followers)') },
+    async ({ id }) => {
+      if (!followerActions) return errorResponse('Follower management is not available')
+      const follower = await followerActions.approve(user, id)
+      if (!follower) return errorResponse('No such follower')
+      return jsonResponse(follower)
+    },
+  )
+
+  server.tool(
+    'reject_follower',
+    'Reject a pending follow request, or remove an existing follower, by the local follower id (from `list_followers`). Sends a Reject and drops them.',
+    { id: z.string().uuid().describe('Local follower id (the `id` from list_followers)') },
+    async ({ id }) => {
+      if (!followerActions) return errorResponse('Follower management is not available')
+      const removed = await followerActions.reject(user, id)
+      if (!removed) return errorResponse('No such follower')
+      return jsonResponse({ id, rejected: true })
     },
   )
 }

--- a/apps/backend/src/routes/feed-followers-router.ts
+++ b/apps/backend/src/routes/feed-followers-router.ts
@@ -1,0 +1,70 @@
+import type { RequestHandler } from 'express'
+
+/**
+ * Feed *followers* route group (owner-facing) — manage the remote actors that
+ * follow this user: list them (all, or just pending requests / accepted), and —
+ * when the user requires manual approval — approve or reject a request.
+ *
+ * Handles: /feed/followers/*
+ *
+ * Listing is pure DB; approve/reject go through the injected `FollowerActions`
+ * (which flip the row and send the signed `Accept` / `Reject`), keeping this
+ * router decoupled from the ActivityPub layer. A `DELETE` on an already-accepted
+ * follower removes them (also sends a `Reject`).
+ */
+import {
+  type FollowerResponse,
+  type FollowersQuery,
+  type FollowersResponse,
+  followersQuerySchema,
+} from '@aurboda/api-spec'
+
+import { listFeedFollowers } from '../db/index.ts'
+import { type FollowerActions, serializeFollower } from '../services/followers.ts'
+import { type TypedRouter, typedRouter } from '../typed-router.ts'
+import { validateQuery } from '../validation.ts'
+
+/** Map the `status` filter to the DB list options. */
+const statusFilter = (status: FollowersQuery['status']): { accepted?: boolean } => {
+  if (status === 'pending') return { accepted: false }
+  if (status === 'accepted') return { accepted: true }
+  return {}
+}
+
+export const createFeedFollowersRouter = (
+  authMiddleware: RequestHandler,
+  actions: FollowerActions,
+): TypedRouter => {
+  const router = typedRouter()
+
+  router.get<Record<string, never>, FollowersResponse, unknown, FollowersQuery>(
+    '/',
+    authMiddleware,
+    validateQuery(followersQuerySchema),
+    async (req, res) => {
+      const user = req.user!
+      const records = await listFeedFollowers(user, statusFilter(req.query.status))
+      res.json({ followers: records.map(serializeFollower), success: true })
+    },
+  )
+
+  router.post<{ id: string }, FollowerResponse>('/:id/approve', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const follower = await actions.approve(user, req.params.id)
+    if (!follower) {
+      return res.status(404).json({ error: 'No such follower', success: false })
+    }
+    res.json({ follower, success: true })
+  })
+
+  router.delete<{ id: string }, FollowerResponse>('/:id', authMiddleware, async (req, res) => {
+    const user = req.user!
+    const removed = await actions.reject(user, req.params.id)
+    if (!removed) {
+      return res.status(404).json({ error: 'No such follower', success: false })
+    }
+    res.json({ success: true })
+  })
+
+  return router
+}

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -146,6 +146,7 @@ export const tableCreationOrder = [
   'feed_tombstone',
   'feed_actor',
   'feed_follower',
+  'feed_follower_columns',
   'feed_following',
   'timeline_entry',
   'timeline_entry_structured',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -159,16 +159,37 @@ export const socialTables: Record<string, string> = {
 
   // Remote actors that follow this user's ActivityPub actor. Keyed by the
   // follower's actor URI; we cache their (personal) inbox and optional shared
-  // inbox so the delivery slice can fan posts out to them. `accepted` records
-  // that we answered their Follow with an Accept.
+  // inbox so the delivery slice can fan posts out to them, plus their handle /
+  // display name / avatar so a follow-request UI can show who is asking.
+  // `accepted` records whether we answered their Follow with an Accept — in
+  // manual-approval mode it stays false (pending) until the owner approves, and
+  // pending followers are kept out of the followers collection + count and
+  // receive no `followers`-only delivery. `follow_activity_uri` is the id of the
+  // Follow they sent, echoed back in the deferred Accept/Reject so their server
+  // matches it to the original request. `id` is a stable local handle for the
+  // approve/reject API + UI (the actor_uri is unwieldy as a path param).
   feed_follower: `
     CREATE TABLE IF NOT EXISTS feed_follower (
-      actor_uri        TEXT PRIMARY KEY,
-      inbox_uri        TEXT NOT NULL,
-      shared_inbox_uri TEXT,
-      accepted         BOOLEAN NOT NULL DEFAULT false,
-      created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      actor_uri           TEXT PRIMARY KEY,
+      id                  UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+      inbox_uri           TEXT NOT NULL,
+      shared_inbox_uri    TEXT,
+      handle              TEXT,
+      display_name        TEXT,
+      avatar_url          TEXT,
+      follow_activity_uri TEXT,
+      accepted            BOOLEAN NOT NULL DEFAULT false,
+      created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
+  `,
+  // Additive migrations for pre-existing feed_follower tables (all idempotent).
+  feed_follower_columns: `
+    ALTER TABLE feed_follower ADD COLUMN IF NOT EXISTS id UUID NOT NULL DEFAULT gen_random_uuid();
+    ALTER TABLE feed_follower ADD COLUMN IF NOT EXISTS handle TEXT;
+    ALTER TABLE feed_follower ADD COLUMN IF NOT EXISTS display_name TEXT;
+    ALTER TABLE feed_follower ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+    ALTER TABLE feed_follower ADD COLUMN IF NOT EXISTS follow_activity_uri TEXT;
+    CREATE UNIQUE INDEX IF NOT EXISTS feed_follower_id_key ON feed_follower (id);
   `,
 
   // Remote (or local) actors this user follows. Keyed by a local `id` (used to

--- a/apps/backend/src/services/activitypub/actor-presentation.ts
+++ b/apps/backend/src/services/activitypub/actor-presentation.ts
@@ -1,0 +1,44 @@
+/**
+ * Extract an actor's presentation (handle / display name / avatar) from a
+ * resolved Fedify actor — shared by the follow direction (`following.ts`, when
+ * we resolve someone we follow) and the follower direction (`federation.ts`,
+ * when someone follows us) so both cache the same fields the same way.
+ *
+ * The handle is derived from `preferredUsername` + the actor id's host (offline,
+ * deterministic — no WebFinger round-trip that could hang). The avatar comes
+ * from the actor's `icon`: Mastodon inlines it (no fetch), but a server that
+ * only links it would make `getIcon()` dereference a URL, so it's bounded by a
+ * timeout — a slow icon host must never hang a synchronous follow/inbox handler.
+ */
+import type { Actor } from '@fedify/fedify/vocab'
+
+import { withTimeout } from '../with-timeout.ts'
+
+export interface ActorPresentation {
+  handle: string | null
+  display_name: string | null
+  avatar_url: string | null
+}
+
+/** Map a `LanguageString | string | null` (Fedify vocab value) to a plain string or null. */
+const toPlainString = (value: unknown): string | null => {
+  if (value == null) return null
+  const str = String(value).trim()
+  return str.length > 0 ? str : null
+}
+
+/** How long to wait for an actor's icon before giving up (avatar is non-essential). */
+const ICON_FETCH_TIMEOUT_MS = 3000
+
+export const extractActorPresentation = async (actor: Actor): Promise<ActorPresentation> => {
+  const username = toPlainString(actor.preferredUsername)
+  const handle = username == null || actor.id == null ? null : `@${username}@${actor.id.host}`
+  let avatarUrl: string | null = null
+  try {
+    const icon = await withTimeout(actor.getIcon(), ICON_FETCH_TIMEOUT_MS)
+    avatarUrl = icon?.url instanceof URL ? icon.url.href : null
+  } catch {
+    avatarUrl = null
+  }
+  return { avatar_url: avatarUrl, display_name: toPlainString(actor.name), handle }
+}

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -12,6 +12,7 @@ import { insertActivity } from '../../db/activities/index.ts'
 import { upsertFeedFollower } from '../../db/feed-follower.ts'
 import { markFeedFollowingAccepted, upsertFeedFollowing } from '../../db/feed-following.ts'
 import { createFeedPost, deleteFeedPost, type FeedPostInput, getFeedTombstone } from '../../db/feed.ts'
+import { upsertUserSettings } from '../../db/settings.ts'
 import { createFeedTombstoneRouter } from '../../routes/feed-tombstone-router.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
 import { buildFeedUpdate } from './deliver.ts'
@@ -81,6 +82,17 @@ describe('Feed federation actor + WebFinger', () => {
     const publicKey = doc.publicKey as { owner?: string; publicKeyPem?: string }
     expect(publicKey.owner).toBe(`${ORIGIN}/users/${user}`)
     expect(publicKey.publicKeyPem).toContain('BEGIN PUBLIC KEY')
+    // Default account is open — not a locked (manual-approval) account.
+    expect(doc.manuallyApprovesFollowers).toBe(false)
+  })
+
+  test('advertises manuallyApprovesFollowers when the user requires manual approval', async () => {
+    const user = getTestUser()
+    await upsertUserSettings(user, { manually_approve_followers: true })
+    const res = await fetchAs2(`/users/${user}`)
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as Record<string, unknown>
+    expect(doc.manuallyApprovesFollowers).toBe(true)
   })
 
   test('builds https URLs from the canonical origin even when the request arrives over http', async () => {
@@ -118,18 +130,26 @@ describe('Feed federation actor + WebFinger', () => {
     expect(res.status).toBe(404)
   })
 
-  test('serves the followers collection from feed_follower', async () => {
+  test('serves the followers collection from feed_follower (accepted only)', async () => {
     const user = getTestUser()
     await upsertFeedFollower(user, {
+      accepted: true,
       actor_uri: 'https://mastodon.example/users/alice',
       inbox_uri: 'https://mastodon.example/users/alice/inbox',
       shared_inbox_uri: 'https://mastodon.example/inbox',
+    })
+    // A pending (unapproved) follower is excluded from the public collection + count.
+    await upsertFeedFollower(user, {
+      accepted: false,
+      actor_uri: 'https://mastodon.example/users/pending',
+      inbox_uri: 'https://mastodon.example/users/pending/inbox',
     })
     const res = await fetchAs2(`/users/${user}/followers`)
     expect(res.status).toBe(200)
     const doc = (await res.json()) as { totalItems?: number; orderedItems?: string[] }
     expect(doc.totalItems).toBe(1)
     expect(doc.orderedItems).toContain('https://mastodon.example/users/alice')
+    expect(doc.orderedItems).not.toContain('https://mastodon.example/users/pending')
   })
 
   test('serves the following collection with only accepted follows', async () => {

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -1,4 +1,5 @@
 import type { FeedStructured } from '@aurboda/api-spec'
+import type { Actor } from '@fedify/fedify/vocab'
 
 import { createFederation, type Federation, type InboxContext, MemoryKvStore } from '@fedify/fedify'
 import {
@@ -24,11 +25,12 @@ import {
  * - actor document (`Person`) with the user's published RSA public key,
  * - WebFinger (`acct:<user>@<host>` → the actor), via `mapHandle`,
  * - key-pairs dispatcher backed by the per-user `feed_actor` keypair,
- * - inbound inbox: `Follow` → persist follower + `Accept`; `Undo{Follow}` →
- *   drop the follower; `Accept`/`Reject` → resolve a Follow WE sent (mark the
- *   `feed_following` row accepted, or drop it); `Create`/`Update` of a `Note`
- *   from an *accepted followee* → ingest into the home timeline (sanitised);
- *   `Delete` → drop the received post. Fedify verifies the HTTP Signature first.
+ * - inbound inbox: `Follow` → persist follower + (unless the user requires
+ *   manual approval) `Accept`; `Undo{Follow}` → drop the follower; `Accept`/
+ *   `Reject` → resolve a Follow WE sent (mark the `feed_following` row accepted,
+ *   or drop it); `Create`/`Update` of a `Note` from an *accepted followee* →
+ *   ingest into the home timeline (sanitised); `Delete` → drop the received
+ *   post. Fedify verifies the HTTP Signature first.
  * - followers + following collections (the latter lists this user's *accepted*
  *   follows), both backed by Postgres.
  *
@@ -41,9 +43,11 @@ import {
   countFeedFollowers,
   countPublicFeedPosts,
   deleteTimelineEntryByUri,
+  getFeedFollowerByActor,
   getFeedFollowingByActor,
   getFeedPostById,
   getOrCreateActorKeyPair,
+  getUserSettings,
   isMissingDatabase,
   listAcceptedFeedFollowing,
   listFeedFollowers,
@@ -56,6 +60,7 @@ import {
 } from '../../db/index.ts'
 import { resolveFeedActivity } from '../feed.ts'
 import { buildProfileUrl } from '../share-urls.ts'
+import { extractActorPresentation } from './actor-presentation.ts'
 import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
@@ -89,6 +94,43 @@ const localFollowerIdentifier = async (
   }
   const recipient = ctx.recipient
   return recipient != null && isValidUsername(recipient) ? recipient : null
+}
+
+/**
+ * Persist an inbound follower and decide whether to accept it now. Auto-accepts
+ * unless the target user requires manual approval — but an already *accepted*
+ * follower re-sending a Follow stays accepted (a re-delivery never demotes them).
+ * Caches the follower's presentation (so the approval UI can show who's asking)
+ * and the Follow's id (echoed in a deferred Accept/Reject). Returns the acceptance
+ * decision, or null if the target user's DB doesn't exist (a Follow to a
+ * nonexistent actor — ignore it) or the sender lacks an id/inbox.
+ */
+const recordInboundFollow = async (
+  user: string,
+  sender: Actor,
+  followActivityUri: string | null,
+): Promise<boolean | null> => {
+  if (sender.id == null || sender.inboxId == null) return null
+  try {
+    const settings = await getUserSettings(user)
+    const existing = await getFeedFollowerByActor(user, sender.id.href)
+    const accepted = existing?.accepted === true || settings?.manually_approve_followers !== true
+    const presentation = await extractActorPresentation(sender)
+    await upsertFeedFollower(user, {
+      accepted,
+      actor_uri: sender.id.href,
+      avatar_url: presentation.avatar_url,
+      display_name: presentation.display_name,
+      follow_activity_uri: followActivityUri,
+      handle: presentation.handle,
+      inbox_uri: sender.inboxId.href,
+      shared_inbox_uri: sender.endpoints?.sharedInbox?.href ?? null,
+    })
+    return accepted
+  } catch (error) {
+    if (isMissingDatabase(error)) return null
+    throw error
+  }
 }
 
 /**
@@ -167,6 +209,10 @@ export const createFeedFederation = (
         throw error
       }
       if (keys.length === 0) return null
+      // Advertise "locked account" when the user requires manual approval, so
+      // Mastodon et al. show a follow *request* and hold the follow pending
+      // (matching our own inbox behaviour of deferring the Accept).
+      const settings = await getUserSettings(identifier)
       return new Person({
         followers: ctx.getFollowersUri(identifier),
         following: ctx.getFollowingUri(identifier),
@@ -175,6 +221,7 @@ export const createFeedFederation = (
         icon: new Image({ url: new URL(`${buildProfileUrl(origin, identifier)}/avatar.png`) }),
         id: ctx.getActorUri(identifier),
         inbox: ctx.getInboxUri(identifier),
+        manuallyApprovesFollowers: settings?.manually_approve_followers === true,
         outbox: ctx.getOutboxUri(identifier),
         preferredUsername: identifier,
         publicKey: keys[0].cryptographicKey,
@@ -206,22 +253,12 @@ export const createFeedFederation = (
       const sender = await follow.getActor(ctx)
       if (sender?.id == null || sender.inboxId == null) return
 
-      try {
-        await upsertFeedFollower(target.identifier, {
-          accepted: true,
-          actor_uri: sender.id.href,
-          inbox_uri: sender.inboxId.href,
-          shared_inbox_uri: sender.endpoints?.sharedInbox?.href ?? null,
-        })
-      } catch (error) {
-        // A syntactically-valid username with no database is a Follow to a
-        // nonexistent actor — ignore it (don't 500 and invite retries), and
-        // don't answer with an Accept.
-        if (isMissingDatabase(error)) return
-        throw error
-      }
-
-      // Answer the Follow so the remote server marks it established.
+      const accepted = await recordInboundFollow(target.identifier, sender, follow.id?.href ?? null)
+      // In manual-approval mode a new/pending follow gets no Accept yet — the
+      // owner approves it later (which sends the Accept). `null` means no such
+      // user (missing DB). Only an accepted follow is answered now, so the remote
+      // server marks it established.
+      if (accepted !== true) return
       await ctx.sendActivity(
         { identifier: target.identifier },
         sender,
@@ -379,7 +416,9 @@ export const createFeedFederation = (
     .setFollowersDispatcher('/users/{identifier}/followers', async (_ctx, identifier) => {
       if (!isValidUsername(identifier)) return { items: [] }
       try {
-        const followers = await listFeedFollowers(identifier)
+        // Only *accepted* followers are published + delivered to (a pending
+        // request isn't a confirmed follower and gets no `followers`-only posts).
+        const followers = await listFeedFollowers(identifier, { accepted: true })
         return {
           items: followers.map((f) => ({
             endpoints: f.shared_inbox_uri ? { sharedInbox: new URL(f.shared_inbox_uri) } : null,

--- a/apps/backend/src/services/activitypub/timeline-enrich.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.ts
@@ -26,8 +26,8 @@ import {
 } from '@aurboda/api-spec'
 
 import { discoverInstance } from '../challenge-federation.ts'
-import { withTimeout } from '../following.ts'
 import { safeFetchGet } from '../safe-fetch.ts'
+import { withTimeout } from '../with-timeout.ts'
 
 /** Aurboda's object-dispatcher path: `/users/{identifier}/feed/{postId}` (postId is a UUID). */
 const FEED_OBJECT_PATH =

--- a/apps/backend/src/services/followers.integration.test.ts
+++ b/apps/backend/src/services/followers.integration.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import type { FollowDeps } from './following.ts'
+
+/**
+ * Integration tests for the follower-approval service against a real per-user
+ * database. Outbound Accept/Reject delivery targets a non-resolving `.example`
+ * inbox, so the POST fails fast and is swallowed (best-effort) — we assert the
+ * local DB effects, which must take hold regardless of delivery.
+ */
+import { getFeedFollowerById, upsertFeedFollower } from '../db/feed-follower.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { createFeedFederation } from './activitypub/federation.ts'
+import { approveFollower, rejectFollower } from './followers.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+const ORIGIN = 'https://aurboda.example'
+
+const deps: FollowDeps = { federation: createFeedFederation(ORIGIN, `${ORIGIN}/api`), origin: ORIGIN }
+
+const pending = {
+  actor_uri: 'https://mastodon.example/users/alice',
+  follow_activity_uri: 'https://mastodon.example/users/alice/follows/1',
+  inbox_uri: 'https://mastodon.example/users/alice/inbox',
+}
+
+describe('Follower approval service integration', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('approving a pending follower marks it accepted', async () => {
+    const user = getTestUser()
+    const rec = await upsertFeedFollower(user, { ...pending, accepted: false })
+
+    const approved = await approveFollower(deps, user, rec.id)
+    expect(approved?.accepted).toBe(true)
+    expect((await getFeedFollowerById(user, rec.id))?.accepted).toBe(true)
+  })
+
+  test('approving an unknown follower returns null and changes nothing', async () => {
+    const user = getTestUser()
+    expect(await approveFollower(deps, user, '00000000-0000-0000-0000-000000000000')).toBeNull()
+  })
+
+  test('rejecting a follower removes it', async () => {
+    const user = getTestUser()
+    const rec = await upsertFeedFollower(user, { ...pending, accepted: false })
+
+    expect(await rejectFollower(deps, user, rec.id)).toBe(true)
+    expect(await getFeedFollowerById(user, rec.id)).toBeNull()
+  })
+
+  test('rejecting an unknown follower returns false', async () => {
+    const user = getTestUser()
+    expect(await rejectFollower(deps, user, '00000000-0000-0000-0000-000000000000')).toBe(false)
+  })
+})

--- a/apps/backend/src/services/followers.test.ts
+++ b/apps/backend/src/services/followers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest'
+
+import type { FeedFollowerRecord } from '../db/index.ts'
+
+import { reconstructFollow, serializeFollower } from './followers.ts'
+
+const record: FeedFollowerRecord = {
+  accepted: false,
+  actor_uri: 'https://mastodon.example/users/alice',
+  avatar_url: 'https://mastodon.example/avatars/alice.png',
+  created_at: new Date('2026-07-04T10:00:00Z'),
+  display_name: 'Alice',
+  follow_activity_uri: 'https://mastodon.example/users/alice/follows/1',
+  handle: '@alice@mastodon.example',
+  id: '11111111-1111-1111-1111-111111111111',
+  inbox_uri: 'https://mastodon.example/users/alice/inbox',
+  shared_inbox_uri: 'https://mastodon.example/inbox',
+}
+
+describe('serializeFollower', () => {
+  test('exposes presentation + acceptance, and never the internal inbox URIs', () => {
+    const dto = serializeFollower(record)
+    expect(dto).toEqual({
+      accepted: false,
+      actor_uri: 'https://mastodon.example/users/alice',
+      avatar_url: 'https://mastodon.example/avatars/alice.png',
+      created_at: '2026-07-04T10:00:00.000Z',
+      display_name: 'Alice',
+      handle: '@alice@mastodon.example',
+      id: '11111111-1111-1111-1111-111111111111',
+    })
+    // Internal delivery details + the raw Follow id must not leak to the owner surface.
+    expect(dto).not.toHaveProperty('inbox_uri')
+    expect(dto).not.toHaveProperty('shared_inbox_uri')
+    expect(dto).not.toHaveProperty('follow_activity_uri')
+  })
+})
+
+describe('reconstructFollow', () => {
+  const ourActor = new URL('https://aurboda.net/users/bob')
+
+  test('rebuilds the Follow with the follower as actor, us as object, echoing the original id', () => {
+    const follow = reconstructFollow(record.actor_uri, ourActor, record.follow_activity_uri)
+    expect(follow.actorId?.href).toBe('https://mastodon.example/users/alice')
+    expect(follow.objectId?.href).toBe('https://aurboda.net/users/bob')
+    expect(follow.id?.href).toBe('https://mastodon.example/users/alice/follows/1')
+  })
+
+  test('omits the id when the original Follow id was not cached (legacy row)', () => {
+    const follow = reconstructFollow(record.actor_uri, ourActor, null)
+    expect(follow.id).toBeNull()
+    expect(follow.actorId?.href).toBe('https://mastodon.example/users/alice')
+    expect(follow.objectId?.href).toBe('https://aurboda.net/users/bob')
+  })
+})

--- a/apps/backend/src/services/followers.ts
+++ b/apps/backend/src/services/followers.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared "followers" business logic — used by both the REST `/feed/followers`
+ * router and the MCP follower tools (parity). This is the *management* side of
+ * the follower relationship: list who follows you and, when you require manual
+ * approval, approve or reject pending follow requests.
+ *
+ * Approving a pending follower marks the `feed_follower` row accepted and sends
+ * the deferred `Accept` (echoing the id of the Follow they sent so their server
+ * matches it to the pending request). Rejecting — or removing an already-accepted
+ * follower — sends a `Reject` and drops the row. Delivery is best-effort and
+ * synchronous, matching the rest of the feed: a failed POST is logged, not
+ * retried (the local state change still takes effect). The pure `serializeFollower`
+ * and `reconstructFollow` mappers are unit-tested; the network orchestration is thin.
+ */
+import type { FollowerActor } from '@aurboda/api-spec'
+
+import { Accept, Follow, Reject } from '@fedify/fedify/vocab'
+
+import type { FeedFollowerRecord } from '../db/index.ts'
+import type { FollowDeps } from './following.ts'
+
+import { removeFeedFollowerById, setFeedFollowerAccepted } from '../db/index.ts'
+
+/**
+ * The network-requiring follower operations, injected into the REST router + MCP
+ * tools (mirroring `FollowActions`) so those layers stay decoupled from the
+ * ActivityPub context and testable without it. Listing followers is pure DB, so
+ * it isn't part of this interface — the router/tools query it directly.
+ */
+export interface FollowerActions {
+  approve: (user: string, id: string) => Promise<FollowerActor | null>
+  reject: (user: string, id: string) => Promise<boolean>
+}
+
+/** Serialise a stored follower for the owner-facing REST/MCP surface (no inbox URIs). */
+export const serializeFollower = (record: FeedFollowerRecord): FollowerActor => ({
+  accepted: record.accepted,
+  actor_uri: record.actor_uri,
+  avatar_url: record.avatar_url,
+  created_at: record.created_at.toISOString(),
+  display_name: record.display_name,
+  handle: record.handle,
+  id: record.id,
+})
+
+/**
+ * Reconstruct the `Follow` a follower sent us, so it can be wrapped in the
+ * `Accept`/`Reject` we send back. Echoing the original Follow id (when we cached
+ * it) lets the follower's server match the response to its pending request.
+ */
+export const reconstructFollow = (
+  followerActorUri: string,
+  ourActorUri: URL,
+  followActivityUri: string | null,
+): Follow =>
+  new Follow({
+    actor: new URL(followerActorUri),
+    id: followActivityUri ? new URL(followActivityUri) : null,
+    object: ourActorUri,
+  })
+
+/** Build the recipient descriptor Fedify's `sendActivity` needs from a stored follower. */
+const followerRecipient = (record: FeedFollowerRecord) => ({
+  endpoints: record.shared_inbox_uri ? { sharedInbox: new URL(record.shared_inbox_uri) } : null,
+  id: new URL(record.actor_uri),
+  inboxId: new URL(record.inbox_uri),
+})
+
+/**
+ * Approve a pending follower: mark them accepted and send the deferred `Accept`.
+ * Returns the updated follower, or null if there's no such follower. The Accept
+ * POST is best-effort (a failure is logged; they're accepted locally regardless).
+ */
+export const approveFollower = async (
+  deps: FollowDeps,
+  user: string,
+  id: string,
+): Promise<FeedFollowerRecord | null> => {
+  const record = await setFeedFollowerAccepted(user, id)
+  if (record == null) return null
+
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  try {
+    await ctx.sendActivity(
+      { identifier: user },
+      followerRecipient(record),
+      new Accept({
+        actor: ctx.getActorUri(user),
+        object: reconstructFollow(record.actor_uri, ctx.getActorUri(user), record.follow_activity_uri),
+      }),
+    )
+  } catch (error) {
+    console.error(`⚠️ Accept delivery failed for ${user} ← ${record.actor_uri}:`, error)
+  }
+
+  return record
+}
+
+/**
+ * Reject a pending follower, or remove an already-accepted one: drop the row and
+ * send a `Reject` to their inbox. Returns false if there was no such follower.
+ * The Reject POST is best-effort (a failure is logged; they're removed locally).
+ */
+export const rejectFollower = async (deps: FollowDeps, user: string, id: string): Promise<boolean> => {
+  const removed = await removeFeedFollowerById(user, id)
+  if (removed == null) return false
+
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  try {
+    await ctx.sendActivity(
+      { identifier: user },
+      followerRecipient(removed),
+      new Reject({
+        actor: ctx.getActorUri(user),
+        object: reconstructFollow(removed.actor_uri, ctx.getActorUri(user), removed.follow_activity_uri),
+      }),
+    )
+  } catch (error) {
+    console.error(`⚠️ Reject delivery failed for ${user} ← ${removed.actor_uri}:`, error)
+  }
+
+  return true
+}

--- a/apps/backend/src/services/following.ts
+++ b/apps/backend/src/services/following.ts
@@ -30,6 +30,12 @@ import {
   removeFeedFollowing,
   upsertFeedFollowing,
 } from '../db/index.ts'
+import { extractActorPresentation } from './activitypub/actor-presentation.ts'
+import { withTimeout } from './with-timeout.ts'
+
+// Re-exported for existing importers (the follow tools + tests) — the util now
+// lives in its own leaf module so `actor-presentation` can share it cycle-free.
+export { withTimeout }
 
 export interface FollowDeps {
   federation: Federation<void>
@@ -57,59 +63,21 @@ export type FollowResult =
   | { ok: true; record: FeedFollowingRecord }
   | { ok: false; status: number; error: string }
 
-/** Map a `LanguageString | string | null` (Fedify vocab value) to a plain string or null. */
-const toPlainString = (value: unknown): string | null => {
-  if (value == null) return null
-  const str = String(value).trim()
-  return str.length > 0 ? str : null
-}
-
-/** How long to wait for an actor's icon before giving up (avatar is non-essential). */
-const ICON_FETCH_TIMEOUT_MS = 3000
-
-/** Reject `promise` if it doesn't settle within `ms` (clearing the timer either way). Exported for testing. */
-export const withTimeout = async <T>(promise: Promise<T>, ms: number): Promise<T> => {
-  let timer: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error('timeout')), ms)
-      }),
-    ])
-  } finally {
-    if (timer) clearTimeout(timer)
-  }
-}
-
 /**
  * Extract the persisted fields of a followee from a resolved Fedify actor, or
- * null if it lacks the id/inbox we require to follow + later unfollow it.
- *
- * The handle is derived from `preferredUsername` + the actor id's host rather
- * than `getActorHandle` (which may WebFinger the host): this is deterministic and
- * offline — good enough for a display handle, and it can't hang. The avatar comes
- * from the actor's embedded `icon` — Mastodon inlines it (no fetch), but a server
- * that only links it would make `getIcon()` dereference a URL, so it's bounded by
- * a timeout: a slow icon host must not hang the synchronous follow. Unit-tested
- * with a constructed `Person`.
+ * null if it lacks the id/inbox we require to follow + later unfollow it. The
+ * presentation (handle / display name / avatar) is resolved by the shared
+ * `extractActorPresentation` (offline handle; timeout-bounded icon deref).
+ * Unit-tested with a constructed `Person`.
  */
 export const actorToFollowingInput = async (actor: Actor): Promise<FeedFollowingInput | null> => {
   if (actor.id == null || actor.inboxId == null) return null
-  const username = toPlainString(actor.preferredUsername)
-  const handle = username == null ? null : `@${username}@${actor.id.host}`
-  let avatarUrl: string | null = null
-  try {
-    const icon = await withTimeout(actor.getIcon(), ICON_FETCH_TIMEOUT_MS)
-    avatarUrl = icon?.url instanceof URL ? icon.url.href : null
-  } catch {
-    avatarUrl = null
-  }
+  const presentation = await extractActorPresentation(actor)
   return {
     actor_uri: actor.id.href,
-    avatar_url: avatarUrl,
-    display_name: toPlainString(actor.name),
-    handle,
+    avatar_url: presentation.avatar_url,
+    display_name: presentation.display_name,
+    handle: presentation.handle,
     inbox_uri: actor.inboxId.href,
     shared_inbox_uri: actor.endpoints?.sharedInbox?.href ?? null,
   }

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -212,6 +212,7 @@ const settingsWithDefaultsSchema = userSettingsResponseSchema.pick({
   garmin_disabled_data_types: true,
   item_icons: true,
   lastfm_username: true,
+  manually_approve_followers: true,
   meal_slots: true,
   rescue_time_key: true,
   sensitivity_areas: true,

--- a/apps/backend/src/services/with-timeout.ts
+++ b/apps/backend/src/services/with-timeout.ts
@@ -1,0 +1,20 @@
+/**
+ * Small shared timeout util for the feed's synchronous, best-effort network
+ * calls (actor icon deref, cross-instance enrichment, …): race a promise
+ * against a timer so a hung remote can never stall an inbox/follow handler.
+ */
+
+/** Reject `promise` if it doesn't settle within `ms` (clearing the timer either way). */
+export const withTimeout = async <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timeout')), ms)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/apps/web/src/pages/Feed/FollowersPanel.tsx
+++ b/apps/web/src/pages/Feed/FollowersPanel.tsx
@@ -1,0 +1,120 @@
+/**
+ * Followers management (#884): see who follows you and — when you've enabled
+ * manual approval in Settings — approve or reject pending follow requests.
+ *
+ * Pending requests surface at the top with Approve / Reject; approving sends the
+ * deferred Accept so the remote server marks the follow established. Accepted
+ * followers are listed below with a Remove action (sends a Reject). With
+ * auto-accept (the default) there are simply never any pending requests.
+ */
+import type { FollowerActor } from '@aurboda/api-spec'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { approveFollower, fetchFollowers, rejectFollower } from '../../state/api'
+
+const Avatar = ({ actor }: { actor: FollowerActor }) =>
+  actor.avatar_url ? (
+    <img class="following-avatar" src={actor.avatar_url} alt="" width={36} height={36} />
+  ) : (
+    <span class="following-avatar following-avatar--blank" aria-hidden="true" />
+  )
+
+const Ident = ({ actor }: { actor: FollowerActor }) => {
+  const name = actor.display_name ?? actor.handle ?? actor.actor_uri
+  return (
+    <span class="following-ident">
+      <span class="following-name">{name}</span>
+      {actor.handle && <span class="following-handle">{actor.handle}</span>}
+    </span>
+  )
+}
+
+const PendingRow = ({ actor }: { actor: FollowerActor }) => {
+  const queryClient = useQueryClient()
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['followers'] })
+  const approve = useMutation({ mutationFn: () => approveFollower(actor.id), onSuccess: invalidate })
+  const reject = useMutation({ mutationFn: () => rejectFollower(actor.id), onSuccess: invalidate })
+  const busy = approve.isPending || reject.isPending
+
+  return (
+    <li class="following-row">
+      <Avatar actor={actor} />
+      <Ident actor={actor} />
+      <span class="followers-actions">
+        <button type="button" class="btn-primary" onClick={() => approve.mutate()} disabled={busy}>
+          {approve.isPending ? 'Approving…' : 'Approve'}
+        </button>
+        <button type="button" class="btn-secondary" onClick={() => reject.mutate()} disabled={busy}>
+          {reject.isPending ? 'Rejecting…' : 'Reject'}
+        </button>
+      </span>
+    </li>
+  )
+}
+
+const AcceptedRow = ({ actor }: { actor: FollowerActor }) => {
+  const queryClient = useQueryClient()
+  const remove = useMutation({
+    mutationFn: () => rejectFollower(actor.id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['followers'] }),
+  })
+
+  return (
+    <li class="following-row">
+      <Avatar actor={actor} />
+      <Ident actor={actor} />
+      <button
+        type="button"
+        class="btn-secondary following-unfollow"
+        onClick={() => remove.mutate()}
+        disabled={remove.isPending}
+      >
+        {remove.isPending ? 'Removing…' : 'Remove'}
+      </button>
+    </li>
+  )
+}
+
+export function FollowersPanel() {
+  const { data: followers, isLoading } = useQuery({
+    queryFn: () => fetchFollowers('all'),
+    queryKey: ['followers'],
+  })
+
+  const pending = followers?.filter((f) => !f.accepted) ?? []
+  const accepted = followers?.filter((f) => f.accepted) ?? []
+
+  return (
+    <section class="following-panel">
+      <h2 class="following-title">Followers</h2>
+
+      {isLoading && <p>Loading…</p>}
+
+      {pending.length > 0 && (
+        <>
+          <h3 class="followers-subtitle">
+            Follow requests <span class="followers-count">{pending.length}</span>
+          </h3>
+          <ul class="following-list">
+            {pending.map((actor) => (
+              <PendingRow key={actor.id} actor={actor} />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {!isLoading && accepted.length === 0 && pending.length === 0 && (
+        <p class="following-empty">No one is following you yet.</p>
+      )}
+
+      {accepted.length > 0 && (
+        <ul class="following-list">
+          {accepted.map((actor) => (
+            <AcceptedRow key={actor.id} actor={actor} />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -13,6 +13,7 @@ import { ShareActivityDialog } from '../../components/ShareActivityDialog'
 import { avatarUrl, deleteFeedPost, fetchFeed } from '../../state/api'
 import { auth } from '../../state/auth'
 import { FeedPostCard, type PostAuthor } from './FeedPostCard'
+import { FollowersPanel } from './FollowersPanel'
 import { FollowingPanel } from './FollowingPanel'
 import { HomeTimeline } from './HomeTimeline'
 import './style.css'
@@ -90,6 +91,8 @@ export function Feed() {
       </p>
 
       <FollowingPanel />
+
+      <FollowersPanel />
 
       <HomeTimeline />
 

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -143,6 +143,31 @@
   flex-shrink: 0;
 }
 
+/* Followers panel — pending-request subsection + approve/reject actions. */
+.followers-subtitle {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.followers-count {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  background: #d97706;
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+}
+
+.followers-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
 /* Native post card — mirrors how the post federates. */
 .feed-post {
   border: 1px solid #e5e7eb;
@@ -289,5 +314,9 @@
 
   .following-avatar {
     background: #374151;
+  }
+
+  .followers-subtitle {
+    color: #d1d5db;
   }
 }

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -28,16 +28,19 @@ export function Settings() {
   const [birthDate, setBirthDate] = useState<string>('')
   const [sex, setSex] = useState<BiologicalSex | null>(null)
   const [hrZones, setHrZones] = useState<HrZoneThresholds | null>(null)
+  const [manualApproval, setManualApproval] = useState(false)
 
   // Save status for each section
   const [personalInfoStatus, setPersonalInfoStatus] = useState<SaveStatus>({ status: 'idle' })
   const [hrZonesStatus, setHrZonesStatus] = useState<SaveStatus>({ status: 'idle' })
+  const [followersStatus, setFollowersStatus] = useState<SaveStatus>({ status: 'idle' })
 
   // Initialize form when data loads
   const initializeForm = () => {
     setBirthDate(userSettings?.birth_date ?? '')
     setSex(userSettings?.sex ?? null)
     setHrZones(userSettings?.hr_zone_start ?? null)
+    setManualApproval(userSettings?.manually_approve_followers ?? false)
   }
 
   // Track if form has been initialized
@@ -116,6 +119,12 @@ export function Settings() {
   const handleResetZones = () => {
     setHrZones(null)
     saveSection({ hr_zone_start: null }, setHrZonesStatus)
+  }
+
+  const handleManualApprovalChange = (e: Event) => {
+    const checked = (e.target as HTMLInputElement).checked
+    setManualApproval(checked)
+    saveSection({ manually_approve_followers: checked }, setFollowersStatus)
   }
 
   if (!isLoggedIn) {
@@ -207,6 +216,24 @@ export function Settings() {
         {hrZones === null && (
           <p class="field-description">Using default thresholds (or age-based if birth date is set).</p>
         )}
+      </SettingsSection>
+
+      <SettingsSection
+        title="Feed & Followers"
+        description="Control who can follow your federated feed."
+        headerExtra={<SaveStatusIndicator state={followersStatus} />}
+      >
+        <div class="form-field">
+          <label class="checkbox-field">
+            <input type="checkbox" checked={manualApproval} onChange={handleManualApprovalChange} />
+            <span>Manually approve new followers</span>
+          </label>
+          <p class="field-description">
+            When on, incoming follows become requests you approve or reject, and only approved followers see
+            your <code>followers</code>-only posts. When off (the default), anyone can follow you
+            automatically.
+          </p>
+        </div>
       </SettingsSection>
 
       <MealPreferencesSettings />

--- a/apps/web/src/pages/Settings/style.css
+++ b/apps/web/src/pages/Settings/style.css
@@ -78,6 +78,22 @@
   margin-bottom: 0.5rem;
 }
 
+/* Inline checkbox + label row (e.g. the manual-follower-approval toggle). */
+.checkbox-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.checkbox-field input[type='checkbox'] {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
 .field-header-row {
   display: flex;
   align-items: baseline;

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -3,6 +3,10 @@ import type {
   FeedPostResponse,
   FeedPostsResponse,
   FollowActorResponse,
+  FollowerActor,
+  FollowerResponse,
+  FollowersQuery,
+  FollowersResponse,
   FollowingActor,
   FollowingResponse,
   ShareActivityBody,
@@ -87,6 +91,31 @@ export const followActor = async (handle: string): Promise<FollowingActor> => {
 /** Unfollow an actor by its local follow id. */
 export const unfollowActor = async (id: string): Promise<void> => {
   await axios.delete(`${API_URL}/feed/following/${id}`, { headers: authHeaders() })
+}
+
+/** List the actors that follow the user, optionally filtered by acceptance state. */
+export const fetchFollowers = async (status: FollowersQuery['status'] = 'all'): Promise<FollowerActor[]> => {
+  const response = await axios.get<FollowersResponse>(`${API_URL}/feed/followers`, {
+    headers: authHeaders(),
+    params: { status },
+  })
+  return response.data.followers
+}
+
+/** Approve a pending follow request by the local follower id. */
+export const approveFollower = async (id: string): Promise<FollowerActor> => {
+  const response = await axios.post<FollowerResponse>(
+    `${API_URL}/feed/followers/${id}/approve`,
+    {},
+    { headers: authHeaders() },
+  )
+  if (!response.data.follower) throw new Error('Approve failed: no follower returned')
+  return response.data.follower
+}
+
+/** Reject a pending follow request, or remove a follower, by the local follower id. */
+export const rejectFollower = async (id: string): Promise<void> => {
+  await axios.delete(`${API_URL}/feed/followers/${id}`, { headers: authHeaders() })
 }
 
 /**

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -57,9 +57,11 @@ acct:<username>@<host>                  e.g. @fiddur@aurboda.net
 
 so anyone on Mastodon (or any fediverse server) can search for `@fiddur@aurboda.net`,
 open the profile, and **Follow**. A `Follow` arrives at the actor's inbox; Aurboda
-verifies its HTTP Signature, records the follower (`feed_follower`), and replies with an
-`Accept` so the remote server marks the relationship established. `Undo{Follow}` removes
-the follower.
+verifies its HTTP Signature and records the follower (`feed_follower`). By default it
+replies immediately with an `Accept` so the remote server marks the relationship
+established; if the user has enabled **manual approval** the follow is held as a pending
+request instead (see [Follower approval](#follower-approval-inbound)). `Undo{Follow}`
+removes the follower.
 
 Canonical absolute URLs (actor id, inbox/outbox, object ids, WebFinger self-link) are
 always built from the configured public base (`WEB_HOST`) as **https**, so they stay
@@ -135,6 +137,32 @@ the rest of the feed — a failed `Follow` POST leaves the pending row so the us
 The actor advertises a **following collection** (`/users/<username>/following`) listing only
 _accepted_ follows (a pending follow isn't a confirmed relationship yet). The followee's
 inbox URIs are internal delivery details and are never exposed on the owner-facing API.
+
+### Follower approval (inbound)
+
+By default an account is **open**: an inbound `Follow` is auto-accepted and answered with an
+`Accept` immediately. A user can instead switch on **manual approval** (the
+`manually_approve_followers` setting) — a "locked account", advertised to the fediverse via
+`manuallyApprovesFollowers: true` on the actor document, so Mastodon shows a follow _request_
+and holds it pending.
+
+With manual approval on, an inbound `Follow`:
+
+1. is recorded in `feed_follower` as **pending** (`accepted = false`) — caching the
+   follower's handle / display name / avatar (so the approval UI can show _who_ is asking)
+   and the id of their `Follow` activity, but **no** `Accept` is sent yet;
+2. surfaces as a request the owner can **approve** or **reject**.
+
+**Approving** flips the row to accepted and sends the deferred `Accept` — echoing the
+original `Follow` id so the follower's server matches it to its pending request.
+**Rejecting** (or later **removing** an accepted follower) sends a `Reject` and drops the
+row. Both are best-effort/synchronous like the rest of the feed. A re-delivered `Follow`
+from an already-accepted follower never demotes them back to pending.
+
+Only **accepted** followers appear in the followers collection + count and receive
+`followers`-only posts — a pending request is not yet a follower. Switching the setting off
+does not retroactively accept the already-pending requests; new follows simply auto-accept
+again. The follower's inbox URIs are internal and never exposed on the owner-facing API.
 
 ### Home timeline (inbound)
 
@@ -282,6 +310,10 @@ resolving.
 - **Follow** — the Feed page's **Following** panel lets you follow a fediverse actor by
   handle (`@user@host`) and see who you follow, with a **Pending** badge until the remote
   server accepts and an **Unfollow** button.
+- **Followers** — the Feed page's **Followers** panel lists who follows you. If you've turned
+  on **Manually approve new followers** (Settings → _Feed & Followers_), incoming follows show
+  up here as **follow requests** with **Approve** / **Reject** buttons; accepted followers can
+  be **Removed**. With approval off (the default), anyone can follow you automatically.
 - **Home timeline** — below the Following panel, the Feed page shows your **Home timeline**:
   posts from the actors you follow, newest-first, as native cards with a **Load more** button
   to page further back. New posts arrive **live** (or via polling fallback) as a **"N new
@@ -300,6 +332,9 @@ Owner-facing (authenticated, scoped to the caller):
 | `GET /feed/following`             | List the actors I follow (accepted + pending)                                                                           |
 | `POST /feed/following`            | Follow an actor by handle (`@user@host` or actor URL)                                                                   |
 | `DELETE /feed/following/:id`      | Unfollow (sends `Undo{Follow}`)                                                                                         |
+| `GET /feed/followers`             | List my followers; `?status=pending\|accepted\|all` (default `all`)                                                     |
+| `POST /feed/followers/:id/approve`| Approve a pending follow request (sends the deferred `Accept`)                                                          |
+| `DELETE /feed/followers/:id`      | Reject a request / remove a follower (sends `Reject`)                                                                   |
 | `GET /feed/timeline`              | My home timeline (posts from followees), newest-first, `?cursor=` to page                                               |
 | `GET /feed/timeline/stream`       | Server-Sent Events stream of live "new posts" pings (falls back to polling)                                             |
 
@@ -321,7 +356,9 @@ Public / federation (unauthenticated):
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
 `update_feed_post`, `delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`,
-and `list_timeline` — all backed by the same services as the REST routes.
+`list_followers`, `approve_follower`, `reject_follower`, and `list_timeline` — all backed by
+the same services as the REST routes. Manual follower approval is toggled with the
+`manually_approve_followers` user setting (`get_user_settings` / `update_user_settings`).
 
 ## Storage
 
@@ -333,8 +370,11 @@ endpoint's authorization check. Each post also holds an unguessable `image_token
 (defaulted at insert) that gates its `followers`-only image URLs. Deleting a
 `public`/`unlisted` post hard-deletes its row
 and, in the same statement, records its id in `feed_tombstone` so the object id can still
-answer `410 Gone`. Followers live in `feed_follower`; the actors this user **follows** live
-in `feed_following` (keyed by a local `id`, with the followee's cached inbox + handle /
+answer `410 Gone`. Followers live in `feed_follower` (keyed by the follower's `actor_uri`,
+with a local `id` for the approve/reject API, the cached inbox + handle / display name /
+avatar, the id of the `Follow` they sent — echoed in a deferred `Accept`/`Reject` — and an
+`accepted` flag that is false while a request is pending); the actors this user **follows**
+live in `feed_following` (keyed by a local `id`, with the followee's cached inbox + handle /
 display name / avatar and an `accepted` flag); the actor's RSA keypair in `feed_actor`.
 Posts received from followees are stored in `timeline_entry` (keyed by the remote note's
 `object_uri` so an `Update`/redelivery replaces in place), holding the **already-sanitised**

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -217,6 +217,68 @@ export const followingResponseSchema = baseResponseSchema
 export type FollowingResponse = z.infer<typeof followingResponseSchema>
 
 // =============================================================================
+// Followers (remote actors that follow this user — owner-facing management)
+// =============================================================================
+
+/** Acceptance state of a follower, and the filter used when listing them. */
+export const followerStatusValues = ['pending', 'accepted', 'all'] as const
+
+export const followerStatusSchema = z.enum(followerStatusValues).meta({
+  description:
+    'Follower acceptance filter: `pending` (awaiting your approval), `accepted` (approved), or `all`.',
+  id: 'FollowerStatus',
+})
+
+export type FollowerStatus = z.infer<typeof followerStatusSchema>
+
+/** Query for listing followers, optionally filtered by acceptance state. */
+export const followersQuerySchema = z
+  .object({
+    status: followerStatusSchema.default('all').meta({
+      description: 'Which followers to return (defaults to `all`).',
+    }),
+  })
+  .meta({ id: 'FollowersQuery' })
+
+export type FollowersQuery = z.infer<typeof followersQuerySchema>
+
+/**
+ * A remote actor that follows this user. Internal delivery details (the
+ * follower's inbox / shared-inbox URIs) are deliberately NOT exposed — only
+ * presentation fields and the acceptance state. `accepted` is false while their
+ * Follow awaits the owner's approval (manual-approval mode).
+ */
+export const followerActorSchema = z
+  .object({
+    accepted: z
+      .boolean()
+      .meta({ description: 'Whether you have approved this follower (else a pending request)' }),
+    actor_uri: z.string().meta({ description: "The follower's ActivityPub actor URI" }),
+    avatar_url: z.string().nullable().meta({ description: "The follower's avatar URL, if known" }),
+    created_at: iso8601DateTimeSchema.meta({ description: 'When the Follow arrived (ISO 8601)' }),
+    display_name: z.string().nullable().meta({ description: "The follower's display name, if known" }),
+    handle: z.string().nullable().meta({ description: "The follower's `@user@host` handle, if resolvable" }),
+    id: z.string().uuid().meta({ description: 'Local id of the follower (used to approve/reject)' }),
+  })
+  .meta({ id: 'FollowerActor' })
+
+export type FollowerActor = z.infer<typeof followerActorSchema>
+
+/** Response wrapping the owner's list of followers (pending and/or accepted). */
+export const followersResponseSchema = baseResponseSchema
+  .extend({ followers: z.array(followerActorSchema) })
+  .meta({ id: 'FollowersResponse' })
+
+export type FollowersResponse = z.infer<typeof followersResponseSchema>
+
+/** Response wrapping a single follower (e.g. the result of approving a request). */
+export const followerResponseSchema = baseResponseSchema
+  .extend({ follower: followerActorSchema.optional() })
+  .meta({ id: 'FollowerResponse' })
+
+export type FollowerResponse = z.infer<typeof followerResponseSchema>
+
+// =============================================================================
 // Home timeline (posts received from followed actors)
 // =============================================================================
 

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -210,6 +210,10 @@ export const updateSettingsInputSchema = z
     lastfm_username: lastFmUsernameSchema.nullable().optional().meta({
       description: 'Last.fm username for scrobble sync (set to null to clear)',
     }),
+    manually_approve_followers: z.boolean().nullable().optional().meta({
+      description:
+        'When true, incoming follows are held as pending requests you approve or reject; when false (default), anyone can follow you automatically (set to null to reset to the default).',
+    }),
     rescue_time_key: rescueTimeKeySchema.nullable().optional().meta({
       description: 'RescueTime API key (set to null to clear)',
     }),
@@ -276,6 +280,9 @@ export const userSettingsResponseSchema = baseResponseSchema
       .nullable()
       .default(null)
       .meta({ description: 'Last.fm username for scrobble sync' }),
+    manually_approve_followers: z.boolean().default(false).meta({
+      description: 'Whether incoming follows are held for manual approval (locked account)',
+    }),
     meal_slots: mealSlotsSchema.default([]).meta({ description: 'Configured meal slots for quick-logging' }),
     oura_configured: z
       .boolean()


### PR DESCRIPTION
## What & why

You asked whether the public-vs-followers distinction meant you could **approve or reject followers**. This adds exactly that: a per-user setting to run either an **open account** (the default — anyone can follow) or a **locked account** where incoming follows become **requests you approve or reject**.

## How

**Setting** — `manually_approve_followers` (user setting, default `false`). When on, the actor document advertises `manuallyApprovesFollowers: true` (a "locked account"), so Mastodon and the wider fediverse show a follow *request* and hold it pending.

**Inbound `Follow`**
- Auto-accepted (immediate `Accept`) unless manual approval is on. A re-delivered Follow from an already-accepted follower never demotes them back to pending.
- In manual mode the follow is recorded in `feed_follower` as **pending** with the follower's cached handle / display name / avatar (so the approval UI shows *who* is asking) and the id of their Follow activity — **no** `Accept` is sent yet.
- Only **accepted** followers appear in the followers collection + count and receive `followers`-only posts (a pending request is not yet a follower).

**Approve / reject**
- **Approve** flips the row to accepted and sends the deferred `Accept`, echoing the original `Follow` id so the follower's server matches it to its pending request.
- **Reject** (or removing an already-accepted follower) sends a `Reject` and drops the row.
- Both are best-effort/synchronous, matching the rest of the feed's delivery model.

## Surface (REST + MCP parity)

- `GET /feed/followers?status=pending|accepted|all`, `POST /feed/followers/:id/approve`, `DELETE /feed/followers/:id`.
- MCP `list_followers`, `approve_follower`, `reject_follower`.
- **Web** — a **Followers** panel on the Feed page (pending requests with Approve/Reject, accepted followers with Remove) and a **Manually approve new followers** toggle in Settings → *Feed & Followers*.

## Notable decisions

- **Default is auto-accept** — non-breaking; preserves today's open-account behaviour. Switching the setting off later does not retroactively accept already-pending requests.
- Shared `extractActorPresentation` (used by both follow directions) and a `with-timeout` leaf util were extracted from `following.ts` to stay DRY and cycle-free.
- `feed_follower` columns (`id`, `handle`, `display_name`, `avatar_url`, `follow_activity_uri`) are added with idempotent `ADD COLUMN IF NOT EXISTS`.

## Testing

- **DB integration** — round-trip, status filter (pending/accepted), approve, remove-by-id, keep-last-known presentation on re-follow.
- **Service integration** — approve/reject DB effects with best-effort delivery failing gracefully to a non-resolving inbox.
- **Federation integration** — actor advertises `manuallyApprovesFollowers` when enabled; followers collection + count are accepted-only (pending excluded).
- **Units** — follower serializer (no inbox leak) + `Follow` reconstruction (echoes / omits the original id).
- `pnpm check` green (0 errors); backend + web suites green; docs (`docs/features/feed.md`) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)