### PR TITLE
feat(android): add Home (dashboard) tab, default to it on launch

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -14,6 +14,7 @@ enum class AppScreen {
 }
 
 enum class MainTab {
+    Home,
     Sync,
     Add,
     Feed,
@@ -24,7 +25,7 @@ enum class MainTab {
 class AppState(
     private val context: Context,
     initialScreen: AppScreen,
-    initialTab: MainTab = MainTab.Sync
+    initialTab: MainTab = MainTab.Home
 ) {
     var currentScreen by mutableStateOf(initialScreen)
         private set
@@ -45,7 +46,7 @@ class AppState(
 
     fun logout() {
         CredentialsManager.clearCredentials(context)
-        currentTab = MainTab.Sync
+        currentTab = MainTab.Home
         currentScreen = AppScreen.Login
     }
 
@@ -67,7 +68,7 @@ fun rememberAppState(initialTab: MainTab? = null): AppState {
         AppState(
             context = context,
             initialScreen = if (hasCredentials) AppScreen.Main else AppScreen.Login,
-            initialTab = initialTab ?: MainTab.Sync
+            initialTab = initialTab ?: MainTab.Home
         )
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -288,6 +288,15 @@ fun AurbodaApp(initialTab: MainTab? = null) {
         net.aurboda.ui.screens.MainScreen(
           currentTab = appState.currentTab,
           onTabSelected = { appState.selectTab(it) },
+          homeContent = { modifier ->
+            net.aurboda.ui.screens.EmbeddedWebScreen(
+              url = "${credentials.serverUrl.trimEnd('/')}/?embed=1",
+              baseUrl = credentials.serverUrl,
+              username = credentials.username,
+              authToken = credentials.authToken,
+              modifier = modifier,
+            )
+          },
           syncContent = { modifier ->
             HealthConnectScreen(
               apiUrl = credentials.apiUrl,

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
@@ -27,6 +28,7 @@ data class BottomNavItem(
 fun MainScreen(
     currentTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
+    homeContent: @Composable (Modifier) -> Unit,
     syncContent: @Composable (Modifier) -> Unit,
     addContent: @Composable (Modifier) -> Unit,
     feedContent: @Composable (Modifier) -> Unit,
@@ -34,6 +36,7 @@ fun MainScreen(
     accountContent: @Composable (Modifier) -> Unit
 ) {
     val navItems = listOf(
+        BottomNavItem(MainTab.Home, "Home", Icons.Default.Home),
         BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Refresh),
         BottomNavItem(MainTab.Add, "Add", Icons.Default.Add),
         BottomNavItem(MainTab.Feed, "Feed", Icons.AutoMirrored.Filled.List),
@@ -56,6 +59,7 @@ fun MainScreen(
         }
     ) { innerPadding ->
         when (currentTab) {
+            MainTab.Home -> homeContent(Modifier.padding(innerPadding))
             MainTab.Sync -> syncContent(Modifier.padding(innerPadding))
             MainTab.Add -> addContent(Modifier.padding(innerPadding))
             MainTab.Feed -> feedContent(Modifier.padding(innerPadding))

--- a/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
@@ -19,9 +19,10 @@ class AppStateTest {
     }
 
     @Test
-    fun `MainTab has Sync, Add, Feed, Live and Account values`() {
+    fun `MainTab has Home, Sync, Add, Feed, Live and Account values`() {
         val tabs = MainTab.entries
-        assertEquals(5, tabs.size)
+        assertEquals(6, tabs.size)
+        assertTrue(tabs.contains(MainTab.Home))
         assertTrue(tabs.contains(MainTab.Sync))
         assertTrue(tabs.contains(MainTab.Add))
         assertTrue(tabs.contains(MainTab.Feed))
@@ -31,11 +32,12 @@ class AppStateTest {
 
     @Test
     fun `MainTab ordinal values are correct`() {
-        assertEquals(0, MainTab.Sync.ordinal)
-        assertEquals(1, MainTab.Add.ordinal)
-        assertEquals(2, MainTab.Feed.ordinal)
-        assertEquals(3, MainTab.Live.ordinal)
-        assertEquals(4, MainTab.Account.ordinal)
+        assertEquals(0, MainTab.Home.ordinal)
+        assertEquals(1, MainTab.Sync.ordinal)
+        assertEquals(2, MainTab.Add.ordinal)
+        assertEquals(3, MainTab.Feed.ordinal)
+        assertEquals(4, MainTab.Live.ordinal)
+        assertEquals(5, MainTab.Account.ordinal)
     }
 
     @Test
@@ -46,6 +48,7 @@ class AppStateTest {
 
     @Test
     fun `MainTab names are descriptive`() {
+        assertEquals("Home", MainTab.Home.name)
         assertEquals("Sync", MainTab.Sync.name)
         assertEquals("Add", MainTab.Add.name)
         assertEquals("Feed", MainTab.Feed.name)

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -12,6 +12,7 @@ A bottom navigation bar (`ui/screens/MainScreen.kt`, tabs in `AppState.kt`'s
 
 | Tab     | Kind      | Why                                                        |
 | ------- | --------- | ---------------------------------------------------------- |
+| Home    | Embedded  | Renders the web app's `/` (the dashboard) in a WebView; the default tab on launch |
 | Sync    | Native    | Health Connect permissions, background sync management     |
 | Add     | Native    | Native date/time pickers, offline entry queue              |
 | Feed    | Embedded  | Renders the web app's `/feed` in a WebView                 |


### PR DESCRIPTION
Adds the main **dashboard** to the app and opens to it by default.

- New **Home** bottom-nav tab (leftmost) rendering the web app's `/?embed=1` in a WebView. For a logged-in user, `/` renders `<Dashboard />`, so the tab shows the main dashboard — reusing the existing `EmbeddedWebScreen` (auth bridge, dark mode, external-link + back handling all apply).
- **Default tab on launch is now Home** (was Sync): `MainTab.Home` is the fallback in `rememberAppState`/`AppState`, and `logout()` resets to it. The widget/shortcut deep-link into `Add` (`EXTRA_OPEN_TAB`) still works.
- Tab order: **Home**, Sync, Add, Feed, Live, Account (existing tabs keep their relative order).

`AppStateTest` updated for the new tab (count, ordinals, names). `:app:assembleDebug` + `:app:testDebugUnitTest` green.

## Note
This makes six bottom-nav tabs. That's at the upper end for a Material bottom bar — workable, but if it feels cramped on a phone we could consolidate later (e.g. fold Sync/Live into a menu). Flagging for your call after seeing it on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)