### PR TITLE
feat(android): notify on new posts from followed accounts (#957 slice 2)

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AurbodaApplication.kt
@@ -26,6 +26,11 @@ class AurbodaApplication : Application() {
     } else {
       Log.d(TAG, "Background sync is not enabled")
     }
+
+    // Resume the home-timeline post notifier across restarts if the user left it on.
+    if (isPostNotificationsEnabled(this)) {
+      NotificationWorker.schedule(this)
+    }
   }
 
   private fun isBackgroundSyncEnabled(context: Context): Boolean {

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -143,6 +143,7 @@ class MainActivity : ComponentActivity() {
   companion object {
     const val EXTRA_OPEN_TAB = "open_tab"
     const val TAB_ADD = "add"
+    const val TAB_FEED = "feed"
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -150,6 +151,7 @@ class MainActivity : ComponentActivity() {
     val initialTab =
       when (intent?.getStringExtra(EXTRA_OPEN_TAB)) {
         TAB_ADD -> MainTab.Add
+        TAB_FEED -> MainTab.Feed
         else -> null
       }
     setContent {

--- a/apps/android/app/src/main/java/net/aurboda/NotificationApi.kt
+++ b/apps/android/app/src/main/java/net/aurboda/NotificationApi.kt
@@ -1,0 +1,44 @@
+package net.aurboda
+
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+
+/**
+ * Read-only backend calls for the post notifier: the newest page of the home
+ * timeline and the following list (to know which actors still have notifications
+ * on). Both return null on any error — the worker simply retries next period.
+ */
+private const val TAG = "NotificationApi"
+
+/** GET {apiUrl}/feed/timeline — newest home-timeline posts. */
+suspend fun fetchTimelinePage(httpClient: HttpClient, apiUrl: String, authToken: String): TimelinePage? =
+    getJson(httpClient, "$apiUrl/feed/timeline", authToken)
+
+/** GET {apiUrl}/feed/following — the actors this user follows (with notify flags). */
+suspend fun fetchFollowingList(httpClient: HttpClient, apiUrl: String, authToken: String): FollowingList? =
+    getJson(httpClient, "$apiUrl/feed/following", authToken)
+
+private suspend inline fun <reified T> getJson(
+    httpClient: HttpClient,
+    url: String,
+    authToken: String,
+): T? =
+    try {
+        val response = httpClient.get(url) {
+            headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        }
+        if (response.status == HttpStatusCode.OK) {
+            appJson.decodeFromString<T>(response.bodyAsText())
+        } else {
+            Log.w(TAG, "GET $url returned ${response.status}")
+            null
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "GET $url failed: ${e.message}")
+        null
+    }

--- a/apps/android/app/src/main/java/net/aurboda/NotificationWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/NotificationWorker.kt
@@ -1,0 +1,132 @@
+package net.aurboda
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodic background poll that notifies the user when accounts they follow post
+ * to their home timeline. Runs only while the user has enabled post
+ * notifications; per-account muting is honoured server-side via each follow's
+ * `notify_on_post` flag. The which-posts-to-notify decision is the pure
+ * [decideNotifications]; this worker is just the I/O + notification plumbing.
+ */
+class NotificationWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val ctx = applicationContext
+        if (!isPostNotificationsEnabled(ctx)) return Result.success()
+
+        val credentials = CredentialsManager.getCredentials(ctx) ?: return Result.success()
+
+        val httpClient = syncHttpClient()
+        try {
+            val following = fetchFollowingList(httpClient, credentials.apiUrl, credentials.authToken)
+                ?: return Result.retry()
+            val timeline = fetchTimelinePage(httpClient, credentials.apiUrl, credentials.authToken)
+                ?: return Result.retry()
+
+            val notifyActors = following.following.filter { it.notifyOnPost }.map { it.actorUri }.toSet()
+            val decision = decideNotifications(timeline.entries, notifyActors, getNotifyHighWater(ctx))
+
+            if (decision.toNotify.isNotEmpty()) {
+                ensureChannel(ctx)
+                decision.toNotify.takeLast(MAX_PER_RUN).forEach { postNotification(ctx, it) }
+            }
+            decision.newHighWater?.let { setNotifyHighWater(ctx, it) }
+            return Result.success()
+        } catch (e: Exception) {
+            Log.w(TAG, "Notification poll failed: ${e.message}")
+            return Result.retry()
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    private fun postNotification(ctx: Context, entry: TimelineEntry) {
+        // areNotificationsEnabled covers the runtime POST_NOTIFICATIONS grant on
+        // 13+ and the user muting the channel/app — skip quietly if off.
+        val manager = NotificationManagerCompat.from(ctx)
+        if (!manager.areNotificationsEnabled()) return
+
+        val openIntent = Intent(ctx, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_FEED)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            ctx,
+            entry.objectUri.hashCode(),
+            openIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(ctx, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(entry.authorLabel)
+            .setContentText(htmlToSnippet(entry.content))
+            .setStyle(NotificationCompat.BigTextStyle().bigText(htmlToSnippet(entry.content, maxLength = 400)))
+            .setAutoCancel(true)
+            .setGroup(GROUP_KEY)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        try {
+            manager.notify(entry.objectUri.hashCode(), notification)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "notify() denied: ${e.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "NotificationWorker"
+        private const val WORK_NAME = "post_notifications_poll"
+        private const val CHANNEL_ID = "post_notifications"
+        private const val GROUP_KEY = "net.aurboda.POSTS"
+        private const val MAX_PER_RUN = 8
+
+        fun ensureChannel(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "New posts",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply { description = "Posts from accounts you follow" }
+            context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+
+        fun schedule(context: Context) {
+            ensureChannel(context)
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+            val request = PeriodicWorkRequestBuilder<NotificationWorker>(15, TimeUnit.MINUTES)
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE, request)
+            Log.d(TAG, "Post-notification poll scheduled")
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            Log.d(TAG, "Post-notification poll cancelled")
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/PostNotificationPrefs.kt
+++ b/apps/android/app/src/main/java/net/aurboda/PostNotificationPrefs.kt
@@ -1,0 +1,33 @@
+package net.aurboda
+
+import android.content.Context
+import java.time.Instant
+
+/**
+ * Persistent settings for the home-timeline post notifier: the user's global
+ * on/off toggle and the high-water mark (latest post already notified about, ISO
+ * string). Stored in the shared app prefs alongside the background-sync flag.
+ */
+private const val POST_NOTIF_PREFS = "AurbodaAppPrefs"
+private const val POST_NOTIF_ENABLED_KEY = "postNotificationsEnabled"
+private const val POST_NOTIF_HIGH_WATER_KEY = "postNotificationsHighWater"
+
+private fun postNotifPrefs(context: Context) =
+    context.getSharedPreferences(POST_NOTIF_PREFS, Context.MODE_PRIVATE)
+
+fun isPostNotificationsEnabled(context: Context): Boolean =
+    postNotifPrefs(context).getBoolean(POST_NOTIF_ENABLED_KEY, false)
+
+fun setPostNotificationsEnabled(context: Context, enabled: Boolean) {
+    postNotifPrefs(context).edit().putBoolean(POST_NOTIF_ENABLED_KEY, enabled).apply()
+}
+
+/** Latest post already notified about, or null if the notifier hasn't run yet. */
+fun getNotifyHighWater(context: Context): Instant? {
+    val raw = postNotifPrefs(context).getString(POST_NOTIF_HIGH_WATER_KEY, null) ?: return null
+    return runCatching { Instant.parse(raw) }.getOrNull()
+}
+
+fun setNotifyHighWater(context: Context, highWater: Instant) {
+    postNotifPrefs(context).edit().putString(POST_NOTIF_HIGH_WATER_KEY, highWater.toString()).apply()
+}

--- a/apps/android/app/src/main/java/net/aurboda/PostNotifications.kt
+++ b/apps/android/app/src/main/java/net/aurboda/PostNotifications.kt
@@ -1,0 +1,103 @@
+package net.aurboda
+
+import java.time.Instant
+import java.time.OffsetDateTime
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Data models + pure decision logic for the home-timeline post notifier
+ * (NotificationWorker). Only the fields the notifier needs are declared; the
+ * shared `appJson` ignores unknown keys, so the rest of the API payload is fine.
+ */
+
+/** One home-timeline post (subset of the backend `TimelineEntry`). */
+@Serializable
+data class TimelineEntry(
+    @SerialName("object_uri") val objectUri: String,
+    @SerialName("actor_uri") val actorUri: String,
+    val handle: String? = null,
+    @SerialName("display_name") val displayName: String? = null,
+    val content: String = "",
+    @SerialName("published_at") val publishedAt: String,
+) {
+    /** Best available human name for the notification title. */
+    val authorLabel: String get() = displayName ?: handle ?: actorUri
+}
+
+/** A page of the home timeline (subset of `TimelineResponse`). */
+@Serializable
+data class TimelinePage(
+    val entries: List<TimelineEntry> = emptyList(),
+)
+
+/** A followed actor (subset of `FollowingActor`) — only what the notifier needs. */
+@Serializable
+data class FollowingActorLite(
+    @SerialName("actor_uri") val actorUri: String,
+    @SerialName("notify_on_post") val notifyOnPost: Boolean = true,
+)
+
+/** The owner's following list (subset of `FollowingResponse`). */
+@Serializable
+data class FollowingList(
+    val following: List<FollowingActorLite> = emptyList(),
+)
+
+/** Outcome of a notifier poll: which posts to notify + the new high-water mark. */
+data class NotifyDecision(
+    /** Posts to raise a notification for, oldest-first. */
+    val toNotify: List<TimelineEntry>,
+    /** New high-water mark (latest post seen), or the previous one when nothing was seen. */
+    val newHighWater: Instant?,
+)
+
+/** Lenient ISO-8601 parse (`Z` or an explicit offset), null when unparseable. */
+fun parsePublishedAt(value: String): Instant? =
+    runCatching { OffsetDateTime.parse(value).toInstant() }.getOrNull()
+
+/**
+ * Decide which timeline posts to notify about.
+ *
+ * Notify a post when it is (a) newer than [highWater], and (b) from an actor in
+ * [notifyActorUris] (a followed account with notifications left on). The new
+ * high-water mark advances to the latest post seen across the whole page — so a
+ * muted or already-seen post never re-triggers.
+ *
+ * On the first run ([highWater] is null) nothing is notified — we only record the
+ * high-water mark, so enabling the feature doesn't dump the whole backlog.
+ */
+fun decideNotifications(
+    entries: List<TimelineEntry>,
+    notifyActorUris: Set<String>,
+    highWater: Instant?,
+): NotifyDecision {
+    val dated = entries.mapNotNull { entry -> parsePublishedAt(entry.publishedAt)?.let { entry to it } }
+    val maxSeen = dated.maxOfOrNull { it.second }
+    val newHighWater = listOfNotNull(highWater, maxSeen).maxOrNull()
+
+    if (highWater == null) {
+        return NotifyDecision(toNotify = emptyList(), newHighWater = newHighWater)
+    }
+
+    val toNotify = dated
+        .filter { (entry, published) -> published.isAfter(highWater) && entry.actorUri in notifyActorUris }
+        .sortedBy { it.second }
+        .map { it.first }
+    return NotifyDecision(toNotify = toNotify, newHighWater = newHighWater)
+}
+
+/** Turn sanitised post HTML into a short plain-text snippet for a notification body. */
+fun htmlToSnippet(html: String, maxLength: Int = 140): String {
+    val text = html
+        .replace(Regex("<[^>]+>"), " ")
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+    return if (text.length > maxLength) text.take(maxLength - 1).trimEnd() + "…" else text
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/AccountScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/AccountScreen.kt
@@ -1,7 +1,13 @@
 package net.aurboda.ui.screens
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +19,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,8 +28,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import net.aurboda.NotificationWorker
+import net.aurboda.isPostNotificationsEnabled
+import net.aurboda.setPostNotificationsEnabled
 
 @Composable
 fun AccountScreen(
@@ -34,6 +46,37 @@ fun AccountScreen(
 ) {
     var editedServerUrl by remember(serverUrl) { mutableStateOf(serverUrl) }
     val hasChanges = editedServerUrl != serverUrl
+
+    val context = LocalContext.current
+    var notifyEnabled by remember { mutableStateOf(isPostNotificationsEnabled(context)) }
+
+    val turnOn = {
+        setPostNotificationsEnabled(context, true)
+        NotificationWorker.schedule(context)
+        notifyEnabled = true
+    }
+    // On Android 13+ raising a notification needs the runtime POST_NOTIFICATIONS
+    // grant; request it when the user turns the feature on.
+    val notifyPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> if (granted) turnOn() else notifyEnabled = false }
+
+    val onNotifyToggle = { want: Boolean ->
+        if (want) {
+            val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+            if (needsPermission) {
+                notifyPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                turnOn()
+            }
+        } else {
+            setPostNotificationsEnabled(context, false)
+            NotificationWorker.cancel(context)
+            notifyEnabled = false
+        }
+    }
 
     Column(
         modifier = modifier
@@ -93,6 +136,27 @@ fun AccountScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
         }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Notify me about new posts",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = "A notification when accounts you follow post. Mute individual accounts on the Feed page.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(checked = notifyEnabled, onCheckedChange = onNotifyToggle)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
 
         OutlinedButton(
             onClick = onLogout,

--- a/apps/android/app/src/test/java/net/aurboda/PostNotificationsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/PostNotificationsTest.kt
@@ -1,0 +1,89 @@
+package net.aurboda
+
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PostNotificationsTest {
+
+    private fun entry(objectUri: String, actorUri: String, published: String) =
+        TimelineEntry(objectUri = objectUri, actorUri = actorUri, publishedAt = published)
+
+    private val alice = "https://mastodon.example/users/alice"
+    private val bob = "https://mastodon.example/users/bob"
+
+    @Test
+    fun `first run notifies nothing but records the high-water mark`() {
+        val entries = listOf(
+            entry("p1", alice, "2026-07-15T10:00:00Z"),
+            entry("p2", bob, "2026-07-15T11:00:00Z"),
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice, bob), highWater = null)
+
+        assertTrue(decision.toNotify.isEmpty())
+        assertEquals(Instant.parse("2026-07-15T11:00:00Z"), decision.newHighWater)
+    }
+
+    @Test
+    fun `notifies only posts newer than high-water from notify-on actors`() {
+        val hw = Instant.parse("2026-07-15T10:00:00Z")
+        val entries = listOf(
+            entry("old", alice, "2026-07-15T09:00:00Z"), // older than hw → skip
+            entry("new-alice", alice, "2026-07-15T10:30:00Z"), // notify
+            entry("new-bob", bob, "2026-07-15T11:00:00Z"), // bob muted → skip
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
+
+        assertEquals(listOf("new-alice"), decision.toNotify.map { it.objectUri })
+        assertEquals(Instant.parse("2026-07-15T11:00:00Z"), decision.newHighWater)
+    }
+
+    @Test
+    fun `toNotify is ordered oldest-first`() {
+        val hw = Instant.parse("2026-07-15T00:00:00Z")
+        val entries = listOf(
+            entry("c", alice, "2026-07-15T12:00:00Z"),
+            entry("a", alice, "2026-07-15T08:00:00Z"),
+            entry("b", alice, "2026-07-15T10:00:00Z"),
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
+        assertEquals(listOf("a", "b", "c"), decision.toNotify.map { it.objectUri })
+    }
+
+    @Test
+    fun `high-water never moves backwards when the page is empty`() {
+        val hw = Instant.parse("2026-07-15T10:00:00Z")
+        val decision = decideNotifications(emptyList(), notifyActorUris = setOf(alice), highWater = hw)
+        assertTrue(decision.toNotify.isEmpty())
+        assertEquals(hw, decision.newHighWater)
+    }
+
+    @Test
+    fun `empty first run leaves high-water null`() {
+        val decision = decideNotifications(emptyList(), notifyActorUris = emptySet(), highWater = null)
+        assertNull(decision.newHighWater)
+    }
+
+    @Test
+    fun `unparseable timestamps are ignored`() {
+        val hw = Instant.parse("2026-07-15T10:00:00Z")
+        val entries = listOf(
+            entry("bad", alice, "not-a-date"),
+            entry("good", alice, "2026-07-15T11:00:00Z"),
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
+        assertEquals(listOf("good"), decision.toNotify.map { it.objectUri })
+        assertEquals(Instant.parse("2026-07-15T11:00:00Z"), decision.newHighWater)
+    }
+
+    @Test
+    fun `htmlToSnippet strips tags, unescapes entities, and truncates`() {
+        assertEquals("Hello world", htmlToSnippet("<p>Hello <b>world</b></p>"))
+        assertEquals("a & b < c", htmlToSnippet("a &amp; b &lt; c"))
+        val long = htmlToSnippet("<p>${"x".repeat(200)}</p>", maxLength = 10)
+        assertTrue(long.endsWith("…"))
+        assertEquals(10, long.length)
+    }
+}

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -30,6 +30,19 @@ hub (after any embedded page has exhausted its own WebView history). Keep
 A tab can move from embedded to native later (e.g. if the feed becomes a heavily
 used, interaction-rich screen) without affecting the other tabs.
 
+## Post notifications
+
+A native background poller (`NotificationWorker`, a periodic WorkManager job)
+notifies the user when accounts they follow post to their home timeline. Each
+run fetches `/feed/following` and `/feed/timeline`, then the pure, unit-tested
+`decideNotifications` (`PostNotifications.kt`) picks which posts to notify: those
+newer than a stored high-water mark and from a followed actor whose server-side
+`notify_on_post` flag is on (toggled per-account on the web Feed page). The first
+run only records the high-water mark, so enabling the feature doesn't dump the
+backlog. The user opts in with the **"Notify me about new posts"** switch on the
+Account screen, which requests `POST_NOTIFICATIONS` (Android 13+) and
+schedules/cancels the worker; tapping a notification opens the Feed tab.
+
 ## Embedded web views
 
 `ui/screens/EmbeddedWebScreen.kt` is the reusable WebView host: it enables


### PR DESCRIPTION
**Slice 2 of #957** (completes it). The Android app now notifies the user when accounts they follow post to their home timeline — honouring the per-account `notify_on_post` flag from slice 1 (#962).

## How it works
- **`NotificationWorker`** — a periodic WorkManager job (15 min, `CONNECTED` constraint, mirroring `SyncWorker`). Each run fetches `/feed/following` (which actors still have notifications on) + `/feed/timeline` (newest posts), decides what's new, and posts notifications.
- **`PostNotifications.kt`** — hand-written kotlinx.serialization DTOs (only the fields needed; `ignoreUnknownKeys`) + the **pure, unit-tested `decideNotifications`**: notify posts newer than a stored **high-water mark** from actors in the notify-on set; the **first run only records the mark** (no backlog dump). Plus `htmlToSnippet` for the body.
- **Opt-in toggle** — a *"Notify me about new posts"* switch on the Account screen requests `POST_NOTIFICATIONS` (Android 13+) and schedules/cancels the worker; `AurbodaApplication` resumes it on app start. Default **off**.
- **Tap → Feed tab** (`MainActivity.TAB_FEED`).
- **Per-account muting** happens on the web Feed page (the 🔔 toggle from #962).

## Tests
- `PostNotificationsTest`: first-run-records-only, newer-than-high-water + notify-on filtering, oldest-first ordering, high-water never regresses, unparseable timestamps ignored, `htmlToSnippet`. `:app:testDebugUnitTest` + `:app:assembleDebug` green.

## Needs on-device verification
End-to-end delivery needs a real account with a followed account that posts — please verify once built: toggle on (permission prompt), then a new post from a followed (un-muted) account raises a notification that opens the Feed; muting that account on the web stops it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)