### PR TITLE
fix(android): keep the soft keyboard from covering focused inputs

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -102,6 +102,14 @@ android {
   testOptions {
     unitTests {
       isIncludeAndroidResources = true
+
+      // One JVM per test class. Compose UI tests leak state between classes in a
+      // shared JVM — a later class's `waitForIdle` then spins until Espresso's
+      // 60s timeout, failing tests that pass in isolation and picking a
+      // different victim on every run.
+      all {
+        it.forkEvery = 1
+      }
     }
   }
 }

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -99,12 +99,19 @@
         android:theme="@style/Theme.Aurboda"
         android:usesCleartextTraffic="true">
 
+        <!--
+            adjustResize keeps the soft keyboard from covering focused inputs on
+            API ≤ 34, where the window still resizes itself. From API 35 the flag
+            is ignored (edge-to-edge is enforced), so the app consumes the IME
+            inset itself — see AurbodaAppShell in MainActivity.kt.
+        -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop"
-            android:theme="@style/Theme.Aurboda">
+            android:theme="@style/Theme.Aurboda"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -12,11 +12,14 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -165,14 +168,39 @@ class MainActivity : ComponentActivity() {
       }
     val initialMorePath = if (openTab == TAB_MORE) intent?.getStringExtra(EXTRA_MORE_PATH) else null
     setContent {
-      AurbodaAppTheme {
-        Surface(
-          modifier = Modifier.fillMaxSize(),
-          color = MaterialTheme.colorScheme.background,
-        ) {
-          AurbodaApp(initialTab = initialTab, initialMorePath = initialMorePath)
-        }
+      AurbodaAppShell {
+        AurbodaApp(initialTab = initialTab, initialMorePath = initialMorePath)
       }
+    }
+  }
+}
+
+/**
+ * The themed surface every screen is drawn on, sized to keep [content] above the
+ * soft keyboard.
+ *
+ * Apps targeting API 35+ are edge-to-edge, so the window no longer resizes for
+ * the IME (`adjustResize` is ignored) and the keyboard covers whatever is
+ * focused — a native text field, or an input in an embedded web page. Consuming
+ * [keyboardInsets] here shrinks the WebView too, which is what makes it scroll
+ * the focused element into view. It also zeroes the navigation-bar inset the
+ * bottom bar would otherwise add on top, so the bar lands flush above the
+ * keyboard.
+ *
+ * [keyboardInsets] is a parameter so tests can supply a fixed inset instead of
+ * driving the platform's IME.
+ */
+@Composable
+fun AurbodaAppShell(
+  keyboardInsets: WindowInsets = WindowInsets.ime,
+  content: @Composable () -> Unit,
+) {
+  AurbodaAppTheme {
+    Surface(
+      modifier = Modifier.fillMaxSize().windowInsetsPadding(keyboardInsets),
+      color = MaterialTheme.colorScheme.background,
+    ) {
+      content()
     }
   }
 }

--- a/apps/android/app/src/test/java/net/aurboda/KeyboardInsetsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/KeyboardInsetsTest.kt
@@ -1,0 +1,71 @@
+package net.aurboda
+
+import android.content.ComponentName
+import android.view.WindowManager
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private val KEYBOARD_HEIGHT = 200.dp
+
+/**
+ * The soft keyboard must never cover a focused input, native or in an embedded
+ * web page. Two independent mechanisms deliver that, one per API range, and
+ * neither is visible in the screens themselves — hence these tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class KeyboardInsetsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /** API ≤ 34: the window still resizes itself, if the manifest asks it to. */
+    // SOFT_INPUT_ADJUST_RESIZE is deprecated precisely because API 35+ ignores
+    // it; it is still the mechanism on the API levels this app also supports.
+    @Suppress("DEPRECATION")
+    @Test
+    fun `main activity asks the window to resize for the keyboard`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val activityInfo = context.packageManager.getActivityInfo(
+            ComponentName(context, MainActivity::class.java),
+            0,
+        )
+
+        assertEquals(
+            WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE,
+            activityInfo.softInputMode and WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST,
+        )
+    }
+
+    /** API 35+: edge-to-edge is enforced, so the shell consumes the IME inset. */
+    @Test
+    fun `app shell shrinks its content by the keyboard height`() {
+        composeTestRule.setContent {
+            AurbodaAppShell(keyboardInsets = WindowInsets(bottom = KEYBOARD_HEIGHT)) {
+                Box(modifier = Modifier.fillMaxSize().testTag("content"))
+            }
+        }
+
+        val windowHeight = composeTestRule.onRoot().fetchSemanticsNode().size.height
+        val contentHeight = composeTestRule.onNodeWithTag("content").fetchSemanticsNode().size.height
+
+        assertEquals(
+            windowHeight - with(composeTestRule.density) { KEYBOARD_HEIGHT.roundToPx() },
+            contentHeight,
+        )
+    }
+}

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -61,6 +61,21 @@ stays light: it is built against a day/night-themed context
 app's `prefers-color-scheme` resolves to dark when the system is dark and its own
 dark CSS applies (the page declares `color-scheme: light dark`).
 
+### Soft keyboard
+
+Focusing an input — a native text field or one inside an embedded page — must
+not leave it behind the keyboard. Two mechanisms cover the supported API range:
+
+- **API ≤ 34:** `android:windowSoftInputMode="adjustResize"` on `MainActivity`
+  lets the system shrink the window.
+- **API 35+:** edge-to-edge is enforced and `adjustResize` is ignored, so the app
+  consumes the IME inset itself — `AurbodaAppShell` (MainActivity.kt) pads every
+  screen by `WindowInsets.ime` (injectable, so tests can supply a fixed inset).
+
+Both paths shrink the WebView rather than sliding it, which is what makes it
+scroll the focused element into view; the injected viewport fix re-pins the page
+height to the new `window.innerHeight`. `KeyboardInsetsTest` covers both.
+
 ### The embed contract (web ↔ native)
 
 The web app supports an **embed mode** (`apps/web/src/embed.ts`):


### PR DESCRIPTION
## Problem

Tapping a text field in an embedded web page (e.g. the note field on an activity) opens the keyboard **on top of** the field, with no way to scroll it up.

The app targets SDK 36. From **API 35 edge-to-edge is enforced and `adjustResize` is ignored**, so the window never shrinks for the IME — and nothing in the app consumed the IME inset. The WebView kept full window height and the keyboard simply drew over it.

## Fix

- **`AurbodaAppShell`** (new, extracted from `MainActivity.onCreate`) pads every screen by `WindowInsets.ime`, so the whole app — bottom bar included — sits above the keyboard. Consuming the inset also zeroes the navigation-bar inset the bottom bar would otherwise add on top, so it lands flush above the keyboard.
- Shrinking the WebView (rather than sliding it) is what makes it scroll the focused element into view; the injected viewport fix re-pins the page height to the new `window.innerHeight`.
- `android:windowSoftInputMode="adjustResize"` for API ≤ 34, where the window still resizes itself.

Native text fields (login, account) were covered the same way and are fixed by the same change.

## Test-suite isolation

`testOptions.unitTests.all { forkEvery = 1 }` — one JVM per test class.

Compose UI tests leak state between classes in a shared JVM: adding a third Compose test class made an *unrelated* class's `waitForIdle` spin until Espresso's 60s timeout, failing 12 tests that pass in isolation and picking a different victim on each run. With isolation the suite is deterministic — three consecutive full runs green, ~40s instead of ~10s (and instead of 12 minutes when it hung).

## Verification

- `KeyboardInsetsTest` covers both paths: the manifest declaration, and that the shell shrinks its content by the keyboard height. Both verified to fail when the corresponding fix is removed.
- Full Android unit suite (243 tests) green ×3; `assembleDebug` green.
- Not verified on a device — no adb device attached here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LatGBTZyYz271275Ks3HtE