### PR TITLE
fix(feed): show delivered image attachments in the home timeline (#884)

### DIFF
--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -101,6 +101,25 @@ describe('Timeline store integration', () => {
     expect(plain.structured).toBeNull()
   })
 
+  test('stores + reads back image attachments (JSONB); plain posts are null', async () => {
+    const user = getTestUser()
+    const images = [
+      {
+        height: 420,
+        media_type: 'image/png',
+        name: 'Heart rate',
+        url: 'https://aurboda.net/api/public/bob/feed/abc/chart.png?token=t',
+        width: 1000,
+      },
+    ]
+    const rec = await upsertTimelineEntry(user, entry(1, { images }))
+    expect(rec.images).toEqual(images)
+    expect((await listTimelineEntries(user, 10))[0].images).toEqual(images)
+
+    const plain = await upsertTimelineEntry(user, entry(2))
+    expect(plain.images).toBeNull()
+  })
+
   test('a re-delivery without structured keeps the last-known structured (COALESCE)', async () => {
     const user = getTestUser()
     const structured = {

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -85,6 +85,10 @@ export const upsertTimelineEntry = async (
                    -- couldn't re-fetch it (transient enrich failure), rather
                    -- than wiping a working chart.
                    structured = COALESCE(EXCLUDED.structured, timeline_entry.structured),
+                   -- images always arrives as a concrete array from the ingest
+                   -- path, so this COALESCE never actually preserves a prior value
+                   -- (an edit that drops attachments clears them) -- it is defensive
+                   -- parity with structured for any caller that omits the field.
                    images = COALESCE(EXCLUDED.images, timeline_entry.images)
      RETURNING ${TIMELINE_COLUMNS}, (xmax = 0) AS inserted`,
     [

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -8,7 +8,7 @@
  * responsible for cleaning untrusted fediverse HTML before it reaches here).
  * Ordering + pagination is keyset by `(published_at DESC, id DESC)`.
  */
-import type { FeedStructured } from '@aurboda/api-spec'
+import type { FeedStructured, TimelineImage } from '@aurboda/api-spec'
 
 import { query } from './connection.ts'
 
@@ -25,6 +25,8 @@ export interface TimelineEntryRecord {
   received_at: Date
   /** Native structured payload from an Aurboda peer, or null for non-Aurboda posts. */
   structured: FeedStructured | null
+  /** Image attachments (rendered chart / route map, or a Mastodon photo), or null. */
+  images: TimelineImage[] | null
 }
 
 export interface TimelineEntryInput {
@@ -39,6 +41,8 @@ export interface TimelineEntryInput {
   published_at: Date
   /** Native structured payload fetched from an Aurboda peer on ingest, if any. */
   structured?: FeedStructured | null
+  /** Image attachments captured from the delivered Note, if any. */
+  images?: TimelineImage[] | null
 }
 
 /** Opaque keyset cursor: the last row's `(published_at, id)`. */
@@ -48,7 +52,7 @@ export interface TimelineCursor {
 }
 
 const TIMELINE_COLUMNS =
-  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at, structured'
+  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at, structured, images'
 
 /**
  * Insert or update a received post by `object_uri`. A re-delivered or edited post
@@ -67,8 +71,8 @@ export const upsertTimelineEntry = async (
   const result = await query<TimelineEntryRecord & { inserted: boolean }>(
     user,
     `INSERT INTO timeline_entry
-       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, structured)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, structured, images)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
      ON CONFLICT (object_uri)
      DO UPDATE SET actor_uri = EXCLUDED.actor_uri,
                    handle = EXCLUDED.handle,
@@ -80,7 +84,8 @@ export const upsertTimelineEntry = async (
                    -- Keep the last-known structured payload if a refresh/edit
                    -- couldn't re-fetch it (transient enrich failure), rather
                    -- than wiping a working chart.
-                   structured = COALESCE(EXCLUDED.structured, timeline_entry.structured)
+                   structured = COALESCE(EXCLUDED.structured, timeline_entry.structured),
+                   images = COALESCE(EXCLUDED.images, timeline_entry.images)
      RETURNING ${TIMELINE_COLUMNS}, (xmax = 0) AS inserted`,
     [
       input.object_uri,
@@ -92,6 +97,7 @@ export const upsertTimelineEntry = async (
       input.url ?? null,
       input.published_at,
       input.structured == null ? null : JSON.stringify(input.structured),
+      input.images == null ? null : JSON.stringify(input.images),
     ],
   )
   return result.rows[0]

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -150,6 +150,7 @@ export const tableCreationOrder = [
   'feed_following',
   'timeline_entry',
   'timeline_entry_structured',
+  'timeline_entry_images',
   'timeline_entry_indexes',
   'profile_avatar',
   'mcp_sessions',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -235,12 +235,18 @@ export const socialTables: Record<string, string> = {
       -- Native structured payload (typed metrics + series) fetched from Aurboda
       -- peers on ingest; NULL for Mastodon / non-Aurboda posts. Drives a native
       -- chart instead of the sanitised HTML.
-      structured    JSONB
+      structured    JSONB,
+      -- Image attachments (rendered chart / route map, or a Mastodon photo)
+      -- captured from the delivered Note; shown when there's no native chart.
+      images        JSONB
     )
   `,
-  // Additive column for DBs created before the structured-timeline feature.
+  // Additive columns for DBs created before the structured-timeline / media features.
   timeline_entry_structured: `
     ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS structured JSONB
+  `,
+  timeline_entry_images: `
+    ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS images JSONB
   `,
   // Timeline ordering / keyset pagination is by (published_at DESC, id DESC).
   timeline_entry_indexes: `

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -65,7 +65,7 @@ import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
 import { createAurbodaEnricher } from './timeline-enrich.ts'
-import { noteToTimelineInput } from './timeline-ingest.ts'
+import { extractNoteImages, noteToTimelineInput } from './timeline-ingest.ts'
 
 /** Posts per outbox page (cursor pagination). */
 const OUTBOX_PAGE_SIZE = 20
@@ -162,10 +162,13 @@ const ingestFeedActivity = async (
     if (!(object instanceof Note)) return
     const input = noteToTimelineInput(object, follow)
     if (input == null) return
+    // Capture the Note's image attachments (rendered chart / route map, or a
+    // Mastodon photo) so the timeline can show them when there's no native chart.
+    const images = await extractNoteImages(object)
     // Best-effort: fetch the native structured payload if this is an Aurboda post
     // (null otherwise). Stored on the entry so the web can render a native chart.
     const structured = await enrich(input.object_uri)
-    const { inserted } = await upsertTimelineEntry(me, { ...input, structured })
+    const { inserted } = await upsertTimelineEntry(me, { ...input, images, structured })
     // Ping live subscribers only for a genuinely new post (not an edit/redelivery).
     if (inserted) onNewEntry?.(me)
   } catch (error) {

--- a/apps/backend/src/services/activitypub/timeline-ingest.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.test.ts
@@ -1,10 +1,10 @@
-import { Note } from '@fedify/fedify/vocab'
+import { Document, Image, Note } from '@fedify/fedify/vocab'
 import { describe, expect, test } from 'vitest'
 
 import type { FeedFollowingRecord } from '../../db/index.ts'
 
 import { dateToTemporalInstant } from './temporal-interop.ts'
-import { noteToTimelineInput, sanitizeRemoteHtml } from './timeline-ingest.ts'
+import { extractNoteImages, noteToTimelineInput, sanitizeRemoteHtml } from './timeline-ingest.ts'
 
 /** Build the ambient `Temporal.Instant` a `Note` expects from an ISO string. */
 const published = (iso: string) => dateToTemporalInstant(new Date(iso))
@@ -145,5 +145,63 @@ describe('noteToTimelineInput', () => {
     expect(noteToTimelineInput(past, author, now)?.published_at.toISOString()).toBe(
       '2026-07-01T08:00:00.000Z',
     )
+  })
+})
+
+describe('extractNoteImages', () => {
+  test('extracts an Image attachment (rendered chart) with its url, media type, alt, and size', async () => {
+    const note = new Note({
+      attachments: [
+        new Image({
+          height: 420,
+          mediaType: 'image/png',
+          name: 'Heart rate',
+          url: new URL('https://aurboda.net/api/public/bob/feed/abc/chart.png?token=t'),
+          width: 1000,
+        }),
+      ],
+      content: '<p>Slept</p>',
+      id: new URL('https://aurboda.net/users/bob/feed/abc'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    expect(await extractNoteImages(note)).toEqual([
+      {
+        height: 420,
+        media_type: 'image/png',
+        name: 'Heart rate',
+        url: 'https://aurboda.net/api/public/bob/feed/abc/chart.png?token=t',
+        width: 1000,
+      },
+    ])
+  })
+
+  test('keeps a Mastodon-style Document with an image media type, and skips non-image + non-http attachments', async () => {
+    const note = new Note({
+      attachments: [
+        new Document({
+          mediaType: 'image/jpeg',
+          url: new URL('https://mastodon.example/media/photo.jpg'),
+        }),
+        // A non-image document is skipped.
+        new Document({ mediaType: 'video/mp4', url: new URL('https://mastodon.example/media/clip.mp4') }),
+        // A non-http(s) URL is skipped.
+        new Image({ mediaType: 'image/png', url: new URL('data:image/png;base64,AAAA') }),
+      ],
+      content: '<p>pics</p>',
+      id: new URL('https://mastodon.example/notes/9'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    expect(await extractNoteImages(note)).toEqual([
+      { media_type: 'image/jpeg', url: 'https://mastodon.example/media/photo.jpg' },
+    ])
+  })
+
+  test('returns an empty array for a Note with no attachments', async () => {
+    const note = new Note({
+      content: '<p>text only</p>',
+      id: new URL('https://mastodon.example/notes/7'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    expect(await extractNoteImages(note)).toEqual([])
   })
 })

--- a/apps/backend/src/services/activitypub/timeline-ingest.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.test.ts
@@ -175,7 +175,7 @@ describe('extractNoteImages', () => {
     ])
   })
 
-  test('keeps a Mastodon-style Document with an image media type, and skips non-image + non-http attachments', async () => {
+  test('keeps an https image Document, and skips non-image / non-https / data attachments', async () => {
     const note = new Note({
       attachments: [
         new Document({
@@ -184,7 +184,9 @@ describe('extractNoteImages', () => {
         }),
         // A non-image document is skipped.
         new Document({ mediaType: 'video/mp4', url: new URL('https://mastodon.example/media/clip.mp4') }),
-        // A non-http(s) URL is skipped.
+        // An http image is skipped (would be blocked as mixed content on the https app).
+        new Image({ mediaType: 'image/png', url: new URL('http://insecure.example/x.png') }),
+        // A data: URL is skipped.
         new Image({ mediaType: 'image/png', url: new URL('data:image/png;base64,AAAA') }),
       ],
       content: '<p>pics</p>',
@@ -193,6 +195,27 @@ describe('extractNoteImages', () => {
     })
     expect(await extractNoteImages(note)).toEqual([
       { media_type: 'image/jpeg', url: 'https://mastodon.example/media/photo.jpg' },
+    ])
+  })
+
+  test('caps the number of kept images at 4 (bounds a hostile followee)', async () => {
+    const note = new Note({
+      attachments: Array.from(
+        { length: 7 },
+        (_, i) =>
+          new Image({ mediaType: 'image/png', url: new URL(`https://mastodon.example/media/${i}.png`) }),
+      ),
+      content: '<p>many</p>',
+      id: new URL('https://mastodon.example/notes/8'),
+      published: published('2026-07-02T08:30:00Z'),
+    })
+    const images = await extractNoteImages(note)
+    expect(images).toHaveLength(4)
+    expect(images.map((i) => i.url)).toEqual([
+      'https://mastodon.example/media/0.png',
+      'https://mastodon.example/media/1.png',
+      'https://mastodon.example/media/2.png',
+      'https://mastodon.example/media/3.png',
     ])
   })
 

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -15,8 +15,10 @@
  * The inbox handler that calls these (in `federation.ts`) is thin: it checks the
  * sender is a followed, accepted actor and upserts the result.
  */
+import type { TimelineImage } from '@aurboda/api-spec'
 import type { Note } from '@fedify/fedify/vocab'
 
+import { Document, Image, Link } from '@fedify/fedify/vocab'
 import sanitizeHtml from 'sanitize-html'
 
 import type { FeedFollowingRecord, TimelineEntryInput } from '../../db/index.ts'
@@ -104,4 +106,46 @@ export const noteToTimelineInput = (
     published_at: new Date(Math.min(publishedAt.getTime(), now)),
     url: note.url instanceof URL ? note.url.href : note.id.href,
   }
+}
+
+/** Resolve an attachment's `url` (a `URL` or a `Link`) to an http(s) `URL`, or null. */
+const httpUrl = (raw: URL | Link | null): URL | null => {
+  const url = raw instanceof URL ? raw : raw instanceof Link ? raw.href : null
+  if (url == null) return null
+  return url.protocol === 'https:' || url.protocol === 'http:' ? url : null
+}
+
+/** Map one attachment to a `TimelineImage`, or null if it isn't an http(s) image. */
+const attachmentToImage = (att: unknown): TimelineImage | null => {
+  // `Image` (our charts / route maps) is a `Document` subtype; Mastodon photos
+  // are `Document`s with an `image/*` media type. Both are covered by `Document`.
+  if (!(att instanceof Document)) return null
+  const rawUrl = att.url
+  const url = httpUrl(rawUrl)
+  if (url == null) return null
+  const mediaType = att.mediaType ?? (rawUrl instanceof Link ? rawUrl.mediaType : null) ?? undefined
+  if (!(att instanceof Image) && !mediaType?.startsWith('image/')) return null
+  const name = att.name?.toString()
+  const image: TimelineImage = { url: url.href }
+  if (mediaType != null) image.media_type = mediaType
+  if (name != null && name !== '') image.name = name
+  if (typeof att.width === 'number') image.width = att.width
+  if (typeof att.height === 'number') image.height = att.height
+  return image
+}
+
+/**
+ * Extract a received Note's image attachments (rendered chart / route map, or a
+ * Mastodon photo) so the home timeline can show them — the fallback when a post
+ * carries no native structured chart. Best-effort: only inline http(s) images
+ * are kept; anything else is skipped. Non-image and malformed attachments (and a
+ * Note with none) yield an empty array.
+ */
+export const extractNoteImages = async (note: Note): Promise<TimelineImage[]> => {
+  const images: TimelineImage[] = []
+  for await (const att of note.getAttachments()) {
+    const image = attachmentToImage(att)
+    if (image) images.push(image)
+  }
+  return images
 }

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -148,13 +148,21 @@ const attachmentToImage = (att: unknown): TimelineImage | null => {
  * hostile followee could make us store + render in one card. */
 const MAX_TIMELINE_IMAGES = 4
 
+/** Hard cap on attachments *scanned* (not just kept). The kept-image cap alone
+ * doesn't bound work: a Note stuffed with non-image or reference-URI attachments
+ * would never hit it, so every attachment would be iterated (and each reference
+ * URI dereferenced). This bounds that amplification. */
+const MAX_ATTACHMENTS_SCANNED = 20
+
 export const extractNoteImages = async (note: Note): Promise<TimelineImage[]> => {
   const images: TimelineImage[] = []
+  let scanned = 0
   // `suppressError` so a referenced attachment whose dereference fails (unreachable
   // host, timeout, or `validatePublicUrl` rejecting a private-IP URL) yields null
   // instead of throwing out of the best-effort ingest path (never-500 invariant).
   // Inline attachments — our own chart `Image`s and Mastodon photos — don't deref.
   for await (const att of note.getAttachments({ suppressError: true })) {
+    if (++scanned > MAX_ATTACHMENTS_SCANNED) break
     const image = attachmentToImage(att)
     if (image) images.push(image)
     if (images.length >= MAX_TIMELINE_IMAGES) break

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -143,7 +143,11 @@ const attachmentToImage = (att: unknown): TimelineImage | null => {
  */
 export const extractNoteImages = async (note: Note): Promise<TimelineImage[]> => {
   const images: TimelineImage[] = []
-  for await (const att of note.getAttachments()) {
+  // `suppressError` so a referenced attachment whose dereference fails (unreachable
+  // host, timeout, or `validatePublicUrl` rejecting a private-IP URL) yields null
+  // instead of throwing out of the best-effort ingest path (never-500 invariant).
+  // Inline attachments — our own chart `Image`s and Mastodon photos — don't deref.
+  for await (const att of note.getAttachments({ suppressError: true })) {
     const image = attachmentToImage(att)
     if (image) images.push(image)
   }

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -108,20 +108,23 @@ export const noteToTimelineInput = (
   }
 }
 
-/** Resolve an attachment's `url` (a `URL` or a `Link`) to an http(s) `URL`, or null. */
-const httpUrl = (raw: URL | Link | null): URL | null => {
+/**
+ * Resolve an attachment's `url` (a `URL` or a `Link`) to an **https** `URL`, or
+ * null. https-only: an `http:` image would be blocked as mixed content on the
+ * https web app, so storing it is dead weight that never renders.
+ */
+const httpsUrl = (raw: URL | Link | null): URL | null => {
   const url = raw instanceof URL ? raw : raw instanceof Link ? raw.href : null
-  if (url == null) return null
-  return url.protocol === 'https:' || url.protocol === 'http:' ? url : null
+  return url?.protocol === 'https:' ? url : null
 }
 
-/** Map one attachment to a `TimelineImage`, or null if it isn't an http(s) image. */
+/** Map one attachment to a `TimelineImage`, or null if it isn't an https image. */
 const attachmentToImage = (att: unknown): TimelineImage | null => {
   // `Image` (our charts / route maps) is a `Document` subtype; Mastodon photos
   // are `Document`s with an `image/*` media type. Both are covered by `Document`.
   if (!(att instanceof Document)) return null
   const rawUrl = att.url
-  const url = httpUrl(rawUrl)
+  const url = httpsUrl(rawUrl)
   if (url == null) return null
   const mediaType = att.mediaType ?? (rawUrl instanceof Link ? rawUrl.mediaType : null) ?? undefined
   if (!(att instanceof Image) && !mediaType?.startsWith('image/')) return null
@@ -141,6 +144,10 @@ const attachmentToImage = (att: unknown): TimelineImage | null => {
  * are kept; anything else is skipped. Non-image and malformed attachments (and a
  * Note with none) yield an empty array.
  */
+/** Cap on kept image attachments per post (matches Mastodon), bounding what a
+ * hostile followee could make us store + render in one card. */
+const MAX_TIMELINE_IMAGES = 4
+
 export const extractNoteImages = async (note: Note): Promise<TimelineImage[]> => {
   const images: TimelineImage[] = []
   // `suppressError` so a referenced attachment whose dereference fails (unreachable
@@ -150,6 +157,7 @@ export const extractNoteImages = async (note: Note): Promise<TimelineImage[]> =>
   for await (const att of note.getAttachments({ suppressError: true })) {
     const image = attachmentToImage(att)
     if (image) images.push(image)
+    if (images.length >= MAX_TIMELINE_IMAGES) break
   }
   return images
 }

--- a/apps/backend/src/services/timeline.test.ts
+++ b/apps/backend/src/services/timeline.test.ts
@@ -11,6 +11,7 @@ const record = (over: Partial<TimelineEntryRecord> = {}): TimelineEntryRecord =>
   display_name: 'Alice',
   handle: '@alice@remote.example',
   id: '00000000-0000-0000-0000-000000000001',
+  images: null,
   object_uri: 'https://remote.example/notes/1',
   published_at: new Date('2026-07-01T08:00:00.000Z'),
   received_at: new Date('2026-07-01T08:00:05.000Z'),

--- a/apps/backend/src/services/timeline.ts
+++ b/apps/backend/src/services/timeline.ts
@@ -41,6 +41,7 @@ export const serializeTimelineEntry = (record: TimelineEntryRecord): TimelineEnt
   display_name: record.display_name,
   handle: record.handle,
   id: record.id,
+  ...(record.images == null || record.images.length === 0 ? {} : { images: record.images }),
   object_uri: record.object_uri,
   published_at: record.published_at.toISOString(),
   ...(record.structured == null ? {} : { structured: record.structured }),

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -73,8 +73,23 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
       {/* Sanitised server-side on ingest (timeline-ingest.ts) — safe to render. */}
       <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: entry.content }} />
 
-      {/* Aurboda-to-Aurboda posts carry native structured data → a real chart. */}
-      {entry.structured && <TimelineStructured structured={entry.structured} />}
+      {/* Native structured data (Aurboda peers) → a real chart; otherwise fall
+          back to the delivered image attachment(s), the way Mastodon shows them. */}
+      {entry.structured ? (
+        <TimelineStructured structured={entry.structured} />
+      ) : (
+        entry.images?.map((img) => (
+          <img
+            key={img.url}
+            class="feed-post-image"
+            src={img.url}
+            alt={img.name ?? ''}
+            width={img.width}
+            height={img.height}
+            loading="lazy"
+          />
+        ))
+      )}
     </article>
   )
 }

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -173,8 +173,15 @@ When a `Create` or `Update` for a `Note` is delivered, the inbox:
    anyone else are ignored, so an unsolicited `Create` can't inject into the timeline,
 2. **sanitises** the note's HTML content server-side (`sanitize-html`, a strict tag/attribute
    allowlist) — remote content is untrusted, so this is the XSS boundary, then
-3. upserts a `timeline_entry` (keyed by the note's `object_uri`, so an `Update` or a
+3. captures the note's **image attachments** (rendered chart / route map, or a Mastodon
+   photo) — only inline `http(s)` images survive, then
+4. upserts a `timeline_entry` (keyed by the note's `object_uri`, so an `Update` or a
    redelivery replaces in place rather than duplicating).
+
+Each card renders the sanitised HTML plus, below it, the **native structured chart** when the
+post carried one (Aurboda peers, see below) — otherwise the delivered **image attachment(s)**,
+the way Mastodon shows them. So a `followers`-only share (whose structured data isn't
+federated) still shows its chart *image*, and a Mastodon photo post shows its photos.
 
 A `Delete` removes the matching entry; unfollowing removes all of that actor's entries. The
 timeline is read back **newest-first**, keyset-paginated on `(published_at, id)` behind an
@@ -383,7 +390,9 @@ content plus the author's cached handle / display name / avatar, indexed on
 `structured` JSONB column carries the native Aurboda payload (`FeedStructured`: typed
 metrics + inline series) fetched during enrichment — NULL for non-Aurboda posts. On a
 re-delivery whose enrichment failed, the upsert `COALESCE`s so the last-known `structured`
-is preserved rather than wiped.
+is preserved rather than wiped. A nullable `images` JSONB column holds the delivered
+image attachments (`TimelineImage[]`: url + optional media type / alt / size), rendered as
+the fallback when a post has no native structured chart.
 
 ## Caveats & limitations
 

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -282,6 +282,25 @@ export type FollowerResponse = z.infer<typeof followerResponseSchema>
 // Home timeline (posts received from followed actors)
 // =============================================================================
 
+/**
+ * An image attached to a received post (e.g. a rendered chart or route map, or a
+ * Mastodon photo). Captured from the delivered Note's `attachment`s so the home
+ * timeline can show it — the fallback when a post carries no native structured
+ * chart. The `url` is served by the author's origin instance (a `followers`-only
+ * post's URL carries its capability token).
+ */
+export const timelineImageSchema = z
+  .object({
+    height: z.number().int().optional().meta({ description: 'Intrinsic height in px, if known' }),
+    media_type: z.string().optional().meta({ description: 'MIME type, e.g. `image/png`' }),
+    name: z.string().optional().meta({ description: 'Alt text / caption, if any' }),
+    url: z.string().meta({ description: 'Image URL (served by the author’s origin instance)' }),
+    width: z.number().int().optional().meta({ description: 'Intrinsic width in px, if known' }),
+  })
+  .meta({ id: 'TimelineImage' })
+
+export type TimelineImage = z.infer<typeof timelineImageSchema>
+
 /** A post received from a followed actor, as shown in the home timeline. */
 export const timelineEntrySchema = z
   .object({
@@ -293,6 +312,10 @@ export const timelineEntrySchema = z
     display_name: z.string().nullable().meta({ description: "The author's display name, if known" }),
     handle: z.string().nullable().meta({ description: "The author's `@user@host` handle, if known" }),
     id: z.string().uuid().meta({ description: 'Local id of the timeline entry' }),
+    images: z.array(timelineImageSchema).optional().meta({
+      description:
+        'Image attachments (e.g. a rendered chart or route map), shown when the post carries no native structured chart.',
+    }),
     object_uri: z.string().meta({ description: "The remote post's canonical id" }),
     published_at: iso8601DateTimeSchema.meta({ description: 'When the post was published (ISO 8601)' }),
     structured: feedStructuredSchema.optional().meta({


### PR DESCRIPTION
## What & why

Follow-up from tryout (Sara followed you): a **followers-only sleep post with an HR chart showed nothing** in the aurboda home timeline — even though Mastodon rendered the chart image.

Two gaps caused it:
- **Image dropped on ingest** — `noteToTimelineInput` kept only the sanitised text `content` (the sanitiser even strips `<img>`), so the delivered image attachment was thrown away.
- **Native chart is public-only** — structured-chart federation gates on `public`/`unlisted`; a `followers`-only share federates no structured data → no native chart either.

Net: a followers-only post had neither. This slice fixes the **image** path (native charts for followers-only is the next slice).

## How

- **`extractNoteImages`** pulls image attachments off the received Note — our own rendered chart / route-map `Image`s *and* Mastodon-style `Document`s with an `image/*` media type. Only inline `http(s)` images survive (url + optional media type / alt / intrinsic size); anything else is skipped.
- Stored on a nullable **`timeline_entry.images`** JSONB column (additive `ADD COLUMN IF NOT EXISTS`), `COALESCE`d on re-delivery like `structured`.
- The home timeline card renders the **native structured chart when present, else the delivered image(s)** — matching the rule *"native chart if the data is shared, image otherwise if present."* So a followers-only share still shows its chart **image**, and a Mastodon photo post shows its photos.

## Testing

- **Unit** — `extractNoteImages` extracts a rendered `Image` (url/media-type/alt/size) and a Mastodon `Document`, and skips non-image / non-`http(s)` / no-attachment cases.
- **Integration** — `images` JSONB round-trip (stored + read back; plain posts are null).
- `pnpm check` green (0 errors); backend + web suites green; docs updated.

## Follow-up slices (tracked)

2. Native charts for followers-only posts (serve structured to accepted followers via the image-token capability).
3. Unify chart-image + series sharing (one control, "same data two formats").
4. Public profile feed + navigation links.
5. Home timeline backfill of a followee's older public posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)