### PR TITLE
feat(web): article rendering + composer (#935)

### DIFF
--- a/apps/web/src/components/ArticleEditorDialog.css
+++ b/apps/web/src/components/ArticleEditorDialog.css
@@ -1,0 +1,118 @@
+/* Article composer — reuses the .share-dialog-* shell (see ShareActivityDialog.css)
+   and adds the block-list layout. */
+.article-editor {
+  max-width: 640px;
+}
+
+.article-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0.5rem 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.article-field-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.article-input {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.article-window {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.article-blocks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+}
+
+.article-block {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  background: #fafafa;
+}
+
+.article-block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+}
+
+.article-block-kind {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #4b5563;
+}
+
+.article-block-controls {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.btn-icon {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 6px;
+  width: 1.9rem;
+  height: 1.9rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #4b5563;
+}
+
+.btn-icon:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.article-chart-fields {
+  display: flex;
+  flex-direction: column;
+}
+
+.article-add-block {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .article-field-label,
+  .article-block-kind {
+    color: #d1d5db;
+  }
+
+  .article-input {
+    background: #111827;
+    border-color: #374151;
+    color: #e5e7eb;
+  }
+
+  .article-block {
+    background: #1f2937;
+    border-color: #374151;
+  }
+
+  .btn-icon {
+    background: #111827;
+    border-color: #374151;
+    color: #d1d5db;
+  }
+}

--- a/apps/web/src/components/ArticleEditorDialog.tsx
+++ b/apps/web/src/components/ArticleEditorDialog.tsx
@@ -1,7 +1,7 @@
 import type { FeedPost, FeedVisibility } from '@aurboda/api-spec'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'preact/hooks'
+import { useRef, useState } from 'preact/hooks'
 
 /**
  * Compose or edit a long-form **article** feed post: a title, an optional
@@ -22,6 +22,14 @@ import './ShareActivityDialog.css'
 import './ArticleEditorDialog.css'
 
 type BlockPatch = Partial<ChartDraft> & Partial<ProseDraft>
+
+/**
+ * A draft block plus a stable identity, used only as the React `key`. Blocks are
+ * reorderable and their children (MarkdownEditor) hold internal tab/focus state,
+ * so a positional key would strand that state on the wrong block after a move —
+ * hence a per-block id that travels with the block instead of the array index.
+ */
+type KeyedBlock = { key: string; block: BlockDraft }
 
 /** One editable content block (prose or chart) with its reorder / remove controls. */
 const ArticleBlockEditor = ({
@@ -121,12 +129,16 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
   const [title, setTitle] = useState(initial.title)
   const [defaultStart, setDefaultStart] = useState(initial.defaultStart)
   const [defaultEnd, setDefaultEnd] = useState(initial.defaultEnd)
-  const [blocks, setBlocks] = useState<BlockDraft[]>(initial.blocks)
+  const nextKey = useRef(0)
+  const keyed = (block: BlockDraft): KeyedBlock => ({ block, key: String(nextKey.current++) })
+  const [blocks, setBlocks] = useState<KeyedBlock[]>(() => initial.blocks.map(keyed))
   const [visibility, setVisibility] = useState<FeedVisibility>(initial.visibility)
   const [validationError, setValidationError] = useState<string | null>(null)
 
   const patchBlock = (i: number, patch: BlockPatch) =>
-    setBlocks((bs) => bs.map((b, j) => (j === i ? ({ ...b, ...patch } as BlockDraft) : b)))
+    setBlocks((bs) =>
+      bs.map((kb, j) => (j === i ? { ...kb, block: { ...kb.block, ...patch } as BlockDraft } : kb)),
+    )
   const removeBlock = (i: number) => setBlocks((bs) => bs.filter((_, j) => j !== i))
   const moveBlock = (i: number, dir: -1 | 1) =>
     setBlocks((bs) => {
@@ -136,13 +148,22 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
       ;[next[i], next[j]] = [next[j], next[i]]
       return next
     })
-  const addProse = () => setBlocks((bs) => [...bs, { markdown: '', type: 'prose' }])
+  const addProse = () => setBlocks((bs) => [...bs, keyed({ markdown: '', type: 'prose' })])
   const addChart = () =>
-    setBlocks((bs) => [...bs, { bucket: '', caption: '', end: '', metric: '', start: '', type: 'chart' }])
+    setBlocks((bs) => [
+      ...bs,
+      keyed({ bucket: '', caption: '', end: '', metric: '', start: '', type: 'chart' }),
+    ])
 
   const mutation = useMutation({
     mutationFn: () => {
-      const result = buildArticleBody({ blocks, defaultEnd, defaultStart, title, visibility })
+      const result = buildArticleBody({
+        blocks: blocks.map((kb) => kb.block),
+        defaultEnd,
+        defaultStart,
+        title,
+        visibility,
+      })
       if (!result.ok) {
         setValidationError(result.error)
         return Promise.reject(new Error('validation'))
@@ -207,10 +228,10 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
         </fieldset>
 
         <div class="article-blocks">
-          {blocks.map((block, i) => (
+          {blocks.map((kb, i) => (
             <ArticleBlockEditor
-              key={i}
-              block={block}
+              key={kb.key}
+              block={kb.block}
               index={i}
               total={blocks.length}
               onPatch={(patch) => patchBlock(i, patch)}

--- a/apps/web/src/components/ArticleEditorDialog.tsx
+++ b/apps/web/src/components/ArticleEditorDialog.tsx
@@ -1,0 +1,257 @@
+import type { FeedPost, FeedVisibility } from '@aurboda/api-spec'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+
+/**
+ * Compose or edit a long-form **article** feed post: a title, an optional
+ * article-level default time window, and an ordered list of prose / chart blocks.
+ * Passing an existing `post` (kind `article`) switches to edit mode (PATCH);
+ * otherwise it creates one (POST). Prose is written in the shared MarkdownEditor;
+ * a chart block picks a metric and an optional window (inheriting the article
+ * default when left blank) — the same shape Claude drafts over MCP.
+ */
+import type { BlockDraft, ChartDraft, ProseDraft } from './article-editor-body'
+
+import { createArticle, updateArticle } from '../state/api'
+import { buildArticleBody, deriveSubmitError, initialArticleEditorState } from './article-editor-body'
+import { MarkdownEditor } from './MarkdownEditor'
+import { MetricPicker } from './MetricPicker'
+import { FEED_VISIBILITY_OPTIONS, VisibilitySelector } from './VisibilitySelector'
+import './ShareActivityDialog.css'
+import './ArticleEditorDialog.css'
+
+type BlockPatch = Partial<ChartDraft> & Partial<ProseDraft>
+
+/** One editable content block (prose or chart) with its reorder / remove controls. */
+const ArticleBlockEditor = ({
+  block,
+  index,
+  total,
+  onPatch,
+  onMove,
+  onRemove,
+}: {
+  block: BlockDraft
+  index: number
+  total: number
+  onPatch: (patch: BlockPatch) => void
+  onMove: (dir: -1 | 1) => void
+  onRemove: () => void
+}) => (
+  <div class="article-block">
+    <div class="article-block-head">
+      <span class="article-block-kind">{block.type === 'prose' ? '¶ Prose' : '📈 Chart'}</span>
+      <div class="article-block-controls">
+        <button
+          type="button"
+          class="btn-icon"
+          aria-label="Move up"
+          disabled={index === 0}
+          onClick={() => onMove(-1)}
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          class="btn-icon"
+          aria-label="Move down"
+          disabled={index === total - 1}
+          onClick={() => onMove(1)}
+        >
+          ↓
+        </button>
+        <button type="button" class="btn-icon" aria-label="Remove block" onClick={onRemove}>
+          ✕
+        </button>
+      </div>
+    </div>
+
+    {block.type === 'prose' ? (
+      <MarkdownEditor
+        value={block.markdown}
+        onChange={(v) => onPatch({ markdown: v })}
+        placeholder="Write your analysis (markdown supported)…"
+      />
+    ) : (
+      <div class="article-chart-fields">
+        <label class="article-field">
+          <span class="article-field-label">Metric</span>
+          <MetricPicker value={block.metric} onChange={(m) => onPatch({ metric: m })} />
+        </label>
+        <div class="article-window">
+          <label class="article-field">
+            <span class="article-field-label">From (optional)</span>
+            <input
+              type="datetime-local"
+              class="article-input"
+              value={block.start}
+              onInput={(e) => onPatch({ start: (e.target as HTMLInputElement).value })}
+            />
+          </label>
+          <label class="article-field">
+            <span class="article-field-label">To (optional)</span>
+            <input
+              type="datetime-local"
+              class="article-input"
+              value={block.end}
+              onInput={(e) => onPatch({ end: (e.target as HTMLInputElement).value })}
+            />
+          </label>
+        </div>
+        <label class="article-field">
+          <span class="article-field-label">Caption (optional)</span>
+          <input
+            type="text"
+            class="article-input"
+            value={block.caption}
+            onInput={(e) => onPatch({ caption: (e.target as HTMLInputElement).value })}
+          />
+        </label>
+      </div>
+    )}
+  </div>
+)
+
+export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClose: () => void }) => {
+  const queryClient = useQueryClient()
+  const editing = post?.kind === 'article'
+  const [initial] = useState(() => initialArticleEditorState(post))
+
+  const [title, setTitle] = useState(initial.title)
+  const [defaultStart, setDefaultStart] = useState(initial.defaultStart)
+  const [defaultEnd, setDefaultEnd] = useState(initial.defaultEnd)
+  const [blocks, setBlocks] = useState<BlockDraft[]>(initial.blocks)
+  const [visibility, setVisibility] = useState<FeedVisibility>(initial.visibility)
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const patchBlock = (i: number, patch: BlockPatch) =>
+    setBlocks((bs) => bs.map((b, j) => (j === i ? ({ ...b, ...patch } as BlockDraft) : b)))
+  const removeBlock = (i: number) => setBlocks((bs) => bs.filter((_, j) => j !== i))
+  const moveBlock = (i: number, dir: -1 | 1) =>
+    setBlocks((bs) => {
+      const j = i + dir
+      if (j < 0 || j >= bs.length) return bs
+      const next = [...bs]
+      ;[next[i], next[j]] = [next[j], next[i]]
+      return next
+    })
+  const addProse = () => setBlocks((bs) => [...bs, { markdown: '', type: 'prose' }])
+  const addChart = () =>
+    setBlocks((bs) => [...bs, { bucket: '', caption: '', end: '', metric: '', start: '', type: 'chart' }])
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const result = buildArticleBody({ blocks, defaultEnd, defaultStart, title, visibility })
+      if (!result.ok) {
+        setValidationError(result.error)
+        return Promise.reject(new Error('validation'))
+      }
+      setValidationError(null)
+      return editing && post ? updateArticle(post.id, result.body) : createArticle(result.body)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      onClose()
+    },
+  })
+
+  const submitError = deriveSubmitError(validationError, mutation.error)
+
+  return (
+    <div class="share-dialog-backdrop" onClick={onClose}>
+      <div class="share-dialog article-editor" onClick={(e) => e.stopPropagation()}>
+        <div class="share-dialog-header">
+          <h2>{editing ? 'Edit article' : 'New article'}</h2>
+          <button type="button" class="share-dialog-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <label class="article-field">
+          <span class="article-field-label">Title</span>
+          <input
+            type="text"
+            class="article-input"
+            value={title}
+            placeholder="e.g. A week of sleep and HRV"
+            onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+          />
+        </label>
+
+        <fieldset class="share-dialog-group">
+          <legend>Default chart window</legend>
+          <p class="share-dialog-note">
+            Chart blocks use this window unless they set their own. Leave blank if every chart sets its own.
+          </p>
+          <div class="article-window">
+            <label class="article-field">
+              <span class="article-field-label">From</span>
+              <input
+                type="datetime-local"
+                class="article-input"
+                value={defaultStart}
+                onInput={(e) => setDefaultStart((e.target as HTMLInputElement).value)}
+              />
+            </label>
+            <label class="article-field">
+              <span class="article-field-label">To</span>
+              <input
+                type="datetime-local"
+                class="article-input"
+                value={defaultEnd}
+                onInput={(e) => setDefaultEnd((e.target as HTMLInputElement).value)}
+              />
+            </label>
+          </div>
+        </fieldset>
+
+        <div class="article-blocks">
+          {blocks.map((block, i) => (
+            <ArticleBlockEditor
+              key={i}
+              block={block}
+              index={i}
+              total={blocks.length}
+              onPatch={(patch) => patchBlock(i, patch)}
+              onMove={(dir) => moveBlock(i, dir)}
+              onRemove={() => removeBlock(i)}
+            />
+          ))}
+        </div>
+
+        <div class="article-add-block">
+          <button type="button" class="btn-secondary" onClick={addProse}>
+            + Prose
+          </button>
+          <button type="button" class="btn-secondary" onClick={addChart}>
+            + Chart
+          </button>
+        </div>
+
+        <VisibilitySelector
+          name="article-visibility"
+          options={FEED_VISIBILITY_OPTIONS}
+          value={visibility}
+          onChange={setVisibility}
+        />
+
+        {submitError && <p class="share-dialog-error">{submitError}</p>}
+
+        <div class="share-dialog-actions">
+          <button type="button" class="btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn-primary"
+            disabled={mutation.isPending || !title.trim()}
+            onClick={() => mutation.mutate()}
+          >
+            {mutation.isPending ? 'Saving…' : editing ? 'Save changes' : 'Publish article'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ArticleEditorDialog.tsx
+++ b/apps/web/src/components/ArticleEditorDialog.tsx
@@ -77,7 +77,7 @@ const ArticleBlockEditor = ({
       <div class="article-chart-fields">
         <label class="article-field">
           <span class="article-field-label">Metric</span>
-          <MetricPicker value={block.metric} onChange={(m) => onPatch({ metric: m })} />
+          <MetricPicker builtinOnly value={block.metric} onChange={(m) => onPatch({ metric: m })} />
         </label>
         <div class="article-window">
           <label class="article-field">

--- a/apps/web/src/components/MetricPicker.tsx
+++ b/apps/web/src/components/MetricPicker.tsx
@@ -27,13 +27,34 @@ const buildEntries = (customMetrics: CustomMetricDefinition[]): MetricEntry[] =>
   return [...builtin, ...custom]
 }
 
+/**
+ * The label to show in the closed input for the selected value: the built-in
+ * display name, else the matching custom metric's description, else the raw value.
+ */
+const displayNameForValue = (value: string, customMetrics: CustomMetricDefinition[]): string => {
+  const displayValue = value ? getMetricDisplayName(value) : ''
+  const customDisplayValue =
+    value && !displayValue.includes(value)
+      ? displayValue
+      : (customMetrics.find((m) => m.name === value)?.description ?? displayValue)
+  return customDisplayValue || value
+}
+
 interface MetricPickerProps {
   value: string
   onChange: (metric: string) => void
   placeholder?: string
+  /** Offer only built-in metrics (hide the user's custom metrics) — e.g. article
+   *  chart blocks accept only built-in `MetricType`s. */
+  builtinOnly?: boolean
 }
 
-export function MetricPicker({ value, onChange, placeholder = 'Search metrics...' }: MetricPickerProps) {
+export function MetricPicker({
+  value,
+  onChange,
+  placeholder = 'Search metrics...',
+  builtinOnly = false,
+}: MetricPickerProps) {
   const [inputValue, setInputValue] = useState('')
   const [isOpen, setIsOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(0)
@@ -46,7 +67,7 @@ export function MetricPicker({ value, onChange, placeholder = 'Search metrics...
     staleTime: 5 * 60 * 1000,
   })
 
-  const entries = buildEntries(customMetrics ?? [])
+  const entries = buildEntries(builtinOnly ? [] : (customMetrics ?? []))
 
   const filtered = entries.filter(
     (entry) =>
@@ -97,13 +118,7 @@ export function MetricPicker({ value, onChange, placeholder = 'Search metrics...
     }
   }
 
-  const displayValue = value ? getMetricDisplayName(value) : ''
-  // Check custom metrics for display name too
-  const customDisplayValue =
-    value && !displayValue.includes(value)
-      ? displayValue
-      : ((customMetrics ?? []).find((m) => m.name === value)?.description ?? displayValue)
-  const shownValue = isOpen ? inputValue : customDisplayValue || value
+  const shownValue = isOpen ? inputValue : displayNameForValue(value, customMetrics ?? [])
 
   return (
     <div class="metric-picker" ref={containerRef}>

--- a/apps/web/src/components/article-editor-body.test.ts
+++ b/apps/web/src/components/article-editor-body.test.ts
@@ -50,13 +50,24 @@ describe('buildArticleBody', () => {
     }
   })
 
-  it('rejects a chart block whose metric is not a valid MetricType', () => {
+  it('prompts to pick a metric when a chart block has none', () => {
     const result = buildArticleBody(
-      state({
-        blocks: [{ bucket: '', caption: '', end: '', metric: 'not_a_metric', start: '', type: 'chart' }],
-      }),
+      state({ blocks: [{ bucket: '', caption: '', end: '', metric: '', start: '', type: 'chart' }] }),
     )
     expect(result).toEqual({ error: 'Pick a metric for chart block 1.', ok: false })
+  })
+
+  it('rejects an unsupported (custom) metric with a clear message', () => {
+    const result = buildArticleBody(
+      state({
+        blocks: [{ bucket: '', caption: '', end: '', metric: 'my_custom_metric', start: '', type: 'chart' }],
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('my_custom_metric')
+      expect(result.error).toContain("custom metrics aren't supported")
+    }
   })
 
   it('omits empty optional fields on a chart block', () => {

--- a/apps/web/src/components/article-editor-body.test.ts
+++ b/apps/web/src/components/article-editor-body.test.ts
@@ -1,0 +1,137 @@
+import type { FeedPost } from '@aurboda/api-spec'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  type ArticleEditorState,
+  buildArticleBody,
+  deriveSubmitError,
+  draftsFromPost,
+  toInputValue,
+  toIso,
+} from './article-editor-body'
+
+const state = (overrides: Partial<ArticleEditorState> = {}): ArticleEditorState => ({
+  blocks: [],
+  defaultEnd: '',
+  defaultStart: '',
+  title: 'A week of HRV',
+  visibility: 'public',
+  ...overrides,
+})
+
+describe('toInputValue / toIso', () => {
+  it('returns empty for a missing ISO and blank input', () => {
+    expect(toInputValue(undefined)).toBe('')
+    expect(toIso('')).toBeUndefined()
+  })
+
+  it('round-trips an instant on a minute boundary (timezone-independent)', () => {
+    const iso = '2026-07-01T00:00:00.000Z'
+    // local datetime-local → back to ISO preserves the instant (seconds dropped).
+    expect(toIso(toInputValue(iso))).toBe(iso)
+  })
+})
+
+describe('buildArticleBody', () => {
+  it('rejects an empty title', () => {
+    const result = buildArticleBody(state({ title: '   ' }))
+    expect(result).toEqual({ error: 'Give your article a title.', ok: false })
+  })
+
+  it('builds a prose block and trims the title', () => {
+    const result = buildArticleBody(
+      state({ blocks: [{ markdown: 'Hello', type: 'prose' }], title: '  Titled  ' }),
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.body.title).toBe('Titled')
+      expect(result.body.blocks).toEqual([{ markdown: 'Hello', type: 'prose' }])
+    }
+  })
+
+  it('rejects a chart block whose metric is not a valid MetricType', () => {
+    const result = buildArticleBody(
+      state({
+        blocks: [{ bucket: '', caption: '', end: '', metric: 'not_a_metric', start: '', type: 'chart' }],
+      }),
+    )
+    expect(result).toEqual({ error: 'Pick a metric for chart block 1.', ok: false })
+  })
+
+  it('omits empty optional fields on a chart block', () => {
+    const result = buildArticleBody(
+      state({
+        blocks: [{ bucket: '', caption: '  ', end: '', metric: 'heart_rate', start: '', type: 'chart' }],
+      }),
+    )
+    expect(result.ok).toBe(true)
+    // No window/bucket/caption keys when they were blank.
+    if (result.ok) expect(result.body.blocks[0]).toEqual({ metric: 'heart_rate', type: 'chart' })
+  })
+
+  it('includes a chart caption and the article default window when set', () => {
+    const result = buildArticleBody(
+      state({
+        blocks: [
+          { bucket: '1h', caption: 'Resting HR', end: '', metric: 'heart_rate', start: '', type: 'chart' },
+        ],
+        defaultEnd: toInputValue('2026-07-07T00:00:00.000Z'),
+        defaultStart: toInputValue('2026-07-01T00:00:00.000Z'),
+      }),
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.body.default_start).toBe('2026-07-01T00:00:00.000Z')
+      expect(result.body.default_end).toBe('2026-07-07T00:00:00.000Z')
+      expect(result.body.blocks[0]).toEqual({
+        bucket: '1h',
+        caption: 'Resting HR',
+        metric: 'heart_rate',
+        type: 'chart',
+      })
+    }
+  })
+})
+
+describe('deriveSubmitError', () => {
+  it('prefers a form-validation error', () => {
+    expect(deriveSubmitError('Give it a title.', new Error('boom'))).toBe('Give it a title.')
+  })
+
+  it('surfaces a real mutation error but ignores the internal validation rejection', () => {
+    expect(deriveSubmitError(null, new Error('Server said no'))).toBe('Server said no')
+    expect(deriveSubmitError(null, new Error('validation'))).toBeNull()
+    expect(deriveSubmitError(null, null)).toBeNull()
+  })
+})
+
+describe('draftsFromPost', () => {
+  it('returns no drafts for a non-article post', () => {
+    expect(draftsFromPost(undefined)).toEqual([])
+    expect(draftsFromPost({ kind: 'activity' } as FeedPost)).toEqual([])
+  })
+
+  it('seeds drafts from a stored article, defaulting optional chart fields to empty strings', () => {
+    const post = {
+      article: {
+        blocks: [
+          { markdown: 'intro', type: 'prose' },
+          { metric: 'heart_rate', type: 'chart' }, // no window/bucket/caption
+        ],
+        title: 'T',
+      },
+      kind: 'article',
+    } as FeedPost
+    const drafts = draftsFromPost(post)
+    expect(drafts[0]).toEqual({ markdown: 'intro', type: 'prose' })
+    expect(drafts[1]).toEqual({
+      bucket: '',
+      caption: '',
+      end: '',
+      metric: 'heart_rate',
+      start: '',
+      type: 'chart',
+    })
+  })
+})

--- a/apps/web/src/components/article-editor-body.ts
+++ b/apps/web/src/components/article-editor-body.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure state → request-body logic for the article editor, kept out of the JSX so
+ * it is unit-testable without rendering (mirrors `feed-metrics.ts`'s
+ * `buildShareBody`). Handles the `datetime-local` ⇄ ISO conversion, seeding the
+ * editor from an existing post, and building/validating the create/update body.
+ */
+import type { ArticleBlock, CreateArticleBody, FeedPost, FeedVisibility } from '@aurboda/api-spec'
+
+import { isValidMetric } from '@aurboda/api-spec'
+
+export interface ProseDraft {
+  type: 'prose'
+  markdown: string
+}
+export interface ChartDraft {
+  type: 'chart'
+  metric: string
+  /** `datetime-local` value ('' = inherit the article default window). */
+  start: string
+  end: string
+  bucket: string
+  caption: string
+}
+export type BlockDraft = ChartDraft | ProseDraft
+
+export interface ArticleEditorState {
+  title: string
+  defaultStart: string
+  defaultEnd: string
+  blocks: BlockDraft[]
+  visibility: FeedVisibility
+}
+
+export type BuildResult = { ok: true; body: CreateArticleBody } | { ok: false; error: string }
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+/** ISO 8601 → a `datetime-local` input value (local time), or '' when absent. */
+export const toInputValue = (iso?: string): string => {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+/** A `datetime-local` value → ISO 8601, or undefined when blank. */
+export const toIso = (local: string): string | undefined =>
+  local ? new Date(local).toISOString() : undefined
+
+/** Seed the editor's block drafts from an existing article post (edit mode). */
+export const draftsFromPost = (post?: FeedPost): BlockDraft[] => {
+  if (!post?.article) return []
+  return post.article.blocks.map(
+    (b): BlockDraft =>
+      b.type === 'prose'
+        ? { markdown: b.markdown, type: 'prose' }
+        : {
+            bucket: b.bucket ?? '',
+            caption: b.caption ?? '',
+            end: toInputValue(b.end),
+            metric: b.metric,
+            start: toInputValue(b.start),
+            type: 'chart',
+          },
+  )
+}
+
+/** Seed the whole editor state from an existing post (edit mode) or empty (compose). */
+export const initialArticleEditorState = (post?: FeedPost): ArticleEditorState => ({
+  blocks: draftsFromPost(post),
+  defaultEnd: toInputValue(post?.article?.default_end),
+  defaultStart: toInputValue(post?.article?.default_start),
+  title: post?.article?.title ?? '',
+  visibility: post?.visibility ?? 'public',
+})
+
+/**
+ * The message to show under the editor: a form-validation error takes precedence,
+ * then a real mutation failure (the internal `'validation'` rejection is not a
+ * user-facing error — it just signals the form was invalid).
+ */
+export const deriveSubmitError = (validationError: string | null, mutationError: unknown): string | null => {
+  if (validationError) return validationError
+  if (mutationError instanceof Error && mutationError.message !== 'validation') return mutationError.message
+  return null
+}
+
+/**
+ * Build the create/update request body from the editor state, or return a
+ * validation error. Requires a title and a valid metric on every chart block;
+ * empty optional fields are omitted. The server re-validates chart windows
+ * (`buildArticleContent`), so this only guards what the form can catch early.
+ */
+export const buildArticleBody = (state: ArticleEditorState): BuildResult => {
+  if (!state.title.trim()) return { error: 'Give your article a title.', ok: false }
+
+  const blocks: ArticleBlock[] = []
+  for (const [i, b] of state.blocks.entries()) {
+    if (b.type === 'prose') {
+      blocks.push({ markdown: b.markdown, type: 'prose' })
+      continue
+    }
+    if (!isValidMetric(b.metric)) return { error: `Pick a metric for chart block ${i + 1}.`, ok: false }
+    blocks.push({
+      metric: b.metric,
+      type: 'chart',
+      ...(toIso(b.start) ? { start: toIso(b.start) } : {}),
+      ...(toIso(b.end) ? { end: toIso(b.end) } : {}),
+      ...(b.bucket ? { bucket: b.bucket } : {}),
+      ...(b.caption.trim() ? { caption: b.caption.trim() } : {}),
+    })
+  }
+
+  return {
+    body: {
+      blocks,
+      title: state.title.trim(),
+      visibility: state.visibility,
+      ...(toIso(state.defaultStart) ? { default_start: toIso(state.defaultStart) } : {}),
+      ...(toIso(state.defaultEnd) ? { default_end: toIso(state.defaultEnd) } : {}),
+    },
+    ok: true,
+  }
+}

--- a/apps/web/src/components/article-editor-body.ts
+++ b/apps/web/src/components/article-editor-body.ts
@@ -99,7 +99,15 @@ export const buildArticleBody = (state: ArticleEditorState): BuildResult => {
       blocks.push({ markdown: b.markdown, type: 'prose' })
       continue
     }
-    if (!isValidMetric(b.metric)) return { error: `Pick a metric for chart block ${i + 1}.`, ok: false }
+    if (!isValidMetric(b.metric)) {
+      // An empty pick vs. an unsupported (custom) metric — article charts accept
+      // only built-in metric types (the picker offers only those, but an article
+      // edited elsewhere could still carry one).
+      const error = b.metric
+        ? `Chart block ${i + 1}: “${b.metric}” can't be charted in an article (custom metrics aren't supported yet).`
+        : `Pick a metric for chart block ${i + 1}.`
+      return { error, ok: false }
+    }
     blocks.push({
       metric: b.metric,
       type: 'chart',

--- a/apps/web/src/pages/Feed/ArticleChartBlock.tsx
+++ b/apps/web/src/pages/Feed/ArticleChartBlock.tsx
@@ -1,0 +1,63 @@
+/**
+ * One inline chart block of an article: a single metric drawn over its locked
+ * `[start, end]` window. Data is re-resolved **live** against the window (no
+ * snapshot) via the owner-authenticated bucketed-metrics endpoint, matching the
+ * article model's "lock the window, not the data" design (#934). The caller
+ * (`ArticleContent`) resolves the effective window (block override else the
+ * article default) and passes concrete ISO strings.
+ */
+import { useQuery } from '@tanstack/react-query'
+
+import { TrendLineChart } from '../../components/charts/TrendLineChart'
+import { fetchBucketedMetrics } from '../../state/api'
+import { getMetricDisplayName } from '../../utils/metricLabels'
+
+const CHART_COLOR = '#673ab8'
+const DAY_MS = 86_400_000
+
+/** Pick a bucket granularity from the window span when the block doesn't fix one. */
+const defaultBucket = (start: Date, end: Date): string =>
+  end.getTime() - start.getTime() <= 2 * DAY_MS ? '1h' : '1d'
+
+export const ArticleChartBlock = ({
+  metric,
+  start,
+  end,
+  bucket,
+  caption,
+}: {
+  metric: string
+  start: string
+  end: string
+  bucket?: string
+  caption?: string
+}) => {
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  const effectiveBucket = bucket ?? defaultBucket(startDate, endDate)
+
+  const { data, isLoading, isError } = useQuery({
+    queryFn: () => fetchBucketedMetrics(startDate, endDate, [metric], effectiveBucket),
+    queryKey: ['article-chart', metric, start, end, effectiveBucket],
+  })
+
+  const points = (data?.buckets ?? [])
+    .map((b) => ({ date: b.start, value: b.metrics[metric]?.avg }))
+    .filter((p): p is { date: string; value: number } => p.value != null)
+
+  return (
+    <figure class="article-chart">
+      <div class="article-chart-title">{getMetricDisplayName(metric)}</div>
+      {isLoading ? (
+        <p class="article-chart-note">Loading chart…</p>
+      ) : isError ? (
+        <p class="article-chart-note">Couldn't load this chart.</p>
+      ) : points.length < 2 ? (
+        <p class="article-chart-note">Not enough data in this window.</p>
+      ) : (
+        <TrendLineChart color={CHART_COLOR} data={points} xDomain={[startDate, endDate]} />
+      )}
+      {caption && <figcaption class="article-chart-caption">{caption}</figcaption>}
+    </figure>
+  )
+}

--- a/apps/web/src/pages/Feed/ArticleContent.tsx
+++ b/apps/web/src/pages/Feed/ArticleContent.tsx
@@ -1,0 +1,47 @@
+/**
+ * Render an article post inline: its title followed by the ordered content
+ * blocks. Prose blocks go through the shared markdown sanitiser (#910 — the XSS
+ * boundary; article prose may be authored by AI or, later, a different user).
+ * Chart blocks resolve their effective window (own override else the article
+ * default) and render live via `ArticleChartBlock`.
+ */
+import type { ArticleContent as ArticleContentType } from '@aurboda/api-spec'
+
+import { renderMarkdown } from '../../utils/markdown'
+import { ArticleChartBlock } from './ArticleChartBlock'
+
+export const ArticleContent = ({ article }: { article: ArticleContentType }) => (
+  <div class="article-content">
+    <h3 class="article-title">{article.title}</h3>
+    {article.blocks.map((block, i) => {
+      if (block.type === 'prose') {
+        return (
+          <div
+            key={`prose-${i}`}
+            class="article-prose"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(block.markdown) }}
+          />
+        )
+      }
+      const start = block.start ?? article.default_start
+      const end = block.end ?? article.default_end
+      if (start == null || end == null) {
+        return (
+          <p key={`chart-${i}`} class="article-chart-note">
+            This chart has no time window.
+          </p>
+        )
+      }
+      return (
+        <ArticleChartBlock
+          key={`chart-${i}`}
+          bucket={block.bucket}
+          caption={block.caption}
+          end={end}
+          metric={block.metric}
+          start={start}
+        />
+      )
+    })}
+  </div>
+)

--- a/apps/web/src/pages/Feed/FeedPostCard.css
+++ b/apps/web/src/pages/Feed/FeedPostCard.css
@@ -89,14 +89,73 @@
   margin-top: 0.75rem;
 }
 
+/* Article posts: title + prose/chart blocks rendered inline in the card. */
+.article-content {
+  margin-top: 0.5rem;
+  color: #1f2937;
+  overflow-wrap: anywhere;
+}
+
+.article-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: #111827;
+}
+
+.article-prose {
+  margin: 0.5rem 0;
+}
+
+.article-prose p {
+  margin: 0 0 0.4rem;
+}
+
+.article-prose p:last-child {
+  margin-bottom: 0;
+}
+
+.article-chart {
+  margin: 0.75rem 0;
+}
+
+.article-chart-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #4b5563;
+  margin-bottom: 0.2rem;
+}
+
+.article-chart-note {
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.article-chart-caption {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin-top: 0.25rem;
+  text-align: center;
+}
+
 @media (prefers-color-scheme: dark) {
   .feed-post {
     border-color: #374151;
   }
 
   .feed-post-name,
-  .feed-post-content {
+  .feed-post-content,
+  .article-content {
     color: #e5e7eb;
+  }
+
+  .article-title {
+    color: #f3f4f6;
+  }
+
+  .article-chart-title {
+    color: #d1d5db;
   }
 
   .feed-post-avatar,

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -13,6 +13,7 @@ import type { ComponentChildren } from 'preact'
 import { formatDistanceToNow } from 'date-fns'
 
 import { API_URL } from '../../config'
+import { ArticleContent } from './ArticleContent'
 import './FeedPostCard.css'
 
 export interface PostAuthor {
@@ -69,9 +70,13 @@ export const FeedPostCard = ({
         </div>
       </header>
 
-      {/* Server-generated, HTML-escaped `content` (see serializeFeedPost) — safe
-          to render directly. Remote timeline content will need sanitising. */}
-      {post.content ? (
+      {/* An article renders its own title + prose/chart blocks (prose sanitised
+          via the shared sanitiser). Otherwise the activity post's server-built,
+          HTML-escaped `content` (see serializeFeedPost) is safe to render
+          directly; remote timeline content will need sanitising. */}
+      {post.kind === 'article' && post.article ? (
+        <ArticleContent article={post.article} />
+      ) : post.content ? (
         <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: post.content }} />
       ) : (
         <div class="feed-post-content">{post.activity_title ?? 'Shared activity'}</div>

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -9,6 +9,7 @@ import type { FeedPost } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
+import { ArticleEditorDialog } from '../../components/ArticleEditorDialog'
 import { ShareActivityDialog } from '../../components/ShareActivityDialog'
 import { avatarUrl, deleteFeedPost, fetchFeed } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -22,6 +23,7 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState(false)
   const activityId = post.activity_id
+  const isArticle = post.kind === 'article'
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteFeedPost(post.id),
@@ -41,7 +43,7 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
         author={author}
         footer={
           <>
-            {activityId && (
+            {(activityId || isArticle) && (
               <button type="button" class="btn-secondary" onClick={() => setEditing(true)}>
                 Edit
               </button>
@@ -53,7 +55,9 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
         }
       />
 
-      {editing && activityId && (
+      {editing && isArticle && <ArticleEditorDialog post={post} onClose={() => setEditing(false)} />}
+
+      {editing && !isArticle && activityId && (
         <ShareActivityDialog
           activityId={activityId}
           activityTitle={post.activity_title}
@@ -69,6 +73,7 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
 
 export function Feed() {
   const { data: posts, isLoading, error } = useQuery({ queryFn: fetchFeed, queryKey: ['feed'] })
+  const [composing, setComposing] = useState(false)
 
   const username = auth.value.user ?? ''
   // The actor handle host is the web host the user is browsing (`<user>@<host>`);
@@ -96,7 +101,13 @@ export function Feed() {
 
       <HomeTimeline />
 
-      <h2 class="feed-section-title">Your posts</h2>
+      <div class="feed-section-header">
+        <h2 class="feed-section-title">Your posts</h2>
+        <button type="button" class="btn-primary" onClick={() => setComposing(true)}>
+          New article
+        </button>
+      </div>
+      {composing && <ArticleEditorDialog onClose={() => setComposing(false)} />}
       {isLoading && <p>Loading…</p>}
       {error && <p class="feed-error">Couldn't load your feed. Please try again.</p>}
       {posts && posts.length === 0 && (

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -38,6 +38,14 @@
   font-size: 1.1rem;
 }
 
+.feed-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 /* Following management panel. */
 .following-panel {
   border: 1px solid #e5e7eb;

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateArticleBody,
   FeedPost,
   FeedPostResponse,
   FeedPostsResponse,
@@ -11,6 +12,7 @@ import type {
   FollowingResponse,
   ShareActivityBody,
   TimelineResponse,
+  UpdateArticleBody,
   UpdateFeedPostBody,
 } from '@aurboda/api-spec'
 
@@ -42,6 +44,24 @@ export const fetchFeed = async (): Promise<FeedPost[]> => {
 /** Update a shared post's metric selection, series opt-in, or visibility. */
 export const updateFeedPost = async (postId: string, body: UpdateFeedPostBody): Promise<FeedPost> => {
   const response = await axios.patch<FeedPostResponse>(`${API_URL}/feed/${postId}`, body, {
+    headers: authHeaders(),
+  })
+  if (!response.data.post) throw new Error('Update failed: no post returned')
+  return response.data.post
+}
+
+/** Publish a long-form article (title + prose + inline chart blocks) to the feed. */
+export const createArticle = async (body: CreateArticleBody): Promise<FeedPost> => {
+  const response = await axios.post<FeedPostResponse>(`${API_URL}/feed/articles`, body, {
+    headers: authHeaders(),
+  })
+  if (!response.data.post) throw new Error('Create failed: no post returned')
+  return response.data.post
+}
+
+/** Edit an article post (title, blocks, default window, visibility). */
+export const updateArticle = async (postId: string, body: UpdateArticleBody): Promise<FeedPost> => {
+  const response = await axios.patch<FeedPostResponse>(`${API_URL}/feed/articles/${postId}`, body, {
     headers: authHeaders(),
   })
   if (!response.data.post) throw new Error('Update failed: no post returned')

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -52,18 +52,30 @@ export const updateFeedPost = async (postId: string, body: UpdateFeedPostBody): 
 
 /** Publish a long-form article (title + prose + inline chart blocks) to the feed. */
 export const createArticle = async (body: CreateArticleBody): Promise<FeedPost> => {
-  const response = await axios.post<FeedPostResponse>(`${API_URL}/feed/articles`, body, {
-    headers: authHeaders(),
-  })
+  let response
+  try {
+    response = await axios.post<FeedPostResponse>(`${API_URL}/feed/articles`, body, {
+      headers: authHeaders(),
+    })
+  } catch (error) {
+    // Surface the server's window-validation reason (e.g. "Chart block 1
+    // (heart_rate) has start on or after end.") instead of a generic HTTP string.
+    throw new Error(apiErrorMessage(error, 'Couldn’t publish the article. Please try again.'))
+  }
   if (!response.data.post) throw new Error('Create failed: no post returned')
   return response.data.post
 }
 
 /** Edit an article post (title, blocks, default window, visibility). */
 export const updateArticle = async (postId: string, body: UpdateArticleBody): Promise<FeedPost> => {
-  const response = await axios.patch<FeedPostResponse>(`${API_URL}/feed/articles/${postId}`, body, {
-    headers: authHeaders(),
-  })
+  let response
+  try {
+    response = await axios.patch<FeedPostResponse>(`${API_URL}/feed/articles/${postId}`, body, {
+      headers: authHeaders(),
+    })
+  } catch (error) {
+    throw new Error(apiErrorMessage(error, 'Couldn’t save the article. Please try again.'))
+  }
   if (!response.data.post) throw new Error('Update failed: no post returned')
   return response.data.post
 }

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -28,9 +28,11 @@ A feed post has a **`kind`**:
   article reuses the whole feed (visibility, federation, timeline, permalinks). The
   ordered blocks live in an `article` JSONB column. Authored via `POST /feed/articles`
   / `PATCH /feed/articles/:postId` (and the `create_article` / `update_article` MCP
-  tools). _Web rendering + editor and federation land in the remaining slices
-  (#935 → #937); an article is authored and shown on the owner's own feed but does not
-  yet fan out to followers._
+  tools), or in the web app's article composer; prose renders through the shared
+  markdown sanitiser and each chart block draws its metric live over the locked window.
+  _Federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
+  (#937); an article is authored and shown on the owner's own feed but does not yet fan
+  out to followers._
 
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:
@@ -358,11 +360,15 @@ resolving.
 
 - **Share** — an activity's detail page has a **Share to feed** button. It opens a dialog
   to pick the summary metrics, optionally opt into full series, and choose the audience.
+- **New article** — the **Feed** page has a **New article** button that opens the article
+  composer: a title, an optional default time window, and an ordered list of **prose**
+  (markdown) and **chart** blocks (a metric + optional per-block window + caption), plus
+  the audience. Each chart draws its metric live over the locked window.
 - **Manage** — the **Feed** page (`/feed`, the 📣 item under the **Sharing** section in
   the sidebar) lists everything
   you've shared, with each post's audience and metrics. From there you can **Edit** a
-  post (re-opens the dialog; saving federates an `Update`) or **Unshare** it (federates a
-  `Delete`).
+  post — an activity share re-opens the share dialog (saving federates an `Update`); an
+  article re-opens the article composer — or **Unshare** it (federates a `Delete`).
 - **Follow** — the Feed page's **Following** panel lets you follow a fediverse actor by
   handle (`@user@host`) and see who you follow, with a **Pending** badge until the remote
   server accepts and an **Unfollow** button.


### PR DESCRIPTION
Third and final **Slice A** PR: view and author **article** posts in the web app, building on the article API from #944. Completes #935.

## Render (feed / home-timeline card)

- `FeedPostCard` gains a `kind === 'article'` branch → **`ArticleContent`**: the title followed by the ordered blocks. **Prose** renders through the shared DOMPurify sanitiser (#910 — the XSS boundary for AI- or other-authored prose).
- **`ArticleChartBlock`** resolves each chart block's effective window (own override else the article default) and draws the metric **live** via the owner-authenticated bucketed-metrics endpoint + the shared `TrendLineChart` — no snapshot, matching "lock the window, not the data". Because it's owner-scoped, a post's chart data stays behind the same auth until the public/federated surface (Slice C) adds the visibility-gated **server** rendering flagged in #943's review.

## Compose / edit

- **`ArticleEditorDialog`** — title, optional default window, and an ordered **add / remove / reorder** list of **prose** (`MarkdownEditor`) and **chart** (`MetricPicker` + per-block window + caption) blocks, plus the reused `VisibilitySelector`. Create → `POST /feed/articles`, edit → `PATCH /feed/articles/:postId`.
- Feed page: a **New article** button and an **Edit** affordance on article cards.
- API client: `createArticle` / `updateArticle`.

## Testability

The pure state→body logic — `buildArticleBody` (+ validation), `datetime-local` ⇄ ISO conversion, edit-mode seeding, submit-error derivation — lives in **`article-editor-body.ts`** so it is unit-tested without a render harness (**11 tests**), matching the repo's testable-without-mocking preference and the web's pure-logic test convention.

## Scope

Owner-facing rendering + authoring. **Federation** as an AS2 `Article` (prose HTML + attached chart PNGs / native inline) and **Reddit/markdown export** are Slice C (#937); a public article's charts don't yet render for unauthenticated viewers (that's the Slice C visibility-gated server endpoint).

## Test

`pnpm check` green (0 errors). Article editor logic: 11 unit tests. Docs updated (web usage + the article note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)