### PR TITLE
fix(android): pin embedded WebView shell height to window.innerHeight (timeline squeeze)

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/EmbeddedWebScreen.kt
@@ -54,6 +54,27 @@ private class AuthBridge(private val authJson: String) {
 }
 
 /**
+ * Pins the app-shell height to `window.innerHeight`. Android WebView can resolve
+ * CSS viewport units (`100vh`) and the `%` height chain to 0 even when the
+ * viewport is sized correctly, which collapses full-height pages (the timeline).
+ * `window.innerHeight` stays reliable, so we set `<html>` to it (in px) and let
+ * `body`/`#app` fill via `%`, re-applying on resize. Injected only in the
+ * WebView, so browsers are unaffected.
+ */
+private const val VIEWPORT_FIX_JS =
+    "(function(){function f(){document.documentElement.style.height=window.innerHeight+'px';" +
+        "if(document.body){document.body.style.height='100%';var a=document.getElementById('app');if(a)a.style.height='100%';}}" +
+        "window.addEventListener('resize',f);document.addEventListener('DOMContentLoaded',f);f();})();"
+
+private fun installViewportFix(webView: WebView, origin: String?) {
+    if (origin != null && WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+        runCatching { WebViewCompat.addDocumentStartJavaScript(webView, VIEWPORT_FIX_JS, setOf(origin)) }
+    }
+    // Re-applied in onPageFinished too (covers WebViews without document-start
+    // support, and pages that finish after the initial DOMContentLoaded).
+}
+
+/**
  * Install the auth bridge (`window.AurbodaNative.getAuth()`) the embedded web
  * app reads at startup.
  *
@@ -164,6 +185,10 @@ fun EmbeddedWebScreen(
                         override fun onPageFinished(view: WebView, url: String?) {
                             loading = false
                             canGoBack = view.canGoBack()
+                            // Re-assert the viewport-height workaround (see
+                            // installViewportFix): covers WebViews without
+                            // document-start support and post-load layout.
+                            view.evaluateJavascript(VIEWPORT_FIX_JS, null)
                         }
 
                         override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
@@ -203,6 +228,7 @@ fun EmbeddedWebScreen(
                             }
                         }
                     }
+                    installViewportFix(this, originOf(baseUrl))
                     webView = this
                     loadUrl(url)
                 }


### PR DESCRIPTION
The **real, verified** fix for the squeezed timeline (supersedes the ineffective #960 approach).

## Root cause (reproduced + instrumented in an emulator)
I booted the API 36 emulator, pointed a WebView at `/timeline?embed=1`, and injected a measurement overlay. Result:

```
iH=915   (window.innerHeight — correct!)
html h=0px  body h=0px
#app oh=0  h=0px  min-height=0px   ← collapsed
.app-content=293  main=293  chart=150
```

So `window.innerHeight` is correct, but the CSS **`100vh` unit and the `%` height chain resolve to 0** in this WebView — a known Android WebView race where Blink's layout viewport height for `vh`/ICB is 0 even though the widget is sized. `#app{height:100vh}` → 0, everything collapses to content height. **#960's `useWideViewPort` did not fix it** (measured `#app=0` with it on). Deferring `loadUrl` until laid-out didn't help either. Setting `<html>` height from `innerHeight` px **did** (`chart 150→772`).

## Fix
A document-start script (injected **only in the WebView**, so browsers are untouched) pins `<html>` height to `window.innerHeight`, lets `body`/`#app` fill via `%`, and re-applies on `resize` (+ re-asserted in `onPageFinished` for WebViews without document-start support).

## Verified
On the emulator, across 3 launches: `chart=772  #app=915  iH=915` — the timeline fills the screen every time (before: `chart=150 #app=0`).

## Follow-up
#960 (`useWideViewPort`) is now redundant for this bug but harmless; leaving it. Could revert separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)