### PR TITLE
fix(android): let the More tab button return to its hub

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import net.aurboda.ui.screens.MoreDestination
 
 enum class AppScreen {
     Login,
@@ -24,12 +25,17 @@ enum class MainTab {
 class AppState(
     private val context: Context,
     initialScreen: AppScreen,
-    initialTab: MainTab = MainTab.Home
+    initialTab: MainTab = MainTab.Home,
+    initialMoreDestination: MoreDestination? = null
 ) {
     var currentScreen by mutableStateOf(initialScreen)
         private set
 
     var currentTab by mutableStateOf(initialTab)
+        private set
+
+    /** The sub-page pushed inside the More tab, or null while its hub is showing. */
+    var moreDestination by mutableStateOf(initialMoreDestination)
         private set
 
     var pendingServerUrl by mutableStateOf<String?>(null)
@@ -46,6 +52,7 @@ class AppState(
     fun logout() {
         CredentialsManager.clearCredentials(context)
         currentTab = MainTab.Home
+        moreDestination = null
         currentScreen = AppScreen.Login
     }
 
@@ -55,19 +62,32 @@ class AppState(
     }
 
     fun selectTab(tab: MainTab) {
+        // Tapping More always shows its hub -- also when More is already the
+        // current tab on one of its sub-pages, which would otherwise leave the
+        // menu unreachable except by the back gesture.
+        if (tab == MainTab.More) moreDestination = null
         currentTab = tab
+    }
+
+    fun openMoreDestination(destination: MoreDestination) {
+        moreDestination = destination
+    }
+
+    fun closeMoreDestination() {
+        moreDestination = null
     }
 }
 
 @Composable
-fun rememberAppState(initialTab: MainTab? = null): AppState {
+fun rememberAppState(initialTab: MainTab? = null, initialMorePath: String? = null): AppState {
     val context = LocalContext.current
     return remember {
         val hasCredentials = CredentialsManager.hasCredentials(context)
         AppState(
             context = context,
             initialScreen = if (hasCredentials) AppScreen.Main else AppScreen.Login,
-            initialTab = initialTab ?: MainTab.Home
+            initialTab = initialTab ?: MainTab.Home,
+            initialMoreDestination = initialMorePath?.let { MoreDestination.Web(it) }
         )
     }
 }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -182,10 +182,9 @@ private const val VERSION_JSON_URL = "https://github.com/fiddur/aurboda/releases
 @Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
 @Composable
 fun AurbodaApp(initialTab: MainTab? = null, initialMorePath: String? = null) {
-  val appState = rememberAppState(initialTab = initialTab)
-  // Consumed once: a widget/notification deep link into a More web page opens it
-  // on first composition, then clears so returning to More later shows the hub.
-  var pendingMorePath by remember { mutableStateOf(initialMorePath) }
+  // A widget/notification deep link into a More web page opens it on first
+  // composition; tapping More later returns to the hub (AppState.selectTab).
+  val appState = rememberAppState(initialTab = initialTab, initialMorePath = initialMorePath)
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
   val ktorHttpClient = remember { syncHttpClient() }
@@ -338,10 +337,11 @@ fun AurbodaApp(initialTab: MainTab? = null, initialMorePath: String? = null) {
           moreContent = { modifier ->
             net.aurboda.ui.screens.MoreScreen(
               credentials = credentials,
+              destination = appState.moreDestination,
+              onSelect = { destination -> appState.openMoreDestination(destination) },
+              onBack = { appState.closeMoreDestination() },
               onServerUrlChange = { newUrl -> appState.changeServerUrl(newUrl) },
               onLogout = { appState.logout() },
-              initialPath = pendingMorePath,
-              onInitialPathConsumed = { pendingMorePath = null },
               modifier = modifier,
             )
           },

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
@@ -16,11 +16,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -98,26 +93,24 @@ val moreGroups: List<MoreGroup> = listOf(
  * screens); the system back gesture returns to the hub — after any embedded page
  * has exhausted its own WebView history (EmbeddedWebScreen owns that inner
  * BackHandler, which is composed after this one so it takes precedence).
+ *
+ * [destination] is hoisted into `AppState` so the bottom bar can pop back to the
+ * hub when More is tapped while a sub-page is showing.
  */
-@Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
 @Composable
 fun MoreScreen(
     credentials: CredentialsManager.Credentials,
+    destination: MoreDestination?,
+    onSelect: (MoreDestination) -> Unit,
+    onBack: () -> Unit,
     onServerUrlChange: (String) -> Unit,
     onLogout: () -> Unit,
     modifier: Modifier = Modifier,
-    initialPath: String? = null,
-    onInitialPathConsumed: () -> Unit = {},
 ) {
-    // A deep link (e.g. the goals widget) can open this hub directly on a web
-    // page; consumed once so a later manual visit to More shows the hub.
-    var destination by remember { mutableStateOf<MoreDestination?>(initialPath?.let { MoreDestination.Web(it) }) }
-    LaunchedEffect(Unit) { if (initialPath != null) onInitialPathConsumed() }
-
     when (val dest = destination) {
-        null -> MoreHub(onSelect = { destination = it }, modifier = modifier)
+        null -> MoreHub(onSelect = onSelect, modifier = modifier)
         else -> {
-            BackHandler { destination = null }
+            BackHandler { onBack() }
             when (dest) {
                 is MoreDestination.Web ->
                     EmbeddedWebScreen(

--- a/apps/android/app/src/test/java/net/aurboda/AppStateNavigationTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateNavigationTest.kt
@@ -1,0 +1,98 @@
+package net.aurboda
+
+import androidx.test.core.app.ApplicationProvider
+import net.aurboda.ui.screens.MoreDestination
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tab/More navigation rules. These exercise [AppState] directly; none of them
+ * touch the credential store, so no encrypted prefs are involved.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class AppStateNavigationTest {
+    private fun appState(
+        initialTab: MainTab = MainTab.Home,
+        initialMoreDestination: MoreDestination? = null,
+    ) = AppState(
+        context = ApplicationProvider.getApplicationContext(),
+        initialScreen = AppScreen.Main,
+        initialTab = initialTab,
+        initialMoreDestination = initialMoreDestination,
+    )
+
+    @Test
+    fun `selecting a tab makes it current`() {
+        val state = appState()
+        state.selectTab(MainTab.Feed)
+        assertEquals(MainTab.Feed, state.currentTab)
+    }
+
+    @Test
+    fun `More starts on the hub`() {
+        assertNull(appState(initialTab = MainTab.More).moreDestination)
+    }
+
+    @Test
+    fun `opening a More destination leaves the hub`() {
+        val state = appState(initialTab = MainTab.More)
+        state.openMoreDestination(MoreDestination.Web("/goals"))
+        assertEquals(MoreDestination.Web("/goals"), state.moreDestination)
+    }
+
+    @Test
+    fun `tapping More while already on a More sub-page returns to the hub`() {
+        val state = appState(initialTab = MainTab.More)
+        state.openMoreDestination(MoreDestination.Web("/goals"))
+
+        state.selectTab(MainTab.More)
+
+        assertEquals(MainTab.More, state.currentTab)
+        assertNull(state.moreDestination)
+    }
+
+    @Test
+    fun `coming back to More from another tab shows the hub`() {
+        val state = appState(initialTab = MainTab.More)
+        state.openMoreDestination(MoreDestination.Live)
+
+        state.selectTab(MainTab.Home)
+        state.selectTab(MainTab.More)
+
+        assertNull(state.moreDestination)
+    }
+
+    @Test
+    fun `closing a More destination returns to the hub`() {
+        val state = appState(initialTab = MainTab.More)
+        state.openMoreDestination(MoreDestination.Account)
+
+        state.closeMoreDestination()
+
+        assertNull(state.moreDestination)
+    }
+
+    @Test
+    fun `a deep link opens More on its destination`() {
+        val state = appState(initialTab = MainTab.More, initialMoreDestination = MoreDestination.Web("/goals"))
+
+        assertEquals(MainTab.More, state.currentTab)
+        assertEquals(MoreDestination.Web("/goals"), state.moreDestination)
+    }
+
+    @Test
+    fun `selecting another tab keeps the deep-linked More destination untouched until More is tapped`() {
+        val state = appState(initialTab = MainTab.More, initialMoreDestination = MoreDestination.Web("/goals"))
+
+        state.selectTab(MainTab.Home)
+        assertEquals(MoreDestination.Web("/goals"), state.moreDestination)
+
+        state.selectTab(MainTab.More)
+        assertNull(state.moreDestination)
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/ui/screens/MoreNavigationUiTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/ui/screens/MoreNavigationUiTest.kt
@@ -1,0 +1,82 @@
+package net.aurboda.ui.screens
+
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import net.aurboda.AppScreen
+import net.aurboda.AppState
+import net.aurboda.CredentialsManager
+import net.aurboda.MainTab
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The More tab wired to a real [AppState], as [net.aurboda.AurbodaApp] wires it:
+ * the bottom-bar More button has to reach the hub from a sub-page, not just from
+ * another tab.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class MoreNavigationUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val credentials =
+        CredentialsManager.Credentials(
+            serverUrl = "https://example.com",
+            username = "tester",
+            authToken = "token",
+        )
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            val appState =
+                remember {
+                    AppState(
+                        context = context,
+                        initialScreen = AppScreen.Main,
+                        initialTab = MainTab.More,
+                    )
+                }
+            MainScreen(
+                currentTab = appState.currentTab,
+                onTabSelected = { appState.selectTab(it) },
+                homeContent = {},
+                addContent = {},
+                feedContent = {},
+                syncContent = {},
+                moreContent = { modifier ->
+                    MoreScreen(
+                        credentials = credentials,
+                        destination = appState.moreDestination,
+                        onSelect = { appState.openMoreDestination(it) },
+                        onBack = { appState.closeMoreDestination() },
+                        onServerUrlChange = {},
+                        onLogout = {},
+                        modifier = modifier,
+                    )
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `tapping More from a More sub-page brings the hub back`() {
+        setContent()
+
+        composeTestRule.onNodeWithText("Account & server").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Account").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("More").performClick()
+
+        composeTestRule.onNodeWithText("Timeline").assertIsDisplayed()
+    }
+}

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -24,7 +24,10 @@ corresponding web page in an embedded WebView (Timeline, Data, Chart, Meals,
 Reports, Settings, Data sources, …). The two native-only screens — **Live**
 sensors (BLE) and **Account** (server URL, logout) — also live in the hub.
 Selecting an entry pushes it in place; the system back gesture returns to the
-hub (after any embedded page has exhausted its own WebView history). Keep
+hub (after any embedded page has exhausted its own WebView history), and so does
+tapping **More** on the bottom bar again. The pushed sub-page lives in
+`AppState.moreDestination` rather than inside `MoreScreen`, so `selectTab` can
+clear it — otherwise the hub would be unreachable from a sub-page. Keep
 `moreGroups` in sync with the web navigation (`apps/web/src/components/nav-links.ts`).
 
 A tab can move from embedded to native later (e.g. if the feed becomes a heavily


### PR DESCRIPTION
## Problem

On any page reachable from the **More** menu (Goals, Timeline, Settings, …) the
More icon in the bottom bar is marked selected and tapping it does nothing. The
hub is only reachable via the system back gesture.

`MoreScreen` owned the pushed sub-page in its own `remember`ed state, so
`onTabSelected(MainTab.More)` was a no-op when More was already the current tab.

## Fix

Hoist that sub-page into `AppState.moreDestination` and clear it in `selectTab`
whenever More is selected — so the button brings the menu up from anywhere the
menu isn't already up. `MoreScreen` becomes stateless (`destination` / `onSelect`
/ `onBack`).

The widget/notification deep link into a More page now seeds the destination at
`AppState` construction, which removes the `pendingMorePath` /
`onInitialPathConsumed` handshake. Behavior is unchanged: leaving More and coming
back still shows the hub.

## Tests

- `AppStateNavigationTest` — 8 tests over the tab/More rules (re-tap returns to
  the hub, returning from another tab shows the hub, deep-link seeding).
- `MoreNavigationUiTest` — Compose/Robolectric test driving the real `MainScreen`
  + `MoreScreen` + `AppState`: open a sub-page, tap **More**, hub is back.

Both fail with the one-line `selectTab` guard removed (verified), and the full
`./gradlew testDebugUnitTest` suite passes (22 suites, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LatGBTZyYz271275Ks3HtE