### PR TITLE
feat(feed): per-actor notify_on_post preference on follows (#957 slice 1)

### DIFF
--- a/apps/backend/src/db/feed-following.integration.test.ts
+++ b/apps/backend/src/db/feed-following.integration.test.ts
@@ -13,6 +13,7 @@ import {
   markFeedFollowingAccepted,
   removeFeedFollowing,
   removeFeedFollowingByActor,
+  updateFeedFollowingNotify,
   upsertFeedFollowing,
 } from './feed-following.ts'
 
@@ -129,6 +130,23 @@ describe('Feed following integration', () => {
     expect(await getFeedFollowing(user, rec.id)).toBeNull()
     // Removing again returns null.
     expect(await removeFeedFollowing(user, rec.id)).toBeNull()
+  })
+
+  test('notify_on_post defaults to true and can be toggled, preserved across re-follow', async () => {
+    const user = getTestUser()
+    const rec = await upsertFeedFollowing(user, alice)
+    expect(rec.notify_on_post).toBe(true)
+
+    const muted = await updateFeedFollowingNotify(user, rec.id, false)
+    expect(muted?.notify_on_post).toBe(false)
+    expect((await getFeedFollowing(user, rec.id))?.notify_on_post).toBe(false)
+
+    // Re-following must not silently re-enable notifications the user muted.
+    const again = await upsertFeedFollowing(user, alice)
+    expect(again.notify_on_post).toBe(false)
+
+    // Toggling an unknown follow returns null.
+    expect(await updateFeedFollowingNotify(user, '00000000-0000-0000-0000-000000000000', true)).toBeNull()
   })
 
   test('removes by actor uri (e.g. on a Reject)', async () => {

--- a/apps/backend/src/db/feed-following.ts
+++ b/apps/backend/src/db/feed-following.ts
@@ -21,6 +21,7 @@ export interface FeedFollowingRecord {
   display_name: string | null
   avatar_url: string | null
   accepted: boolean
+  notify_on_post: boolean
   created_at: Date
 }
 
@@ -34,7 +35,7 @@ export interface FeedFollowingInput {
 }
 
 const FEED_FOLLOWING_COLUMNS =
-  'id, actor_uri, inbox_uri, shared_inbox_uri, handle, display_name, avatar_url, accepted, created_at'
+  'id, actor_uri, inbox_uri, shared_inbox_uri, handle, display_name, avatar_url, accepted, notify_on_post, created_at'
 
 /**
  * Insert or update a followee by actor URI. Re-following refreshes the cached
@@ -136,6 +137,20 @@ export const removeFeedFollowing = async (user: string, id: string): Promise<Fee
 export const removeFeedFollowingByActor = async (user: string, actorUri: string): Promise<boolean> => {
   const result = await query(user, `DELETE FROM feed_following WHERE actor_uri = $1`, [actorUri])
   return (result.rowCount ?? 0) > 0
+}
+
+/** Set whether new posts from a followee (by local id) should notify. */
+export const updateFeedFollowingNotify = async (
+  user: string,
+  id: string,
+  notifyOnPost: boolean,
+): Promise<FeedFollowingRecord | null> => {
+  const result = await query<FeedFollowingRecord>(
+    user,
+    `UPDATE feed_following SET notify_on_post = $1 WHERE id = $2 RETURNING ${FEED_FOLLOWING_COLUMNS}`,
+    [notifyOnPost, id],
+  )
+  return result.rows[0] ?? null
 }
 
 /** Mark a pending follow accepted (the followee's server answered with `Accept`). */

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -301,6 +301,7 @@ export {
   markFeedFollowingAccepted,
   removeFeedFollowing,
   removeFeedFollowingByActor,
+  updateFeedFollowingNotify,
   upsertFeedFollowing,
 } from './feed-following.ts'
 

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -27,6 +27,7 @@ import {
   listFeedFollowers,
   listFeedFollowing,
   listFeedPosts,
+  updateFeedFollowingNotify,
   updateFeedPost,
 } from '../db/index.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
@@ -186,6 +187,20 @@ export const registerFeedTools = (
       const removed = await followActions.unfollow(user, id)
       if (!removed) return errorResponse('Not following that actor')
       return jsonResponse({ id, unfollowed: true })
+    },
+  )
+
+  server.tool(
+    'set_following_notify',
+    'Enable or disable notifications for new posts from a followed actor (by the local follow id from `list_following`).',
+    {
+      id: z.string().uuid().describe('Local follow id (the `id` from list_following)'),
+      notify_on_post: z.boolean().describe('Whether new posts from this actor should notify'),
+    },
+    async ({ id, notify_on_post }) => {
+      const record = await updateFeedFollowingNotify(user, id, notify_on_post)
+      if (!record) return errorResponse('Not following that actor')
+      return jsonResponse(serializeFollowing(record))
     },
   )
 

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -11,6 +11,7 @@ import {
   timelineQuerySchema,
   updateArticleBodySchema,
   updateFeedPostBodySchema,
+  updateFollowingBodySchema,
 } from '@aurboda/api-spec'
 import { z } from 'zod'
 
@@ -195,7 +196,7 @@ export const registerFeedTools = (
     'Enable or disable notifications for new posts from a followed actor (by the local follow id from `list_following`).',
     {
       id: z.string().uuid().describe('Local follow id (the `id` from list_following)'),
-      notify_on_post: z.boolean().describe('Whether new posts from this actor should notify'),
+      ...updateFollowingBodySchema.shape,
     },
     async ({ id, notify_on_post }) => {
       const record = await updateFeedFollowingNotify(user, id, notify_on_post)

--- a/apps/backend/src/routes/feed-following-router.ts
+++ b/apps/backend/src/routes/feed-following-router.ts
@@ -16,9 +16,11 @@ import {
   followActorBodySchema,
   type FollowActorResponse,
   type FollowingResponse,
+  type UpdateFollowingBody,
+  updateFollowingBodySchema,
 } from '@aurboda/api-spec'
 
-import { listFeedFollowing } from '../db/index.ts'
+import { listFeedFollowing, updateFeedFollowingNotify } from '../db/index.ts'
 import { type FollowActions, serializeFollowing } from '../services/following.ts'
 import { type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody } from '../validation.ts'
@@ -46,6 +48,20 @@ export const createFeedFollowingRouter = (
         return res.status(result.status).json({ error: result.error, success: false })
       }
       res.json({ actor: serializeFollowing(result.record), success: true })
+    },
+  )
+
+  router.patch<{ id: string }, FollowActorResponse, UpdateFollowingBody>(
+    '/:id',
+    authMiddleware,
+    validateBody(updateFollowingBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const record = await updateFeedFollowingNotify(user, req.params.id, req.body.notify_on_post)
+      if (!record) {
+        return res.status(404).json({ error: 'Not following that actor', success: false })
+      }
+      res.json({ actor: serializeFollowing(record), success: true })
     },
   )
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -149,6 +149,7 @@ export const tableCreationOrder = [
   'feed_follower',
   'feed_follower_columns',
   'feed_following',
+  'feed_following_notify',
   'timeline_entry',
   'timeline_entry_structured',
   'timeline_entry_images',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -224,8 +224,13 @@ export const socialTables: Record<string, string> = {
       display_name     TEXT,
       avatar_url       TEXT,
       accepted         BOOLEAN NOT NULL DEFAULT false,
+      notify_on_post   BOOLEAN NOT NULL DEFAULT true,
       created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
+  `,
+  // Additive migration for pre-existing feed_following tables (idempotent).
+  feed_following_notify: `
+    ALTER TABLE feed_following ADD COLUMN IF NOT EXISTS notify_on_post BOOLEAN NOT NULL DEFAULT true
   `,
 
   // The user's home timeline: posts received from actors they follow (inbound

--- a/apps/backend/src/services/activitypub/timeline-backfill.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-backfill.test.ts
@@ -16,6 +16,7 @@ const followee = (accepted: boolean): FeedFollowingRecord => ({
   handle: '@alice@mastodon.example',
   id: 'follow-1',
   inbox_uri: `${ACTOR}/inbox`,
+  notify_on_post: true,
   shared_inbox_uri: null,
 })
 

--- a/apps/backend/src/services/activitypub/timeline-ingest.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.test.ts
@@ -59,6 +59,7 @@ describe('noteToTimelineInput', () => {
     handle: '@alice@mastodon.example',
     id: '11111111-1111-1111-1111-111111111111',
     inbox_uri: 'https://mastodon.example/users/alice/inbox',
+    notify_on_post: true,
     shared_inbox_uri: null,
   }
 

--- a/apps/backend/src/services/challenge-federation.ts
+++ b/apps/backend/src/services/challenge-federation.ts
@@ -17,7 +17,6 @@ import {
   type WellKnownAurboda,
   wellKnownAurbodaSchema,
 } from '@aurboda/api-spec'
-
 import { isAxiosError } from 'axios'
 
 import { isValidUsername } from '../api/auth-routes.ts'

--- a/apps/backend/src/services/chart-data.test.ts
+++ b/apps/backend/src/services/chart-data.test.ts
@@ -1,6 +1,6 @@
-import type * as TimeSeriesModule from '../db/time-series.ts'
-
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type * as TimeSeriesModule from '../db/time-series.ts'
 
 import * as db from '../db/index.ts'
 import { buildBucketExpr, getChartData } from './chart-data.ts'

--- a/apps/backend/src/services/following.test.ts
+++ b/apps/backend/src/services/following.test.ts
@@ -60,6 +60,7 @@ describe('serializeFollowing', () => {
       handle: '@alice@mastodon.example',
       id: '11111111-1111-1111-1111-111111111111',
       inbox_uri: 'https://mastodon.example/users/alice/inbox',
+      notify_on_post: false,
       shared_inbox_uri: 'https://mastodon.example/inbox',
     }
 
@@ -72,6 +73,7 @@ describe('serializeFollowing', () => {
       display_name: 'Alice',
       handle: '@alice@mastodon.example',
       id: '11111111-1111-1111-1111-111111111111',
+      notify_on_post: false,
     })
     // Internal delivery details must not leak to the owner-facing surface.
     expect(dto).not.toHaveProperty('inbox_uri')

--- a/apps/backend/src/services/following.ts
+++ b/apps/backend/src/services/following.ts
@@ -92,6 +92,7 @@ export const serializeFollowing = (record: FeedFollowingRecord): FollowingActor 
   display_name: record.display_name,
   handle: record.handle,
   id: record.id,
+  notify_on_post: record.notify_on_post,
 })
 
 /** The AS2 id we mint for our outbound Follow of a followee (stable per row). */

--- a/apps/backend/src/services/mutations.test.ts
+++ b/apps/backend/src/services/mutations.test.ts
@@ -1,6 +1,6 @@
-import type * as TimeSeriesModule from '../db/time-series.ts'
-
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type * as TimeSeriesModule from '../db/time-series.ts'
 
 import * as db from '../db/index.ts'
 import { parseMetricEntityId, toMetricEntityId } from './metric-entity-id.ts'
@@ -683,7 +683,12 @@ describe('bulkAddMetrics', () => {
     const result = await bulkAddMetrics('testuser', [
       // Default source 'aurboda' is allowed for cumulative metrics.
       { metric: 'steps', time: new Date('2026-05-27T00:00:00Z'), value: 5000 },
-      { metric: 'steps', source: 'health_connect_aggregate', time: new Date('2026-05-28T00:00:00Z'), value: 6000 },
+      {
+        metric: 'steps',
+        source: 'health_connect_aggregate',
+        time: new Date('2026-05-28T00:00:00Z'),
+        value: 6000,
+      },
     ])
 
     expect(result.inserted).toBe(2)

--- a/apps/backend/src/services/safe-fetch.ts
+++ b/apps/backend/src/services/safe-fetch.ts
@@ -39,8 +39,9 @@ const isBlockedIPv6 = (raw: string): boolean => {
   // real hosts are unaffected while embedded-IPv4 tricks are all blocked.
   if (ip.startsWith('::')) return true
   if (ip.startsWith('64:ff9b:')) return true // NAT64 (embeds an IPv4 in the low bits)
-  if (ip.startsWith('fe8') || ip.startsWith('fe9') || ip.startsWith('fea') || ip.startsWith('feb'))
-    {return true} // fe80::/10 link-local
+  if (ip.startsWith('fe8') || ip.startsWith('fe9') || ip.startsWith('fea') || ip.startsWith('feb')) {
+    return true
+  } // fe80::/10 link-local
   if (ip.startsWith('fc') || ip.startsWith('fd')) return true // fc00::/7 unique-local
   return false
 }

--- a/apps/backend/src/services/shared-dashboard-data.ts
+++ b/apps/backend/src/services/shared-dashboard-data.ts
@@ -176,7 +176,9 @@ const resolveBarChart = async (
         ? [
             {
               bucket_start: b.bucket_start,
-              series: Object.fromEntries(Object.entries(b.series).map(([name, value]) => [mask(name), value])),
+              series: Object.fromEntries(
+                Object.entries(b.series).map(([name, value]) => [mask(name), value]),
+              ),
             },
           ]
         : [],

--- a/apps/web/src/pages/Feed/FollowingPanel.tsx
+++ b/apps/web/src/pages/Feed/FollowingPanel.tsx
@@ -9,14 +9,21 @@ import type { FollowingActor } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
-import { fetchFollowing, followActor, unfollowActor } from '../../state/api'
+import { fetchFollowing, followActor, unfollowActor, updateFollowingNotify } from '../../state/api'
 import { ActorName } from './ActorName'
 
 const FollowingRow = ({ actor }: { actor: FollowingActor }) => {
   const queryClient = useQueryClient()
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['following'] })
   const unfollow = useMutation({
     mutationFn: () => unfollowActor(actor.id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['following'] }),
+    onSuccess: invalidate,
+  })
+  // Per-actor notification toggle (used by the app to decide which followed
+  // accounts' new posts push a notification).
+  const notify = useMutation({
+    mutationFn: () => updateFollowingNotify(actor.id, !actor.notify_on_post),
+    onSuccess: invalidate,
   })
 
   const name = actor.display_name ?? actor.handle ?? actor.actor_uri
@@ -38,6 +45,16 @@ const FollowingRow = ({ actor }: { actor: FollowingActor }) => {
           Pending
         </span>
       )}
+      <button
+        type="button"
+        class="following-notify"
+        aria-pressed={actor.notify_on_post}
+        onClick={() => notify.mutate()}
+        disabled={notify.isPending}
+        title={actor.notify_on_post ? 'Notifications on — tap to mute' : 'Muted — tap to notify on new posts'}
+      >
+        {actor.notify_on_post ? '🔔' : '🔕'}
+      </button>
       <button
         type="button"
         class="btn-secondary following-unfollow"

--- a/apps/web/src/pages/Feed/style.css
+++ b/apps/web/src/pages/Feed/style.css
@@ -175,6 +175,25 @@
   flex-shrink: 0;
 }
 
+/* Per-actor notification toggle (bell / muted bell). */
+.following-notify {
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1.15rem;
+  line-height: 1;
+  padding: 0.2rem 0.3rem;
+}
+
+.following-notify[aria-pressed='false'] {
+  opacity: 0.45;
+}
+
+.following-notify:disabled {
+  cursor: default;
+}
+
 /* Followers panel — pending-request subsection + approve/reject actions. */
 .followers-subtitle {
   margin: 0.75rem 0 0;

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -125,6 +125,17 @@ export const unfollowActor = async (id: string): Promise<void> => {
   await axios.delete(`${API_URL}/feed/following/${id}`, { headers: authHeaders() })
 }
 
+/** Toggle whether new posts from a followed actor notify (by its local follow id). */
+export const updateFollowingNotify = async (id: string, notify_on_post: boolean): Promise<FollowingActor> => {
+  const response = await axios.patch<FollowActorResponse>(
+    `${API_URL}/feed/following/${id}`,
+    { notify_on_post },
+    { headers: authHeaders() },
+  )
+  if (!response.data.actor) throw new Error('Update failed: no actor returned')
+  return response.data.actor
+}
+
 /** List the actors that follow the user, optionally filtered by acceptance state. */
 export const fetchFollowers = async (status: FollowersQuery['status'] = 'all'): Promise<FollowerActor[]> => {
   const response = await axios.get<FollowersResponse>(`${API_URL}/feed/followers`, {

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -156,6 +156,11 @@ and removes the row. Local follows use the exact same path (delivered to the loc
 over loopback), so there is no special-casing. Delivery is best-effort/synchronous, matching
 the rest of the feed — a failed `Follow` POST leaves the pending row so the user can retry.
 
+Each follow carries a **`notify_on_post`** flag (default `true`), toggled per-actor with the
+bell in the web Following panel (or the `set_following_notify` MCP tool / `PATCH
+/feed/following/:id`). It controls whether the Android app raises a notification for that
+actor's new home-timeline posts; muting is preserved across a re-follow.
+
 The actor advertises a **following collection** (`/users/<username>/following`) listing only
 _accepted_ follows (a pending follow isn't a confirmed relationship yet). The followee's
 inbox URIs are internal delivery details and are never exposed on the owner-facing API.

--- a/packages/api-spec/src/schemas/admin.ts
+++ b/packages/api-spec/src/schemas/admin.ts
@@ -34,7 +34,10 @@ export const serverStatusResponseSchema = baseResponseSchema
       .boolean()
       .optional()
       .meta({ description: 'Whether this instance supports cross-instance federation' }),
-    product: z.literal('aurboda').optional().meta({ description: 'Product identifier for federation discovery' }),
+    product: z
+      .literal('aurboda')
+      .optional()
+      .meta({ description: 'Product identifier for federation discovery' }),
     // For backwards compatibility
     signup_allowed: z
       .boolean()

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -358,10 +358,24 @@ export const followingActorSchema = z
     display_name: z.string().nullable().meta({ description: "The followee's display name, if known" }),
     handle: z.string().nullable().meta({ description: "The followee's `@user@host` handle, if resolvable" }),
     id: z.string().uuid().meta({ description: 'Local id of the follow (used to unfollow)' }),
+    notify_on_post: z.boolean().meta({
+      description: "Whether to notify on this actor's new posts (used by the app for push notifications)",
+    }),
   })
   .meta({ id: 'FollowingActor' })
 
 export type FollowingActor = z.infer<typeof followingActorSchema>
+
+/** Body for updating a follow's per-actor settings (currently the notify toggle). */
+export const updateFollowingBodySchema = z
+  .object({
+    notify_on_post: z.boolean().meta({
+      description: "Whether to notify on this actor's new posts",
+    }),
+  })
+  .meta({ id: 'UpdateFollowingBody' })
+
+export type UpdateFollowingBody = z.infer<typeof updateFollowingBodySchema>
 
 /** Response wrapping a single follow (e.g. the result of following an actor). */
 export const followActorResponseSchema = baseResponseSchema


### PR DESCRIPTION
**Slice 1 of #957** (post notifications). Adds a per-followed-account preference for whether that actor's new posts should notify — the backend + web foundation the Android background poller (Slice 2) will read.

## Layers (API/MCP parity)
- **DB**: `notify_on_post BOOLEAN NOT NULL DEFAULT true` on `feed_following`, with an idempotent additive migration. Kept out of the upsert `SET`, so **muting survives a re-follow**.
- **api-spec**: `notify_on_post` on `FollowingActor`; new `UpdateFollowingBody` schema.
- **backend**: `updateFeedFollowingNotify` DB fn → `PATCH /feed/following/:id` (REST) and `set_following_notify` (MCP); `serializeFollowing` exposes the field.
- **web**: a 🔔/🔕 toggle per row in the **Following** panel + `updateFollowingNotify` client.
- **docs**: `docs/features/feed.md`.

## Tests
- Integration: default `true`, toggle, persistence, **preserved across re-follow**, null for unknown id.
- Affected suites green: backend unit + `feed-following` integration + `feed-router`, web (548).

## Next (Slice 2)
Android WorkManager poller reading `notify_on_post`.

## Note
`oxfmt` reflowed a few pre-unformatted files (braces only) — kept per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)