### PR TITLE
feat(feed): backfill the home timeline with a followee's recent posts on follow (#884)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -59,6 +59,7 @@ import { createFeedTombstoneRouter } from './routes/feed-tombstone-router.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
 import { deliverFeedDelete, deliverFeedPost, deliverFeedUpdate } from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
+import { createTimelineBackfiller } from './services/activitypub/timeline-backfill.ts'
 import { auditError } from './services/audit-log.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
 import { createCalorieQueue, type CalorieQueue } from './services/calorie-queue.ts'
@@ -331,7 +332,14 @@ const main = async () => {
   // MCP feed tools, and the REST feed router). `feedDeliver` fans a shared post
   // out to followers, fire-and-forget, so it's identical whether a post is
   // created via MCP or REST.
-  const feedFederation = createFeedFederation(webHost, apiBaseUrl, onNewTimelineEntry)
+  // On a follow being accepted, backfill the followee's recent public posts into
+  // the follower's timeline (fire-and-forget, time-boxed). `backfill` is defined
+  // just below and only invoked later (on an inbound Accept), so the forward
+  // reference is safe.
+  const feedFederation = createFeedFederation(webHost, apiBaseUrl, onNewTimelineEntry, (user, actorUri) =>
+    backfill(user, actorUri),
+  )
+  const backfill = createTimelineBackfiller(feedFederation, webHost)
   const feedDeps = { apiBaseUrl, federation: feedFederation, origin: webHost }
   const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>
     console.error(`⚠️ feed ${op} delivery failed for ${user}/${postId}:`, err)

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -135,14 +135,6 @@ const recordInboundFollow = async (
 }
 
 /**
- * Ingest a `Create`/`Update` of a `Note` into the recipient's home timeline —
- * but ONLY if the sender is an *accepted* followee (so the timeline can't be
- * injected into by a stranger who delivers to our inbox). The author's
- * presentation comes from the cached `feed_following` row; the Note's HTML is
- * sanitised in `noteToTimelineInput`. Best-effort: unresolvable objects and
- * non-Notes are ignored, and a missing DB never 500s (which would invite retries).
- */
-/**
  * Ingest one `Note` from an accepted followee into `user`'s home timeline: map it
  * to a timeline entry (author from the cached `feed_following` row, content
  * sanitised), capture its image attachments, best-effort fetch the native Aurboda
@@ -174,6 +166,14 @@ export const ingestNoteForRecipient = async (
   if (inserted) onNewEntry?.(user)
 }
 
+/**
+ * Ingest a `Create`/`Update` of a `Note` into the recipient's home timeline —
+ * but ONLY if the sender is an *accepted* followee (so the timeline can't be
+ * injected into by a stranger who delivers to our inbox). Resolves the recipient
+ * and the cached followee row, then hands off to `ingestNoteForRecipient`.
+ * Best-effort: unresolvable objects and non-Notes are ignored, and a missing DB
+ * never 500s (which would invite retries).
+ */
 const ingestFeedActivity = async (
   ctx: InboxContext<void>,
   activity: Create | Update,

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -43,6 +43,7 @@ import {
   countFeedFollowers,
   countPublicFeedPosts,
   deleteTimelineEntryByUri,
+  type FeedFollowingRecord,
   getFeedFollowerByActor,
   getFeedFollowingByActor,
   getFeedPostById,
@@ -141,6 +142,38 @@ const recordInboundFollow = async (
  * sanitised in `noteToTimelineInput`. Best-effort: unresolvable objects and
  * non-Notes are ignored, and a missing DB never 500s (which would invite retries).
  */
+/**
+ * Ingest one `Note` from an accepted followee into `user`'s home timeline: map it
+ * to a timeline entry (author from the cached `feed_following` row, content
+ * sanitised), capture its image attachments, best-effort fetch the native Aurboda
+ * structured chart, and upsert keyed on the Note's id (so a redelivery or edit
+ * replaces in place). `onNewEntry` fires only for a genuinely new row — the
+ * on-follow backfill omits it, since its historical posts aren't "new".
+ *
+ * Shared by inbound `Create`/`Update` delivery and the backfill, so both build a
+ * timeline entry identically.
+ */
+export const ingestNoteForRecipient = async (
+  user: string,
+  note: Note,
+  followee: FeedFollowingRecord,
+  enrich: (objectUri: string, token?: string) => Promise<FeedStructured | null>,
+  onNewEntry?: (user: string) => void,
+): Promise<void> => {
+  const input = noteToTimelineInput(note, followee)
+  if (input == null) return
+  // Capture the Note's image attachments (rendered chart / route map, or a
+  // Mastodon photo) so the timeline can show them when there's no native chart.
+  const images = await extractNoteImages(note)
+  // Best-effort: fetch the native structured payload if this is an Aurboda post
+  // (null otherwise). A followers-only post authorizes the fetch with the same
+  // capability token embedded in its delivered image URL. Stored on the entry so
+  // the web can render a native chart in place of the image.
+  const structured = await enrich(input.object_uri, capabilityTokenFrom(images))
+  const { inserted } = await upsertTimelineEntry(user, { ...input, images, structured })
+  if (inserted) onNewEntry?.(user)
+}
+
 const ingestFeedActivity = async (
   ctx: InboxContext<void>,
   activity: Create | Update,
@@ -160,19 +193,7 @@ const ingestFeedActivity = async (
     if (follow == null || !follow.accepted) return
     const object = await activity.getObject({ suppressError: true })
     if (!(object instanceof Note)) return
-    const input = noteToTimelineInput(object, follow)
-    if (input == null) return
-    // Capture the Note's image attachments (rendered chart / route map, or a
-    // Mastodon photo) so the timeline can show them when there's no native chart.
-    const images = await extractNoteImages(object)
-    // Best-effort: fetch the native structured payload if this is an Aurboda post
-    // (null otherwise). A followers-only post authorizes the fetch with the same
-    // capability token embedded in its delivered image URL. Stored on the entry so
-    // the web can render a native chart in place of the image.
-    const structured = await enrich(input.object_uri, capabilityTokenFrom(images))
-    const { inserted } = await upsertTimelineEntry(me, { ...input, images, structured })
-    // Ping live subscribers only for a genuinely new post (not an edit/redelivery).
-    if (inserted) onNewEntry?.(me)
+    await ingestNoteForRecipient(me, object, follow, enrich, onNewEntry)
   } catch (error) {
     if (isMissingDatabase(error)) return
     throw error
@@ -184,6 +205,11 @@ export const createFeedFederation = (
   apiBaseUrl: string,
   /** Fire-and-forget: called with the recipient when a genuinely new post is ingested. */
   onNewTimelineEntry?: (user: string) => void,
+  /**
+   * Fire-and-forget: called with `(recipient, followeeActorUri)` when a follow WE
+   * sent becomes accepted, to backfill the followee's recent public posts.
+   */
+  onFollowAccepted?: (user: string, actorUri: string) => void,
 ): Federation<void> => {
   const federation = createFederation<void>({
     kv: new MemoryKvStore(),
@@ -298,6 +324,12 @@ export const createFeedFederation = (
         if (isMissingDatabase(error)) return
         throw error
       }
+      // The follow is now established → backfill the followee's recent public
+      // posts so the timeline isn't empty until they next post. Fire-and-forget
+      // (a slow/large outbox must never block inbox processing), and after the
+      // accept is durably recorded. Covers remote *and* local follows: a local
+      // followee's auto-Accept loops back through this same handler.
+      onFollowAccepted?.(me, accept.actorId.href)
     })
     .on(Reject, async (ctx, reject) => {
       // Reject of a Follow we sent — the followee declined; drop our pending row.

--- a/apps/backend/src/services/activitypub/timeline-backfill.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-backfill.test.ts
@@ -1,0 +1,105 @@
+import { Note } from '@fedify/fedify/vocab'
+import { describe, expect, test } from 'vitest'
+
+import type { FeedFollowingRecord } from '../../db/index.ts'
+
+import { backfillFolloweeTimeline, type BackfillDeps } from './timeline-backfill.ts'
+
+const ACTOR = 'https://mastodon.example/users/alice'
+
+const followee = (accepted: boolean): FeedFollowingRecord => ({
+  accepted,
+  actor_uri: ACTOR,
+  avatar_url: null,
+  created_at: new Date('2026-07-01T00:00:00Z'),
+  display_name: 'Alice',
+  handle: '@alice@mastodon.example',
+  id: 'follow-1',
+  inbox_uri: `${ACTOR}/inbox`,
+  shared_inbox_uri: null,
+})
+
+const note = (n: number): Note => new Note({ id: new URL(`https://mastodon.example/notes/${n}`) })
+
+/** A deps builder that records the notes handed to `ingestNote`. */
+const makeDeps = (overrides: Partial<BackfillDeps> = {}): BackfillDeps & { ingested: string[] } => {
+  const ingested: string[] = []
+  return {
+    fetchRecentNotes: async () => [note(1), note(2)],
+    getFollowee: async () => followee(true),
+    ingested,
+    ingestNote: async (_user, n) => {
+      ingested.push(n.id?.href ?? '')
+    },
+    ...overrides,
+  }
+}
+
+describe('backfillFolloweeTimeline', () => {
+  test('ingests each fetched note for the recipient and returns the count', async () => {
+    const deps = makeDeps()
+    const count = await backfillFolloweeTimeline(deps, 'bob', ACTOR)
+    expect(count).toBe(2)
+    expect(deps.ingested).toEqual(['https://mastodon.example/notes/1', 'https://mastodon.example/notes/2'])
+  })
+
+  test('passes the resolved followee through to ingestNote', async () => {
+    const seen: FeedFollowingRecord[] = []
+    const deps = makeDeps({
+      fetchRecentNotes: async () => [note(1)],
+      ingestNote: async (_user, _note, f) => {
+        seen.push(f)
+      },
+    })
+    await backfillFolloweeTimeline(deps, 'bob', ACTOR)
+    expect(seen).toHaveLength(1)
+    expect(seen[0].actor_uri).toBe(ACTOR)
+  })
+
+  test('skips (no outbox fetch) when the follow is not accepted', async () => {
+    let fetched = false
+    const deps = makeDeps({
+      fetchRecentNotes: async () => {
+        fetched = true
+        return [note(1)]
+      },
+      getFollowee: async () => followee(false),
+    })
+    expect(await backfillFolloweeTimeline(deps, 'bob', ACTOR)).toBe(0)
+    expect(fetched).toBe(false)
+  })
+
+  test('skips when there is no such follow', async () => {
+    const deps = makeDeps({ getFollowee: async () => null })
+    expect(await backfillFolloweeTimeline(deps, 'bob', ACTOR)).toBe(0)
+  })
+
+  test('returns 0 when the outbox fetch fails (best-effort)', async () => {
+    const deps = makeDeps({
+      fetchRecentNotes: async () => {
+        throw new Error('outbox unreachable')
+      },
+    })
+    expect(await backfillFolloweeTimeline(deps, 'bob', ACTOR)).toBe(0)
+  })
+
+  test('returns 0 when the followee lookup throws (e.g. missing DB)', async () => {
+    const deps = makeDeps({
+      getFollowee: async () => {
+        throw new Error('missing database')
+      },
+    })
+    expect(await backfillFolloweeTimeline(deps, 'bob', ACTOR)).toBe(0)
+  })
+
+  test('continues past a single note that fails to ingest', async () => {
+    const deps = makeDeps({
+      fetchRecentNotes: async () => [note(1), note(2), note(3)],
+      ingestNote: async (_user, n) => {
+        if (n.id?.href.endsWith('/2')) throw new Error('bad note')
+      },
+    })
+    // Two of three succeed; the failing one is skipped, not fatal.
+    expect(await backfillFolloweeTimeline(deps, 'bob', ACTOR)).toBe(2)
+  })
+})

--- a/apps/backend/src/services/activitypub/timeline-backfill.ts
+++ b/apps/backend/src/services/activitypub/timeline-backfill.ts
@@ -1,0 +1,143 @@
+/**
+ * Home-timeline backfill on follow (#884).
+ *
+ * When a follow WE sent becomes accepted, fetch the followee's recent PUBLIC
+ * posts from their ActivityPub outbox and ingest them into the follower's home
+ * timeline — so the timeline isn't empty until the followee next posts. The
+ * outbox only carries `public`/`unlisted` posts, so followers-only and older
+ * private posts are correctly never backfilled.
+ *
+ * Best-effort throughout: a followee whose outbox is unreachable, private, or
+ * slow simply yields no backfill — it never blocks or fails the follow. The
+ * orchestration (`backfillFolloweeTimeline`) is Fedify- and DB-free via injected
+ * deps, so it unit-tests without network or a database; the thin Fedify outbox
+ * fetch is the only piece that talks to the wire.
+ */
+import type { Federation } from '@fedify/fedify'
+
+import { Collection, Create, isActor, Note } from '@fedify/fedify/vocab'
+
+import { type FeedFollowingRecord, getFeedFollowingByActor } from '../../db/index.ts'
+import { withTimeout } from '../with-timeout.ts'
+import { ingestNoteForRecipient } from './federation.ts'
+import { createAurbodaEnricher } from './timeline-enrich.ts'
+
+/** Most recent posts pulled from a followee's outbox on backfill. */
+const BACKFILL_LIMIT = 20
+/** Cap on outbox items scanned to find `BACKFILL_LIMIT` Notes — bounds a huge/cyclic outbox. */
+const MAX_SCANNED = 80
+/** Whole-backfill timeout so a slow outbox can't keep the task alive indefinitely. */
+const BACKFILL_TIMEOUT_MS = 15_000
+
+export interface BackfillDeps {
+  /** Up to `limit` of the actor's most recent public Notes, newest-first (best-effort). */
+  fetchRecentNotes: (actorUri: string, limit: number) => Promise<Note[]>
+  getFollowee: (user: string, actorUri: string) => Promise<FeedFollowingRecord | null>
+  ingestNote: (user: string, note: Note, followee: FeedFollowingRecord) => Promise<void>
+}
+
+/**
+ * Backfill `user`'s timeline with the followee's recent public posts, returning
+ * the number ingested. Skips silently unless the row is (still) an accepted
+ * follow, and never throws — a failed outbox fetch or a single bad note just
+ * yields fewer posts.
+ */
+export const backfillFolloweeTimeline = async (
+  deps: BackfillDeps,
+  user: string,
+  actorUri: string,
+  limit: number = BACKFILL_LIMIT,
+): Promise<number> => {
+  let followee: FeedFollowingRecord | null
+  try {
+    followee = await deps.getFollowee(user, actorUri)
+  } catch {
+    return 0
+  }
+  if (followee == null || !followee.accepted) return 0
+
+  let notes: Note[]
+  try {
+    notes = await deps.fetchRecentNotes(actorUri, limit)
+  } catch {
+    return 0
+  }
+
+  let ingested = 0
+  for (const note of notes) {
+    try {
+      await deps.ingestNote(user, note, followee)
+      ingested++
+    } catch {
+      // One unresolvable / malformed note shouldn't abort the rest of the page.
+    }
+  }
+  return ingested
+}
+
+/**
+ * Fetch up to `limit` of an actor's most recent public Notes from their outbox,
+ * using the federation context's document loader (the same signed-fetch path as
+ * actor resolution). Bounded by `limit` Notes and `MAX_SCANNED` items so a huge
+ * or cyclic outbox can't run away; any resolution failure yields fewer/no notes.
+ * Outbox entries are usually `Create` activities wrapping the Note; some servers
+ * also list bare Notes. Boosts and other activities are ignored.
+ */
+const fetchRecentOutboxNotes = async (
+  federation: Federation<void>,
+  origin: string,
+  actorUri: string,
+  limit: number,
+): Promise<Note[]> => {
+  const ctx = await federation.createContext(new URL(origin))
+  const actor = await ctx.lookupObject(actorUri)
+  if (!isActor(actor) || actor.outboxId == null) return []
+  const outbox = await ctx.lookupObject(actor.outboxId)
+  if (!(outbox instanceof Collection)) return []
+
+  const notes: Note[] = []
+  let scanned = 0
+  for await (const item of ctx.traverseCollection(outbox, { suppressError: true })) {
+    if (++scanned > MAX_SCANNED) break
+    let note: Note | null = null
+    if (item instanceof Note) note = item
+    else if (item instanceof Create) {
+      const object = await item.getObject({ suppressError: true })
+      if (object instanceof Note) note = object
+    }
+    if (note != null) {
+      notes.push(note)
+      if (notes.length >= limit) break
+    }
+  }
+  return notes
+}
+
+/**
+ * Production backfiller wired to Fedify (outbox fetch), the real enricher, and
+ * the DB. Returns the fire-and-forget trigger to pass as `createFeedFederation`'s
+ * `onFollowAccepted`: it time-boxes the whole backfill and swallows every error,
+ * so a slow or hostile outbox can never affect inbox processing.
+ */
+export const createTimelineBackfiller = (
+  federation: Federation<void>,
+  origin: string,
+): ((user: string, actorUri: string) => void) => {
+  const enrich = createAurbodaEnricher()
+  const deps: BackfillDeps = {
+    fetchRecentNotes: (actorUri, limit) => fetchRecentOutboxNotes(federation, origin, actorUri, limit),
+    getFollowee: getFeedFollowingByActor,
+    ingestNote: (user, note, followee) => ingestNoteForRecipient(user, note, followee, enrich),
+  }
+  return (user, actorUri) => {
+    void withTimeout(backfillFolloweeTimeline(deps, user, actorUri), BACKFILL_TIMEOUT_MS)
+      .then((count) => {
+        if (count > 0) {
+          console.info(`📥 Backfilled ${count} post(s) from ${actorUri} into ${user}'s timeline`)
+        }
+      })
+      .catch(() => {
+        // Best-effort — a timeout or fetch failure just means no backfill.
+      })
+  }
+}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -196,6 +196,19 @@ attribute to the sender (so an accepted followee can't overwrite another actor's
 colliding its id); and `published_at` is **clamped to "not in the future"** on ingest (it's the
 sort key, so a far-future timestamp would otherwise pin a post to the top).
 
+**Backfill on follow.** So the timeline isn't empty until a new followee next posts, accepting
+a follow triggers a one-off **backfill**: the followee's recent **public** posts are fetched
+from their ActivityPub **outbox** and ingested through the exact same path as live delivery
+(same sanitisation, image capture, structured enrichment, and `object_uri` upsert — so a
+backfilled post that later arrives live just updates in place). It's driven off the `Accept`,
+so it covers **remote** followees (on their server's Accept) and **local** ones alike (a local
+follow auto-accepts through the same handler). Only the **outbox** is read, so `followers`-only
+and older private posts are never backfilled — exactly what a non-follower could already see.
+Backfill is **best-effort and bounded**: fire-and-forget (a slow or unreachable outbox never
+blocks the follow), capped at the latest ~20 posts, and time-boxed. Backfilled posts are
+historical, so they don't trigger the live **"N new posts"** pill — they simply appear in the
+timeline on the next load, in their published order.
+
 ### Native charts from Aurboda peers (structured enrichment)
 
 A delivered `Note` carries only the Mastodon-compatible HTML — Fedify's typed vocab drops the


### PR DESCRIPTION
## Summary

Final slice of the #884 tryout follow-ups. From Sara's report:

> ...and I guess in the timeline it could also be present, even if older things only shared with followers of course won't be present.

Following someone left the home timeline **empty until they next posted**. Now, when a follow you sent is accepted, that person's recent **public** posts are fetched from their ActivityPub outbox and ingested, so your timeline is populated immediately — while their older followers-only/private posts are correctly excluded (exactly Sara's caveat).

## What changed

- **Shared ingest core** — factored `ingestNoteForRecipient` out of `ingestFeedActivity`: the one path that maps a `Note` → timeline entry (sanitise HTML, capture image attachments, best-effort structured-chart enrichment, upsert keyed on `object_uri`). Live delivery and backfill now build entries identically, so a backfilled post that later arrives live just updates in place — no duplicates.
- **New `timeline-backfill.ts`:**
  - `backfillFolloweeTimeline(deps, user, actorUri)` — the orchestration, **Fedify- and DB-free via injected deps**, so it unit-tests without network or a database. Skips non-accepted follows; best-effort (a failed outbox fetch or a single bad note just yields fewer posts).
  - A thin Fedify outbox fetcher — `ctx.lookupObject(actor).outboxId` → `traverseCollection`, bounded to **~20 Notes / 80 scanned items**, accepting `Create{Note}` and bare `Note` entries.
  - `createTimelineBackfiller` — production wiring: real enricher + DB, **time-boxed (15s) and fire-and-forget**.
- **Trigger** — an injected `onFollowAccepted` callback fired from the inbox `Accept` handler (after the accept is durably recorded). This covers **remote** followees (their server's Accept) *and* **local** ones (a local follow auto-accepts back through the same handler), with a single hook. It never blocks or 500s inbox processing.

## Behaviour notes

- **Only the outbox is read**, so `followers`-only and older private posts are never backfilled — a follower sees exactly what a non-follower already could, plus live followers-only posts going forward.
- Backfilled posts are **historical**, so they don't fire the live "N new posts" pill — they appear in the timeline (in published order) on the next load.
- Bounded + time-boxed + fire-and-forget, so a large/slow/hostile outbox can't affect the follow or the inbox.

## Tests

- `timeline-backfill.test.ts` — orchestration: ingests each note & returns the count, passes the followee through, skips non-accepted/missing follows, returns 0 on outbox-fetch or followee-lookup failure, and continues past a single bad note.
- Existing `timeline-ingest` + `federation.integration` suites still green after the `ingestNoteForRecipient` refactor.
- Full `pnpm check` clean.

## Wraps up #884 tryout follow-ups

This is slice 5 of 5 (after #929, #930, #931, #932). Sara can now follow you, immediately see your recent public posts backfilled into her timeline, get live native charts/images going forward, and click through to your `/u/` profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)