### PR TITLE
fix(feed): mobile horizontal overflow + WebView system dark mode

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
@@ -3,6 +3,7 @@ package net.aurboda.ui.screens
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Bitmap
+import android.view.ContextThemeWrapper
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -28,8 +29,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import net.aurboda.R
 import org.json.JSONObject
 
 /**
@@ -114,9 +117,20 @@ fun EmbeddedWebScreen(
         AndroidView(
             modifier = Modifier.fillMaxSize(),
             factory = { ctx ->
-                WebView(ctx).apply {
+                // Build the WebView against a day/night-themed context so its
+                // `isLightTheme` (and thus the page's `prefers-color-scheme`)
+                // follows the system dark-mode setting, even though the native
+                // app UI stays on the light Theme.Aurboda.
+                val webViewContext = ContextThemeWrapper(ctx, R.style.Theme_Aurboda_WebView)
+                WebView(webViewContext).apply {
                     settings.javaScriptEnabled = true
                     settings.domStorageEnabled = true
+                    // Let the embedded web app's own dark styles apply when the
+                    // system is in dark mode (the page declares color-scheme
+                    // support, so WebView uses its CSS rather than auto-inverting).
+                    if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+                        WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, true)
+                    }
                     installAuthBridge(this, authJson, originOf(baseUrl))
                     webViewClient = object : WebViewClient() {
                         override fun shouldOverrideUrlLoading(

--- a/apps/android/app/src/main/res/values/themes.xml
+++ b/apps/android/app/src/main/res/values/themes.xml
@@ -2,4 +2,13 @@
 <resources>
 
     <style name="Theme.Aurboda" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <!--
+      Day/night theme used only as the context for the embedded WebView, so its
+      `isLightTheme` follows the system dark-mode setting. That drives the
+      WebView's `prefers-color-scheme`, letting the embedded web app render dark
+      like it does in the browser (see EmbeddedWebScreen). The native UI keeps
+      the light Theme.Aurboda above.
+    -->
+    <style name="Theme.Aurboda.WebView" parent="android:Theme.DeviceDefault.DayNight" />
 </resources>

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -1,4 +1,6 @@
 .feed-page {
+  box-sizing: border-box;
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: 1rem;

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -30,6 +30,12 @@ or `404` on the page shell — a client-rendered SPA returns `200` for `/feed`, 
 token-expiry `401`s surface on client-side `fetch`, not the main-frame load), and
 lets the system back gesture walk the WebView history first.
 
+The WebView follows the **system dark-mode** setting even though the native UI
+stays light: it is built against a day/night-themed context
+(`Theme.Aurboda.WebView`) with algorithmic darkening allowed, so the embedded web
+app's `prefers-color-scheme` resolves to dark when the system is dark and its own
+dark CSS applies (the page declares `color-scheme: light dark`).
+
 ### The embed contract (web ↔ native)
 
 The web app supports an **embed mode** (`apps/web/src/embed.ts`):


### PR DESCRIPTION
Two fixes spotted comparing the Feed on web vs the app WebView on mobile.

## 1. Horizontal overflow (web, affects browser + app)
`.feed-page` had `padding: 1rem` with no `box-sizing` reset (there is no global reset — components set their own), so it extended ~32px past the viewport → slight sideways scroll on both the mobile browser and the embedded WebView. Fixed with `box-sizing: border-box` (+ explicit `width: 100%`).

## 2. WebView ignored system dark mode (Android)
The browser rendered the Feed dark (system preference), but the app's WebView stayed light. Root cause: `Theme.Aurboda` is hardcoded `android:Theme.Material.Light`, and a WebView derives `prefers-color-scheme` from its context's `isLightTheme`.

Fix: build the WebView against a **day/night-themed context** (`Theme.Aurboda.WebView` → `Theme.DeviceDefault.DayNight`) and enable `WebSettingsCompat.setAlgorithmicDarkeningAllowed`. The `Configuration` already carries the system night flag, so `isLightTheme` now follows the system and the page's own dark CSS applies (`index.html` already declares `color-scheme: light dark`). **Native UI stays on the light theme** — only the embedded WebView follows the system.

## Verification
- `:app:assembleDebug` + `:app:testDebugUnitTest` green; web `check` green.
- Dark-mode behavior needs a visual check on-device (toggle system dark mode on the Feed tab) — it can't be asserted in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)