### PR TITLE
perf(analyze): don't block correlations on inline provider syncs

### DIFF
--- a/apps/backend/src/services/correlations/activity-impact.ts
+++ b/apps/backend/src/services/correlations/activity-impact.ts
@@ -7,6 +7,7 @@ import type { ActivityImpactResult, TimeWindowStats } from './types.ts'
 
 import { getAllActivitiesInRange, getProductivity, getTimeSeries } from '../../db/index.ts'
 import { getPlaceVisits } from '../locations.ts'
+import { triggerCorrelationSyncs } from './background-sync.ts'
 import { getDataInRange, mean, stddev } from './utils.ts'
 
 /**
@@ -27,15 +28,9 @@ export async function getActivityImpact(
   start.setDate(start.getDate() - periodDays)
   start.setHours(0, 0, 0, 0)
 
-  // Auto-sync if provider available
-  if (sync) {
-    await Promise.all([
-      sync.syncOuraIfNeeded(user, 'tags'),
-      sync.syncOuraIfNeeded(user, 'sessions'),
-      sync.syncRescueTimeIfNeeded(user),
-      sync.syncCalendarsIfNeeded(user),
-    ])
-  }
+  // Freshness syncs run in the background — never block this retrospective
+  // analysis on a slow external sync (see background-sync.ts).
+  triggerCorrelationSyncs(sync, user)
 
   // Fetch HRV/HR/stress data
   const [hrvData, hrData, stressData] = await Promise.all([

--- a/apps/backend/src/services/correlations/hrv-activities.ts
+++ b/apps/backend/src/services/correlations/hrv-activities.ts
@@ -14,6 +14,7 @@ import type {
 
 import { getAllActivitiesInRange, getProductivity, getTimeSeries } from '../../db/index.ts'
 import { getPlaceVisits } from '../locations.ts'
+import { triggerCorrelationSyncs } from './background-sync.ts'
 import { addBaselineDelta, calculateHrvStats, getDataInRange, pearsonCorrelation } from './utils.ts'
 
 /**
@@ -32,15 +33,10 @@ export async function getHrvActivitiesCorrelation(
   start.setDate(start.getDate() - periodDays)
   start.setHours(0, 0, 0, 0)
 
-  // Auto-sync if provider available
-  if (sync) {
-    await Promise.all([
-      sync.syncOuraIfNeeded(user, 'tags'),
-      sync.syncOuraIfNeeded(user, 'sessions'),
-      sync.syncRescueTimeIfNeeded(user),
-      sync.syncCalendarsIfNeeded(user),
-    ])
-  }
+  // Freshness syncs run in the background — never block the (retrospective)
+  // analysis on a slow external sync, which could take minutes (see
+  // background-sync.ts). Data is fresh for the next request.
+  triggerCorrelationSyncs(sync, user)
 
   // Fetch all data in parallel
   const [hrvData, hrData, stressData, productivity, locations, activities] = await Promise.all([

--- a/docs/features/correlations.md
+++ b/docs/features/correlations.md
@@ -134,4 +134,4 @@ Different categories sample HRV from different time windows:
 - The Pearson correlation coefficient requires at least 3 data points and only measures linear relationships. Non-linear associations won't be captured.
 - Correlation does not imply causation. A strong correlation between two events might be caused by a third, unmeasured factor.
 - Tag correlations look at a 30-minute window before the tag, which means the HRV/HR values reflect your state leading into the tagged event, not necessarily caused by it.
-- Auto-sync is triggered before correlation computation, which may add a brief delay on the first load.
+- Auto-sync is triggered in the background (fire-and-forget) — it never blocks correlation computation, so the analysis returns from existing data immediately. Newly synced data lands on the next request, so the first load after a stale period may reflect slightly out-of-date data.


### PR DESCRIPTION
Addresses the "Analyze spins for minutes" issue (the "optimize first" direction).

## Root cause
`getHrvActivitiesCorrelation` (the Analyze **context** tab) and `getActivityImpact` (the row-click before/during/after detail) **awaited external freshness syncs** (Oura tags/sessions, RescueTime, calendars) *inline* before computing. A first/stale sync hits external APIs and can take minutes — long enough to blow the HTTP timeout — so the page just shows "Analyzing correlations…" indefinitely.

The fire-and-forget **`triggerCorrelationSyncs`** helper already exists for exactly this ("Correlation analysis is retrospective … it must never block the response on live external syncs") and is used by `explore.ts` / `generic.ts` — these two services simply never got migrated.

## Fix
Swap the blocking `await Promise.all([...syncs])` for `triggerCorrelationSyncs(sync, user)` in both. The (retrospective) analysis now returns from existing DB data immediately; the syncs refresh in the background so data is fresh next time. Both services already fire the exact sync set the helper does, so no behavior change beyond not blocking.

## Tests
All 88 correlation tests pass; typecheck clean.

## Follow-up (if still slow)
With syncs no longer blocking, the remaining cost is the raw HRV/HR fetch over the period (continuous HR can be large). If that's still slow, the next step is bucketing that fetch (`getTimeSeriesBucketed`) and/or caching results — flagged, not needed yet. (`event-probability.ts` has the same blocking pattern with a different sync set; left out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)