### PR TITLE
feat(feed): unify the heart-rate chart image and series into one share control (#884)

### DIFF
--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -15,7 +15,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { fetchBucketedMetrics, fetchRawLocations, shareActivity, updateFeedPost } from '../state/api'
-import { defaultsFromChart, SERIES_METRICS, SUMMARY_METRICS } from './feed-metrics'
+import {
+  buildShareBody,
+  defaultsFromChart,
+  initialSeriesSelection,
+  SERIES_METRICS,
+  SUMMARY_METRICS,
+} from './feed-metrics'
 import { FEED_VISIBILITY_OPTIONS, VisibilitySelector } from './VisibilitySelector'
 import './ShareActivityDialog.css'
 
@@ -115,39 +121,36 @@ export function ShareActivityDialog({
   )
   // Preselect from the post's shared series (edit) or the charted metrics (create),
   // intersected with keys this dialog can represent — keeps the state typed as
-  // `Set<MetricType>` without a cast.
+  // `Set<MetricType>` without a cast. `initialSeriesSelection` folds a legacy
+  // chart-image post into the heart-rate series (one control governs both).
   const [series, setSeries] = useState<Set<MetricType>>(
-    () =>
-      new Set(
-        post
-          ? SERIES_METRICS.map((m) => m.key).filter((k) => post.series_metrics.includes(k))
-          : defaults.series,
-      ),
+    () => new Set(post ? initialSeriesSelection(post) : defaults.series),
   )
   const [visibility, setVisibility] = useState<FeedVisibility>(post?.visibility ?? 'public')
-  const [includeChart, setIncludeChart] = useState(post?.include_chart ?? false)
   const [includeMap, setIncludeMap] = useState(post?.include_map ?? false)
   const { summaryOptions, seriesOptions, canChart, canMap } = useShareableMetricOptions(
     activityStart,
     activityEnd,
     post?.included_metrics,
-    post?.series_metrics,
+    // Offer the heart-rate series on an edit whenever the post shares it in either
+    // format, so the unified control is always toggleable (never stuck checked).
+    post ? initialSeriesSelection(post) : undefined,
     post?.include_chart,
     post?.include_map,
   )
 
   const mutation = useMutation({
     mutationFn: () => {
-      // Only send metrics the dialog actually offered (drops defaults hidden as
-      // irrelevant); the backend still ignores any with no data. Attachments are
-      // only requested when their toggle is offered (chart needs HR, map needs GPS).
-      const body = {
-        include_chart: canChart && includeChart,
-        include_map: canMap && includeMap,
-        included_metrics: summaryOptions.map((m) => m.key).filter((k) => summary.has(k)),
-        series_metrics: seriesOptions.map((m) => m.key).filter((k) => series.has(k)),
+      const body = buildShareBody({
+        canChart,
+        canMap,
+        includeMap,
+        series,
+        seriesOptions,
+        summary,
+        summaryOptions,
         visibility,
-      }
+      })
       return post ? updateFeedPost(post.id, body) : shareActivity(activityId, body)
     },
     onSuccess: (result) => {
@@ -193,8 +196,8 @@ export function ShareActivityDialog({
             <legend>Share full time-series</legend>
             <p class="share-dialog-note">
               {mirroredFromChart
-                ? 'Higher resolution — more revealing than a summary. Pre-checked to match the activity chart; uncheck any you would rather not share.'
-                : 'Higher resolution — more revealing than a summary. Off by default.'}
+                ? 'Higher resolution — more revealing than a summary. Pre-checked to match the activity chart; uncheck any you would rather not share. Heart rate is also shared as a chart image.'
+                : 'Higher resolution — more revealing than a summary. Off by default. Heart rate is also shared as a chart image.'}
             </p>
             <div class="share-dialog-options">
               {seriesOptions.map(({ key, label }) => (
@@ -211,30 +214,18 @@ export function ShareActivityDialog({
           </fieldset>
         )}
 
-        {(canChart || canMap) && (
+        {canMap && (
           <fieldset class="share-dialog-group">
             <legend>Images</legend>
             <div class="share-dialog-options">
-              {canChart && (
-                <label class="share-dialog-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={includeChart}
-                    onChange={(e) => setIncludeChart((e.target as HTMLInputElement).checked)}
-                  />
-                  Heart-rate chart
-                </label>
-              )}
-              {canMap && (
-                <label class="share-dialog-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={includeMap}
-                    onChange={(e) => setIncludeMap((e.target as HTMLInputElement).checked)}
-                  />
-                  Route map
-                </label>
-              )}
+              <label class="share-dialog-checkbox">
+                <input
+                  type="checkbox"
+                  checked={includeMap}
+                  onChange={(e) => setIncludeMap((e.target as HTMLInputElement).checked)}
+                />
+                Route map
+              </label>
             </div>
           </fieldset>
         )}

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -138,6 +138,10 @@ export function ShareActivityDialog({
     post?.include_chart,
     post?.include_map,
   )
+  // The series fieldset also renders for activities with only non-HR series (e.g.
+  // speed/power, no heart rate); only mention the chart image when heart rate is
+  // actually offered as a control here.
+  const offersHeartRate = seriesOptions.some((m) => m.key === 'heart_rate')
 
   const mutation = useMutation({
     mutationFn: () => {
@@ -196,8 +200,9 @@ export function ShareActivityDialog({
             <legend>Share full time-series</legend>
             <p class="share-dialog-note">
               {mirroredFromChart
-                ? 'Higher resolution — more revealing than a summary. Pre-checked to match the activity chart; uncheck any you would rather not share. Heart rate is also shared as a chart image.'
-                : 'Higher resolution — more revealing than a summary. Off by default. Heart rate is also shared as a chart image.'}
+                ? 'Higher resolution — more revealing than a summary. Pre-checked to match the activity chart; uncheck any you would rather not share.'
+                : 'Higher resolution — more revealing than a summary. Off by default.'}
+              {offersHeartRate && ' Heart rate is also shared as a chart image.'}
             </p>
             <div class="share-dialog-options">
               {seriesOptions.map(({ key, label }) => (

--- a/apps/web/src/components/feed-metrics.test.ts
+++ b/apps/web/src/components/feed-metrics.test.ts
@@ -1,6 +1,16 @@
+import type { MetricType } from '@aurboda/api-spec'
+
 import { describe, expect, it } from 'vitest'
 
-import { DEFAULT_SUMMARY, defaultsFromChart, seriesLabel, summaryLabel } from './feed-metrics'
+import {
+  buildShareBody,
+  DEFAULT_SUMMARY,
+  defaultsFromChart,
+  initialSeriesSelection,
+  seriesLabel,
+  type ShareSelection,
+  summaryLabel,
+} from './feed-metrics'
 
 describe('defaultsFromChart', () => {
   it('falls back to DEFAULT_SUMMARY and no series when chart metrics are unknown', () => {
@@ -25,6 +35,75 @@ describe('defaultsFromChart', () => {
     const { summary, series } = defaultsFromChart(['hrv_rmssd'])
     expect(summary).toEqual(['duration'])
     expect(series).toEqual([])
+  })
+})
+
+describe('initialSeriesSelection', () => {
+  it('keeps the representable series the post already shares, in canonical order', () => {
+    expect(initialSeriesSelection({ include_chart: false, series_metrics: ['speed', 'heart_rate'] })).toEqual(
+      ['heart_rate', 'speed'],
+    )
+  })
+
+  it('folds a chart-image post into the heart-rate series (unified control)', () => {
+    expect(initialSeriesSelection({ include_chart: true, series_metrics: [] })).toEqual(['heart_rate'])
+    // Other shared series are kept; heart rate is appended once.
+    expect(initialSeriesSelection({ include_chart: true, series_metrics: ['speed'] })).toEqual([
+      'speed',
+      'heart_rate',
+    ])
+  })
+
+  it('does not duplicate heart rate when the post shares both the image and the series', () => {
+    expect(initialSeriesSelection({ include_chart: true, series_metrics: ['heart_rate'] })).toEqual([
+      'heart_rate',
+    ])
+  })
+
+  it('shares nothing when neither the chart image nor any series is opted in', () => {
+    expect(initialSeriesSelection({ include_chart: false, series_metrics: [] })).toEqual([])
+  })
+})
+
+describe('buildShareBody', () => {
+  const base: ShareSelection = {
+    canChart: true,
+    canMap: true,
+    includeMap: false,
+    series: new Set<MetricType>(),
+    seriesOptions: [{ key: 'heart_rate' }, { key: 'speed' }],
+    summary: new Set<string>(),
+    summaryOptions: [{ key: 'duration' }, { key: 'heart_rate_avg' }],
+    visibility: 'public',
+  }
+
+  it('attaches the chart image exactly when the heart-rate series is shared', () => {
+    expect(buildShareBody({ ...base, series: new Set<MetricType>(['heart_rate']) })).toMatchObject({
+      include_chart: true,
+      series_metrics: ['heart_rate'],
+    })
+    expect(buildShareBody({ ...base, series: new Set<MetricType>(['speed']) })).toMatchObject({
+      include_chart: false,
+      series_metrics: ['speed'],
+    })
+  })
+
+  it('never attaches a chart image the activity cannot render (no heart-rate data)', () => {
+    const body = buildShareBody({ ...base, canChart: false, series: new Set<MetricType>(['heart_rate']) })
+    // The series opt-in is still honoured; only the image is suppressed.
+    expect(body).toMatchObject({ include_chart: false, series_metrics: ['heart_rate'] })
+  })
+
+  it('only sends metrics the dialog offered, and gates the map on GPS availability', () => {
+    const body = buildShareBody({
+      ...base,
+      canMap: false,
+      includeMap: true,
+      summary: new Set(['duration', 'calories']), // calories not offered → dropped
+    })
+    expect(body.included_metrics).toEqual(['duration'])
+    expect(body.include_map).toBe(false)
+    expect(body.visibility).toBe('public')
   })
 })
 

--- a/apps/web/src/components/feed-metrics.ts
+++ b/apps/web/src/components/feed-metrics.ts
@@ -3,7 +3,7 @@
  * view), so the labels a post is created with match the labels it's displayed
  * with.
  */
-import type { MetricType } from '@aurboda/api-spec'
+import type { FeedPost, FeedVisibility, MetricType, ShareActivityBody } from '@aurboda/api-spec'
 
 /**
  * Scalar summaries the backend knows how to resolve (see
@@ -50,6 +50,55 @@ export const defaultsFromChart = (chartMetrics?: string[]): { summary: string[];
     ],
   }
 }
+
+/**
+ * The heart-rate chart image and the heart-rate *series* are the same data in two
+ * formats, so the share dialog offers a single heart-rate control. Opting into the
+ * heart-rate series therefore also attaches the rendered chart image — an
+ * interactive native chart for Aurboda followers plus a PNG for Mastodon and other
+ * peers. `include_chart` is derived here, never toggled separately.
+ */
+const HEART_RATE: MetricType = 'heart_rate'
+
+/**
+ * Which heart-rate series a post starts with in edit mode. A post that attached
+ * the chart image but predates the unified control (no `heart_rate` in
+ * `series_metrics`) is still treated as sharing heart rate, so the one control
+ * shows checked — and re-saving backfills the series the image already implied.
+ */
+export const initialSeriesSelection = (
+  post: Pick<FeedPost, 'include_chart' | 'series_metrics'>,
+): MetricType[] => {
+  const keys = SERIES_METRICS.map((m) => m.key).filter((k) => post.series_metrics.includes(k))
+  if (post.include_chart && !keys.includes(HEART_RATE)) keys.push(HEART_RATE)
+  return keys
+}
+
+/** The dialog's current selection, resolved against what the activity can offer. */
+export interface ShareSelection {
+  summary: Set<string>
+  series: Set<MetricType>
+  includeMap: boolean
+  visibility: FeedVisibility
+  summaryOptions: readonly { key: string }[]
+  seriesOptions: readonly { key: MetricType }[]
+  canChart: boolean
+  canMap: boolean
+}
+
+/**
+ * Build the share/update request body from the dialog selection. Only metrics the
+ * dialog actually offered are sent (unavailable ones are dropped, not defaulted),
+ * and `include_chart` follows the heart-rate series toggle — the chart image is
+ * the image format of that one shared series, so the two can't diverge.
+ */
+export const buildShareBody = (sel: ShareSelection): ShareActivityBody => ({
+  include_chart: sel.canChart && sel.series.has(HEART_RATE),
+  include_map: sel.canMap && sel.includeMap,
+  included_metrics: sel.summaryOptions.map((m) => m.key).filter((k) => sel.summary.has(k)),
+  series_metrics: sel.seriesOptions.map((m) => m.key).filter((k) => sel.series.has(k)),
+  visibility: sel.visibility,
+})
 
 /** Human label for a stored `included_metrics` key (falls back to the raw key). */
 export const summaryLabel = (key: string): string => SUMMARY_METRICS.find((m) => m.key === key)?.label ?? key

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -269,9 +269,16 @@ not the underlying high-resolution series, which stays `followers`-excluded enti
 Responses are `no-store`, so an unshare / cleared flag / a public→followers flip takes
 effect immediately (the now-untoken'd public URL 404s). The route is drawn over an
 **OpenStreetMap street basemap** (see below); **no privacy trimming** is applied (area
-masking is a planned follow-up), so a route map reveals the precise area. The share dialog
-only offers the chart toggle when the activity has heart-rate data and the map toggle when
-it has an actual GPS track.
+masking is a planned follow-up), so a route map reveals the precise area.
+
+The chart image and the heart-rate **series** are the same data in two formats, so the
+share dialog exposes them as **one control**: opting into the heart-rate series
+(`series_metrics` ∋ `heart_rate`) also sets `include_chart`, so Aurboda followers get the
+native interactive chart (from the series) and Mastodon/other peers get the rendered PNG.
+The dialog derives `include_chart` from that one toggle rather than offering it separately
+(the REST/MCP fields stay independent for programmatic callers). It only offers the
+heart-rate control when the activity has heart-rate data, and the map toggle when it has an
+actual GPS track.
 
 **Route basemap.** The route map projects the GPS track into Web Mercator, fetches the
 covering OpenStreetMap tiles, and composites them behind the track (with a white halo for


### PR DESCRIPTION
## Summary

Third slice of the #884 tryout follow-ups. Your note when scoping this work:

> Sharing a chart could be the same checkbox as sharing the corresponding data series in detail, it's the same data in two formats.

The heart-rate **chart image** (`include_chart`, a rendered PNG for Mastodon) and the heart-rate **series** (`series_metrics ∋ heart_rate`, which — since Slice 2 (#930) — renders a native interactive chart for Aurboda followers) are exactly that: one dataset in two formats. This slice fuses them in the share dialog into **one control**.

## What changed (web share dialog only)

- Opting into the **heart-rate series** now also attaches the **chart image** — `include_chart` is *derived* from the heart-rate toggle, never set separately. So one decision covers both audiences (native chart for peers, PNG for Mastodon), and the two formats can't diverge.
- The separate **"Heart-rate chart"** checkbox is gone from the dialog's *Images* section (now just the route map). The *Share full time-series* note explains heart rate is also shared as a chart image.
- Two pure helpers extracted into `feed-metrics.ts` and unit-tested (no component-render mocking):
  - `buildShareBody(selection)` — derives the request body; `include_chart = canChart && series.has('heart_rate')`, so the image is suppressed when the activity has no HR data to render.
  - `initialSeriesSelection(post)` — on **edit**, folds a post that attached the chart image but predates this control (no `heart_rate` in `series_metrics`) into the heart-rate series, so the unified control shows checked and stays toggleable.

## Scope / behaviour note

- The REST API and MCP `share_activity`/`update_feed_post` fields (`include_chart`, `series_metrics`) stay **independent** — a programmatic caller keeps the granular control. Only the web dialog fuses them.
- **Editing a legacy image-only post** (chart image attached, series never opted in) and saving will now *also* share the heart-rate series (the image already implied that data). This is the intended "same data, two formats" unification, but it is a small exposure increase on re-save — flagging it explicitly. Such posts only exist from the last few days of tryouts.

## Tests

`feed-metrics.test.ts` — 12 pass, incl. new coverage for `buildShareBody` (image attached iff HR series shared; image suppressed when no HR data; offered-metric filtering; map gated on GPS) and `initialSeriesSelection` (canonical order, chart-image fold, no duplicate, empty). Full `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)