### PR TITLE
feat(feed): render article correlation blocks as a live scatter (#936)

### DIFF
--- a/apps/web/src/pages/Feed/ArticleContent.tsx
+++ b/apps/web/src/pages/Feed/ArticleContent.tsx
@@ -2,14 +2,15 @@
  * Render an article post inline: its title followed by the ordered content
  * blocks. Prose blocks go through the shared markdown sanitiser (#910 — the XSS
  * boundary; article prose may be authored by AI or, later, a different user).
- * Chart blocks resolve their effective window (own override else the article
- * default) and render live via `ArticleChartBlock`. Correlation-block rendering
- * (a live scatter) lands in a follow-up; they're skipped here for now.
+ * Chart and correlation blocks resolve their effective window (own override else
+ * the article default) and render live via `ArticleChartBlock` /
+ * `ArticleCorrelationBlock`.
  */
 import type { ArticleContent as ArticleContentType } from '@aurboda/api-spec'
 
 import { renderMarkdown } from '../../utils/markdown'
 import { ArticleChartBlock } from './ArticleChartBlock'
+import { ArticleCorrelationBlock } from './ArticleCorrelationBlock'
 
 export const ArticleContent = ({ article }: { article: ArticleContentType }) => (
   <div class="article-content">
@@ -24,10 +25,28 @@ export const ArticleContent = ({ article }: { article: ArticleContentType }) => 
           />
         )
       }
-      // Correlation-block rendering (a live scatter) lands in a follow-up.
-      if (block.type === 'correlation') return null
       const start = block.start ?? article.default_start
       const end = block.end ?? article.default_end
+      if (block.type === 'correlation') {
+        if (start == null || end == null) {
+          return (
+            <p key={`corr-${i}`} class="article-chart-note">
+              This correlation has no time window.
+            </p>
+          )
+        }
+        return (
+          <ArticleCorrelationBlock
+            key={`corr-${i}`}
+            caption={block.caption}
+            end={end}
+            lagDays={block.lag_days}
+            outcome={block.outcome}
+            start={start}
+            trigger={block.trigger}
+          />
+        )
+      }
       if (start == null || end == null) {
         return (
           <p key={`chart-${i}`} class="article-chart-note">

--- a/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
+++ b/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
@@ -38,12 +38,14 @@ const CorrelationScatterSvg = ({ data }: { data: ContinuousCorrelationData }) =>
   const sy = (y: number) => H - PAD.bottom - ((y - yMin) / (yMax - yMin || 1)) * (H - PAD.top - PAD.bottom)
   const reg = linearRegression(xs, ys)
 
+  const label = `Scatter of ${describeSelectorAxis(data.trigger)} versus ${describeSelectorAxis(data.outcome)}; r=${fmt(data.pearson)}, n=${data.n}`
+
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} class="article-scatter" role="img">
+    <svg viewBox={`0 0 ${W} ${H}`} class="article-scatter" role="img" aria-label={label}>
       <line x1={PAD.left} y1={H - PAD.bottom} x2={W - PAD.right} y2={H - PAD.bottom} stroke="#ccc" />
       <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={H - PAD.bottom} stroke="#ccc" />
       {data.series.map((p) => (
-        <circle cx={sx(p.trigger)} cy={sy(p.outcome)} r={3} fill={POINT_COLOR} opacity={0.45} />
+        <circle key={p.date} cx={sx(p.trigger)} cy={sy(p.outcome)} r={3} fill={POINT_COLOR} opacity={0.45} />
       ))}
       {reg && (
         <line
@@ -74,8 +76,13 @@ const CorrelationScatterSvg = ({ data }: { data: ContinuousCorrelationData }) =>
   )
 }
 
-/** ISO instant → inclusive `YYYY-MM-DD` regime bound for the correlation query. */
-const toDay = (iso: string): string => new Date(iso).toISOString().slice(0, 10)
+/**
+ * ISO instant → inclusive `YYYY-MM-DD` regime bound for the correlation query.
+ * Take the date straight off the ISO string (every ISO 8601 datetime starts with
+ * `YYYY-MM-DD`) so the bound is the author's wall-clock day — not a UTC day that
+ * could roll back for a window authored with a non-UTC offset near midnight.
+ */
+const toDay = (iso: string): string => iso.slice(0, 10)
 
 export const ArticleCorrelationBlock = ({
   trigger,

--- a/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
+++ b/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
@@ -38,7 +38,14 @@ const CorrelationScatterSvg = ({ data }: { data: ContinuousCorrelationData }) =>
   const sy = (y: number) => H - PAD.bottom - ((y - yMin) / (yMax - yMin || 1)) * (H - PAD.top - PAD.bottom)
   const reg = linearRegression(xs, ys)
 
-  const label = `Scatter of ${describeSelectorAxis(data.trigger)} versus ${describeSelectorAxis(data.outcome)}; r=${fmt(data.pearson)}, n=${data.n}`
+  // For a binary/presence trigger (0/1 — tags, activities, apps) a Pearson r is
+  // misleading, so lead with the present-vs-absent group comparison instead, the
+  // same call the Correlations explorer makes.
+  const gc = data.group_comparison
+  const headline = gc?.trigger_is_binary
+    ? `Δ(present−absent)=${fmt(gc.difference)} · d=${fmt(gc.cohens_d)} · n=${data.n} · p=${fmtP(gc.welch?.p_value)}`
+    : `r=${fmt(data.pearson)} · ρ=${fmt(data.spearman)} · n=${data.n} · p=${fmtP(data.pearson_p)}`
+  const label = `Scatter of ${describeSelectorAxis(data.trigger)} versus ${describeSelectorAxis(data.outcome)}; ${headline}`
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} class="article-scatter" role="img" aria-label={label}>
@@ -58,7 +65,7 @@ const CorrelationScatterSvg = ({ data }: { data: ContinuousCorrelationData }) =>
         />
       )}
       <text x={PAD.left + 6} y={PAD.top + 12} class="article-scatter-annot">
-        r={fmt(data.pearson)} · ρ={fmt(data.spearman)} · n={data.n} · p={fmtP(data.pearson_p)}
+        {headline}
       </text>
       <text x={(PAD.left + (W - PAD.right)) / 2} y={H - 8} text-anchor="middle" class="article-scatter-axis">
         {describeSelectorAxis(data.trigger)}

--- a/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
+++ b/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
@@ -1,0 +1,121 @@
+/**
+ * One inline correlation block of an article: a scatter of a `trigger` predictor
+ * against an `outcome`, both resolved **live** over the block's locked
+ * `[start, end]` window (no snapshot) via the owner-authenticated continuous
+ * correlation endpoint. The caller (`ArticleContent`) resolves the effective
+ * window (block override else the article default) and passes concrete ISO
+ * strings. The scatter reuses the shared correlation maths (`linearRegression`,
+ * `describeSelectorAxis`) — a purpose-built, compact in-card render rather than
+ * the full Correlations-explorer visualisation.
+ */
+import type { ContinuousCorrelationData, CorrelationSelector } from '@aurboda/api-spec'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchContinuousCorrelation } from '../../state/api'
+import { describeSelectorAxis, linearRegression } from '../Correlations/exploreCharts'
+
+const W = 520
+const H = 300
+const PAD = { bottom: 44, left: 52, right: 16, top: 16 }
+const POINT_COLOR = '#673ab8'
+const REG_COLOR = '#e0457b'
+
+const fmt = (value: number | null | undefined, digits = 2): string =>
+  value == null ? '—' : value.toFixed(digits)
+
+const fmtP = (p: number | null | undefined): string => (p == null ? '—' : p < 0.001 ? '<0.001' : p.toFixed(3))
+
+/** The scatter itself: points + OLS regression line + r/ρ/n/p annotation + axes. */
+const CorrelationScatterSvg = ({ data }: { data: ContinuousCorrelationData }) => {
+  const xs = data.series.map((p) => p.trigger)
+  const ys = data.series.map((p) => p.outcome)
+  const xMin = Math.min(...xs)
+  const xMax = Math.max(...xs)
+  const yMin = Math.min(...ys)
+  const yMax = Math.max(...ys)
+  const sx = (x: number) => PAD.left + ((x - xMin) / (xMax - xMin || 1)) * (W - PAD.left - PAD.right)
+  const sy = (y: number) => H - PAD.bottom - ((y - yMin) / (yMax - yMin || 1)) * (H - PAD.top - PAD.bottom)
+  const reg = linearRegression(xs, ys)
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} class="article-scatter" role="img">
+      <line x1={PAD.left} y1={H - PAD.bottom} x2={W - PAD.right} y2={H - PAD.bottom} stroke="#ccc" />
+      <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={H - PAD.bottom} stroke="#ccc" />
+      {data.series.map((p) => (
+        <circle cx={sx(p.trigger)} cy={sy(p.outcome)} r={3} fill={POINT_COLOR} opacity={0.45} />
+      ))}
+      {reg && (
+        <line
+          x1={sx(xMin)}
+          y1={sy(reg.slope * xMin + reg.intercept)}
+          x2={sx(xMax)}
+          y2={sy(reg.slope * xMax + reg.intercept)}
+          stroke={REG_COLOR}
+          stroke-width={2}
+        />
+      )}
+      <text x={PAD.left + 6} y={PAD.top + 12} class="article-scatter-annot">
+        r={fmt(data.pearson)} · ρ={fmt(data.spearman)} · n={data.n} · p={fmtP(data.pearson_p)}
+      </text>
+      <text x={(PAD.left + (W - PAD.right)) / 2} y={H - 8} text-anchor="middle" class="article-scatter-axis">
+        {describeSelectorAxis(data.trigger)}
+      </text>
+      <text
+        x={14}
+        y={(PAD.top + (H - PAD.bottom)) / 2}
+        text-anchor="middle"
+        class="article-scatter-axis"
+        transform={`rotate(-90 14 ${(PAD.top + (H - PAD.bottom)) / 2})`}
+      >
+        {describeSelectorAxis(data.outcome)}
+      </text>
+    </svg>
+  )
+}
+
+/** ISO instant → inclusive `YYYY-MM-DD` regime bound for the correlation query. */
+const toDay = (iso: string): string => new Date(iso).toISOString().slice(0, 10)
+
+export const ArticleCorrelationBlock = ({
+  trigger,
+  outcome,
+  lagDays,
+  start,
+  end,
+  caption,
+}: {
+  trigger: CorrelationSelector
+  outcome: CorrelationSelector
+  lagDays?: number
+  start: string
+  end: string
+  caption?: string
+}) => {
+  const { data, isLoading, isError } = useQuery({
+    queryFn: () =>
+      fetchContinuousCorrelation({
+        outcome,
+        period_end: toDay(end),
+        period_start: toDay(start),
+        trigger,
+        ...(lagDays ? { lag_days: lagDays } : {}),
+      }),
+    queryKey: ['article-correlation', JSON.stringify(trigger), JSON.stringify(outcome), lagDays, start, end],
+  })
+
+  return (
+    <figure class="article-chart">
+      {isLoading ? (
+        <p class="article-chart-note">Loading correlation…</p>
+      ) : isError ? (
+        <p class="article-chart-note">Couldn't load this correlation.</p>
+      ) : !data || data.n < 3 ? (
+        <p class="article-chart-note">Not enough overlapping data in this window.</p>
+      ) : (
+        <CorrelationScatterSvg data={data} />
+      )}
+      {caption && <figcaption class="article-chart-caption">{caption}</figcaption>}
+    </figure>
+  )
+}

--- a/apps/web/src/pages/Feed/FeedPostCard.css
+++ b/apps/web/src/pages/Feed/FeedPostCard.css
@@ -139,6 +139,21 @@
   text-align: center;
 }
 
+.article-scatter {
+  width: 100%;
+  height: auto;
+}
+
+.article-scatter-annot {
+  font-size: 12px;
+  fill: #4b5563;
+}
+
+.article-scatter-axis {
+  font-size: 11px;
+  fill: #6b7280;
+}
+
 @media (prefers-color-scheme: dark) {
   .feed-post {
     border-color: #374151;
@@ -156,6 +171,14 @@
 
   .article-chart-title {
     color: #d1d5db;
+  }
+
+  .article-scatter-annot {
+    fill: #d1d5db;
+  }
+
+  .article-scatter-axis {
+    fill: #9ca3af;
   }
 
   .feed-post-avatar,

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -34,8 +34,9 @@ A feed post has a **`kind`**:
   `update_article` MCP tools), or in the web app's article composer; prose renders
   through the shared markdown sanitiser and each windowed block resolves its data live
   over the locked window.
-  _The correlation-block scatter render and its composer UI land within this slice
-  (#936); federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
+  _The correlation-block composer UI (selector pickers) lands within this slice (#936) —
+  correlation blocks already render as a live scatter and are authorable over MCP/API;
+  federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
   (#937), so an article is authored and shown on the owner's own feed but does not yet
   fan out to followers._
 


### PR DESCRIPTION
Part of #934 (Shareable analysis Articles), **Slice B (#936)** — second PR (web render). Builds on the schema + backend from #946.

Correlation article blocks now **render** on the owner's feed as a live scatter.

## What's here

- **`ArticleCorrelationBlock`** (`pages/Feed/ArticleCorrelationBlock.tsx`) — resolves the block's effective window (own override else the article default), fetches the continuous daily correlation **live** over that window via the owner-authenticated `POST /correlations/continuous`, and draws a compact in-card scatter: points, an OLS regression line, and an `r · ρ · n · p` annotation with selector-labelled axes. Loading / error / "not enough overlapping data" states mirror `ArticleChartBlock`.
- **`ArticleContent`** — renders correlation blocks (replacing the interim skip from #946), with the same "no time window" fallback as chart blocks.
- **CSS** — `.article-scatter*` styles (light + dark) alongside the existing `.article-chart*`.

## Notes

- **DRY** — reuses the shared, unit-tested correlation maths (`linearRegression`, `describeSelectorAxis` from the explorer's `exploreCharts.ts`). The SVG is a purpose-built compact render rather than the explorer's full scatter/box-plot component; unifying the two SVGs would entangle the box-plot mode and the explorer's CSS, so it's left as a possible future cleanup.
- **Live, owner-scoped** — data is re-resolved live (no snapshot). The fetch is owner-authenticated, so this renders only for the article owner; **public/federated correlation rendering is deferred to Slice C (#937)** alongside the public chart-image work — consistent with how chart blocks render client-side today.
- **Tests** — following the codebase convention, fetch/render components (`ArticleChartBlock`) carry no unit test; the reused maths is covered by `exploreCharts.test.ts`.

## Follow-up in this slice

- **Composer** — trigger/outcome selector pickers (+ window + lag) in the article editor, replacing the read-only passthrough row from #946, populated from `GET /correlations/selectors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)