### PR TITLE
feat(feed): compose correlation blocks in the article editor (#936)

### DIFF
--- a/apps/web/src/components/ArticleEditorDialog.tsx
+++ b/apps/web/src/components/ArticleEditorDialog.tsx
@@ -91,6 +91,7 @@ const CorrelationBlockFields = ({
       <span class="article-field-label">Lag days (optional)</span>
       <input
         type="number"
+        step="1"
         class="article-input"
         value={block.lagDays}
         placeholder="0 — days the outcome lags the trigger"

--- a/apps/web/src/components/ArticleEditorDialog.tsx
+++ b/apps/web/src/components/ArticleEditorDialog.tsx
@@ -1,27 +1,34 @@
-import type { FeedPost, FeedVisibility } from '@aurboda/api-spec'
+import type { CorrelationSelectorsData, FeedPost, FeedVisibility } from '@aurboda/api-spec'
 
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRef, useState } from 'preact/hooks'
 
 /**
  * Compose or edit a long-form **article** feed post: a title, an optional
- * article-level default time window, and an ordered list of prose / chart blocks.
- * Passing an existing `post` (kind `article`) switches to edit mode (PATCH);
- * otherwise it creates one (POST). Prose is written in the shared MarkdownEditor;
- * a chart block picks a metric and an optional window (inheriting the article
- * default when left blank) — the same shape Claude drafts over MCP.
+ * article-level default time window, and an ordered list of prose / chart /
+ * correlation blocks. Passing an existing `post` (kind `article`) switches to
+ * edit mode (PATCH); otherwise it creates one (POST). Prose is written in the
+ * shared MarkdownEditor; a chart block picks a metric and an optional window; a
+ * correlation block picks a trigger + outcome selector — the same shapes Claude
+ * drafts over MCP. Windowed blocks inherit the article default when left blank.
  */
-import type { BlockDraft, ChartDraft, ProseDraft } from './article-editor-body'
+import type { BlockDraft, ChartDraft, CorrelationDraft, ProseDraft } from './article-editor-body'
 
-import { createArticle, updateArticle } from '../state/api'
-import { buildArticleBody, deriveSubmitError, initialArticleEditorState } from './article-editor-body'
+import { createArticle, fetchCorrelationSelectors, updateArticle } from '../state/api'
+import {
+  buildArticleBody,
+  deriveSubmitError,
+  emptyCorrelationDraft,
+  initialArticleEditorState,
+} from './article-editor-body'
 import { MarkdownEditor } from './MarkdownEditor'
 import { MetricPicker } from './MetricPicker'
+import { ALL_SELECTOR_KINDS, SelectorPicker } from './SelectorPicker'
 import { FEED_VISIBILITY_OPTIONS, VisibilitySelector } from './VisibilitySelector'
 import './ShareActivityDialog.css'
 import './ArticleEditorDialog.css'
 
-type BlockPatch = Partial<ChartDraft> & Partial<ProseDraft>
+type BlockPatch = Partial<ChartDraft> & Partial<CorrelationDraft> & Partial<ProseDraft>
 
 /**
  * A draft block plus a stable identity, used only as the React `key`. Blocks are
@@ -31,15 +38,86 @@ type BlockPatch = Partial<ChartDraft> & Partial<ProseDraft>
  */
 type KeyedBlock = { key: string; block: BlockDraft }
 
+/** The editable fields of a correlation block: trigger + outcome selectors, window, lag, caption. */
+const CorrelationBlockFields = ({
+  block,
+  selectors,
+  onPatch,
+}: {
+  block: CorrelationDraft
+  selectors: CorrelationSelectorsData | undefined
+  onPatch: (patch: BlockPatch) => void
+}) => (
+  <div class="article-chart-fields">
+    <label class="article-field">
+      <span class="article-field-label">Trigger (predictor)</span>
+      <SelectorPicker
+        value={block.trigger}
+        onChange={(s) => onPatch({ trigger: s })}
+        selectors={selectors}
+        allowedKinds={ALL_SELECTOR_KINDS}
+      />
+    </label>
+    <label class="article-field">
+      <span class="article-field-label">Outcome</span>
+      <SelectorPicker
+        value={block.outcome}
+        onChange={(s) => onPatch({ outcome: s })}
+        selectors={selectors}
+        allowedKinds={ALL_SELECTOR_KINDS}
+      />
+    </label>
+    <div class="article-window">
+      <label class="article-field">
+        <span class="article-field-label">From (optional)</span>
+        <input
+          type="datetime-local"
+          class="article-input"
+          value={block.start}
+          onInput={(e) => onPatch({ start: (e.target as HTMLInputElement).value })}
+        />
+      </label>
+      <label class="article-field">
+        <span class="article-field-label">To (optional)</span>
+        <input
+          type="datetime-local"
+          class="article-input"
+          value={block.end}
+          onInput={(e) => onPatch({ end: (e.target as HTMLInputElement).value })}
+        />
+      </label>
+    </div>
+    <label class="article-field">
+      <span class="article-field-label">Lag days (optional)</span>
+      <input
+        type="number"
+        class="article-input"
+        value={block.lagDays}
+        placeholder="0 — days the outcome lags the trigger"
+        onInput={(e) => onPatch({ lagDays: (e.target as HTMLInputElement).value })}
+      />
+    </label>
+    <label class="article-field">
+      <span class="article-field-label">Caption (optional)</span>
+      <input
+        type="text"
+        class="article-input"
+        value={block.caption}
+        onInput={(e) => onPatch({ caption: (e.target as HTMLInputElement).value })}
+      />
+    </label>
+  </div>
+)
+
 /**
- * One content block with its reorder / remove controls. Prose and chart blocks
- * are editable inline; a correlation block is shown read-only for now (authored
- * over MCP/API) but can still be reordered or removed.
+ * One content block with its reorder / remove controls. Prose, chart, and
+ * correlation blocks are all editable inline.
  */
 const ArticleBlockEditor = ({
   block,
   index,
   total,
+  selectors,
   onPatch,
   onMove,
   onRemove,
@@ -47,6 +125,7 @@ const ArticleBlockEditor = ({
   block: BlockDraft
   index: number
   total: number
+  selectors: CorrelationSelectorsData | undefined
   onPatch: (patch: BlockPatch) => void
   onMove: (dir: -1 | 1) => void
   onRemove: () => void
@@ -88,10 +167,7 @@ const ArticleBlockEditor = ({
         placeholder="Write your analysis (markdown supported)…"
       />
     ) : block.type === 'correlation' ? (
-      <p class="share-dialog-note">
-        Correlation block — authored via Claude/MCP for now. You can reorder or remove it here; editing its
-        selectors in the composer is coming soon.
-      </p>
+      <CorrelationBlockFields block={block} selectors={selectors} onPatch={onPatch} />
     ) : (
       <div class="article-chart-fields">
         <label class="article-field">
@@ -136,6 +212,11 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
   const queryClient = useQueryClient()
   const editing = post?.kind === 'article'
   const [initial] = useState(() => initialArticleEditorState(post))
+  const { data: selectors } = useQuery({
+    queryFn: fetchCorrelationSelectors,
+    queryKey: ['correlationSelectors'],
+    staleTime: 5 * 60 * 1000,
+  })
 
   const [title, setTitle] = useState(initial.title)
   const [defaultStart, setDefaultStart] = useState(initial.defaultStart)
@@ -165,6 +246,7 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
       ...bs,
       keyed({ bucket: '', caption: '', end: '', metric: '', start: '', type: 'chart' }),
     ])
+  const addCorrelation = () => setBlocks((bs) => [...bs, keyed(emptyCorrelationDraft())])
 
   const mutation = useMutation({
     mutationFn: () => {
@@ -245,6 +327,7 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
               block={kb.block}
               index={i}
               total={blocks.length}
+              selectors={selectors}
               onPatch={(patch) => patchBlock(i, patch)}
               onMove={(dir) => moveBlock(i, dir)}
               onRemove={() => removeBlock(i)}
@@ -258,6 +341,9 @@ export const ArticleEditorDialog = ({ post, onClose }: { post?: FeedPost; onClos
           </button>
           <button type="button" class="btn-secondary" onClick={addChart}>
             + Chart
+          </button>
+          <button type="button" class="btn-secondary" onClick={addCorrelation}>
+            + Correlation
           </button>
         </div>
 

--- a/apps/web/src/components/SelectorPicker.css
+++ b/apps/web/src/components/SelectorPicker.css
@@ -1,0 +1,14 @@
+.selector-picker {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.selector-picker select,
+.selector-picker input {
+  padding: 6px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}

--- a/apps/web/src/components/SelectorPicker.tsx
+++ b/apps/web/src/components/SelectorPicker.tsx
@@ -1,0 +1,122 @@
+/**
+ * Pick a correlation **selector** — a data dimension (a metric, a nutrient, or a
+ * regex over activities / productivity) that the correlation engine resolves to a
+ * daily series. A kind dropdown plus the inputs for that kind, autocompleted from
+ * the discovered `selectors`. Shared by the Correlations explorer and the article
+ * composer's correlation blocks.
+ */
+import type { CorrelationSelector, CorrelationSelectorsData, NutrientKey } from '@aurboda/api-spec'
+
+import './SelectorPicker.css'
+
+const NUTRIENTS: NutrientKey[] = ['calories', 'protein', 'carbs', 'fat', 'fiber']
+
+/** Human labels for selector kinds (the raw kind is opaque in a dropdown). */
+const KIND_LABELS: Partial<Record<CorrelationSelector['kind'], string>> = {
+  activity: 'activity / tag',
+  productivity_app: 'productivity app',
+  productivity_category: 'productivity category',
+}
+
+/** Every selector kind offered when either side may be continuous (e.g. article blocks). */
+export const ALL_SELECTOR_KINDS: CorrelationSelector['kind'][] = [
+  'metric',
+  'activity',
+  'nutrition',
+  'productivity_category',
+  'productivity_app',
+]
+
+export function SelectorPicker({
+  value,
+  onChange,
+  selectors,
+  allowedKinds,
+}: {
+  value: CorrelationSelector
+  onChange: (s: CorrelationSelector) => void
+  selectors: CorrelationSelectorsData | undefined
+  allowedKinds: CorrelationSelector['kind'][]
+}) {
+  const setKind = (kind: CorrelationSelector['kind']) => {
+    switch (kind) {
+      case 'metric':
+        return onChange({ kind: 'metric', metric: '' })
+      case 'nutrition':
+        return onChange({ kind: 'nutrition', nutrient: 'carbs' })
+      case 'activity':
+        return onChange({ kind: 'activity', pattern: '' })
+      case 'productivity_category':
+      case 'productivity_app':
+        return onChange({ kind, pattern: '' })
+      default:
+        return onChange({ kind: 'activity', pattern: '' })
+    }
+  }
+
+  return (
+    <div class="selector-picker">
+      <select
+        value={value.kind}
+        onChange={(e) => setKind((e.target as HTMLSelectElement).value as CorrelationSelector['kind'])}
+      >
+        {allowedKinds.map((k) => (
+          <option value={k}>{KIND_LABELS[k] ?? k}</option>
+        ))}
+      </select>
+
+      {value.kind === 'metric' && (
+        <>
+          <input
+            list="selector-metric-options"
+            placeholder="metric (e.g. sleep_score)"
+            value={value.metric}
+            onInput={(e) => onChange({ ...value, metric: (e.target as HTMLInputElement).value })}
+          />
+          <datalist id="selector-metric-options">
+            {selectors?.metrics.map((m) => (
+              <option value={m.value}>{m.label}</option>
+            ))}
+          </datalist>
+        </>
+      )}
+
+      {value.kind === 'nutrition' && (
+        <select
+          value={value.nutrient}
+          onChange={(e) =>
+            onChange({ kind: 'nutrition', nutrient: (e.target as HTMLSelectElement).value as NutrientKey })
+          }
+        >
+          {NUTRIENTS.map((n) => (
+            <option value={n}>{n}</option>
+          ))}
+        </select>
+      )}
+
+      {(value.kind === 'tag' ||
+        value.kind === 'activity' ||
+        value.kind === 'productivity_category' ||
+        value.kind === 'productivity_app') && (
+        <>
+          <input
+            list={`selector-pattern-options-${value.kind}`}
+            placeholder="pattern (regex)"
+            value={value.pattern}
+            onInput={(e) => onChange({ ...value, pattern: (e.target as HTMLInputElement).value })}
+          />
+          <datalist id={`selector-pattern-options-${value.kind}`}>
+            {(value.kind === 'productivity_category'
+              ? selectors?.productivity_categories
+              : value.kind === 'tag'
+                ? selectors?.tags
+                : selectors?.activity_types
+            )?.map((o) => (
+              <option value={o.value}>{o.label}</option>
+            ))}
+          </datalist>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/article-editor-body.test.ts
+++ b/apps/web/src/components/article-editor-body.test.ts
@@ -7,6 +7,7 @@ import {
   buildArticleBody,
   deriveSubmitError,
   draftsFromPost,
+  emptyCorrelationDraft,
   toInputValue,
   toIso,
 } from './article-editor-body'
@@ -118,23 +119,60 @@ describe('deriveSubmitError', () => {
 })
 
 const correlationBlock: Extract<ArticleBlock, { type: 'correlation' }> = {
+  caption: 'HRV vs training',
   end: '2026-07-07T00:00:00.000Z',
+  lag_days: 1,
   outcome: { kind: 'metric', metric: 'sleep_score' },
   start: '2026-07-01T00:00:00.000Z',
   trigger: { kind: 'activity', pattern: 'exercise' },
   type: 'correlation',
 }
 
-describe('correlation passthrough', () => {
-  it('seeds a verbatim passthrough draft from a stored correlation block', () => {
+const completeCorrelationDraft = () => ({
+  ...emptyCorrelationDraft(),
+  outcome: { kind: 'metric' as const, metric: 'sleep_score' },
+  trigger: { kind: 'activity' as const, pattern: 'exercise' },
+})
+
+describe('correlation drafts', () => {
+  it('seeds an editable draft from a stored correlation block', () => {
     const post = { article: { blocks: [correlationBlock], title: 'T' }, kind: 'article' } as FeedPost
-    expect(draftsFromPost(post)).toEqual([{ block: correlationBlock, type: 'correlation' }])
+    expect(draftsFromPost(post)).toEqual([
+      {
+        caption: 'HRV vs training',
+        end: toInputValue('2026-07-07T00:00:00.000Z'),
+        lagDays: '1',
+        outcome: { kind: 'metric', metric: 'sleep_score' },
+        start: toInputValue('2026-07-01T00:00:00.000Z'),
+        trigger: { kind: 'activity', pattern: 'exercise' },
+        type: 'correlation',
+      },
+    ])
   })
 
-  it('emits the stored correlation block back unchanged (lossless round-trip)', () => {
-    const result = buildArticleBody(state({ blocks: [{ block: correlationBlock, type: 'correlation' }] }))
+  it('round-trips a stored correlation block through seed → build (lossless)', () => {
+    const post = { article: { blocks: [correlationBlock], title: 'T' }, kind: 'article' } as FeedPost
+    const result = buildArticleBody(state({ blocks: draftsFromPost(post) }))
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.body.blocks[0]).toEqual(correlationBlock)
+  })
+
+  it('rejects a correlation block with an unfilled trigger', () => {
+    const result = buildArticleBody(state({ blocks: [emptyCorrelationDraft()] }))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('trigger')
+  })
+
+  it('omits empty optional fields (no window / lag / caption)', () => {
+    const result = buildArticleBody(state({ blocks: [completeCorrelationDraft()] }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.body.blocks[0]).toEqual({
+        outcome: { kind: 'metric', metric: 'sleep_score' },
+        trigger: { kind: 'activity', pattern: 'exercise' },
+        type: 'correlation',
+      })
+    }
   })
 })
 

--- a/apps/web/src/components/article-editor-body.test.ts
+++ b/apps/web/src/components/article-editor-body.test.ts
@@ -163,6 +163,18 @@ describe('correlation drafts', () => {
     if (!result.ok) expect(result.error).toContain('trigger')
   })
 
+  it('rejects a non-integer lag (caught early, not left to the server)', () => {
+    const result = buildArticleBody(state({ blocks: [{ ...completeCorrelationDraft(), lagDays: '1.5' }] }))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('whole number')
+  })
+
+  it('keeps an integer lag on the built block', () => {
+    const result = buildArticleBody(state({ blocks: [{ ...completeCorrelationDraft(), lagDays: '2' }] }))
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.body.blocks[0]).toMatchObject({ lag_days: 2 })
+  })
+
   it('omits empty optional fields (no window / lag / caption)', () => {
     const result = buildArticleBody(state({ blocks: [completeCorrelationDraft()] }))
     expect(result.ok).toBe(true)

--- a/apps/web/src/components/article-editor-body.ts
+++ b/apps/web/src/components/article-editor-body.ts
@@ -156,6 +156,9 @@ const buildCorrelationBlock = (b: CorrelationDraft, i: number): BlockResult => {
   const missing = selectorIncomplete(b.trigger) ? 'trigger' : selectorIncomplete(b.outcome) ? 'outcome' : null
   if (missing) return { error: `Correlation block ${i + 1}: choose a ${missing} (metric or pattern).` }
   const lag = Number(b.lagDays)
+  if (b.lagDays.trim() && !Number.isInteger(lag)) {
+    return { error: `Correlation block ${i + 1}: lag days must be a whole number.` }
+  }
   return {
     block: {
       outcome: b.outcome,
@@ -163,7 +166,7 @@ const buildCorrelationBlock = (b: CorrelationDraft, i: number): BlockResult => {
       type: 'correlation',
       ...(toIso(b.start) ? { start: toIso(b.start) } : {}),
       ...(toIso(b.end) ? { end: toIso(b.end) } : {}),
-      ...(b.lagDays.trim() && Number.isFinite(lag) && lag !== 0 ? { lag_days: lag } : {}),
+      ...(b.lagDays.trim() && lag !== 0 ? { lag_days: lag } : {}),
       ...(b.caption.trim() ? { caption: b.caption.trim() } : {}),
     },
   }

--- a/apps/web/src/components/article-editor-body.ts
+++ b/apps/web/src/components/article-editor-body.ts
@@ -4,7 +4,13 @@
  * `buildShareBody`). Handles the `datetime-local` ⇄ ISO conversion, seeding the
  * editor from an existing post, and building/validating the create/update body.
  */
-import type { ArticleBlock, CreateArticleBody, FeedPost, FeedVisibility } from '@aurboda/api-spec'
+import type {
+  ArticleBlock,
+  CorrelationSelector,
+  CreateArticleBody,
+  FeedPost,
+  FeedVisibility,
+} from '@aurboda/api-spec'
 
 import { isValidMetric } from '@aurboda/api-spec'
 
@@ -21,17 +27,34 @@ export interface ChartDraft {
   bucket: string
   caption: string
 }
-/**
- * A correlation block, kept verbatim. The web composer can't yet author or edit
- * correlation blocks (they're created over MCP/API); this passthrough lets the
- * editor round-trip an existing one — reorder/remove it — without dropping it.
- * A dedicated editing UI (selector pickers) lands in a follow-up.
- */
+/** A correlation block: a trigger×outcome scatter over the block's (or article's) window. */
 export interface CorrelationDraft {
   type: 'correlation'
-  block: Extract<ArticleBlock, { type: 'correlation' }>
+  trigger: CorrelationSelector
+  outcome: CorrelationSelector
+  /** `datetime-local` value ('' = inherit the article default window). */
+  start: string
+  end: string
+  /** Number-input value ('' = no lag). */
+  lagDays: string
+  caption: string
 }
 export type BlockDraft = ChartDraft | CorrelationDraft | ProseDraft
+
+/** A fresh correlation draft for the "+ Correlation" button (empty selectors). */
+export const emptyCorrelationDraft = (): CorrelationDraft => ({
+  caption: '',
+  end: '',
+  lagDays: '',
+  outcome: { kind: 'metric', metric: '' },
+  start: '',
+  trigger: { kind: 'activity', pattern: '' },
+  type: 'correlation',
+})
+
+/** A selector the author hasn't finished filling in (no metric / no pattern). */
+const selectorIncomplete = (s: CorrelationSelector): boolean =>
+  s.kind === 'metric' ? !s.metric.trim() : s.kind === 'nutrition' ? false : !s.pattern.trim()
 
 export interface ArticleEditorState {
   title: string
@@ -61,7 +84,17 @@ export const draftsFromPost = (post?: FeedPost): BlockDraft[] => {
   if (!post?.article) return []
   return post.article.blocks.map((b): BlockDraft => {
     if (b.type === 'prose') return { markdown: b.markdown, type: 'prose' }
-    if (b.type === 'correlation') return { block: b, type: 'correlation' }
+    if (b.type === 'correlation') {
+      return {
+        caption: b.caption ?? '',
+        end: toInputValue(b.end),
+        lagDays: b.lag_days != null ? String(b.lag_days) : '',
+        outcome: b.outcome,
+        start: toInputValue(b.start),
+        trigger: b.trigger,
+        type: 'correlation',
+      }
+    }
     return {
       bucket: b.bucket ?? '',
       caption: b.caption ?? '',
@@ -93,11 +126,55 @@ export const deriveSubmitError = (validationError: string | null, mutationError:
   return null
 }
 
+type BlockResult = { block: ArticleBlock } | { error: string }
+
+/** Build one chart block from its draft, or a validation error. */
+const buildChartBlock = (b: ChartDraft, i: number): BlockResult => {
+  if (!isValidMetric(b.metric)) {
+    // An empty pick vs. an unsupported (custom) metric — article charts accept
+    // only built-in metric types (the picker offers only those, but an article
+    // edited elsewhere could still carry one).
+    const error = b.metric
+      ? `Chart block ${i + 1}: “${b.metric}” can't be charted in an article (custom metrics aren't supported yet).`
+      : `Pick a metric for chart block ${i + 1}.`
+    return { error }
+  }
+  return {
+    block: {
+      metric: b.metric,
+      type: 'chart',
+      ...(toIso(b.start) ? { start: toIso(b.start) } : {}),
+      ...(toIso(b.end) ? { end: toIso(b.end) } : {}),
+      ...(b.bucket ? { bucket: b.bucket } : {}),
+      ...(b.caption.trim() ? { caption: b.caption.trim() } : {}),
+    },
+  }
+}
+
+/** Build one correlation block from its draft, or a validation error. */
+const buildCorrelationBlock = (b: CorrelationDraft, i: number): BlockResult => {
+  const missing = selectorIncomplete(b.trigger) ? 'trigger' : selectorIncomplete(b.outcome) ? 'outcome' : null
+  if (missing) return { error: `Correlation block ${i + 1}: choose a ${missing} (metric or pattern).` }
+  const lag = Number(b.lagDays)
+  return {
+    block: {
+      outcome: b.outcome,
+      trigger: b.trigger,
+      type: 'correlation',
+      ...(toIso(b.start) ? { start: toIso(b.start) } : {}),
+      ...(toIso(b.end) ? { end: toIso(b.end) } : {}),
+      ...(b.lagDays.trim() && Number.isFinite(lag) && lag !== 0 ? { lag_days: lag } : {}),
+      ...(b.caption.trim() ? { caption: b.caption.trim() } : {}),
+    },
+  }
+}
+
 /**
  * Build the create/update request body from the editor state, or return a
- * validation error. Requires a title and a valid metric on every chart block;
- * empty optional fields are omitted. The server re-validates chart windows
- * (`buildArticleContent`), so this only guards what the form can catch early.
+ * validation error. Requires a title, a valid metric on every chart block, and a
+ * filled-in trigger + outcome on every correlation block; empty optional fields
+ * are omitted. The server re-validates windows (`buildArticleContent`), so this
+ * only guards what the form can catch early.
  */
 export const buildArticleBody = (state: ArticleEditorState): BuildResult => {
   if (!state.title.trim()) return { error: 'Give your article a title.', ok: false }
@@ -108,27 +185,9 @@ export const buildArticleBody = (state: ArticleEditorState): BuildResult => {
       blocks.push({ markdown: b.markdown, type: 'prose' })
       continue
     }
-    if (b.type === 'correlation') {
-      blocks.push(b.block)
-      continue
-    }
-    if (!isValidMetric(b.metric)) {
-      // An empty pick vs. an unsupported (custom) metric — article charts accept
-      // only built-in metric types (the picker offers only those, but an article
-      // edited elsewhere could still carry one).
-      const error = b.metric
-        ? `Chart block ${i + 1}: “${b.metric}” can't be charted in an article (custom metrics aren't supported yet).`
-        : `Pick a metric for chart block ${i + 1}.`
-      return { error, ok: false }
-    }
-    blocks.push({
-      metric: b.metric,
-      type: 'chart',
-      ...(toIso(b.start) ? { start: toIso(b.start) } : {}),
-      ...(toIso(b.end) ? { end: toIso(b.end) } : {}),
-      ...(b.bucket ? { bucket: b.bucket } : {}),
-      ...(b.caption.trim() ? { caption: b.caption.trim() } : {}),
-    })
+    const built = b.type === 'correlation' ? buildCorrelationBlock(b, i) : buildChartBlock(b, i)
+    if ('error' in built) return { error: built.error, ok: false }
+    blocks.push(built.block)
   }
 
   return {

--- a/apps/web/src/pages/Correlations/Explore.tsx
+++ b/apps/web/src/pages/Correlations/Explore.tsx
@@ -1,18 +1,17 @@
 import type {
   ContinuousCorrelationData,
   CorrelationSelector,
-  CorrelationSelectorsData,
   EventOutcome,
   GenericCorrelationData,
   GroupComparison,
   LagExposureResultData,
-  NutrientKey,
   TriggerCondition,
 } from '@aurboda/api-spec'
 
 import { signal } from '@preact/signals'
 import { useQuery } from '@tanstack/react-query'
 
+import { SelectorPicker } from '../../components/SelectorPicker'
 import {
   fetchContinuousCorrelation,
   fetchCorrelationSelectors,
@@ -49,8 +48,6 @@ const periodDays = signal(365)
 // Bumped on each Run to trigger the query.
 const runToken = signal(0)
 
-const NUTRIENTS: NutrientKey[] = ['calories', 'protein', 'carbs', 'fat', 'fiber']
-
 // Trigger kinds offered in the picker (event mode has no metric trigger). The
 // legacy 'tag' kind is intentionally omitted — tags were merged into activities,
 // so 'activity' already matches them (and its picker autocompletes every
@@ -64,13 +61,6 @@ const EVENT_TRIGGER_KINDS: CorrelationSelector['kind'][] = [
 
 // Every selector kind (continuous mode allows a metric on either side).
 const ALL_SELECTOR_KINDS: CorrelationSelector['kind'][] = ['metric', ...EVENT_TRIGGER_KINDS]
-
-/** Human labels for selector kinds (the raw kind is opaque in a dropdown). */
-const KIND_LABELS: Partial<Record<CorrelationSelector['kind'], string>> = {
-  activity: 'activity / tag',
-  productivity_app: 'productivity app',
-  productivity_category: 'productivity category',
-}
 
 /** Switch mode, clamping the trigger to a kind valid in the new mode. */
 const setMode = (next: Mode) => {
@@ -162,101 +152,6 @@ const buildRequest = () => {
     return { outcome, triggerCondition }
   }
   return null
-}
-
-// --- Selector picker (kind + value) ---
-function SelectorPicker({
-  value,
-  onChange,
-  selectors,
-  allowedKinds,
-}: {
-  value: CorrelationSelector
-  onChange: (s: CorrelationSelector) => void
-  selectors: CorrelationSelectorsData | undefined
-  allowedKinds: CorrelationSelector['kind'][]
-}) {
-  const setKind = (kind: CorrelationSelector['kind']) => {
-    switch (kind) {
-      case 'metric':
-        return onChange({ kind: 'metric', metric: '' })
-      case 'nutrition':
-        return onChange({ kind: 'nutrition', nutrient: 'carbs' })
-      case 'activity':
-        return onChange({ kind: 'activity', pattern: '' })
-      case 'productivity_category':
-      case 'productivity_app':
-        return onChange({ kind, pattern: '' })
-      default:
-        return onChange({ kind: 'activity', pattern: '' })
-    }
-  }
-
-  return (
-    <div class="selector-picker">
-      <select
-        value={value.kind}
-        onChange={(e) => setKind((e.target as HTMLSelectElement).value as CorrelationSelector['kind'])}
-      >
-        {allowedKinds.map((k) => (
-          <option value={k}>{KIND_LABELS[k] ?? k}</option>
-        ))}
-      </select>
-
-      {value.kind === 'metric' && (
-        <>
-          <input
-            list="metric-options"
-            placeholder="metric (e.g. sleep_score)"
-            value={value.metric}
-            onInput={(e) => onChange({ ...value, metric: (e.target as HTMLInputElement).value })}
-          />
-          <datalist id="metric-options">
-            {selectors?.metrics.map((m) => (
-              <option value={m.value}>{m.label}</option>
-            ))}
-          </datalist>
-        </>
-      )}
-
-      {value.kind === 'nutrition' && (
-        <select
-          value={value.nutrient}
-          onChange={(e) =>
-            onChange({ kind: 'nutrition', nutrient: (e.target as HTMLSelectElement).value as NutrientKey })
-          }
-        >
-          {NUTRIENTS.map((n) => (
-            <option value={n}>{n}</option>
-          ))}
-        </select>
-      )}
-
-      {(value.kind === 'tag' ||
-        value.kind === 'activity' ||
-        value.kind === 'productivity_category' ||
-        value.kind === 'productivity_app') && (
-        <>
-          <input
-            list={`pattern-options-${value.kind}`}
-            placeholder="pattern (regex)"
-            value={value.pattern}
-            onInput={(e) => onChange({ ...value, pattern: (e.target as HTMLInputElement).value })}
-          />
-          <datalist id={`pattern-options-${value.kind}`}>
-            {(value.kind === 'productivity_category'
-              ? selectors?.productivity_categories
-              : value.kind === 'tag'
-                ? selectors?.tags
-                : selectors?.activity_types
-            )?.map((o) => (
-              <option value={o.value}>{o.label}</option>
-            ))}
-          </datalist>
-        </>
-      )}
-    </div>
-  )
 }
 
 // --- Results: per-lag relative-risk bars with 95% CI whiskers ---

--- a/apps/web/src/pages/Correlations/style.css
+++ b/apps/web/src/pages/Correlations/style.css
@@ -416,14 +416,7 @@
   font-weight: 600;
   color: #374151;
 }
-.selector-picker {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  align-items: center;
-}
-.selector-picker select,
-.selector-picker input,
+/* `.selector-picker` styling lives with the shared SelectorPicker component. */
 .explore-regime input,
 .explore-row > input {
   padding: 6px 8px;

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -34,9 +34,7 @@ A feed post has a **`kind`**:
   `update_article` MCP tools), or in the web app's article composer; prose renders
   through the shared markdown sanitiser and each windowed block resolves its data live
   over the locked window.
-  _The correlation-block composer UI (selector pickers) lands within this slice (#936) —
-  correlation blocks already render as a live scatter and are authorable over MCP/API;
-  federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
+  _Federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
   (#937), so an article is authored and shown on the owner's own feed but does not yet
   fan out to followers._
 
@@ -368,8 +366,10 @@ resolving.
   to pick the summary metrics, optionally opt into full series, and choose the audience.
 - **New article** — the **Feed** page has a **New article** button that opens the article
   composer: a title, an optional default time window, and an ordered list of **prose**
-  (markdown) and **chart** blocks (a metric + optional per-block window + caption), plus
-  the audience. Each chart draws its metric live over the locked window.
+  (markdown), **chart** (a metric + optional per-block window + caption), and **correlation**
+  (a trigger + outcome selector + optional lag/window/caption) blocks, plus the audience.
+  Each chart draws its metric live over the locked window; each correlation draws a live
+  scatter (with the coefficients) over its window.
 - **Manage** — the **Feed** page (`/feed`, the 📣 item under the **Sharing** section in
   the sidebar) lists everything
   you've shared, with each post's audience and metrics. From there you can **Edit** a


### PR DESCRIPTION
Part of #934 (Shareable analysis Articles), **Slice B (#936)** — final PR (web composer). Builds on the schema/backend (#946) and render (#947).

Correlation article blocks are now **fully authorable in the web composer** — completing Slice B.

## What's here

- **Shared `SelectorPicker`** — lifted the correlation selector picker (kind dropdown + per-kind autocompleted inputs) out of the Correlations explorer into `components/SelectorPicker.tsx` (with its `KIND_LABELS`/`NUTRIENTS`, co-located CSS, and an exported `ALL_SELECTOR_KINDS`). The explorer imports it; behaviour unchanged. Both surfaces now build selectors the same way.
- **Composer** — the article editor replaces the read-only correlation passthrough row (from #946) with a real editor: **trigger** + **outcome** pickers, an optional per-block window, **lag-days**, and a caption; a **+ Correlation** button adds one. The dialog fetches the correlation selectors to autocomplete the pickers.
- **`article-editor-body`** — `CorrelationDraft` is now editable (selectors + `datetime-local` window + `lagDays` + caption) instead of the verbatim passthrough; `draftsFromPost` seeds it and `buildArticleBody` validates both selectors are filled in, then emits the block (empty optional fields omitted). Extracted `buildChartBlock`/`buildCorrelationBlock` to keep `buildArticleBody` under the complexity budget; `emptyCorrelationDraft` for the add button.
- **Tests** — seed→build lossless round-trip, unfilled-trigger rejection, empty-field omission (16 pass). **Docs** — composer bullet + article overview updated.

## Slice B is complete after this

Schema/backend (#946) → live scatter render (#947) → composer (this). What remains for the epic is **Slice C (#937)**: federation (AS2 `Article` + attached PNGs / native inline) and Reddit/markdown export, plus the deferred public/followers-gated server rendering of chart and correlation images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)