### PR TITLE
fix(android): give embedded WebView a proper layout viewport (timeline squeeze)

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
@@ -125,6 +125,13 @@ fun EmbeddedWebScreen(
                 WebView(webViewContext).apply {
                     settings.javaScriptEnabled = true
                     settings.domStorageEnabled = true
+                    // Establish a proper layout viewport from the page's
+                    // `<meta viewport>` (width=device-width, initial-scale=1).
+                    // Without this the WebView doesn't give viewport-height /
+                    // flex-fill layouts a stable height, collapsing full-height
+                    // pages like the timeline (scale stays 1:1 either way).
+                    settings.useWideViewPort = true
+                    settings.loadWithOverviewMode = true
                     // Let the embedded web app's own dark styles apply when the
                     // system is in dark mode (the page declares color-scheme
                     // support, so WebView uses its CSS rather than auto-inverting).


### PR DESCRIPTION
## Symptom
Full-height embedded pages — the **timeline** — render squeezed into a small band in the app, while identical in the browser.

## Diagnosis
The embed CSS is **not** at fault. I rendered `/timeline?embed=1` in **headless Chromium** (same engine as Android WebView) at phone size and it fills full height correctly:

> chart spans 00:00→20:00 over the whole viewport — container fills as intended.

So it's an **Android WebView runtime** difference: with `useWideViewPort` off (the default), the WebView doesn't build a layout viewport from the page's `<meta name="viewport" content="width=device-width, initial-scale=1">`, so `100vh` / `%` / flex-fill heights get no stable reference and collapse. Content-height pages (Home, Feed) never exposed this because they don't depend on viewport height.

## Fix
Enable on the embedded WebView:
```kotlin
settings.useWideViewPort = true
settings.loadWithOverviewMode = true
```
The viewport meta already pins `width=device-width, initial-scale=1`, so scale stays 1:1; Home/Feed are unaffected.

## Verification
- `:app:compileDebugKotlin` + `:app:testDebugUnitTest` green.
- **Needs an on-device check** (I can't run the Android WebView here): open More → Timeline and confirm the chart now fills the screen. If it's still squeezed, the fallback is a post-load relayout nudge — I'll iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)