### PR TITLE
feat(feed): article correlation blocks — schema + validation (#936)

### DIFF
--- a/apps/backend/src/services/article.test.ts
+++ b/apps/backend/src/services/article.test.ts
@@ -2,10 +2,18 @@ import type { ArticleContent } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
-import { buildArticleContent, chartBlockWindow, mergeArticleContent } from './article.ts'
+import { blockWindow, buildArticleContent, mergeArticleContent } from './article.ts'
 
 const WEEK_START = '2026-07-01T00:00:00.000Z'
 const WEEK_END = '2026-07-07T00:00:00.000Z'
+
+/** A valid correlation block: exercise (trigger) against sleep score (outcome), with an optional window. */
+const corrBlock = (window: { start?: string; end?: string } = {}): ArticleContent['blocks'][number] => ({
+  outcome: { kind: 'metric', metric: 'sleep_score' },
+  trigger: { kind: 'activity', pattern: 'exercise' },
+  type: 'correlation',
+  ...window,
+})
 
 const content = (overrides: Partial<ArticleContent> = {}): ArticleContent => ({
   blocks: [],
@@ -15,9 +23,9 @@ const content = (overrides: Partial<ArticleContent> = {}): ArticleContent => ({
   ...overrides,
 })
 
-describe('chartBlockWindow', () => {
+describe('blockWindow', () => {
   test('uses the block override when present', () => {
-    const win = chartBlockWindow(
+    const win = blockWindow(
       { end: '2026-07-03T00:00:00.000Z', start: '2026-07-02T00:00:00.000Z' },
       { default_end: WEEK_END, default_start: WEEK_START },
     )
@@ -26,7 +34,7 @@ describe('chartBlockWindow', () => {
 
   test('falls back to the article default per-edge', () => {
     // Only `start` is overridden; `end` inherits the article default.
-    const win = chartBlockWindow(
+    const win = blockWindow(
       { start: '2026-07-02T00:00:00.000Z' },
       { default_end: WEEK_END, default_start: WEEK_START },
     )
@@ -111,6 +119,43 @@ describe('buildArticleContent', () => {
     )
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error).toContain('Chart block 2')
+  })
+
+  test('accepts a correlation block that inherits the article default window', () => {
+    const result = buildArticleContent(content({ blocks: [corrBlock()] }))
+    expect(result.ok).toBe(true)
+  })
+
+  test('accepts a correlation block with its own window even without an article default', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [corrBlock({ end: '2026-07-02T00:00:00.000Z', start: '2026-07-01T00:00:00.000Z' })],
+        default_end: undefined,
+        default_start: undefined,
+      }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test('rejects a correlation block with no window and no article default', () => {
+    const result = buildArticleContent(
+      content({ blocks: [corrBlock()], default_end: undefined, default_start: undefined }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Correlation block 1')
+      expect(result.error).toContain('no time window')
+    }
+  })
+
+  test('rejects a correlation block whose start is on or after its end', () => {
+    const result = buildArticleContent(
+      content({
+        blocks: [corrBlock({ end: '2026-07-01T00:00:00.000Z', start: '2026-07-02T00:00:00.000Z' })],
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('Correlation block 1')
   })
 })
 

--- a/apps/backend/src/services/article.ts
+++ b/apps/backend/src/services/article.ts
@@ -2,19 +2,19 @@
  * Article business logic shared by the REST `/feed/articles` routes and the MCP
  * `create_article` / `update_article` tools (parity).
  *
- * An article's chart blocks each render over a locked `[start, end]` window. A
- * block may carry its own window or inherit the article-level default; this
- * module resolves that inheritance and validates that every chart block ends up
- * with a sane bounded window, so a malformed article is rejected at the write
- * boundary rather than failing later at render time. Pure and synchronous —
- * unit-testable without a DB.
+ * An article's chart and correlation blocks each render over a locked
+ * `[start, end]` window. A block may carry its own window or inherit the
+ * article-level default; this module resolves that inheritance and validates
+ * that every windowed block ends up with a sane bounded window, so a malformed
+ * article is rejected at the write boundary rather than failing later at render
+ * time. Pure and synchronous — unit-testable without a DB.
  */
-import type { ArticleContent, UpdateArticleBody } from '@aurboda/api-spec'
+import type { ArticleBlock, ArticleContent, UpdateArticleBody } from '@aurboda/api-spec'
 
 export type BuildArticleResult = { ok: true; article: ArticleContent } | { ok: false; error: string }
 
-/** A chart block's effective window: its own override, else the article default. */
-export const chartBlockWindow = (
+/** A windowed block's effective window: its own override, else the article default. */
+export const blockWindow = (
   block: { start?: string; end?: string },
   content: { default_start?: string; default_end?: string },
 ): { start?: string; end?: string } => ({
@@ -22,23 +22,28 @@ export const chartBlockWindow = (
   start: block.start ?? content.default_start,
 })
 
+/** A human label for a block in a validation error (1-based, with the block's subject). */
+const blockLabel = (block: ArticleBlock, index: number): string =>
+  block.type === 'chart' ? `Chart block ${index + 1} (${block.metric})` : `Correlation block ${index + 1}`
+
 /**
- * Validate a fully-formed article's content: every chart block must resolve to a
- * bounded window (its own override or the article default) with start < end.
- * Returns the content to persist, or an error message for a 400.
+ * Validate a fully-formed article's content: every chart and correlation block
+ * must resolve to a bounded window (its own override or the article default)
+ * with start < end. Returns the content to persist, or an error message for a 400.
  */
 export const buildArticleContent = (content: ArticleContent): BuildArticleResult => {
   for (const [i, block] of content.blocks.entries()) {
-    if (block.type !== 'chart') continue
-    const { end, start } = chartBlockWindow(block, content)
+    if (block.type !== 'chart' && block.type !== 'correlation') continue
+    const { end, start } = blockWindow(block, content)
+    const label = blockLabel(block, i)
     if (start == null || end == null) {
       return {
-        error: `Chart block ${i + 1} (${block.metric}) has no time window — set its start/end or an article default_start/default_end.`,
+        error: `${label} has no time window — set its start/end or an article default_start/default_end.`,
         ok: false,
       }
     }
     if (new Date(start).getTime() >= new Date(end).getTime()) {
-      return { error: `Chart block ${i + 1} (${block.metric}) has start on or after end.`, ok: false }
+      return { error: `${label} has start on or after end.`, ok: false }
     }
   }
   return { article: content, ok: true }

--- a/apps/web/src/components/ArticleEditorDialog.tsx
+++ b/apps/web/src/components/ArticleEditorDialog.tsx
@@ -31,7 +31,11 @@ type BlockPatch = Partial<ChartDraft> & Partial<ProseDraft>
  */
 type KeyedBlock = { key: string; block: BlockDraft }
 
-/** One editable content block (prose or chart) with its reorder / remove controls. */
+/**
+ * One content block with its reorder / remove controls. Prose and chart blocks
+ * are editable inline; a correlation block is shown read-only for now (authored
+ * over MCP/API) but can still be reordered or removed.
+ */
 const ArticleBlockEditor = ({
   block,
   index,
@@ -49,7 +53,9 @@ const ArticleBlockEditor = ({
 }) => (
   <div class="article-block">
     <div class="article-block-head">
-      <span class="article-block-kind">{block.type === 'prose' ? '¶ Prose' : '📈 Chart'}</span>
+      <span class="article-block-kind">
+        {block.type === 'prose' ? '¶ Prose' : block.type === 'correlation' ? '🔗 Correlation' : '📈 Chart'}
+      </span>
       <div class="article-block-controls">
         <button
           type="button"
@@ -81,6 +87,11 @@ const ArticleBlockEditor = ({
         onChange={(v) => onPatch({ markdown: v })}
         placeholder="Write your analysis (markdown supported)…"
       />
+    ) : block.type === 'correlation' ? (
+      <p class="share-dialog-note">
+        Correlation block — authored via Claude/MCP for now. You can reorder or remove it here; editing its
+        selectors in the composer is coming soon.
+      </p>
     ) : (
       <div class="article-chart-fields">
         <label class="article-field">

--- a/apps/web/src/components/article-editor-body.test.ts
+++ b/apps/web/src/components/article-editor-body.test.ts
@@ -1,4 +1,4 @@
-import type { FeedPost } from '@aurboda/api-spec'
+import type { ArticleBlock, FeedPost } from '@aurboda/api-spec'
 
 import { describe, expect, it } from 'vitest'
 
@@ -114,6 +114,27 @@ describe('deriveSubmitError', () => {
     expect(deriveSubmitError(null, new Error('Server said no'))).toBe('Server said no')
     expect(deriveSubmitError(null, new Error('validation'))).toBeNull()
     expect(deriveSubmitError(null, null)).toBeNull()
+  })
+})
+
+const correlationBlock: Extract<ArticleBlock, { type: 'correlation' }> = {
+  end: '2026-07-07T00:00:00.000Z',
+  outcome: { kind: 'metric', metric: 'sleep_score' },
+  start: '2026-07-01T00:00:00.000Z',
+  trigger: { kind: 'activity', pattern: 'exercise' },
+  type: 'correlation',
+}
+
+describe('correlation passthrough', () => {
+  it('seeds a verbatim passthrough draft from a stored correlation block', () => {
+    const post = { article: { blocks: [correlationBlock], title: 'T' }, kind: 'article' } as FeedPost
+    expect(draftsFromPost(post)).toEqual([{ block: correlationBlock, type: 'correlation' }])
+  })
+
+  it('emits the stored correlation block back unchanged (lossless round-trip)', () => {
+    const result = buildArticleBody(state({ blocks: [{ block: correlationBlock, type: 'correlation' }] }))
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.body.blocks[0]).toEqual(correlationBlock)
   })
 })
 

--- a/apps/web/src/components/article-editor-body.ts
+++ b/apps/web/src/components/article-editor-body.ts
@@ -21,7 +21,17 @@ export interface ChartDraft {
   bucket: string
   caption: string
 }
-export type BlockDraft = ChartDraft | ProseDraft
+/**
+ * A correlation block, kept verbatim. The web composer can't yet author or edit
+ * correlation blocks (they're created over MCP/API); this passthrough lets the
+ * editor round-trip an existing one — reorder/remove it — without dropping it.
+ * A dedicated editing UI (selector pickers) lands in a follow-up.
+ */
+export interface CorrelationDraft {
+  type: 'correlation'
+  block: Extract<ArticleBlock, { type: 'correlation' }>
+}
+export type BlockDraft = ChartDraft | CorrelationDraft | ProseDraft
 
 export interface ArticleEditorState {
   title: string
@@ -49,19 +59,18 @@ export const toIso = (local: string): string | undefined =>
 /** Seed the editor's block drafts from an existing article post (edit mode). */
 export const draftsFromPost = (post?: FeedPost): BlockDraft[] => {
   if (!post?.article) return []
-  return post.article.blocks.map(
-    (b): BlockDraft =>
-      b.type === 'prose'
-        ? { markdown: b.markdown, type: 'prose' }
-        : {
-            bucket: b.bucket ?? '',
-            caption: b.caption ?? '',
-            end: toInputValue(b.end),
-            metric: b.metric,
-            start: toInputValue(b.start),
-            type: 'chart',
-          },
-  )
+  return post.article.blocks.map((b): BlockDraft => {
+    if (b.type === 'prose') return { markdown: b.markdown, type: 'prose' }
+    if (b.type === 'correlation') return { block: b, type: 'correlation' }
+    return {
+      bucket: b.bucket ?? '',
+      caption: b.caption ?? '',
+      end: toInputValue(b.end),
+      metric: b.metric,
+      start: toInputValue(b.start),
+      type: 'chart',
+    }
+  })
 }
 
 /** Seed the whole editor state from an existing post (edit mode) or empty (compose). */
@@ -97,6 +106,10 @@ export const buildArticleBody = (state: ArticleEditorState): BuildResult => {
   for (const [i, b] of state.blocks.entries()) {
     if (b.type === 'prose') {
       blocks.push({ markdown: b.markdown, type: 'prose' })
+      continue
+    }
+    if (b.type === 'correlation') {
+      blocks.push(b.block)
       continue
     }
     if (!isValidMetric(b.metric)) {

--- a/apps/web/src/pages/Feed/ArticleContent.tsx
+++ b/apps/web/src/pages/Feed/ArticleContent.tsx
@@ -3,7 +3,8 @@
  * blocks. Prose blocks go through the shared markdown sanitiser (#910 — the XSS
  * boundary; article prose may be authored by AI or, later, a different user).
  * Chart blocks resolve their effective window (own override else the article
- * default) and render live via `ArticleChartBlock`.
+ * default) and render live via `ArticleChartBlock`. Correlation-block rendering
+ * (a live scatter) lands in a follow-up; they're skipped here for now.
  */
 import type { ArticleContent as ArticleContentType } from '@aurboda/api-spec'
 
@@ -23,6 +24,8 @@ export const ArticleContent = ({ article }: { article: ArticleContentType }) => 
           />
         )
       }
+      // Correlation-block rendering (a live scatter) lands in a follow-up.
+      if (block.type === 'correlation') return null
       const start = block.start ?? article.default_start
       const end = block.end ?? article.default_end
       if (start == null || end == null) {

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -21,18 +21,23 @@ A feed post has a **`kind`**:
 - **`activity`** (the default) — references one of the user's activities and shares a
   bounded metric selection (below). This is the original and, so far, only end-to-end
   kind.
-- **`article`** — a long-form post: a `title`, markdown prose, and inline **chart
-  blocks**, each over a locked `[start, end]` window (blocks inherit an article-level
-  default window unless they override it). Charts re-resolve **live** against their
-  locked window — no data snapshot. Modelled as a post kind on the same storage, so an
-  article reuses the whole feed (visibility, federation, timeline, permalinks). The
-  ordered blocks live in an `article` JSONB column. Authored via `POST /feed/articles`
-  / `PATCH /feed/articles/:postId` (and the `create_article` / `update_article` MCP
-  tools), or in the web app's article composer; prose renders through the shared
-  markdown sanitiser and each chart block draws its metric live over the locked window.
-  _Federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
-  (#937); an article is authored and shown on the owner's own feed but does not yet fan
-  out to followers._
+- **`article`** — a long-form post: a `title`, markdown prose, and inline **chart** and
+  **correlation** blocks, each over a locked `[start, end]` window (blocks inherit an
+  article-level default window unless they override it). Data re-resolves **live**
+  against the locked window — no data snapshot. A **chart block** draws one metric; a
+  **correlation block** pairs a `trigger` and an `outcome` selector (the exploratory
+  correlation engine's dimensions, with an optional `lag_days`) and renders as a scatter
+  with the Pearson/Spearman coefficients and n. Modelled as a post kind on the same
+  storage, so an article reuses the whole feed (visibility, federation, timeline,
+  permalinks). The ordered blocks live in an `article` JSONB column. Authored via
+  `POST /feed/articles` / `PATCH /feed/articles/:postId` (and the `create_article` /
+  `update_article` MCP tools), or in the web app's article composer; prose renders
+  through the shared markdown sanitiser and each windowed block resolves its data live
+  over the locked window.
+  _The correlation-block scatter render and its composer UI land within this slice
+  (#936); federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
+  (#937), so an article is authored and shown on the owner's own feed but does not yet
+  fan out to followers._
 
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:
@@ -395,7 +400,7 @@ Owner-facing (authenticated, scoped to the caller):
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `GET /feed`                        | List my feed posts (each enriched with the shared activity's title/type and merged-span window, resolved at query time) |
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
-| `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart blocks)                                                    |
+| `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                        |
 | `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                           |
 | `PATCH /feed/:postId`              | Edit an activity post's selection / visibility / attachments                                                            |
 | `DELETE /feed/:postId`             | Unpublish any post (an activity post's public series stops resolving)                                                    |

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -25,6 +25,7 @@
 import { z } from 'zod'
 
 import { baseResponseSchema, iso8601DateTimeSchema, metricTypeSchema } from './common.ts'
+import { selectorSchema } from './correlations.ts'
 import { feedStructuredSchema, publicSeriesSampleSchema } from './feed-structured.ts'
 import { shareVisibilityValues } from './visibility.ts'
 
@@ -155,26 +156,58 @@ export const articleChartBlockSchema = z
   })
   .meta({ description: 'A metric chart over a locked window', id: 'ArticleChartBlock' })
 
-/** An ordered content block of an article. Correlation blocks arrive in a later slice (#936). */
+/**
+ * A correlation block: a scatter of two data dimensions (a `trigger` predictor
+ * against an `outcome`) over a locked `[start, end]` window, reusing the
+ * exploratory correlation engine's selectors. Like a chart block, the window is
+ * re-resolved live (never snapshotted) and inherits the article's default window
+ * when `start`/`end` are omitted. `lag_days` shifts the outcome forward relative
+ * to the trigger (e.g. does today's training load predict tomorrow's HRV).
+ */
+export const articleCorrelationBlockSchema = z
+  .object({
+    caption: z.string().max(280).optional().meta({ description: 'Optional caption shown under the scatter' }),
+    end: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: "Window end (ISO 8601); inherits the article's default window if omitted" }),
+    lag_days: z
+      .number()
+      .int()
+      .optional()
+      .meta({ description: 'Days the outcome lags the trigger (default: 0)' }),
+    outcome: selectorSchema.meta({ description: 'Outcome dimension' }),
+    start: iso8601DateTimeSchema
+      .optional()
+      .meta({ description: "Window start (ISO 8601); inherits the article's default window if omitted" }),
+    trigger: selectorSchema.meta({ description: 'Trigger / predictor dimension' }),
+    type: z.literal('correlation'),
+  })
+  .meta({ description: 'A correlation scatter over a locked window', id: 'ArticleCorrelationBlock' })
+
+/** An ordered content block of an article. */
 export const articleBlockSchema = z
-  .discriminatedUnion('type', [articleProseBlockSchema, articleChartBlockSchema])
-  .meta({ description: 'An article content block (prose or chart)', id: 'ArticleBlock' })
+  .discriminatedUnion('type', [
+    articleProseBlockSchema,
+    articleChartBlockSchema,
+    articleCorrelationBlockSchema,
+  ])
+  .meta({ description: 'An article content block (prose, chart, or correlation)', id: 'ArticleBlock' })
 
 export type ArticleBlock = z.infer<typeof articleBlockSchema>
 
 /**
  * The stored content of an article post: a title, an optional article-level
- * default window that chart blocks inherit, and the ordered blocks.
+ * default window that chart and correlation blocks inherit, and the ordered blocks.
  */
 export const articleContentSchema = z
   .object({
     blocks: z.array(articleBlockSchema).max(100).meta({ description: 'Ordered content blocks' }),
     default_end: iso8601DateTimeSchema
       .optional()
-      .meta({ description: 'Default window end inherited by chart blocks (ISO 8601)' }),
+      .meta({ description: 'Default window end inherited by chart and correlation blocks (ISO 8601)' }),
     default_start: iso8601DateTimeSchema
       .optional()
-      .meta({ description: 'Default window start inherited by chart blocks (ISO 8601)' }),
+      .meta({ description: 'Default window start inherited by chart and correlation blocks (ISO 8601)' }),
     title: z.string().min(1).max(200).meta({ description: 'Article title' }),
   })
   .meta({ id: 'ArticleContent' })
@@ -261,13 +294,13 @@ export const createArticleBodySchema = z
       .array(articleBlockSchema)
       .max(100)
       .default([])
-      .meta({ description: 'Ordered content blocks (prose + charts)' }),
+      .meta({ description: 'Ordered content blocks (prose, charts, correlations)' }),
     default_end: iso8601DateTimeSchema
       .optional()
-      .meta({ description: 'Default window end inherited by chart blocks (ISO 8601)' }),
+      .meta({ description: 'Default window end inherited by chart and correlation blocks (ISO 8601)' }),
     default_start: iso8601DateTimeSchema
       .optional()
-      .meta({ description: 'Default window start inherited by chart blocks (ISO 8601)' }),
+      .meta({ description: 'Default window start inherited by chart and correlation blocks (ISO 8601)' }),
     title: z.string().min(1).max(200).meta({ description: 'Article title' }),
     visibility: feedVisibilitySchema.default('public'),
   })


### PR DESCRIPTION
Part of #934 (Shareable analysis Articles), **Slice B (#936)** — first PR (schema + backend + lossless web integration).

Adds a **correlation** article block: a scatter of a `trigger` predictor against an `outcome` over a locked `[start, end]` window, reusing the exploratory correlation engine's selectors (`CorrelationSelector`) plus an optional `lag_days`. Like a chart block, it inherits the article's default window and re-resolves **live** (no snapshot).

## What's here

**Schema + backend**
- **api-spec** — `articleCorrelationBlockSchema` (`{ type: 'correlation', trigger, outcome, lag_days?, start?, end?, caption? }`) added to the `articleBlockSchema` discriminated union; imports `selectorSchema` from `correlations.ts` (no import cycle — correlations imports only `common`). This gives **MCP↔REST parity automatically**: `create_article`/`update_article` and `POST`/`PATCH /feed/articles` both consume the blocks union, so they accept correlation blocks with no new tool or route.
- **backend** — generalized `chartBlockWindow` → `blockWindow` and extended `buildArticleContent` to validate correlation blocks' effective windows (bounded, `start < end`) via a shared per-block error label.

**Web (lossless, no new UI yet)**
Adding a variant to the shared union forces web to handle it. To keep web compiling **without losing data**:
- `article-editor-body` — a `CorrelationDraft` passthrough carries the stored block verbatim, so `draftsFromPost` → editor → `buildArticleBody` round-trips it. Editing an MCP-authored article no longer risks dropping a correlation block.
- `ArticleEditorDialog` — a correlation block shows as a read-only row (reorder/remove work; a "🔗 Correlation" chip + note).
- `ArticleContent` — correlation blocks are skipped in render for now.

**Tests** — 15 backend `buildArticleContent` cases (incl. 4 correlation-window ones) + 2 web round-trip cases for the passthrough. **Docs** — `docs/features/feed.md` article section + API table updated.

Feed article-block schemas aren't part of the generated OpenAPI/Kotlin (feed endpoints aren't in `openapi.ts`), so `pnpm generate` produced no diff — same as Slice A's #943.

## Follow-ups in this slice

- **Render** — extract the `ScatterPlot` from the Correlations explorer into a reusable component and add `ArticleCorrelationBlock` (client-side authed `fetchContinuousCorrelation` over the block's effective window → scatter + r/ρ/n + caption); wire it into `ArticleContent`.
- **Composer** — replace the read-only editor row with real trigger/outcome selector pickers (+ window + lag), populated from `GET /correlations/selectors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)