### PR TITLE
feat(android): embed web Feed as a native tab via WebView

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -16,6 +16,7 @@ enum class AppScreen {
 enum class MainTab {
     Sync,
     Add,
+    Feed,
     Live,
     Account
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -302,6 +302,15 @@ fun AurbodaApp(initialTab: MainTab? = null) {
               modifier = modifier,
             )
           },
+          feedContent = { modifier ->
+            net.aurboda.ui.screens.EmbeddedWebScreen(
+              url = "${credentials.serverUrl.trimEnd('/')}/feed?embed=1",
+              baseUrl = credentials.serverUrl,
+              username = credentials.username,
+              authToken = credentials.authToken,
+              modifier = modifier,
+            )
+          },
           liveContent = { modifier ->
             net.aurboda.ui.screens.LiveScreen(
               modifier = modifier,

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
@@ -1,0 +1,157 @@
+package net.aurboda.ui.screens
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.graphics.Bitmap
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import org.json.JSONObject
+
+/**
+ * Bridge exposed to the embedded web app as `window.AurbodaNative`. The web app
+ * reads [getAuth] at startup to share the native app's bearer token instead of
+ * prompting for a second login (see apps/web/src/embed.ts).
+ */
+private class AuthBridge(private val authJson: String) {
+    @JavascriptInterface
+    fun getAuth(): String = authJson
+}
+
+/**
+ * Hosts a page of the web app inside a WebView so native and web share one
+ * implementation. The native app supplies navigation, the web app renders in
+ * embed mode (chrome hidden). Links to other domains open in the external
+ * browser; same-origin links stay in the WebView.
+ *
+ * @param url the web page to load (already carrying `?embed=1`)
+ * @param baseUrl the server origin, used to decide which links are external
+ */
+@Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun EmbeddedWebScreen(
+    url: String,
+    baseUrl: String,
+    username: String,
+    authToken: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var loading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var canGoBack by remember { mutableStateOf(false) }
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    val authJson = remember(username, authToken) {
+        JSONObject().put("user", username).put("token", authToken).toString()
+    }
+
+    // Let the WebView consume the system back gesture to walk its own history
+    // before the back press falls through to leaving the screen.
+    BackHandler(enabled = canGoBack) {
+        webView?.goBack()
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                WebView(ctx).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    addJavascriptInterface(AuthBridge(authJson), "AurbodaNative")
+                    webViewClient = object : WebViewClient() {
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView,
+                            request: WebResourceRequest,
+                        ): Boolean {
+                            if (isExternalLink(baseUrl, request.url.toString())) {
+                                runCatching {
+                                    context.startActivity(
+                                        Intent(Intent.ACTION_VIEW, request.url)
+                                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                                    )
+                                }
+                                return true
+                            }
+                            return false
+                        }
+
+                        override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+                            loading = true
+                            errorMessage = null
+                        }
+
+                        override fun onPageFinished(view: WebView, url: String?) {
+                            loading = false
+                            canGoBack = view.canGoBack()
+                        }
+
+                        override fun onReceivedError(
+                            view: WebView,
+                            request: WebResourceRequest,
+                            error: WebResourceError,
+                        ) {
+                            // Only the main frame failing is a page load error;
+                            // ignore failed sub-resources (images, tiles, etc.).
+                            if (request.isForMainFrame) {
+                                loading = false
+                                errorMessage = "Could not load page"
+                            }
+                        }
+                    }
+                    webView = this
+                    loadUrl(url)
+                }
+            },
+            onRelease = { it.destroy() },
+        )
+
+        if (loading && errorMessage == null) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        }
+
+        errorMessage?.let { message ->
+            Column(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(message)
+                Button(
+                    onClick = {
+                        errorMessage = null
+                        loading = true
+                        webView?.reload()
+                    },
+                ) {
+                    Text("Retry")
+                }
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
@@ -2,6 +2,7 @@ package net.aurboda.ui.screens
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
@@ -28,12 +29,14 @@ fun MainScreen(
     onTabSelected: (MainTab) -> Unit,
     syncContent: @Composable (Modifier) -> Unit,
     addContent: @Composable (Modifier) -> Unit,
+    feedContent: @Composable (Modifier) -> Unit,
     liveContent: @Composable (Modifier) -> Unit,
     accountContent: @Composable (Modifier) -> Unit
 ) {
     val navItems = listOf(
         BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Refresh),
         BottomNavItem(MainTab.Add, "Add", Icons.Default.Add),
+        BottomNavItem(MainTab.Feed, "Feed", Icons.AutoMirrored.Filled.List),
         BottomNavItem(MainTab.Live, "Live", Icons.Default.PlayArrow),
         BottomNavItem(MainTab.Account, "Account", Icons.Default.Person)
     )
@@ -55,6 +58,7 @@ fun MainScreen(
         when (currentTab) {
             MainTab.Sync -> syncContent(Modifier.padding(innerPadding))
             MainTab.Add -> addContent(Modifier.padding(innerPadding))
+            MainTab.Feed -> feedContent(Modifier.padding(innerPadding))
             MainTab.Live -> liveContent(Modifier.padding(innerPadding))
             MainTab.Account -> accountContent(Modifier.padding(innerPadding))
         }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/WebLink.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/WebLink.kt
@@ -1,0 +1,20 @@
+package net.aurboda.ui.screens
+
+import java.net.URI
+
+/**
+ * Whether [target] points outside the origin of [base] and should therefore open
+ * in the external browser instead of the embedded WebView.
+ *
+ * A different host is external; non-http(s) schemes (mailto:, tel:, intent:) are
+ * external too. Relative or unparseable targets have no host of their own and
+ * stay in the WebView. Host comparison ignores case and port.
+ */
+fun isExternalLink(base: String, target: String): Boolean {
+    val baseHost = runCatching { URI(base).host }.getOrNull() ?: return false
+    val targetUri = runCatching { URI(target) }.getOrNull() ?: return false
+    val scheme = targetUri.scheme?.lowercase()
+    if (scheme != null && scheme != "http" && scheme != "https") return true
+    val targetHost = targetUri.host ?: return false
+    return !targetHost.equals(baseHost, ignoreCase = true)
+}

--- a/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
@@ -19,11 +19,12 @@ class AppStateTest {
     }
 
     @Test
-    fun `MainTab has Sync, Add, Live and Account values`() {
+    fun `MainTab has Sync, Add, Feed, Live and Account values`() {
         val tabs = MainTab.entries
-        assertEquals(4, tabs.size)
+        assertEquals(5, tabs.size)
         assertTrue(tabs.contains(MainTab.Sync))
         assertTrue(tabs.contains(MainTab.Add))
+        assertTrue(tabs.contains(MainTab.Feed))
         assertTrue(tabs.contains(MainTab.Live))
         assertTrue(tabs.contains(MainTab.Account))
     }
@@ -32,8 +33,9 @@ class AppStateTest {
     fun `MainTab ordinal values are correct`() {
         assertEquals(0, MainTab.Sync.ordinal)
         assertEquals(1, MainTab.Add.ordinal)
-        assertEquals(2, MainTab.Live.ordinal)
-        assertEquals(3, MainTab.Account.ordinal)
+        assertEquals(2, MainTab.Feed.ordinal)
+        assertEquals(3, MainTab.Live.ordinal)
+        assertEquals(4, MainTab.Account.ordinal)
     }
 
     @Test
@@ -46,6 +48,7 @@ class AppStateTest {
     fun `MainTab names are descriptive`() {
         assertEquals("Sync", MainTab.Sync.name)
         assertEquals("Add", MainTab.Add.name)
+        assertEquals("Feed", MainTab.Feed.name)
         assertEquals("Live", MainTab.Live.name)
         assertEquals("Account", MainTab.Account.name)
     }

--- a/apps/android/app/src/test/java/net/aurboda/ui/screens/WebLinkTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/ui/screens/WebLinkTest.kt
@@ -1,0 +1,44 @@
+package net.aurboda.ui.screens
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WebLinkTest {
+
+    @Test
+    fun `same host is internal`() {
+        assertFalse(isExternalLink("https://aurboda.net", "https://aurboda.net/timeline"))
+    }
+
+    @Test
+    fun `different host is external`() {
+        assertTrue(isExternalLink("https://aurboda.net", "https://www.strava.com/activities/1"))
+    }
+
+    @Test
+    fun `subdomain is external`() {
+        assertTrue(isExternalLink("https://aurboda.net", "https://blog.aurboda.net/post"))
+    }
+
+    @Test
+    fun `non-http scheme is external`() {
+        assertTrue(isExternalLink("https://aurboda.net", "mailto:hi@aurboda.net"))
+        assertTrue(isExternalLink("https://aurboda.net", "tel:+123456789"))
+    }
+
+    @Test
+    fun `relative path stays internal`() {
+        assertFalse(isExternalLink("https://aurboda.net", "/timeline"))
+    }
+
+    @Test
+    fun `host comparison ignores case`() {
+        assertFalse(isExternalLink("https://Aurboda.net", "https://aurboda.NET/feed"))
+    }
+
+    @Test
+    fun `same host different port stays internal`() {
+        assertFalse(isExternalLink("http://192.168.1.5:3000", "http://192.168.1.5:8080/feed"))
+    }
+}

--- a/apps/web/src/components/widgets/MetricCardWidget.tsx
+++ b/apps/web/src/components/widgets/MetricCardWidget.tsx
@@ -46,7 +46,11 @@ const baselineToData = (baseline: BaselineData | null, metric: BaselineMetric): 
     case 'hrv_30day':
       return { ...empty, trend_percent: null, value: baseline.hrv.avg30day }
     case 'rhr_7day':
-      return { ...empty, trend_percent: baseline.resting_hr.trend_percent, value: baseline.resting_hr.avg7day }
+      return {
+        ...empty,
+        trend_percent: baseline.resting_hr.trend_percent,
+        value: baseline.resting_hr.avg7day,
+      }
     case 'rhr_30day':
       return { ...empty, trend_percent: null, value: baseline.resting_hr.avg30day }
   }

--- a/apps/web/src/components/widgets/PublicWidgetRenderer.tsx
+++ b/apps/web/src/components/widgets/PublicWidgetRenderer.tsx
@@ -27,26 +27,17 @@ interface PublicWidgetRendererProps {
 export function PublicWidgetRenderer({ widget, data }: PublicWidgetRendererProps) {
   switch (widget.type) {
     case 'metric_card':
-      return (
-        <MetricCardView config={widget.config} data={data?.type === 'metric_card' ? data.data : null} />
-      )
+      return <MetricCardView config={widget.config} data={data?.type === 'metric_card' ? data.data : null} />
     case 'sparkline_card':
       return (
-        <SparklineCardView
-          config={widget.config}
-          data={data?.type === 'sparkline_card' ? data.data : null}
-        />
+        <SparklineCardView config={widget.config} data={data?.type === 'sparkline_card' ? data.data : null} />
       )
     case 'trend_chart':
-      return (
-        <TrendChartView config={widget.config} data={data?.type === 'trend_chart' ? data.data : null} />
-      )
+      return <TrendChartView config={widget.config} data={data?.type === 'trend_chart' ? data.data : null} />
     case 'bar_chart':
       return <BarChartView config={widget.config} data={data?.type === 'bar_chart' ? data.data : null} />
     case 'correlation':
-      return (
-        <CorrelationView config={widget.config} data={data?.type === 'correlation' ? data.data : null} />
-      )
+      return <CorrelationView config={widget.config} data={data?.type === 'correlation' ? data.data : null} />
     case 'activity_summary':
       return (
         <ActivitySummaryView

--- a/apps/web/src/embed.test.ts
+++ b/apps/web/src/embed.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+
+import { computeEmbedded, parseNativeAuth } from './embed'
+
+describe('computeEmbedded', () => {
+  test('true when the embed query flag is set', () => {
+    expect(computeEmbedded('?embed=1', null)).toBe(true)
+    expect(computeEmbedded('?foo=bar&embed=1', null)).toBe(true)
+  })
+
+  test('true when a previously-detected flag is stored', () => {
+    expect(computeEmbedded('', '1')).toBe(true)
+    expect(computeEmbedded('?other=x', '1')).toBe(true)
+  })
+
+  test('false for a normal browser session', () => {
+    expect(computeEmbedded('', null)).toBe(false)
+    expect(computeEmbedded('?embed=0', null)).toBe(false)
+    expect(computeEmbedded('?embed=true', null)).toBe(false)
+  })
+})
+
+describe('parseNativeAuth', () => {
+  test('parses a full auth payload', () => {
+    expect(parseNativeAuth('{"user":"fiddur","token":"abc","is_admin":true}')).toEqual({
+      is_admin: true,
+      token: 'abc',
+      user: 'fiddur',
+    })
+  })
+
+  test('tolerates a missing is_admin / user', () => {
+    expect(parseNativeAuth('{"token":"abc"}')).toEqual({
+      is_admin: undefined,
+      token: 'abc',
+      user: undefined,
+    })
+  })
+
+  test('returns null without a usable token', () => {
+    expect(parseNativeAuth('{"user":"fiddur"}')).toBeNull()
+    expect(parseNativeAuth('{"token":""}')).toBeNull()
+    expect(parseNativeAuth('{"token":123}')).toBeNull()
+  })
+
+  test('returns null for missing or malformed input', () => {
+    expect(parseNativeAuth(null)).toBeNull()
+    expect(parseNativeAuth(undefined)).toBeNull()
+    expect(parseNativeAuth('')).toBeNull()
+    expect(parseNativeAuth('not json')).toBeNull()
+    expect(parseNativeAuth('[]')).toBeNull()
+    expect(parseNativeAuth('"string"')).toBeNull()
+  })
+})

--- a/apps/web/src/embed.ts
+++ b/apps/web/src/embed.ts
@@ -1,0 +1,88 @@
+/**
+ * Support for running the web app embedded inside the native Android app's
+ * WebView. The native shell loads pages with `?embed=1` and exposes an auth
+ * bridge (`window.AurbodaNative`) so the WebView shares the app's bearer token
+ * without a second login. In embed mode the web chrome (header/sidebar/footer)
+ * is hidden because the native app supplies navigation — see AppShell.
+ */
+
+declare global {
+  interface Window {
+    /** Bridge injected by the Android app's WebView (see EmbeddedWebScreen.kt). */
+    AurbodaNative?: { getAuth?: () => string | null }
+  }
+}
+
+const EMBED_QUERY_KEY = 'embed'
+const EMBED_STORAGE_KEY = 'aurboda_embed'
+
+/**
+ * Pure: is this an embedded (native WebView) session? The native app appends
+ * `?embed=1` on the initial load; `stored` carries a previously-detected flag so
+ * the mode survives client-side navigation that drops the query string.
+ */
+export function computeEmbedded(search: string, stored: string | null): boolean {
+  const params = new URLSearchParams(search)
+  if (params.get(EMBED_QUERY_KEY) === '1') return true
+  return stored === '1'
+}
+
+let embeddedCache: boolean | undefined
+
+/**
+ * Whether the web app is running inside the Android app's WebView. Detected once
+ * from the initial URL and persisted to sessionStorage so it holds across
+ * client-side navigation.
+ */
+export function isEmbedded(): boolean {
+  if (embeddedCache !== undefined) return embeddedCache
+  const stored = sessionStorage.getItem(EMBED_STORAGE_KEY)
+  const embedded = computeEmbedded(window.location.search, stored)
+  if (embedded) sessionStorage.setItem(EMBED_STORAGE_KEY, '1')
+  embeddedCache = embedded
+  return embedded
+}
+
+export interface EmbedAuth {
+  user?: string
+  token?: string
+  is_admin?: boolean
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Pure: parse the JSON handed over by the native auth bridge into an auth state.
+ * Returns null for missing/malformed input or a payload without a token, so
+ * callers fall back to browser-stored credentials.
+ */
+export function parseNativeAuth(raw: string | null | undefined): EmbedAuth | null {
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) return null
+  const { token, user, is_admin } = parsed
+  if (typeof token !== 'string' || token === '') return null
+  return {
+    is_admin: typeof is_admin === 'boolean' ? is_admin : undefined,
+    token,
+    user: typeof user === 'string' ? user : undefined,
+  }
+}
+
+/** Read auth handed over by the native WebView bridge, if present. */
+export function readNativeAuth(): EmbedAuth | null {
+  const bridge = window.AurbodaNative
+  if (!bridge?.getAuth) return null
+  try {
+    return parseNativeAuth(bridge.getAuth())
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -6,6 +6,7 @@ import { LocationProvider, Route, Router, useLocation } from 'preact-iso'
 import { Footer } from './components/Footer.jsx'
 import { Header } from './components/Header.jsx'
 import { Sidebar } from './components/Sidebar.jsx'
+import { isEmbedded } from './embed.js'
 import { NotFound } from './pages/_404.jsx'
 import { ActivityTypeMeta } from './pages/ActivityTypeMeta/index.jsx'
 import { ActivityTypes } from './pages/ActivityTypes/index.jsx'
@@ -67,7 +68,10 @@ function AppShell() {
   // standalone page), but a logged-in user keeps their nav so they can navigate
   // away without the browser back button. The footer renders on every page.
   const { path } = useLocation()
-  const showNav = shouldShowNav(path, Boolean(auth.value.token))
+  // Embedded in the native app's WebView: the app supplies navigation, so hide
+  // all web chrome (header, sidebar, footer) and just render page content.
+  const embedded = isEmbedded()
+  const showNav = !embedded && shouldShowNav(path, Boolean(auth.value.token))
 
   return (
     <>
@@ -130,7 +134,7 @@ function AppShell() {
             <Route default component={NotFound} />
           </Router>
         </main>
-        <Footer />
+        {!embedded && <Footer />}
       </div>
     </>
   )

--- a/apps/web/src/pages/Challenges/Join.tsx
+++ b/apps/web/src/pages/Challenges/Join.tsx
@@ -49,7 +49,9 @@ export function ChallengeJoin() {
         <h1>Join a challenge</h1>
         <p>
           Please{' '}
-          <a href={`/login?next=${encodeURIComponent(`/challenges/join?challenge=${encodeURIComponent(challengeUrl)}`)}`}>
+          <a
+            href={`/login?next=${encodeURIComponent(`/challenges/join?challenge=${encodeURIComponent(challengeUrl)}`)}`}
+          >
             log in
           </a>{' '}
           to join this challenge on your instance.

--- a/apps/web/src/pages/Challenges/PublicChallenge.tsx
+++ b/apps/web/src/pages/Challenges/PublicChallenge.tsx
@@ -130,10 +130,7 @@ export function PublicChallenge({
             // end_ts is the exclusive window end (midnight after the last day); step back
             // one ms so the axis ends on the inclusive last competing day (matching the
             // header) rather than drawing a trailing tick on the day after.
-            xDomain={[
-              new Date(challenge.start_ts),
-              new Date(new Date(challenge.end_ts).getTime() - 1),
-            ]}
+            xDomain={[new Date(challenge.start_ts), new Date(new Date(challenge.end_ts).getTime() - 1)]}
           />
         ) : (
           <p class="public-muted">No data yet.</p>

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -4,12 +4,17 @@ import { signal } from '@preact/signals'
 import axios from 'axios'
 
 import { API_URL } from '../config'
+import { readNativeAuth } from '../embed'
 
 export type SignupMode = 'open' | 'invite_only' | 'closed'
 
+// When running embedded in the native app, seed auth from the WebView bridge so
+// the app's bearer token is shared without a second login; otherwise fall back
+// to browser-stored credentials.
+const nativeAuth = readNativeAuth()
 const savedAuth = localStorage.getItem('auth')
 export const auth = signal<{ user?: string; token?: string; is_admin?: boolean }>(
-  savedAuth ? JSON.parse(savedAuth) : {},
+  nativeAuth ?? (savedAuth ? JSON.parse(savedAuth) : {}),
 )
 auth.subscribe((value) => localStorage.setItem('auth', JSON.stringify(value)))
 

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -1,0 +1,51 @@
+# Android App Architecture
+
+The Android app (`apps/android`, Jetpack Compose) is a **hybrid** of native
+screens and embedded web views. Device-bound features stay native; read- and
+config-heavy screens are embedded from the web app so we don't maintain two
+implementations of the same UI.
+
+## Navigation
+
+A bottom navigation bar (`ui/screens/MainScreen.kt`, tabs in `AppState.kt`'s
+`MainTab`) hosts the tabs:
+
+| Tab     | Kind      | Why                                                        |
+| ------- | --------- | ---------------------------------------------------------- |
+| Sync    | Native    | Health Connect permissions, background sync management     |
+| Add     | Native    | Native date/time pickers, offline entry queue              |
+| Feed    | Embedded  | Renders the web app's `/feed` in a WebView                 |
+| Live    | Native    | Bluetooth (BLE) sensor scanning + live heart rate          |
+| Account | Native    | Server URL, logout                                         |
+
+A tab can move from embedded to native later (e.g. if the feed becomes a heavily
+used, interaction-rich screen) without affecting the other tabs.
+
+## Embedded web views
+
+`ui/screens/EmbeddedWebScreen.kt` is the reusable WebView host: it enables
+JavaScript + DOM storage, shows a native loading spinner and a retry-able error
+state, and lets the system back gesture walk the WebView history first.
+
+### The embed contract (web ↔ native)
+
+The web app supports an **embed mode** (`apps/web/src/embed.ts`):
+
+- The native app loads pages with `?embed=1`. In embed mode the web app hides its
+  own chrome (header, sidebar, footer) because the native app provides
+  navigation. The flag is persisted to `sessionStorage` so it survives
+  client-side navigation that drops the query string.
+- **Auth is shared, not re-entered.** The WebView injects a JavaScript bridge,
+  `window.AurbodaNative.getAuth()`, returning `{ user, token }` JSON. The web app
+  reads it at startup (`readNativeAuth`) and seeds its bearer-token auth from it,
+  falling back to browser-stored credentials when the bridge is absent. This
+  works because both the web app (localStorage) and the Android app
+  (EncryptedSharedPreferences) authenticate with the same stateless bearer token.
+
+### External links
+
+Links inside an embedded page that point **outside the server's origin** open in
+the external browser (via `ACTION_VIEW`); same-origin links stay in the WebView.
+The decision is a pure, unit-tested helper: `ui/screens/WebLink.kt`
+(`isExternalLink`). Non-http(s) schemes (`mailto:`, `tel:`, …) are treated as
+external.


### PR DESCRIPTION
## What & why

First slice of a **hybrid Android architecture**: keep device-bound screens native, embed the web app for read/config-heavy screens so we don't maintain two implementations. This wires up the **Feed** tab as an embedded web view and lays the reusable foundation (WebView host + web-side embed contract) that future embedded pages (timeline, settings, …) build on.

## Android

- New **Feed** bottom-nav tab hosting `/feed?embed=1` via a reusable `EmbeddedWebScreen` — JavaScript + DOM storage enabled, native loading spinner and retry-able error state, and the system back gesture walks the WebView history before leaving the screen.
- **Shared auth, no second login**: the WebView injects `window.AurbodaNative.getAuth()` returning the app's bearer token; the web app seeds its auth from it. Works because web (localStorage) and Android (EncryptedSharedPreferences) use the same stateless bearer token.
- **External links open in the browser**: links outside the server origin launch `ACTION_VIEW`; same-origin links stay in the WebView. Decision is a pure, unit-tested helper (`WebLink.kt` / `isExternalLink`).

## Web

- **Embed mode** (`?embed=1`, persisted to `sessionStorage`): hides header/sidebar/footer since the native app provides navigation (`apps/web/src/embed.ts`, wired into `AppShell`).
- Seeds auth from the native bridge when embedded, falling back to browser-stored credentials.

## Tests

- Web: `embed.test.ts` covers `computeEmbedded` + `parseNativeAuth` (541 web tests pass).
- Android: `WebLinkTest` covers same-origin/cross-origin/subdomain/scheme/relative/case/port; `AppStateTest` updated for the new tab. Full `testDebugUnitTest` green.

## Docs

- `docs/android-app.md` documents the hybrid architecture and the web↔native embed contract.

## Notes

- A few unrelated web files (`Challenges/*`, `widgets/*`) are reformatted by `oxfmt` (they were merged to develop unformatted); kept per repo convention of committing formatter output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)