### PR TITLE
feat(feed): serve the crisp chart as image/svg+xml (#901)

### DIFF
--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -66,6 +66,7 @@ import { createWellKnownRouter, type WellKnownConfig } from '../routes/well-know
 import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
 import { fetchOsmTile } from '../services/activitypub/osm-tiles.ts'
 import { loadAvatarDataUri } from '../services/avatar-resolve.ts'
+import { buildChartSvg } from '../services/charts/chart-svg.ts'
 import { resolveFeedActivity } from '../services/feed.ts'
 import { createOgImageRenderer } from '../services/og-image.ts'
 import { createTemplateLoader } from '../services/web-template.ts'
@@ -177,6 +178,7 @@ export const mountRestRouters = ({
         (await getLocations(user, start, end)).locations.map((l) => l.coordinates),
       getSeries: getTimeSeries,
       renderChart: renderChartPng,
+      renderChartSvg: buildChartSvg,
       // Draw the route over the OSM basemap; falls back to a bare shape if tiles
       // can't be fetched (e.g. offline).
       renderRoute: (coords) => renderRoutePng(coords, { fetchTile: fetchOsmTile }),

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -4,9 +4,13 @@ import { type Response, Router } from 'express'
  * Public feed-post image endpoints (UNAUTHENTICATED).
  *
  * Handles: GET /public/:username/feed/:postId/chart.png
+ *          GET /public/:username/feed/:postId/chart.svg
  *          GET /public/:username/feed/:postId/route.png
  *
- * Rendered on demand from the shared activity's data. An image is served for a
+ * The chart is offered both ways from the same series over the same window: a
+ * rasterised PNG that every consumer understands (Mastodon attaches it) and a
+ * crisp, scalable `image/svg+xml` for Aurboda-native rendering (#901). Rendered
+ * on demand from the shared activity's data. An image is served for a
  * `public`/`unlisted` post that opted into that attachment (`include_chart` /
  * `include_map`); a `followers`-only post is served only when the request carries
  * the post's unguessable capability `?token=` (embedded solely in the Note
@@ -36,6 +40,8 @@ export interface FeedImageDeps {
   getSeries: (user: string, metric: string, start: Date, end: Date) => Promise<[Date, number][]>
   getRoute: (user: string, start: Date, end: Date) => Promise<[number, number][]>
   renderChart: (series: [Date, number][]) => Promise<Buffer>
+  /** Build the crisp `image/svg+xml` chart (same data as `renderChart`, no raster). */
+  renderChartSvg: (series: [Date, number][]) => string
   renderRoute: (coords: [number, number][]) => Promise<Buffer>
 }
 
@@ -113,6 +119,11 @@ const sendPng = (res: Response, png: Buffer) => {
   res.type('png').send(png)
 }
 
+const sendSvg = (res: Response, svg: Buffer) => {
+  res.setHeader('Cache-Control', 'no-store') // revocable, same as the PNG
+  res.type('image/svg+xml').send(svg)
+}
+
 export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
   const router = Router()
   const cached = createRenderCache()
@@ -129,6 +140,23 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
     })
     if (!png) return notFound(res)
     sendPng(res, png)
+  })
+
+  router.get('/public/:username/feed/:postId/chart.svg', async (req, res) => {
+    const { postId, username } = req.params
+    const token = typeof req.query.token === 'string' ? req.query.token : undefined
+    const activity = await resolveImageWindow(deps, username, postId, 'include_chart', token)
+    if (!activity?.end_time) return notFound(res)
+    const { end_time, start_time } = activity
+    // Cached under a distinct key from the PNG; the built SVG string is stored as
+    // its UTF-8 bytes so it shares the same buffer LRU (the DB series fetch is the
+    // cost worth caching, not the string build).
+    const svg = await cached(`chartsvg:${username}:${postId}`, async () => {
+      const series = await deps.getSeries(username, 'heart_rate', start_time, end_time)
+      return series.length === 0 ? null : Buffer.from(deps.renderChartSvg(series), 'utf8')
+    })
+    if (!svg) return notFound(res)
+    sendSvg(res, svg)
   })
 
   router.get('/public/:username/feed/:postId/route.png', async (req, res) => {

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -266,8 +266,15 @@ unauthenticated endpoints:
 
 ```
 GET /api/public/:username/feed/:postId/chart.png
+GET /api/public/:username/feed/:postId/chart.svg
 GET /api/public/:username/feed/:postId/route.png
 ```
+
+The chart is offered in two formats over the same series and window: the **PNG** is
+what Mastodon and other peers attach, while **`chart.svg`** serves the same chart as
+crisp, scalable `image/svg+xml` for **Aurboda-native** rendering (it stays sharp at
+any size). Both share the same eligibility gate, capability-token model, and
+`no-store` revocability.
 
 An image is served when the matching flag was opted into. `public`/`unlisted` posts
 serve their images unauthenticated. A `followers`-only post's image URLs instead carry
@@ -383,7 +390,8 @@ Public / federation (unauthenticated):
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `GET /public/:username/series`                 | Bucketed samples for a **shared** series within its window                                                 |
 | `GET /public/:username/feed/:postId`           | Native structured post (`FeedStructured`: typed metrics + inline series) for Aurboda-to-Aurboda enrichment |
-| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart for an opted-in post (`?token=` for followers-only)                                      |
+| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart (PNG) for an opted-in post (`?token=` for followers-only)                                |
+| `GET /public/:username/feed/:postId/chart.svg` | Same HR chart as crisp `image/svg+xml` for Aurboda-native rendering (`?token=` for followers-only)         |
 | `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post (`?token=` for followers-only)                                 |
 | `GET /public/:username/posts`                  | A user's public/unlisted posts (newest-first, latest page) for their profile feed                          |
 | `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                                                               |


### PR DESCRIPTION
## What

Adds `GET /public/:username/feed/:postId/chart.svg` alongside the existing `chart.png`, serving the **same series over the same locked window** as a scalable `image/svg+xml` built by the shared `buildChartSvg` renderer (#941) — no rasterisation, so it's crisp at any size for **Aurboda-native** rendering (#901).

## Details

- Same eligibility gate as the PNG (`resolveImageWindow` — public/unlisted, or followers-only with the capability `?token=`), same `no-store` revocability.
- Its own render-cache key (`chartsvg:…`); the built SVG is stored as UTF-8 bytes so it reuses the existing buffer LRU — the DB series fetch is the cost worth caching, not the string build.
- New injected dep `renderChartSvg: buildChartSvg` (mirrors `renderChart`), wired in the composition root.

## Why now

This is the inline-chart building block **Slice A (#935) depends on** ("SVG native chart — inline chart rendering"): the web app / native consumers embed the crisp SVG, which degrades to the PNG attachment for Mastodon.

## Scope

Delivers the **endpoint** half of #901. The `aurboda:charts` AS2 discovery link (so remote Aurboda peers auto-find this SVG) is deferred to the **federation slice (#937)**, where the article's federation object and the PNG-vs-SVG degrade are wired together — keeping this PR out of the two federation object builders.

## Test

`pnpm check` green (0 errors). `feed-image-router.test.ts` + `chart-svg.test.ts` pass (25); the new route reuses the already-tested `resolveImageWindow`, `createRenderCache`, and `buildChartSvg`.

Foundation for the shareable-analysis **Articles** epic (#934).

🤖 Generated with [Claude Code](https://claude.com/claude-code)