### PR TITLE
perf(activities): window summary metrics by binary search, not a rescan

### DIFF
--- a/apps/backend/src/services/queries/activity-summary-metrics.test.ts
+++ b/apps/backend/src/services/queries/activity-summary-metrics.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
-import { computeActivitySummaryMetrics, type SummaryMetricSeries } from './activity-summary-metrics.ts'
+import {
+  computeActivitySummaryMetrics,
+  type SummaryMetricSeries,
+  windowBounds,
+} from './activity-summary-metrics.ts'
 
 const start = new Date('2024-01-15T10:00:00Z')
 const end = new Date('2024-01-15T10:10:00Z') // 10 minutes
@@ -196,5 +200,57 @@ describe('computeActivitySummaryMetrics', () => {
     }
     const result = computeActivitySummaryMetrics({ end_time: end, start_time: start }, series)
     expect(result.avg_hr).toBe(135)
+  })
+})
+
+describe('windowBounds', () => {
+  const points: [Date, number][] = [0, 60, 120, 180, 240].map((sec) => [at(sec), sec])
+
+  test('covers an inclusive range', () => {
+    expect(windowBounds(points, at(60), at(180))).toEqual([1, 4])
+  })
+
+  test('includes a point landing exactly on either edge', () => {
+    // The pre-binary-search filter was `t >= start && t <= end`, so both ends
+    // are inclusive — an activity's first and last sample must not drop out.
+    expect(windowBounds(points, at(0), at(240))).toEqual([0, 5])
+    expect(windowBounds(points, at(120), at(120))).toEqual([2, 3])
+  })
+
+  test('returns an empty range when nothing falls inside', () => {
+    expect(windowBounds(points, at(300), at(400))).toEqual([5, 5])
+    expect(windowBounds(points, at(-100), at(-50))).toEqual([0, 0])
+    expect(windowBounds(points, at(61), at(119))).toEqual([2, 2])
+  })
+
+  test('handles an empty series', () => {
+    expect(windowBounds([], at(0), at(60))).toEqual([0, 0])
+  })
+
+  test('agrees with a linear scan across every offset pair', () => {
+    // Parity with the filter this replaced, which is the only guarantee that
+    // matters — binary search is easy to get subtly wrong at the edges.
+    const offsets = [-30, 0, 30, 60, 90, 120, 150, 180, 210, 240, 270]
+    for (const from of offsets) {
+      for (const to of offsets) {
+        if (to < from) continue
+        const [lo, hi] = windowBounds(points, at(from), at(to))
+        const scanned = points.filter(([t]) => t >= at(from) && t <= at(to))
+        expect(points.slice(lo, hi)).toEqual(scanned)
+      }
+    }
+  })
+
+  test('windows a long series without rescanning it per activity', () => {
+    // The outage shape: one series fetched for a wide span, many activities each
+    // asking for their own window. 200k points is ~2.3 days at 1Hz.
+    const long: [Date, number][] = Array.from({ length: 200_000 }, (_, i) => [at(i), i])
+    const activityStarts = Array.from({ length: 500 }, (_, i) => i * 400)
+
+    for (const offset of activityStarts) {
+      const [lo, hi] = windowBounds(long, at(offset), at(offset + 100))
+      expect(hi - lo).toBe(101)
+      expect(long[lo][1]).toBe(offset)
+    }
   })
 })

--- a/apps/backend/src/services/queries/activity-summary-metrics.ts
+++ b/apps/backend/src/services/queries/activity-summary-metrics.ts
@@ -10,8 +10,6 @@
 
 import type { ActivitySummaryMetrics, MetricType } from '@aurboda/api-spec'
 
-import { maxOf } from '../numeric-extremes.ts'
-
 type TimeSeriesPoint = [Date, number]
 
 /** Time-series metrics needed to compute summary fields. */
@@ -40,19 +38,69 @@ const round = (value: number, decimals: number): number => {
   return Math.round(value * f) / f
 }
 
-const positiveValues = (points: TimeSeriesPoint[]): number[] => points.flatMap(([, v]) => (v > 0 ? [v] : []))
+/**
+ * Index of the first point at or after `time`. Valid because
+ * `getTimeSeriesMultiMetric` orders by `(metric, time)`.
+ */
+const lowerBound = (points: TimeSeriesPoint[], time: number): number => {
+  let lo = 0
+  let hi = points.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (points[mid][0].getTime() < time) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
 
-const mean = (values: number[]): number | undefined =>
-  values.length === 0 ? undefined : values.reduce((s, v) => s + v, 0) / values.length
+/**
+ * Half-open index range `[lo, hi)` covering `[start, end]` inclusive.
+ *
+ * Replaces a `filter` over the whole series. The caller fetches one series for
+ * the entire requested span and asks for a window per activity per metric, so a
+ * scan made the enrichment `O(activities × metrics × series)` — a wide timeline
+ * range over per-second data blocked the event loop long enough to stop the
+ * process answering anything. Binary search makes it `O(log series + window)`.
+ */
+export const windowBounds = (points: TimeSeriesPoint[], start: Date, end: Date): [number, number] => [
+  lowerBound(points, start.getTime()),
+  // end is inclusive; +1ms finds the first point strictly after it
+  lowerBound(points, end.getTime() + 1),
+]
 
-const inRange = (points: TimeSeriesPoint[], start: Date, end: Date): TimeSeriesPoint[] =>
-  points.filter(([t]) => t >= start && t <= end)
+/** Mean of the positive values in `[lo, hi)`, or undefined when there are none. */
+const meanPositive = (points: TimeSeriesPoint[], lo: number, hi: number): number | undefined => {
+  let sum = 0
+  let count = 0
+  for (let i = lo; i < hi; i++) {
+    const value = points[i][1]
+    if (value > 0) {
+      sum += value
+      count++
+    }
+  }
+  return count === 0 ? undefined : sum / count
+}
 
-/** Sum the positive deltas (gain) and negated negative deltas (loss). */
-const elevationGainLoss = (points: TimeSeriesPoint[]): { gain: number; loss: number } => {
+/** Largest positive value in `[lo, hi)`, or undefined when there is none. */
+const maxPositive = (points: TimeSeriesPoint[], lo: number, hi: number): number | undefined => {
+  let max: number | undefined
+  for (let i = lo; i < hi; i++) {
+    const value = points[i][1]
+    if (value > 0 && (max === undefined || value > max)) max = value
+  }
+  return max
+}
+
+/** Sum the positive deltas (gain) and negated negative deltas (loss) in `[lo, hi)`. */
+const elevationGainLoss = (
+  points: TimeSeriesPoint[],
+  lo: number,
+  hi: number,
+): { gain: number; loss: number } => {
   let gain = 0
   let loss = 0
-  for (let i = 1; i < points.length; i++) {
+  for (let i = lo + 1; i < hi; i++) {
     const delta = points[i][1] - points[i - 1][1]
     if (delta > 0) gain += delta
     else if (delta < 0) loss -= delta
@@ -102,22 +150,22 @@ const computePace = (
 
 const computeHrFromSeries = (
   current: { avg_hr?: number; max_hr?: number },
-  hrValues: number[],
+  avg: number | undefined,
+  max: number | undefined,
 ): { avg_hr?: number; max_hr?: number } => {
-  if (hrValues.length === 0) return {}
   const out: { avg_hr?: number; max_hr?: number } = {}
-  if (current.avg_hr === undefined) {
-    out.avg_hr = Math.round(hrValues.reduce((s, v) => s + v, 0) / hrValues.length)
-  }
-  if (current.max_hr === undefined) out.max_hr = maxOf(hrValues)
+  if (current.avg_hr === undefined && avg !== undefined) out.avg_hr = Math.round(avg)
+  if (current.max_hr === undefined && max !== undefined) out.max_hr = max
   return out
 }
 
 const computeElevationFromSeries = (
   points: TimeSeriesPoint[],
+  lo: number,
+  hi: number,
 ): { elevation_gain?: number; elevation_loss?: number } => {
-  if (points.length < 2) return {}
-  const { gain, loss } = elevationGainLoss(points)
+  if (hi - lo < 2) return {}
+  const { gain, loss } = elevationGainLoss(points, lo, hi)
   const out: { elevation_gain?: number; elevation_loss?: number } = {}
   if (gain > 0) out.elevation_gain = round(gain, 1)
   if (loss > 0) out.elevation_loss = round(loss, 1)
@@ -126,9 +174,11 @@ const computeElevationFromSeries = (
 
 const computeBodyBatteryFromSeries = (
   points: TimeSeriesPoint[],
+  lo: number,
+  hi: number,
 ): { body_battery_before?: number; body_battery_after?: number } => {
-  if (points.length === 0) return {}
-  return { body_battery_after: points[points.length - 1][1], body_battery_before: points[0][1] }
+  if (hi === lo) return {}
+  return { body_battery_after: points[hi - 1][1], body_battery_before: points[lo][1] }
 }
 
 /**
@@ -147,20 +197,33 @@ export const computeActivitySummaryMetrics = (
   const end = activity.end_time
   if (!end) return result
 
-  const window = (metric: SummaryMetric): TimeSeriesPoint[] =>
-    inRange(series[metric] ?? [], activity.start_time, end)
+  /** Series for `metric` plus the index range covering this activity. */
+  const window = (metric: SummaryMetric) => {
+    const points = series[metric] ?? []
+    const [lo, hi] = windowBounds(points, activity.start_time, end)
+    return { hi, lo, points }
+  }
   const avgPositive = (metric: SummaryMetric, decimals: number): number | undefined => {
-    const v = mean(positiveValues(window(metric)))
+    const { hi, lo, points } = window(metric)
+    const v = meanPositive(points, lo, hi)
     return v === undefined ? undefined : round(v, decimals)
   }
 
-  const speedAvgRaw = mean(positiveValues(window('speed')))
+  const speed = window('speed')
+  const hr = window('heart_rate')
+  const elevation = window('elevation')
+  const bodyBattery = window('body_battery')
+
   Object.assign(
     result,
-    computePace(speedAvgRaw, result.distance, (end.getTime() - activity.start_time.getTime()) / 1000),
-    computeHrFromSeries(result, positiveValues(window('heart_rate'))),
-    computeElevationFromSeries(window('elevation')),
-    computeBodyBatteryFromSeries(window('body_battery')),
+    computePace(
+      meanPositive(speed.points, speed.lo, speed.hi),
+      result.distance,
+      (end.getTime() - activity.start_time.getTime()) / 1000,
+    ),
+    computeHrFromSeries(result, meanPositive(hr.points, hr.lo, hr.hi), maxPositive(hr.points, hr.lo, hr.hi)),
+    computeElevationFromSeries(elevation.points, elevation.lo, elevation.hi),
+    computeBodyBatteryFromSeries(bodyBattery.points, bodyBattery.lo, bodyBattery.hi),
   )
   result.avg_cadence = avgPositive('run_cadence', 1) ?? result.avg_cadence
   result.avg_stride_length = avgPositive('stride_length', 2) ?? result.avg_stride_length


### PR DESCRIPTION
## The hot path

`queryActivities` fetches one time-series per summary metric for the **entire requested span** (`activities.ts:181-183`), then `computeActivitySummaryMetrics` called `inRange` — a full `points.filter(...)` — once per activity **per metric**, across 8 metrics:

```ts
const window = (metric) => inRange(series[metric] ?? [], activity.start_time, end)
```

So enrichment was `O(activities × 8 × series)`, synchronous on the event loop, with two array allocations per metric per activity (`filter` then `flatMap` in `positiveValues`).

That is what stopped the backend answering anything after a wide timeline zoom-out. Nothing crashed — one request held the only thread long enough that `/api/version` never got a turn, and the browser's retries queued more of the same. The `RangeError` in that incident was a separate symptom, fixed in #980.

## The change

`windowBounds` binary-searches the `[lo, hi)` index range, which is valid because `getTimeSeriesMultiMetric` orders by `(metric, time)`. The aggregates (`meanPositive`, `maxPositive`, `elevationGainLoss`, body-battery first/last) now read that range in place instead of slicing.

Per activity per metric: `O(series)` with two allocations → `O(log series + window)` with none.

## Behaviour is unchanged

All 13 existing tests pass untouched. The new ones cover the parts binary search gets subtly wrong:

- both edges inclusive (the old predicate was `t >= start && t <= end`, so an activity's first and last sample must not drop out);
- empty ranges before, after, and *between* points;
- an empty series;
- **parity with the old scan**: `points.slice(lo, hi)` equals `points.filter(...)` for every pair of offsets, including ones that land between samples;
- the outage shape — a 200k-point series (~2.3 days at 1 Hz) windowed by 500 activities.

## What this does *not* address

The **fetch volume**. A months-wide span still asks the DB for every summary-metric row in it and materialises them as JS `[Date, number]` pairs, and no amount of windowing helps once that is tens of millions of rows.

I have deliberately not built bucketing or a span guard for it yet, because the evidence points elsewhere for the reported incident: the `RangeError` was `>65k` HR points inside a *single* activity window, i.e. one activity spanning 18h+ at 1 Hz, and `hasExerciseLike` only matches `activity_type === 'exercise'` exactly — not subtypes — so the wide fetch is narrower in practice than it looks. Worth measuring a real year-wide request against this branch before designing for it, rather than guessing at the shape.

`pnpm check` clean; 2296 backend unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWdJQ7hJVBqnAiypgzshEK