### PR TITLE
fix(garmin): resolve versioned typeKeys and never FK-fail a sync batch

### DIFF
--- a/apps/backend/src/integrations/garmin/process.integration.test.ts
+++ b/apps/backend/src/integrations/garmin/process.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration test for Garmin activity type resolution.
+ *
+ * Runs processGarminData against a real PostgreSQL instance so the
+ * activities → activity_type_definitions foreign key is actually enforced:
+ * an unmapped Garmin typeKey must degrade to a defined type instead of
+ * failing the insert and taking the rest of the batch with it.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { query } from '../../db/connection.ts'
+import {
+  activityTypeExists,
+  deleteGarminActivityWithWrongType,
+  insertActivity,
+  insertLocations,
+  insertRawRecord,
+  insertTimeSeries,
+} from '../../db/index.ts'
+import { softDeleteLocationRange } from '../../db/locations.ts'
+import { auditError } from '../../services/audit-log.ts'
+import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
+import { processGarminData } from './process.ts'
+
+const CONTAINER_TIMEOUT = 120_000
+
+const realDeps = {
+  activityTypeExists,
+  auditError,
+  deleteGarminActivityWithWrongType,
+  insertActivity,
+  insertLocations,
+  insertRawRecord,
+  insertTimeSeries,
+  softDeleteLocationRange,
+}
+
+const makeActivity = (overrides: Record<string, unknown> = {}) => ({
+  activityId: 12345,
+  activityName: 'Morning Row',
+  activityType: { typeKey: 'rowing_v2' },
+  averageHR: 145,
+  beginTimestamp: 1736924400000,
+  calories: 350,
+  distance: 5000,
+  duration: 1800,
+  elapsedDuration: 1800,
+  elevationGain: 0,
+  maxHR: 175,
+  startTimeGMT: '2025-01-15T07:00:00.000',
+  steps: 0,
+  vO2MaxValue: 0,
+  ...overrides,
+})
+
+const getStoredActivities = async (user: string) => {
+  const result = await query(
+    user,
+    `SELECT activity_type, title, data FROM activities WHERE source = 'garmin' ORDER BY start_time, title`,
+    [],
+  )
+  return result.rows as { activity_type: string; data: Record<string, unknown>; title: string }[]
+}
+
+describe('Garmin activity type resolution (integration)', () => {
+  beforeAll(async () => {
+    await startTestDb()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('stores a versioned typeKey under its unversioned activity type', async () => {
+    const user = getTestUser()
+
+    const count = await processGarminData(user, 'activities', [makeActivity()], realDeps)
+
+    expect(count).toBe(1)
+    const stored = await getStoredActivities(user)
+    expect(stored).toHaveLength(1)
+    expect(stored[0].activity_type).toBe('rowing')
+    expect(stored[0].data.garmin_type_key).toBeUndefined()
+  })
+
+  test('stores an unknown typeKey as other_workout instead of violating the foreign key', async () => {
+    const user = getTestUser()
+
+    const count = await processGarminData(
+      user,
+      'activities',
+      [makeActivity({ activityName: 'Kite Day', activityType: { typeKey: 'kitesurfing' } })],
+      realDeps,
+    )
+
+    expect(count).toBe(1)
+    const stored = await getStoredActivities(user)
+    expect(stored).toHaveLength(1)
+    expect(stored[0].activity_type).toBe('other_workout')
+    expect(stored[0].data.garmin_type_key).toBe('kitesurfing')
+  })
+
+  test('a failing activity does not stop the rest of the batch', async () => {
+    const user = getTestUser()
+
+    // title is VARCHAR(255) — an over-long one fails at the DB, standing in for
+    // any per-activity error Garmin might hand us.
+    const data = [
+      makeActivity({ activityId: 1, activityName: 'x'.repeat(300) }),
+      makeActivity({ activityId: 2, activityName: 'Evening Row' }),
+    ]
+
+    const count = await processGarminData(user, 'activities', data, realDeps)
+
+    expect(count).toBe(1)
+    const stored = await getStoredActivities(user)
+    expect(stored).toHaveLength(1)
+    expect(stored[0].title).toBe('Evening Row')
+
+    const audit = await query(user, `SELECT message, details FROM audit_log WHERE level = 'error'`, [])
+    expect(audit.rows).toHaveLength(1)
+    expect(audit.rows[0].message).toContain('1')
+  })
+})

--- a/apps/backend/src/integrations/garmin/process.test.ts
+++ b/apps/backend/src/integrations/garmin/process.test.ts
@@ -5,7 +5,19 @@ import type { GarminProcessDeps } from './process.ts'
 
 import { extractNumericValue, processActivityDetail, processGarminData } from './process.ts'
 
+/** Activity types the mocked activity_type_definitions table contains. */
+const definedActivityTypes = new Set([
+  'meditation',
+  'other_workout',
+  'rowing',
+  'rowing_machine',
+  'running',
+  'yoga',
+])
+
 const mockDeps: GarminProcessDeps = {
+  activityTypeExists: vi.fn(async (_user: string, name: string) => definedActivityTypes.has(name)),
+  auditError: vi.fn(),
   deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   insertActivity: vi.fn().mockResolvedValue(undefined),
   insertLocations: vi.fn().mockResolvedValue(undefined),
@@ -858,11 +870,12 @@ describe('processGarminData', () => {
       expect(activityArg.title).toBe('running')
     })
 
-    test('uses "unknown" as activity_type when activityType is missing', async () => {
+    test('falls back to other_workout when activityType is missing', async () => {
       await processGarminData(user, 'activities', [makeActivity({ activityType: null })], mockDeps)
 
       const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
-      expect(activityArg.activity_type).toBe('unknown')
+      expect(activityArg.activity_type).toBe('other_workout')
+      expect(activityArg.data).toMatchObject({ garmin_type_key: 'unknown' })
     })
 
     test('processes multiple activities and returns count', async () => {
@@ -930,6 +943,84 @@ describe('processGarminData', () => {
 
       const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
       expect(activityArg.activity_type).toBe('running')
+    })
+
+    test('strips the version suffix from a versioned typeKey', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityName: 'Gothenburg Rowing', activityType: { typeKey: 'rowing_v2' } })],
+        mockDeps,
+      )
+
+      const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activityArg.activity_type).toBe('rowing')
+      expect(activityArg.data).not.toHaveProperty('garmin_type_key')
+    })
+
+    test('applies the override map to the unversioned form of a versioned typeKey', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityType: { typeKey: 'indoor_rowing_v2' } })],
+        mockDeps,
+      )
+
+      const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activityArg.activity_type).toBe('rowing_machine')
+    })
+
+    test('falls back to other_workout for a typeKey with no definition', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityName: 'Kite Day', activityType: { typeKey: 'kitesurfing' } })],
+        mockDeps,
+      )
+
+      const activityArg = vi.mocked(mockDeps.insertActivity).mock.calls[0]![1]
+      expect(activityArg.activity_type).toBe('other_workout')
+      expect(activityArg.data).toMatchObject({ garmin_type_key: 'kitesurfing' })
+      expect(activityArg.title).toBe('Kite Day')
+    })
+
+    test('deletes the previous activity using the resolved type, not the raw typeKey', async () => {
+      await processGarminData(
+        user,
+        'activities',
+        [makeActivity({ activityType: { typeKey: 'rowing_v2' } })],
+        mockDeps,
+      )
+
+      expect(mockDeps.deleteGarminActivityWithWrongType).toHaveBeenCalledWith(user, 12345, 'rowing')
+    })
+
+    test('looks up each distinct typeKey only once per batch', async () => {
+      const data = [
+        makeActivity({ activityId: 1, activityType: { typeKey: 'rowing_v2' } }),
+        makeActivity({ activityId: 2, activityType: { typeKey: 'rowing_v2' } }),
+        makeActivity({ activityId: 3, activityType: { typeKey: 'yoga' } }),
+      ]
+
+      await processGarminData(user, 'activities', data, mockDeps)
+
+      expect(mockDeps.activityTypeExists).toHaveBeenCalledTimes(2)
+    })
+
+    test('keeps processing the batch when one activity fails', async () => {
+      vi.mocked(mockDeps.insertActivity).mockRejectedValueOnce(new Error('boom'))
+      const data = [makeActivity({ activityId: 1 }), makeActivity({ activityId: 2 })]
+
+      const result = await processGarminData(user, 'activities', data, mockDeps)
+
+      expect(result).toBe(1)
+      expect(mockDeps.insertActivity).toHaveBeenCalledTimes(2)
+      expect(mockDeps.auditError).toHaveBeenCalledWith(
+        user,
+        'sync',
+        expect.stringContaining('1'),
+        expect.objectContaining({ error: 'boom' }),
+      )
     })
 
     test('calls deleteGarminActivityWithWrongType before insert', async () => {

--- a/apps/backend/src/integrations/garmin/process.ts
+++ b/apps/backend/src/integrations/garmin/process.ts
@@ -22,6 +22,7 @@ import type {
 } from './client.ts'
 
 import {
+  activityTypeExists,
   deleteGarminActivityWithWrongType,
   insertActivity,
   insertLocations,
@@ -29,6 +30,7 @@ import {
   insertTimeSeries,
   softDeleteLocationRange,
 } from '../../db/index.ts'
+import { auditError } from '../../services/audit-log.ts'
 
 // ============================================================================
 // Types
@@ -66,6 +68,8 @@ export const garminDataTypes: GarminDataType[] = [
 // ============================================================================
 
 export interface GarminProcessDeps {
+  activityTypeExists: typeof activityTypeExists
+  auditError: typeof auditError
   deleteGarminActivityWithWrongType: typeof deleteGarminActivityWithWrongType
   insertActivity: typeof insertActivity
   insertLocations: typeof insertLocations
@@ -75,6 +79,8 @@ export interface GarminProcessDeps {
 }
 
 const defaultDeps: GarminProcessDeps = {
+  activityTypeExists,
+  auditError,
   deleteGarminActivityWithWrongType,
   insertActivity,
   insertLocations,
@@ -97,6 +103,47 @@ const garminTypeKeyOverrides: Record<string, string> = {
   stair_stepper: 'stair_climbing_machine',
   stationary_biking: 'biking_stationary',
   treadmill_running: 'running_treadmill',
+}
+
+/** Activity type used when a Garmin typeKey resolves to no known definition. */
+const fallbackActivityType = 'other_workout'
+
+/**
+ * Garmin revises sport keys in place and marks the new shape with a version
+ * suffix (`rowing_v2`, `indoor_rowing_v2`, …). The suffix carries no meaning
+ * for us, so drop it and resolve the unversioned key.
+ */
+const stripVersionSuffix = (typeKey: string): string => typeKey.replace(/_v\d+$/, '')
+
+interface ResolvedActivityType {
+  activity_type: string
+  /** The original Garmin typeKey, kept only when it could not be mapped. */
+  unmapped_key?: string
+}
+
+/**
+ * Resolve a Garmin typeKey to an activity type that exists in
+ * activity_type_definitions. Unknown keys degrade to `other_workout` instead of
+ * failing the insert on the activities → activity_type_definitions foreign key,
+ * which would abort the rest of the batch and every day of the sync range.
+ */
+const resolveActivityType = async (
+  user: string,
+  typeKey: string,
+  deps: GarminProcessDeps,
+  cache: Map<string, ResolvedActivityType>,
+): Promise<ResolvedActivityType> => {
+  const cached = cache.get(typeKey)
+  if (cached) return cached
+
+  const unversioned = stripVersionSuffix(typeKey)
+  const mapped = garminTypeKeyOverrides[typeKey] ?? garminTypeKeyOverrides[unversioned] ?? unversioned
+  const resolved: ResolvedActivityType = (await deps.activityTypeExists(user, mapped))
+    ? { activity_type: mapped }
+    : { activity_type: fallbackActivityType, unmapped_key: typeKey }
+
+  cache.set(typeKey, resolved)
+  return resolved
 }
 
 // ============================================================================
@@ -442,6 +489,61 @@ const processBodyBattery = async (
 // ---------------------------------------------------------------------------
 // Activities (exercise)
 // ---------------------------------------------------------------------------
+const processActivity = async (
+  user: string,
+  act: IActivity,
+  deps: GarminProcessDeps,
+  typeCache: Map<string, ResolvedActivityType>,
+): Promise<void> => {
+  const externalId = `garmin-activity-${act.activityId}`
+  const startTime = new Date(act.startTimeGMT || act.beginTimestamp)
+  const durationMs = (act.duration || act.elapsedDuration || 0) * 1000
+  const endTime = new Date(startTime.getTime() + durationMs)
+
+  await deps.insertRawRecord(user, makeRaw('garmin_activity', externalId, startTime, act))
+
+  const activityTypeKey = act.activityType?.typeKey ?? 'unknown'
+  const resolved = await resolveActivityType(user, activityTypeKey, deps, typeCache)
+  const exerciseTitle = act.activityName || activityTypeKey
+
+  // Clean up any existing activity with a different type (handles re-sync after type mapping changes)
+  await deps.deleteGarminActivityWithWrongType(user, act.activityId, resolved.activity_type)
+
+  const activity: Activity = {
+    activity_type: resolved.activity_type,
+    data: {
+      average_hr: act.averageHR,
+      calories: act.calories,
+      distance: act.distance,
+      elevation_gain: act.elevationGain,
+      garmin_activity_id: act.activityId,
+      ...(resolved.unmapped_key ? { garmin_type_key: resolved.unmapped_key } : {}),
+      max_hr: act.maxHR,
+      steps: act.steps,
+      vo2_max: act.vO2MaxValue,
+    },
+    end_time: endTime,
+    source: 'garmin',
+    start_time: startTime,
+    title: exerciseTitle,
+  }
+  await deps.insertActivity(user, activity)
+
+  // Time series from activity summary
+  const points: TimeSeriesPoint[] = []
+  if (act.vO2MaxValue > 0) {
+    points.push({
+      metric: 'vo2_max',
+      source: 'garmin',
+      time: startTime,
+      unit: 'mL/kg/min',
+      value: act.vO2MaxValue,
+    })
+  }
+
+  if (points.length > 0) await deps.insertTimeSeries(user, points)
+}
+
 const processActivities = async (
   user: string,
   data: IActivity[],
@@ -449,57 +551,23 @@ const processActivities = async (
 ): Promise<number> => {
   if (!Array.isArray(data) || data.length === 0) return 0
 
+  const typeCache = new Map<string, ResolvedActivityType>()
   let count = 0
   for (const act of data) {
     if (!act?.activityId) continue
 
-    const externalId = `garmin-activity-${act.activityId}`
-    const startTime = new Date(act.startTimeGMT || act.beginTimestamp)
-    const durationMs = (act.duration || act.elapsedDuration || 0) * 1000
-    const endTime = new Date(startTime.getTime() + durationMs)
-
-    await deps.insertRawRecord(user, makeRaw('garmin_activity', externalId, startTime, act))
-
-    const activityTypeKey = act.activityType?.typeKey ?? 'unknown'
-    const activityType = garminTypeKeyOverrides[activityTypeKey] ?? activityTypeKey
-    const exerciseTitle = act.activityName || activityTypeKey
-
-    // Clean up any existing activity with a different type (handles re-sync after type mapping changes)
-    await deps.deleteGarminActivityWithWrongType(user, act.activityId, activityType)
-
-    const activity: Activity = {
-      activity_type: activityType,
-      data: {
-        average_hr: act.averageHR,
-        calories: act.calories,
-        distance: act.distance,
-        elevation_gain: act.elevationGain,
-        garmin_activity_id: act.activityId,
-        max_hr: act.maxHR,
-        steps: act.steps,
-        vo2_max: act.vO2MaxValue,
-      },
-      end_time: endTime,
-      source: 'garmin',
-      start_time: startTime,
-      title: exerciseTitle,
-    }
-    await deps.insertActivity(user, activity)
-
-    // Time series from activity summary
-    const points: TimeSeriesPoint[] = []
-    if (act.vO2MaxValue > 0) {
-      points.push({
-        metric: 'vo2_max',
-        source: 'garmin',
-        time: startTime,
-        unit: 'mL/kg/min',
-        value: act.vO2MaxValue,
+    // One bad activity must not cost us the rest of the batch — Garmin returns
+    // the most recent activities on every day of the sync range, so a persistent
+    // failure here would otherwise block every later activity indefinitely.
+    try {
+      await processActivity(user, act, deps, typeCache)
+      count++
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      deps.auditError(user, 'sync', `Failed to process Garmin activity ${act.activityId}`, {
+        error: message,
       })
     }
-
-    if (points.length > 0) await deps.insertTimeSeries(user, points)
-    count++
   }
   return count
 }

--- a/apps/backend/src/integrations/garmin/resync.integration.test.ts
+++ b/apps/backend/src/integrations/garmin/resync.integration.test.ts
@@ -10,8 +10,15 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import type { GarminActivityDetailResponse } from './client.ts'
 
-import { getTimeSeries, insertLocations, insertRawRecord, insertTimeSeries } from '../../db/index.ts'
+import {
+  activityTypeExists,
+  getTimeSeries,
+  insertLocations,
+  insertRawRecord,
+  insertTimeSeries,
+} from '../../db/index.ts'
 import { softDeleteLocationRange } from '../../db/locations.ts'
+import { auditError } from '../../services/audit-log.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
 import { processActivityDetail } from './process.ts'
 
@@ -35,6 +42,8 @@ describe('Garmin resync integration', () => {
   })
 
   const realDeps = {
+    activityTypeExists,
+    auditError,
     deleteGarminActivityWithWrongType: async () => null as string | null,
     insertActivity: async () => '' as string,
     insertLocations,

--- a/apps/backend/src/integrations/garmin/sync.test.ts
+++ b/apps/backend/src/integrations/garmin/sync.test.ts
@@ -13,6 +13,7 @@ import {
 
 // Mock the db module (include all exports used by garmin-process.ts too)
 vi.mock('../../db/index.ts', () => ({
+  activityTypeExists: vi.fn().mockResolvedValue(true),
   deleteGarminActivityWithWrongType: vi.fn().mockResolvedValue(null),
   getActivitiesNeedingDetail: vi.fn().mockResolvedValue([]),
   getSyncState: vi.fn(),

--- a/docs/garmin.md
+++ b/docs/garmin.md
@@ -23,6 +23,16 @@ All data is also preserved as raw JSON in the `raw_records` table.
 
 > **Note on `calories_active` and `calories_total`:** these metrics are stored from Garmin's daily summary (source `garmin`) but **excluded from queries** — aurboda recomputes them per-minute from HR data using the zone-METs model and is the authoritative source for both metrics. See [`docs/features/calories.md`](./features/calories.md) for the model and the source-filter rationale.
 
+## Activity Type Mapping
+
+Garmin labels each activity with a `typeKey` (e.g. `running`, `indoor_rowing`, `rowing_v2`). It is resolved to an aurboda activity type in this order:
+
+1. **Override map** — Garmin names that differ from the Health Connect exercise names used in `@aurboda/api-spec` (e.g. `treadmill_running` → `running_treadmill`, `indoor_rowing` → `rowing_machine`, `breathwork` → `meditation`). Aligning the names keeps cross-source merging working.
+2. **Version suffix stripped** — Garmin revises sport keys in place and marks them with a version suffix, so `rowing_v2` resolves as `rowing` and `indoor_rowing_v2` goes through the override map as `indoor_rowing`.
+3. **Fallback** — if the resulting name has no row in `activity_type_definitions`, the activity is stored as `other_workout` with the original key kept in `data.garmin_type_key`. Without this, an unrecognized sport would violate the `activities.activity_type` foreign key and abort the rest of the batch.
+
+Grep `data.garmin_type_key` (via `query_activities` or `query_raw_records`) to find sports worth adding to the override map. A failure on one activity is logged to the audit log and does not stop the remaining activities in the batch.
+
 ## Admin Setup
 
 No server-side admin configuration is needed. Unlike Oura (which requires OAuth client credentials), Garmin Connect integration uses per-user credentials to authenticate directly with Garmin's web services.


### PR DESCRIPTION
## Problem

Garmin sync reported one error per date:

```json
{ "date": "2026-08-03", "error": "insert or update on table \"activities\" violates foreign key constraint \"fk_activities_type\"" }
```

The raw payload showed the culprit:

```json
{ "activityName": "Gothenburg Rowing", "activityType": { "typeKey": "rowing_v2" } }
```

`rowing` and `rowing_machine` both exist as builtin definitions — Garmin has just moved to a versioned key. `processActivities` passed the raw `typeKey` straight through to `activities.activity_type`, which has a FK to `activity_type_definitions(name)`, so the insert threw.

Blast radius was larger than one activity:

- activities are fetched by offset/limit, not per day (`sync.ts:310-312`), so the same bad activity re-threw on **every** day of the sync range;
- `processActivities` had no per-activity isolation, so every activity behind it in the batch was skipped too.

## Fix

Activity type resolution (`resolveActivityType`):

1. override map on the raw `typeKey` (unchanged behaviour);
2. **strip Garmin's version suffix** — `rowing_v2` → `rowing`, `indoor_rowing_v2` → the existing `indoor_rowing` override → `rowing_machine`;
3. **fall back to `other_workout`** when the resolved name has no definition, keeping the original key in `data.garmin_type_key` so unmapped sports are discoverable rather than silently lost.

Results are cached per batch, so it costs one `activityTypeExists` lookup per distinct typeKey.

Each activity is also processed in its own `try`/`catch` with the failure audit-logged, so one bad activity can no longer take the batch with it. This incidentally fixes `act.activityType?.typeKey ?? 'unknown'`, which was itself a type with no definition.

## Tests

- Unit (`process.test.ts`): version-suffix stripping, override-after-strip, fallback + `garmin_type_key`, resolved type passed to `deleteGarminActivityWithWrongType`, per-typeKey lookup caching, batch survives a failing activity.
- Integration (`process.integration.test.ts`, new): runs `processGarminData` against a real PostgreSQL container **with the FK enforced**, so it reproduces the original failure and proves the three paths land rows.
- Docs: new "Activity Type Mapping" section in `docs/garmin.md`.

`pnpm check` clean; 2253 backend unit tests pass.

## Follow-up

Nothing to clean up in the DB — the failed inserts never landed. A Garmin resync after deploy picks the activity up (the raw records were already stored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWdJQ7hJVBqnAiypgzshEK