### PR TITLE
feat(feed): article post kind — schema + JSONB persistence (#935)

### DIFF
--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -7,7 +7,9 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import { deleteActivity, insertActivity } from './activities/index.ts'
 import {
+  type ArticlePostInput,
   countPublicFeedPosts,
+  createArticlePost,
   createFeedPost,
   deleteFeedPost,
   type FeedPostInput,
@@ -44,6 +46,27 @@ const postInput = (overrides: Partial<FeedPostInput> = {}): FeedPostInput => ({
   ...overrides,
 })
 
+const articleInput = (overrides: Partial<ArticlePostInput> = {}): ArticlePostInput => ({
+  article: {
+    blocks: [
+      { markdown: '# Sleep vs HRV\n\nA look at the last week.', type: 'prose' },
+      {
+        bucket: '1h',
+        caption: 'Resting HR over the week',
+        end: '2026-07-07T00:00:00.000Z',
+        metric: 'heart_rate',
+        start: '2026-07-01T00:00:00.000Z',
+        type: 'chart',
+      },
+    ],
+    default_end: '2026-07-07T00:00:00.000Z',
+    default_start: '2026-07-01T00:00:00.000Z',
+    title: 'A week of sleep and HRV',
+  },
+  visibility: 'public',
+  ...overrides,
+})
+
 describe('Feed posts integration', () => {
   beforeAll(async () => {
     await startTestDb()
@@ -70,6 +93,9 @@ describe('Feed posts integration', () => {
     expect(created.included_metrics).toEqual(['duration', 'distance', 'heart_rate_avg'])
     expect(created.series_metrics).toEqual(['heart_rate'])
     expect(created.visibility).toBe('public')
+    // An activity share defaults to the `activity` kind and carries no article.
+    expect(created.kind).toBe('activity')
+    expect(created.article).toBeNull()
 
     const fetched = await getFeedPostById(user, created.id)
     expect(fetched?.id).toBe(created.id)
@@ -182,6 +208,63 @@ describe('Feed posts integration', () => {
       expect((await listPublicFeedPostsPage(user, 2, 0)).map((p) => p.id)).toEqual([c.id, b.id])
       expect((await listPublicFeedPostsPage(user, 2, 2)).map((p) => p.id)).toEqual([a.id])
       expect(await listPublicFeedPostsPage(user, 2, 4)).toEqual([])
+    })
+  })
+
+  describe('article posts', () => {
+    test('creates an article and round-trips the JSONB payload by id', async () => {
+      const user = getTestUser()
+      const created = await createArticlePost(user, articleInput())
+
+      expect(created.kind).toBe('article')
+      expect(created.activity_id).toBeNull()
+      expect(created.included_metrics).toEqual([])
+      expect(created.series_metrics).toEqual([])
+      expect(created.article?.title).toBe('A week of sleep and HRV')
+      expect(created.article?.blocks).toHaveLength(2)
+      expect(created.article?.blocks[0]).toEqual({
+        markdown: '# Sleep vs HRV\n\nA look at the last week.',
+        type: 'prose',
+      })
+      expect(created.article?.default_start).toBe('2026-07-01T00:00:00.000Z')
+
+      // The parsed JSONB survives a fresh read.
+      const fetched = await getFeedPostById(user, created.id)
+      expect(fetched?.kind).toBe('article')
+      expect(fetched?.article).toEqual(created.article)
+    })
+
+    test('replaces the whole article payload on update, touching updated_at', async () => {
+      const user = getTestUser()
+      const created = await createArticlePost(user, articleInput())
+
+      const nextArticle = {
+        blocks: [{ markdown: 'Rewritten.', type: 'prose' as const }],
+        title: 'Revised analysis',
+      }
+      const updated = await updateFeedPost(user, created.id, {
+        article: nextArticle,
+        visibility: 'unlisted',
+      })
+      expect(updated?.article).toEqual(nextArticle)
+      expect(updated?.article?.default_start).toBeUndefined() // replaced, not merged
+      expect(updated?.visibility).toBe('unlisted')
+      expect(updated?.updated_at.getTime()).toBeGreaterThanOrEqual(created.updated_at.getTime())
+    })
+
+    test('appears in the owner feed and the public outbox listings', async () => {
+      const user = getTestUser()
+      const article = await createArticlePost(user, articleInput({ visibility: 'public' }))
+      expect((await listFeedPosts(user)).map((p) => p.id)).toContain(article.id)
+      const publicPosts = await listPublicFeedPosts(user)
+      expect(publicPosts.map((p) => p.id)).toContain(article.id)
+      expect(publicPosts.find((p) => p.id === article.id)?.article?.title).toBe('A week of sleep and HRV')
+    })
+
+    test('a followers-only article stays out of the public outbox', async () => {
+      const user = getTestUser()
+      await createArticlePost(user, articleInput({ visibility: 'followers' }))
+      expect(await listPublicFeedPosts(user)).toEqual([])
     })
   })
 

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -1,4 +1,4 @@
-import type { FeedVisibility } from '@aurboda/api-spec'
+import type { ArticleContent, FeedPostKind, FeedVisibility } from '@aurboda/api-spec'
 
 /**
  * Feed posts — activities a user published to their federated feed.
@@ -16,12 +16,16 @@ import { query } from './connection.ts'
 
 export interface FeedPostRecord {
   id: string
+  /** `activity` (shares an activity) or `article` (long-form prose + chart blocks). */
+  kind: FeedPostKind
   activity_id: string | null
   included_metrics: string[]
   series_metrics: string[]
   visibility: FeedVisibility
   include_map: boolean
   include_chart: boolean
+  /** Stored article payload (title + default window + blocks); null for `activity` posts. */
+  article: ArticleContent | null
   /** Unguessable capability token for `followers`-only image URLs (see schema). */
   image_token: string
   created_at: Date
@@ -37,25 +41,36 @@ export interface FeedPostInput {
   include_chart: boolean
 }
 
+/** Input for creating an `article` post (no activity anchor / shared metrics). */
+export interface ArticlePostInput {
+  visibility: FeedVisibility
+  article: ArticleContent
+}
+
 export interface FeedPostPatch {
   included_metrics?: string[]
   series_metrics?: string[]
   visibility?: FeedVisibility
   include_map?: boolean
   include_chart?: boolean
+  /** Replacement article payload (whole `article` JSONB), for editing an article post. */
+  article?: ArticleContent
 }
 
 const FEED_POST_COLUMNS =
-  'id, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, image_token, created_at, updated_at'
+  'id, kind, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, article, image_token, created_at, updated_at'
 
 interface FeedPostRow {
   id: string
+  kind: FeedPostKind
   activity_id: string | null
   included_metrics: string[]
   series_metrics: string[]
   visibility: FeedVisibility
   include_map: boolean
   include_chart: boolean
+  // pg parses a jsonb column to its JS value on read (null for `activity` posts).
+  article: ArticleContent | null
   image_token: string
   created_at: Date
   updated_at: Date
@@ -78,6 +93,22 @@ export const createFeedPost = async (user: string, input: FeedPostInput): Promis
       input.include_map,
       input.include_chart,
     ],
+  )
+  return mapFeedPost(result.rows[0])
+}
+
+/**
+ * Create an `article` post: no activity anchor and no shared metrics, just the
+ * article payload (title + default window + blocks) in the `article` JSONB. The
+ * `kind`/`activity_id`/metric columns fall to their table defaults where not set.
+ */
+export const createArticlePost = async (user: string, input: ArticlePostInput): Promise<FeedPostRecord> => {
+  const result = await query<FeedPostRow>(
+    user,
+    `INSERT INTO feed_posts (kind, visibility, article)
+     VALUES ('article', $1, $2)
+     RETURNING ${FEED_POST_COLUMNS}`,
+    [input.visibility, JSON.stringify(input.article)],
   )
   return mapFeedPost(result.rows[0])
 }
@@ -162,6 +193,7 @@ export const updateFeedPost = async (
   if (patch.visibility !== undefined) set('visibility', patch.visibility)
   if (patch.include_map !== undefined) set('include_map', patch.include_map)
   if (patch.include_chart !== undefined) set('include_chart', patch.include_chart)
+  if (patch.article !== undefined) set('article', JSON.stringify(patch.article))
 
   if (sets.length === 0) return getFeedPostById(user, id)
 

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -14,12 +14,14 @@ const activity: ImageActivity = {
 
 const makePost = (overrides: Partial<FeedPostRecord> = {}): FeedPostRecord => ({
   activity_id: ACTIVITY_ID,
+  article: null,
   created_at: new Date('2026-07-01T08:00:00Z'),
   id: POST_ID,
   image_token: 'secret-token',
   include_chart: true,
   include_map: true,
   included_metrics: [],
+  kind: 'activity',
   series_metrics: [],
   updated_at: new Date('2026-07-01T08:00:00Z'),
   visibility: 'public',

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -142,6 +142,7 @@ export const tableCreationOrder = [
   'challenge_participations',
   'challenge_participations_indexes',
   'feed_posts',
+  'feed_posts_article_columns',
   'feed_posts_indexes',
   'feed_tombstone',
   'feed_actor',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -108,19 +108,32 @@ export const socialTables: Record<string, string> = {
   // server can fetch them even though the endpoint is otherwise unauthenticated —
   // the fediverse fetches media without HTTP signatures, so a signed-request gate
   // wouldn't be exercised. `public`/`unlisted` images need no token.
+  // `kind` discriminates an `activity` post (shares an activity — the default and
+  // the only kind before articles) from an `article` post (long-form prose + inline
+  // chart blocks). An article's content — title, default window, ordered blocks —
+  // lives in the `article` JSONB and its `activity_id`/metric columns stay empty;
+  // an activity post leaves `article` NULL. Modelled as a kind on the same table so
+  // articles reuse the whole feed (visibility, federation, timeline, permalinks).
   feed_posts: `
     CREATE TABLE IF NOT EXISTS feed_posts (
       id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      kind              VARCHAR(12) NOT NULL DEFAULT 'activity',
       activity_id       UUID,
       included_metrics  TEXT[] NOT NULL DEFAULT '{}',
       series_metrics    TEXT[] NOT NULL DEFAULT '{}',
       visibility        VARCHAR(12) NOT NULL DEFAULT 'public',
       include_map       BOOLEAN NOT NULL DEFAULT false,
       include_chart     BOOLEAN NOT NULL DEFAULT false,
+      article           JSONB,
       image_token       TEXT NOT NULL DEFAULT gen_random_uuid()::text,
       created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
+  `,
+  // Additive columns for feed_posts tables created before the article kind (all idempotent).
+  feed_posts_article_columns: `
+    ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS kind VARCHAR(12) NOT NULL DEFAULT 'activity';
+    ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS article JSONB;
   `,
   // `idx_feed_posts_series` is a GIN index over the shared-series set — the hot
   // path for the public series endpoint's `metric = ANY(series_metrics)` check.

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -99,12 +99,16 @@ export const serializeFeedPost = async (user: string, record: FeedPostRecord): P
     activity_start_time: activity?.start_time.toISOString(),
     activity_title: activity?.title,
     activity_type: activity?.activity_type,
+    // The stored article payload (title + default window + blocks); present only
+    // for `article` posts, which carry no activity and so no resolved `content`.
+    article: record.article ?? undefined,
     content,
     created_at: record.created_at.toISOString(),
     id: record.id,
     include_chart: record.include_chart,
     include_map: record.include_map,
     included_metrics: record.included_metrics,
+    kind: record.kind,
     series_metrics: record.series_metrics,
     updated_at: record.updated_at.toISOString(),
     visibility: record.visibility,

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -16,8 +16,22 @@ The feed is built on [Fedify](https://fedify.dev). It has three layers:
 
 ## Feed posts
 
-A **feed post** references one of the user's activities and records the explicit metric
-selection that bounds what is shared:
+A feed post has a **`kind`**:
+
+- **`activity`** (the default) — references one of the user's activities and shares a
+  bounded metric selection (below). This is the original and, so far, only end-to-end
+  kind.
+- **`article`** — a long-form post: a `title`, markdown prose, and inline **chart
+  blocks**, each over a locked `[start, end]` window (blocks inherit an article-level
+  default window unless they override it). Charts re-resolve **live** against their
+  locked window — no data snapshot. Modelled as a post kind on the same storage, so an
+  article reuses the whole feed (visibility, federation, timeline, permalinks). The
+  ordered blocks live in an `article` JSONB column. _Storage + schema foundation is in
+  place; the create/edit API, MCP tools, and web rendering land in follow-up slices
+  (#935 → #937)._
+
+An **`activity`** feed post references one of the user's activities and records the
+explicit metric selection that bounds what is shared:
 
 - **`included_metrics`** — the scalar summaries the user opted to share (e.g.
   `duration`, `distance`, `heart_rate_avg`, `heart_rate_max`, `hr_zone_minutes`,
@@ -410,7 +424,10 @@ the same services as the REST routes. Manual follower approval is toggled with t
 
 ## Storage
 
-Feed posts live in the user's own database in the `feed_posts` table. `activity_id` is a
+Feed posts live in the user's own database in the `feed_posts` table. A `kind` column
+discriminates an `activity` post from an `article` post; an article's content (title +
+default window + ordered blocks) lives in a nullable `article` JSONB column, and its
+`activity_id`/metric columns stay empty. `activity_id` is a
 **soft reference** (no foreign key): activities are soft-deleted and the series lookup
 re-checks `deleted_at` at query time, so a removed activity simply stops resolving rather
 than cascading a delete. A GIN index over `series_metrics` backs the public series

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -100,6 +100,87 @@ export const updateFeedPostBodySchema = z
 
 export type UpdateFeedPostBody = z.infer<typeof updateFeedPostBodySchema>
 
+// =============================================================================
+// Article posts (long-form: title + markdown prose + inline chart blocks)
+// =============================================================================
+
+/**
+ * The kind of a feed post. `activity` (the default) shares one of the user's
+ * activities; `article` is a long-form post carrying markdown prose and inline
+ * chart blocks over locked time windows. Modelled as a post *kind* rather than a
+ * separate entity so articles reuse the whole feed (visibility, federation, home
+ * timeline, the public-profile feed, permalinks).
+ */
+export const feedPostKindSchema = z
+  .enum(['activity', 'article'])
+  .meta({ description: 'Feed post kind: an activity share or a long-form article', id: 'FeedPostKind' })
+
+export type FeedPostKind = z.infer<typeof feedPostKindSchema>
+
+/** A prose block: a run of markdown, rendered through the shared sanitiser (#910). */
+export const articleProseBlockSchema = z
+  .object({
+    markdown: z
+      .string()
+      .max(20_000)
+      .meta({ description: 'Markdown prose (rendered to sanitised HTML at the sink)' }),
+    type: z.literal('prose'),
+  })
+  .meta({ description: 'A markdown prose block', id: 'ArticleProseBlock' })
+
+/**
+ * A chart block: one shared metric drawn over a locked `[start, end]` window.
+ * The window is what makes the chart stable and citable — data is re-resolved
+ * live against it, never snapshotted. When `start`/`end` are omitted the block
+ * inherits the article's default window.
+ */
+export const articleChartBlockSchema = z
+  .object({
+    bucket: z
+      .string()
+      .regex(/^\d+[smhd]$/, 'Must be {number}{unit} where unit is s, m, h, or d')
+      .optional()
+      .meta({
+        description: 'Bucket granularity (e.g. `5s`, `1h`, `1d`); the server picks a default if omitted',
+      }),
+    caption: z.string().max(280).optional().meta({ description: 'Optional caption shown under the chart' }),
+    end: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: "Window end (ISO 8601); inherits the article's default window if omitted" }),
+    metric: metricTypeSchema.meta({ description: 'The metric to chart' }),
+    start: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: "Window start (ISO 8601); inherits the article's default window if omitted" }),
+    type: z.literal('chart'),
+  })
+  .meta({ description: 'A metric chart over a locked window', id: 'ArticleChartBlock' })
+
+/** An ordered content block of an article. Correlation blocks arrive in a later slice (#936). */
+export const articleBlockSchema = z
+  .discriminatedUnion('type', [articleProseBlockSchema, articleChartBlockSchema])
+  .meta({ description: 'An article content block (prose or chart)', id: 'ArticleBlock' })
+
+export type ArticleBlock = z.infer<typeof articleBlockSchema>
+
+/**
+ * The stored content of an article post: a title, an optional article-level
+ * default window that chart blocks inherit, and the ordered blocks.
+ */
+export const articleContentSchema = z
+  .object({
+    blocks: z.array(articleBlockSchema).max(100).meta({ description: 'Ordered content blocks' }),
+    default_end: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: 'Default window end inherited by chart blocks (ISO 8601)' }),
+    default_start: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: 'Default window start inherited by chart blocks (ISO 8601)' }),
+    title: z.string().min(1).max(200).meta({ description: 'Article title' }),
+  })
+  .meta({ id: 'ArticleContent' })
+
+export type ArticleContent = z.infer<typeof articleContentSchema>
+
 /** A feed post as seen by its owner. */
 export const feedPostSchema = z
   .object({
@@ -129,6 +210,11 @@ export const feedPostSchema = z
       .string()
       .optional()
       .meta({ description: "The shared activity's type (e.g. `exercise`)" }),
+    // Present only for `article` posts (the stored title + default window +
+    // ordered blocks); absent for `activity` posts.
+    article: articleContentSchema
+      .optional()
+      .meta({ description: 'Article content, present only for `article` posts' }),
     // The exact HTML `content` that federates for this post (headline + shared
     // scalar summary), so a client can render the post WYSIWYG — matching what
     // Mastodon shows — instead of reconstructing it from the metric keys. Absent
@@ -142,6 +228,7 @@ export const feedPostSchema = z
     include_chart: z.boolean().meta({ description: 'Whether a chart image is attached' }),
     include_map: z.boolean().meta({ description: 'Whether a route-map image is attached' }),
     included_metrics: z.array(z.string()).meta({ description: 'Shared scalar-summary metric keys' }),
+    kind: feedPostKindSchema.meta({ description: 'Post kind (`activity` or `article`)' }),
     series_metrics: z.array(z.string()).meta({ description: 'Explicitly-shared series metrics' }),
     updated_at: z.string().meta({ description: 'Last update timestamp (ISO 8601)' }),
     visibility: feedVisibilitySchema,
@@ -163,6 +250,47 @@ export const feedPostsResponseSchema = baseResponseSchema
   .meta({ id: 'FeedPostsResponse' })
 
 export type FeedPostsResponse = z.infer<typeof feedPostsResponseSchema>
+
+/**
+ * Body for creating an article post. No activity anchor and no shared
+ * metrics/series — an article carries its own title, default window, and blocks.
+ */
+export const createArticleBodySchema = z
+  .object({
+    blocks: z
+      .array(articleBlockSchema)
+      .max(100)
+      .default([])
+      .meta({ description: 'Ordered content blocks (prose + charts)' }),
+    default_end: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: 'Default window end inherited by chart blocks (ISO 8601)' }),
+    default_start: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: 'Default window start inherited by chart blocks (ISO 8601)' }),
+    title: z.string().min(1).max(200).meta({ description: 'Article title' }),
+    visibility: feedVisibilitySchema.default('public'),
+  })
+  .meta({ id: 'CreateArticleBody' })
+
+export type CreateArticleBody = z.infer<typeof createArticleBodySchema>
+
+/** Body for editing an article post (all fields optional; a given field replaces the stored one). */
+export const updateArticleBodySchema = z
+  .object({
+    blocks: z
+      .array(articleBlockSchema)
+      .max(100)
+      .optional()
+      .meta({ description: 'Replacement ordered content blocks' }),
+    default_end: iso8601DateTimeSchema.optional().meta({ description: 'Default window end (ISO 8601)' }),
+    default_start: iso8601DateTimeSchema.optional().meta({ description: 'Default window start (ISO 8601)' }),
+    title: z.string().min(1).max(200).optional().meta({ description: 'Article title' }),
+    visibility: feedVisibilitySchema.optional(),
+  })
+  .meta({ id: 'UpdateArticleBody' })
+
+export type UpdateArticleBody = z.infer<typeof updateArticleBodySchema>
 
 // =============================================================================
 // Following (the actors this user follows — inbound feed direction)


### PR DESCRIPTION
First PR of **Slice A** (#935) for the shareable-analysis **Articles** epic (#934): the `article` feed-post kind at the **schema + storage layer**.

An article is a long-form post — a title, markdown prose, and inline **chart blocks** over locked `[start, end]` windows — modelled as a *kind* on the existing `feed_posts` table so it reuses the whole feed (visibility, federation, timeline, permalinks) instead of being a separate entity.

## api-spec (single source)

- `FeedPostKind` (`activity` | `article`).
- `ArticleProseBlock` / `ArticleChartBlock` → discriminated `ArticleBlock`; `ArticleContent` (`title` + optional `default_start`/`default_end` window + ordered `blocks`).
- Chart block = a `metric` + optional `start`/`end` override (inherits the article default window) + optional `bucket`/`caption`. Charts re-resolve **live** against the locked window — no snapshot. Correlation blocks are Slice B (#936).
- `CreateArticleBody` / `UpdateArticleBody`; `FeedPost` gains required `kind` and optional `article`.

## Backend

- `feed_posts` gains `kind VARCHAR(12) DEFAULT 'activity'` + `article JSONB` — idempotent additive migration for existing DBs, registered in the table-creation order.
- `db/feed.ts`: `FeedPostRecord`/`Row` carry `kind` + parsed `article`; new `createArticlePost`; `updateFeedPost` patches the whole `article` JSONB; `FeedPostPatch` gains `article`.
- `serializeFeedPost` surfaces `kind` + `article` (article posts carry no activity, so no resolved `content`).

## Scope

**Storage + schema foundation only.** The create/edit **REST endpoints + MCP tools** (parity) and **web rendering + editor** land in the following Slice A PRs. `docs/features/feed.md` documents the new kind and column.

## Test

`pnpm check` green (0 errors). Feed DB **integration tests** (testcontainers) cover: article create + round-trip (JSONB parse), whole-payload update (replace-not-merge, touches `updated_at`), and public-outbox inclusion/exclusion by visibility — plus a regression assert that an activity share defaults to `kind: 'activity'` with `article: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)