### PR TITLE
feat(android): consolidate nav to Home/Add/Feed/Sync + a More hub

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -15,11 +15,10 @@ enum class AppScreen {
 
 enum class MainTab {
     Home,
-    Sync,
     Add,
     Feed,
-    Live,
-    Account
+    Sync,
+    More
 }
 
 class AppState(

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -320,15 +320,9 @@ fun AurbodaApp(initialTab: MainTab? = null) {
               modifier = modifier,
             )
           },
-          liveContent = { modifier ->
-            net.aurboda.ui.screens.LiveScreen(
-              modifier = modifier,
-            )
-          },
-          accountContent = { modifier ->
-            net.aurboda.ui.screens.AccountScreen(
-              username = credentials.username,
-              serverUrl = credentials.serverUrl,
+          moreContent = { modifier ->
+            net.aurboda.ui.screens.MoreScreen(
+              credentials = credentials,
               onServerUrlChange = { newUrl -> appState.changeServerUrl(newUrl) },
               onLogout = { appState.logout() },
               modifier = modifier,

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MainScreen.kt
@@ -5,8 +5,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -29,19 +28,17 @@ fun MainScreen(
     currentTab: MainTab,
     onTabSelected: (MainTab) -> Unit,
     homeContent: @Composable (Modifier) -> Unit,
-    syncContent: @Composable (Modifier) -> Unit,
     addContent: @Composable (Modifier) -> Unit,
     feedContent: @Composable (Modifier) -> Unit,
-    liveContent: @Composable (Modifier) -> Unit,
-    accountContent: @Composable (Modifier) -> Unit
+    syncContent: @Composable (Modifier) -> Unit,
+    moreContent: @Composable (Modifier) -> Unit
 ) {
     val navItems = listOf(
         BottomNavItem(MainTab.Home, "Home", Icons.Default.Home),
-        BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Refresh),
         BottomNavItem(MainTab.Add, "Add", Icons.Default.Add),
         BottomNavItem(MainTab.Feed, "Feed", Icons.AutoMirrored.Filled.List),
-        BottomNavItem(MainTab.Live, "Live", Icons.Default.PlayArrow),
-        BottomNavItem(MainTab.Account, "Account", Icons.Default.Person)
+        BottomNavItem(MainTab.Sync, "Sync", Icons.Default.Refresh),
+        BottomNavItem(MainTab.More, "More", Icons.Default.Menu)
     )
 
     Scaffold(
@@ -60,11 +57,10 @@ fun MainScreen(
     ) { innerPadding ->
         when (currentTab) {
             MainTab.Home -> homeContent(Modifier.padding(innerPadding))
-            MainTab.Sync -> syncContent(Modifier.padding(innerPadding))
             MainTab.Add -> addContent(Modifier.padding(innerPadding))
             MainTab.Feed -> feedContent(Modifier.padding(innerPadding))
-            MainTab.Live -> liveContent(Modifier.padding(innerPadding))
-            MainTab.Account -> accountContent(Modifier.padding(innerPadding))
+            MainTab.Sync -> syncContent(Modifier.padding(innerPadding))
+            MainTab.More -> moreContent(Modifier.padding(innerPadding))
         }
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
@@ -1,0 +1,173 @@
+package net.aurboda.ui.screens
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import net.aurboda.CredentialsManager
+
+/** A destination reachable from the "More" hub. */
+sealed interface MoreDestination {
+    /** A web page rendered in an embedded WebView at [path] (e.g. "/timeline"). */
+    data class Web(val path: String) : MoreDestination
+
+    /** The native live-sensor (BLE) screen. */
+    data object Live : MoreDestination
+
+    /** The native account / server-URL screen. */
+    data object Account : MoreDestination
+}
+
+data class MoreItem(val label: String, val destination: MoreDestination)
+
+data class MoreGroup(val header: String, val items: List<MoreItem>)
+
+/**
+ * The "More" hub contents: everything not on the bottom bar. Most entries open
+ * the corresponding web page embedded; Live and Account stay native. Keep in
+ * sync with the web navigation (see apps/web/src/components/nav-links.ts).
+ */
+val moreGroups: List<MoreGroup> = listOf(
+    MoreGroup(
+        "Explore",
+        listOf(
+            MoreItem("Timeline", MoreDestination.Web("/timeline")),
+            MoreItem("Data", MoreDestination.Web("/data")),
+            MoreItem("Chart", MoreDestination.Web("/chart")),
+            MoreItem("Goals", MoreDestination.Web("/goals")),
+            MoreItem("Places", MoreDestination.Web("/places")),
+        ),
+    ),
+    MoreGroup(
+        "Log",
+        listOf(
+            MoreItem("Meals", MoreDestination.Web("/meals")),
+            MoreItem("Reports", MoreDestination.Web("/reports")),
+        ),
+    ),
+    MoreGroup(
+        "Sharing",
+        listOf(
+            MoreItem("Shared dashboards", MoreDestination.Web("/shared-dashboards")),
+            MoreItem("Challenges", MoreDestination.Web("/challenges")),
+        ),
+    ),
+    MoreGroup(
+        "Analyze & manage",
+        listOf(
+            MoreItem("Analyze", MoreDestination.Web("/correlations")),
+            MoreItem("Activity types", MoreDestination.Web("/activity-types")),
+            MoreItem("Deduction rules", MoreDestination.Web("/deduction-rules")),
+            MoreItem("Data sources", MoreDestination.Web("/data-sources")),
+            MoreItem("Settings", MoreDestination.Web("/settings")),
+            MoreItem("Audit log", MoreDestination.Web("/audit-log")),
+        ),
+    ),
+    MoreGroup(
+        "Device & account",
+        listOf(
+            MoreItem("Live sensors", MoreDestination.Live),
+            MoreItem("Account & server", MoreDestination.Account),
+        ),
+    ),
+)
+
+/**
+ * The "More" tab: a hub listing every screen not on the bottom bar. Selecting an
+ * entry pushes it in place (embedded web page, or the native Live / Account
+ * screens); the system back gesture returns to the hub — after any embedded page
+ * has exhausted its own WebView history (EmbeddedWebScreen owns that inner
+ * BackHandler, which is composed after this one so it takes precedence).
+ */
+@Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
+@Composable
+fun MoreScreen(
+    credentials: CredentialsManager.Credentials,
+    onServerUrlChange: (String) -> Unit,
+    onLogout: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var destination by remember { mutableStateOf<MoreDestination?>(null) }
+
+    when (val dest = destination) {
+        null -> MoreHub(onSelect = { destination = it }, modifier = modifier)
+        else -> {
+            BackHandler { destination = null }
+            when (dest) {
+                is MoreDestination.Web ->
+                    EmbeddedWebScreen(
+                        url = "${credentials.serverUrl.trimEnd('/')}${dest.path}?embed=1",
+                        baseUrl = credentials.serverUrl,
+                        username = credentials.username,
+                        authToken = credentials.authToken,
+                        modifier = modifier,
+                    )
+
+                MoreDestination.Live -> LiveScreen(modifier = modifier)
+
+                MoreDestination.Account ->
+                    AccountScreen(
+                        username = credentials.username,
+                        serverUrl = credentials.serverUrl,
+                        onServerUrlChange = onServerUrlChange,
+                        onLogout = onLogout,
+                        modifier = modifier,
+                    )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoreHub(onSelect: (MoreDestination) -> Unit, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        moreGroups.forEach { group ->
+            Text(
+                text = group.header,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
+            )
+            group.items.forEach { item ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSelect(item.destination) }
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = item.label,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+                }
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateTest.kt
@@ -19,25 +19,23 @@ class AppStateTest {
     }
 
     @Test
-    fun `MainTab has Home, Sync, Add, Feed, Live and Account values`() {
+    fun `MainTab has Home, Add, Feed, Sync and More values`() {
         val tabs = MainTab.entries
-        assertEquals(6, tabs.size)
+        assertEquals(5, tabs.size)
         assertTrue(tabs.contains(MainTab.Home))
-        assertTrue(tabs.contains(MainTab.Sync))
         assertTrue(tabs.contains(MainTab.Add))
         assertTrue(tabs.contains(MainTab.Feed))
-        assertTrue(tabs.contains(MainTab.Live))
-        assertTrue(tabs.contains(MainTab.Account))
+        assertTrue(tabs.contains(MainTab.Sync))
+        assertTrue(tabs.contains(MainTab.More))
     }
 
     @Test
     fun `MainTab ordinal values are correct`() {
         assertEquals(0, MainTab.Home.ordinal)
-        assertEquals(1, MainTab.Sync.ordinal)
-        assertEquals(2, MainTab.Add.ordinal)
-        assertEquals(3, MainTab.Feed.ordinal)
-        assertEquals(4, MainTab.Live.ordinal)
-        assertEquals(5, MainTab.Account.ordinal)
+        assertEquals(1, MainTab.Add.ordinal)
+        assertEquals(2, MainTab.Feed.ordinal)
+        assertEquals(3, MainTab.Sync.ordinal)
+        assertEquals(4, MainTab.More.ordinal)
     }
 
     @Test
@@ -49,10 +47,9 @@ class AppStateTest {
     @Test
     fun `MainTab names are descriptive`() {
         assertEquals("Home", MainTab.Home.name)
-        assertEquals("Sync", MainTab.Sync.name)
         assertEquals("Add", MainTab.Add.name)
         assertEquals("Feed", MainTab.Feed.name)
-        assertEquals("Live", MainTab.Live.name)
-        assertEquals("Account", MainTab.Account.name)
+        assertEquals("Sync", MainTab.Sync.name)
+        assertEquals("More", MainTab.More.name)
     }
 }

--- a/apps/android/app/src/test/java/net/aurboda/ui/screens/MoreScreenTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/ui/screens/MoreScreenTest.kt
@@ -1,0 +1,37 @@
+package net.aurboda.ui.screens
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MoreScreenTest {
+
+    private val allItems = moreGroups.flatMap { it.items }
+    private val webPaths = allItems.mapNotNull { (it.destination as? MoreDestination.Web)?.path }
+
+    @Test
+    fun `every web path is absolute and non-empty`() {
+        assertTrue(webPaths.isNotEmpty())
+        webPaths.forEach { path ->
+            assertTrue("path should start with '/': $path", path.startsWith("/"))
+            assertTrue("path should have a segment: $path", path.length > 1)
+        }
+    }
+
+    @Test
+    fun `web paths are unique`() {
+        assertEquals(webPaths.size, webPaths.toSet().size)
+    }
+
+    @Test
+    fun `item labels are unique`() {
+        val labels = allItems.map { it.label }
+        assertEquals(labels.size, labels.toSet().size)
+    }
+
+    @Test
+    fun `native Live and Account destinations are present exactly once`() {
+        assertEquals(1, allItems.count { it.destination == MoreDestination.Live })
+        assertEquals(1, allItems.count { it.destination == MoreDestination.Account })
+    }
+}

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -8,16 +8,24 @@ implementations of the same UI.
 ## Navigation
 
 A bottom navigation bar (`ui/screens/MainScreen.kt`, tabs in `AppState.kt`'s
-`MainTab`) hosts the tabs:
+`MainTab`) hosts five tabs:
 
-| Tab     | Kind      | Why                                                        |
-| ------- | --------- | ---------------------------------------------------------- |
-| Home    | Embedded  | Renders the web app's `/` (the dashboard) in a WebView; the default tab on launch |
-| Sync    | Native    | Health Connect permissions, background sync management     |
-| Add     | Native    | Native date/time pickers, offline entry queue              |
-| Feed    | Embedded  | Renders the web app's `/feed` in a WebView                 |
-| Live    | Native    | Bluetooth (BLE) sensor scanning + live heart rate          |
-| Account | Native    | Server URL, logout                                         |
+| Tab  | Kind     | Why                                                                     |
+| ---- | -------- | ----------------------------------------------------------------------- |
+| Home | Embedded | Web `/` (the dashboard); the default tab on launch                      |
+| Add  | Native   | Native date/time pickers, offline entry queue                           |
+| Feed | Embedded | Web `/feed`                                                             |
+| Sync | Native   | Health Connect permissions, background sync management                  |
+| More | Hub      | Native list of everything else (`ui/screens/MoreScreen.kt`)             |
+
+There are far more web pages than fit on a bottom bar, so the **More** tab is a
+hub (`MoreScreen.kt`, `moreGroups`): a grouped list where each entry opens the
+corresponding web page in an embedded WebView (Timeline, Data, Chart, Meals,
+Reports, Settings, Data sources, …). The two native-only screens — **Live**
+sensors (BLE) and **Account** (server URL, logout) — also live in the hub.
+Selecting an entry pushes it in place; the system back gesture returns to the
+hub (after any embedded page has exhausted its own WebView history). Keep
+`moreGroups` in sync with the web navigation (`apps/web/src/components/nav-links.ts`).
 
 A tab can move from embedded to native later (e.g. if the feed becomes a heavily
 used, interaction-rich screen) without affecting the other tabs.


### PR DESCRIPTION
Implements the agreed navigation model (**native bar + "More" hub**), replacing the cramped six-tab bar.

## Bottom bar (5 tabs)
`Home · Add · Feed · Sync · More`
- **Home** — embedded `/` (dashboard), default tab.
- **Add** — native quick-add.
- **Feed** — embedded `/feed`.
- **Sync** — native Health Connect / background sync.
- **More** — the hub.

## More hub (`MoreScreen.kt`)
A grouped, scrollable list of everything else. Each web entry opens embedded via `EmbeddedWebScreen`; the two native-only screens live here too:
- **Explore**: Timeline, Data, Chart, Goals, Places
- **Log**: Meals, Reports
- **Sharing**: Shared dashboards, Challenges
- **Analyze & manage**: Analyze, Activity types, Deduction rules, Data sources, Settings, Audit log
- **Device & account**: Live sensors (native BLE), Account & server (native)

Selecting an entry pushes it in place; the system back gesture returns to the hub — after any embedded page has exhausted its own WebView history (`EmbeddedWebScreen`'s inner `BackHandler` composes after the hub's, so it wins first). `moreGroups` is a plain data list, unit-tested (`MoreScreenTest`) and kept in sync with the web nav per the parity rule.

## Also
- `MainTab` is now `Home, Add, Feed, Sync, More`; `AppStateTest` + `docs/android-app.md` updated.
- `:app:assembleDebug` + `:app:testDebugUnitTest` green.

## Needs on-device check
Navigation flow: More → tap an entry → embedded page → back returns to hub; Live/Account still work from the hub; server-URL change + logout still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)