### PR TITLE
feat(feed): article authoring API — MCP + REST parity (#935)

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -318,7 +318,9 @@ export { emitTimelineNotify, openTimelineChannel } from './timeline-notify.ts'
 
 // Feed posts
 export {
+  type ArticlePostInput,
   countPublicFeedPosts,
+  createArticlePost,
   createFeedPost,
   deleteFeedPost,
   type FeedPostInput,

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -4,10 +4,12 @@
  * and `/feed/following` capabilities.
  */
 import {
+  createArticleBodySchema,
   followActorBodySchema,
   followersQuerySchema,
   shareActivityBodySchema,
   timelineQuerySchema,
+  updateArticleBodySchema,
   updateFeedPostBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
@@ -17,6 +19,7 @@ import type { FollowerActions } from '../services/followers.ts'
 import type { FollowActions } from '../services/following.ts'
 
 import {
+  createArticlePost,
   createFeedPost,
   deleteFeedPost,
   getActivityById,
@@ -26,6 +29,7 @@ import {
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
+import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { serializeFeedPost } from '../services/feed.ts'
 import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
@@ -97,8 +101,42 @@ export const registerFeedTools = (
   )
 
   server.tool(
+    'create_article',
+    'Publish a long-form ARTICLE to your feed: a title, markdown prose, and inline chart blocks over locked time windows. `blocks` is an ordered list of `{type:"prose", markdown}` or `{type:"chart", metric, start?, end?, bucket?, caption?}`. A chart block over `[start, end]` re-resolves live against that window; omit its start/end to inherit `default_start`/`default_end`. Use this (not `share_activity`) for a written analysis spanning multiple charts.',
+    { ...createArticleBodySchema.shape },
+    async (body) => {
+      const built = buildArticleContent({
+        blocks: body.blocks,
+        default_end: body.default_end,
+        default_start: body.default_start,
+        title: body.title,
+      })
+      if (!built.ok) return errorResponse(built.error)
+      const record = await createArticlePost(user, { article: built.article, visibility: body.visibility })
+      return jsonResponse(await serializeFeedPost(user, record))
+    },
+  )
+
+  server.tool(
+    'update_article',
+    'Update an ARTICLE post (title, blocks, default window, visibility). Provided fields replace the stored ones; omitted fields are unchanged. The `blocks` array, when given, replaces the whole ordered block list.',
+    { id: z.string().uuid().describe('Feed post ID'), ...updateArticleBodySchema.shape },
+    async ({ id, ...body }) => {
+      const existing = await getFeedPostById(user, id)
+      if (!existing || existing.kind !== 'article' || existing.article == null) {
+        return errorResponse('Article not found')
+      }
+      const built = buildArticleContent(mergeArticleContent(existing.article, body))
+      if (!built.ok) return errorResponse(built.error)
+      const record = await updateFeedPost(user, id, { article: built.article, visibility: body.visibility })
+      if (!record) return errorResponse('Article not found')
+      return jsonResponse(await serializeFeedPost(user, record))
+    },
+  )
+
+  server.tool(
     'delete_feed_post',
-    'Delete a feed post by ID. Unpublishes it and stops its public series from resolving.',
+    'Delete a feed post (activity share or article) by ID. Unpublishes it and stops its public series from resolving.',
     { id: z.string().uuid().describe('Feed post ID') },
     async ({ id }) => {
       const existing = await getFeedPostById(user, id)

--- a/apps/backend/src/routes/feed-router.integration.test.ts
+++ b/apps/backend/src/routes/feed-router.integration.test.ts
@@ -1,0 +1,133 @@
+import type { RequestHandler } from 'express'
+import type { AddressInfo } from 'node:net'
+
+import express from 'express'
+import supertest from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+/**
+ * Integration test for the owner-facing article routes on the feed router
+ * (`POST /feed/articles`, `PATCH /feed/articles/:postId`) against a live
+ * database — the route + `buildArticleContent`/`mergeArticleContent` service +
+ * serializer composition over the already-unit-tested pieces. Federation is a
+ * later slice, so no `deliver` is wired here.
+ */
+import { createFeedPost } from '../db/feed.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { createFeedRouter } from './feed-router.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+const auth: RequestHandler = (req, _res, next) => {
+  req.user = getTestUser()
+  next()
+}
+
+const startApp = () => {
+  const app = express()
+  app.use(express.json())
+  app.use('/feed', createFeedRouter(auth))
+  const server = app.listen(0)
+  const port = (server.address() as AddressInfo).port
+  const close = () =>
+    new Promise<void>((resolve) => {
+      server.closeAllConnections()
+      server.close(() => resolve())
+    })
+  return { close, request: supertest(`http://127.0.0.1:${port}`) }
+}
+
+const articleBody = () => ({
+  blocks: [
+    { markdown: '# Sleep vs HRV\n\nA look at the week.', type: 'prose' },
+    { caption: 'Resting HR', metric: 'heart_rate', type: 'chart' }, // inherits the default window
+  ],
+  default_end: '2026-07-07T00:00:00.000Z',
+  default_start: '2026-07-01T00:00:00.000Z',
+  title: 'A week of sleep and HRV',
+  visibility: 'public',
+})
+
+describe('Article feed routes (integration)', () => {
+  let app: ReturnType<typeof startApp>
+
+  beforeAll(async () => {
+    await startTestDb()
+    app = startApp()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await app.close()
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('POST /feed/articles creates an article and returns the serialized post', async () => {
+    const res = await app.request.post('/feed/articles').send(articleBody())
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.post.kind).toBe('article')
+    expect(res.body.post.activity_id).toBeNull()
+    expect(res.body.post.article.title).toBe('A week of sleep and HRV')
+    expect(res.body.post.article.blocks).toHaveLength(2)
+    expect(res.body.post.visibility).toBe('public')
+  })
+
+  test('POST /feed/articles rejects a chart block with no resolvable window (400)', async () => {
+    const res = await app.request.post('/feed/articles').send({
+      // No default window and the chart block has none either.
+      blocks: [{ metric: 'heart_rate', type: 'chart' }],
+      title: 'Broken',
+      visibility: 'public',
+    })
+    expect(res.status).toBe(400)
+    expect(res.body.success).toBe(false)
+    expect(res.body.error).toContain('no time window')
+  })
+
+  test('PATCH /feed/articles/:postId replaces provided fields', async () => {
+    const created = await app.request.post('/feed/articles').send(articleBody())
+    const id = created.body.post.id
+
+    const res = await app.request
+      .patch(`/feed/articles/${id}`)
+      .send({ blocks: [{ markdown: 'Rewritten.', type: 'prose' }], title: 'Revised', visibility: 'unlisted' })
+    expect(res.status).toBe(200)
+    expect(res.body.post.article.title).toBe('Revised')
+    expect(res.body.post.article.blocks).toEqual([{ markdown: 'Rewritten.', type: 'prose' }])
+    expect(res.body.post.visibility).toBe('unlisted')
+    // The default window was not part of the patch, so it is preserved.
+    expect(res.body.post.article.default_start).toBe('2026-07-01T00:00:00.000Z')
+  })
+
+  test('PATCH /feed/articles/:postId 404s for an unknown id', async () => {
+    const res = await app.request
+      .patch('/feed/articles/00000000-0000-0000-0000-000000000000')
+      .send({ title: 'x' })
+    expect(res.status).toBe(404)
+  })
+
+  test('PATCH /feed/articles/:postId 404s for a non-article (activity) post', async () => {
+    const activityPost = await createFeedPost(getTestUser(), {
+      activity_id: null,
+      include_chart: false,
+      include_map: false,
+      included_metrics: [],
+      series_metrics: [],
+      visibility: 'public',
+    })
+    const res = await app.request.patch(`/feed/articles/${activityPost.id}`).send({ title: 'nope' })
+    expect(res.status).toBe(404)
+  })
+
+  test('DELETE /feed/:postId removes an article', async () => {
+    const created = await app.request.post('/feed/articles').send(articleBody())
+    const del = await app.request.delete(`/feed/${created.body.post.id}`)
+    expect(del.status).toBe(200)
+    const list = await app.request.get('/feed')
+    expect(list.body.posts.map((p: { id: string }) => p.id)).not.toContain(created.body.post.id)
+  })
+})

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -10,6 +10,8 @@
  */
 import {
   type BaseResponse,
+  type CreateArticleBody,
+  createArticleBodySchema,
   type FeedPostResponse,
   type FeedPostsResponse,
   type ShareActivityBody,
@@ -17,6 +19,8 @@ import {
   type TimelineQuery,
   timelineQuerySchema,
   type TimelineResponse,
+  type UpdateArticleBody,
+  updateArticleBodySchema,
   type UpdateFeedPostBody,
   updateFeedPostBodySchema,
 } from '@aurboda/api-spec'
@@ -25,6 +29,7 @@ import type { Activity, FeedPostRecord } from '../db/index.ts'
 import type { TimelineHub } from '../services/timeline-hub.ts'
 
 import {
+  createArticlePost,
   createFeedPost,
   deleteFeedPost,
   getActivityById,
@@ -32,6 +37,7 @@ import {
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
+import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { serializeFeedPost } from '../services/feed.ts'
 import { getTimelinePage } from '../services/timeline.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
@@ -150,6 +156,53 @@ export const createFeedRouter = (
       })
       // Fan the post out to followers (best-effort; never blocks the response).
       deliver?.created(user, record, activity)
+      res.json({ post: await serializeFeedPost(user, record), success: true })
+    },
+  )
+
+  // Article posts (long-form: title + prose + inline chart blocks). Create/edit
+  // have their own body shape; delete reuses `DELETE /:postId`. Registered before
+  // the generic `/:postId` routes. Federation of articles is a later slice, so
+  // these do not (yet) call `deliver` — an article is authored and shown on the
+  // owner's feed but does not fan out to followers until then.
+  router.post<Record<string, never>, FeedPostResponse, CreateArticleBody>(
+    '/articles',
+    authMiddleware,
+    validateBody(createArticleBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const built = buildArticleContent({
+        blocks: req.body.blocks,
+        default_end: req.body.default_end,
+        default_start: req.body.default_start,
+        title: req.body.title,
+      })
+      if (!built.ok) return res.status(400).json({ error: built.error, success: false })
+      const record = await createArticlePost(user, {
+        article: built.article,
+        visibility: req.body.visibility,
+      })
+      res.json({ post: await serializeFeedPost(user, record), success: true })
+    },
+  )
+
+  router.patch<{ postId: string }, FeedPostResponse, UpdateArticleBody>(
+    '/articles/:postId',
+    authMiddleware,
+    validateBody(updateArticleBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const existing = await getFeedPostById(user, req.params.postId)
+      if (!existing || existing.kind !== 'article' || existing.article == null) {
+        return res.status(404).json({ error: 'Article not found', success: false })
+      }
+      const built = buildArticleContent(mergeArticleContent(existing.article, req.body))
+      if (!built.ok) return res.status(400).json({ error: built.error, success: false })
+      const record = await updateFeedPost(user, req.params.postId, {
+        article: built.article,
+        visibility: req.body.visibility,
+      })
+      if (!record) return res.status(404).json({ error: 'Article not found', success: false })
       res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )

--- a/apps/backend/src/services/article.test.ts
+++ b/apps/backend/src/services/article.test.ts
@@ -1,0 +1,138 @@
+import type { ArticleContent } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import { buildArticleContent, chartBlockWindow, mergeArticleContent } from './article.ts'
+
+const WEEK_START = '2026-07-01T00:00:00.000Z'
+const WEEK_END = '2026-07-07T00:00:00.000Z'
+
+const content = (overrides: Partial<ArticleContent> = {}): ArticleContent => ({
+  blocks: [],
+  default_end: WEEK_END,
+  default_start: WEEK_START,
+  title: 'A week of HRV',
+  ...overrides,
+})
+
+describe('chartBlockWindow', () => {
+  test('uses the block override when present', () => {
+    const win = chartBlockWindow(
+      { end: '2026-07-03T00:00:00.000Z', start: '2026-07-02T00:00:00.000Z' },
+      { default_end: WEEK_END, default_start: WEEK_START },
+    )
+    expect(win).toEqual({ end: '2026-07-03T00:00:00.000Z', start: '2026-07-02T00:00:00.000Z' })
+  })
+
+  test('falls back to the article default per-edge', () => {
+    // Only `start` is overridden; `end` inherits the article default.
+    const win = chartBlockWindow(
+      { start: '2026-07-02T00:00:00.000Z' },
+      { default_end: WEEK_END, default_start: WEEK_START },
+    )
+    expect(win).toEqual({ end: WEEK_END, start: '2026-07-02T00:00:00.000Z' })
+  })
+})
+
+describe('buildArticleContent', () => {
+  test('accepts prose-only content (no windows needed)', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [{ markdown: 'Hello', type: 'prose' }],
+        default_end: undefined,
+        default_start: undefined,
+      }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test('accepts a chart block that inherits the article default window', () => {
+    const result = buildArticleContent(content({ blocks: [{ metric: 'heart_rate', type: 'chart' }] }))
+    expect(result).toEqual({ article: expect.objectContaining({ title: 'A week of HRV' }), ok: true })
+  })
+
+  test('accepts a chart block with its own window even without an article default', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [
+          {
+            end: '2026-07-02T00:00:00.000Z',
+            metric: 'heart_rate',
+            start: '2026-07-01T00:00:00.000Z',
+            type: 'chart',
+          },
+        ],
+        default_end: undefined,
+        default_start: undefined,
+      }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test('rejects a chart block with no window and no article default', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [{ metric: 'heart_rate', type: 'chart' }],
+        default_end: undefined,
+        default_start: undefined,
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('no time window')
+  })
+
+  test('rejects a chart block whose start is on or after its end', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [
+          {
+            end: '2026-07-01T00:00:00.000Z',
+            metric: 'heart_rate',
+            start: '2026-07-02T00:00:00.000Z',
+            type: 'chart',
+          },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('start on or after end')
+  })
+
+  test('reports the 1-based index of the offending block', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [
+          { markdown: 'intro', type: 'prose' },
+          { metric: 'stress_level', type: 'chart' }, // block 2, no window
+        ],
+        default_end: undefined,
+        default_start: undefined,
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('Chart block 2')
+  })
+})
+
+describe('mergeArticleContent', () => {
+  const existing = content({ blocks: [{ markdown: 'original', type: 'prose' }] })
+
+  test('replaces only the provided fields, keeping the rest', () => {
+    const merged = mergeArticleContent(existing, { title: 'Renamed' })
+    expect(merged.title).toBe('Renamed')
+    expect(merged.blocks).toEqual(existing.blocks)
+    expect(merged.default_start).toBe(WEEK_START)
+  })
+
+  test('replaces the blocks when provided', () => {
+    const merged = mergeArticleContent(existing, { blocks: [{ markdown: 'rewritten', type: 'prose' }] })
+    expect(merged.blocks).toEqual([{ markdown: 'rewritten', type: 'prose' }])
+    expect(merged.title).toBe(existing.title) // untouched
+  })
+
+  test('keeps the existing default window when the patch omits it', () => {
+    const merged = mergeArticleContent(existing, { title: 'x' })
+    expect(merged.default_start).toBe(WEEK_START)
+    expect(merged.default_end).toBe(WEEK_END)
+  })
+})

--- a/apps/backend/src/services/article.ts
+++ b/apps/backend/src/services/article.ts
@@ -1,0 +1,63 @@
+/**
+ * Article business logic shared by the REST `/feed/articles` routes and the MCP
+ * `create_article` / `update_article` tools (parity).
+ *
+ * An article's chart blocks each render over a locked `[start, end]` window. A
+ * block may carry its own window or inherit the article-level default; this
+ * module resolves that inheritance and validates that every chart block ends up
+ * with a sane bounded window, so a malformed article is rejected at the write
+ * boundary rather than failing later at render time. Pure and synchronous —
+ * unit-testable without a DB.
+ */
+import type { ArticleContent, UpdateArticleBody } from '@aurboda/api-spec'
+
+export type BuildArticleResult = { ok: true; article: ArticleContent } | { ok: false; error: string }
+
+/** A chart block's effective window: its own override, else the article default. */
+export const chartBlockWindow = (
+  block: { start?: string; end?: string },
+  content: { default_start?: string; default_end?: string },
+): { start?: string; end?: string } => ({
+  end: block.end ?? content.default_end,
+  start: block.start ?? content.default_start,
+})
+
+/**
+ * Validate a fully-formed article's content: every chart block must resolve to a
+ * bounded window (its own override or the article default) with start < end.
+ * Returns the content to persist, or an error message for a 400.
+ */
+export const buildArticleContent = (content: ArticleContent): BuildArticleResult => {
+  for (const [i, block] of content.blocks.entries()) {
+    if (block.type !== 'chart') continue
+    const { end, start } = chartBlockWindow(block, content)
+    if (start == null || end == null) {
+      return {
+        error: `Chart block ${i + 1} (${block.metric}) has no time window — set its start/end or an article default_start/default_end.`,
+        ok: false,
+      }
+    }
+    if (new Date(start).getTime() >= new Date(end).getTime()) {
+      return { error: `Chart block ${i + 1} (${block.metric}) has start on or after end.`, ok: false }
+    }
+  }
+  return { article: content, ok: true }
+}
+
+/**
+ * Apply an update patch onto the stored article, replacing only the provided
+ * fields (title / blocks / default window); an omitted field keeps its stored
+ * value. `visibility` is a separate post column, handled by the caller. The
+ * merged content still goes through `buildArticleContent` for validation.
+ */
+export const mergeArticleContent = (existing: ArticleContent, patch: UpdateArticleBody): ArticleContent => {
+  const merged: ArticleContent = {
+    blocks: patch.blocks ?? existing.blocks,
+    title: patch.title ?? existing.title,
+  }
+  const defaultStart = patch.default_start ?? existing.default_start
+  const defaultEnd = patch.default_end ?? existing.default_end
+  if (defaultStart !== undefined) merged.default_start = defaultStart
+  if (defaultEnd !== undefined) merged.default_end = defaultEnd
+  return merged
+}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -26,9 +26,11 @@ A feed post has a **`kind`**:
   default window unless they override it). Charts re-resolve **live** against their
   locked window — no data snapshot. Modelled as a post kind on the same storage, so an
   article reuses the whole feed (visibility, federation, timeline, permalinks). The
-  ordered blocks live in an `article` JSONB column. _Storage + schema foundation is in
-  place; the create/edit API, MCP tools, and web rendering land in follow-up slices
-  (#935 → #937)._
+  ordered blocks live in an `article` JSONB column. Authored via `POST /feed/articles`
+  / `PATCH /feed/articles/:postId` (and the `create_article` / `update_article` MCP
+  tools). _Web rendering + editor and federation land in the remaining slices
+  (#935 → #937); an article is authored and shown on the owner's own feed but does not
+  yet fan out to followers._
 
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:
@@ -387,8 +389,10 @@ Owner-facing (authenticated, scoped to the caller):
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `GET /feed`                        | List my feed posts (each enriched with the shared activity's title/type and merged-span window, resolved at query time) |
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
-| `PATCH /feed/:postId`              | Edit selection / visibility / attachments                                                                               |
-| `DELETE /feed/:postId`             | Unpublish (its public series stops resolving)                                                                           |
+| `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart blocks)                                                    |
+| `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                           |
+| `PATCH /feed/:postId`              | Edit an activity post's selection / visibility / attachments                                                            |
+| `DELETE /feed/:postId`             | Unpublish any post (an activity post's public series stops resolving)                                                    |
 | `GET /feed/following`              | List the actors I follow (accepted + pending)                                                                           |
 | `POST /feed/following`             | Follow an actor by handle (`@user@host` or actor URL)                                                                   |
 | `DELETE /feed/following/:id`       | Unfollow (sends `Undo{Follow}`)                                                                                         |
@@ -417,9 +421,11 @@ Public / federation (unauthenticated):
 | `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
-`update_feed_post`, `delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`,
-`list_followers`, `approve_follower`, `reject_follower`, and `list_timeline` — all backed by
-the same services as the REST routes. Manual follower approval is toggled with the
+`create_article`, `update_article`, `update_feed_post`, `delete_feed_post`, `list_following`,
+`follow_actor`, `unfollow_actor`, `list_followers`, `approve_follower`, `reject_follower`, and
+`list_timeline` — all backed by the same services as the REST routes (`create_article` /
+`update_article` ↔ `POST /feed/articles` / `PATCH /feed/articles/:postId`), so an article can
+be drafted conversationally by Claude via the same tools. Manual follower approval is toggled with the
 `manually_approve_followers` user setting (`get_user_settings` / `update_user_settings`).
 
 ## Storage


### PR DESCRIPTION
Second PR of **Slice A** (#935): create + edit **article** posts over both MCP and REST from one shared service (parity), building on the storage model from #943.

## Service (`services/article.ts`, pure + unit-tested)

- **`buildArticleContent`** — resolves each chart block's **effective window** (its own `start`/`end` override, else the article `default_start`/`default_end`) and rejects a chart block with **no bounded window** or **start ≥ end**, at the write boundary (so a malformed article never reaches render time).
- **`mergeArticleContent`** — applies an update patch onto the stored article: provided fields replace, omitted fields keep.

## Parity

- **MCP:** `create_article` / `update_article` (via api-spec `.shape`), mirroring `share_activity` / `update_feed_post`.
- **REST:** `POST /feed/articles`, `PATCH /feed/articles/:postId` (typed router, api-spec-validated), registered before the generic `/:postId` routes. Delete reuses `DELETE /:postId`. A malformed article → **400**; editing a non-article post via the article route → **404**.

## Not in this PR (deliberately)

**No federation.** Articles are authored and shown on the owner's own feed but do not fan out to followers (the `deliver` hooks are unwired for articles). Every activity-assuming outbox / object / structured-post path already guards `activity_id == null`, so a public article is simply skipped there for now — **verified**, no regression. Federation as an AS2 `Article` + Reddit export is Slice C (#937); web rendering + editor is the next Slice A PR.

## Test

- Article **service unit tests** (11): window inheritance, prose-only, windowless-chart rejection, start≥end, 1-based block index, merge semantics.
- **feed-router integration test** (6, testcontainers + supertest): create + round-trip, the 400 windowless-chart rejection, patch-replaces-fields (default window preserved), 404s (unknown id / non-article post), and delete.
- `pnpm check` green (0 errors). Docs updated (API table + MCP tool list + the article note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)