### PR TITLE
feat(android): open Goals from the goal widget, keep screen if app already open

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -103,6 +103,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.Aurboda">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -144,23 +144,33 @@ class MainActivity : ComponentActivity() {
     const val EXTRA_OPEN_TAB = "open_tab"
     const val TAB_ADD = "add"
     const val TAB_FEED = "feed"
+    const val TAB_MORE = "more"
+
+    /** With [EXTRA_OPEN_TAB] = [TAB_MORE], the More web page to open (e.g. "/goals"). */
+    const val EXTRA_MORE_PATH = "more_path"
   }
 
+  // Deep links (widget / notification) only steer the initial screen on a cold
+  // start. The activity is `singleTop`, so when it's already open the launch is
+  // delivered to onNewIntent (not overridden) and the current screen is kept.
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    val openTab = intent?.getStringExtra(EXTRA_OPEN_TAB)
     val initialTab =
-      when (intent?.getStringExtra(EXTRA_OPEN_TAB)) {
+      when (openTab) {
         TAB_ADD -> MainTab.Add
         TAB_FEED -> MainTab.Feed
+        TAB_MORE -> MainTab.More
         else -> null
       }
+    val initialMorePath = if (openTab == TAB_MORE) intent?.getStringExtra(EXTRA_MORE_PATH) else null
     setContent {
       AurbodaAppTheme {
         Surface(
           modifier = Modifier.fillMaxSize(),
           color = MaterialTheme.colorScheme.background,
         ) {
-          AurbodaApp(initialTab = initialTab)
+          AurbodaApp(initialTab = initialTab, initialMorePath = initialMorePath)
         }
       }
     }
@@ -171,8 +181,11 @@ private const val VERSION_JSON_URL = "https://github.com/fiddur/aurboda/releases
 
 @Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
 @Composable
-fun AurbodaApp(initialTab: MainTab? = null) {
+fun AurbodaApp(initialTab: MainTab? = null, initialMorePath: String? = null) {
   val appState = rememberAppState(initialTab = initialTab)
+  // Consumed once: a widget/notification deep link into a More web page opens it
+  // on first composition, then clears so returning to More later shows the hub.
+  var pendingMorePath by remember { mutableStateOf(initialMorePath) }
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
   val ktorHttpClient = remember { syncHttpClient() }
@@ -327,6 +340,8 @@ fun AurbodaApp(initialTab: MainTab? = null) {
               credentials = credentials,
               onServerUrlChange = { newUrl -> appState.changeServerUrl(newUrl) },
               onLogout = { appState.logout() },
+              initialPath = pendingMorePath,
+              onInitialPathConsumed = { pendingMorePath = null },
               modifier = modifier,
             )
           },

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -105,8 +106,13 @@ fun MoreScreen(
     onServerUrlChange: (String) -> Unit,
     onLogout: () -> Unit,
     modifier: Modifier = Modifier,
+    initialPath: String? = null,
+    onInitialPathConsumed: () -> Unit = {},
 ) {
-    var destination by remember { mutableStateOf<MoreDestination?>(null) }
+    // A deep link (e.g. the goals widget) can open this hub directly on a web
+    // page; consumed once so a later manual visit to More shows the hub.
+    var destination by remember { mutableStateOf<MoreDestination?>(initialPath?.let { MoreDestination.Web(it) }) }
+    LaunchedEffect(Unit) { if (initialPath != null) onInitialPathConsumed() }
 
     when (val dest = destination) {
         null -> MoreHub(onSelect = { destination = it }, modifier = modifier)

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -50,11 +50,14 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
   ) {
     val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
 
-    // Set up click handler to open the app on the Data tab
+    // Tapping the widget opens the app on the Goals page. SINGLE_TOP reuses an
+    // already-running app (keeping whatever screen it's on) rather than
+    // recreating it; the Goals deep link only applies on a cold start.
     val openAppIntent =
       Intent(context, MainActivity::class.java).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-        putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_ADD)
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_MORE)
+        putExtra(MainActivity.EXTRA_MORE_PATH, "/goals")
       }
     val pendingIntent =
       PendingIntent.getActivity(


### PR DESCRIPTION
Tapping the goal widget now opens the app on the **Goals** page (which is embedded in the app now), but doesn't yank you off your current screen if the app's already open.

## Changes
- **Widget → Goals**: `HrZoneWidgetProvider` now deep-links to the embedded Goals page (`More → /goals`) via `EXTRA_OPEN_TAB=more` + `EXTRA_MORE_PATH=/goals` (was opening the Add tab).
- **Keep current screen if already open**: `MainActivity` is now `launchMode=singleTop`, and the widget launches with `FLAG_ACTIVITY_SINGLE_TOP`. When the app is already running it's reused via `onNewIntent` (not overridden), so it stays on whatever screen it's on. The Goals deep link is applied **only on a cold start** (`onCreate`).
- **One-shot deep link**: `MoreScreen` takes an `initialPath` consumed once (`LaunchedEffect` + `onInitialPathConsumed`), so a later *manual* visit to More still shows the hub, not Goals.

## Verification
`:app:assembleDebug` + `:app:testDebugUnitTest` green. Deep-link/launch behavior needs an on-device check (place the goal widget, tap it cold → lands on Goals; tap it while the app is open on another screen → stays put).

🤖 Generated with [Claude Code](https://claude.com/claude-code)