### PR TITLE
feat(feed): server-side article-block rendering + AS2 Article federation (#937 Slice C, part 1)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,6 +30,7 @@
     "express": "^5.1.0",
     "fit-file-parser": "^2.3.3",
     "jsdom": "^26.1.0",
+    "marked": "^17.0.3",
     "multer": "^2.1.1",
     "node-ical": "^0.25.1",
     "pg": "^8.13.1",

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -57,7 +57,15 @@ import { stravaClient } from './integrations/strava/client.ts'
 import { createMcpRouter } from './mcp.ts'
 import { createFeedTombstoneRouter } from './routes/feed-tombstone-router.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
-import { deliverFeedDelete, deliverFeedPost, deliverFeedUpdate } from './services/activitypub/deliver.ts'
+import {
+  deliverFeedArticleDelete,
+  deliverFeedArticlePost,
+  deliverFeedArticleUpdate,
+  deliverFeedDelete,
+  deliverFeedPost,
+  deliverFeedUpdate,
+  toDeliverableArticle,
+} from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
 import { createTimelineBackfiller } from './services/activitypub/timeline-backfill.ts'
 import { auditError } from './services/audit-log.ts'
@@ -352,8 +360,14 @@ const main = async () => {
         await deliverFeedPost(feedDeps, user, post, resolved)
       })().catch(onDeliverError('create', user, post.id))
     },
+    // An article has no linked activity, so its Delete is tombstoned from the
+    // article object id; every other post from the Note id.
     deleted: (user, post) => {
-      void deliverFeedDelete(feedDeps, user, post).catch(onDeliverError('delete', user, post.id))
+      const article = toDeliverableArticle(post)
+      const run = article
+        ? deliverFeedArticleDelete(feedDeps, user, article)
+        : deliverFeedDelete(feedDeps, user, post)
+      void run.catch(onDeliverError('delete', user, post.id))
     },
     // Resolve the (merged-span) activity inside the fire-and-forget boundary so a
     // lookup failure never bubbles into the (already-committed) edit's response.
@@ -363,6 +377,20 @@ const main = async () => {
         const activity = await resolveFeedActivity(user, post.activity_id)
         if (activity) await deliverFeedUpdate(feedDeps, user, post, activity)
       })().catch(onDeliverError('update', user, post.id))
+    },
+    // Articles fan out as an AS2 Article (built purely from stored content — no
+    // activity to resolve). Best-effort, same as the Note path.
+    createdArticle: (user, post) => {
+      const article = toDeliverableArticle(post)
+      if (article) {
+        void deliverFeedArticlePost(feedDeps, user, article).catch(onDeliverError('create', user, post.id))
+      }
+    },
+    updatedArticle: (user, post) => {
+      const article = toDeliverableArticle(post)
+      if (article) {
+        void deliverFeedArticleUpdate(feedDeps, user, article).catch(onDeliverError('update', user, post.id))
+      }
     },
   }
   // The network-requiring follow operations, bound to the same federation +

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -58,7 +58,6 @@ import { createMcpRouter } from './mcp.ts'
 import { createFeedTombstoneRouter } from './routes/feed-tombstone-router.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
 import {
-  deliverFeedArticleDelete,
   deliverFeedArticlePost,
   deliverFeedArticleUpdate,
   deliverFeedDelete,
@@ -360,14 +359,10 @@ const main = async () => {
         await deliverFeedPost(feedDeps, user, post, resolved)
       })().catch(onDeliverError('create', user, post.id))
     },
-    // An article has no linked activity, so its Delete is tombstoned from the
-    // article object id; every other post from the Note id.
+    // Articles and activities share the Note object id, so a deleted post of
+    // either kind tombstones there — one path.
     deleted: (user, post) => {
-      const article = toDeliverableArticle(post)
-      const run = article
-        ? deliverFeedArticleDelete(feedDeps, user, article)
-        : deliverFeedDelete(feedDeps, user, post)
-      void run.catch(onDeliverError('delete', user, post.id))
+      void deliverFeedDelete(feedDeps, user, post).catch(onDeliverError('delete', user, post.id))
     },
     // Resolve the (merged-span) activity inside the fire-and-forget boundary so a
     // lookup failure never bubbles into the (already-committed) edit's response.

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -373,8 +373,8 @@ const main = async () => {
         if (activity) await deliverFeedUpdate(feedDeps, user, post, activity)
       })().catch(onDeliverError('update', user, post.id))
     },
-    // Articles fan out as an AS2 Article (built purely from stored content — no
-    // activity to resolve). Best-effort, same as the Note path.
+    // Articles fan out as a Create{Note}/Update{Note} built purely from stored
+    // content (no activity to resolve). Best-effort, same as the activity path.
     createdArticle: (user, post) => {
       const article = toDeliverableArticle(post)
       if (article) {

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -16,7 +16,6 @@ import type { FollowerActions } from '../services/followers.ts'
 import type { FollowActions } from '../services/following.ts'
 import type { InvitationAuth } from '../services/invitation.ts'
 import type { OuraWebhookManager } from '../services/oura-webhook-manager.ts'
-import type { SyncProvider } from '../services/queries/index.ts'
 import type { TimelineHub } from '../services/timeline-hub.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 import type { AnyMiddleware } from '../typed-router.ts'
@@ -63,12 +62,15 @@ import { createTrainingLoadRouter } from '../routes/training-load-router.ts'
 import { createTrendsRouter } from '../routes/trends-router.ts'
 import { createWebAuthnRouter } from '../routes/webauthn-router.ts'
 import { createWellKnownRouter, type WellKnownConfig } from '../routes/well-known-router.ts'
-import { renderChartPng, renderRoutePng } from '../services/activitypub/feed-images.ts'
+import { renderChartPng, renderRoutePng, renderScatterPng } from '../services/activitypub/feed-images.ts'
 import { fetchOsmTile } from '../services/activitypub/osm-tiles.ts'
 import { loadAvatarDataUri } from '../services/avatar-resolve.ts'
 import { buildChartSvg } from '../services/charts/chart-svg.ts'
+import { buildScatterSvg } from '../services/charts/scatter-svg.ts'
+import { getContinuousCorrelation } from '../services/correlations/index.ts'
 import { resolveFeedActivity } from '../services/feed.ts'
 import { createOgImageRenderer } from '../services/og-image.ts'
+import { type SyncProvider, queryMetricsBucketed } from '../services/queries/index.ts'
 import { createTemplateLoader } from '../services/web-template.ts'
 
 interface RestRoutesDeps {
@@ -173,6 +175,39 @@ export const mountRestRouters = ({
       // Merged-span window so the rendered chart/route cover what the user
       // shared, matching the Note's duration/metrics (#881).
       getActivity: resolveFeedActivity,
+      // An article chart block's bucketed metric series over its locked window
+      // (mirrors the web's live bucketed render).
+      getArticleChartSeries: async (user, metric, start, end, bucket) => {
+        const result = await queryMetricsBucketed(user, [metric], start, end, bucket)
+        const series: [Date, number][] = []
+        for (const b of result.buckets) {
+          const avg = b.metrics[metric]?.avg
+          if (avg != null) series.push([new Date(b.start), avg])
+        }
+        return series
+      },
+      // An article correlation block's continuous scatter over its locked window;
+      // null when too sparse to be meaningful (n < 3), which 404s the image.
+      getCorrelationScatter: async (user, { end, lagDays, outcome, start, trigger }) => {
+        const c = await getContinuousCorrelation(user, {
+          lagDays,
+          outcome,
+          periodEnd: end.toISOString().slice(0, 10),
+          periodStart: start.toISOString().slice(0, 10),
+          trigger,
+        })
+        if (c.n < 3) return null
+        return {
+          group_comparison: c.group_comparison,
+          n: c.n,
+          outcome,
+          pearson: c.pearson,
+          pearson_p: c.pearson_p,
+          series: c.series,
+          spearman: c.spearman,
+          trigger,
+        }
+      },
       getPost: getFeedPostById,
       getRoute: async (user, start, end) =>
         (await getLocations(user, start, end)).locations.map((l) => l.coordinates),
@@ -182,6 +217,8 @@ export const mountRestRouters = ({
       // Draw the route over the OSM basemap; falls back to a bare shape if tiles
       // can't be fetched (e.g. offline).
       renderRoute: (coords) => renderRoutePng(coords, { fetchTile: fetchOsmTile }),
+      renderScatter: renderScatterPng,
+      renderScatterSvg: buildScatterSvg,
     }),
   )
   httpd.use(createPublicSharesRouter(webHost))

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -200,12 +200,12 @@ export const mountRestRouters = ({
       },
       // An article correlation block's continuous scatter over its locked window;
       // null when too sparse to be meaningful (n < 3), which 404s the image.
-      getCorrelationScatter: async (user, { end, lagDays, outcome, start, trigger }) => {
+      getCorrelationScatter: async (user, { lagDays, outcome, periodEnd, periodStart, trigger }) => {
         const c = await getContinuousCorrelation(user, {
           lagDays,
           outcome,
-          periodEnd: end.toISOString().slice(0, 10),
-          periodStart: start.toISOString().slice(0, 10),
+          periodEnd,
+          periodStart,
           trigger,
         })
         if (c.n < 3) return null

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -20,7 +20,13 @@ import type { TimelineHub } from '../services/timeline-hub.ts'
 import type { WebAuthnService } from '../services/webauthn.ts'
 import type { AnyMiddleware } from '../typed-router.ts'
 
-import { getFeedPostById, getLocations, getTimeSeries, markActivityDetailSynced } from '../db/index.ts'
+import {
+  getFeedPostById,
+  getLocations,
+  getTimeSeries,
+  getUserSettings,
+  markActivityDetailSynced,
+} from '../db/index.ts'
 import { processActivityDetail } from '../integrations/garmin/process.ts'
 import { createActivitiesRouter } from '../routes/activities-router.ts'
 import { createActivityTypesRouter } from '../routes/activity-types-router.ts'
@@ -176,9 +182,15 @@ export const mountRestRouters = ({
       // shared, matching the Note's duration/metrics (#881).
       getActivity: resolveFeedActivity,
       // An article chart block's bucketed metric series over its locked window
-      // (mirrors the web's live bucketed render).
+      // (mirrors the web's live bucketed render). Bucket in the author's own
+      // timezone (`device_timezone`, IANA — auto-detected from their device) so a
+      // `1d` bucket splits on the author's calendar days, matching the web render
+      // (which sends the browser tz); falls back to UTC when it's unset.
       getArticleChartSeries: async (user, metric, start, end, bucket) => {
-        const result = await queryMetricsBucketed(user, [metric], start, end, bucket)
+        const settings = await getUserSettings(user)
+        const result = await queryMetricsBucketed(user, [metric], start, end, bucket, {
+          tz: settings?.device_timezone ?? undefined,
+        })
         const series: [Date, number][] = []
         for (const b of result.buckets) {
           const avg = b.metrics[metric]?.avg

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -96,8 +96,10 @@ export const registerFeedTools = (
         visibility: body.visibility,
       })
       if (!record) return errorResponse('Feed post not found')
-      // Federate the edit as an Update, same as the REST update route.
-      deliver?.updated(user, record)
+      // Federate the edit as an Update, same as the REST update route. An article
+      // has no linked activity, so route it through the article path.
+      if (record.kind === 'article') deliver?.updatedArticle(user, record)
+      else deliver?.updated(user, record)
       return jsonResponse(await serializeFeedPost(user, record))
     },
   )

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -115,6 +115,7 @@ export const registerFeedTools = (
       })
       if (!built.ok) return errorResponse(built.error)
       const record = await createArticlePost(user, { article: built.article, visibility: body.visibility })
+      deliver?.createdArticle(user, record)
       return jsonResponse(await serializeFeedPost(user, record))
     },
   )
@@ -132,6 +133,7 @@ export const registerFeedTools = (
       if (!built.ok) return errorResponse(built.error)
       const record = await updateFeedPost(user, id, { article: built.article, visibility: body.visibility })
       if (!record) return errorResponse('Article not found')
+      deliver?.updatedArticle(user, record)
       return jsonResponse(await serializeFeedPost(user, record))
     },
   )

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -6,6 +6,7 @@ import type { FeedPostRecord } from '../db/index.ts'
 import type { ScatterSvgData } from '../services/charts/scatter-svg.ts'
 
 import {
+  createNegativeCache,
   createRenderCache,
   type FeedImageDeps,
   type ImageActivity,
@@ -144,6 +145,22 @@ describe('resolveArticleBlock', () => {
     })
   })
 
+  test('correlation day bounds are the ISO window’s wall-clock day, not the UTC day', async () => {
+    // `…T23:30:00-05:00` is 2026-07-02T04:30Z — a Date round-trip would give the
+    // UTC day 07-02; the wall-clock day (matching the web scatter) is 07-01.
+    const offset = article([
+      {
+        end: '2026-07-10T00:00:00Z',
+        outcome: { kind: 'metric', metric: 'sleep_score' },
+        start: '2026-07-01T23:30:00-05:00',
+        trigger: { kind: 'metric', metric: 'steps' },
+        type: 'correlation',
+      },
+    ])
+    const block = await resolveArticleBlock(deps(articlePost(offset)), 'fiddur', POST_ID, 0)
+    expect(block).toMatchObject({ periodEnd: '2026-07-10', periodStart: '2026-07-01', type: 'correlation' })
+  })
+
   test('inherits the article default window when the block omits its own', async () => {
     const content = article([{ metric: 'heart_rate', type: 'chart' }], {
       default_end: WINDOW.end,
@@ -226,9 +243,9 @@ describe('renderArticleBlockImage', () => {
     updatedAt: UPDATED,
   }
   const correlationBlock: ResolvedArticleBlock = {
-    end: END,
     outcome: { kind: 'metric', metric: 'sleep_score' },
-    start: START,
+    periodEnd: '2026-07-08',
+    periodStart: '2026-07-01',
     trigger: { kind: 'metric', metric: 'steps' },
     type: 'correlation',
     updatedAt: UPDATED,
@@ -269,10 +286,10 @@ describe('renderArticleBlockImage', () => {
     const png = await renderArticleBlockImage(d, 'fiddur', correlationBlock, 'png')
     expect(png).toEqual(Buffer.from('scatter-png'))
     expect(d.getCorrelationScatter).toHaveBeenCalledWith('fiddur', {
-      end: END,
       lagDays: undefined,
       outcome: correlationBlock.type === 'correlation' ? correlationBlock.outcome : undefined,
-      start: START,
+      periodEnd: '2026-07-08',
+      periodStart: '2026-07-01',
       trigger: correlationBlock.type === 'correlation' ? correlationBlock.trigger : undefined,
     })
   })
@@ -292,6 +309,19 @@ describe('renderArticleBlockImage', () => {
     const png = await renderArticleBlockImage(d, 'fiddur', { ...chartBlock, bucket: '0s' }, 'png')
     expect(png).toBeNull()
     expect(d.getArticleChartSeries).not.toHaveBeenCalled()
+  })
+})
+
+describe('createNegativeCache', () => {
+  test('remembers a negative key and evicts the oldest past the bound', () => {
+    const neg = createNegativeCache(2)
+    expect(neg.has('a')).toBe(false)
+    neg.add('a')
+    neg.add('b')
+    expect(neg.has('a')).toBe(true)
+    neg.add('c') // over the bound → evicts the oldest ('a')
+    expect(neg.has('a')).toBe(false)
+    expect(neg.has('c')).toBe(true)
   })
 })
 

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -145,19 +145,19 @@ describe('resolveArticleBlock', () => {
     })
   })
 
-  test('correlation day bounds are the ISO window’s wall-clock day, not the UTC day', async () => {
-    // `…T23:30:00-05:00` is 2026-07-02T04:30Z — a Date round-trip would give the
-    // UTC day 07-02; the wall-clock day (matching the web scatter) is 07-01.
-    const offset = article([
+  test('correlation day bounds are the ISO window’s date part (matches the web toDay)', async () => {
+    // Windows are Z-only (iso8601DateTimeSchema), so the day is `iso.slice(0, 10)` —
+    // slicing the raw string, not round-tripping through Date, keeps web parity exact.
+    const corr = article([
       {
-        end: '2026-07-10T00:00:00Z',
+        end: '2026-07-10T06:00:00Z',
         outcome: { kind: 'metric', metric: 'sleep_score' },
-        start: '2026-07-01T23:30:00-05:00',
+        start: '2026-07-01T18:00:00Z',
         trigger: { kind: 'metric', metric: 'steps' },
         type: 'correlation',
       },
     ])
-    const block = await resolveArticleBlock(deps(articlePost(offset)), 'fiddur', POST_ID, 0)
+    const block = await resolveArticleBlock(deps(articlePost(corr)), 'fiddur', POST_ID, 0)
     expect(block).toMatchObject({ periodEnd: '2026-07-10', periodStart: '2026-07-01', type: 'correlation' })
   })
 

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -1,8 +1,15 @@
+import type { ArticleContent } from '@aurboda/api-spec'
+
 import { describe, expect, test, vi } from 'vitest'
 
 import type { FeedPostRecord } from '../db/index.ts'
 
-import { createRenderCache, type ImageActivity, resolveImageWindow } from './feed-image-router.ts'
+import {
+  createRenderCache,
+  type ImageActivity,
+  resolveArticleBlock,
+  resolveImageWindow,
+} from './feed-image-router.ts'
 
 const POST_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 const ACTIVITY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -88,6 +95,103 @@ describe('resolveImageWindow', () => {
   test('null for an open-ended activity (no bounded window)', async () => {
     const openEnded = { start_time: activity.start_time }
     expect(await resolveImageWindow(deps(makePost(), openEnded), 'fiddur', POST_ID, 'include_map')).toBeNull()
+  })
+})
+
+const WINDOW = { end: '2026-07-02T00:00:00Z', start: '2026-07-01T00:00:00Z' }
+
+const article = (blocks: ArticleContent['blocks'], extra: Partial<ArticleContent> = {}): ArticleContent => ({
+  blocks,
+  title: 'My analysis',
+  ...extra,
+})
+
+const articlePost = (content: ArticleContent, overrides: Partial<FeedPostRecord> = {}): FeedPostRecord =>
+  makePost({ activity_id: null, article: content, kind: 'article', ...overrides })
+
+describe('resolveArticleBlock', () => {
+  const chart = article([{ end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' }])
+  const correlation = article([
+    {
+      end: WINDOW.end,
+      outcome: { kind: 'metric', metric: 'sleep_score' },
+      start: WINDOW.start,
+      trigger: { kind: 'metric', metric: 'steps' },
+      type: 'correlation',
+    },
+  ])
+
+  test('resolves a chart block to its metric and window', async () => {
+    const block = await resolveArticleBlock(deps(articlePost(chart)), 'fiddur', POST_ID, 0)
+    expect(block).toMatchObject({
+      end: new Date(WINDOW.end),
+      metric: 'heart_rate',
+      start: new Date(WINDOW.start),
+      type: 'chart',
+    })
+  })
+
+  test('resolves a correlation block with its selectors', async () => {
+    const block = await resolveArticleBlock(deps(articlePost(correlation)), 'fiddur', POST_ID, 0)
+    expect(block).toMatchObject({
+      outcome: { kind: 'metric', metric: 'sleep_score' },
+      trigger: { kind: 'metric', metric: 'steps' },
+      type: 'correlation',
+    })
+  })
+
+  test('inherits the article default window when the block omits its own', async () => {
+    const content = article([{ metric: 'heart_rate', type: 'chart' }], {
+      default_end: WINDOW.end,
+      default_start: WINDOW.start,
+    })
+    const block = await resolveArticleBlock(deps(articlePost(content)), 'fiddur', POST_ID, 0)
+    expect(block).toMatchObject({ end: new Date(WINDOW.end), start: new Date(WINDOW.start), type: 'chart' })
+  })
+
+  test('carries the post updated_at (so an edit busts the image cache)', async () => {
+    const updated_at = new Date('2026-07-05T09:00:00Z')
+    const block = await resolveArticleBlock(deps(articlePost(chart, { updated_at })), 'fiddur', POST_ID, 0)
+    expect(block?.updatedAt).toEqual(updated_at)
+  })
+
+  test('null for a prose block, an out-of-range, negative, or non-integer index', async () => {
+    const content = article([{ markdown: '# hi', type: 'prose' }, ...chart.blocks])
+    expect(await resolveArticleBlock(deps(articlePost(content)), 'fiddur', POST_ID, 0)).toBeNull() // prose
+    expect(await resolveArticleBlock(deps(articlePost(content)), 'fiddur', POST_ID, 5)).toBeNull() // out of range
+    expect(await resolveArticleBlock(deps(articlePost(content)), 'fiddur', POST_ID, -1)).toBeNull()
+    expect(await resolveArticleBlock(deps(articlePost(content)), 'fiddur', POST_ID, 1.5)).toBeNull()
+    expect(await resolveArticleBlock(deps(articlePost(content)), 'fiddur', POST_ID, Number.NaN)).toBeNull()
+  })
+
+  test('null for a non-article post', async () => {
+    expect(await resolveArticleBlock(deps(makePost()), 'fiddur', POST_ID, 0)).toBeNull()
+  })
+
+  test('gated on visibility only — no include_chart flag needed for an article', async () => {
+    // A public article block resolves even with include_chart off (articles have
+    // no opt-in flag; visibility is the whole boundary, #943).
+    const post = articlePost(chart, { include_chart: false })
+    expect(await resolveArticleBlock(deps(post), 'fiddur', POST_ID, 0)).not.toBeNull()
+  })
+
+  test('followers-only: null without a token, resolves with the matching token, null with a wrong one', async () => {
+    const post = articlePost(chart, { image_token: 'secret-token', visibility: 'followers' })
+    expect(await resolveArticleBlock(deps(post), 'fiddur', POST_ID, 0)).toBeNull()
+    expect(await resolveArticleBlock(deps(post), 'fiddur', POST_ID, 0, 'wrong')).toBeNull()
+    expect(await resolveArticleBlock(deps(post), 'fiddur', POST_ID, 0, 'secret-token')).not.toBeNull()
+  })
+
+  test('null when a block resolves to an unbounded or non-increasing window', async () => {
+    const noWindow = article([{ metric: 'heart_rate', type: 'chart' }]) // no block window, no article default
+    expect(await resolveArticleBlock(deps(articlePost(noWindow)), 'fiddur', POST_ID, 0)).toBeNull()
+    const reversed = article([{ end: WINDOW.start, metric: 'heart_rate', start: WINDOW.end, type: 'chart' }])
+    expect(await resolveArticleBlock(deps(articlePost(reversed)), 'fiddur', POST_ID, 0)).toBeNull()
+  })
+
+  test('null for an invalid username or non-UUID post id (no DB hit)', async () => {
+    expect(await resolveArticleBlock(deps(articlePost(chart)), 'Bad..Name', POST_ID, 0)).toBeNull()
+    expect(await resolveArticleBlock(deps(articlePost(chart)), 'fiddur', 'not-a-uuid', 0)).toBeNull()
   })
 })
 

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -3,11 +3,15 @@ import type { ArticleContent } from '@aurboda/api-spec'
 import { describe, expect, test, vi } from 'vitest'
 
 import type { FeedPostRecord } from '../db/index.ts'
+import type { ScatterSvgData } from '../services/charts/scatter-svg.ts'
 
 import {
   createRenderCache,
+  type FeedImageDeps,
   type ImageActivity,
+  renderArticleBlockImage,
   resolveArticleBlock,
+  type ResolvedArticleBlock,
   resolveImageWindow,
 } from './feed-image-router.ts'
 
@@ -192,6 +196,102 @@ describe('resolveArticleBlock', () => {
   test('null for an invalid username or non-UUID post id (no DB hit)', async () => {
     expect(await resolveArticleBlock(deps(articlePost(chart)), 'Bad..Name', POST_ID, 0)).toBeNull()
     expect(await resolveArticleBlock(deps(articlePost(chart)), 'fiddur', 'not-a-uuid', 0)).toBeNull()
+  })
+})
+
+describe('renderArticleBlockImage', () => {
+  const START = new Date('2026-07-01T00:00:00Z')
+  const END = new Date('2026-07-08T00:00:00Z')
+  const UPDATED = new Date('2026-07-09T00:00:00Z')
+  const series: [Date, number][] = [
+    [START, 60],
+    [END, 65],
+  ]
+  const scatter: ScatterSvgData = {
+    group_comparison: null,
+    n: 5,
+    outcome: { kind: 'metric', metric: 'sleep_score' },
+    pearson: 0.5,
+    pearson_p: 0.01,
+    series: [{ outcome: 2, trigger: 1 }],
+    spearman: 0.5,
+    trigger: { kind: 'metric', metric: 'steps' },
+  }
+
+  const chartBlock: ResolvedArticleBlock = {
+    end: END,
+    metric: 'heart_rate',
+    start: START,
+    type: 'chart',
+    updatedAt: UPDATED,
+  }
+  const correlationBlock: ResolvedArticleBlock = {
+    end: END,
+    outcome: { kind: 'metric', metric: 'sleep_score' },
+    start: START,
+    trigger: { kind: 'metric', metric: 'steps' },
+    type: 'correlation',
+    updatedAt: UPDATED,
+  }
+
+  const mkDeps = (over: Partial<FeedImageDeps> = {}): FeedImageDeps => ({
+    getActivity: async () => null,
+    getArticleChartSeries: vi.fn(async () => series),
+    getCorrelationScatter: vi.fn(async () => scatter),
+    getPost: async () => null,
+    getRoute: async () => [],
+    getSeries: async () => [],
+    renderChart: vi.fn(async () => Buffer.from('chart-png')),
+    renderChartSvg: vi.fn(() => '<svg>chart</svg>'),
+    renderRoute: async () => Buffer.from(''),
+    renderScatter: vi.fn(async () => Buffer.from('scatter-png')),
+    renderScatterSvg: vi.fn(() => '<svg>scatter</svg>'),
+    ...over,
+  })
+
+  test('renders a chart block as PNG (labelled with the metric display name)', async () => {
+    const d = mkDeps()
+    const png = await renderArticleBlockImage(d, 'fiddur', chartBlock, 'png')
+    expect(png).toEqual(Buffer.from('chart-png'))
+    expect(d.getArticleChartSeries).toHaveBeenCalledWith('fiddur', 'heart_rate', START, END, '1d')
+    expect(d.renderChart).toHaveBeenCalledWith(series, { color: '#673ab8', label: 'Heart Rate' })
+  })
+
+  test('renders a chart block as SVG bytes', async () => {
+    const d = mkDeps()
+    const svg = await renderArticleBlockImage(d, 'fiddur', chartBlock, 'svg')
+    expect(svg).toEqual(Buffer.from('<svg>chart</svg>', 'utf8'))
+    expect(d.renderScatter).not.toHaveBeenCalled()
+  })
+
+  test('renders a correlation block via the scatter renderer', async () => {
+    const d = mkDeps()
+    const png = await renderArticleBlockImage(d, 'fiddur', correlationBlock, 'png')
+    expect(png).toEqual(Buffer.from('scatter-png'))
+    expect(d.getCorrelationScatter).toHaveBeenCalledWith('fiddur', {
+      end: END,
+      lagDays: undefined,
+      outcome: correlationBlock.type === 'correlation' ? correlationBlock.outcome : undefined,
+      start: START,
+      trigger: correlationBlock.type === 'correlation' ? correlationBlock.trigger : undefined,
+    })
+  })
+
+  test('null when the chart has < 2 points', async () => {
+    const d = mkDeps({ getArticleChartSeries: vi.fn(async () => [[START, 60]] as [Date, number][]) })
+    expect(await renderArticleBlockImage(d, 'fiddur', chartBlock, 'png')).toBeNull()
+  })
+
+  test('null when the correlation is too sparse (getCorrelationScatter → null)', async () => {
+    const d = mkDeps({ getCorrelationScatter: vi.fn(async () => null) })
+    expect(await renderArticleBlockImage(d, 'fiddur', correlationBlock, 'png')).toBeNull()
+  })
+
+  test('null for a zero-duration bucket, without hitting the DB (avoids a date_bin 500)', async () => {
+    const d = mkDeps()
+    const png = await renderArticleBlockImage(d, 'fiddur', { ...chartBlock, bucket: '0s' }, 'png')
+    expect(png).toBeNull()
+    expect(d.getArticleChartSeries).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -1,5 +1,3 @@
-import { type Response, Router } from 'express'
-
 /**
  * Public feed-post image endpoints (UNAUTHENTICATED).
  *
@@ -20,10 +18,17 @@ import { type Response, Router } from 'express'
  * effect immediately — the untoken'd public URL then 404s). Mounted before the
  * generic `/public/:username/:slug` resolver.
  */
+import type { ArticleContent, CorrelationSelector, MetricType } from '@aurboda/api-spec'
+
+import { defaultArticleChartBucket, getMetricDisplayName } from '@aurboda/api-spec'
+import { type Response, Router } from 'express'
+
 import type { FeedPostRecord } from '../db/index.ts'
+import type { ScatterSvgData } from '../services/charts/scatter-svg.ts'
 
 import { isValidUsername } from '../api/auth-routes.ts'
 import { isMissingDatabase } from '../db/index.ts'
+import { blockWindow } from '../services/article.ts'
 import { isCapabilityAuthorized } from '../services/feed-capability.ts'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -34,16 +39,60 @@ export interface ImageActivity {
   end_time?: Date
 }
 
+/** Optional chart styling — an article block labels its chart with the metric. */
+export interface ChartRenderOpts {
+  label?: string
+  color?: string
+}
+
+/** The window-resolved inputs for one article correlation block's scatter. */
+export interface CorrelationBlockParams {
+  trigger: CorrelationSelector
+  outcome: CorrelationSelector
+  lagDays?: number
+  start: Date
+  end: Date
+}
+
 export interface FeedImageDeps {
   getPost: (user: string, postId: string) => Promise<FeedPostRecord | null>
   getActivity: (user: string, activityId: string) => Promise<ImageActivity | null>
   getSeries: (user: string, metric: string, start: Date, end: Date) => Promise<[Date, number][]>
   getRoute: (user: string, start: Date, end: Date) => Promise<[number, number][]>
-  renderChart: (series: [Date, number][]) => Promise<Buffer>
+  renderChart: (series: [Date, number][], opts?: ChartRenderOpts) => Promise<Buffer>
   /** Build the crisp `image/svg+xml` chart (same data as `renderChart`, no raster). */
-  renderChartSvg: (series: [Date, number][]) => string
+  renderChartSvg: (series: [Date, number][], opts?: ChartRenderOpts) => string
   renderRoute: (coords: [number, number][]) => Promise<Buffer>
+  /** A bucketed metric series for an article chart block over its locked window. */
+  getArticleChartSeries: (
+    user: string,
+    metric: MetricType,
+    start: Date,
+    end: Date,
+    bucket: string,
+  ) => Promise<[Date, number][]>
+  /** The continuous correlation for an article correlation block, or null when too sparse (n < 3). */
+  getCorrelationScatter: (user: string, params: CorrelationBlockParams) => Promise<ScatterSvgData | null>
+  renderScatter: (data: ScatterSvgData) => Promise<Buffer>
+  renderScatterSvg: (data: ScatterSvgData) => string
 }
+
+/**
+ * One article chart/correlation block resolved to its render inputs: the block's
+ * kind and its effective `[start, end]` window (its own override, else the
+ * article default). Prose blocks and out-of-range indices don't resolve.
+ */
+export type ResolvedArticleBlock =
+  | { type: 'chart'; metric: MetricType; bucket?: string; start: Date; end: Date; updatedAt: Date }
+  | {
+      type: 'correlation'
+      trigger: CorrelationSelector
+      outcome: CorrelationSelector
+      lagDays?: number
+      start: Date
+      end: Date
+      updatedAt: Date
+    }
 
 /**
  * A tiny memoising render cache with in-flight de-duplication (mirrors
@@ -110,6 +159,117 @@ export const resolveImageWindow = async (
   return activity
 }
 
+/**
+ * Resolve one article chart/correlation block to its render inputs, or `null`
+ * when the request isn't eligible: invalid username / non-UUID id / bad index,
+ * missing DB, missing post, a non-article post, a `followers`-only post without a
+ * matching capability `token`, an out-of-range or prose block, or a block whose
+ * effective window is unbounded / non-increasing. Pure of Express — unit-testable.
+ *
+ * Unlike a shared activity's chart, an article block has NO `include_chart`
+ * opt-in flag: a chart/correlation block can embed any metric over any window, so
+ * the post's visibility (public/unlisted open; followers-only via the unguessable
+ * `token`) is the whole authorization boundary (#943).
+ */
+/**
+ * Load the article behind an image request and authorize it, or `null` when
+ * ineligible (invalid username / non-UUID id, missing DB, missing post, a
+ * non-article post, or a `followers`-only post without a matching capability
+ * `token`). Split out of `resolveArticleBlock` to keep each piece simple.
+ */
+const loadArticleForImage = async (
+  deps: Pick<FeedImageDeps, 'getPost'>,
+  username: string,
+  postId: string,
+  token?: string,
+): Promise<{ article: ArticleContent; updatedAt: Date } | null> => {
+  if (!isValidUsername(username) || !UUID_RE.test(postId)) return null
+  let post: FeedPostRecord | null
+  try {
+    post = await deps.getPost(username, postId)
+  } catch (error) {
+    if (isMissingDatabase(error)) return null
+    throw error
+  }
+  if (post == null || post.kind !== 'article' || post.article == null) return null
+  if (!isCapabilityAuthorized(post, token)) return null
+  return { article: post.article, updatedAt: post.updated_at }
+}
+
+export const resolveArticleBlock = async (
+  deps: Pick<FeedImageDeps, 'getPost'>,
+  username: string,
+  postId: string,
+  index: number,
+  token?: string,
+): Promise<ResolvedArticleBlock | null> => {
+  if (!Number.isInteger(index) || index < 0) return null
+  const loaded = await loadArticleForImage(deps, username, postId, token)
+  if (loaded == null) return null
+  const block = loaded.article.blocks[index]
+  if (block == null || (block.type !== 'chart' && block.type !== 'correlation')) return null
+  const { end, start } = blockWindow(block, loaded.article)
+  if (start == null || end == null) return null
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  if (startDate.getTime() >= endDate.getTime()) return null
+  const updatedAt = loaded.updatedAt
+  if (block.type === 'chart') {
+    return {
+      bucket: block.bucket,
+      end: endDate,
+      metric: block.metric,
+      start: startDate,
+      type: 'chart',
+      updatedAt,
+    }
+  }
+  return {
+    end: endDate,
+    lagDays: block.lag_days,
+    outcome: block.outcome,
+    start: startDate,
+    trigger: block.trigger,
+    type: 'correlation',
+    updatedAt,
+  }
+}
+
+/** Article-chart line colour, matching the web inline render (`ArticleChartBlock`). */
+const ARTICLE_CHART_COLOR = '#673ab8'
+
+/**
+ * Render one resolved article block to its image bytes (PNG or the crisp SVG),
+ * or `null` when the block has too little data to draw (a chart needs ≥ 2 points;
+ * a correlation needs n ≥ 3, surfaced by `getCorrelationScatter` returning null).
+ * Pure of Express so the routes stay thin.
+ */
+const renderArticleBlockImage = async (
+  deps: FeedImageDeps,
+  user: string,
+  block: ResolvedArticleBlock,
+  format: 'png' | 'svg',
+): Promise<Buffer | null> => {
+  if (block.type === 'chart') {
+    const bucket = block.bucket ?? defaultArticleChartBucket(block.start, block.end)
+    const series = await deps.getArticleChartSeries(user, block.metric, block.start, block.end, bucket)
+    if (series.length < 2) return null
+    const opts: ChartRenderOpts = { color: ARTICLE_CHART_COLOR, label: getMetricDisplayName(block.metric) }
+    return format === 'png'
+      ? deps.renderChart(series, opts)
+      : Buffer.from(deps.renderChartSvg(series, opts), 'utf8')
+  }
+  const data = await deps.getCorrelationScatter(user, {
+    end: block.end,
+    lagDays: block.lagDays,
+    outcome: block.outcome,
+    start: block.start,
+    trigger: block.trigger,
+  })
+  if (data == null) return null
+  return format === 'png' ? deps.renderScatter(data) : Buffer.from(deps.renderScatterSvg(data), 'utf8')
+}
+
 const notFound = (res: Response) => res.status(404).json({ error: 'Not found', success: false })
 
 const sendPng = (res: Response, png: Buffer) => {
@@ -171,6 +331,35 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
     })
     if (!png) return notFound(res)
     sendPng(res, png)
+  })
+
+  // Article chart/correlation block images. Gated by post visibility + capability
+  // token only (no `include_chart` flag — a block can embed any metric, so
+  // visibility is the whole boundary, #943). Cache key includes the post's
+  // `updated_at` so editing the article serves a fresh render (articles, unlike
+  // shared activities, are mutable).
+  router.get('/public/:username/feed/:postId/blocks/:index/image.png', async (req, res) => {
+    const { index, postId, username } = req.params
+    const token = typeof req.query.token === 'string' ? req.query.token : undefined
+    const block = await resolveArticleBlock(deps, username, postId, Number(index), token)
+    if (!block) return notFound(res)
+    const png = await cached(`blockpng:${username}:${postId}:${index}:${block.updatedAt.getTime()}`, () =>
+      renderArticleBlockImage(deps, username, block, 'png'),
+    )
+    if (!png) return notFound(res)
+    sendPng(res, png)
+  })
+
+  router.get('/public/:username/feed/:postId/blocks/:index/image.svg', async (req, res) => {
+    const { index, postId, username } = req.params
+    const token = typeof req.query.token === 'string' ? req.query.token : undefined
+    const block = await resolveArticleBlock(deps, username, postId, Number(index), token)
+    if (!block) return notFound(res)
+    const svg = await cached(`blocksvg:${username}:${postId}:${index}:${block.updatedAt.getTime()}`, () =>
+      renderArticleBlockImage(deps, username, block, 'svg'),
+    )
+    if (!svg) return notFound(res)
+    sendSvg(res, svg)
   })
 
   return router

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -53,10 +53,12 @@ export interface CorrelationBlockParams {
   outcome: CorrelationSelector
   lagDays?: number
   /**
-   * Inclusive day bounds (`YYYY-MM-DD`), sliced from the block's ISO window so they
-   * are the author's wall-clock days — NOT a UTC-normalised day. Matches the web
-   * scatter's `iso.slice(0, 10)`, so an offset-bearing ISO (e.g. from `create_article`
-   * over MCP) covers the same day range in-app and in the federated/exported PNG.
+   * Inclusive day bounds (`YYYY-MM-DD`), sliced straight from the block's ISO
+   * window (`iso.slice(0, 10)`) to match the web scatter's `toDay()`. Block windows
+   * are `Z`-only (`iso8601DateTimeSchema` = `z.iso.datetime()`, offset false), so
+   * this is the UTC day — but slicing the raw string rather than round-tripping
+   * through `Date` keeps that parity exact and stays correct if the schema ever
+   * gains offset support.
    */
   periodStart: string
   periodEnd: string

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -52,8 +52,14 @@ export interface CorrelationBlockParams {
   trigger: CorrelationSelector
   outcome: CorrelationSelector
   lagDays?: number
-  start: Date
-  end: Date
+  /**
+   * Inclusive day bounds (`YYYY-MM-DD`), sliced from the block's ISO window so they
+   * are the author's wall-clock days — NOT a UTC-normalised day. Matches the web
+   * scatter's `iso.slice(0, 10)`, so an offset-bearing ISO (e.g. from `create_article`
+   * over MCP) covers the same day range in-app and in the federated/exported PNG.
+   */
+  periodStart: string
+  periodEnd: string
 }
 
 export interface FeedImageDeps {
@@ -91,8 +97,8 @@ export type ResolvedArticleBlock =
       trigger: CorrelationSelector
       outcome: CorrelationSelector
       lagDays?: number
-      start: Date
-      end: Date
+      periodStart: string
+      periodEnd: string
       updatedAt: Date
     }
 
@@ -128,6 +134,29 @@ export const createRenderCache = (maxEntries = 200) => {
     } finally {
       inFlight.delete(key)
     }
+  }
+}
+
+/**
+ * A bounded set of cache keys whose render produced NO image (a sparse block →
+ * 404). `createRenderCache` deliberately never caches a `null`, so a
+ * publicly-listed sparse correlation block would otherwise re-run the full
+ * `getContinuousCorrelation` (two selector resolutions over the whole window) on
+ * every unauthenticated hit, uncached and unthrottled. Remembering the negative
+ * under the same hourly-bucketed key bounds that to one render per hour — the key
+ * rolls over hourly, so a block that later gains data re-renders.
+ */
+export const createNegativeCache = (maxEntries = 500) => {
+  const seen = new Map<string, true>()
+  return {
+    add: (key: string) => {
+      if (seen.size >= maxEntries) {
+        const oldest = seen.keys().next().value
+        if (oldest !== undefined) seen.delete(oldest)
+      }
+      seen.set(key, true)
+    },
+    has: (key: string) => seen.has(key),
   }
 }
 
@@ -227,10 +256,12 @@ export const resolveArticleBlock = async (
     }
   }
   return {
-    end: endDate,
+    // Slice the day off the RAW ISO (author's wall-clock day), like the web
+    // scatter — not the UTC day a Date round-trip would give.
     lagDays: block.lag_days,
     outcome: block.outcome,
-    start: startDate,
+    periodEnd: end.slice(0, 10),
+    periodStart: start.slice(0, 10),
     trigger: block.trigger,
     type: 'correlation',
     updatedAt,
@@ -267,10 +298,10 @@ export const renderArticleBlockImage = async (
       : Buffer.from(deps.renderChartSvg(series, opts), 'utf8')
   }
   const data = await deps.getCorrelationScatter(user, {
-    end: block.end,
     lagDays: block.lagDays,
     outcome: block.outcome,
-    start: block.start,
+    periodEnd: block.periodEnd,
+    periodStart: block.periodStart,
     trigger: block.trigger,
   })
   if (data == null) return null
@@ -354,6 +385,9 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
   // comparatively expensive render.
   const blockCacheKey = (kind: string, username: string, postId: string, index: number, updatedAt: Date) =>
     `${kind}:${username}:${postId}:${index}:${updatedAt.getTime()}:${Math.floor(Date.now() / 3_600_000)}`
+  // Remembers the "no image" outcome (a sparse block 404s) under the same hourly
+  // key, so a public sparse block doesn't re-run the render engine on every hit.
+  const negativeBlocks = createNegativeCache()
 
   router.get('/public/:username/feed/:postId/blocks/:index/image.png', async (req, res) => {
     const { index, postId, username } = req.params
@@ -361,10 +395,13 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
     const idx = Number(index)
     const block = await resolveArticleBlock(deps, username, postId, idx, token)
     if (!block) return notFound(res)
-    const png = await cached(blockCacheKey('blockpng', username, postId, idx, block.updatedAt), () =>
-      renderArticleBlockImage(deps, username, block, 'png'),
-    )
-    if (!png) return notFound(res)
+    const key = blockCacheKey('blockpng', username, postId, idx, block.updatedAt)
+    if (negativeBlocks.has(key)) return notFound(res)
+    const png = await cached(key, () => renderArticleBlockImage(deps, username, block, 'png'))
+    if (!png) {
+      negativeBlocks.add(key)
+      return notFound(res)
+    }
     sendPng(res, png)
   })
 
@@ -374,10 +411,13 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
     const idx = Number(index)
     const block = await resolveArticleBlock(deps, username, postId, idx, token)
     if (!block) return notFound(res)
-    const svg = await cached(blockCacheKey('blocksvg', username, postId, idx, block.updatedAt), () =>
-      renderArticleBlockImage(deps, username, block, 'svg'),
-    )
-    if (!svg) return notFound(res)
+    const key = blockCacheKey('blocksvg', username, postId, idx, block.updatedAt)
+    if (negativeBlocks.has(key)) return notFound(res)
+    const svg = await cached(key, () => renderArticleBlockImage(deps, username, block, 'svg'))
+    if (!svg) {
+      negativeBlocks.add(key)
+      return notFound(res)
+    }
     sendSvg(res, svg)
   })
 

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -4,6 +4,8 @@
  * Handles: GET /public/:username/feed/:postId/chart.png
  *          GET /public/:username/feed/:postId/chart.svg
  *          GET /public/:username/feed/:postId/route.png
+ *          GET /public/:username/feed/:postId/blocks/:index/image.png
+ *          GET /public/:username/feed/:postId/blocks/:index/image.svg
  *
  * The chart is offered both ways from the same series over the same window: a
  * rasterised PNG that every consumer understands (Mastodon attaches it) and a
@@ -160,18 +162,6 @@ export const resolveImageWindow = async (
 }
 
 /**
- * Resolve one article chart/correlation block to its render inputs, or `null`
- * when the request isn't eligible: invalid username / non-UUID id / bad index,
- * missing DB, missing post, a non-article post, a `followers`-only post without a
- * matching capability `token`, an out-of-range or prose block, or a block whose
- * effective window is unbounded / non-increasing. Pure of Express — unit-testable.
- *
- * Unlike a shared activity's chart, an article block has NO `include_chart`
- * opt-in flag: a chart/correlation block can embed any metric over any window, so
- * the post's visibility (public/unlisted open; followers-only via the unguessable
- * `token`) is the whole authorization boundary (#943).
- */
-/**
  * Load the article behind an image request and authorize it, or `null` when
  * ineligible (invalid username / non-UUID id, missing DB, missing post, a
  * non-article post, or a `followers`-only post without a matching capability
@@ -196,6 +186,18 @@ const loadArticleForImage = async (
   return { article: post.article, updatedAt: post.updated_at }
 }
 
+/**
+ * Resolve one article chart/correlation block to its render inputs, or `null`
+ * when the request isn't eligible: invalid username / non-UUID id / bad index,
+ * missing DB, missing post, a non-article post, a `followers`-only post without a
+ * matching capability `token`, an out-of-range or prose block, or a block whose
+ * effective window is unbounded / non-increasing. Pure of Express — unit-testable.
+ *
+ * Unlike a shared activity's chart, an article block has NO `include_chart`
+ * opt-in flag: a chart/correlation block can embed any metric over any window, so
+ * the post's visibility (public/unlisted open; followers-only via the unguessable
+ * `token`) is the whole authorization boundary (#943).
+ */
 export const resolveArticleBlock = async (
   deps: Pick<FeedImageDeps, 'getPost'>,
   username: string,

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -348,15 +348,20 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
   // whole process lifetime — the block re-resolves its data live (#934), matching
   // the web inline render within ≤ 1h. Articles, unlike shared activities, are
   // mutable and their windows can gain data after publish.
-  const blockCacheKey = (kind: string, username: string, postId: string, index: string, updatedAt: Date) =>
+  // Cache key uses the NORMALISED numeric index (not the raw path string), so
+  // `Number`-equivalent spellings (`0`, `00`, `1e0`, `0x0`) collapse to one entry
+  // and can't each dodge the hourly-bucket rate limit on this unauthenticated,
+  // comparatively expensive render.
+  const blockCacheKey = (kind: string, username: string, postId: string, index: number, updatedAt: Date) =>
     `${kind}:${username}:${postId}:${index}:${updatedAt.getTime()}:${Math.floor(Date.now() / 3_600_000)}`
 
   router.get('/public/:username/feed/:postId/blocks/:index/image.png', async (req, res) => {
     const { index, postId, username } = req.params
     const token = typeof req.query.token === 'string' ? req.query.token : undefined
-    const block = await resolveArticleBlock(deps, username, postId, Number(index), token)
+    const idx = Number(index)
+    const block = await resolveArticleBlock(deps, username, postId, idx, token)
     if (!block) return notFound(res)
-    const png = await cached(blockCacheKey('blockpng', username, postId, index, block.updatedAt), () =>
+    const png = await cached(blockCacheKey('blockpng', username, postId, idx, block.updatedAt), () =>
       renderArticleBlockImage(deps, username, block, 'png'),
     )
     if (!png) return notFound(res)
@@ -366,9 +371,10 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
   router.get('/public/:username/feed/:postId/blocks/:index/image.svg', async (req, res) => {
     const { index, postId, username } = req.params
     const token = typeof req.query.token === 'string' ? req.query.token : undefined
-    const block = await resolveArticleBlock(deps, username, postId, Number(index), token)
+    const idx = Number(index)
+    const block = await resolveArticleBlock(deps, username, postId, idx, token)
     if (!block) return notFound(res)
-    const svg = await cached(blockCacheKey('blocksvg', username, postId, index, block.updatedAt), () =>
+    const svg = await cached(blockCacheKey('blocksvg', username, postId, idx, block.updatedAt), () =>
       renderArticleBlockImage(deps, username, block, 'svg'),
     )
     if (!svg) return notFound(res)

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -240,13 +240,17 @@ export const resolveArticleBlock = async (
 /** Article-chart line colour, matching the web inline render (`ArticleChartBlock`). */
 const ARTICLE_CHART_COLOR = '#673ab8'
 
+/** A zero-duration bucket (`0s`, `00m`, …) passes the block schema regex but is
+ * invalid for `date_bin` (`date_bin('0 seconds', …)` errors) — treat it as no image. */
+const isZeroDurationBucket = (bucket: string): boolean => /^0+[smhd]$/.test(bucket)
+
 /**
  * Render one resolved article block to its image bytes (PNG or the crisp SVG),
  * or `null` when the block has too little data to draw (a chart needs ≥ 2 points;
- * a correlation needs n ≥ 3, surfaced by `getCorrelationScatter` returning null).
- * Pure of Express so the routes stay thin.
+ * a correlation needs n ≥ 3, surfaced by `getCorrelationScatter` returning null)
+ * or its bucket is a zero duration. Pure of Express so the routes stay thin.
  */
-const renderArticleBlockImage = async (
+export const renderArticleBlockImage = async (
   deps: FeedImageDeps,
   user: string,
   block: ResolvedArticleBlock,
@@ -254,6 +258,7 @@ const renderArticleBlockImage = async (
 ): Promise<Buffer | null> => {
   if (block.type === 'chart') {
     const bucket = block.bucket ?? defaultArticleChartBucket(block.start, block.end)
+    if (isZeroDurationBucket(bucket)) return null
     const series = await deps.getArticleChartSeries(user, block.metric, block.start, block.end, bucket)
     if (series.length < 2) return null
     const opts: ChartRenderOpts = { color: ARTICLE_CHART_COLOR, label: getMetricDisplayName(block.metric) }
@@ -338,14 +343,20 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
   // Article chart/correlation block images. Gated by post visibility + capability
   // token only (no `include_chart` flag — a block can embed any metric, so
   // visibility is the whole boundary, #943). Cache key includes the post's
-  // `updated_at` so editing the article serves a fresh render (articles, unlike
-  // shared activities, are mutable).
+  // `updated_at` (busts on an edit) AND a coarse hourly bucket, so a locked
+  // window that later gains backfilled data can't serve a stale render for the
+  // whole process lifetime — the block re-resolves its data live (#934), matching
+  // the web inline render within ≤ 1h. Articles, unlike shared activities, are
+  // mutable and their windows can gain data after publish.
+  const blockCacheKey = (kind: string, username: string, postId: string, index: string, updatedAt: Date) =>
+    `${kind}:${username}:${postId}:${index}:${updatedAt.getTime()}:${Math.floor(Date.now() / 3_600_000)}`
+
   router.get('/public/:username/feed/:postId/blocks/:index/image.png', async (req, res) => {
     const { index, postId, username } = req.params
     const token = typeof req.query.token === 'string' ? req.query.token : undefined
     const block = await resolveArticleBlock(deps, username, postId, Number(index), token)
     if (!block) return notFound(res)
-    const png = await cached(`blockpng:${username}:${postId}:${index}:${block.updatedAt.getTime()}`, () =>
+    const png = await cached(blockCacheKey('blockpng', username, postId, index, block.updatedAt), () =>
       renderArticleBlockImage(deps, username, block, 'png'),
     )
     if (!png) return notFound(res)
@@ -357,7 +368,7 @@ export const createFeedImageRouter = (deps: FeedImageDeps): Router => {
     const token = typeof req.query.token === 'string' ? req.query.token : undefined
     const block = await resolveArticleBlock(deps, username, postId, Number(index), token)
     if (!block) return notFound(res)
-    const svg = await cached(`blocksvg:${username}:${postId}:${index}:${block.updatedAt.getTime()}`, () =>
+    const svg = await cached(blockCacheKey('blocksvg', username, postId, index, block.updatedAt), () =>
       renderArticleBlockImage(deps, username, block, 'svg'),
     )
     if (!svg) return notFound(res)

--- a/apps/backend/src/routes/feed-router.integration.test.ts
+++ b/apps/backend/src/routes/feed-router.integration.test.ts
@@ -3,18 +3,19 @@ import type { AddressInfo } from 'node:net'
 
 import express from 'express'
 import supertest from 'supertest'
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
 /**
  * Integration test for the owner-facing article routes on the feed router
  * (`POST /feed/articles`, `PATCH /feed/articles/:postId`) against a live
  * database — the route + `buildArticleContent`/`mergeArticleContent` service +
- * serializer composition over the already-unit-tested pieces. Federation is a
- * later slice, so no `deliver` is wired here.
+ * serializer composition over the already-unit-tested pieces. A fake `deliver`
+ * spy covers the article fan-out branches (including `kind === 'article'` on the
+ * generic `PATCH /:postId`); the actual AS2 delivery is unit-tested in `deliver`.
  */
 import { createFeedPost } from '../db/feed.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
-import { createFeedRouter } from './feed-router.ts'
+import { type FeedDeliver, createFeedRouter } from './feed-router.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 
@@ -23,10 +24,10 @@ const auth: RequestHandler = (req, _res, next) => {
   next()
 }
 
-const startApp = () => {
+const startApp = (deliver?: FeedDeliver) => {
   const app = express()
   app.use(express.json())
-  app.use('/feed', createFeedRouter(auth))
+  app.use('/feed', createFeedRouter(auth, deliver))
   const server = app.listen(0)
   const port = (server.address() as AddressInfo).port
   const close = () =>
@@ -129,5 +130,32 @@ describe('Article feed routes (integration)', () => {
     expect(del.status).toBe(200)
     const list = await app.request.get('/feed')
     expect(list.body.posts.map((p: { id: string }) => p.id)).not.toContain(created.body.post.id)
+  })
+
+  test('article fan-out: create → createdArticle; generic PATCH /:postId → updatedArticle (not updated)', async () => {
+    const deliver: FeedDeliver = {
+      created: vi.fn(),
+      createdArticle: vi.fn(),
+      deleted: vi.fn(),
+      updated: vi.fn(),
+      updatedArticle: vi.fn(),
+    }
+    const spied = startApp(deliver)
+    try {
+      const created = await spied.request.post('/feed/articles').send(articleBody())
+      expect(created.status).toBe(200)
+      expect(deliver.createdArticle).toHaveBeenCalledTimes(1)
+
+      // The GENERIC patch (not /feed/articles/:postId) on an article must route
+      // through `updatedArticle` — `updated` no-ops for a post with no activity.
+      const patched = await spied.request
+        .patch(`/feed/${created.body.post.id}`)
+        .send({ visibility: 'followers' })
+      expect(patched.status).toBe(200)
+      expect(deliver.updatedArticle).toHaveBeenCalledTimes(1)
+      expect(deliver.updated).not.toHaveBeenCalled()
+    } finally {
+      await spied.close()
+    }
   })
 })

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -166,7 +166,7 @@ export const createFeedRouter = (
 
   // Article posts (long-form: title + prose + inline chart/correlation blocks).
   // Create/edit have their own body shape; delete reuses `DELETE /:postId`.
-  // Registered before the generic `/:postId` routes. Federated as an AS2 `Article`
+  // Registered before the generic `/:postId` routes. Federated as a `Note`
   // (fan-out is best-effort and never blocks the response).
   router.post<Record<string, never>, FeedPostResponse, CreateArticleBody>(
     '/articles',

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -229,8 +229,11 @@ export const createFeedRouter = (
         return res.status(404).json({ error: 'Feed post not found', success: false })
       }
       // Federate the edit as an Update so followers replace the stored object.
-      // Fire-and-forget: the impl resolves the activity, so it can't 500 here.
-      deliver?.updated(user, record)
+      // Fire-and-forget: the impl resolves what it needs, so it can't 500 here.
+      // An article (e.g. a visibility flip via this generic route) has no linked
+      // activity, so it must go through the article path — `updated` would no-op.
+      if (record.kind === 'article') deliver?.updatedArticle(user, record)
+      else deliver?.updated(user, record)
       res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -60,6 +60,10 @@ export interface FeedDeliver {
   created: (user: string, post: FeedPostRecord, activity: Activity) => void
   updated: (user: string, post: FeedPostRecord) => void
   deleted: (user: string, post: FeedPostRecord) => void
+  /** Fan a freshly-published article out to followers (no linked activity). */
+  createdArticle: (user: string, post: FeedPostRecord) => void
+  /** Federate an article edit as an `Update` so followers replace the stored object. */
+  updatedArticle: (user: string, post: FeedPostRecord) => void
 }
 
 export const createFeedRouter = (
@@ -160,11 +164,10 @@ export const createFeedRouter = (
     },
   )
 
-  // Article posts (long-form: title + prose + inline chart blocks). Create/edit
-  // have their own body shape; delete reuses `DELETE /:postId`. Registered before
-  // the generic `/:postId` routes. Federation of articles is a later slice, so
-  // these do not (yet) call `deliver` — an article is authored and shown on the
-  // owner's feed but does not fan out to followers until then.
+  // Article posts (long-form: title + prose + inline chart/correlation blocks).
+  // Create/edit have their own body shape; delete reuses `DELETE /:postId`.
+  // Registered before the generic `/:postId` routes. Federated as an AS2 `Article`
+  // (fan-out is best-effort and never blocks the response).
   router.post<Record<string, never>, FeedPostResponse, CreateArticleBody>(
     '/articles',
     authMiddleware,
@@ -182,6 +185,7 @@ export const createFeedRouter = (
         article: built.article,
         visibility: req.body.visibility,
       })
+      deliver?.createdArticle(user, record)
       res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )
@@ -203,6 +207,7 @@ export const createFeedRouter = (
         visibility: req.body.visibility,
       })
       if (!record) return res.status(404).json({ error: 'Article not found', success: false })
+      deliver?.updatedArticle(user, record)
       res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )

--- a/apps/backend/src/routes/feed-tombstone-router.test.ts
+++ b/apps/backend/src/routes/feed-tombstone-router.test.ts
@@ -35,11 +35,6 @@ describe('buildTombstoneJsonLd', () => {
       type: 'Tombstone',
     })
   })
-
-  test('emits formerType Article when asked (deleted article id)', () => {
-    const id = 'https://aurboda.net/users/fiddur/feed/' + POST_ID + '/article'
-    expect(buildTombstoneJsonLd(id, DELETED_AT, 'Article')).toMatchObject({ formerType: 'Article', id })
-  })
 })
 
 describe('GET /users/:username/feed/:postId (tombstone)', () => {
@@ -53,18 +48,6 @@ describe('GET /users/:username/feed/:postId (tombstone)', () => {
       deleted: DELETED_AT.toISOString(),
       formerType: 'Note',
       id: `https://aurboda.net/users/fiddur/feed/${POST_ID}`,
-      type: 'Tombstone',
-    })
-  })
-
-  test('serves 410 with formerType Article at the article id for a tombstoned article', async () => {
-    const res = await supertest(buildApp()).get(`/users/fiddur/feed/${POST_ID}/article`)
-    expect(res.status).toBe(410)
-    expect(res.body).toEqual({
-      '@context': 'https://www.w3.org/ns/activitystreams',
-      deleted: DELETED_AT.toISOString(),
-      formerType: 'Article',
-      id: `https://aurboda.net/users/fiddur/feed/${POST_ID}/article`,
       type: 'Tombstone',
     })
   })

--- a/apps/backend/src/routes/feed-tombstone-router.test.ts
+++ b/apps/backend/src/routes/feed-tombstone-router.test.ts
@@ -35,6 +35,11 @@ describe('buildTombstoneJsonLd', () => {
       type: 'Tombstone',
     })
   })
+
+  test('emits formerType Article when asked (deleted article id)', () => {
+    const id = 'https://aurboda.net/users/fiddur/feed/' + POST_ID + '/article'
+    expect(buildTombstoneJsonLd(id, DELETED_AT, 'Article')).toMatchObject({ formerType: 'Article', id })
+  })
 })
 
 describe('GET /users/:username/feed/:postId (tombstone)', () => {
@@ -48,6 +53,18 @@ describe('GET /users/:username/feed/:postId (tombstone)', () => {
       deleted: DELETED_AT.toISOString(),
       formerType: 'Note',
       id: `https://aurboda.net/users/fiddur/feed/${POST_ID}`,
+      type: 'Tombstone',
+    })
+  })
+
+  test('serves 410 with formerType Article at the article id for a tombstoned article', async () => {
+    const res = await supertest(buildApp()).get(`/users/fiddur/feed/${POST_ID}/article`)
+    expect(res.status).toBe(410)
+    expect(res.body).toEqual({
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      deleted: DELETED_AT.toISOString(),
+      formerType: 'Article',
+      id: `https://aurboda.net/users/fiddur/feed/${POST_ID}/article`,
       type: 'Tombstone',
     })
   })

--- a/apps/backend/src/routes/feed-tombstone-router.ts
+++ b/apps/backend/src/routes/feed-tombstone-router.ts
@@ -1,7 +1,8 @@
 /**
  * `410 Gone` Tombstone for deleted feed-post objects (UNAUTHENTICATED).
  *
- * Handles: GET /users/:username/feed/:postId
+ * Handles: GET /users/:username/feed/:postId          (deleted activity `Note`)
+ *          GET /users/:username/feed/:postId/article  (deleted `Article`)
  *
  * A shared post's object row is hard-deleted on unshare, so Fedify's object
  * dispatcher returns `null` and `@fedify/express` falls through (`next()`). This
@@ -16,7 +17,7 @@
  * Fedify's `handleObject` serialises a returned `Tombstone` as `200`, so the 410
  * can't come from the dispatcher; the Express layer is the only place to set it.
  */
-import { type Response, Router } from 'express'
+import { type RequestHandler, type Response, Router } from 'express'
 
 import { isValidUsername } from '../api/auth-routes.ts'
 import { isMissingDatabase } from '../db/index.ts'
@@ -30,49 +31,76 @@ export interface FeedTombstoneDeps {
   getTombstone: (user: string, postId: string) => Promise<{ deleted_at: Date } | null>
 }
 
+/** The AS2 type a tombstoned object formerly had (`Note` for an activity share, `Article` for an article). */
+export type TombstoneFormerType = 'Article' | 'Note'
+
 /**
  * The AS2 `Tombstone` JSON-LD served at a deleted object's id. `id` mirrors the
- * object dispatcher's canonical note id (`<origin>/users/<user>/feed/<postId>`);
- * `formerType`/`deleted` are the standard Tombstone descriptors.
+ * object dispatcher's canonical id (`<origin>/users/<user>/feed/<postId>` for a
+ * `Note`, `…/article` for an `Article`); `formerType`/`deleted` are the standard
+ * Tombstone descriptors.
  */
-export const buildTombstoneJsonLd = (id: string, deletedAt: Date) => ({
+export const buildTombstoneJsonLd = (
+  id: string,
+  deletedAt: Date,
+  formerType: TombstoneFormerType = 'Note',
+) => ({
   '@context': 'https://www.w3.org/ns/activitystreams',
   deleted: deletedAt.toISOString(),
-  formerType: 'Note',
+  formerType,
   id,
   type: 'Tombstone',
 })
 
-const sendTombstone = (res: Response, id: string, deletedAt: Date) => {
+const sendTombstone = (
+  res: Response,
+  id: string,
+  deletedAt: Date,
+  formerType: TombstoneFormerType = 'Note',
+) => {
   // Match the object endpoint: no caching, so a re-share at a new id (or any
   // future change) is never served stale.
   res.setHeader('Cache-Control', 'no-store')
   res
     .status(410)
     .type('application/activity+json')
-    .send(JSON.stringify(buildTombstoneJsonLd(id, deletedAt)))
+    .send(JSON.stringify(buildTombstoneJsonLd(id, deletedAt, formerType)))
 }
 
 export const createFeedTombstoneRouter = (deps: FeedTombstoneDeps): Router => {
   const base = deps.origin.replace(/\/+$/, '')
   const router = Router()
 
-  router.get('/users/:username/feed/:postId', async (req, res, next) => {
-    const { postId, username } = req.params
-    if (!isValidUsername(username) || !UUID_RE.test(postId)) return next()
-    let tombstone: { deleted_at: Date } | null
-    try {
-      tombstone = await deps.getTombstone(username, postId)
-    } catch (error) {
-      // A syntactically-valid username with no database is not a tombstone.
-      if (isMissingDatabase(error)) return next()
-      throw error
+  // One tombstone row (recorded per postId on delete) backs both the `Note` id
+  // and the `Article` id — the path suffix selects which object was tombstoned
+  // and its `formerType`. A remote server only ever dereferences the `…/article`
+  // id for an actual article (it received a `Create{Article}` at that id).
+  const tombstoneHandler =
+    (suffix: string, formerType: TombstoneFormerType): RequestHandler<{ postId: string; username: string }> =>
+    async (req, res, next) => {
+      const { postId, username } = req.params
+      if (!isValidUsername(username) || !UUID_RE.test(postId)) return next()
+      let tombstone: { deleted_at: Date } | null
+      try {
+        tombstone = await deps.getTombstone(username, postId)
+      } catch (error) {
+        // A syntactically-valid username with no database is not a tombstone.
+        if (isMissingDatabase(error)) return next()
+        throw error
+      }
+      if (tombstone == null) return next()
+      // isValidUsername guarantees URL-safe chars, so no encoding needed to match
+      // the dispatcher's `getObjectUri(…)` output exactly.
+      sendTombstone(
+        res,
+        `${base}/users/${username}/feed/${postId}${suffix}`,
+        tombstone.deleted_at,
+        formerType,
+      )
     }
-    if (tombstone == null) return next()
-    // isValidUsername guarantees URL-safe chars, so no encoding needed to match
-    // the dispatcher's `getObjectUri(Note, …)` output exactly.
-    sendTombstone(res, `${base}/users/${username}/feed/${postId}`, tombstone.deleted_at)
-  })
+
+  router.get('/users/:username/feed/:postId', tombstoneHandler('', 'Note'))
+  router.get('/users/:username/feed/:postId/article', tombstoneHandler('/article', 'Article'))
 
   return router
 }

--- a/apps/backend/src/routes/feed-tombstone-router.ts
+++ b/apps/backend/src/routes/feed-tombstone-router.ts
@@ -1,8 +1,7 @@
 /**
  * `410 Gone` Tombstone for deleted feed-post objects (UNAUTHENTICATED).
  *
- * Handles: GET /users/:username/feed/:postId          (deleted activity `Note`)
- *          GET /users/:username/feed/:postId/article  (deleted `Article`)
+ * Handles: GET /users/:username/feed/:postId
  *
  * A shared post's object row is hard-deleted on unshare, so Fedify's object
  * dispatcher returns `null` and `@fedify/express` falls through (`next()`). This
@@ -12,12 +11,13 @@
  * object is *permanently* gone (vs a `404`, which reads as transient/unknown).
  * Anything without a tombstone — a live post (served by Fedify, never reaches
  * here), a `followers`-only id, or one that never existed — falls through to the
- * normal 404.
+ * normal 404. Articles federate as a `Note` at this same id, so a deleted article
+ * tombstones here too (formerType `Note`).
  *
  * Fedify's `handleObject` serialises a returned `Tombstone` as `200`, so the 410
  * can't come from the dispatcher; the Express layer is the only place to set it.
  */
-import { type RequestHandler, type Response, Router } from 'express'
+import { type Response, Router } from 'express'
 
 import { isValidUsername } from '../api/auth-routes.ts'
 import { isMissingDatabase } from '../db/index.ts'
@@ -31,76 +31,49 @@ export interface FeedTombstoneDeps {
   getTombstone: (user: string, postId: string) => Promise<{ deleted_at: Date } | null>
 }
 
-/** The AS2 type a tombstoned object formerly had (`Note` for an activity share, `Article` for an article). */
-export type TombstoneFormerType = 'Article' | 'Note'
-
 /**
  * The AS2 `Tombstone` JSON-LD served at a deleted object's id. `id` mirrors the
- * object dispatcher's canonical id (`<origin>/users/<user>/feed/<postId>` for a
- * `Note`, `…/article` for an `Article`); `formerType`/`deleted` are the standard
- * Tombstone descriptors.
+ * object dispatcher's canonical note id (`<origin>/users/<user>/feed/<postId>`);
+ * `formerType`/`deleted` are the standard Tombstone descriptors.
  */
-export const buildTombstoneJsonLd = (
-  id: string,
-  deletedAt: Date,
-  formerType: TombstoneFormerType = 'Note',
-) => ({
+export const buildTombstoneJsonLd = (id: string, deletedAt: Date) => ({
   '@context': 'https://www.w3.org/ns/activitystreams',
   deleted: deletedAt.toISOString(),
-  formerType,
+  formerType: 'Note',
   id,
   type: 'Tombstone',
 })
 
-const sendTombstone = (
-  res: Response,
-  id: string,
-  deletedAt: Date,
-  formerType: TombstoneFormerType = 'Note',
-) => {
+const sendTombstone = (res: Response, id: string, deletedAt: Date) => {
   // Match the object endpoint: no caching, so a re-share at a new id (or any
   // future change) is never served stale.
   res.setHeader('Cache-Control', 'no-store')
   res
     .status(410)
     .type('application/activity+json')
-    .send(JSON.stringify(buildTombstoneJsonLd(id, deletedAt, formerType)))
+    .send(JSON.stringify(buildTombstoneJsonLd(id, deletedAt)))
 }
 
 export const createFeedTombstoneRouter = (deps: FeedTombstoneDeps): Router => {
   const base = deps.origin.replace(/\/+$/, '')
   const router = Router()
 
-  // One tombstone row (recorded per postId on delete) backs both the `Note` id
-  // and the `Article` id — the path suffix selects which object was tombstoned
-  // and its `formerType`. A remote server only ever dereferences the `…/article`
-  // id for an actual article (it received a `Create{Article}` at that id).
-  const tombstoneHandler =
-    (suffix: string, formerType: TombstoneFormerType): RequestHandler<{ postId: string; username: string }> =>
-    async (req, res, next) => {
-      const { postId, username } = req.params
-      if (!isValidUsername(username) || !UUID_RE.test(postId)) return next()
-      let tombstone: { deleted_at: Date } | null
-      try {
-        tombstone = await deps.getTombstone(username, postId)
-      } catch (error) {
-        // A syntactically-valid username with no database is not a tombstone.
-        if (isMissingDatabase(error)) return next()
-        throw error
-      }
-      if (tombstone == null) return next()
-      // isValidUsername guarantees URL-safe chars, so no encoding needed to match
-      // the dispatcher's `getObjectUri(…)` output exactly.
-      sendTombstone(
-        res,
-        `${base}/users/${username}/feed/${postId}${suffix}`,
-        tombstone.deleted_at,
-        formerType,
-      )
+  router.get('/users/:username/feed/:postId', async (req, res, next) => {
+    const { postId, username } = req.params
+    if (!isValidUsername(username) || !UUID_RE.test(postId)) return next()
+    let tombstone: { deleted_at: Date } | null
+    try {
+      tombstone = await deps.getTombstone(username, postId)
+    } catch (error) {
+      // A syntactically-valid username with no database is not a tombstone.
+      if (isMissingDatabase(error)) return next()
+      throw error
     }
-
-  router.get('/users/:username/feed/:postId', tombstoneHandler('', 'Note'))
-  router.get('/users/:username/feed/:postId/article', tombstoneHandler('/article', 'Article'))
+    if (tombstone == null) return next()
+    // isValidUsername guarantees URL-safe chars, so no encoding needed to match
+    // the dispatcher's `getObjectUri(Note, …)` output exactly.
+    sendTombstone(res, `${base}/users/${username}/feed/${postId}`, tombstone.deleted_at)
+  })
 
   return router
 }

--- a/apps/backend/src/services/activitypub/article-object.test.ts
+++ b/apps/backend/src/services/activitypub/article-object.test.ts
@@ -9,6 +9,15 @@ const WINDOW = { end: '2026-07-02T00:00:00Z', start: '2026-07-01T00:00:00Z' }
 const article = (blocks: ArticleContent['blocks']): ArticleContent => ({ blocks, title: 'My analysis' })
 
 describe('renderArticleContentHtml', () => {
+  test('leads the content with the title (Mastodon ignores a Note’s name)', () => {
+    // An all-charts article with no captions still federates a non-empty status —
+    // the title — rather than just attachment URLs.
+    const html = renderArticleContentHtml(
+      article([{ end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' }]),
+    )
+    expect(html).toContain('<p><strong>My analysis</strong></p>')
+  })
+
   test('renders prose markdown to HTML', () => {
     const html = renderArticleContentHtml(
       article([{ markdown: '# Sleep\n\nSlept **well**.', type: 'prose' }]),
@@ -51,7 +60,7 @@ describe('renderArticleContentHtml', () => {
       ]),
     )
     expect(html).toContain('**not bold** &lt;b&gt;x&lt;/b&gt;')
-    expect(html).not.toContain('<strong>')
+    expect(html).not.toContain('<strong>not bold') // the caption's markdown is NOT rendered
     expect(html).not.toContain('<b>x</b>')
   })
 

--- a/apps/backend/src/services/activitypub/article-object.test.ts
+++ b/apps/backend/src/services/activitypub/article-object.test.ts
@@ -38,6 +38,23 @@ describe('renderArticleContentHtml', () => {
     expect(html).toContain('<h6')
   })
 
+  test('emits a caption as plain escaped text, not markdown (matches the web figcaption)', () => {
+    const html = renderArticleContentHtml(
+      article([
+        {
+          caption: '**not bold** <b>x</b>',
+          end: WINDOW.end,
+          metric: 'heart_rate',
+          start: WINDOW.start,
+          type: 'chart',
+        },
+      ]),
+    )
+    expect(html).toContain('**not bold** &lt;b&gt;x&lt;/b&gt;')
+    expect(html).not.toContain('<strong>')
+    expect(html).not.toContain('<b>x</b>')
+  })
+
   test('includes chart/correlation captions but not the images (those are attachments)', () => {
     const html = renderArticleContentHtml(
       article([

--- a/apps/backend/src/services/activitypub/article-object.test.ts
+++ b/apps/backend/src/services/activitypub/article-object.test.ts
@@ -27,6 +27,17 @@ describe('renderArticleContentHtml', () => {
     expect(html).not.toContain('onerror')
   })
 
+  test('keeps GFM tables and images in the federated content (richer than the inbound allowlist)', () => {
+    const md = '| a | b |\n| - | - |\n| 1 | 2 |\n\n![alt](https://ex.example/p.png)\n\n---\n\n###### h6'
+    const html = renderArticleContentHtml(article([{ markdown: md, type: 'prose' }]))
+    expect(html).toContain('<table>')
+    expect(html).toContain('<td>1</td>')
+    expect(html).toContain('<img')
+    expect(html).toContain('https://ex.example/p.png')
+    expect(html).toContain('<hr')
+    expect(html).toContain('<h6')
+  })
+
   test('includes chart/correlation captions but not the images (those are attachments)', () => {
     const html = renderArticleContentHtml(
       article([

--- a/apps/backend/src/services/activitypub/article-object.test.ts
+++ b/apps/backend/src/services/activitypub/article-object.test.ts
@@ -71,6 +71,8 @@ describe('renderArticleContentHtml', () => {
 
 describe('articleImageAttachments', () => {
   const base = 'https://aurboda.example/api/public/fiddur/feed/POST'
+  const UPDATED = new Date('2026-07-09T00:00:00Z')
+  const V = String(UPDATED.getTime())
   const withBlocks = (blocks: ArticleContent['blocks']): ArticleContent => article(blocks)
   const chart = { end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' } as const
   const correlation = {
@@ -81,28 +83,33 @@ describe('articleImageAttachments', () => {
     type: 'correlation',
   } as const
 
-  test('one image per chart/correlation block, indexed by block position, no token when public', () => {
+  test('one image per chart/correlation block, versioned by updated_at, no token when public', () => {
     const atts = articleImageAttachments(
       'https://aurboda.example/api',
       'fiddur',
       'POST',
       'public',
       'secret-token',
+      UPDATED,
       withBlocks([{ markdown: 'Intro', type: 'prose' }, chart, correlation]),
     )
-    expect(atts.map((a) => a.url?.href)).toEqual([`${base}/blocks/1/image.png`, `${base}/blocks/2/image.png`])
+    expect(atts.map((a) => a.url?.href)).toEqual([
+      `${base}/blocks/1/image.png?v=${V}`,
+      `${base}/blocks/2/image.png?v=${V}`,
+    ])
   })
 
-  test('followers-only attachments carry the capability token (#893)', () => {
+  test('followers-only attachments carry the capability token + version (#893)', () => {
     const atts = articleImageAttachments(
       'https://aurboda.example/api',
       'fiddur',
       'POST',
       'followers',
       'secret-token',
+      UPDATED,
       withBlocks([chart]),
     )
-    expect(atts.map((a) => a.url?.href)).toEqual([`${base}/blocks/0/image.png?token=secret-token`])
+    expect(atts.map((a) => a.url?.href)).toEqual([`${base}/blocks/0/image.png?v=${V}&token=secret-token`])
   })
 
   test('names an attachment from its caption, else its data label', () => {
@@ -112,6 +119,7 @@ describe('articleImageAttachments', () => {
       'POST',
       'public',
       'secret-token',
+      UPDATED,
       withBlocks([{ ...chart, caption: 'Overnight HR' }, correlation]),
     )
     expect(atts[0].name?.toString()).toBe('Overnight HR')
@@ -125,6 +133,7 @@ describe('articleImageAttachments', () => {
       'POST',
       'public',
       'secret-token',
+      UPDATED,
       withBlocks([{ markdown: 'Just words', type: 'prose' }]),
     )
     expect(atts).toEqual([])

--- a/apps/backend/src/services/activitypub/article-object.test.ts
+++ b/apps/backend/src/services/activitypub/article-object.test.ts
@@ -1,0 +1,104 @@
+import type { ArticleContent } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import { articleImageAttachments, renderArticleContentHtml } from './article-object.ts'
+
+const WINDOW = { end: '2026-07-02T00:00:00Z', start: '2026-07-01T00:00:00Z' }
+
+const article = (blocks: ArticleContent['blocks']): ArticleContent => ({ blocks, title: 'My analysis' })
+
+describe('renderArticleContentHtml', () => {
+  test('renders prose markdown to HTML', () => {
+    const html = renderArticleContentHtml(
+      article([{ markdown: '# Sleep\n\nSlept **well**.', type: 'prose' }]),
+    )
+    expect(html).toContain('<h1')
+    expect(html).toContain('Sleep')
+    expect(html).toContain('<strong>well</strong>')
+  })
+
+  test('strips script/style from authored markdown (the #910 boundary, server side)', () => {
+    const html = renderArticleContentHtml(
+      article([{ markdown: 'Hi <script>alert(1)</script> <img src=x onerror=alert(2)>', type: 'prose' }]),
+    )
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('alert(1)')
+    expect(html).not.toContain('onerror')
+  })
+
+  test('includes chart/correlation captions but not the images (those are attachments)', () => {
+    const html = renderArticleContentHtml(
+      article([
+        { markdown: 'Intro', type: 'prose' },
+        { caption: 'HR trend', end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' },
+        { end: WINDOW.end, metric: 'steps', start: WINDOW.start, type: 'chart' }, // no caption → nothing
+      ]),
+    )
+    expect(html).toContain('Intro')
+    expect(html).toContain('HR trend')
+    expect(html).not.toContain('img') // images ride as attachments, not inline
+  })
+})
+
+describe('articleImageAttachments', () => {
+  const base = 'https://aurboda.example/api/public/fiddur/feed/POST'
+  const withBlocks = (blocks: ArticleContent['blocks']): ArticleContent => article(blocks)
+  const chart = { end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' } as const
+  const correlation = {
+    end: WINDOW.end,
+    outcome: { kind: 'metric', metric: 'sleep_score' },
+    start: WINDOW.start,
+    trigger: { kind: 'metric', metric: 'steps' },
+    type: 'correlation',
+  } as const
+
+  test('one image per chart/correlation block, indexed by block position, no token when public', () => {
+    const atts = articleImageAttachments(
+      'https://aurboda.example/api',
+      'fiddur',
+      'POST',
+      'public',
+      'secret-token',
+      withBlocks([{ markdown: 'Intro', type: 'prose' }, chart, correlation]),
+    )
+    expect(atts.map((a) => a.url?.href)).toEqual([`${base}/blocks/1/image.png`, `${base}/blocks/2/image.png`])
+  })
+
+  test('followers-only attachments carry the capability token (#893)', () => {
+    const atts = articleImageAttachments(
+      'https://aurboda.example/api',
+      'fiddur',
+      'POST',
+      'followers',
+      'secret-token',
+      withBlocks([chart]),
+    )
+    expect(atts.map((a) => a.url?.href)).toEqual([`${base}/blocks/0/image.png?token=secret-token`])
+  })
+
+  test('names an attachment from its caption, else its data label', () => {
+    const atts = articleImageAttachments(
+      'https://aurboda.example/api',
+      'fiddur',
+      'POST',
+      'public',
+      'secret-token',
+      withBlocks([{ ...chart, caption: 'Overnight HR' }, correlation]),
+    )
+    expect(atts[0].name?.toString()).toBe('Overnight HR')
+    expect(atts[1].name?.toString()).toContain('steps') // correlation label from selectors
+  })
+
+  test('no attachments for a prose-only article', () => {
+    const atts = articleImageAttachments(
+      'https://aurboda.example/api',
+      'fiddur',
+      'POST',
+      'public',
+      'secret-token',
+      withBlocks([{ markdown: 'Just words', type: 'prose' }]),
+    )
+    expect(atts).toEqual([])
+  })
+})

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -96,20 +96,33 @@ const renderProse = (markdown: string): string =>
   sanitizeArticleHtml(marked.parse(markdown, { async: false, breaks: true, gfm: true }))
 
 /**
- * The AS2 `content` HTML for an article: each prose block rendered from markdown,
- * and each chart/correlation block's caption (when set) as a paragraph. A caption
- * is emitted as plain escaped text — NOT markdown — to match the web, which shows
- * it as text in a `<figcaption>`; the chart images themselves ride as attachments
- * (`articleImageAttachments`), which a fediverse client lays out after the content.
+ * The AS2 `content` HTML for an article: the **title** as a bold heading, then
+ * each prose block rendered from markdown, and each chart/correlation block's
+ * caption (when set) as a paragraph.
+ *
+ * The title leads the `content` because Mastodon's status parser ignores a Note's
+ * `name` (it only falls back to `name` for *converted* object types like Article),
+ * so a title left only in `name` never renders — and an all-charts article with no
+ * captions would otherwise federate as an empty status with just attachments. The
+ * bold heading mirrors how Mastodon renders a converted type's title; `name` is
+ * still set on the Note for Aurboda peers / software that does read it.
+ *
+ * A caption is emitted as plain escaped text — NOT markdown — to match the web,
+ * which shows it as text in a `<figcaption>`; the chart images themselves ride as
+ * attachments (`articleImageAttachments`), which a fediverse client lays out after
+ * the content.
  */
-export const renderArticleContentHtml = (article: ArticleContent): string =>
-  article.blocks
+export const renderArticleContentHtml = (article: ArticleContent): string => {
+  const heading = `<p><strong>${escapeXml(article.title)}</strong></p>`
+  const body = article.blocks
     .map((block) => {
       if (block.type === 'prose') return renderProse(block.markdown)
       return block.caption ? `<p>${escapeXml(block.caption)}</p>` : ''
     })
     .filter((html) => html.length > 0)
     .join('\n')
+  return body.length > 0 ? `${heading}\n${body}` : heading
+}
 
 /** A human name for a block's attachment: its caption, else a label from its data. */
 const attachmentName = (block: Extract<ArticleBlock, { type: 'chart' | 'correlation' }>): string => {

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -26,10 +26,6 @@ import { CHART_HEIGHT, CHART_WIDTH } from '../charts/chart-svg.ts'
 import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
 import { isPubliclyVisible } from './object.ts'
 
-// GFM + hard line breaks, matching the web's `renderMarkdown` (#910) so an
-// article reads the same in-app and federated.
-marked.setOptions({ breaks: true, gfm: true })
-
 /**
  * Sanitise authored article prose for outbound federation. Extends the inbound
  * fediverse allowlist (`sanitizeRemoteHtml`) with the block elements a QS write-up
@@ -89,9 +85,13 @@ const sanitizeArticleHtml = (html: string): string =>
     },
   })
 
-/** Render one run of authored markdown to sanitised, federation-safe HTML. */
+/**
+ * Render one run of authored markdown to sanitised, federation-safe HTML. Options
+ * (GFM + hard line breaks) are passed per call, matching the web's `renderMarkdown`
+ * (#910) without mutating `marked`'s process-wide defaults for every other importer.
+ */
 const renderProse = (markdown: string): string =>
-  sanitizeArticleHtml(marked.parse(markdown, { async: false }))
+  sanitizeArticleHtml(marked.parse(markdown, { async: false, breaks: true, gfm: true }))
 
 /**
  * The AS2 `content` HTML for an article: each prose block rendered from markdown,

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -1,9 +1,11 @@
 /**
  * The AS2 representation of an article's prose and inline blocks for federation.
  *
- * An article federates as an AS2 `Article` (built in `deliver.ts`): the title is
- * its `name`, the prose is HTML `content`, and each chart/correlation block is an
- * attached PNG so a plain fediverse client (Mastodon) shows prose + images. Aurboda
+ * An article federates as a `Note` (built in `deliver.ts`): the title is its
+ * `name`, the prose is HTML `content`, and each chart/correlation block is an
+ * attached PNG so a plain fediverse client (Mastodon) shows the prose + images
+ * inline. (A `Note`, not an AS2 `Article`: Mastodon treats `Article` as a
+ * converted type and discards its `content`, rendering only name + link.) Aurboda
  * peers get the richer inline render via the structured-enrichment channel (a
  * later slice); this module builds only the Mastodon-compatible surface.
  *
@@ -22,7 +24,7 @@ import { Image } from '@fedify/fedify/vocab'
 import { marked } from 'marked'
 import sanitizeHtml from 'sanitize-html'
 
-import { CHART_HEIGHT, CHART_WIDTH } from '../charts/chart-svg.ts'
+import { CHART_HEIGHT, CHART_WIDTH, escapeXml } from '../charts/chart-svg.ts'
 import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
 import { isPubliclyVisible } from './object.ts'
 
@@ -93,10 +95,6 @@ const sanitizeArticleHtml = (html: string): string =>
 const renderProse = (markdown: string): string =>
   sanitizeArticleHtml(marked.parse(markdown, { async: false, breaks: true, gfm: true }))
 
-/** Escape text for safe inclusion as HTML character data. */
-const escapeHtml = (s: string): string =>
-  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
-
 /**
  * The AS2 `content` HTML for an article: each prose block rendered from markdown,
  * and each chart/correlation block's caption (when set) as a paragraph. A caption
@@ -108,7 +106,7 @@ export const renderArticleContentHtml = (article: ArticleContent): string =>
   article.blocks
     .map((block) => {
       if (block.type === 'prose') return renderProse(block.markdown)
-      return block.caption ? `<p>${escapeHtml(block.caption)}</p>` : ''
+      return block.caption ? `<p>${escapeXml(block.caption)}</p>` : ''
     })
     .filter((html) => html.length > 0)
     .join('\n')

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -134,10 +134,17 @@ export const articleImageAttachments = (
   postId: string,
   visibility: FeedVisibility,
   imageToken: string,
+  updatedAt: Date,
   article: ArticleContent,
 ): Image[] => {
   const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${postId}`
-  const query = isPubliclyVisible(visibility) ? '' : `?token=${encodeURIComponent(imageToken)}`
+  // `v` = the post's last-edited epoch: the render cache busts on edit, but the URL
+  // itself must change too, or a remote media cache (Mastodon re-hosts attachments
+  // at receipt) keeps the pre-edit PNG and the `Update{Article}` never shows the new
+  // chart. The image endpoint ignores `v` (it only reads `token`).
+  const params = new URLSearchParams({ v: String(updatedAt.getTime()) })
+  if (!isPubliclyVisible(visibility)) params.set('token', imageToken)
+  const query = `?${params.toString()}`
   const images: Image[] = []
   article.blocks.forEach((block, index) => {
     if (block.type !== 'chart' && block.type !== 'correlation') return

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -7,28 +7,91 @@
  * peers get the richer inline render via the structured-enrichment channel (a
  * later slice); this module builds only the Mastodon-compatible surface.
  *
- * Prose markdown is rendered with `marked` and then run through the shared
- * `sanitizeRemoteHtml` allowlist — the same safe fediverse HTML subset applied to
- * inbound content — so the outbound `content` can never carry a script/style/`img
- * onerror` payload from user- or AI-authored markdown (#910's boundary, server side).
+ * Prose markdown is rendered with `marked` and then sanitised through an outbound
+ * allowlist (`sanitizeArticleHtml`) — an XSS boundary like the inbound fediverse
+ * sanitiser, but with the block elements a QS write-up uses (GFM tables, images,
+ * `hr`, h5/h6) that Mastodon renders in `content` and the web sink (DOMPurify via
+ * `utils/markdown.ts`) already keeps — so an article reads the same in-app and
+ * federated, and can never carry a script/style/`img onerror` payload (#910's
+ * boundary, server side).
  */
 import type { ArticleContent, ArticleBlock, FeedVisibility } from '@aurboda/api-spec'
 
 import { describeSelectorAxis, getMetricDisplayName } from '@aurboda/api-spec'
 import { Image } from '@fedify/fedify/vocab'
 import { marked } from 'marked'
+import sanitizeHtml from 'sanitize-html'
 
 import { CHART_HEIGHT, CHART_WIDTH } from '../charts/chart-svg.ts'
 import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
 import { isPubliclyVisible } from './object.ts'
-import { sanitizeRemoteHtml } from './timeline-ingest.ts'
 
 // GFM + hard line breaks, matching the web's `renderMarkdown` (#910) so an
 // article reads the same in-app and federated.
 marked.setOptions({ breaks: true, gfm: true })
 
+/**
+ * Sanitise authored article prose for outbound federation. Extends the inbound
+ * fediverse allowlist (`sanitizeRemoteHtml`) with the block elements a QS write-up
+ * uses — GFM tables, images, `hr`, h5/h6 — all of which Mastodon renders in
+ * `content` and the web DOMPurify sink already keeps, so authored formatting isn't
+ * silently flattened on the way out. Still a hard XSS boundary: no script/style/
+ * iframe/event handlers survive, and link/image URLs are http(s)/mailto only.
+ */
+const sanitizeArticleHtml = (html: string): string =>
+  sanitizeHtml(html, {
+    allowedAttributes: {
+      a: ['href', 'rel', 'target', 'class', 'translate'],
+      img: ['src', 'alt', 'title'],
+      ol: ['start'],
+      span: ['class', 'translate'],
+      td: ['colspan', 'rowspan'],
+      th: ['colspan', 'rowspan', 'scope'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+    allowedTags: [
+      'p',
+      'br',
+      'a',
+      'span',
+      'em',
+      'strong',
+      'b',
+      'i',
+      'del',
+      's',
+      'u',
+      'pre',
+      'code',
+      'blockquote',
+      'ul',
+      'ol',
+      'li',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'hr',
+      'img',
+      'table',
+      'thead',
+      'tbody',
+      'tfoot',
+      'tr',
+      'td',
+      'th',
+    ],
+    disallowedTagsMode: 'discard',
+    transformTags: {
+      a: sanitizeHtml.simpleTransform('a', { rel: 'nofollow noopener noreferrer', target: '_blank' }),
+    },
+  })
+
 /** Render one run of authored markdown to sanitised, federation-safe HTML. */
-const renderProse = (markdown: string): string => sanitizeRemoteHtml(marked.parse(markdown, { async: false }))
+const renderProse = (markdown: string): string =>
+  sanitizeArticleHtml(marked.parse(markdown, { async: false }))
 
 /**
  * The AS2 `content` HTML for an article: each prose block rendered from markdown,

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -12,9 +12,11 @@
  * Prose markdown is rendered with `marked` and then sanitised through an outbound
  * allowlist (`sanitizeArticleHtml`) — an XSS boundary like the inbound fediverse
  * sanitiser, but with the block elements a QS write-up uses (GFM tables, images,
- * `hr`, h5/h6) that Mastodon renders in `content` and the web sink (DOMPurify via
- * `utils/markdown.ts`) already keeps — so an article reads the same in-app and
- * federated, and can never carry a script/style/`img onerror` payload (#910's
+ * `hr`, h5/h6) that the web sink (DOMPurify via `utils/markdown.ts`) keeps, so an
+ * article reads the same in-app and on renderers that support them. (Mastodon's
+ * OWN inbound sanitiser strips tables/images/`hr` from a remote `content`, so a
+ * results table degrades to run-together cell text there — see `docs/features/feed.md`.)
+ * Either way it can never carry a script/style/`img onerror` payload (#910's
  * boundary, server side).
  */
 import type { ArticleContent, ArticleBlock, FeedVisibility } from '@aurboda/api-spec'
@@ -31,12 +33,14 @@ import { isPubliclyVisible } from './object.ts'
 /**
  * Sanitise authored article prose for outbound federation. A superset of the
  * inbound fediverse allowlist (`sanitizeRemoteHtml`) — the same safe base, plus
- * the block elements a QS write-up uses (GFM tables, images, `hr`, h5/h6), all of
- * which Mastodon renders in `content` and the web DOMPurify sink already keeps, so
- * authored formatting isn't silently flattened on the way out. (The two configs
- * are maintained separately, not literally shared — inbound is intentionally
- * stricter.) Still a hard XSS boundary: no script/style/iframe/event handlers
- * survive, and link/image URLs are http(s)/mailto only.
+ * the block elements a QS write-up uses (GFM tables, images, `hr`, h5/h6), which
+ * the web DOMPurify sink keeps, so authored formatting isn't flattened on the way
+ * out for renderers that support them. (Mastodon's own inbound sanitiser drops
+ * tables/images/`hr`, so those degrade there; non-Mastodon consumers and the
+ * future Aurboda-peer path render them.) The two configs are maintained
+ * separately, not literally shared — inbound is intentionally stricter. Still a
+ * hard XSS boundary: no script/style/iframe/event handlers survive, and
+ * link/image URLs are http(s)/mailto only.
  */
 const sanitizeArticleHtml = (html: string): string =>
   sanitizeHtml(html, {

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -29,12 +29,14 @@ import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
 import { isPubliclyVisible } from './object.ts'
 
 /**
- * Sanitise authored article prose for outbound federation. Extends the inbound
- * fediverse allowlist (`sanitizeRemoteHtml`) with the block elements a QS write-up
- * uses — GFM tables, images, `hr`, h5/h6 — all of which Mastodon renders in
- * `content` and the web DOMPurify sink already keeps, so authored formatting isn't
- * silently flattened on the way out. Still a hard XSS boundary: no script/style/
- * iframe/event handlers survive, and link/image URLs are http(s)/mailto only.
+ * Sanitise authored article prose for outbound federation. A superset of the
+ * inbound fediverse allowlist (`sanitizeRemoteHtml`) — the same safe base, plus
+ * the block elements a QS write-up uses (GFM tables, images, `hr`, h5/h6), all of
+ * which Mastodon renders in `content` and the web DOMPurify sink already keeps, so
+ * authored formatting isn't silently flattened on the way out. (The two configs
+ * are maintained separately, not literally shared — inbound is intentionally
+ * stricter.) Still a hard XSS boundary: no script/style/iframe/event handlers
+ * survive, and link/image URLs are http(s)/mailto only.
  */
 const sanitizeArticleHtml = (html: string): string =>
   sanitizeHtml(html, {

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -1,0 +1,89 @@
+/**
+ * The AS2 representation of an article's prose and inline blocks for federation.
+ *
+ * An article federates as an AS2 `Article` (built in `deliver.ts`): the title is
+ * its `name`, the prose is HTML `content`, and each chart/correlation block is an
+ * attached PNG so a plain fediverse client (Mastodon) shows prose + images. Aurboda
+ * peers get the richer inline render via the structured-enrichment channel (a
+ * later slice); this module builds only the Mastodon-compatible surface.
+ *
+ * Prose markdown is rendered with `marked` and then run through the shared
+ * `sanitizeRemoteHtml` allowlist — the same safe fediverse HTML subset applied to
+ * inbound content — so the outbound `content` can never carry a script/style/`img
+ * onerror` payload from user- or AI-authored markdown (#910's boundary, server side).
+ */
+import type { ArticleContent, ArticleBlock, FeedVisibility } from '@aurboda/api-spec'
+
+import { describeSelectorAxis, getMetricDisplayName } from '@aurboda/api-spec'
+import { Image } from '@fedify/fedify/vocab'
+import { marked } from 'marked'
+
+import { CHART_HEIGHT, CHART_WIDTH } from '../charts/chart-svg.ts'
+import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
+import { isPubliclyVisible } from './object.ts'
+import { sanitizeRemoteHtml } from './timeline-ingest.ts'
+
+// GFM + hard line breaks, matching the web's `renderMarkdown` (#910) so an
+// article reads the same in-app and federated.
+marked.setOptions({ breaks: true, gfm: true })
+
+/** Render one run of authored markdown to sanitised, federation-safe HTML. */
+const renderProse = (markdown: string): string => sanitizeRemoteHtml(marked.parse(markdown, { async: false }))
+
+/**
+ * The AS2 `content` HTML for an article: each prose block rendered from markdown,
+ * and each chart/correlation block's caption (when set) as a paragraph — the chart
+ * images themselves ride as attachments (`articleImageAttachments`), which a
+ * fediverse client lays out after the content.
+ */
+export const renderArticleContentHtml = (article: ArticleContent): string =>
+  article.blocks
+    .map((block) => {
+      if (block.type === 'prose') return renderProse(block.markdown)
+      return block.caption ? renderProse(block.caption) : ''
+    })
+    .filter((html) => html.length > 0)
+    .join('\n')
+
+/** A human name for a block's attachment: its caption, else a label from its data. */
+const attachmentName = (block: Extract<ArticleBlock, { type: 'chart' | 'correlation' }>): string => {
+  if (block.caption) return block.caption
+  return block.type === 'chart'
+    ? getMetricDisplayName(block.metric)
+    : `${describeSelectorAxis(block.trigger)} vs ${describeSelectorAxis(block.outcome)}`
+}
+
+/**
+ * Image attachments for an article's chart/correlation blocks: one PNG per block,
+ * pointing at the gated on-demand endpoint (`/feed/<id>/blocks/<index>/image.png`).
+ * `public`/`unlisted` are served unauthenticated; a `followers`-only article's URLs
+ * carry the post's unguessable capability `?token=` (the fediverse fetches media
+ * unsigned), embedded only in the object delivered to followers.
+ */
+export const articleImageAttachments = (
+  apiBaseUrl: string,
+  user: string,
+  postId: string,
+  visibility: FeedVisibility,
+  imageToken: string,
+  article: ArticleContent,
+): Image[] => {
+  const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${postId}`
+  const query = isPubliclyVisible(visibility) ? '' : `?token=${encodeURIComponent(imageToken)}`
+  const images: Image[] = []
+  article.blocks.forEach((block, index) => {
+    if (block.type !== 'chart' && block.type !== 'correlation') return
+    const [width, height] =
+      block.type === 'chart' ? [CHART_WIDTH, CHART_HEIGHT] : [SCATTER_WIDTH, SCATTER_HEIGHT]
+    images.push(
+      new Image({
+        height,
+        mediaType: 'image/png',
+        name: attachmentName(block),
+        url: new URL(`${base}/blocks/${index}/image.png${query}`),
+        width,
+      }),
+    )
+  })
+  return images
+}

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -93,17 +93,22 @@ const sanitizeArticleHtml = (html: string): string =>
 const renderProse = (markdown: string): string =>
   sanitizeArticleHtml(marked.parse(markdown, { async: false, breaks: true, gfm: true }))
 
+/** Escape text for safe inclusion as HTML character data. */
+const escapeHtml = (s: string): string =>
+  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;')
+
 /**
  * The AS2 `content` HTML for an article: each prose block rendered from markdown,
- * and each chart/correlation block's caption (when set) as a paragraph — the chart
- * images themselves ride as attachments (`articleImageAttachments`), which a
- * fediverse client lays out after the content.
+ * and each chart/correlation block's caption (when set) as a paragraph. A caption
+ * is emitted as plain escaped text — NOT markdown — to match the web, which shows
+ * it as text in a `<figcaption>`; the chart images themselves ride as attachments
+ * (`articleImageAttachments`), which a fediverse client lays out after the content.
  */
 export const renderArticleContentHtml = (article: ArticleContent): string =>
   article.blocks
     .map((block) => {
       if (block.type === 'prose') return renderProse(block.markdown)
-      return block.caption ? renderProse(block.caption) : ''
+      return block.caption ? `<p>${escapeHtml(block.caption)}</p>` : ''
     })
     .filter((html) => html.length > 0)
     .join('\n')

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -1,7 +1,18 @@
-import { Tombstone } from '@fedify/fedify/vocab'
+import type { ArticleContent } from '@aurboda/api-spec'
+
+import { Article, Tombstone } from '@fedify/fedify/vocab'
 import { describe, expect, test } from 'vitest'
 
-import { buildFeedDelete, type DeliverablePost, imageAttachments, recipients } from './deliver.ts'
+import {
+  buildFeedArticle,
+  buildFeedArticleCreate,
+  buildFeedArticleDelete,
+  buildFeedDelete,
+  type DeliverableArticle,
+  type DeliverablePost,
+  imageAttachments,
+  recipients,
+} from './deliver.ts'
 import { createFeedFederation } from './federation.ts'
 
 const PUBLIC = 'https://www.w3.org/ns/activitystreams#Public'
@@ -114,5 +125,79 @@ describe('imageAttachments', () => {
 
   test('attaches nothing when neither flag is set', () => {
     expect(imageAttachments(apiBaseUrl, 'fiddur', post({}))).toEqual([])
+  })
+})
+
+describe('article delivery', () => {
+  const ORIGIN = 'https://aurboda.example'
+  const POST_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  const articleContent: ArticleContent = {
+    blocks: [
+      { markdown: 'I slept **better** after cutting caffeine.', type: 'prose' },
+      {
+        caption: 'HR',
+        end: '2026-07-02T00:00:00Z',
+        metric: 'heart_rate',
+        start: '2026-07-01T00:00:00Z',
+        type: 'chart',
+      },
+    ],
+    title: 'Caffeine & sleep',
+  }
+  const deliverableArticle = (visibility: DeliverableArticle['visibility']): DeliverableArticle => ({
+    article: articleContent,
+    created_at: new Date('2026-07-03T00:00:00Z'),
+    id: POST_ID,
+    image_token: 'secret-token',
+    updated_at: new Date('2026-07-04T09:00:00Z'),
+    visibility,
+  })
+
+  const contextFor = () => createFeedFederation(ORIGIN, `${ORIGIN}/api`).createContext(new URL(ORIGIN))
+  // Articles serve at a path distinct from the Note object dispatcher.
+  const articleId = `${ORIGIN}/users/fiddur/feed/${POST_ID}/article`
+  // Attachments are embedded Image objects, iterated (not URL refs in attachmentIds).
+  const countAttachments = async (object: Article): Promise<number> => {
+    let n = 0
+    for await (const _ of object.getAttachments()) n++
+    return n
+  }
+
+  test('buildFeedArticle is an AS2 Article with title, prose HTML, one attachment per chart block', async () => {
+    const ctx = await contextFor()
+    const object = buildFeedArticle(ctx, 'fiddur', deliverableArticle('public'), `${ORIGIN}/api`)
+    expect(object).toBeInstanceOf(Article)
+    expect(object.id?.href).toBe(articleId)
+    expect(object.name?.toString()).toBe('Caffeine & sleep')
+    expect(object.content?.toString()).toContain('<strong>better</strong>')
+    // One attachment for the single chart block; its URL/token logic is asserted
+    // in article-object.test.ts.
+    expect(await countAttachments(object)).toBe(1)
+  })
+
+  test('a followers-only article addresses followers, never Public', async () => {
+    const ctx = await contextFor()
+    const object = buildFeedArticle(ctx, 'fiddur', deliverableArticle('followers'), `${ORIGIN}/api`)
+    expect(hrefs([...object.toIds])).toEqual([`${ORIGIN}/users/fiddur/followers`])
+    expect(hrefs([...object.ccIds])).toEqual([])
+  })
+
+  test('buildFeedArticleCreate wraps the Article in a Create at the #create fragment', async () => {
+    const ctx = await contextFor()
+    const create = await buildFeedArticleCreate(ctx, 'fiddur', deliverableArticle('public'), `${ORIGIN}/api`)
+    expect(create.id?.href).toBe(`${articleId}#create`)
+    expect(create.actorId?.href).toBe(`${ORIGIN}/users/fiddur`)
+    const object = await create.getObject()
+    expect(object).toBeInstanceOf(Article)
+    expect(object?.id?.href).toBe(articleId)
+  })
+
+  test('buildFeedArticleDelete tombstones the article object id', async () => {
+    const ctx = await contextFor()
+    const del = buildFeedArticleDelete(ctx, 'fiddur', deliverableArticle('public'))
+    expect(del.id?.href).toBe(`${articleId}#delete`)
+    const object = await del.getObject()
+    expect(object).toBeInstanceOf(Tombstone)
+    expect(object?.id?.href).toBe(articleId)
   })
 })

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -1,12 +1,11 @@
 import type { ArticleContent } from '@aurboda/api-spec'
 
-import { Article, Tombstone } from '@fedify/fedify/vocab'
+import { Note, Tombstone } from '@fedify/fedify/vocab'
 import { describe, expect, test } from 'vitest'
 
 import {
-  buildFeedArticle,
-  buildFeedArticleCreate,
-  buildFeedArticleDelete,
+  buildArticleNote,
+  buildArticleNoteCreate,
   buildFeedDelete,
   type DeliverableArticle,
   type DeliverablePost,
@@ -154,20 +153,23 @@ describe('article delivery', () => {
   })
 
   const contextFor = () => createFeedFederation(ORIGIN, `${ORIGIN}/api`).createContext(new URL(ORIGIN))
-  // Articles serve at a path distinct from the Note object dispatcher.
-  const articleId = `${ORIGIN}/users/fiddur/feed/${POST_ID}/article`
+  // An article's Note shares the standard Note object id (a post is an article OR
+  // an activity, never both), so a deleted article tombstones there like any post.
+  const noteId = `${ORIGIN}/users/fiddur/feed/${POST_ID}`
   // Attachments are embedded Image objects, iterated (not URL refs in attachmentIds).
-  const countAttachments = async (object: Article): Promise<number> => {
+  const countAttachments = async (object: Note): Promise<number> => {
     let n = 0
     for await (const _ of object.getAttachments()) n++
     return n
   }
 
-  test('buildFeedArticle is an AS2 Article with title, prose HTML, one attachment per chart block', async () => {
+  test('buildArticleNote is a Note with title, prose HTML, one attachment per chart block', async () => {
     const ctx = await contextFor()
-    const object = buildFeedArticle(ctx, 'fiddur', deliverableArticle('public'), `${ORIGIN}/api`)
-    expect(object).toBeInstanceOf(Article)
-    expect(object.id?.href).toBe(articleId)
+    const object = buildArticleNote(ctx, 'fiddur', deliverableArticle('public'), `${ORIGIN}/api`)
+    // A Note (not an AS2 Article) — Mastodon discards Article content, so a Note is
+    // what renders the prose + images inline.
+    expect(object).toBeInstanceOf(Note)
+    expect(object.id?.href).toBe(noteId)
     expect(object.name?.toString()).toBe('Caffeine & sleep')
     expect(object.content?.toString()).toContain('<strong>better</strong>')
     // One attachment for the single chart block; its URL/token logic is asserted
@@ -177,27 +179,18 @@ describe('article delivery', () => {
 
   test('a followers-only article addresses followers, never Public', async () => {
     const ctx = await contextFor()
-    const object = buildFeedArticle(ctx, 'fiddur', deliverableArticle('followers'), `${ORIGIN}/api`)
+    const object = buildArticleNote(ctx, 'fiddur', deliverableArticle('followers'), `${ORIGIN}/api`)
     expect(hrefs([...object.toIds])).toEqual([`${ORIGIN}/users/fiddur/followers`])
     expect(hrefs([...object.ccIds])).toEqual([])
   })
 
-  test('buildFeedArticleCreate wraps the Article in a Create at the #create fragment', async () => {
+  test('buildArticleNoteCreate wraps the Note in a Create at the #create fragment', async () => {
     const ctx = await contextFor()
-    const create = await buildFeedArticleCreate(ctx, 'fiddur', deliverableArticle('public'), `${ORIGIN}/api`)
-    expect(create.id?.href).toBe(`${articleId}#create`)
+    const create = buildArticleNoteCreate(ctx, 'fiddur', deliverableArticle('public'), `${ORIGIN}/api`)
+    expect(create.id?.href).toBe(`${noteId}#create`)
     expect(create.actorId?.href).toBe(`${ORIGIN}/users/fiddur`)
     const object = await create.getObject()
-    expect(object).toBeInstanceOf(Article)
-    expect(object?.id?.href).toBe(articleId)
-  })
-
-  test('buildFeedArticleDelete tombstones the article object id', async () => {
-    const ctx = await contextFor()
-    const del = buildFeedArticleDelete(ctx, 'fiddur', deliverableArticle('public'))
-    expect(del.id?.href).toBe(`${articleId}#delete`)
-    const object = await del.getObject()
-    expect(object).toBeInstanceOf(Tombstone)
-    expect(object?.id?.href).toBe(articleId)
+    expect(object).toBeInstanceOf(Note)
+    expect(object?.id?.href).toBe(noteId)
   })
 })

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -1,4 +1,4 @@
-import type { FeedVisibility } from '@aurboda/api-spec'
+import type { ArticleContent, FeedVisibility } from '@aurboda/api-spec'
 /**
  * Build and deliver a shared feed post over ActivityPub.
  *
@@ -20,8 +20,11 @@ import type { FeedVisibility } from '@aurboda/api-spec'
  */
 import type { Context, Federation } from '@fedify/fedify'
 
-import { Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/vocab'
+import { Article, Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/vocab'
 
+import type { FeedPostRecord } from '../../db/index.ts'
+
+import { articleImageAttachments, renderArticleContentHtml } from './article-object.ts'
 import { resolveActivityScalars } from './feed-activity.ts'
 import { addressingFor, feedPostContent, isPubliclyVisible } from './object.ts'
 import { dateToTemporalInstant } from './temporal-interop.ts'
@@ -250,4 +253,168 @@ export const deliverFeedDelete = async (
   const ctx = await deps.federation.createContext(new URL(deps.origin))
   const del = buildFeedDelete(ctx, user, post)
   await ctx.sendActivity({ identifier: user }, 'followers', del)
+}
+
+// ---------------------------------------------------------------------------
+// Articles (long-form posts). An article federates as an AS2 `Article` object
+// (title + prose HTML + attached block PNGs) rather than a `Note`. It has no
+// linked activity, so its object/`Create`/`Update`/`Delete` are built purely
+// from the stored article content — no scalar resolution.
+// ---------------------------------------------------------------------------
+
+/** The delivery-facing view of an article post (its `article` guaranteed present). */
+export interface DeliverableArticle {
+  id: string
+  visibility: FeedVisibility
+  created_at: Date
+  updated_at: Date
+  image_token: string
+  article: ArticleContent
+}
+
+/** Narrow a stored feed post to a `DeliverableArticle`, or null when it isn't an article. */
+export const toDeliverableArticle = (post: FeedPostRecord): DeliverableArticle | null =>
+  post.kind === 'article' && post.article != null
+    ? {
+        article: post.article,
+        created_at: post.created_at,
+        id: post.id,
+        image_token: post.image_token,
+        updated_at: post.updated_at,
+        visibility: post.visibility,
+      }
+    : null
+
+/**
+ * The article's canonical object id/url — its own object-dispatcher path, distinct
+ * from the `Note` path so an article and an activity post never collide. The
+ * delivered object, the outbox item, and the object served at this URL are all
+ * built by `buildFeedArticle`, so they stay identical.
+ */
+const articleObjectUri = (ctx: Context<void>, user: string, postId: string): URL =>
+  ctx.getObjectUri(Article, { identifier: user, postId })
+
+/**
+ * Build the Fedify `Article` for a post: the Mastodon-compatible object (title
+ * `name` + prose HTML `content` + chart/correlation PNG attachments), addressed
+ * per visibility. Synchronous — an article carries no activity to resolve.
+ */
+export const buildFeedArticle = (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverableArticle,
+  apiBaseUrl: string,
+): Article => {
+  const objectId = articleObjectUri(ctx, user, post.id)
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Article({
+    attachments: articleImageAttachments(
+      apiBaseUrl,
+      user,
+      post.id,
+      post.visibility,
+      post.image_token,
+      post.article,
+    ),
+    attribution: ctx.getActorUri(user),
+    ccs: cc,
+    content: renderArticleContentHtml(post.article),
+    id: objectId,
+    name: post.article.title,
+    published: dateToTemporalInstant(post.created_at),
+    tos: to,
+    url: objectId,
+  })
+}
+
+/** Wrap the article in the `Create` delivered to followers and listed in the outbox. */
+export const buildFeedArticleCreate = (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverableArticle,
+  apiBaseUrl: string,
+): Create => {
+  const objectId = articleObjectUri(ctx, user, post.id)
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Create({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${objectId.href}#create`),
+    object: buildFeedArticle(ctx, user, post, apiBaseUrl),
+    published: dateToTemporalInstant(post.created_at),
+    tos: to,
+  })
+}
+
+/** Wrap the (re-resolved) article in an `Update`; id carries `updated_at` so each edit is distinct. */
+export const buildFeedArticleUpdate = (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverableArticle,
+  apiBaseUrl: string,
+): Update => {
+  const objectId = articleObjectUri(ctx, user, post.id)
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Update({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${objectId.href}#update-${post.updated_at.getTime()}`),
+    object: buildFeedArticle(ctx, user, post, apiBaseUrl),
+    tos: to,
+  })
+}
+
+/** The `Delete{Tombstone}` for a removed article — tombstones the article object id. */
+export const buildFeedArticleDelete = (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverableArticle,
+): Delete => {
+  const objectId = articleObjectUri(ctx, user, post.id)
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Delete({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${objectId.href}#delete`),
+    object: new Tombstone({ id: objectId }),
+    tos: to,
+  })
+}
+
+/** Build and send the `Create{Article}` for a freshly-published article to its followers. */
+export const deliverFeedArticlePost = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverableArticle,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  await ctx.sendActivity(
+    { identifier: user },
+    'followers',
+    buildFeedArticleCreate(ctx, user, post, deps.apiBaseUrl),
+  )
+}
+
+/** Build and send the `Update{Article}` for an edited article to its followers. */
+export const deliverFeedArticleUpdate = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverableArticle,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  await ctx.sendActivity(
+    { identifier: user },
+    'followers',
+    buildFeedArticleUpdate(ctx, user, post, deps.apiBaseUrl),
+  )
+}
+
+/** Build and send the `Delete{Tombstone}` for a removed article to its followers. */
+export const deliverFeedArticleDelete = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverableArticle,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  await ctx.sendActivity({ identifier: user }, 'followers', buildFeedArticleDelete(ctx, user, post))
 }

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -20,7 +20,7 @@ import type { ArticleContent, FeedVisibility } from '@aurboda/api-spec'
  */
 import type { Context, Federation } from '@fedify/fedify'
 
-import { Article, Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/vocab'
+import { Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/vocab'
 
 import type { FeedPostRecord } from '../../db/index.ts'
 
@@ -256,10 +256,13 @@ export const deliverFeedDelete = async (
 }
 
 // ---------------------------------------------------------------------------
-// Articles (long-form posts). An article federates as an AS2 `Article` object
-// (title + prose HTML + attached block PNGs) rather than a `Note`. It has no
-// linked activity, so its object/`Create`/`Update`/`Delete` are built purely
-// from the stored article content — no scalar resolution.
+// Articles (long-form posts). An article federates as a `Note` — Mastodon
+// discards `content` for AS2 `Article` (a converted type) and renders only
+// name + url, so a Note is what actually shows the prose + attached images. The
+// article's Note is served on the SAME object path as an activity's Note (they
+// never collide — a post is one or the other), so a deleted article tombstones
+// there like any post. Aurboda peers get the richer inline render via structured
+// enrichment (a later slice), not the AS2 object type. No activity to resolve.
 // ---------------------------------------------------------------------------
 
 /** The delivery-facing view of an article post (its `article` guaranteed present). */
@@ -286,28 +289,20 @@ export const toDeliverableArticle = (post: FeedPostRecord): DeliverableArticle |
     : null
 
 /**
- * The article's canonical object id/url — its own object-dispatcher path, distinct
- * from the `Note` path so an article and an activity post never collide. The
- * delivered object, the outbox item, and the object served at this URL are all
- * built by `buildFeedArticle`, so they stay identical.
+ * Build the Fedify `Note` for an article: the Mastodon-compatible object (title
+ * `name` + prose HTML `content` + chart/correlation PNG attachments), at the
+ * post's canonical Note id, addressed per visibility. Synchronous — an article
+ * carries no activity to resolve. A deleted article tombstones at this same id.
  */
-const articleObjectUri = (ctx: Context<void>, user: string, postId: string): URL =>
-  ctx.getObjectUri(Article, { identifier: user, postId })
-
-/**
- * Build the Fedify `Article` for a post: the Mastodon-compatible object (title
- * `name` + prose HTML `content` + chart/correlation PNG attachments), addressed
- * per visibility. Synchronous — an article carries no activity to resolve.
- */
-export const buildFeedArticle = (
+export const buildArticleNote = (
   ctx: Context<void>,
   user: string,
   post: DeliverableArticle,
   apiBaseUrl: string,
-): Article => {
-  const objectId = articleObjectUri(ctx, user, post.id)
+): Note => {
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
-  return new Article({
+  return new Note({
     attachments: articleImageAttachments(
       apiBaseUrl,
       user,
@@ -320,69 +315,52 @@ export const buildFeedArticle = (
     attribution: ctx.getActorUri(user),
     ccs: cc,
     content: renderArticleContentHtml(post.article),
-    id: objectId,
+    id: noteId,
     name: post.article.title,
     published: dateToTemporalInstant(post.created_at),
     tos: to,
-    url: objectId,
+    url: noteId,
   })
 }
 
-/** Wrap the article in the `Create` delivered to followers and listed in the outbox. */
-export const buildFeedArticleCreate = (
+/** Wrap the article's Note in the `Create` delivered to followers and listed in the outbox. */
+export const buildArticleNoteCreate = (
   ctx: Context<void>,
   user: string,
   post: DeliverableArticle,
   apiBaseUrl: string,
 ): Create => {
-  const objectId = articleObjectUri(ctx, user, post.id)
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
   return new Create({
     actor: ctx.getActorUri(user),
     ccs: cc,
-    id: new URL(`${objectId.href}#create`),
-    object: buildFeedArticle(ctx, user, post, apiBaseUrl),
+    id: new URL(`${noteId.href}#create`),
+    object: buildArticleNote(ctx, user, post, apiBaseUrl),
     published: dateToTemporalInstant(post.created_at),
     tos: to,
   })
 }
 
-/** Wrap the (re-resolved) article in an `Update`; id carries `updated_at` so each edit is distinct. */
-export const buildFeedArticleUpdate = (
+/** Wrap the (re-resolved) article Note in an `Update`; id carries `updated_at` so each edit is distinct. */
+export const buildArticleNoteUpdate = (
   ctx: Context<void>,
   user: string,
   post: DeliverableArticle,
   apiBaseUrl: string,
 ): Update => {
-  const objectId = articleObjectUri(ctx, user, post.id)
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
   return new Update({
     actor: ctx.getActorUri(user),
     ccs: cc,
-    id: new URL(`${objectId.href}#update-${post.updated_at.getTime()}`),
-    object: buildFeedArticle(ctx, user, post, apiBaseUrl),
+    id: new URL(`${noteId.href}#update-${post.updated_at.getTime()}`),
+    object: buildArticleNote(ctx, user, post, apiBaseUrl),
     tos: to,
   })
 }
 
-/** The `Delete{Tombstone}` for a removed article — tombstones the article object id. */
-export const buildFeedArticleDelete = (
-  ctx: Context<void>,
-  user: string,
-  post: DeliverableArticle,
-): Delete => {
-  const objectId = articleObjectUri(ctx, user, post.id)
-  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
-  return new Delete({
-    actor: ctx.getActorUri(user),
-    ccs: cc,
-    id: new URL(`${objectId.href}#delete`),
-    object: new Tombstone({ id: objectId }),
-    tos: to,
-  })
-}
-
-/** Build and send the `Create{Article}` for a freshly-published article to its followers. */
+/** Build and send the `Create{Note}` for a freshly-published article to its followers. */
 export const deliverFeedArticlePost = async (
   deps: FeedDeliveryDeps,
   user: string,
@@ -392,11 +370,11 @@ export const deliverFeedArticlePost = async (
   await ctx.sendActivity(
     { identifier: user },
     'followers',
-    buildFeedArticleCreate(ctx, user, post, deps.apiBaseUrl),
+    buildArticleNoteCreate(ctx, user, post, deps.apiBaseUrl),
   )
 }
 
-/** Build and send the `Update{Article}` for an edited article to its followers. */
+/** Build and send the `Update{Note}` for an edited article to its followers. */
 export const deliverFeedArticleUpdate = async (
   deps: FeedDeliveryDeps,
   user: string,
@@ -406,16 +384,6 @@ export const deliverFeedArticleUpdate = async (
   await ctx.sendActivity(
     { identifier: user },
     'followers',
-    buildFeedArticleUpdate(ctx, user, post, deps.apiBaseUrl),
+    buildArticleNoteUpdate(ctx, user, post, deps.apiBaseUrl),
   )
-}
-
-/** Build and send the `Delete{Tombstone}` for a removed article to its followers. */
-export const deliverFeedArticleDelete = async (
-  deps: FeedDeliveryDeps,
-  user: string,
-  post: DeliverableArticle,
-): Promise<void> => {
-  const ctx = await deps.federation.createContext(new URL(deps.origin))
-  await ctx.sendActivity({ identifier: user }, 'followers', buildFeedArticleDelete(ctx, user, post))
 }

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -314,6 +314,7 @@ export const buildFeedArticle = (
       post.id,
       post.visibility,
       post.image_token,
+      post.updated_at,
       post.article,
     ),
     attribution: ctx.getActorUri(user),

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -375,6 +375,27 @@ describe('Feed federation actor + WebFinger', () => {
     expect(gone.body.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
   })
 
+  test('serves a 410 Tombstone (formerType Article) after a public article is deleted (#937)', async () => {
+    const user = getTestUser()
+    const post = await createArticlePost(user, {
+      article: { blocks: [{ markdown: 'Gone soon.', type: 'prose' }], title: 'Ephemeral' },
+      visibility: 'public',
+    })
+    const app = buildFederatedApp()
+    const articlePath = `/users/${user}/feed/${post.id}/article`
+
+    // Live: the article object dispatcher serves the Article (200).
+    expect((await getObject(app, articlePath)).status).toBe(200)
+
+    // Unshare, then the article id returns 410 Gone with formerType Article.
+    await deleteFeedPost(user, post.id)
+    const gone = await getObject(app, articlePath)
+    expect(gone.status).toBe(410)
+    expect(gone.body.type).toBe('Tombstone')
+    expect(gone.body.formerType).toBe('Article')
+    expect(gone.body.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}/article`)
+  })
+
   test('a deleted followers-only object stays 404 (no public tombstone)', async () => {
     const user = getTestUser()
     const activityId = await insertExercise(user)

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -269,6 +269,8 @@ describe('Feed federation actor + WebFinger', () => {
     expect(doc.type).toBe('Note')
     expect(doc.id).toBe(noteId)
     expect(doc.name).toBe('Weekly review')
+    // Title leads the content (Mastodon ignores a Note's name); prose follows.
+    expect(doc.content).toContain('<strong>Weekly review</strong>')
     expect(doc.content).toContain('<strong>analysis</strong>')
   })
 

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -229,7 +229,7 @@ describe('Feed federation actor + WebFinger', () => {
     expect(new Date(doc.published ?? '').getTime()).toBe(post.created_at.getTime())
   })
 
-  test('federates an article as a Create{Article} in the outbox and serves its object (#937)', async () => {
+  test('federates an article as a Create{Note} in the outbox and serves its object (#937)', async () => {
     const user = getTestUser()
     const post = await createArticlePost(user, {
       article: {
@@ -247,9 +247,10 @@ describe('Feed federation actor + WebFinger', () => {
       },
       visibility: 'public',
     })
-    const articleId = `${ORIGIN}/users/${user}/feed/${post.id}/article`
+    // An article federates as a Note at the standard post object id (Mastodon
+    // discards Article content, so a Note is what renders the prose).
+    const noteId = `${ORIGIN}/users/${user}/feed/${post.id}`
 
-    // The outbox lists the article as a Create{Article} at the article object id.
     const page = (await (await fetchAs2(`/users/${user}/outbox?cursor=0`)).json()) as {
       orderedItems?: unknown[]
     }
@@ -258,15 +259,17 @@ describe('Feed federation actor + WebFinger', () => {
     const create = items[0] as { type: string; object: string | { id: string; type: string } }
     expect(create.type).toBe('Create')
     const object = typeof create.object === 'string' ? { id: create.object, type: '' } : create.object
-    expect(object.id).toBe(articleId)
+    expect(object.id).toBe(noteId)
 
-    // The article object dispatcher serves it as an AS2 Article with its title.
-    const res = await fetchAs2(`/users/${user}/feed/${post.id}/article`)
+    // The object dispatcher serves the article as a Note: title in `name`, the
+    // prose (rendered markdown) in `content` so Mastodon shows it.
+    const res = await fetchAs2(`/users/${user}/feed/${post.id}`)
     expect(res.status).toBe(200)
-    const doc = (await res.json()) as { type: string; id: string; name?: string }
-    expect(doc.type).toBe('Article')
-    expect(doc.id).toBe(articleId)
+    const doc = (await res.json()) as { type: string; id: string; name?: string; content?: string }
+    expect(doc.type).toBe('Note')
+    expect(doc.id).toBe(noteId)
     expect(doc.name).toBe('Weekly review')
+    expect(doc.content).toContain('<strong>analysis</strong>')
   })
 
   test('serves the merged-span duration for a shared merged activity (#881)', async () => {
@@ -375,25 +378,27 @@ describe('Feed federation actor + WebFinger', () => {
     expect(gone.body.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
   })
 
-  test('serves a 410 Tombstone (formerType Article) after a public article is deleted (#937)', async () => {
+  test('serves a 410 Tombstone after a public article is deleted (#937)', async () => {
     const user = getTestUser()
     const post = await createArticlePost(user, {
       article: { blocks: [{ markdown: 'Gone soon.', type: 'prose' }], title: 'Ephemeral' },
       visibility: 'public',
     })
     const app = buildFederatedApp()
-    const articlePath = `/users/${user}/feed/${post.id}/article`
+    // An article's Note is served at the standard post object id.
+    const notePath = `/users/${user}/feed/${post.id}`
 
-    // Live: the article object dispatcher serves the Article (200).
-    expect((await getObject(app, articlePath)).status).toBe(200)
+    // Live: the object dispatcher serves the article as a Note (200).
+    const live = await getObject(app, notePath)
+    expect(live.status).toBe(200)
+    expect(live.body.type).toBe('Note')
 
-    // Unshare, then the article id returns 410 Gone with formerType Article.
+    // Unshare, then the same id returns 410 Gone with a Tombstone.
     await deleteFeedPost(user, post.id)
-    const gone = await getObject(app, articlePath)
+    const gone = await getObject(app, notePath)
     expect(gone.status).toBe(410)
     expect(gone.body.type).toBe('Tombstone')
-    expect(gone.body.formerType).toBe('Article')
-    expect(gone.body.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}/article`)
+    expect(gone.body.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
   })
 
   test('a deleted followers-only object stays 404 (no public tombstone)', async () => {

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -11,7 +11,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { insertActivity } from '../../db/activities/index.ts'
 import { upsertFeedFollower } from '../../db/feed-follower.ts'
 import { markFeedFollowingAccepted, upsertFeedFollowing } from '../../db/feed-following.ts'
-import { createFeedPost, deleteFeedPost, type FeedPostInput, getFeedTombstone } from '../../db/feed.ts'
+import {
+  createArticlePost,
+  createFeedPost,
+  deleteFeedPost,
+  type FeedPostInput,
+  getFeedTombstone,
+} from '../../db/feed.ts'
 import { upsertUserSettings } from '../../db/settings.ts'
 import { createFeedTombstoneRouter } from '../../routes/feed-tombstone-router.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
@@ -221,6 +227,46 @@ describe('Feed federation actor + WebFinger', () => {
     // remote servers order it correctly.
     expect(doc.published).toBeDefined()
     expect(new Date(doc.published ?? '').getTime()).toBe(post.created_at.getTime())
+  })
+
+  test('federates an article as a Create{Article} in the outbox and serves its object (#937)', async () => {
+    const user = getTestUser()
+    const post = await createArticlePost(user, {
+      article: {
+        blocks: [
+          { markdown: 'My **analysis**.', type: 'prose' },
+          {
+            caption: 'HR',
+            end: '2026-07-02T00:00:00Z',
+            metric: 'heart_rate',
+            start: '2026-07-01T00:00:00Z',
+            type: 'chart',
+          },
+        ],
+        title: 'Weekly review',
+      },
+      visibility: 'public',
+    })
+    const articleId = `${ORIGIN}/users/${user}/feed/${post.id}/article`
+
+    // The outbox lists the article as a Create{Article} at the article object id.
+    const page = (await (await fetchAs2(`/users/${user}/outbox?cursor=0`)).json()) as {
+      orderedItems?: unknown[]
+    }
+    const items = page.orderedItems ?? []
+    expect(items).toHaveLength(1)
+    const create = items[0] as { type: string; object: string | { id: string; type: string } }
+    expect(create.type).toBe('Create')
+    const object = typeof create.object === 'string' ? { id: create.object, type: '' } : create.object
+    expect(object.id).toBe(articleId)
+
+    // The article object dispatcher serves it as an AS2 Article with its title.
+    const res = await fetchAs2(`/users/${user}/feed/${post.id}/article`)
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { type: string; id: string; name?: string }
+    expect(doc.type).toBe('Article')
+    expect(doc.id).toBe(articleId)
+    expect(doc.name).toBe('Weekly review')
   })
 
   test('serves the merged-span duration for a shared merged activity (#881)', async () => {

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -4,6 +4,7 @@ import type { Actor } from '@fedify/fedify/vocab'
 import { createFederation, type Federation, type InboxContext, MemoryKvStore } from '@fedify/fedify'
 import {
   Accept,
+  Article,
   Create,
   Delete,
   Follow,
@@ -62,7 +63,13 @@ import {
 import { resolveFeedActivity } from '../feed.ts'
 import { buildProfileUrl } from '../share-urls.ts'
 import { extractActorPresentation } from './actor-presentation.ts'
-import { buildFeedCreate, buildFeedNote } from './deliver.ts'
+import {
+  buildFeedArticle,
+  buildFeedArticleCreate,
+  buildFeedCreate,
+  buildFeedNote,
+  toDeliverableArticle,
+} from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
 import { capabilityTokenFrom, createAurbodaEnricher } from './timeline-enrich.ts'
@@ -390,6 +397,28 @@ export const createFeedFederation = (
     },
   )
 
+  // Individual article object, served at its own path (distinct from the Note
+  // dispatcher above) as an AS2 `Article`. Same public/unlisted-only gate: a
+  // `followers`-only article is delivered with its object inline, so its id never
+  // needs an unauthenticated fetch.
+  federation.setObjectDispatcher(
+    Article,
+    '/users/{identifier}/feed/{postId}/article',
+    async (ctx, { identifier, postId }) => {
+      if (!isValidUsername(identifier) || !UUID_RE.test(postId)) return null
+      let post
+      try {
+        post = await getFeedPostById(identifier, postId)
+      } catch (error) {
+        if (isMissingDatabase(error)) return null
+        throw error
+      }
+      if (post == null || !isPubliclyVisible(post.visibility)) return null
+      const article = toDeliverableArticle(post)
+      return article == null ? null : buildFeedArticle(ctx, identifier, article, apiBaseUrl)
+    },
+  )
+
   // Outbox: the user's public + unlisted posts as `Create` activities, so a
   // Mastodon profile shows them. Cursor-paginated (`OUTBOX_PAGE_SIZE` per page)
   // so an unauthenticated fetch never resolves every post's scalars at once; the
@@ -414,6 +443,10 @@ export const createFeedFederation = (
       const items = (
         await Promise.all(
           posts.map(async (post) => {
+            // Articles federate as `Create{Article}` (no linked activity); every
+            // other post as `Create{Note}` from its resolved activity.
+            const article = toDeliverableArticle(post)
+            if (article != null) return buildFeedArticleCreate(ctx, identifier, article, apiBaseUrl)
             if (post.activity_id == null) return null
             const activity = await resolveFeedActivity(identifier, post.activity_id)
             return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity, apiBaseUrl)

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -4,7 +4,6 @@ import type { Actor } from '@fedify/fedify/vocab'
 import { createFederation, type Federation, type InboxContext, MemoryKvStore } from '@fedify/fedify'
 import {
   Accept,
-  Article,
   Create,
   Delete,
   Follow,
@@ -64,8 +63,8 @@ import { resolveFeedActivity } from '../feed.ts'
 import { buildProfileUrl } from '../share-urls.ts'
 import { extractActorPresentation } from './actor-presentation.ts'
 import {
-  buildFeedArticle,
-  buildFeedArticleCreate,
+  buildArticleNote,
+  buildArticleNoteCreate,
   buildFeedCreate,
   buildFeedNote,
   toDeliverableArticle,
@@ -388,34 +387,17 @@ export const createFeedFederation = (
         if (isMissingDatabase(error)) return null
         throw error
       }
-      if (post == null || post.activity_id == null || !isPubliclyVisible(post.visibility)) return null
+      if (post == null || !isPubliclyVisible(post.visibility)) return null
+      // An article and an activity share this Note id (a post is one or the
+      // other). An article's Note is built from its stored content — no activity.
+      const article = toDeliverableArticle(post)
+      if (article != null) return buildArticleNote(ctx, identifier, article, apiBaseUrl)
+      if (post.activity_id == null) return null
       // Resolve the merged-span activity so the served Note matches what the user
       // shared (and what we delivered), not just the anchor sub-activity (#881).
       const activity = await resolveFeedActivity(identifier, post.activity_id)
       if (activity == null) return null
       return buildFeedNote(ctx, identifier, post, activity, apiBaseUrl)
-    },
-  )
-
-  // Individual article object, served at its own path (distinct from the Note
-  // dispatcher above) as an AS2 `Article`. Same public/unlisted-only gate: a
-  // `followers`-only article is delivered with its object inline, so its id never
-  // needs an unauthenticated fetch.
-  federation.setObjectDispatcher(
-    Article,
-    '/users/{identifier}/feed/{postId}/article',
-    async (ctx, { identifier, postId }) => {
-      if (!isValidUsername(identifier) || !UUID_RE.test(postId)) return null
-      let post
-      try {
-        post = await getFeedPostById(identifier, postId)
-      } catch (error) {
-        if (isMissingDatabase(error)) return null
-        throw error
-      }
-      if (post == null || !isPubliclyVisible(post.visibility)) return null
-      const article = toDeliverableArticle(post)
-      return article == null ? null : buildFeedArticle(ctx, identifier, article, apiBaseUrl)
     },
   )
 
@@ -443,10 +425,11 @@ export const createFeedFederation = (
       const items = (
         await Promise.all(
           posts.map(async (post) => {
-            // Articles federate as `Create{Article}` (no linked activity); every
-            // other post as `Create{Note}` from its resolved activity.
+            // Articles federate as `Create{Note}` built from their stored content
+            // (no linked activity); every other post as `Create{Note}` from its
+            // resolved activity.
             const article = toDeliverableArticle(post)
-            if (article != null) return buildFeedArticleCreate(ctx, identifier, article, apiBaseUrl)
+            if (article != null) return buildArticleNoteCreate(ctx, identifier, article, apiBaseUrl)
             if (post.activity_id == null) return null
             const activity = await resolveFeedActivity(identifier, post.activity_id)
             return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity, apiBaseUrl)

--- a/apps/backend/src/services/activitypub/feed-images.ts
+++ b/apps/backend/src/services/activitypub/feed-images.ts
@@ -17,6 +17,7 @@
 import sharp from 'sharp'
 
 import { buildChartSvg } from '../charts/chart-svg.ts'
+import { type ScatterSvgData, buildScatterSvg } from '../charts/scatter-svg.ts'
 import { chooseZoom, latToWorldY, lonToWorldX, TILE_SIZE, type TileFetcher } from './osm-tiles.ts'
 
 const ROUTE_W = 700
@@ -62,6 +63,14 @@ export const renderChartPng = (
   series: [Date, number][],
   opts: { color?: string; label?: string } = {},
 ): Promise<Buffer> => svgToPng(buildChartSvg(series, opts))
+
+/**
+ * A correlation scatter (trigger × outcome + OLS line + headline) rasterized to
+ * PNG for an article correlation-block feed attachment. The SVG is built by the
+ * shared `buildScatterSvg` renderer (the same scatter the web draws inline); this
+ * only adds the `sharp` rasterization.
+ */
+export const renderScatterPng = (data: ScatterSvgData): Promise<Buffer> => svgToPng(buildScatterSvg(data))
 
 const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v))
 

--- a/apps/backend/src/services/charts/scatter-svg.test.ts
+++ b/apps/backend/src/services/charts/scatter-svg.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+
+import { type ScatterSvgData, buildScatterSvg } from './scatter-svg.ts'
+
+const base: ScatterSvgData = {
+  group_comparison: null,
+  n: 4,
+  outcome: { kind: 'metric', metric: 'sleep_score' },
+  pearson: 0.82,
+  pearson_p: 0.0004,
+  series: [
+    { outcome: 70, trigger: 10 },
+    { outcome: 82, trigger: 25 },
+    { outcome: 78, trigger: 40 },
+    { outcome: 90, trigger: 55 },
+  ],
+  spearman: 0.8,
+  trigger: { kind: 'metric', metric: 'steps' },
+}
+
+describe('buildScatterSvg', () => {
+  test('produces a well-formed SVG with the default dimensions', () => {
+    const svg = buildScatterSvg(base)
+    expect(svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg"')).toBe(true)
+    expect(svg.trimEnd().endsWith('</svg>')).toBe(true)
+    expect(svg).toContain('width="900"')
+    expect(svg).toContain('height="600"')
+    expect(svg).toContain('viewBox="0 0 900 600"')
+  })
+
+  test('draws one point circle per aligned pair and a regression line', () => {
+    const svg = buildScatterSvg(base)
+    expect(svg.match(/<circle /g)).toHaveLength(base.series.length)
+    expect(svg).toContain(`stroke="#f472b6"`) // OLS regression line colour
+  })
+
+  test('leads with the Pearson headline for a continuous trigger', () => {
+    const svg = buildScatterSvg(base)
+    expect(svg).toContain('r=0.82')
+    expect(svg).toContain('ρ=0.80')
+    expect(svg).toContain('n=4')
+    expect(svg).toContain('p=&lt;0.001') // <0.001, XML-escaped
+  })
+
+  test('leads with the group comparison for a binary/presence trigger', () => {
+    const svg = buildScatterSvg({
+      ...base,
+      group_comparison: {
+        cohens_d: 0.9,
+        difference: 6.5,
+        trigger_is_binary: true,
+        welch: { p_value: 0.012 },
+      },
+      series: [
+        { outcome: 72, trigger: 0 },
+        { outcome: 74, trigger: 0 },
+        { outcome: 84, trigger: 1 },
+        { outcome: 88, trigger: 1 },
+      ],
+      trigger: { kind: 'tag', pattern: 'sauna' },
+    })
+    expect(svg).toContain('Δ(present−absent)=6.50')
+    expect(svg).toContain('d=0.90')
+    expect(svg).toContain('p=0.012')
+    expect(svg).not.toContain('ρ=') // the Pearson/Spearman headline is suppressed
+  })
+
+  test('labels both axes from the selectors', () => {
+    const svg = buildScatterSvg(base)
+    expect(svg).toContain('steps') // trigger axis (x)
+    expect(svg).toContain('sleep_score') // outcome axis (y)
+    expect(svg).toContain('transform="rotate(-90') // y-axis label rotated
+  })
+
+  test('renders a dash for null coefficients rather than crashing', () => {
+    const svg = buildScatterSvg({ ...base, pearson: null, pearson_p: null, spearman: null })
+    expect(svg).toContain('r=—')
+    expect(svg).toContain('p=—')
+  })
+})

--- a/apps/backend/src/services/charts/scatter-svg.ts
+++ b/apps/backend/src/services/charts/scatter-svg.ts
@@ -78,8 +78,12 @@ const headlineOf = (data: ScatterSvgData): string => {
 export const buildScatterSvg = (data: ScatterSvgData, opts: ScatterSvgOptions = {}): string => {
   const width = opts.width ?? SCATTER_WIDTH
   const height = opts.height ?? SCATTER_HEIGHT
-  const xs = data.series.map((p) => p.trigger)
-  const ys = data.series.map((p) => p.outcome)
+  // Drop any non-finite pair (a single NaN would make Math.min/Math.max NaN and
+  // yield an SVG sharp can't rasterise). Not reachable from the current engine —
+  // cheap insurance, matching buildChartSvg's own finite-filter.
+  const points = data.series.filter((p) => Number.isFinite(p.trigger) && Number.isFinite(p.outcome))
+  const xs = points.map((p) => p.trigger)
+  const ys = points.map((p) => p.outcome)
   const xMin = Math.min(...xs)
   const xMax = Math.max(...xs)
   const yMin = Math.min(...ys)
@@ -92,7 +96,7 @@ export const buildScatterSvg = (data: ScatterSvgData, opts: ScatterSvgOptions = 
   const regLine = reg
     ? `<line x1="${sx(xMin).toFixed(1)}" y1="${sy(reg.slope * xMin + reg.intercept).toFixed(1)}" x2="${sx(xMax).toFixed(1)}" y2="${sy(reg.slope * xMax + reg.intercept).toFixed(1)}" stroke="${REG_COLOR}" stroke-width="3"/>`
     : ''
-  const points = data.series
+  const circles = points
     .map(
       (p) =>
         `<circle cx="${sx(p.trigger).toFixed(1)}" cy="${sy(p.outcome).toFixed(1)}" r="5" fill="${POINT_COLOR}" opacity="0.5"/>`,
@@ -108,7 +112,7 @@ export const buildScatterSvg = (data: ScatterSvgData, opts: ScatterSvgOptions = 
   <rect width="${width}" height="${height}" fill="${SCATTER_BG}" rx="16"/>
   <line x1="${PAD.left}" y1="${height - PAD.bottom}" x2="${width - PAD.right}" y2="${height - PAD.bottom}" stroke="${AXIS_COLOR}" stroke-width="2"/>
   <line x1="${PAD.left}" y1="${PAD.top}" x2="${PAD.left}" y2="${height - PAD.bottom}" stroke="${AXIS_COLOR}" stroke-width="2"/>
-  ${points}
+  ${circles}
   ${regLine}
   <text x="${PAD.left + 8}" y="${PAD.top - 16}" fill="${TEXT_COLOR}" font-family="${FONT}" font-size="24" font-weight="700">${escapeXml(headlineOf(data))}</text>
   <text x="${(PAD.left + (width - PAD.right)) / 2}" y="${height - 20}" fill="${MUTED_COLOR}" font-family="${FONT}" font-size="22" text-anchor="middle">${escapeXml(xAxis)}</text>

--- a/apps/backend/src/services/charts/scatter-svg.ts
+++ b/apps/backend/src/services/charts/scatter-svg.ts
@@ -1,0 +1,117 @@
+/**
+ * The shared server-side correlation **scatter** renderer: an aligned daily
+ * `trigger` × `outcome` series → a self-contained SVG **string**.
+ *
+ * The companion to `chart-svg.ts` for the *correlation* article block. It is the
+ * server-side twin of the web `ArticleCorrelationBlock` scatter — same maths
+ * (`linearRegression`, `describeSelectorAxis` from the shared api-spec source),
+ * same present-vs-absent headline for a binary trigger — rendered on the dark
+ * card background so a rasterised PNG reads legibly as a standalone Mastodon
+ * attachment (the web draws the same scatter inline on a light card). Pure and
+ * synchronous — unit-testable on the string; rasterize with `sharp` for the PNG.
+ */
+import type { CorrelationSelector } from '@aurboda/api-spec'
+
+import { describeSelectorAxis, linearRegression } from '@aurboda/api-spec'
+
+import { escapeXml, scale } from './chart-svg.ts'
+
+/** Default scatter dimensions (feed attachment size); overridable per call. */
+export const SCATTER_WIDTH = 900
+export const SCATTER_HEIGHT = 600
+const PAD = { bottom: 64, left: 80, right: 28, top: 44 }
+/** Dark card background, matching the metric chart and route map. */
+const SCATTER_BG = '#0b0f19'
+const AXIS_COLOR = '#4b5563'
+const POINT_COLOR = '#a78bfa'
+const REG_COLOR = '#f472b6'
+const TEXT_COLOR = '#e5e7eb'
+const MUTED_COLOR = '#9ca3af'
+const FONT = 'Liberation Sans, sans-serif'
+
+/** The subset of a continuous-correlation result this renderer draws. */
+export interface ScatterSvgData {
+  series: { trigger: number; outcome: number }[]
+  pearson: number | null
+  spearman: number | null
+  pearson_p: number | null
+  n: number
+  group_comparison: {
+    trigger_is_binary: boolean
+    difference?: number | null
+    cohens_d?: number | null
+    welch?: { p_value?: number | null } | null
+  } | null
+  trigger: CorrelationSelector
+  outcome: CorrelationSelector
+}
+
+export interface ScatterSvgOptions {
+  width?: number
+  height?: number
+}
+
+const fmt = (value: number | null | undefined, digits = 2): string =>
+  value == null ? '—' : value.toFixed(digits)
+
+const fmtP = (p: number | null | undefined): string => (p == null ? '—' : p < 0.001 ? '<0.001' : p.toFixed(3))
+
+/**
+ * The headline stat line. For a binary/presence trigger (0/1 — tags, activities,
+ * apps) a Pearson r is misleading, so lead with the present-vs-absent group
+ * comparison instead, the same choice the web scatter and Correlations explorer
+ * make.
+ */
+const headlineOf = (data: ScatterSvgData): string => {
+  const gc = data.group_comparison
+  return gc?.trigger_is_binary
+    ? `Δ(present−absent)=${fmt(gc.difference)} · d=${fmt(gc.cohens_d)} · n=${data.n} · p=${fmtP(gc.welch?.p_value)}`
+    : `r=${fmt(data.pearson)} · ρ=${fmt(data.spearman)} · n=${data.n} · p=${fmtP(data.pearson_p)}`
+}
+
+/**
+ * Build the correlation scatter as a self-contained SVG string: points, an OLS
+ * regression line, the r/ρ/n/p (or group-comparison) headline, and the two
+ * selector axis labels. `data.series` must be non-empty (the caller 404s an
+ * empty/too-small window). Pure and synchronous.
+ */
+export const buildScatterSvg = (data: ScatterSvgData, opts: ScatterSvgOptions = {}): string => {
+  const width = opts.width ?? SCATTER_WIDTH
+  const height = opts.height ?? SCATTER_HEIGHT
+  const xs = data.series.map((p) => p.trigger)
+  const ys = data.series.map((p) => p.outcome)
+  const xMin = Math.min(...xs)
+  const xMax = Math.max(...xs)
+  const yMin = Math.min(...ys)
+  const yMax = Math.max(...ys)
+
+  const sx = (x: number) => scale(x, xMin, xMax, PAD.left, width - PAD.right)
+  const sy = (y: number) => scale(y, yMin, yMax, height - PAD.bottom, PAD.top)
+
+  const reg = linearRegression(xs, ys)
+  const regLine = reg
+    ? `<line x1="${sx(xMin).toFixed(1)}" y1="${sy(reg.slope * xMin + reg.intercept).toFixed(1)}" x2="${sx(xMax).toFixed(1)}" y2="${sy(reg.slope * xMax + reg.intercept).toFixed(1)}" stroke="${REG_COLOR}" stroke-width="3"/>`
+    : ''
+  const points = data.series
+    .map(
+      (p) =>
+        `<circle cx="${sx(p.trigger).toFixed(1)}" cy="${sy(p.outcome).toFixed(1)}" r="5" fill="${POINT_COLOR}" opacity="0.5"/>`,
+    )
+    .join('')
+
+  const xAxis = describeSelectorAxis(data.trigger)
+  const yAxis = describeSelectorAxis(data.outcome)
+  const yLabelX = 24
+  const yLabelY = (PAD.top + (height - PAD.bottom)) / 2
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <rect width="${width}" height="${height}" fill="${SCATTER_BG}" rx="16"/>
+  <line x1="${PAD.left}" y1="${height - PAD.bottom}" x2="${width - PAD.right}" y2="${height - PAD.bottom}" stroke="${AXIS_COLOR}" stroke-width="2"/>
+  <line x1="${PAD.left}" y1="${PAD.top}" x2="${PAD.left}" y2="${height - PAD.bottom}" stroke="${AXIS_COLOR}" stroke-width="2"/>
+  ${points}
+  ${regLine}
+  <text x="${PAD.left + 8}" y="${PAD.top - 16}" fill="${TEXT_COLOR}" font-family="${FONT}" font-size="24" font-weight="700">${escapeXml(headlineOf(data))}</text>
+  <text x="${(PAD.left + (width - PAD.right)) / 2}" y="${height - 20}" fill="${MUTED_COLOR}" font-family="${FONT}" font-size="22" text-anchor="middle">${escapeXml(xAxis)}</text>
+  <text x="${yLabelX}" y="${yLabelY}" fill="${MUTED_COLOR}" font-family="${FONT}" font-size="22" text-anchor="middle" transform="rotate(-90 ${yLabelX} ${yLabelY})">${escapeXml(yAxis)}</text>
+</svg>`
+}

--- a/apps/backend/src/services/meals.integration.test.ts
+++ b/apps/backend/src/services/meals.integration.test.ts
@@ -247,6 +247,13 @@ describe('Meals service integration tests', () => {
   })
 
   describe('queryFrequentMeals', () => {
+    // `queryFrequentMeals` only looks back `since_days` (default 90), so these
+    // fixtures must be dated relative to *now* — hardcoded dates silently age out
+    // of the window and the query returns nothing (they broke CI once April 2026
+    // crossed the 90-day boundary). Keep the two occurrences correctly ordered.
+    const OLDER = new Date(Date.now() - 20 * 86_400_000).toISOString()
+    const NEWER = new Date(Date.now() - 10 * 86_400_000).toISOString()
+
     test('returns frequent names with food items and icon from most recent occurrence', async () => {
       const user = getTestUser()
       const banana = await upsertFoodItem(user, {
@@ -269,7 +276,7 @@ describe('Meals service integration tests', () => {
         food_items: [{ food_item_id: banana.id, name: 'Banana', quantity: 1 }],
         meal_type: 'breakfast',
         name: 'Bananmacka',
-        time: '2026-04-20T08:00:00Z',
+        time: OLDER,
       })
       await addMeal(user, {
         food_items: [
@@ -278,7 +285,7 @@ describe('Meals service integration tests', () => {
         ],
         meal_type: 'breakfast',
         name: 'Bananmacka',
-        time: '2026-04-26T08:00:00Z',
+        time: NEWER,
       })
 
       const result = await queryFrequentMeals(user, { meal_type: 'breakfast' })
@@ -299,7 +306,7 @@ describe('Meals service integration tests', () => {
       await addMeal(user, {
         meal_type: 'breakfast',
         name: 'Toast',
-        time: '2026-04-26T08:00:00Z',
+        time: NEWER,
       })
 
       const result = await queryFrequentMeals(user, { meal_type: 'breakfast' })

--- a/apps/web/src/pages/Correlations/exploreCharts.ts
+++ b/apps/web/src/pages/Correlations/exploreCharts.ts
@@ -3,34 +3,13 @@
  * JSX so the maths (regression, quartiles, axis labelling) is unit-testable.
  */
 
-import type { CorrelationSelector } from '@aurboda/api-spec'
-
-import { isValidMetric, metricUnits } from '@aurboda/api-spec'
-
-export interface RegressionLine {
-  slope: number
-  intercept: number
-}
-
-/** Ordinary least-squares fit y = slope·x + intercept, or null when undefined. */
-export const linearRegression = (xs: number[], ys: number[]): RegressionLine | null => {
-  const n = xs.length
-  if (n < 2 || xs.length !== ys.length) return null
-  let sx = 0
-  let sy = 0
-  let sxx = 0
-  let sxy = 0
-  for (let i = 0; i < n; i++) {
-    sx += xs[i]
-    sy += ys[i]
-    sxx += xs[i] * xs[i]
-    sxy += xs[i] * ys[i]
-  }
-  const denom = n * sxx - sx * sx
-  if (denom === 0) return null
-  const slope = (n * sxy - sx * sy) / denom
-  return { slope, intercept: (sy - slope * sx) / n }
-}
+/**
+ * `linearRegression`, `RegressionLine`, and `describeSelectorAxis` moved to
+ * `@aurboda/api-spec` (shared single source with the backend scatter renderer)
+ * and are re-exported here so existing web imports keep working. This module
+ * keeps the web-only `fiveNumberSummary` used by the box-plot render.
+ */
+export { describeSelectorAxis, linearRegression, type RegressionLine } from '@aurboda/api-spec'
 
 export interface FiveNumberSummary {
   min: number
@@ -52,25 +31,4 @@ export const fiveNumberSummary = (values: number[]): FiveNumberSummary | null =>
     return s[lo] + (s[hi] - s[lo]) * (idx - lo)
   }
   return { min: s[0], q1: quantile(0.25), median: quantile(0.5), q3: quantile(0.75), max: s[s.length - 1] }
-}
-
-/** Short axis label for a selector, including its unit where known. */
-export const describeSelectorAxis = (selector: CorrelationSelector): string => {
-  switch (selector.kind) {
-    case 'metric': {
-      if (!isValidMetric(selector.metric)) return selector.metric || 'metric'
-      const unit = metricUnits[selector.metric]
-      return unit ? `${selector.metric} (${unit})` : selector.metric
-    }
-    case 'nutrition':
-      return `${selector.nutrient} (${selector.nutrient === 'calories' ? 'kcal' : 'g'})`
-    case 'activity':
-      return `${selector.pattern || 'activity'} (${selector.measure === 'duration_min' ? 'min' : 'count'})`
-    case 'productivity_category':
-    case 'productivity_app':
-      return `${selector.pattern || 'productivity'} (min)`
-    case 'tag':
-    default:
-      return `${selector.pattern || 'tag'} (count)`
-  }
 }

--- a/apps/web/src/pages/Feed/ArticleChartBlock.tsx
+++ b/apps/web/src/pages/Feed/ArticleChartBlock.tsx
@@ -6,6 +6,7 @@
  * (`ArticleContent`) resolves the effective window (block override else the
  * article default) and passes concrete ISO strings.
  */
+import { defaultArticleChartBucket } from '@aurboda/api-spec'
 import { useQuery } from '@tanstack/react-query'
 
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
@@ -13,11 +14,6 @@ import { fetchBucketedMetrics } from '../../state/api'
 import { getMetricDisplayName } from '../../utils/metricLabels'
 
 const CHART_COLOR = '#673ab8'
-const DAY_MS = 86_400_000
-
-/** Pick a bucket granularity from the window span when the block doesn't fix one. */
-const defaultBucket = (start: Date, end: Date): string =>
-  end.getTime() - start.getTime() <= 2 * DAY_MS ? '1h' : '1d'
 
 export const ArticleChartBlock = ({
   metric,
@@ -34,7 +30,7 @@ export const ArticleChartBlock = ({
 }) => {
   const startDate = new Date(start)
   const endDate = new Date(end)
-  const effectiveBucket = bucket ?? defaultBucket(startDate, endDate)
+  const effectiveBucket = bucket ?? defaultArticleChartBucket(startDate, endDate)
 
   const { data, isLoading, isError } = useQuery({
     queryFn: () => fetchBucketedMetrics(startDate, endDate, [metric], effectiveBucket),

--- a/apps/web/src/utils/metricLabels.ts
+++ b/apps/web/src/utils/metricLabels.ts
@@ -1,59 +1,11 @@
-import { builtinDashboardMetrics } from '@aurboda/api-spec'
+import { builtinDashboardMetrics, metricLabels } from '@aurboda/api-spec'
 
 /**
- * Friendly display names for built-in metrics.
+ * Friendly metric display names live in `@aurboda/api-spec` (the single source
+ * shared with the backend server-side chart renderer). Re-exported here so the
+ * existing web import path keeps working.
  */
-export const metricLabels: Record<string, string> = {
-  body_fat: 'Body Fat',
-  calories_active: 'Active Calories',
-  calories_basal: 'Basal Calories',
-  calories_total: 'Total Calories',
-  distance: 'Distance',
-  floors_climbed: 'Floors Climbed',
-  heart_rate: 'Heart Rate',
-  hr_zone_0_sec: 'Zone 0 (Below Z1)',
-  hr_zone_1_sec: 'Zone 1',
-  hr_zone_2_sec: 'Zone 2',
-  hr_zone_3_sec: 'Zone 3',
-  hr_zone_4_sec: 'Zone 4',
-  hr_zone_5_sec: 'Zone 5',
-  hrv_7day: 'HRV (7-day)',
-  hrv_30day: 'HRV (30-day)',
-  hrv_rmssd: 'HRV (RMSSD)',
-  readiness_score: 'Readiness Score',
-  resilience_score: 'Resilience Score',
-  resting_heart_rate: 'Resting HR',
-  rhr_7day: 'Resting HR (7-day)',
-  rhr_30day: 'Resting HR (30-day)',
-  sleep_score: 'Sleep Score',
-  spo2: 'SpO2',
-  steps: 'Steps',
-  vo2_max: 'VO2 Max',
-  weight: 'Weight',
-  zone2_weekly: 'Zone 2 (Weekly)',
-  // Garmin metrics
-  stress_level: 'Stress Level',
-  body_battery: 'Body Battery',
-  training_readiness: 'Training Readiness',
-  intensity_minutes: 'Intensity Minutes',
-  respiratory_rate: 'Respiratory Rate',
-  cardiovascular_age: 'Cardiovascular Age',
-  // Running dynamics
-  run_cadence: 'Run Cadence',
-  stride_length: 'Stride Length',
-  ground_contact_time: 'Ground Contact Time',
-  vertical_ratio: 'Vertical Ratio',
-  elevation: 'Elevation',
-  vertical_oscillation: 'Vertical Oscillation',
-  vertical_speed: 'Vertical Speed',
-  grade_adjusted_speed: 'Grade Adjusted Speed',
-  performance_condition: 'Performance Condition',
-}
-
-/**
- * Get a display name for any metric, falling back to the raw name.
- */
-export const getMetricDisplayName = (metric: string): string => metricLabels[metric] ?? metric
+export { getMetricDisplayName, metricLabels } from '@aurboda/api-spec'
 
 /**
  * Built-in dashboard metrics with their display names.

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -37,9 +37,13 @@ A feed post has a **`kind`**:
   HTML in `content`, and a rendered PNG per chart/correlation block attached) so followers
   on Mastodon see the prose and images inline. (A `Note`, not an AS2 `Article`: Mastodon
   treats `Article` as a converted type and discards its `content`, rendering only a title
-  and link.) A richer inline render for Aurboda peers — inbound ingestion plus structured
-  enrichment — is a later slice (**#968**); until then an Aurboda follower doesn't yet see
-  a federated article.
+  and link.) The prose is sanitised through an allowlist wide enough for a QS write-up
+  (GFM tables, images, `hr`, headings); note that **Mastodon's own inbound sanitiser then
+  strips tables/images/`hr`** from a remote status, so a results table degrades to
+  run-together cell text there — the charts still arrive as image attachments, and
+  non-Mastodon / Aurboda-peer renderers keep the full formatting. A richer inline render
+  for Aurboda peers — inbound ingestion plus structured enrichment — is a later slice
+  (**#968**); until then an Aurboda follower doesn't yet see a federated article.
   _Reddit/markdown export is the remaining part of #937._
 
 An **`activity`** feed post references one of the user's activities and records the

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -33,11 +33,13 @@ A feed post has a **`kind`**:
   `POST /feed/articles` / `PATCH /feed/articles/:postId` (and the `create_article` /
   `update_article` MCP tools), or in the web app's article composer; prose renders
   through the shared markdown sanitiser and each windowed block resolves its data live
-  over the locked window. An article **federates as an AS2 `Article`** (title, prose
-  HTML, and a rendered PNG per chart/correlation block) so followers on Mastodon see the
-  prose and images. A richer inline render for Aurboda peers — inbound `Article`
-  ingestion plus structured enrichment — is a later slice (**#968**); until then an
-  Aurboda follower doesn't yet see a federated article.
+  over the locked window. An article **federates as a `Note`** (title in `name`, prose
+  HTML in `content`, and a rendered PNG per chart/correlation block attached) so followers
+  on Mastodon see the prose and images inline. (A `Note`, not an AS2 `Article`: Mastodon
+  treats `Article` as a converted type and discards its `content`, rendering only a title
+  and link.) A richer inline render for Aurboda peers — inbound ingestion plus structured
+  enrichment — is a later slice (**#968**); until then an Aurboda follower doesn't yet see
+  a federated article.
   _Reddit/markdown export is the remaining part of #937._
 
 An **`activity`** feed post references one of the user's activities and records the
@@ -120,15 +122,15 @@ uses), so nothing denormalised is persisted on the post.
 ### Outbox & object serving
 
 - **Outbox** (`/users/<username>/outbox`) — a **cursor-paginated** `OrderedCollection`
-  of the user's `public` + `unlisted` posts as `Create` activities, newest-first, so the
-  actor's profile shows their posts. An activity share is a `Create{Note}`; an article is
-  a `Create{Article}`. The root returns `totalItems` + `first`/`last` page links; each
-  page (`?cursor=<offset>`) serves up to a fixed page size with a `next` link.
-  `followers`-only posts are never listed.
+  of the user's `public` + `unlisted` posts as `Create{Note}` activities, newest-first, so
+  the actor's profile shows their posts — both an activity share and an article are a
+  `Create{Note}`. The root returns `totalItems` + `first`/`last` page links; each page
+  (`?cursor=<offset>`) serves up to a fixed page size with a `next` link. `followers`-only
+  posts are never listed.
 - **Object** (`/users/<username>/feed/<postId>`) — the post's `Note`, served at its
-  canonical id so a remote server can dereference it. An **article** is served as an AS2
-  `Article` at a distinct id (`…/feed/<postId>/article`). Only `public`/`unlisted` resolve;
-  `followers`-only and unknown ids return 404. Once a `public`/`unlisted` post is
+  canonical id so a remote server can dereference it (an article's Note carries its prose
+  in `content`; an activity's carries the shared-scalars summary). Only `public`/`unlisted`
+  resolve; `followers`-only and unknown ids return 404. Once a `public`/`unlisted` post is
   **deleted**, that id returns **`410 Gone` with an AS2 `Tombstone`** (recorded in
   `feed_tombstone`) so a dereferencing server learns the object is _permanently_ gone
   rather than transiently missing. A `followers`-only id is never tombstoned — it never
@@ -332,7 +334,7 @@ on every hit. The AS2 `Image` attachment URL also carries `?v=<updated_at>` so a
 media cache (which re-hosts the PNG at receipt) re-fetches after an edit.
 
 A block image endpoint **404s** when the block is too sparse to draw (a chart with < 2
-points, a correlation with n < 3) or has a zero-duration bucket. The AS2 `Article`
+points, a correlation with n < 3) or has a zero-duration bucket. The article's `Note`
 attaches one `Image` per chart/correlation block **unconditionally** (the attachment list
 is built without a synchronous pre-render), so a sparse block ships an attachment URL
 that resolves to 404 — a plain fediverse client just shows one fewer image.
@@ -470,8 +472,7 @@ Public / federation (unauthenticated):
 | `GET /users/:username/outbox`                                | Public + unlisted posts as `Create` activities                                                             |
 | `GET /users/:username/followers`                             | The actor's followers collection                                                                           |
 | `GET /users/:username/following`                             | The actor's following collection (accepted follows only)                                                   |
-| `GET /users/:username/feed/:postId`                          | A single post's `Note` (or `410` Tombstone once deleted)                                                   |
-| `GET /users/:username/feed/:postId/article`                  | A single article post's AS2 `Article` object (public/unlisted only)                                        |
+| `GET /users/:username/feed/:postId`                          | A single post's `Note` — an activity share or an article (or `410` Tombstone once deleted)                 |
 | `POST /users/:username/inbox` (+ `/inbox`)                   | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -33,11 +33,11 @@ A feed post has a **`kind`**:
   `POST /feed/articles` / `PATCH /feed/articles/:postId` (and the `create_article` /
   `update_article` MCP tools), or in the web app's article composer; prose renders
   through the shared markdown sanitiser and each windowed block resolves its data live
-  over the locked window. An article **federates as an AS2 `Article`** (title + prose
-  HTML + a rendered PNG per chart/correlation block) so followers on Mastodon see prose
-  + images. A richer inline render for Aurboda peers — inbound `Article` ingestion plus
-  structured enrichment — is a later slice (**#968**); until then an Aurboda follower
-  doesn't yet see a federated article.
+  over the locked window. An article **federates as an AS2 `Article`** (title, prose
+  HTML, and a rendered PNG per chart/correlation block) so followers on Mastodon see the
+  prose and images. A richer inline render for Aurboda peers — inbound `Article`
+  ingestion plus structured enrichment — is a later slice (**#968**); until then an
+  Aurboda follower doesn't yet see a federated article.
   _Reddit/markdown export is the remaining part of #937._
 
 An **`activity`** feed post references one of the user's activities and records the
@@ -320,8 +320,16 @@ correlation block can embed any metric over any window, so the post's **visibili
 the whole authorization boundary (public/unlisted open; `followers`-only via the
 `?token=` capability). The chart block renders the metric bucketed over the locked
 window; the correlation block renders the scatter with its OLS line and coefficient
-headline. Because an article (unlike a shared activity) is editable, the render cache
-keys on the post's `updated_at` so an edit serves a fresh image.
+headline. It buckets in the author's timezone (`settings.tz`), matching the web inline
+render. Because an article (unlike a shared activity) is editable **and** its locked
+window can later gain backfilled data, the render cache keys on the post's `updated_at`
+**and** a coarse hourly bucket, so an edit or new data serves a fresh image within ≤ 1h.
+
+A block image endpoint **404s** when the block is too sparse to draw (a chart with < 2
+points, a correlation with n < 3) or has a zero-duration bucket. The AS2 `Article`
+attaches one `Image` per chart/correlation block **unconditionally** (the attachment list
+is built without a synchronous pre-render), so a sparse block ships an attachment URL
+that resolves to 404 — a plain fediverse client just shows one fewer image.
 
 An image is served when the matching flag was opted into. `public`/`unlisted` posts
 serve their images unauthenticated. A `followers`-only post's image URLs instead carry
@@ -426,10 +434,10 @@ Owner-facing (authenticated, scoped to the caller):
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `GET /feed`                        | List my feed posts (each enriched with the shared activity's title/type and merged-span window, resolved at query time) |
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
-| `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                        |
-| `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                           |
+| `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                       |
+| `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                          |
 | `PATCH /feed/:postId`              | Edit an activity post's selection / visibility / attachments                                                            |
-| `DELETE /feed/:postId`             | Unpublish any post (an activity post's public series stops resolving)                                                    |
+| `DELETE /feed/:postId`             | Unpublish any post (an activity post's public series stops resolving)                                                   |
 | `GET /feed/following`              | List the actors I follow (accepted + pending)                                                                           |
 | `POST /feed/following`             | Follow an actor by handle (`@user@host` or actor URL)                                                                   |
 | `DELETE /feed/following/:id`       | Unfollow (sends `Undo{Follow}`)                                                                                         |
@@ -441,24 +449,24 @@ Owner-facing (authenticated, scoped to the caller):
 
 Public / federation (unauthenticated):
 
-| Method & path                                  | Purpose                                                                                                    |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `GET /public/:username/series`                 | Bucketed samples for a **shared** series within its window                                                 |
-| `GET /public/:username/feed/:postId`           | Native structured post (`FeedStructured`: typed metrics + inline series) for Aurboda-to-Aurboda enrichment |
-| `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart (PNG) for an opted-in post (`?token=` for followers-only)                                |
-| `GET /public/:username/feed/:postId/chart.svg` | Same HR chart as crisp `image/svg+xml` for Aurboda-native rendering (`?token=` for followers-only)         |
-| `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post (`?token=` for followers-only)                                 |
-| `GET /public/:username/feed/:postId/blocks/:index/image.png` | Rendered PNG of an article's chart/correlation block (visibility-gated; `?token=` for followers-only) |
-| `GET /public/:username/feed/:postId/blocks/:index/image.svg` | Same article block as crisp `image/svg+xml`                                                          |
-| `GET /public/:username/posts`                  | A user's public/unlisted posts (newest-first, latest page) for their profile feed                          |
-| `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                                                               |
-| `GET /users/:username`                         | The actor document (`Person`)                                                                              |
-| `GET /users/:username/outbox`                  | Public + unlisted posts as `Create` activities                                                             |
-| `GET /users/:username/followers`               | The actor's followers collection                                                                           |
-| `GET /users/:username/following`               | The actor's following collection (accepted follows only)                                                   |
-| `GET /users/:username/feed/:postId`            | A single post's `Note` (or `410` Tombstone once deleted)                                                   |
-| `GET /users/:username/feed/:postId/article`    | A single article post's AS2 `Article` object (public/unlisted only)                                        |
-| `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
+| Method & path                                                | Purpose                                                                                                    |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `GET /public/:username/series`                               | Bucketed samples for a **shared** series within its window                                                 |
+| `GET /public/:username/feed/:postId`                         | Native structured post (`FeedStructured`: typed metrics + inline series) for Aurboda-to-Aurboda enrichment |
+| `GET /public/:username/feed/:postId/chart.png`               | Rendered HR chart (PNG) for an opted-in post (`?token=` for followers-only)                                |
+| `GET /public/:username/feed/:postId/chart.svg`               | Same HR chart as crisp `image/svg+xml` for Aurboda-native rendering (`?token=` for followers-only)         |
+| `GET /public/:username/feed/:postId/route.png`               | Rendered GPS route map for an opted-in post (`?token=` for followers-only)                                 |
+| `GET /public/:username/feed/:postId/blocks/:index/image.png` | Rendered PNG of an article's chart/correlation block (visibility-gated; `?token=` for followers-only)      |
+| `GET /public/:username/feed/:postId/blocks/:index/image.svg` | Same article block as crisp `image/svg+xml`                                                                |
+| `GET /public/:username/posts`                                | A user's public/unlisted posts (newest-first, latest page) for their profile feed                          |
+| `GET /.well-known/webfinger`                                 | Resolve `acct:<username>@<host>` → the actor                                                               |
+| `GET /users/:username`                                       | The actor document (`Person`)                                                                              |
+| `GET /users/:username/outbox`                                | Public + unlisted posts as `Create` activities                                                             |
+| `GET /users/:username/followers`                             | The actor's followers collection                                                                           |
+| `GET /users/:username/following`                             | The actor's following collection (accepted follows only)                                                   |
+| `GET /users/:username/feed/:postId`                          | A single post's `Note` (or `410` Tombstone once deleted)                                                   |
+| `GET /users/:username/feed/:postId/article`                  | A single article post's AS2 `Article` object (public/unlisted only)                                        |
+| `POST /users/:username/inbox` (+ `/inbox`)                   | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
 `create_article`, `update_article`, `update_feed_post`, `delete_feed_post`, `list_following`,

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -320,10 +320,16 @@ correlation block can embed any metric over any window, so the post's **visibili
 the whole authorization boundary (public/unlisted open; `followers`-only via the
 `?token=` capability). The chart block renders the metric bucketed over the locked
 window; the correlation block renders the scatter with its OLS line and coefficient
-headline. It buckets in the author's timezone (`settings.tz`), matching the web inline
-render. Because an article (unlike a shared activity) is editable **and** its locked
-window can later gain backfilled data, the render cache keys on the post's `updated_at`
-**and** a coarse hourly bucket, so an edit or new data serves a fresh image within ≤ 1h.
+headline. It buckets in the author's **device timezone** (`device_timezone`, set by the
+Android app) so a `1d` bucket splits on the author's calendar days like the web render;
+for an author whose device timezone is unknown it falls back to UTC (the web render uses
+the live browser timezone, so the two can differ by a day only in that case). Because an
+article (unlike a shared activity) is editable **and** its locked window can later gain
+backfilled data, the render cache keys on the post's `updated_at` **and** a coarse hourly
+bucket, so an edit or new data serves a fresh image within ≤ 1h; a `null` (no-data) render
+is remembered under the same key so a sparse public block can't re-run the render engine
+on every hit. The AS2 `Image` attachment URL also carries `?v=<updated_at>` so a remote
+media cache (which re-hosts the PNG at receipt) re-fetches after an edit.
 
 A block image endpoint **404s** when the block is too sparse to draw (a chart with < 2
 points, a correlation with n < 3) or has a zero-duration bucket. The AS2 `Article`

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -35,7 +35,9 @@ A feed post has a **`kind`**:
   through the shared markdown sanitiser and each windowed block resolves its data live
   over the locked window. An article **federates as an AS2 `Article`** (title + prose
   HTML + a rendered PNG per chart/correlation block) so followers on Mastodon see prose
-  + images; Aurboda peers get the richer inline render via structured enrichment.
+  + images. A richer inline render for Aurboda peers — inbound `Article` ingestion plus
+  structured enrichment — is a later slice (**#968**); until then an Aurboda follower
+  doesn't yet see a federated article.
   _Reddit/markdown export is the remaining part of #937._
 
 An **`activity`** feed post references one of the user's activities and records the

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -33,10 +33,10 @@ A feed post has a **`kind`**:
   `POST /feed/articles` / `PATCH /feed/articles/:postId` (and the `create_article` /
   `update_article` MCP tools), or in the web app's article composer; prose renders
   through the shared markdown sanitiser and each windowed block resolves its data live
-  over the locked window.
-  _Federation as an AS2 `Article` + Reddit/markdown export is the remaining slice
-  (#937), so an article is authored and shown on the owner's own feed but does not yet
-  fan out to followers._
+  over the locked window. An article **federates as an AS2 `Article`** (title + prose
+  HTML + a rendered PNG per chart/correlation block) so followers on Mastodon see prose
+  + images; Aurboda peers get the richer inline render via structured enrichment.
+  _Reddit/markdown export is the remaining part of #937._
 
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:
@@ -119,11 +119,13 @@ uses), so nothing denormalised is persisted on the post.
 
 - **Outbox** (`/users/<username>/outbox`) — a **cursor-paginated** `OrderedCollection`
   of the user's `public` + `unlisted` posts as `Create` activities, newest-first, so the
-  actor's profile shows their posts. The root returns `totalItems` + `first`/`last` page
-  links; each page (`?cursor=<offset>`) serves up to a fixed page size with a `next` link.
+  actor's profile shows their posts. An activity share is a `Create{Note}`; an article is
+  a `Create{Article}`. The root returns `totalItems` + `first`/`last` page links; each
+  page (`?cursor=<offset>`) serves up to a fixed page size with a `next` link.
   `followers`-only posts are never listed.
 - **Object** (`/users/<username>/feed/<postId>`) — the post's `Note`, served at its
-  canonical id so a remote server can dereference it. Only `public`/`unlisted` resolve;
+  canonical id so a remote server can dereference it. An **article** is served as an AS2
+  `Article` at a distinct id (`…/feed/<postId>/article`). Only `public`/`unlisted` resolve;
   `followers`-only and unknown ids return 404. Once a `public`/`unlisted` post is
   **deleted**, that id returns **`410 Gone` with an AS2 `Tombstone`** (recorded in
   `feed_tombstone`) so a dereferencing server learns the object is _permanently_ gone
@@ -303,6 +305,22 @@ crisp, scalable `image/svg+xml` for **Aurboda-native** rendering (it stays sharp
 any size). Both share the same eligibility gate, capability-token model, and
 `no-store` revocability.
 
+An **article** renders one image per chart/correlation block for the same reason (so
+Mastodon and export tools attach a raster of each block), at its own endpoints:
+
+```
+GET /api/public/:username/feed/:postId/blocks/:index/image.png
+GET /api/public/:username/feed/:postId/blocks/:index/image.svg
+```
+
+Unlike an activity chart, a block has **no `include_chart` opt-in flag** — a chart or
+correlation block can embed any metric over any window, so the post's **visibility** is
+the whole authorization boundary (public/unlisted open; `followers`-only via the
+`?token=` capability). The chart block renders the metric bucketed over the locked
+window; the correlation block renders the scatter with its OLS line and coefficient
+headline. Because an article (unlike a shared activity) is editable, the render cache
+keys on the post's `updated_at` so an edit serves a fresh image.
+
 An image is served when the matching flag was opted into. `public`/`unlisted` posts
 serve their images unauthenticated. A `followers`-only post's image URLs instead carry
 the post's **unguessable capability token** (`?token=<image_token>`), which is embedded
@@ -428,6 +446,8 @@ Public / federation (unauthenticated):
 | `GET /public/:username/feed/:postId/chart.png` | Rendered HR chart (PNG) for an opted-in post (`?token=` for followers-only)                                |
 | `GET /public/:username/feed/:postId/chart.svg` | Same HR chart as crisp `image/svg+xml` for Aurboda-native rendering (`?token=` for followers-only)         |
 | `GET /public/:username/feed/:postId/route.png` | Rendered GPS route map for an opted-in post (`?token=` for followers-only)                                 |
+| `GET /public/:username/feed/:postId/blocks/:index/image.png` | Rendered PNG of an article's chart/correlation block (visibility-gated; `?token=` for followers-only) |
+| `GET /public/:username/feed/:postId/blocks/:index/image.svg` | Same article block as crisp `image/svg+xml`                                                          |
 | `GET /public/:username/posts`                  | A user's public/unlisted posts (newest-first, latest page) for their profile feed                          |
 | `GET /.well-known/webfinger`                   | Resolve `acct:<username>@<host>` → the actor                                                               |
 | `GET /users/:username`                         | The actor document (`Person`)                                                                              |
@@ -435,6 +455,7 @@ Public / federation (unauthenticated):
 | `GET /users/:username/followers`               | The actor's followers collection                                                                           |
 | `GET /users/:username/following`               | The actor's following collection (accepted follows only)                                                   |
 | `GET /users/:username/feed/:postId`            | A single post's `Note` (or `410` Tombstone once deleted)                                                   |
+| `GET /users/:username/feed/:postId/article`    | A single article post's AS2 `Article` object (public/unlisted only)                                        |
 | `POST /users/:username/inbox` (+ `/inbox`)     | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -337,7 +337,11 @@ A block image endpoint **404s** when the block is too sparse to draw (a chart wi
 points, a correlation with n < 3) or has a zero-duration bucket. The article's `Note`
 attaches one `Image` per chart/correlation block **unconditionally** (the attachment list
 is built without a synchronous pre-render), so a sparse block ships an attachment URL
-that resolves to 404 — a plain fediverse client just shows one fewer image.
+that resolves to 404 — a plain fediverse client just shows one fewer image. Note also
+that **Mastodon caps a remote status at 4 media attachments** (`MEDIA_ATTACHMENTS_LIMIT`)
+when processing an inbound `Create`, so an article with more than four chart/correlation
+blocks shows only its first four images there (Aurboda peers, which fetch the native
+payload, aren't capped).
 
 An image is served when the matching flag was opted into. `public`/`unlisted` posts
 serve their images unauthenticated. A `followers`-only post's image URLs instead carry

--- a/packages/api-spec/src/schemas/common.ts
+++ b/packages/api-spec/src/schemas/common.ts
@@ -358,6 +358,62 @@ export const getMetricUnit = (
 }
 
 /**
+ * Friendly display names for built-in metrics. Shared single source used by the
+ * web UI (chart titles, pickers, goals) and the backend server-side chart
+ * renderer (article-block PNGs), so a metric reads the same everywhere. Falls
+ * back to the raw metric name for anything not listed (e.g. custom metrics).
+ */
+export const metricLabels: Record<string, string> = {
+  body_fat: 'Body Fat',
+  calories_active: 'Active Calories',
+  calories_basal: 'Basal Calories',
+  calories_total: 'Total Calories',
+  distance: 'Distance',
+  floors_climbed: 'Floors Climbed',
+  heart_rate: 'Heart Rate',
+  hr_zone_0_sec: 'Zone 0 (Below Z1)',
+  hr_zone_1_sec: 'Zone 1',
+  hr_zone_2_sec: 'Zone 2',
+  hr_zone_3_sec: 'Zone 3',
+  hr_zone_4_sec: 'Zone 4',
+  hr_zone_5_sec: 'Zone 5',
+  hrv_7day: 'HRV (7-day)',
+  hrv_30day: 'HRV (30-day)',
+  hrv_rmssd: 'HRV (RMSSD)',
+  readiness_score: 'Readiness Score',
+  resilience_score: 'Resilience Score',
+  resting_heart_rate: 'Resting HR',
+  rhr_7day: 'Resting HR (7-day)',
+  rhr_30day: 'Resting HR (30-day)',
+  sleep_score: 'Sleep Score',
+  spo2: 'SpO2',
+  steps: 'Steps',
+  vo2_max: 'VO2 Max',
+  weight: 'Weight',
+  zone2_weekly: 'Zone 2 (Weekly)',
+  // Garmin metrics
+  stress_level: 'Stress Level',
+  body_battery: 'Body Battery',
+  training_readiness: 'Training Readiness',
+  intensity_minutes: 'Intensity Minutes',
+  respiratory_rate: 'Respiratory Rate',
+  cardiovascular_age: 'Cardiovascular Age',
+  // Running dynamics
+  run_cadence: 'Run Cadence',
+  stride_length: 'Stride Length',
+  ground_contact_time: 'Ground Contact Time',
+  vertical_ratio: 'Vertical Ratio',
+  elevation: 'Elevation',
+  vertical_oscillation: 'Vertical Oscillation',
+  vertical_speed: 'Vertical Speed',
+  grade_adjusted_speed: 'Grade Adjusted Speed',
+  performance_condition: 'Performance Condition',
+}
+
+/** Get a display name for any metric, falling back to the raw name. */
+export const getMetricDisplayName = (metric: string): string => metricLabels[metric] ?? metric
+
+/**
  * Check if a string is a valid metric (built-in or custom).
  */
 export const isValidMetricOrCustom = (

--- a/packages/api-spec/src/schemas/correlations.ts
+++ b/packages/api-spec/src/schemas/correlations.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod'
 
-import { createDataResponseSchema } from './common.ts'
+import { createDataResponseSchema, isValidMetric, metricUnits } from './common.ts'
 
 // ============================================================================
 // Common schemas
@@ -798,6 +798,62 @@ export const selectorSchema = z
   .meta({ id: 'CorrelationSelector' })
 
 export type CorrelationSelector = z.infer<typeof selectorSchema>
+
+/**
+ * Short axis label for a selector, including its unit where known. Shared single
+ * source for the correlation scatter axes on the web (Explore + article blocks)
+ * and the backend server-side scatter renderer (article-block PNGs), so an axis
+ * reads the same in-app and in a federated/exported image.
+ */
+export const describeSelectorAxis = (selector: CorrelationSelector): string => {
+  switch (selector.kind) {
+    case 'metric': {
+      if (!isValidMetric(selector.metric)) return selector.metric || 'metric'
+      const unit = metricUnits[selector.metric]
+      return unit ? `${selector.metric} (${unit})` : selector.metric
+    }
+    case 'nutrition':
+      return `${selector.nutrient} (${selector.nutrient === 'calories' ? 'kcal' : 'g'})`
+    case 'activity':
+      return `${selector.pattern || 'activity'} (${selector.measure === 'duration_min' ? 'min' : 'count'})`
+    case 'productivity_category':
+    case 'productivity_app':
+      return `${selector.pattern || 'productivity'} (min)`
+    case 'tag':
+    default:
+      return `${selector.pattern || 'tag'} (count)`
+  }
+}
+
+/** An ordinary-least-squares fit `y = slope·x + intercept`. */
+export interface RegressionLine {
+  slope: number
+  intercept: number
+}
+
+/**
+ * Ordinary least-squares fit `y = slope·x + intercept`, or null when undefined
+ * (fewer than 2 points, mismatched lengths, or zero x-variance). Shared by the
+ * web and backend correlation scatter renderers.
+ */
+export const linearRegression = (xs: number[], ys: number[]): RegressionLine | null => {
+  const n = xs.length
+  if (n < 2 || xs.length !== ys.length) return null
+  let sx = 0
+  let sy = 0
+  let sxx = 0
+  let sxy = 0
+  for (let i = 0; i < n; i++) {
+    sx += xs[i]
+    sy += ys[i]
+    sxx += xs[i] * xs[i]
+    sxy += xs[i] * ys[i]
+  }
+  const denom = n * sxx - sx * sx
+  if (denom === 0) return null
+  const slope = (n * sxy - sx * sy) / denom
+  return { intercept: (sy - slope * sx) / n, slope }
+}
 
 /** How partially-logged nutrition days are treated in continuous correlation. */
 export const nutritionCompletenessSchema = z.enum(['all', 'complete_only']).meta({

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -157,6 +157,16 @@ export const articleChartBlockSchema = z
   .meta({ description: 'A metric chart over a locked window', id: 'ArticleChartBlock' })
 
 /**
+ * Pick a bucket granularity for an article chart block from its window span when
+ * the block doesn't fix one (`bucket` omitted). Shared single source used by both
+ * the web inline render and the backend server-side chart PNG, so a chart buckets
+ * the same in-app and in a federated/exported image: hourly for a window up to
+ * two days, otherwise daily.
+ */
+export const defaultArticleChartBucket = (start: Date, end: Date): string =>
+  end.getTime() - start.getTime() <= 2 * 86_400_000 ? '1h' : '1d'
+
+/**
  * A correlation block: a scatter of two data dimensions (a `trigger` predictor
  * against an `outcome`) over a locked `[start, end]` window, reusing the
  * exploratory correlation engine's selectors. Like a chart block, the window is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      marked:
+        specifier: ^17.0.3
+        version: 17.0.3
       multer:
         specifier: ^2.1.1
         version: 2.1.1


### PR DESCRIPTION
> [!NOTE]
> **Correction (2026-08-19, see #970):** contrary to the C2 description below, the shipped code federates an article as a **`Create{Note}`** at the shared post object path (`…/users/<user>/feed/<id>`) — not as an AS2 `Article` at a separate `…/article` id. Mastodon discards `content` on converted types like `Article`, so a `Note` is what actually shows the prose + attached images. `docs/features/feed.md` (updated in this PR) describes the real behaviour; the C2 prose below is stale from a pre-review revision.

Part of #934 (Shareable analysis Articles). This is the first of two PRs for **Slice C (#937)** — consolidated into larger PRs to minimise Docker rebuilds on `develop`. This one delivers **server-side article-block image rendering (C1)** and **AS2 `Article` federation (C2)**; a follow-up covers native peer enrichment (C3) + Reddit/markdown export (C4).

## C1 — gated server-side article-block images

New endpoints, rendered on demand:

```
GET /public/:username/feed/:postId/blocks/:index/image.{png,svg}
```

- **Security gate (lands the #943-deferred work).** Unlike an activity chart, an article block has **no `include_chart` opt-in flag** — a chart/correlation block can embed *any* metric over *any* window, so the post's **visibility** is the whole authorization boundary: `public`/`unlisted` open; `followers`-only reachable only via the post's unguessable `?token=` (constant-time compare); `no-store`. Mirrors the existing `chart.png` gate (`resolveImageWindow` → new `resolveArticleBlock`).
- **Chart blocks** reuse `buildChartSvg` over a bucketed metric series matching the web's live render (shared `defaultArticleChartBucket`).
- **Correlation blocks** get a new pure server scatter renderer (`scatter-svg.ts`) — the server twin of the web `ArticleCorrelationBlock`: same OLS line + binary-trigger group-comparison headline, on the dark card background.
- The render cache keys on the post's `updated_at`, so editing an article serves a fresh image (articles, unlike shared activities, are mutable).
- **DRY:** moved `metricLabels`/`getMetricDisplayName`, `describeSelectorAxis`, and `linearRegression` into `@aurboda/api-spec` as the single source; web re-exports so existing imports keep working.

## C2 — AS2 Article federation

- An article federates as an AS2 **`Article`** (title `name` + sanitised prose HTML `content` + one PNG attachment per chart/correlation block), so Mastodon shows prose + images. Its object id is its own dispatcher path (`…/feed/<id>/article`), distinct from the `Note` path.
- Prose markdown → HTML via `marked` + the shared `sanitizeRemoteHtml` allowlist (the #910 XSS boundary, server side).
- Outbox now lists articles as `Create{Article}` (previously dropped on the `activity_id` guard); the `Article` object dispatcher serves them; article delete tombstones the article object id.
- `FeedDeliver` gains `createdArticle`/`updatedArticle`; the REST `/feed/articles` routes and the `create_article`/`update_article` MCP tools fan out (parity).

## Testing

- `pnpm check` green (tsgo + oxlint) across api-spec / backend / web.
- Unit: `resolveArticleBlock` (visibility gate, window inheritance, prose/out-of-range/non-article rejection), `buildScatterSvg`, article content/attachments, the Article builders.
- Integration (testcontainers): an article appears in the outbox as `Create{Article}` and resolves as an `Article`; existing federation + feed-router integration suites still pass.

Adds `marked` to the backend. Docs updated (`docs/features/feed.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
