### PR TITLE
refactor(charts): shared server-side chart SVG renderer (#901, #888)

### DIFF
--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -2,7 +2,9 @@
  * Render feed-post attachment images (a metric line chart and a GPS route map)
  * as PNGs, from raw series / coordinate data.
  *
- * The chart is a pure, self-contained SVG rasterized with `sharp`. The route map
+ * The chart SVG is built by the shared `buildChartSvg` renderer (so the feed PNG
+ * and the crisp `image/svg+xml` path stay one implementation) and rasterized here
+ * with `sharp`. The route map
  * is drawn over an **OpenStreetMap street basemap**: the track is projected into
  * Web Mercator (the tiles' projection), the covering tiles are fetched and
  * composited behind it, and the required "© OpenStreetMap contributors"
@@ -14,10 +16,9 @@
  */
 import sharp from 'sharp'
 
+import { buildChartSvg } from '../charts/chart-svg.ts'
 import { chooseZoom, latToWorldY, lonToWorldX, TILE_SIZE, type TileFetcher } from './osm-tiles.ts'
 
-const CHART_W = 1000
-const CHART_H = 420
 const ROUTE_W = 700
 const ROUTE_H = 700
 const PAD = 40
@@ -51,45 +52,16 @@ const mapWithConcurrency = async <T, R>(
 
 const svgToPng = (svg: string): Promise<Buffer> => sharp(Buffer.from(svg)).png().toBuffer()
 
-/** Scale a value from `[min, max]` into `[lo, hi]`; collapses to the midpoint when the range is empty. */
-const scale = (v: number, min: number, max: number, lo: number, hi: number): number =>
-  max === min ? (lo + hi) / 2 : lo + ((v - min) / (max - min)) * (hi - lo)
-
 /**
- * A metric line chart (e.g. heart rate). `series` is `[time, value]` pairs,
- * assumed time-ordered; non-finite values are dropped. Renders a bg, a smooth
- * polyline, and min/max value labels.
+ * A metric line chart (e.g. heart rate) rasterized to PNG for the feed
+ * attachment. The SVG itself is built by the shared `buildChartSvg` renderer (so
+ * the `image/svg+xml` and PNG paths stay one implementation); this only adds the
+ * `sharp` rasterization.
  */
-export const renderChartPng = async (
+export const renderChartPng = (
   series: [Date, number][],
   opts: { color?: string; label?: string } = {},
-): Promise<Buffer> => {
-  const color = opts.color ?? '#ef4444'
-  const pts = series.filter(([, v]) => Number.isFinite(v))
-  const times = pts.map(([t]) => t.getTime())
-  const vals = pts.map(([, v]) => v)
-  const tMin = Math.min(...times)
-  const tMax = Math.max(...times)
-  const vMin = Math.min(...vals)
-  const vMax = Math.max(...vals)
-
-  const x = (t: number) => scale(t, tMin, tMax, PAD, CHART_W - PAD)
-  const y = (v: number) => scale(v, vMin, vMax, CHART_H - PAD, PAD)
-  const polyline = pts.map(([t, v]) => `${x(t.getTime()).toFixed(1)},${y(v).toFixed(1)}`).join(' ')
-
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${CHART_W}" height="${CHART_H}" viewBox="0 0 ${CHART_W} ${CHART_H}">
-  <rect width="${CHART_W}" height="${CHART_H}" fill="#0b0f19" rx="16"/>
-  ${pts.length >= 2 ? `<polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="4" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
-  <text x="${PAD}" y="${PAD - 12}" fill="#e5e7eb" font-family="Liberation Sans, sans-serif" font-size="26" font-weight="700">${escapeXml(opts.label ?? 'Heart rate')}</text>
-  <text x="${CHART_W - PAD}" y="${PAD}" fill="#9ca3af" font-family="Liberation Sans, sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMax) ? Math.round(vMax) : ''}</text>
-  <text x="${CHART_W - PAD}" y="${CHART_H - PAD}" fill="#9ca3af" font-family="Liberation Sans, sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMin) ? Math.round(vMin) : ''}</text>
-</svg>`
-  return svgToPng(svg)
-}
-
-/** Escape text for safe inclusion in SVG. */
-const escapeXml = (s: string): string =>
-  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+): Promise<Buffer> => svgToPng(buildChartSvg(series, opts))
 
 const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v))
 

--- a/apps/backend/src/services/charts/chart-svg.test.ts
+++ b/apps/backend/src/services/charts/chart-svg.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildChartSvg } from './chart-svg.ts'
+
+const series: [Date, number][] = [
+  [new Date('2026-07-01T06:30:00Z'), 70],
+  [new Date('2026-07-01T06:35:00Z'), 95],
+  [new Date('2026-07-01T06:40:00Z'), 88],
+  [new Date('2026-07-01T06:45:00Z'), 60],
+]
+
+describe('buildChartSvg', () => {
+  test('produces a well-formed SVG with the default dimensions', () => {
+    const svg = buildChartSvg(series)
+    expect(svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg"')).toBe(true)
+    expect(svg.trimEnd().endsWith('</svg>')).toBe(true)
+    expect(svg).toContain('width="1000"')
+    expect(svg).toContain('height="420"')
+    expect(svg).toContain('viewBox="0 0 1000 420"')
+  })
+
+  test('draws a polyline through every point for a multi-point series', () => {
+    const svg = buildChartSvg(series)
+    const match = /<polyline points="([^"]+)"/.exec(svg)
+    expect(match).not.toBeNull()
+    // One coordinate pair per point, and the extremes map to the padding edges:
+    // highest value (95) hits the top pad (y=40), lowest (60) the bottom (y=380).
+    const coords = (match?.[1] ?? '').split(' ')
+    expect(coords).toHaveLength(series.length)
+    expect(coords[0]).toBe('40.0,282.9') // first point (value 70), x at left pad
+    expect(coords[1]).toBe('346.7,40.0') // peak value (95) → top pad
+    expect(coords[3]).toBe('960.0,380.0') // last point (min value 60) → right/bottom pad
+  })
+
+  test('labels the min and max values, rounded', () => {
+    const svg = buildChartSvg(series)
+    expect(svg).toContain('>95</text>') // max
+    expect(svg).toContain('>60</text>') // min
+  })
+
+  test('omits the polyline (but still renders) for a single point', () => {
+    const svg = buildChartSvg([[new Date('2026-07-01T06:30:00Z'), 70]])
+    expect(svg).not.toContain('<polyline')
+    expect(svg).toContain('>70</text>') // still labels the value
+  })
+
+  test('drops non-finite values before plotting', () => {
+    const svg = buildChartSvg([
+      [new Date('2026-07-01T06:30:00Z'), 70],
+      [new Date('2026-07-01T06:35:00Z'), Number.NaN],
+    ])
+    // Only one finite point remains → no polyline, no empty min/max labels.
+    expect(svg).not.toContain('<polyline')
+    expect(svg).toContain('>70</text>')
+  })
+
+  test('renders an empty series without throwing and without a polyline', () => {
+    const svg = buildChartSvg([])
+    expect(svg).not.toContain('<polyline')
+    // No finite values → Math.min/max are ±Infinity, so labels are blank.
+    expect(svg).toContain('text-anchor="end"></text>')
+  })
+
+  test('uses the given colour for the stroke', () => {
+    expect(buildChartSvg(series, { color: '#22c55e' })).toContain('stroke="#22c55e"')
+  })
+
+  test('uses the default heart-rate colour and label when none given', () => {
+    const svg = buildChartSvg(series)
+    expect(svg).toContain('stroke="#ef4444"')
+    expect(svg).toContain('>Heart rate</text>')
+  })
+
+  test('honours custom width and height', () => {
+    const svg = buildChartSvg(series, { width: 600, height: 300 })
+    expect(svg).toContain('width="600"')
+    expect(svg).toContain('height="300"')
+    expect(svg).toContain('viewBox="0 0 600 300"')
+  })
+
+  test('XML-escapes the label to prevent SVG injection', () => {
+    const svg = buildChartSvg(series, { label: 'HR <b>&"peak"' })
+    expect(svg).toContain('HR &lt;b&gt;&amp;&quot;peak&quot;')
+    expect(svg).not.toContain('<b>')
+  })
+})

--- a/apps/backend/src/services/charts/chart-svg.ts
+++ b/apps/backend/src/services/charts/chart-svg.ts
@@ -1,0 +1,83 @@
+/**
+ * The shared server-side chart renderer: a metric time series → a self-contained
+ * SVG **string**.
+ *
+ * This is deliberately sharp-free — it builds only the SVG markup, so it is a
+ * pure, synchronous function that unit tests can assert on directly (the string),
+ * not just on an opaque rasterized PNG. Two very different consumers need the same
+ * chart from the same data, and this is the single implementation both share:
+ *
+ *   - **PNG** for the ActivityPub feed attachment / OG snapshot / Reddit export —
+ *     `sharp(Buffer.from(svg)).png()` (Mastodon and other non-Aurboda consumers
+ *     that can't re-resolve the live series get this raster). librsvg (via sharp)
+ *     needs the bundled Liberation fonts registered in the Docker image to render
+ *     the `<text>` labels — see the Dockerfile font setup.
+ *   - **`image/svg+xml`** served directly for crisp Aurboda-native rendering
+ *     (`aurboda:charts`, #901); browsers fall back through the `font-family` list
+ *     to their own sans-serif, so no bundled font is required for that path.
+ *
+ * The chart draws only from shared metric types (the same data as the series
+ * endpoint), so the window `[start, end]` a caller resolves the series over is
+ * what makes the chart stable and citable (#934 articles lock that window).
+ */
+
+/** Default chart dimensions (feed attachment size); overridable per call. */
+export const CHART_WIDTH = 1000
+export const CHART_HEIGHT = 420
+const PAD = 40
+/** Dark card background, matching the route map and OG gradient's dark end. */
+const CHART_BG = '#0b0f19'
+/** Default line colour (heart-rate red) — kept as the default for feed parity. */
+const DEFAULT_COLOR = '#ef4444'
+const DEFAULT_LABEL = 'Heart rate'
+
+export interface ChartSvgOptions {
+  /** Line stroke colour. */
+  color?: string
+  /** Title drawn top-left. */
+  label?: string
+  /** Overall SVG width in px. */
+  width?: number
+  /** Overall SVG height in px. */
+  height?: number
+}
+
+/** Escape text for safe inclusion in SVG/XML. */
+export const escapeXml = (s: string): string =>
+  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+
+/** Scale a value from `[min, max]` into `[lo, hi]`; collapses to the midpoint when the range is empty. */
+export const scale = (v: number, min: number, max: number, lo: number, hi: number): number =>
+  max === min ? (lo + hi) / 2 : lo + ((v - min) / (max - min)) * (hi - lo)
+
+/**
+ * Build a metric line chart as a self-contained SVG string. `series` is
+ * `[time, value]` pairs, assumed time-ordered; non-finite values are dropped.
+ * Renders a rounded background, a smooth polyline (only with ≥ 2 points), and the
+ * min/max value labels. Pure and synchronous — rasterize with `sharp` for PNG or
+ * serve the string directly as `image/svg+xml`.
+ */
+export const buildChartSvg = (series: [Date, number][], opts: ChartSvgOptions = {}): string => {
+  const color = opts.color ?? DEFAULT_COLOR
+  const width = opts.width ?? CHART_WIDTH
+  const height = opts.height ?? CHART_HEIGHT
+  const pts = series.filter(([, v]) => Number.isFinite(v))
+  const times = pts.map(([t]) => t.getTime())
+  const vals = pts.map(([, v]) => v)
+  const tMin = Math.min(...times)
+  const tMax = Math.max(...times)
+  const vMin = Math.min(...vals)
+  const vMax = Math.max(...vals)
+
+  const x = (t: number) => scale(t, tMin, tMax, PAD, width - PAD)
+  const y = (v: number) => scale(v, vMin, vMax, height - PAD, PAD)
+  const polyline = pts.map(([t, v]) => `${x(t.getTime()).toFixed(1)},${y(v).toFixed(1)}`).join(' ')
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <rect width="${width}" height="${height}" fill="${CHART_BG}" rx="16"/>
+  ${pts.length >= 2 ? `<polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="4" stroke-linejoin="round" stroke-linecap="round"/>` : ''}
+  <text x="${PAD}" y="${PAD - 12}" fill="#e5e7eb" font-family="Liberation Sans, sans-serif" font-size="26" font-weight="700">${escapeXml(opts.label ?? DEFAULT_LABEL)}</text>
+  <text x="${width - PAD}" y="${PAD}" fill="#9ca3af" font-family="Liberation Sans, sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMax) ? Math.round(vMax) : ''}</text>
+  <text x="${width - PAD}" y="${height - PAD}" fill="#9ca3af" font-family="Liberation Sans, sans-serif" font-size="22" text-anchor="end">${Number.isFinite(vMin) ? Math.round(vMin) : ''}</text>
+</svg>`
+}


### PR DESCRIPTION
## What

Extracts the metric line-chart SVG out of `renderChartPng`'s inlined string into a pure, `sharp`-free **`buildChartSvg(series, opts) → string`** in `apps/backend/src/services/charts/chart-svg.ts` — the single implementation the two upcoming foundations share.

## Why

Both foundations need the **same chart from the same data** by two different paths:

- **`image/svg+xml` served directly** for crisp Aurboda-native rendering — `aurboda:charts` (#901).
- **`sharp`-rasterized PNG** for the OG snapshot / Mastodon attachment / Reddit export (#888).

Keeping the chart as one pure string builder avoids two implementations (the exact concern #888 calls out) and — because it's now a plain synchronous string function — makes the chart **directly unit-testable** rather than only assertable through an opaque PNG.

## Changes

- **New** `services/charts/chart-svg.ts`: `buildChartSvg(series, opts)` with configurable colour / label / width / height, plus shared `escapeXml` / `scale` helpers.
- **New** `chart-svg.test.ts`: 10 unit tests on the SVG string — polyline geometry (exact scaled coords), min/max labels, single-point / empty / non-finite handling, custom colour & size, XML-escaped label (SVG-injection guard).
- `renderChartPng` is now a thin `svgToPng(buildChartSvg(...))` wrapper — **byte-identical default output**, so the feed attachment PNG is unchanged (existing feed-images tests still pass).

## Scope / not in this PR

No behaviour change. This is the shared renderer only; the two consumers land next:
- #901 — serve the SVG as `image/svg+xml` + the `aurboda:charts` AS2 property (degrade to PNG for Mastodon).
- #888 — embed a chart snapshot into the OG card (`chartDataUri` slot).

Foundation for the shareable-analysis **Articles** epic (#934).

## Test

`pnpm check` green (0 errors); `chart-svg.test.ts` (10) + `feed-images.test.ts` (8) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)