### PR TITLE
feat(feed): federate native charts to accepted followers (#884)

### DIFF
--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -1,4 +1,5 @@
 import { type Response, Router } from 'express'
+
 /**
  * Public feed-post image endpoints (UNAUTHENTICATED).
  *
@@ -15,31 +16,13 @@ import { type Response, Router } from 'express'
  * effect immediately — the untoken'd public URL then 404s). Mounted before the
  * generic `/public/:username/:slug` resolver.
  */
-import { timingSafeEqual } from 'node:crypto'
-
 import type { FeedPostRecord } from '../db/index.ts'
 
 import { isValidUsername } from '../api/auth-routes.ts'
 import { isMissingDatabase } from '../db/index.ts'
-import { isPubliclyVisible } from '../services/activitypub/object.ts'
+import { isCapabilityAuthorized } from '../services/feed-capability.ts'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-/** Constant-time string compare (avoids leaking the token via response timing). */
-const tokenMatches = (provided: string, expected: string): boolean => {
-  const a = Buffer.from(provided)
-  const b = Buffer.from(expected)
-  return a.length === b.length && timingSafeEqual(a, b)
-}
-
-/**
- * Whether an image request may see this post: `public`/`unlisted` are always
- * served; a `followers`-only post is served only when the request carries the
- * post's unguessable capability token (`?token=…`), which is embedded only in
- * the Note delivered to followers (#893).
- */
-const isImageAuthorized = (post: FeedPostRecord, token: string | undefined): boolean =>
-  isPubliclyVisible(post.visibility) || (token != null && tokenMatches(token, post.image_token))
 
 /** The window an image renders over. */
 export interface ImageActivity {
@@ -113,7 +96,7 @@ export const resolveImageWindow = async (
     if (isMissingDatabase(error)) return null
     throw error
   }
-  if (post == null || !isImageAuthorized(post, token) || !post[flag] || post.activity_id == null) {
+  if (post == null || !isCapabilityAuthorized(post, token) || !post[flag] || post.activity_id == null) {
     return null
   }
   const activity = await deps.getActivity(username, post.activity_id)

--- a/apps/backend/src/routes/feed-public-router.ts
+++ b/apps/backend/src/routes/feed-public-router.ts
@@ -67,17 +67,21 @@ export const createFeedPublicRouter = (): TypedRouter => {
 
   // The native structured post (typed metrics + inline series) another Aurboda
   // instance fetches on ingest to render a chart. Same data-scoping as `/series`
-  // — only public/unlisted posts and only the metrics/series actually shared.
+  // and only the metrics/series actually shared. `public`/`unlisted` resolve
+  // unconditionally; a `followers`-only post resolves only with a matching
+  // capability `?token=` (the same token that authorizes its followers-only
+  // images), so an accepted follower's instance can render the native chart.
   // `no-store` for the same revocability reason as the series endpoint.
-  router.get<{ username: string; postId: string }, FeedPostStructuredResponse>(
+  router.get<{ username: string; postId: string }, FeedPostStructuredResponse, unknown, { token?: string }>(
     '/public/:username/feed/:postId',
     async (req, res) => {
       const { postId, username } = req.params
       if (!isValidUsername(username) || !UUID_RE.test(postId)) {
         return res.status(404).json({ error: 'Not found', success: false })
       }
+      const token = typeof req.query.token === 'string' ? req.query.token : undefined
       try {
-        const structured = await resolveStructuredPost(username, postId)
+        const structured = await resolveStructuredPost(username, postId, token)
         if (!structured) {
           return res.status(404).json({ error: 'Not found', success: false })
         }

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -64,7 +64,7 @@ import { extractActorPresentation } from './actor-presentation.ts'
 import { buildFeedCreate, buildFeedNote } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
-import { createAurbodaEnricher } from './timeline-enrich.ts'
+import { capabilityTokenFrom, createAurbodaEnricher } from './timeline-enrich.ts'
 import { extractNoteImages, noteToTimelineInput } from './timeline-ingest.ts'
 
 /** Posts per outbox page (cursor pagination). */
@@ -146,7 +146,7 @@ const ingestFeedActivity = async (
   activity: Create | Update,
   onNewEntry?: (user: string) => void,
   /** Best-effort fetch of the post's native Aurboda structured data (null if not an Aurboda post). */
-  enrich: (objectUri: string) => Promise<FeedStructured | null> = async () => null,
+  enrich: (objectUri: string, token?: string) => Promise<FeedStructured | null> = async () => null,
 ): Promise<void> => {
   // The recipient (whose timeline this is) comes from the personal inbox owner.
   // Unlike Accept/Reject there's no inner Follow to derive it from, so this relies
@@ -166,8 +166,10 @@ const ingestFeedActivity = async (
     // Mastodon photo) so the timeline can show them when there's no native chart.
     const images = await extractNoteImages(object)
     // Best-effort: fetch the native structured payload if this is an Aurboda post
-    // (null otherwise). Stored on the entry so the web can render a native chart.
-    const structured = await enrich(input.object_uri)
+    // (null otherwise). A followers-only post authorizes the fetch with the same
+    // capability token embedded in its delivered image URL. Stored on the entry so
+    // the web can render a native chart in place of the image.
+    const structured = await enrich(input.object_uri, capabilityTokenFrom(images))
     const { inserted } = await upsertTimelineEntry(me, { ...input, images, structured })
     // Ping live subscribers only for a genuinely new post (not an edit/redelivery).
     if (inserted) onNewEntry?.(me)

--- a/apps/backend/src/services/activitypub/timeline-enrich.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.test.ts
@@ -2,7 +2,12 @@ import type { FeedStructured, WellKnownAurboda } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
-import { type AurbodaEnrichDeps, enrichFromAurboda, parseAurbodaFeedUrl } from './timeline-enrich.ts'
+import {
+  type AurbodaEnrichDeps,
+  capabilityTokenFrom,
+  enrichFromAurboda,
+  parseAurbodaFeedUrl,
+} from './timeline-enrich.ts'
 
 const UUID = '11111111-2222-4333-8444-555555555555'
 
@@ -105,5 +110,39 @@ describe('enrichFromAurboda', () => {
       fetchStructured: async () => ({ structured: { nope: true }, success: true }),
     }
     expect(await enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps)).toBeNull()
+  })
+
+  test('passes the capability token as ?token= so a followers-only post authorizes', async () => {
+    let fetchedUrl = ''
+    const deps: AurbodaEnrichDeps = {
+      discover: async () => wellKnown,
+      fetchStructured: async (url) => {
+        fetchedUrl = url
+        return { structured, success: true }
+      },
+    }
+    await enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps, 'secret token/&')
+    expect(fetchedUrl).toBe(`https://aurboda.net/api/public/fredrik/feed/${UUID}?token=secret%20token%2F%26`)
+  })
+})
+
+describe('capabilityTokenFrom', () => {
+  const image = (url: string) => ({ url })
+
+  test('lifts the token from a followers-only image URL', () => {
+    expect(
+      capabilityTokenFrom([image('https://aurboda.net/api/public/bob/feed/abc/chart.png?token=t0k')]),
+    ).toBe('t0k')
+  })
+
+  test('returns undefined for a public image URL (no token) or no images', () => {
+    expect(
+      capabilityTokenFrom([image('https://aurboda.net/api/public/bob/feed/abc/chart.png')]),
+    ).toBeUndefined()
+    expect(capabilityTokenFrom([])).toBeUndefined()
+  })
+
+  test('skips a malformed URL and finds the token on a later image', () => {
+    expect(capabilityTokenFrom([image('not a url'), image('https://h.example/x.png?token=abc')])).toBe('abc')
   })
 })

--- a/apps/backend/src/services/activitypub/timeline-enrich.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.ts
@@ -22,6 +22,7 @@
 import {
   type FeedStructured,
   feedPostStructuredResponseSchema,
+  type TimelineImage,
   type WellKnownAurboda,
 } from '@aurboda/api-spec'
 
@@ -65,18 +66,41 @@ export interface AurbodaEnrichDeps {
 const trimSlashes = (s: string): string => s.replace(/\/+$/, '')
 
 /**
+ * The capability token embedded in a `followers`-only post's delivered image URL
+ * (`…/chart.png?token=…`), reused to authorize the structured fetch for the same
+ * post — or undefined for a public post (no token) or a post with no images. It's
+ * the same `image_token` the origin instance checks, so an accepted follower's
+ * instance can fetch the native chart it was already allowed to see the image of.
+ */
+export const capabilityTokenFrom = (images: TimelineImage[]): string | undefined => {
+  for (const img of images) {
+    try {
+      const token = new URL(img.url).searchParams.get('token')
+      if (token) return token
+    } catch {
+      // A malformed image URL carries no usable token — skip it.
+    }
+  }
+  return undefined
+}
+
+/**
  * Fetch the structured payload for an Aurboda feed-post object URI, or null if
  * the post isn't an Aurboda post, the host doesn't federate, or anything fails.
+ * `token` (lifted from the delivered image URL) authorizes a `followers`-only
+ * post; a public post needs none.
  */
 export const enrichFromAurboda = async (
   objectUri: string,
   deps: AurbodaEnrichDeps,
+  token?: string,
 ): Promise<FeedStructured | null> => {
   const parsed = parseAurbodaFeedUrl(objectUri)
   if (parsed == null) return null
   try {
     const wellKnown = await deps.discover(parsed.origin)
-    const url = `${trimSlashes(wellKnown.api_base)}/public/${encodeURIComponent(parsed.user)}/feed/${parsed.postId}`
+    const base = `${trimSlashes(wellKnown.api_base)}/public/${encodeURIComponent(parsed.user)}/feed/${parsed.postId}`
+    const url = token == null ? base : `${base}?token=${encodeURIComponent(token)}`
     const body = await deps.fetchStructured(url)
     const result = feedPostStructuredResponseSchema.safeParse(body)
     if (!result.success || !result.data.structured) return null
@@ -94,14 +118,17 @@ const ENRICH_TIMEOUT_MS = 12_000
  * fetch, bounded by a total timeout so a slow peer can't stall ingest, and
  * swallowing every error to `null` (enrichment is never allowed to fail ingest).
  */
-export const createAurbodaEnricher = (): ((objectUri: string) => Promise<FeedStructured | null>) => {
+export const createAurbodaEnricher = (): ((
+  objectUri: string,
+  token?: string,
+) => Promise<FeedStructured | null>) => {
   const deps: AurbodaEnrichDeps = {
     discover: discoverInstance,
     fetchStructured: async (url) => (await safeFetchGet(url)).data,
   }
-  return async (objectUri) => {
+  return async (objectUri, token) => {
     try {
-      return await withTimeout(enrichFromAurboda(objectUri, deps), ENRICH_TIMEOUT_MS)
+      return await withTimeout(enrichFromAurboda(objectUri, deps, token), ENRICH_TIMEOUT_MS)
     } catch {
       return null
     }

--- a/apps/backend/src/services/feed-capability.ts
+++ b/apps/backend/src/services/feed-capability.ts
@@ -1,0 +1,32 @@
+import type { FeedVisibility } from '@aurboda/api-spec'
+
+/**
+ * Capability-token authorization for a shared post's data endpoints.
+ *
+ * `public`/`unlisted` posts are always served. A `followers`-only post is served
+ * only when the request carries the post's unguessable `image_token` (`?token=…`),
+ * which is embedded solely in the Note delivered to followers. Shared by the media
+ * (chart / route image) and structured-post endpoints so both enforce it
+ * identically — a follower's instance reuses the same token (lifted from the
+ * delivered image URL) to fetch the native structured chart.
+ */
+import { timingSafeEqual } from 'node:crypto'
+
+import { isPubliclyVisible } from './activitypub/object.ts'
+
+/** Constant-time string compare (avoids leaking the token via response timing). */
+export const tokenMatches = (provided: string, expected: string): boolean => {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+/**
+ * Whether a request (optionally carrying `token`) may see this post's shared
+ * data: `public`/`unlisted` always; a `followers`-only post only with a matching
+ * capability token.
+ */
+export const isCapabilityAuthorized = (
+  post: { visibility: FeedVisibility; image_token: string },
+  token: string | undefined,
+): boolean => isPubliclyVisible(post.visibility) || (token != null && tokenMatches(token, post.image_token))

--- a/apps/backend/src/services/feed-structured.integration.test.ts
+++ b/apps/backend/src/services/feed-structured.integration.test.ts
@@ -99,7 +99,7 @@ describe('resolveStructuredPost', () => {
     expect(structured?.series).toEqual([])
   })
 
-  test('returns null for a followers-only post (not publicly visible)', async () => {
+  test('gates a followers-only post on the capability token', async () => {
     const user = getTestUser()
     const activityId = await seedActivityWithHeartRate(user)
     const post = await createFeedPost(user, {
@@ -110,7 +110,13 @@ describe('resolveStructuredPost', () => {
       series_metrics: ['heart_rate'],
       visibility: 'followers',
     })
+    // No token / wrong token → not authorized.
     expect(await resolveStructuredPost(user, post.id)).toBeNull()
+    expect(await resolveStructuredPost(user, post.id, 'wrong')).toBeNull()
+    // The post's own capability token (delivered to followers) → resolves.
+    const structured = await resolveStructuredPost(user, post.id, post.image_token)
+    expect(structured?.series.map((s) => s.metric)).toEqual(['heart_rate'])
+    expect(structured?.metrics.map((m) => m.key)).toEqual(['heart_rate_avg'])
   })
 
   test('returns null for an unknown post id', async () => {

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -12,9 +12,9 @@
  */
 import { type FeedStructured, type FeedStructuredSeries, metricTypeSchema } from '@aurboda/api-spec'
 
-import { findCoveringSharedSeriesWindow, getFeedPostById } from '../db/index.ts'
+import { getFeedPostById } from '../db/index.ts'
 import { resolveActivityScalars } from './activitypub/feed-activity.ts'
-import { isPubliclyVisible } from './activitypub/object.ts'
+import { isCapabilityAuthorized } from './feed-capability.ts'
 import { resolvePublicSeries } from './feed-series.ts'
 import { resolveFeedActivity } from './feed.ts'
 import { queryMetricsBucketed } from './queries/index.ts'
@@ -23,8 +23,15 @@ import { queryMetricsBucketed } from './queries/index.ts'
 const SERIES_BUCKET = '5s'
 
 /**
- * Resolve a post's shared series to inline samples, reusing the public-series
- * data-scoping (an unshared/uncovered metric resolves to nothing, never leaks).
+ * Resolve a post's opted-in series to inline samples over its activity window.
+ *
+ * The authorization boundary is the post itself: `resolveStructuredPost` has
+ * already checked the caller may see this post, and we only ever iterate the
+ * post's own `seriesMetrics` over its own `[start, end]`. So the covering window
+ * *is* that window — we don't route through the public-only
+ * `findCoveringSharedSeriesWindow` (which correctly rejects a `followers`-only
+ * share for the public `/series` endpoint, but would wrongly blank the chart
+ * here for a token-authorized follower).
  */
 const resolveStructuredSeries = async (
   user: string,
@@ -37,7 +44,7 @@ const resolveStructuredSeries = async (
     const parsed = metricTypeSchema.safeParse(raw)
     if (!parsed.success) continue
     const result = await resolvePublicSeries(parsed.data, start, end, SERIES_BUCKET, {
-      findCoveringWindow: (m, s, e) => findCoveringSharedSeriesWindow(user, m, s, e),
+      findCoveringWindow: async () => ({ end_time: end, start_time: start }),
       queryBucketed: (m, s, e, b) => queryMetricsBucketed(user, [m], s, e, b, {}),
     })
     if (result) {
@@ -54,11 +61,19 @@ const resolveStructuredSeries = async (
 
 /**
  * Build the structured payload for one of `user`'s feed posts, or null if it is
- * unknown, has no resolvable activity, or is not publicly visible.
+ * unknown, has no resolvable activity, or the requester isn't authorized to see
+ * it. `public`/`unlisted` posts resolve unconditionally; a `followers`-only post
+ * resolves only with a matching capability `token` (the same token that
+ * authorizes its followers-only images), so an accepted follower's instance can
+ * render the native chart while a public guess still 404s.
  */
-export const resolveStructuredPost = async (user: string, postId: string): Promise<FeedStructured | null> => {
+export const resolveStructuredPost = async (
+  user: string,
+  postId: string,
+  token?: string,
+): Promise<FeedStructured | null> => {
   const post = await getFeedPostById(user, postId)
-  if (post == null || post.activity_id == null || !isPubliclyVisible(post.visibility)) return null
+  if (post == null || post.activity_id == null || !isCapabilityAuthorized(post, token)) return null
 
   const activity = await resolveFeedActivity(user, post.activity_id)
   if (activity == null) return null

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -180,8 +180,9 @@ When a `Create` or `Update` for a `Note` is delivered, the inbox:
 
 Each card renders the sanitised HTML plus, below it, the **native structured chart** when the
 post carried one (Aurboda peers, see below) — otherwise the delivered **image attachment(s)**,
-the way Mastodon shows them. So a `followers`-only share (whose structured data isn't
-federated) still shows its chart *image*, and a Mastodon photo post shows its photos.
+the way Mastodon shows them. A `followers`-only Aurboda share federates its native chart to
+accepted followers too (via the capability token, see below), so a follower gets the
+interactive chart rather than just the flat image; a Mastodon photo post shows its photos.
 
 A `Delete` removes the matching entry; unfollowing removes all of that actor's entries. The
 timeline is read back **newest-first**, keyset-paginated on `(published_at, id)` behind an
@@ -207,14 +208,19 @@ structured data out-of-band on ingest:
    (`FeedStructured`: activity type/window, typed scalar `metrics`, and inline high-resolution
    `series` samples). It reuses the exact same scalar resolution as delivery and the same
    data-scoped series resolution as the [public series endpoint](#public-series-endpoint-the-privacy-boundary),
-   so a peer can never read more than the author shared; only `public`/`unlisted` posts resolve.
+   so a peer can never read more than the author shared. `public`/`unlisted` posts resolve
+   unconditionally; a `followers`-only post resolves only with a matching `?token=<image_token>`
+   — the **same capability token** that authorizes its followers-only images (below), so the
+   structured chart and the image share one authorization boundary.
 2. **Detect + fetch.** On ingesting a `Create`/`Update`, if the note's id matches Aurboda's own
    object path (`/users/{user}/feed/{postId}` — a Mastodon status id never does, so no needless
    request is made), the receiver discovers the peer via `/.well-known/aurboda` and fetches its
-   structured endpoint. All fetches are **SSRF-guarded** (`safe-fetch`: public hosts only, no
-   redirects, size + time bounded) and time-boxed; the origin is the accepted followee's own
-   host. Any failure (non-Aurboda host, 404, malformed, timeout) is swallowed — the post still
-   shows with its HTML.
+   structured endpoint. For a `followers`-only post it lifts the capability token from the
+   delivered image URL (the `?token=` embedded only in the follower's `Note`) and forwards it,
+   so an accepted follower fetches the native chart while a public guess still 404s. All fetches
+   are **SSRF-guarded** (`safe-fetch`: public hosts only, no redirects, size + time bounded) and
+   time-boxed; the origin is the accepted followee's own host. Any failure (non-Aurboda host,
+   404, malformed, timeout) is swallowed — the post still shows with its HTML.
 3. **Store + render.** The payload is stored on `timeline_entry.structured` (JSONB, NULL for
    non-Aurboda posts; a redelivery that can't re-fetch keeps the last-known value). The web
    timeline card renders a native `TrendLineChart` per shared series when `structured` is present.


### PR DESCRIPTION
## Summary

Second slice of the #884 tryout follow-ups (after #929 timeline media rendering). Sara followed the user and got a sleep activity shared with an HR chart, but her aurboda timeline showed **neither** the chart image **nor** a native chart — because the native structured chart was **public-only**. This slice federates the native chart to **accepted followers** too, so a follower sees the interactive chart instead of only the flat image.

## What changed

Authorization reuses the post's **existing capability token** — the same unguessable `image_token` that already gates a followers-only post's chart/route images, embedded only in the `Note` delivered to followers.

- **Shared authz** — extracted `isCapabilityAuthorized` into `services/feed-capability.ts` so the media and structured endpoints enforce one identical boundary (`public`/`unlisted` always; `followers`-only only with a matching token). The feed-image router now delegates to it instead of its own copy.
- **Structured resolver** — `resolveStructuredPost(user, postId, token?)` resolves a followers-only post only with a matching token. Its series are scoped by the post's own activity window (the post itself is the authorization boundary), bypassing the public-only covering-window check that would otherwise blank the chart for an authorized follower.
- **Route** — `GET /public/:username/feed/:postId` reads `?token=` and forwards it.
- **Ingest** — the enricher lifts the token from the delivered image URL (`capabilityTokenFrom`) and passes it to the structured fetch, so an accepted follower's instance fetches the chart it may already see the image of. A public guess (no/wrong token) still 404s.

Best-effort and additive as before: any failure falls back to the HTML + image.

## Tests

- `timeline-enrich.test.ts` — `?token=` forwarding + `capabilityTokenFrom` (lifts token, skips malformed URLs, undefined for public/no images).
- `feed-structured.integration.test.ts` — a followers-only post is null without a token and with a wrong token, and resolves (metrics + series) with `post.image_token`.
- Full `pnpm check` clean; affected backend suite green (52 tests).

## Docs

`docs/features/feed.md` — the native-charts (structured enrichment) and card-rendering sections now describe followers-only federation via the capability token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)