### PR TITLE
feat(feed): link all followers, follow-back, drop profile Share button

### DIFF
--- a/apps/web/src/pages/Feed/ActorName.tsx
+++ b/apps/web/src/pages/Feed/ActorName.tsx
@@ -1,0 +1,20 @@
+import { actorProfileLink } from './profile-link'
+
+/**
+ * An actor's display name, linked to their profile: the local `/u/:username`
+ * page for a local actor, or their own (remote) URL — opened externally (a new
+ * tab in the browser, the system browser from the embedded app) — for a
+ * fediverse actor on another instance. Falls back to plain text when the actor
+ * URI isn't linkable.
+ */
+export const ActorName = ({ name, actorUri }: { name: string; actorUri: string }) => {
+  const link = actorProfileLink(actorUri, window.location.host)
+  if (!link) return <>{name}</>
+  return link.external ? (
+    <a href={link.href} target="_blank" rel="noopener noreferrer">
+      {name}
+    </a>
+  ) : (
+    <a href={link.href}>{name}</a>
+  )
+}

--- a/apps/web/src/pages/Feed/FollowersPanel.tsx
+++ b/apps/web/src/pages/Feed/FollowersPanel.tsx
@@ -11,8 +11,8 @@ import type { FollowerActor } from '@aurboda/api-spec'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { approveFollower, fetchFollowers, rejectFollower } from '../../state/api'
-import { localProfilePath } from './profile-link'
+import { approveFollower, fetchFollowers, fetchFollowing, followActor, rejectFollower } from '../../state/api'
+import { ActorName } from './ActorName'
 
 const Avatar = ({ actor }: { actor: FollowerActor }) =>
   actor.avatar_url ? (
@@ -23,10 +23,11 @@ const Avatar = ({ actor }: { actor: FollowerActor }) =>
 
 const Ident = ({ actor }: { actor: FollowerActor }) => {
   const name = actor.display_name ?? actor.handle ?? actor.actor_uri
-  const profilePath = localProfilePath(actor.actor_uri, window.location.host)
   return (
     <span class="following-ident">
-      <span class="following-name">{profilePath ? <a href={profilePath}>{name}</a> : name}</span>
+      <span class="following-name">
+        <ActorName name={name} actorUri={actor.actor_uri} />
+      </span>
       {actor.handle && <span class="following-handle">{actor.handle}</span>}
     </span>
   )
@@ -55,25 +56,45 @@ const PendingRow = ({ actor }: { actor: FollowerActor }) => {
   )
 }
 
-const AcceptedRow = ({ actor }: { actor: FollowerActor }) => {
+const AcceptedRow = ({ actor, isFollowing }: { actor: FollowerActor; isFollowing: boolean }) => {
   const queryClient = useQueryClient()
   const remove = useMutation({
     mutationFn: () => rejectFollower(actor.id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['followers'] }),
+  })
+  // Follow back with the follower's handle (or actor URI — the endpoint accepts
+  // either). Once it lands, the ['following'] list refetches and `isFollowing`
+  // flips true, hiding this button.
+  const followBack = useMutation({
+    mutationFn: () => followActor(actor.handle ?? actor.actor_uri),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['following'] }),
   })
 
   return (
     <li class="following-row">
       <Avatar actor={actor} />
       <Ident actor={actor} />
-      <button
-        type="button"
-        class="btn-secondary following-unfollow"
-        onClick={() => remove.mutate()}
-        disabled={remove.isPending}
-      >
-        {remove.isPending ? 'Removing…' : 'Remove'}
-      </button>
+      <span class="followers-actions">
+        {!isFollowing && (
+          <button
+            type="button"
+            class="btn-primary"
+            onClick={() => followBack.mutate()}
+            disabled={followBack.isPending}
+            title="Follow this account back"
+          >
+            {followBack.isPending ? 'Following…' : 'Follow back'}
+          </button>
+        )}
+        <button
+          type="button"
+          class="btn-secondary following-unfollow"
+          onClick={() => remove.mutate()}
+          disabled={remove.isPending}
+        >
+          {remove.isPending ? 'Removing…' : 'Remove'}
+        </button>
+      </span>
     </li>
   )
 }
@@ -83,6 +104,10 @@ export function FollowersPanel() {
     queryFn: () => fetchFollowers('all'),
     queryKey: ['followers'],
   })
+  // Who you already follow — drives whether an accepted follower shows "Follow
+  // back". Shares the ['following'] key with FollowingPanel, so it's one fetch.
+  const { data: following } = useQuery({ queryFn: fetchFollowing, queryKey: ['following'] })
+  const followingUris = new Set((following ?? []).map((f) => f.actor_uri))
 
   const pending = followers?.filter((f) => !f.accepted) ?? []
   const accepted = followers?.filter((f) => f.accepted) ?? []
@@ -113,7 +138,7 @@ export function FollowersPanel() {
       {accepted.length > 0 && (
         <ul class="following-list">
           {accepted.map((actor) => (
-            <AcceptedRow key={actor.id} actor={actor} />
+            <AcceptedRow key={actor.id} actor={actor} isFollowing={followingUris.has(actor.actor_uri)} />
           ))}
         </ul>
       )}

--- a/apps/web/src/pages/Feed/FollowersPanel.tsx
+++ b/apps/web/src/pages/Feed/FollowersPanel.tsx
@@ -95,6 +95,13 @@ const AcceptedRow = ({ actor, isFollowing }: { actor: FollowerActor; isFollowing
           {remove.isPending ? 'Removing…' : 'Remove'}
         </button>
       </span>
+      {followBack.isError && (
+        <span class="following-row-error" role="alert">
+          {followBack.error instanceof Error && followBack.error.message
+            ? followBack.error.message
+            : "Couldn't follow back. Try again."}
+        </span>
+      )}
     </li>
   )
 }

--- a/apps/web/src/pages/Feed/FollowingPanel.tsx
+++ b/apps/web/src/pages/Feed/FollowingPanel.tsx
@@ -10,7 +10,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { fetchFollowing, followActor, unfollowActor } from '../../state/api'
-import { localProfilePath } from './profile-link'
+import { ActorName } from './ActorName'
 
 const FollowingRow = ({ actor }: { actor: FollowingActor }) => {
   const queryClient = useQueryClient()
@@ -20,7 +20,6 @@ const FollowingRow = ({ actor }: { actor: FollowingActor }) => {
   })
 
   const name = actor.display_name ?? actor.handle ?? actor.actor_uri
-  const profilePath = localProfilePath(actor.actor_uri, window.location.host)
   return (
     <li class="following-row">
       {actor.avatar_url ? (
@@ -29,7 +28,9 @@ const FollowingRow = ({ actor }: { actor: FollowingActor }) => {
         <span class="following-avatar following-avatar--blank" aria-hidden="true" />
       )}
       <span class="following-ident">
-        <span class="following-name">{profilePath ? <a href={profilePath}>{name}</a> : name}</span>
+        <span class="following-name">
+          <ActorName name={name} actorUri={actor.actor_uri} />
+        </span>
         {actor.handle && <span class="following-handle">{actor.handle}</span>}
       </span>
       {!actor.accepted && (

--- a/apps/web/src/pages/Feed/profile-link.test.ts
+++ b/apps/web/src/pages/Feed/profile-link.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { localProfilePath } from './profile-link'
+import { actorProfileLink, localProfilePath } from './profile-link'
 
 describe('localProfilePath', () => {
   const HOST = 'aurboda.net'
@@ -22,5 +22,28 @@ describe('localProfilePath', () => {
 
   it('returns null for a malformed URI', () => {
     expect(localProfilePath('not a url', HOST)).toBeNull()
+  })
+})
+
+describe('actorProfileLink', () => {
+  const HOST = 'aurboda.net'
+
+  it('links a local actor to its /u/:username page, not external', () => {
+    expect(actorProfileLink('https://aurboda.net/users/fredrik', HOST)).toEqual({
+      external: false,
+      href: '/u/fredrik',
+    })
+  })
+
+  it('links a remote actor to its own URL, flagged external', () => {
+    expect(actorProfileLink('https://mastodon.social/users/alice', HOST)).toEqual({
+      external: true,
+      href: 'https://mastodon.social/users/alice',
+    })
+  })
+
+  it('returns null for a non-http(s) or malformed actor URI', () => {
+    expect(actorProfileLink('mailto:alice@mastodon.social', HOST)).toBeNull()
+    expect(actorProfileLink('not a url', HOST)).toBeNull()
   })
 })

--- a/apps/web/src/pages/Feed/profile-link.ts
+++ b/apps/web/src/pages/Feed/profile-link.ts
@@ -17,3 +17,29 @@ export const localProfilePath = (actorUri: string, host: string): string | null 
     return null
   }
 }
+
+export interface ActorProfileLink {
+  /** Where the actor's name should link. */
+  href: string
+  /** True for a remote actor — the link leaves this instance, so it should open
+   *  externally (a new tab in the browser, the system browser from the app). */
+  external: boolean
+}
+
+/**
+ * A link to an actor's profile: the local `/u/:username` page when the actor
+ * lives on `host`, otherwise the actor's own (remote) URL flagged `external`.
+ * Only http(s) actor URIs are linkable; anything else returns null so callers
+ * render plain text.
+ */
+export const actorProfileLink = (actorUri: string, host: string): ActorProfileLink | null => {
+  const local = localProfilePath(actorUri, host)
+  if (local) return { external: false, href: local }
+  try {
+    const url = new URL(actorUri)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    return { external: true, href: actorUri }
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -101,6 +101,17 @@
   display: flex;
   align-items: center;
   gap: 0.6rem;
+  /* Lets a full-width child (e.g. a follow-back error) drop to its own line
+     without disturbing the avatar/name/actions on the first line. */
+  flex-wrap: wrap;
+}
+
+/* Follow-back failure message, shown on its own line under the follower row. */
+.following-row-error {
+  flex-basis: 100%;
+  margin: 0.15rem 0 0;
+  color: #991b1b;
+  font-size: 0.8rem;
 }
 
 .following-avatar {

--- a/apps/web/src/pages/PublicProfile/index.tsx
+++ b/apps/web/src/pages/PublicProfile/index.tsx
@@ -7,7 +7,6 @@ import { useRoute } from 'preact-iso'
  */
 import type { PostAuthor } from '../Feed/FeedPostCard'
 
-import { ShareLinkButton } from '../../components/ShareLinkButton'
 import { avatarUrl, fetchPublicPosts, fetchPublicProfile } from '../../state/api'
 import { FeedPostCard } from '../Feed/FeedPostCard'
 import './style.css'
@@ -70,7 +69,8 @@ export function PublicProfile() {
   return (
     <div class="public-profile">
       {/* A <div>, not <header>: the global `header` rule paints a #673ab8 bar
-          (mobile nav style) that made the purple Share button invisible (#883). */}
+          (mobile nav style) behind the content, so avoid the semantic element
+          here (#883). */}
       <div class="public-profile-header">
         <img
           class="public-avatar"
@@ -80,7 +80,6 @@ export function PublicProfile() {
           height={80}
         />
         <h1>@{username}</h1>
-        <ShareLinkButton url={window.location.href} title={`@${username} on Aurboda`} />
       </div>
 
       <section class="public-section">


### PR DESCRIPTION
Three small social-UX changes from using the embedded feed in the app.

## 1. Link every actor, including remote ones
The Followers (and Following) lists only linked *local* actors; remote fediverse actors rendered as plain text. Now every actor's name links to their profile:
- **Local** → `/u/:username` (stays in the app WebView).
- **Remote** → the actor's own URL, `target="_blank"` — a new tab in the browser, and the **system browser from the app** (the WebView's `isExternalLink` handling sends off-origin links out).

New shared `actorProfileLink()` helper + `ActorName` component, reused by both panels (removes the duplicated inline link logic).

## 2. Follow back
Accepted followers you don't already follow get a **Follow back** button (uses the follower's handle, or actor URI — the `/feed/following` endpoint accepts either). It disappears once the follow lands (the `['following']` query refetches). The panel shares that query key with the Following panel, so it's a single fetch.

## 3. Remove the profile Share button
Dropped the `ShareLinkButton` from `/u/:username` — it wasn't useful there. (The `.public-profile` overflow was fixed separately in #952.)

## Tests
- `actorProfileLink` unit tests (local / remote-external / non-http+malformed → null); 548 web tests pass, `check` green.
- The follow-back and external-link-out behaviors are UI wiring — worth an on-device check (Feed → Followers → Follow back; tap a remote follower → opens system browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)