### PR TITLE
feat(feed): article structured enrichment for peers + Reddit/markdown export (#937 Slice C, part 2)

### DIFF
--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -168,7 +168,7 @@ export const mountRestRouters = ({
   // feed router's `/:postId`.
   httpd.use('/feed/following', createFeedFollowingRouter(authMiddleware, followActions))
   httpd.use('/feed/followers', createFeedFollowersRouter(authMiddleware, followerActions))
-  httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver, timelineHub))
+  httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver, timelineHub, apiBaseUrl))
   httpd.use('/challenges', createChallengesRouter(authMiddleware, webHost, apiBaseUrl))
   httpd.use(createChallengeDataRouter())
   // Public feed series must be mounted before the generic /public/:username/:slug

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -69,6 +69,7 @@ describe('Timeline store integration', () => {
       activity_type: 'exercise',
       duration_seconds: 1800,
       end_time: '2026-07-01T08:30:00.000Z',
+      kind: 'activity' as const,
       metrics: [
         { key: 'heart_rate_avg', unit: 'bpm', value: 142 },
         { key: 'hr_zone_minutes', value: { z2: 22, z3: 8 } },
@@ -124,6 +125,7 @@ describe('Timeline store integration', () => {
     const user = getTestUser()
     const structured = {
       activity_type: 'exercise',
+      kind: 'activity' as const,
       metrics: [{ key: 'distance', unit: 'km', value: 5 }],
       series: [],
       start_time: '2026-07-01T08:00:00.000Z',

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -8,7 +8,7 @@
  * responsible for cleaning untrusted fediverse HTML before it reaches here).
  * Ordering + pagination is keyset by `(published_at DESC, id DESC)`.
  */
-import type { FeedStructured, TimelineImage } from '@aurboda/api-spec'
+import type { FeedStructuredPost, TimelineImage } from '@aurboda/api-spec'
 
 import { query } from './connection.ts'
 
@@ -24,7 +24,7 @@ export interface TimelineEntryRecord {
   published_at: Date
   received_at: Date
   /** Native structured payload from an Aurboda peer, or null for non-Aurboda posts. */
-  structured: FeedStructured | null
+  structured: FeedStructuredPost | null
   /** Image attachments (rendered chart / route map, or a Mastodon photo), or null. */
   images: TimelineImage[] | null
 }
@@ -40,7 +40,7 @@ export interface TimelineEntryInput {
   url?: string | null
   published_at: Date
   /** Native structured payload fetched from an Aurboda peer on ingest, if any. */
-  structured?: FeedStructured | null
+  structured?: FeedStructuredPost | null
   /** Image attachments captured from the delivered Note, if any. */
   images?: TimelineImage[] | null
 }

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -99,7 +99,7 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
   }
   registerReportTools(server, user)
   registerSharedDashboardTools(server, user)
-  registerFeedTools(server, user, deps.feedDeliver, deps.followActions, deps.followerActions)
+  registerFeedTools(server, user, deps.feedDeliver, deps.followActions, deps.followerActions, deps.apiBaseUrl)
   registerChallengeTools(server, user, { apiBaseUrl: deps.apiBaseUrl, webHost: deps.webHost })
   registerScreentimeCategoryTools(server, user)
   registerDebugTools(server, user)

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -31,6 +31,7 @@ import {
   updateFeedFollowingNotify,
   updateFeedPost,
 } from '../db/index.ts'
+import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { serializeFeedPost } from '../services/feed.ts'
@@ -149,6 +150,13 @@ export const registerFeedTools = (
     async ({ id }) => {
       const post = await getFeedPostById(user, id)
       if (!post || post.kind !== 'article' || post.article == null) return errorResponse('Article not found')
+      // Export targets a public paste; a followers-only article's images need its
+      // private token, so refuse rather than leak it (parity with the REST route).
+      if (!isPubliclyVisible(post.visibility)) {
+        return errorResponse(
+          'A followers-only article can’t be exported — its charts need a private link. Make it public or unlisted first.',
+        )
+      }
       if (!apiBaseUrl) return errorResponse('Export is not available')
       const markdown = buildArticleMarkdown(
         apiBaseUrl,

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -31,6 +31,7 @@ import {
   updateFeedFollowingNotify,
   updateFeedPost,
 } from '../db/index.ts'
+import { buildArticleMarkdown } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { serializeFeedPost } from '../services/feed.ts'
 import { serializeFollower } from '../services/followers.ts'
@@ -51,6 +52,7 @@ export const registerFeedTools = (
   deliver?: FeedDeliver,
   followActions?: FollowActions,
   followerActions?: FollowerActions,
+  apiBaseUrl?: string,
 ) => {
   server.tool(
     'list_feed',
@@ -137,6 +139,27 @@ export const registerFeedTools = (
       if (!record) return errorResponse('Article not found')
       deliver?.updatedArticle(user, record)
       return jsonResponse(await serializeFeedPost(user, record))
+    },
+  )
+
+  server.tool(
+    'export_article_markdown',
+    'Export a published ARTICLE as paste-ready markdown for a text-only destination (e.g. r/QuantifiedSelf): the title, the prose blocks verbatim, and one image link per chart/correlation block pointing at its rendered PNG. Paste the result and add your own write-up around the linked charts.',
+    { id: z.string().uuid().describe('Feed post ID (must be an article)') },
+    async ({ id }) => {
+      const post = await getFeedPostById(user, id)
+      if (!post || post.kind !== 'article' || post.article == null) return errorResponse('Article not found')
+      if (!apiBaseUrl) return errorResponse('Export is not available')
+      const markdown = buildArticleMarkdown(
+        apiBaseUrl,
+        user,
+        post.id,
+        post.visibility,
+        post.image_token,
+        post.updated_at,
+        post.article,
+      )
+      return jsonResponse({ markdown })
     },
   )
 

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -30,7 +30,7 @@ import type { ScatterSvgData } from '../services/charts/scatter-svg.ts'
 
 import { isValidUsername } from '../api/auth-routes.ts'
 import { isMissingDatabase } from '../db/index.ts'
-import { blockWindow } from '../services/article.ts'
+import { blockWindow, isZeroDurationBucket } from '../services/article.ts'
 import { isCapabilityAuthorized } from '../services/feed-capability.ts'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -272,10 +272,6 @@ export const resolveArticleBlock = async (
 
 /** Article-chart line colour, matching the web inline render (`ArticleChartBlock`). */
 const ARTICLE_CHART_COLOR = '#673ab8'
-
-/** A zero-duration bucket (`0s`, `00m`, …) passes the block schema regex but is
- * invalid for `date_bin` (`date_bin('0 seconds', …)` errors) — treat it as no image. */
-const isZeroDurationBucket = (bucket: string): boolean => /^0+[smhd]$/.test(bucket)
 
 /**
  * Render one resolved article block to its image bytes (PNG or the crisp SVG),

--- a/apps/backend/src/routes/feed-image-router.ts
+++ b/apps/backend/src/routes/feed-image-router.ts
@@ -105,18 +105,20 @@ export type ResolvedArticleBlock =
     }
 
 /**
- * A tiny memoising render cache with in-flight de-duplication (mirrors
- * og-image-router): repeated fetches for the same image serve a cached buffer,
- * and concurrent misses collapse to a single render. Rendering is CPU-heavy and
- * the source data (a past activity's series/GPS) is effectively immutable, so a
- * bounded LRU + process-restart eviction is enough. `produce` returning `null`
- * (no data) is NOT cached. The caller checks eligibility BEFORE consulting this,
- * so an unshared/visibility-changed post 404s and never reaches the cache.
+ * A tiny memoising cache with in-flight de-duplication (mirrors og-image-router):
+ * repeated fetches for the same key serve the cached value, and concurrent misses
+ * collapse to a single `produce`. Producing is expensive (a rasterised image, or
+ * a many-block structured payload) and the source is effectively immutable per
+ * key, so a bounded LRU + process-restart eviction is enough. `produce` returning
+ * `null` (no data / unauthorized) is NOT cached. The caller checks eligibility
+ * BEFORE consulting this, so an unshared/visibility-changed post 404s and never
+ * reaches the cache. Generic over the cached value (defaults to `Buffer` for the
+ * image endpoints; the structured endpoint caches its payload object).
  */
-export const createRenderCache = (maxEntries = 200) => {
-  const cache = new Map<string, Buffer>()
-  const inFlight = new Map<string, Promise<Buffer | null>>()
-  return async (key: string, produce: () => Promise<Buffer | null>): Promise<Buffer | null> => {
+export const createRenderCache = <T = Buffer>(maxEntries = 200) => {
+  const cache = new Map<string, T>()
+  const inFlight = new Map<string, Promise<T | null>>()
+  return async (key: string, produce: () => Promise<T | null>): Promise<T | null> => {
     const cached = cache.get(key)
     if (cached) return cached
     const pending = inFlight.get(key)
@@ -124,15 +126,15 @@ export const createRenderCache = (maxEntries = 200) => {
     const promise = produce()
     inFlight.set(key, promise)
     try {
-      const png = await promise
-      if (png) {
+      const value = await promise
+      if (value) {
         if (cache.size >= maxEntries) {
           const oldest = cache.keys().next().value
           if (oldest !== undefined) cache.delete(oldest)
         }
-        cache.set(key, png)
+        cache.set(key, value)
       }
-      return png
+      return value
     } finally {
       inFlight.delete(key)
     }

--- a/apps/backend/src/routes/feed-public-router.ts
+++ b/apps/backend/src/routes/feed-public-router.ts
@@ -16,6 +16,7 @@
 import {
   type FeedPostsResponse,
   type FeedPostStructuredResponse,
+  type FeedStructuredPost,
   type PublicSeriesQuery,
   publicSeriesQuerySchema,
   type PublicSeriesResponse,
@@ -29,6 +30,7 @@ import { serializeFeedPost } from '../services/feed.ts'
 import { queryMetricsBucketed } from '../services/queries/index.ts'
 import { type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateQuery } from '../validation.ts'
+import { createRenderCache } from './feed-image-router.ts'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -37,6 +39,14 @@ const PROFILE_FEED_LIMIT = 50
 
 export const createFeedPublicRouter = (): TypedRouter => {
   const router = typedRouter()
+  // Caches the serialised structured payload (JSON bytes) for the unauthenticated
+  // `/feed/:postId` endpoint, which resolves up to 100 blocks per request — the
+  // same bounded LRU + in-flight de-dup the block images use. Keyed on the
+  // capability token (so a public request never sees a followers-only payload, and
+  // a wrong token 404s and isn't cached) and a coarse hourly bucket (staleness on
+  // an edit is bounded to ≤1h — acceptable for a peer-fetched enrichment payload;
+  // an `updated_at`-keyed version + a per-block sample cap is #972).
+  const structuredCache = createRenderCache<FeedStructuredPost>()
 
   router.get<{ username: string }, PublicSeriesResponse, unknown, PublicSeriesQuery>(
     '/public/:username/series',
@@ -115,7 +125,8 @@ export const createFeedPublicRouter = (): TypedRouter => {
       }
       const token = typeof req.query.token === 'string' ? req.query.token : undefined
       try {
-        const structured = await resolveStructuredPost(username, postId, token)
+        const key = `structured:${username}:${postId}:${token ?? ''}:${Math.floor(Date.now() / 3_600_000)}`
+        const structured = await structuredCache(key, () => resolveStructuredPost(username, postId, token))
         if (!structured) {
           return res.status(404).json({ error: 'Not found', success: false })
         }

--- a/apps/backend/src/routes/feed-public-router.ts
+++ b/apps/backend/src/routes/feed-public-router.ts
@@ -25,7 +25,7 @@ import {
 import { isValidUsername } from '../api/auth-routes.ts'
 import { findCoveringSharedSeriesWindow, isMissingDatabase, listPublicFeedPostsPage } from '../db/index.ts'
 import { resolvePublicSeries } from '../services/feed-series.ts'
-import { resolveStructuredPost } from '../services/feed-structured.ts'
+import { loadAuthorizedStructuredPost, resolveStructuredContent } from '../services/feed-structured.ts'
 import { serializeFeedPost } from '../services/feed.ts'
 import { queryMetricsBucketed } from '../services/queries/index.ts'
 import { type TypedRouter, typedRouter } from '../typed-router.ts'
@@ -39,14 +39,16 @@ const PROFILE_FEED_LIMIT = 50
 
 export const createFeedPublicRouter = (): TypedRouter => {
   const router = typedRouter()
-  // Caches the serialised structured payload (JSON bytes) for the unauthenticated
+  // Caches the resolved structured payload OBJECT for the unauthenticated
   // `/feed/:postId` endpoint, which resolves up to 100 blocks per request — the
-  // same bounded LRU + in-flight de-dup the block images use. Keyed on the
-  // capability token (so a public request never sees a followers-only payload, and
-  // a wrong token 404s and isn't cached) and a coarse hourly bucket (staleness on
-  // an edit is bounded to ≤1h — acceptable for a peer-fetched enrichment payload;
-  // an `updated_at`-keyed version + a per-block sample cap is #972).
-  const structuredCache = createRenderCache<FeedStructuredPost>()
+  // same bounded LRU + in-flight de-dup the block images use. The route authorizes
+  // the post BEFORE consulting this cache (like the sibling image routes), so the
+  // capability token is NOT part of the key: a `followers`-only payload never
+  // reaches the cache via a public request, and an anonymous `?token=…` walk can't
+  // inflate the key space. Keyed on `updated_at` (busts on an edit, no ≤1h edit
+  // staleness) — a smaller cap than the image LRU because a payload can be large
+  // (a per-block sample cap is #972). Producing `null` (no content) isn't cached.
+  const structuredCache = createRenderCache<FeedStructuredPost>(50)
 
   router.get<{ username: string }, PublicSeriesResponse, unknown, PublicSeriesQuery>(
     '/public/:username/series',
@@ -125,8 +127,15 @@ export const createFeedPublicRouter = (): TypedRouter => {
       }
       const token = typeof req.query.token === 'string' ? req.query.token : undefined
       try {
-        const key = `structured:${username}:${postId}:${token ?? ''}:${Math.floor(Date.now() / 3_600_000)}`
-        const structured = await structuredCache(key, () => resolveStructuredPost(username, postId, token))
+        // Authorize BEFORE the cache: an unauthorized post 404s and never reaches
+        // it, so the token stays out of the key and a revoked/flipped post stops
+        // resolving immediately. Cache keyed on `updated_at` so an edit busts it.
+        const post = await loadAuthorizedStructuredPost(username, postId, token)
+        if (!post) {
+          return res.status(404).json({ error: 'Not found', success: false })
+        }
+        const key = `structured:${username}:${postId}:${post.updated_at.getTime()}`
+        const structured = await structuredCache(key, () => resolveStructuredContent(username, post))
         if (!structured) {
           return res.status(404).json({ error: 'Not found', success: false })
         }

--- a/apps/backend/src/routes/feed-public-router.ts
+++ b/apps/backend/src/routes/feed-public-router.ts
@@ -45,9 +45,14 @@ export const createFeedPublicRouter = (): TypedRouter => {
   // the post BEFORE consulting this cache (like the sibling image routes), so the
   // capability token is NOT part of the key: a `followers`-only payload never
   // reaches the cache via a public request, and an anonymous `?token=…` walk can't
-  // inflate the key space. Keyed on `updated_at` (busts on an edit, no ≤1h edit
-  // staleness) — a smaller cap than the image LRU because a payload can be large
-  // (a per-block sample cap is #972). Producing `null` (no content) isn't cached.
+  // inflate the key space. Keyed on `updated_at` AND a coarse hourly bucket — the
+  // SAME two-part key the block-image cache uses for the same live-resolved article
+  // data: `updated_at` busts on an edit, and the hourly term bounds staleness from
+  // *backfilled measurements inside an already-locked window* (which don't touch
+  // `updated_at`) to ≤1h, so this endpoint can't freeze into a lifetime snapshot
+  // while its own PNG stays live (#934 locks the window, not the data). A smaller
+  // cap than the image LRU because a payload can be large (per-block sample cap is
+  // #972). Producing `null` (no content) isn't cached.
   const structuredCache = createRenderCache<FeedStructuredPost>(50)
 
   router.get<{ username: string }, PublicSeriesResponse, unknown, PublicSeriesQuery>(
@@ -134,7 +139,7 @@ export const createFeedPublicRouter = (): TypedRouter => {
         if (!post) {
           return res.status(404).json({ error: 'Not found', success: false })
         }
-        const key = `structured:${username}:${postId}:${post.updated_at.getTime()}`
+        const key = `structured:${username}:${postId}:${post.updated_at.getTime()}:${Math.floor(Date.now() / 3_600_000)}`
         const structured = await structuredCache(key, () => resolveStructuredContent(username, post))
         if (!structured) {
           return res.status(404).json({ error: 'Not found', success: false })

--- a/apps/backend/src/routes/feed-router.integration.test.ts
+++ b/apps/backend/src/routes/feed-router.integration.test.ts
@@ -211,4 +211,13 @@ describe('GET /feed/articles/:postId/export (Reddit/markdown export, C4)', () =>
     const res = await noBase.request.get(`/feed/articles/${created.body.post.id}/export`)
     expect(res.status).toBe(503)
   })
+
+  test('400s for a followers-only article (its images need a private token)', async () => {
+    const created = await withBase.request
+      .post('/feed/articles')
+      .send({ ...articleBody(), visibility: 'followers' })
+    const res = await withBase.request.get(`/feed/articles/${created.body.post.id}/export`)
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('followers-only')
+  })
 })

--- a/apps/backend/src/routes/feed-router.integration.test.ts
+++ b/apps/backend/src/routes/feed-router.integration.test.ts
@@ -24,10 +24,10 @@ const auth: RequestHandler = (req, _res, next) => {
   next()
 }
 
-const startApp = (deliver?: FeedDeliver) => {
+const startApp = (deliver?: FeedDeliver, apiBaseUrl?: string) => {
   const app = express()
   app.use(express.json())
-  app.use('/feed', createFeedRouter(auth, deliver))
+  app.use('/feed', createFeedRouter(auth, deliver, undefined, apiBaseUrl))
   const server = app.listen(0)
   const port = (server.address() as AddressInfo).port
   const close = () =>
@@ -157,5 +157,58 @@ describe('Article feed routes (integration)', () => {
     } finally {
       await spied.close()
     }
+  })
+})
+
+describe('GET /feed/articles/:postId/export (Reddit/markdown export, C4)', () => {
+  let withBase: ReturnType<typeof startApp>
+  let noBase: ReturnType<typeof startApp>
+
+  beforeAll(async () => {
+    await startTestDb()
+    withBase = startApp(undefined, 'https://aurboda.example/api')
+    noBase = startApp()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await withBase.close()
+    await noBase.close()
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('returns paste-ready markdown linking each block to its C1 image endpoint', async () => {
+    const created = await withBase.request.post('/feed/articles').send(articleBody())
+    const postId = created.body.post.id
+    const res = await withBase.request.get(`/feed/articles/${postId}/export`)
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.markdown).toContain('# A week of sleep and HRV')
+    expect(res.body.markdown).toContain('A look at the week.')
+    expect(res.body.markdown).toContain(
+      `https://aurboda.example/api/public/${getTestUser()}/feed/${postId}/blocks/1/image.png`,
+    )
+  })
+
+  test('404s for a non-article post', async () => {
+    const activityPost = await createFeedPost(getTestUser(), {
+      activity_id: null,
+      include_chart: false,
+      include_map: false,
+      included_metrics: [],
+      series_metrics: [],
+      visibility: 'public',
+    })
+    const res = await withBase.request.get(`/feed/articles/${activityPost.id}/export`)
+    expect(res.status).toBe(404)
+  })
+
+  test('503s when the server has no apiBaseUrl configured', async () => {
+    const created = await noBase.request.post('/feed/articles').send(articleBody())
+    const res = await noBase.request.get(`/feed/articles/${created.body.post.id}/export`)
+    expect(res.status).toBe(503)
   })
 })

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -9,6 +9,7 @@
  * the public read surface lives in `feed-public-router.ts`.
  */
 import {
+  type ArticleExportResponse,
   type BaseResponse,
   type CreateArticleBody,
   createArticleBodySchema,
@@ -37,6 +38,7 @@ import {
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
+import { buildArticleMarkdown } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { serializeFeedPost } from '../services/feed.ts'
 import { getTimelinePage } from '../services/timeline.ts'
@@ -70,6 +72,7 @@ export const createFeedRouter = (
   authMiddleware: AnyMiddleware,
   deliver?: FeedDeliver,
   hub?: TimelineHub,
+  apiBaseUrl?: string,
 ): TypedRouter => {
   const router = typedRouter()
 
@@ -209,6 +212,35 @@ export const createFeedRouter = (
       if (!record) return res.status(404).json({ error: 'Article not found', success: false })
       deliver?.updatedArticle(user, record)
       res.json({ post: await serializeFeedPost(user, record), success: true })
+    },
+  )
+
+  // Reddit/markdown export (C4): a paste-ready rendering of the article's title
+  // + prose + one image link per chart/correlation block (the C1 endpoint).
+  // Registered before the generic `/:postId` routes, like the other `/articles`
+  // sub-routes.
+  router.get<{ postId: string }, ArticleExportResponse>(
+    '/articles/:postId/export',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      const post = await getFeedPostById(user, req.params.postId)
+      if (!post || post.kind !== 'article' || post.article == null) {
+        return res.status(404).json({ error: 'Article not found', success: false })
+      }
+      if (!apiBaseUrl) {
+        return res.status(503).json({ error: 'Export is not available', success: false })
+      }
+      const markdown = buildArticleMarkdown(
+        apiBaseUrl,
+        user,
+        post.id,
+        post.visibility,
+        post.image_token,
+        post.updated_at,
+        post.article,
+      )
+      res.json({ markdown, success: true })
     },
   )
 

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -38,6 +38,7 @@ import {
   listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
+import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { serializeFeedPost } from '../services/feed.ts'
@@ -227,6 +228,16 @@ export const createFeedRouter = (
       const post = await getFeedPostById(user, req.params.postId)
       if (!post || post.kind !== 'article' || post.article == null) {
         return res.status(404).json({ error: 'Article not found', success: false })
+      }
+      // The export is for pasting to a PUBLIC destination; a followers-only
+      // article's chart images require its private capability token, so refuse
+      // rather than emit that token into publicly-pasted text.
+      if (!isPubliclyVisible(post.visibility)) {
+        return res.status(400).json({
+          error:
+            'A followers-only article can’t be exported — its charts need a private link. Make it public or unlisted first.',
+          success: false,
+        })
       }
       if (!apiBaseUrl) {
         return res.status(503).json({ error: 'Export is not available', success: false })

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -19,14 +19,13 @@
  * Either way it can never carry a script/style/`img onerror` payload (#910's
  * boundary, server side).
  */
-import type { ArticleContent, ArticleBlock, FeedVisibility } from '@aurboda/api-spec'
+import type { ArticleContent, FeedVisibility } from '@aurboda/api-spec'
 
-import { describeSelectorAxis, getMetricDisplayName } from '@aurboda/api-spec'
 import { Image } from '@fedify/fedify/vocab'
 import { marked } from 'marked'
 import sanitizeHtml from 'sanitize-html'
 
-import { articleBlockImageUrl } from '../article.ts'
+import { articleBlockImageUrl, articleBlockLabel } from '../article.ts'
 import { CHART_HEIGHT, CHART_WIDTH, escapeXml } from '../charts/chart-svg.ts'
 import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
 
@@ -130,14 +129,6 @@ export const renderArticleContentHtml = (article: ArticleContent): string => {
   return body.length > 0 ? `${heading}\n${body}` : heading
 }
 
-/** A human name for a block's attachment: its caption, else a label from its data. */
-const attachmentName = (block: Extract<ArticleBlock, { type: 'chart' | 'correlation' }>): string => {
-  if (block.caption) return block.caption
-  return block.type === 'chart'
-    ? getMetricDisplayName(block.metric)
-    : `${describeSelectorAxis(block.trigger)} vs ${describeSelectorAxis(block.outcome)}`
-}
-
 /**
  * Image attachments for an article's chart/correlation blocks: one PNG per block,
  * pointing at the gated on-demand endpoint (`/feed/<id>/blocks/<index>/image.png`).
@@ -163,13 +154,15 @@ export const articleImageAttachments = (
       new Image({
         height,
         mediaType: 'image/png',
-        name: attachmentName(block),
+        name: articleBlockLabel(block),
         // `v` = the post's last-edited epoch: the render cache busts on edit, but
         // the URL itself must change too, or a remote media cache (Mastodon
         // re-hosts attachments at receipt) keeps the pre-edit PNG and the
         // `Update{Article}` never shows the new chart. The image endpoint ignores
         // `v` (it only reads `token`).
-        url: new URL(articleBlockImageUrl(apiBaseUrl, user, postId, visibility, imageToken, updatedAt, index)),
+        url: new URL(
+          articleBlockImageUrl(apiBaseUrl, user, postId, visibility, imageToken, updatedAt, index),
+        ),
         width,
       }),
     )

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -26,9 +26,9 @@ import { Image } from '@fedify/fedify/vocab'
 import { marked } from 'marked'
 import sanitizeHtml from 'sanitize-html'
 
+import { articleBlockImageUrl } from '../article.ts'
 import { CHART_HEIGHT, CHART_WIDTH, escapeXml } from '../charts/chart-svg.ts'
 import { SCATTER_HEIGHT, SCATTER_WIDTH } from '../charts/scatter-svg.ts'
-import { isPubliclyVisible } from './object.ts'
 
 /**
  * Sanitise authored article prose for outbound federation. A superset of the
@@ -154,14 +154,6 @@ export const articleImageAttachments = (
   updatedAt: Date,
   article: ArticleContent,
 ): Image[] => {
-  const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${postId}`
-  // `v` = the post's last-edited epoch: the render cache busts on edit, but the URL
-  // itself must change too, or a remote media cache (Mastodon re-hosts attachments
-  // at receipt) keeps the pre-edit PNG and the `Update{Article}` never shows the new
-  // chart. The image endpoint ignores `v` (it only reads `token`).
-  const params = new URLSearchParams({ v: String(updatedAt.getTime()) })
-  if (!isPubliclyVisible(visibility)) params.set('token', imageToken)
-  const query = `?${params.toString()}`
   const images: Image[] = []
   article.blocks.forEach((block, index) => {
     if (block.type !== 'chart' && block.type !== 'correlation') return
@@ -172,7 +164,12 @@ export const articleImageAttachments = (
         height,
         mediaType: 'image/png',
         name: attachmentName(block),
-        url: new URL(`${base}/blocks/${index}/image.png${query}`),
+        // `v` = the post's last-edited epoch: the render cache busts on edit, but
+        // the URL itself must change too, or a remote media cache (Mastodon
+        // re-hosts attachments at receipt) keeps the pre-edit PNG and the
+        // `Update{Article}` never shows the new chart. The image endpoint ignores
+        // `v` (it only reads `token`).
+        url: new URL(articleBlockImageUrl(apiBaseUrl, user, postId, visibility, imageToken, updatedAt, index)),
         width,
       }),
     )

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -1,4 +1,4 @@
-import type { FeedStructured } from '@aurboda/api-spec'
+import type { FeedStructuredPost } from '@aurboda/api-spec'
 import type { Actor } from '@fedify/fedify/vocab'
 
 import { createFederation, type Federation, type InboxContext, MemoryKvStore } from '@fedify/fedify'
@@ -155,7 +155,7 @@ export const ingestNoteForRecipient = async (
   user: string,
   note: Note,
   followee: FeedFollowingRecord,
-  enrich: (objectUri: string, token?: string) => Promise<FeedStructured | null>,
+  enrich: (objectUri: string, token?: string) => Promise<FeedStructuredPost | null>,
   onNewEntry?: (user: string) => void,
 ): Promise<void> => {
   const input = noteToTimelineInput(note, followee)
@@ -185,7 +185,7 @@ const ingestFeedActivity = async (
   activity: Create | Update,
   onNewEntry?: (user: string) => void,
   /** Best-effort fetch of the post's native Aurboda structured data (null if not an Aurboda post). */
-  enrich: (objectUri: string, token?: string) => Promise<FeedStructured | null> = async () => null,
+  enrich: (objectUri: string, token?: string) => Promise<FeedStructuredPost | null> = async () => null,
 ): Promise<void> => {
   // The recipient (whose timeline this is) comes from the personal inbox owner.
   // Unlike Accept/Reject there's no inner Follow to derive it from, so this relies

--- a/apps/backend/src/services/activitypub/timeline-enrich.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.test.ts
@@ -74,6 +74,23 @@ describe('enrichFromAurboda', () => {
     ])
   })
 
+  test('tolerates a kind-less payload from a peer on the previous release (tags it activity)', async () => {
+    // The un-tagged `FeedStructured` shape a peer running the previous release emits.
+    const legacy = {
+      activity_type: 'exercise',
+      metrics: [{ key: 'heart_rate_avg', unit: 'bpm', value: 142 }],
+      series: [],
+      start_time: '2026-07-01T08:00:00.000Z',
+    }
+    const deps: AurbodaEnrichDeps = {
+      discover: async () => wellKnown,
+      fetchStructured: async () => ({ structured: legacy, success: true }),
+    }
+    const result = await enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps)
+    // The preprocess shim tags it `kind:'activity'` so it parses instead of being dropped.
+    expect(result).toEqual(structured)
+  })
+
   test('returns null (no fetch) for a non-Aurboda-shaped object URI', async () => {
     let fetched = false
     const deps: AurbodaEnrichDeps = {

--- a/apps/backend/src/services/activitypub/timeline-enrich.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.test.ts
@@ -1,4 +1,4 @@
-import type { FeedStructured, WellKnownAurboda } from '@aurboda/api-spec'
+import type { FeedStructuredActivity, WellKnownAurboda } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
@@ -44,8 +44,9 @@ const wellKnown: WellKnownAurboda = {
   version: '1.0.0',
 }
 
-const structured: FeedStructured = {
+const structured: FeedStructuredActivity = {
   activity_type: 'exercise',
+  kind: 'activity',
   metrics: [{ key: 'heart_rate_avg', unit: 'bpm', value: 142 }],
   series: [],
   start_time: '2026-07-01T08:00:00.000Z',

--- a/apps/backend/src/services/activitypub/timeline-enrich.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.ts
@@ -20,8 +20,8 @@
  * The network dependencies are injected so the mapping is unit-testable offline.
  */
 import {
-  type FeedStructured,
   feedPostStructuredResponseSchema,
+  type FeedStructuredPost,
   type TimelineImage,
   type WellKnownAurboda,
 } from '@aurboda/api-spec'
@@ -94,7 +94,7 @@ export const enrichFromAurboda = async (
   objectUri: string,
   deps: AurbodaEnrichDeps,
   token?: string,
-): Promise<FeedStructured | null> => {
+): Promise<FeedStructuredPost | null> => {
   const parsed = parseAurbodaFeedUrl(objectUri)
   if (parsed == null) return null
   try {
@@ -121,7 +121,7 @@ const ENRICH_TIMEOUT_MS = 12_000
 export const createAurbodaEnricher = (): ((
   objectUri: string,
   token?: string,
-) => Promise<FeedStructured | null>) => {
+) => Promise<FeedStructuredPost | null>) => {
   const deps: AurbodaEnrichDeps = {
     discover: discoverInstance,
     fetchStructured: async (url) => (await safeFetchGet(url)).data,

--- a/apps/backend/src/services/article-export.test.ts
+++ b/apps/backend/src/services/article-export.test.ts
@@ -1,0 +1,87 @@
+import type { ArticleContent } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import { buildArticleMarkdown } from './article-export.ts'
+
+const WINDOW = { end: '2026-07-02T00:00:00Z', start: '2026-07-01T00:00:00Z' }
+const UPDATED = new Date('2026-07-09T00:00:00Z')
+const V = String(UPDATED.getTime())
+const base = 'https://aurboda.example/api/public/fiddur/feed/POST'
+
+const article = (blocks: ArticleContent['blocks']): ArticleContent => ({ blocks, title: 'My analysis' })
+
+const render = (
+  blocks: ArticleContent['blocks'],
+  visibility: 'public' | 'unlisted' | 'followers' = 'public',
+) =>
+  buildArticleMarkdown(
+    'https://aurboda.example/api',
+    'fiddur',
+    'POST',
+    visibility,
+    'secret-token',
+    UPDATED,
+    article(blocks),
+  )
+
+describe('buildArticleMarkdown', () => {
+  test('leads with an H1 title', () => {
+    const md = render([{ markdown: 'Slept well.', type: 'prose' }])
+    expect(md).toContain('# My analysis')
+  })
+
+  test('includes prose verbatim', () => {
+    const md = render([{ markdown: '## Sleep\n\nSlept **well**.', type: 'prose' }])
+    expect(md).toContain('## Sleep')
+    expect(md).toContain('Slept **well**.')
+  })
+
+  test('links a chart block to its C1 image endpoint', () => {
+    const md = render([{ end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' }])
+    expect(md).toContain(`![Heart Rate](${base}/blocks/0/image.png?v=${V})`)
+  })
+
+  test('links a correlation block, labelled from its selectors when no caption', () => {
+    const md = render([
+      {
+        end: WINDOW.end,
+        outcome: { kind: 'metric', metric: 'sleep_score' },
+        start: WINDOW.start,
+        trigger: { kind: 'metric', metric: 'steps' },
+        type: 'correlation',
+      },
+    ])
+    expect(md).toContain(`(${base}/blocks/0/image.png?v=${V})`)
+    expect(md).toContain('steps')
+    expect(md).toContain('sleep_score')
+  })
+
+  test('uses the caption as alt text and adds an italic caption line', () => {
+    const md = render([
+      { caption: 'Overnight HR', end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' },
+    ])
+    expect(md).toContain('![Overnight HR]')
+    expect(md).toContain('*Overnight HR*')
+  })
+
+  test('escapes a `]` in the caption so it cannot close the image markdown early', () => {
+    const md = render([
+      { caption: 'HR [bpm]', end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' },
+    ])
+    expect(md).toContain('![HR [bpm\\]]')
+  })
+
+  test('carries the capability token for a followers-only post', () => {
+    const md = render(
+      [{ end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' }],
+      'followers',
+    )
+    expect(md).toContain(`?v=${V}&token=secret-token`)
+  })
+
+  test('renders a prose-only article without dangling image sections', () => {
+    const md = render([{ markdown: 'Just words', type: 'prose' }])
+    expect(md).toBe('# My analysis\n\nJust words')
+  })
+})

--- a/apps/backend/src/services/article-export.test.ts
+++ b/apps/backend/src/services/article-export.test.ts
@@ -65,11 +65,19 @@ describe('buildArticleMarkdown', () => {
     expect(md).toContain('*Overnight HR*')
   })
 
-  test('escapes a `]` in the caption so it cannot close the image markdown early', () => {
+  test('escapes both `[` and `]` in the caption so an unbalanced bracket cannot break the image markdown', () => {
     const md = render([
       { caption: 'HR [bpm]', end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' },
     ])
-    expect(md).toContain('![HR [bpm\\]]')
+    // Both brackets escaped, so a lone `[` can't be matched against a later `]`.
+    expect(md).toContain('![HR \\[bpm\\]]')
+  })
+
+  test('escapes an unbalanced lone `[` in the caption', () => {
+    const md = render([
+      { caption: 'run[ start', end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' },
+    ])
+    expect(md).toContain('![run\\[ start]')
   })
 
   test('public/unlisted image URLs carry no token (a followers-only article is refused at the route)', () => {

--- a/apps/backend/src/services/article-export.test.ts
+++ b/apps/backend/src/services/article-export.test.ts
@@ -72,12 +72,13 @@ describe('buildArticleMarkdown', () => {
     expect(md).toContain('![HR [bpm\\]]')
   })
 
-  test('carries the capability token for a followers-only post', () => {
+  test('public/unlisted image URLs carry no token (a followers-only article is refused at the route)', () => {
     const md = render(
       [{ end: WINDOW.end, metric: 'heart_rate', start: WINDOW.start, type: 'chart' }],
-      'followers',
+      'unlisted',
     )
-    expect(md).toContain(`?v=${V}&token=secret-token`)
+    expect(md).toContain(`?v=${V})`)
+    expect(md).not.toContain('token=')
   })
 
   test('renders a prose-only article without dangling image sections', () => {

--- a/apps/backend/src/services/article-export.ts
+++ b/apps/backend/src/services/article-export.ts
@@ -15,8 +15,17 @@ import type { ArticleContent, FeedVisibility } from '@aurboda/api-spec'
 
 import { articleBlockImageUrl, articleBlockLabel } from './article.ts'
 
-/** Collapse newlines (markdown alt/caption text is a single line) and escape `]` so it can't close the image syntax early. */
-const inlineText = (text: string): string => text.replaceAll(/\s+/g, ' ').trim().replaceAll(']', '\\]')
+/**
+ * Collapse newlines (markdown alt/caption text is a single line) and escape both
+ * `[` and `]` so an unbalanced bracket can't break the `![alt](url)` syntax — a
+ * lone `[` (e.g. a tag selector's regex `pattern` surfaced by `describeSelectorAxis`,
+ * or a caption) would otherwise let CommonMark match the `]` against the inner `[`.
+ */
+const inlineText = (text: string): string =>
+  text
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+    .replaceAll(/([[\]])/g, '\\$1')
 
 /**
  * Render an article as paste-ready markdown: an H1 title, each prose block's

--- a/apps/backend/src/services/article-export.ts
+++ b/apps/backend/src/services/article-export.ts
@@ -43,7 +43,7 @@ export const buildArticleMarkdown = (
   updatedAt: Date,
   article: ArticleContent,
 ): string => {
-  const sections = [`# ${article.title}`]
+  const sections = [`# ${inlineText(article.title)}`]
   article.blocks.forEach((block, index) => {
     if (block.type === 'prose') {
       sections.push(block.markdown)

--- a/apps/backend/src/services/article-export.ts
+++ b/apps/backend/src/services/article-export.ts
@@ -11,21 +11,12 @@
  * on-demand image endpoint rather than embedding rendered data itself, so no
  * chart/correlation resolution happens here.
  */
-import type { ArticleBlock, ArticleContent, FeedVisibility } from '@aurboda/api-spec'
+import type { ArticleContent, FeedVisibility } from '@aurboda/api-spec'
 
-import { describeSelectorAxis, getMetricDisplayName } from '@aurboda/api-spec'
-
-import { articleBlockImageUrl } from './article.ts'
+import { articleBlockImageUrl, articleBlockLabel } from './article.ts'
 
 /** Collapse newlines (markdown alt/caption text is a single line) and escape `]` so it can't close the image syntax early. */
 const inlineText = (text: string): string => text.replaceAll(/\s+/g, ' ').trim().replaceAll(']', '\\]')
-
-/** A human label for a chart/correlation block's image: its caption, else a label from its data. */
-const blockLabel = (block: Extract<ArticleBlock, { type: 'chart' | 'correlation' }>): string =>
-  block.caption ??
-  (block.type === 'chart'
-    ? getMetricDisplayName(block.metric)
-    : `${describeSelectorAxis(block.trigger)} vs ${describeSelectorAxis(block.outcome)}`)
 
 /**
  * Render an article as paste-ready markdown: an H1 title, each prose block's
@@ -49,7 +40,7 @@ export const buildArticleMarkdown = (
       sections.push(block.markdown)
       return
     }
-    const label = inlineText(blockLabel(block))
+    const label = inlineText(articleBlockLabel(block))
     const url = articleBlockImageUrl(apiBaseUrl, user, postId, visibility, imageToken, updatedAt, index)
     const lines = [`![${label}](${url})`]
     if (block.caption) lines.push(`*${inlineText(block.caption)}*`)

--- a/apps/backend/src/services/article-export.ts
+++ b/apps/backend/src/services/article-export.ts
@@ -1,0 +1,59 @@
+/**
+ * Reddit/markdown export (C4): a paste-ready markdown rendering of an article —
+ * title, prose, and one image link per chart/correlation block (via the C1
+ * `blocks/:index/image.png` endpoint) — for pasting into a text-only
+ * destination like r/QuantifiedSelf, where the author adds their own write-up
+ * around the linked charts. Reuses the exact same block-image URL the AS2
+ * attachment builder points at (`articleBlockImageUrl`), so the export and the
+ * federated image always agree.
+ *
+ * Pure and synchronous: the markdown only LINKS to the already-gated,
+ * on-demand image endpoint rather than embedding rendered data itself, so no
+ * chart/correlation resolution happens here.
+ */
+import type { ArticleBlock, ArticleContent, FeedVisibility } from '@aurboda/api-spec'
+
+import { describeSelectorAxis, getMetricDisplayName } from '@aurboda/api-spec'
+
+import { articleBlockImageUrl } from './article.ts'
+
+/** Collapse newlines (markdown alt/caption text is a single line) and escape `]` so it can't close the image syntax early. */
+const inlineText = (text: string): string => text.replaceAll(/\s+/g, ' ').trim().replaceAll(']', '\\]')
+
+/** A human label for a chart/correlation block's image: its caption, else a label from its data. */
+const blockLabel = (block: Extract<ArticleBlock, { type: 'chart' | 'correlation' }>): string =>
+  block.caption ??
+  (block.type === 'chart'
+    ? getMetricDisplayName(block.metric)
+    : `${describeSelectorAxis(block.trigger)} vs ${describeSelectorAxis(block.outcome)}`)
+
+/**
+ * Render an article as paste-ready markdown: an H1 title, each prose block's
+ * markdown verbatim, and each chart/correlation block as a markdown image link
+ * to its rendered PNG (the C1 endpoint), with its caption (else a data label)
+ * as both the image's alt text and an italic line underneath it — the markdown
+ * equivalent of the web/federated render's `<figcaption>`.
+ */
+export const buildArticleMarkdown = (
+  apiBaseUrl: string,
+  user: string,
+  postId: string,
+  visibility: FeedVisibility,
+  imageToken: string,
+  updatedAt: Date,
+  article: ArticleContent,
+): string => {
+  const sections = [`# ${article.title}`]
+  article.blocks.forEach((block, index) => {
+    if (block.type === 'prose') {
+      sections.push(block.markdown)
+      return
+    }
+    const label = inlineText(blockLabel(block))
+    const url = articleBlockImageUrl(apiBaseUrl, user, postId, visibility, imageToken, updatedAt, index)
+    const lines = [`![${label}](${url})`]
+    if (block.caption) lines.push(`*${inlineText(block.caption)}*`)
+    sections.push(lines.join('\n'))
+  })
+  return sections.join('\n\n')
+}

--- a/apps/backend/src/services/article.test.ts
+++ b/apps/backend/src/services/article.test.ts
@@ -2,7 +2,13 @@ import type { ArticleContent } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
-import { blockWindow, buildArticleContent, mergeArticleContent } from './article.ts'
+import {
+  articleBlockImageUrl,
+  blockWindow,
+  buildArticleContent,
+  isZeroDurationBucket,
+  mergeArticleContent,
+} from './article.ts'
 
 const WEEK_START = '2026-07-01T00:00:00.000Z'
 const WEEK_END = '2026-07-07T00:00:00.000Z'
@@ -156,6 +162,61 @@ describe('buildArticleContent', () => {
     )
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error).toContain('Correlation block 1')
+  })
+})
+
+describe('isZeroDurationBucket', () => {
+  test('flags zero-duration buckets in any unit', () => {
+    expect(isZeroDurationBucket('0s')).toBe(true)
+    expect(isZeroDurationBucket('00m')).toBe(true)
+    expect(isZeroDurationBucket('0h')).toBe(true)
+    expect(isZeroDurationBucket('0d')).toBe(true)
+  })
+
+  test('accepts a normal bucket', () => {
+    expect(isZeroDurationBucket('5s')).toBe(false)
+    expect(isZeroDurationBucket('1h')).toBe(false)
+  })
+})
+
+describe('articleBlockImageUrl', () => {
+  const UPDATED = new Date('2026-07-09T00:00:00Z')
+  const V = String(UPDATED.getTime())
+  const base = 'https://aurboda.example/api/public/fiddur/feed/POST'
+
+  test('no token for a public/unlisted post', () => {
+    expect(
+      articleBlockImageUrl('https://aurboda.example/api', 'fiddur', 'POST', 'public', 'secret', UPDATED, 0),
+    ).toBe(`${base}/blocks/0/image.png?v=${V}`)
+  })
+
+  test('carries the capability token for a followers-only post', () => {
+    expect(
+      articleBlockImageUrl(
+        'https://aurboda.example/api',
+        'fiddur',
+        'POST',
+        'followers',
+        'secret',
+        UPDATED,
+        2,
+      ),
+    ).toBe(`${base}/blocks/2/image.png?v=${V}&token=secret`)
+  })
+
+  test('supports the svg format', () => {
+    expect(
+      articleBlockImageUrl(
+        'https://aurboda.example/api',
+        'fiddur',
+        'POST',
+        'public',
+        'secret',
+        UPDATED,
+        1,
+        'svg',
+      ),
+    ).toBe(`${base}/blocks/1/image.svg?v=${V}`)
   })
 })
 

--- a/apps/backend/src/services/article.ts
+++ b/apps/backend/src/services/article.ts
@@ -11,6 +11,8 @@
  */
 import type { ArticleBlock, ArticleContent, FeedVisibility, UpdateArticleBody } from '@aurboda/api-spec'
 
+import { isPubliclyVisible } from './activitypub/object.ts'
+
 export type BuildArticleResult = { ok: true; article: ArticleContent } | { ok: false; error: string }
 
 /**
@@ -41,7 +43,8 @@ export const articleBlockImageUrl = (
 ): string => {
   const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${postId}`
   const params = new URLSearchParams({ v: String(updatedAt.getTime()) })
-  if (visibility === 'followers') params.set('token', imageToken)
+  // Allowlist (public/unlisted are open); any other visibility needs the token.
+  if (!isPubliclyVisible(visibility)) params.set('token', imageToken)
   return `${base}/blocks/${index}/image.${format}?${params.toString()}`
 }
 

--- a/apps/backend/src/services/article.ts
+++ b/apps/backend/src/services/article.ts
@@ -9,9 +9,41 @@
  * article is rejected at the write boundary rather than failing later at render
  * time. Pure and synchronous — unit-testable without a DB.
  */
-import type { ArticleBlock, ArticleContent, UpdateArticleBody } from '@aurboda/api-spec'
+import type { ArticleBlock, ArticleContent, FeedVisibility, UpdateArticleBody } from '@aurboda/api-spec'
 
 export type BuildArticleResult = { ok: true; article: ArticleContent } | { ok: false; error: string }
+
+/**
+ * A zero-duration bucket (`0s`, `00m`, …) passes the block schema regex but is
+ * invalid for `date_bin` (`date_bin('0 seconds', …)` errors) — treat it as no
+ * data. Shared by the block-image renderer and the structured-enrichment
+ * resolver, both of which bucket a chart block over its locked window.
+ */
+export const isZeroDurationBucket = (bucket: string): boolean => /^0+[smhd]$/.test(bucket)
+
+/**
+ * The public URL of one article chart/correlation block's rendered image (the
+ * C1 endpoint), including the cache-busting `?v=<updated_at>` and, for a
+ * `followers`-only post, the capability `?token=`. Shared by the outbound AS2
+ * attachment builder (`articleImageAttachments`) and the markdown export
+ * (`article-export.ts`), so the two surfaces can never point at different URLs
+ * for the same block.
+ */
+export const articleBlockImageUrl = (
+  apiBaseUrl: string,
+  user: string,
+  postId: string,
+  visibility: FeedVisibility,
+  imageToken: string,
+  updatedAt: Date,
+  index: number,
+  format: 'png' | 'svg' = 'png',
+): string => {
+  const base = `${apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(user)}/feed/${postId}`
+  const params = new URLSearchParams({ v: String(updatedAt.getTime()) })
+  if (visibility === 'followers') params.set('token', imageToken)
+  return `${base}/blocks/${index}/image.${format}?${params.toString()}`
+}
 
 /** A windowed block's effective window: its own override, else the article default. */
 export const blockWindow = (

--- a/apps/backend/src/services/article.ts
+++ b/apps/backend/src/services/article.ts
@@ -11,9 +11,27 @@
  */
 import type { ArticleBlock, ArticleContent, FeedVisibility, UpdateArticleBody } from '@aurboda/api-spec'
 
+import { describeSelectorAxis, getMetricDisplayName } from '@aurboda/api-spec'
+
 import { isPubliclyVisible } from './activitypub/object.ts'
 
 export type BuildArticleResult = { ok: true; article: ArticleContent } | { ok: false; error: string }
+
+/**
+ * A human label for a chart/correlation block: its caption, else a label from its
+ * data (the metric display name, or `trigger vs outcome`). Shared single source
+ * for the AS2 image attachment name (`articleImageAttachments`) and the markdown
+ * export (`article-export.ts`) so the two can't diverge. A blank caption falls
+ * back to the data label.
+ */
+export const articleBlockLabel = (
+  block: Extract<ArticleBlock, { type: 'chart' | 'correlation' }>,
+): string => {
+  if (block.caption) return block.caption
+  return block.type === 'chart'
+    ? getMetricDisplayName(block.metric)
+    : `${describeSelectorAxis(block.trigger)} vs ${describeSelectorAxis(block.outcome)}`
+}
 
 /**
  * A zero-duration bucket (`0s`, `00m`, …) passes the block schema regex but is

--- a/apps/backend/src/services/feed-series.test.ts
+++ b/apps/backend/src/services/feed-series.test.ts
@@ -33,6 +33,7 @@ describe('floorSeriesBucket', () => {
     expect(floorSeriesBucket('60s')).toBe('60s')
     expect(floorSeriesBucket('1m')).toBe('1m')
     expect(floorSeriesBucket('2h')).toBe('2h')
+    expect(floorSeriesBucket('1d')).toBe('1d') // `d` is understood, not floored to 5s
   })
 
   test('falls back to 5s for a malformed bucket', () => {

--- a/apps/backend/src/services/feed-series.ts
+++ b/apps/backend/src/services/feed-series.ts
@@ -51,7 +51,7 @@ export interface PublicSeriesResult {
   samples: PublicSeriesSample[]
 }
 
-const BUCKET_UNIT_SECONDS: Record<string, number> = { h: 3600, m: 60, s: 1 }
+const BUCKET_UNIT_SECONDS: Record<string, number> = { d: 86_400, h: 3600, m: 60, s: 1 }
 
 /**
  * Project one metric's stats out of a bucketed-query result into
@@ -84,7 +84,7 @@ export const samplesFromBucketedResult = (
  * becomes `5s`.
  */
 export const floorSeriesBucket = (bucket: string): BucketSize => {
-  const match = bucket.match(/^(\d+)([smh])$/)
+  const match = bucket.match(/^(\d+)([smhd])$/)
   if (!match) return `${MIN_SERIES_BUCKET_SECONDS}s`
   const seconds = parseInt(match[1], 10) * BUCKET_UNIT_SECONDS[match[2]]
   return seconds < MIN_SERIES_BUCKET_SECONDS ? `${MIN_SERIES_BUCKET_SECONDS}s` : (bucket as BucketSize)

--- a/apps/backend/src/services/feed-series.ts
+++ b/apps/backend/src/services/feed-series.ts
@@ -54,6 +54,31 @@ export interface PublicSeriesResult {
 const BUCKET_UNIT_SECONDS: Record<string, number> = { h: 3600, m: 60, s: 1 }
 
 /**
+ * Project one metric's stats out of a bucketed-query result into
+ * `PublicSeriesSample[]`, dropping any bucket the metric has no stats for.
+ * Shared by the public `/series` endpoint and the article structured/chart-block
+ * resolvers, which all bucket the same way and want the same sample shape.
+ */
+export const samplesFromBucketedResult = (
+  result: QueryMetricsBucketedResult,
+  metric: MetricType,
+): PublicSeriesSample[] =>
+  result.buckets.flatMap((b) => {
+    const stats = b.metrics[metric]
+    if (!stats) return []
+    const sample: PublicSeriesSample = {
+      avg: stats.avg,
+      count: stats.count,
+      end: b.end,
+      max: stats.max,
+      min: stats.min,
+      start: b.start,
+    }
+    if (stats.sum !== undefined) sample.sum = stats.sum
+    return [sample]
+  })
+
+/**
  * Floor a series bucket string to `MIN_SERIES_BUCKET_SECONDS`. Anything at or
  * above the minimum is returned unchanged; anything below (including `0s`)
  * becomes `5s`.
@@ -89,21 +114,7 @@ export const resolvePublicSeries = async (
 
   const effectiveBucket = floorSeriesBucket(bucket)
   const result = await deps.queryBucketed(metric, start, end, effectiveBucket)
-
-  const samples: PublicSeriesSample[] = result.buckets.flatMap((b) => {
-    const stats = b.metrics[metric]
-    if (!stats) return []
-    const sample: PublicSeriesSample = {
-      avg: stats.avg,
-      count: stats.count,
-      end: b.end,
-      max: stats.max,
-      min: stats.min,
-      start: b.start,
-    }
-    if (stats.sum !== undefined) sample.sum = stats.sum
-    return [sample]
-  })
+  const samples = samplesFromBucketedResult(result, metric)
 
   return {
     bucket: effectiveBucket,

--- a/apps/backend/src/services/feed-structured.integration.test.ts
+++ b/apps/backend/src/services/feed-structured.integration.test.ts
@@ -3,11 +3,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 /**
  * Integration test for the structured-post resolver served at
  * `GET /public/:user/feed/:postId` — the payload an Aurboda peer fetches to
- * render a native chart. Exercises the real scalar + series resolution and the
- * public/unlisted gate against a live database.
+ * render a native chart or article. Exercises the real scalar + series
+ * resolution (activity posts) and the real bucketed-chart + continuous-
+ * correlation resolution (article posts), plus the shared public/unlisted gate,
+ * against a live database.
  */
 import { insertActivity } from '../db/activities/index.ts'
-import { createFeedPost } from '../db/feed.ts'
+import { createArticlePost, createFeedPost } from '../db/feed.ts'
 import { insertTimeSeries } from '../db/time-series.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import { resolveStructuredPost } from './feed-structured.ts'
@@ -65,18 +67,19 @@ describe('resolveStructuredPost', () => {
 
     const structured = await resolveStructuredPost(user, post.id)
     expect(structured).not.toBeNull()
-    expect(structured?.activity_type).toBe('exercise')
-    expect(structured?.start_time).toBe(START.toISOString())
-    expect(structured?.end_time).toBe(END.toISOString())
-    expect(structured?.duration_seconds).toBe(2400)
+    if (structured?.kind !== 'activity') throw new Error('expected an activity payload')
+    expect(structured.activity_type).toBe('exercise')
+    expect(structured.start_time).toBe(START.toISOString())
+    expect(structured.end_time).toBe(END.toISOString())
+    expect(structured.duration_seconds).toBe(2400)
 
-    const byKey = Object.fromEntries((structured?.metrics ?? []).map((m) => [m.key, m.value]))
+    const byKey = Object.fromEntries(structured.metrics.map((m) => [m.key, m.value]))
     expect(byKey.heart_rate_avg).toBe(150)
     expect(byKey.duration).toBe(2400)
 
     // The opted-in series is inlined with non-empty samples at the floored bucket.
-    expect(structured?.series).toHaveLength(1)
-    const hr = structured?.series[0]
+    expect(structured.series).toHaveLength(1)
+    const hr = structured.series[0]
     expect(hr?.metric).toBe('heart_rate')
     expect(hr?.bucket).toBe('5s')
     expect(hr?.samples.length).toBeGreaterThan(0)
@@ -95,8 +98,9 @@ describe('resolveStructuredPost', () => {
       visibility: 'public',
     })
     const structured = await resolveStructuredPost(user, post.id)
-    expect(structured?.metrics.map((m) => m.key)).toEqual(['heart_rate_avg'])
-    expect(structured?.series).toEqual([])
+    if (structured?.kind !== 'activity') throw new Error('expected an activity payload')
+    expect(structured.metrics.map((m) => m.key)).toEqual(['heart_rate_avg'])
+    expect(structured.series).toEqual([])
   })
 
   test('gates a followers-only post on the capability token', async () => {
@@ -115,12 +119,126 @@ describe('resolveStructuredPost', () => {
     expect(await resolveStructuredPost(user, post.id, 'wrong')).toBeNull()
     // The post's own capability token (delivered to followers) → resolves.
     const structured = await resolveStructuredPost(user, post.id, post.image_token)
-    expect(structured?.series.map((s) => s.metric)).toEqual(['heart_rate'])
-    expect(structured?.metrics.map((m) => m.key)).toEqual(['heart_rate_avg'])
+    if (structured?.kind !== 'activity') throw new Error('expected an activity payload')
+    expect(structured.series.map((s) => s.metric)).toEqual(['heart_rate'])
+    expect(structured.metrics.map((m) => m.key)).toEqual(['heart_rate_avg'])
   })
 
   test('returns null for an unknown post id', async () => {
     const user = getTestUser()
     expect(await resolveStructuredPost(user, '00000000-0000-4000-8000-000000000000')).toBeNull()
+  })
+})
+
+describe('resolveStructuredPost — article posts', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('resolves prose verbatim and a chart block’s bucketed samples over its window', async () => {
+    const user = getTestUser()
+    // Dense heart-rate samples across the window (5-minute cadence, 150 bpm) so
+    // the default `1h` bucket (a ≤2-day window) has real data to aggregate.
+    await insertTimeSeries(
+      user,
+      Array.from({ length: 8 }, (_, i) => ({
+        metric: 'heart_rate' as const,
+        source: 'garmin' as const,
+        time: new Date(START.getTime() + i * 5 * 60_000),
+        value: 150,
+      })),
+    )
+    const post = await createArticlePost(user, {
+      article: {
+        blocks: [
+          { markdown: 'Slept **well**.', type: 'prose' },
+          { end: END.toISOString(), metric: 'heart_rate', start: START.toISOString(), type: 'chart' },
+        ],
+        title: 'My analysis',
+      },
+      visibility: 'public',
+    })
+
+    const structured = await resolveStructuredPost(user, post.id)
+    expect(structured?.kind).toBe('article')
+    if (structured?.kind !== 'article') throw new Error('expected an article payload')
+    expect(structured.title).toBe('My analysis')
+    expect(structured.blocks).toEqual([
+      { markdown: 'Slept **well**.', type: 'prose' },
+      expect.objectContaining({ metric: 'heart_rate', type: 'chart' }),
+    ])
+    const chart = structured.blocks[1]
+    if (chart.type !== 'chart') throw new Error('expected a chart block')
+    expect(chart.bucket).toBe('1h')
+    expect(chart.samples.length).toBeGreaterThan(0)
+    expect(chart.samples[0].avg).toBe(150)
+  })
+
+  test('resolves a correlation block (present unconditionally, even with no overlapping data)', async () => {
+    const user = getTestUser()
+    const post = await createArticlePost(user, {
+      article: {
+        blocks: [
+          {
+            end: END.toISOString(),
+            outcome: { kind: 'metric', metric: 'sleep_score' },
+            start: START.toISOString(),
+            trigger: { kind: 'metric', metric: 'steps' },
+            type: 'correlation',
+          },
+        ],
+        title: 'Steps vs sleep',
+      },
+      visibility: 'public',
+    })
+
+    const structured = await resolveStructuredPost(user, post.id)
+    if (structured?.kind !== 'article') throw new Error('expected an article payload')
+    expect(structured.blocks).toHaveLength(1)
+    const block = structured.blocks[0]
+    if (block.type !== 'correlation') throw new Error('expected a correlation block')
+    // No data seeded for either dimension — n is 0, not an error, so the block
+    // still resolves (unlike the block-image endpoint, which would 404 below n < 3).
+    expect(block.n).toBe(0)
+    expect(block.series).toEqual([])
+    expect(block.trigger).toEqual({ kind: 'metric', metric: 'steps' })
+    expect(block.outcome).toEqual({ kind: 'metric', metric: 'sleep_score' })
+  })
+
+  test('gates a followers-only article on the capability token', async () => {
+    const user = getTestUser()
+    const post = await createArticlePost(user, {
+      article: { blocks: [{ markdown: 'Private thoughts', type: 'prose' }], title: 'Private' },
+      visibility: 'followers',
+    })
+    expect(await resolveStructuredPost(user, post.id)).toBeNull()
+    expect(await resolveStructuredPost(user, post.id, 'wrong')).toBeNull()
+    const structured = await resolveStructuredPost(user, post.id, post.image_token)
+    expect(structured?.kind).toBe('article')
+  })
+
+  test('omits a chart/correlation block whose window is invalid (start on or after end)', async () => {
+    const user = getTestUser()
+    const post = await createArticlePost(user, {
+      article: {
+        blocks: [
+          { markdown: 'Intro', type: 'prose' },
+          { end: START.toISOString(), metric: 'heart_rate', start: END.toISOString(), type: 'chart' },
+        ],
+        title: 'Broken window',
+      },
+      visibility: 'public',
+    })
+    const structured = await resolveStructuredPost(user, post.id)
+    if (structured?.kind !== 'article') throw new Error('expected an article payload')
+    expect(structured.blocks).toEqual([{ markdown: 'Intro', type: 'prose' }])
   })
 })

--- a/apps/backend/src/services/feed-structured.integration.test.ts
+++ b/apps/backend/src/services/feed-structured.integration.test.ts
@@ -182,6 +182,42 @@ describe('resolveStructuredPost — article posts', () => {
     expect(chart.samples[0].avg).toBe(150)
   })
 
+  test('keeps a `1d` chart bucket as authored (not rewritten)', async () => {
+    const user = getTestUser()
+    await insertTimeSeries(
+      user,
+      Array.from({ length: 8 }, (_, i) => ({
+        metric: 'heart_rate' as const,
+        source: 'garmin' as const,
+        time: new Date(START.getTime() + i * 5 * 60_000),
+        value: 150,
+      })),
+    )
+    const post = await createArticlePost(user, {
+      article: {
+        blocks: [
+          {
+            bucket: '1d',
+            end: END.toISOString(),
+            metric: 'heart_rate',
+            start: START.toISOString(),
+            type: 'chart',
+          },
+        ],
+        title: 'Daily',
+      },
+      visibility: 'public',
+    })
+    const structured = await resolveStructuredPost(user, post.id)
+    if (structured?.kind !== 'article') throw new Error('expected an article payload')
+    const chart = structured.blocks[0]
+    if (chart.type !== 'chart') throw new Error('expected a chart block')
+    // `1d` is passed through — NOT rewritten (a broken floor turned it into `5s`).
+    expect(chart.bucket).toBe('1d')
+    expect(chart.samples.length).toBeGreaterThan(0)
+    expect(chart.samples[0].avg).toBe(150)
+  })
+
   test('resolves a correlation block (present unconditionally, even with no overlapping data)', async () => {
     const user = getTestUser()
     const post = await createArticlePost(user, {

--- a/apps/backend/src/services/feed-structured.integration.test.ts
+++ b/apps/backend/src/services/feed-structured.integration.test.ts
@@ -218,6 +218,34 @@ describe('resolveStructuredPost — article posts', () => {
     expect(chart.samples[0].avg).toBe(150)
   })
 
+  test('floors a sub-5s chart bucket on this unauthenticated endpoint', async () => {
+    const user = getTestUser()
+    await insertTimeSeries(user, [
+      { metric: 'heart_rate' as const, source: 'garmin' as const, time: START, value: 150 },
+    ])
+    const post = await createArticlePost(user, {
+      article: {
+        blocks: [
+          {
+            bucket: '1s',
+            end: END.toISOString(),
+            metric: 'heart_rate',
+            start: START.toISOString(),
+            type: 'chart',
+          },
+        ],
+        title: 'Dense',
+      },
+      visibility: 'public',
+    })
+    const structured = await resolveStructuredPost(user, post.id)
+    if (structured?.kind !== 'article') throw new Error('expected an article payload')
+    const chart = structured.blocks[0]
+    if (chart.type !== 'chart') throw new Error('expected a chart block')
+    // `1s` is floored to the 5s public-series minimum (not queried at 1s).
+    expect(chart.bucket).toBe('5s')
+  })
+
   test('resolves a correlation block (present unconditionally, even with no overlapping data)', async () => {
     const user = getTestUser()
     const post = await createArticlePost(user, {

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -36,7 +36,7 @@ import { resolveActivityScalars } from './activitypub/feed-activity.ts'
 import { blockWindow, isZeroDurationBucket } from './article.ts'
 import { getContinuousCorrelation } from './correlations/explore.ts'
 import { isCapabilityAuthorized } from './feed-capability.ts'
-import { resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
+import { floorSeriesBucket, resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
 import { resolveFeedActivity } from './feed.ts'
 import { queryMetricsBucketed } from './queries/index.ts'
 
@@ -98,8 +98,12 @@ const resolveStructuredChartBlock = async (
   const startDate = new Date(start)
   const endDate = new Date(end)
   if (startDate.getTime() >= endDate.getTime()) return null
-  const bucket = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
-  if (isZeroDurationBucket(bucket)) return null
+  const rawBucket = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
+  if (isZeroDurationBucket(rawBucket)) return null
+  // Floor to the public-series minimum (5s), like `resolvePublicSeries`, so an
+  // author-chosen sub-5s bucket can't balloon the sample count on this
+  // unauthenticated endpoint (see #972 for a fuller payload cap + cache).
+  const bucket = floorSeriesBucket(rawBucket)
 
   const result = await queryMetricsBucketed(user, [block.metric], startDate, endDate, bucket, { tz })
   const samples = samplesFromBucketedResult(result, block.metric)

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -30,6 +30,8 @@ import type {
 
 import { defaultArticleChartBucket, metricTypeSchema } from '@aurboda/api-spec'
 
+import type { FeedPostRecord } from '../db/index.ts'
+
 import { getFeedPostById, getUserSettings } from '../db/index.ts'
 import { metricUnits } from '../schema.ts'
 import { resolveActivityScalars } from './activitypub/feed-activity.ts'
@@ -206,21 +208,40 @@ const resolveStructuredArticle = async (
 }
 
 /**
- * Build the structured payload for one of `user`'s feed posts, or null if it is
- * unknown, has no resolvable content, or the requester isn't authorized to see
- * it. `public`/`unlisted` posts resolve unconditionally; a `followers`-only post
- * resolves only with a matching capability `token` (the same token that
- * authorizes its followers-only images), so an accepted follower's instance can
- * render the native chart/article while a public guess still 404s.
+ * Load one of `user`'s feed posts and authorize the requester, or null if the
+ * post is unknown or the caller isn't allowed to see it. `public`/`unlisted`
+ * posts authorize unconditionally; a `followers`-only post authorizes only with
+ * a matching capability `token` (the same token that authorizes its
+ * followers-only images), so an accepted follower's instance can render the
+ * native chart/article while a public guess still 404s.
+ *
+ * Split from the content resolution so the unauthenticated `/feed/:postId` route
+ * can authorize BEFORE consulting its cache (mirroring the sibling image routes'
+ * `resolveImageWindow`/`resolveArticleBlock`): the `token` never enters the cache
+ * key, an anonymous walk of `?token=…` can't inflate the key space, and flipping
+ * a post to `followers` (or deleting it) drops it immediately instead of serving
+ * a pre-authorized payload until a cache bucket rolls.
  */
-export const resolveStructuredPost = async (
+export const loadAuthorizedStructuredPost = async (
   user: string,
   postId: string,
   token?: string,
-): Promise<FeedStructuredPost | null> => {
+): Promise<FeedPostRecord | null> => {
   const post = await getFeedPostById(user, postId)
   if (post == null || !isCapabilityAuthorized(post, token)) return null
+  return post
+}
 
+/**
+ * Resolve an already-authorized post to its structured payload, or null when it
+ * has no resolvable content (an article with no body, an activity post with no
+ * linked/resolvable activity). Caller MUST have authorized `post` first (via
+ * `loadAuthorizedStructuredPost`) — this does no visibility check.
+ */
+export const resolveStructuredContent = async (
+  user: string,
+  post: FeedPostRecord,
+): Promise<FeedStructuredPost | null> => {
   if (post.kind === 'article') {
     if (post.article == null) return null
     return resolveStructuredArticle(user, post.article)
@@ -256,4 +277,21 @@ export const resolveStructuredPost = async (
     )
   }
   return structured
+}
+
+/**
+ * Build the structured payload for one of `user`'s feed posts, or null if it is
+ * unknown, not authorized for the caller, or has no resolvable content. A thin
+ * load-then-resolve convenience over `loadAuthorizedStructuredPost` +
+ * `resolveStructuredContent`; the cached `/feed/:postId` route calls those two
+ * directly so it can authorize before consulting its cache.
+ */
+export const resolveStructuredPost = async (
+  user: string,
+  postId: string,
+  token?: string,
+): Promise<FeedStructuredPost | null> => {
+  const post = await loadAuthorizedStructuredPost(user, postId, token)
+  if (post == null) return null
+  return resolveStructuredContent(user, post)
 }

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -36,7 +36,7 @@ import { resolveActivityScalars } from './activitypub/feed-activity.ts'
 import { blockWindow, isZeroDurationBucket } from './article.ts'
 import { getContinuousCorrelation } from './correlations/explore.ts'
 import { isCapabilityAuthorized } from './feed-capability.ts'
-import { resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
+import { floorSeriesBucket, resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
 import { resolveFeedActivity } from './feed.ts'
 import { queryMetricsBucketed } from './queries/index.ts'
 
@@ -98,12 +98,14 @@ const resolveStructuredChartBlock = async (
   const startDate = new Date(start)
   const endDate = new Date(end)
   if (startDate.getTime() >= endDate.getTime()) return null
-  // Bucket as authored (same as the block-image path — including `1d`, which
-  // `floorSeriesBucket` doesn't understand). Bounding this unauthenticated
-  // payload (a sample cap + cache) is tracked in #972, alongside the block-image
-  // endpoint's #969 — kept out of this PR so both surfaces get one fix.
-  const bucket = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
-  if (isZeroDurationBucket(bucket)) return null
+  // Floor sub-5s buckets to the public-series minimum, like `resolvePublicSeries`
+  // — an author-stored `1s` bucket over a wide window would otherwise yield
+  // ~600k buckets on this unauthenticated endpoint. `floorSeriesBucket` now
+  // understands `d`, so the common `1d`/`1h` buckets pass through unchanged. A
+  // fuller sample cap + cache is tracked in #972 (with the block image's #969).
+  const authored = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
+  if (isZeroDurationBucket(authored)) return null
+  const bucket = floorSeriesBucket(authored)
 
   const result = await queryMetricsBucketed(user, [block.metric], startDate, endDate, bucket, { tz })
   const samples = samplesFromBucketedResult(result, block.metric)

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -36,7 +36,7 @@ import { resolveActivityScalars } from './activitypub/feed-activity.ts'
 import { blockWindow, isZeroDurationBucket } from './article.ts'
 import { getContinuousCorrelation } from './correlations/explore.ts'
 import { isCapabilityAuthorized } from './feed-capability.ts'
-import { floorSeriesBucket, resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
+import { resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
 import { resolveFeedActivity } from './feed.ts'
 import { queryMetricsBucketed } from './queries/index.ts'
 
@@ -98,12 +98,12 @@ const resolveStructuredChartBlock = async (
   const startDate = new Date(start)
   const endDate = new Date(end)
   if (startDate.getTime() >= endDate.getTime()) return null
-  const rawBucket = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
-  if (isZeroDurationBucket(rawBucket)) return null
-  // Floor to the public-series minimum (5s), like `resolvePublicSeries`, so an
-  // author-chosen sub-5s bucket can't balloon the sample count on this
-  // unauthenticated endpoint (see #972 for a fuller payload cap + cache).
-  const bucket = floorSeriesBucket(rawBucket)
+  // Bucket as authored (same as the block-image path — including `1d`, which
+  // `floorSeriesBucket` doesn't understand). Bounding this unauthenticated
+  // payload (a sample cap + cache) is tracked in #972, alongside the block-image
+  // endpoint's #969 — kept out of this PR so both surfaces get one fix.
+  const bucket = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
+  if (isZeroDurationBucket(bucket)) return null
 
   const result = await queryMetricsBucketed(user, [block.metric], startDate, endDate, bucket, { tz })
   const samples = samplesFromBucketedResult(result, block.metric)

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -1,21 +1,42 @@
 /**
- * Build the native structured representation of a shared exercise post — the
- * payload served at `GET /public/:username/feed/:postId` and fetched by a
- * following Aurboda instance to render a native chart + typed stats instead of
- * the Mastodon-style HTML.
+ * Build the native structured representation of a shared post — the payload
+ * served at `GET /public/:username/feed/:postId` and fetched by a following
+ * Aurboda instance to render a native chart/article instead of the
+ * Mastodon-style HTML.
  *
- * Reuses the exact same shared-scalar resolution as delivery/the object
- * dispatcher (`resolveActivityScalars`) and the exact same data-scoped series
- * resolution as the public `/series` endpoint (`resolvePublicSeries`), so what a
- * peer renders can never exceed what the author shared. Only `public`/`unlisted`
- * posts resolve (the same gate as the object dispatcher and outbox).
+ * An `activity` post reuses the exact same shared-scalar resolution as
+ * delivery/the object dispatcher (`resolveActivityScalars`) and the exact same
+ * data-scoped series resolution as the public `/series` endpoint
+ * (`resolvePublicSeries`), so what a peer renders can never exceed what the
+ * author shared. An `article` post resolves each chart/correlation block live
+ * over its own locked window — the same bucketing (`queryMetricsBucketed`) and
+ * correlation engine (`getContinuousCorrelation`) the block's own PNG and the
+ * web's inline render use — so a peer's native render matches byte-for-byte
+ * what the author sees. Only `public`/`unlisted` posts resolve unconditionally;
+ * a `followers`-only post resolves only with a matching capability `token`
+ * (the same gate as the object dispatcher, the outbox, and the block images).
  */
-import { type FeedStructured, type FeedStructuredSeries, metricTypeSchema } from '@aurboda/api-spec'
+import type {
+  ArticleBlock,
+  ArticleContent,
+  FeedStructuredActivity,
+  FeedStructuredArticle,
+  FeedStructuredArticleBlock,
+  FeedStructuredArticleChartBlock,
+  FeedStructuredArticleCorrelationBlock,
+  FeedStructuredPost,
+  FeedStructuredSeries,
+} from '@aurboda/api-spec'
 
-import { getFeedPostById } from '../db/index.ts'
+import { defaultArticleChartBucket, metricTypeSchema } from '@aurboda/api-spec'
+
+import { getFeedPostById, getUserSettings } from '../db/index.ts'
+import { metricUnits } from '../schema.ts'
 import { resolveActivityScalars } from './activitypub/feed-activity.ts'
+import { blockWindow, isZeroDurationBucket } from './article.ts'
+import { getContinuousCorrelation } from './correlations/explore.ts'
 import { isCapabilityAuthorized } from './feed-capability.ts'
-import { resolvePublicSeries } from './feed-series.ts'
+import { resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
 import { resolveFeedActivity } from './feed.ts'
 import { queryMetricsBucketed } from './queries/index.ts'
 
@@ -60,20 +81,146 @@ const resolveStructuredSeries = async (
 }
 
 /**
+ * Resolve one article `chart` block to its structured samples over its
+ * effective window (own override, else the article default), or `null` when
+ * the block has no bounded window or a zero-duration bucket. Mirrors
+ * `renderArticleBlockImage`'s chart path, minus the raster step — the samples
+ * are the payload here, not a rendered image.
+ */
+const resolveStructuredChartBlock = async (
+  user: string,
+  block: Extract<ArticleBlock, { type: 'chart' }>,
+  content: ArticleContent,
+  tz: string | undefined,
+): Promise<FeedStructuredArticleChartBlock | null> => {
+  const { end, start } = blockWindow(block, content)
+  if (start == null || end == null) return null
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  if (startDate.getTime() >= endDate.getTime()) return null
+  const bucket = block.bucket ?? defaultArticleChartBucket(startDate, endDate)
+  if (isZeroDurationBucket(bucket)) return null
+
+  const result = await queryMetricsBucketed(user, [block.metric], startDate, endDate, bucket, { tz })
+  const samples = samplesFromBucketedResult(result, block.metric)
+
+  const resolved: FeedStructuredArticleChartBlock = {
+    bucket,
+    end,
+    metric: block.metric,
+    samples,
+    start,
+    type: 'chart',
+  }
+  if (block.caption !== undefined) resolved.caption = block.caption
+  const unit = metricUnits[block.metric]
+  if (unit) resolved.unit = unit
+  return resolved
+}
+
+/**
+ * Resolve one article `correlation` block to its computed correlation +
+ * aligned scatter over its effective window, or `null` when the block has no
+ * bounded window. Mirrors `renderArticleBlockImage`'s correlation path (the
+ * same `getContinuousCorrelation` call), minus the raster step. Unlike the
+ * image path (which 404s below n < 3), every windowed correlation block
+ * resolves here — the receiver renders the same "not enough data" fallback the
+ * web's live `ArticleCorrelationBlock` shows for a sparse result.
+ */
+const resolveStructuredCorrelationBlock = async (
+  user: string,
+  block: Extract<ArticleBlock, { type: 'correlation' }>,
+  content: ArticleContent,
+): Promise<FeedStructuredArticleCorrelationBlock | null> => {
+  const { end, start } = blockWindow(block, content)
+  if (start == null || end == null) return null
+  if (new Date(start).getTime() >= new Date(end).getTime()) return null
+
+  const c = await getContinuousCorrelation(user, {
+    lagDays: block.lag_days,
+    outcome: block.outcome,
+    periodEnd: end.slice(0, 10),
+    periodStart: start.slice(0, 10),
+    trigger: block.trigger,
+  })
+
+  const resolved: FeedStructuredArticleCorrelationBlock = {
+    end,
+    group_comparison: c.group_comparison,
+    n: c.n,
+    outcome: block.outcome,
+    pearson: c.pearson,
+    pearson_p: c.pearson_p,
+    series: c.series,
+    spearman: c.spearman,
+    start,
+    trigger: block.trigger,
+    type: 'correlation',
+  }
+  if (block.caption !== undefined) resolved.caption = block.caption
+  if (block.lag_days !== undefined) resolved.lag_days = block.lag_days
+  return resolved
+}
+
+/**
+ * Build the structured payload for an article post: its title and every block,
+ * resolved in order. A prose block passes its raw markdown through unchanged
+ * (rendered by the receiver's own sanitising renderer — #910); a chart or
+ * correlation block resolves live over its locked window and is omitted only
+ * when that window itself is invalid (unbounded or non-increasing) — the same
+ * condition `resolveArticleBlock` treats as ineligible for an image.
+ *
+ * Chart buckets in the author's own device timezone (`device_timezone`),
+ * matching the block-image renderer, so a `1d` bucket splits on the author's
+ * calendar days.
+ */
+const resolveStructuredArticle = async (
+  user: string,
+  article: ArticleContent,
+): Promise<FeedStructuredArticle> => {
+  const settings = await getUserSettings(user)
+  const tz = settings?.device_timezone ?? undefined
+
+  const blocks: FeedStructuredArticleBlock[] = []
+  for (const block of article.blocks) {
+    if (block.type === 'prose') {
+      blocks.push({ markdown: block.markdown, type: 'prose' })
+      continue
+    }
+    if (block.type === 'chart') {
+      const resolved = await resolveStructuredChartBlock(user, block, article, tz)
+      if (resolved) blocks.push(resolved)
+      continue
+    }
+    const resolved = await resolveStructuredCorrelationBlock(user, block, article)
+    if (resolved) blocks.push(resolved)
+  }
+
+  return { blocks, kind: 'article', title: article.title }
+}
+
+/**
  * Build the structured payload for one of `user`'s feed posts, or null if it is
- * unknown, has no resolvable activity, or the requester isn't authorized to see
+ * unknown, has no resolvable content, or the requester isn't authorized to see
  * it. `public`/`unlisted` posts resolve unconditionally; a `followers`-only post
  * resolves only with a matching capability `token` (the same token that
  * authorizes its followers-only images), so an accepted follower's instance can
- * render the native chart while a public guess still 404s.
+ * render the native chart/article while a public guess still 404s.
  */
 export const resolveStructuredPost = async (
   user: string,
   postId: string,
   token?: string,
-): Promise<FeedStructured | null> => {
+): Promise<FeedStructuredPost | null> => {
   const post = await getFeedPostById(user, postId)
-  if (post == null || post.activity_id == null || !isCapabilityAuthorized(post, token)) return null
+  if (post == null || !isCapabilityAuthorized(post, token)) return null
+
+  if (post.kind === 'article') {
+    if (post.article == null) return null
+    return resolveStructuredArticle(user, post.article)
+  }
+
+  if (post.activity_id == null) return null
 
   const activity = await resolveFeedActivity(user, post.activity_id)
   if (activity == null) return null
@@ -88,8 +235,9 @@ export const resolveStructuredPost = async (
     ? await resolveStructuredSeries(user, post.series_metrics, activity.start_time, activity.end_time)
     : []
 
-  const structured: FeedStructured = {
+  const structured: FeedStructuredActivity = {
     activity_type: activity.activity_type,
+    kind: 'activity',
     metrics: scalars.map(({ key, unit, value }) => ({ key, value, ...(unit === undefined ? {} : { unit }) })),
     series,
     start_time: activity.start_time.toISOString(),

--- a/apps/web/src/components/ArticleExportDialog.tsx
+++ b/apps/web/src/components/ArticleExportDialog.tsx
@@ -8,10 +8,11 @@ import { useQuery } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { fetchArticleExport } from '../state/api'
+import './ArticleEditorDialog.css' // for `.article-input`
 import './ShareActivityDialog.css'
 
 export const ArticleExportDialog = ({ postId, onClose }: { postId: string; onClose: () => void }) => {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, error } = useQuery({
     queryFn: () => fetchArticleExport(postId),
     queryKey: ['article-export', postId],
   })
@@ -45,7 +46,11 @@ export const ArticleExportDialog = ({ postId, onClose }: { postId: string; onClo
         </p>
 
         {isLoading && <p>Loading…</p>}
-        {isError && <p class="share-dialog-error">Couldn't export this article. Please try again.</p>}
+        {isError && (
+          <p class="share-dialog-error">
+            {error instanceof Error ? error.message : 'Couldn’t export this article. Please try again.'}
+          </p>
+        )}
         {data && (
           <>
             <textarea

--- a/apps/web/src/components/ArticleExportDialog.tsx
+++ b/apps/web/src/components/ArticleExportDialog.tsx
@@ -1,0 +1,71 @@
+/**
+ * Reddit/markdown export (C4): fetch an article's paste-ready markdown (title +
+ * prose + one image link per chart/correlation block) and let the user copy it
+ * for pasting into a text-only destination like r/QuantifiedSelf, adding their
+ * own write-up around the linked charts.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+
+import { fetchArticleExport } from '../state/api'
+import './ShareActivityDialog.css'
+
+export const ArticleExportDialog = ({ postId, onClose }: { postId: string; onClose: () => void }) => {
+  const { data, isLoading, isError } = useQuery({
+    queryFn: () => fetchArticleExport(postId),
+    queryKey: ['article-export', postId],
+  })
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    if (!data) return
+    try {
+      await navigator.clipboard.writeText(data)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard access can be denied (permissions, insecure context) — the
+      // textarea below is still there to select-and-copy manually.
+    }
+  }
+
+  return (
+    <div class="share-dialog-backdrop" onClick={onClose}>
+      <div class="share-dialog" onClick={(e) => e.stopPropagation()}>
+        <div class="share-dialog-header">
+          <h2>Export markdown</h2>
+          <button type="button" class="share-dialog-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <p class="share-dialog-note">
+          Paste this into r/QuantifiedSelf or a similar text-only destination — add your own write-up around
+          the linked charts.
+        </p>
+
+        {isLoading && <p>Loading…</p>}
+        {isError && <p class="share-dialog-error">Couldn't export this article. Please try again.</p>}
+        {data && (
+          <>
+            <textarea
+              class="article-input"
+              readOnly
+              rows={16}
+              value={data}
+              onClick={(e) => e.currentTarget.select()}
+            />
+            <div class="share-dialog-actions">
+              <button type="button" class="btn-primary" onClick={copy}>
+                {copied ? 'Copied!' : 'Copy to clipboard'}
+              </button>
+              <button type="button" class="btn-secondary" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ArticleExportDialog.tsx
+++ b/apps/web/src/components/ArticleExportDialog.tsx
@@ -15,6 +15,10 @@ export const ArticleExportDialog = ({ postId, onClose }: { postId: string; onClo
   const { data, isLoading, isError, error } = useQuery({
     queryFn: () => fetchArticleExport(postId),
     queryKey: ['article-export', postId],
+    // Every failure this route produces is deterministic (400 for a non-public
+    // article, 404, 503), never transient — so surface it immediately instead of
+    // letting the default `retry: 3` stall on "Loading…" through exponential backoff.
+    retry: false,
   })
   const [copied, setCopied] = useState(false)
 

--- a/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
+++ b/apps/web/src/pages/Feed/ArticleCorrelationBlock.tsx
@@ -26,8 +26,25 @@ const fmt = (value: number | null | undefined, digits = 2): string =>
 
 const fmtP = (p: number | null | undefined): string => (p == null ? '—' : p < 0.001 ? '<0.001' : p.toFixed(3))
 
+/**
+ * The subset of a continuous-correlation result the scatter draws — the same
+ * fields `ContinuousCorrelationData` and a resolved `FeedStructuredArticleCorrelationBlock`
+ * both carry, so this component renders either a live fetch result or a
+ * structured-enrichment payload without an adapter.
+ */
+export interface CorrelationScatterData {
+  series: { date: string; trigger: number; outcome: number }[]
+  pearson: number | null
+  spearman: number | null
+  pearson_p: number | null
+  n: number
+  group_comparison: ContinuousCorrelationData['group_comparison']
+  trigger: CorrelationSelector
+  outcome: CorrelationSelector
+}
+
 /** The scatter itself: points + OLS regression line + r/ρ/n/p annotation + axes. */
-const CorrelationScatterSvg = ({ data }: { data: ContinuousCorrelationData }) => {
+export const CorrelationScatterSvg = ({ data }: { data: CorrelationScatterData }) => {
   const xs = data.series.map((p) => p.trigger)
   const ys = data.series.map((p) => p.outcome)
   const xMin = Math.min(...xs)

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -73,11 +73,16 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
         </div>
       </header>
 
-      {/* Sanitised server-side on ingest (timeline-ingest.ts) — safe to render. */}
-      <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: entry.content }} />
+      {/* Sanitised server-side on ingest (timeline-ingest.ts) — safe to render.
+          Suppressed for a native article render (below), whose `content` is the
+          same title + prose + captions — else the article shows twice. */}
+      {entry.structured?.kind !== 'article' && (
+        <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: entry.content }} />
+      )}
 
-      {/* Native structured data (Aurboda peers) → a real chart; otherwise fall
-          back to the delivered image attachment(s), the way Mastodon shows them. */}
+      {/* Native structured data (Aurboda peers) → a real chart / inline article;
+          otherwise fall back to the delivered image attachment(s), the way
+          Mastodon shows them. */}
       {entry.structured ? (
         <TimelineStructured structured={entry.structured} />
       ) : (

--- a/apps/web/src/pages/Feed/TimelineArticle.tsx
+++ b/apps/web/src/pages/Feed/TimelineArticle.tsx
@@ -1,0 +1,69 @@
+/**
+ * Native rendering of a federated ARTICLE post's structured enrichment (C3): the
+ * title followed by its resolved blocks — prose, a chart per windowed metric,
+ * and a correlation scatter — all built from data embedded in the structured
+ * payload fetched on ingest (`GET /public/:username/feed/:postId`). Unlike the
+ * author's own `ArticleContent`/`ArticleChartBlock`/`ArticleCorrelationBlock`
+ * (which fetch live from the author's authenticated endpoints), this renders
+ * only the data the payload already carries — a receiving peer has no
+ * credentials to fetch more.
+ *
+ * Prose is the author's raw markdown, rendered through the same sanitising
+ * `renderMarkdown` the author's own composer uses (the #910 XSS boundary),
+ * since a remote peer's markdown is untrusted content.
+ */
+import type { FeedStructuredArticle, FeedStructuredArticleBlock } from '@aurboda/api-spec'
+
+import { TrendLineChart } from '../../components/charts/TrendLineChart'
+import { renderMarkdown } from '../../utils/markdown'
+import { getMetricDisplayName } from '../../utils/metricLabels'
+import { CorrelationScatterSvg } from './ArticleCorrelationBlock'
+
+const CHART_COLOR = '#673ab8'
+
+const TimelineArticleBlock = ({ block }: { block: FeedStructuredArticleBlock }) => {
+  if (block.type === 'prose') {
+    return <div class="article-prose" dangerouslySetInnerHTML={{ __html: renderMarkdown(block.markdown) }} />
+  }
+
+  if (block.type === 'chart') {
+    const points = block.samples
+      .map((s) => ({ date: s.start, value: s.avg }))
+      .filter((p): p is { date: string; value: number } => p.value != null)
+    return (
+      <figure class="article-chart">
+        <div class="article-chart-title">{getMetricDisplayName(block.metric)}</div>
+        {points.length < 2 ? (
+          <p class="article-chart-note">Not enough data in this window.</p>
+        ) : (
+          <TrendLineChart
+            color={CHART_COLOR}
+            data={points}
+            xDomain={[new Date(block.start), new Date(block.end)]}
+          />
+        )}
+        {block.caption && <figcaption class="article-chart-caption">{block.caption}</figcaption>}
+      </figure>
+    )
+  }
+
+  return (
+    <figure class="article-chart">
+      {block.n < 3 ? (
+        <p class="article-chart-note">Not enough overlapping data in this window.</p>
+      ) : (
+        <CorrelationScatterSvg data={block} />
+      )}
+      {block.caption && <figcaption class="article-chart-caption">{block.caption}</figcaption>}
+    </figure>
+  )
+}
+
+export const TimelineArticle = ({ article }: { article: FeedStructuredArticle }) => (
+  <div class="article-content">
+    <h3 class="article-title">{article.title}</h3>
+    {article.blocks.map((block, i) => (
+      <TimelineArticleBlock key={i} block={block} />
+    ))}
+  </div>
+)

--- a/apps/web/src/pages/Feed/TimelineArticle.tsx
+++ b/apps/web/src/pages/Feed/TimelineArticle.tsx
@@ -8,22 +8,26 @@
  * only the data the payload already carries — a receiving peer has no
  * credentials to fetch more.
  *
- * Prose is the author's raw markdown, rendered through the same sanitising
- * `renderMarkdown` the author's own composer uses (the #910 XSS boundary),
- * since a remote peer's markdown is untrusted content.
+ * Prose is the remote author's raw markdown, rendered through `renderRemoteMarkdown`
+ * (the #910 XSS boundary, plus `<img>` forbidden) — a remote peer's markdown is
+ * untrusted, so it can't smuggle a tracking pixel into the reader's timeline; the
+ * post's images arrive only via its declared attachments.
  */
 import type { FeedStructuredArticle, FeedStructuredArticleBlock } from '@aurboda/api-spec'
 
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
-import { renderMarkdown } from '../../utils/markdown'
+import { renderRemoteMarkdown } from '../../utils/markdown'
 import { getMetricDisplayName } from '../../utils/metricLabels'
 import { CorrelationScatterSvg } from './ArticleCorrelationBlock'
+import './FeedPostCard.css' // `.article-prose` / `.article-chart*` / `.article-scatter*`
 
 const CHART_COLOR = '#673ab8'
 
 const TimelineArticleBlock = ({ block }: { block: FeedStructuredArticleBlock }) => {
   if (block.type === 'prose') {
-    return <div class="article-prose" dangerouslySetInnerHTML={{ __html: renderMarkdown(block.markdown) }} />
+    return (
+      <div class="article-prose" dangerouslySetInnerHTML={{ __html: renderRemoteMarkdown(block.markdown) }} />
+    )
   }
 
   if (block.type === 'chart') {

--- a/apps/web/src/pages/Feed/TimelineStructured.tsx
+++ b/apps/web/src/pages/Feed/TimelineStructured.tsx
@@ -1,16 +1,21 @@
 /**
- * Native rendering of a timeline post's Aurboda structured data: an interactive
- * line chart per shared high-resolution series (hover shows real values) instead
- * of a static image or plain text. Only rendered for posts from Aurboda
- * instances (which carry `structured`); Mastodon posts have none.
+ * Native rendering of a timeline post's Aurboda structured data. An `activity`
+ * post renders an interactive line chart per shared high-resolution series
+ * (hover shows real values) instead of a static image or plain text; an
+ * `article` post renders the full inline article (title + resolved blocks —
+ * see `TimelineArticle`). Only rendered for posts from Aurboda instances
+ * (which carry `structured`); Mastodon posts have none.
  */
-import type { FeedStructured } from '@aurboda/api-spec'
+import type { FeedStructuredPost } from '@aurboda/api-spec'
 
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
 import { structuredChartSeries } from './timeline-structured'
+import { TimelineArticle } from './TimelineArticle'
 import './TimelineStructured.css'
 
-export function TimelineStructured({ structured }: { structured: FeedStructured }) {
+export function TimelineStructured({ structured }: { structured: FeedStructuredPost }) {
+  if (structured.kind === 'article') return <TimelineArticle article={structured} />
+
   const series = structuredChartSeries(structured)
   if (series.length === 0) return null
   return (

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { ArticleEditorDialog } from '../../components/ArticleEditorDialog'
+import { ArticleExportDialog } from '../../components/ArticleExportDialog'
 import { ShareActivityDialog } from '../../components/ShareActivityDialog'
 import { avatarUrl, deleteFeedPost, fetchFeed } from '../../state/api'
 import { auth } from '../../state/auth'
@@ -22,6 +23,7 @@ import './style.css'
 function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState(false)
+  const [exporting, setExporting] = useState(false)
   const activityId = post.activity_id
   const isArticle = post.kind === 'article'
 
@@ -48,6 +50,11 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
                 Edit
               </button>
             )}
+            {isArticle && (
+              <button type="button" class="btn-secondary" onClick={() => setExporting(true)}>
+                Export markdown
+              </button>
+            )}
             <button type="button" class="btn-danger" onClick={onUnshare} disabled={deleteMutation.isPending}>
               {deleteMutation.isPending ? 'Unsharing…' : 'Unshare'}
             </button>
@@ -56,6 +63,8 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
       />
 
       {editing && isArticle && <ArticleEditorDialog post={post} onClose={() => setEditing(false)} />}
+
+      {exporting && isArticle && <ArticleExportDialog postId={post.id} onClose={() => setExporting(false)} />}
 
       {editing && !isArticle && activityId && (
         <ShareActivityDialog

--- a/apps/web/src/pages/Feed/timeline-structured.test.ts
+++ b/apps/web/src/pages/Feed/timeline-structured.test.ts
@@ -1,4 +1,4 @@
-import type { FeedStructured } from '@aurboda/api-spec'
+import type { FeedStructuredActivity } from '@aurboda/api-spec'
 
 import { describe, expect, test } from 'vitest'
 
@@ -6,8 +6,9 @@ import { structuredChartSeries } from './timeline-structured'
 
 const sample = (start: string, avg: number) => ({ avg, count: 1, end: start, max: avg, min: avg, start })
 
-const structured = (over: Partial<FeedStructured> = {}): FeedStructured => ({
+const structured = (over: Partial<FeedStructuredActivity> = {}): FeedStructuredActivity => ({
   activity_type: 'exercise',
+  kind: 'activity',
   metrics: [],
   series: [],
   start_time: '2026-07-01T08:00:00.000Z',
@@ -75,5 +76,9 @@ describe('structuredChartSeries', () => {
 
   test('returns an empty array when there are no series', () => {
     expect(structuredChartSeries(structured())).toEqual([])
+  })
+
+  test('returns an empty array for an article post (rendered by TimelineArticle instead)', () => {
+    expect(structuredChartSeries({ blocks: [], kind: 'article', title: 'My analysis' })).toEqual([])
   })
 })

--- a/apps/web/src/pages/Feed/timeline-structured.ts
+++ b/apps/web/src/pages/Feed/timeline-structured.ts
@@ -5,8 +5,10 @@
  *
  * Each shared series becomes a `{ date, value }[]` line (bucket start → avg),
  * dropping any series with fewer than two points (`TrendLineChart` needs ≥2).
+ * Only meaningful for an `activity` post's typed series; an `article` post
+ * renders via `TimelineArticle` instead, so this returns `[]` for one.
  */
-import type { FeedStructured } from '@aurboda/api-spec'
+import type { FeedStructuredPost } from '@aurboda/api-spec'
 
 export interface ChartSeries {
   metric: string
@@ -35,9 +37,15 @@ const prettify = (key: string): string => {
 /**
  * Chart-ready series for a structured post, newest metrics first as shared.
  * Series with fewer than two samples are dropped (a line needs two points).
+ * Returns `[]` for an `article` post (rendered by `TimelineArticle` instead).
  */
-export const structuredChartSeries = (structured: FeedStructured): ChartSeries[] =>
-  structured.series
+export const structuredChartSeries = (structured: FeedStructuredPost): ChartSeries[] => {
+  // Only an article renders elsewhere (TimelineArticle). Everything else — an
+  // activity share, or a legacy entry stored before the `kind` tag existed — has
+  // the activity series shape, so gate on `article` (not `!== 'activity'`) to
+  // avoid dropping the native chart on pre-existing timeline entries.
+  if (structured.kind === 'article') return []
+  return structured.series
     .map((series) => ({
       color: SERIES_META[series.metric]?.color ?? DEFAULT_COLOR,
       data: series.samples.map((sample) => ({ date: sample.start, value: sample.avg })),
@@ -45,3 +53,4 @@ export const structuredChartSeries = (structured: FeedStructured): ChartSeries[]
       metric: series.metric,
     }))
     .filter((series) => series.data.length >= 2)
+}

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -1,4 +1,5 @@
 import type {
+  ArticleExportResponse,
   CreateArticleBody,
   FeedPost,
   FeedPostResponse,
@@ -83,6 +84,19 @@ export const updateArticle = async (postId: string, body: UpdateArticleBody): Pr
 /** Unshare a post (removes it from the feed and retracts it from followers). */
 export const deleteFeedPost = async (postId: string): Promise<void> => {
   await axios.delete(`${API_URL}/feed/${postId}`, { headers: authHeaders() })
+}
+
+/**
+ * Export an article as paste-ready markdown (title + prose + one image link per
+ * chart/correlation block) for pasting into a text-only destination like
+ * r/QuantifiedSelf.
+ */
+export const fetchArticleExport = async (postId: string): Promise<string> => {
+  const response = await axios.get<ArticleExportResponse>(`${API_URL}/feed/articles/${postId}/export`, {
+    headers: authHeaders(),
+  })
+  if (!response.data.markdown) throw new Error('Export failed: no markdown returned')
+  return response.data.markdown
 }
 
 /** List the actors the user follows (accepted + pending), newest-first. */

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -92,9 +92,16 @@ export const deleteFeedPost = async (postId: string): Promise<void> => {
  * r/QuantifiedSelf.
  */
 export const fetchArticleExport = async (postId: string): Promise<string> => {
-  const response = await axios.get<ArticleExportResponse>(`${API_URL}/feed/articles/${postId}/export`, {
-    headers: authHeaders(),
-  })
+  let response
+  try {
+    response = await axios.get<ArticleExportResponse>(`${API_URL}/feed/articles/${postId}/export`, {
+      headers: authHeaders(),
+    })
+  } catch (error) {
+    // Surface the server's reason (e.g. "A followers-only article can't be
+    // exported…") so the user knows to make it public first.
+    throw new Error(apiErrorMessage(error, 'Couldn’t export this article. Please try again.'))
+  }
   if (!response.data.markdown) throw new Error('Export failed: no markdown returned')
   return response.data.markdown
 }

--- a/apps/web/src/utils/markdown.test.ts
+++ b/apps/web/src/utils/markdown.test.ts
@@ -28,6 +28,20 @@ describe('renderRemoteMarkdown', () => {
     expect(html).toContain('<table>')
     expect(html).not.toContain('<script')
   })
+
+  it('hardens links with rel=nofollow noopener noreferrer and target=_blank', () => {
+    const html = renderRemoteMarkdown('[x](https://example.com)')
+    expect(html).toContain('rel="nofollow noopener noreferrer"')
+    expect(html).toContain('target="_blank"')
+  })
+
+  it('does not leave the link-hardening hook active for renderMarkdown (own content)', () => {
+    // renderRemoteMarkdown adds+removes its afterSanitizeAttributes hook within one
+    // synchronous call; a later renderMarkdown must not inherit it.
+    renderRemoteMarkdown('[peer](https://peer.example)')
+    const own = renderMarkdown('[mine](https://example.com)')
+    expect(own).not.toContain('nofollow')
+  })
 })
 
 describe('renderMarkdown', () => {

--- a/apps/web/src/utils/markdown.test.ts
+++ b/apps/web/src/utils/markdown.test.ts
@@ -4,17 +4,28 @@ import { describe, expect, it } from 'vitest'
 import { renderMarkdown, renderRemoteMarkdown } from './markdown'
 
 describe('renderRemoteMarkdown', () => {
-  it('forbids <img> (a remote peer must not smuggle a tracking pixel)', () => {
-    const html = renderRemoteMarkdown('text ![](https://tracker.example/px.gif?u=victim)')
-    expect(html).not.toContain('<img')
+  it('drops every media tracker vector, not just <img>', () => {
+    const html = renderRemoteMarkdown(
+      'text ![](https://tracker.example/a.gif)\n\n' +
+        '<div style="background-image:url(https://tracker.example/b.png)"></div>\n' +
+        '<video poster="https://tracker.example/c.gif"></video><svg><image href="https://tracker.example/d"/></svg>',
+    )
     expect(html).not.toContain('tracker.example')
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('<video')
+    expect(html).not.toContain('poster')
+    expect(html).not.toContain('style=')
+    expect(html).not.toContain('<svg')
     expect(html).toContain('text')
   })
 
-  it('still renders safe formatting and strips scripts', () => {
-    const html = renderRemoteMarkdown('**bold** [x](https://example.com) <script>alert(1)</script>')
+  it('still renders the safe allowlisted formatting and strips scripts', () => {
+    const html = renderRemoteMarkdown(
+      '**bold** [x](https://example.com)\n\n| a |\n| - |\n| 1 |\n\n<script>alert(1)</script>',
+    )
     expect(html).toContain('<strong>bold</strong>')
     expect(html).toContain('href="https://example.com"')
+    expect(html).toContain('<table>')
     expect(html).not.toContain('<script')
   })
 })

--- a/apps/web/src/utils/markdown.test.ts
+++ b/apps/web/src/utils/markdown.test.ts
@@ -1,7 +1,23 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
 
-import { renderMarkdown } from './markdown'
+import { renderMarkdown, renderRemoteMarkdown } from './markdown'
+
+describe('renderRemoteMarkdown', () => {
+  it('forbids <img> (a remote peer must not smuggle a tracking pixel)', () => {
+    const html = renderRemoteMarkdown('text ![](https://tracker.example/px.gif?u=victim)')
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('tracker.example')
+    expect(html).toContain('text')
+  })
+
+  it('still renders safe formatting and strips scripts', () => {
+    const html = renderRemoteMarkdown('**bold** [x](https://example.com) <script>alert(1)</script>')
+    expect(html).toContain('<strong>bold</strong>')
+    expect(html).toContain('href="https://example.com"')
+    expect(html).not.toContain('<script')
+  })
+})
 
 describe('renderMarkdown', () => {
   it('renders GFM markdown to HTML', () => {

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -20,14 +20,53 @@ marked.setOptions({ breaks: true, gfm: true })
 /** Render user/AI-authored markdown to sanitised HTML safe for a `dangerouslySetInnerHTML` sink. */
 export const renderMarkdown = (md: string): string => DOMPurify.sanitize(marked.parse(md, { async: false }))
 
+// The allowlist for REMOTE (peer-authored) markdown — the same strict tag/attr
+// set the backend's inbound `sanitizeRemoteHtml` uses, so both inbound-federation
+// surfaces enforce one policy. Crucially it has NO media tags: a one-item
+// `FORBID_TAGS: ['img']` denylist on DOMPurify's broad default would still let a
+// remote peer smuggle a tracking pixel via `<style background-image>`, `<video
+// poster>`, `<audio>/<source srcset>`, `<svg><image href>` or `<input type=image>`.
+// Remote images arrive only via the post's declared attachment list, never inline.
+const REMOTE_ALLOWED_TAGS = [
+  'p',
+  'br',
+  'a',
+  'span',
+  'em',
+  'strong',
+  'b',
+  'i',
+  'del',
+  's',
+  'u',
+  'pre',
+  'code',
+  'blockquote',
+  'ul',
+  'ol',
+  'li',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+]
+const REMOTE_ALLOWED_ATTR = ['href', 'rel', 'target', 'class', 'translate', 'start']
+
 /**
  * Render markdown authored by a REMOTE peer (e.g. a federated article's prose) to
- * sanitised HTML. Like `renderMarkdown`, but **forbids `<img>`** — a remote
- * instance must not smuggle a tracking pixel into the reader's timeline card;
- * remote images arrive only via the post's declared attachment list. Mirrors the
- * backend's inbound `sanitizeRemoteHtml` policy (which also drops `<img>`), so
- * both inbound-federation surfaces enforce one allowlist. (marked emits `<a>`
- * without `target`, so there's no tabnabbing vector to harden here.)
+ * sanitised HTML under the strict `REMOTE_ALLOWED_*` allowlist above — an
+ * XSS-and-tracker boundary for untrusted federated content, mirroring the backend
+ * `sanitizeRemoteHtml`. Use this (not `renderMarkdown`) for any markdown that
+ * originates on another instance.
  */
 export const renderRemoteMarkdown = (md: string): string =>
-  DOMPurify.sanitize(marked.parse(md, { async: false }), { FORBID_TAGS: ['img'] })
+  DOMPurify.sanitize(marked.parse(md, { async: false }), {
+    ALLOWED_ATTR: REMOTE_ALLOWED_ATTR,
+    ALLOWED_TAGS: REMOTE_ALLOWED_TAGS,
+  })

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -20,13 +20,16 @@ marked.setOptions({ breaks: true, gfm: true })
 /** Render user/AI-authored markdown to sanitised HTML safe for a `dangerouslySetInnerHTML` sink. */
 export const renderMarkdown = (md: string): string => DOMPurify.sanitize(marked.parse(md, { async: false }))
 
-// The allowlist for REMOTE (peer-authored) markdown — the same strict tag/attr
-// set the backend's inbound `sanitizeRemoteHtml` uses, so both inbound-federation
-// surfaces enforce one policy. Crucially it has NO media tags: a one-item
+// The allowlist for REMOTE (peer-authored) markdown — a stricter *superset* of the
+// backend's inbound `sanitizeRemoteHtml` allowlist (it adds the GFM table tags
+// `table`/`thead`/`tbody`/`tr`/`th`/`td`), so both inbound-federation surfaces
+// enforce essentially one policy. Crucially it has NO media tags: a one-item
 // `FORBID_TAGS: ['img']` denylist on DOMPurify's broad default would still let a
 // remote peer smuggle a tracking pixel via `<style background-image>`, `<video
 // poster>`, `<audio>/<source srcset>`, `<svg><image href>` or `<input type=image>`.
 // Remote images arrive only via the post's declared attachment list, never inline.
+// Links are additionally hardened by `hardenRemoteLink` below (the backend does the
+// same via `transformTags`), so allowing `rel`/`target` here can't leave them off.
 const REMOTE_ALLOWED_TAGS = [
   'p',
   'br',
@@ -59,14 +62,37 @@ const REMOTE_ALLOWED_TAGS = [
 const REMOTE_ALLOWED_ATTR = ['href', 'rel', 'target', 'class', 'translate', 'start']
 
 /**
+ * Harden every link in remote prose exactly as the backend's inbound
+ * `sanitizeRemoteHtml` does: force `rel="nofollow noopener noreferrer"` and
+ * `target="_blank"`. `marked` emits bare `<a href>` (no rel/target), so without
+ * this a federated peer's prose would leak a `Referer` to the link target and
+ * carry no `nofollow`/`noopener` — unlike the same peer's HTML on the same card.
+ */
+const hardenRemoteLink = (node: Element): void => {
+  if (node.nodeName === 'A') {
+    node.setAttribute('rel', 'nofollow noopener noreferrer')
+    node.setAttribute('target', '_blank')
+  }
+}
+
+/**
  * Render markdown authored by a REMOTE peer (e.g. a federated article's prose) to
  * sanitised HTML under the strict `REMOTE_ALLOWED_*` allowlist above — an
  * XSS-and-tracker boundary for untrusted federated content, mirroring the backend
  * `sanitizeRemoteHtml`. Use this (not `renderMarkdown`) for any markdown that
  * originates on another instance.
  */
-export const renderRemoteMarkdown = (md: string): string =>
-  DOMPurify.sanitize(marked.parse(md, { async: false }), {
-    ALLOWED_ATTR: REMOTE_ALLOWED_ATTR,
-    ALLOWED_TAGS: REMOTE_ALLOWED_TAGS,
-  })
+export const renderRemoteMarkdown = (md: string): string => {
+  // The link-hardening hook is scoped to this one synchronous sanitise: added,
+  // used, and removed with no `await` between, so it never leaks onto
+  // `renderMarkdown` (own content, which shouldn't be force-`nofollow`ed).
+  DOMPurify.addHook('afterSanitizeAttributes', hardenRemoteLink)
+  try {
+    return DOMPurify.sanitize(marked.parse(md, { async: false }), {
+      ALLOWED_ATTR: REMOTE_ALLOWED_ATTR,
+      ALLOWED_TAGS: REMOTE_ALLOWED_TAGS,
+    })
+  } finally {
+    DOMPurify.removeHook('afterSanitizeAttributes')
+  }
+}

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -19,3 +19,15 @@ marked.setOptions({ breaks: true, gfm: true })
 
 /** Render user/AI-authored markdown to sanitised HTML safe for a `dangerouslySetInnerHTML` sink. */
 export const renderMarkdown = (md: string): string => DOMPurify.sanitize(marked.parse(md, { async: false }))
+
+/**
+ * Render markdown authored by a REMOTE peer (e.g. a federated article's prose) to
+ * sanitised HTML. Like `renderMarkdown`, but **forbids `<img>`** — a remote
+ * instance must not smuggle a tracking pixel into the reader's timeline card;
+ * remote images arrive only via the post's declared attachment list. Mirrors the
+ * backend's inbound `sanitizeRemoteHtml` policy (which also drops `<img>`), so
+ * both inbound-federation surfaces enforce one allowlist. (marked emits `<a>`
+ * without `target`, so there's no tabnabbing vector to harden here.)
+ */
+export const renderRemoteMarkdown = (md: string): string =>
+  DOMPurify.sanitize(marked.parse(md, { async: false }), { FORBID_TAGS: ['img'] })

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -41,10 +41,21 @@ A feed post has a **`kind`**:
   (GFM tables, images, `hr`, headings); note that **Mastodon's own inbound sanitiser then
   strips tables/images/`hr`** from a remote status, so a results table degrades to
   run-together cell text there — the charts still arrive as image attachments, and
-  non-Mastodon / Aurboda-peer renderers keep the full formatting. A richer inline render
-  for Aurboda peers — inbound ingestion plus structured enrichment — is a later slice
-  (**#968**); until then an Aurboda follower doesn't yet see a federated article.
-  _Reddit/markdown export is the remaining part of #937._
+  non-Mastodon / Aurboda-peer renderers keep the full formatting. Because an article
+  federates as an ordinary `Note`, an Aurboda peer's existing inbound timeline ingestion
+  (see [Home timeline](#home-timeline-inbound)) already stores it like any other post —
+  sanitised prose + image attachments — with no article-specific ingest code. On top of
+  that, a following Aurboda instance's [structured-enrichment
+  fetch](#native-charts-from-aurboda-peers-structured-enrichment) resolves an article to
+  its native `FeedStructuredArticle` payload (title + every block re-resolved live —
+  bucketed chart samples, or the computed correlation + scatter points), so an Aurboda
+  follower's timeline renders the full inline article — real interactive charts and
+  scatters — instead of just the flattened prose and attached PNGs a Mastodon follower
+  sees. **Export** — `GET /feed/articles/:postId/export` (and the `export_article_markdown`
+  MCP tool) renders an article as paste-ready markdown — the title, the prose blocks
+  verbatim, and one image link per chart/correlation block (the block-image endpoint
+  below) — for pasting into a text-only destination like r/QuantifiedSelf, where the
+  author adds their own write-up around the linked charts.
 
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:
@@ -255,28 +266,43 @@ plain HTML when a post comes from **another Aurboda instance**, the receiver fet
 structured data out-of-band on ingest:
 
 1. **Emit.** Every instance serves `GET /public/:username/feed/:postId` — a native JSON payload
-   (`FeedStructured`: activity type/window, typed scalar `metrics`, and inline high-resolution
-   `series` samples). It reuses the exact same scalar resolution as delivery and the same
-   data-scoped series resolution as the [public series endpoint](#public-series-endpoint-the-privacy-boundary),
-   so a peer can never read more than the author shared. `public`/`unlisted` posts resolve
+   (`FeedStructuredPost`: a discriminated union on `kind`). An **activity** post resolves to
+   `FeedStructuredActivity` (activity type/window, typed scalar `metrics`, and inline
+   high-resolution `series` samples), reusing the exact same scalar resolution as delivery and
+   the same data-scoped series resolution as the [public series
+   endpoint](#public-series-endpoint-the-privacy-boundary). An **article** post resolves to
+   `FeedStructuredArticle` (the title and every block, resolved in the same order as the
+   article: a prose block's raw markdown verbatim; a chart block's bucketed samples over its
+   locked window, bucketed the same way as its block image; a correlation block's computed
+   Pearson/Spearman/n, the present-vs-absent group comparison, and the aligned scatter points —
+   the same `getContinuousCorrelation` call the block image uses). Either way a peer can never
+   read more than the author shared/published. `public`/`unlisted` posts resolve
    unconditionally; a `followers`-only post resolves only with a matching `?token=<image_token>`
    — the **same capability token** that authorizes its followers-only images (below), so the
-   structured chart and the image share one authorization boundary.
+   structured payload and the images share one authorization boundary.
 2. **Detect + fetch.** On ingesting a `Create`/`Update`, if the note's id matches Aurboda's own
    object path (`/users/{user}/feed/{postId}` — a Mastodon status id never does, so no needless
    request is made), the receiver discovers the peer via `/.well-known/aurboda` and fetches its
-   structured endpoint. For a `followers`-only post it lifts the capability token from the
-   delivered image URL (the `?token=` embedded only in the follower's `Note`) and forwards it,
-   so an accepted follower fetches the native chart while a public guess still 404s. All fetches
-   are **SSRF-guarded** (`safe-fetch`: public hosts only, no redirects, size + time bounded) and
-   time-boxed; the origin is the accepted followee's own host. Any failure (non-Aurboda host,
-   404, malformed, timeout) is swallowed — the post still shows with its HTML.
+   structured endpoint — the same path for an activity share or an article, since both federate
+   as a `Note` and the object id doesn't distinguish them. For a `followers`-only post it lifts
+   the capability token from the delivered image URL (the `?token=` embedded only in the
+   follower's `Note`) and forwards it, so an accepted follower fetches the native payload while a
+   public guess still 404s. All fetches are **SSRF-guarded** (`safe-fetch`: public hosts only, no
+   redirects, size + time bounded) and time-boxed; the origin is the accepted followee's own
+   host. Any failure (non-Aurboda host, 404, malformed, timeout) is swallowed — the post still
+   shows with its HTML.
 3. **Store + render.** The payload is stored on `timeline_entry.structured` (JSONB, NULL for
    non-Aurboda posts; a redelivery that can't re-fetch keeps the last-known value). The web
-   timeline card renders a native `TrendLineChart` per shared series when `structured` is present.
+   timeline card renders, per `structured.kind`: a native `TrendLineChart` per shared series for
+   an **activity** post, or the full inline article — title, prose, per-block chart/scatter — for
+   an **article** post (mirroring the author's own live `ArticleContent` render, but built from
+   the embedded payload rather than a live fetch, since a receiving peer has no credentials to
+   call the author's authenticated endpoints).
 
-Enrichment is strictly best-effort and additive: it never blocks or fails basic ingest, and
-series that weren't shared (the opt-in) simply produce no chart.
+Enrichment is strictly best-effort and additive: it never blocks or fails basic ingest, an
+activity's series that weren't shared (the opt-in) simply produce no chart, and an article's
+chart/correlation block with too little data renders the same "not enough data" fallback the
+author's own live render shows.
 
 ### Live updates
 
@@ -423,7 +449,10 @@ resolving.
   the sidebar) lists everything
   you've shared, with each post's audience and metrics. From there you can **Edit** a
   post — an activity share re-opens the share dialog (saving federates an `Update`); an
-  article re-opens the article composer — or **Unshare** it (federates a `Delete`).
+  article re-opens the article composer — or **Unshare** it (federates a `Delete`). An
+  article also has an **Export markdown** button that fetches its paste-ready markdown
+  export and offers a **Copy to clipboard** button for pasting into r/QuantifiedSelf or a
+  similar text-only destination.
 - **Follow** — the Feed page's **Following** panel lets you follow a fediverse actor by
   handle (`@user@host`) and see who you follow, with a **Pending** badge until the remote
   server accepts and an **Unfollow** button.
@@ -452,6 +481,7 @@ Owner-facing (authenticated, scoped to the caller):
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
 | `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                       |
 | `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                          |
+| `GET /feed/articles/:postId/export`| Export an article as paste-ready markdown (title + prose + one image link per block) for Reddit/text-only destinations  |
 | `PATCH /feed/:postId`              | Edit an activity post's selection / visibility / attachments                                                            |
 | `DELETE /feed/:postId`             | Unpublish any post (an activity post's public series stops resolving)                                                   |
 | `GET /feed/following`              | List the actors I follow (accepted + pending)                                                                           |
@@ -468,7 +498,7 @@ Public / federation (unauthenticated):
 | Method & path                                                | Purpose                                                                                                    |
 | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `GET /public/:username/series`                               | Bucketed samples for a **shared** series within its window                                                 |
-| `GET /public/:username/feed/:postId`                         | Native structured post (`FeedStructured`: typed metrics + inline series) for Aurboda-to-Aurboda enrichment |
+| `GET /public/:username/feed/:postId`                         | Native structured post (`FeedStructuredPost`: an activity's typed metrics + inline series, or an article's title + resolved blocks) for Aurboda-to-Aurboda enrichment |
 | `GET /public/:username/feed/:postId/chart.png`               | Rendered HR chart (PNG) for an opted-in post (`?token=` for followers-only)                                |
 | `GET /public/:username/feed/:postId/chart.svg`               | Same HR chart as crisp `image/svg+xml` for Aurboda-native rendering (`?token=` for followers-only)         |
 | `GET /public/:username/feed/:postId/route.png`               | Rendered GPS route map for an opted-in post (`?token=` for followers-only)                                 |
@@ -484,12 +514,14 @@ Public / federation (unauthenticated):
 | `POST /users/:username/inbox` (+ `/inbox`)                   | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
-`create_article`, `update_article`, `update_feed_post`, `delete_feed_post`, `list_following`,
-`follow_actor`, `unfollow_actor`, `list_followers`, `approve_follower`, `reject_follower`, and
-`list_timeline` — all backed by the same services as the REST routes (`create_article` /
-`update_article` ↔ `POST /feed/articles` / `PATCH /feed/articles/:postId`), so an article can
-be drafted conversationally by Claude via the same tools. Manual follower approval is toggled with the
-`manually_approve_followers` user setting (`get_user_settings` / `update_user_settings`).
+`create_article`, `update_article`, `export_article_markdown`, `update_feed_post`,
+`delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`, `list_followers`,
+`approve_follower`, `reject_follower`, and `list_timeline` — all backed by the same services as
+the REST routes (`create_article` / `update_article` ↔ `POST /feed/articles` / `PATCH
+/feed/articles/:postId`; `export_article_markdown` ↔ `GET /feed/articles/:postId/export`), so an
+article can be drafted conversationally by Claude via the same tools. Manual follower approval is
+toggled with the `manually_approve_followers` user setting (`get_user_settings` /
+`update_user_settings`).
 
 ## Storage
 
@@ -514,8 +546,9 @@ Posts received from followees are stored in `timeline_entry` (keyed by the remot
 `object_uri` so an `Update`/redelivery replaces in place), holding the **already-sanitised**
 content plus the author's cached handle / display name / avatar, indexed on
 `(published_at DESC, id DESC)` for the keyset-paginated home timeline. A nullable
-`structured` JSONB column carries the native Aurboda payload (`FeedStructured`: typed
-metrics + inline series) fetched during enrichment — NULL for non-Aurboda posts. On a
+`structured` JSONB column carries the native Aurboda payload (`FeedStructuredPost`: an
+activity's typed metrics + inline series, or an article's title + resolved blocks) fetched
+during enrichment — NULL for non-Aurboda posts. On a
 re-delivery whose enrichment failed, the upsert `COALESCE`s so the last-known `structured`
 is preserved rather than wiped. A nullable `images` JSONB column holds the delivered
 image attachments (`TimelineImage[]`: url + optional media type / alt / size), rendered as

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -55,7 +55,10 @@ A feed post has a **`kind`**:
   MCP tool) renders an article as paste-ready markdown — the title, the prose blocks
   verbatim, and one image link per chart/correlation block (the block-image endpoint
   below) — for pasting into a text-only destination like r/QuantifiedSelf, where the
-  author adds their own write-up around the linked charts.
+  author adds their own write-up around the linked charts. A **`followers`-only** article
+  can't be exported (400): the export targets a public paste, but its chart images require
+  the post's private capability token, which must never land in publicly-pasted text —
+  make the article public or unlisted first.
 
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:

--- a/packages/api-spec/src/schemas/feed-structured.ts
+++ b/packages/api-spec/src/schemas/feed-structured.ts
@@ -1,11 +1,13 @@
 /**
- * Structured, machine-readable representation of a shared exercise post — the
- * data an Aurboda instance federates to *other Aurboda instances* so they can
- * render a native chart + typed stats instead of just the Mastodon-style HTML.
+ * Structured, machine-readable representation of a shared exercise or article
+ * post — the data an Aurboda instance federates to *other Aurboda instances* so
+ * they can render a native chart + typed stats instead of just the
+ * Mastodon-style HTML.
  *
- * A leaf module (imports only `common`) so both the public-series endpoint and
- * the timeline entry can reuse `publicSeriesSampleSchema` without a circular
- * import back through `feed.ts`.
+ * Imports only `common` and `correlations` (never `feed.ts`), so both the
+ * public-series endpoint and the timeline entry can reuse
+ * `publicSeriesSampleSchema` without a circular import back through `feed.ts`;
+ * `correlations.ts` is itself a `common`-only leaf, so no cycle is introduced.
  *
  * The origin instance serves this at `GET /public/:username/feed/:postId`
  * (see the backend feed-public router); a following instance fetches it on
@@ -14,6 +16,7 @@
 import { z } from 'zod'
 
 import { iso8601DateTimeSchema } from './common.ts'
+import { alignedPointSchema, groupComparisonSchema, selectorSchema } from './correlations.ts'
 
 /**
  * One bucketed sample. Individual-measurement timestamps are deliberately
@@ -88,3 +91,125 @@ export const feedStructuredSchema = z
   .meta({ id: 'FeedStructured' })
 
 export type FeedStructured = z.infer<typeof feedStructuredSchema>
+
+/**
+ * `FeedStructured` tagged with its post kind, so a consumer of the discriminated
+ * `FeedStructuredPost` union (below) can narrow on `kind` before reading the
+ * activity-shaped fields. The wire shape is otherwise identical to
+ * `FeedStructured` — this is purely the `kind` tag for the union.
+ */
+export const feedStructuredActivitySchema = feedStructuredSchema
+  .extend({ kind: z.literal('activity').meta({ description: 'Discriminator: an activity-share post' }) })
+  .meta({ id: 'FeedStructuredActivity' })
+
+export type FeedStructuredActivity = z.infer<typeof feedStructuredActivitySchema>
+
+// =============================================================================
+// Article structured enrichment (FeedStructuredArticle)
+// =============================================================================
+
+/**
+ * A resolved prose block: the author's raw markdown, unmodified. Rendered
+ * through the receiver's own sanitising markdown renderer (the same `#910`
+ * boundary the owner's web app uses for its own posts) rather than pre-rendered
+ * HTML, so a receiving Aurboda peer controls its own sanitisation rather than
+ * trusting a remote instance's HTML.
+ */
+export const feedStructuredArticleProseBlockSchema = z
+  .object({ markdown: z.string().meta({ description: 'Raw authored markdown' }), type: z.literal('prose') })
+  .meta({ description: 'A resolved prose block', id: 'FeedStructuredArticleProseBlock' })
+
+export type FeedStructuredArticleProseBlock = z.infer<typeof feedStructuredArticleProseBlockSchema>
+
+/**
+ * A resolved chart block: the metric bucketed over its locked `[start, end]`
+ * window (the same bucketing the block's own PNG/inline render uses), so a
+ * receiving peer can draw a real interactive chart instead of only linking the
+ * rendered image.
+ */
+export const feedStructuredArticleChartBlockSchema = z
+  .object({
+    bucket: z.string().meta({ description: 'Effective bucket granularity used to resolve `samples`' }),
+    caption: z.string().optional().meta({ description: 'Optional caption' }),
+    end: iso8601DateTimeSchema.meta({ description: "Block's locked window end (ISO 8601)" }),
+    metric: z.string().meta({ description: 'The charted metric' }),
+    samples: z
+      .array(publicSeriesSampleSchema)
+      .meta({ description: 'Bucketed samples over the window (may be too few to draw a line)' }),
+    start: iso8601DateTimeSchema.meta({ description: "Block's locked window start (ISO 8601)" }),
+    type: z.literal('chart'),
+    unit: z.string().optional().meta({ description: 'Unit of the metric, if known' }),
+  })
+  .meta({ description: 'A resolved chart block', id: 'FeedStructuredArticleChartBlock' })
+
+export type FeedStructuredArticleChartBlock = z.infer<typeof feedStructuredArticleChartBlockSchema>
+
+/**
+ * A resolved correlation block: the computed continuous correlation (Pearson /
+ * Spearman / n / the present-vs-absent group comparison) and the aligned daily
+ * scatter points over its locked window — the same shape the server-side
+ * scatter PNG and the web `ArticleCorrelationBlock` render from, so a receiving
+ * peer can draw the identical scatter natively.
+ */
+export const feedStructuredArticleCorrelationBlockSchema = z
+  .object({
+    caption: z.string().optional().meta({ description: 'Optional caption' }),
+    end: iso8601DateTimeSchema.meta({ description: "Block's locked window end (ISO 8601)" }),
+    group_comparison: groupComparisonSchema
+      .nullable()
+      .meta({ description: 'Present-vs-absent group comparison; null when there is no split to compare' }),
+    lag_days: z.number().int().optional().meta({ description: 'Days the outcome lags the trigger' }),
+    n: z.number().int().meta({ description: 'Number of aligned day pairs' }),
+    outcome: selectorSchema.meta({ description: 'Outcome dimension' }),
+    pearson: z.number().nullable().meta({ description: 'Pearson correlation (-1..1)' }),
+    pearson_p: z.number().nullable().meta({ description: 'Two-sided p-value for the Pearson correlation' }),
+    series: z.array(alignedPointSchema).meta({ description: 'Aligned daily scatter points' }),
+    spearman: z.number().nullable().meta({ description: 'Spearman rank correlation (-1..1)' }),
+    start: iso8601DateTimeSchema.meta({ description: "Block's locked window start (ISO 8601)" }),
+    trigger: selectorSchema.meta({ description: 'Trigger / predictor dimension' }),
+    type: z.literal('correlation'),
+  })
+  .meta({ description: 'A resolved correlation block', id: 'FeedStructuredArticleCorrelationBlock' })
+
+export type FeedStructuredArticleCorrelationBlock = z.infer<typeof feedStructuredArticleCorrelationBlockSchema>
+
+/** One resolved article content block (prose, chart, or correlation). */
+export const feedStructuredArticleBlockSchema = z
+  .discriminatedUnion('type', [
+    feedStructuredArticleProseBlockSchema,
+    feedStructuredArticleChartBlockSchema,
+    feedStructuredArticleCorrelationBlockSchema,
+  ])
+  .meta({ description: 'A resolved article content block', id: 'FeedStructuredArticleBlock' })
+
+export type FeedStructuredArticleBlock = z.infer<typeof feedStructuredArticleBlockSchema>
+
+/**
+ * The native structured representation of a shared *article* post: its title
+ * and ordered blocks, each resolved to its locked window's live data. Served at
+ * the same `GET /public/:username/feed/:postId` endpoint as an activity's
+ * `FeedStructuredActivity` (see `FeedStructuredPost`) so a following Aurboda
+ * instance renders a native inline article — real interactive charts and
+ * scatters — instead of only the Mastodon-style prose + attached PNGs.
+ */
+export const feedStructuredArticleSchema = z
+  .object({
+    blocks: z.array(feedStructuredArticleBlockSchema).meta({ description: 'Ordered, resolved content blocks' }),
+    kind: z.literal('article').meta({ description: 'Discriminator: an article post' }),
+    title: z.string().meta({ description: 'Article title' }),
+  })
+  .meta({ id: 'FeedStructuredArticle' })
+
+export type FeedStructuredArticle = z.infer<typeof feedStructuredArticleSchema>
+
+/**
+ * Discriminated union of everything the structured-enrichment endpoint may
+ * return: an activity share's typed scalars/series, or an article's title +
+ * resolved blocks. `kind` tells a consuming peer (and the web timeline card)
+ * which native render to use.
+ */
+export const feedStructuredPostSchema = z
+  .discriminatedUnion('kind', [feedStructuredActivitySchema, feedStructuredArticleSchema])
+  .meta({ id: 'FeedStructuredPost' })
+
+export type FeedStructuredPost = z.infer<typeof feedStructuredPostSchema>

--- a/packages/api-spec/src/schemas/feed-structured.ts
+++ b/packages/api-spec/src/schemas/feed-structured.ts
@@ -171,7 +171,9 @@ export const feedStructuredArticleCorrelationBlockSchema = z
   })
   .meta({ description: 'A resolved correlation block', id: 'FeedStructuredArticleCorrelationBlock' })
 
-export type FeedStructuredArticleCorrelationBlock = z.infer<typeof feedStructuredArticleCorrelationBlockSchema>
+export type FeedStructuredArticleCorrelationBlock = z.infer<
+  typeof feedStructuredArticleCorrelationBlockSchema
+>
 
 /** One resolved article content block (prose, chart, or correlation). */
 export const feedStructuredArticleBlockSchema = z
@@ -194,7 +196,9 @@ export type FeedStructuredArticleBlock = z.infer<typeof feedStructuredArticleBlo
  */
 export const feedStructuredArticleSchema = z
   .object({
-    blocks: z.array(feedStructuredArticleBlockSchema).meta({ description: 'Ordered, resolved content blocks' }),
+    blocks: z
+      .array(feedStructuredArticleBlockSchema)
+      .meta({ description: 'Ordered, resolved content blocks' }),
     kind: z.literal('article').meta({ description: 'Discriminator: an article post' }),
     title: z.string().meta({ description: 'Article title' }),
   })
@@ -207,9 +211,17 @@ export type FeedStructuredArticle = z.infer<typeof feedStructuredArticleSchema>
  * return: an activity share's typed scalars/series, or an article's title +
  * resolved blocks. `kind` tells a consuming peer (and the web timeline card)
  * which native render to use.
+ *
+ * A payload with NO `kind` is treated as an `activity` before discriminating, so
+ * enrichment fetched from a peer running the *previous* release (which emitted
+ * the un-tagged `FeedStructured` shape) still parses instead of silently dropping
+ * the native chart during a rolling upgrade.
  */
 export const feedStructuredPostSchema = z
-  .discriminatedUnion('kind', [feedStructuredActivitySchema, feedStructuredArticleSchema])
+  .preprocess(
+    (v) => (v != null && typeof v === 'object' && !('kind' in v) ? { ...v, kind: 'activity' } : v),
+    z.discriminatedUnion('kind', [feedStructuredActivitySchema, feedStructuredArticleSchema]),
+  )
   .meta({ id: 'FeedStructuredPost' })
 
 export type FeedStructuredPost = z.infer<typeof feedStructuredPostSchema>

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -26,7 +26,7 @@ import { z } from 'zod'
 
 import { baseResponseSchema, iso8601DateTimeSchema, metricTypeSchema } from './common.ts'
 import { selectorSchema } from './correlations.ts'
-import { feedStructuredSchema, publicSeriesSampleSchema } from './feed-structured.ts'
+import { feedStructuredPostSchema, publicSeriesSampleSchema } from './feed-structured.ts'
 import { shareVisibilityValues } from './visibility.ts'
 
 /**
@@ -503,9 +503,9 @@ export const timelineEntrySchema = z
     }),
     object_uri: z.string().meta({ description: "The remote post's canonical id" }),
     published_at: iso8601DateTimeSchema.meta({ description: 'When the post was published (ISO 8601)' }),
-    structured: feedStructuredSchema.optional().meta({
+    structured: feedStructuredPostSchema.optional().meta({
       description:
-        'Native structured data (typed metrics + series), present only for posts from Aurboda instances — drives a native chart instead of the HTML.',
+        'Native structured data (an activity share’s typed metrics/series, or an article’s title + resolved blocks), present only for posts from Aurboda instances — drives a native render instead of the HTML.',
     }),
     url: z.string().nullable().meta({ description: 'Link to the original post' }),
   })
@@ -595,11 +595,33 @@ export type PublicSeriesResponse = z.infer<typeof publicSeriesResponseSchema>
 
 /**
  * Response for the public *structured post* endpoint (`GET /public/:username/feed/:postId`).
- * `structured` is absent (with `success: false`) for unknown / non-public / non-exercise posts.
- * Consumed by another Aurboda instance on ingest to render a native chart.
+ * `structured` is absent (with `success: false`) for unknown / non-public posts. Consumed by
+ * another Aurboda instance on ingest to render a native chart or article.
  */
 export const feedPostStructuredResponseSchema = baseResponseSchema
-  .extend({ structured: feedStructuredSchema.optional() })
+  .extend({ structured: feedStructuredPostSchema.optional() })
   .meta({ id: 'FeedPostStructuredResponse' })
 
 export type FeedPostStructuredResponse = z.infer<typeof feedPostStructuredResponseSchema>
+
+// =============================================================================
+// Reddit/markdown export (C4)
+// =============================================================================
+
+/**
+ * Response for the article markdown-export endpoint: a paste-ready rendering of
+ * the article's title + prose, with each chart/correlation block as a link to
+ * its rendered PNG (the C1 block-image endpoint) — meant for pasting into a
+ * text-only destination like r/QuantifiedSelf. `markdown` is absent (with
+ * `success: false`) for an unknown id or a non-article post.
+ */
+export const articleExportResponseSchema = baseResponseSchema
+  .extend({
+    markdown: z
+      .string()
+      .optional()
+      .meta({ description: 'Paste-ready markdown: title + prose + one image link per chart/correlation block' }),
+  })
+  .meta({ id: 'ArticleExportResponse' })
+
+export type ArticleExportResponse = z.infer<typeof articleExportResponseSchema>


### PR DESCRIPTION
Completes **Slice C (#937)** of epic #934 (Shareable Articles) — the second and final PR, combining **C3** (native structured enrichment for Aurboda peers) and **C4** (Reddit/markdown export). Follows PR 1 (#967, merged), where articles federate as a **Note** (so Mastodon already renders prose + attached chart PNGs, and peers already ingest them as timeline Notes) — C3 layers the *richer* native render on top.

## C3 — native structured enrichment for Aurboda peers
- The public structured endpoint (`GET /public/:username/feed/:postId` → `resolveStructuredPost`) now handles **articles**. New `FeedStructuredArticle` variant in api-spec; `structured` (both the endpoint response and the timeline entry) becomes a **`kind`-discriminated union** (`FeedStructuredActivity | FeedStructuredArticle`), so activity payloads now carry `kind:'activity'`.
- Each block resolves **live over its locked window**, mirroring the C1 image path exactly: chart blocks bucket via `queryMetricsBucketed` (author `device_timezone`, shared `defaultArticleChartBucket` / `isZeroDurationBucket`, `samplesFromBucketedResult`); correlation blocks run `getContinuousCorrelation` (wall-clock day bounds). Same **visibility + capability-token gate** as the block images. Prose ships **raw markdown** so the receiving peer sanitises it itself (#910) — never trusting remote HTML.
- Web: `TimelineArticle` renders a peer's article inline (prose + native chart + scatter); `CorrelationScatterSvg` is exported with a shared structural type so it draws either a live fetch or a structured payload with no adapter. **Legacy timeline entries** (stored `structured` without a `kind`) still render as activity.

## C4 — Reddit/markdown export
- `buildArticleMarkdown` (pure) → title + prose + one image link per chart/correlation block, via the shared `articleBlockImageUrl` (the same URL the AS2 attachment points at). **REST** `GET /feed/articles/:postId/export` + **MCP** `export_article_markdown` (parity), plus an `ArticleExportDialog` with copy-to-clipboard.

## DRY
`isZeroDurationBucket` + `articleBlockImageUrl` moved to `services/article.ts`; `samplesFromBucketedResult` extracted from `resolvePublicSeries`.

## Testing
`pnpm check` clean (0 errors, api-spec/backend/web); unit tests (article, article-export, timeline-enrich, timeline-structured) + integration tests (feed-structured, feed-router) all green locally.

_Provenance: the bulk was produced by a scheduled agent that couldn't push from its sandbox; applied, reviewed, and fixed here (the legacy-entry `structuredChartSeries` guard) before pushing._

🤖 Generated with [Claude Code](https://claude.com/claude-code)