### PR TITLE
fix(app): embedded profile overflow + back nav across SPA navigations

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
@@ -159,6 +159,14 @@ fun EmbeddedWebScreen(
                             canGoBack = view.canGoBack()
                         }
 
+                        override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
+                            // The embedded app is a client-side SPA: in-app
+                            // navigation happens via pushState, which does not
+                            // fire onPageFinished. Refresh here too so the back
+                            // gesture walks WebView history instead of leaving.
+                            canGoBack = view.canGoBack()
+                        }
+
                         override fun onReceivedError(
                             view: WebView,
                             request: WebResourceRequest,

--- a/apps/web/src/pages/PublicProfile/style.css
+++ b/apps/web/src/pages/PublicProfile/style.css
@@ -1,4 +1,6 @@
 .public-profile {
+  box-sizing: border-box;
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: 2rem 1.5rem;


### PR DESCRIPTION
Two issues found navigating from the Feed into a follower's public profile inside the app WebView.

## 1. Profile page too wide (web)
`.public-profile` had `padding: 2rem 1.5rem` with no `box-sizing` reset, so it ran ~48px past the viewport on mobile — the Share button got clipped off the right edge. Fixed with `box-sizing: border-box` + `width: 100%`, matching the earlier `.feed-page` fix (#951).

## 2. System back gesture closed the app instead of returning to the feed (Android)
`canGoBack` was only refreshed in `onPageFinished`. The embedded app is a client-side Preact/preact-iso SPA, so in-app navigation (Feed → `/u/:user`) happens via `pushState`, which does **not** fire `onPageFinished` — so `canGoBack` stayed `false`, the `BackHandler` stayed disabled, and the back gesture fell through and left the screen.

Fix: also refresh `canGoBack` in `doUpdateVisitedHistory`, which fires on `pushState`, so the back gesture walks the WebView history back to the feed.

## Verification
- `:app:compileDebugKotlin` + `:app:testDebugUnitTest` green; web `check` green.
- Back-gesture behavior needs an on-device check (Feed → tap a local follower → swipe back → should return to the feed, not exit).

## Note
This is the second page (after Feed) to hit the mobile padding overflow — there's no global `box-sizing` reset in the web app, so each page container with padding overflows. A global reset would fix it once for every current and future embedded page; flagged for discussion rather than bundled here (broad blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)