### PR TITLE
fix(feed): sharing-page polish — card header purple leak + clipped Share button (#916, #906)

### DIFF
--- a/apps/web/src/pages/Feed/FeedPostCard.css
+++ b/apps/web/src/pages/Feed/FeedPostCard.css
@@ -12,6 +12,10 @@
   display: flex;
   align-items: center;
   gap: 0.6rem;
+  /* This is a semantic <header>, which the global `header` rule paints purple
+     (a hidden legacy top-bar, re-shown here by `display: flex`). Clear it so the
+     card doesn't get a purple banner behind the handle (#916). */
+  background: none;
 }
 
 .feed-post-avatar {

--- a/apps/web/src/pages/PublicProfile/style.css
+++ b/apps/web/src/pages/PublicProfile/style.css
@@ -13,10 +13,17 @@
   align-items: center;
   gap: 1rem;
   margin-bottom: 1rem;
+  /* Let the Share button wrap to a new line instead of being pushed off-screen
+     by a long, non-wrapping `@handle` on narrow viewports (#906). */
+  flex-wrap: wrap;
 }
 
 .public-profile-header h1 {
   margin: 0;
+  /* A long handle has no spaces to break on; allow it to wrap and shrink within
+     the row rather than forcing the row wider than the viewport. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .public-avatar {


### PR DESCRIPTION
Warm-up polish on the sharing surfaces we shipped in #884/#932, ahead of the analysis-Articles epic (#934). Two `tryout-finding` bugs:

- **#916** — the feed post card's semantic `<header class="feed-post-head">` inherited the global `header { background: #673ab8; display: none }` rule; `display: flex` re-shows it but never clears the background, so a purple banner painted behind the handle (unreadable). Fixed by clearing `background` on `.feed-post-head`.
- **#906** — on narrow/mobile viewports the public-profile header (`display: flex` row: avatar + non-wrapping `<h1>@handle</h1>` + `margin-left:auto` Share button) pushed the Share button off-screen, since a long `@handle` has no spaces to break on. Fixed by `flex-wrap: wrap` on the header plus `min-width: 0; overflow-wrap: anywhere` on the `h1`, so the button wraps to a reachable line and long handles wrap in place.

CSS-only. Closes #916, closes #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)